### PR TITLE
fix: [M3-6999] - Remove Docker Compose hardcoded container names

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,9 +92,8 @@ services:
       context: .
       dockerfile: ./packages/manager/Dockerfile
       target: manager
-    container_name: web
     ports:
-      - "3000:3000"
+      - "3000"
     volumes:
       - ./packages/manager:/home/node/app/packages/manager
       - ./package.json:/home/node/app/package.json
@@ -105,34 +104,11 @@ services:
       timeout: 10s
       retries: 10
 
-  # Cypress runners for end-to-end tests.
-  e2e-1:
+  e2e:
     <<: *default-runner
-    container_name: cloud-e2e-1
     environment:
       <<: *default-env
-      MANAGER_OAUTH: ${MANAGER_OAUTH_1}
-
-  e2e-2:
-    <<: *default-runner
-    container_name: cloud-e2e-2
-    environment:
-      <<: *default-env
-      MANAGER_OAUTH: ${MANAGER_OAUTH_2}
-
-  e2e-3:
-    <<: *default-runner
-    container_name: cloud-e2e-3
-    environment:
-      <<: *default-env
-      MANAGER_OAUTH: ${MANAGER_OAUTH_3}
-
-  e2e-4:
-    <<: *default-runner
-    container_name: cloud-e2e-4
-    environment:
-      <<: *default-env
-      MANAGER_OAUTH: ${MANAGER_OAUTH_4}
+      MANAGER_OAUTH: ${MANAGER_OAUTH}
 
   region-1:
     build:


### PR DESCRIPTION
## Description 📝
This PR attempts to resolve the Jenkins E2E test instability we've seen caused by conflicts related to the `web` service and its name.

There is a corresponding internal PR which modifies the pipeline to take these changes into account. Both PRs will need to be merged at the same time to limit test breakage. Additionally, existing branches will need to pull in the latest changes from `develop` to avoid breakage.

## Major Changes 🔄
* Removed `web` service hardcoded port and container name so that multiple containers serving Cloud Manager can run simultaneously on a single host
* Removed the hardcoded container name from the test runner services, allowing me to consolidate the `e2e-1`, `e2e-2`, etc. services into a single `e2e` service

## How to test 🧪
This isn't easily testable, but I will abort the automatic test run that kicks off against this PR and re-run it with the pipeline changes in place to demonstrate that the pipeline works as expected.