### PR TITLE
fix: Fix StackScript test by using latest images available

### DIFF
--- a/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
@@ -287,7 +287,7 @@ describe('Create stackscripts', () => {
     cy.visitWithLogin('/stackscripts/create');
     cy.defer(createLinodeAndImage(), {
       label: 'creating Linode and Image',
-      timeout: 180000,
+      timeout: 360000,
     }).then((privateImage) => {
       cy.fixture(stackscriptBasicPath).then((stackscriptBasic) => {
         fillOutStackscriptForm(

--- a/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
@@ -140,8 +140,8 @@ describe('Create stackscripts', () => {
   it('creates a StackScript and deploys a Linode with it', () => {
     const stackscriptLabel = randomLabel();
     const stackscriptDesc = randomPhrase();
-    const stackscriptImage = 'Alpine 3.17';
-    const stackscriptImageTag = 'alpine3.17';
+    const stackscriptImage = 'Alpine 3.18';
+    const stackscriptImageTag = 'alpine3.18';
 
     const linodeLabel = randomLabel();
     const linodeRegion = chooseRegion();
@@ -271,13 +271,13 @@ describe('Create stackscripts', () => {
      */
     const imageSamples = [
       { label: 'AlmaLinux 9', sel: 'linode/almalinux9' },
-      { label: 'Alpine 3.17', sel: 'linode/alpine3.17' },
+      { label: 'Alpine 3.18', sel: 'linode/alpine3.18' },
       { label: 'Arch Linux', sel: 'linode/arch' },
       { label: 'CentOS Stream 9', sel: 'linode/centos-stream9' },
-      { label: 'Debian 11', sel: 'linode/debian11' },
-      { label: 'Fedora 37', sel: 'linode/fedora37' },
+      { label: 'Debian 12', sel: 'linode/debian12' },
+      { label: 'Fedora 38', sel: 'linode/fedora38' },
       { label: 'Rocky Linux 9', sel: 'linode/rocky9' },
-      { label: 'Ubuntu 22.10', sel: 'linode/ubuntu22.10' },
+      { label: 'Ubuntu 23.04', sel: 'linode/ubuntu23.04' },
     ];
 
     interceptCreateStackScript().as('createStackScript');

--- a/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
@@ -264,7 +264,7 @@ describe('Create stackscripts', () => {
    * - Confirms that private images can be selected when deploying with "Any/All" StackScripts.
    * - Confirms that a Linode can be deployed using StackScript with private image.
    */
-  it.only('creates a StackScript with Any/All target image', () => {
+  it('creates a StackScript with Any/All target image', () => {
     const stackscriptLabel = randomLabel();
     const stackscriptDesc = randomPhrase();
     const stackscriptImage = 'Any/All';


### PR DESCRIPTION
## Description 📝
Our StackScript test broke because one of the Images the test selects, `Ubuntu 22.10`, became deprecated and tripped up a Cypress selector.

This quickly fixes the test by updating the images used by the tests to their latest versions.

There's potential to fix this permanently by making an API request to fetch the same data that's shown in Cloud, but this happens so infrequently that today I opted to fix it quickly but plan to revisit this in the future.

## How to test 🧪
We can rely on the automated tests for this, but reviewers can use the following command to run the affected test locally:

```bash
yarn cy:run -s "cypress/e2e/core/stackscripts/create-stackscripts.spec.ts"
```
