### PR TITLE
fix: [M3-7092] - Typo in NodeBalancer landing table column header

### DIFF
--- a/packages/manager/.changeset/pr-9648-fixed-1694120022815.md
+++ b/packages/manager/.changeset/pr-9648-fixed-1694120022815.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Typo in NodeBalancer landing table column header ([#9648](https://github.com/linode/manager/pull/9648))

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
@@ -106,7 +106,7 @@ export const NodeBalancersLanding = () => {
               <TableCell>Backend Status</TableCell>
             </Hidden>
             <Hidden mdDown>
-              <TableCell>Transfered</TableCell>
+              <TableCell>Transferred</TableCell>
               <TableCell>Ports</TableCell>
             </Hidden>
             <TableCell>IP Address</TableCell>


### PR DESCRIPTION
## Description 📝
"Transfered" is not a word and should be "Transferred": https://dictionary.cambridge.org/dictionary/english/transferred. 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-09-07 at 1 42 20 PM](https://github.com/linode/manager/assets/114685994/ae7452d8-5139-4ad6-b0df-db853015a062) | ![Screenshot 2023-09-07 at 1 51 09 PM](https://github.com/linode/manager/assets/114685994/42c636b6-8753-4fee-9d0e-32dbd1231922) |

## How to test 🧪
2. **How to reproduce the issue (if applicable)?**
- Go to https://cloud.linode.com/nodebalancers with at least one nodebalancer on your account and observe the typo in the table.
4. **How to verify changes?**
- Go to http://localhost:3000/nodebalancers with at least one nodebalancer on your account and observe the corrected typo in the table.


