### PR TITLE
refactor: [M3-6669] - Replaced deprecated keycodes

### DIFF
--- a/packages/manager/.changeset/pr-9527-tech-stories-1691605134705.md
+++ b/packages/manager/.changeset/pr-9527-tech-stories-1691605134705.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Replaced deprecated keycodes  ([#9527](https://github.com/linode/manager/pull/9527))

--- a/packages/manager/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.tsx
@@ -120,7 +120,7 @@ export const ActionMenu = React.memo((props: Props) => {
   };
 
   const handleKeyPress = (e: React.KeyboardEvent) => {
-    if (toggleOpenCallback && e.keyCode === 13) {
+    if (toggleOpenCallback && e.key === 'Enter') {
       toggleOpenCallback();
     }
   };

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesTable.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesTable.tsx
@@ -218,7 +218,7 @@ export const ProcessesTableRow: React.FC<ProcessTableRowProps> = React.memo(
     return (
       <TableRow
         onKeyUp={(e: any) =>
-          e.keyCode === 13 && setSelectedProcess({ name, user })
+          e.key === 'Enter' && setSelectedProcess({ name, user })
         }
         ariaLabel={`${name} for ${user}`}
         data-testid="longview-service-row"

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -244,7 +244,7 @@ export const SearchBar = (props: CombinedProps) => {
 
   const onKeyDown = (e: any) => {
     if (
-      e.keyCode === 13 &&
+      e.key === 'Enter' &&
       searchText !== '' &&
       (!combinedResults || combinedResults.length < 1)
     ) {


### PR DESCRIPTION
## Description 📝
Replaced deprecated keycodes.

## Major Changes 🔄
event.keyCode === 13
becomes
event.key === 'Enter'

Link for conversions: https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values

## How to test 🧪
1. SearchBar.tsx: In the search bar at the top of the page, type the name of one of your Linodes, hover over it, and then hit the `Enter` key. You should navigate to the details page.
2. ActionMenu.tsx: Navigate to the `Linodes` page, hit the Action Menu (`...`) for any linode, hover over any option, and hit the `Enter` key. That option should be executed.
3. ProcessesTable.tsx: Navigate to the `Longview` page. Click `View Details` on any of the Longviews. Navigate to the `Processes` tab. Hover over any process and try to hit the 'Enter' key. This functionality wasn't working pre-changes and still is not working. Refer to comment down below for more information.

