### PR TITLE
fix: linodes empty state - styles needed to be swapped

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesLanding/AppsSection.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/AppsSection.tsx
@@ -69,46 +69,46 @@ const AppsSection = () => {
   return <StyledAppSectionDiv>{appLinks}</StyledAppSectionDiv>;
 };
 
-const StyledLink = styled(Link, { label: 'StyledLink' })(({ theme }) => ({
-  alignItems: 'center',
-  aspectRatio: '1 / 1',
-  borderLeft: `1px solid ${
-    theme.name === 'dark' ? '#3a3f46' : theme.color.border3
-  }`,
-  color:
-    theme.name === 'dark'
-      ? theme.textColors.linkActiveLight
-      : theme.palette.primary.main,
-  display: 'flex',
-  height: '100%',
-  justifyContent: 'center',
-}));
-
 const StyledAppLinkDiv = styled('div', { label: 'StyledAppLinkDiv' })(
   ({ theme }) => ({
-    '&:focus': {
-      textDecoration: 'none',
-    },
-    '&:hover': {
-      textDecoration: 'none',
-    },
     alignItems: 'center',
-    backgroundColor:
-      theme.name === 'dark' ? theme.bg.primaryNavPaper : theme.bg.offWhite,
-    border: `1px solid ${
+    aspectRatio: '1 / 1',
+    borderLeft: `1px solid ${
       theme.name === 'dark' ? '#3a3f46' : theme.color.border3
     }`,
-    color: theme.palette.text.primary,
+    color:
+      theme.name === 'dark'
+        ? theme.textColors.linkActiveLight
+        : theme.palette.primary.main,
     display: 'flex',
-    fontSize: '0.875rem',
-    fontWeight: 700,
-    gridColumn: 'span 1',
-    height: theme.spacing(4.75),
-    justifyContent: 'space-between',
-    maxWidth: theme.spacing(20),
-    paddingLeft: theme.spacing(),
+    height: '100%',
+    justifyContent: 'center',
   })
 );
+
+const StyledLink = styled(Link, { label: 'StyledLink' })(({ theme }) => ({
+  '&:focus': {
+    textDecoration: 'none',
+  },
+  '&:hover': {
+    textDecoration: 'none',
+  },
+  alignItems: 'center',
+  backgroundColor:
+    theme.name === 'dark' ? theme.bg.primaryNavPaper : theme.bg.offWhite,
+  border: `1px solid ${
+    theme.name === 'dark' ? '#3a3f46' : theme.color.border3
+  }`,
+  color: theme.palette.text.primary,
+  display: 'flex',
+  fontSize: '0.875rem',
+  fontWeight: 700,
+  gridColumn: 'span 1',
+  height: theme.spacing(4.75),
+  justifyContent: 'space-between',
+  maxWidth: theme.spacing(20),
+  paddingLeft: theme.spacing(),
+}));
 
 const StyledAppSectionDiv = styled('div', { label: 'StyledAppSectionDiv' })(
   ({ theme }) => ({


### PR DESCRIPTION
## Description 📝
**Brief description explaining the purpose of the changes**

## Major Changes 🔄
- `StyledLink` and `StyledAppLinkDiv` styles needed to be swapped.

## Preview 📷

| Before  | After   | Prod |
| ------- | ------- | ------- |
| ![Screenshot 2023-08-07 at 2 37 08 PM](https://github.com/linode/manager/assets/125309814/8e0d3e7f-2bfd-460e-b409-33cb72a4c53d) | ![Screenshot 2023-08-07 at 2 36 40 PM](https://github.com/linode/manager/assets/125309814/6dd304ce-0592-475b-9820-b3f9e21b8115) | ![Screenshot 2023-08-07 at 2 36 46 PM](https://github.com/linode/manager/assets/125309814/b094c480-8873-4088-8ca9-29b9f4252add) |

## How to test 🧪
1. Don't have any linodes in account
2. Go to http://localhost:3000/linodes
3. Observe fixes