### PR TITLE
fix: [M3-6898] - Markup in Help landing

### DIFF
--- a/packages/manager/src/features/Help/Panels/AlgoliaSearchBar.tsx
+++ b/packages/manager/src/features/Help/Panels/AlgoliaSearchBar.tsx
@@ -125,7 +125,7 @@ const AlgoliaSearchBar = (props: CombinedProps) => {
           disabled={!searchEnabled}
           hideLabel
           inputValue={inputValue}
-          isClearable={false}
+          isClearable={true}
           isMulti={false}
           label="Search for answers"
           onChange={handleSelect}
@@ -139,6 +139,6 @@ const AlgoliaSearchBar = (props: CombinedProps) => {
   );
 };
 
-export default withSearch({ highlight: true, hitsPerPage: 10 })(
+export default withSearch({ highlight: false, hitsPerPage: 10 })(
   withRouter(AlgoliaSearchBar)
 );


### PR DESCRIPTION
## Description 📝
Fixes the UI bug which was causing markup to appear in the `AlgoliaSearchBar` in the `/Support` landing page. Also makes it possible for text to be cleared via `isClearable` prop.

## Major Changes 🔄
**List highlighting major changes**
- Change `isClearable={false}` to `isClearable={true}`
- Change `highlight: true` to `highlight: false`


## Preview 📷
| Before  | After   |
| ------- | ------- |
|  ![before](https://github.com/linode/manager/assets/119514965/dfb7805e-61d7-46ae-9637-602c5236cc68) | ![after](https://github.com/linode/manager/assets/119514965/7a5451e8-653a-4039-868d-8391a877897f) |

## How to test 🧪
1. Navigate to `/Support` landing page and type in a search term.
2. Use the mouse to click on one of the results, this will open a new tab.
3. Close the new tab.
4. Inspect the text inside the `AlgoliaSearchBar` and verify that the markup defect has been resolved.
5. Look for the 'X' icon and verify that it works as expected.

