### PR TITLE
fix: [M3-6836] - Fix Firewalls Breadcrumb

### DIFF
--- a/packages/manager/.changeset/pr-9554-fixed-1692219454826.md
+++ b/packages/manager/.changeset/pr-9554-fixed-1692219454826.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Firewalls breadcrumb containing the firewall id ([#9554](https://github.com/linode/manager/pull/9554))

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -48,7 +48,7 @@ export const FirewallDetail = () => {
     },
   ];
 
-  const tabIndex = tab ? tabs.findIndex((t) => t.routeName.endsWith(tab)) : 0;
+  const tabIndex = tab ? tabs.findIndex((t) => t.routeName.endsWith(tab)) : -1;
 
   const { data: firewall, error, isLoading } = useFirewallQuery(firewallId);
 
@@ -102,7 +102,10 @@ export const FirewallDetail = () => {
         docsLink="https://linode.com/docs/platform/cloud-firewall/getting-started-with-cloud-firewall/"
         title="Firewall Details"
       />
-      <Tabs index={tabIndex} onChange={(i) => history.push(tabs[i].routeName)}>
+      <Tabs
+        index={tabIndex === -1 ? 0 : tabIndex}
+        onChange={(i) => history.push(tabs[i].routeName)}
+      >
         <TabLinkList tabs={tabs} />
 
         <TabPanels>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import {
-  matchPath,
-  useHistory,
-  useLocation,
-  useParams,
-  useRouteMatch,
-} from 'react-router-dom';
+import { useHistory, useParams } from 'react-router-dom';
 
 import { CircleProgress } from 'src/components/CircleProgress';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
@@ -30,9 +24,7 @@ const FirewallRulesLanding = React.lazy(
 );
 
 export const FirewallDetail = () => {
-  const { id } = useParams<{ id: string }>();
-  const { url } = useRouteMatch();
-  const location = useLocation();
+  const { id, tab } = useParams<{ id: string; tab?: string }>();
   const history = useHistory();
   const { data: profile } = useProfile();
   const { data: grants } = useGrants();
@@ -47,22 +39,16 @@ export const FirewallDetail = () => {
 
   const tabs = [
     {
-      routeName: `${url}/rules`,
+      routeName: `/firewalls/${id}/rules`,
       title: 'Rules',
     },
     {
-      routeName: `${url}/linodes`,
+      routeName: `/firewalls/${id}/linodes`,
       title: 'Linodes',
     },
   ];
 
-  const matches = (p: string) => {
-    return Boolean(matchPath(p, { path: location.pathname }));
-  };
-
-  const navToURL = (index: number) => {
-    history.push(tabs[index].routeName);
-  };
+  const tabIndex = tab ? tabs.findIndex((t) => t.routeName.endsWith(tab)) : 0;
 
   const { data: firewall, error, isLoading } = useFirewallQuery(firewallId);
 
@@ -110,19 +96,13 @@ export const FirewallDetail = () => {
             onCancel: resetEditableLabel,
             onEdit: handleLabelChange,
           },
-          pathname: location.pathname,
+          pathname: `/firewalls/${firewall.label}`,
         }}
         docsLabel="Docs"
         docsLink="https://linode.com/docs/platform/cloud-firewall/getting-started-with-cloud-firewall/"
         title="Firewall Details"
       />
-      <Tabs
-        index={Math.max(
-          tabs.findIndex((tab) => matches(tab.routeName)),
-          0
-        )}
-        onChange={navToURL}
-      >
+      <Tabs index={tabIndex} onChange={(i) => history.push(tabs[i].routeName)}>
         <TabLinkList tabs={tabs} />
 
         <TabPanels>

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useHistory, useRouteMatch } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 
 import { CircleProgress } from 'src/components/CircleProgress';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
@@ -26,6 +26,8 @@ import { FirewallRow } from './FirewallRow';
 const preferenceKey = 'firewalls';
 
 const FirewallLanding = () => {
+  const location = useLocation();
+  const history = useHistory();
   const pagination = usePagination(1, preferenceKey);
   const { handleOrderChange, order, orderBy } = useOrder(
     {
@@ -47,10 +49,7 @@ const FirewallLanding = () => {
 
   const { data, error, isLoading } = useFirewallsQuery(params, filter);
 
-  const [
-    isCreateFirewallDrawerOpen,
-    setIsCreateFirewallDrawerOpen,
-  ] = React.useState<boolean>(false);
+  const isCreateFirewallDrawerOpen = location.pathname.endsWith('create');
 
   const [isModalOpen, setIsModalOpen] = React.useState<boolean>(false);
   const [dialogMode, setDialogMode] = React.useState<Mode>('enable');
@@ -81,26 +80,13 @@ const FirewallLanding = () => {
     openModal('disable', id);
   };
 
-  const onOpenCreateDrawer = React.useCallback(
-    () => setIsCreateFirewallDrawerOpen(true),
-    [setIsCreateFirewallDrawerOpen]
-  );
+  const onOpenCreateDrawer = () => {
+    history.replace('/firewalls/create');
+  };
 
-  // On-the-fly route matching so this component can open the drawer itself.
-  const createFirewallRouteMatch = Boolean(useRouteMatch('/firewalls/create'));
-
-  React.useEffect(() => {
-    if (createFirewallRouteMatch) {
-      onOpenCreateDrawer();
-    }
-  }, [createFirewallRouteMatch, onOpenCreateDrawer]);
-
-  const { replace } = useHistory();
-
-  const closeDrawer = React.useCallback(() => {
-    setIsCreateFirewallDrawerOpen(false);
-    replace('/firewalls');
-  }, [setIsCreateFirewallDrawerOpen, replace]);
+  const onCloseCreateDrawer = () => {
+    history.replace('/firewalls');
+  };
 
   const handlers: FirewallHandlers = {
     triggerDeleteFirewall: handleOpenDeleteFirewallModal,
@@ -117,7 +103,7 @@ const FirewallLanding = () => {
       <>
         <FirewallLandingEmptyState openAddFirewallDrawer={onOpenCreateDrawer} />
         <CreateFirewallDrawer
-          onClose={() => setIsCreateFirewallDrawerOpen(false)}
+          onClose={onCloseCreateDrawer}
           open={isCreateFirewallDrawerOpen}
         />
       </>
@@ -184,7 +170,7 @@ const FirewallLanding = () => {
         pageSize={pagination.pageSize}
       />
       <CreateFirewallDrawer
-        onClose={closeDrawer}
+        onClose={onCloseCreateDrawer}
         open={isCreateFirewallDrawerOpen}
       />
       <FirewallDialog

--- a/packages/manager/src/features/Firewalls/index.tsx
+++ b/packages/manager/src/features/Firewalls/index.tsx
@@ -18,7 +18,7 @@ const Firewall = () => {
       <React.Fragment>
         <DocumentTitleSegment segment="Firewalls" />
         <Switch>
-          <Route component={FirewallLanding} exact path={`${path}(/create)?`} />
+          <Route component={FirewallLanding} exact path={`${path}/create`} />
           <Route component={FirewallDetail} path={`${path}/:id/:tab?`} />
           <Route component={FirewallLanding} />
         </Switch>

--- a/packages/manager/src/features/Firewalls/index.tsx
+++ b/packages/manager/src/features/Firewalls/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Route, RouteComponentProps, Switch } from 'react-router-dom';
+import { Route, Switch, useRouteMatch } from 'react-router-dom';
 
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { SuspenseLoader } from 'src/components/SuspenseLoader';
@@ -10,12 +10,8 @@ const FirewallLanding = React.lazy(
 
 const FirewallDetail = React.lazy(() => import('./FirewallDetail'));
 
-type Props = RouteComponentProps<{}>;
-
-const Firewall = (props: Props) => {
-  const {
-    match: { path },
-  } = props;
+const Firewall = () => {
+  const { path } = useRouteMatch();
 
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
@@ -23,7 +19,7 @@ const Firewall = (props: Props) => {
         <DocumentTitleSegment segment="Firewalls" />
         <Switch>
           <Route component={FirewallLanding} exact path={`${path}(/create)?`} />
-          <Route component={FirewallDetail} path={`${path}/:id`} />
+          <Route component={FirewallDetail} path={`${path}/:id/:tab?`} />
           <Route component={FirewallLanding} />
         </Switch>
       </React.Fragment>


### PR DESCRIPTION
## Description 📝
- Fixes the firewalls breadcrumb incorrectly containing the `id` 🍞
- Caused by https://github.com/linode/manager/pull/8856 I think

## Major Changes 🔄
- Clean up tabs logic to be more readable and simple 🧼
- Fix breadcrumb by passing it a pathname with the firewall's `label` 🍞
- Greatly improves the `/firewalls/create` routing code and behavior 🔗

## Preview 📷

| Before  | After   |
| ------- | ------- |
| Breadcrumb has `id` 😕 | Breadcrumb has only the `label` ✅ |
| ![Screenshot 2023-08-16 at 4 39 51 PM](https://github.com/linode/manager/assets/115251059/68b2b70c-519d-49c6-a1e2-b024c83417c6) | ![Screenshot 2023-08-16 at 4 39 38 PM](https://github.com/linode/manager/assets/115251059/d1f0f496-d256-4c07-a8eb-5ef3fead72b4) |
| Create drawer does not correlate with the URL 😕 | Create drawer is 1:1 with the URL ✅ |
| <video src="https://github.com/linode/manager/assets/115251059/bf949524-68d5-40aa-a884-48f599bca3b1"/> | <video src="https://github.com/linode/manager/assets/115251059/2bf4532c-8329-4b29-b702-f2f8f332d2e6"/> |

## How to test 🧪
- Test Firewall navigation in general
- Test that the firewall breadcrumb looks and works as expected
- Test the deep linking of `/firewalls/create` 🔗