### PR TITLE
feat: [M3-6758] - Add VPC items to invoice table

### DIFF
--- a/packages/manager/src/factories/billing.ts
+++ b/packages/manager/src/factories/billing.ts
@@ -19,6 +19,18 @@ export const invoiceItemFactory = Factory.Sync.makeFactory<InvoiceItem>({
   unit_price: '0.0075',
 });
 
+export const invoiceItemFactoryVPC = Factory.Sync.makeFactory<InvoiceItem>({
+  amount: 5,
+  from: '2023-01-01T12:00:00',
+  label: Factory.each((i) => `VPC (${i})`),
+  quantity: 1,
+  tax: 0,
+  to: '2023-01-31T12:00:00',
+  total: 5,
+  type: 'hourly',
+  unit_price: '0.0075',
+});
+
 const paymentDate = new Date('2020-01-01T00:00:00');
 export const paymentFactory = Factory.Sync.makeFactory<Payment>({
   date: Factory.each((i) => {

--- a/packages/manager/src/factories/billing.ts
+++ b/packages/manager/src/factories/billing.ts
@@ -31,6 +31,20 @@ export const invoiceItemFactoryVPC = Factory.Sync.makeFactory<InvoiceItem>({
   unit_price: '0.0075',
 });
 
+export const invoiceItemFactoryVPCNetworkTransfer = Factory.Sync.makeFactory<InvoiceItem>(
+  {
+    amount: 5,
+    from: '2023-01-01T12:00:00',
+    label: 'VPC Network Transfer',
+    quantity: 100,
+    tax: 0,
+    to: '2023-01-31T12:00:00',
+    total: 5,
+    type: 'hourly',
+    unit_price: '0.0075',
+  }
+);
+
 const paymentDate = new Date('2020-01-01T00:00:00');
 export const paymentFactory = Factory.Sync.makeFactory<Payment>({
   date: Factory.each((i) => {

--- a/packages/manager/src/factories/billing.ts
+++ b/packages/manager/src/factories/billing.ts
@@ -19,32 +19,6 @@ export const invoiceItemFactory = Factory.Sync.makeFactory<InvoiceItem>({
   unit_price: '0.0075',
 });
 
-export const invoiceItemFactoryVPC = Factory.Sync.makeFactory<InvoiceItem>({
-  amount: 5,
-  from: '2023-01-01T12:00:00',
-  label: Factory.each((i) => `VPC (${i})`),
-  quantity: 1,
-  tax: 0,
-  to: '2023-01-31T12:00:00',
-  total: 5,
-  type: 'hourly',
-  unit_price: '0.0075',
-});
-
-export const invoiceItemFactoryVPCNetworkTransfer = Factory.Sync.makeFactory<InvoiceItem>(
-  {
-    amount: 5,
-    from: '2023-01-01T12:00:00',
-    label: 'VPC Network Transfer',
-    quantity: 100,
-    tax: 0,
-    to: '2023-01-31T12:00:00',
-    total: 5,
-    type: 'hourly',
-    unit_price: '0.0075',
-  }
-);
-
 const paymentDate = new Date('2020-01-01T00:00:00');
 export const paymentFactory = Factory.Sync.makeFactory<Payment>({
   date: Factory.each((i) => {

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -73,7 +73,7 @@ const renderQuantity = (v: null | number, label?: string) => {
   }
 
   return label === 'VPC Network Transfer' ? `${v} GB` : `${v}`;
-  // potential TODO: VPC - map network quantity value to GB, TB, etc?
+  // potential TODO: VPC - depending on network transfer quantity size, map value to MB, GB, TB, etc?
 };
 
 const RenderData = (props: { items: InvoiceItem[] }) => {

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -67,7 +67,14 @@ const InvoiceTable = (props: Props) => {
 const renderDate = (v: null | string) =>
   v ? <DateTimeDisplay data-qa-invoice-date value={v} /> : null;
 
-const renderQuantity = (v: null | number) => (v ? v : null);
+const renderQuantity = (v: null | number, label?: string) => {
+  if (!v) {
+    return null;
+  }
+
+  return label === 'VPC Network Transfer' ? `${v} GB` : `${v}`;
+  // potential TODO: VPC - map network quantity value to GB, TB, etc?
+};
 
 const RenderData = (props: { items: InvoiceItem[] }) => {
   const { items } = props;
@@ -98,12 +105,7 @@ const RenderData = (props: { items: InvoiceItem[] }) => {
                   {renderDate(to)}
                 </TableCell>
                 <TableCell data-qa-quantity parentColumn="Quantity">
-                  {renderQuantity(quantity)}
-                  {`${
-                    quantity !== null && label === 'VPC Network Transfer'
-                      ? ' GB' // placeholder, follow up with api team
-                      : ''
-                  }`}
+                  {renderQuantity(quantity, label)}
                 </TableCell>
                 <TableCell data-qa-unit-price parentColumn="Unit Price">
                   {unit_price !== 'None' && renderUnitPrice(unit_price)}

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -99,6 +99,11 @@ const RenderData = (props: { items: InvoiceItem[] }) => {
                 </TableCell>
                 <TableCell data-qa-quantity parentColumn="Quantity">
                   {renderQuantity(quantity)}
+                  {`${
+                    quantity !== null && label === 'VPC Network Transfer'
+                      ? ' GB' // placeholder, follow up with api team
+                      : ''
+                  }`}
                 </TableCell>
                 <TableCell data-qa-unit-price parentColumn="Unit Price">
                   {unit_price !== 'None' && renderUnitPrice(unit_price)}

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -40,8 +40,6 @@ import {
   incidentResponseFactory,
   invoiceFactory,
   invoiceItemFactory,
-  invoiceItemFactoryVPC,
-  invoiceItemFactoryVPCNetworkTransfer,
   kubeEndpointFactory,
   kubernetesAPIResponse,
   kubernetesVersionFactory,
@@ -880,8 +878,8 @@ export const handlers = [
   }),
   rest.get('*invoices/:invoiceId/items', (req, res, ctx) => {
     const items = [
-      invoiceItemFactoryVPC.build(),
-      invoiceItemFactoryVPCNetworkTransfer.build(),
+      invoiceItemFactory.build({ label: 'VPC' }),
+      invoiceItemFactory.build({ label: 'VPC Network Transfer' }),
       ...invoiceItemFactory.buildList(10),
     ];
     return res(ctx.json(makeResourcePage(items, { page: 1, pages: 4 })));

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -40,6 +40,7 @@ import {
   incidentResponseFactory,
   invoiceFactory,
   invoiceItemFactory,
+  invoiceItemFactoryVPC,
   kubeEndpointFactory,
   kubernetesAPIResponse,
   kubernetesVersionFactory,
@@ -877,7 +878,10 @@ export const handlers = [
     return res(ctx.json({ kubeconfig: 'SSBhbSBhIHRlYXBvdA==' }));
   }),
   rest.get('*invoices/:invoiceId/items', (req, res, ctx) => {
-    const items = invoiceItemFactory.buildList(10);
+    const items = [
+      invoiceItemFactoryVPC.build(),
+      ...invoiceItemFactory.buildList(10),
+    ];
     return res(ctx.json(makeResourcePage(items, { page: 1, pages: 4 })));
   }),
   rest.get('*/account', (req, res, ctx) => {

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -41,6 +41,7 @@ import {
   invoiceFactory,
   invoiceItemFactory,
   invoiceItemFactoryVPC,
+  invoiceItemFactoryVPCNetworkTransfer,
   kubeEndpointFactory,
   kubernetesAPIResponse,
   kubernetesVersionFactory,
@@ -880,6 +881,7 @@ export const handlers = [
   rest.get('*invoices/:invoiceId/items', (req, res, ctx) => {
     const items = [
       invoiceItemFactoryVPC.build(),
+      invoiceItemFactoryVPCNetworkTransfer.build(),
       ...invoiceItemFactory.buildList(10),
     ];
     return res(ctx.json(makeResourcePage(items, { page: 1, pages: 4 })));


### PR DESCRIPTION
## Description 📝
- Add VPC items to invoice table: currently there will be no backend changes to invoice endpoints, so there's not much to do here -- vpc related invoice items should just automatically get populated in the invoice table 

## Major Changes 🔄
- Check whether invoice item is 'VPC Network Transfer' to determine if we need to add a unit to the rendered quantity

## Preview 📷
![image](https://github.com/linode/manager/assets/139280159/3997c57d-8619-4ea3-b0b5-bfda0b827e00)

## How to test 🧪
1. Go to one of your invoices and turn on MSW. Check to see if you can see VPC items in MSW
