### PR TITLE
hotfix: [M3-7085] Edit VLAN config validation bug

### DIFF
--- a/packages/validation/.changeset/pr-9641-fixed-1694095072428.md
+++ b/packages/validation/.changeset/pr-9641-fixed-1694095072428.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Fixed
+---
+
+Edit interfaces config validation to allow null values for label and ipam_address ([#9641](https://github.com/linode/manager/pull/9641))

--- a/packages/validation/src/linodes.schema.ts
+++ b/packages/validation/src/linodes.schema.ts
@@ -145,10 +145,14 @@ export const linodeInterfaceSchema = array()
             /[a-zA-Z0-9-]+/,
             'Must include only ASCII letters, numbers, and dashes'
           ),
-        otherwise: string().test({
-          name: testnameDisallowedBasedOnPurpose('VLAN'),
-          message: testmessageDisallowedBasedOnPurpose('vlan', 'label'),
-          test: (value) => typeof value === 'undefined' || value === '',
+        otherwise: string().when('label', {
+          is: null,
+          then: string().nullable(),
+          otherwise: string().test({
+            name: testnameDisallowedBasedOnPurpose('VLAN'),
+            message: testmessageDisallowedBasedOnPurpose('vlan', 'label'),
+            test: (value) => typeof value === 'undefined' || value === '',
+          }),
         }),
       }),
       ipam_address: string().when('purpose', {
@@ -158,10 +162,17 @@ export const linodeInterfaceSchema = array()
           message: 'Must be a valid IPv4 range, e.g. 192.0.2.0/24.',
           test: validateIP,
         }),
-        otherwise: string().test({
-          name: testnameDisallowedBasedOnPurpose('VLAN'),
-          message: testmessageDisallowedBasedOnPurpose('vlan', 'ipam_address'),
-          test: (value) => typeof value === 'undefined' || value === '',
+        otherwise: string().when('ipam_address', {
+          is: null,
+          then: string().nullable(),
+          otherwise: string().test({
+            name: testnameDisallowedBasedOnPurpose('VLAN'),
+            message: testmessageDisallowedBasedOnPurpose(
+              'vlan',
+              'ipam_address'
+            ),
+            test: (value) => typeof value === 'undefined' || value === '',
+          }),
         }),
       }),
       primary: boolean().notRequired(),


### PR DESCRIPTION
## Description 📝
Latest API release was responsible for exposing an issue with our validation schema when editing a linode config.

**NOTE**: I will write an e2e test to cover this issue in a subsequent PR

Our config interfaces properly types `interface.label` and `interface.ipam_address` as `string | null`, however our yup schema validation (which apparently never encountered a null value before) was throwing an error.

![Screenshot 2023-09-06 at 08 58 36](https://github.com/linode/manager/assets/130582365/9f9cebb0-fd30-467e-9e72-2d71d555f660)

This is due to the fact that the API now seems to return a default public record (brand new Linode created with VLAN) in the interface array which has `null` `ipam_address` & `label`. 

⚠️ I am wondering if this is the desired behavior (because of this it is impossible to add a new public interface when editing - you will get an "Only one public interface per config is allowed." error). CC @jaalah @jcallahan-akamai @bnussman 

ex payload for config interfaces with a newly created linode with VLAN

```JSON
"interfaces": [
        {
          "id": 659956,
          "purpose": "public",
          "ipam_address": null,
          "label": null
        },
        {
          "id": 659957,
          "purpose": "vlan",
          "ipam_address": "",
          "label": "testvlan"
        }
      ]
```

Wether or not this is intended, our validation schema should still be able to handle `null` values as defined by our types so this PR should be relevant nonetheless.

## Major Changes 🔄
- Allow `null` interface record `label` & `ipam_address` to go through YUP validation


## How to test 🧪
1. Pull code locally
2. Create a new Linode with an attached VLAN
3. Navigate to `/linodes/49433992/configurations` and edit config
![Screenshot 2023-09-07 at 09 53 40](https://github.com/linode/manager/assets/130582365/60bc1a0a-b030-49ae-86f3-d198a9111d20)
4. Try saving the form and confirm no errors in the console and PUT config API request succeeds


