### PR TITLE
hotfix: Disable Configs API call when VPC is off

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2023-08-30] - v1.100.2
+
+### Fixed:
+
+- Extra API calls for Linode Configs ([#9609](https://github.com/linode/manager/pull/9609))
+
+
 ## [2023-08-22] - v1.100.1
 
 ### Fixed:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.100.1",
+  "version": "1.100.2",
   "private": true,
   "bugs": {
     "url": "https://github.com/Linode/manager/issues"

--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -63,7 +63,8 @@ export const LinodeRow = (props: Props) => {
 
   // TODO: VPC - later if there is a way to directly get a linode's vpc, replace this
   const { data: configs, isLoading: configsLoading } = useAllLinodeConfigsQuery(
-    id
+    id,
+    flags.vpc
   );
   const vpcId = getVPCId(configs ?? []);
   const { data: vpc, isLoading: vpcLoading } = useVPCQuery(


### PR DESCRIPTION
## Description 📝
- Disable extra Configs API call when VPC is off

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-08-30 at 3 46 51 PM](https://github.com/linode/manager/assets/115251059/65eaa9fc-14a4-4b7d-995e-717c766b00b2) | ![Screenshot 2023-08-30 at 3 47 40 PM](https://github.com/linode/manager/assets/115251059/9a9c4502-ba77-4683-8b70-9d79ca010662) |

## How to test 🧪
- Make sure configs API calls **do not** happen when the VPC flag is off