### PR TITLE
fix: Enable Sentry Tracing explicitly

### DIFF
--- a/packages/manager/src/initSentry.ts
+++ b/packages/manager/src/initSentry.ts
@@ -12,6 +12,8 @@ import redactAccessToken from 'src/utilities/redactAccessToken';
 import packageJson from '../package.json';
 
 export const initSentry = () => {
+  const environment = getSentryEnvironment();
+
   if (SENTRY_URL) {
     init({
       allowUrls: [
@@ -29,7 +31,8 @@ export const initSentry = () => {
         /^chrome:\/\//i,
       ],
       dsn: SENTRY_URL,
-      environment: getSentryEnvironment(),
+      enableTracing: true,
+      environment,
       ignoreErrors: [
         // Random plugins/extensions
         'top.GLOBALS',
@@ -79,6 +82,7 @@ export const initSentry = () => {
       ],
       integrations: [new BrowserTracing()],
       release: packageJson.version,
+      tracesSampleRate: environment === 'production' ? 0.2 : 1,
     });
   }
 };


### PR DESCRIPTION
## Description 📝

- Follow up to https://github.com/linode/manager/pull/9337 and https://github.com/linode/manager/pull/9428
- I just forgot to commit a `tracesSampleRate` which resulted in a feature being disabled when I expected it to be enabled

## How to test 🧪
- Test that we get basic performance metrics in Sentry once this is merged into `staging`