### PR TITLE
refactor: [M3-7006] - Make `UserMenu` use MUI instead of Reach UI

### DIFF
--- a/packages/manager/.changeset/pr-9533-tech-stories-1691707780382.md
+++ b/packages/manager/.changeset/pr-9533-tech-stories-1691707780382.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Make UserMenu use MUI instead of Reach UI ([#9533](https://github.com/linode/manager/pull/9533))

--- a/packages/manager/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.tsx
@@ -24,14 +24,6 @@ export interface Action {
 const useStyles = makeStyles()((theme: Theme) => ({
   button: {
     '&[data-reach-menu-button]': {
-      '&:hover': {
-        backgroundColor: '#3683dc',
-        color: '#fff',
-      },
-      '&[aria-expanded="true"]': {
-        backgroundColor: '#3683dc',
-        color: '#fff',
-      },
       alignItems: 'center',
       background: 'none',
       border: 'none',

--- a/packages/manager/src/components/Link.tsx
+++ b/packages/manager/src/components/Link.tsx
@@ -116,6 +116,7 @@ export const Link = (props: LinkProps) => {
     </a>
   ) : (
     <RouterLink
+      data-testid="internal-link"
       {...routerLinkProps}
       className={cx(
         classes.root,
@@ -124,7 +125,6 @@ export const Link = (props: LinkProps) => {
         },
         className
       )}
-      data-testid="internal-link"
     />
   );
 };

--- a/packages/manager/src/components/UserMenu.stories.mdx
+++ b/packages/manager/src/components/UserMenu.stories.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
 import { profileFactory } from 'src/factories';
-import UserMenu from 'src/features/TopMenu/UserMenu/';
+import { UserMenu } from 'src/features/TopMenu/UserMenu';
 import { useProfile } from 'src/queries/profile';
 
 <Meta title="Features/Navigation/User Menu" component={UserMenu} />

--- a/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
@@ -2,7 +2,6 @@ import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
 import { styled } from '@mui/material/styles';
 import classNames from 'classnames';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import { makeStyles } from 'tss-react/mui';
 
 import { Accordion } from 'src/components/Accordion';
@@ -10,6 +9,7 @@ import { Box } from 'src/components/Box';
 import { StyledLinkButton } from 'src/components/Button/StyledLinkButton';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { Hidden } from 'src/components/Hidden';
+import { Link } from 'src/components/Link';
 import { Typography } from 'src/components/Typography';
 
 import type { Theme } from '@mui/material/styles';

--- a/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
@@ -11,16 +11,12 @@ import { StyledLinkButton } from 'src/components/Button/StyledLinkButton';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { Hidden } from 'src/components/Hidden';
 import { Typography } from 'src/components/Typography';
-import { menuLinkStyle } from 'src/features/TopMenu/UserMenu/UserMenu';
 
 import type { Theme } from '@mui/material/styles';
 
 const useStyles = makeStyles()((theme: Theme) => ({
   inverted: {
     transform: 'rotate(180deg)',
-  },
-  menuItemLink: {
-    ...menuLinkStyle(theme.textColors.linkActiveLight),
   },
   notificationSpacing: {
     '& > div:not(:first-child)': {
@@ -91,11 +87,7 @@ export const NotificationSection = (props: NotificationSectionProps) => {
                   <Typography variant="h3">{header}</Typography>
                   {showMoreTarget && (
                     <strong>
-                      <Link
-                        className={classes.menuItemLink}
-                        style={{ padding: 0 }}
-                        to={showMoreTarget}
-                      >
+                      <Link style={{ padding: 0 }} to={showMoreTarget}>
                         {showMoreText ?? 'View history'}
                       </Link>
                     </strong>

--- a/packages/manager/src/features/TopMenu/TopMenu.tsx
+++ b/packages/manager/src/features/TopMenu/TopMenu.tsx
@@ -16,6 +16,7 @@ import NotificationMenu from './NotificationMenu';
 import SearchBar from './SearchBar';
 import { TopMenuIcon } from './TopMenuIcon';
 import { UserMenu } from './UserMenu';
+import { Box } from 'src/components/Box';
 
 const useStyles = makeStyles((theme: Theme) => ({
   appBar: {
@@ -61,17 +62,11 @@ const TopMenu = (props: Props) => {
   return (
     <React.Fragment>
       {isLoggedInAsCustomer && (
-        <div
-          style={{
-            backgroundColor: 'pink',
-            padding: '1em',
-            textAlign: 'center',
-          }}
-        >
-          <Typography style={{ color: 'black', fontSize: '1.2em' }}>
+        <Box bgcolor="pink" padding="1em" textAlign="center">
+          <Typography color="black" fontSize="1.2em">
             You are logged in as customer: <strong>{username}</strong>
           </Typography>
-        </div>
+        </Box>
       )}
       <AppBar className={classes.appBar}>
         <Toolbar className={classes.toolbar} variant="dense">

--- a/packages/manager/src/features/TopMenu/TopMenu.tsx
+++ b/packages/manager/src/features/TopMenu/TopMenu.tsx
@@ -15,7 +15,7 @@ import { Help } from './Help';
 import NotificationMenu from './NotificationMenu';
 import SearchBar from './SearchBar';
 import { TopMenuIcon } from './TopMenuIcon';
-import UserMenu from './UserMenu';
+import { UserMenu } from './UserMenu';
 
 const useStyles = makeStyles((theme: Theme) => ({
   appBar: {

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.test.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.test.tsx
@@ -1,11 +1,10 @@
-import { screen } from '@testing-library/react';
 import * as React from 'react';
 
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
-import UserMenu from './UserMenu';
+import { UserMenu } from './UserMenu';
 
 it('renders without crashing', () => {
-  renderWithTheme(<UserMenu />);
-  expect(screen.queryByText('My Profile')).not.toBeNull();
+  const { getByRole } = renderWithTheme(<UserMenu />);
+  expect(getByRole('button')).toBeInTheDocument();
 });

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -129,15 +129,20 @@ export const UserMenu = React.memo(() => {
       return undefined;
     }
     if (open) {
-      return <KeyboardArrowUp />;
+      return <KeyboardArrowUp sx={{ height: 26, width: 26 }} />;
     }
-    return <KeyboardArrowDown />;
+    return (
+      <KeyboardArrowDown sx={{ color: '#9ea4ae', height: 26, width: 26 }} />
+    );
   };
 
   return (
     <>
       <Button
         sx={(theme) => ({
+          '& .MuiButton-endIcon': {
+            marginLeft: '4px',
+          },
           backgroundColor: open ? theme.bg.app : undefined,
           height: '50px',
           minWidth: 'unset',
@@ -170,7 +175,12 @@ export const UserMenu = React.memo(() => {
         open={open}
       >
         <Stack minWidth={250} spacing={2}>
-          <Box sx={{ fontSize: '1.1rem' }}>
+          <Box
+            sx={(theme) => ({
+              color: theme.textColors.headlineStatic,
+              fontSize: '1.1rem',
+            })}
+          >
             <strong>{userName}</strong>
           </Box>
           <Box>
@@ -212,8 +222,9 @@ export const UserMenu = React.memo(() => {
   );
 });
 
-const Heading = styled(Typography)({
+const Heading = styled(Typography)(({ theme }) => ({
+  color: theme.textColors.headlineStatic,
   fontSize: '.75rem',
   letterSpacing: 1.875,
   textTransform: 'uppercase',
-});
+}));

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -144,6 +144,7 @@ export const UserMenu = React.memo(() => {
           textTransform: 'none',
         })}
         aria-describedby={id}
+        data-testid="nav-group-profile"
         disableRipple
         endIcon={getEndIcon()}
         onClick={handleClick}

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -162,7 +162,8 @@ export const UserMenu = React.memo(() => {
       <Popover
         PaperProps={{
           sx: {
-            padding: 2.5,
+            paddingX: 2.5,
+            paddingY: 2,
           },
         }}
         anchorOrigin={{
@@ -175,14 +176,12 @@ export const UserMenu = React.memo(() => {
         open={open}
       >
         <Stack minWidth={250} spacing={2}>
-          <Box
-            sx={(theme) => ({
-              color: theme.textColors.headlineStatic,
-              fontSize: '1.1rem',
-            })}
+          <Typography
+            color={(theme) => theme.textColors.headlineStatic}
+            fontSize="1.1rem"
           >
             <strong>{userName}</strong>
-          </Box>
+          </Typography>
           <Box>
             <Heading>My Profile</Heading>
             <Divider color="#9ea4ae" />

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -1,20 +1,14 @@
 import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUp from '@mui/icons-material/KeyboardArrowUp';
+import { styled } from '@mui/material';
 import Popover from '@mui/material/Popover';
 import Stack from '@mui/material/Stack';
 import Grid from '@mui/material/Unstable_Grid2';
-import { Theme } from '@mui/material/styles';
-import { makeStyles } from '@mui/styles';
-// import {
-//   MenuButton,
-//   MenuItems,
-//   MenuLink,
-//   MenuPopover,
-//   Menu as ReachMenu,
-// } from '@reach/menu-button';
-// import { positionRight } from '@reach/popover';
 import * as React from 'react';
-import { Button } from 'src/components/Button/Button';
 
+import { Box } from 'src/components/Box';
+import { Button } from 'src/components/Button/Button';
+import { Divider } from 'src/components/Divider';
 import { GravatarByEmail } from 'src/components/GravatarByEmail';
 import { Hidden } from 'src/components/Hidden';
 import { Link } from 'src/components/Link';
@@ -27,203 +21,6 @@ interface MenuLink {
   hide?: boolean;
   href: string;
 }
-
-export const menuLinkStyle = (linkColor: string) => ({
-  '&[data-reach-menu-item]': {
-    '&:focus, &:hover': {
-      backgroundColor: 'transparent',
-      color: linkColor,
-    },
-    '&[data-reach-menu-item][data-selected]:not(:hover)': {
-      backgroundColor: 'transparent',
-      color: linkColor,
-      outline: 'dotted 1px #c1c1c0',
-    },
-    alignItems: 'center',
-    color: linkColor,
-    cursor: 'pointer',
-    display: 'flex',
-    fontSize: '0.875rem',
-    padding: '8px 24px',
-  },
-  lineHeight: 1,
-});
-
-const useStyles = makeStyles((theme: Theme) => ({
-  accountColumn: {
-    whiteSpace: 'normal',
-    width: '100%',
-  },
-  button: {
-    '&:focus': {
-      '& $username': {
-        color: theme.palette.primary.main,
-      },
-    },
-    '&:hover, &.active': {
-      '& $userWrapper': {
-        boxShadow: '0 0 10px #bbb',
-      },
-      '& $username': {
-        color: theme.palette.primary.main,
-      },
-    },
-    borderRadius: 30,
-    order: 4,
-    padding: theme.spacing(1),
-  },
-  caret: {
-    color: '#9ea4ae',
-    fontSize: 26,
-    marginLeft: 2,
-    marginTop: 2,
-    [theme.breakpoints.down('md')]: {
-      display: 'none',
-    },
-  },
-  gravatar: {
-    borderRadius: '50%',
-    height: 30,
-    width: 30,
-  },
-  hidden: {
-    ...theme.visually.hidden,
-  },
-  inlineUserName: {
-    fontSize: '0.875rem',
-    paddingLeft: theme.spacing(),
-  },
-  leftIcon: {
-    borderRadius: '50%',
-    height: 30,
-    width: 30,
-  },
-  menu: {
-    transform: `translateY(${theme.spacing(1)})`,
-  },
-  menuButton: {
-    '&[data-reach-menu-button]': {
-      '&[aria-expanded="true"]': {
-        '& $caret': {
-          color: '#0683E3',
-          marginTop: 4,
-          transform: 'rotate(180deg)',
-        },
-        background: theme.bg.app,
-      },
-      backgroundColor: 'transparent',
-      border: 'none',
-      borderRadius: 0,
-      color: '#c9c7c7',
-      cursor: 'pointer',
-      fontSize: '1rem',
-      height: 50,
-      textTransform: 'inherit',
-      [theme.breakpoints.down('md')]: {
-        paddingLeft: 12,
-        paddingRight: 12,
-      },
-      [theme.breakpoints.down(360)]: {
-        paddingLeft: theme.spacing(),
-        paddingRight: theme.spacing(),
-      },
-    },
-    alignItems: 'center',
-    display: 'flex',
-    lineHeight: 1,
-    paddingRight: 10,
-    [theme.breakpoints.down(360)]: {
-      paddingLeft: 3,
-    },
-    [theme.breakpoints.up('sm')]: {
-      paddingLeft: 12,
-    },
-  },
-  menuHeader: {
-    borderBottom: '1px solid #9ea4ae',
-    color: theme.textColors.headlineStatic,
-    fontSize: '.75rem',
-    letterSpacing: 1.875,
-    marginBottom: theme.spacing(),
-    marginLeft: theme.spacing(3),
-    marginRight: theme.spacing(3),
-    padding: '16px 0 8px',
-    textTransform: 'uppercase',
-  },
-  menuItem: {
-    '&:hover, &:focus': {
-      backgroundColor: theme.name === 'light' ? '#3a3f46' : '#23262a',
-      color: 'white',
-    },
-    fontFamily: 'LatoWeb',
-    fontSize: '.9rem',
-  },
-  menuItemLink: menuLinkStyle(theme.textColors.linkActiveLight),
-  menuItemList: {
-    '&[data-reach-menu-items]': {
-      backgroundColor: theme.bg.bgPaper,
-      border: 'none',
-      padding: 0,
-      paddingBottom: theme.spacing(1.5),
-      width: 300,
-    },
-    boxShadow: '0 2px 3px 3px rgba(0, 0, 0, 0.1)',
-  },
-  menuPopover: {
-    '&[data-reach-menu], &[data-reach-menu-popover]': {
-      position: 'absolute',
-      [theme.breakpoints.down('lg')]: {
-        left: 0,
-      },
-      top: 50,
-      zIndex: 3000,
-    },
-  },
-  profileWrapper: {
-    '& > div': {
-      whiteSpace: 'normal',
-    },
-    marginBottom: theme.spacing(2),
-  },
-  userName: {
-    color: theme.textColors.headlineStatic,
-    fontSize: '1.1rem',
-    marginLeft: theme.spacing(3),
-    marginRight: theme.spacing(3),
-    marginTop: -1,
-    paddingTop: theme.spacing(2),
-  },
-  userWrapper: {
-    '& svg': {
-      color: '#c9c7c7',
-      height: 30,
-      width: 30,
-    },
-    alignItems: 'center',
-    borderRadius: '50%',
-    display: 'flex',
-    height: 30,
-    justifyContent: 'center',
-    [theme.breakpoints.down('lg')]: {
-      height: '28px',
-      width: '28px',
-    },
-    transition: theme.transitions.create(['box-shadow']),
-    width: 30,
-  },
-  username: {
-    maxWidth: '135px',
-    overflow: 'hidden',
-    paddingRight: 15,
-    textOverflow: 'ellipsis',
-    // Hides username as soon as things start to scroll
-    [theme.breakpoints.down(1345)]: {
-      ...theme.visually.hidden,
-    },
-    transition: theme.transitions.create(['color']),
-    whiteSpace: 'nowrap',
-  },
-}));
 
 const profileLinks: MenuLink[] = [
   {
@@ -243,9 +40,7 @@ const profileLinks: MenuLink[] = [
   { display: 'Log Out', href: '/logout' },
 ];
 
-export const UserMenu = () => {
-  const classes = useStyles();
-
+export const UserMenu = React.memo(() => {
   const {
     _hasAccountAccess,
     _isRestrictedUser,
@@ -306,40 +101,51 @@ export const UserMenu = () => {
 
   const userName = profile?.username ?? '';
 
-  const renderLink = (menuLink: MenuLink) =>
-    menuLink.hide ? null : (
-      <Grid key={menuLink.display} xs={12}>
+  const renderLink = (link: MenuLink) => {
+    if (link.hide) {
+      return null;
+    }
+
+    return (
+      <Grid key={link.display} xs={12}>
         <Link
-          className={classes.menuItemLink}
-          data-testid={`menu-item-${menuLink.display}`}
+          data-testid={`menu-item-${link.display}`}
+          onClick={handleClose}
           style={{ fontSize: '0.875rem' }}
-          to={menuLink.href}
+          to={link.href}
         >
-          {menuLink.display}
+          {link.display}
         </Link>
       </Grid>
     );
+  };
 
   return (
     <>
-      <Button aria-describedby={id} onClick={handleClick}>
-        <GravatarByEmail
-          className={classes.userWrapper}
-          email={profile?.email ?? ''}
-        />
+      <Button
+        sx={(theme) => ({
+          backgroundColor: open ? theme.bg.app : undefined,
+          height: '50px',
+          textTransform: 'none',
+        })}
+        aria-describedby={id}
+        disableRipple
+        endIcon={open ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
+        onClick={handleClick}
+        startIcon={<GravatarByEmail email={profile?.email ?? ''} />}
+      >
         <Hidden mdDown>
-          <Typography className={classes.inlineUserName}>{userName}</Typography>
+          <Typography sx={{ fontSize: '0.875rem' }}>{userName}</Typography>
         </Hidden>
-        <KeyboardArrowDown className={classes.caret} />
       </Button>
       <Popover
         PaperProps={{
           sx: {
-            minWidth: 300,
+            padding: 2.5,
           },
         }}
         anchorOrigin={{
-          horizontal: 'left',
+          horizontal: 'right',
           vertical: 'bottom',
         }}
         anchorEl={anchorEl}
@@ -347,38 +153,33 @@ export const UserMenu = () => {
         onClose={handleClose}
         open={open}
       >
-        <div className={classes.menuItemList}>
-          <div className={classes.userName}>
+        <Stack minWidth={250} spacing={2}>
+          <Box sx={{ fontSize: '1.1rem' }}>
             <strong>{userName}</strong>
-          </div>
-          <div className={classes.menuHeader}>My Profile</div>
-          <Grid container marginX={3} rowSpacing={1}>
-            <Grid
-              className={classes.profileWrapper}
-              direction="column"
-              wrap="nowrap"
-              xs={6}
-            >
-              {profileLinks.slice(0, 4).map(renderLink)}
+          </Box>
+          <Box>
+            <Heading>My Profile</Heading>
+            <Divider color="#9ea4ae" />
+            <Grid container rowSpacing={1.5}>
+              <Grid direction="column" wrap="nowrap" xs={6}>
+                {profileLinks.slice(0, 4).map(renderLink)}
+              </Grid>
+              <Grid direction="column" wrap="nowrap" xs={6}>
+                {profileLinks.slice(4).map(renderLink)}
+              </Grid>
             </Grid>
-            <Grid
-              className={classes.profileWrapper}
-              direction="column"
-              wrap="nowrap"
-              xs={6}
-            >
-              {profileLinks.slice(4).map(renderLink)}
-            </Grid>
-          </Grid>
-          {_hasAccountAccess ? (
-            <>
-              <div className={classes.menuHeader}>Account</div>
-              <Stack marginX={3} spacing={2}>
+          </Box>
+          {_hasAccountAccess && (
+            <Box>
+              <Heading>Account</Heading>
+              <Divider color="#9ea4ae" />
+              <Stack mt={1} spacing={1.5}>
                 {accountLinks.map((menuLink) =>
                   menuLink.hide ? null : (
                     <Link
                       data-testid={`menu-item-${menuLink.display}`}
                       key={menuLink.display}
+                      onClick={handleClose}
                       style={{ fontSize: '0.875rem' }}
                       to={menuLink.href}
                     >
@@ -387,12 +188,16 @@ export const UserMenu = () => {
                   )
                 )}
               </Stack>
-            </>
-          ) : null}
-        </div>
+            </Box>
+          )}
+        </Stack>
       </Popover>
     </>
   );
-};
+});
 
-export default React.memo(UserMenu);
+const Heading = styled(Typography)({
+  fontSize: '.75rem',
+  letterSpacing: 1.875,
+  textTransform: 'uppercase',
+});

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -1,6 +1,6 @@
 import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUp from '@mui/icons-material/KeyboardArrowUp';
-import { styled } from '@mui/material';
+import { Theme, styled, useMediaQuery } from '@mui/material';
 import Popover from '@mui/material/Popover';
 import Stack from '@mui/material/Stack';
 import Grid from '@mui/material/Unstable_Grid2';
@@ -46,6 +46,10 @@ export const UserMenu = React.memo(() => {
     _isRestrictedUser,
     profile,
   } = useAccountManagement();
+
+  const matchesSmDown = useMediaQuery((theme: Theme) =>
+    theme.breakpoints.down('sm')
+  );
 
   const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
     null
@@ -120,17 +124,28 @@ export const UserMenu = React.memo(() => {
     );
   };
 
+  const getEndIcon = () => {
+    if (matchesSmDown) {
+      return undefined;
+    }
+    if (open) {
+      return <KeyboardArrowUp />;
+    }
+    return <KeyboardArrowDown />;
+  };
+
   return (
     <>
       <Button
         sx={(theme) => ({
           backgroundColor: open ? theme.bg.app : undefined,
           height: '50px',
+          minWidth: 'unset',
           textTransform: 'none',
         })}
         aria-describedby={id}
         disableRipple
-        endIcon={open ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
+        endIcon={getEndIcon()}
         onClick={handleClick}
         startIcon={<GravatarByEmail email={profile?.email ?? ''} />}
       >

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -1,21 +1,23 @@
 import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
+import Popover from '@mui/material/Popover';
+import Stack from '@mui/material/Stack';
 import Grid from '@mui/material/Unstable_Grid2';
 import { Theme } from '@mui/material/styles';
 import { makeStyles } from '@mui/styles';
-import {
-  MenuButton,
-  MenuItems,
-  MenuLink,
-  MenuPopover,
-  Menu as ReachMenu,
-} from '@reach/menu-button';
-import { positionRight } from '@reach/popover';
+// import {
+//   MenuButton,
+//   MenuItems,
+//   MenuLink,
+//   MenuPopover,
+//   Menu as ReachMenu,
+// } from '@reach/menu-button';
+// import { positionRight } from '@reach/popover';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
+import { Button } from 'src/components/Button/Button';
 
 import { GravatarByEmail } from 'src/components/GravatarByEmail';
 import { Hidden } from 'src/components/Hidden';
-import { Tooltip } from 'src/components/Tooltip';
+import { Link } from 'src/components/Link';
 import { Typography } from 'src/components/Typography';
 import { useAccountManagement } from 'src/hooks/useAccountManagement';
 import { useGrants } from 'src/queries/profile';
@@ -241,7 +243,7 @@ const profileLinks: MenuLink[] = [
   { display: 'Log Out', href: '/logout' },
 ];
 
-export const UserMenu: React.FC<{}> = () => {
+export const UserMenu = () => {
   const classes = useStyles();
 
   const {
@@ -249,6 +251,21 @@ export const UserMenu: React.FC<{}> = () => {
     _isRestrictedUser,
     profile,
   } = useAccountManagement();
+
+  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
+    null
+  );
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popover' : undefined;
 
   const { data: grants } = useGrants();
 
@@ -292,96 +309,89 @@ export const UserMenu: React.FC<{}> = () => {
   const renderLink = (menuLink: MenuLink) =>
     menuLink.hide ? null : (
       <Grid key={menuLink.display} xs={12}>
-        <MenuLink
-          as={Link}
+        <Link
           className={classes.menuItemLink}
           data-testid={`menu-item-${menuLink.display}`}
+          style={{ fontSize: '0.875rem' }}
           to={menuLink.href}
         >
           {menuLink.display}
-        </MenuLink>
+        </Link>
       </Grid>
     );
 
   return (
-    <div>
-      <ReachMenu>
-        <Tooltip
-          disableTouchListener
-          enterDelay={500}
-          leaveDelay={0}
-          title="Profile & Account"
-        >
-          <MenuButton
-            className={classes.menuButton}
-            data-testid="nav-group-profile"
-          >
-            <GravatarByEmail
-              className={classes.userWrapper}
-              email={profile?.email ?? ''}
-            />
-            <Hidden mdDown>
-              <Typography className={classes.inlineUserName}>
-                {userName}
-              </Typography>
-            </Hidden>
-            <KeyboardArrowDown className={classes.caret} />
-          </MenuButton>
-        </Tooltip>
-        <MenuPopover
-          className={classes.menuPopover}
-          data-qa-user-menu
-          position={positionRight}
-        >
-          <MenuItems className={classes.menuItemList}>
-            <div className={classes.userName}>
-              <strong>{userName}</strong>
-            </div>
-            <div className={classes.menuHeader}>My Profile</div>
-            <Grid container>
-              <Grid
-                className={classes.profileWrapper}
-                direction="column"
-                wrap="nowrap"
-                xs={6}
-              >
-                {profileLinks.slice(0, 4).map(renderLink)}
-              </Grid>
-              <Grid
-                className={classes.profileWrapper}
-                direction="column"
-                wrap="nowrap"
-                xs={6}
-              >
-                {profileLinks.slice(4).map(renderLink)}
-              </Grid>
+    <>
+      <Button aria-describedby={id} onClick={handleClick}>
+        <GravatarByEmail
+          className={classes.userWrapper}
+          email={profile?.email ?? ''}
+        />
+        <Hidden mdDown>
+          <Typography className={classes.inlineUserName}>{userName}</Typography>
+        </Hidden>
+        <KeyboardArrowDown className={classes.caret} />
+      </Button>
+      <Popover
+        PaperProps={{
+          sx: {
+            minWidth: 300,
+          },
+        }}
+        anchorOrigin={{
+          horizontal: 'left',
+          vertical: 'bottom',
+        }}
+        anchorEl={anchorEl}
+        id={id}
+        onClose={handleClose}
+        open={open}
+      >
+        <div className={classes.menuItemList}>
+          <div className={classes.userName}>
+            <strong>{userName}</strong>
+          </div>
+          <div className={classes.menuHeader}>My Profile</div>
+          <Grid container marginX={3} rowSpacing={1}>
+            <Grid
+              className={classes.profileWrapper}
+              direction="column"
+              wrap="nowrap"
+              xs={6}
+            >
+              {profileLinks.slice(0, 4).map(renderLink)}
             </Grid>
-            {_hasAccountAccess ? (
-              <>
-                <div className={classes.menuHeader}>Account</div>
-                <Grid container>
-                  <Grid className={classes.accountColumn}>
-                    {accountLinks.map((menuLink) =>
-                      menuLink.hide ? null : (
-                        <MenuLink
-                          as={Link}
-                          className={classes.menuItemLink}
-                          data-testid={`menu-item-${menuLink.display}`}
-                          key={menuLink.display}
-                          to={menuLink.href}
-                        >
-                          {menuLink.display}
-                        </MenuLink>
-                      )
-                    )}
-                  </Grid>
-                </Grid>
-              </>
-            ) : null}
-          </MenuItems>
-        </MenuPopover>
-      </ReachMenu>
-    </div>
+            <Grid
+              className={classes.profileWrapper}
+              direction="column"
+              wrap="nowrap"
+              xs={6}
+            >
+              {profileLinks.slice(4).map(renderLink)}
+            </Grid>
+          </Grid>
+          {_hasAccountAccess ? (
+            <>
+              <div className={classes.menuHeader}>Account</div>
+              <Stack marginX={3} spacing={2}>
+                {accountLinks.map((menuLink) =>
+                  menuLink.hide ? null : (
+                    <Link
+                      data-testid={`menu-item-${menuLink.display}`}
+                      key={menuLink.display}
+                      style={{ fontSize: '0.875rem' }}
+                      to={menuLink.href}
+                    >
+                      {menuLink.display}
+                    </Link>
+                  )
+                )}
+              </Stack>
+            </>
+          ) : null}
+        </div>
+      </Popover>
+    </>
   );
 };
 

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -60,7 +60,7 @@ export const UserMenu = React.memo(() => {
   };
 
   const open = Boolean(anchorEl);
-  const id = open ? 'simple-popover' : undefined;
+  const id = open ? 'user-menu-popover' : undefined;
 
   const { data: grants } = useGrants();
 

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -12,6 +12,7 @@ import { Divider } from 'src/components/Divider';
 import { GravatarByEmail } from 'src/components/GravatarByEmail';
 import { Hidden } from 'src/components/Hidden';
 import { Link } from 'src/components/Link';
+import { Tooltip } from 'src/components/Tooltip';
 import { Typography } from 'src/components/Typography';
 import { useAccountManagement } from 'src/hooks/useAccountManagement';
 import { useGrants } from 'src/queries/profile';
@@ -138,27 +139,34 @@ export const UserMenu = React.memo(() => {
 
   return (
     <>
-      <Button
-        sx={(theme) => ({
-          '& .MuiButton-endIcon': {
-            marginLeft: '4px',
-          },
-          backgroundColor: open ? theme.bg.app : undefined,
-          height: '50px',
-          minWidth: 'unset',
-          textTransform: 'none',
-        })}
-        aria-describedby={id}
-        data-testid="nav-group-profile"
-        disableRipple
-        endIcon={getEndIcon()}
-        onClick={handleClick}
-        startIcon={<GravatarByEmail email={profile?.email ?? ''} />}
+      <Tooltip
+        disableTouchListener
+        enterDelay={500}
+        leaveDelay={0}
+        title="Profile & Account"
       >
-        <Hidden mdDown>
-          <Typography sx={{ fontSize: '0.875rem' }}>{userName}</Typography>
-        </Hidden>
-      </Button>
+        <Button
+          sx={(theme) => ({
+            '& .MuiButton-endIcon': {
+              marginLeft: '4px',
+            },
+            backgroundColor: open ? theme.bg.app : undefined,
+            height: '50px',
+            minWidth: 'unset',
+            textTransform: 'none',
+          })}
+          aria-describedby={id}
+          data-testid="nav-group-profile"
+          disableRipple
+          endIcon={getEndIcon()}
+          onClick={handleClick}
+          startIcon={<GravatarByEmail email={profile?.email ?? ''} />}
+        >
+          <Hidden mdDown>
+            <Typography sx={{ fontSize: '0.875rem' }}>{userName}</Typography>
+          </Hidden>
+        </Button>
+      </Tooltip>
       <Popover
         PaperProps={{
           sx: {
@@ -175,7 +183,7 @@ export const UserMenu = React.memo(() => {
         onClose={handleClose}
         open={open}
       >
-        <Stack minWidth={250} spacing={2}>
+        <Stack data-qa-user-menu minWidth={250} spacing={2}>
           <Typography
             color={(theme) => theme.textColors.headlineStatic}
             fontSize="1.1rem"

--- a/packages/manager/src/features/TopMenu/UserMenu/index.ts
+++ b/packages/manager/src/features/TopMenu/UserMenu/index.ts
@@ -1,2 +1,1 @@
-import UserMenu from './UserMenu';
-export default UserMenu;
+export { UserMenu } from './UserMenu';

--- a/packages/manager/src/foundations/themes/dark.ts
+++ b/packages/manager/src/foundations/themes/dark.ts
@@ -209,9 +209,6 @@ export const darkTheme: ThemeOptions = {
           '&:hover': {
             backgroundColor: '#000',
           },
-          '&[aria-expanded="true"]': {
-            backgroundColor: primaryColors.dark,
-          },
           color: primaryColors.main,
         },
       },


### PR DESCRIPTION
## Description 📝

- The codebase has many different packages that all do the same things, we are trying to consolidate. In this case, we want to use MUI's Menu/Popper/Popover components instead of Reach UI's Menu
- This is similar to https://github.com/linode/manager/pull/9224

## Major Changes 🔄
- Makes `UserMenu` use a MUI `Popover` instead of a Reach UI `Menu`
- Uses **a ton** less one-off styles

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-08-10 at 6 51 46 PM](https://github.com/linode/manager/assets/115251059/1e35e904-7a90-4e8f-b807-81d61b5d09e3) | ![Screenshot 2023-08-10 at 6 51 52 PM](https://github.com/linode/manager/assets/115251059/d446ffd0-3bb1-4828-ac50-9e359744090d) |

## How to test 🧪
> [!important]
> I know the styles aren't 1:1 but I did my best to get them close. Also, does this new implementation have any negative impact on accessibility?

- Verify the `UserMenu` still works as expected and looks similar to the old one
