### PR TITLE
fix: Redirect the user back to `/linodes` when Linode is deleted from Linode Details

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -238,6 +238,9 @@ const LinodeDetailHeader = () => {
         onClose={closeDialogs}
       />
       <DeleteLinodeDialog
+        onSuccess={() => {
+          history.push('/linodes');
+        }}
         linodeId={matchedLinodeId}
         onClose={closeDialogs}
         open={deleteDialogOpen}


### PR DESCRIPTION
## Description 📝

- During the React Query for Linodes refactor, we missed a somewhat important redirect

## Major Changes 🔄
- Send the user back to `/linodes` when they delete a Linode from the Linodes Details page

## Preview 📷

### Before 😖

https://github.com/linode/manager/assets/115251059/dc1e670e-8b12-4950-b545-fc7a94027e4c

### After 🎉

https://github.com/linode/manager/assets/115251059/1494b5ff-7651-44f3-b1f4-d5e0521de62d

## How to test 🧪
- Delete a Linode from the Linodes Landing page and verify nothing is changed
- Delete a Linode from the Linodes Details page and verify that you get sent to `/linodes`