### PR TITLE
fix: Allow Cypress to make API requests against non-Prod environments

### DIFF
--- a/packages/manager/cypress.config.ts
+++ b/packages/manager/cypress.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
       return setupPlugins(on, config, [
         loadEnvironmentConfig,
         nodeVersionCheck,
-        authenticateApi,
+        // authenticateApi,
         configureTestSuite,
         vitePreprocess,
         disableGoogleSafeBrowsing,

--- a/packages/manager/cypress/support/api/authentication.ts
+++ b/packages/manager/cypress/support/api/authentication.ts
@@ -5,6 +5,13 @@
 import { baseRequest } from '@linode/api-v4/lib/request';
 import { oauthToken } from 'support/constants/api';
 
+const getApiRequestUrl = (baseUrl, originalRequestUrl) => {
+  const defaultApiRoot = 'https://api.linode.com/v4';
+  const apiRoot = Cypress.env('REACT_APP_API_ROOT') || defaultApiRoot;
+
+  return originalRequestUrl.replace(baseUrl, apiRoot);
+};
+
 /**
  * Intercepts all Linode API v4 requests and applies an authorization header.
  *
@@ -25,6 +32,7 @@ export const authenticate = function () {
           authorization: `Bearer ${oauthToken}`,
         },
       },
+      url: getApiRequestUrl(config.baseURL, config.url),
     };
   });
 };


### PR DESCRIPTION
There's more investigation and work that needs to be done here, but I'm opening this PR to unblock some developers on the Edge Experience team who are currently unable to run the tests.
