### PR TITLE
fix: [M3-6950] - Restored longview active table rows and arrow

### DIFF
--- a/packages/manager/.changeset/pr-9643-fixed-1694103276021.md
+++ b/packages/manager/.changeset/pr-9643-fixed-1694103276021.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fixed selected state of longview processes table ([#9643](https://github.com/linode/manager/pull/9643))

--- a/packages/manager/src/components/TableRow/TableRow.styles.ts
+++ b/packages/manager/src/components/TableRow/TableRow.styles.ts
@@ -69,12 +69,6 @@ export const StyledTableRow = styled(_TableRow, {
 
 export const StyledTableDataCell = styled('td', {
   label: 'StyledTableDataCell',
-})(() => ({
-  padding: 0,
-}));
-
-export const StyledActiveCaret = styled('span', {
-  label: 'StyledActiveCaret',
 })(({ theme }) => ({
   '&:after': {
     border: 'solid',
@@ -104,4 +98,5 @@ export const StyledActiveCaret = styled('span', {
     transform: 'translateY(-50%)',
     width: 0,
   },
+  padding: 0,
 }));

--- a/packages/manager/src/components/TableRow/TableRow.styles.ts
+++ b/packages/manager/src/components/TableRow/TableRow.styles.ts
@@ -46,13 +46,14 @@ export const StyledTableRow = styled(_TableRow, {
         },
       },
     },
-    '&:before': {
+
+    '&.Mui-selected': {
+      '&:hover': {
+        backgroundColor: theme.bg.lightBlue1,
+      },
       backgroundColor: theme.bg.lightBlue1,
-      borderColor: theme.borderColors.borderTable,
-      transition: 'none',
+      boxShadow: `inset 3px 0 0 ${theme.bg.lightBlue1}`,
     },
-    backgroundColor: theme.bg.lightBlue1,
-    boxShadow: `inset 3px 0 0 ${theme.bg.lightBlue1}`,
     transform: 'scale(1)',
   }),
   ...(props.highlight && {
@@ -76,44 +77,31 @@ export const StyledActiveCaret = styled('span', {
   label: 'StyledActiveCaret',
 })(({ theme }) => ({
   '&:after': {
-    background: `linear-gradient(to right bottom, ${theme.palette.primary.light} 0%, ${theme.palette.primary.light} 49%, transparent 50.1%)`,
-    content: '""',
-    height: '50%',
-    left: 0,
+    border: 'solid',
+    borderColor: 'rgba(136, 183, 213, 0)',
+    borderLeftColor: theme.bg.lightBlue1,
+    borderWidth: '19px',
+    content: "''",
+    height: 0,
+    left: '100%',
+    pointerEvents: 'none',
     position: 'absolute',
-    top: '50%',
-    width: 15,
+    top: 'calc(50% - 1px)',
+    transform: 'translateY(-50%)',
+    width: 0,
   },
   '&:before': {
-    background: `linear-gradient(to right top, ${theme.palette.primary.light} 0%, ${theme.palette.primary.light} 49%, transparent 50.1%)`,
-    content: '""',
-    height: '50%',
-    left: 0,
+    border: 'solid',
+    borderColor: 'rgba(194, 225, 245, 0)',
+    borderLeftColor: theme.palette.primary.light,
+    borderWidth: '20px',
+    content: "''",
+    height: 0,
+    left: '100%',
+    pointerEvents: 'none',
     position: 'absolute',
-    top: 0,
-    width: 15,
-  },
-}));
-
-export const StyledActiveCaretOverlay = styled('span', {
-  label: 'StyledActiveCaretOverlay',
-})(({ theme }) => ({
-  '&:after': {
-    background: `linear-gradient(to right bottom, ${theme.bg.lightBlue1} 0%, ${theme.bg.lightBlue1} 45%, transparent 46.1%)`,
-    bottom: 0,
-    content: '""',
-    height: '50%',
-    left: 0,
-    position: 'absolute',
-    width: 15,
-  },
-  '&:before': {
-    background: `linear-gradient(to right top, ${theme.bg.lightBlue1} 0%, ${theme.bg.lightBlue1} 45%, transparent 46.1%)`,
-    content: '""',
-    height: '50%',
-    left: 0,
-    position: 'absolute',
-    top: 0,
-    width: 15,
+    top: 'calc(50% - 1px)',
+    transform: 'translateY(-50%)',
+    width: 0,
   },
 }));

--- a/packages/manager/src/components/TableRow/TableRow.tsx
+++ b/packages/manager/src/components/TableRow/TableRow.tsx
@@ -5,7 +5,6 @@ import { Hidden } from 'src/components/Hidden';
 
 import {
   StyledActiveCaret,
-  StyledActiveCaretOverlay,
   StyledTableDataCell,
   StyledTableRow,
 } from './TableRow.styles';
@@ -29,6 +28,7 @@ export const TableRow = React.memo((props: TableRowProps) => {
     <StyledTableRow
       aria-label={ariaLabel ?? `View Details`}
       ref={domRef}
+      selected={selected}
       {...rest}
     >
       {props.children}
@@ -36,7 +36,6 @@ export const TableRow = React.memo((props: TableRowProps) => {
         <Hidden lgDown>
           <StyledTableDataCell>
             <StyledActiveCaret />
-            <StyledActiveCaretOverlay />
           </StyledTableDataCell>
         </Hidden>
       )}

--- a/packages/manager/src/components/TableRow/TableRow.tsx
+++ b/packages/manager/src/components/TableRow/TableRow.tsx
@@ -3,11 +3,7 @@ import * as React from 'react';
 
 import { Hidden } from 'src/components/Hidden';
 
-import {
-  StyledActiveCaret,
-  StyledTableDataCell,
-  StyledTableRow,
-} from './TableRow.styles';
+import { StyledTableDataCell, StyledTableRow } from './TableRow.styles';
 
 export interface TableRowProps extends _TableRowProps {
   ariaLabel?: string;
@@ -34,9 +30,7 @@ export const TableRow = React.memo((props: TableRowProps) => {
       {props.children}
       {selected && (
         <Hidden lgDown>
-          <StyledTableDataCell>
-            <StyledActiveCaret />
-          </StyledTableDataCell>
+          <StyledTableDataCell />
         </Hidden>
       )}
     </StyledTableRow>


### PR DESCRIPTION
## Description 📝
There was an issue on the longview processes table where the entire row was not highlighted, and the arrow was not in the correct place. This is important because the data to the right of the table is contingent on the selected row.

## Major Changes 🔄
- We needed `selected={selected}` passed to the styled component
- Removed unnecessary styled components for the arrow
- Simplified how we create the css arrow

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-09-07 at 12 09 34 PM](https://github.com/linode/manager/assets/125309814/382f850b-fdb0-4bf3-809f-966daf48b8fd) | ![Screenshot 2023-09-07 at 11 59 28 AM](https://github.com/linode/manager/assets/125309814/6b9857bd-c2b4-48e3-8078-795da93e6326)  |

https://github.com/linode/manager/assets/125309814/c9689759-4ace-48e0-9b50-4ca7501cb3a2

## How to test 🧪
1. Create a new Linode (I used Debian 11)
2. Create a new Longview client
3. Copy the installation curl command
4. SSH into your Linode and paste the installation command
5. Note: I had start the longview service with systemctl: `sudo systemctl start longview` following https://www.linode.com/docs/products/tools/longview/guides/troubleshooting/
6. Go to `/longview/clients/{ID}/processes`
7. Ensure that the row is properly highlighted
8. Ensure that an arrow appears to the right of the row (outside of the actual row itself)
