### PR TITLE
fix: [M3-7024] - Fix Hively visual regression

### DIFF
--- a/packages/manager/.changeset/pr-9548-fixed-1692123558409.md
+++ b/packages/manager/.changeset/pr-9548-fixed-1692123558409.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Hively icons showing external link icons ([#9548](https://github.com/linode/manager/pull/9548))

--- a/packages/manager/src/components/Link.tsx
+++ b/packages/manager/src/components/Link.tsx
@@ -32,6 +32,11 @@ export interface LinkProps extends _LinkProps {
    * @default false
    */
   forceCopyColor?: boolean;
+  /**
+   * Optional prop to forcefully hide the external icon
+   * @default false
+   */
+  hideIcon?: boolean;
 }
 
 /**
@@ -64,6 +69,7 @@ export const Link = (props: LinkProps) => {
     forceCopyColor,
     onClick,
     to,
+    hideIcon,
   } = props;
   const { classes, cx } = useStyles();
   const sanitizedUrl = () => sanitizeUrl(to);
@@ -104,7 +110,7 @@ export const Link = (props: LinkProps) => {
       target="_blank"
     >
       {children}
-      {external && (
+      {external && !hideIcon && (
         <span
           className={cx(classes.iconContainer, {
             [classes.forceCopyColor]: forceCopyColor,

--- a/packages/manager/src/features/Support/Hively.tsx
+++ b/packages/manager/src/features/Support/Hively.tsx
@@ -1,5 +1,4 @@
-import { Theme } from '@mui/material/styles';
-import { makeStyles } from '@mui/styles';
+import Stack from '@mui/material/Stack';
 import { DateTime } from 'luxon';
 import * as React from 'react';
 
@@ -9,30 +8,6 @@ import { Typography } from 'src/components/Typography';
 import { parseAPIDate } from 'src/utilities/date';
 
 import { OFFICIAL_USERNAMES } from './ticketUtils';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  hivelyContainer: {
-    alignItems: 'center',
-    borderTop: `1px solid ${theme.color.grey2}`,
-    display: 'flex',
-    flexFlow: 'row nowrap',
-    margin: `${theme.spacing(3)} ${theme.spacing(1)} 0`,
-    paddingTop: theme.spacing(1),
-  },
-  hivelyImage: {
-    margin: 3,
-    width: '25px',
-  },
-  hivelyLink: {
-    color: theme.color.black,
-    marginRight: theme.spacing(2),
-    textDecoration: 'none',
-  },
-  hivelyLinkIcon: {
-    display: 'inline-block',
-    marginRight: theme.spacing(1),
-  },
-}));
 
 interface Props {
   linodeUsername: string;
@@ -65,24 +40,23 @@ export const shouldRenderHively = (
   }
 };
 
-export const Hively: React.FC<Props> = (props) => {
-  const classes = useStyles();
+export const Hively = (props: Props) => {
   const { linodeUsername, replyId, ticketId } = props;
   const href = `https://secure.teamhively.com/ratings/add/account/587/source/hs/ext/${linodeUsername}/ticket/${ticketId}-${replyId}/rating/`;
 
   return (
-    <div className={classes.hivelyContainer}>
+    <>
       <Divider />
-      <Typography component="span">
-        <Link className={classes.hivelyLink} external to={href + '3'}>
-          How did I do?
-        </Link>
-      </Typography>
-      <span>
+      <Stack alignItems="center" direction="row" pl={1} spacing={1.5}>
+        <Typography mr={3}>
+          <Link external to={href + '3'}>
+            How did I do?
+          </Link>
+        </Typography>
         <Link
           accessibleAriaLabel="Happy feedback"
-          className={classes.hivelyLinkIcon}
           external
+          hideIcon
           to={href + '3'}
         >
           <img
@@ -90,13 +64,12 @@ export const Hively: React.FC<Props> = (props) => {
               'https://secure.teamhively.com/system/smileys/icons/000/000/541/px_25/icon_positive.png'
             }
             alt="Happy face emoji"
-            className={classes.hivelyImage}
           />
         </Link>
         <Link
           accessibleAriaLabel="Mediocre feedback"
-          className={classes.hivelyLinkIcon}
           external
+          hideIcon
           to={href + '2'}
         >
           <img
@@ -104,13 +77,12 @@ export const Hively: React.FC<Props> = (props) => {
               'https://secure.teamhively.com/system/smileys/icons/000/000/542/px_25/icon_indifferent.png'
             }
             alt="Indifferent face emoji"
-            className={classes.hivelyImage}
           />
         </Link>
         <Link
           accessibleAriaLabel="Unhappy feedback"
-          className={classes.hivelyLinkIcon}
           external
+          hideIcon
           to={href + '1'}
         >
           <img
@@ -118,10 +90,9 @@ export const Hively: React.FC<Props> = (props) => {
               'https://secure.teamhively.com/system/smileys/icons/000/000/543/px_25/icon_negative.png'
             }
             alt="Sad Face emoji"
-            className={classes.hivelyImage}
           />
         </Link>
-      </span>
-    </div>
+      </Stack>
+    </>
   );
 };


### PR DESCRIPTION
## Description 📝
- Fixes Hively link visual bug 🎨
- Caused by https://github.com/linode/manager/pull/9411

## Major Changes 🔄
- Added `hideIcon` prop to the `<Link />` component for special cases like this
  - I probably could have used a plain `<a>` here but I figured we'd want to use `<Link />` for consistency
- Cleans up styles and fixes UI bug
- Remove use of `makeStyles`
- Removed use of `React.FC`

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-08-15 at 2 11 15 PM](https://github.com/linode/manager/assets/115251059/ace81023-3d95-4953-b6a9-f02e9523173a) | ![Screenshot 2023-08-15 at 2 11 02 PM](https://github.com/linode/manager/assets/115251059/d1726a1e-f59d-4956-b7e4-215397293874) |

## How to test 🧪
- You can either create a support ticket in the **dev** environment and respond to yourself OR just manually make this section render by modifying the code
- Verify that the Hively section looks better!