### PR TITLE
refactor: Make Cloud Manager Cypress test clean-up more granular

### DIFF
--- a/packages/manager/cypress/e2e/core/firewalls/create-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/create-firewall.spec.ts
@@ -6,14 +6,18 @@ import { interceptCreateFirewall } from 'support/intercepts/firewalls';
 import { randomString, randomLabel } from 'support/util/random';
 import { ui } from 'support/ui';
 import { chooseRegion } from 'support/util/regions';
+import { cleanUp } from 'support/util/cleanup';
 
 authenticate();
 describe('create firewall', () => {
+  before(() => {
+    cleanUp(['linodes', 'firewalls']);
+  });
+
   /*
    * - Creates a firewall that is not assigned to a Linode.
    * - Confirms that an error message appears upon submitting without a label.
    * - Confirms that firewall is listed correctly on firewalls landing page.
-   * - Confirms that tags exist on firewall.
    */
   it('creates a firewall without a linode', () => {
     const firewall = {
@@ -41,7 +45,8 @@ describe('create firewall', () => {
       });
     cy.wait('@createFirewall');
 
-    // Confirm that firewall is listed on landing page with expected configuration.
+    // Confirm redirect to landing page and that new firewall is listed.
+    cy.url().should('endWith', '/firewalls');
     cy.findByText(firewall.label)
       .closest('tr')
       .within(() => {

--- a/packages/manager/cypress/e2e/core/firewalls/delete-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/delete-firewall.spec.ts
@@ -1,14 +1,18 @@
-import { createFirewall } from '@linode/api-v4/lib/firewalls';
-import { Firewall } from '@linode/api-v4/types';
+import { createFirewall, Firewall } from '@linode/api-v4';
 import { firewallFactory } from 'src/factories/firewalls';
 import { authenticate } from 'support/api/authentication';
 import { randomLabel } from 'support/util/random';
 import { ui } from 'support/ui';
 import { fbtVisible, fbtClick } from 'support/helpers';
 import { chooseRegion } from 'support/util/regions';
+import { cleanUp } from 'support/util/cleanup';
 
 authenticate();
 describe('delete firewall', () => {
+  before(() => {
+    cleanUp('firewalls');
+  });
+
   /*
    * - Clicks "Delete" action menu item for firewall but cancels operation.
    * - Clicks "Delete" action menu item for firewall and confirms operation.

--- a/packages/manager/cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import { linodeFactory } from '@src/factories';
+import { authenticate } from 'support/api/authentication';
 import { createLinode } from 'support/api/linodes';
 import {
   getClick,
@@ -12,6 +13,7 @@ import {
 import { mockGetLinodeDetails } from 'support/intercepts/linodes';
 import { ui } from 'support/ui';
 import { selectRegionString } from 'support/ui/constants';
+import { cleanUp } from 'support/util/cleanup';
 import { apiMatcher } from 'support/util/intercepts';
 import { randomString } from 'support/util/random';
 
@@ -46,7 +48,12 @@ const fakeRegionsData = {
   ],
 };
 
+authenticate();
 describe('Migrate Linode With Firewall', () => {
+  before(() => {
+    cleanUp('firewalls');
+  });
+
   it('test migrate flow - mocking all data', () => {
     const fakeLinodeId = 9999;
     const fakeFirewallId = 6666;

--- a/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
@@ -22,6 +22,7 @@ import { randomItem, randomString, randomLabel } from 'support/util/random';
 import { fbtVisible, fbtClick } from 'support/helpers';
 import { ui } from 'support/ui';
 import { chooseRegion } from 'support/util/regions';
+import { cleanUp } from 'support/util/cleanup';
 
 const portPresetMap = {
   '22': 'SSH',
@@ -164,6 +165,10 @@ const createLinodeAndFirewall = async (
 
 authenticate();
 describe('update firewall', () => {
+  before(() => {
+    cleanUp('firewalls');
+  });
+
   /*
    * - Confirms that a linode can be added and removed from a firewall.
    * - Confirms that inbound rules can be added and removed from a firewall.

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -9,6 +9,8 @@ import { chooseRegion } from 'support/util/regions';
 import { interceptCreateCluster } from 'support/intercepts/lke';
 import { ui } from 'support/ui';
 import { randomLabel, randomNumber, randomItem } from 'support/util/random';
+import { cleanUp } from 'support/util/cleanup';
+import { authenticate } from 'support/api/authentication';
 
 /**
  * Gets the label for an LKE plan as shown in creation plan table.
@@ -54,7 +56,12 @@ const getSimilarPlans = (
   });
 };
 
+authenticate();
 describe('LKE Cluster Creation', () => {
+  before(() => {
+    cleanUp('lke-clusters');
+  });
+
   /*
    * - Confirms that users can create a cluster by completing the LKE create form.
    * - Confirms that LKE cluster is created.

--- a/packages/manager/cypress/e2e/core/linodes/smoke-delete-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/smoke-delete-linode.spec.ts
@@ -1,8 +1,15 @@
+import { authenticate } from 'support/api/authentication';
 import { createLinode } from 'support/api/linodes';
 import { ui } from 'support/ui';
+import { cleanUp } from 'support/util/cleanup';
 import { apiMatcher } from 'support/util/intercepts';
 
+authenticate();
 describe('delete linode', () => {
+  before(() => {
+    cleanUp('linodes');
+  });
+
   it('deletes linode from linode details page', () => {
     createLinode().then((linode) => {
       // catch delete request

--- a/packages/manager/cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
@@ -20,6 +20,7 @@ import { randomLabel } from 'support/util/random';
 import { chooseRegion, getRegionById } from 'support/util/regions';
 import { authenticate } from 'support/api/authentication';
 import { mockGetLinodes } from 'support/intercepts/linodes';
+import { cleanUp } from 'support/util/cleanup';
 
 const mockLinodes = new Array(5).fill(null).map(
   (_item: null, index: number): Linode => {
@@ -390,6 +391,10 @@ describe('linode landing checks', () => {
 });
 
 describe('linode landing actions', () => {
+  before(() => {
+    cleanUp('linodes');
+  });
+
   it('deleting multiple linodes with action menu', () => {
     const mockAccountSettings = accountSettingsFactory.build({
       managed: false,

--- a/packages/manager/cypress/e2e/core/longview/longview.spec.ts
+++ b/packages/manager/cypress/e2e/core/longview/longview.spec.ts
@@ -4,9 +4,16 @@ import { createLinode } from 'support/api/linodes';
 import { createClient } from 'support/api/longview';
 import { containsVisible, fbtVisible, getVisible } from 'support/helpers';
 import { waitForAppLoad } from 'support/ui/common';
+import { cleanUp } from 'support/util/cleanup';
+import { authenticate } from 'support/api/authentication';
 
 /* eslint-disable sonarjs/no-duplicate-string */
+authenticate();
 describe('longview', () => {
+  before(() => {
+    cleanUp('longview-clients');
+  });
+
   it('tests longview', () => {
     const linodePassword = randomString(32);
     const clientLabel = randomLabel();

--- a/packages/manager/cypress/e2e/core/nodebalancers/smoke-create-nodebal.spec.ts
+++ b/packages/manager/cypress/e2e/core/nodebalancers/smoke-create-nodebal.spec.ts
@@ -12,11 +12,13 @@ import { apiMatcher } from 'support/util/intercepts';
 import { randomLabel } from 'support/util/random';
 import { chooseRegion, getRegionById } from 'support/util/regions';
 import { ui } from 'support/ui';
+import { cleanUp } from 'support/util/cleanup';
+import { authenticate } from 'support/api/authentication';
 
 const deployNodeBalancer = () => {
-  // This is not an error, the tag is deploy-linode
   cy.get('[data-qa-deploy-nodebalancer]').click();
 };
+
 const createNodeBalancerWithUI = (nodeBal) => {
   const regionName = getRegionById(nodeBal.region).label;
   cy.visitWithLogin('/nodebalancers/create');
@@ -41,7 +43,12 @@ const createNodeBalancerWithUI = (nodeBal) => {
   deployNodeBalancer();
 };
 
+authenticate();
 describe('create NodeBalancer', () => {
+  before(() => {
+    cleanUp(['tags', 'node-balancers']);
+  });
+
   it('creates a nodebal - positive', () => {
     // create a linode in NW where the NB will be created
     const region = chooseRegion();

--- a/packages/manager/cypress/e2e/core/objectStorage/access-key.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/access-key.e2e.spec.ts
@@ -11,9 +11,14 @@ import {
 } from 'support/intercepts/object-storage';
 import { randomLabel } from 'support/util/random';
 import { ui } from 'support/ui';
+import { cleanUp } from 'support/util/cleanup';
 
 authenticate();
 describe('object storage access key end-to-end tests', () => {
+  before(() => {
+    cleanUp('obj-access-keys');
+  });
+
   /*
    * - Creates an access key with unlimited access
    * - Confirms that access key and secret key from API response are displayed.

--- a/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
@@ -14,6 +14,7 @@ import {
 } from 'support/intercepts/object-storage';
 import { ui } from 'support/ui';
 import { randomLabel } from 'support/util/random';
+import { cleanUp } from 'support/util/cleanup';
 
 // Message shown on-screen when user navigates to an empty bucket.
 const emptyBucketMessage = 'This bucket is empty.';
@@ -94,6 +95,10 @@ const assertStatusForUrlAtAlias = (
 
 authenticate();
 describe('object storage end-to-end tests', () => {
+  before(() => {
+    cleanUp('obj-buckets');
+  });
+
   /*
    * - Tests object bucket creation flow using real API responses.
    * - Confirms that bucket can be created.

--- a/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
@@ -12,6 +12,7 @@ import { createLinode, getLinodeDisks } from '@linode/api-v4/lib/linodes';
 import { createImage } from '@linode/api-v4/lib/images';
 import { chooseRegion } from 'support/util/regions';
 import { SimpleBackoffMethod } from 'support/util/backoff';
+import { cleanUp } from 'support/util/cleanup';
 
 // StackScript fixture paths.
 const stackscriptBasicPath = 'stackscripts/stackscript-basic.sh';
@@ -135,6 +136,10 @@ const createLinodeAndImage = async () => {
 
 authenticate();
 describe('Create stackscripts', () => {
+  before(() => {
+    cleanUp('stackscripts');
+  });
+
   /*
    * - Creates a StackScript with user-defined fields.
    * - Confirms that an error message appears upon submitting script without a shebang.

--- a/packages/manager/cypress/e2e/core/stackscripts/delete-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/delete-stackscripts.spec.ts
@@ -9,7 +9,7 @@ import { ui } from 'support/ui';
 authenticate();
 describe('Delete stackscripts', () => {
   /*
-   * - Deletes the stackscripts.
+   * - Confirms StackScript deletion UI flow using mocked API data.
    * - Confirms that the stackscript item still exist when cancelling the delete operation.
    * - Confirms that the stackscript item can be deleted successfully.
    * - Confirms that "Automate Deployment with StackScripts!" welcome page appears when user has no StackScript.

--- a/packages/manager/cypress/e2e/core/volumes/attach-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/attach-volume.spec.ts
@@ -12,6 +12,7 @@ import { randomLabel, randomString } from 'support/util/random';
 import { ui } from 'support/ui';
 import { chooseRegion } from 'support/util/regions';
 import { interceptGetLinodeConfigs } from 'support/intercepts/linodes';
+import { cleanUp } from 'support/util/cleanup';
 
 // Local storage override to force volume table to list up to 100 items.
 // This is a workaround while we wait to get stuck volumes removed.
@@ -45,6 +46,10 @@ const createLinodeAndAttachVolume = async (): Promise<[Linode, Volume]> => {
 
 authenticate();
 describe('volume attach and detach flows', () => {
+  before(() => {
+    cleanUp('volumes');
+  });
+
   /*
    * - Clicks "Attach" action menu item for volume, selects Linode with common region, and submits form.
    * - Confirms that volume attach toast appears and that Linode is listed as attached for Volume.

--- a/packages/manager/cypress/e2e/core/volumes/clone-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/clone-volume.spec.ts
@@ -3,6 +3,7 @@ import { Volume } from '@linode/api-v4/types';
 import { volumeRequestPayloadFactory } from 'src/factories/volume';
 import { authenticate } from 'support/api/authentication';
 import { interceptCloneVolume } from 'support/intercepts/volumes';
+import { cleanUp } from 'support/util/cleanup';
 import { randomLabel } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
 
@@ -15,6 +16,10 @@ const pageSizeOverride = {
 
 authenticate();
 describe('volume clone flow', () => {
+  before(() => {
+    cleanUp('volumes');
+  });
+
   /*
    * - Clicks "Clone" action menu item for volume, enters new label, and submits form.
    * - Confirms that new volume appears in landing page with expected label and size.

--- a/packages/manager/cypress/e2e/core/volumes/create-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/create-volume.spec.ts
@@ -2,6 +2,7 @@ import type { Linode } from '@linode/api-v4/types';
 import { createLinode } from '@linode/api-v4/lib/linodes';
 import { createLinodeRequestFactory } from 'src/factories/linodes';
 import { authenticate } from 'support/api/authentication';
+import { cleanUp } from 'support/util/cleanup';
 import { containsClick, fbtVisible, fbtClick, getClick } from 'support/helpers';
 import { interceptCreateVolume } from 'support/intercepts/volumes';
 import { randomNumber, randomString, randomLabel } from 'support/util/random';
@@ -17,10 +18,13 @@ const pageSizeOverride = {
 
 authenticate();
 describe('volume create flow', () => {
+  before(() => {
+    cleanUp('volumes');
+  });
+
   /*
    * - Creates a volume that is not attached to a Linode.
    * - Confirms that volume is listed correctly on volumes landing page.
-   * - Confirms that tags exist on volume.
    */
   it('creates an unattached volume', () => {
     const region = chooseRegion();

--- a/packages/manager/cypress/e2e/core/volumes/delete-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/delete-volume.spec.ts
@@ -6,6 +6,7 @@ import { interceptDeleteVolume } from 'support/intercepts/volumes';
 import { randomLabel } from 'support/util/random';
 import { ui } from 'support/ui';
 import { chooseRegion } from 'support/util/regions';
+import { cleanUp } from 'support/util/cleanup';
 
 // Local storage override to force volume table to list up to 100 items.
 // This is a workaround while we wait to get stuck volumes removed.
@@ -16,6 +17,10 @@ const pageSizeOverride = {
 
 authenticate();
 describe('volume delete flow', () => {
+  before(() => {
+    cleanUp('volumes');
+  });
+
   /*
    * - Clicks "Delete" action menu item for volume but cancels operation.
    * - Clicks "Delete" action menu item for volume and confirms operation.

--- a/packages/manager/cypress/e2e/core/volumes/resize-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/resize-volume.spec.ts
@@ -3,6 +3,7 @@ import { Volume } from '@linode/api-v4/types';
 import { volumeRequestPayloadFactory } from 'src/factories/volume';
 import { authenticate } from 'support/api/authentication';
 import { interceptResizeVolume } from 'support/intercepts/volumes';
+import { cleanUp } from 'support/util/cleanup';
 import { randomNumber, randomLabel } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
 
@@ -15,6 +16,10 @@ const pageSizeOverride = {
 
 authenticate();
 describe('volume resize flow', () => {
+  before(() => {
+    cleanUp('volumes');
+  });
+
   /*
    * - Clicks "Resize" action menu item for volume, enters new size, and submits form.
    * - Confirms that volume resize drawer appears after submitting form.

--- a/packages/manager/cypress/e2e/core/volumes/update-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/update-volume.spec.ts
@@ -4,9 +4,14 @@ import { volumeRequestPayloadFactory } from 'src/factories/volume';
 import { authenticate } from 'support/api/authentication';
 import { randomLabel } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
+import { cleanUp } from 'support/util/cleanup';
 
 authenticate();
 describe('volume update flow', () => {
+  before(() => {
+    cleanUp(['tags', 'volumes']);
+  });
+
   /*
    * - Confirms that volume label and tags can be changed from the Volumes landing page.
    */

--- a/packages/manager/cypress/e2e/region/images/create-machine-image-from-linode.spec.ts
+++ b/packages/manager/cypress/e2e/region/images/create-machine-image-from-linode.spec.ts
@@ -5,10 +5,11 @@ import { authenticate } from 'support/api/authentication';
 import { imageCaptureProcessingTimeout } from 'support/constants/images';
 import { ui } from 'support/ui';
 import { SimpleBackoffMethod } from 'support/util/backoff';
+import { cleanUp } from 'support/util/cleanup';
 import { depaginate } from 'support/util/paginate';
 import { pollLinodeStatus } from 'support/util/polling';
 import { randomLabel, randomPhrase, randomString } from 'support/util/random';
-import { describeRegions } from 'support/util/regions';
+import { testRegions } from 'support/util/regions';
 
 /**
  * Creates a Linode, waits for it to boot, and returns the Linode and its disk.
@@ -34,14 +35,18 @@ const createAndBootLinode = async (
 };
 
 authenticate();
-describeRegions('Capture Machine Images', (region: Region) => {
+describe('Capture Machine Images', () => {
+  before(() => {
+    cleanUp('images');
+  });
+
   /*
    * - Captures a machine image from a Linode in the targeted region.
    * - Confirms that user is redirected to landing page upon image capture.
    * - Confirms that user is shown toast notifications related to the image's status.
    * - Confirms that the image finishes processing successfully.
    */
-  it('can capture a Machine Image from a Linode', () => {
+  testRegions('can capture a Machine Image from a Linode', (region) => {
     const imageLabel = randomLabel();
     const imageDescription = randomPhrase();
 

--- a/packages/manager/cypress/e2e/region/images/update-delete-machine-image.spec.ts
+++ b/packages/manager/cypress/e2e/region/images/update-delete-machine-image.spec.ts
@@ -8,9 +8,10 @@ import { authenticate } from 'support/api/authentication';
 import { imageUploadProcessingTimeout } from 'support/constants/images';
 import { ui } from 'support/ui';
 import { SimpleBackoffMethod } from 'support/util/backoff';
+import { cleanUp } from 'support/util/cleanup';
 import { pollImageStatus } from 'support/util/polling';
 import { randomLabel, randomPhrase } from 'support/util/random';
-import { describeRegions } from 'support/util/regions';
+import { testRegions } from 'support/util/regions';
 
 /**
  * Uploads a machine image and waits for it to become available.
@@ -52,7 +53,11 @@ const uploadMachineImage = async (region: Region, data: Blob) => {
 };
 
 authenticate();
-describeRegions('Delete Machine Images', (region: Region) => {
+describe('Delete Machine Images', () => {
+  before(() => {
+    cleanUp('images');
+  });
+
   /*
    * - Updates and deletes a Machine Image for the targeted region.
    * - Confirms that Image label and description can be updated.
@@ -60,7 +65,7 @@ describeRegions('Delete Machine Images', (region: Region) => {
    * - Confirms that Image can be deleted.
    * - Confirms that deleted Image is removed from the landing page.
    */
-  it('can update and delete a Machine Image', () => {
+  testRegions('can update and delete a Machine Image', (region) => {
     const newLabel = randomLabel();
     const newDescription = randomPhrase();
 

--- a/packages/manager/cypress/e2e/region/images/upload-machine-image.spec.ts
+++ b/packages/manager/cypress/e2e/region/images/upload-machine-image.spec.ts
@@ -1,19 +1,25 @@
 import type { Region } from '@linode/api-v4';
 import 'cypress-file-upload';
+import { authenticate } from 'support/api/authentication';
 import { imageUploadProcessingTimeout } from 'support/constants/images';
 import { interceptUploadImage } from 'support/intercepts/images';
 import { ui } from 'support/ui';
+import { cleanUp } from 'support/util/cleanup';
 import { randomLabel, randomPhrase } from 'support/util/random';
-import { describeRegions } from 'support/util/regions';
+import { testRegions } from 'support/util/regions';
 
-describeRegions('Upload Machine Images', (region: Region) => {
+authenticate();
+describe('Upload Machine Images', () => {
+  before(() => {
+    cleanUp('images');
+  });
   /*
    * - Confirms that users can upload Machine Images to the targeted region.
    * - Confirms that user is redirected back to landing page.
    * - Confirms that uploaded Image is listed on the landing page.
    * - Confirms that Image uploads successfully and landing page reflects its status.
    */
-  it('can upload a Machine Image', () => {
+  testRegions('can upload a Machine Image', (region: Region) => {
     const imageLabel = randomLabel();
     const imageDescription = randomPhrase();
     const imageFile = 'machine-images/test-image.gz';

--- a/packages/manager/cypress/e2e/region/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/region/linodes/create-linode.spec.ts
@@ -1,16 +1,16 @@
-import { describeRegions } from 'support/util/regions';
+import { testRegions } from 'support/util/regions';
 import { ui } from 'support/ui';
 import { randomLabel, randomString } from 'support/util/random';
 import { interceptCreateLinode } from 'support/intercepts/linodes';
 import type { Region } from '@linode/api-v4';
 
-describeRegions('Create Linodes', (region: Region) => {
+describe('Create Linodes', () => {
   /*
    * - Navigates to Linode create page.
    * - Selects a region, plan (Dedicated 4 GB), and enters label and password.
    * - Clicks "Create Linode" and confirms that new Linode boots.
    */
-  it('can create and boot a Linode', () => {
+  testRegions('can create and boot a Linode', (region: Region) => {
     const label = randomLabel();
 
     interceptCreateLinode().as('createLinode');

--- a/packages/manager/cypress/e2e/region/linodes/delete-linode.spec.ts
+++ b/packages/manager/cypress/e2e/region/linodes/delete-linode.spec.ts
@@ -10,9 +10,14 @@ import {
   interceptGetLinodeDetails,
   interceptGetLinodes,
 } from 'support/intercepts/linodes';
+import { cleanUp } from 'support/util/cleanup';
 
 authenticate();
 describeRegions('Delete Linodes', (region: Region) => {
+  before(() => {
+    cleanUp('linodes');
+  });
+
   /*
    * - Navigates to a Linode details page.
    * - Deletes the Linode via the "Delete" action menu item.

--- a/packages/manager/cypress/e2e/region/linodes/update-linode.spec.ts
+++ b/packages/manager/cypress/e2e/region/linodes/update-linode.spec.ts
@@ -4,6 +4,7 @@ import { createLinodeRequestFactory } from '@src/factories';
 import { authenticate } from 'support/api/authentication';
 import { interceptGetLinodeDetails } from 'support/intercepts/linodes';
 import { ui } from 'support/ui';
+import { cleanUp } from 'support/util/cleanup';
 import { depaginate } from 'support/util/paginate';
 import { randomLabel, randomString } from 'support/util/random';
 import { describeRegions } from 'support/util/regions';
@@ -22,6 +23,10 @@ const makeLinodePayload = (region: string, booted: boolean) => {
 
 authenticate();
 describeRegions('Can update Linodes', (region) => {
+  before(() => {
+    cleanUp('linodes');
+  });
+
   /*
    * - Navigates to a Linode details page's "Settings" tab.
    * - Enters a new label and clicks "Save".

--- a/packages/manager/cypress/support/api/lke.ts
+++ b/packages/manager/cypress/support/api/lke.ts
@@ -36,7 +36,7 @@ const isPoolReady = (pool: KubeNodePoolResponse): boolean =>
  *
  * @returns Promise that resolves when test LKE clusters have been deleted.
  */
-export const deleteAllTestLkeClusters = async (): Promise<any[]> => {
+export const deleteAllTestLkeClusters = async (): Promise<void> => {
   const clusters = await depaginate<KubernetesCluster>((page: number) =>
     getKubernetesClusters({ page, page_size: pageSize })
   );
@@ -53,5 +53,6 @@ export const deleteAllTestLkeClusters = async (): Promise<any[]> => {
       }
     });
 
-  return Promise.all(clusterDeletionPromises);
+  await Promise.all(clusterDeletionPromises);
+  return;
 };

--- a/packages/manager/cypress/support/api/objectStorage.ts
+++ b/packages/manager/cypress/support/api/objectStorage.ts
@@ -82,7 +82,8 @@ export const deleteAllTestBuckets = async () => {
     }
   );
 
-  return Promise.all(deleteBucketsPromises);
+  await Promise.all(deleteBucketsPromises);
+  return;
 };
 
 /**
@@ -92,9 +93,7 @@ export const deleteAllTestBuckets = async () => {
  *
  * @returns Promise that resolves when all test access keys are deleted.
  */
-export const deleteAllTestAccessKeys = async (): Promise<
-  ObjectStorageKey[]
-> => {
+export const deleteAllTestAccessKeys = async (): Promise<void> => {
   authenticate();
   const getAccessKeysPage = (page: number) => getObjectStorageKeys({ page });
 
@@ -112,5 +111,6 @@ export const deleteAllTestAccessKeys = async (): Promise<
     }
   );
 
-  return Promise.all(revokeAccessKeysPromises);
+  await Promise.all(revokeAccessKeysPromises);
+  return;
 };

--- a/packages/manager/cypress/support/api/volumes.ts
+++ b/packages/manager/cypress/support/api/volumes.ts
@@ -1,8 +1,9 @@
 import { Volume, deleteVolume, detachVolume, getVolumes } from '@linode/api-v4';
 import { pageSize } from 'support/constants/api';
 import { depaginate } from 'support/util/paginate';
-
+import { timeout } from 'support/util/backoff';
 import { isTestLabel } from './common';
+import { attemptWithBackoff, SimpleBackoffMethod } from 'support/util/backoff';
 
 /**
  * Delete all Volumes whose labels are prefixed "cy-test-".
@@ -23,7 +24,21 @@ export const deleteAllTestVolumes = async (): Promise<void> => {
       if (volume.linode_id) {
         await detachVolume(volume.id);
       }
-      await deleteVolume(volume.id);
+      /*
+       * Make 10 attempts to delete the volume, waiting 10 seconds between
+       * each attempt.
+       *
+       * This is necessary when the volume has been recently detached; the API
+       * request to detach the volume responds successfully, indicating that the
+       * volume has been detached, but subsequent attempts to delete the volume
+       * often fail with an error message indicating that the volume has not yet
+       * been detached.
+       */
+      const backoff = new SimpleBackoffMethod(10000, {
+        maxAttempts: 10,
+      });
+
+      await attemptWithBackoff(backoff, () => deleteVolume(volume.id));
     });
 
   await Promise.all(detachDeletePromises);

--- a/packages/manager/cypress/support/e2e.ts
+++ b/packages/manager/cypress/support/e2e.ts
@@ -16,25 +16,9 @@
 import chaiString from 'chai-string';
 import 'cypress-real-events/support';
 
-import { authenticate } from './api/authentication';
-import { deleteAllTestData } from './ui/common';
-
 // chai is a global exposed by Cypress which means
 // we can just simply extend it
 chai.use(chaiString);
 
-authenticate();
-
 import './commands';
 import './request-tracking';
-
-// Runs before each test file.
-before(() => {
-  cy.defer(deleteAllTestData(), {
-    // Describe action in Cypress output.
-    label: 'Cleaning up test resources',
-
-    // Make sure there's enough time to accommodate retries when necessary.
-    timeout: 120000,
-  });
-});

--- a/packages/manager/cypress/support/ui/common.ts
+++ b/packages/manager/cypress/support/ui/common.ts
@@ -1,25 +1,7 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
 import { Method } from 'axios';
 import { RouteMatcher } from 'cypress/types/net-stubbing';
-import { deleteAllTestLkeClusters } from 'support/api/lke';
-import {
-  deleteAllTestAccessKeys,
-  deleteAllTestBuckets,
-} from 'support/api/objectStorage';
-import { deleteAllTestOAuthApps } from 'support/api/profile';
-import { SimpleBackoffMethod, attemptWithBackoff } from 'support/util/backoff';
 import { apiMatcher } from 'support/util/intercepts';
-
-import { deleteAllTestDomains } from '../api/domains';
-import { cancelAllTestEntityTransfers } from '../api/entityTransfer';
-import { deleteAllTestFirewalls } from '../api/firewalls';
-import { deleteAllTestImages } from '../api/images';
-import { deleteAllTestLinodes } from '../api/linodes';
-import { deleteAllTestClients } from '../api/longview';
-import { deleteAllTestNodeBalancers } from '../api/nodebalancers';
-import { deleteAllTestStackScripts } from '../api/stackscripts';
-import { deleteAllTestTags } from '../api/tags';
-import { deleteAllTestVolumes } from '../api/volumes';
 
 export const waitForAppLoad = (path = '/', withLogin = true) => {
   cy.intercept('GET', apiMatcher('account')).as('getAccount');
@@ -54,40 +36,5 @@ export const interceptOnce = (
     if (count < 2) {
       req.reply(response);
     }
-  });
-};
-
-/**
- * Deletes all test data on the account.
- *
- * In case an HTTP error occurs, 2 additional attempts will be made to delete
- * the data with a 45 second delay between attempts.
- */
-export const deleteAllTestData = async () => {
-  const backoff = new SimpleBackoffMethod(45000, {
-    maxAttempts: 3,
-  });
-
-  await attemptWithBackoff(backoff, async () => {
-    // Cancel service transfers first, then Linodes, before attempting to delete
-    // any other entities.
-    await cancelAllTestEntityTransfers();
-    await deleteAllTestLinodes();
-
-    // Delete remaining test data.
-    await Promise.all([
-      deleteAllTestLkeClusters(),
-      deleteAllTestNodeBalancers(),
-      deleteAllTestImages(),
-      deleteAllTestClients(),
-      deleteAllTestFirewalls(),
-      deleteAllTestStackScripts(),
-      deleteAllTestDomains(),
-      deleteAllTestBuckets(),
-      deleteAllTestAccessKeys(),
-      deleteAllTestTags(),
-      deleteAllTestVolumes(),
-      deleteAllTestOAuthApps(),
-    ]);
   });
 };

--- a/packages/manager/cypress/support/util/cleanup.ts
+++ b/packages/manager/cypress/support/util/cleanup.ts
@@ -1,0 +1,80 @@
+import { deleteAllTestDomains } from 'support/api/domains';
+import { cancelAllTestEntityTransfers } from 'support/api/entityTransfer';
+import { deleteAllTestFirewalls } from 'support/api/firewalls';
+import { deleteAllTestImages } from 'support/api/images';
+import { deleteAllTestLinodes } from 'support/api/linodes';
+import { deleteAllTestLkeClusters } from 'support/api/lke';
+import { deleteAllTestClients } from 'support/api/longview';
+import { deleteAllTestNodeBalancers } from 'support/api/nodebalancers';
+import {
+  deleteAllTestAccessKeys,
+  deleteAllTestBuckets,
+} from 'support/api/objectStorage';
+import { deleteAllTestStackScripts } from 'support/api/stackscripts';
+import { deleteAllTestTags } from 'support/api/tags';
+import { deleteAllTestVolumes } from 'support/api/volumes';
+
+/** Types of resources that can be cleaned up. */
+export type CleanUpResource =
+  | 'domains'
+  | 'firewalls'
+  | 'images'
+  | 'linodes'
+  | 'lke-clusters'
+  | 'longview-clients'
+  | 'node-balancers'
+  | 'obj-access-keys'
+  | 'obj-buckets'
+  | 'service-transfers'
+  | 'stackscripts'
+  | 'tags'
+  | 'volumes';
+
+/** Object that maps resources to their corresponding clean up function. */
+type CleanUpMap = {
+  [key in CleanUpResource]: () => Promise<void>;
+};
+
+// Map `CleanUpResource` strings to the clean up functions they execute.
+const cleanUpMap: CleanUpMap = {
+  domains: () => deleteAllTestDomains(),
+  firewalls: () => deleteAllTestFirewalls(),
+  images: () => deleteAllTestImages(),
+  linodes: () => deleteAllTestLinodes(),
+  'lke-clusters': () => deleteAllTestLkeClusters(),
+  'longview-clients': () => deleteAllTestClients(),
+  'node-balancers': () => deleteAllTestNodeBalancers(),
+  'obj-access-keys': () => deleteAllTestAccessKeys(),
+  'obj-buckets': () => deleteAllTestBuckets(),
+  'service-transfers': () => cancelAllTestEntityTransfers(),
+  stackscripts: () => deleteAllTestStackScripts(),
+  tags: () => deleteAllTestTags(),
+  volumes: () => deleteAllTestVolumes(),
+};
+
+/**
+ * Cleans up test resources of the given type(s).
+ *
+ * @param resources - Types of resources to clean up.
+ *
+ * @example
+ * await cleanUp('linodes'); // Clean up a single type of resource.
+ * await cleanUp(['linodes', 'volumes']); // Clean up Linodes and then Volumes.
+ *
+ * @returns Promise that resolves when desired resources are cleaned up.
+ */
+export const cleanUp = (resources: CleanUpResource | CleanUpResource[]) => {
+  const resourcesArray = Array.isArray(resources) ? resources : [resources];
+  const promise = async () => {
+    for (const resource of resourcesArray) {
+      const cleanFunction = cleanUpMap[resource];
+      // Perform clean-up sequentially to avoid API rate limiting.
+      // eslint-disable-next-line no-await-in-loop
+      await cleanFunction();
+    }
+  };
+  return cy.defer(
+    promise(),
+    `cleaning up test resources: ${resourcesArray.join(', ')}`
+  );
+};


### PR DESCRIPTION
## Description 📝
This changes the behavior of our test resource clean up when running Cypress.

Currently, Cypress sends API requests to delete all test account data (i.e. any resources with labels starting with `cy-test-`) before it runs every `.spec.ts` file.

This changes the clean up behavior so that only relevant test account resources are cleaned up at the beginning of each test. This brings advantages and disadvantages, so I'd like to hear the opinion of the team before moving forward with this.

### Advantages ✅
* **Better performance**: Because test account data is only deleted when required, performance should improve for most tests since less time will be spent fetching and deleting resources. The majority of our tests require no clean up at all.
* **Improved stability**: Bad HTTP responses during test clean up is one of our biggest causes of test flake. Reducing the amount of clean up that's performed should dramatically improve flakiness, and when bad responses do occur, the resulting test failure will actually be relevant since tests only clean up resources when necessary

### Disadvantages ❌
* **Accumulation of test resources**: Test resources will accumulate more under this model since clean up will be less frequent. This should not impact test stability but may become a burden when running tests locally since more test resources will be leftover. Additionally, this may increase the test account maintenance burden in certain circumstances (like when we need to free up resources for certain regions, etc.)
* **Greater consideration needed when writing tests**: Right now, very little consideration regarding clean up is required when writing new tests. This change will force us to consider the state that the test account must be in for each test to function, and will require us to explicitly clean up resources to achieve that state in a `before()` hook.

(If anybody can think of any other advantages or disadvantages I'd be happy to add them to the lists above)

## Major Changes 🔄
- Remove existing clean up behavior
- Add clean up utils
- Implement clean up individually in each test which requires it
- Improve resiliency of attached Volume clean up

## How to test 🧪
We can rely on the automated tests to confirm this is stable (I plan to run it multiple times). However, I am more concerned about the developer experience implications that come with this change.