### PR TITLE
fix: Fix domain test by using key=value format for TXT records

### DIFF
--- a/packages/manager/cypress/e2e/core/domains/smoke-create-domain-records.spec.ts
+++ b/packages/manager/cypress/e2e/core/domains/smoke-create-domain-records.spec.ts
@@ -1,9 +1,14 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import { createDomain, deleteAllTestDomains } from 'support/api/domains';
-import { randomIp, randomLabel, randomDomainName } from 'support/util/random';
-import { fbtClick, getClick } from 'support/helpers';
 import { authenticate } from 'support/api/authentication';
+import { createDomain, deleteAllTestDomains } from 'support/api/domains';
+import { fbtClick, getClick } from 'support/helpers';
 import { interceptCreateDomainRecord } from 'support/intercepts/domains';
+import {
+  randomDomainName,
+  randomIp,
+  randomLabel,
+  randomString,
+} from 'support/util/random';
 
 const createRecords = () => [
   {
@@ -49,7 +54,7 @@ const createRecords = () => [
       },
       {
         name: '[data-qa-target="Value"]',
-        value: randomLabel(),
+        value: `${randomLabel()}=${randomString()}`,
         skipCheck: false,
       },
     ],


### PR DESCRIPTION
## Description 📝
Fixes the failing test in `smoke-create-domain-records.spec.ts` by changing the value used when inserting a TXT record.

A recent improvement in the API added additional validation to these records which caused our test to begin failing, and updating the test to use the expected format resolves the issue.

## How to test 🧪
We can rely on the automated tests for this, but you can also run the test locally with this command:

```bash
yarn cy:run -s "cypress/e2e/core/domains/smoke-create-domain-records.spec.ts"
```