### PR TITLE
fix: Resolve test account Machine Image resource accumulation by authenticating clean up requests

### DIFF
--- a/packages/manager/cypress/e2e/core/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/machine-image-upload.spec.ts
@@ -4,6 +4,7 @@ import { makeResourcePage } from '@src/mocks/serverHandlers';
 import 'cypress-file-upload';
 import { RecPartial } from 'factory.ts';
 import { DateTime } from 'luxon';
+import { authenticate } from 'support/api/authentication';
 import { fbtClick, fbtVisible, getClick } from 'support/helpers';
 import {
   mockDeleteImage,
@@ -134,6 +135,7 @@ const uploadImage = (label: string) => {
   cy.intercept('POST', apiMatcher('images/upload')).as('imageUpload');
 };
 
+authenticate();
 describe('machine image', () => {
   before(() => {
     cleanUp('images');


### PR DESCRIPTION
## Description 📝
This fixes Machine Image resources from accumulating on our test accounts, which has recently been causing some test failures.

In this case, the `cleanUp('images');` call was not deleting any of the desired Images because I forgot to call `authenticate()` first. In most cases this results in a 401, but the Images endpoint can be called without authentication (only returning public Images in that case) so the issue slipped under the radar.

(The test accounts have been cleaned up in the meantime)

## How to test 🧪
We can rely on the automated tests for this.