### PR TITLE
feat: [M3-6747] - Add filter subnets field

### DIFF
--- a/packages/manager/.changeset/pr-9647-upcoming-features-1694186188307.md
+++ b/packages/manager/.changeset/pr-9647-upcoming-features-1694186188307.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add filter subnets field ([#9647](https://github.com/linode/manager/pull/9647))

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.tsx
@@ -182,7 +182,7 @@ const VPCDetail = () => {
         })}
         padding={`${theme.spacing(2)} ${theme.spacing()}`}
       >
-        <Typography variant="h2">Subnets</Typography>
+        <Typography variant="h2">Subnets ({vpc.subnets.length})</Typography>
       </Box>
       <VPCSubnetsTable vpcId={vpc.id} />
     </>

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.test.tsx
@@ -20,7 +20,7 @@ afterEach(() => {
 const loadingTestId = 'circle-progress';
 
 describe('VPC Subnets table', () => {
-  it('should display subnet label, id, ip range, number of linodes, and action menu', async () => {
+  it('should display filter input, subnet label, id, ip range, number of linodes, and action menu', async () => {
     const subnet = subnetFactory.build({ linodes: [1, 2, 3] });
     server.use(
       rest.get('*/vpcs/:vpcId/subnets', (req, res, ctx) => {
@@ -31,12 +31,14 @@ describe('VPC Subnets table', () => {
     const {
       getAllByRole,
       getAllByText,
+      getByPlaceholderText,
       getByTestId,
       getByText,
     } = renderWithTheme(<VPCSubnetsTable vpcId={1} />, { queryClient });
 
     await waitForElementToBeRemoved(getByTestId(loadingTestId));
 
+    getByPlaceholderText('Filter Subnets by label or id');
     getByText('Subnet Label');
     getByText(subnet.label);
     getByText('Subnet ID');

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
@@ -6,6 +6,7 @@ import {
   CollapsibleTable,
   TableItem,
 } from 'src/components/CollapsibleTable/CollapsibleTable';
+import { DebouncedSearchTextField } from 'src/components/DebouncedSearchTextField';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { Hidden } from 'src/components/Hidden';
 import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFooter';
@@ -30,6 +31,8 @@ interface Props {
 const preferenceKey = 'vpc-subnets';
 
 export const VPCSubnetsTable = ({ vpcId }: Props) => {
+  const [subnetsFilterText, setSubnetsFilterText] = React.useState('');
+
   const pagination = usePagination(1, preferenceKey);
 
   const { handleOrderChange, order, orderBy } = useOrder(
@@ -45,14 +48,37 @@ export const VPCSubnetsTable = ({ vpcId }: Props) => {
     ['+order_by']: orderBy,
   };
 
+  const generateSubnetsXFilter = (searchText: string) => {
+    if (searchText === '') {
+      return filter;
+    }
+    return {
+      '+or': [
+        {
+          label: { '+contains': searchText },
+        },
+        {
+          id: { '+contains': searchText },
+        },
+      ],
+      ...filter,
+    };
+  };
+
   const { data: subnets, error, isLoading } = useSubnetsQuery(
     vpcId,
     {
       page: pagination.page,
       page_size: pagination.pageSize,
     },
-    filter
+    generateSubnetsXFilter(subnetsFilterText)
   );
+
+  const handleSearch = (searchText: string) => {
+    setSubnetsFilterText(searchText);
+    // If you're on page 2+, need to go back to page 1 to see the actual results
+    pagination.handlePageChange(1);
+  };
 
   if (isLoading) {
     return <CircleProgress />;
@@ -144,6 +170,15 @@ export const VPCSubnetsTable = ({ vpcId }: Props) => {
 
   return (
     <>
+      <DebouncedSearchTextField
+        debounceTime={400}
+        hideLabel
+        isSearching={false}
+        label="Filter Subnets by label or id"
+        onSearch={handleSearch}
+        placeholder="Filter Subnets by label or id"
+        sx={{ paddingBottom: 2 }}
+      />
       <CollapsibleTable
         TableItems={getTableItems()}
         TableRowEmpty={<TableRowEmpty colSpan={5} message={'No Subnets'} />}

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
@@ -171,7 +171,7 @@ export const VPCSubnetsTable = ({ vpcId }: Props) => {
   return (
     <>
       <DebouncedSearchTextField
-        debounceTime={400}
+        debounceTime={250}
         hideLabel
         isSearching={false}
         label="Filter Subnets by label or id"


### PR DESCRIPTION
## Description 📝
- Add the ability to filter the subnets table by label or id in the VPC details page
- Display the number of subnets in parenthesis

## Preview 📷
https://github.com/linode/manager/assets/115299789/92875da1-a095-4558-80ea-975f960659fd

## How to test 🧪
```
yarn test VPCSubnetsTable
```
Create some subnets in a VPC and try to filter by label/id. Ensure that table column sorting still works.
