### PR TITLE
fix: [M3-6668] Broken K8 node pool infinite scrolling

### DIFF
--- a/packages/manager/.changeset/pr-9509-fixed-1691434601314.md
+++ b/packages/manager/.changeset/pr-9509-fixed-1691434601314.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Broken K8 node pool infinite scrolling ([#9509](https://github.com/linode/manager/pull/9509))
+Broken K8 node pools display infinite scrolling ([#9509](https://github.com/linode/manager/pull/9509))

--- a/packages/manager/.changeset/pr-9509-fixed-1691434601314.md
+++ b/packages/manager/.changeset/pr-9509-fixed-1691434601314.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Broken K8 node pool infinite scrolling ([#9509](https://github.com/linode/manager/pull/9509))

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -195,7 +195,7 @@ export const NodePoolsDisplay = (props: Props) => {
                 );
               })}
               {pools?.length > numPoolsToDisplay && (
-                <Waypoint onEnter={handleShowMore} scrollableAncestor="window">
+                <Waypoint onEnter={handleShowMore}>
                   <div style={{ minHeight: 50 }} />
                 </Waypoint>
               )}


### PR DESCRIPTION
### ## Description 📝
The `scrollableAncestor="window"` prop on the `Waypoint` instance was breaking the infinite scrolling for the node pools on a K8 cluster detail. From what I can understand and read, the prop is responsible for:

> A custom ancestor to determine if the target is visible in it. This is useful in cases where you do not want the immediate scrollable ancestor to be the container. For example, when your target is in a div that has overflow auto but you are detecting onEnter based on the window.

Which we are not doing at all since our handler is based on a count of node pools. 

Removing this prop fixes the issue (loads the next 25 node pools on scroll) and does not appear to introduce any other regression.

## How to test 🧪
1. Pull code locally, and create 10 node pools on a given k8 cluster (no need to test with 25, we just want to test what happens when scrolling past the vertical viewport)
2. Modify the `NodePoolsDisplay` count on the [default state](https://github.com/linode/manager/blob/2cd99d78e085034c81651c99794a2877336e09b1/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx#L90) to `5` so Waypoint can trigger earlier
3. Confirm you get all 10 node pools displayed once scrolling down (you may not see any loading state but all should be present almost instantly once scrolling down)


