### PR TITLE
Chore: Enable local storage for MSW feature flags

### DIFF
--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -5,6 +5,9 @@ import { Dispatch } from 'src/hooks/types';
 import useFlags from 'src/hooks/useFlags';
 import { setMockFeatureFlags } from 'src/store/mockFeatureFlags';
 import Grid from '@mui/material/Unstable_Grid2';
+import { getStorage, setStorage } from 'src/utilities/storage';
+
+const MOCK_FEATURE_FLAGS_STORAGE_KEY = 'devTools/mock-feature-flags';
 
 const options: { label: string; flag: keyof Flags }[] = [
   { label: 'Metadata', flag: 'metadata' },
@@ -17,11 +20,23 @@ const FeatureFlagTool: React.FC<{}> = () => {
   const dispatch: Dispatch = useDispatch();
   const flags = useFlags();
 
+  React.useEffect(() => {
+    const storedFlags = getStorage(MOCK_FEATURE_FLAGS_STORAGE_KEY);
+    if (storedFlags) {
+      dispatch(setMockFeatureFlags(storedFlags));
+    }
+  }, [dispatch]);
+
   const handleCheck = (
     e: React.ChangeEvent<HTMLInputElement>,
     flag: keyof FlagSet
   ) => {
     dispatch(setMockFeatureFlags({ [flag]: e.target.checked }));
+    const updatedFlags = JSON.stringify({
+      ...getStorage(MOCK_FEATURE_FLAGS_STORAGE_KEY),
+      [flag]: e.target.checked,
+    });
+    setStorage(MOCK_FEATURE_FLAGS_STORAGE_KEY, updatedFlags);
   };
 
   return (


### PR DESCRIPTION
Super tiny PR to persist our MSW flag choices via local storage.

## Testing
Enable an MSW flag and reload the page. 