### PR TITLE
fix: Make `lke-create.spec.ts` use non-deprecated Kubernetes version

### DIFF
--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -65,7 +65,7 @@ describe('LKE Cluster Creation', () => {
   it('can create an LKE cluster', () => {
     const clusterLabel = randomLabel();
     const clusterRegion = chooseRegion();
-    const clusterVersion = '1.25';
+    const clusterVersion = '1.26';
     const clusterPlans = new Array(2)
       .fill(null)
       .map(() => randomItem(lkeClusterPlans));


### PR DESCRIPTION
## Description 📝
- Kubernetes 1.25 has been deprecated so run the e2e tests with `1.26`

## How to test 🧪
- Verify e2e passes below in the PR checks ⬇️
  - (`continuous-integration/cloud-manager-tests ` is the name for the e2e tests)