### PR TITLE
fix: Linode Select clear behavior by using `null` instead of `-1` in form state

### DIFF
--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -248,8 +248,8 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
             setFieldValue('linode_id', linode.id);
             setFieldValue('region', linode.region);
           } else {
-            // If the LinodeSelect is cleared, reset the values for Region and Config
             setFieldValue('linode_id', null);
+            setFieldValue('config_id', null);
           }
         };
 

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -39,10 +39,7 @@ import {
 import { isNilOrEmpty } from 'src/utilities/isNilOrEmpty';
 import { maybeCastToNumber } from 'src/utilities/maybeCastToNumber';
 
-import {
-  ConfigSelect,
-  initialValueDefaultId,
-} from '../VolumeDrawer/ConfigSelect';
+import { ConfigSelect } from '../VolumeDrawer/ConfigSelect';
 import LabelField from '../VolumeDrawer/LabelField';
 import NoticePanel from '../VolumeDrawer/NoticePanel';
 import SizeField from '../VolumeDrawer/SizeField';
@@ -171,14 +168,10 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
 
         createVolume({
           config_id:
-            config_id === initialValueDefaultId
-              ? undefined
-              : maybeCastToNumber(config_id),
+            config_id === null ? undefined : maybeCastToNumber(config_id),
           label,
           linode_id:
-            linode_id === initialValueDefaultId
-              ? undefined
-              : maybeCastToNumber(linode_id),
+            linode_id === null ? undefined : maybeCastToNumber(linode_id),
           region:
             isNilOrEmpty(region) || region === 'none' ? undefined : region,
           size: maybeCastToNumber(size),
@@ -237,7 +230,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
 
         const generalError = status
           ? status.generalError
-          : config_id === initialValueDefaultId
+          : config_id !== null
           ? errors.config_id
           : undefined;
 
@@ -256,7 +249,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
             setFieldValue('region', linode.region);
           } else {
             // If the LinodeSelect is cleared, reset the values for Region and Config
-            setFieldValue('linode_id', initialValueDefaultId);
+            setFieldValue('linode_id', null);
           }
         };
 
@@ -312,7 +305,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
                   <RegionSelect
                     handleSelection={(value) => {
                       setFieldValue('region', value);
-                      setFieldValue('linode_id', initialValueDefaultId);
+                      setFieldValue('linode_id', null);
                     }}
                     regions={
                       regions?.filter((eachRegion) =>
@@ -423,17 +416,17 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
 };
 
 interface FormState {
-  config_id: number;
+  config_id: null | number;
   label: string;
-  linode_id: number;
+  linode_id: null | number;
   region: string;
   size: number;
 }
 
 const initialValues: FormState = {
-  config_id: initialValueDefaultId,
+  config_id: null,
   label: '',
-  linode_id: initialValueDefaultId,
+  linode_id: null,
   region: '',
   size: 20,
 };

--- a/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
@@ -7,15 +7,13 @@ import { useAllLinodeConfigsQuery } from 'src/queries/linodes/configs';
 interface Props {
   disabled?: boolean;
   error?: string;
-  linodeId: number;
+  linodeId: null | number;
   name: string;
   onBlur: (e: any) => void;
   onChange: (value: number) => void;
-  value: number;
+  value: null | number;
   width?: number;
 }
-
-export const initialValueDefaultId = -1;
 
 export const ConfigSelect = React.memo((props: Props) => {
   const {
@@ -30,8 +28,8 @@ export const ConfigSelect = React.memo((props: Props) => {
   } = props;
 
   const { data: configs, error: configsError } = useAllLinodeConfigsQuery(
-    linodeId,
-    linodeId !== initialValueDefaultId
+    linodeId ?? -1,
+    linodeId !== null
   );
 
   const configList = configs?.map((config) => {
@@ -47,7 +45,7 @@ export const ConfigSelect = React.memo((props: Props) => {
     }
   }, [configList, onChange, value]);
 
-  if (linodeId === initialValueDefaultId) {
+  if (linodeId === null) {
     return null;
   }
 

--- a/packages/validation/src/volumes.schema.ts
+++ b/packages/validation/src/volumes.schema.ts
@@ -22,7 +22,7 @@ export const CreateVolumeSchema = object({
     is: (id: any) => id === undefined || id === '',
     then: string().required('Must provide a region or a Linode ID.'),
   }),
-  linode_id: number(),
+  linode_id: number().nullable(),
   size: createSizeValidation(10),
   label: string()
     .required('Label is required.')
@@ -30,7 +30,7 @@ export const CreateVolumeSchema = object({
     .trim()
     .min(1, 'Label must be between 1 and 32 characters.')
     .max(32, 'Label must be 32 characters or less.'),
-  config_id: number().typeError('Config ID must be a number.'),
+  config_id: number().nullable().typeError('Config ID must be a number.'),
   tags: array().of(string()),
 });
 


### PR DESCRIPTION
## Description 📝
- Makes the Volume Create form match production's behavior
- The `LinodeSelect` was expecting `null` to clear the type-ahead input, but we were using -1 to represent no selection. Switching `-1` to `null` allows the `LinodeSelect` to work as expected


## The Bug  🪲

> [!important]
> Notice how the type-ahead (aka input value) of the MUI Autocomplete does **not** clear

https://github.com/linode/manager/assets/115251059/2c54dc2a-12f2-4ea8-87fa-6d4923df8473

## Expected Behavior ✅

https://github.com/linode/manager/assets/115251059/d071a6ae-8c2f-47b6-baac-e12c5c7eb53e


## How to test 🧪
- Verify that `/volumes/create`  works the same as production

and also

- Type a label
- Pick a Region
- Pick a Linode
- Clear the Region input
- Verify that the Linode Select clears completely (no type-ahead and no value in the form state) 