### PR TITLE
feat: Allow NodeBalancer creation without config

### DIFF
--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -408,44 +408,37 @@ export const NodeBalancerConfigPanel = (
           </Grid>
         </Grid>
       </Grid>
-
-      {(forEdit || configIdx !== 0) && (
-        <React.Fragment>
-          <Grid xs={12}>
-            <Divider />
-          </Grid>
-          <Grid
-            alignItems="center"
-            container
-            justifyContent="flex-end"
-            spacing={2}
-          >
-            <StyledActionsPanel
-              primaryButtonProps={
-                forEdit
-                  ? {
-                      'data-testid': 'save-config',
-                      disabled,
-                      label: 'Save',
-                      loading: submitting,
-                      onClick: onSave,
-                    }
-                  : undefined
-              }
-              secondaryButtonProps={
-                forEdit || configIdx !== 0
-                  ? {
-                      'data-testid': 'delete-config',
-                      disabled,
-                      label: 'Delete',
-                      onClick: props.onDelete,
-                    }
-                  : undefined
-              }
-            />
-          </Grid>
-        </React.Fragment>
-      )}
+      <React.Fragment>
+        <Grid xs={12}>
+          <Divider />
+        </Grid>
+        <Grid
+          alignItems="center"
+          container
+          justifyContent="flex-end"
+          spacing={2}
+        >
+          <StyledActionsPanel
+            primaryButtonProps={
+              forEdit
+                ? {
+                    'data-testid': 'save-config',
+                    disabled,
+                    label: 'Save',
+                    loading: submitting,
+                    onClick: onSave,
+                  }
+                : undefined
+            }
+            secondaryButtonProps={{
+              'data-testid': 'delete-config',
+              disabled,
+              label: 'Delete',
+              onClick: props.onDelete,
+            }}
+          />
+        </Grid>
+      </React.Fragment>
     </Grid>
   );
 };


### PR DESCRIPTION
## Description 📝
A configuration is not strictly required when invoking [the NodeBalancer creation API](https://www.linode.com/docs/api/nodebalancers/#nodebalancer-create), and only the region is required. I think it would be nicer if we can do the same thing in cloud manager. I think sometimes an user may want to create a nodebalancer and config it later, and this might be able to make their work easier.
 
```bash
curl -H "Content-Type: application/json" \
    -H "Authorization: Bearer $TOKEN" \
    -X POST -d '{"region": "us-central"}' https://api.linode.com/v4/nodebalancers 
```

I am not familiar with manager development, so please feel free to close the PR this change is not desired, or commit to this branch if there is anything else you guys would like to add.

## Major Changes 🔄
- Allow NodeBalancer creation without config

## Preview 📷
**Include a screenshot or screen recording of the change**

> **Note**: Use `<video src="" />` tag when including recordings in table

| Before  | After   |
| ------- | ------- |
| <img width="1231" alt="image" src="https://github.com/linode/manager/assets/121905282/169c4fd5-9c34-4e71-9b42-03850291ba6f"> | <img width="1183" alt="image" src="https://github.com/linode/manager/assets/121905282/dc383fda-47ab-4163-b0d5-9ee832eb2cf0"> |

## How to test 🧪
Not sure
