### PR TITLE
feat: [M3-6974] - Add DC Specific Pricing to NodeBalancer Create

### DIFF
--- a/packages/manager/.changeset/pr-9566-upcoming-features-1692376980714.md
+++ b/packages/manager/.changeset/pr-9566-upcoming-features-1692376980714.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add DC Specific Pricing to NodeBalancer Create ([#9566](https://github.com/linode/manager/pull/9566))

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -50,6 +50,9 @@ import {
 
 import type { NodeBalancerConfigFieldsWithStatus } from './types';
 import type { APIError } from '@linode/api-v4/lib/types';
+import { getDCSpecificPrice } from 'src/utilities/pricing/dynamicPricing';
+import { NODEBALANCER_PRICE } from 'src/utilities/pricing/constants';
+import { useFlags } from 'src/hooks/useFlags';
 
 interface NodeBalancerFieldsState {
   configs: (NodeBalancerConfigFieldsWithStatus & { errors?: any })[];
@@ -109,6 +112,8 @@ const NodeBalancerCreate = () => {
 
   const theme = useTheme<Theme>();
   const matchesSmDown = useMediaQuery(theme.breakpoints.down('md'));
+
+  const flags = useFlags();
 
   const disabled =
     Boolean(profile?.restricted) && !grants?.global.add_nodebalancers;
@@ -388,6 +393,28 @@ const NodeBalancerCreate = () => {
   const regionLabel = regions?.find((r) => r.id === nodeBalancerFields.region)
     ?.label;
 
+  const price = getDCSpecificPrice({
+    basePrice: NODEBALANCER_PRICE,
+    flags,
+    regionId: nodeBalancerFields.region,
+  });
+
+  const summaryItems = [
+    { title: regionLabel },
+    { details: nodeBalancerFields.configs.length, title: 'Configs' },
+    {
+      details: nodeBalancerFields.configs.reduce(
+        (acc, config) => acc + config.nodes.length,
+        0
+      ),
+      title: 'Nodes',
+    },
+  ].filter((item) => Boolean(item.title));
+
+  if (nodeBalancerFields.region) {
+    summaryItems.unshift({ title: `$${price}/month` });
+  }
+
   return (
     <React.Fragment>
       <DocumentTitleSegment segment="Create a NodeBalancer" />
@@ -534,18 +561,7 @@ const NodeBalancerCreate = () => {
         Add another Configuration
       </Button>
       <CheckoutSummary
-        displaySections={[
-          { title: '$10/month' },
-          { title: regionLabel },
-          { details: nodeBalancerFields.configs.length, title: 'Configs' },
-          {
-            details: nodeBalancerFields.configs.reduce(
-              (acc, config) => acc + config.nodes.length,
-              0
-            ),
-            title: 'Nodes',
-          },
-        ].filter((item) => Boolean(item.title))}
+        displaySections={summaryItems}
         heading={`Summary ${nodeBalancerFields.label ?? ''}`}
       />
       <Box

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -16,7 +16,7 @@ export interface DataCenterPricingOptions {
    * The `id` of the region we intended to get the price for.
    * @example us-east
    */
-  regionId: Region['id'];
+  regionId: Region['id'] | undefined;
 }
 
 // The key is a region id and the value is the percentage
@@ -41,7 +41,7 @@ export const getDCSpecificPrice = ({
   flags,
   regionId,
 }: DataCenterPricingOptions) => {
-  if (!flags?.dcSpecificPricing) {
+  if (!flags?.dcSpecificPricing || !regionId) {
     return basePrice.toFixed(2);
   }
 


### PR DESCRIPTION
## Description 📝
- Adds DC Specific pricing to the NodeBalancer Create page 💵

## Major Changes 🔄
- Allows a undefined region to be passed to `getDCSpecificPrice` 🚫
- Makes NodeBalancer Create show a dynamic price 💵

## Preview 📷

https://github.com/linode/manager/assets/115251059/e6b1d6a4-6d62-487f-af51-93e41c36cd8a

## How to test 🧪
- Go to `http://localhost:3000/nodebalancers/create`
- Verify that no price shows when no region is selected
- Verify that the price in normal regions is `$10.00`
- Verify that the price in **Sao Paulo** and **Jakarta** are higher