### PR TITLE
hotfix: [M3-7084] - Fix Restricted User Permissions after entity creation

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2023-09-05] - v1.101.1
+
+
+### Fixed:
+
+-  Restricted users unable to edit Firewall after creation ([#9637](https://github.com/linode/manager/pull/9637))
+
 ## [2023-09-05] - v1.101.0
 
 

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2023-09-05] - v1.101.1
+## [2023-09-07] - v1.101.1
 
 
 ### Fixed:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.101.0",
+  "version": "1.101.1",
   "private": true,
   "bugs": {
     "url": "https://github.com/Linode/manager/issues"

--- a/packages/manager/src/queries/databases.ts
+++ b/packages/manager/src/queries/databases.ts
@@ -41,6 +41,7 @@ import { EventWithStore } from 'src/events';
 import { getAll } from 'src/utilities/getAll';
 
 import { queryPresets, updateInPaginatedStore } from './base';
+import { queryKey as PROFILE_QUERY_KEY } from './profile';
 
 export const queryKey = 'databases';
 
@@ -114,6 +115,8 @@ export const useCreateDatabaseMutation = () => {
         queryClient.invalidateQueries(`${queryKey}-list`);
         // Add database to the cache
         queryClient.setQueryData([queryKey, data.id], data);
+        // If a restricted user creates an entity, we must make sure grants are up to date.
+        queryClient.invalidateQueries([PROFILE_QUERY_KEY, 'grants']);
       },
     }
   );

--- a/packages/manager/src/queries/domains.ts
+++ b/packages/manager/src/queries/domains.ts
@@ -25,6 +25,8 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { EventWithStore } from 'src/events';
 import { getAll } from 'src/utilities/getAll';
 
+import { queryKey as PROFILE_QUERY_KEY } from './profile';
+
 export const queryKey = 'domains';
 
 export const useDomainsQuery = (params: Params, filter: Filter) =>
@@ -54,6 +56,8 @@ export const useCreateDomainMutation = () => {
     onSuccess: (domain) => {
       queryClient.invalidateQueries([queryKey, 'paginated']);
       queryClient.setQueryData([queryKey, 'domain', domain.id], domain);
+      // If a restricted user creates an entity, we must make sure grants are up to date.
+      queryClient.invalidateQueries([PROFILE_QUERY_KEY, 'grants']);
     },
   });
 };

--- a/packages/manager/src/queries/firewalls.ts
+++ b/packages/manager/src/queries/firewalls.ts
@@ -26,8 +26,8 @@ import { EventWithStore } from 'src/events';
 import { queryKey as linodesQueryKey } from 'src/queries/linodes/linodes';
 import { getAll } from 'src/utilities/getAll';
 
-import { queryKey as PROFILE_QUERY_KEY } from './profile';
 import { updateInPaginatedStore } from './base';
+import { queryKey as PROFILE_QUERY_KEY } from './profile';
 
 export const queryKey = 'firewall';
 
@@ -122,7 +122,7 @@ export const useCreateFirewall = () => {
       onSuccess(firewall) {
         queryClient.invalidateQueries([queryKey, 'paginated']);
         queryClient.setQueryData([queryKey, 'firewall', firewall.id], firewall);
-        // If a restricted user created a Firewall, grants will be re-fetched.
+        // If a restricted user creates an entity, we must make sure grants are up to date.
         queryClient.invalidateQueries([PROFILE_QUERY_KEY, 'grants']);
       },
     }

--- a/packages/manager/src/queries/firewalls.ts
+++ b/packages/manager/src/queries/firewalls.ts
@@ -26,6 +26,7 @@ import { EventWithStore } from 'src/events';
 import { queryKey as linodesQueryKey } from 'src/queries/linodes/linodes';
 import { getAll } from 'src/utilities/getAll';
 
+import { queryKey as PROFILE_QUERY_KEY } from './profile';
 import { updateInPaginatedStore } from './base';
 
 export const queryKey = 'firewall';
@@ -121,6 +122,8 @@ export const useCreateFirewall = () => {
       onSuccess(firewall) {
         queryClient.invalidateQueries([queryKey, 'paginated']);
         queryClient.setQueryData([queryKey, 'firewall', firewall.id], firewall);
+        // If a restricted user created a Firewall, grants will be re-fetched.
+        queryClient.invalidateQueries([PROFILE_QUERY_KEY, 'grants']);
       },
     }
   );

--- a/packages/manager/src/queries/images.ts
+++ b/packages/manager/src/queries/images.ts
@@ -27,6 +27,7 @@ import { EventWithStore } from 'src/events';
 import { getAll } from 'src/utilities/getAll';
 
 import { doesItemExistInPaginatedStore, updateInPaginatedStore } from './base';
+import { queryKey as PROFILE_QUERY_KEY } from './profile';
 
 export const queryKey = 'images';
 
@@ -53,6 +54,8 @@ export const useCreateImageMutation = () => {
     {
       onSuccess() {
         queryClient.invalidateQueries(`${queryKey}-list`);
+        // If a restricted user creates an entity, we must make sure grants are up to date.
+        queryClient.invalidateQueries([PROFILE_QUERY_KEY, 'grants']);
       },
     }
   );

--- a/packages/manager/src/queries/kubernetes.ts
+++ b/packages/manager/src/queries/kubernetes.ts
@@ -36,6 +36,7 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { getAll } from 'src/utilities/getAll';
 
 import { queryPresets, updateInPaginatedStore } from './base';
+import { queryKey as PROFILE_QUERY_KEY } from './profile';
 
 export const queryKey = `kubernetes`;
 
@@ -139,6 +140,8 @@ export const useCreateKubernetesClusterMutation = () => {
     {
       onSuccess() {
         queryClient.invalidateQueries([`${queryKey}-list`]);
+        // If a restricted user creates an entity, we must make sure grants are up to date.
+        queryClient.invalidateQueries([PROFILE_QUERY_KEY, 'grants']);
       },
     }
   );

--- a/packages/manager/src/queries/linodes/linodes.ts
+++ b/packages/manager/src/queries/linodes/linodes.ts
@@ -39,6 +39,8 @@ import { queryKey as accountNotificationsQueryKey } from '../accountNotification
 import { queryPresets } from '../base';
 import { getAllLinodeKernelsRequest, getAllLinodesRequest } from './requests';
 
+import { queryKey as PROFILE_QUERY_KEY } from '../profile';
+
 export const queryKey = 'linodes';
 
 export const useLinodesQuery = (
@@ -154,6 +156,8 @@ export const useCreateLinodeMutation = () => {
         [queryKey, 'linode', linode.id, 'details'],
         linode
       );
+      // If a restricted user creates an entity, we must make sure grants are up to date.
+      queryClient.invalidateQueries([PROFILE_QUERY_KEY, 'grants']);
     },
   });
 };

--- a/packages/manager/src/queries/nodebalancers.ts
+++ b/packages/manager/src/queries/nodebalancers.ts
@@ -34,6 +34,7 @@ import { parseAPIDate } from 'src/utilities/date';
 import { getAll } from 'src/utilities/getAll';
 
 import { itemInListCreationHandler, itemInListMutationHandler } from './base';
+import { queryKey as PROFILE_QUERY_KEY } from './profile';
 
 export const queryKey = 'nodebalancers';
 
@@ -108,6 +109,8 @@ export const useNodebalancerCreateMutation = () => {
       onSuccess(data) {
         queryClient.invalidateQueries([queryKey]);
         queryClient.setQueryData([queryKey, 'nodebalancer', data.id], data);
+        // If a restricted user creates an entity, we must make sure grants are up to date.
+        queryClient.invalidateQueries([PROFILE_QUERY_KEY, 'grants']);
       },
     }
   );

--- a/packages/manager/src/queries/volumes.ts
+++ b/packages/manager/src/queries/volumes.ts
@@ -28,6 +28,7 @@ import { EventWithStore } from 'src/events';
 import { getAll } from 'src/utilities/getAll';
 
 import { updateInPaginatedStore } from './base';
+import { queryKey as PROFILE_QUERY_KEY } from './profile';
 
 export const queryKey = 'volumes';
 
@@ -125,6 +126,8 @@ export const useCreateVolumeMutation = () => {
   return useMutation<Volume, APIError[], VolumeRequestPayload>(createVolume, {
     onSuccess() {
       queryClient.invalidateQueries([queryKey]);
+      // If a restricted user creates an entity, we must make sure grants are up to date.
+      queryClient.invalidateQueries([PROFILE_QUERY_KEY, 'grants']);
     },
   });
 };

--- a/packages/validation/.changeset/pr-9641-fixed-1694095072428.md
+++ b/packages/validation/.changeset/pr-9641-fixed-1694095072428.md
@@ -1,5 +1,0 @@
----
-"@linode/validation": Fixed
----
-
-Edit interfaces config validation to allow null values for label and ipam_address ([#9641](https://github.com/linode/manager/pull/9641))

--- a/packages/validation/CHANGELOG.md
+++ b/packages/validation/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2023-09-07] - v0.30.1
+
+
+### Fixed:
+
+- Edit interfaces config validation to allow null values for label and ipam_address ([#9641](https://github.com/linode/manager/pull/9641))
+
 ## [2023-09-05] - v0.30.0
 
 

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/validation",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "Yup validation schemas for use with the Linode APIv4",
   "type": "module",
   "main": "lib/index.cjs",


### PR DESCRIPTION
## Description 📝

- FIxes bug where restricted users would not have read-write permissions after they created a firewall

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/115251059/269ec1fd-364d-4962-aaca-6cd776a2760b" /> | <video src="https://github.com/linode/manager/assets/115251059/da0fb2a9-45fd-443c-bffb-be7743783289" /> |

## How to test 🧪
- As a restricted user
  - Create a firewall
  - Verify that a GET to `/v4/profile/grants` happens
  - Verify that you can edit that firewall immediately after creation
- As a non-restricted user
  - Create a firewall
  - Verify you **don't** see a GET to `/v4/profile/grants` (because it's unnecessary for an unrestricted user)
  - Verify that you can edit that firewall immediately after creation