### PR TITLE
M3-6577: Add Cypress coverage for Linode deletion from details page

### DIFF
--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -4,6 +4,7 @@
 
 import { apiMatcher } from 'support/util/intercepts';
 import { paginateResponse } from 'support/util/paginate';
+import { makeResponse } from 'support/util/response';
 
 import type { Disk, Linode, Volume } from '@linode/api-v4/types';
 
@@ -123,5 +124,22 @@ export const mockGetLinodeDisks = (
     'GET',
     apiMatcher(`linode/instances/${linodeId}/disks*`),
     paginateResponse(disks)
+  );
+};
+
+/**
+ * Intercepts DELETE request to delete linode and mocks response.
+ *
+ * @param linodeId - ID of Linode for intercepted request.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockDeleteLinodes = (
+  linodeId: number
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'DELETE',
+    apiMatcher(`linode/instances/${linodeId}`),
+    makeResponse({})
   );
 };


### PR DESCRIPTION
## Description 📝
Add new coverage for Linode deletion from Linode landing page.

## Major Changes 🔄
- Add a new test for for Linode deletion from Linode landing page.

## How to test 🧪
`yarn cy:run -s "cypress/e2e/core/linodes/smoke-delete-linode.spec.ts"`

