### PR TITLE
refactor: [M3-6267] - MUI v5 Migration - `SRC > Features > GlobalNotifications`

### DIFF
--- a/packages/manager/src/features/GlobalNotifications/APIMaintenanceBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/APIMaintenanceBanner.tsx
@@ -13,7 +13,7 @@ interface Props {
   suppliedMaintenances: SuppliedMaintenanceData[] | undefined;
 }
 
-export const APIMaintenanceBanner: React.FC<Props> = (props) => {
+export const APIMaintenanceBanner = React.memo((props: Props) => {
   const { suppliedMaintenances } = props;
 
   const { data: maintenancesData } = useMaintenanceQuery({
@@ -92,6 +92,4 @@ export const APIMaintenanceBanner: React.FC<Props> = (props) => {
       )}
     </>
   );
-};
-
-export default React.memo(APIMaintenanceBanner);
+});

--- a/packages/manager/src/features/GlobalNotifications/ComplianceBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceBanner.tsx
@@ -10,7 +10,7 @@ import { useNotificationsQuery } from 'src/queries/accountNotifications';
 
 import { isEUModelContractNotification } from '../NotificationCenter/NotificationData/useFormattedNotifications';
 
-const ComplianceBanner = () => {
+export const ComplianceBanner = () => {
   const context = React.useContext(complianceUpdateContext);
   const { data: notifications } = useNotificationsQuery();
 
@@ -54,5 +54,3 @@ const StyledActionButton = styled(Button)(({}) => ({
   marginLeft: 12,
   minWidth: 150,
 }));
-
-export default ComplianceBanner;

--- a/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
@@ -12,7 +12,7 @@ import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
 import EUAgreementCheckbox from '../Account/Agreements/EUAgreementCheckbox';
 
-const ComplianceUpdateModal = () => {
+export const ComplianceUpdateModal = () => {
   const [error, setError] = React.useState('');
   const [checked, setChecked] = React.useState(false);
   const queryClient = useQueryClient();
@@ -93,5 +93,3 @@ const ComplianceUpdateModal = () => {
     </ConfirmationDialog>
   );
 };
-
-export default ComplianceUpdateModal;

--- a/packages/manager/src/features/GlobalNotifications/EmailBounce.styles.tsx
+++ b/packages/manager/src/features/GlobalNotifications/EmailBounce.styles.tsx
@@ -1,0 +1,22 @@
+import { styled } from '@mui/material/styles';
+import Grid from '@mui/material/Unstable_Grid2';
+
+import { Button } from 'src/components/Button/Button';
+
+export const StyledGrid = styled(Grid, { label: 'StyledGrid' })(
+  ({ theme }) => ({
+    justifyContent: 'flex-end',
+    [theme.breakpoints.down('md')]: {
+      justifyContent: 'flex-start',
+      marginBottom: theme.spacing(0.5),
+      marginLeft: 2,
+      marginTop: theme.spacing(1),
+    },
+  })
+);
+
+export const StyledButton = styled(Button, { label: 'StyledButton' })(
+  ({ theme }) => ({
+    marginLeft: theme.spacing(2),
+  })
+);

--- a/packages/manager/src/features/GlobalNotifications/EmailBounce.tsx
+++ b/packages/manager/src/features/GlobalNotifications/EmailBounce.tsx
@@ -1,7 +1,6 @@
 import Grid from '@mui/material/Unstable_Grid2';
-import { Theme } from '@mui/material/styles';
+import { useTheme, Theme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import { makeStyles, useTheme } from '@mui/styles';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
@@ -12,6 +11,7 @@ import { Typography } from 'src/components/Typography';
 import { useAccount, useMutateAccount } from 'src/queries/account';
 import { useNotificationsQuery } from 'src/queries/accountNotifications';
 import { useMutateProfile, useProfile } from 'src/queries/profile';
+import { StyledButton, StyledGrid } from './EmailBounce.styles';
 
 // =============================================================================
 // <EmailBounceNotificationSection />
@@ -85,20 +85,6 @@ export const EmailBounceNotificationSection = React.memo(() => {
 // =============================================================================
 // <EmailBounceNotification />
 // =============================================================================
-const useEmailBounceNotificationStyles = makeStyles((theme: Theme) => ({
-  buttonContainer: {
-    justifyContent: 'flex-end',
-    [theme.breakpoints.down('md')]: {
-      justifyContent: 'flex-start',
-      marginBottom: 4,
-      marginLeft: 2,
-      marginTop: 8,
-    },
-  },
-  updateButton: {
-    marginLeft: 16,
-  },
-}));
 
 interface Props {
   changeEmail: () => void;
@@ -108,8 +94,6 @@ interface Props {
 
 const EmailBounceNotification = React.memo((props: Props) => {
   const { changeEmail, confirmEmail, text } = props;
-
-  const classes = useEmailBounceNotificationStyles();
 
   const { enqueueSnackbar } = useSnackbar();
 
@@ -148,13 +132,7 @@ const EmailBounceNotification = React.memo((props: Props) => {
         <Grid lg={8} md={6} xs={12}>
           {text}
         </Grid>
-        <Grid
-          className={classes.buttonContainer}
-          container
-          lg={4}
-          md={6}
-          xs={12}
-        >
+        <StyledGrid container lg={4} md={6} xs={12}>
           <Button
             buttonType="primary"
             data-testid="confirmButton"
@@ -163,15 +141,14 @@ const EmailBounceNotification = React.memo((props: Props) => {
           >
             {confirmationText}
           </Button>
-          <Button
+          <StyledButton
             buttonType="secondary"
-            className={classes.updateButton}
             data-testid="updateButton"
             onClick={changeEmail}
           >
             {updateText}
-          </Button>
-        </Grid>
+          </StyledButton>
+        </StyledGrid>
       </Grid>
     </Notice>
   );

--- a/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
+++ b/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
@@ -6,11 +6,11 @@ import { useDismissibleNotifications } from 'src/hooks/useDismissibleNotificatio
 import { useFlags } from 'src/hooks/useFlags';
 
 import { APIMaintenanceBanner } from './APIMaintenanceBanner';
-import ComplianceBanner from './ComplianceBanner';
-import ComplianceUpdateModal from './ComplianceUpdateModal';
+import { ComplianceBanner } from './ComplianceBanner';
+import { ComplianceUpdateModal } from './ComplianceUpdateModal';
 import { EmailBounceNotificationSection } from './EmailBounce';
-import RegionStatusBanner from './RegionStatusBanner';
-import TaxCollectionBanner from './TaxCollectionBanner';
+import { RegionStatusBanner } from './RegionStatusBanner';
+import { TaxCollectionBanner } from './TaxCollectionBanner';
 
 export const GlobalNotifications = () => {
   const flags = useFlags();

--- a/packages/manager/src/features/GlobalNotifications/RegionStatusBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/RegionStatusBanner.tsx
@@ -1,14 +1,9 @@
-import { Region } from '@linode/api-v4/lib/regions/types';
 import * as React from 'react';
 
 import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
 import { Typography } from 'src/components/Typography';
 import { useRegionsQuery } from 'src/queries/regions';
-
-export interface Props {
-  regions: Region[];
-}
 
 const getFacilitiesList = (warnings: string[]) => (
   <ul>
@@ -57,7 +52,7 @@ const renderBanner = (statusWarnings: string[]): JSX.Element => {
   );
 };
 
-export const RegionStatusBanner = () => {
+export const RegionStatusBanner = React.memo(() => {
   const { data: regions } = useRegionsQuery();
 
   const labelsOfRegionsWithOutages = regions
@@ -73,6 +68,4 @@ export const RegionStatusBanner = () => {
       {renderBanner(labelsOfRegionsWithOutages)}
     </Notice>
   );
-};
-
-export default React.memo(RegionStatusBanner);
+});

--- a/packages/manager/src/features/GlobalNotifications/TaxCollectionBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/TaxCollectionBanner.tsx
@@ -1,5 +1,4 @@
-import { Theme } from '@mui/material/styles';
-import { makeStyles } from '@mui/styles';
+import { styled } from '@mui/material/styles';
 import { DateTime } from 'luxon';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
@@ -11,16 +10,7 @@ import { Typography } from 'src/components/Typography';
 import { useFlags } from 'src/hooks/useFlags';
 import { useAccount } from 'src/queries/account';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  button: {
-    marginLeft: theme.spacing(2),
-    minWidth: 140,
-    whiteSpace: 'nowrap',
-  },
-}));
-
-const TaxCollectionBanner = () => {
-  const classes = useStyles();
+export const TaxCollectionBanner = () => {
   const history = useHistory();
   const flags = useFlags();
 
@@ -63,13 +53,12 @@ const TaxCollectionBanner = () => {
     bannerRegions.length > 0 && bannerRegions.includes(account.state);
 
   const actionButton = bannerHasAction ? (
-    <Button
+    <StyledButton
       buttonType="primary"
-      className={classes.button}
       onClick={() => history.push('/account/billing/edit')}
     >
       Update Tax ID
-    </Button>
+    </StyledButton>
   ) : undefined;
 
   return (isEntireCountryTaxable || isUserInTaxableRegion) &&
@@ -92,4 +81,10 @@ const TaxCollectionBanner = () => {
   ) : null;
 };
 
-export default TaxCollectionBanner;
+const StyledButton = styled(Button, { label: 'StyledButton ' })(
+  ({ theme }) => ({
+    marginLeft: theme.spacing(2),
+    minWidth: 140,
+    whiteSpace: 'nowrap',
+  })
+);


### PR DESCRIPTION
## Description 📝
 - part of MUI v5 overall refactor and cleanup: converted styles to styled components, removed React.FC and default exports

## How to test 🧪
- Verify that global notifications functionality and appearance of APIMaintenanceBanner, ComplianceBanner, ComplianceUpdateModal, EmailBounce, GlobalNotifications, RegionStatusBanner, and TaxCollectionBanner is the same (only EmailBounce and TaxCollectionBanner had styling conversions)

**Example:** `feat: [M3-1234] - Allow user to view their login history`
