### PR TITLE
hotfix: Timezone Form Styles and revert FromStrackScriptContent to a class component 

### DIFF
--- a/packages/manager/.changeset/pr-9573-fixed-1692642029020.md
+++ b/packages/manager/.changeset/pr-9573-fixed-1692642029020.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Timezone Form Styles ([#9573](https://github.com/linode/manager/pull/9573))

--- a/packages/manager/.changeset/pr-9573-fixed-1692642029020.md
+++ b/packages/manager/.changeset/pr-9573-fixed-1692642029020.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Timezone Form Styles ([#9573](https://github.com/linode/manager/pull/9573))

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2023-08-22] - v1.100.1
+
+### Fixed:
+
+- Incorrect timezone form styles on profile page ([#9573](https://github.com/linode/manager/pull/9573))
+
+
 ## [2023-08-21] - v1.100.0
 
 

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed:
 
 - Incorrect timezone form styles on profile page ([#9573](https://github.com/linode/manager/pull/9573))
+- Create Linode from Stackscript field state bug ([#9573](https://github.com/linode/manager/pull/9573))
 
 
 ## [2023-08-21] - v1.100.0

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.100.0",
+  "version": "1.100.1",
   "private": true,
   "bugs": {
     "url": "https://github.com/Linode/manager/issues"

--- a/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -99,15 +99,13 @@ export const TimezoneForm = (props: Props) => {
         />
         <ActionsPanel
           primaryButtonProps={{
-            'data-testid': 'tz-submit',
             disabled,
             label: 'Update Timezone',
             loading: isLoading,
             onClick: onSubmit,
             sx: {
-              backgroundColor: 'red',
               color: 'white',
-              marginTop: (theme: Theme) => theme.breakpoints.up('md') && 16,
+              marginTop: (theme: Theme) => (theme.breakpoints.up('md') ? 2 : 0),
               minWidth: 180,
             },
           }}

--- a/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -104,7 +104,6 @@ export const TimezoneForm = (props: Props) => {
             loading: isLoading,
             onClick: onSubmit,
             sx: {
-              color: 'white',
               marginTop: (theme: Theme) => (theme.breakpoints.up('md') ? 2 : 0),
               minWidth: 180,
             },


### PR DESCRIPTION
## Description 📝
Timezone Form Styles:
- The timezone form on `/profile/display` had some unintended styling 🎨
- Caused by https://github.com/linode/manager/pull/9341

Stackscripts:
- Hotfix to revert state bug with `FromStrackScriptContent` after it was converted to a functional component in https://github.com/linode/manager/commit/af161f33b451d35c2175c19465eeb4c710f30c72

## Major Changes 🔄
Timezone Form Styles:
- Removes red background 🔴
- Fixes incorrect `marginTop` 🔝

Stackscripts:
- Reverts FromStrackScriptContent to class component

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-08-21 at 2 16 41 PM](https://github.com/linode/manager/assets/115251059/50755316-665f-4b27-9956-a5c223bc4def) | ![Screenshot 2023-08-21 at 2 17 27 PM](https://github.com/linode/manager/assets/115251059/5f2c8a73-0ed0-4cb6-9544-a9b290e68b84) |

## How to test 🧪
Timezone Form Styles:
- Test the timezone form on `/profile/display`

StackScripts:
- Go to create Linode > create from stackscript > select hwdsl2 / setup-ipsec-vpn
- Confirm (comparing with production) that all fields in `setup-ipsec-vpn Setup` fieldset behave properly