### PR TITLE
fix: Linode Crate - Attach VLAN - Grid Conatiner

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
@@ -134,7 +134,7 @@ export const InterfaceSelect = (props: Props) => {
         </Grid>
       )}
       {purpose === 'vlan' ? (
-        <Grid md={7} sm={9} xs={12}>
+        <Grid container>
           <Grid
             sx={{
               flexDirection: 'row',


### PR DESCRIPTION
## Description 📝
- Fixes the alignment of the Select and Inputs in the Attach VLAN section on the Linode create page

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-09-05 at 2 48 37 PM](https://github.com/linode/manager/assets/115251059/de07697c-6623-4771-af99-35a13943ae6a) | ![Screenshot 2023-09-05 at 2 48 47 PM](https://github.com/linode/manager/assets/115251059/d9eda717-deb7-486f-beac-a73cb61cb7da) |

## How to test 🧪
- Go to `/linodes/create` and verify that the Attach VLAN section looks like production