### PR TITLE
fix: Allow auto-generated Linode `label` to be cleared

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -342,7 +342,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
       selectedStackScriptLabel,
     } = this.state;
 
-    if (customLabel?.length) {
+    if (customLabel !== undefined) {
       return customLabel;
     }
 


### PR DESCRIPTION
## Description 📝

- Fixes unclearable Linode `label` on the Linode Create page
- Caused by https://github.com/linode/manager/pull/9421

## The Bug 🪲

> [!NOTE]
> I am pressing backspace but the label keeps repopulating

https://github.com/linode/manager/assets/115251059/be6395e6-f242-4dd8-b659-7e056f66c0ea

## How to test 🧪
- Verify you can fully backspace the auto-generated Linode label on the Linode Create flow
- Please compare behavior to production to verify no behavior has been changed