### PR TITLE
fix: [M3-7099] - Metadata CLI command

### DIFF
--- a/packages/manager/.changeset/pr-9665-fixed-1694552506393.md
+++ b/packages/manager/.changeset/pr-9665-fixed-1694552506393.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Metadata CLI command ([#9665](https://github.com/linode/manager/pull/9665))

--- a/packages/manager/src/utilities/generate-cli.test.ts
+++ b/packages/manager/src/utilities/generate-cli.test.ts
@@ -8,6 +8,9 @@ const linodeData = {
   ...linodeRequest,
   authorized_users: ['Linny', 'Gritty'],
   backup_id: undefined,
+  metadata: {
+    user_data: 'cmVrbmpnYmloZXVma2xkbQpqZXZia2Y=',
+  },
   stackscript_data: {
     gh_username: 'linode',
   },
@@ -15,16 +18,18 @@ const linodeData = {
 };
 
 const linodeDataForCLI = `
-  --label ${linodeRequest.label} \\
-  --root_pass ${linodeRequest.root_pass} \\
-  --image ${linodeRequest.image} \\
-  --type ${linodeRequest.type} \\
-  --region ${linodeRequest.region} \\
+  linode-cli linodes create \\
   --booted ${linodeRequest.booted} \\
-  --stackscript_id 10079 \\
-  --stackscript_data '{"gh_username": "linode"}' \\
+  --image ${linodeRequest.image} \\
+  --label ${linodeRequest.label} \\
+  --region ${linodeRequest.region} \\
+  --root_pass ${linodeRequest.root_pass} \\
+  --type ${linodeRequest.type} \\
   --authorized_users Linny \\
-  --authorized_users Gritty
+  --authorized_users Gritty \\
+  --metadata.user_data="cmVrbmpnYmloZXVma2xkbQpqZXZia2Y=" \\
+  --stackscript_data '{"gh_username": "linode"}' \\
+  --stackscript_id 10079
 `.trim();
 
 const generatedCommand = generateCLICommand(linodeData);
@@ -36,7 +41,7 @@ describe('generateCLICommand', () => {
     ).toBeTruthy();
   });
 
-  it.skip('should return a linode-cli command with the data provided formatted as arguments', () => {
+  it('should return a linode-cli command with the data provided formatted as arguments', () => {
     expect(generatedCommand).toMatch(linodeDataForCLI);
   });
 

--- a/packages/manager/src/utilities/generate-cli.ts
+++ b/packages/manager/src/utilities/generate-cli.ts
@@ -1,3 +1,5 @@
+import { UserData } from '@linode/api-v4/lib/linodes/types';
+
 // Credit: https://github.com/xxorax/node-shell-escape
 function escapeStringForCLI(s: string): string {
   if (/[^A-Za-z0-9_\/:=-]/.test(s)) {
@@ -50,12 +52,18 @@ const parseString = (key: string, value: string) => {
 const dataEntriesReduce = (acc: string[], [key, value]: JSONFieldToArray) => {
   if (value === undefined || value === null) {
     return acc;
-  } else if (Array.isArray(value)) {
+  }
+  if (Array.isArray(value)) {
     if (value.length === 0) {
       return acc;
     }
     acc.push(parseArray(key, value));
     return acc;
+  }
+
+  if (key === 'metadata') {
+    const userData = value as UserData;
+    acc.push(`  --${key}.user_data="${userData.user_data}"`);
   } else if (typeof value === 'object') {
     const valueAsString = convertObjectToCLIArg(value);
     acc.push(`  --${key} ${valueAsString}`);


### PR DESCRIPTION
## Description 📝
Fix metadata command when creating with the Linode CLI

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![cli before](https://github.com/linode/manager/assets/115299789/92e4b8b8-3da8-4239-b887-4c0043cd1937) |  ![cli after](https://github.com/linode/manager/assets/115299789/44efc0f1-9ce4-48ac-8121-a8d833ff170d) |
| ![cli command before](https://github.com/linode/manager/assets/115299789/ad1b54cf-6eda-4db1-9303-32b367c357b0) | ![cli command after](https://github.com/linode/manager/assets/115299789/380672cd-b8db-478b-8db6-b10cdff00cf6) |

## How to test 🧪
```
yarn test packages/manager/src/utilities/generate-cli.test.ts
```
- Go to `/linodes/create` and fill out the create form with a cloud-init compatible image and a metadata compatible region (e.g. Washington, DC)
- Enter some text in the User Data field of the Add User Data accordion
- Click the `Create Using Command Line` button and click on the `Linode CLI` tab
- Ensure that the metadata command is `--metadata.user_data="<user_data>"` instead of `--metadata '{"user_data": "<user_data>"}'`