### PR TITLE
fix: [M3-6006] - Make images landing page "Edit" buttons consistent

### DIFF
--- a/packages/manager/.changeset/pr-9424-fixed-1689773023166.md
+++ b/packages/manager/.changeset/pr-9424-fixed-1689773023166.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Make "edit" button for images landing page consistent ([#9424](https://github.com/linode/manager/pull/9424))

--- a/packages/manager/src/features/Images/ImagesActionMenu.tsx
+++ b/packages/manager/src/features/Images/ImagesActionMenu.tsx
@@ -1,14 +1,9 @@
 import { Event } from '@linode/api-v4/lib/account';
 import { ImageStatus } from '@linode/api-v4/lib/images/types';
-import { Theme } from '@mui/material/styles';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import { useTheme } from '@mui/styles';
-import { splitAt } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import ActionMenu, { Action } from 'src/components/ActionMenu';
-import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
 
 export interface Handlers {
   [index: string]: any;
@@ -31,9 +26,6 @@ interface Props extends Handlers {
 type CombinedProps = Props & RouteComponentProps<{}>;
 
 export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
-  const theme = useTheme<Theme>();
-  const matchesSmDown = useMediaQuery(theme.breakpoints.down('md'));
-
   const {
     description,
     event,
@@ -119,40 +111,11 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
     event,
   ]);
 
-  /**
-   * Moving all actions to the dropdown menu to prevent visual mismatches
-   * between different Image types/statuses.
-   *
-   * Leaving the logic in place in case until the decision has been officially OK'd.
-   *
-   * 7/2023 update: Below logic to move all actions to the dropdown menu didn't always work, so
-   * have ensured that all actions will always be in the dropdown menu. Leaving the previous logic
-   * in comments as a reference just in case, but this change makes it so that the actions list
-   * doesn't need to be split anymore at all...
-   */
-  // const splitActionsArrayIndex =
-  //   !matchesSmDown && status === 'pending_upload' ? 1 : 0;
-  const [inlineActions, menuActions] = splitAt(0, actions);
-
   return (
-    <>
-      {!matchesSmDown &&
-        inlineActions.map((action) => {
-          return (
-            <InlineMenuAction
-              actionText={action.title}
-              disabled={action.disabled}
-              key={action.title}
-              onClick={action.onClick}
-              tooltip={action.tooltip}
-            />
-          );
-        })}
-      <ActionMenu
-        actionsList={menuActions}
-        ariaLabel={`Action menu for Image ${props.label}`}
-      />
-    </>
+    <ActionMenu
+      actionsList={actions}
+      ariaLabel={`Action menu for Image ${props.label}`}
+    />
   );
 };
 

--- a/packages/manager/src/features/Images/ImagesActionMenu.tsx
+++ b/packages/manager/src/features/Images/ImagesActionMenu.tsx
@@ -124,10 +124,15 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
    * between different Image types/statuses.
    *
    * Leaving the logic in place in case until the decision has been officially OK'd.
+   *
+   * 7/2023 update: Below logic to move all actions to the dropdown menu didn't always work, so
+   * have ensured that all actions will always be in the dropdown menu. Leaving the previous logic
+   * in comments as a reference just in case, but this change makes it so that the actions list
+   * doesn't need to be split anymore at all...
    */
-  const splitActionsArrayIndex =
-    !matchesSmDown && status === 'pending_upload' ? 1 : 0;
-  const [inlineActions, menuActions] = splitAt(splitActionsArrayIndex, actions);
+  // const splitActionsArrayIndex =
+  //   !matchesSmDown && status === 'pending_upload' ? 1 : 0;
+  const [inlineActions, menuActions] = splitAt(0, actions);
 
   return (
     <>


### PR DESCRIPTION
## Description 📝
Moved edit image action item into drop down menu

## Major Changes 🔄
**List highlighting major changes**
- Ensure that all menu actions are in a dropdown menu for ImagesActionMenu.tsx regardless of image status

## Preview 📷
before:
![image](https://github.com/linode/manager/assets/139280159/a3ef318a-af7a-4aa7-a5c1-30624b1aeab6)

after:
![image](https://github.com/linode/manager/assets/139280159/3045412e-91b2-4e2e-a1c5-bf972ad5ef5b)

## How to test 🧪
Verify that when uploading an image, when the image is in 'Processing' state, the edit button is inside the dropdown menu; verify that actions still work as expected


