### PR TITLE
fix: [M3-7002] Topbar Search fixes

### DIFF
--- a/packages/manager/.changeset/pr-9534-fixed-1691788679611.md
+++ b/packages/manager/.changeset/pr-9534-fixed-1691788679611.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Issues with circular dependency and blur bhaviors on main search field ([#9534](https://github.com/linode/manager/pull/9534))

--- a/packages/manager/src/components/EnhancedSelect/components/SelectPlaceholder.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/SelectPlaceholder.tsx
@@ -13,6 +13,7 @@ export const SelectPlaceholder = (props: Props) => {
       data-qa-multi-select={
         props.isMulti ? props.selectProps.placeholder : false
       }
+      className="select-placeholder"
       data-qa-select-placeholder
     >
       {props.children}

--- a/packages/manager/src/components/Tag/Tag.tsx
+++ b/packages/manager/src/components/Tag/Tag.tsx
@@ -1,5 +1,6 @@
 import Close from '@mui/icons-material/Close';
 import { styled } from '@mui/material/styles';
+import { omit } from 'lodash';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -34,9 +35,11 @@ export const Tag = (props: TagProps) => {
   // If maxLength is set, truncate display to that length.
   const _label = maxLength ? truncateEnd(label, maxLength) : label;
 
+  const tagProps = omit(props, ['asSuggestion', 'closeMenu']);
+
   return (
     <StyledChip
-      {...props}
+      {...tagProps}
       deleteIcon={
         chipProps.onDelete ? (
           <StyledDeleteButton

--- a/packages/manager/src/features/Search/ResultRow.tsx
+++ b/packages/manager/src/features/Search/ResultRow.tsx
@@ -20,6 +20,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: '100%',
   },
   labelCell: {
+    '& a': {
+      display: 'inline-block',
+    },
     [theme.breakpoints.up('md')]: {
       width: '35%',
     },
@@ -39,8 +42,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: '100%',
   },
   root: {
-    cursor: 'pointer',
-    paddingBottom: '0 !important',
+    '& td': {
+      paddingBottom: 2,
+      paddingTop: 2,
+    },
+    paddingBottom: '2px !important',
     paddingTop: '0 !important',
     transition: theme.transitions.create(['background-color']),
     width: '100%',
@@ -81,7 +87,9 @@ export const ResultRow: React.FC<CombinedProps> = (props) => {
         >
           {result.label}
         </Link>
-        <Typography variant="body1">{result.data.description}</Typography>
+        <Typography fontSize={'0.80rem'} variant="body1">
+          {result.data.description}
+        </Typography>
       </TableCell>
       <TableCell className={classes.regionCell}>
         {result.data.region && <RegionIndicator region={result.data.region} />}

--- a/packages/manager/src/features/Search/ResultRow.tsx
+++ b/packages/manager/src/features/Search/ResultRow.tsx
@@ -43,8 +43,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   root: {
     '& td': {
-      paddingBottom: 2,
-      paddingTop: 2,
+      paddingBottom: 4,
+      paddingTop: 4,
     },
     paddingBottom: '2px !important',
     paddingTop: '0 !important',

--- a/packages/manager/src/features/Search/SearchLanding.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.tsx
@@ -163,6 +163,12 @@ export const SearchLanding: React.FC<CombinedProps> = (props) => {
     (linodes ?? []).map((linode) => linode.type).filter(isNotNullOrUndefined)
   );
   const types = extendTypesQueryResult(typesQuery);
+
+  const searchableLinodes = (linodes ?? []).map((linode) => {
+    const imageLabel = getImageLabelForLinode(linode, publicImages ?? []);
+    return formatLinode(linode, types, imageLabel);
+  });
+
   const [apiResults, setAPIResults] = React.useState<any>({});
   const [apiError, setAPIError] = React.useState<null | string>(null);
   const [apiSearchLoading, setAPILoading] = React.useState<boolean>(false);
@@ -200,11 +206,6 @@ export const SearchLanding: React.FC<CombinedProps> = (props) => {
     if (isLargeAccount) {
       _searchAPI(query);
     } else {
-      const searchableLinodes = (linodes ?? []).map((linode) => {
-        const imageLabel = getImageLabelForLinode(linode, publicImages ?? []);
-        return formatLinode(linode, types, imageLabel);
-      });
-
       search(
         query,
         objectStorageBuckets?.buckets ?? [],

--- a/packages/manager/src/features/Search/SearchLanding.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.tsx
@@ -163,12 +163,6 @@ export const SearchLanding: React.FC<CombinedProps> = (props) => {
     (linodes ?? []).map((linode) => linode.type).filter(isNotNullOrUndefined)
   );
   const types = extendTypesQueryResult(typesQuery);
-
-  const searchableLinodes = (linodes ?? []).map((linode) => {
-    const imageLabel = getImageLabelForLinode(linode, publicImages ?? []);
-    return formatLinode(linode, types, imageLabel);
-  });
-
   const [apiResults, setAPIResults] = React.useState<any>({});
   const [apiError, setAPIError] = React.useState<null | string>(null);
   const [apiSearchLoading, setAPILoading] = React.useState<boolean>(false);
@@ -206,6 +200,11 @@ export const SearchLanding: React.FC<CombinedProps> = (props) => {
     if (isLargeAccount) {
       _searchAPI(query);
     } else {
+      const searchableLinodes = (linodes ?? []).map((linode) => {
+        const imageLabel = getImageLabelForLinode(linode, publicImages ?? []);
+        return formatLinode(linode, types, imageLabel);
+      });
+
       search(
         query,
         objectStorageBuckets?.buckets ?? [],
@@ -231,7 +230,7 @@ export const SearchLanding: React.FC<CombinedProps> = (props) => {
     _privateImages,
     regions,
     nodebalancers,
-    searchableLinodes,
+    linodes,
   ]);
 
   const getErrorMessage = () => {

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.styles.ts
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.styles.ts
@@ -79,10 +79,21 @@ const styles = (theme: Theme) =>
       },
       '& .react-select__value-container': {
         '& p': {
-          fontSize: '0.875rem',
           overflow: 'visible',
         },
+        fontSize: '0.875rem',
         overflow: 'hidden',
+      },
+      '& .select-placeholder': {
+        opacity: 1,
+        transition: theme.transitions.create(['opacity'], {
+          duration: theme.transitions.duration.shortest,
+        }),
+      },
+      '&.active': {
+        '& .select-placeholder': {
+          opacity: 0.5,
+        },
       },
       alignItems: 'center',
       backgroundColor: theme.bg.app,

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -118,7 +118,6 @@ export const SearchBar = (props: CombinedProps) => {
     { is_public: true },
     searchActive
   );
-
   const { data: linodes, isLoading: linodesLoading } = useAllLinodesQuery(
     {},
     {},

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -56,7 +56,7 @@ const Option = (props: any) => {
 export const selectStyles = {
   control: (base: any) => ({
     ...base,
-    backgroundColor: '#f4f4f4',
+    backgroundColor: 'pink',
     border: 0,
     margin: 0,
     width: '100%',
@@ -344,6 +344,7 @@ export const SearchBar = (props: CombinedProps) => {
           openMenuOnClick={false}
           openMenuOnFocus={false}
           options={finalOptions}
+          styles={selectStyles}
           value={value}
         />
         <IconButton


### PR DESCRIPTION
## Description 📝
This PR addresses a few issues with the top search bar and the search landing page. Some (the circular dependency for instance) seem to be newer degradations while the others may have never been addressed or prioritized. 

The task involves improvements to the basic search (not the dropdown search results who remained untouched).

Notably, the improvements made to the UX are related to the state of the search field value while interacting with the search field and navigating the application. 

Please see the self review for details about the fixes

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-08-11 at 23 09 45](https://github.com/linode/manager/assets/130582365/3e2d4f32-51fa-42d3-967e-7d3dd6efae4c) | ![Screenshot 2023-08-11 at 23 10 04](https://github.com/linode/manager/assets/130582365/2fa00a96-f577-4905-9098-3bf87c96789d) |

## How to test 🧪
1. Pull code locally and test the search bar with various search terms, making sure to either click the first "View search results page for {term}" or click enter after typing the search term
