### PR TITLE
fix: Fix E2E failures caused by inadequate resource clean-up

### DIFF
--- a/packages/manager/cypress/e2e/core/images/smoke-create-image.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/smoke-create-image.spec.ts
@@ -1,11 +1,13 @@
-import type { Image, Linode, Disk } from '@linode/api-v4/types';
+import type { Linode, Disk } from '@linode/api-v4/types';
 import { imageFactory } from 'src/factories/images';
+import { authenticate } from 'support/api/authentication';
 import { createLinode, deleteLinodeById } from 'support/api/linodes';
 import {
   mockCreateImage,
   mockGetCustomImages,
 } from 'support/intercepts/images';
 import { mockGetLinodeDisks } from 'support/intercepts/linodes';
+import { cleanUp } from 'support/util/cleanup';
 import { randomLabel, randomNumber, randomPhrase } from 'support/util/random';
 
 const diskLabel = 'Debian 10 Disk';
@@ -31,7 +33,12 @@ const mockDisks: Disk[] = [
   },
 ];
 
+authenticate();
 describe('create image', () => {
+  before(() => {
+    cleanUp('linodes');
+  });
+
   it('captures image from Linode and mocks create image', () => {
     const imageLabel = randomLabel();
     const imageDescription = randomPhrase();

--- a/packages/manager/cypress/e2e/core/linodes/backup-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/backup-linode.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-disable sonarjs/no-duplicate-string */
+import { authenticate } from 'support/api/authentication';
 import { createLinode, deleteLinodeById } from 'support/api/linodes';
 import {
   containsClick,
@@ -8,9 +9,15 @@ import {
   getClick,
 } from 'support/helpers';
 import { ui } from 'support/ui';
+import { cleanUp } from 'support/util/cleanup';
 import { apiMatcher } from 'support/util/intercepts';
 
+authenticate();
 describe('linode backups', () => {
+  before(() => {
+    cleanUp('linodes');
+  });
+
   it('enable backups', () => {
     createLinode().then((linode) => {
       // intercept request

--- a/packages/manager/cypress/e2e/core/longview/longview.spec.ts
+++ b/packages/manager/cypress/e2e/core/longview/longview.spec.ts
@@ -11,7 +11,7 @@ import { authenticate } from 'support/api/authentication';
 authenticate();
 describe('longview', () => {
   before(() => {
-    cleanUp('longview-clients');
+    cleanUp(['linodes', 'longview-clients']);
   });
 
   it('tests longview', () => {


### PR DESCRIPTION
## Description 📝
Another test resource clean-up PR! This stems from the changes made in #9529. This should fix some of the failures we've recently seen in these specs:

- `smoke-create-image.spec.ts`
- `backup-linode.spec.ts`
- `longview.spec.ts` 

In all 3 cases, the test failures are due to the tests creating Linodes but failing to clean up existing Linodes first.

## How to test 🧪
We can rely on the automated test run to confirm that these 3 specs pass, indicating that these changes haven't broken the tests. However, manual testing may be required to confirm that the clean up actually functions as expected:

1. Create some test Linodes whose labels start with `cy-test-`
2. Navigate to the Linodes landing page in your browser, and stay there
3. Separately run one of the spec files above, and observe in your browser that the Linodes you created in step 1 get cleaned up automatically by the test
4. Repeat steps 1-3 for the other 2 spec files