### PR TITLE
feat: [M3-6754] - [on hold] Create new react list component

### DIFF
--- a/packages/manager/.changeset/pr-9594-upcoming-features-1692971598640.md
+++ b/packages/manager/.changeset/pr-9594-upcoming-features-1692971598640.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Create scrollable list component and custom list items ([#9594](https://github.com/linode/manager/pull/9594))

--- a/packages/manager/src/components/ScrollableList/CustomListItems/CheckedLinodeListItem.tsx
+++ b/packages/manager/src/components/ScrollableList/CustomListItems/CheckedLinodeListItem.tsx
@@ -4,8 +4,9 @@ import * as React from 'react';
 
 import { Checkbox } from 'src/components/Checkbox';
 import { ListItem } from 'src/components/ListItem';
-import type { ListItemProps } from 'src/components/ListItem';
 import { ListItemText } from 'src/components/ListItemText';
+
+import type { ListItemProps } from 'src/components/ListItem';
 
 export interface LinodeListItemProps extends ListItemProps {
   /**
@@ -33,10 +34,10 @@ export const CheckedLinodeListItem = (props: Props) => {
   const { checked, linode, onClickListItem, ...listItemProps } = props;
 
   return (
-    <ListItem sx={{ padding: 0 }} key={linode.id} {...listItemProps}>
+    <ListItem {...listItemProps} key={linode.id} sx={{ padding: 0 }}>
       <ListItemButton
         onClick={() => onClickListItem(linode)}
-        sx={{ padding: 0, minHeight: '44px' }}
+        sx={{ minHeight: '44px', padding: 0 }}
       >
         <Checkbox checked={checked} />
         <ListItemText>{linode.label}</ListItemText>

--- a/packages/manager/src/components/ScrollableList/CustomListItems/CheckedLinodeListItem.tsx
+++ b/packages/manager/src/components/ScrollableList/CustomListItems/CheckedLinodeListItem.tsx
@@ -1,0 +1,45 @@
+import { Linode } from '@linode/api-v4';
+import { ListItemButton } from '@mui/material';
+import * as React from 'react';
+
+import { Checkbox } from 'src/components/Checkbox';
+import { ListItem } from 'src/components/ListItem';
+import { ListItemText } from 'src/components/ListItemText';
+
+export interface LinodeListItemProps {
+  /**
+   * The list of all Linode items to render as an individual list item
+   */
+  linode: Linode;
+
+  /**
+   * The action when clicking this list item
+   */
+  onClickListItem: (item: Linode) => void;
+}
+
+interface Props extends LinodeListItemProps {
+  /**
+   * Is this list item currently checked
+   */
+  checked: boolean;
+}
+
+/**
+ *  A list item for Linodes in which this item can be checked
+ */
+export const CheckedLinodeListItem = (props: Props) => {
+  const { checked, linode, onClickListItem } = props;
+
+  return (
+    <ListItem sx={{ padding: 0 }} key={linode.id}>
+      <ListItemButton
+        onClick={() => onClickListItem(linode)}
+        sx={{ padding: 0, minHeight: '44px' }}
+      >
+        <Checkbox checked={checked} />
+        <ListItemText>{linode.label}</ListItemText>
+      </ListItemButton>
+    </ListItem>
+  );
+};

--- a/packages/manager/src/components/ScrollableList/CustomListItems/CheckedLinodeListItem.tsx
+++ b/packages/manager/src/components/ScrollableList/CustomListItems/CheckedLinodeListItem.tsx
@@ -4,9 +4,10 @@ import * as React from 'react';
 
 import { Checkbox } from 'src/components/Checkbox';
 import { ListItem } from 'src/components/ListItem';
+import type { ListItemProps } from 'src/components/ListItem';
 import { ListItemText } from 'src/components/ListItemText';
 
-export interface LinodeListItemProps {
+export interface LinodeListItemProps extends ListItemProps {
   /**
    * The list of all Linode items to render as an individual list item
    */
@@ -29,10 +30,10 @@ interface Props extends LinodeListItemProps {
  *  A list item for Linodes in which this item can be checked
  */
 export const CheckedLinodeListItem = (props: Props) => {
-  const { checked, linode, onClickListItem } = props;
+  const { checked, linode, onClickListItem, ...listItemProps } = props;
 
   return (
-    <ListItem sx={{ padding: 0 }} key={linode.id}>
+    <ListItem sx={{ padding: 0 }} key={linode.id} {...listItemProps}>
       <ListItemButton
         onClick={() => onClickListItem(linode)}
         sx={{ padding: 0, minHeight: '44px' }}

--- a/packages/manager/src/components/ScrollableList/CustomListItems/CheckedLinodeListItem.tsx
+++ b/packages/manager/src/components/ScrollableList/CustomListItems/CheckedLinodeListItem.tsx
@@ -10,25 +10,25 @@ import type { ListItemProps } from 'src/components/ListItem';
 
 export interface LinodeListItemProps extends ListItemProps {
   /**
-   * The list of all Linode items to render as an individual list item
+   * The Linode to render as a list item
    */
   linode: Linode;
 
   /**
-   * The action when clicking this list item
+   * The action to execute when clicking this list item
    */
   onClickListItem: (item: Linode) => void;
 }
 
 interface Props extends LinodeListItemProps {
   /**
-   * Is this list item currently checked
+   * Determines whether or not the list item checked
    */
   checked: boolean;
 }
 
 /**
- *  A list item for Linodes in which this item can be checked
+ *  A checkable list item for a Linode
  */
 export const CheckedLinodeListItem = (props: Props) => {
   const { checked, linode, onClickListItem, ...listItemProps } = props;

--- a/packages/manager/src/components/ScrollableList/CustomListItems/CheckedLinodeListItem.tsx
+++ b/packages/manager/src/components/ScrollableList/CustomListItems/CheckedLinodeListItem.tsx
@@ -37,10 +37,12 @@ export const CheckedLinodeListItem = (props: Props) => {
     <ListItem {...listItemProps} key={linode.id} sx={{ padding: 0 }}>
       <ListItemButton
         onClick={() => onClickListItem(linode)}
-        sx={{ minHeight: '44px', padding: 0 }}
+        sx={{ minHeight: '40px', padding: 0 }}
       >
         <Checkbox checked={checked} />
-        <ListItemText>{linode.label}</ListItemText>
+        <ListItemText sx={(theme) => ({ marginLeft: theme.spacing(0.5) })}>
+          {linode.label}
+        </ListItemText>
       </ListItemButton>
     </ListItem>
   );

--- a/packages/manager/src/components/ScrollableList/CustomListItems/RemovableLinodeListItem.tsx
+++ b/packages/manager/src/components/ScrollableList/CustomListItems/RemovableLinodeListItem.tsx
@@ -10,9 +10,8 @@ import { ListItemText } from 'src/components/ListItemText';
  * A list item for Linodes in which this item can be removed from a list
  */
 export const RemovableLinodeListItem = (props: LinodeListItemProps) => {
-  const { linode, onClickListItem } = props;
+  const { linode, onClickListItem, ...listItemProps } = props;
 
-  // cleanup all later
   return (
     <ListItem
       sx={{ padding: 0, minHeight: '44px' }}
@@ -22,6 +21,7 @@ export const RemovableLinodeListItem = (props: LinodeListItemProps) => {
           <Close />
         </IconButton>
       }
+      {...listItemProps}
     >
       <ListItemText sx={{ marginLeft: '16px' }}>{linode.label}</ListItemText>
     </ListItem>

--- a/packages/manager/src/components/ScrollableList/CustomListItems/RemovableLinodeListItem.tsx
+++ b/packages/manager/src/components/ScrollableList/CustomListItems/RemovableLinodeListItem.tsx
@@ -1,10 +1,11 @@
 import Close from '@mui/icons-material/Close';
 import * as React from 'react';
 
-import type { LinodeListItemProps } from './CheckedLinodeListItem';
 import { IconButton } from 'src/components/IconButton';
 import { ListItem } from 'src/components/ListItem';
 import { ListItemText } from 'src/components/ListItemText';
+
+import type { LinodeListItemProps } from './CheckedLinodeListItem';
 
 /**
  * A list item for Linodes in which this item can be removed from a list
@@ -14,16 +15,18 @@ export const RemovableLinodeListItem = (props: LinodeListItemProps) => {
 
   return (
     <ListItem
-      sx={{ padding: 0, minHeight: '44px' }}
-      key={linode.id}
+      {...listItemProps}
       secondaryAction={
-        <IconButton sx={{ padding: 0 }} onClick={() => onClickListItem(linode)}>
+        <IconButton onClick={() => onClickListItem(linode)} sx={{ padding: 0 }}>
           <Close />
         </IconButton>
       }
-      {...listItemProps}
+      key={linode.id}
+      sx={{ minHeight: '44px', padding: 0 }}
     >
-      <ListItemText sx={{ marginLeft: '16px' }}>{linode.label}</ListItemText>
+      <ListItemText sx={(theme) => ({ marginLeft: theme.spacing(2) })}>
+        {linode.label}
+      </ListItemText>
     </ListItem>
   );
 };

--- a/packages/manager/src/components/ScrollableList/CustomListItems/RemovableLinodeListItem.tsx
+++ b/packages/manager/src/components/ScrollableList/CustomListItems/RemovableLinodeListItem.tsx
@@ -1,9 +1,12 @@
 import Close from '@mui/icons-material/Close';
+import { styled } from '@mui/material';
+import { ListItemButton } from '@mui/material';
 import * as React from 'react';
 
 import { IconButton } from 'src/components/IconButton';
+import { Link } from 'src/components/Link';
 import { ListItem } from 'src/components/ListItem';
-import { ListItemText } from 'src/components/ListItemText';
+import { Typography } from 'src/components/Typography';
 
 import type { LinodeListItemProps } from './CheckedLinodeListItem';
 
@@ -22,11 +25,29 @@ export const RemovableLinodeListItem = (props: LinodeListItemProps) => {
         </IconButton>
       }
       key={linode.id}
-      sx={{ minHeight: '44px', padding: 0 }}
+      sx={{ padding: 0 }}
     >
-      <ListItemText sx={(theme) => ({ marginLeft: theme.spacing(2) })}>
-        {linode.label}
-      </ListItemText>
+      {/* TODO: unsure of the exact user flow, but based on the mockup, seems like each linode listed
+      should have a link back to its detail page. Will change later if needed */}
+      <ListItemButton sx={{ minHeight: '40px', padding: 0 }}>
+        <StyledLink
+          style={{ textDecoration: 'none' }}
+          to={`/linodes/${linode.id}`}
+        >
+          <Typography
+            sx={(theme) => ({ color: theme.textColors.linkActiveLight })}
+            variant="body1"
+          >
+            {linode.label}
+          </Typography>
+        </StyledLink>
+      </ListItemButton>
     </ListItem>
   );
 };
+
+const StyledLink = styled(Link, { label: 'StyledLink' })(({ theme }) => ({
+  height: '100%',
+  padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
+  width: '100%',
+}));

--- a/packages/manager/src/components/ScrollableList/CustomListItems/RemovableLinodeListItem.tsx
+++ b/packages/manager/src/components/ScrollableList/CustomListItems/RemovableLinodeListItem.tsx
@@ -1,0 +1,29 @@
+import Close from '@mui/icons-material/Close';
+import * as React from 'react';
+
+import type { LinodeListItemProps } from './CheckedLinodeListItem';
+import { IconButton } from 'src/components/IconButton';
+import { ListItem } from 'src/components/ListItem';
+import { ListItemText } from 'src/components/ListItemText';
+
+/**
+ * A list item for Linodes in which this item can be removed from a list
+ */
+export const RemovableLinodeListItem = (props: LinodeListItemProps) => {
+  const { linode, onClickListItem } = props;
+
+  // cleanup all later
+  return (
+    <ListItem
+      sx={{ padding: 0, minHeight: '44px' }}
+      key={linode.id}
+      secondaryAction={
+        <IconButton sx={{ padding: 0 }} onClick={() => onClickListItem(linode)}>
+          <Close />
+        </IconButton>
+      }
+    >
+      <ListItemText sx={{ marginLeft: '16px' }}>{linode.label}</ListItemText>
+    </ListItem>
+  );
+};

--- a/packages/manager/src/components/ScrollableList/CustomListItems/RemovableLinodeListItem.tsx
+++ b/packages/manager/src/components/ScrollableList/CustomListItems/RemovableLinodeListItem.tsx
@@ -11,7 +11,7 @@ import { Typography } from 'src/components/Typography';
 import type { LinodeListItemProps } from './CheckedLinodeListItem';
 
 /**
- * A list item for Linodes in which this item can be removed from a list
+ * A removable list item for a Linode
  */
 export const RemovableLinodeListItem = (props: LinodeListItemProps) => {
   const { linode, onClickListItem, ...listItemProps } = props;

--- a/packages/manager/src/components/ScrollableList/ScrollableList.stories.tsx
+++ b/packages/manager/src/components/ScrollableList/ScrollableList.stories.tsx
@@ -1,0 +1,134 @@
+import { Linode } from '@linode/api-v4';
+import * as React from 'react';
+
+import { Button } from '../Button/Button';
+import { CheckedLinodeListItem } from './CustomListItems/CheckedLinodeListItem';
+import { RemovableLinodeListItem } from './CustomListItems/RemovableLinodeListItem';
+import { ScrollableList } from './ScrollableList';
+import { ListItem } from 'src/components/ListItem';
+import type { Meta, StoryObj } from '@storybook/react';
+
+type Story = StoryObj<typeof ScrollableList>;
+
+const listItems = [
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+].map((num) => {
+  return { id: num, label: `my-linode-${num}` };
+}) as Linode[];
+
+/**
+ * Default example of a scrollable list
+ */
+export const Default: Story = {
+  args: {
+    ListItems: listItems.map((item) => {
+      return <ListItem key={item.id}>{item.label}</ListItem>;
+    }),
+  },
+  render: (args) => {
+    return <ScrollableList {...args} />;
+  },
+};
+
+/**
+ * Example of a scrollable list with checkable list items
+ */
+export const CheckedListItemsExample: Story = {
+  render: () => {
+    const ScrollableListWrapper = () => {
+      const [checkedItems, setCheckedItems] = React.useState(new Set<number>());
+      const handleCheck = (item: Linode) => {
+        const newCheckedItems = new Set<number>([...Array.from(checkedItems)]);
+        if (newCheckedItems.has(item.id)) {
+          newCheckedItems.delete(item.id);
+        } else {
+          newCheckedItems.add(item.id);
+        }
+        setCheckedItems(newCheckedItems);
+      };
+
+      const checkedListItems = listItems.map((item) => {
+        return (
+          <CheckedLinodeListItem
+            key={item.id}
+            linode={item}
+            onClickListItem={handleCheck}
+            checked={checkedItems.has(item.id)}
+          />
+        );
+      });
+
+      return <ScrollableList ListItems={checkedListItems} />;
+    };
+
+    return <ScrollableListWrapper />;
+  },
+};
+
+/**
+ * Example of a scrollable list with removable list items
+ */
+export const RemovableListItemsExample: Story = {
+  render: () => {
+    const ScrollableListWrapper = () => {
+      const [linodesInList, setLinodesInList] = React.useState(listItems);
+
+      const handleRemove = (item: Linode) => {
+        setLinodesInList(
+          [...linodesInList].filter((linode) => linode.id !== item.id)
+        );
+      };
+
+      const resetList = () => {
+        setLinodesInList([...listItems]);
+      };
+
+      const removableListItems = linodesInList.map((item) => {
+        return (
+          <RemovableLinodeListItem
+            key={item.id}
+            linode={item}
+            onClickListItem={handleRemove}
+          />
+        );
+      });
+
+      return (
+        <>
+          <ScrollableList ListItems={removableListItems} />
+          <Button sx={{ marginTop: 2 }} onClick={resetList}>
+            Reset list
+          </Button>
+        </>
+      );
+    };
+
+    return <ScrollableListWrapper />;
+  },
+};
+
+const meta: Meta<typeof ScrollableList> = {
+  component: ScrollableList,
+  title: 'Components/ScrollableList',
+};
+
+export default meta;

--- a/packages/manager/src/components/ScrollableList/ScrollableList.stories.tsx
+++ b/packages/manager/src/components/ScrollableList/ScrollableList.stories.tsx
@@ -1,11 +1,13 @@
 import { Linode } from '@linode/api-v4';
 import * as React from 'react';
 
+import { ListItem } from 'src/components/ListItem';
+
 import { Button } from '../Button/Button';
 import { CheckedLinodeListItem } from './CustomListItems/CheckedLinodeListItem';
 import { RemovableLinodeListItem } from './CustomListItems/RemovableLinodeListItem';
 import { ScrollableList } from './ScrollableList';
-import { ListItem } from 'src/components/ListItem';
+
 import type { Meta, StoryObj } from '@storybook/react';
 
 type Story = StoryObj<typeof ScrollableList>;
@@ -36,7 +38,7 @@ const listItems = [
 }) as Linode[];
 
 /**
- * Default example of a scrollable list
+ * Simple example of a scrollable list
  */
 export const Default: Story = {
   args: {
@@ -69,15 +71,15 @@ export const CheckedListItemsExample: Story = {
       const checkedListItems = listItems.map((item) => {
         return (
           <CheckedLinodeListItem
+            checked={checkedItems.has(item.id)}
             key={item.id}
             linode={item}
             onClickListItem={handleCheck}
-            checked={checkedItems.has(item.id)}
           />
         );
       });
 
-      return <ScrollableList ListItems={checkedListItems} />;
+      return <ScrollableList ListItems={checkedListItems} maxHeight={445} />;
     };
 
     return <ScrollableListWrapper />;
@@ -114,8 +116,8 @@ export const RemovableListItemsExample: Story = {
 
       return (
         <>
-          <ScrollableList ListItems={removableListItems} />
-          <Button sx={{ marginTop: 2 }} onClick={resetList}>
+          <ScrollableList ListItems={removableListItems} maxHeight={445} />
+          <Button onClick={resetList} sx={{ marginTop: 2 }}>
             Reset list
           </Button>
         </>

--- a/packages/manager/src/components/ScrollableList/ScrollableList.stories.tsx
+++ b/packages/manager/src/components/ScrollableList/ScrollableList.stories.tsx
@@ -116,7 +116,7 @@ export const RemovableListItemsExample: Story = {
 
       return (
         <>
-          <ScrollableList ListItems={removableListItems} maxHeight={445} />
+          <ScrollableList ListItems={removableListItems} />
           <Button onClick={resetList} sx={{ marginTop: 2 }}>
             Reset list
           </Button>

--- a/packages/manager/src/components/ScrollableList/ScrollableList.stories.tsx
+++ b/packages/manager/src/components/ScrollableList/ScrollableList.stories.tsx
@@ -130,7 +130,7 @@ export const RemovableListItemsExample: Story = {
 
 const meta: Meta<typeof ScrollableList> = {
   component: ScrollableList,
-  title: 'Components/ScrollableList',
+  title: 'Components/Scrollable List',
 };
 
 export default meta;

--- a/packages/manager/src/components/ScrollableList/ScrollableList.tsx
+++ b/packages/manager/src/components/ScrollableList/ScrollableList.tsx
@@ -22,7 +22,7 @@ interface Props extends ListProps {
 }
 
 /**
- * A simple list that is scrollable if there is a large number of list items
+ * A simple list that becomes scrollable if it has a lot of list items
  */
 export const ScrollableList = (props: Props) => {
   const { ListItems, maxHeight, maxWidth, ...listProps } = props;

--- a/packages/manager/src/components/ScrollableList/ScrollableList.tsx
+++ b/packages/manager/src/components/ScrollableList/ScrollableList.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+
 import { List } from 'src/components/List';
+
 import type { ListProps } from 'src/components/List';
 
 interface Props extends ListProps {
@@ -7,22 +9,32 @@ interface Props extends ListProps {
    * The list items to render
    */
   ListItems: JSX.Element[];
+
+  /**
+   * The maxHeight of the list component, in px
+   */
+  maxHeight?: number;
+
+  /**
+   * The maxWidth of the list component, in px
+   */
+  maxWidth?: number;
 }
 
 /**
  * A simple list that is scrollable if there is a large number of list items
  */
 export const ScrollableList = (props: Props) => {
-  const { ListItems, ...listProps } = props;
+  const { ListItems, maxHeight, maxWidth, ...listProps } = props;
   return (
     <List
-      sx={{
-        maxWidth: '450px',
-        maxHeight: '445px',
-        overflow: 'auto',
-        border: '1px solid #CCCCCC',
-      }}
       {...listProps}
+      sx={{
+        border: '1px solid #CCCCCC',
+        maxHeight: maxHeight ? `${maxHeight}px` : '400px',
+        maxWidth: maxWidth ? `${maxWidth}px` : '450px',
+        overflow: 'auto',
+      }}
     >
       {ListItems}
     </List>

--- a/packages/manager/src/components/ScrollableList/ScrollableList.tsx
+++ b/packages/manager/src/components/ScrollableList/ScrollableList.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { List } from 'src/components/List';
+import type { ListProps } from 'src/components/List';
 
-interface Props {
+interface Props extends ListProps {
   /**
    * The list items to render
    */
@@ -12,15 +13,16 @@ interface Props {
  * A simple list that is scrollable if there is a large number of list items
  */
 export const ScrollableList = (props: Props) => {
-  const { ListItems } = props;
+  const { ListItems, ...listProps } = props;
   return (
     <List
       sx={{
         maxWidth: '450px',
-        maxHeight: '400px',
+        maxHeight: '445px',
         overflow: 'auto',
         border: '1px solid #CCCCCC',
       }}
+      {...listProps}
     >
       {ListItems}
     </List>

--- a/packages/manager/src/components/ScrollableList/ScrollableList.tsx
+++ b/packages/manager/src/components/ScrollableList/ScrollableList.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { List } from 'src/components/List';
+
+interface Props {
+  /**
+   * The list items to render
+   */
+  ListItems: JSX.Element[];
+}
+
+/**
+ * A simple list that is scrollable if there is a large number of list items
+ */
+export const ScrollableList = (props: Props) => {
+  const { ListItems } = props;
+  return (
+    <List
+      sx={{
+        maxWidth: '450px',
+        maxHeight: '400px',
+        overflow: 'auto',
+        border: '1px solid #CCCCCC',
+      }}
+    >
+      {ListItems}
+    </List>
+  );
+};


### PR DESCRIPTION
turns out I was working off the wrong designs 😢 
brb + ON HOLD until decision meeting about new component vs using existing multi select

## Description 📝
- created simple scrollable list 
- the majority of the logic would really be in the custom list items -- I have a version where all of this is one component, on [this branch](https://github.com/linode/manager/compare/develop...coliu-akamai:manager:feat-m3-6754) that I was first working on, before feeling like this wasn't as clean as an approach that I'd hoped.

## Major Changes 🔄
- Scrollable list component
- custom list items 

## Preview 📷
(this would be used for the unassign linodes drawer)
![image](https://github.com/linode/manager/assets/139280159/847eaea4-4cdc-40f2-bb52-6eabd179ca79)

(this would be used for the assign linodes drawer)
![image](https://github.com/linode/manager/assets/139280159/26acec69-0452-4bd6-a666-0e3d39b60d91)
![image](https://github.com/linode/manager/assets/139280159/4df6d95e-9ffe-4516-b36e-55ae51debc2c)

## How to test 🧪
`yarn storybook` --> ScrollableList
