### PR TITLE
chore: Only enable `useIsLargeAccount` when it's absolutely needed

### DIFF
--- a/packages/manager/.changeset/pr-9435-tech-stories-1689887826129.md
+++ b/packages/manager/.changeset/pr-9435-tech-stories-1689887826129.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Only enable useIsLargeAccount when it's absolutely needed ([#9435](https://github.com/linode/manager/pull/9435))

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -89,10 +89,12 @@ export const SearchBar = (props: CombinedProps) => {
 
   const history = useHistory();
 
-  const isLargeAccount = useIsLargeAccount();
+  const isLargeAccount = useIsLargeAccount(searchActive);
 
-  // Only request things if the search bar is open/active.
-  const shouldMakeRequests = searchActive && !isLargeAccount;
+  // Only request things if the search bar is open/active and we
+  // know if the account is large or not
+  const shouldMakeRequests =
+    searchActive && isLargeAccount !== undefined && !isLargeAccount;
 
   const { data: objectStorageClusters } = useObjectStorageClusters(
     shouldMakeRequests

--- a/packages/manager/src/hooks/useIsLargeAccount.ts
+++ b/packages/manager/src/hooks/useIsLargeAccount.ts
@@ -1,7 +1,12 @@
 import { LARGE_ACCOUNT_THRESHOLD } from 'src/constants';
 import { useLinodesQuery } from 'src/queries/linodes/linodes';
 
-export const useIsLargeAccount = () => {
-  const { data: linodesData } = useLinodesQuery();
-  return linodesData ? linodesData.results > LARGE_ACCOUNT_THRESHOLD : false;
+export const useIsLargeAccount = (enabled = true) => {
+  const { data: linodesData } = useLinodesQuery({}, {}, enabled);
+
+  if (!linodesData) {
+    return undefined;
+  }
+
+  return linodesData.results > LARGE_ACCOUNT_THRESHOLD;
 };


### PR DESCRIPTION
## Description 📝

- Makes it so Cloud Manager will only try fetch Linodes when it absolutely needs to
  - After https://github.com/linode/manager/pull/9421 is merged, if you were to load the app to a non-linodes route, for the first time ever in Cloud Manager's history, Linodes will not be fetched! 🎉

## Major Changes 🔄
- Disable `useIsLargeAccount` until we absolutely need to know if the account is large or not

## Preview 📷
**Include a screenshot or screen recording of the change**

> Notice how there is one less fetch. After https://github.com/linode/manager/pull/9421 is also merged, there will be zero fetches to Linodes initially

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-07-20 at 5 13 09 PM](https://github.com/linode/manager/assets/115251059/98f455d8-426d-47de-9a32-ac966410a037) | ![Screenshot 2023-07-20 at 5 12 43 PM](https://github.com/linode/manager/assets/115251059/87f00825-036c-484c-a9ef-cd1b003d5632) |

## How to test 🧪
- Checkout this PR
- Configure Dev Tools to show API requests
- Observe that this PR does one less fetch to the Linodes endpoint when you initially load the app to a non-linode related roure