### PR TITLE
refactor: [M3-6342] - MUI v5 Migration - SRC > Component > GaugePercent

### DIFF
--- a/packages/manager/.changeset/pr-9420-tech-stories-1689780372828.md
+++ b/packages/manager/.changeset/pr-9420-tech-stories-1689780372828.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+MUI v5 Migration - SRC > Component > GaugePercent ([#9420](https://github.com/linode/manager/pull/9420))

--- a/packages/manager/src/components/GaugePercent/GaugePercent.stories.mdx
+++ b/packages/manager/src/components/GaugePercent/GaugePercent.stories.mdx
@@ -9,11 +9,11 @@ import { Typography } from 'src/components/Typography';
 - **Chart.js** is the charting tool we use for gauges
 - Best used to show percentages
 
-export const Template = (args) => <Gauge {...args} />;
+export const Template = (args) => <GaugePercent {...args} />;
 
 <Canvas>
   <Story
-    name="Gauge"
+    name="GaugePercent"
     args={{
       value: 50,
       max: 200,
@@ -79,4 +79,4 @@ export const Template = (args) => <Gauge {...args} />;
   </Story>
 </Canvas>
 
-<ArgsTable story="Gauge" sort="requiredFirst"/>
+<ArgsTable story="GaugePercent" sort="requiredFirst"/>

--- a/packages/manager/src/components/GaugePercent/GaugePercent.stories.mdx
+++ b/packages/manager/src/components/GaugePercent/GaugePercent.stories.mdx
@@ -1,5 +1,5 @@
 import { Canvas, Meta, Story, ArgsTable } from '@storybook/addon-docs';
-import Gauge from './GaugePercent';
+import { GaugePercent } from './GaugePercent';
 import { Typography } from 'src/components/Typography';
 
 <Meta title="Components/Analytics & Graphs" component={Gauge} />

--- a/packages/manager/src/components/GaugePercent/GaugePercent.stories.mdx
+++ b/packages/manager/src/components/GaugePercent/GaugePercent.stories.mdx
@@ -2,7 +2,7 @@ import { Canvas, Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import { GaugePercent } from './GaugePercent';
 import { Typography } from 'src/components/Typography';
 
-<Meta title="Components/Analytics & Graphs" component={Gauge} />
+<Meta title="Components/Analytics & Graphs" component={GaugePercent} />
 
 # 📈 Gauges
 

--- a/packages/manager/src/components/GaugePercent/GaugePercent.styles.ts
+++ b/packages/manager/src/components/GaugePercent/GaugePercent.styles.ts
@@ -2,10 +2,8 @@ import { styled } from '@mui/material/styles';
 import { isPropValid } from 'src/utilities/isPropValid';
 import { GaugePercentProps } from './GaugePercent';
 
-type StyledGaugePercentProps = Pick<
-  GaugePercentProps,
-  'width' | 'height' | 'innerTextFontSize'
->;
+type StyledGaugePercentProps = Pick<GaugePercentProps, 'innerTextFontSize'> &
+  Required<Pick<GaugePercentProps, 'width' | 'height'>>;
 
 const propKeys = ['width', 'height', 'innerTextFontSize'];
 
@@ -22,7 +20,7 @@ export const StyledSubTitleDiv = styled('div', {
 
 export const StyledInnerTextDiv = styled('div', {
   shouldForwardProp: (prop) => isPropValid(propKeys, prop),
-})<StyledGaugePercentProps>(({ theme, height = 300, width }) => ({
+})<StyledGaugePercentProps>(({ theme, height, width }) => ({
   position: 'absolute',
   top: `calc(${height + 30}px / 2)`,
   width: width,

--- a/packages/manager/src/components/GaugePercent/GaugePercent.styles.ts
+++ b/packages/manager/src/components/GaugePercent/GaugePercent.styles.ts
@@ -1,0 +1,40 @@
+import { styled } from '@mui/material/styles';
+import { isPropValid } from 'src/utilities/isPropValid';
+import { GaugePercentProps } from './GaugePercent';
+
+type StyledGaugePercentProps = Pick<
+  GaugePercentProps,
+  'width' | 'height' | 'innerTextFontSize'
+>;
+
+const propKeys = ['width', 'height', 'innerTextFontSize'];
+
+export const StyledSubTitleDiv = styled('div', {
+  shouldForwardProp: (prop) => isPropValid(propKeys, prop),
+})<StyledGaugePercentProps>(({ theme, width, height, innerTextFontSize }) => ({
+  color: theme.color.headline,
+  fontSize: innerTextFontSize || theme.spacing(2.5),
+  position: 'absolute',
+  textAlign: 'center',
+  top: `calc(${height}px + ${theme.spacing(1.25)})`,
+  width: width,
+}));
+
+export const StyledInnerTextDiv = styled('div', {
+  shouldForwardProp: (prop) => isPropValid(propKeys, prop),
+})<StyledGaugePercentProps>(({ theme, height = 300, width }) => ({
+  position: 'absolute',
+  top: `calc(${height + 30}px / 2)`,
+  width: width,
+  textAlign: 'center',
+  fontSize: '1rem',
+  color: theme.palette.text.primary,
+}));
+
+export const StyledGaugeWrapperDiv = styled('div', {
+  shouldForwardProp: (prop) => isPropValid(propKeys, prop),
+})<StyledGaugePercentProps>(({ theme, height, width }) => ({
+  position: 'relative',
+  width: width,
+  height: `calc(${height}px + ${theme.spacing(3.75)})`,
+}));

--- a/packages/manager/src/components/GaugePercent/GaugePercent.tsx
+++ b/packages/manager/src/components/GaugePercent/GaugePercent.tsx
@@ -1,61 +1,28 @@
-import { Theme } from '@mui/material/styles';
-import { WithTheme, makeStyles, withTheme } from '@mui/styles';
-import { Chart } from 'chart.js';
 import * as React from 'react';
-import { compose } from 'recompose';
+import { useTheme } from '@mui/material/styles';
+import { Chart } from 'chart.js';
+import {
+  StyledSubTitleDiv,
+  StyledInnerTextDiv,
+  StyledGaugeWrapperDiv,
+} from './GaugePercent.styles';
 
-interface Options {
-  fontSize?: number;
-  height: number;
-  width: number | string;
-}
-
-const useStyles = (options: Options) =>
-  makeStyles((theme: Theme) => ({
-    gaugeWrapper: {
-      position: 'relative',
-      width: `50%`,
-    },
-    innerText: {
-      color: theme.palette.text.primary,
-      fontSize: '1rem',
-      position: 'absolute',
-      textAlign: 'center',
-      top: `calc(${options.height + 30}px / 2)`,
-      width: options.width,
-    },
-    subTitle: {
-      color: theme.color.headline,
-      fontSize: options.fontSize || theme.spacing(2.5),
-      position: 'absolute',
-      textAlign: 'center',
-      top: `calc(${options.height}px + ${theme.spacing(1.25)})`,
-      width: options.width,
-    },
-  }));
-
-interface Props {
-  filledInColor?: string;
+export interface GaugePercentProps {
+  width?: number | string;
   height?: number;
+  filledInColor?: string;
+  nonFilledInColor?: string;
+  value: number;
+  max: number;
   innerText?: string;
   innerTextFontSize?: number;
-  max: number;
-  nonFilledInColor?: string;
-  subTitle?: JSX.Element | null | string;
-  value: number;
-  width?: number | string;
+  subTitle?: string | JSX.Element | null;
 }
 
-type CombinedProps = Props & WithTheme;
-
-const GaugePercent: React.FC<CombinedProps> = (props) => {
+export const GaugePercent = React.memo((props: GaugePercentProps) => {
+  const theme = useTheme();
   const width = props.width || 300;
   const height = props.height || 300;
-  const classes = useStyles({
-    fontSize: props.innerTextFontSize,
-    height,
-    width,
-  })();
 
   /**
    * if the value exceeds the maximum (e.g Longview Load), just make the max 0
@@ -70,16 +37,16 @@ const GaugePercent: React.FC<CombinedProps> = (props) => {
 
   const graphDatasets = [
     {
-      backgroundColor: [
-        props.filledInColor || props.theme.palette.primary.main,
-        props.nonFilledInColor || props.theme.color.grey2,
-      ],
       borderWidth: 0,
+      hoverBackgroundColor: [
+        props.filledInColor || theme.palette.primary.main,
+        props.nonFilledInColor || theme.color.grey2,
+      ],
       /** so basically, index 0 is the filled in, index 1 is the full graph percentage */
       data: [props.value, finalMax],
-      hoverBackgroundColor: [
-        props.filledInColor || props.theme.palette.primary.main,
-        props.nonFilledInColor || props.theme.color.grey2,
+      backgroundColor: [
+        props.filledInColor || theme.palette.primary.main,
+        props.nonFilledInColor || theme.color.grey2,
       ],
     },
   ];
@@ -88,16 +55,16 @@ const GaugePercent: React.FC<CombinedProps> = (props) => {
       animateRotate: false,
       animateScale: false,
     },
+    maintainAspectRatio: false,
+    rotation: -1.25 * Math.PI,
     circumference: 1.5 * Math.PI,
     cutoutPercentage: 70,
+    responsive: true,
     /** get rid of all hover events with events: [] */
     events: [],
     legend: {
       display: false,
     },
-    maintainAspectRatio: false,
-    responsive: true,
-    rotation: -1.25 * Math.PI,
   };
 
   const graphRef: React.RefObject<any> = React.useRef(null);
@@ -108,38 +75,36 @@ const GaugePercent: React.FC<CombinedProps> = (props) => {
     // https://dev.to/vcanales/using-chart-js-in-a-function-component-with-react-hooks-246l
     if (graphRef.current) {
       new Chart(graphRef.current.getContext('2d'), {
+        type: 'doughnut',
         data: {
           datasets: graphDatasets,
         },
         options: graphOptions,
-        type: 'doughnut',
       });
     }
   });
   return (
-    <div
-      style={{
-        height: `calc(${height}px + ${props.theme.spacing(3.75)})`,
-        width,
-      }}
-      className={classes.gaugeWrapper}
-    >
+    <StyledGaugeWrapperDiv width={width} height={height}>
       <canvas height={height} ref={graphRef} />
       {props.innerText && (
-        <div className={classes.innerText} data-testid="gauge-innertext">
+        <StyledInnerTextDiv
+          data-testid="gauge-innertext"
+          width={width}
+          height={height}
+        >
           {props.innerText}
-        </div>
+        </StyledInnerTextDiv>
       )}
       {props.subTitle && (
-        <div className={classes.subTitle} data-testid="gauge-subtext">
+        <StyledSubTitleDiv
+          data-testid="gauge-subtext"
+          width={width}
+          height={height}
+          innerTextFontSize={props.innerTextFontSize}
+        >
           {props.subTitle}
-        </div>
+        </StyledSubTitleDiv>
       )}
-    </div>
+    </StyledGaugeWrapperDiv>
   );
-};
-
-export default compose<CombinedProps, Props>(
-  React.memo,
-  withTheme
-)(GaugePercent);
+});

--- a/packages/manager/src/components/GaugePercent/index.ts
+++ b/packages/manager/src/components/GaugePercent/index.ts
@@ -1,1 +1,0 @@
-export { default } from './GaugePercent';

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
@@ -2,7 +2,7 @@ import { WithTheme, withTheme } from '@mui/styles';
 import { clamp, pathOr } from 'ramda';
 import * as React from 'react';
 
-import GaugePercent from 'src/components/GaugePercent';
+import { GaugePercent } from 'src/components/GaugePercent/GaugePercent';
 import { Typography } from 'src/components/Typography';
 import withClientStats, {
   Props as LVDataProps,

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
@@ -2,7 +2,7 @@ import { WithTheme, withTheme } from '@mui/styles';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 
-import GaugePercent from 'src/components/GaugePercent';
+import { GaugePercent } from 'src/components/GaugePercent/GaugePercent';
 import { Typography } from 'src/components/Typography';
 import withClientData, {
   Props as LVDataProps,

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Network.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Network.tsx
@@ -2,7 +2,7 @@ import { WithTheme, withTheme } from '@mui/styles';
 import * as React from 'react';
 import { compose } from 'recompose';
 
-import GaugePercent from 'src/components/GaugePercent';
+import { GaugePercent } from 'src/components/GaugePercent/GaugePercent';
 import { Typography } from 'src/components/Typography';
 import withClientStats, {
   Props as LVDataProps,

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
@@ -2,7 +2,7 @@ import { WithTheme, withTheme } from '@mui/styles';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 
-import GaugePercent from 'src/components/GaugePercent';
+import { GaugePercent } from 'src/components/GaugePercent/GaugePercent';
 import { Typography } from 'src/components/Typography';
 import withClientData, {
   Props as LVDataProps,

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Storage.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Storage.tsx
@@ -1,7 +1,7 @@
 import { WithTheme, withTheme } from '@mui/styles';
 import * as React from 'react';
 
-import GaugePercent from 'src/components/GaugePercent';
+import { GaugePercent } from 'src/components/GaugePercent/GaugePercent';
 import { Typography } from 'src/components/Typography';
 import withClientStats, {
   Props as LVDataProps,

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Swap.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Swap.tsx
@@ -2,7 +2,7 @@ import { WithTheme, withTheme } from '@mui/styles';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 
-import GaugePercent from 'src/components/GaugePercent';
+import { GaugePercent } from 'src/components/GaugePercent/GaugePercent';
 import { Typography } from 'src/components/Typography';
 import withClientData, {
   Props as LVDataProps,


### PR DESCRIPTION
## Description 📝
Ran Codemod against SRC > Component > GaugePercent

## Major Changes 🔄
- [x] Run codemod
- [x] Remove React.FC and rename interface 'Props' to '{ComponentName}Props'
- [x] Remove 'CombinedProps' 
- [x] Remove makeStyles for new styled API. We typically use 'Styled ComponentName) as our prefix
- [x] Export component inline
- [x] Any style attributes can be converted to 'sx prop' or 'styled API'
- [x] Move styled api calls to separate file (< 100 lines)

## Preview 📷
Before:
![Screenshot 2023-07-18 at 5 00 59 PM](https://github.com/linode/manager/assets/139489745/2a721d2b-8be9-4fcf-8637-d84e128add88)

After:
![Screenshot 2023-07-18 at 5 02 12 PM](https://github.com/linode/manager/assets/139489745/8ec8211c-9398-4f8a-8311-57c662656c4c)


## How to test 🧪
Go to the Longview section and make sure the functionality and the visual components are the same.

![Screenshot 2023-07-18 at 5 04 23 PM](https://github.com/linode/manager/assets/139489745/bcdabac4-c3b2-4c36-8571-23db67e7c16c)

Note: You might need to setup a Longview client: 
1. Create a new Linode (ex. Debian 11, Debian 12 does not work)
2. Create a new Longview client (Click the "Add Client" button)
3. Copy the installation curl command
4. SSH into your Linode and paste the installation command

Reference: https://www.linode.com/docs/products/tools/longview/guides/troubleshooting/