### PR TITLE
fix: Duplicate `key` error on Linodes Landing

### DIFF
--- a/packages/manager/.changeset/pr-9543-tech-stories-1692026704155.md
+++ b/packages/manager/.changeset/pr-9543-tech-stories-1692026704155.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Duplicate key error on Linode and NodeBalancer Landing ([#9543](https://github.com/linode/manager/pull/9543))

--- a/packages/manager/src/features/Linodes/LinodesLanding/IPAddress.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/IPAddress.tsx
@@ -1,4 +1,4 @@
-import { tail } from 'ramda';
+import { tail } from 'lodash';
 import * as React from 'react';
 
 import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
@@ -11,11 +11,6 @@ import {
   StyledRenderIPDiv,
   StyledRootDiv,
 } from './IPAddress.styles';
-
-type RenderIPData = {
-  ip: string;
-  key?: number;
-};
 
 export interface IPAddressProps {
   /**
@@ -100,7 +95,7 @@ export const IPAddress = (props: IPAddressProps) => {
     );
   };
 
-  const renderIP = ({ ip, key }: RenderIPData) => {
+  const renderIP = (ip: string) => {
     const handlers = showTooltipOnIpHover
       ? {
           onMouseEnter: handleMouseEnter,
@@ -111,7 +106,6 @@ export const IPAddress = (props: IPAddressProps) => {
     return (
       <StyledRenderIPDiv
         {...handlers}
-        key={`${key}-${ip}`}
         showTooltipOnIpHover={showTooltipOnIpHover}
       >
         <CopyTooltip copyableText data-qa-copy-ip-text text={ip} />
@@ -122,22 +116,14 @@ export const IPAddress = (props: IPAddressProps) => {
 
   return (
     <StyledRootDiv showAll={showAll}>
-      {!showAll
-        ? renderIP({ ip: formattedIPS[0] })
-        : formattedIPS.map((a, i) => {
-            return renderIP({ ip: a, key: i });
-          })}
+      {!showAll ? renderIP(formattedIPS[0]) : formattedIPS.map(renderIP)}
 
       {formattedIPS.length > 1 && showMore && !showAll && (
         <ShowMore
-          render={(ipsAsArray: string[]) => {
-            return ipsAsArray.map((ip, idx) =>
-              renderIP({ ip: ip.replace('/64', ''), key: idx })
-            );
-          }}
           ariaItemType="IP addresses"
           data-qa-ip-more
           items={tail(formattedIPS)}
+          render={(ipsAsArray: string[]) => ipsAsArray.map(renderIP)}
         />
       )}
     </StyledRootDiv>


### PR DESCRIPTION
## Description 📝

- Fixes the duplicate key error when on the Linodes Landing page (and NodeBalancer landing page)

## Major Changes 🔄
- Use **lodash** instead of **ramda** `tail()` function
- Clean up `IPAddress.tsx` while fixing the bug

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-08-14 at 11 18 33 AM](https://github.com/linode/manager/assets/115251059/29f7036e-6c02-4988-b798-a7dadeb403e8) | ![Screenshot 2023-08-14 at 11 18 19 AM](https://github.com/linode/manager/assets/115251059/3cb93dc5-d666-4e71-9ab7-aadabcdf0c4f) |

## How to test 🧪
- Have at least 1 Linode 
- Go to `/linodes`
- Verify you don't see a console error about duplicate keys