### PR TITLE
fix: Billing Summary UI Regression from MUI Update

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -3,7 +3,7 @@ import { ActivePromotion } from '@linode/api-v4/lib/account/types';
 import { GridSize } from '@mui/material/Grid';
 import Grid from '@mui/material/Unstable_Grid2';
 import { Breakpoint } from '@mui/material/styles';
-import { styled, useTheme } from '@mui/material/styles';
+import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 
@@ -22,10 +22,6 @@ import { BillingPaper } from '../../BillingDetail';
 import PaymentDrawer from './PaymentDrawer';
 import PromoDialog from './PromoDialog';
 import { PromoDisplay } from './PromoDisplay';
-
-const GridContainer = styled(Grid)({
-  marginBottom: 0,
-});
 
 interface BillingSummaryProps {
   balance: number;
@@ -163,7 +159,7 @@ export const BillingSummary = (props: BillingSummaryProps) => {
 
   return (
     <>
-      <GridContainer container spacing={2} xs={12}>
+      <Grid container margin={0} spacing={2} xs={12}>
         <Grid {...gridDimensions} sm={6}>
           <BillingPaper variant="outlined">
             <Typography variant="h3">Account Balance</Typography>
@@ -257,7 +253,7 @@ export const BillingSummary = (props: BillingSummaryProps) => {
             </Box>
           </BillingPaper>
         </Grid>
-      </GridContainer>
+      </Grid>
       <PaymentDrawer
         onClose={closePaymentDrawer}
         open={paymentDrawerOpen}


### PR DESCRIPTION
## Description 📝

- Caused by https://github.com/linode/manager/pull/9603

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-09-01 at 10 24 48 AM](https://github.com/linode/manager/assets/115251059/dc8e69d7-9b71-4ad5-a418-f6628296d99c) | ![Screenshot 2023-09-01 at 10 25 22 AM](https://github.com/linode/manager/assets/115251059/12028174-dc84-44a0-8375-4835932523fe) |


## How to test 🧪
- Verify `/account/billing` looks good 🎨