### PR TITLE
feat: [M3-7029] - Add AGLB Certificate Create Drawer

### DIFF
--- a/packages/api-v4/src/aglb/certificates.ts
+++ b/packages/api-v4/src/aglb/certificates.ts
@@ -8,6 +8,7 @@ import Request, {
 import { BETA_API_ROOT } from 'src/constants';
 import { Filter, Params, ResourcePage } from '../types';
 import { Certificate, CreateCertificatePayload } from './types';
+import { CreateCertificateSchema } from '@linode/validation';
 
 /**
  * getLoadbalancerCertificates
@@ -60,7 +61,7 @@ export const createLoadbalancerCertificate = (
       `${BETA_API_ROOT}/aglb/${encodeURIComponent(loadbalancerId)}/certificates`
     ),
     setMethod('POST'),
-    setData(data)
+    setData(data, CreateCertificateSchema)
   );
 
 /**

--- a/packages/manager/.changeset/pr-9616-upcoming-features-1693507025003.md
+++ b/packages/manager/.changeset/pr-9616-upcoming-features-1693507025003.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add AGLB Certificate Create Drawer ([#9616](https://github.com/linode/manager/pull/9616))

--- a/packages/manager/cypress/e2e/core/loadBalancers/load-balancer-details-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/loadBalancers/load-balancer-details-page.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * @file Integration tests for Akamai Global Load Balancer details page.
+ */
+
+import {
+  mockAppendFeatureFlags,
+  mockGetFeatureFlagClientstream,
+} from 'support/intercepts/feature-flags';
+import { makeFeatureFlagData } from 'support/util/feature-flags';
+import { loadbalancerFactory, certificateFactory } from '@src/factories';
+import { ui } from 'support/ui';
+import { randomLabel, randomString } from 'support/util/random';
+import {
+  mockGetLoadBalancer,
+  mockGetLoadBalancerCertificates,
+  mockUploadLoadBalancerCertificate,
+} from 'support/intercepts/load-balancers';
+
+/**
+ * Uploads a Load Balancer certificate using the "Upload Certificate" drawer.
+ *
+ * This function assumes the "Upload Certificate" drawer is already open.
+ *
+ * @param type - Certificate type; either 'tls' or 'service-target'.
+ * @param label - Certificate label.
+ */
+const uploadCertificate = (type: 'tls' | 'service-target', label: string) => {
+  const radioSelector =
+    type === 'tls' ? '[data-qa-cert-tls]' : '[data-qa-cert-service-target]';
+
+  ui.drawer
+    .findByTitle('Upload Certificate')
+    .should('be.visible')
+    .within(() => {
+      cy.get(radioSelector).should('be.visible').click();
+
+      cy.findByLabelText('Label').should('be.visible').type(label);
+
+      cy.findByLabelText('TLS Certificate')
+        .should('be.visible')
+        .type(randomString(32));
+
+      cy.findByLabelText('Private Key')
+        .should('be.visible')
+        .type(randomString(32));
+
+      ui.buttonGroup
+        .findButtonByTitle('Upload Certificate')
+        .scrollIntoView()
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+    });
+};
+
+describe('Akamai Global Load Balancer details page', () => {
+  /*
+   * - Confirms Load Balancer certificate upload UI flow using mocked API requests.
+   * - Confirms that TLS and Service Target certificates can be uploaded.
+   * - Confirms that certificates table update to reflects uploaded certificates.
+   */
+  it('can upload a Load Balancer Certificate', () => {
+    const mockLoadBalancer = loadbalancerFactory.build();
+    const mockLoadBalancerCertTls = certificateFactory.build({
+      label: randomLabel(),
+      type: 'downstream',
+    });
+    const mockLoadBalancerCertServiceTarget = certificateFactory.build({
+      label: randomLabel(),
+      type: 'ca',
+    });
+
+    mockAppendFeatureFlags({
+      aglb: makeFeatureFlagData(true),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+    mockGetLoadBalancer(mockLoadBalancer).as('getLoadBalancer');
+    mockGetLoadBalancerCertificates(mockLoadBalancer.id, []).as(
+      'getCertificates'
+    );
+
+    cy.visitWithLogin(`/loadbalancers/${mockLoadBalancer.id}/certificates`);
+    cy.wait([
+      '@getFeatureFlags',
+      '@getClientStream',
+      '@getLoadBalancer',
+      '@getCertificates',
+    ]);
+
+    // Confirm that no certificates are listed.
+    cy.findByText('No items to display.').should('be.visible');
+
+    // Upload a TLS certificate.
+    ui.button
+      .findByTitle('Upload Certificate')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    mockUploadLoadBalancerCertificate(
+      mockLoadBalancer.id,
+      mockLoadBalancerCertTls
+    ).as('uploadCertificate');
+    mockGetLoadBalancerCertificates(mockLoadBalancer.id, [
+      mockLoadBalancerCertTls,
+    ]).as('getCertificates');
+    uploadCertificate('tls', mockLoadBalancerCertTls.label);
+
+    // Confirm that new certificate is listed in the table with expected info.
+    cy.wait(['@uploadCertificate', '@getCertificates']);
+    cy.findByText(mockLoadBalancerCertTls.label)
+      .should('be.visible')
+      .closest('tr')
+      .within(() => {
+        cy.findByText('TLS Certificate').should('be.visible');
+      });
+
+    ui.button
+      .findByTitle('Upload Certificate')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    // Upload a service target certificate.
+    mockUploadLoadBalancerCertificate(
+      mockLoadBalancer.id,
+      mockLoadBalancerCertServiceTarget
+    ).as('uploadCertificate');
+    mockGetLoadBalancerCertificates(mockLoadBalancer.id, [
+      mockLoadBalancerCertTls,
+      mockLoadBalancerCertServiceTarget,
+    ]).as('getCertificates');
+    uploadCertificate(
+      'service-target',
+      mockLoadBalancerCertServiceTarget.label
+    );
+
+    // Confirm that both new certificates are listed in the table with expected info.
+    cy.wait(['@uploadCertificate', '@getCertificates']);
+    cy.findByText(mockLoadBalancerCertTls.label).should('be.visible');
+    cy.findByText(mockLoadBalancerCertServiceTarget.label)
+      .should('be.visible')
+      .closest('tr')
+      .within(() => {
+        cy.findByText('Service Target Certificate').should('be.visible');
+      });
+  });
+});

--- a/packages/manager/cypress/support/intercepts/load-balancers.ts
+++ b/packages/manager/cypress/support/intercepts/load-balancers.ts
@@ -5,7 +5,24 @@ import type {
   ServiceTarget,
   Loadbalancer,
   Configuration,
+  Certificate,
 } from '@linode/api-v4';
+import { makeResponse } from 'support/util/response';
+
+/**
+ * Intercepts GET request to fetch an AGLB load balancer and mocks response.
+ *
+ * @param loadBalancer - Load balancer with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetLoadBalancer = (loadBalancer: Loadbalancer) => {
+  return cy.intercept(
+    'GET',
+    apiMatcher(`/aglb/${loadBalancer.id}`),
+    makeResponse(loadBalancer)
+  );
+};
 
 /**
  * Intercepts GET request to retrieve AGLB load balancers and mocks response.
@@ -38,6 +55,43 @@ export const mockGetLoadBalancerConfigurations = (
     'GET',
     apiMatcher(`/aglb/${loadBalancerId}/configurations*`),
     paginateResponse(configurations)
+  );
+};
+
+/**
+ * Intercepts GET requests to retrieve AGLB load balancer certificates and mocks response.
+ *
+ * @param loadBalancerId - ID of load balancer for which to mock certificates.
+ * @param certificates - Load balancer certificates with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetLoadBalancerCertificates = (
+  loadBalancerId: number,
+  certificates: Certificate[]
+) => {
+  return cy.intercept(
+    'GET',
+    apiMatcher(`/aglb/${loadBalancerId}/certificates*`),
+    paginateResponse(certificates)
+  );
+};
+
+/**
+ * Intercepts POST request to upload an AGLB load balancer certificate and mocks a success response.
+ *
+ * @param loadBalancerId - ID of load balancer for which to mock certificates.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockUploadLoadBalancerCertificate = (
+  loadBalancerId: number,
+  certificate: Certificate
+) => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`/aglb/${loadBalancerId}/certificates`),
+    makeResponse(certificate)
   );
 };
 

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/CreateCertificateDrawer.test.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/CreateCertificateDrawer.test.tsx
@@ -1,0 +1,31 @@
+import { act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { CreateCertificateDrawer } from './CreateCertificateDrawer';
+
+describe('CreateCertificateDrawer', () => {
+  it('should be submittable when form is filled out correctly', async () => {
+    const onClose = jest.fn();
+
+    const { getByLabelText, getByTestId } = renderWithTheme(
+      <CreateCertificateDrawer loadbalancerId={0} onClose={onClose} open />
+    );
+
+    const labelInput = getByLabelText('Label');
+    const certInput = getByLabelText('TLS Certificate');
+    const keyInput = getByLabelText('Private Key');
+
+    act(() => {
+      userEvent.type(labelInput, 'my-cert-0');
+      userEvent.type(certInput, 'massive cert');
+      userEvent.type(keyInput, 'massive key');
+
+      userEvent.click(getByTestId('submit'));
+    });
+
+    await waitFor(() => expect(onClose).toBeCalled());
+  });
+});

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/CreateCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/CreateCertificateDrawer.tsx
@@ -1,0 +1,130 @@
+import { CreateCertificatePayload } from '@linode/api-v4';
+import { Stack } from '@mui/material';
+import { useFormik } from 'formik';
+import React from 'react';
+
+import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
+import { Drawer } from 'src/components/Drawer';
+import { FormControlLabel } from 'src/components/FormControlLabel';
+import { Notice } from 'src/components/Notice/Notice';
+import { Radio } from 'src/components/Radio/Radio';
+import { RadioGroup } from 'src/components/RadioGroup';
+import { TextField } from 'src/components/TextField';
+import { Typography } from 'src/components/Typography';
+import { useLoadBalancerCertificateCreateMutation } from 'src/queries/aglb/certificates';
+import { getErrorMap } from 'src/utilities/errorUtils';
+
+interface Props {
+  loadbalancerId: number;
+  onClose: () => void;
+  open: boolean;
+}
+
+export const CreateCertificateDrawer = (props: Props) => {
+  const { loadbalancerId, onClose: _onClose, open } = props;
+
+  const onClose = () => {
+    formik.resetForm();
+    _onClose();
+    reset();
+  };
+
+  const {
+    error,
+    mutateAsync: createCertificate,
+    reset,
+  } = useLoadBalancerCertificateCreateMutation(loadbalancerId);
+
+  const formik = useFormik<CreateCertificatePayload>({
+    initialValues: {
+      certificate: '',
+      key: '',
+      label: '',
+      type: 'downstream',
+    },
+    async onSubmit(values) {
+      await createCertificate(values);
+      onClose();
+    },
+  });
+
+  const errorMap = getErrorMap(['label', 'key', 'certificate'], error);
+
+  return (
+    <Drawer onClose={onClose} open={open} title="Upload Certificate">
+      <form onSubmit={formik.handleSubmit}>
+        {errorMap.none && <Notice text={errorMap.none} variant="error" />}
+        <Typography mb={2}>
+          Upload the certificates for Load Balancer authentication.
+        </Typography>
+        <RadioGroup
+          name="type"
+          onChange={formik.handleChange}
+          value={formik.values.type}
+        >
+          <FormControlLabel
+            label={
+              <Stack spacing={1}>
+                <Typography>TLS Certificate</Typography>
+                <Typography>
+                  Used by your load balancer to terminate the connection and
+                  decrypt request from client prior to sending the request to
+                  the endpoints in your Service Targets. You can specify a Host
+                  Header. Also referred to as SSL Certificate.
+                </Typography>
+              </Stack>
+            }
+            control={<Radio />}
+            value="downstream"
+          />
+          <FormControlLabel
+            label={
+              <Stack spacing={1}>
+                <Typography>Service Target Certificate</Typography>
+                <Typography>
+                  Used by the load balancer to accept responses from your
+                  endpoints in your Service Target. This is the certificate
+                  installed on your Endpoints.
+                </Typography>
+              </Stack>
+            }
+            control={<Radio />}
+            sx={{ mt: 2 }}
+            value="ca"
+          />
+        </RadioGroup>
+        <TextField
+          errorText={errorMap.label}
+          label="Label"
+          name="label"
+          onChange={formik.handleChange}
+          value={formik.values.label}
+        />
+        <TextField
+          errorText={errorMap.certificate}
+          label="TLS Certificate"
+          labelTooltipText="TODO"
+          multiline
+          name="certificate"
+          onChange={formik.handleChange}
+          value={formik.values.certificate}
+        />
+        <TextField
+          errorText={errorMap.key}
+          label="Private Key"
+          labelTooltipText="TODO"
+          multiline
+          name="key"
+          value={formik.values.key}
+        />
+        <ActionsPanel
+          primaryButtonProps={{
+            'data-testid': 'submit',
+            label: 'Upload Certificate',
+            type: 'submit',
+          }}
+        />
+      </form>
+    </Drawer>
+  );
+};

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/CreateCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/CreateCertificateDrawer.tsx
@@ -116,6 +116,7 @@ export const CreateCertificateDrawer = (props: Props) => {
           labelTooltipText="TODO"
           multiline
           name="key"
+          onChange={formik.handleChange}
           value={formik.values.key}
         />
         <ActionsPanel

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/CreateCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/CreateCertificateDrawer.tsx
@@ -74,7 +74,7 @@ export const CreateCertificateDrawer = (props: Props) => {
                 </Typography>
               </Stack>
             }
-            control={<Radio />}
+            control={<Radio data-qa-cert-tls />}
             sx={{ alignItems: 'flex-start' }}
             value="downstream"
           />
@@ -89,7 +89,7 @@ export const CreateCertificateDrawer = (props: Props) => {
                 </Typography>
               </Stack>
             }
-            control={<Radio />}
+            control={<Radio data-qa-cert-service-target />}
             sx={{ alignItems: 'flex-start', mt: 2 }}
             value="ca"
           />

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/CreateCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/CreateCertificateDrawer.tsx
@@ -108,6 +108,7 @@ export const CreateCertificateDrawer = (props: Props) => {
           multiline
           name="certificate"
           onChange={formik.handleChange}
+          trimmed
           value={formik.values.certificate}
         />
         <TextField
@@ -117,6 +118,7 @@ export const CreateCertificateDrawer = (props: Props) => {
           multiline
           name="key"
           onChange={formik.handleChange}
+          trimmed
           value={formik.values.key}
         />
         <ActionsPanel

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/CreateCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/CreateCertificateDrawer.tsx
@@ -64,7 +64,7 @@ export const CreateCertificateDrawer = (props: Props) => {
         >
           <FormControlLabel
             label={
-              <Stack spacing={1}>
+              <Stack mt={1.5} spacing={1}>
                 <Typography>TLS Certificate</Typography>
                 <Typography>
                   Used by your load balancer to terminate the connection and
@@ -75,11 +75,12 @@ export const CreateCertificateDrawer = (props: Props) => {
               </Stack>
             }
             control={<Radio />}
+            sx={{ alignItems: 'flex-start' }}
             value="downstream"
           />
           <FormControlLabel
             label={
-              <Stack spacing={1}>
+              <Stack mt={1.5} spacing={1}>
                 <Typography>Service Target Certificate</Typography>
                 <Typography>
                   Used by the load balancer to accept responses from your
@@ -89,7 +90,7 @@ export const CreateCertificateDrawer = (props: Props) => {
               </Stack>
             }
             control={<Radio />}
-            sx={{ mt: 2 }}
+            sx={{ alignItems: 'flex-start', mt: 2 }}
             value="ca"
           />
         </RadioGroup>

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerCertificates.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerCertificates.tsx
@@ -25,6 +25,7 @@ import { usePagination } from 'src/hooks/usePagination';
 import { useLoadBalancerCertificatesQuery } from 'src/queries/aglb/certificates';
 
 import type { Certificate, Filter } from '@linode/api-v4';
+import { CreateCertificateDrawer } from './Certificates/CreateCertificateDrawer';
 
 const PREFERENCE_KEY = 'loadbalancer-certificates';
 
@@ -38,6 +39,7 @@ type CertificateTypeFilter = 'all' | Certificate['type'];
 export const LoadBalancerCertificates = () => {
   const { loadbalancerId } = useParams<{ loadbalancerId: string }>();
 
+  const [isCreateDrawerOpen, setIsCreateDrawerOpen] = useState(false);
   const [type, setType] = useState<CertificateTypeFilter>('all');
   const [query, setQuery] = useState<string>();
 
@@ -134,7 +136,12 @@ export const LoadBalancerCertificates = () => {
           value={query}
         />
         <Box flexGrow={1} />
-        <Button buttonType="primary">Upload Certificate</Button>
+        <Button
+          buttonType="primary"
+          onClick={() => setIsCreateDrawerOpen(true)}
+        >
+          Upload Certificate
+        </Button>
       </Stack>
       <Table>
         <TableHead>
@@ -184,6 +191,11 @@ export const LoadBalancerCertificates = () => {
         handleSizeChange={pagination.handlePageSizeChange}
         page={pagination.page}
         pageSize={pagination.pageSize}
+      />
+      <CreateCertificateDrawer
+        loadbalancerId={Number(loadbalancerId)}
+        onClose={() => setIsCreateDrawerOpen(false)}
+        open={isCreateDrawerOpen}
       />
     </>
   );

--- a/packages/manager/src/queries/aglb/certificates.ts
+++ b/packages/manager/src/queries/aglb/certificates.ts
@@ -1,11 +1,15 @@
-import { getLoadbalancerCertificates } from '@linode/api-v4';
-import { useQuery } from 'react-query';
+import {
+  createLoadbalancerCertificate,
+  getLoadbalancerCertificates,
+} from '@linode/api-v4';
+import { useQuery, useQueryClient, useMutation } from 'react-query';
 
 import { QUERY_KEY } from './loadbalancers';
 
 import type {
   APIError,
   Certificate,
+  CreateCertificatePayload,
   Filter,
   Params,
   ResourcePage,
@@ -20,5 +24,22 @@ export const useLoadBalancerCertificatesQuery = (
     [QUERY_KEY, 'loadbalancer', id, 'certificates', params, filter],
     () => getLoadbalancerCertificates(id, params, filter),
     { keepPreviousData: true }
+  );
+};
+
+export const useLoadBalancerCertificateCreateMutation = (id: number) => {
+  const queryClient = useQueryClient();
+  return useMutation<Certificate, APIError[], CreateCertificatePayload>(
+    (data) => createLoadbalancerCertificate(id, data),
+    {
+      onSuccess() {
+        queryClient.invalidateQueries([
+          QUERY_KEY,
+          'loadbalancer',
+          id,
+          'certificates',
+        ]);
+      },
+    }
   );
 };

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -6,6 +6,7 @@ export * from './firewalls.schema';
 export * from './images.schema';
 export * from './kubernetes.schema';
 export * from './linodes.schema';
+export * from './loadbalancers.schema';
 export * from './longview.schema';
 export * from './managed.schema';
 export * from './networking.schema';

--- a/packages/validation/src/loadbalancers.schema.ts
+++ b/packages/validation/src/loadbalancers.schema.ts
@@ -1,8 +1,11 @@
 import { object, string } from 'yup';
 
 export const CreateCertificateSchema = object({
-  certificate: string().required(),
-  key: string(),
-  label: string().required(),
-  type: string().oneOf(['downstream', 'ca']).required(),
+  certificate: string().required('Certificate is required.'),
+  key: string().when('type', {
+    is: 'downstream',
+    then: string().required('Private Key is required.'),
+  }),
+  label: string().required('Label is required.'),
+  type: string().oneOf(['downstream', 'ca']).required('Type is required.'),
 });

--- a/packages/validation/src/loadbalancers.schema.ts
+++ b/packages/validation/src/loadbalancers.schema.ts
@@ -1,0 +1,8 @@
+import { object, string } from 'yup';
+
+export const CreateCertificateSchema = object({
+  certificate: string().required(),
+  key: string(),
+  label: string().required(),
+  type: string().oneOf(['downstream', 'ca']).required(),
+});


### PR DESCRIPTION
## Description 📝

- Adds Create Certificate Drawer ✨

## Preview 📷
![Screenshot 2023-08-31 at 2 34 38 PM](https://github.com/linode/manager/assets/115251059/ebe3e3a8-43ba-487d-a3cb-8fc10a68ec71)


## How to test 🧪
- Go to `http://localhost:3000/loadbalancers/1/certificates` with the **MSW on** and try to upload a certificate (you can use fake values)
- Nothing will really happen when you submit the form successfully because of the inherent nature of React Query and the MSW
- Check client side validation