### PR TITLE
fix: Fix VPC landing page test import

### DIFF
--- a/packages/manager/cypress/e2e/core/vpc/vpc-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/vpc/vpc-landing-page.spec.ts
@@ -7,7 +7,7 @@ import {
   mockGetVPCs,
   mockDeleteVPC,
   mockUpdateVPC,
-} from 'support/intercepts/vpcs';
+} from 'support/intercepts/vpc';
 import { vpcFactory } from '@src/factories';
 import { ui } from 'support/ui';
 import { randomLabel, randomPhrase } from 'support/util/random';


### PR DESCRIPTION
## Description 📝
This is a tiny change to fix the TypeScript error we're seeing when running `vpc-landing-page.spec.ts`. It looks like we did a find+replace of `vpc` to `vpcs` which also inadvertently touched the import.

## How to test 🧪
Run `yarn && yarn build && yarn start:manager:ci`, and then run:

```bash
yarn cy:run -s "cypress/e2e/core/vpc/vpc-landing-page.spec.ts"
```