### PR TITLE
feat: [M3-6965] - Update api-v4 and mocks for DC-specific pricing

### DIFF
--- a/packages/api-v4/.changeset/pr-9586-upcoming-features-1692798602248.md
+++ b/packages/api-v4/.changeset/pr-9586-upcoming-features-1692798602248.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Upcoming Features
+---
+
+Update account and linode types for DC-specific pricing ([#9586](https://github.com/linode/manager/pull/9586))

--- a/packages/api-v4/src/account/account.ts
+++ b/packages/api-v4/src/account/account.ts
@@ -9,8 +9,8 @@ import {
   AccountSettings,
   CancelAccount,
   CancelAccountPayload,
-  NetworkUtilization,
   Agreements,
+  RegionalNetworkUtilization,
 } from './types';
 
 /**
@@ -31,7 +31,7 @@ export const getAccountInfo = () => {
  *
  */
 export const getNetworkUtilization = () =>
-  Request<NetworkUtilization>(
+  Request<RegionalNetworkUtilization>(
     setURL(`${API_ROOT}/account/transfer`),
     setMethod('GET')
   );

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -1,5 +1,6 @@
 import { APIWarning } from '../types';
 import { Beta } from '../betas/types';
+import { Region } from 'src/regions';
 
 export interface User {
   username: string;
@@ -117,6 +118,7 @@ export interface InvoiceItem {
   unit_price: null | string;
   tax: number;
   total: number;
+  region: Region['id'];
 }
 
 export interface Payment {
@@ -170,6 +172,12 @@ export interface NetworkUtilization {
   billable: number;
   used: number;
   quota: number;
+}
+export interface RegionalNetworkUtilization extends NetworkUtilization {
+  region_transfers: RegionalTransferObject[];
+}
+export interface RegionalTransferObject extends NetworkUtilization {
+  id: Region['id'];
 }
 
 export interface NetworkTransfer {

--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -310,7 +310,7 @@ export interface LinodeType extends BaseType {
   price: PriceObject;
   region_prices: RegionPriceObject[];
   addons: {
-    backups: { price: PriceObject };
+    backups: { price: PriceObject; region_prices: RegionPriceObject[] };
   };
 }
 

--- a/packages/manager/.changeset/pr-9586-upcoming-features-1692798648869.md
+++ b/packages/manager/.changeset/pr-9586-upcoming-features-1692798648869.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update mocks for DC-specific pricing API responses ([#9586](https://github.com/linode/manager/pull/9586))

--- a/packages/manager/src/components/EntityHeader/EntityHeader.stories.tsx
+++ b/packages/manager/src/components/EntityHeader/EntityHeader.stories.tsx
@@ -84,6 +84,18 @@ export const Default: Story = {
                     hourly: 0.0015,
                     monthly: 5,
                   },
+                  region_prices: [
+                    {
+                      hourly: 0.0048,
+                      id: 'id-cgk',
+                      monthly: 3.57,
+                    },
+                    {
+                      hourly: 0.0056,
+                      id: 'br-gru',
+                      monthly: 4.17,
+                    },
+                  ],
                 },
               },
               class: 'standard',

--- a/packages/manager/src/factories/account.ts
+++ b/packages/manager/src/factories/account.ts
@@ -1,7 +1,7 @@
 import {
   Account,
   ActivePromotion,
-  NetworkUtilization,
+  RegionalNetworkUtilization,
 } from '@linode/api-v4/lib/account/types';
 import * as Factory from 'factory.ts';
 
@@ -60,10 +60,14 @@ export const accountFactory = Factory.Sync.makeFactory<Account>({
   zip: '19106',
 });
 
-export const accountTransferFactory = Factory.Sync.makeFactory<NetworkUtilization>(
+export const accountTransferFactory = Factory.Sync.makeFactory<RegionalNetworkUtilization>(
   {
     billable: 0,
     quota: 11347,
     used: 50,
+    region_transfers: [
+      { id: 'id-cgk', billable: 0, quota: 10000, used: 10 },
+      { id: 'br-gru', billable: 0, quota: 15000, used: 20 },
+    ],
   }
 );

--- a/packages/manager/src/factories/billing.ts
+++ b/packages/manager/src/factories/billing.ts
@@ -12,6 +12,7 @@ export const invoiceItemFactory = Factory.Sync.makeFactory<InvoiceItem>({
   from: '2020-01-01T12:00:00',
   label: Factory.each((i) => `Nanode 1GB - my-linode-${i} (${i})`),
   quantity: 730,
+  region: 'id-cgk',
   tax: 0,
   to: '2020-01-31T12:00:00',
   total: 5,

--- a/packages/manager/src/factories/linodes.ts
+++ b/packages/manager/src/factories/linodes.ts
@@ -1,4 +1,4 @@
-import { NetworkUtilization } from '@linode/api-v4/lib/account';
+import { RegionalNetworkUtilization } from '@linode/api-v4/lib/account';
 import {
   CreateLinodeRequest,
   Linode,
@@ -123,11 +123,15 @@ export const linodeBackupsFactory = Factory.Sync.makeFactory<LinodeBackups>({
   },
 });
 
-export const linodeTransferFactory = Factory.Sync.makeFactory<NetworkUtilization>(
+export const linodeTransferFactory = Factory.Sync.makeFactory<RegionalNetworkUtilization>(
   {
     billable: 0,
     quota: 1950,
     used: 13956637,
+    region_transfers: [
+      { id: 'id-cgk', billable: 0, quota: 10000, used: 10 },
+      { id: 'br-gru', billable: 0, quota: 15000, used: 20 },
+    ],
   }
 );
 
@@ -138,6 +142,18 @@ export const linodeTypeFactory = Factory.Sync.makeFactory<LinodeType>({
         hourly: 0.004,
         monthly: 2.5,
       },
+      region_prices: [
+        {
+          hourly: 0.0048,
+          id: 'id-cgk',
+          monthly: 3.57,
+        },
+        {
+          hourly: 0.0056,
+          id: 'br-gru',
+          monthly: 4.17,
+        },
+      ],
     },
   },
   class: 'standard',
@@ -181,6 +197,18 @@ export const proDedicatedTypeFactory = Factory.Sync.makeFactory<LinodeType>({
         hourly: null,
         monthly: null,
       },
+      region_prices: [
+        {
+          hourly: null,
+          id: null,
+          monthly: null,
+        },
+        {
+          hourly: null,
+          id: null,
+          monthly: null,
+        },
+      ],
     },
   },
   class: 'prodedicated',

--- a/packages/manager/src/factories/types.ts
+++ b/packages/manager/src/factories/types.ts
@@ -8,6 +8,18 @@ export const typeFactory = Factory.Sync.makeFactory<LinodeType>({
         hourly: 10,
         monthly: 10,
       },
+      region_prices: [
+        {
+          hourly: 0.0048,
+          id: 'id-cgk',
+          monthly: 3.57,
+        },
+        {
+          hourly: 0.0056,
+          id: 'br-gru',
+          monthly: 4.17,
+        },
+      ],
     },
   },
   class: 'standard',

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -612,7 +612,14 @@ export const handlers = [
   }),
   rest.get('*/linode/instances/:id', async (req, res, ctx) => {
     const id = Number(req.params.id);
-    return res(ctx.json(linodeFactory.build({ id })));
+    return res(
+      ctx.json(
+        linodeFactory.build({
+          backups: { enabled: false },
+          id,
+        })
+      )
+    );
   }),
   rest.delete('*/instances/*', async (req, res, ctx) => {
     return res(ctx.json({}));

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -605,6 +605,11 @@ export const handlers = [
         label: 'eu-linode',
         region: 'eu-west',
       }),
+      linodeFactory.build({
+        backups: { enabled: false },
+        label: 'DC-Specific Pricing Linode',
+        region: 'id-cgk',
+      }),
       eventLinode,
       multipleIPLinode,
     ];

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -920,6 +920,15 @@ export const handlers = [
     });
     return res(ctx.json(makeResourcePage([linodeInvoice, akamaiInvoice])));
   }),
+  rest.get('*/account/invoices/:invoiceId', (req, res, ctx) => {
+    const linodeInvoice = invoiceFactory.build({
+      date: '2022-12-01T18:04:01',
+      id: 1234,
+      label: 'LinodeInvoice',
+    });
+    return res(ctx.json(linodeInvoice));
+  }),
+
   rest.get('*/account/maintenance', (req, res, ctx) => {
     accountMaintenanceFactory.resetSequenceNumber();
     const page = Number(req.url.searchParams.get('page') || 1);

--- a/packages/manager/src/queries/accountTransfer.ts
+++ b/packages/manager/src/queries/accountTransfer.ts
@@ -1,5 +1,5 @@
 import {
-  NetworkUtilization,
+  RegionalNetworkUtilization,
   getNetworkUtilization,
 } from '@linode/api-v4/lib/account';
 import { APIError } from '@linode/api-v4/lib/types';
@@ -8,7 +8,7 @@ import { useQuery } from 'react-query';
 import { queryPresets } from './base';
 
 export const useAccountTransfer = () =>
-  useQuery<NetworkUtilization, APIError[]>(
+  useQuery<RegionalNetworkUtilization, APIError[]>(
     'network-utilization',
     getNetworkUtilization,
     queryPresets.oneTimeFetch


### PR DESCRIPTION
## Description 📝
Updates api-v4 types and mocks for expected DC-specific pricing changes to API responses.

Note: #9572 includes the api-v4 updates for adding `region_prices` to a Linode; I'll pull those changes in once that PR is merged.

## How to test 🧪
1. **How to setup test environment?**
- Turn the Mock Service Worker on.
- Ensure the DC-Specific Pricing flag is on.
4. **How to verify changes?**
- With **mocks on,** go to the following pages and confirm using the browser dev tools' network tab that the API responses returned for the following endpoints have the data you'd expect based on the example payload in the API spec. The API spec is linked in this ticket or the epic.:
   - Linode Create: confirm `backups` has added `region_prices` list for the `linode/types` endpoint
   - MNTP dialog:  confirm `region_transfers` has been added to the `account/transfers` endpoint
   - Invoice Details (go to http://localhost:3000/account/billing/ and click on an invoice): confirm `region` has been added for the `account/invoices/:id/items` endpoint