### PR TITLE
fix: Capture less Sentry performance data in production

### DIFF
--- a/packages/manager/src/initSentry.ts
+++ b/packages/manager/src/initSentry.ts
@@ -82,7 +82,7 @@ export const initSentry = () => {
       ],
       integrations: [new BrowserTracing()],
       release: packageJson.version,
-      tracesSampleRate: environment === 'production' ? 0.2 : 1,
+      tracesSampleRate: environment === 'production' ? 0.1 : 1,
     });
   }
 };


### PR DESCRIPTION
## Description 📝
- Decreases our Sentry performance capture rate from 20% to 10% in production

We used 100,000 transactions in 5 days with a capture rate of 20%. We need 100,000 transactions to last us 1 month so we need to use a percentage less than ~16%

## How to test 🧪
- Double check my math!