### PR TITLE
fix: [M3-6688] - Alignment Issue on Service Transfers Page

### DIFF
--- a/packages/manager/.changeset/pr-9491-fixed-1691152316740.md
+++ b/packages/manager/.changeset/pr-9491-fixed-1691152316740.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Alignment Issue on Service Transfers Page ([#9491](https://github.com/linode/manager/pull/9491))

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/TransferControls.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/TransferControls.tsx
@@ -24,7 +24,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     [theme.breakpoints.down('md')]: {
       flexBasis: '100%',
       marginBottom: theme.spacing(1),
-      marginLeft: 0,
     },
     whiteSpace: 'nowrap',
   },
@@ -58,36 +57,22 @@ const useStyles = makeStyles((theme: Theme) => ({
       width: 'calc(600px - 32px)',
     },
     [theme.breakpoints.down('sm')]: {
-      '&.MuiGrid-item': {
-        padding: 0,
-      },
-      margin: 0,
       padding: 0,
       width: '100%',
-    },
-    [theme.breakpoints.down(xs_sm)]: {
-      paddingTop: 0,
-    },
-    [theme.breakpoints.up('md')]: {
-      '&.MuiGrid-item': {
-        paddingRight: 0,
-      },
     },
   },
   makeTransferButton: {
     marginBottom: theme.spacing(),
     minWidth: 152,
     [theme.breakpoints.down('md')]: {
-      marginBottom: 0,
-      marginRight: theme.spacing(),
       width: '100%',
     },
     [theme.breakpoints.down('sm')]: {
       margin: `${theme.spacing()} 0`,
-      width: '100%',
     },
     [theme.breakpoints.down(xs_sm)]: {
       marginTop: 0,
+      minWidth: 'auto',
     },
     whiteSpace: 'nowrap',
   },
@@ -101,21 +86,13 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   root: {
     margin: `${theme.spacing(2)} 0`,
-    [theme.breakpoints.down('lg')]: {
-      alignItems: 'flex-end',
-    },
     [theme.breakpoints.down('md')]: {
       alignItems: 'flex-start',
       flexDirection: 'column',
       marginLeft: theme.spacing(2),
     },
     [theme.breakpoints.down('sm')]: {
-      marginLeft: theme.spacing(2),
       marginRight: theme.spacing(2),
-      marginTop: theme.spacing(),
-    },
-    [theme.breakpoints.down(xs_sm)]: {
-      alignItems: 'flex-start',
     },
   },
   transferInput: {
@@ -123,9 +100,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       width: 240,
     },
     [theme.breakpoints.down('md')]: {
-      width: '100%',
-    },
-    [theme.breakpoints.down('sm')]: {
       width: '100%',
     },
     width: 360,
@@ -136,12 +110,9 @@ const useStyles = makeStyles((theme: Theme) => ({
         flexGrow: 1,
       },
       flexBasis: '100%',
-      // width: 'calc(100% - 16px)',
       width: 'calc(600px-32px)',
     },
     [theme.breakpoints.down('sm')]: {
-      margin: 0,
-      padding: 0,
       width: '100%',
     },
   },

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/TransferControls.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/TransferControls.tsx
@@ -14,13 +14,12 @@ import ConfirmTransferDialog from './ConfirmTransferDialog';
 
 // sm = 600, md = 960, lg = 1280
 
-const xs_sm = 450,
-  sm_md = 800;
+const xs_sm = 450;
 
 const useStyles = makeStyles((theme: Theme) => ({
   label: {
     color: theme.textColors.headlineStatic,
-    // fontSize: '1rem',
+    fontSize: '1rem',
     marginRight: theme.spacing(),
     [theme.breakpoints.down('md')]: {
       flexBasis: '100%',
@@ -114,12 +113,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       marginLeft: theme.spacing(2),
       marginRight: theme.spacing(2),
       marginTop: theme.spacing(),
-    },
-    [theme.breakpoints.down(sm_md)]: {
-      alignItems: 'flex-start',
-      flexDirection: 'column',
-      marginLeft: theme.spacing(2),
-      marginRight: theme.spacing(2),
     },
     [theme.breakpoints.down(xs_sm)]: {
       alignItems: 'flex-start',

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/TransferControls.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/TransferControls.tsx
@@ -12,13 +12,19 @@ import { Typography } from 'src/components/Typography';
 
 import ConfirmTransferDialog from './ConfirmTransferDialog';
 
+// sm = 600, md = 960, lg = 1280
+
+const xs_sm = 450,
+  sm_md = 800;
+
 const useStyles = makeStyles((theme: Theme) => ({
   label: {
     color: theme.textColors.headlineStatic,
-    fontSize: '1rem',
+    // fontSize: '1rem',
     marginRight: theme.spacing(),
     [theme.breakpoints.down('md')]: {
-      marginBottom: 4,
+      flexBasis: '100%',
+      marginBottom: theme.spacing(1),
       marginLeft: 0,
     },
     whiteSpace: 'nowrap',
@@ -29,20 +35,39 @@ const useStyles = makeStyles((theme: Theme) => ({
       flexWrap: 'wrap',
     },
     [theme.breakpoints.down('md')]: {
+      '& > div': {
+        margin: 0,
+        padding: 0,
+      },
+      marginBottom: theme.spacing(1),
+      padding: 0,
+      width: 'calc(600px - 32px)',
+    },
+    [theme.breakpoints.down('sm')]: {
+      margin: `${theme.spacing(1)} 0`,
+      width: '100%',
+    },
+    [theme.breakpoints.down(xs_sm)]: {
       alignItems: 'flex-start',
       flexDirection: 'column',
-      marginLeft: theme.spacing(),
     },
   },
   makeTransfer: {
     paddingLeft: 0,
     paddingRight: 0,
+    [theme.breakpoints.down('md')]: {
+      width: 'calc(600px - 32px)',
+    },
     [theme.breakpoints.down('sm')]: {
       '&.MuiGrid-item': {
         padding: 0,
       },
       margin: 0,
+      padding: 0,
       width: '100%',
+    },
+    [theme.breakpoints.down(xs_sm)]: {
+      paddingTop: 0,
     },
     [theme.breakpoints.up('md')]: {
       '&.MuiGrid-item': {
@@ -51,34 +76,53 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   makeTransferButton: {
+    marginBottom: theme.spacing(),
     minWidth: 152,
-    [theme.breakpoints.down('lg')]: {
-      marginBottom: theme.spacing(),
-    },
     [theme.breakpoints.down('md')]: {
-      margin: 0,
+      marginBottom: 0,
+      marginRight: theme.spacing(),
+      width: '100%',
     },
     [theme.breakpoints.down('sm')]: {
-      margin: 0,
-      marginBottom: theme.spacing(),
-      marginTop: theme.spacing(),
-      width: 'calc(100% - 32px)',
+      margin: `${theme.spacing()} 0`,
+      width: '100%',
+    },
+    [theme.breakpoints.down(xs_sm)]: {
+      marginTop: 0,
     },
     whiteSpace: 'nowrap',
   },
   reviewDetails: {
     marginLeft: theme.spacing(2),
+    [theme.breakpoints.down(xs_sm)]: {
+      marginLeft: 0,
+      marginTop: theme.spacing(),
+      width: '100%',
+    },
   },
   root: {
     margin: `${theme.spacing(2)} 0`,
     [theme.breakpoints.down('lg')]: {
       alignItems: 'flex-end',
     },
-    [theme.breakpoints.down('sm')]: {
+    [theme.breakpoints.down('md')]: {
+      alignItems: 'flex-start',
       flexDirection: 'column',
+      marginLeft: theme.spacing(2),
+    },
+    [theme.breakpoints.down('sm')]: {
       marginLeft: theme.spacing(2),
       marginRight: theme.spacing(2),
       marginTop: theme.spacing(),
+    },
+    [theme.breakpoints.down(sm_md)]: {
+      alignItems: 'flex-start',
+      flexDirection: 'column',
+      marginLeft: theme.spacing(2),
+      marginRight: theme.spacing(2),
+    },
+    [theme.breakpoints.down(xs_sm)]: {
+      alignItems: 'flex-start',
     },
   },
   transferInput: {
@@ -86,7 +130,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       width: 240,
     },
     [theme.breakpoints.down('md')]: {
-      width: 200,
+      width: '100%',
     },
     [theme.breakpoints.down('sm')]: {
       width: '100%',
@@ -94,11 +138,18 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: 360,
   },
   transferInputWrapper: {
-    [theme.breakpoints.down('sm')]: {
+    [theme.breakpoints.down('md')]: {
       '& > div': {
         flexGrow: 1,
       },
-      width: 'calc(100% - 16px)',
+      flexBasis: '100%',
+      // width: 'calc(100% - 16px)',
+      width: 'calc(600px-32px)',
+    },
+    [theme.breakpoints.down('sm')]: {
+      margin: 0,
+      padding: 0,
+      width: '100%',
     },
   },
 }));


### PR DESCRIPTION
## Description 📝
Fixed the input alignment in Account > Service Transfers

## Major Changes 🔄
- Fixed alignment for screen size <960
- Fixed alignment for screen size <600
- Fixed alignment for screen size <450

## Preview 📷

| Before  | After   |
| --- | --- |
| ![Screenshot 2023-08-03 at 8 00 39 PM](https://github.com/linode/manager/assets/139489745/be7782a4-9d32-461c-a3ef-1a8e1af999c5) | ![Screenshot 2023-08-03 at 8 05 45 PM](https://github.com/linode/manager/assets/139489745/15564471-3f96-4cbc-8bb3-0148b08c1edf) |
| ![Screenshot 2023-08-03 at 8 03 15 PM](https://github.com/linode/manager/assets/139489745/775b09a1-0f32-4305-9547-6fff7fbbcafa) | ![Screenshot 2023-08-03 at 8 10 18 PM](https://github.com/linode/manager/assets/139489745/56a7a457-8215-4a30-986d-02a066c0da5d) |
| ![Screenshot 2023-08-03 at 8 03 37 PM](https://github.com/linode/manager/assets/139489745/2697c9d5-6750-48f8-8877-7a1acbcfe7a2) | ![Screenshot 2023-08-03 at 8 06 12 PM](https://github.com/linode/manager/assets/139489745/40ed69e5-e28d-414f-9aa3-da03f8c7e0e2) |

## How to test 🧪
1. Navigate to Account > Service Transfer
2. Make sure the alignment looks good for all browser pixel widths
