### PR TITLE
fix: `withDocumentTitleProvider` type-checking error

### DIFF
--- a/packages/manager/src/components/DocumentTitle/DocumentTitle.tsx
+++ b/packages/manager/src/components/DocumentTitle/DocumentTitle.tsx
@@ -63,11 +63,11 @@ export const DocumentTitleSegment = (props: Props) => {
   );
 };
 
-type Wrapper = (Component: React.ComponentType<{}>) => React.FC<unknown>;
+type Wrapper = <Props>(
+  Component: React.ComponentType<Props>
+) => React.FC<Props>;
 
-export const withDocumentTitleProvider: Wrapper = (
-  Component: React.ComponentType<{}>
-) => (props) => {
+export const withDocumentTitleProvider: Wrapper = (Component) => (props) => {
   let titleSegments: string[] = [];
 
   const updateDocumentTitle = () => {

--- a/packages/manager/src/components/DocumentTitle/DocumentTitle.tsx
+++ b/packages/manager/src/components/DocumentTitle/DocumentTitle.tsx
@@ -63,11 +63,9 @@ export const DocumentTitleSegment = (props: Props) => {
   );
 };
 
-type Wrapper = <Props>(
+export const withDocumentTitleProvider = <Props extends {}>(
   Component: React.ComponentType<Props>
-) => React.FC<Props>;
-
-export const withDocumentTitleProvider: Wrapper = (Component) => (props) => {
+) => (props: Props) => {
   let titleSegments: string[] = [];
 
   const updateDocumentTitle = () => {


### PR DESCRIPTION
## Description 📝

- Type-checking on `develop` is failing ❌
- Fixes type error relating to https://github.com/linode/manager/pull/9406

## Major Changes 🔄
- Uses a generic to type `withDocumentTitleProvider`

## How to test 🧪
- Verify type checking passes