### PR TITLE
refactor: [M3 6730] - LinodeSelect - Allow fully custom noOptionsText

### DIFF
--- a/packages/manager/.changeset/pr-9452-tech-stories-1690342391207.md
+++ b/packages/manager/.changeset/pr-9452-tech-stories-1690342391207.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+LinodeSelect - Allow fully custom noOptionsText ([#9452](https://github.com/linode/manager/pull/9452))

--- a/packages/manager/cypress/e2e/core/volumes/attach-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/attach-volume.spec.ts
@@ -11,6 +11,7 @@ import {
 import { randomLabel, randomString } from 'support/util/random';
 import { ui } from 'support/ui';
 import { chooseRegion } from 'support/util/regions';
+import { interceptGetLinodeConfigs } from 'support/intercepts/linodes';
 
 // Local storage override to force volume table to list up to 100 items.
 // This is a workaround while we wait to get stuck volumes removed.
@@ -69,6 +70,7 @@ describe('volume attach and detach flows', () => {
     cy.defer(entityPromise, 'creating Volume and Linode').then(
       ([volume, linode]: [Volume, Linode]) => {
         interceptAttachVolume(volume.id).as('attachVolume');
+        interceptGetLinodeConfigs(linode.id).as('getLinodeConfigs');
         cy.visitWithLogin('/volumes', {
           localStorageOverrides: pageSizeOverride,
         });
@@ -97,6 +99,8 @@ describe('volume attach and detach flows', () => {
             .findByTitle(linode.label)
             .should('be.visible')
             .click();
+
+          cy.wait('@getLinodeConfigs');
 
           ui.button.findByTitle('Attach').should('be.visible').click();
         });

--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -55,6 +55,22 @@ export const interceptGetLinodeDetails = (
 };
 
 /**
+ * Intercepts GET request to retrieve Linode configs.
+ *
+ * @param linodeId - ID of Linode for intercepted request.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptGetLinodeConfigs = (
+  linodeId: number
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher(`linode/instances/${linodeId}/configs*`)
+  );
+};
+
+/**
  * Intercepts GET request to retrieve Linode details and mocks response.
  *
  * @param linodeId - ID of Linode for intercepted request.

--- a/packages/manager/src/features/Linodes/LinodeSelect/LinodeSelect.stories.tsx
+++ b/packages/manager/src/features/Linodes/LinodeSelect/LinodeSelect.stories.tsx
@@ -1,5 +1,9 @@
+import { Linode } from '@linode/api-v4/lib/linodes';
 import { action } from '@storybook/addon-actions';
 import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { Typography } from 'src/components/Typography';
 
 import { LinodeSelect } from './LinodeSelect';
 
@@ -8,6 +12,12 @@ import type {
   LinodeSingleSelectProps,
 } from './LinodeSelect';
 import type { Meta, StoryObj } from '@storybook/react';
+
+const linodes = [
+  { id: 1, label: 'Linode 1' },
+  { id: 2, label: 'Linode 2' },
+  { id: 3, label: 'Linode 3' },
+];
 
 const meta: Meta<LinodeMultiSelectProps | LinodeSingleSelectProps> = {
   argTypes: {
@@ -28,7 +38,28 @@ type Story = StoryObj<typeof LinodeSelect>;
 
 /** Default Linode Select */
 export const Default: Story = {
-  args: {},
+  args: {
+    options: linodes as Linode[],
+  },
+  render: (args) => <LinodeSelect {...args} />,
+};
+
+export const noOptionsMessage: Story = {
+  args: {
+    label: 'Select a Linode',
+    noOptionsMessage: (
+      <Typography>
+        You have no VPCs. Go to{' '}
+        <Link data-testid="abuse-ticket-link" to={'/linodes'}>
+          VPC
+        </Link>{' '}
+        to create one. Any data you have entered will be lost leaving this page.
+      </Typography>
+    ),
+    options: [],
+    placeholder: 'Select a Linode',
+    value: null,
+  },
   render: (args) => <LinodeSelect {...args} />,
 };
 

--- a/packages/manager/src/features/Linodes/LinodeSelect/LinodeSelect.stories.tsx
+++ b/packages/manager/src/features/Linodes/LinodeSelect/LinodeSelect.stories.tsx
@@ -1,9 +1,6 @@
 import { Linode } from '@linode/api-v4/lib/linodes';
 import { action } from '@storybook/addon-actions';
 import React from 'react';
-import { Link } from 'react-router-dom';
-
-import { Typography } from 'src/components/Typography';
 
 import { LinodeSelect } from './LinodeSelect';
 
@@ -48,15 +45,8 @@ export const Default: Story = {
 export const noOptionsMessage: Story = {
   args: {
     label: 'Select a Linode',
-    noOptionsMessage: (
-      <Typography>
-        You have no VPCs. Go to{' '}
-        <Link data-testid="abuse-ticket-link" to={'/linodes'}>
-          VPC
-        </Link>{' '}
-        to create one. Any data you have entered will be lost leaving this page.
-      </Typography>
-    ),
+    noOptionsMessage:
+      'This is a custom message when there are no options to display.',
     options: [],
     placeholder: 'Select a Linode',
     value: null,

--- a/packages/manager/src/features/Linodes/LinodeSelect/LinodeSelect.stories.tsx
+++ b/packages/manager/src/features/Linodes/LinodeSelect/LinodeSelect.stories.tsx
@@ -17,6 +17,7 @@ const linodes = [
   { id: 1, label: 'Linode 1' },
   { id: 2, label: 'Linode 2' },
   { id: 3, label: 'Linode 3' },
+  { id: 4, label: 'Linode 4' },
 ];
 
 const meta: Meta<LinodeMultiSelectProps | LinodeSingleSelectProps> = {
@@ -65,6 +66,12 @@ export const noOptionsMessage: Story = {
 
 /* Linode Multi-select */
 export const MultiSelect: Story = {
-  args: {},
+  args: {
+    multiple: true,
+    onSelectionChange: (selected) => {
+      action('onSelectionChange')(selected.map((linode) => linode.id));
+    },
+    value: [1, 2],
+  },
   render: (args) => <LinodeSelect {...args} />,
 };

--- a/packages/manager/src/features/Linodes/LinodeSelect/LinodeSelect.tsx
+++ b/packages/manager/src/features/Linodes/LinodeSelect/LinodeSelect.tsx
@@ -32,7 +32,7 @@ interface LinodeSelectProps {
   /** Optionally disable top margin for input label */
   noMarginTop?: boolean;
   /** Message displayed when no options match the user's search. */
-  noOptionsMessage?: string;
+  noOptionsMessage?: JSX.Element | string;
   /** Called when the input loses focus. */
   onBlur?: (e: React.FocusEvent) => void;
   /* The options to display in the select. */
@@ -144,14 +144,15 @@ export const LinodeSelect = (
         renderOptionLabel ? renderOptionLabel(linode) : linode.label
       }
       noOptionsText={
-        <i>
-          {noOptionsMessage ??
-            getDefaultNoOptionsMessage(
+        noOptionsMessage ?? (
+          <i>
+            {getDefaultNoOptionsMessage(
               error,
               linodesDataLoading,
               filteredLinodes
             )}
-        </i>
+          </i>
+        )
       }
       onChange={(_, value) =>
         multiple && Array.isArray(value)

--- a/packages/manager/src/features/Linodes/LinodeSelect/LinodeSelect.tsx
+++ b/packages/manager/src/features/Linodes/LinodeSelect/LinodeSelect.tsx
@@ -32,7 +32,7 @@ interface LinodeSelectProps {
   /** Optionally disable top margin for input label */
   noMarginTop?: boolean;
   /** Message displayed when no options match the user's search. */
-  noOptionsMessage?: JSX.Element | string;
+  noOptionsMessage?: string;
   /** Called when the input loses focus. */
   onBlur?: (e: React.FocusEvent) => void;
   /* The options to display in the select. */


### PR DESCRIPTION
## Description 📝
We want to allow for a fully custom `noOptionsText` without italics

## Major Changes 🔄
- Added two additional storybook stories for custom no options text and multi-select
- Allow for a fully custom `noOptionsText` without italics

## Preview 📷
> **Note**
The mult-select is just a visual with the `actions` tab used to show data received by event handler. Don't expect to uncheck/check additional options.

| Screenshots   | |
| ------- | ------- |
| <img width="442" alt="Screenshot 2023-07-25 at 11 21 16 PM" src="https://github.com/linode/manager/assets/125309814/2e9f75ea-b318-4163-9484-6d41f4e7449d"> | <img width="462" alt="Screenshot 2023-07-25 at 11 21 21 PM" src="https://github.com/linode/manager/assets/125309814/95c66aef-8f98-496f-b37f-63d0f99bdc3b"> |

## How to test 🧪
1. Go to storybook page http://localhost:6006/?path=/story/components-linode-select--default
2. Observe you can customize the `noOptionsMessage` prop.