### PR TITLE
feat: [M3-7096] - Show Region `label` in addition to `id` on Invoices

### DIFF
--- a/packages/manager/.changeset/pr-9663-upcoming-features-1694534723160.md
+++ b/packages/manager/.changeset/pr-9663-upcoming-features-1694534723160.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add Region label to DC specific pricing invoices ([#9663](https://github.com/linode/manager/pull/9663))

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -45,6 +45,7 @@ import { formatDate } from 'src/utilities/formatDate';
 import { getAll } from 'src/utilities/getAll';
 
 import { getTaxID } from '../../billingUtils';
+import { useRegionsQuery } from 'src/queries/regions';
 
 const useStyles = makeStyles()((theme: Theme) => ({
   activeSince: {
@@ -186,6 +187,8 @@ export const BillingActivityPanel = (props: Props) => {
 
   const { data: profile } = useProfile();
   const { data: account } = useAccount();
+  const { data: regions } = useRegionsQuery();
+
   const isAkamaiCustomer = account?.billing_source === 'akamai';
 
   const { classes } = useStyles();
@@ -243,13 +246,14 @@ export const BillingActivityPanel = (props: Props) => {
         .then(async (invoiceItems) => {
           pdfLoading.delete(id);
 
-          const result = await printInvoice(
-            account!,
+          const result = await printInvoice({
+            account,
+            flags,
             invoice,
-            invoiceItems,
+            items: invoiceItems,
+            regions: regions ?? [],
             taxes,
-            flags
-          );
+          });
 
           if (result.status === 'error') {
             pdfErrors.add(id);
@@ -260,7 +264,7 @@ export const BillingActivityPanel = (props: Props) => {
           pdfErrors.add(id);
         });
     },
-    [account, flags, invoices, pdfErrors, pdfLoading]
+    [account, flags, invoices, pdfErrors, pdfLoading, regions]
   );
 
   const downloadPaymentPDF = React.useCallback(

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -7,28 +7,29 @@ import {
 } from '@linode/api-v4/lib/account';
 import { APIError } from '@linode/api-v4/lib/types';
 import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft';
-import { Box } from 'src/components/Box';
 import Grid from '@mui/material/Unstable_Grid2';
 import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
 
+import { Box } from 'src/components/Box';
 import { Button } from 'src/components/Button/Button';
 import { Currency } from 'src/components/Currency';
 import { DownloadCSV } from 'src/components/DownloadCSV/DownloadCSV';
 import { IconButton } from 'src/components/IconButton';
 import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
-import { Typography } from 'src/components/Typography';
 import { Paper } from 'src/components/Paper';
+import { Typography } from 'src/components/Typography';
 import { printInvoice } from 'src/features/Billing/PdfGenerator/PdfGenerator';
 import { useFlags } from 'src/hooks/useFlags';
 import { useAccount } from 'src/queries/account';
+import { useRegionsQuery } from 'src/queries/regions';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getAll } from 'src/utilities/getAll';
 
 import { getShouldUseAkamaiBilling } from '../billingUtils';
-import InvoiceTable from './InvoiceTable';
+import { InvoiceTable } from './InvoiceTable';
 
 export const InvoiceDetail = () => {
   const { invoiceId } = useParams<{ invoiceId: string }>();
@@ -37,6 +38,7 @@ export const InvoiceDetail = () => {
   const csvRef = React.useRef<any>();
 
   const { data: account } = useAccount();
+  const { data: regions } = useRegionsQuery();
 
   const [invoice, setInvoice] = React.useState<Invoice | undefined>(undefined);
   const [items, setItems] = React.useState<InvoiceItem[] | undefined>(
@@ -85,7 +87,15 @@ export const InvoiceDetail = () => {
   ) => {
     const taxes =
       flags[getShouldUseAkamaiBilling(invoice.date) ? 'taxes' : 'taxBanner'];
-    const result = await printInvoice(account, invoice, items, taxes, flags);
+
+    const result = await printInvoice({
+      account,
+      flags,
+      invoice,
+      items,
+      regions: regions ?? [],
+      taxes,
+    });
 
     setPDFGenerationError(result.status === 'error' ? result.error : undefined);
   };

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -44,7 +44,7 @@ export const InvoiceTable = (props: Props) => {
   const { classes } = useStyles();
   const MIN_PAGE_SIZE = 25;
   const flags = useFlags();
-  const columns = flags.dcSpecificPricing ? 9 : 8;
+  const NUM_COLUMNS = flags.dcSpecificPricing ? 9 : 8;
 
   const {
     data: regions,
@@ -56,13 +56,13 @@ export const InvoiceTable = (props: Props) => {
 
   const renderTableContent = () => {
     if (loading || regionsLoading) {
-      return <TableRowLoading columns={columns} />;
+      return <TableRowLoading columns={NUM_COLUMNS} />;
     }
 
     if (regionsError) {
       return (
         <TableRowError
-          colSpan={columns}
+          colSpan={NUM_COLUMNS}
           message="Unable to retrieve regions for this invoice."
         />
       );
@@ -71,7 +71,7 @@ export const InvoiceTable = (props: Props) => {
     if (errors) {
       return (
         <TableRowError
-          colSpan={columns}
+          colSpan={NUM_COLUMNS}
           message="Unable to retrieve invoice items."
         />
       );
@@ -134,7 +134,7 @@ export const InvoiceTable = (props: Props) => {
               {count > MIN_PAGE_SIZE && (
                 <TableRow>
                   <TableCell
-                    colSpan={columns}
+                    colSpan={NUM_COLUMNS}
                     sx={{ paddingLeft: '0px !important' }}
                   >
                     <PaginationFooter
@@ -154,7 +154,7 @@ export const InvoiceTable = (props: Props) => {
       );
     }
 
-    return <TableRowEmpty colSpan={columns} />;
+    return <TableRowEmpty colSpan={NUM_COLUMNS} />;
   };
 
   return (

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -133,7 +133,10 @@ export const InvoiceTable = (props: Props) => {
               ))}
               {count > MIN_PAGE_SIZE && (
                 <TableRow>
-                  <TableCell colSpan={columns}>
+                  <TableCell
+                    colSpan={columns}
+                    sx={{ paddingLeft: '0px !important' }}
+                  >
                     <PaginationFooter
                       count={count}
                       eventCategory="invoice_items"

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -18,6 +18,8 @@ import { TableRowError } from 'src/components/TableRowError/TableRowError';
 import { TableRowLoading } from 'src/components/TableRowLoading/TableRowLoading';
 import { renderUnitPrice } from 'src/features/Billing/billingUtils';
 import { useFlags } from 'src/hooks/useFlags';
+import { useRegionsQuery } from 'src/queries/regions';
+
 import { getInvoiceRegion } from '../PdfGenerator/utils';
 
 const useStyles = makeStyles()((theme: Theme) => ({
@@ -38,11 +40,119 @@ interface Props {
   loading: boolean;
 }
 
-const InvoiceTable = (props: Props) => {
+export const InvoiceTable = (props: Props) => {
   const { classes } = useStyles();
+  const MIN_PAGE_SIZE = 25;
   const flags = useFlags();
+  const columns = flags.dcSpecificPricing ? 9 : 8;
+
+  const {
+    data: regions,
+    error: regionsError,
+    isLoading: regionsLoading,
+  } = useRegionsQuery();
 
   const { errors, items, loading } = props;
+
+  const renderTableContent = () => {
+    if (loading || regionsLoading) {
+      return <TableRowLoading columns={columns} />;
+    }
+
+    if (regionsError) {
+      return (
+        <TableRowError
+          colSpan={columns}
+          message="Unable to retrieve regions for this invoice."
+        />
+      );
+    }
+
+    if (errors) {
+      return (
+        <TableRowError
+          colSpan={columns}
+          message="Unable to retrieve invoice items."
+        />
+      );
+    }
+
+    if (items && items.length > 0) {
+      return (
+        <Paginate data={items} pageSize={25}>
+          {({
+            count,
+            data: paginatedData,
+            handlePageChange,
+            handlePageSizeChange,
+            page,
+            pageSize,
+          }) => (
+            <React.Fragment>
+              {paginatedData.map((invoiceItem: InvoiceItem) => (
+                <TableRow
+                  key={`${invoiceItem.label}-${invoiceItem.from}-${invoiceItem.to}`}
+                >
+                  <TableCell data-qa-description parentColumn="Description">
+                    {invoiceItem.label}
+                  </TableCell>
+                  <TableCell data-qa-from parentColumn="From">
+                    {renderDate(invoiceItem.from)}
+                  </TableCell>
+                  <TableCell data-qa-to parentColumn="To">
+                    {renderDate(invoiceItem.to)}
+                  </TableCell>
+                  <TableCell data-qa-quantity parentColumn="Quantity">
+                    {renderQuantity(invoiceItem.quantity)}
+                  </TableCell>
+                  {flags.dcSpecificPricing && (
+                    <TableCell parentColumn="Region">
+                      {getInvoiceRegion(invoiceItem, regions ?? [])}
+                    </TableCell>
+                  )}
+                  <TableCell data-qa-unit-price parentColumn="Unit Price">
+                    {invoiceItem.unit_price !== 'None' &&
+                      renderUnitPrice(invoiceItem.unit_price)}
+                  </TableCell>
+                  <TableCell data-qa-amount parentColumn="Amount (USD)">
+                    <Currency
+                      quantity={invoiceItem.amount}
+                      wrapInParentheses={invoiceItem.amount < 0}
+                    />
+                  </TableCell>
+                  <TableCell data-qa-tax parentColumn="Tax (USD)">
+                    <Currency quantity={invoiceItem.tax} />
+                  </TableCell>
+                  <TableCell data-qa-total parentColumn="Total (USD)">
+                    <Currency
+                      quantity={invoiceItem.total}
+                      wrapInParentheses={invoiceItem.total < 0}
+                    />
+                  </TableCell>
+                </TableRow>
+              ))}
+              {count > MIN_PAGE_SIZE && (
+                <TableRow>
+                  <TableCell colSpan={columns}>
+                    <PaginationFooter
+                      count={count}
+                      eventCategory="invoice_items"
+                      handlePageChange={handlePageChange}
+                      handleSizeChange={handlePageSizeChange}
+                      page={page}
+                      pageSize={pageSize}
+                    />
+                  </TableCell>
+                </TableRow>
+              )}
+            </React.Fragment>
+          )}
+        </Paginate>
+      );
+    }
+
+    return <TableRowEmpty colSpan={columns} />;
+  };
 
   return (
     <Table aria-label="Invoice Details" className={classes.table} noBorder>
@@ -59,130 +169,12 @@ const InvoiceTable = (props: Props) => {
           <TableCell>Total (USD)</TableCell>
         </TableRow>
       </TableHead>
-      <TableBody>
-        <MaybeRenderContent errors={errors} items={items} loading={loading} />
-      </TableBody>
+      <TableBody>{renderTableContent()}</TableBody>
     </Table>
   );
 };
 
 const renderDate = (v: null | string) =>
-  v ? <DateTimeDisplay data-qa-invoice-date value={v} /> : null;
+  v ? <DateTimeDisplay value={v} /> : null;
 
 const renderQuantity = (v: null | number) => (v ? v : null);
-
-const RenderData = (props: { items: InvoiceItem[] }) => {
-  const flags = useFlags();
-  const { items } = props;
-
-  const MIN_PAGE_SIZE = 25;
-
-  return (
-    <Paginate data={items} pageSize={25}>
-      {({
-        count,
-        data: paginatedData,
-        handlePageChange,
-        handlePageSizeChange,
-        page,
-        pageSize,
-      }) => (
-        <React.Fragment>
-          {paginatedData.map((invoiceItem: InvoiceItem) => (
-            <TableRow
-              key={`${invoiceItem.label}-${invoiceItem.from}-${invoiceItem.to}`}
-            >
-              <TableCell data-qa-description parentColumn="Description">
-                {invoiceItem.label}
-              </TableCell>
-              <TableCell data-qa-from parentColumn="From">
-                {renderDate(invoiceItem.from)}
-              </TableCell>
-              <TableCell data-qa-to parentColumn="To">
-                {renderDate(invoiceItem.to)}
-              </TableCell>
-              <TableCell data-qa-quantity parentColumn="Quantity">
-                {renderQuantity(invoiceItem.quantity)}
-              </TableCell>
-              {flags.dcSpecificPricing && (
-                <TableCell parentColumn="Region">
-                  {getInvoiceRegion(invoiceItem)}
-                </TableCell>
-              )}
-              <TableCell data-qa-unit-price parentColumn="Unit Price">
-                {invoiceItem.unit_price !== 'None' &&
-                  renderUnitPrice(invoiceItem.unit_price)}
-              </TableCell>
-              <TableCell data-qa-amount parentColumn="Amount (USD)">
-                <Currency
-                  quantity={invoiceItem.amount}
-                  wrapInParentheses={invoiceItem.amount < 0}
-                />
-              </TableCell>
-              <TableCell data-qa-tax parentColumn="Tax (USD)">
-                <Currency quantity={invoiceItem.tax} />
-              </TableCell>
-              <TableCell data-qa-total parentColumn="Total (USD)">
-                <Currency
-                  quantity={invoiceItem.total}
-                  wrapInParentheses={invoiceItem.total < 0}
-                />
-              </TableCell>
-            </TableRow>
-          ))}
-          {count > MIN_PAGE_SIZE && (
-            <TableRow>
-              <TableCell
-                style={{
-                  paddingTop: 2,
-                }}
-                colSpan={8}
-              >
-                <PaginationFooter
-                  count={count}
-                  eventCategory="invoice_items"
-                  handlePageChange={handlePageChange}
-                  handleSizeChange={handlePageSizeChange}
-                  page={page}
-                  pageSize={pageSize}
-                />
-              </TableCell>
-            </TableRow>
-          )}
-        </React.Fragment>
-      )}
-    </Paginate>
-  );
-};
-
-const MaybeRenderContent = (props: {
-  errors?: APIError[];
-  items?: any[];
-  loading: boolean;
-}) => {
-  const flags = useFlags();
-  const { errors, items, loading } = props;
-
-  const columns = flags.dcSpecificPricing ? 9 : 8;
-
-  if (loading) {
-    return <TableRowLoading columns={columns} />;
-  }
-
-  if (errors) {
-    return (
-      <TableRowError
-        colSpan={columns}
-        message="Unable to retrieve invoice items."
-      />
-    );
-  }
-
-  if (items && items.length > 0) {
-    return <RenderData items={items} />;
-  }
-
-  return <TableRowEmpty colSpan={columns} />;
-};
-
-export default InvoiceTable;

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -26,6 +26,8 @@ import {
   pageMargin,
 } from './utils';
 
+import type { Region } from '@linode/api-v4';
+
 const baseFont = 'helvetica';
 
 const addLeftHeader = (
@@ -179,14 +181,24 @@ const getAkamaiLogo = () => {
     });
 };
 
+interface PrintInvoiceOptions {
+  account: Account;
+  flags: FlagSet;
+  invoice: Invoice;
+  items: InvoiceItem[];
+  /**
+   * Used to add Region labels to the `Region` column
+   */
+  regions: Region[];
+  taxes: FlagSet['taxBanner'] | FlagSet['taxes'];
+  timezone?: string;
+}
+
 export const printInvoice = async (
-  account: Account,
-  invoice: Invoice,
-  items: InvoiceItem[],
-  taxes: FlagSet['taxBanner'] | FlagSet['taxes'],
-  flags: FlagSet,
-  timezone?: string
+  options: PrintInvoiceOptions
 ): Promise<PdfResult> => {
+  const { account, flags, invoice, items, taxes, timezone, regions } = options;
+
   try {
     const itemsPerPage = 12;
     const date = formatDate(invoice.date, {
@@ -265,7 +277,14 @@ export const printInvoice = async (
         text: `Invoice: #${invoiceId}`,
       });
 
-      createInvoiceItemsTable(doc, itemsChunk, flags, timezone);
+      createInvoiceItemsTable({
+        doc,
+        flags,
+        items: itemsChunk,
+        regions,
+        timezone,
+      });
+
       createFooter(doc, baseFont, account.country, invoice.date);
       if (index < itemsChunks.length - 1) {
         doc.addPage();

--- a/packages/manager/src/features/Billing/PdfGenerator/utils.test.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/utils.test.ts
@@ -28,4 +28,17 @@ describe('getInvoiceRegion', () => {
 
     expect(getInvoiceRegion(invoiceItems, regions)).toBe(null);
   });
+  it('should return "Gloabl" if the invoice item is about Transfer and region is null', () => {
+    // This is what a Global network transfer invoice item will look like
+    const invoiceItems = invoiceItemFactory.build({
+      label: 'Transfer Overage',
+      region: null,
+    });
+    const regions = regionFactory.buildList(1, {
+      id: 'id-cgk',
+      label: 'Jakarta, ID',
+    });
+
+    expect(getInvoiceRegion(invoiceItems, regions)).toBe('Global');
+  });
 });

--- a/packages/manager/src/features/Billing/PdfGenerator/utils.test.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/utils.test.ts
@@ -1,0 +1,31 @@
+import { invoiceItemFactory, regionFactory } from 'src/factories';
+
+import { getInvoiceRegion } from './utils';
+
+describe('getInvoiceRegion', () => {
+  it('should get a formatted label given invoice items and regions', () => {
+    const invoiceItems = invoiceItemFactory.build({ region: 'id-cgk' });
+    const regions = regionFactory.buildList(1, {
+      id: 'id-cgk',
+      label: 'Jakarta, ID',
+    });
+
+    expect(getInvoiceRegion(invoiceItems, regions)).toBe(
+      'Jakarta, ID (id-cgk)'
+    );
+  });
+  it('should fallback to slug if no region matches', () => {
+    const invoiceItems = invoiceItemFactory.build({ region: 'id-cgk' });
+
+    expect(getInvoiceRegion(invoiceItems, [])).toBe('id-cgk');
+  });
+  it('passthrough null if the invoice item does not have a region', () => {
+    const invoiceItems = invoiceItemFactory.build({ region: null });
+    const regions = regionFactory.buildList(1, {
+      id: 'id-cgk',
+      label: 'Jakarta, ID',
+    });
+
+    expect(getInvoiceRegion(invoiceItems, regions)).toBe(null);
+  });
+});

--- a/packages/manager/src/features/Billing/PdfGenerator/utils.test.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/utils.test.ts
@@ -19,7 +19,7 @@ describe('getInvoiceRegion', () => {
 
     expect(getInvoiceRegion(invoiceItems, [])).toBe('id-cgk');
   });
-  it('passthrough null if the invoice item does not have a region', () => {
+  it('should passthrough null if the invoice item does not have a region', () => {
     const invoiceItems = invoiceItemFactory.build({ region: null });
     const regions = regionFactory.buildList(1, {
       id: 'id-cgk',
@@ -28,7 +28,7 @@ describe('getInvoiceRegion', () => {
 
     expect(getInvoiceRegion(invoiceItems, regions)).toBe(null);
   });
-  it('should return "Gloabl" if the invoice item is about Transfer and region is null', () => {
+  it('should return "Global" if the invoice item is about Transfer and region is null', () => {
     // This is what a Global network transfer invoice item will look like
     const invoiceItems = invoiceItemFactory.build({
       label: 'Transfer Overage',

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -939,11 +939,11 @@ export const handlers = [
             region: 'br-gru',
           }),
           invoiceItemFactory.build({
-            label: 'Outbound Transfer',
+            label: 'Outbound Transfer Overage',
             region: null,
           }),
           invoiceItemFactory.build({
-            label: 'Outbound Transfer',
+            label: 'Outbound Transfer Overage',
             region: 'id-cgk',
           }),
         ])


### PR DESCRIPTION
## Description 📝

- Displays regions using their `label` and `id` in the DC specific pricing invoices. This ticket is a follow up to address some feedback from #9597. 

## Preview 📷

![Screenshot 2023-09-12 at 10 39 26 AM](https://github.com/linode/manager/assets/115251059/22a125a6-e47e-4152-9b30-43278cc9a9a1)

![Screenshot 2023-09-12 at 10 45 17 AM](https://github.com/linode/manager/assets/115251059/56881d7f-7789-45ab-ac9d-f12586818fb1)

> [!important]
> The CSV does not contain the region `label` because I followed the current pattern of showing "pure" API data. (Notice how the dates are in the API's format)

![Screenshot 2023-09-12 at 10 41 20 AM](https://github.com/linode/manager/assets/115251059/5e54d3d8-e041-4a68-9cf2-7e1e00ecc91f)

## How to test 🧪
- Verify that you see Region `label`s and `id`s on the Invoices with the `DC Specific Pricing` feature flag on
- Verify you **do not** see the region column when the flag is **off**
