### PR TITLE
hotfix: revert FromStrackScriptContent to a class component

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2023-08-22] - v1.100.1
+
+### Fixed
+
+- Create Linode from Stackscript field state bug ([#9579](https://github.com/linode/manager/pull/9579))
+
 ## [2023-08-21] - v1.100.0
 
 

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.100.0",
+  "version": "1.100.1",
   "private": true,
   "bugs": {
     "url": "https://github.com/Linode/manager/issues"


### PR DESCRIPTION
Hotfix to revert state bug with `FromStrackScriptContent` after it was converted to a functional component in https://github.com/linode/manager/commit/af161f33b451d35c2175c19465eeb4c710f30c72

- Go to create Linode > create from stackscript > select hwdsl2 / setup-ipsec-vpn
- Confirm (comparing with production) that all fields in `setup-ipsec-vpn Setup` fieldset behave properly
