### PR TITLE
change: Allow Cypress file watching to be disabled using environment variable

### DIFF
--- a/docs/development-guide/08-testing.md
+++ b/docs/development-guide/08-testing.md
@@ -203,13 +203,14 @@ These environment variables facilitate splitting the Cypress run between multipl
 | `CY_TEST_SPLIT_RUN_INDEX` | Numeric index for each Cypress test runner | `1`, `2`, etc. | Unset                      |
 | `CY_TEST_SPLIT_RUN_TOTAL` | Total number of runners for the tests      | `2`            | Unset                      |
 
-###### Logging & Reporting
+###### Development, Logging, and Reporting
 Environment variables related to Cypress logging and reporting, as well as report generation.
 
-| Environment Variable   | Description                                     | Example   | Default                    |
-|------------------------|-------------------------------------------------|-----------|----------------------------|
-| `CY_TEST_USER_REPORT`  | Log test account information when tests begin   | `1`       | Unset; disabled by default |
-| `CY_TEST_JUNIT_REPORT` | Enable JUnit reporting                          | `1`       | Unset; disabled by default |
+| Environment Variable            | Description                                   | Example   | Default                    |
+|---------------------------------|-----------------------------------------------|-----------|----------------------------|
+| `CY_TEST_USER_REPORT`           | Log test account information when tests begin | `1`       | Unset; disabled by default |
+| `CY_TEST_JUNIT_REPORT`          | Enable JUnit reporting                        | `1`       | Unset; disabled by default |
+| `CY_TEST_DISABLE_FILE_WATCHING` | Disable file watching in Cypress UI           | `1`       | Unset; disabled by default |
 
 ### Writing End-to-End Tests
 

--- a/packages/manager/cypress.config.ts
+++ b/packages/manager/cypress.config.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import { defineConfig } from 'cypress';
 import { setupPlugins } from './cypress/support/plugins';
+import { configureFileWatching } from './cypress/support/plugins/configure-file-watching';
 import { configureTestSuite } from './cypress/support/plugins/configure-test-suite';
 import { disableGoogleSafeBrowsing } from './cypress/support/plugins/disable-google-safe-browsing';
 import { discardPassedTestRecordings } from './cypress/support/plugins/discard-passed-test-recordings';
@@ -52,6 +53,7 @@ export default defineConfig({
         loadEnvironmentConfig,
         nodeVersionCheck,
         authenticateApi,
+        configureFileWatching,
         configureTestSuite,
         vitePreprocess,
         disableGoogleSafeBrowsing,

--- a/packages/manager/cypress/support/plugins/configure-file-watching.ts
+++ b/packages/manager/cypress/support/plugins/configure-file-watching.ts
@@ -1,0 +1,22 @@
+/**
+ * @file Allows Cypress file watching to be configured via env vars or .env files.
+ */
+
+import type { CypressPlugin } from './plugin';
+
+// The name of the environment variable to read when checking file watch configuration.
+const envVarName = 'CY_TEST_DISABLE_FILE_WATCHING';
+
+/**
+ * Optionally disables file watching when using the Cypress debugger.
+ *
+ * File watching is disabled if `CY_TEST_DISABLE_FILE_WATCHING` is set, and
+ * remains enabled otherwise.
+ *
+ * @returns Cypress configuration object.
+ */
+export const configureFileWatching: CypressPlugin = (_on, config) => {
+  const shouldWatch = !config.env[envVarName];
+  config.watchForFileChanges = shouldWatch;
+  return config;
+};


### PR DESCRIPTION
## Description 📝
Allows file watching and automatic reloading to be disabled via an environment variable (including in `.env`) when using the Cypress UI.

By default, Cypress's UI will automatically reload a test if any changes are made to the spec file which can be disruptive. This PR allows the behavior to optionally be disabled by setting the `CY_TEST_DISABLE_FILE_WATCHING` environment variable when running Cypress.

Developers can permanently set this behavior by adding it to their `.env` file.

## Major Changes 🔄
- Reads `CY_TEST_DISABLE_FILE_WATCHING` environment variable to determine whether or not to disable file watching UI
- Adds docs for `CY_TEST_DISABLE_FILE_WATCHING`

## How to test 🧪
1. Run `yarn cy:debug`
2. Run a test, and modify and save the corresponding test file; observe that Cypress reloads automatically
3. Close Cypress, and run it again with the environment variable: `CY_TEST_DISABLE_FILE_WATCHING=1 yarn cy:debug`
4. Repeat step 2, confirm that Cypress does not reload automatically
