### PR TITLE
fix: [M3-7040] - Longview crashing the app with a negative number of CPU cores

### DIFF
--- a/packages/manager/.changeset/pr-9563-fixed-1692305293304.md
+++ b/packages/manager/.changeset/pr-9563-fixed-1692305293304.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Longview crashing the app with a negative number of CPU cores ([#9563](https://github.com/linode/manager/pull/9563))

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
@@ -83,6 +83,11 @@ export const sumCPUUsage = (CPUData: Record<string, CPU> = {}) => {
 };
 
 export const normalizeValue = (value: number, numCores: number) => {
+  // Clamp with throw if `max` is less than `min` and as of Aug 17th, 2023,
+  // the Longview service allows users to have a negative number of cores.
+  if (numCores < 0) {
+    return 0;
+  }
   const clamped = clamp(0, 100 * numCores)(value);
   return Math.round(clamped);
 };


### PR DESCRIPTION
## Description 📝
- Cloud Manager would crash for a Longview client with a negative number of cores
  - I don't know why we allow users to have a negative number of cores 😅
 
## Major Changes 🔄
- Make sure `clamp` won't throw

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-08-17 at 4 41 04 PM](https://github.com/linode/manager/assets/115251059/a00f04f8-d647-4aee-8e7f-49430007da81) | ![Screenshot 2023-08-17 at 4 40 26 PM](https://github.com/linode/manager/assets/115251059/0f36c4d6-51d2-451c-a841-0941dfa3dbce) |

## How to test 🧪
- Create a Debian 10 (or similar) Linode
- Create a Longview client and set it up with that Linode you just created
  - It's super easy, don't worry!
- Edit `/opt/linode/longview/Linode/Longview/DataGetter/SysInfo.pm` and change line 67 from `my $cores = grep {/processor/} @cpu_info;` to `my $cores = -1;`
- Start the Longview process with `service longview start`
- Go to your Longview client in cloud manager and verify you see `-1` cores and no crash