### PR TITLE
fix: [M3-6658] - Cleared Firewall Drawer Inputs

### DIFF
--- a/packages/manager/.changeset/pr-9459-fixed-1690565333481.md
+++ b/packages/manager/.changeset/pr-9459-fixed-1690565333481.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Create Firewall drawer input persisting after firewall creation or cancellation ([#9459](https://github.com/linode/manager/pull/9459))

--- a/packages/manager/.changeset/pr-9459-tech-stories-1690511497337.md
+++ b/packages/manager/.changeset/pr-9459-tech-stories-1690511497337.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Cleared Firewall Drawer Inputs ([#9459](https://github.com/linode/manager/pull/9459))

--- a/packages/manager/.changeset/pr-9459-tech-stories-1690511497337.md
+++ b/packages/manager/.changeset/pr-9459-tech-stories-1690511497337.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Cleared Firewall Drawer Inputs ([#9459](https://github.com/linode/manager/pull/9459))

--- a/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
@@ -56,6 +56,7 @@ export const CreateFirewallDrawer = React.memo(
       handleChange,
       handleSubmit,
       isSubmitting,
+      resetForm,
       setFieldValue,
       status,
       values,
@@ -110,6 +111,12 @@ export const CreateFirewallDrawer = React.memo(
       validateOnChange: false,
       validationSchema: CreateFirewallSchema,
     });
+
+    React.useEffect(() => {
+      if (open) {
+        resetForm();
+      }
+    }, [open]);
 
     const userCannotAddFirewall =
       _isRestrictedUser && !_hasGrant('add_firewalls');


### PR DESCRIPTION
## Description 📝
Issue: The data entered into the "Create Firewall" drawer persists after cancelling or creating a firewall.

## Major Changes 🔄
Reset the form inputs every time the drawer is opened.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/139489745/a3aa7aaf-6d3d-46a8-9c5e-6dd8c1663f8b" /> | <video src="https://github.com/linode/manager/assets/139489745/10b7c81a-6a86-419e-b548-30a871727def" /> |

## How to test 🧪
1. Navigate to the Firewalls tab
2. Hit "Create Firewall"
3. Enter some text into the fields, try closing the drawer and creating a test firewall. Open the window again and make sure the inputs are cleared.

