### PR TITLE
fix: [M3-6985] - User data input crash

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -57,6 +57,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - VPC landing page ([#9467](https://github.com/linode/manager/pull/9467))
 - Add basic routing and files for VPC ([#9474](https://github.com/linode/manager/pull/9474))
+- Fix User data input crash ([#9494](https://github.com/linode/manager/pull/9494))
 
 ## [2023-07-28] - v1.98.1
 

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
@@ -699,7 +699,7 @@ export class LinodeCreate extends React.PureComponent<
 
     if (this.props.userData) {
       payload['metadata'] = {
-        user_data: window.btoa(this.props.userData),
+        user_data: window.btoa(encodeURIComponent(this.props.userData)),
       };
     }
 


### PR DESCRIPTION
## Description 📝
Cloud was crashing when pasting user data from https://gist.githubusercontent.com/ngaffa/15d46c98dd82620c8120ddf7398d6dbd/raw/1b5efe9669f62ddfc50b9bdb746294fa8b3cfc6e/cloud-init.yaml 

It seems that what looks like an apostrophe is actually a UTF-8-encoded right single quotation mark which the `btoa` function doesn't support. The fix was to encode the user input before calling `btoa`

## Preview 📷
| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/115299789/539e315d-948d-4a6b-8f81-be4db9b67afc" />| <video src="https://github.com/linode/manager/assets/115299789/1d3f2412-ee17-40c7-b8e2-83859eccedd7" /> |

## How to test 🧪
- Go to Linode Create
- Select a cloud-init compatible image
- Select a Metadata compatible region (Washington DC or Paris)
- Observe that pasting the gist content in the User Data input field doesn't crash Cloud while it crashes in prod/dev
