### PR TITLE
fix: [M3-6799] - Linode Select Dropdown Z-index

### DIFF
--- a/packages/manager/.changeset/pr-9417-fixed-1689705981191.md
+++ b/packages/manager/.changeset/pr-9417-fixed-1689705981191.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fix LinodeSelect styling ([#9417](https://github.com/linode/manager/pull/9417))

--- a/packages/manager/src/features/Linodes/LinodeSelect/LinodeSelect.styles.tsx
+++ b/packages/manager/src/features/Linodes/LinodeSelect/LinodeSelect.styles.tsx
@@ -32,6 +32,7 @@ export const CustomPopper = (props: PopperProps) => {
             ? { width: `calc(${props.style.width} + 2px)` }
             : { width: props.style.width + 2 }
           : {}),
+        zIndex: 1,
       }}
       data-qa-autocomplete-popper
       modifiers={[{ enabled: false, name: 'preventOverflow' }]}

--- a/packages/manager/src/features/Linodes/LinodeSelect/LinodeSelectV2.tsx
+++ b/packages/manager/src/features/Linodes/LinodeSelect/LinodeSelectV2.tsx
@@ -93,6 +93,7 @@ export const LinodeSelectV2 = (
 
   return (
     <Autocomplete
+      disablePortal={true}
       ListboxProps={{
         onScroll: (event: React.SyntheticEvent) => {
           const listboxNode = event.currentTarget;


### PR DESCRIPTION
## Description 📝
Fix LinodeSelect dropdown styling to make sure items don't appear over the global nav

## Major Changes 🔄
- add zIndex property and disablePortal prop to underlying component

## Preview 📷
before
![image](https://github.com/linode/manager/assets/139280159/46ac2541-98de-49ab-899d-3ad1261314fe)

after
![image](https://github.com/linode/manager/assets/139280159/4a45222d-1157-49a6-b70d-e3a494923af3)
![image](https://github.com/linode/manager/assets/139280159/e02d29a6-c9ea-41b0-acb2-2a5ba3b0fe0c)

## How to test
- go to  `/images/create/disk ` or `/domains/create` to ensure linode select works as expected, and to `/firewalls` and see if the linode dropdown for creating a firewall/adding linodes to a firewall still look the same



