### PR TITLE
fix: [M3-7030] - Creating a database redirects to new instance's details page

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -276,7 +276,7 @@ const DatabaseCreate = () => {
 
     try {
       const response = await createDatabase(createPayload);
-      history.push(`/databases/${response.id}`);
+      history.push(`/databases/${response.engine}/${response.id}`);
     } catch (errors) {
       const ipErrors = errors.filter(
         (error: APIError) => error.field === 'allow_list'

--- a/packages/manager/src/features/Databases/index.tsx
+++ b/packages/manager/src/features/Databases/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
 
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { SuspenseLoader } from 'src/components/SuspenseLoader';
@@ -9,16 +9,19 @@ const DatabaseDetail = React.lazy(() => import('./DatabaseDetail'));
 const DatabaseCreate = React.lazy(() => import('./DatabaseCreate'));
 
 const Database = () => {
+  const { path } = useRouteMatch();
+
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <DocumentTitleSegment segment="Databases" />
       <Switch>
-        <Route component={DatabaseCreate} path="/databases/create" />
+        <Route component={DatabaseLanding} exact path={path} />
+        <Route component={DatabaseCreate} path={`${path}/create`} />
         <Route
           component={DatabaseDetail}
-          path="/databases/:engine/:databaseId"
+          path={`${path}/:engine/:databaseId`}
         />
-        <Route component={DatabaseLanding} exact strict />
+        <Redirect to="/databases" />
       </Switch>
     </React.Suspense>
   );


### PR DESCRIPTION
## Description 📝
This fixes an issue where creating a DBaaS instance redirects the user to `/databases/:id` instead of `/databases/:engineType/:id`, causing them to see the DBaaS landing page instead of the new instance's details page.

Additionally, this updates the behavior of the landing page so that navigating to invalid paths, like `/databases/:id`, redirects back to `/databases`. I chose this behavior, rather than a _Not Found_ error, because the Images landing page also behaves this way and it was the closest parallel I could find to this DBaaS situation. Open to feedback here.

## Major Changes 🔄
- Creating a DBaaS instance redirects to `/databases/:engineType/:id` instead of `/databases/:id`
- Navigating to `/databases/:id` (or any other invalid path) redirects back to `/databases`
- Updated DBaaS create test for this change

## How to test 🧪
Observe results of the automated e2e tests to confirm that core DBaaS functionality remains in tact.

The following should also be confirmed:

- Navigating to `/databases/:id` redirects back to `/databases`
- Other DBaaS routes are not impacted (like `/databases/create`, `/databases/:engineType/:id`, etc.)