### PR TITLE
chore: [M3-6691] - Add DC-specific pricing feature flag

### DIFF
--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -15,6 +15,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'databaseBeta', label: 'Database Beta' },
   { flag: 'vpc', label: 'VPC' },
   { flag: 'aglb', label: 'AGLB' },
+  { flag: 'dcSpecificPricing', label: 'DC-Specific Pricing' },
 ];
 
 const FeatureFlagTool: React.FC<{}> = () => {

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -41,9 +41,9 @@ type OneClickApp = Record<string, string>;
 export interface Flags {
   aglb: boolean;
   apiMaintenance: APIMaintenance;
-  selfServeBetas: boolean;
   databaseBeta: boolean;
   databases: boolean;
+  dcSpecificPricing: boolean;
   ipv6Sharing: boolean;
   kubernetesDashboardAvailability: boolean;
   mainContentBanner: MainContentBanner;
@@ -55,6 +55,7 @@ export interface Flags {
   promotionalOffers: PromotionalOffer[];
   referralBannerText: ReferralBannerText;
   regionDropdown: boolean;
+  selfServeBetas: boolean;
   taxBanner: TaxBanner;
   taxCollectionBanner: TaxCollectionBanner;
   taxes: Taxes;


### PR DESCRIPTION
## Description 📝
This flag gates our upcoming changes for DC-specific pricing. 

## Major Changes 🔄
- Creates the feature flag in Launch Darkly
- Adds the feature flag to `featureFlags.ts`
- Adds the feature flag to dev tools

## Preview 📷
![Screenshot 2023-08-17 at 9 34 49 AM](https://github.com/linode/manager/assets/114685994/d9161cdf-50b2-4321-8eb5-1b9d8e4e7b8e)

## How to test 🧪
1. **How to verify changes?**
- Check out this branch.
- Confirm the new feature flag is returned from Launch Darkly in the network requests of the browser dev tools.
- Confirm that DC-Specific Pricing shows up in the dev tools under the Feature Flags section. 
