### PR TITLE
fix:[M3-6500] - Enhanced Select fields text cut off at bottom

### DIFF
--- a/packages/manager/.changeset/pr-9521-fixed-1691588152719.md
+++ b/packages/manager/.changeset/pr-9521-fixed-1691588152719.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fix styling syntax error. ([#9521](https://github.com/linode/manager/pull/9521))

--- a/packages/manager/src/components/EnhancedSelect/Select.styles.ts
+++ b/packages/manager/src/components/EnhancedSelect/Select.styles.ts
@@ -219,7 +219,7 @@ export const useStyles = makeStyles()((theme: Theme) => ({
     '& .react-select__single-value': {
       color: theme.palette.text.primary,
       overflow: 'hidden',
-      padding: `$theme.spacing(1) 0`,
+      padding: `${theme.spacing(1)} 0`,
     },
     '& .react-select__value-container': {
       '& > div': {


### PR DESCRIPTION

## Description 📝
**Fixed the styling syntax error.**

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/119517080/854eb514-208c-401f-a1e7-be7d26527550) | ![image](https://github.com/linode/manager/assets/119517080/5996dc24-0f79-4239-a52d-af63704381ce) |

##How to test

- Navigate to http://localhost:3000/support/tickets.
- Validate dropdown input field "What is this regarding?".