### PR TITLE
fix: MUI Theme Base CSS Styles

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
@@ -42,6 +42,7 @@ const useStyles = makeStyles<void, 'linkItem'>()(
       color: '#fff',
       display: 'flex',
       fontFamily: 'LatoWebBold', // we keep this bold at all times
+      fontSize: '1rem',
       opacity: 1,
       position: 'relative',
       transition: theme.transitions.create(['color']),

--- a/packages/manager/src/components/Table/Table.styles.ts
+++ b/packages/manager/src/components/Table/Table.styles.ts
@@ -36,7 +36,6 @@ export const StyledTableWrapper = styled('div', {
         borderTop: `2px solid ${theme.borderColors.borderTable}`,
         color: theme.textColors.tableHeader,
         fontFamily: theme.font.bold,
-        fontSize: '0.875em !important',
         padding: '10px 15px',
       },
     },

--- a/packages/manager/src/features/Footer/Footer.tsx
+++ b/packages/manager/src/features/Footer/Footer.tsx
@@ -14,6 +14,7 @@ interface Props {
 const useStyles = makeStyles()((theme: Theme) => ({
   container: {
     backgroundColor: theme.bg.main,
+    fontSize: '1rem',
     margin: 0,
     padding: '4px 0px',
     [theme.breakpoints.down('sm')]: {

--- a/packages/manager/src/foundations/themes/dark.ts
+++ b/packages/manager/src/foundations/themes/dark.ts
@@ -552,6 +552,7 @@ export const darkTheme: ThemeOptions = {
   name: 'dark',
   palette: {
     background: {
+      default: customDarkModeOptions.bg.app,
       paper: '#2e3238',
     },
     divider: primaryColors.divider,

--- a/packages/manager/src/foundations/themes/light.ts
+++ b/packages/manager/src/foundations/themes/light.ts
@@ -1405,6 +1405,9 @@ export const lightTheme: ThemeOptions = {
   },
   name: 'light', // @todo remove this because we leverage pallete.mode now
   palette: {
+    background: {
+      default: bg.app,
+    },
     divider: primaryColors.divider,
     error: {
       dark: '#cd2227',

--- a/packages/manager/src/index.tsx
+++ b/packages/manager/src/index.tsx
@@ -20,6 +20,7 @@ import LinodeThemeWrapper from './LinodeThemeWrapper';
 import { loadDevTools, shouldEnableDevTools } from './dev-tools/load';
 import './index.css';
 import { queryClientFactory } from './queries/base';
+import CssBaseline from '@mui/material/CssBaseline';
 
 const queryClient = queryClientFactory();
 const store = storeFactory(queryClient);
@@ -58,6 +59,7 @@ const ContextWrapper = () => (
   <ReduxStoreProvider store={store}>
     <QueryClientProvider client={queryClient}>
       <LinodeThemeWrapper>
+        <CssBaseline />
         <React.Suspense fallback={<SplashScreen />}>
           <Switch>
             <Route component={OAuthCallbackPage} exact path="/oauth/callback" />


### PR DESCRIPTION
## Description 📝
- Oh no! Our MUI theme isn't installed correctly! 😖
- The background color of the body is white ⚪️ in dark mode and it drives me absolutely nuts 🌰

## Major Changes 🔄
- Set missing UI theme styles
- Add `<CssBaseline />` to mount base styles

## Preview 📷

### Before ☹️

https://github.com/linode/manager/assets/115251059/b3088fa1-0e78-484d-8dab-a52049db4ea4

### After 😁

https://github.com/linode/manager/assets/115251059/6e9aa519-b56e-48ce-9a07-38931fe054f9

## How to test 🧪
- Checkout this PR
- Check that the body's background in light mode is white
- Check that the body's background is in dark mode is gray
- Check for general style regressions