### PR TITLE
feat: Basic Select Component

### DIFF
--- a/packages/manager/.changeset/pr-9618-added-1693517370679.md
+++ b/packages/manager/.changeset/pr-9618-added-1693517370679.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+New Basic Select Component ([#9618](https://github.com/linode/manager/pull/9618))

--- a/packages/manager/src/components/Select.stories.tsx
+++ b/packages/manager/src/components/Select.stories.tsx
@@ -1,0 +1,52 @@
+import { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import { MenuItem } from './MenuItem';
+import { Select } from './Select';
+
+const meta: Meta<typeof Select> = {
+  component: Select,
+  title: 'Components/Select',
+};
+
+type Story = StoryObj<typeof Select>;
+
+const children = [
+  <MenuItem key="10" value={10}>
+    Ten
+  </MenuItem>,
+  <MenuItem key="20" value={20}>
+    Twenty
+  </MenuItem>,
+  <MenuItem key="30" value={30}>
+    Thirty
+  </MenuItem>,
+];
+
+export const Default: Story = {
+  args: {
+    children,
+    label: 'Select',
+  },
+  render: (args) => <Select {...args} />,
+};
+
+export const Error: Story = {
+  args: {
+    children,
+    errorText: 'The option you selected is invalid.',
+    label: 'Select',
+  },
+  render: (args) => <Select {...args} />,
+};
+
+export const HelperText: Story = {
+  args: {
+    children,
+    helperText: 'Select an option to see more.',
+    label: 'Select',
+  },
+  render: (args) => <Select {...args} />,
+};
+
+export default meta;

--- a/packages/manager/src/components/Select.tsx
+++ b/packages/manager/src/components/Select.tsx
@@ -5,23 +5,71 @@ import React from 'react';
 import { convertToKebabCase } from 'src/utilities/convertToKebobCase';
 
 import { FormControl } from './FormControl';
+import { FormHelperText } from './FormHelperText';
 import { InputLabel } from './InputLabel';
 
 interface Props extends SelectProps {
+  /**
+   * Props to pass to the underlying FormControl
+   */
   FormControlProps?: FormControlProps;
+  /**
+   * Error text to render below the Select
+   */
+  errorText?: string;
+  /**
+   * Error text to render below the Select
+   */
+  helperText?: string;
+  /**
+   * Label for the Input
+   */
   label: string;
 }
 
+/**
+ * A simple Select component intended to work and look like our TextField component.
+ * Reccomended to use when there is a finite set of options and no complex features such as autocomplete are needed.
+ */
 export const Select = (props: Props) => {
-  const { FormControlProps, ...SelectProps } = props;
+  const { FormControlProps, errorText, helperText, ...SelectProps } = props;
 
   const id = convertToKebabCase(props.label);
   const labelId = `${id}-label`;
+  const errorTextId = `${id}-error-text`;
+  const helperTextId = `${id}-helper-text`;
+
+  const ariaDescribedBy: string[] = [];
+
+  if (helperText) {
+    ariaDescribedBy.push(helperTextId);
+  }
+
+  if (errorText) {
+    ariaDescribedBy.push(errorTextId);
+  }
+
+  const error = Boolean(errorText);
 
   return (
-    <FormControl {...FormControlProps} variant="standard">
+    <FormControl
+      {...FormControlProps}
+      error={error}
+      sx={{ marginTop: '0' }}
+      variant="standard"
+    >
       <InputLabel id={labelId}>{props.label}</InputLabel>
-      <_Select id={id} labelId={labelId} {...SelectProps} />
+      <_Select
+        area-aria-describedby={ariaDescribedBy.join(',')}
+        area-aria-labelledby={labelId}
+        id={id}
+        labelId={labelId}
+        {...SelectProps}
+      />
+      {helperText && (
+        <FormHelperText id={helperTextId}>{helperText}</FormHelperText>
+      )}
+      {error && <FormHelperText id={errorTextId}>{errorText}</FormHelperText>}
     </FormControl>
   );
 };

--- a/packages/manager/src/components/Select.tsx
+++ b/packages/manager/src/components/Select.tsx
@@ -1,0 +1,27 @@
+import { FormControlProps } from '@mui/material';
+import _Select, { SelectProps } from '@mui/material/Select';
+import React from 'react';
+
+import { convertToKebabCase } from 'src/utilities/convertToKebobCase';
+
+import { FormControl } from './FormControl';
+import { InputLabel } from './InputLabel';
+
+interface Props extends SelectProps {
+  FormControlProps?: FormControlProps;
+  label: string;
+}
+
+export const Select = (props: Props) => {
+  const { FormControlProps, ...SelectProps } = props;
+
+  const id = convertToKebabCase(props.label);
+  const labelId = `${id}-label`;
+
+  return (
+    <FormControl {...FormControlProps} variant="standard">
+      <InputLabel id={labelId}>{props.label}</InputLabel>
+      <_Select id={id} labelId={labelId} {...SelectProps} />
+    </FormControl>
+  );
+};

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerCertificates.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerCertificates.tsx
@@ -1,5 +1,5 @@
 import CloseIcon from '@mui/icons-material/Close';
-import { IconButton } from '@mui/material';
+import { IconButton, MenuItem } from '@mui/material';
 import Stack from '@mui/material/Stack';
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
@@ -8,9 +8,9 @@ import { ActionMenu } from 'src/components/ActionMenu';
 import { Box } from 'src/components/Box';
 import { Button } from 'src/components/Button/Button';
 import { CircleProgress } from 'src/components/CircleProgress';
-import EnhancedSelect from 'src/components/EnhancedSelect';
 import { InputAdornment } from 'src/components/InputAdornment';
 import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFooter';
+import { Select } from 'src/components/Select';
 import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
 import { TableCell } from 'src/components/TableCell';
@@ -79,12 +79,6 @@ export const LoadBalancerCertificates = () => {
     return <CircleProgress />;
   }
 
-  const filterOptions = [
-    { label: 'All', value: 'all' },
-    { label: 'TLS Certificates', value: 'tls' },
-    { label: 'Service Target Certificates', value: 'ca' },
-  ];
-
   return (
     <>
       <Stack
@@ -95,19 +89,16 @@ export const LoadBalancerCertificates = () => {
         mb={2}
         mt={1.5}
       >
-        <EnhancedSelect
-          styles={{
-            container: () => ({
-              maxWidth: '200px',
-            }),
-          }}
-          isClearable={false}
+        <Select
           label="Certificate Type"
-          noMarginTop
-          onChange={(option) => setType(option?.value as CertificateTypeFilter)}
-          options={filterOptions}
-          value={filterOptions.find((option) => option.value === type) ?? null}
-        />
+          onChange={(e) => setType(e.target.value as CertificateTypeFilter)}
+          sx={{ minWidth: 250 }}
+          value={type}
+        >
+          <MenuItem value="all">All</MenuItem>
+          <MenuItem value="downstream">TLS Certificates</MenuItem>
+          <MenuItem value="ca">Service Target Certificates</MenuItem>
+        </Select>
         <TextField
           InputProps={{
             endAdornment: (

--- a/packages/manager/src/foundations/themes/dark.ts
+++ b/packages/manager/src/foundations/themes/dark.ts
@@ -566,6 +566,11 @@ export const darkTheme: ThemeOptions = {
       paper: '#2e3238',
     },
     divider: primaryColors.divider,
+    error: {
+      dark: '#fb6d6d',
+      light: '#fb6d6d',
+      main: '#fb6d6d',
+    },
     mode: 'dark',
     primary: primaryColors,
     text: {

--- a/packages/manager/src/foundations/themes/dark.ts
+++ b/packages/manager/src/foundations/themes/dark.ts
@@ -369,13 +369,6 @@ export const darkTheme: ThemeOptions = {
         },
       },
     },
-    MuiInputBase: {
-      styleOverrides: {
-        root: {
-          backgroundColor: '#444',
-        },
-      },
-    },
     MuiListItem: {
       styleOverrides: {
         root: {

--- a/packages/manager/src/foundations/themes/dark.ts
+++ b/packages/manager/src/foundations/themes/dark.ts
@@ -369,6 +369,13 @@ export const darkTheme: ThemeOptions = {
         },
       },
     },
+    MuiInputBase: {
+      styleOverrides: {
+        root: {
+          backgroundColor: '#444',
+        },
+      },
+    },
     MuiListItem: {
       styleOverrides: {
         root: {
@@ -411,7 +418,11 @@ export const darkTheme: ThemeOptions = {
       },
     },
     MuiSelect: {
-      styleOverrides: {},
+      styleOverrides: {
+        standard: {
+          backgroundColor: '#444',
+        },
+      },
     },
     MuiSnackbarContent: {
       styleOverrides: {

--- a/packages/manager/src/foundations/themes/light.ts
+++ b/packages/manager/src/foundations/themes/light.ts
@@ -889,9 +889,6 @@ export const lightTheme: ThemeOptions = {
             backgroundColor: primaryColors.main,
             color: primaryColors.white,
           },
-          '.Mui-selected': {
-            color: primaryColors.text,
-          },
           color: primaryColors.text,
           fontFamily: latoWeb.normal,
           fontSize: '.9rem',
@@ -903,11 +900,6 @@ export const lightTheme: ThemeOptions = {
           transition: `${'background-color 150ms cubic-bezier(0.4, 0, 0.2, 1), '}
         ${'color .2s cubic-bezier(0.4, 0, 0.2, 1)'}`,
           whiteSpace: 'initial',
-        },
-        selected: {
-          ':hover': {
-            color: `${primaryColors.text} !important`,
-          },
         },
       },
     },

--- a/packages/manager/src/foundations/themes/light.ts
+++ b/packages/manager/src/foundations/themes/light.ts
@@ -762,11 +762,19 @@ export const lightTheme: ThemeOptions = {
           '&::placeholder': {
             opacity: 0.42,
           },
-          height: 'auto',
+        },
+        root: {
+          backgroundColor: primaryColors.white,
+          borderRadius: '0 !important',
+          maxHeight: 35,
         },
       },
     },
     MuiInputLabel: {
+      defaultProps: {
+        disableAnimation: true,
+        shrink: true,
+      },
       styleOverrides: {
         formControl: {
           position: 'relative',
@@ -838,6 +846,9 @@ export const lightTheme: ThemeOptions = {
       },
     },
     MuiMenu: {
+      defaultProps: {
+        marginThreshold: 0,
+      },
       styleOverrides: {
         paper: {
           '& .selectMenuList': {
@@ -874,14 +885,12 @@ export const lightTheme: ThemeOptions = {
           '& em': {
             fontStyle: 'normal !important',
           },
-          '&$selected, &$selected:hover': {
-            backgroundColor: 'transparent',
-            color: primaryColors.main,
-            opacity: 1,
-          },
-          '&:hover': {
+          '&:hover:not(.Mui-selected)': {
             backgroundColor: primaryColors.main,
-            color: 'white',
+            color: primaryColors.white,
+          },
+          '.Mui-selected': {
+            color: primaryColors.text,
           },
           color: primaryColors.text,
           fontFamily: latoWeb.normal,
@@ -895,7 +904,11 @@ export const lightTheme: ThemeOptions = {
         ${'color .2s cubic-bezier(0.4, 0, 0.2, 1)'}`,
           whiteSpace: 'initial',
         },
-        selected: {},
+        selected: {
+          ':hover': {
+            color: `${primaryColors.text} !important`,
+          },
+        },
       },
     },
     MuiPaper: {
@@ -968,21 +981,17 @@ export const lightTheme: ThemeOptions = {
       },
     },
     MuiSelect: {
+      defaultProps: {
+        notched: false,
+      },
       styleOverrides: {
-        disabled: {},
         icon: {
           color: '#aaa !important',
-          height: 28,
-          marginRight: 4,
-          marginTop: -2,
-          opacity: 0.5,
-          transition: 'color 225ms ease-in-out',
-          width: 28,
+          fontSize: '24px !important',
+          marginRight: '4px',
         },
-        select: {
-          '&:focus': {
-            backgroundColor: 'transparent',
-          },
+        standard: {
+          backgroundColor: primaryColors.white,
         },
       },
     },

--- a/packages/manager/src/foundations/themes/light.ts
+++ b/packages/manager/src/foundations/themes/light.ts
@@ -1416,9 +1416,9 @@ export const lightTheme: ThemeOptions = {
   palette: {
     divider: primaryColors.divider,
     error: {
-      dark: '#cd2227',
-      light: '#f8dedf',
-      main: '#f8dedf',
+      dark: '#ca0813',
+      light: '#ca0813',
+      main: '#ca0813',
     },
     info: {
       dark: '#3682dd',


### PR DESCRIPTION
## Description 📝

- Adds a new Select component

## Why ❓

- So we don't have to always use `<EnhancedSelect />`
- So we don't have to use `<TextField select />` to achieve a basic select
  -  This will allow us to better refine the `<TextField />` implimentation
- Gives us a simple and accessible select component

## Preview 📷
![Screenshot 2023-08-31 at 5 27 30 PM](https://github.com/linode/manager/assets/115251059/a1c31f8c-8ec4-47e8-85bd-12d25196a58f)

## How to test 🧪
- Test the component in Storybook **or** on `http://localhost:3000/loadbalancers/0/certificates` with the MSW on