### PR TITLE
fix: [M3-7062] - Hide User Data accordion in Linode Rebuild dialog for unsupported regions

### DIFF
--- a/packages/manager/.changeset/pr-9602-fixed-1693332727991.md
+++ b/packages/manager/.changeset/pr-9602-fixed-1693332727991.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Hide User Data accordion in Linode Rebuild dialog for unsupported regions ([#9602](https://github.com/linode/manager/pull/9602))

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
@@ -28,6 +28,7 @@ import { WithTypesProps } from 'src/containers/types.container';
 import { FeatureFlagConsumerProps } from 'src/containers/withFeatureFlagConsumer.container';
 import { WithLinodesProps } from 'src/containers/withLinodes.container';
 import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
+import { regionSupportsMetadata } from 'src/features/Linodes/LinodesCreate/utilities';
 import {
   getMonthlyAndHourlyNodePricing,
   utoa,
@@ -343,14 +344,12 @@ export class LinodeCreate extends React.PureComponent<
         'cloud-init'
       );
 
-    const regionSupportsMetadata =
-      this.props.regionsData
-        .find((region) => region.id === this.props.selectedRegionID)
-        ?.capabilities.includes('Metadata') ?? false;
-
     const showUserData =
       this.props.flags.metadata &&
-      regionSupportsMetadata &&
+      regionSupportsMetadata(
+        this.props.regionsData,
+        this.props.selectedRegionID ?? ''
+      ) &&
       (imageIsCloudInitCompatible || linodeIsCloudInitCompatible);
 
     return (

--- a/packages/manager/src/features/Linodes/LinodesCreate/utilities.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/utilities.tsx
@@ -112,3 +112,14 @@ export const utoa = (data: string) => {
     return data;
   }
 };
+
+export const regionSupportsMetadata = (
+  regionsData: Region[],
+  region: string
+) => {
+  return (
+    regionsData
+      .find((regionData) => regionData.id === region)
+      ?.capabilities.includes('Metadata') ?? false
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/LinodeRebuildDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/LinodeRebuildDialog.tsx
@@ -111,6 +111,7 @@ export const LinodeRebuildDialog = (props: Props) => {
           handleRebuildError={handleRebuildError}
           linodeId={linodeId ?? -1}
           linodeLabel={linode?.label}
+          linodeRegion={linode?.region}
           onClose={onClose}
           passwordHelperText={passwordHelperText}
         />

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -4,13 +4,13 @@ import {
   rebuildLinode,
 } from '@linode/api-v4/lib/linodes';
 import { RebuildLinodeSchema } from '@linode/validation/lib/linodes.schema';
+import Grid from '@mui/material/Unstable_Grid2';
 import { Formik, FormikProps } from 'formik';
 import { useSnackbar } from 'notistack';
 import { isEmpty } from 'ramda';
 import * as React from 'react';
 
 import AccessPanel from 'src/components/AccessPanel/AccessPanel';
-import Grid from '@mui/material/Unstable_Grid2';
 import { Box } from 'src/components/Box';
 import { Checkbox } from 'src/components/Checkbox';
 import { Divider } from 'src/components/Divider';
@@ -18,9 +18,11 @@ import ImageSelect from 'src/components/ImageSelect';
 import { TypeToConfirm } from 'src/components/TypeToConfirm/TypeToConfirm';
 import { resetEventsPolling } from 'src/eventsPolling';
 import { UserDataAccordion } from 'src/features/Linodes/LinodesCreate/UserDataAccordion/UserDataAccordion';
+import { regionSupportsMetadata } from 'src/features/Linodes/LinodesCreate/utilities';
 import { useFlags } from 'src/hooks/useFlags';
 import { useAllImagesQuery } from 'src/queries/images';
 import { usePreferences } from 'src/queries/preferences';
+import { useRegionsQuery } from 'src/queries/regions';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import {
   handleFieldErrors,
@@ -40,6 +42,7 @@ interface Props {
   handleRebuildError: (status: string) => void;
   linodeId: number;
   linodeLabel?: string;
+  linodeRegion?: string;
   onClose: () => void;
   passwordHelperText: string;
 }
@@ -66,6 +69,7 @@ export const RebuildFromImage = (props: Props) => {
     handleRebuildError,
     linodeId,
     linodeLabel,
+    linodeRegion,
     onClose,
     passwordHelperText,
   } = props;
@@ -76,6 +80,7 @@ export const RebuildFromImage = (props: Props) => {
   const flags = useFlags();
 
   const { data: _imagesData, error: imagesError } = useAllImagesQuery();
+  const { data: regionsData } = useRegionsQuery();
 
   const RebuildSchema = () => extendValidationSchema(RebuildLinodeSchema);
 
@@ -200,6 +205,7 @@ export const RebuildFromImage = (props: Props) => {
 
         const shouldDisplayUserDataAccordion =
           flags.metadata &&
+          regionSupportsMetadata(regionsData ?? [], linodeRegion ?? '') &&
           Boolean(
             values.image &&
               _imagesData
@@ -250,8 +256,8 @@ export const RebuildFromImage = (props: Props) => {
                     }
                     renderNotice={
                       <StyledNotice
-                        variant="success"
                         text="Adding new user data is recommended as part of the rebuild process."
+                        variant="success"
                       />
                     }
                     disabled={shouldReuseUserData}

--- a/packages/manager/src/features/Linodes/MigrateLinode/MigrateLinode.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/MigrateLinode.tsx
@@ -12,6 +12,7 @@ import { Typography } from 'src/components/Typography';
 import { MBpsInterDC } from 'src/constants';
 import { resetEventsPolling } from 'src/eventsPolling';
 import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
+import { regionSupportsMetadata } from 'src/features/Linodes/LinodesCreate/utilities';
 import useEvents from 'src/hooks/useEvents';
 import { useFlags } from 'src/hooks/useFlags';
 import {
@@ -124,13 +125,12 @@ export const MigrateLinode = React.memo((props: Props) => {
       return;
     }
 
-    const regionSupportsMetadata = (_region: string) =>
-      regionsData
-        ?.find((region) => region.id === _region)
-        ?.capabilities.includes('Metadata') ?? false;
-
-    const currentRegionSupportsMetadata = regionSupportsMetadata(linode.region);
+    const currentRegionSupportsMetadata = regionSupportsMetadata(
+      regionsData ?? [],
+      linode.region
+    );
     const selectedRegionSupportsMetadata = regionSupportsMetadata(
+      regionsData ?? [],
       selectedRegion
     );
 


### PR DESCRIPTION
## Description 📝
We missed a region check in the Linode Rebuild dialog, causing the Add User Data accordion to display when rebuilding a Linode on regions that do not support Metadata. This PR adds a `regionSupportsMetadata` utility function to be used in the Rebuild dialog as well as other places where the accordion is displayed.

Note: I hid the IP addresses for preview purposes

## Preview 📷
| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/115299789/5ec91adb-3904-4478-8d24-5b5b589082a3" /> | <video src="https://github.com/linode/manager/assets/115299789/d8062546-bb3a-4cae-aaf0-e70b0effc7fa" /> |

## How to test 🧪
- Go to the Linodes landing page and rebuild a Linode whose region does not support Metadata (which is any region other than Washington, DC and Paris, FR)
- Select an Image that is compatible with cloud-init
- Observe that the accordion does not display