### PR TITLE
fix: [M3-6828] fix to css specificity in SideMenu after linting

### DIFF
--- a/packages/manager/src/components/SideMenu.tsx
+++ b/packages/manager/src/components/SideMenu.tsx
@@ -14,12 +14,12 @@ const useStyles = makeStyles((theme: Theme) => ({
         opacity: 1,
       },
       overflowY: 'auto',
-      width: `190px !important`,
+      width: '190px !important',
     },
     [theme.breakpoints.up('sm')]: {
       overflowY: 'hidden',
     },
-    width: `52px !important`,
+    width: '52px !important',
   },
   desktopMenu: {
     transform: 'none',


### PR DESCRIPTION
## Description 📝
The linting PR introduced a regression with the SideMenu (when collapsed) due to css specificity and ordering. 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-07-17 at 10 37 59 AM](https://github.com/linode/manager/assets/130582365/967975ce-1141-45c9-ba93-5ba7b62529a0) | ![Screenshot 2023-07-17 at 10 37 43 AM](https://github.com/linode/manager/assets/130582365/c1474f9e-f0c7-4d36-b84a-2908c4dde2fe) |

## How to test 🧪
1. Pull change locally and confirm behavior of primary nav in all states

