### PR TITLE
fix: Make feature flag dev tools show reality

### DIFF
--- a/packages/manager/.changeset/pr-9567-tech-stories-1692380986951.md
+++ b/packages/manager/.changeset/pr-9567-tech-stories-1692380986951.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Make feature flag dev tools show reality ([#9567](https://github.com/linode/manager/pull/9567))

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -2,12 +2,12 @@ import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 import { useDispatch } from 'react-redux';
 
+import withFeatureFlagProvider from 'src/containers/withFeatureFlagProvider.container';
 import { FlagSet, Flags } from 'src/featureFlags';
 import { Dispatch } from 'src/hooks/types';
 import { useFlags } from 'src/hooks/useFlags';
 import { setMockFeatureFlags } from 'src/store/mockFeatureFlags';
 import { getStorage, setStorage } from 'src/utilities/storage';
-import withFeatureFlagProvider from 'src/containers/withFeatureFlagProvider.container';
 
 const MOCK_FEATURE_FLAGS_STORAGE_KEY = 'devTools/mock-feature-flags';
 

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -7,6 +7,7 @@ import { Dispatch } from 'src/hooks/types';
 import { useFlags } from 'src/hooks/useFlags';
 import { setMockFeatureFlags } from 'src/store/mockFeatureFlags';
 import { getStorage, setStorage } from 'src/utilities/storage';
+import withFeatureFlagProvider from 'src/containers/withFeatureFlagProvider.container';
 
 const MOCK_FEATURE_FLAGS_STORAGE_KEY = 'devTools/mock-feature-flags';
 
@@ -74,4 +75,4 @@ const FeatureFlagTool: React.FC<{}> = () => {
   );
 };
 
-export default FeatureFlagTool;
+export default withFeatureFlagProvider(FeatureFlagTool);

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -13,7 +13,6 @@ const MOCK_FEATURE_FLAGS_STORAGE_KEY = 'devTools/mock-feature-flags';
 
 const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'metadata', label: 'Metadata' },
-  { flag: 'databaseBeta', label: 'Database Beta' },
   { flag: 'vpc', label: 'VPC' },
   { flag: 'aglb', label: 'AGLB' },
   { flag: 'dcSpecificPricing', label: 'DC-Specific Pricing' },


### PR DESCRIPTION
## Description 📝
- Makes it so the dev tools flag checkboxes actually represent which flags are on/off in real life
  - They have been very confusing and misleading in certain circumstances creating a confusing developer experience.
- Also, thoughts on reverting #9400?
  - I'd prefer to have my local app match exactly what launchdarkly has by default, does anyone else feel this way?

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-08-18 at 1 31 10 PM](https://github.com/linode/manager/assets/115251059/f4a60971-8fb8-4ea6-b026-d01103bc23ef) | ![Screenshot 2023-08-18 at 1 29 44 PM](https://github.com/linode/manager/assets/115251059/c2403489-d680-4676-b418-9d3d519e0f2b)

## How to test 🧪
- Clear local storage and make sure the dev tools show feature flags accurately 