### PR TITLE
feat: [M3-6737] - Add Collapsible Table Component

### DIFF
--- a/packages/manager/src/components/CollapsibleTable.stories.tsx
+++ b/packages/manager/src/components/CollapsibleTable.stories.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+import { Table } from 'src/components/Table';
+import { TableBody } from 'src/components/TableBody';
+import { TableCell } from 'src/components/TableCell';
+import { TableHead } from 'src/components/TableHead';
+import { TableRow } from 'src/components/TableRow';
+
+import { CollapsibleTable } from './CollapsibleTable';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+export const Default: StoryObj<typeof CollapsibleTable> = {
+  args: {
+    TableItems: [
+      {
+        InnerTable: (
+          <Table aria-label="Linode" size="small">
+            <TableHead style={{ fontSize: '.875rem' }}>
+              <TableRow>
+                <TableCell sx={{ width: '24%' }}>Date</TableCell>
+                <TableCell sx={{ width: '14%' }}>Customer</TableCell>
+                <TableCell sx={{ width: '10%' }}>Amount</TableCell>
+                <TableCell sx={{ width: '20%' }}>Total price ($)</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              <TableRow>
+                <TableCell>2020-01-05</TableCell>
+                <TableCell>11091700</TableCell>
+                <TableCell>3</TableCell>
+                <TableCell>11.97</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>2020-01-02</TableCell>
+                <TableCell>Anonymous</TableCell>
+                <TableCell>1</TableCell>
+                <TableCell>3.99</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        ),
+        OuterTableCells: (
+          <>
+            <TableCell>159</TableCell>
+            <TableCell>6</TableCell>
+            <TableCell>24</TableCell>
+          </>
+        ),
+        id: 1,
+        label: 'Frozen Yoghurt',
+      },
+    ],
+    TableRowHead: (
+      <TableRow>
+        <TableCell sx={{ width: '24%' }}>Dessert (100g serving)</TableCell>
+        <TableCell sx={{ width: '14%' }}>Calories</TableCell>
+        <TableCell sx={{ width: '18%' }}>Fat (g)</TableCell>
+        <TableCell sx={{ width: '10%' }}>Carbs (g) </TableCell>
+        <TableCell></TableCell>
+      </TableRow>
+    ),
+  },
+  render: (args) => {
+    return <CollapsibleTable {...args} />;
+  },
+};
+
+const meta: Meta<typeof CollapsibleTable> = {
+  component: CollapsibleTable,
+  title: 'Components/Table/CollapsibleTable',
+};
+
+export default meta;

--- a/packages/manager/src/components/CollapsibleTable.tsx
+++ b/packages/manager/src/components/CollapsibleTable.tsx
@@ -1,0 +1,44 @@
+import Paper from '@mui/material/Paper';
+import TableContainer from '@mui/material/TableContainer';
+import * as React from 'react';
+
+import { Table } from 'src/components/Table';
+import { TableBody } from 'src/components/TableBody';
+import { TableHead } from 'src/components/TableHead';
+import { CollapsibleRow } from 'src/features/VPC/VPCDetail/CollapsibleRow';
+
+export interface TableItem {
+  InnerTable: JSX.Element;
+  OuterTableCells: JSX.Element;
+  id: number;
+  label: string;
+}
+
+interface Props {
+  TableItems: TableItem[];
+  TableRowHead: JSX.Element;
+}
+
+export const CollapsibleTable = (props: Props) => {
+  const { TableItems, TableRowHead } = props;
+
+  return (
+    <TableContainer component={Paper}>
+      <Table aria-label="collapsible table">
+        <TableHead>{TableRowHead}</TableHead>
+        <TableBody>
+          {TableItems.map((item) => {
+            return (
+              <CollapsibleRow
+                InnerTable={item.InnerTable}
+                OuterTableCells={item.OuterTableCells}
+                key={item.id}
+                label={item.label}
+              />
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};

--- a/packages/manager/src/features/VPC/VPCDetail/CollapsibleRow.tsx
+++ b/packages/manager/src/features/VPC/VPCDetail/CollapsibleRow.tsx
@@ -1,0 +1,65 @@
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import Box from '@mui/material/Box';
+import Collapse from '@mui/material/Collapse';
+import IconButton from '@mui/material/IconButton';
+import { styled } from '@mui/material/styles';
+import * as React from 'react';
+
+import { TableCell } from 'src/components/TableCell';
+import { TableRow } from 'src/components/TableRow';
+
+interface Props {
+  InnerTable: JSX.Element;
+  OuterTableCells: JSX.Element;
+  label: string;
+}
+
+export const CollapsibleRow = (props: Props) => {
+  const { InnerTable, OuterTableCells, label } = props;
+
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <>
+      <StyledOuterTableRow>
+        <TableCell component="th" scope="row">
+          <IconButton
+            aria-label="expand row"
+            onClick={() => setOpen(!open)}
+            size="small"
+            sx={{ padding: 1 }}
+          >
+            {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+          </IconButton>
+          {label}
+        </TableCell>
+        {OuterTableCells}
+      </StyledOuterTableRow>
+      <StyledTableRow>
+        <TableCell colSpan={6} style={{ border: 'none', padding: 0 }}>
+          <Collapse in={open} timeout="auto" unmountOnExit>
+            <Box>{InnerTable}</Box>
+          </Collapse>
+        </TableCell>
+      </StyledTableRow>
+    </>
+  );
+};
+
+const StyledOuterTableRow = styled(TableRow, {
+  label: 'StyledOuterTableRow',
+})(() => ({
+  '& > *': { borderBottom: 'unset' },
+  '& th': {
+    '&:first-of-type': {
+      paddingLeft: 0,
+    },
+  },
+}));
+
+const StyledTableRow = styled(TableRow, {
+  label: 'StyledTableRow',
+})(() => ({
+  height: 'auto',
+}));


### PR DESCRIPTION
## Description 📝
Add a generic Collapsible Table Component so that the Subnets table and Firewalls Detail --> Linodes tab can implement it

Note: Styles may not be perfect but will be further refined in the components that use the collapsible table

## Preview 📷
https://github.com/linode/manager/assets/115299789/17176dc7-078c-4817-8323-61238fc7c366

## How to test 🧪
Run `yarn storybook` and go to http://localhost:6006/?path=/docs/components-table-collapsibletable--documentation