### PR TITLE
feat: [M3-7107] - Add AGLB Certificate Delete Dialog

### DIFF
--- a/packages/manager/.changeset/pr-9666-upcoming-features-1694557714134.md
+++ b/packages/manager/.changeset/pr-9666-upcoming-features-1694557714134.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add AGLB Certificate Delete Dialog ([#9666](https://github.com/linode/manager/pull/9666))

--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -79,6 +79,7 @@ const StyledBox = styled(Box)(({ theme: { spacing } }) => ({
   },
   display: 'flex',
   justifyContent: 'flex-end',
+  marginTop: spacing(2),
   paddingBottom: spacing(1),
   paddingTop: spacing(2),
 }));

--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -79,7 +79,6 @@ const StyledBox = styled(Box)(({ theme: { spacing } }) => ({
   },
   display: 'flex',
   justifyContent: 'flex-end',
-  marginTop: spacing(2),
   paddingBottom: spacing(1),
   paddingTop: spacing(2),
 }));

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/DeleteCertificateDialog.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/DeleteCertificateDialog.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
+import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
+import { useLoadBalancerCertificateDeleteMutation } from 'src/queries/aglb/certificates';
+
+import type { Certificate } from '@linode/api-v4';
+
+interface Props {
+  certificate: Certificate | undefined;
+  loadbalancerId: number;
+  onClose: () => void;
+  open: boolean;
+}
+
+export const DeleteCertificateDialog = (props: Props) => {
+  const { certificate, loadbalancerId, onClose, open } = props;
+
+  const {
+    error,
+    isLoading,
+    mutateAsync,
+  } = useLoadBalancerCertificateDeleteMutation(
+    loadbalancerId,
+    certificate?.id ?? -1
+  );
+
+  const onDelete = async () => {
+    await mutateAsync();
+    onClose();
+  };
+
+  return (
+    <ConfirmationDialog
+      actions={
+        <ActionsPanel
+          primaryButtonProps={{
+            label: 'Delete',
+            loading: isLoading,
+            onClick: onDelete,
+          }}
+          secondaryButtonProps={{
+            label: 'Cancel',
+            onClick: onClose,
+          }}
+        />
+      }
+      error={error?.[0]?.reason}
+      onClose={onClose}
+      open={open}
+      title={`Delete Certificate ${certificate?.label}?`}
+    >
+      Are you sure you want to delete this certificate?
+    </ConfirmationDialog>
+  );
+};

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerCertificates.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerCertificates.tsx
@@ -41,6 +41,8 @@ type CertificateTypeFilter = 'all' | Certificate['type'];
 export const LoadBalancerCertificates = () => {
   const { loadbalancerId } = useParams<{ loadbalancerId: string }>();
 
+  const id = Number(loadbalancerId);
+
   const [isCreateDrawerOpen, setIsCreateDrawerOpen] = useState(false);
   const [isDeleteDrawerOpen, setIsDeleteDrawerOpen] = useState(false);
 
@@ -75,7 +77,7 @@ export const LoadBalancerCertificates = () => {
   }
 
   const { data, error, isLoading } = useLoadBalancerCertificatesQuery(
-    Number(loadbalancerId),
+    id,
     {
       page: pagination.page,
       page_size: pagination.pageSize,
@@ -213,13 +215,13 @@ export const LoadBalancerCertificates = () => {
         pageSize={pagination.pageSize}
       />
       <CreateCertificateDrawer
-        loadbalancerId={Number(loadbalancerId)}
+        loadbalancerId={id}
         onClose={() => setIsCreateDrawerOpen(false)}
         open={isCreateDrawerOpen}
       />
       <DeleteCertificateDialog
         certificate={selectedCertificate}
-        loadbalancerId={Number(loadbalancerId)}
+        loadbalancerId={id}
         onClose={() => setIsDeleteDrawerOpen(false)}
         open={isDeleteDrawerOpen}
       />

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerCertificates.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerCertificates.tsx
@@ -24,8 +24,10 @@ import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
 import { useLoadBalancerCertificatesQuery } from 'src/queries/aglb/certificates';
 
-import type { Certificate, Filter } from '@linode/api-v4';
 import { CreateCertificateDrawer } from './Certificates/CreateCertificateDrawer';
+import { DeleteCertificateDialog } from './Certificates/DeleteCertificateDialog';
+
+import type { Certificate, Filter } from '@linode/api-v4';
 
 const PREFERENCE_KEY = 'loadbalancer-certificates';
 
@@ -40,6 +42,10 @@ export const LoadBalancerCertificates = () => {
   const { loadbalancerId } = useParams<{ loadbalancerId: string }>();
 
   const [isCreateDrawerOpen, setIsCreateDrawerOpen] = useState(false);
+  const [isDeleteDrawerOpen, setIsDeleteDrawerOpen] = useState(false);
+
+  const [selectedCertificateId, setSelectedCertificateId] = useState<number>();
+
   const [type, setType] = useState<CertificateTypeFilter>('all');
   const [query, setQuery] = useState<string>();
 
@@ -77,6 +83,11 @@ export const LoadBalancerCertificates = () => {
     filter
   );
 
+  const onDeleteCertificate = (certificate: Certificate) => {
+    setIsDeleteDrawerOpen(true);
+    setSelectedCertificateId(certificate.id);
+  };
+
   if (isLoading) {
     return <CircleProgress />;
   }
@@ -87,6 +98,10 @@ export const LoadBalancerCertificates = () => {
     { label: 'Service Target Certificates', value: 'ca' },
   ];
 
+  const selectedCertificate = data?.data.find(
+    (cert) => cert.id === selectedCertificateId
+  );
+
   return (
     <>
       <Stack
@@ -94,8 +109,8 @@ export const LoadBalancerCertificates = () => {
         direction="row"
         flexWrap="wrap"
         gap={2}
-        mb={2}
-        mt={1.5}
+        mb={1}
+        mt={1}
       >
         <EnhancedSelect
           styles={{
@@ -168,17 +183,22 @@ export const LoadBalancerCertificates = () => {
         <TableBody>
           {error && <TableRowError colSpan={3} message={error?.[0].reason} />}
           {data?.results === 0 && <TableRowEmpty colSpan={3} />}
-          {data?.data.map(({ label, type }) => (
-            <TableRow key={`${label}-${type}`}>
-              <TableCell>{label}</TableCell>
-              <TableCell>{CERTIFICATE_TYPE_LABEL_MAP[type]}</TableCell>
+          {data?.data.map((certificate) => (
+            <TableRow key={`${certificate.label}-${certificate.type}`}>
+              <TableCell>{certificate.label}</TableCell>
+              <TableCell>
+                {CERTIFICATE_TYPE_LABEL_MAP[certificate.type]}
+              </TableCell>
               <TableCell actionCell>
                 <ActionMenu
                   actionsList={[
                     { onClick: () => null, title: 'Edit' },
-                    { onClick: () => null, title: 'Delete' },
+                    {
+                      onClick: () => onDeleteCertificate(certificate),
+                      title: 'Delete',
+                    },
                   ]}
-                  ariaLabel={`Action Menu for certificate ${label}`}
+                  ariaLabel={`Action Menu for certificate ${certificate.label}`}
                 />
               </TableCell>
             </TableRow>
@@ -196,6 +216,12 @@ export const LoadBalancerCertificates = () => {
         loadbalancerId={Number(loadbalancerId)}
         onClose={() => setIsCreateDrawerOpen(false)}
         open={isCreateDrawerOpen}
+      />
+      <DeleteCertificateDialog
+        certificate={selectedCertificate}
+        loadbalancerId={Number(loadbalancerId)}
+        onClose={() => setIsDeleteDrawerOpen(false)}
+        open={isDeleteDrawerOpen}
       />
     </>
   );

--- a/packages/manager/src/queries/aglb/certificates.ts
+++ b/packages/manager/src/queries/aglb/certificates.ts
@@ -1,5 +1,6 @@
 import {
   createLoadbalancerCertificate,
+  deleteLoadbalancerCertificate,
   getLoadbalancerCertificates,
 } from '@linode/api-v4';
 import {
@@ -26,22 +27,52 @@ export const useLoadBalancerCertificatesQuery = (
   filter: Filter
 ) => {
   return useQuery<ResourcePage<Certificate>, APIError[]>(
-    [QUERY_KEY, 'loadbalancer', id, 'certificates', params, filter],
+    [
+      QUERY_KEY,
+      'loadbalancer',
+      id,
+      'certificates',
+      'paginated',
+      params,
+      filter,
+    ],
     () => getLoadbalancerCertificates(id, params, filter),
     { keepPreviousData: true }
   );
 };
 
-export const useLoadBalancerCertificateCreateMutation = (id: number) => {
+export const useLoadBalancerCertificateCreateMutation = (
+  loadbalancerId: number
+) => {
   const queryClient = useQueryClient();
   return useMutation<Certificate, APIError[], CreateCertificatePayload>(
-    (data) => createLoadbalancerCertificate(id, data),
+    (data) => createLoadbalancerCertificate(loadbalancerId, data),
     {
       onSuccess() {
         queryClient.invalidateQueries([
           QUERY_KEY,
           'loadbalancer',
-          id,
+          loadbalancerId,
+          'certificates',
+        ]);
+      },
+    }
+  );
+};
+
+export const useLoadBalancerCertificateDeleteMutation = (
+  loadbalancerId: number,
+  certificateId: number
+) => {
+  const queryClient = useQueryClient();
+  return useMutation<{}, APIError[]>(
+    () => deleteLoadbalancerCertificate(loadbalancerId, certificateId),
+    {
+      onSuccess() {
+        queryClient.invalidateQueries([
+          QUERY_KEY,
+          'loadbalancer',
+          loadbalancerId,
           'certificates',
         ]);
       },


### PR DESCRIPTION
## Description 📝
- Adds a basic Delete Confirmation Dialog to the Certificate page
  - The decision to use a basic confirmation dialog rather than a type-to-confirm has been confirmed by UX  ✅

## Preview 📷

![Screenshot 2023-09-12 at 6 26 47 PM](https://github.com/linode/manager/assets/115251059/16cd6b37-e2f4-41d2-8795-8ed09fae17e7)

## How to test 🧪
- Turn on the MSW
- Go to `http://localhost:3000/loadbalancers/0/certificates`
- Try to delete a certificate
  - Test the dialog for functionality and style
  - **Note** The certificate won't actually disappear upon deletion because of how the MSW and React Query work