### PR TITLE
fix: Kube checkout bar copy 

### DIFF
--- a/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
@@ -21,6 +21,7 @@ interface CheckoutBarProps {
   isMakingRequest?: boolean;
   onDeploy: () => void;
   priceHelperText?: string;
+  priceSelectionText?: string;
   submitText?: string;
 }
 
@@ -35,6 +36,7 @@ const CheckoutBar = (props: CheckoutBarProps) => {
     isMakingRequest,
     onDeploy,
     priceHelperText,
+    priceSelectionText,
     submitText,
   } = props;
 
@@ -61,10 +63,7 @@ const CheckoutBar = (props: CheckoutBarProps) => {
           {price ? (
             <DisplayPrice interval="mo" price={price} />
           ) : (
-            <Typography>
-              Select a Region and add a Node Pool to view pricing and create a
-              cluster.
-            </Typography>
+            <Typography>{priceSelectionText}</Typography>
           )}
           {priceHelperText && price > 0 && (
             <Typography

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
@@ -32,10 +32,7 @@ const renderComponent = (_props: Props) =>
 describe('KubeCheckoutBar', () => {
   it('should render helper text and disable create button until a region has been selected', async () => {
     const { findByText, getByTestId, getByText } = renderWithTheme(
-      <KubeCheckoutBar {...props} region="" />,
-      {
-        flags: { dcSpecificPricing: true },
-      }
+      <KubeCheckoutBar {...props} region="" />
     );
 
     await waitForElementToBeRemoved(getByTestId('circle-progress'));

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
@@ -2,7 +2,10 @@ import { waitForElementToBeRemoved } from '@testing-library/react';
 import * as React from 'react';
 
 import { nodePoolFactory } from 'src/factories/kubernetesCluster';
-import { LKE_HA_PRICE } from 'src/utilities/pricing/constants';
+import {
+  LKE_CREATE_CLUSTER_CHECKOUT,
+  LKE_HA_PRICE,
+} from 'src/utilities/pricing/constants';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import KubeCheckoutBar, { Props } from './KubeCheckoutBar';
@@ -27,7 +30,7 @@ const renderComponent = (_props: Props) =>
   renderWithTheme(<KubeCheckoutBar {..._props} />);
 
 describe('KubeCheckoutBar', () => {
-  it('with DC-specific pricing feature flag, should render helper text and disable create button until a region has been selected', async () => {
+  it('should render helper text and disable create button until a region has been selected', async () => {
     const { findByText, getByTestId, getByText } = renderWithTheme(
       <KubeCheckoutBar {...props} region="" />,
       {
@@ -37,9 +40,7 @@ describe('KubeCheckoutBar', () => {
 
     await waitForElementToBeRemoved(getByTestId('circle-progress'));
 
-    await findByText(
-      'Select a Region and add a Node Pool to view pricing and create a cluster.'
-    );
+    await findByText(LKE_CREATE_CLUSTER_CHECKOUT);
     expect(getByText('Create Cluster').closest('button')).toBeDisabled();
   });
 

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -19,6 +19,7 @@ import { isEURegion } from 'src/utilities/formatRegion';
 
 import { getTotalClusterPrice, nodeWarning } from '../kubeUtils';
 import NodePoolSummary from './NodePoolSummary';
+import { LKE_CREATE_CLUSTER_CHECKOUT } from 'src/utilities/pricing/constants';
 
 export interface Props {
   createCluster: () => void;
@@ -96,7 +97,7 @@ export const KubeCheckoutBar: React.FC<Props> = (props) => {
             )
           : undefined
       }
-      priceSelectionText="Select a Region, HA choice, and add a Node Pool to view pricing and create a cluster."
+      priceSelectionText={LKE_CREATE_CLUSTER_CHECKOUT}
       data-qa-checkout-bar
       disabled={disableCheckout}
       heading="Cluster Summary"

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -96,6 +96,7 @@ export const KubeCheckoutBar: React.FC<Props> = (props) => {
             )
           : undefined
       }
+      priceSelectionText="Select a Region, HA choice, and add a Node Pool to view pricing and create a cluster."
       data-qa-checkout-bar
       disabled={disableCheckout}
       heading="Cluster Summary"

--- a/packages/manager/src/utilities/pricing/constants.ts
+++ b/packages/manager/src/utilities/pricing/constants.ts
@@ -4,3 +4,6 @@
 export const NODEBALANCER_PRICE = 10;
 
 export const LKE_HA_PRICE = 60;
+
+export const LKE_CREATE_CLUSTER_CHECKOUT =
+  'Select a Region, HA choice, and add a Node Pool to view pricing and create a cluster.';


### PR DESCRIPTION
## Description 📝
Clarifies that HA selection is also needed to create a cluster. Also moves the copy to a prop because it shouldn't have been in `CheckoutBar`, a core component. 

Relates to changes made in #9568 and #9489. 

Still not sure that user feedback in this form is ideal because if a user selects a node pool and a region, the text is replaced with the price and user still can't submit without an HA selection.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-08-31 at 9 22 03 AM](https://github.com/linode/manager/assets/114685994/d22c6b79-0e77-4e60-87b1-f32a3db7323b) | ![Screenshot 2023-08-31 at 9 21 19 AM](https://github.com/linode/manager/assets/114685994/46ce4487-7592-44ef-8cb4-ba6149920938) |


## How to test 🧪
1. **How to verify changes?**
Play around with the kube create form, selecting HA, region, and node pool options.
