### PR TITLE
chore: Remove `React.FC` from docs examples

### DIFF
--- a/docs/development-guide/05-fetching-data.md
+++ b/docs/development-guide/05-fetching-data.md
@@ -40,7 +40,7 @@ import * as React from 'react';
 import { getProfile } from '@linode/api-v4/lib/profile';
 // ... other imports
 
-const UsernameDisplay: React.FC<> = () => {
+const UsernameDisplay = () => {
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<APIError | null>(null);
   const [profile, setProfile] = React.useState<Profile | null>(null);
@@ -114,7 +114,7 @@ Loading and error states are managed by React Query. The earlier username displa
 import * as React from "react";
 import { useProfile } from "src/queries/profile";
 
-const UsernameDisplay: React.FC<> = () => {
+const UsernameDisplay = () => {
   const { loading, error, data: profile } = useProfile();
 
   if (loading) {
@@ -157,7 +157,7 @@ import profileContainer, {
   Props as ProfileProps,
 } from "src/containers/profile.container";
 
-const UsernameDisplay: React.FC<ProfileProps> = (props) => {
+const UsernameDisplay = (props: ProfileProps) => {
   const { requestProfile, profileLoading, profileError, profileData } = props;
 
   React.useEffect(() => requestProfile, []);

--- a/docs/development-guide/06-performance.md
+++ b/docs/development-guide/06-performance.md
@@ -11,7 +11,7 @@ interface Props {
   linode: Linode;
 }
 
-const LinodeLabelDisplay: React.FC<Props> = (props) => {
+const LinodeLabelDisplay = (props: Props) => {
   return <span>{props.linode.label}</span>;
 };
 
@@ -20,7 +20,7 @@ interface Props {
   label: string;
 }
 
-const LinodeLabelDisplay: React.FC<Props> = (props) => {
+const LinodeLabelDisplay = (props: Props) => {
   return <span>{props.label}</span>;
 };
 

--- a/docs/development-guide/11-feature-flags.md
+++ b/docs/development-guide/11-feature-flags.md
@@ -32,7 +32,7 @@ To consume a feature flag from a function component, use the `useFlags` hook:
 import * as React from "react";
 import { useFlags } from "src/hooks/useFlags";
 
-const ImagesPricingBanner: React.FC<> = () => {
+const ImagesPricingBanner = () => {
   const flags = useFlags();
 
   if (flags.imagesPricingBanner) {

--- a/packages/api-v4/REACT.md
+++ b/packages/api-v4/REACT.md
@@ -38,7 +38,7 @@ import { getLinodes, Linode } from '@linode/api-v4/lib/linodes'
 import { APIError, ResourcePage } from '@linode/api-v4/lib/types';
 import React from 'react'
 
-const MyComponent: React.FC<{}> = () => {
+const MyComponent = () => {
   const [linodes, setLinodesData] = React.useState<Linode[] | undefined>(undefined);
   const [errors, setErrors] = React.useState<APIError[] | undefined>(undefined);
   const [loading, setLoading] = React.useState<boolean>(false);


### PR DESCRIPTION
## Description 📝

- Remove `React.FC` usage from our docs because we don't use `React.FC` anymore
  - https://medium.com/raccoons-group/why-you-probably-shouldnt-use-react-fc-to-type-your-react-components-37ca1243dd13

## How to test 🧪

- Check diff and make sure I didn't mess up any examples in the docs