### PR TITLE
feat: [M3-6732] - Make VLAN section in Linode Create an Accordion

### DIFF
--- a/packages/manager/.changeset/pr-9414-changed-1689694769486.md
+++ b/packages/manager/.changeset/pr-9414-changed-1689694769486.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Make VLAN section in Linode Create an Accordion ([#9414](https://github.com/linode/manager/pull/9414))

--- a/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.tsx
@@ -17,7 +17,7 @@ import { useImageQuery } from 'src/queries/images';
 import { CreateTypes } from 'src/store/linodeCreate/linodeCreate.actions';
 import { privateIPRegex } from 'src/utilities/ipUtils';
 
-import AttachVLAN from './AttachVLAN';
+import { AttachVLAN } from './AttachVLAN';
 
 const useStyles = makeStyles((theme: Theme) => ({
   addons: {
@@ -163,7 +163,7 @@ export const AddonsPanel = React.memo((props: AddonsPanelProps) => {
 
   return (
     <>
-      {showVlans ? (
+      {showVlans && (
         <AttachVLAN
           handleVLANChange={handleVLANChange}
           helperText={vlanDisabledReason}
@@ -174,13 +174,13 @@ export const AddonsPanel = React.memo((props: AddonsPanelProps) => {
           region={selectedRegionID}
           vlanLabel={vlanLabel}
         />
-      ) : null}
+      )}
       <Paper className={classes.addons} data-qa-add-ons>
         <Typography className={classes.title} variant="h2">
           Add-ons{' '}
-          {backupsDisabledReason ? (
+          {backupsDisabledReason && (
             <TooltipIcon status="help" text={backupsDisabledReason} />
-          ) : null}
+          )}
         </Typography>
         {showBackupsWarning && (
           <Notice warning>

--- a/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.tsx
@@ -1,10 +1,10 @@
 import { Interface, Linode } from '@linode/api-v4/lib/linodes';
-import Grid from '@mui/material/Unstable_Grid2';
 import { Theme } from '@mui/material/styles';
 import { makeStyles } from '@mui/styles';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 
+import { Box } from 'src/components/Box';
 import { Checkbox } from 'src/components/Checkbox';
 import { Currency } from 'src/components/Currency';
 import { Divider } from 'src/components/Divider';
@@ -116,11 +116,9 @@ export const AddonsPanel = React.memo((props: AddonsPanelProps) => {
     const { backupsMonthly } = props;
     return (
       backupsMonthly && (
-        <Grid>
-          <Typography variant="body1">
-            <Currency quantity={backupsMonthly} /> per month
-          </Typography>
-        </Grid>
+        <Typography variant="body1">
+          <Currency quantity={backupsMonthly} /> per month
+        </Typography>
       )
     );
   };
@@ -189,72 +187,60 @@ export const AddonsPanel = React.memo((props: AddonsPanelProps) => {
             <TooltipIcon status="help" text={backupsDisabledReason} />
           ) : null}
         </Typography>
-        <Grid container>
-          {showBackupsWarning && (
-            <Notice warning>
-              Linodes must have a disk formatted with an ext3 or ext4 file
-              system to use the backup service.
-            </Notice>
+        {showBackupsWarning && (
+          <Notice warning>
+            Linodes must have a disk formatted with an ext3 or ext4 file system
+            to use the backup service.
+          </Notice>
+        )}
+        <FormControlLabel
+          control={
+            <Checkbox
+              data-qa-check-backups={
+                accountBackups ? 'auto backup enabled' : 'auto backup disabled'
+              }
+              checked={accountBackups || props.backups}
+              disabled={accountBackups || disabled || isBareMetal}
+              onChange={changeBackups}
+            />
+          }
+          label={
+            <Box display="flex">
+              <Box sx={{ marginRight: 2 }}>Backups</Box>
+              {renderBackupsPrice()}
+            </Box>
+          }
+          className={classes.label}
+        />
+        <Typography className={classes.caption} variant="body1">
+          {accountBackups ? (
+            <React.Fragment>
+              You have enabled automatic backups for your account. This Linode
+              will automatically have backups enabled. To change this setting,{' '}
+              <Link to={'/account/settings'}>click here.</Link>
+            </React.Fragment>
+          ) : (
+            <React.Fragment>
+              Three backup slots are executed and rotated automatically: a daily
+              backup, a 2-7 day old backup, and an 8-14 day old backup. Plans
+              are priced according to the Linode plan selected above.
+            </React.Fragment>
           )}
-          <Grid xs={12}>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  data-qa-check-backups={
-                    accountBackups
-                      ? 'auto backup enabled'
-                      : 'auto backup disabled'
-                  }
-                  checked={accountBackups || props.backups}
-                  disabled={accountBackups || disabled || isBareMetal}
-                  onChange={changeBackups}
-                />
-              }
-              label={
-                <Grid alignItems="center" container spacing={2}>
-                  <Grid>Backups</Grid>
-                  {renderBackupsPrice()}
-                </Grid>
-              }
-              className={classes.label}
+        </Typography>
+        <Divider />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={isPrivateIPChecked}
+              data-qa-check-private-ip
+              data-testid="private_ip"
+              disabled={disabled}
+              onChange={togglePrivateIP}
             />
-            <Typography className={classes.caption} variant="body1">
-              {accountBackups ? (
-                <React.Fragment>
-                  You have enabled automatic backups for your account. This
-                  Linode will automatically have backups enabled. To change this
-                  setting, <Link to={'/account/settings'}>click here.</Link>
-                </React.Fragment>
-              ) : (
-                <React.Fragment>
-                  Three backup slots are executed and rotated automatically: a
-                  daily backup, a 2-7 day old backup, and an 8-14 day old
-                  backup. Plans are priced according to the Linode plan selected
-                  above.
-                </React.Fragment>
-              )}
-            </Typography>
-          </Grid>
-        </Grid>
-
-        <Grid container>
-          <Grid xs={12}>
-            <Divider />
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={isPrivateIPChecked}
-                  data-qa-check-private-ip
-                  data-testid="private_ip"
-                  disabled={disabled}
-                  onChange={togglePrivateIP}
-                />
-              }
-              className={classes.label}
-              label="Private IP"
-            />
-          </Grid>
-        </Grid>
+          }
+          className={classes.label}
+          label="Private IP"
+        />
       </Paper>
     </>
   );

--- a/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.tsx
@@ -13,11 +13,13 @@ import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import Paper from 'src/components/core/Paper';
+import useFlags from 'src/hooks/useFlags';
 import { useImageQuery } from 'src/queries/images';
 import { CreateTypes } from 'src/store/linodeCreate/linodeCreate.actions';
 import { privateIPRegex } from 'src/utilities/ipUtils';
 
-import { AttachVLAN } from './AttachVLAN';
+import AttachVLAN from './AttachVLAN';
+import { VLANAccordion } from './VLANAccordion';
 
 const useStyles = makeStyles((theme: Theme) => ({
   addons: {
@@ -88,6 +90,7 @@ export const AddonsPanel = React.memo((props: AddonsPanelProps) => {
   } = props;
 
   const classes = useStyles();
+  const flags = useFlags();
 
   const { data: image } = useImageQuery(
     selectedImageID ?? '',
@@ -163,8 +166,21 @@ export const AddonsPanel = React.memo((props: AddonsPanelProps) => {
 
   return (
     <>
-      {showVlans && (
-        <AttachVLAN
+      {!flags.vpc &&
+        showVlans && ( // @TODO Delete this conditional and AttachVLAN component once VPC is released
+          <AttachVLAN
+            handleVLANChange={handleVLANChange}
+            helperText={vlanDisabledReason}
+            ipamAddress={ipamAddress}
+            ipamError={ipamError}
+            labelError={labelError}
+            readOnly={disabled || Boolean(vlanDisabledReason)}
+            region={selectedRegionID}
+            vlanLabel={vlanLabel}
+          />
+        )}
+      {flags.vpc && showVlans && (
+        <VLANAccordion
           handleVLANChange={handleVLANChange}
           helperText={vlanDisabledReason}
           ipamAddress={ipamAddress}

--- a/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.tsx
@@ -44,9 +44,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   title: {
     marginBottom: theme.spacing(2),
   },
-  vlan: {
-    marginTop: theme.spacing(3),
-  },
 }));
 
 export interface AddonsPanelProps {
@@ -167,18 +164,16 @@ export const AddonsPanel = React.memo((props: AddonsPanelProps) => {
   return (
     <>
       {showVlans ? (
-        <Paper className={classes.vlan} data-qa-add-ons>
-          <AttachVLAN
-            handleVLANChange={handleVLANChange}
-            helperText={vlanDisabledReason}
-            ipamAddress={ipamAddress}
-            ipamError={ipamError}
-            labelError={labelError}
-            readOnly={disabled || Boolean(vlanDisabledReason)}
-            region={selectedRegionID}
-            vlanLabel={vlanLabel}
-          />
-        </Paper>
+        <AttachVLAN
+          handleVLANChange={handleVLANChange}
+          helperText={vlanDisabledReason}
+          ipamAddress={ipamAddress}
+          ipamError={ipamError}
+          labelError={labelError}
+          readOnly={disabled || Boolean(vlanDisabledReason)}
+          region={selectedRegionID}
+          vlanLabel={vlanLabel}
+        />
       ) : null}
       <Paper className={classes.addons} data-qa-add-ons>
         <Typography className={classes.title} variant="h2">

--- a/packages/manager/src/features/Linodes/LinodesCreate/AttachVLAN.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/AttachVLAN.tsx
@@ -1,12 +1,14 @@
 import { Interface } from '@linode/api-v4/lib/linodes';
+import Grid from '@mui/material/Unstable_Grid2';
+import { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 import * as React from 'react';
 import { useQueryClient } from 'react-query';
 
-import { Accordion } from 'src/components/Accordion';
-import { Box } from 'src/components/Box';
 import ExternalLink from 'src/components/ExternalLink';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
+import Paper from 'src/components/core/Paper';
 import { useRegionsQuery } from 'src/queries/regions';
 import { queryKey as vlansQueryKey } from 'src/queries/vlans';
 import arrayToList from 'src/utilities/arrayToDelimiterSeparatedList';
@@ -16,6 +18,24 @@ import {
 } from 'src/utilities/doesRegionSupportFeature';
 
 import InterfaceSelect from '../LinodesDetail/LinodeSettings/InterfaceSelect';
+
+// @TODO Delete this file when VPC is released
+const useStyles = makeStyles((theme: Theme) => ({
+  paragraphBreak: {
+    marginTop: theme.spacing(2),
+  },
+  title: {
+    '& button': {
+      paddingLeft: theme.spacing(),
+    },
+    alignItems: 'center',
+    display: 'flex',
+    marginBottom: theme.spacing(2),
+  },
+  vlan: {
+    marginTop: theme.spacing(3),
+  },
+}));
 
 interface Props {
   handleVLANChange: (updatedInterface: Interface) => void;
@@ -28,7 +48,9 @@ interface Props {
   vlanLabel: string;
 }
 
-export const AttachVLAN = React.memo((props: Props) => {
+type CombinedProps = Props;
+
+const AttachVLAN: React.FC<CombinedProps> = (props) => {
   const {
     handleVLANChange,
     helperText,
@@ -39,6 +61,8 @@ export const AttachVLAN = React.memo((props: Props) => {
     region,
     vlanLabel,
   } = props;
+
+  const classes = useStyles();
 
   const queryClient = useQueryClient();
 
@@ -66,61 +90,45 @@ export const AttachVLAN = React.memo((props: Props) => {
   )}.`;
 
   return (
-    <Accordion
-      detailProps={{
-        sx: {
-          padding: '0px 24px 24px 24px',
-        },
-      }}
-      heading={
-        <Box display="flex">
-          VLAN
-          {helperText && (
-            <TooltipIcon
-              status="help"
-              sxTooltipIcon={{ alignItems: 'baseline', padding: '0 8px' }}
-              text={helperText}
-            />
-          )}
-        </Box>
-      }
-      summaryProps={{
-        sx: {
-          padding: '5px 24px 0px 24px',
-        },
-      }}
-      sx={{
-        marginTop: 2,
-      }}
-    >
-      <Typography>{regionalAvailabilityMessage}</Typography>
-      <Typography sx={{ marginTop: 2 }} variant="body1">
-        VLANs are used to create a private L2 Virtual Local Area Network between
-        Linodes. A VLAN created or attached in this section will be assigned to
-        the eth1 interface, with eth0 being used for connections to the public
-        internet. VLAN configurations can be further edited in the
-        Linode&rsquo;s{' '}
-        <ExternalLink
-          hideIcon
-          link="https://www.linode.com/docs/guides/linode-configuration-profiles/"
-          text="Configuration Profile"
-        />
-        .
+    <Paper className={classes.vlan} data-qa-add-ons>
+      <Typography className={classes.title} variant="h2">
+        Attach a VLAN{' '}
+        {helperText ? <TooltipIcon status="help" text={helperText} /> : null}
       </Typography>
-      <InterfaceSelect
-        handleChange={(newInterface: Interface) =>
-          handleVLANChange(newInterface)
-        }
-        fromAddonsPanel
-        ipamAddress={ipamAddress}
-        ipamError={ipamError}
-        label={vlanLabel}
-        labelError={labelError}
-        purpose="vlan"
-        readOnly={readOnly || !regionSupportsVLANs || false}
-        region={region}
-        slotNumber={1}
-      />
-    </Accordion>
+      <Grid container>
+        <Grid xs={12}>
+          <Typography>{regionalAvailabilityMessage}</Typography>
+          <Typography className={classes.paragraphBreak} variant="body1">
+            VLANs are used to create a private L2 Virtual Local Area Network
+            between Linodes. A VLAN created or attached in this section will be
+            assigned to the eth1 interface, with eth0 being used for connections
+            to the public internet. VLAN configurations can be further edited in
+            the Linode&rsquo;s{' '}
+            <ExternalLink
+              hideIcon
+              link="https://www.linode.com/docs/guides/linode-configuration-profiles/"
+              text="Configuration Profile"
+            />
+            .
+          </Typography>
+          <InterfaceSelect
+            handleChange={(newInterface: Interface) =>
+              handleVLANChange(newInterface)
+            }
+            fromAddonsPanel
+            ipamAddress={ipamAddress}
+            ipamError={ipamError}
+            label={vlanLabel}
+            labelError={labelError}
+            purpose="vlan"
+            readOnly={readOnly || !regionSupportsVLANs || false}
+            region={region}
+            slotNumber={1}
+          />
+        </Grid>
+      </Grid>
+    </Paper>
   );
-});
+};
+
+export default React.memo(AttachVLAN);

--- a/packages/manager/src/features/Linodes/LinodesCreate/AttachVLAN.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/AttachVLAN.tsx
@@ -1,6 +1,4 @@
 import { Interface } from '@linode/api-v4/lib/linodes';
-import { Theme } from '@mui/material/styles';
-import { makeStyles } from '@mui/styles';
 import * as React from 'react';
 import { useQueryClient } from 'react-query';
 
@@ -19,20 +17,6 @@ import {
 
 import InterfaceSelect from '../LinodesDetail/LinodeSettings/InterfaceSelect';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  paragraphBreak: {
-    marginTop: theme.spacing(2),
-  },
-  title: {
-    '& button': {
-      paddingLeft: theme.spacing(),
-    },
-    alignItems: 'center',
-    display: 'flex',
-    marginBottom: theme.spacing(2),
-  },
-}));
-
 interface Props {
   handleVLANChange: (updatedInterface: Interface) => void;
   helperText?: string;
@@ -44,9 +28,7 @@ interface Props {
   vlanLabel: string;
 }
 
-type CombinedProps = Props;
-
-const AttachVLAN: React.FC<CombinedProps> = (props) => {
+export const AttachVLAN = React.memo((props: Props) => {
   const {
     handleVLANChange,
     helperText,
@@ -57,8 +39,6 @@ const AttachVLAN: React.FC<CombinedProps> = (props) => {
     region,
     vlanLabel,
   } = props;
-
-  const classes = useStyles();
 
   const queryClient = useQueryClient();
 
@@ -114,7 +94,7 @@ const AttachVLAN: React.FC<CombinedProps> = (props) => {
       }}
     >
       <Typography>{regionalAvailabilityMessage}</Typography>
-      <Typography className={classes.paragraphBreak} variant="body1">
+      <Typography sx={{ marginTop: 2 }} variant="body1">
         VLANs are used to create a private L2 Virtual Local Area Network between
         Linodes. A VLAN created or attached in this section will be assigned to
         the eth1 interface, with eth0 being used for connections to the public
@@ -143,6 +123,4 @@ const AttachVLAN: React.FC<CombinedProps> = (props) => {
       />
     </Accordion>
   );
-};
-
-export default React.memo(AttachVLAN);
+});

--- a/packages/manager/src/features/Linodes/LinodesCreate/AttachVLAN.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/AttachVLAN.tsx
@@ -1,10 +1,11 @@
 import { Interface } from '@linode/api-v4/lib/linodes';
-import Grid from '@mui/material/Unstable_Grid2';
 import { Theme } from '@mui/material/styles';
 import { makeStyles } from '@mui/styles';
 import * as React from 'react';
 import { useQueryClient } from 'react-query';
 
+import { Accordion } from 'src/components/Accordion';
+import { Box } from 'src/components/Box';
 import ExternalLink from 'src/components/ExternalLink';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
@@ -85,44 +86,62 @@ const AttachVLAN: React.FC<CombinedProps> = (props) => {
   )}.`;
 
   return (
-    <>
-      <Typography className={classes.title} variant="h2">
-        Attach a VLAN{' '}
-        {helperText ? <TooltipIcon status="help" text={helperText} /> : null}
-      </Typography>
-      <Grid container>
-        <Grid xs={12}>
-          <Typography>{regionalAvailabilityMessage}</Typography>
-          <Typography className={classes.paragraphBreak} variant="body1">
-            VLANs are used to create a private L2 Virtual Local Area Network
-            between Linodes. A VLAN created or attached in this section will be
-            assigned to the eth1 interface, with eth0 being used for connections
-            to the public internet. VLAN configurations can be further edited in
-            the Linode&rsquo;s{' '}
-            <ExternalLink
-              hideIcon
-              link="https://www.linode.com/docs/guides/linode-configuration-profiles/"
-              text="Configuration Profile"
+    <Accordion
+      detailProps={{
+        sx: {
+          padding: '0px 24px 24px 24px',
+        },
+      }}
+      heading={
+        <Box display="flex">
+          VLAN
+          {helperText && (
+            <TooltipIcon
+              status="help"
+              sxTooltipIcon={{ alignItems: 'baseline', padding: '0 8px' }}
+              text={helperText}
             />
-            .
-          </Typography>
-          <InterfaceSelect
-            handleChange={(newInterface: Interface) =>
-              handleVLANChange(newInterface)
-            }
-            fromAddonsPanel
-            ipamAddress={ipamAddress}
-            ipamError={ipamError}
-            label={vlanLabel}
-            labelError={labelError}
-            purpose="vlan"
-            readOnly={readOnly || !regionSupportsVLANs || false}
-            region={region}
-            slotNumber={1}
-          />
-        </Grid>
-      </Grid>
-    </>
+          )}
+        </Box>
+      }
+      summaryProps={{
+        sx: {
+          padding: '5px 24px 0px 24px',
+        },
+      }}
+      sx={{
+        marginTop: 2,
+      }}
+    >
+      <Typography>{regionalAvailabilityMessage}</Typography>
+      <Typography className={classes.paragraphBreak} variant="body1">
+        VLANs are used to create a private L2 Virtual Local Area Network between
+        Linodes. A VLAN created or attached in this section will be assigned to
+        the eth1 interface, with eth0 being used for connections to the public
+        internet. VLAN configurations can be further edited in the
+        Linode&rsquo;s{' '}
+        <ExternalLink
+          hideIcon
+          link="https://www.linode.com/docs/guides/linode-configuration-profiles/"
+          text="Configuration Profile"
+        />
+        .
+      </Typography>
+      <InterfaceSelect
+        handleChange={(newInterface: Interface) =>
+          handleVLANChange(newInterface)
+        }
+        fromAddonsPanel
+        ipamAddress={ipamAddress}
+        ipamError={ipamError}
+        label={vlanLabel}
+        labelError={labelError}
+        purpose="vlan"
+        readOnly={readOnly || !regionSupportsVLANs || false}
+        region={region}
+        slotNumber={1}
+      />
+    </Accordion>
   );
 };
 

--- a/packages/manager/src/features/Linodes/LinodesCreate/VLANAccordion.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/VLANAccordion.tsx
@@ -1,0 +1,127 @@
+import { Interface } from '@linode/api-v4/lib/linodes';
+import * as React from 'react';
+import { useQueryClient } from 'react-query';
+
+import { Accordion } from 'src/components/Accordion';
+import { Box } from 'src/components/Box';
+import ExternalLink from 'src/components/ExternalLink';
+import { TooltipIcon } from 'src/components/TooltipIcon';
+import { Typography } from 'src/components/Typography';
+import { useRegionsQuery } from 'src/queries/regions';
+import { queryKey as vlansQueryKey } from 'src/queries/vlans';
+import arrayToList from 'src/utilities/arrayToDelimiterSeparatedList';
+import {
+  doesRegionSupportFeature,
+  regionsWithFeature,
+} from 'src/utilities/doesRegionSupportFeature';
+
+import InterfaceSelect from '../LinodesDetail/LinodeSettings/InterfaceSelect';
+
+interface Props {
+  handleVLANChange: (updatedInterface: Interface) => void;
+  helperText?: string;
+  ipamAddress: string;
+  ipamError?: string;
+  labelError?: string;
+  readOnly?: boolean;
+  region?: string;
+  vlanLabel: string;
+}
+
+export const VLANAccordion = React.memo((props: Props) => {
+  const {
+    handleVLANChange,
+    helperText,
+    ipamAddress,
+    ipamError,
+    labelError,
+    readOnly,
+    region,
+    vlanLabel,
+  } = props;
+
+  const queryClient = useQueryClient();
+
+  React.useEffect(() => {
+    // Ensure VLANs are fresh.
+    queryClient.invalidateQueries(vlansQueryKey);
+  }, []);
+
+  const regions = useRegionsQuery().data ?? [];
+  const selectedRegion = region || '';
+
+  const regionSupportsVLANs = doesRegionSupportFeature(
+    selectedRegion,
+    regions,
+    'Vlans'
+  );
+
+  const regionsThatSupportVLANs = regionsWithFeature(regions, 'Vlans').map(
+    (region) => region.label
+  );
+
+  const regionalAvailabilityMessage = `VLANs are currently available in ${arrayToList(
+    regionsThatSupportVLANs,
+    ';'
+  )}.`;
+
+  return (
+    <Accordion
+      detailProps={{
+        sx: {
+          padding: '0px 24px 24px 24px',
+        },
+      }}
+      heading={
+        <Box display="flex">
+          VLAN
+          {helperText && (
+            <TooltipIcon
+              status="help"
+              sxTooltipIcon={{ alignItems: 'baseline', padding: '0 8px' }}
+              text={helperText}
+            />
+          )}
+        </Box>
+      }
+      summaryProps={{
+        sx: {
+          padding: '5px 24px 0px 24px',
+        },
+      }}
+      sx={{
+        marginTop: 2,
+      }}
+      data-qa-add-ons
+    >
+      <Typography>{regionalAvailabilityMessage}</Typography>
+      <Typography sx={{ marginTop: 2 }} variant="body1">
+        VLANs are used to create a private L2 Virtual Local Area Network between
+        Linodes. A VLAN created or attached in this section will be assigned to
+        the eth1 interface, with eth0 being used for connections to the public
+        internet. VLAN configurations can be further edited in the
+        Linode&rsquo;s{' '}
+        <ExternalLink
+          hideIcon
+          link="https://www.linode.com/docs/guides/linode-configuration-profiles/"
+          text="Configuration Profile"
+        />
+        .
+      </Typography>
+      <InterfaceSelect
+        handleChange={(newInterface: Interface) =>
+          handleVLANChange(newInterface)
+        }
+        fromAddonsPanel
+        ipamAddress={ipamAddress}
+        ipamError={ipamError}
+        label={vlanLabel}
+        labelError={labelError}
+        purpose="vlan"
+        readOnly={readOnly || !regionSupportsVLANs || false}
+        region={region}
+        slotNumber={1}
+      />
+    </Accordion>
+  );
+});


### PR DESCRIPTION
## Description 📝
We want to demote VLAN in favor of VPC, so the VLAN section will now be hidden inside an accordion.

## Preview 📷
https://github.com/linode/manager/assets/115299789/b73b7c9c-f265-4f40-a72b-10d5b1b6bfaf

## How to test 🧪
Go to `/linodes/create` and scroll down to the VLAN section. Using the dev tools, turn the VPC feature flag on/off
