### PR TITLE
fix: Billing Contact UI Regression from by MUI Update

### DIFF
--- a/packages/manager/.changeset/pr-9667-fixed-1694576063628.md
+++ b/packages/manager/.changeset/pr-9667-fixed-1694576063628.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Billing Contact UI Regression caused by MUI Update ([#9667](https://github.com/linode/manager/pull/9667))

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
@@ -1,4 +1,3 @@
-import { Box } from 'src/components/Box';
 import Grid from '@mui/material/Unstable_Grid2';
 import { styled } from '@mui/material/styles';
 import countryData from 'country-region-data';
@@ -104,7 +103,7 @@ const ContactInformation = (props: Props) => {
     (_country) => _country.countryShortCode === country
   )?.countryName;
 
-  const sxBox = {
+  const sxGrid = {
     flex: 1,
     maxWidth: '100%',
     position: 'relative',
@@ -140,7 +139,7 @@ const ContactInformation = (props: Props) => {
             state ||
             zip ||
             country) && (
-            <Box sx={sxBox}>
+            <Grid sx={sxGrid}>
               {(firstName || lastName) && (
                 <StyledTypography
                   data-qa-contact-name
@@ -170,10 +169,9 @@ const ContactInformation = (props: Props) => {
                 {city && state && ','} {state} {zip}
               </StyledTypography>
               <StyledTypography>{countryName}</StyledTypography>
-            </Box>
+            </Grid>
           )}
-
-          <Box sx={sxBox}>
+          <Grid sx={sxGrid}>
             <StyledTypography
               data-qa-contact-email
               sx={{ wordBreak: 'break-all' }}
@@ -188,7 +186,7 @@ const ContactInformation = (props: Props) => {
                 <strong>Tax ID</strong> {taxId}
               </StyledTypography>
             )}
-          </Box>
+          </Grid>
         </Grid>
       </BillingPaper>
       <BillingContactDrawer


### PR DESCRIPTION
## Description 📝

- Fixes alignment issue with Billing Contact information on the Account page (`http://localhost:3000/account/billing`)
- Caused by https://github.com/linode/manager/pull/9603 and related to 
  - https://github.com/linode/manager/pull/9623
  - https://github.com/linode/manager/pull/9622

## The Fix 🔨
- It seems that MUI need `<Grid>` to be a child of `<Grid container>` rather than a `<Box>` so it can correctly apply Grid styles

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-09-12 at 11 27 35 PM](https://github.com/linode/manager/assets/115251059/43c6a79a-7a17-477f-8d7c-d25ac5a6d5d9) | ![Screenshot 2023-09-12 at 11 27 49 PM](https://github.com/linode/manager/assets/115251059/dcd8b99b-406c-4e40-b37f-de1fbba97ace) |

## How to test 🧪
- Go to `http://localhost:3000/account/billing` and check the alignment and responsiveness of the Billing Contact section