### PR TITLE
fix: [M3-6498] - User Permissions table radio button misalignment on mobile

### DIFF
--- a/packages/manager/.changeset/pr-9499-fixed-1691416274996.md
+++ b/packages/manager/.changeset/pr-9499-fixed-1691416274996.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-In Account -> Users, the permissions table radio buttons are unaligned on mobile view ([#9499](https://github.com/linode/manager/pull/9499))
+User Permissions table radio button misalignment on mobile

--- a/packages/manager/.changeset/pr-9499-fixed-1691416274996.md
+++ b/packages/manager/.changeset/pr-9499-fixed-1691416274996.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+In Account -> Users, the permissions table radio buttons are unaligned on mobile view ([#9499](https://github.com/linode/manager/pull/9499))

--- a/packages/manager/src/features/Users/UserPermissionsEntitySection.tsx
+++ b/packages/manager/src/features/Users/UserPermissionsEntitySection.tsx
@@ -76,7 +76,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       width: '100%',
       [theme.breakpoints.down('sm')]: {
         paddingRight: '0 !important',
-        paddingLeft: 0,
       },
     },
   },


### PR DESCRIPTION
## Description 📝
 Users, the permissions table radio buttons are unaligned on mobile view

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/119517080/45408715-2111-4ccf-af2f-2fbeb97f3524) | ![image](https://github.com/linode/manager/assets/119517080/d668ff8f-dfc7-4ed1-88f1-cfa358df0180) |

## How to test 🧪
1. **Navigate to http://localhost:3000/account/users/user/permissions**
2. **validate the layout in small screen.** 


