### PR TITLE
fix: [M3-7050] re-instate copy tooltip hover state in Linode Summary

### DIFF
--- a/packages/manager/.changeset/pr-9587-fixed-1692802396223.md
+++ b/packages/manager/.changeset/pr-9587-fixed-1692802396223.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+CopyTooltip hover state in Linode Summary ([#9587](https://github.com/linode/manager/pull/9587))

--- a/packages/manager/src/components/CopyTooltip/CopyTooltip.tsx
+++ b/packages/manager/src/components/CopyTooltip/CopyTooltip.tsx
@@ -21,13 +21,13 @@ export interface CopyTooltipProps {
    */
   onClickCallback?: () => void;
   /**
-   * The text to be copied to the clipboard.
-   */
-  text: string;
-  /**
    * The placement of the tooltip.
    */
   placement?: TooltipProps['placement'];
+  /**
+   * The text to be copied to the clipboard.
+   */
+  text: string;
 }
 
 /**
@@ -38,7 +38,7 @@ export interface CopyTooltipProps {
 
 export const CopyTooltip = (props: CopyTooltipProps) => {
   const [copied, setCopied] = React.useState<boolean>(false);
-  const { className, copyableText, onClickCallback, text, placement } = props;
+  const { className, copyableText, onClickCallback, placement, text } = props;
 
   const handleIconClick = () => {
     setCopied(true);
@@ -51,6 +51,7 @@ export const CopyTooltip = (props: CopyTooltipProps) => {
 
   return (
     <Tooltip
+      className="copy-tooltip"
       data-qa-copied
       placement={placement ?? 'top'}
       title={copied ? 'Copied!' : 'Copy'}

--- a/packages/manager/src/features/Linodes/LinodeEntityDetail.styles.ts
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetail.styles.ts
@@ -211,7 +211,7 @@ export const StyledGradientDiv = styled('div', { label: 'StyledGradientDiv' })(
 );
 
 export const StyledTableRow = styled(TableRow, { label: 'StyledTableRow' })({
-  '&:hover $copy > svg, & $copy:focus > svg': {
+  '&:hover .copy-tooltip > svg, & .copy-tooltip:focus > svg': {
     opacity: 1,
   },
 });

--- a/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
@@ -33,20 +33,6 @@ import { formatDate } from 'src/utilities/formatDate';
 import { formatStorageUnits } from 'src/utilities/formatStorageUnits';
 import { pluralize } from 'src/utilities/pluralize';
 
-import {
-  StyledBodyGrid,
-  StyledChip,
-  StyledColumnLabelGrid,
-  StyledCopyTooltip,
-  StyledGradientDiv,
-  StyledLink,
-  StyledRightColumnGrid,
-  StyledSummaryGrid,
-  StyledTable,
-  StyledTableCell,
-  StyledTableGrid,
-  StyledTableRow,
-} from './LinodeEntityDetail.styles';
 import { ipv4TableID } from './LinodesDetail/LinodeNetworking/LinodeIPAddresses';
 import { lishLink, sshLink } from './LinodesDetail/utilities';
 import { LinodeHandlers } from './LinodesLanding/LinodesLanding';
@@ -55,6 +41,20 @@ import {
   getProgressOrDefault,
   isEventWithSecondaryLinodeStatus,
 } from './transitions';
+import {
+  StyledChip,
+  StyledLink,
+  StyledBodyGrid,
+  StyledColumnLabelGrid,
+  StyledRightColumnGrid,
+  StyledSummaryGrid,
+  StyledTable,
+  StyledTableGrid,
+  StyledTableCell,
+  StyledCopyTooltip,
+  StyledGradientDiv,
+  StyledTableRow,
+} from './LinodeEntityDetail.styles';
 
 interface LinodeEntityDetailProps {
   id: number;
@@ -226,19 +226,19 @@ const Header = (props: HeaderProps & { handlers: LinodeHandlers }) => {
 
   return (
     <EntityHeader
-      isSummaryView={isSummaryView}
       title={<StyledLink to={`linodes/${linodeId}`}>{linodeLabel}</StyledLink>}
+      isSummaryView={isSummaryView}
       variant={variant}
     >
       <Box sx={sxBoxFlex}>
         <StyledChip
-          component="span"
-          data-qa-linode-status
           hasSecondaryStatus={hasSecondaryStatus}
           isOffline={isOffline}
           isOther={isOther}
           isRunning={isRunning}
           isSummaryView={isSummaryView}
+          component="span"
+          data-qa-linode-status
           label={formattedStatus}
           pill={true}
         />
@@ -346,12 +346,12 @@ export const Body = React.memo((props: BodyProps) => {
     <StyledBodyGrid container direction="row" spacing={2}>
       {/* @todo: Rewrite this code to make it dynamic. It's very similar to the LKE display. */}
       <Grid
-        sx={{
-          flexBasis: '25%',
-        }}
         container
         direction="column"
         spacing={2}
+        sx={{
+          flexBasis: '25%',
+        }}
       >
         <StyledColumnLabelGrid>Summary</StyledColumnLabelGrid>
         <StyledSummaryGrid container direction="row" spacing={2}>

--- a/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
@@ -33,6 +33,20 @@ import { formatDate } from 'src/utilities/formatDate';
 import { formatStorageUnits } from 'src/utilities/formatStorageUnits';
 import { pluralize } from 'src/utilities/pluralize';
 
+import {
+  StyledBodyGrid,
+  StyledChip,
+  StyledColumnLabelGrid,
+  StyledCopyTooltip,
+  StyledGradientDiv,
+  StyledLink,
+  StyledRightColumnGrid,
+  StyledSummaryGrid,
+  StyledTable,
+  StyledTableCell,
+  StyledTableGrid,
+  StyledTableRow,
+} from './LinodeEntityDetail.styles';
 import { ipv4TableID } from './LinodesDetail/LinodeNetworking/LinodeIPAddresses';
 import { lishLink, sshLink } from './LinodesDetail/utilities';
 import { LinodeHandlers } from './LinodesLanding/LinodesLanding';
@@ -41,20 +55,6 @@ import {
   getProgressOrDefault,
   isEventWithSecondaryLinodeStatus,
 } from './transitions';
-import {
-  StyledChip,
-  StyledLink,
-  StyledBodyGrid,
-  StyledColumnLabelGrid,
-  StyledRightColumnGrid,
-  StyledSummaryGrid,
-  StyledTable,
-  StyledTableGrid,
-  StyledTableCell,
-  StyledCopyTooltip,
-  StyledGradientDiv,
-  StyledTableRow,
-} from './LinodeEntityDetail.styles';
 
 interface LinodeEntityDetailProps {
   id: number;
@@ -226,19 +226,19 @@ const Header = (props: HeaderProps & { handlers: LinodeHandlers }) => {
 
   return (
     <EntityHeader
-      title={<StyledLink to={`linodes/${linodeId}`}>{linodeLabel}</StyledLink>}
       isSummaryView={isSummaryView}
+      title={<StyledLink to={`linodes/${linodeId}`}>{linodeLabel}</StyledLink>}
       variant={variant}
     >
       <Box sx={sxBoxFlex}>
         <StyledChip
+          component="span"
+          data-qa-linode-status
           hasSecondaryStatus={hasSecondaryStatus}
           isOffline={isOffline}
           isOther={isOther}
           isRunning={isRunning}
           isSummaryView={isSummaryView}
-          component="span"
-          data-qa-linode-status
           label={formattedStatus}
           pill={true}
         />
@@ -346,12 +346,12 @@ export const Body = React.memo((props: BodyProps) => {
     <StyledBodyGrid container direction="row" spacing={2}>
       {/* @todo: Rewrite this code to make it dynamic. It's very similar to the LKE display. */}
       <Grid
-        container
-        direction="column"
-        spacing={2}
         sx={{
           flexBasis: '25%',
         }}
+        container
+        direction="column"
+        spacing={2}
       >
         <StyledColumnLabelGrid>Summary</StyledColumnLabelGrid>
         <StyledSummaryGrid container direction="row" spacing={2}>


### PR DESCRIPTION
## Description 📝
Small fix to a regression from https://github.com/linode/manager/pull/9501 to re-add the hover tooltip in Linode summary

## Preview 📷
![Screenshot 2023-08-23 at 16 50 02](https://github.com/linode/manager/assets/130582365/41b7b8b4-c8c9-48c2-b994-4676d60b87a7)

