### PR TITLE
fix: Fix automated Cypress tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ x-e2e-runners:
       condition: service_healthy
   env_file: ./packages/manager/.env
   volumes: *default-volumes
-  entrypoint: ['yarn', 'cy:ci', '--record', '--parallel', "--ci-build-id=${BUILD_ID}"]
+  entrypoint: ['yarn', 'cy:ci']
 
 services:
   # Serves a local instance of Cloud Manager for Cypress to use for its tests.


### PR DESCRIPTION
## Description 📝
Sorry guys! When I merged the regions PR earlier, it also brought back some params related to Cypress recording that don't belong.

## How to test 🧪
If the e2e tests run against this PR, we should be good (they don't even necessarily need to pass, the tests themselves just need to run)