### PR TITLE
fix: IP Address copy icon regression

### DIFF
--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -97,9 +97,11 @@ export const SummaryPanel = () => {
         <StyledSection>
           <StyledIPGrouping data-qa-ip>
             {nodebalancer?.ipv4 && (
-              <IPAddress ips={[nodebalancer?.ipv4]} showMore />
+              <IPAddress ips={[nodebalancer?.ipv4]} isHovered={true} showMore />
             )}
-            {nodebalancer?.ipv6 && <IPAddress ips={[nodebalancer?.ipv6]} />}
+            {nodebalancer?.ipv6 && (
+              <IPAddress ips={[nodebalancer?.ipv6]} isHovered={true} />
+            )}
           </StyledIPGrouping>
         </StyledSection>
       </StyledSummarySection>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerTableRow.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerTableRow.tsx
@@ -57,7 +57,7 @@ export const NodeBalancerTableRow = (props: Props) => {
         </TableCell>
       </Hidden>
       <TableCell>
-        <IPAddress ips={[ipv4]} showMore />
+        <IPAddress ips={[ipv4]} isHovered={true} showMore />
       </TableCell>
       <Hidden smDown>
         <TableCell data-qa-region>


### PR DESCRIPTION
## Description 📝
Due to styling changes in the IPAddress component (see this pr: https://github.com/linode/manager/pull/9445), the copy icon stopped showing up for Nodebalancers in both the Nodebalancer landing page and a Nodebalancer details page.

(Something interesting to note is that the Linodes landing page and the NodeBalancer landing pages have different behavior for the IP address copy icon. This PR just restores the NodeBalancer IP address behavior to what it used to be, but might be worth looking into trying to get them to have matching behavior)

## Major Changes 🔄
- Make IP address' copy icons show up for node balancer pages

## Preview 📷
**prod**:
![image](https://github.com/linode/manager/assets/139280159/da4bdffb-9cae-410c-872c-415f6cb00df2)
![image](https://github.com/linode/manager/assets/139280159/755ba27c-4f0c-4084-8c45-eeaee3e2b969)

**not prod**:
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/139280159/036adcff-c40e-46e5-a61b-427eeb11277b) | ![image](https://github.com/linode/manager/assets/139280159/5282c423-f429-45ed-a31a-040b3aaad0a7) |

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/139280159/740b81c1-158a-480d-b5b4-966512c58cd1) | ![image](https://github.com/linode/manager/assets/139280159/f6c70dc3-8022-489a-8fa6-45f61113304a) |

## How to test 🧪
Navigate to Nodebalancer's landing page or a single node balancer's summary page and confirm that IP address copy icon behavior is the same as prod


