### PR TITLE
refactor: [M3-6342] - MUI v5 Migration - SRC > Component > GaugePercent

### DIFF
--- a/packages/manager/src/components/GaugePercent/GaugePercent.styles.ts
+++ b/packages/manager/src/components/GaugePercent/GaugePercent.styles.ts
@@ -1,0 +1,40 @@
+import { styled } from '@mui/material/styles';
+import { isPropValid } from 'src/utilities/isPropValid';
+import { GaugePercentProps } from './GaugePercent';
+
+type StyledGaugePercentProps = Pick<
+  GaugePercentProps,
+  'width' | 'height' | 'innerTextFontSize'
+>;
+
+const propKeys = ['width', 'height', 'innerTextFontSize'];
+
+export const StyledSubTitleDiv = styled('div', {
+  shouldForwardProp: (prop) => isPropValid(propKeys, prop),
+})<StyledGaugePercentProps>(({ theme, width, height, innerTextFontSize }) => ({
+  color: theme.color.headline,
+  fontSize: innerTextFontSize || theme.spacing(2.5),
+  position: 'absolute',
+  textAlign: 'center',
+  top: `calc(${height}px + ${theme.spacing(1.25)})`,
+  width: width,
+}));
+
+export const StyledInnerTextDiv = styled('div', {
+  shouldForwardProp: (prop) => isPropValid(propKeys, prop),
+})<StyledGaugePercentProps>(({ theme, height = 300, width }) => ({
+  position: 'absolute',
+  top: `calc(${height + 30}px / 2)`,
+  width: width,
+  textAlign: 'center',
+  fontSize: '1rem',
+  color: theme.palette.text.primary,
+}));
+
+export const StyledGaugeWrapperDiv = styled('div', {
+  shouldForwardProp: (prop) => isPropValid(propKeys, prop),
+})<StyledGaugePercentProps>(({ theme, height, width }) => ({
+  position: 'relative',
+  width: width,
+  height: `calc(${height}px + ${theme.spacing(3.75)})`,
+}));

--- a/packages/manager/src/components/GaugePercent/GaugePercent.tsx
+++ b/packages/manager/src/components/GaugePercent/GaugePercent.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { compose } from 'recompose';
-import { makeStyles, withTheme, WithTheme } from '@mui/styles';
+import { makeStyles } from 'tss-react/mui';
+import { withTheme, WithTheme } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import { Chart } from 'chart.js';
 
@@ -11,7 +12,7 @@ interface Options {
 }
 
 const useStyles = (options: Options) =>
-  makeStyles((theme: Theme) => ({
+  makeStyles()((theme: Theme) => ({
     gaugeWrapper: {
       position: 'relative',
       width: `50%`,
@@ -51,7 +52,7 @@ type CombinedProps = Props & WithTheme;
 const GaugePercent: React.FC<CombinedProps> = (props) => {
   const width = props.width || 300;
   const height = props.height || 300;
-  const classes = useStyles({
+  const { classes } = useStyles({
     width,
     height,
     fontSize: props.innerTextFontSize,

--- a/packages/manager/src/components/GaugePercent/GaugePercent.tsx
+++ b/packages/manager/src/components/GaugePercent/GaugePercent.tsx
@@ -49,7 +49,7 @@ interface Props {
 
 type CombinedProps = Props & WithTheme;
 
-const GaugePercent: React.FC<CombinedProps> = (props) => {
+const GaugePercent = (props: CombinedProps) => {
   const width = props.width || 300;
   const height = props.height || 300;
   const { classes } = useStyles({

--- a/packages/manager/src/components/GaugePercent/GaugePercent.tsx
+++ b/packages/manager/src/components/GaugePercent/GaugePercent.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import { compose } from 'recompose';
-import { withTheme, WithTheme } from '@mui/styles';
-import { styled } from '@mui/material/styles';
+import { useTheme } from '@mui/material/styles';
 import { Chart } from 'chart.js';
-import { isPropValid } from 'src/utilities/isPropValid';
+import {
+  StyledSubTitleDiv,
+  StyledInnerTextDiv,
+  StyledGaugeWrapperDiv,
+} from './GaugePercent.styles';
 
-interface Props {
+export interface GaugePercentProps {
   width?: number | string;
   height?: number;
   filledInColor?: string;
@@ -17,9 +19,8 @@ interface Props {
   subTitle?: string | JSX.Element | null;
 }
 
-type GaugePercentProps = Props & WithTheme;
-
-export const GaugePercent = (props: GaugePercentProps) => {
+export const GaugePercent = React.memo((props: GaugePercentProps) => {
+  const theme = useTheme();
   const width = props.width || 300;
   const height = props.height || 300;
 
@@ -38,14 +39,14 @@ export const GaugePercent = (props: GaugePercentProps) => {
     {
       borderWidth: 0,
       hoverBackgroundColor: [
-        props.filledInColor || props.theme.palette.primary.main,
-        props.nonFilledInColor || props.theme.color.grey2,
+        props.filledInColor || theme.palette.primary.main,
+        props.nonFilledInColor || theme.color.grey2,
       ],
       /** so basically, index 0 is the filled in, index 1 is the full graph percentage */
       data: [props.value, finalMax],
       backgroundColor: [
-        props.filledInColor || props.theme.palette.primary.main,
-        props.nonFilledInColor || props.theme.color.grey2,
+        props.filledInColor || theme.palette.primary.main,
+        props.nonFilledInColor || theme.color.grey2,
       ],
     },
   ];
@@ -83,59 +84,27 @@ export const GaugePercent = (props: GaugePercentProps) => {
     }
   });
   return (
-    <StyledGaugeWrapperDiv {...props} height={height} width={width}>
+    <StyledGaugeWrapperDiv width={width} height={height}>
       <canvas height={height} ref={graphRef} />
       {props.innerText && (
         <StyledInnerTextDiv
           data-testid="gauge-innertext"
-          {...props}
-          height={height}
           width={width}
+          height={height}
         >
           {props.innerText}
         </StyledInnerTextDiv>
       )}
       {props.subTitle && (
-        <StyledSubTitleDiv data-testid="gauge-subtext" {...props}>
+        <StyledSubTitleDiv
+          data-testid="gauge-subtext"
+          width={width}
+          height={height}
+          innerTextFontSize={props.innerTextFontSize}
+        >
           {props.subTitle}
         </StyledSubTitleDiv>
       )}
     </StyledGaugeWrapperDiv>
   );
-};
-
-const StyledSubTitleDiv = styled('div', {
-  shouldForwardProp: (prop) =>
-    isPropValid(['width', 'height', 'innerTextFontSize'], prop),
-})<GaugePercentProps>(({ theme, ...props }) => ({
-  color: theme.color.headline,
-  fontSize: props.innerTextFontSize || theme.spacing(2.5),
-  position: 'absolute',
-  textAlign: 'center',
-  top: `calc(${props.height}px + ${theme.spacing(1.25)})`,
-  width: props.width,
-}));
-
-const StyledInnerTextDiv = styled('div', {
-  shouldForwardProp: (prop) => prop !== 'height' && prop !== 'width',
-})<GaugePercentProps>(({ theme, height = 300, width }) => ({
-  position: 'absolute',
-  top: `calc(${height + 30}px / 2)`,
-  width: width,
-  textAlign: 'center',
-  fontSize: '1rem',
-  color: theme.palette.text.primary,
-}));
-
-const StyledGaugeWrapperDiv = styled('div', {
-  shouldForwardProp: (prop) => prop !== 'height' && prop !== 'width',
-})<GaugePercentProps>(({ theme, height, width }) => ({
-  position: 'relative',
-  width: width,
-  height: `calc(${height}px + ${theme.spacing(3.75)})`,
-}));
-
-export default compose<GaugePercentProps, Props>(
-  React.memo,
-  withTheme
-)(GaugePercent);
+});

--- a/packages/manager/src/components/GaugePercent/GaugePercent.tsx
+++ b/packages/manager/src/components/GaugePercent/GaugePercent.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { compose } from 'recompose';
 import { withTheme, WithTheme } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import { Chart } from 'chart.js';
-import { Box } from 'src/components/Box';
+import { isPropValid } from 'src/utilities/isPropValid';
 
 interface Props {
   width?: number | string;
@@ -83,47 +83,57 @@ export const GaugePercent = (props: GaugePercentProps) => {
     }
   });
   return (
-    <Box
-      sx={{
-        position: 'relative',
-        width: width,
-        height: `calc(${height}px + ${props.theme.spacing(3.75)})`,
-      }}
-    >
+    <StyledGaugeWrapperDiv {...props} height={height} width={width}>
       <canvas height={height} ref={graphRef} />
       {props.innerText && (
-        <Box
+        <StyledInnerTextDiv
           data-testid="gauge-innertext"
-          sx={(theme: Theme) => ({
-            position: 'absolute',
-            top: `calc(${height + 30}px / 2)`,
-            width: width,
-            textAlign: 'center',
-            fontSize: '1rem',
-            color: theme.palette.text.primary,
-          })}
+          {...props}
+          height={height}
+          width={width}
         >
           {props.innerText}
-        </Box>
+        </StyledInnerTextDiv>
       )}
       {props.subTitle && (
-        <Box
-          data-testid="gauge-subtext"
-          sx={(theme: Theme) => ({
-            position: 'absolute',
-            width: width,
-            textAlign: 'center',
-            top: `calc(${height}px + ${theme.spacing(1.25)})`,
-            fontSize: props.innerTextFontSize || theme.spacing(2.5),
-            color: theme.color.headline,
-          })}
-        >
+        <StyledSubTitleDiv data-testid="gauge-subtext" {...props}>
           {props.subTitle}
-        </Box>
+        </StyledSubTitleDiv>
       )}
-    </Box>
+    </StyledGaugeWrapperDiv>
   );
 };
+
+const StyledSubTitleDiv = styled('div', {
+  shouldForwardProp: (prop) =>
+    isPropValid(['width', 'height', 'innerTextFontSize'], prop),
+})<GaugePercentProps>(({ theme, ...props }) => ({
+  color: theme.color.headline,
+  fontSize: props.innerTextFontSize || theme.spacing(2.5),
+  position: 'absolute',
+  textAlign: 'center',
+  top: `calc(${props.height}px + ${theme.spacing(1.25)})`,
+  width: props.width,
+}));
+
+const StyledInnerTextDiv = styled('div', {
+  shouldForwardProp: (prop) => prop !== 'height' && prop !== 'width',
+})<GaugePercentProps>(({ theme, height = 300, width }) => ({
+  position: 'absolute',
+  top: `calc(${height + 30}px / 2)`,
+  width: width,
+  textAlign: 'center',
+  fontSize: '1rem',
+  color: theme.palette.text.primary,
+}));
+
+const StyledGaugeWrapperDiv = styled('div', {
+  shouldForwardProp: (prop) => prop !== 'height' && prop !== 'width',
+})<GaugePercentProps>(({ theme, height, width }) => ({
+  position: 'relative',
+  width: width,
+  height: `calc(${height}px + ${theme.spacing(3.75)})`,
+}));
 
 export default compose<GaugePercentProps, Props>(
   React.memo,

--- a/packages/manager/src/components/GaugePercent/GaugePercent.tsx
+++ b/packages/manager/src/components/GaugePercent/GaugePercent.tsx
@@ -1,39 +1,9 @@
 import * as React from 'react';
 import { compose } from 'recompose';
-import { makeStyles } from 'tss-react/mui';
 import { withTheme, WithTheme } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import { Chart } from 'chart.js';
-
-interface Options {
-  width: number | string;
-  height: number;
-  fontSize?: number;
-}
-
-const useStyles = (options: Options) =>
-  makeStyles()((theme: Theme) => ({
-    gaugeWrapper: {
-      position: 'relative',
-      width: `50%`,
-    },
-    innerText: {
-      position: 'absolute',
-      top: `calc(${options.height + 30}px / 2)`,
-      width: options.width,
-      textAlign: 'center',
-      fontSize: '1rem',
-      color: theme.palette.text.primary,
-    },
-    subTitle: {
-      position: 'absolute',
-      width: options.width,
-      textAlign: 'center',
-      top: `calc(${options.height}px + ${theme.spacing(1.25)})`,
-      fontSize: options.fontSize || theme.spacing(2.5),
-      color: theme.color.headline,
-    },
-  }));
+import { Box } from 'src/components/Box';
 
 interface Props {
   width?: number | string;
@@ -47,16 +17,11 @@ interface Props {
   subTitle?: string | JSX.Element | null;
 }
 
-type CombinedProps = Props & WithTheme;
+type GaugePercentProps = Props & WithTheme;
 
-const GaugePercent = (props: CombinedProps) => {
+export const GaugePercent = (props: GaugePercentProps) => {
   const width = props.width || 300;
   const height = props.height || 300;
-  const { classes } = useStyles({
-    width,
-    height,
-    fontSize: props.innerTextFontSize,
-  })();
 
   /**
    * if the value exceeds the maximum (e.g Longview Load), just make the max 0
@@ -118,29 +83,49 @@ const GaugePercent = (props: CombinedProps) => {
     }
   });
   return (
-    <div
-      className={classes.gaugeWrapper}
-      style={{
-        width,
+    <Box
+      sx={{
+        position: 'relative',
+        width: width,
         height: `calc(${height}px + ${props.theme.spacing(3.75)})`,
       }}
     >
       <canvas height={height} ref={graphRef} />
       {props.innerText && (
-        <div data-testid="gauge-innertext" className={classes.innerText}>
+        <Box
+          data-testid="gauge-innertext"
+          sx={(theme: Theme) => ({
+            position: 'absolute',
+            top: `calc(${height + 30}px / 2)`,
+            width: width,
+            textAlign: 'center',
+            fontSize: '1rem',
+            color: theme.palette.text.primary,
+          })}
+        >
           {props.innerText}
-        </div>
+        </Box>
       )}
       {props.subTitle && (
-        <div data-testid="gauge-subtext" className={classes.subTitle}>
+        <Box
+          data-testid="gauge-subtext"
+          sx={(theme: Theme) => ({
+            position: 'absolute',
+            width: width,
+            textAlign: 'center',
+            top: `calc(${height}px + ${theme.spacing(1.25)})`,
+            fontSize: props.innerTextFontSize || theme.spacing(2.5),
+            color: theme.color.headline,
+          })}
+        >
           {props.subTitle}
-        </div>
+        </Box>
       )}
-    </div>
+    </Box>
   );
 };
 
-export default compose<CombinedProps, Props>(
+export default compose<GaugePercentProps, Props>(
   React.memo,
   withTheme
 )(GaugePercent);

--- a/packages/manager/src/components/GaugePercent/index.ts
+++ b/packages/manager/src/components/GaugePercent/index.ts
@@ -1,1 +1,0 @@
-export { default } from './GaugePercent';

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
@@ -2,7 +2,7 @@ import { clamp, pathOr } from 'ramda';
 import * as React from 'react';
 import { WithTheme, withTheme } from '@mui/styles';
 import { Typography } from 'src/components/Typography';
-import GaugePercent from 'src/components/GaugePercent';
+import { GaugePercent } from 'src/components/GaugePercent/GaugePercent';
 import { pluralize } from 'src/utilities/pluralize';
 import { CPU } from '../../request.types';
 import { baseGaugeProps, BaseProps as Props } from './common';

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
@@ -2,7 +2,7 @@ import { pathOr } from 'ramda';
 import * as React from 'react';
 import { WithTheme, withTheme } from '@mui/styles';
 import { Typography } from 'src/components/Typography';
-import GaugePercent from 'src/components/GaugePercent';
+import { GaugePercent } from 'src/components/GaugePercent/GaugePercent';
 import withClientData, {
   Props as LVDataProps,
 } from 'src/containers/longview.stats.container';

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Network.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Network.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { compose } from 'recompose';
 import { WithTheme, withTheme } from '@mui/styles';
 import { Typography } from 'src/components/Typography';
-import GaugePercent from 'src/components/GaugePercent';
+import { GaugePercent } from 'src/components/GaugePercent/GaugePercent';
 import withClientStats, {
   Props as LVDataProps,
 } from 'src/containers/longview.stats.container';

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
@@ -2,7 +2,7 @@ import { pathOr } from 'ramda';
 import * as React from 'react';
 import { WithTheme, withTheme } from '@mui/styles';
 import { Typography } from 'src/components/Typography';
-import GaugePercent from 'src/components/GaugePercent';
+import { GaugePercent } from 'src/components/GaugePercent/GaugePercent';
 import {
   generateTotalMemory,
   generateUsedMemory,

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Storage.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Storage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { WithTheme, withTheme } from '@mui/styles';
 import { Typography } from 'src/components/Typography';
-import GaugePercent from 'src/components/GaugePercent';
+import { GaugePercent } from 'src/components/GaugePercent/GaugePercent';
 import withClientStats, {
   Props as LVDataProps,
 } from 'src/containers/longview.stats.container';

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Swap.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Swap.tsx
@@ -2,7 +2,7 @@ import { pathOr } from 'ramda';
 import * as React from 'react';
 import { WithTheme, withTheme } from '@mui/styles';
 import { Typography } from 'src/components/Typography';
-import GaugePercent from 'src/components/GaugePercent';
+import { GaugePercent } from 'src/components/GaugePercent/GaugePercent';
 import withClientData, {
   Props as LVDataProps,
 } from 'src/containers/longview.stats.container';


### PR DESCRIPTION
## Description 📝
Ran Codemod against SRC > Component > GaugePercent

## Major Changes 🔄
- [x] Run codemod
- [x] Remove React.FC and rename interface 'Props' to '{ComponentName}Props'
- [x] Remove 'CombinedProps' 
- [x] Remove makeStyles for new styled API. We typically use 'Styled ComponentName) as our prefix
- [x] Export component inline
- [x] Any style attributes can be converted to 'sx prop' or 'styled API'
- [x] Move styled api calls to separate file (< 100 lines)

## Preview 📷
Before:
![Screenshot 2023-07-18 at 5 00 59 PM](https://github.com/linode/manager/assets/139489745/2a721d2b-8be9-4fcf-8637-d84e128add88)

After:
![Screenshot 2023-07-18 at 5 02 12 PM](https://github.com/linode/manager/assets/139489745/8ec8211c-9398-4f8a-8311-57c662656c4c)


## How to test 🧪
Go to the Longview section and make sure the functionality and the visual components are the same.

![Screenshot 2023-07-18 at 5 04 23 PM](https://github.com/linode/manager/assets/139489745/bcdabac4-c3b2-4c36-8571-23db67e7c16c)

Note: You might need to setup a Longview client: 
1. Create a new Linode (ex. Debian 11, Debian 12 does not work)
2. Create a new Longview client (Click the "Add Client" button)
3. Copy the installation curl command
4. SSH into your Linode and paste the installation command

Reference: https://www.linode.com/docs/products/tools/longview/guides/troubleshooting/