### PR TITLE
fix: Make drawer full width for app detail drawer on mobile viewport

### DIFF
--- a/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
+++ b/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
@@ -64,7 +64,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     [theme.breakpoints.up('sm')]: {
       width: 480,
     },
-    width: 300,
   },
   wrapAppName: {
     maxWidth: 'fit-content',


### PR DESCRIPTION
## Description 📝
fixes the issue where drawers for the marketplace apps weren't full width

## Major Changes 🔄
- remove line that set width to be 300px for any view

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/139280159/1beec7de-8772-46e2-a8a6-85e96505e38e) | ![image](https://github.com/linode/manager/assets/139280159/3774e3f5-4472-402c-9894-4f0e1510241c) |

## How to test 🧪
1. Test that the app detail drawer on marketplace is full width on mobile viewports
