### PR TITLE
fix: Add Gopaddle & re-add Wazuh Marketplace apps

### DIFF
--- a/packages/manager/.changeset/pr-9473-fixed-1690900164385.md
+++ b/packages/manager/.changeset/pr-9473-fixed-1690900164385.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Add Gopaddle & re-add Wazuh Marketplace apps ([#9473](https://github.com/linode/manager/pull/9473))

--- a/packages/manager/src/features/StackScripts/stackScriptUtils.ts
+++ b/packages/manager/src/features/StackScripts/stackScriptUtils.ts
@@ -124,6 +124,7 @@ export const baseApps = {
   '1096122': 'Mastodon',
   '1102900': 'Apache Airflow',
   '1102902': 'HaltDOS Community WAF',
+  '1102905': 'Gopaddle',
   '1102904': 'Superinsight',
   '1102906': 'Passky',
   '1102907': 'ONLYOFFICE Docs',

--- a/packages/manager/src/features/StackScripts/stackScriptUtils.ts
+++ b/packages/manager/src/features/StackScripts/stackScriptUtils.ts
@@ -87,7 +87,7 @@ export const baseApps = {
   '869623': 'JetBackup',
   '912262': 'Harbor',
   '912264': 'Rocket.Chat',
-  // '913276': 'Wazuh', temporarily hide until OCA-1177 is addressed
+  '913276': 'Wazuh',
   '913277': 'BeEF',
   '923029': 'OpenLiteSpeed Django',
   '923030': 'OpenLiteSpeed Rails',


### PR DESCRIPTION
## Description 📝
Gopaddle was missing from the app list, this PR re-adds that and wazuh per OCA-1177

## How to test 🧪
Go to Marketplace and search for the apps, ensure that they show up