### PR TITLE
chore: Add 'Upcoming Features' to the changeset types

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -40,6 +40,6 @@ Feel free to open an issue to report a bug or request a feature.
     - Run `yarn changeset`from the root, choose the package to create a changeset for, and provide a description for the change.
     You can either have it committed automatically or do it manually if you need to edit it.
     - A changeset is optional, it merely depends if it falls in one of the following categories:
-    `Added`, `Fixed`, `Changed`, `Removed`, `Tech Stories`
+    `Added`, `Fixed`, `Changed`, `Removed`, `Tech Stories`, `Upcoming Features`
 
 Two reviews from members of the Cloud Manager team are required before merge. After approval, all pull requests are squash merged.

--- a/packages/api-v4/.changeset/README.md
+++ b/packages/api-v4/.changeset/README.md
@@ -1,7 +1,7 @@
 # Changesets
 
 This directory gets auto-populated when running `yarn changeset`.
-You can however add your changesets manually as well, knowing that the [TYPE] is limited to the following options `Added`, `Fixed`, `Changed`, `Removed`, `Tech Stories`, and follow this format:
+You can however add your changesets manually as well, knowing that the [TYPE] is limited to the following options `Added`, `Fixed`, `Changed`, `Removed`, `Tech Stories`, `Upcoming Features` and follow this format:
 
 ```md
 ---

--- a/packages/manager/.changeset/README.md
+++ b/packages/manager/.changeset/README.md
@@ -1,7 +1,7 @@
 # Changesets
 
 This directory gets auto-populated when running `yarn changeset`.
-You can however add your changesets manually as well, knowing that the [TYPE] is limited to the following options `Added`, `Fixed`, `Changed`, `Removed`, `Tech Stories`, and follow this format:
+You can however add your changesets manually as well, knowing that the [TYPE] is limited to the following options `Added`, `Fixed`, `Changed`, `Removed`, `Tech Stories`, `Upcoming Features` and follow this format:
 
 ```md
 ---

--- a/packages/manager/.changeset/pr-9419-tech-stories-1689716682370.md
+++ b/packages/manager/.changeset/pr-9419-tech-stories-1689716682370.md
@@ -2,4 +2,4 @@
 "@linode/manager": Tech Stories
 ---
 
-refactor: [M3-6899] - MUI v5 Migration - SRC > Components > Dialog ([#9419](https://github.com/linode/manager/pull/9419))
+MUI v5 Migration - SRC > Components > Dialog ([#9419](https://github.com/linode/manager/pull/9419))

--- a/packages/validation/.changeset/README.md
+++ b/packages/validation/.changeset/README.md
@@ -1,7 +1,7 @@
 # Changesets
 
 This directory gets auto-populated when running `yarn changeset`.
-You can however add your changesets manually as well, knowing that the [TYPE] is limited to the following options `Added`, `Fixed`, `Changed`, `Removed`, `Tech Stories`, and follow this format:
+You can however add your changesets manually as well, knowing that the [TYPE] is limited to the following options `Added`, `Fixed`, `Changed`, `Removed`, `Tech Stories`, `Upcoming Features` and follow this format:
 
 ```md
 ---

--- a/scripts/changelog/utils/constants.mjs
+++ b/scripts/changelog/utils/constants.mjs
@@ -13,6 +13,7 @@ export const CHANGESET_TYPES = [
   "Changed",
   "Removed",
   "Tech Stories",
+  "Upcoming Features",
 ];
 export const OWNER = "linode";
 export const REPO = "manager";


### PR DESCRIPTION
## Description 📝
During the [v1.98.0 release](https://github.com/linode/manager/releases/tag/linode-manager%40v1.98.0), we added an Upcoming Features section to our changelog. If we want to continue this in our future releases, offically adding this changeset type to our automated changelog generation script will allow us to categorize our changesets more easily/accurately.

## Preview 📷
![Screenshot 2023-08-01 at 11 10 19 AM](https://github.com/linode/manager/assets/114685994/5455c3c5-3179-40bf-86eb-6fb8d4530b97)

## How to test 🧪
Run `yarn changeset` and confirm Upcoming Features is listed under the changeset types to select from. Create a changeset of that type, don't commit it, and run `yarn generate-changelogs` to confirm a changelog is generated with an Upcoming Features section. 
