### PR TITLE
feat: [M3-7037] Introduce dynamic pricing utils

### DIFF
--- a/packages/manager/.changeset/pr-9564-added-1692350316540.md
+++ b/packages/manager/.changeset/pr-9564-added-1692350316540.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Introduce Introduce dynamic pricing utils and constants ([#9564](https://github.com/linode/manager/pull/9564))

--- a/packages/manager/.changeset/pr-9564-added-1692350316540.md
+++ b/packages/manager/.changeset/pr-9564-added-1692350316540.md
@@ -1,5 +1,5 @@
 ---
-"@linode/manager": Added
+"@linode/manager": Upcoming Features
 ---
 
-Introduce Introduce dynamic pricing utils and constants ([#9564](https://github.com/linode/manager/pull/9564))
+Introduce dynamic pricing utils and constants ([#9564](https://github.com/linode/manager/pull/9564))

--- a/packages/manager/src/utilities/pricing/constants.ts
+++ b/packages/manager/src/utilities/pricing/constants.ts
@@ -1,10 +1,6 @@
 // These values will eventually come from the API, but for now they are hardcoded and
 // used to generate the region based dynamic pricing.
 
-// I am unsure where this value is actually coming from and if it should be included here
-// TODO - DYNAMIC_PRICING: confirm this should be hardcoded
-export const BACKUP_PRICE = 5;
-
 export const NODEBALANCER_PRICE = 10;
 
 export const LKE_HA_PRICE = 60;

--- a/packages/manager/src/utilities/pricing/constants.ts
+++ b/packages/manager/src/utilities/pricing/constants.ts
@@ -1,0 +1,10 @@
+// These values will eventually come from the API, but for now they are hardcoded and
+// used to generate the region based dynamic pricing.
+
+// I am unsure where this value is actually coming from and if it should be included here
+// TODO - DYNAMIC_PRICING: confirm this should be hardcoded
+export const BACKUP_PRICE = 5;
+
+export const NODEBALANCER_PRICE = 10;
+
+export const LKE_HA_PRICE = 60;

--- a/packages/manager/src/utilities/pricing/dynamicPricing.test.tsx
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.test.tsx
@@ -1,8 +1,8 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
 
+import { BACKUP_PRICE } from './constants';
 import { getDCSpecificPricingDisplay } from './dynamicPricing';
-import { getBackupPrice } from './entityPricing';
 
 import type { DataCenterPricingProps } from './dynamicPricing';
 
@@ -19,7 +19,7 @@ describe('getDCSpecificPricingDisplay', () => {
 
     const priceElement = getByTestId('price');
     expect(priceElement).toBeInTheDocument();
-    expect(priceElement.textContent).toBe(getBackupPrice().toFixed(2));
+    expect(priceElement.textContent).toBe(BACKUP_PRICE.toFixed(2));
   });
 
   it('calculates dynamic pricing for a region with an increase', () => {

--- a/packages/manager/src/utilities/pricing/dynamicPricing.test.tsx
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.test.tsx
@@ -7,7 +7,7 @@ import { getBackupPrice } from './entityPricing';
 import type { DataCenterPricingProps } from './dynamicPricing';
 
 describe('getDCSpecificPricingDisplay', () => {
-  it('calculates dynamic pricing for a region without an upcost', () => {
+  it('calculates dynamic pricing for a region without an increase', () => {
     const props: DataCenterPricingProps = {
       entity: 'Backup',
       regionId: 'us-east',
@@ -22,7 +22,7 @@ describe('getDCSpecificPricingDisplay', () => {
     expect(priceElement.textContent).toBe(getBackupPrice().toFixed(2));
   });
 
-  it('calculates dynamic pricing for a region with an upcost', () => {
+  it('calculates dynamic pricing for a region with an increase', () => {
     const props: DataCenterPricingProps = {
       entity: 'Volume',
       regionId: 'id-cgk',

--- a/packages/manager/src/utilities/pricing/dynamicPricing.test.tsx
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.test.tsx
@@ -1,0 +1,56 @@
+import { render } from '@testing-library/react';
+import * as React from 'react';
+
+import { getDCSpecificPricingDisplay } from './dynamicPricing';
+
+import type { DataCenterPricingProps } from './dynamicPricing';
+
+import { getBackupPrice } from './entityPricing';
+
+describe('getDCSpecificPricingDisplay', () => {
+  it('calculates dynamic pricing for a region without an upcost', () => {
+    const props: DataCenterPricingProps = {
+      entity: 'Backup',
+      regionId: 'us-east',
+    };
+
+    const { getByTestId } = render(
+      <div data-testid="price">{getDCSpecificPricingDisplay(props)}</div>
+    );
+
+    const priceElement = getByTestId('price');
+    expect(priceElement).toBeInTheDocument(); // Make sure the element is in the document
+    expect(priceElement.textContent).toBe(getBackupPrice().toFixed(2));
+  });
+
+  it('calculates dynamic pricing for a region with an upcost', () => {
+    const props: DataCenterPricingProps = {
+      entity: 'Volume',
+      regionId: 'id-cgk',
+      size: 20,
+    };
+
+    const { getByTestId } = render(
+      <div data-testid="price">{getDCSpecificPricingDisplay(props)}</div>
+    );
+
+    const priceElement = getByTestId('price');
+    expect(priceElement).toBeInTheDocument(); // Make sure the element is in the document
+    expect(priceElement.textContent).toBe('2.40');
+  });
+
+  it('handles default case correctly', () => {
+    const props: DataCenterPricingProps = {
+      entity: 'InvalidEntity' as DataCenterPricingProps['entity'],
+      regionId: 'invalid-region',
+    };
+
+    const { getByTestId } = render(
+      <div data-testid="price">{getDCSpecificPricingDisplay(props)}</div>
+    );
+
+    const priceElement = getByTestId('price');
+    expect(priceElement).toBeInTheDocument(); // Make sure the element is in the document
+    expect(priceElement.textContent).toBe('0.00');
+  });
+});

--- a/packages/manager/src/utilities/pricing/dynamicPricing.test.tsx
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.test.tsx
@@ -2,10 +2,9 @@ import { render } from '@testing-library/react';
 import * as React from 'react';
 
 import { getDCSpecificPricingDisplay } from './dynamicPricing';
+import { getBackupPrice } from './entityPricing';
 
 import type { DataCenterPricingProps } from './dynamicPricing';
-
-import { getBackupPrice } from './entityPricing';
 
 describe('getDCSpecificPricingDisplay', () => {
   it('calculates dynamic pricing for a region without an upcost', () => {
@@ -19,7 +18,7 @@ describe('getDCSpecificPricingDisplay', () => {
     );
 
     const priceElement = getByTestId('price');
-    expect(priceElement).toBeInTheDocument(); // Make sure the element is in the document
+    expect(priceElement).toBeInTheDocument();
     expect(priceElement.textContent).toBe(getBackupPrice().toFixed(2));
   });
 
@@ -35,7 +34,7 @@ describe('getDCSpecificPricingDisplay', () => {
     );
 
     const priceElement = getByTestId('price');
-    expect(priceElement).toBeInTheDocument(); // Make sure the element is in the document
+    expect(priceElement).toBeInTheDocument();
     expect(priceElement.textContent).toBe('2.40');
   });
 
@@ -50,7 +49,7 @@ describe('getDCSpecificPricingDisplay', () => {
     );
 
     const priceElement = getByTestId('price');
-    expect(priceElement).toBeInTheDocument(); // Make sure the element is in the document
+    expect(priceElement).toBeInTheDocument();
     expect(priceElement.textContent).toBe('0.00');
   });
 });

--- a/packages/manager/src/utilities/pricing/dynamicPricing.test.tsx
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.test.tsx
@@ -1,44 +1,41 @@
-import { BACKUP_PRICE } from './constants';
-import { getDCSpecificPricingDisplay } from './dynamicPricing';
+import { getDCSpecificPrice } from './dynamicPricing';
+import { getVolumePrice } from './entityPricing';
 
 describe('getDCSpecificPricingDisplay', () => {
   it('calculates dynamic pricing for a region without an increase', () => {
     expect(
-      getDCSpecificPricingDisplay({
-        entity: 'Backup',
+      getDCSpecificPrice({
+        basePrice: getVolumePrice(20),
         flags: { dcSpecificPricing: true },
         regionId: 'us-east',
       })
-    ).toBe(BACKUP_PRICE.toFixed(2));
+    ).toBe('2.00');
   });
 
   it('calculates dynamic pricing for a region with an increase', () => {
     expect(
-      getDCSpecificPricingDisplay({
-        entity: 'Volume',
+      getDCSpecificPrice({
+        basePrice: getVolumePrice(20),
         flags: { dcSpecificPricing: true },
         regionId: 'id-cgk',
-        size: 20,
       })
     ).toBe('2.40');
   });
 
   it('does not apply dc specific pricing when flag is off', () => {
     expect(
-      getDCSpecificPricingDisplay({
-        entity: 'Volume',
+      getDCSpecificPrice({
+        basePrice: getVolumePrice(20),
         flags: { dcSpecificPricing: false },
         regionId: 'id-cgk',
-        size: 20,
       })
     ).toBe('2.00');
   });
 
   it('handles default case correctly', () => {
     expect(
-      getDCSpecificPricingDisplay({
-        // @ts-expect-error intentionally breaking type to verify the function works
-        entity: 'InvalidEntity',
+      getDCSpecificPrice({
+        basePrice: 0,
         flags: { dcSpecificPricing: true },
         regionId: 'invalid-region',
       })

--- a/packages/manager/src/utilities/pricing/dynamicPricing.test.tsx
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.test.tsx
@@ -6,6 +6,7 @@ describe('getDCSpecificPricingDisplay', () => {
     expect(
       getDCSpecificPricingDisplay({
         entity: 'Backup',
+        flags: { dcSpecificPricing: true },
         regionId: 'us-east',
       })
     ).toBe(BACKUP_PRICE.toFixed(2));
@@ -15,10 +16,22 @@ describe('getDCSpecificPricingDisplay', () => {
     expect(
       getDCSpecificPricingDisplay({
         entity: 'Volume',
+        flags: { dcSpecificPricing: true },
         regionId: 'id-cgk',
         size: 20,
       })
     ).toBe('2.40');
+  });
+
+  it('does not apply dc specific pricing when flag is off', () => {
+    expect(
+      getDCSpecificPricingDisplay({
+        entity: 'Volume',
+        flags: { dcSpecificPricing: false },
+        regionId: 'id-cgk',
+        size: 20,
+      })
+    ).toBe('2.00');
   });
 
   it('handles default case correctly', () => {
@@ -26,6 +39,7 @@ describe('getDCSpecificPricingDisplay', () => {
       getDCSpecificPricingDisplay({
         // @ts-expect-error intentionally breaking type to verify the function works
         entity: 'InvalidEntity',
+        flags: { dcSpecificPricing: true },
         regionId: 'invalid-region',
       })
     ).toBe('0.00');

--- a/packages/manager/src/utilities/pricing/dynamicPricing.test.tsx
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.test.tsx
@@ -4,11 +4,11 @@ import * as React from 'react';
 import { BACKUP_PRICE } from './constants';
 import { getDCSpecificPricingDisplay } from './dynamicPricing';
 
-import type { DataCenterPricingProps } from './dynamicPricing';
+import type { DataCenterPricingOptions } from './dynamicPricing';
 
 describe('getDCSpecificPricingDisplay', () => {
   it('calculates dynamic pricing for a region without an increase', () => {
-    const props: DataCenterPricingProps = {
+    const props: DataCenterPricingOptions = {
       entity: 'Backup',
       regionId: 'us-east',
     };
@@ -23,7 +23,7 @@ describe('getDCSpecificPricingDisplay', () => {
   });
 
   it('calculates dynamic pricing for a region with an increase', () => {
-    const props: DataCenterPricingProps = {
+    const props: DataCenterPricingOptions = {
       entity: 'Volume',
       regionId: 'id-cgk',
       size: 20,
@@ -39,8 +39,8 @@ describe('getDCSpecificPricingDisplay', () => {
   });
 
   it('handles default case correctly', () => {
-    const props: DataCenterPricingProps = {
-      entity: 'InvalidEntity' as DataCenterPricingProps['entity'],
+    const props: DataCenterPricingOptions = {
+      entity: 'InvalidEntity' as DataCenterPricingOptions['entity'],
       regionId: 'invalid-region',
     };
 

--- a/packages/manager/src/utilities/pricing/dynamicPricing.test.tsx
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.test.tsx
@@ -1,55 +1,33 @@
-import { render } from '@testing-library/react';
-import * as React from 'react';
-
 import { BACKUP_PRICE } from './constants';
 import { getDCSpecificPricingDisplay } from './dynamicPricing';
 
-import type { DataCenterPricingOptions } from './dynamicPricing';
-
 describe('getDCSpecificPricingDisplay', () => {
   it('calculates dynamic pricing for a region without an increase', () => {
-    const props: DataCenterPricingOptions = {
-      entity: 'Backup',
-      regionId: 'us-east',
-    };
-
-    const { getByTestId } = render(
-      <div data-testid="price">{getDCSpecificPricingDisplay(props)}</div>
-    );
-
-    const priceElement = getByTestId('price');
-    expect(priceElement).toBeInTheDocument();
-    expect(priceElement.textContent).toBe(BACKUP_PRICE.toFixed(2));
+    expect(
+      getDCSpecificPricingDisplay({
+        entity: 'Backup',
+        regionId: 'us-east',
+      })
+    ).toBe(BACKUP_PRICE.toFixed(2));
   });
 
   it('calculates dynamic pricing for a region with an increase', () => {
-    const props: DataCenterPricingOptions = {
-      entity: 'Volume',
-      regionId: 'id-cgk',
-      size: 20,
-    };
-
-    const { getByTestId } = render(
-      <div data-testid="price">{getDCSpecificPricingDisplay(props)}</div>
-    );
-
-    const priceElement = getByTestId('price');
-    expect(priceElement).toBeInTheDocument();
-    expect(priceElement.textContent).toBe('2.40');
+    expect(
+      getDCSpecificPricingDisplay({
+        entity: 'Volume',
+        regionId: 'id-cgk',
+        size: 20,
+      })
+    ).toBe('2.40');
   });
 
   it('handles default case correctly', () => {
-    const props: DataCenterPricingOptions = {
-      entity: 'InvalidEntity' as DataCenterPricingOptions['entity'],
-      regionId: 'invalid-region',
-    };
-
-    const { getByTestId } = render(
-      <div data-testid="price">{getDCSpecificPricingDisplay(props)}</div>
-    );
-
-    const priceElement = getByTestId('price');
-    expect(priceElement).toBeInTheDocument();
-    expect(priceElement.textContent).toBe('0.00');
+    expect(
+      getDCSpecificPricingDisplay({
+        // @ts-expect-error intentionally breaking type to verify the function works
+        entity: 'InvalidEntity',
+        regionId: 'invalid-region',
+      })
+    ).toBe('0.00');
   });
 });

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -8,8 +8,8 @@ import {
 import type { Region } from '@linode/api-v4';
 
 interface CalculatePriceProps {
+  increaseValue: IncreaseValue;
   initialPrice: number;
-  upcostValue: UpcostValue;
 }
 
 export interface DataCenterPricingProps {
@@ -18,22 +18,22 @@ export interface DataCenterPricingProps {
   size?: number;
 }
 
-enum UpcostRegion {
+enum IncreasedRegion {
   jakarta = 'id-cgk',
   saoPaulo = 'br-gru',
 }
 
 /**
- * The UpcostValue represents a percentage of the initial price.
+ * The IncreaseValue represents a percentage of the initial price.
  * We may want to be able to control this value from a flag before being able to fetch it from the API.
  */
-enum UpcostValue {
-  jakartaUpcost = 20,
-  saoPauloUpcost = 30,
+enum IncreaseValue {
+  jakarta = 20,
+  saoPaulo = 30,
 }
 
 /**
- * This function is used to calculate the dynamic pricing for a given entity, based on potential region upcosts.
+ * This function is used to calculate the dynamic pricing for a given entity, based on potential region increased costs.
  * @param entity The entity to calculate pricing for.
  * @param region The region to calculate pricing for.
  * @param size An optional size value for entities that require it for field validation (ex: Volumes).
@@ -50,8 +50,8 @@ export const getDCSpecificPricingDisplay = ({
   regionId,
   size,
 }: DataCenterPricingProps) => {
-  const isJakarta: boolean = regionId === UpcostRegion.jakarta;
-  const isSaoPaulo: boolean = regionId === UpcostRegion.saoPaulo;
+  const isJakarta: boolean = regionId === IncreasedRegion.jakarta;
+  const isSaoPaulo: boolean = regionId === IncreasedRegion.saoPaulo;
   const backupPrice = getBackupPrice();
   const lkePrice = getLKEClusterHAPrice();
   const nodeBalancerPrice = getNodeBalancerPrice();
@@ -60,13 +60,13 @@ export const getDCSpecificPricingDisplay = ({
   const getDynamicPrice = (initialPrice: number): string => {
     if (isJakarta) {
       return calculatePrice({
+        increaseValue: IncreaseValue.jakarta,
         initialPrice,
-        upcostValue: UpcostValue.jakartaUpcost,
       });
     } else if (isSaoPaulo) {
       return calculatePrice({
+        increaseValue: IncreaseValue.saoPaulo,
         initialPrice,
-        upcostValue: UpcostValue.saoPauloUpcost,
       });
     } else {
       return initialPrice.toFixed(2);
@@ -87,9 +87,12 @@ export const getDCSpecificPricingDisplay = ({
   }
 };
 
-const calculatePrice = ({ initialPrice, upcostValue }: CalculatePriceProps) => {
+const calculatePrice = ({
+  increaseValue,
+  initialPrice,
+}: CalculatePriceProps) => {
   const price = Number(initialPrice);
-  const upcost = price * (upcostValue / 100);
+  const increase = price * (increaseValue / 100);
 
-  return (price + upcost).toFixed(2);
+  return (price + increase).toFixed(2);
 };

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -1,9 +1,6 @@
-import {
-  getBackupPrice,
-  getLKEClusterHAPrice,
-  getNodeBalancerPrice,
-  getVolumePrice,
-} from 'src/utilities/pricing/entityPricing';
+import { getVolumePrice } from 'src/utilities/pricing/entityPricing';
+
+import { BACKUP_PRICE, LKE_HA_PRICE, NODEBALANCER_PRICE } from './constants';
 
 import type { Region } from '@linode/api-v4';
 
@@ -36,7 +33,7 @@ enum IncreaseValue {
  * This function is used to calculate the dynamic pricing for a given entity, based on potential region increased costs.
  * @param entity The entity to calculate pricing for.
  * @param region The region to calculate pricing for.
- * @param size An optional size value for entities that require it for field validation (ex: Volumes).
+ * @param size An optional size value for entities that require it for price based on it (ex: Volume).
  * @example
  * const price = getDCSpecificPricing({
  *   entity: 'Volume',
@@ -52,9 +49,6 @@ export const getDCSpecificPricingDisplay = ({
 }: DataCenterPricingProps) => {
   const isJakarta: boolean = regionId === IncreasedRegion.jakarta;
   const isSaoPaulo: boolean = regionId === IncreasedRegion.saoPaulo;
-  const backupPrice = getBackupPrice();
-  const lkePrice = getLKEClusterHAPrice();
-  const nodeBalancerPrice = getNodeBalancerPrice();
   const volumePrice: number = getVolumePrice(size);
 
   const getDynamicPrice = (initialPrice: number): string => {
@@ -75,11 +69,11 @@ export const getDCSpecificPricingDisplay = ({
 
   switch (entity) {
     case 'Backup':
-      return getDynamicPrice(backupPrice);
+      return getDynamicPrice(BACKUP_PRICE);
     case 'LKE HA':
-      return getDynamicPrice(lkePrice);
+      return getDynamicPrice(LKE_HA_PRICE);
     case 'Nodebalancer':
-      return getDynamicPrice(nodeBalancerPrice);
+      return getDynamicPrice(NODEBALANCER_PRICE);
     case 'Volume':
       return getDynamicPrice(volumePrice);
     default:

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -50,7 +50,6 @@ export const getDCSpecificPricingDisplay = ({
   regionId,
   size,
 }: DataCenterPricingProps) => {
-  let price;
   const isJakarta: boolean = regionId === UpcostRegion.jakarta;
   const isSaoPaulo: boolean = regionId === UpcostRegion.saoPaulo;
   const backupPrice = getBackupPrice();
@@ -76,23 +75,16 @@ export const getDCSpecificPricingDisplay = ({
 
   switch (entity) {
     case 'Backup':
-      price = getDynamicPrice(backupPrice);
-      break;
+      return getDynamicPrice(backupPrice);
     case 'LKE HA':
-      price = getDynamicPrice(lkePrice);
-      break;
+      return getDynamicPrice(lkePrice);
     case 'Nodebalancer':
-      price = getDynamicPrice(nodeBalancerPrice);
-      break;
+      return getDynamicPrice(nodeBalancerPrice);
     case 'Volume':
-      price = getDynamicPrice(volumePrice);
-      break;
-
+      return getDynamicPrice(volumePrice);
     default:
-      price = '0.00';
+      return '0.00';
   }
-
-  return price;
 };
 
 const calculatePrice = ({ initialPrice, upcostValue }: CalculatePriceProps) => {

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -1,0 +1,103 @@
+import {
+  getBackupPrice,
+  getLKEClusterHAPrice,
+  getNodeBalancerPrice,
+  getVolumePrice,
+} from 'src/utilities/pricing/entityPricing';
+
+import type { Region } from '@linode/api-v4';
+
+interface CalculatePriceProps {
+  initialPrice: number;
+  upcostValue: UpcostValue;
+}
+
+interface DataCenterPricingProps {
+  entity: 'Backup' | 'LKE HA' | 'Nodebalancer' | 'Volume';
+  regionId: Region['id'];
+  value: number;
+}
+
+enum UpcostRegion {
+  jakarta = 'id-cgk',
+  saoPaulo = 'br-gru',
+}
+
+/**
+ * The UpcostValue represents a percentage of the initial price.
+ * We may want to be able to control this value from a flag before being able to fetch it from the API.
+ */
+enum UpcostValue {
+  jakartaUpcost = 20,
+  saoPauloUpcost = 30,
+}
+
+/**
+ * This function is used to calculate the dynamic pricing for a given entity, based on potential region upcosts.
+ * @param entity The entity to calculate pricing for.
+ * @param region The region to calculate pricing for.
+ * @param value The value to calculate pricing for.
+ * @example
+ * const price = getDCSpecificPricing({
+ *   entity: 'Volume',
+ *   regionId: 'us-east-1a',
+ *   value: 20,
+ * });
+ * @returns
+ */
+export const getDCSpecificPricingDisplay = ({
+  entity,
+  regionId,
+  value,
+}: DataCenterPricingProps) => {
+  let price;
+  const isJakarta: boolean = regionId === UpcostRegion.jakarta;
+  const isSaoPaulo: boolean = regionId === UpcostRegion.saoPaulo;
+  const backupPrice = getBackupPrice();
+  const lkePrice = getLKEClusterHAPrice();
+  const nodeBalancerPrice = getNodeBalancerPrice();
+  const volumePrice: number = getVolumePrice(value);
+
+  const getDynamicPrice = (initialPrice: number): string => {
+    if (isJakarta) {
+      return calculatePrice({
+        initialPrice,
+        upcostValue: UpcostValue.jakartaUpcost,
+      });
+    } else if (isSaoPaulo) {
+      return calculatePrice({
+        initialPrice,
+        upcostValue: UpcostValue.saoPauloUpcost,
+      });
+    } else {
+      return initialPrice.toFixed(2);
+    }
+  };
+
+  switch (entity) {
+    case 'Backup':
+      price = getDynamicPrice(backupPrice);
+      break;
+    case 'LKE HA':
+      price = getDynamicPrice(lkePrice);
+      break;
+    case 'Nodebalancer':
+      price = getDynamicPrice(nodeBalancerPrice);
+      break;
+    case 'Volume':
+      price = getDynamicPrice(volumePrice);
+      break;
+
+    default:
+      price = '0.00';
+  }
+
+  return price;
+};
+
+const calculatePrice = ({ initialPrice, upcostValue }: CalculatePriceProps) => {
+  const price = Number(initialPrice);
+  const upcost = price * (upcostValue / 100);
+
+  return (price + upcost).toFixed(2);
+};

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -2,8 +2,20 @@ import type { Region } from '@linode/api-v4';
 import type { FlagSet } from 'src/featureFlags';
 
 export interface DataCenterPricingOptions {
+  /**
+   * The base price for an entity.
+   * @example 5.00
+   */
   basePrice: number;
+  /**
+   * Our feature flags so we can determined whether or not to add price increase.
+   * @example { dcSpecificPricing: true }
+   */
   flags: FlagSet;
+  /**
+   * The `id` of the region we intended to get the price for.
+   * @example us-east
+   */
   regionId: Region['id'];
 }
 
@@ -16,9 +28,6 @@ const priceIncreaseMap = {
 
 /**
  * This function is used to calculate the dynamic pricing for a given entity, based on potential region increased costs.
- * @param entity The entity to calculate pricing for.
- * @param region The region to calculate pricing for.
- * @param size An optional size value for entities that require it for price based on it (ex: Volume).
  * @example
  * const price = getDCSpecificPrice({
  *   basePrice: getVolumePrice(20),
@@ -40,7 +49,7 @@ export const getDCSpecificPrice = ({
 
   if (increaseFactor !== undefined) {
     // If increaseFactor is defined, it means the region has a price increase
-    // and that we should apply it.
+    // and we should apply it.
     const increase = basePrice * increaseFactor;
 
     return (basePrice + increase).toFixed(2);

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -3,7 +3,7 @@ import { getVolumePrice } from 'src/utilities/pricing/entityPricing';
 import { BACKUP_PRICE, LKE_HA_PRICE, NODEBALANCER_PRICE } from './constants';
 
 import type { Region } from '@linode/api-v4';
-import type { Flags } from 'src/featureFlags';
+import type { FlagSet } from 'src/featureFlags';
 
 interface CalculatePriceOptions {
   increaseValue: number;
@@ -12,7 +12,7 @@ interface CalculatePriceOptions {
 
 export interface DataCenterPricingOptions {
   entity: 'Backup' | 'LKE HA' | 'Nodebalancer' | 'Volume';
-  flags: Flags;
+  flags: FlagSet;
   regionId: Region['id'];
   size?: number;
 }
@@ -39,14 +39,14 @@ const priceIncreaseMap = {
  */
 export const getDCSpecificPricingDisplay = ({
   entity,
+  flags,
   regionId,
   size,
-  flags,
 }: DataCenterPricingOptions) => {
   const increaseValue = priceIncreaseMap[regionId] as number | undefined;
 
   const getDynamicPrice = (initialPrice: number): string => {
-    if (!flags) {
+    if (!flags.dcSpecificPricing) {
       return initialPrice.toFixed(2);
     }
 

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -36,12 +36,12 @@ enum UpcostValue {
  * This function is used to calculate the dynamic pricing for a given entity, based on potential region upcosts.
  * @param entity The entity to calculate pricing for.
  * @param region The region to calculate pricing for.
- * @param value The value to calculate pricing for.
+ * @param size An optional size value for entities that require it for field validation (ex: Volumes).
  * @example
  * const price = getDCSpecificPricing({
  *   entity: 'Volume',
  *   regionId: 'us-east-1a',
- *   value: 20,
+ *   size: 20,
  * });
  * @returns
  */

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -40,8 +40,6 @@ export const getDCSpecificPricingDisplay = ({
   regionId,
   size,
 }: DataCenterPricingOptions) => {
-  const volumePrice: number = getVolumePrice(size);
-
   const increaseValue = priceIncreaseMap[regionId] as number | undefined;
 
   const getDynamicPrice = (initialPrice: number): string => {
@@ -63,6 +61,7 @@ export const getDCSpecificPricingDisplay = ({
     case 'Nodebalancer':
       return getDynamicPrice(NODEBALANCER_PRICE);
     case 'Volume':
+      const volumePrice: number = getVolumePrice(size);
       return getDynamicPrice(volumePrice);
     default:
       return '0.00';

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -12,10 +12,10 @@ interface CalculatePriceProps {
   upcostValue: UpcostValue;
 }
 
-interface DataCenterPricingProps {
+export interface DataCenterPricingProps {
   entity: 'Backup' | 'LKE HA' | 'Nodebalancer' | 'Volume';
   regionId: Region['id'];
-  value: number;
+  size?: number;
 }
 
 enum UpcostRegion {
@@ -48,7 +48,7 @@ enum UpcostValue {
 export const getDCSpecificPricingDisplay = ({
   entity,
   regionId,
-  value,
+  size,
 }: DataCenterPricingProps) => {
   let price;
   const isJakarta: boolean = regionId === UpcostRegion.jakarta;
@@ -56,7 +56,7 @@ export const getDCSpecificPricingDisplay = ({
   const backupPrice = getBackupPrice();
   const lkePrice = getLKEClusterHAPrice();
   const nodeBalancerPrice = getNodeBalancerPrice();
-  const volumePrice: number = getVolumePrice(value);
+  const volumePrice: number = getVolumePrice(size);
 
   const getDynamicPrice = (initialPrice: number): string => {
     if (isJakarta) {

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -3,6 +3,7 @@ import { getVolumePrice } from 'src/utilities/pricing/entityPricing';
 import { BACKUP_PRICE, LKE_HA_PRICE, NODEBALANCER_PRICE } from './constants';
 
 import type { Region } from '@linode/api-v4';
+import type { Flags } from 'src/featureFlags';
 
 interface CalculatePriceOptions {
   increaseValue: number;
@@ -11,6 +12,7 @@ interface CalculatePriceOptions {
 
 export interface DataCenterPricingOptions {
   entity: 'Backup' | 'LKE HA' | 'Nodebalancer' | 'Volume';
+  flags: Flags;
   regionId: Region['id'];
   size?: number;
 }
@@ -39,10 +41,15 @@ export const getDCSpecificPricingDisplay = ({
   entity,
   regionId,
   size,
+  flags,
 }: DataCenterPricingOptions) => {
   const increaseValue = priceIncreaseMap[regionId] as number | undefined;
 
   const getDynamicPrice = (initialPrice: number): string => {
+    if (!flags) {
+      return initialPrice.toFixed(2);
+    }
+
     if (increaseValue !== undefined) {
       return calculatePrice({
         increaseValue,

--- a/packages/manager/src/utilities/pricing/entityPricing.ts
+++ b/packages/manager/src/utilities/pricing/entityPricing.ts
@@ -1,5 +1,9 @@
+// These values will eventually come from the API, but for now they are hardcoded and
+// used to generate the region based dynamic pricing.
+
 export const getBackupPrice = () => {
-  // I am unsure where this value is actually coming from
+  // I am unsure where this value is actually coming from and if it should be included here
+  // TODO - DYNAMIC_PRICING: confirm this should be hardcoded
   return 5;
 };
 

--- a/packages/manager/src/utilities/pricing/entityPricing.ts
+++ b/packages/manager/src/utilities/pricing/entityPricing.ts
@@ -3,8 +3,8 @@ export const getBackupPrice = () => {
   return 5;
 };
 
-export const getVolumePrice = (size: number) => {
-  return size >= 10 ? size / 10 : 0;
+export const getVolumePrice = (size?: number) => {
+  return size ? (size >= 10 ? size / 10 : 0) : 0;
 };
 
 export const getNodeBalancerPrice = () => {

--- a/packages/manager/src/utilities/pricing/entityPricing.ts
+++ b/packages/manager/src/utilities/pricing/entityPricing.ts
@@ -1,20 +1,5 @@
-// These values will eventually come from the API, but for now they are hardcoded and
-// used to generate the region based dynamic pricing.
-
-export const getBackupPrice = () => {
-  // I am unsure where this value is actually coming from and if it should be included here
-  // TODO - DYNAMIC_PRICING: confirm this should be hardcoded
-  return 5;
-};
+// These utils will be used for pricing calculations based on a size variation
 
 export const getVolumePrice = (size?: number) => {
   return size ? (size >= 10 ? size / 10 : 0) : 0;
-};
-
-export const getNodeBalancerPrice = () => {
-  return 10;
-};
-
-export const getLKEClusterHAPrice = () => {
-  return 60;
 };

--- a/packages/manager/src/utilities/pricing/entityPricing.ts
+++ b/packages/manager/src/utilities/pricing/entityPricing.ts
@@ -1,5 +1,11 @@
 // These utils will be used for pricing calculations based on a size variation
 
+/**
+ * Gets the base price of a volume based on its size.
+ *
+ * @param size The size of a Volume in GBs
+ * @returns the base price of a volume based on its size
+ */
 export const getVolumePrice = (size?: number) => {
   return size ? (size >= 10 ? size / 10 : 0) : 0;
 };

--- a/packages/manager/src/utilities/pricing/entityPricing.ts
+++ b/packages/manager/src/utilities/pricing/entityPricing.ts
@@ -1,0 +1,16 @@
+export const getBackupPrice = () => {
+  // I am unsure where this value is actually coming from
+  return 5;
+};
+
+export const getVolumePrice = (size: number) => {
+  return size >= 10 ? size / 10 : 0;
+};
+
+export const getNodeBalancerPrice = () => {
+  return 10;
+};
+
+export const getLKEClusterHAPrice = () => {
+  return 60;
+};


### PR DESCRIPTION
## Description 📝
This PR introduces utils and constants for region based dynamic pricing based on region, while waiting for our pricing endpoint, so it's is a bit of throwaway work, tho some bits can be hopefully re-used in the future, specifically the region based increase calculation.

We will need to iterate on this as we go but this is a good starting point to tackle the entities we're confident the pricing can be hardcoded this way (Backup (?),  LKE HA, Nodebalancer, Volume).

Please see self review for more details.

## Preview 📷

![Screenshot 2023-08-18 at 11 10 30](https://github.com/linode/manager/assets/130582365/72c93ac9-3c2e-4103-88a8-033a3584e85b)

This screenshot was taken while testing the `getDCSpecificPricingDisplay` util in the Volume Create flow, which you can easily do by modifying   the following way:

**`CreateVolumeForm.tsx`**
![Screenshot 2023-08-18 at 11 14 01](https://github.com/linode/manager/assets/130582365/c64ae62a-4434-479a-ae04-41906f55e48a)

& 

**`SizeField.tsx`**
![Screenshot 2023-08-18 at 11 15 35](https://github.com/linode/manager/assets/130582365/d3558d26-8027-49d2-a769-d79ab0ad4eb6)

## How to test 🧪
See preview section
