### PR TITLE
feat: [M3-7048] - Add DC-specific pricing for Kubernetes node pools

### DIFF
--- a/packages/manager/.changeset/pr-9606-upcoming-features-1693548349929.md
+++ b/packages/manager/.changeset/pr-9606-upcoming-features-1693548349929.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add DC-specific pricing to Kubernetes node pools ([#9606](https://github.com/linode/manager/pull/9606))

--- a/packages/manager/src/factories/types.ts
+++ b/packages/manager/src/factories/types.ts
@@ -2,6 +2,7 @@ import { LinodeType } from '@linode/api-v4/lib/linodes/types';
 import * as Factory from 'factory.ts';
 
 import type { PlanSelectionType } from 'src/features/components/PlansPanel/types';
+import type { ExtendedType } from 'src/utilities/extendType';
 
 export const typeFactory = Factory.Sync.makeFactory<LinodeType>({
   addons: {
@@ -74,3 +75,42 @@ export const planSelectionTypeFactory = Factory.Sync.makeFactory<PlanSelectionTy
     vcpus: typeFactory.build().vcpus,
   }
 );
+
+export const extendedTypeFactory = Factory.Sync.makeFactory<ExtendedType>({
+  addons: {
+    backups: {
+      price: {
+        hourly: 0.004,
+        monthly: 2.5,
+      },
+      region_prices: [
+        {
+          hourly: 0.0048,
+          id: 'id-cgk',
+          monthly: 3.57,
+        },
+        {
+          hourly: 0.0056,
+          id: 'br-gru',
+          monthly: 4.17,
+        },
+      ],
+    },
+  },
+  class: typeFactory.build().class,
+  disk: typeFactory.build().disk,
+  formattedLabel: '',
+  gpus: typeFactory.build().gpus,
+  heading: 'Dedicated 20 GB',
+  id: typeFactory.build().id,
+  isDeprecated: false,
+  label: typeFactory.build().label,
+  memory: typeFactory.build().memory,
+  network_out: typeFactory.build().network_out,
+  price: typeFactory.build().price,
+  region_prices: typeFactory.build().region_prices,
+  subHeadings: ['$10/mo ($0.015/hr)', '8 CPU, 1024 GB Storage, 16 GB RAM'],
+  successor: typeFactory.build().successor,
+  transfer: typeFactory.build().transfer,
+  vcpus: typeFactory.build().vcpus,
+});

--- a/packages/manager/src/features/Kubernetes/ClusterList/KubernetesClusterRow.test.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/KubernetesClusterRow.test.tsx
@@ -6,7 +6,7 @@ import { wrapWithTableBody, wrapWithTheme } from 'src/utilities/testHelpers';
 
 import { KubernetesClusterRow, Props } from './KubernetesClusterRow';
 
-const cluster = kubernetesClusterFactory.build();
+const cluster = kubernetesClusterFactory.build({ region: 'us-central' });
 
 const props: Props = {
   cluster,

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -354,6 +354,7 @@ export const CreateCluster = () => {
             isPlanPanelDisabled={isPlanPanelDisabled}
             isSelectedRegionEligibleForPlan={isSelectedRegionEligibleForPlan}
             regionsData={regionsData}
+            selectedRegionId={selectedRegionID}
             types={typesData || []}
             typesLoading={typesLoading}
           />

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.test.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.test.tsx
@@ -13,6 +13,7 @@ const props: NodePoolPanelProps = {
   isPlanPanelDisabled: () => false,
   isSelectedRegionEligibleForPlan: () => false,
   regionsData: [],
+  selectedRegionId: 'us-east',
   types: extendedTypes,
   typesLoading: false,
 };

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -17,6 +17,7 @@ export interface NodePoolPanelProps {
   isPlanPanelDisabled: (planType?: LinodeTypeClass) => boolean;
   isSelectedRegionEligibleForPlan: (planType?: LinodeTypeClass) => boolean;
   regionsData: Region[];
+  selectedRegionId: Region['id'];
   types: ExtendedType[];
   typesError?: string;
   typesLoading: boolean;
@@ -52,6 +53,7 @@ const Panel: React.FunctionComponent<NodePoolPanelProps> = (props) => {
     isPlanPanelDisabled,
     isSelectedRegionEligibleForPlan,
     regionsData,
+    selectedRegionId,
     types,
   } = props;
 
@@ -101,6 +103,7 @@ const Panel: React.FunctionComponent<NodePoolPanelProps> = (props) => {
           regionsData={regionsData}
           resetValues={() => null} // In this flow we don't want to clear things on tab changes
           selectedID={selectedType}
+          selectedRegionID={selectedRegionId}
           updatePlanCount={updatePlanCount}
         />
       </Grid>

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
@@ -78,4 +78,25 @@ describe('KubeCheckoutBar', () => {
     // 5 node pools * 3 linodes per pool * 10 per linode + 60 per month per cluster for HA
     await findByText(/\$210\.00/);
   });
+
+  it('should display the DC-Specific total price of the cluster for a region with a price increase if the DC-Specific pricing feature flag is on', async () => {
+    const { findByText } = renderWithTheme(
+      <KubeCheckoutBar {...props} region="id-cgk" />,
+      {
+        flags: { dcSpecificPricing: true },
+      }
+    );
+
+    // 5 node pools * 3 linodes per pool * 10 per linode * 20% increase for Jakarta
+    await findByText(/\$180\.00/);
+  });
+
+  it('should display the base total price of the cluster for a region with a price increase if the DC-Specific pricing feature flag is off', async () => {
+    const { findByText } = renderWithTheme(
+      <KubeCheckoutBar {...props} region="id-cgk" />
+    );
+
+    // 5 node pools * 3 linodes per pool * 10 per linode * no price increase for Jakarta
+    await findByText(/\$150\.00/);
+  });
 });

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { nodePoolFactory } from 'src/factories/kubernetesCluster';
 import {
-  LKE_CREATE_CLUSTER_CHECKOUT,
+  LKE_CREATE_CLUSTER_CHECKOUT_MESSAGE,
   LKE_HA_PRICE,
 } from 'src/utilities/pricing/constants';
 import { renderWithTheme } from 'src/utilities/testHelpers';
@@ -37,7 +37,7 @@ describe('KubeCheckoutBar', () => {
 
     await waitForElementToBeRemoved(getByTestId('circle-progress'));
 
-    await findByText(LKE_CREATE_CLUSTER_CHECKOUT);
+    await findByText(LKE_CREATE_CLUSTER_CHECKOUT_MESSAGE);
     expect(getByText('Create Cluster').closest('button')).toBeDisabled();
   });
 

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -17,10 +17,10 @@ import { useProfile } from 'src/queries/profile';
 import { useSpecificTypes } from 'src/queries/types';
 import { extendTypesQueryResult } from 'src/utilities/extendType';
 import { isEURegion } from 'src/utilities/formatRegion';
+import { LKE_CREATE_CLUSTER_CHECKOUT_MESSAGE } from 'src/utilities/pricing/constants';
 
 import { getTotalClusterPrice, nodeWarning } from '../kubeUtils';
 import NodePoolSummary from './NodePoolSummary';
-import { LKE_CREATE_CLUSTER_CHECKOUT } from 'src/utilities/pricing/constants';
 
 export interface Props {
   createCluster: () => void;
@@ -104,12 +104,12 @@ export const KubeCheckoutBar: React.FC<Props> = (props) => {
             })
           : undefined
       }
-      priceSelectionText={LKE_CREATE_CLUSTER_CHECKOUT}
       data-qa-checkout-bar
       disabled={disableCheckout}
       heading="Cluster Summary"
       isMakingRequest={submitting}
       onDeploy={createCluster}
+      priceSelectionText={LKE_CREATE_CLUSTER_CHECKOUT_MESSAGE}
       submitText="Create Cluster"
     >
       <>

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -10,7 +10,10 @@ import { Divider } from 'src/components/Divider';
 import { Notice } from 'src/components/Notice/Notice';
 import { RenderGuard } from 'src/components/RenderGuard';
 import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
-import { getMonthlyPrice } from 'src/features/Kubernetes/kubeUtils';
+import {
+  getKubernetesMonthlyPrice,
+  getTotalClusterPrice,
+} from 'src/utilities/pricing/kubernetes';
 import { useFlags } from 'src/hooks/useFlags';
 import { useAccountAgreements } from 'src/queries/accountAgreements';
 import { useProfile } from 'src/queries/profile';
@@ -19,7 +22,7 @@ import { extendTypesQueryResult } from 'src/utilities/extendType';
 import { isEURegion } from 'src/utilities/formatRegion';
 import { LKE_CREATE_CLUSTER_CHECKOUT_MESSAGE } from 'src/utilities/pricing/constants';
 
-import { getTotalClusterPrice, nodeWarning } from '../kubeUtils';
+import { nodeWarning } from '../kubeUtils';
 import NodePoolSummary from './NodePoolSummary';
 
 export interface Props {
@@ -120,7 +123,7 @@ export const KubeCheckoutBar: React.FC<Props> = (props) => {
             }
             price={
               region !== ''
-                ? getMonthlyPrice({
+                ? getKubernetesMonthlyPrice({
                     count: thisPool.count,
                     flags,
                     region,

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeClusterSpecs.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeClusterSpecs.tsx
@@ -13,11 +13,9 @@ import { extendTypesQueryResult } from 'src/utilities/extendType';
 import { pluralize } from 'src/utilities/pluralize';
 import { LKE_HA_PRICE } from 'src/utilities/pricing/constants';
 import { getDCSpecificPrice } from 'src/utilities/pricing/dynamicPricing';
+import { getTotalClusterPrice } from 'src/utilities/pricing/kubernetes';
 
-import {
-  getTotalClusterMemoryCPUAndStorage,
-  getTotalClusterPrice,
-} from '../kubeUtils';
+import { getTotalClusterMemoryCPUAndStorage } from '../kubeUtils';
 
 interface Props {
   cluster: KubernetesCluster;

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeClusterSpecs.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeClusterSpecs.tsx
@@ -71,22 +71,26 @@ export const KubeClusterSpecs = (props: Props) => {
 
   const displayRegion = region?.label ?? cluster.region;
 
+  const highAvailabilityPrice = cluster.control_plane.high_availability
+    ? parseFloat(
+        getDCSpecificPrice({
+          basePrice: LKE_HA_PRICE,
+          flags,
+          regionId: region?.id,
+        })
+      )
+    : undefined;
+
   const kubeSpecsLeft = [
     `Version ${cluster.k8s_version}`,
     displayRegion,
-    `$${getTotalClusterPrice(
-      pools ?? [],
-      types ?? [],
-      cluster.control_plane.high_availability
-        ? parseFloat(
-            getDCSpecificPrice({
-              basePrice: LKE_HA_PRICE,
-              flags,
-              regionId: region?.id,
-            })
-          )
-        : undefined
-    ).toFixed(2)}/month`,
+    `$${getTotalClusterPrice({
+      flags,
+      highAvailabilityPrice,
+      pools: pools ?? [],
+      region: region?.id,
+      types: types ?? [],
+    }).toFixed(2)}/month`,
   ];
 
   const kubeSpecsRight = [

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
@@ -7,20 +7,20 @@ import { Box } from 'src/components/Box';
 import { Drawer } from 'src/components/Drawer';
 import { Notice } from 'src/components/Notice/Notice';
 import { Typography } from 'src/components/Typography';
+import { useFlags } from 'src/hooks/useFlags';
 import { useCreateNodePoolMutation } from 'src/queries/kubernetes';
 import { useAllTypes } from 'src/queries/types';
 import { extendType } from 'src/utilities/extendType';
 import { filterCurrentTypes } from 'src/utilities/filterCurrentLinodeTypes';
 import { plansNoticesUtils } from 'src/utilities/planNotices';
 import { pluralize } from 'src/utilities/pluralize';
+import { getLinodeRegionPrice } from 'src/utilities/pricing/linodes';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
 import { KubernetesPlansPanel } from '../../KubernetesPlansPanel/KubernetesPlansPanel';
 import { nodeWarning } from '../../kubeUtils';
 
 import type { Region } from '@linode/api-v4';
-import { getLinodeRegionPrice } from 'src/utilities/pricing/linodes';
-import { useFlags } from 'src/hooks/useFlags';
 
 const useStyles = makeStyles((theme: Theme) => ({
   boxOuter: {
@@ -195,6 +195,7 @@ export const AddNodePoolDrawer = (props: Props) => {
           regionsData={regionsData}
           resetValues={resetDrawer}
           selectedID={selectedTypeInfo?.planId}
+          selectedRegionID={clusterRegionId}
           updatePlanCount={updatePlanCount}
         />
         {selectedTypeInfo &&

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -211,6 +211,7 @@ export const NodePoolsDisplay = (props: Props) => {
             />
             <ResizeNodePoolDrawer
               kubernetesClusterId={clusterID}
+              kubernetesRegionId={clusterRegionId}
               nodePool={selectedPool}
               onClose={() => setIsResizeDrawerOpen(false)}
               open={isResizeDrawerOpen}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/ResizeNodePoolDrawer.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/ResizeNodePoolDrawer.test.tsx
@@ -13,6 +13,7 @@ const smallPool = nodePoolFactory.build({ count: 2 });
 
 const props: Props = {
   kubernetesClusterId: 1,
+  kubernetesRegionId: 'us-east',
   nodePool: pool,
   onClose: jest.fn(),
   open: true,

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/ResizeNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/ResizeNodePoolDrawer.tsx
@@ -1,4 +1,4 @@
-import { KubeNodePoolResponse } from '@linode/api-v4';
+import { KubeNodePoolResponse, Region } from '@linode/api-v4';
 import { Theme } from '@mui/material/styles';
 import { makeStyles } from '@mui/styles';
 import * as React from 'react';
@@ -9,10 +9,12 @@ import { Drawer } from 'src/components/Drawer';
 import { EnhancedNumberInput } from 'src/components/EnhancedNumberInput/EnhancedNumberInput';
 import { Notice } from 'src/components/Notice/Notice';
 import { Typography } from 'src/components/Typography';
+import { useFlags } from 'src/hooks/useFlags';
 import { useUpdateNodePoolMutation } from 'src/queries/kubernetes';
 import { useSpecificTypes } from 'src/queries/types';
 import { extendType } from 'src/utilities/extendType';
 import { pluralize } from 'src/utilities/pluralize';
+import { getLinodeRegionPrice } from 'src/utilities/pricing/linodes';
 
 import { getMonthlyPrice, nodeWarning } from '../../kubeUtils';
 
@@ -32,6 +34,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export interface Props {
   kubernetesClusterId: number;
+  kubernetesRegionId: Region['id'];
   nodePool: KubeNodePoolResponse | undefined;
   onClose: () => void;
   open: boolean;
@@ -41,7 +44,13 @@ const resizeWarning = `Resizing to fewer nodes will delete random nodes from
 the pool.`;
 
 export const ResizeNodePoolDrawer = (props: Props) => {
-  const { kubernetesClusterId, nodePool, onClose, open } = props;
+  const {
+    kubernetesClusterId,
+    kubernetesRegionId,
+    nodePool,
+    onClose,
+    open,
+  } = props;
   const classes = useStyles();
 
   const typesQuery = useSpecificTypes(nodePool?.type ? [nodePool.type] : []);
@@ -55,6 +64,8 @@ export const ResizeNodePoolDrawer = (props: Props) => {
     isLoading,
     mutateAsync: updateNodePool,
   } = useUpdateNodePoolMutation(kubernetesClusterId, nodePool?.id ?? -1);
+
+  const flags = useFlags();
 
   const [updatedCount, setUpdatedCount] = React.useState<number>(
     nodePool?.count ?? 0
@@ -73,8 +84,6 @@ export const ResizeNodePoolDrawer = (props: Props) => {
     setUpdatedCount(Math.min(100, Math.floor(value)));
   };
 
-  const pricePerNode = planType?.price.monthly ?? 0;
-
   if (!nodePool) {
     // This should never happen, but it keeps TypeScript happy and avoids crashing if we
     // are unable to load the specified pool.
@@ -87,11 +96,20 @@ export const ResizeNodePoolDrawer = (props: Props) => {
     });
   };
 
-  const totalMonthlyPrice = getMonthlyPrice(
-    nodePool.type,
-    nodePool.count,
-    planType ? [planType] : []
-  );
+  const pricePerNode =
+    (flags.dcSpecificPricing && planType
+      ? getLinodeRegionPrice(planType, kubernetesRegionId)?.monthly
+      : planType?.price.monthly) || 0;
+
+  const totalMonthlyPrice =
+    planType &&
+    getMonthlyPrice({
+      count: nodePool.count,
+      flags,
+      region: kubernetesRegionId,
+      type: nodePool.type,
+      types: planType ? [planType] : [],
+    });
 
   return (
     <Drawer

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/ResizeNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/ResizeNodePoolDrawer.tsx
@@ -14,9 +14,10 @@ import { useUpdateNodePoolMutation } from 'src/queries/kubernetes';
 import { useSpecificTypes } from 'src/queries/types';
 import { extendType } from 'src/utilities/extendType';
 import { pluralize } from 'src/utilities/pluralize';
+import { getKubernetesMonthlyPrice } from 'src/utilities/pricing/kubernetes';
 import { getLinodeRegionPrice } from 'src/utilities/pricing/linodes';
 
-import { getMonthlyPrice, nodeWarning } from '../../kubeUtils';
+import { nodeWarning } from '../../kubeUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
   helperText: {
@@ -103,7 +104,7 @@ export const ResizeNodePoolDrawer = (props: Props) => {
 
   const totalMonthlyPrice =
     planType &&
-    getMonthlyPrice({
+    getKubernetesMonthlyPrice({
       count: nodePool.count,
       flags,
       region: kubernetesRegionId,

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.test.tsx
@@ -1,35 +1,28 @@
 import * as React from 'react';
 
-import { extendedTypes } from 'src/__data__/ExtendedType';
-import { PLAN_NO_REGION_SELECTED_MESSAGE } from 'src/utilities/pricing/constants';
-import { renderWithTheme } from 'src/utilities/testHelpers';
+import { extendedTypeFactory } from 'src/factories/types';
+import { PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE } from 'src/utilities/pricing/constants';
+import { mockMatchMedia, renderWithTheme } from 'src/utilities/testHelpers';
 
 import {
   KubernetesPlanContainer,
   KubernetesPlanContainerProps,
 } from './KubernetesPlanContainer';
 
-// const types = linodeTypeFactory.build({
-//   price: {
-//     hourly: 0.1,
-//     monthly: 5,
-//   },
-//   region_prices: [],
-// });
+const plans = extendedTypeFactory.buildList(2);
 
 const props: KubernetesPlanContainerProps = {
-  disabled: false,
   getTypeCount: jest.fn(),
-  onAdd: jest.fn(),
   onSelect: jest.fn(),
-  plans: extendedTypes,
-  selectedID: '1234',
-  selectedRegionID: 'us-east',
+  plans,
+  selectedRegionID: undefined,
   updatePlanCount: jest.fn(),
 };
 
+beforeAll(() => mockMatchMedia());
+
 describe('KubernetesPlanContainer', () => {
-  it.skip('with the DC-specific pricing feature flag off, it should display plans and pricing without a region', async () => {
+  it('should display a table with column headers', async () => {
     const { findByLabelText, findByText } = renderWithTheme(
       <KubernetesPlanContainer {...props} />
     );
@@ -37,20 +30,21 @@ describe('KubernetesPlanContainer', () => {
     const table = await findByLabelText('List of Linode Plans');
     expect(table).toBeInTheDocument();
 
-    await findByText('Monthly');
+    await findByText('Plan');
     await findByText('Hourly');
-    expect(
-      await findByText(PLAN_NO_REGION_SELECTED_MESSAGE)
-    ).not.toBeInTheDocument();
+    await findByText('Monthly');
+    await findByText('RAM');
+    await findByText('CPUs');
+    await findByText('Storage');
+    await findByText('Quantity');
   });
 
-  it.skip('with the DC-specific pricing feature flag on, it should not display plans and pricing without a region selected', async () => {
-    const { findByText } = renderWithTheme(
-      <KubernetesPlanContainer {...props} selectedRegionID={undefined} />,
+  it('should display no region selection message without a region selection when the DC-specific pricing feature flag is on ', async () => {
+    const { getByText } = renderWithTheme(
+      <KubernetesPlanContainer {...props} />,
       { flags: { dcSpecificPricing: true } }
     );
 
-    await findByText(PLAN_NO_REGION_SELECTED_MESSAGE);
-    expect(await findByText('/$/')).not.toBeInTheDocument();
+    expect(getByText(PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE)).toBeVisible();
   });
 });

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.test.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+
+import { extendedTypes } from 'src/__data__/ExtendedType';
+import { PLAN_NO_REGION_SELECTED_MESSAGE } from 'src/utilities/pricing/constants';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import {
+  KubernetesPlanContainer,
+  KubernetesPlanContainerProps,
+} from './KubernetesPlanContainer';
+
+// const types = linodeTypeFactory.build({
+//   price: {
+//     hourly: 0.1,
+//     monthly: 5,
+//   },
+//   region_prices: [],
+// });
+
+const props: KubernetesPlanContainerProps = {
+  disabled: false,
+  getTypeCount: jest.fn(),
+  onAdd: jest.fn(),
+  onSelect: jest.fn(),
+  plans: extendedTypes,
+  selectedID: '1234',
+  selectedRegionID: 'us-east',
+  updatePlanCount: jest.fn(),
+};
+
+describe('KubernetesPlanContainer', () => {
+  it.skip('with the DC-specific pricing feature flag off, it should display plans and pricing without a region', async () => {
+    const { findByLabelText, findByText } = renderWithTheme(
+      <KubernetesPlanContainer {...props} />
+    );
+
+    const table = await findByLabelText('List of Linode Plans');
+    expect(table).toBeInTheDocument();
+
+    await findByText('Monthly');
+    await findByText('Hourly');
+    expect(
+      await findByText(PLAN_NO_REGION_SELECTED_MESSAGE)
+    ).not.toBeInTheDocument();
+  });
+
+  it.skip('with the DC-specific pricing feature flag on, it should not display plans and pricing without a region selected', async () => {
+    const { findByText } = renderWithTheme(
+      <KubernetesPlanContainer {...props} selectedRegionID={undefined} />,
+      { flags: { dcSpecificPricing: true } }
+    );
+
+    await findByText(PLAN_NO_REGION_SELECTED_MESSAGE);
+    expect(await findByText('/$/')).not.toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
@@ -11,7 +11,7 @@ import { TableRow } from 'src/components/TableRow';
 import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
 import { useFlags } from 'src/hooks/useFlags';
 import { ExtendedType } from 'src/utilities/extendType';
-import { PLAN_NO_REGION_SELECTED_MESSAGE } from 'src/utilities/pricing/constants';
+import { PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE } from 'src/utilities/pricing/constants';
 
 import { KubernetesPlanSelection } from './KubernetesPlanSelection';
 
@@ -89,7 +89,7 @@ export const KubernetesPlanContainer = (
             spacingLeft={8}
             spacingTop={8}
             sx={{ '& p': { fontSize: '0.875rem' } }}
-            text={PLAN_NO_REGION_SELECTED_MESSAGE}
+            text={PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE}
             variant="info"
           />
         ) : (
@@ -124,7 +124,7 @@ export const KubernetesPlanContainer = (
               {shouldDisplayNoRegionSelectedMessage ? (
                 <TableRowEmpty
                   colSpan={9}
-                  message={PLAN_NO_REGION_SELECTED_MESSAGE}
+                  message={PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE}
                 />
               ) : (
                 renderPlanSelection()

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
@@ -2,6 +2,7 @@ import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 
 import { Hidden } from 'src/components/Hidden';
+import { Notice } from 'src/components/Notice/Notice';
 import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
 import { TableCell } from 'src/components/TableCell';
@@ -83,7 +84,13 @@ export const KubernetesPlanContainer = (props: Props) => {
     <Grid container spacing={2}>
       <Hidden mdUp>
         {shouldDisplayNoRegionSelectedMessage ? (
-          <TableRowEmpty colSpan={9} message={NO_REGION_SELECTED_MESSAGE} />
+          <Notice
+            spacingLeft={8}
+            spacingTop={8}
+            sx={{ '& p': { fontSize: '0.875rem' } }}
+            text={NO_REGION_SELECTED_MESSAGE}
+            variant="info"
+          />
         ) : (
           renderPlanSelection()
         )}

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
@@ -7,6 +7,8 @@ import { TableBody } from 'src/components/TableBody';
 import { TableCell } from 'src/components/TableCell';
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
+import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
+import { useFlags } from 'src/hooks/useFlags';
 import { ExtendedType } from 'src/utilities/extendType';
 
 import { KubernetesPlanSelection } from './KubernetesPlanSelection';
@@ -21,6 +23,8 @@ const tableCells = [
   { cellName: 'Quantity', center: false, noWrap: false, testId: 'quantity' },
 ];
 
+const NO_REGION_SELECTED_MESSAGE = 'Select a region to view plans and prices.';
+
 interface Props {
   disabled?: boolean;
   getTypeCount: (planId: string) => number;
@@ -28,6 +32,7 @@ interface Props {
   onSelect: (key: string) => void;
   plans: ExtendedType[];
   selectedID?: string;
+  selectedRegionID?: string;
   updatePlanCount: (planId: string, newCount: number) => void;
 }
 
@@ -39,25 +44,49 @@ export const KubernetesPlanContainer = (props: Props) => {
     onSelect,
     plans,
     selectedID,
+    selectedRegionID,
     updatePlanCount,
   } = props;
+
+  const flags = useFlags();
+
+  const shouldDisplayNoRegionSelectedMessage =
+    flags.dcSpecificPricing && !selectedRegionID;
+
+  const renderPlanSelection = React.useCallback(() => {
+    return plans.map((plan, id) => (
+      <KubernetesPlanSelection
+        disabled={disabled}
+        getTypeCount={getTypeCount}
+        idx={id}
+        key={id}
+        onAdd={onAdd}
+        onSelect={onSelect}
+        selectedID={selectedID}
+        selectedRegionID={selectedRegionID}
+        type={plan}
+        updatePlanCount={updatePlanCount}
+      />
+    ));
+  }, [
+    disabled,
+    getTypeCount,
+    onAdd,
+    onSelect,
+    plans,
+    selectedID,
+    selectedRegionID,
+    updatePlanCount,
+  ]);
 
   return (
     <Grid container spacing={2}>
       <Hidden mdUp>
-        {plans.map((plan, id) => (
-          <KubernetesPlanSelection
-            disabled={disabled}
-            getTypeCount={getTypeCount}
-            idx={id}
-            key={id}
-            onAdd={onAdd}
-            onSelect={onSelect}
-            selectedID={selectedID}
-            type={plan}
-            updatePlanCount={updatePlanCount}
-          />
-        ))}
+        {shouldDisplayNoRegionSelectedMessage ? (
+          <TableRowEmpty colSpan={9} message={NO_REGION_SELECTED_MESSAGE} />
+        ) : (
+          renderPlanSelection()
+        )}
       </Hidden>
       <Hidden mdDown>
         <Grid lg={12} xs={12}>
@@ -84,19 +113,14 @@ export const KubernetesPlanContainer = (props: Props) => {
               </TableRow>
             </TableHead>
             <TableBody role="grid">
-              {plans.map((plan, id) => (
-                <KubernetesPlanSelection
-                  disabled={disabled}
-                  getTypeCount={getTypeCount}
-                  idx={id}
-                  key={id}
-                  onAdd={onAdd}
-                  onSelect={onSelect}
-                  selectedID={selectedID}
-                  type={plan}
-                  updatePlanCount={updatePlanCount}
+              {shouldDisplayNoRegionSelectedMessage ? (
+                <TableRowEmpty
+                  colSpan={9}
+                  message={NO_REGION_SELECTED_MESSAGE}
                 />
-              ))}
+              ) : (
+                renderPlanSelection()
+              )}
             </TableBody>
           </Table>
         </Grid>

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
@@ -11,6 +11,7 @@ import { TableRow } from 'src/components/TableRow';
 import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
 import { useFlags } from 'src/hooks/useFlags';
 import { ExtendedType } from 'src/utilities/extendType';
+import { PLAN_NO_REGION_SELECTED_MESSAGE } from 'src/utilities/pricing/constants';
 
 import { KubernetesPlanSelection } from './KubernetesPlanSelection';
 
@@ -24,9 +25,7 @@ const tableCells = [
   { cellName: 'Quantity', center: false, noWrap: false, testId: 'quantity' },
 ];
 
-const NO_REGION_SELECTED_MESSAGE = 'Select a region to view plans and prices.';
-
-interface Props {
+export interface KubernetesPlanContainerProps {
   disabled?: boolean;
   getTypeCount: (planId: string) => number;
   onAdd?: (key: string, value: number) => void;
@@ -37,7 +36,9 @@ interface Props {
   updatePlanCount: (planId: string, newCount: number) => void;
 }
 
-export const KubernetesPlanContainer = (props: Props) => {
+export const KubernetesPlanContainer = (
+  props: KubernetesPlanContainerProps
+) => {
   const {
     disabled,
     getTypeCount,
@@ -88,7 +89,7 @@ export const KubernetesPlanContainer = (props: Props) => {
             spacingLeft={8}
             spacingTop={8}
             sx={{ '& p': { fontSize: '0.875rem' } }}
-            text={NO_REGION_SELECTED_MESSAGE}
+            text={PLAN_NO_REGION_SELECTED_MESSAGE}
             variant="info"
           />
         ) : (
@@ -123,7 +124,7 @@ export const KubernetesPlanContainer = (props: Props) => {
               {shouldDisplayNoRegionSelectedMessage ? (
                 <TableRowEmpty
                   colSpan={9}
-                  message={NO_REGION_SELECTED_MESSAGE}
+                  message={PLAN_NO_REGION_SELECTED_MESSAGE}
                 />
               ) : (
                 renderPlanSelection()

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
@@ -1,0 +1,58 @@
+import { render, waitFor } from '@testing-library/react';
+import * as React from 'react';
+
+import { extendedTypes } from 'src/__data__/ExtendedType';
+import { wrapWithTableBody } from 'src/utilities/testHelpers';
+
+import {
+  KubernetesPlanSelection,
+  KubernetesPlanSelectionProps,
+} from './KubernetesPlanSelection';
+
+const props: KubernetesPlanSelectionProps = {
+  disabled: false,
+  getTypeCount: jest.fn(),
+  idx: 0,
+  onAdd: jest.fn(),
+  onSelect: jest.fn(),
+  selectedID: '1234',
+  selectedRegionID: 'us-east',
+  type: extendedTypes[0],
+  updatePlanCount: jest.fn(),
+};
+
+describe('KubernetesPlanSelection', () => {
+  it('Includes the plan label, monthly, and hourly price', async () => {
+    const { queryAllByText } = render(
+      wrapWithTableBody(<KubernetesPlanSelection {...props} />)
+    );
+
+    await waitFor(() => expect(queryAllByText('Linode 1 GB')));
+    await waitFor(() => expect(queryAllByText('$10')));
+    await waitFor(() => expect(queryAllByText('$0.015')));
+  });
+
+  it('Includes a DC-specific monthly and hourly price in a region with a price increase when the DC-Specific pricing feature flag on', async () => {
+    const { queryAllByText } = render(
+      wrapWithTableBody(
+        <KubernetesPlanSelection {...props} selectedRegionID="id-cgk" />,
+        { flags: { dcSpecificPricing: true } }
+      )
+    );
+
+    await waitFor(() => expect(queryAllByText('Linode 1 GB')));
+    await waitFor(() => expect(queryAllByText('$12')));
+    await waitFor(() => expect(queryAllByText('$0.018')));
+  });
+
+  it('Uses the base monthly and hourly price in a region with a price increase when the DC-Specific pricing feature flag off', async () => {
+    const { queryAllByText } = render(
+      wrapWithTableBody(
+        <KubernetesPlanSelection {...props} selectedRegionID="id-cgk" />
+      )
+    );
+
+    await waitFor(() => expect(queryAllByText('$10')));
+    await waitFor(() => expect(queryAllByText('$0.015')));
+  });
+});

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
@@ -1,58 +1,136 @@
-import { render, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import * as React from 'react';
 
-import { extendedTypes } from 'src/__data__/ExtendedType';
-import { wrapWithTableBody } from 'src/utilities/testHelpers';
+import { extendedTypeFactory } from 'src/factories/types';
+import { breakpoints } from 'src/foundations/breakpoints';
+import {
+  renderWithTheme,
+  resizeScreenSize,
+  wrapWithTableBody,
+} from 'src/utilities/testHelpers';
 
 import {
   KubernetesPlanSelection,
   KubernetesPlanSelectionProps,
 } from './KubernetesPlanSelection';
 
+const planHeader = 'Dedicated 20 GB';
+const baseHourlyPrice = '$0.015';
+const baseMonthlyPrice = '$10';
+const regionHourlyPrice = '$0.018';
+const regionMonthlyPrice = '$12';
+const ram = '16 GB';
+const cpu = '8';
+const storage = '1024 GB';
+
+const extendedType = extendedTypeFactory.build();
+
 const props: KubernetesPlanSelectionProps = {
-  disabled: false,
   getTypeCount: jest.fn(),
   idx: 0,
   onAdd: jest.fn(),
   onSelect: jest.fn(),
-  selectedID: '1234',
   selectedRegionID: 'us-east',
-  type: extendedTypes[0],
+  type: extendedType,
   updatePlanCount: jest.fn(),
 };
 
-describe('KubernetesPlanSelection', () => {
-  it('Includes the plan label, monthly, and hourly price', async () => {
-    const { queryAllByText } = render(
+describe('KubernetesPlanSelection (table, desktop view)', () => {
+  beforeAll(() => {
+    resizeScreenSize(breakpoints.values.lg);
+  });
+
+  it('displays the plan header label, monthly and hourly price, RAM, CPUs, storage, and quantity selection', async () => {
+    const { getByText, queryByTestId } = render(
       wrapWithTableBody(<KubernetesPlanSelection {...props} />)
     );
 
-    await waitFor(() => expect(queryAllByText('Linode 1 GB')));
-    await waitFor(() => expect(queryAllByText('$10')));
-    await waitFor(() => expect(queryAllByText('$0.015')));
+    const quantity = queryByTestId('quantity-input');
+    const addPlanButton = getByText('Add', { exact: true }).closest('button');
+
+    expect(getByText(planHeader)).toBeInTheDocument();
+    expect(getByText(baseHourlyPrice)).toBeInTheDocument();
+    expect(getByText(baseMonthlyPrice)).toBeInTheDocument();
+    expect(getByText(ram)).toBeInTheDocument();
+    expect(getByText(cpu)).toBeInTheDocument();
+    expect(getByText(storage)).toBeInTheDocument();
+
+    expect(quantity).toBeInTheDocument();
+    expect(addPlanButton).toBeInTheDocument();
   });
 
-  it('Includes a DC-specific monthly and hourly price in a region with a price increase when the DC-Specific pricing feature flag on', async () => {
-    const { queryAllByText } = render(
+  it('displays DC-specific prices in a region with a price increase when the DC-Specific pricing feature flag is on', async () => {
+    const { queryByText } = render(
       wrapWithTableBody(
         <KubernetesPlanSelection {...props} selectedRegionID="id-cgk" />,
         { flags: { dcSpecificPricing: true } }
       )
     );
 
-    await waitFor(() => expect(queryAllByText('Linode 1 GB')));
-    await waitFor(() => expect(queryAllByText('$12')));
-    await waitFor(() => expect(queryAllByText('$0.018')));
+    expect(queryByText(regionHourlyPrice)).toBeInTheDocument();
+    expect(queryByText(regionMonthlyPrice)).toBeInTheDocument();
   });
 
-  it('Uses the base monthly and hourly price in a region with a price increase when the DC-Specific pricing feature flag off', async () => {
-    const { queryAllByText } = render(
+  it('displays base prices in a region with a price increase when the DC-Specific pricing feature flag is off', async () => {
+    const { queryByText } = render(
       wrapWithTableBody(
         <KubernetesPlanSelection {...props} selectedRegionID="id-cgk" />
       )
     );
 
-    await waitFor(() => expect(queryAllByText('$10')));
-    await waitFor(() => expect(queryAllByText('$0.015')));
+    expect(queryByText(baseHourlyPrice)).toBeInTheDocument();
+    expect(queryByText(baseMonthlyPrice)).toBeInTheDocument();
+  });
+
+  describe('KubernetesPlanSelection (cards, mobile view)', () => {
+    beforeAll(() => {
+      resizeScreenSize(breakpoints.values.sm);
+    });
+
+    it('displays the plan header label, monthly and hourly price, RAM, CPUs, and storage', async () => {
+      const { getByText } = renderWithTheme(
+        <KubernetesPlanSelection {...props} />
+      );
+
+      expect(getByText(planHeader)).toBeInTheDocument();
+      expect(
+        getByText(`${baseMonthlyPrice}/mo`, { exact: false })
+      ).toBeInTheDocument();
+      expect(
+        getByText(`${baseHourlyPrice}/hr`, { exact: false })
+      ).toBeInTheDocument();
+      expect(getByText(`${cpu} CPU`, { exact: false })).toBeInTheDocument();
+      expect(
+        getByText(`${storage} Storage`, { exact: false })
+      ).toBeInTheDocument();
+      expect(getByText(`${ram} RAM`, { exact: false })).toBeInTheDocument();
+    });
+
+    it('displays DC-specific prices in a region with a price increase when the DC-Specific pricing feature flag on', async () => {
+      const { getByText } = renderWithTheme(
+        <KubernetesPlanSelection {...props} selectedRegionID="id-cgk" />,
+        { flags: { dcSpecificPricing: true } }
+      );
+
+      expect(
+        getByText(`${regionMonthlyPrice}/mo`, { exact: false })
+      ).toBeInTheDocument();
+      expect(
+        getByText(`${regionHourlyPrice}/hr`, { exact: false })
+      ).toBeInTheDocument();
+    });
+
+    it('displays base prices in a region with a price increase when the DC-Specific pricing feature flag off', async () => {
+      const { getByText } = renderWithTheme(
+        <KubernetesPlanSelection {...props} selectedRegionID="id-cgk" />
+      );
+
+      expect(
+        getByText(`${baseMonthlyPrice}/mo`, { exact: false })
+      ).toBeInTheDocument();
+      expect(
+        getByText(`${baseHourlyPrice}/hr`, { exact: false })
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
@@ -49,8 +49,11 @@ export const KubernetesPlanSelection = (props: Props) => {
       ? getLinodeRegionPrice(type, selectedRegionID)
       : type.price;
 
-  // We don't want network information for LKE so we remove the last two elements.
-  const subHeadings = type.subHeadings.slice(0, -2);
+  // We don't want flat-rate pricing or network information for LKE so we select only the second type element.
+  const subHeadings = [
+    `$${price.monthly}/mo ($${price.hourly}/hr)`,
+    type.subHeadings[1],
+  ];
 
   const renderVariant = () => (
     <Grid xs={12}>

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
@@ -1,3 +1,5 @@
+import { PriceObject } from '@linode/api-v4';
+import { Region } from '@linode/api-v4/lib/regions';
 import Grid from '@mui/material/Unstable_Grid2';
 import { styled } from '@mui/material/styles';
 import * as React from 'react';
@@ -8,7 +10,9 @@ import { Hidden } from 'src/components/Hidden';
 import { SelectionCard } from 'src/components/SelectionCard/SelectionCard';
 import { TableCell } from 'src/components/TableCell';
 import { StyledDisabledTableRow } from 'src/features/components/PlansPanel/PlansPanel.styles';
+import { useFlags } from 'src/hooks/useFlags';
 import { ExtendedType } from 'src/utilities/extendType';
+import { getLinodeRegionPrice } from 'src/utilities/pricing/linodes';
 import { convertMegabytesTo } from 'src/utilities/unitConversions';
 
 interface Props {
@@ -18,6 +22,7 @@ interface Props {
   onAdd?: (key: string, value: number) => void;
   onSelect: (key: string) => void;
   selectedID?: string;
+  selectedRegionID?: Region['id'];
   type: ExtendedType;
   updatePlanCount: (planId: string, newCount: number) => void;
 }
@@ -30,11 +35,19 @@ export const KubernetesPlanSelection = (props: Props) => {
     onAdd,
     onSelect,
     selectedID,
+    selectedRegionID,
     type,
     updatePlanCount,
   } = props;
 
+  const flags = useFlags();
+
   const count = getTypeCount(type.id);
+
+  const price: PriceObject =
+    flags.dcSpecificPricing && selectedRegionID
+      ? getLinodeRegionPrice(type, selectedRegionID)
+      : type.price;
 
   // We don't want network information for LKE so we remove the last two elements.
   const subHeadings = type.subHeadings.slice(0, -2);
@@ -70,8 +83,8 @@ export const KubernetesPlanSelection = (props: Props) => {
           key={type.id}
         >
           <TableCell data-qa-plan-name>{type.heading}</TableCell>
-          <TableCell data-qa-monthly> ${type.price.monthly}</TableCell>
-          <TableCell data-qa-hourly>{`$` + type.price.hourly}</TableCell>
+          <TableCell data-qa-monthly> ${price.monthly}</TableCell>
+          <TableCell data-qa-hourly>${price.hourly}</TableCell>
           <TableCell center data-qa-ram>
             {convertMegabytesTo(type.memory, true)}
           </TableCell>

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
@@ -15,7 +15,7 @@ import { ExtendedType } from 'src/utilities/extendType';
 import { getLinodeRegionPrice } from 'src/utilities/pricing/linodes';
 import { convertMegabytesTo } from 'src/utilities/unitConversions';
 
-interface Props {
+export interface KubernetesPlanSelectionProps {
   disabled?: boolean;
   getTypeCount: (planId: string) => number;
   idx: number;
@@ -27,7 +27,9 @@ interface Props {
   updatePlanCount: (planId: string, newCount: number) => void;
 }
 
-export const KubernetesPlanSelection = (props: Props) => {
+export const KubernetesPlanSelection = (
+  props: KubernetesPlanSelectionProps
+) => {
   const {
     disabled,
     getTypeCount,

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
@@ -31,6 +31,7 @@ interface Props {
   regionsData: Region[];
   resetValues: () => void;
   selectedID?: string;
+  selectedRegionID?: Region['id'] | string;
   types: ExtendedType[];
   updatePlanCount: (planId: string, newCount: number) => void;
 }
@@ -51,6 +52,7 @@ export const KubernetesPlansPanel = (props: Props) => {
     regionsData,
     resetValues,
     selectedID,
+    selectedRegionID,
     types,
     updatePlanCount,
   } = props;
@@ -77,6 +79,7 @@ export const KubernetesPlansPanel = (props: Props) => {
               onSelect={onSelect}
               plans={plans[plan]}
               selectedID={selectedID}
+              selectedRegionID={selectedRegionID}
               updatePlanCount={updatePlanCount}
             />
           </>

--- a/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
@@ -4,106 +4,12 @@ import {
   nodePoolFactory,
 } from 'src/factories';
 import { extendType } from 'src/utilities/extendType';
-import { LKE_HA_PRICE } from 'src/utilities/pricing/constants';
 
-import {
-  getMonthlyPrice,
-  getTotalClusterMemoryCPUAndStorage,
-  getTotalClusterPrice,
-} from './kubeUtils';
-
-const mockNodePool = nodePoolFactory.build({
-  count: 2,
-  type: 'g1-fake-1',
-});
-
-const types = linodeTypeFactory
-  .buildList(2, {
-    id: 'g1-fake-1',
-    price: {
-      monthly: 5,
-    },
-  })
-  .map(extendType);
+import { getTotalClusterMemoryCPUAndStorage } from './kubeUtils';
 
 describe('helper functions', () => {
   const badPool = nodePoolFactory.build({
     type: 'not-a-real-type',
-  });
-  const region = 'us_east';
-
-  describe('getMonthlyPrice', () => {
-    it('should multiply node price by node count', () => {
-      const expectedPrice = (types[0].price.monthly ?? 0) * mockNodePool.count;
-      expect(
-        getMonthlyPrice({
-          count: mockNodePool.count,
-          flags: { dcSpecificPricing: false },
-          region,
-          type: mockNodePool.type,
-          types,
-        })
-      ).toBe(expectedPrice);
-    });
-
-    it('should return zero for bad input', () => {
-      expect(
-        getMonthlyPrice({
-          count: badPool.count,
-          flags: { dcSpecificPricing: false },
-          region,
-          type: badPool.type,
-          types,
-        })
-      ).toBe(0);
-    });
-  });
-
-  describe('getTotalClusterPrice', () => {
-    it('should calculate the total cluster price', () => {
-      expect(
-        getTotalClusterPrice({
-          flags: { dcSpecificPricing: false },
-          pools: [mockNodePool, mockNodePool],
-          region,
-          types,
-        })
-      ).toBe(20);
-    });
-
-    it('should calculate the total cluster DC-specific price for a region with a price increase when the DC-Specific pricing feature flag is on', () => {
-      expect(
-        getTotalClusterPrice({
-          flags: { dcSpecificPricing: true },
-          pools: [mockNodePool, mockNodePool],
-          region: 'id-cgk',
-          types,
-        })
-      ).toBe(48);
-    });
-
-    it('should calculate the total cluster base price for a region with a price increase when the DC-Specific pricing feature flag is off', () => {
-      expect(
-        getTotalClusterPrice({
-          flags: { dcSpecificPricing: false },
-          pools: [mockNodePool, mockNodePool],
-          region: 'id-cgk',
-          types,
-        })
-      ).toBe(20);
-    });
-
-    it('should calculate the total cluster price with HA enabled', () => {
-      expect(
-        getTotalClusterPrice({
-          flags: { dcSpecificPricing: false },
-          highAvailabilityPrice: LKE_HA_PRICE,
-          pools: [mockNodePool, mockNodePool],
-          region,
-          types,
-        })
-      ).toBe(20 + LKE_HA_PRICE);
-    });
   });
 
   describe('Get total cluster memory/CPUs', () => {

--- a/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
@@ -71,6 +71,28 @@ describe('helper functions', () => {
       ).toBe(20);
     });
 
+    it('should calculate the total cluster DC-specific price for a region with a price increase when the DC-Specific pricing feature flag is on', () => {
+      expect(
+        getTotalClusterPrice({
+          flags: { dcSpecificPricing: true },
+          pools: [mockNodePool, mockNodePool],
+          region: 'id-cgk',
+          types,
+        })
+      ).toBe(48);
+    });
+
+    it('should calculate the total cluster base price for a region with a price increase when the DC-Specific pricing feature flag is off', () => {
+      expect(
+        getTotalClusterPrice({
+          flags: { dcSpecificPricing: false },
+          pools: [mockNodePool, mockNodePool],
+          region: 'id-cgk',
+          types,
+        })
+      ).toBe(20);
+    });
+
     it('should calculate the total cluster price with HA enabled', () => {
       expect(
         getTotalClusterPrice({

--- a/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
@@ -30,30 +30,56 @@ describe('helper functions', () => {
   const badPool = nodePoolFactory.build({
     type: 'not-a-real-type',
   });
+  const region = 'us_east';
 
   describe('getMonthlyPrice', () => {
     it('should multiply node price by node count', () => {
       const expectedPrice = (types[0].price.monthly ?? 0) * mockNodePool.count;
       expect(
-        getMonthlyPrice(mockNodePool.type, mockNodePool.count, types)
+        getMonthlyPrice({
+          count: mockNodePool.count,
+          flags: { dcSpecificPricing: false },
+          region,
+          type: mockNodePool.type,
+          types,
+        })
       ).toBe(expectedPrice);
     });
 
     it('should return zero for bad input', () => {
-      expect(getMonthlyPrice(badPool.type, badPool.count, types)).toBe(0);
+      expect(
+        getMonthlyPrice({
+          count: badPool.count,
+          flags: { dcSpecificPricing: false },
+          region,
+          type: badPool.type,
+          types,
+        })
+      ).toBe(0);
     });
   });
 
   describe('getTotalClusterPrice', () => {
     it('should calculate the total cluster price', () => {
-      expect(getTotalClusterPrice([mockNodePool, mockNodePool], types)).toBe(
-        20
-      );
+      expect(
+        getTotalClusterPrice({
+          flags: { dcSpecificPricing: false },
+          pools: [mockNodePool, mockNodePool],
+          region,
+          types,
+        })
+      ).toBe(20);
     });
 
     it('should calculate the total cluster price with HA enabled', () => {
       expect(
-        getTotalClusterPrice([mockNodePool, mockNodePool], types, LKE_HA_PRICE)
+        getTotalClusterPrice({
+          flags: { dcSpecificPricing: false },
+          highAvailabilityPrice: LKE_HA_PRICE,
+          pools: [mockNodePool, mockNodePool],
+          region,
+          types,
+        })
       ).toBe(20 + LKE_HA_PRICE);
     });
   });

--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -18,7 +18,7 @@ interface MonthlyPriceOptions {
   count: number;
   flags: FlagSet;
   region: Region['id'] | undefined;
-  type: string;
+  type: ExtendedType | string;
   types: ExtendedType[];
 }
 
@@ -30,6 +30,10 @@ interface TotalClusterPriceOptions {
   types: ExtendedType[];
 }
 
+/**
+ * Calculates the monthly price of a group of linodes based on region and types.
+ * @returns The monthly price for the linodes, or 0 if price cannot be calculated
+ */
 export const getMonthlyPrice = ({
   count,
   flags,
@@ -37,19 +41,23 @@ export const getMonthlyPrice = ({
   type,
   types,
 }: MonthlyPriceOptions) => {
-  if (!types) {
-    return 0;
+  if (!types || !type || !region) {
+    return 0; // TODO
   }
   const thisType = types.find((t: ExtendedType) => t.id === type);
   const monthlyPrice = flags.dcSpecificPricing
-    ? thisType && region
-      ? getLinodeRegionPrice(thisType, region).monthly
-      : undefined
+    ? thisType
+      ? getLinodeRegionPrice(thisType, region)?.monthly
+      : 0
     : thisType?.price.monthly;
 
   return thisType ? (monthlyPrice ?? 0) * count : 0;
 };
 
+/**
+ * Calculates the total monthly price of all pools in a cluster, plus HA if enabled.
+ * @returns The total monthly cluster price
+ */
 export const getTotalClusterPrice = ({
   flags,
   highAvailabilityPrice,

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -712,7 +712,11 @@ export const handlers = [
   rest.put('*/lke/clusters/:clusterId', async (req, res, ctx) => {
     const id = Number(req.params.clusterId);
     const k8s_version = req.params.k8s_version;
-    const cluster = kubernetesAPIResponse.build({ id, k8s_version });
+    const cluster = kubernetesAPIResponse.build({
+      id,
+      k8s_version,
+      region: 'id_cgk',
+    });
     return res(ctx.json(cluster));
   }),
   rest.get('*/lke/clusters/:clusterId/pools', async (req, res, ctx) => {

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -715,7 +715,6 @@ export const handlers = [
     const cluster = kubernetesAPIResponse.build({
       id,
       k8s_version,
-      region: 'id_cgk',
     });
     return res(ctx.json(cluster));
   }),

--- a/packages/manager/src/utilities/pricing/constants.ts
+++ b/packages/manager/src/utilities/pricing/constants.ts
@@ -6,5 +6,5 @@ export const LKE_HA_PRICE = 60;
 // Other constants
 export const PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE =
   'Select a region to view plans and prices.';
-export const LKE_CREATE_CLUSTER_CHECKOUT =
+export const LKE_CREATE_CLUSTER_CHECKOUT_MESSAGE =
   'Select a Region, HA choice, and add a Node Pool to view pricing and create a cluster.';

--- a/packages/manager/src/utilities/pricing/kubernetes.test.tsx
+++ b/packages/manager/src/utilities/pricing/kubernetes.test.tsx
@@ -1,0 +1,100 @@
+import { linodeTypeFactory, nodePoolFactory } from 'src/factories';
+import { extendType } from 'src/utilities/extendType';
+import { LKE_HA_PRICE } from 'src/utilities/pricing/constants';
+
+import { getKubernetesMonthlyPrice, getTotalClusterPrice } from './kubernetes';
+
+const mockNodePool = nodePoolFactory.build({
+  count: 2,
+  type: 'g1-fake-1',
+});
+
+const types = linodeTypeFactory
+  .buildList(2, {
+    id: 'g1-fake-1',
+    price: {
+      monthly: 5,
+    },
+  })
+  .map(extendType);
+
+describe('helper functions', () => {
+  const badPool = nodePoolFactory.build({
+    type: 'not-a-real-type',
+  });
+  const region = 'us_east';
+
+  describe('getMonthlyPrice', () => {
+    it('should multiply node price by node count', () => {
+      const expectedPrice = (types[0].price.monthly ?? 0) * mockNodePool.count;
+      expect(
+        getKubernetesMonthlyPrice({
+          count: mockNodePool.count,
+          flags: { dcSpecificPricing: false },
+          region,
+          type: mockNodePool.type,
+          types,
+        })
+      ).toBe(expectedPrice);
+    });
+
+    it('should return zero for bad input', () => {
+      expect(
+        getKubernetesMonthlyPrice({
+          count: badPool.count,
+          flags: { dcSpecificPricing: false },
+          region,
+          type: badPool.type,
+          types,
+        })
+      ).toBe(0);
+    });
+  });
+
+  describe('getTotalClusterPrice', () => {
+    it('should calculate the total cluster price', () => {
+      expect(
+        getTotalClusterPrice({
+          flags: { dcSpecificPricing: false },
+          pools: [mockNodePool, mockNodePool],
+          region,
+          types,
+        })
+      ).toBe(20);
+    });
+
+    it('should calculate the total cluster DC-specific price for a region with a price increase when the DC-Specific pricing feature flag is on', () => {
+      expect(
+        getTotalClusterPrice({
+          flags: { dcSpecificPricing: true },
+          pools: [mockNodePool, mockNodePool],
+          region: 'id-cgk',
+          types,
+        })
+      ).toBe(48);
+    });
+
+    it('should calculate the total cluster base price for a region with a price increase when the DC-Specific pricing feature flag is off', () => {
+      expect(
+        getTotalClusterPrice({
+          flags: { dcSpecificPricing: false },
+          pools: [mockNodePool, mockNodePool],
+          region: 'id-cgk',
+          types,
+        })
+      ).toBe(20);
+    });
+
+    it('should calculate the total cluster price with HA enabled', () => {
+      expect(
+        getTotalClusterPrice({
+          flags: { dcSpecificPricing: false },
+          highAvailabilityPrice: LKE_HA_PRICE,
+          pools: [mockNodePool, mockNodePool],
+          region,
+          types,
+        })
+      ).toBe(20 + LKE_HA_PRICE);
+    });
+  });
+});

--- a/packages/manager/src/utilities/pricing/kubernetes.ts
+++ b/packages/manager/src/utilities/pricing/kubernetes.ts
@@ -1,0 +1,72 @@
+import { getLinodeRegionPrice } from 'src/utilities/pricing/linodes';
+
+import type { KubeNodePoolResponse, Region } from '@linode/api-v4/lib';
+import type { FlagSet } from 'src/featureFlags';
+import type { ExtendedType } from 'src/utilities/extendType';
+
+interface MonthlyPriceOptions {
+  count: number;
+  flags: FlagSet;
+  region: Region['id'] | undefined;
+  type: ExtendedType | string;
+  types: ExtendedType[];
+}
+
+interface TotalClusterPriceOptions {
+  flags: FlagSet;
+  highAvailabilityPrice?: number;
+  pools: KubeNodePoolResponse[];
+  region: Region['id'] | undefined;
+  types: ExtendedType[];
+}
+
+/**
+ * Calculates the monthly price of a group of linodes based on region and types.
+ * @returns The monthly price for the linodes, or 0 if price cannot be calculated
+ */
+export const getKubernetesMonthlyPrice = ({
+  count,
+  flags,
+  region,
+  type,
+  types,
+}: MonthlyPriceOptions) => {
+  if (!types || !type || !region) {
+    return 0; // TODO
+  }
+  const thisType = types.find((t: ExtendedType) => t.id === type);
+  const monthlyPrice = flags.dcSpecificPricing
+    ? thisType
+      ? getLinodeRegionPrice(thisType, region)?.monthly
+      : 0
+    : thisType?.price.monthly;
+
+  return thisType ? (monthlyPrice ?? 0) * count : 0;
+};
+
+/**
+ * Calculates the total monthly price of all pools in a cluster, plus HA if enabled.
+ * @returns The total monthly cluster price
+ */
+export const getTotalClusterPrice = ({
+  flags,
+  highAvailabilityPrice,
+  pools,
+  region,
+  types,
+}: TotalClusterPriceOptions) => {
+  const price = pools.reduce((accumulator, node) => {
+    return (
+      accumulator +
+      getKubernetesMonthlyPrice({
+        count: node.count,
+        flags,
+        region,
+        type: node.type,
+        types,
+      })
+    );
+  }, 0);
+
+  return highAvailabilityPrice ? price + highAvailabilityPrice : price;
+};


### PR DESCRIPTION
## Description 📝
This PR adds DC-specific pricing for Kubernetes node pools in the create flow and on the details page in add/resize drawers.

## Major Changes 🔄
**With the mocks and feature flag on:**
Kube Create page:
- When a region **is selected**, the Node Pools table displays the hourly and monthly pricing corresponding to the selected region.
- When a region **is not selected,** the Node Pools table does not display rows, and instead displays a message: "Select a Region to view plans and prices."
- The Cluster Summary displays correctly calculated DC-specific pricing based on the Linode's region – both Node Pool line items and the total.
- When either a region or a pool is not selected, the cluster summary does not display prices and displays helper text indicating what selections must be made for pricing and cluster creation.

Kube Details page:
- Kube cluster specs displays a correctly calculated total DC-specific total price of the cluster/month. 

Add a Node Pool drawer:
- The Node Pools table displays the hourly and monthly pricing corresponding to the region the cluster is in.
- The drawer copy displays correctly calculated DC-specific pricing based on the cluster's region.

Resize Pool drawer:
- The drawer copy displays correctly calculated DC-specific pricing based on the cluster's region.

## Preview 📷
| Flow/Component | Before  | After   |
| ------- | ------- | ------- |
| Create Cluster -> Node Pool Panel & Plan Selection | ![Screenshot 2023-08-30 at 4 14 48 PM](https://github.com/linode/manager/assets/114685994/157051b5-3a53-4e25-b6ee-8bbf2dda90ff) ![Screenshot 2023-08-30 at 4 12 25 PM](https://github.com/linode/manager/assets/114685994/45a9018f-75ae-4c56-a301-3ccffdad10fb) | ![Screenshot 2023-08-30 at 10 35 21 AM](https://github.com/linode/manager/assets/114685994/77526dd4-ae32-44c4-9989-39c4b90b2dde) ![Screenshot 2023-08-30 at 3 20 42 PM](https://github.com/linode/manager/assets/114685994/7c9ef500-07f9-4903-b73b-676aad97f444)|
| Create Cluster -> Checkout Bar | ![Screenshot 2023-08-30 at 4 13 05 PM](https://github.com/linode/manager/assets/114685994/febb4136-6740-4119-b5e7-29b5f9e94d0d) | ![Screenshot 2023-08-30 at 4 21 03 PM](https://github.com/linode/manager/assets/114685994/bad5aab3-473d-435b-b407-a939903e8767)|
| Kubenetes Cluster Details -> Specs | ![Screenshot 2023-08-30 at 3 30 22 PM](https://github.com/linode/manager/assets/114685994/8cc6fda6-e6d5-4706-b65b-8c3c44f695be) | ![Screenshot 2023-08-30 at 3 30 14 PM](https://github.com/linode/manager/assets/114685994/eeb54d28-5be2-434f-a826-1d483ee8cb2e)|
| Kubernetes Cluster Details -> Add Node Pool Drawer  | ![Screenshot 2023-08-30 at 3 30 46 PM](https://github.com/linode/manager/assets/114685994/418cd599-063f-4769-9a92-cafc470fb976) | ![Screenshot 2023-08-30 at 3 31 02 PM](https://github.com/linode/manager/assets/114685994/e99676cf-6bc7-4f2e-86da-9dafe1e84148) |
| Kubernetes Cluster Details -> Resize Node Pool Drawer  | ![Screenshot 2023-08-30 at 3 31 43 PM](https://github.com/linode/manager/assets/114685994/f4eae87c-5803-4ca9-9ec3-3af748b34208) | ![Screenshot 2023-08-30 at 3 31 27 PM](https://github.com/linode/manager/assets/114685994/6db5ba55-c457-4125-b108-6716d1696857)|

## How to test 🧪
1. **How to setup test environment?**
- Ensure `DC-Specific Pricing` flag and MSW are both **on**.
- To test, I temporarily modified the `kubernetesAPIResponse` and `kubernetesClusterFactory` factories and replaces `region: 'us-central'` with `region: 'id-cgk'`.

3. **How to verify changes?**

- Test that the above changes are visible with the DC-Specific Pricing flag **on** and not visible with the flag **off**.
- Confirm that the plans selection cards in mobile view update dynamically with region selection when the flag is on and the notice looks good.

5. **How to run Unit or E2E tests?**
```
yarn test NodePoolPanel kubeUtils ResizeNodePoolDrawer KubeCheckoutBar KubernetesPlanContainer KubernetesPlanSelection
```

I did not cover the Add/Resize Node Pool drawers. There is an `lke-update.spec.ts` testing adding and resizing node pools; these should be updated in an e2e ticket.
