### PR TITLE
chore: [M3-6954] - Change `Premium` to `Premium CPU`

### DIFF
--- a/packages/manager/.changeset/pr-9484-changed-1690998482707.md
+++ b/packages/manager/.changeset/pr-9484-changed-1690998482707.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Renamed `Premium` to `Premium CPU` in plans tables ([#9484](https://github.com/linode/manager/pull/9484))

--- a/packages/manager/src/features/Linodes/LinodesCreate/SelectPlanPanel/utils.ts
+++ b/packages/manager/src/features/Linodes/LinodesCreate/SelectPlanPanel/utils.ts
@@ -141,7 +141,7 @@ export const planTabInfoContent = {
   premium: {
     dataId: 'data-qa-premium',
     key: 'premium',
-    title: 'Premium',
+    title: 'Premium CPU',
     typography:
       'Premium CPU instances guarantee a minimum processor generation of AMD EPYC\u2122 Milan or newer to ensure consistent high performance for more demanding workloads.',
   },


### PR DESCRIPTION
## Description 📝

- Change `Premium` to `Premium CPU` in the Plans table

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-08-02 at 1 44 38 PM](https://github.com/linode/manager/assets/115251059/bcd266c2-5ada-4634-b060-7b9a78b32c83) | ![Screenshot 2023-08-02 at 1 44 15 PM](https://github.com/linode/manager/assets/115251059/baf71a99-8692-4366-80c1-f9ab68ca64ed) |

## How to test 🧪
- Verify you now see `Premium CPU` instead of just `Premium` in affected plans table
  - Check the Linode create page (`http://localhost:3000/linodes/create`)
  - Check the Kubernetes create page (`http://localhost:3000/kubernetes/create`)