### PR TITLE
M3-6614 Add Cypress tests for Linode landing page 'Summary View'

### DIFF
--- a/packages/manager/cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
@@ -360,12 +360,9 @@ describe('linode landing checks', () => {
     getVisible('[aria-label="Toggle display"]').should('be.enabled').click();
 
     mockLinodes.forEach((linode) => {
-      // Get the upper 3 parent layers to check each table item.
       cy.findByText(linode.label)
         .should('be.visible')
-        .parent()
-        .parent()
-        .parent()
+        .closest('[data-qa-linode-card]')
         .within(() => {
           cy.findByText('Summary').should('be.visible');
           cy.findByText('IP Addresses').should('be.visible');

--- a/packages/manager/cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
@@ -350,6 +350,46 @@ describe('linode landing checks', () => {
       cy.findByText(linode.label).should('be.visible');
     });
   });
+
+  it('checks summary view for linode table', () => {
+    mockGetLinodes(mockLinodes).as('getLinodes');
+    cy.visitWithLogin('/linodes');
+    cy.wait('@getLinodes');
+
+    // Check 'Summary View' button works as expected that can be visiable, enabled and clickable
+    getVisible('[aria-label="Toggle display"]').should('be.enabled').click();
+
+    mockLinodes.forEach((linode) => {
+      // Get the upper 3 parent layers to check each table item.
+      cy.findByText(linode.label)
+        .should('be.visible')
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          cy.findByText('Summary').should('be.visible');
+          cy.findByText('IP Addresses').should('be.visible');
+          cy.findByText('Access').should('be.visible');
+
+          cy.findByText('Plan:').should('be.visible');
+          cy.findByText('Region:').should('be.visible');
+          cy.findByText('Linode ID:').should('be.visible');
+          cy.findByText('Created:').should('be.visible');
+        });
+    });
+
+    // Toggle the 'List View' button to check the display of table items are back to the original view.
+    getVisible('[aria-label="Toggle display"]').should('be.enabled').click();
+
+    cy.findByText('Summary').should('not.exist');
+    cy.findByText('IP Addresses').should('not.exist');
+    cy.findByText('Access').should('not.exist');
+
+    cy.findByText('Plan:').should('not.exist');
+    cy.findByText('Region:').should('not.exist');
+    cy.findByText('Linode ID:').should('not.exist');
+    cy.findByText('Created:').should('not.exist');
+  });
 });
 
 describe('linode landing actions', () => {

--- a/packages/manager/src/features/Linodes/LinodesLanding/CardView.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/CardView.tsx
@@ -68,7 +68,7 @@ const CardView = (props: RenderLinodesProps) => {
       <Grid className="m0" container style={{ width: '100%' }}>
         {data.map((linode, idx: number) => (
           <React.Fragment key={`linode-card-${idx}`}>
-            <StyledSummaryGrid xs={12}>
+            <StyledSummaryGrid xs={12} data-qa-linode-card={linode.id}>
               <LinodeEntityDetail
                 handlers={{
                   onOpenDeleteDialog: () =>


### PR DESCRIPTION
## Description 📝
Add Cypress tests for Linode landing page "Summary View" button

## Major Changes 🔄
- Add test to verify "Summary View" button works as expected.

## How to test 🧪
`yarn cy:run -s "cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts"`

