### PR TITLE
fix: [M3-7088] - Fix typo in `CloseTicketLink.tsx`

### DIFF
--- a/packages/manager/.changeset/pr-9639-fixed-1694031609043.md
+++ b/packages/manager/.changeset/pr-9639-fixed-1694031609043.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fix typo in CloseTicketLink.tsx ([#9639](https://github.com/linode/manager/pull/9639))

--- a/packages/manager/src/features/Support/SupportTicketDetail/CloseTicketLink.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/CloseTicketLink.tsx
@@ -37,7 +37,7 @@ export const CloseTicketLink = ({ ticketId }: Props) => {
     <ActionsPanel
       primaryButtonProps={{
         'data-testid': 'dialog-submit',
-        label: 'Confrim',
+        label: 'Confirm',
         loading: isLoading,
         onClick: closeTicket,
       }}


### PR DESCRIPTION
## Description 📝
This fixes a typo on the "Confirm Ticket Close" modal, displayed when closing a support ticket.


## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-09-06 at 2 40 31 PM](https://github.com/linode/manager/assets/114753608/2fd18f30-4b36-4851-8f45-136ecddc0c8e) | ![Screenshot 2023-09-06 at 2 40 17 PM](https://github.com/linode/manager/assets/114753608/da18f68b-d9dd-455e-b2e0-1a7d5862e27b) |

## How to test 🧪
1. Pull down this code and run it locally
2. In ReplyActions.tsx, change L34 to: `{true && <CloseTicketLink ticketId={ticketId} />}`
3. Go to http://localhost:3000/support/tickets/0 (mocks on)
4. Click "close this ticket" near the bottom of the screen to see this modal.