### PR TITLE
Feat: [M3-6806] AGLB - Add LoadBalancer create menu entry

### DIFF
--- a/packages/manager/.changeset/pr-9405-added-1689345233361.md
+++ b/packages/manager/.changeset/pr-9405-added-1689345233361.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+AGLB - Add LoadBalancer create menu entry ([#9405](https://github.com/linode/manager/pull/9405))

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.test.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import { fireEvent } from '@testing-library/react';
+import { AddNewMenu } from './AddNewMenu';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+describe('AddNewMenu', () => {
+  test('renders the Create button', () => {
+    const { getByText } = renderWithTheme(<AddNewMenu />);
+    const createButton = getByText('Create');
+    expect(createButton).toBeInTheDocument();
+  });
+
+  test('opens the menu on button click', () => {
+    const { getByText, getByRole } = renderWithTheme(<AddNewMenu />);
+    const createButton = getByText('Create');
+    fireEvent.click(createButton);
+    const menu = getByRole('menu');
+    expect(menu).toBeInTheDocument();
+  });
+
+  test('renders Linode menu item', () => {
+    const { getByText } = renderWithTheme(<AddNewMenu />);
+    const createButton = getByText('Create');
+    fireEvent.click(createButton);
+    const menuItem = getByText('Linode');
+    expect(menuItem).toBeInTheDocument();
+  });
+
+  test('navigates to Linode create page on Linode menu item click', () => {
+    // Create a mock history object
+    const history = createMemoryHistory();
+
+    // Render the component with the Router and history
+    const { getByText } = renderWithTheme(
+      <Router history={history}>
+        <AddNewMenu />
+      </Router>
+    );
+
+    const createButton = getByText('Create');
+    fireEvent.click(createButton);
+
+    const menuItem = getByText('Linode');
+    fireEvent.click(menuItem);
+
+    // Assert that the history's location has changed to the expected URL
+    expect(history.location.pathname).toBe('/linodes/create');
+  });
+
+  test('does not render hidden menu item', () => {
+    const mockedUseFlags = jest.fn().mockReturnValue({ aglb: false });
+    jest.mock('src/hooks/useFlags', () => ({
+      __esModule: true,
+      default: mockedUseFlags,
+    }));
+
+    const { getByText, queryByText } = renderWithTheme(<AddNewMenu />);
+    const createButton = getByText('Create');
+    fireEvent.click(createButton);
+    const hiddenMenuItem = queryByText('LoadBalancer');
+    expect(hiddenMenuItem).toBeNull();
+  });
+});

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.test.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.test.tsx
@@ -59,7 +59,7 @@ describe('AddNewMenu', () => {
     const { getByText, queryByText } = renderWithTheme(<AddNewMenu />);
     const createButton = getByText('Create');
     fireEvent.click(createButton);
-    const hiddenMenuItem = queryByText('LoadBalancer');
+    const hiddenMenuItem = queryByText('Global Load Balancer');
     expect(hiddenMenuItem).toBeNull();
   });
 });

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -13,6 +13,7 @@ import DatabaseIcon from 'src/assets/icons/entityIcons/database.svg';
 import { Button } from 'src/components/Button/Button';
 import { Divider } from 'src/components/Divider';
 import { Link } from 'react-router-dom';
+import useFlags from 'src/hooks/useFlags';
 import {
   Box,
   ListItemIcon,
@@ -23,9 +24,19 @@ import {
   useTheme,
 } from '@mui/material';
 
+interface LinkProps {
+  entity: string;
+  description: string;
+  hide?: boolean;
+  icon: React.ComponentClass<any, any>;
+  link: string;
+  attr?: { [key: string]: boolean };
+}
+
 export const AddNewMenu = () => {
   const theme = useTheme();
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const flags = useFlags();
 
   const open = Boolean(anchorEl);
 
@@ -36,7 +47,7 @@ export const AddNewMenu = () => {
     setAnchorEl(null);
   };
 
-  const links = [
+  const links: LinkProps[] = [
     {
       entity: 'Linode',
       description: 'High performance SSD Linux servers',
@@ -48,6 +59,15 @@ export const AddNewMenu = () => {
       description: 'Attach additional storage to your Linode',
       icon: VolumeIcon,
       link: '/volumes/create',
+    },
+    {
+      entity: 'LoadBalancer',
+      // TODO AGLB: Replace with AGLB copy when available
+      description: 'Ensure your services are highly available',
+      // TODO AGLB: Change this icon to the AGLB icon when available
+      icon: DomainIcon,
+      link: '/loadbalancer/create',
+      hide: !flags.aglb,
     },
     {
       entity: 'NodeBalancer',
@@ -134,42 +154,48 @@ export const AddNewMenu = () => {
           },
         }}
       >
-        {links.map((link, i) => [
-          i !== 0 && <Divider spacingTop={0} spacingBottom={0} />,
-          <MenuItem
-            key={link.entity}
-            onClick={handleClose}
-            sx={{
-              paddingY: 1.5,
-              '&:hover': {
-                // This MUI Menu gets special colors compared
-                // to a standard menu such as the NodeBalancer Config Node Mode select menu
-                backgroundColor: theme.bg.app,
-              },
-            }}
-            component={Link}
-            to={link.link}
-            {...link.attr}
-            style={{
-              // We have to do this because in packages/manager/src/index.css we force underline links
-              textDecoration: 'none',
-            }}
-          >
-            <ListItemIcon>
-              <link.icon
-                width={20}
-                height={20}
-                color={theme.palette.text.primary}
-              />
-            </ListItemIcon>
-            <Stack>
-              <Typography variant="h3" color={theme.textColors.linkActiveLight}>
-                {link.entity}
-              </Typography>
-              <Typography>{link.description}</Typography>
-            </Stack>
-          </MenuItem>,
-        ])}
+        {links.map(
+          (link, i) =>
+            !link.hide && [
+              i !== 0 && <Divider spacingTop={0} spacingBottom={0} />,
+              <MenuItem
+                key={link.entity}
+                onClick={handleClose}
+                sx={{
+                  paddingY: 1.5,
+                  '&:hover': {
+                    // This MUI Menu gets special colors compared
+                    // to a standard menu such as the NodeBalancer Config Node Mode select menu
+                    backgroundColor: theme.bg.app,
+                  },
+                }}
+                component={Link}
+                to={link.link}
+                {...link.attr}
+                style={{
+                  // We have to do this because in packages/manager/src/index.css we force underline links
+                  textDecoration: 'none',
+                }}
+              >
+                <ListItemIcon>
+                  <link.icon
+                    width={20}
+                    height={20}
+                    color={theme.palette.text.primary}
+                  />
+                </ListItemIcon>
+                <Stack>
+                  <Typography
+                    variant="h3"
+                    color={theme.textColors.linkActiveLight}
+                  >
+                    {link.entity}
+                  </Typography>
+                  <Typography>{link.description}</Typography>
+                </Stack>
+              </MenuItem>,
+            ]
+        )}
       </Menu>
     </Box>
   );

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -61,7 +61,7 @@ export const AddNewMenu = () => {
       link: '/volumes/create',
     },
     {
-      entity: 'LoadBalancer',
+      entity: 'Global Load Balancer',
       // TODO AGLB: Replace with AGLB copy when available
       description: 'Ensure your services are highly available',
       // TODO AGLB: Change this icon to the AGLB icon when available


### PR DESCRIPTION
## Description 📝
Small PR to add the AGLB create menu entry - also added a test for good measure since I was adding a prop

Subtitle and icon are TODO items

## Preview 📷

![Screenshot 2023-07-14 at 10 39 34 AM](https://github.com/linode/manager/assets/130582365/513e4e0f-9d28-46a8-abb6-1b51168f4388)


## How to test 🧪

1. Pull code locally, enable both MSW & the AGLB flag
2. Confirm presence and behavior of new create menu entry
3. Verify there's no regression with the create menu when the flag is off


