### PR TITLE
chore: [M3-7042] - DC-Specific Pricing Copy and Link Cleanup

### DIFF
--- a/packages/manager/.changeset/pr-9670-upcoming-features-1694618602374.md
+++ b/packages/manager/.changeset/pr-9670-upcoming-features-1694618602374.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Standardize "region" and "data center" copy for DC-specific pricing ([#9670](https://github.com/linode/manager/pull/9670))

--- a/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
@@ -62,7 +62,7 @@ describe('clone linode', () => {
 
     const newLinodeLabel = `${linodePayload.label}-clone`;
 
-    // TODO Remove feature flag mocks once DC pricing is live.
+    // TODO: DC Pricing - M3-7073: Remove feature flag mocks once DC pricing is live.
     mockAppendFeatureFlags({
       dcSpecificPricing: makeFeatureFlagData(false),
     }).as('getFeatureFlags');
@@ -156,11 +156,11 @@ describe('clone linode', () => {
       '@getLinodeTypes',
     ]);
 
-    // TODO Move these assertions to end-to-end test once `dcSpecificPricing` flag goes away.
-    // TODO Remove this assertion when DC-specific pricing notice goes away.
+    // TODO: DC Pricing - M3-7073: Move these assertions to end-to-end test once `dcSpecificPricing` flag goes away.
+    // TODO: DC Pricing - M3-7086: Remove this assertion when DC-specific pricing notice goes away.
     cy.findByText(dcPricingRegionNotice, { exact: false }).should('be.visible');
 
-    // TODO Uncomment docs link assertion when docs links are added.
+    // TODO: DC Pricing - M3-7086: Uncomment docs link assertion when docs links are added.
     // cy.findByText(dcPricingDocsLabel)
     //   .should('be.visible')
     //   .should('have.attr', 'href', dcPricingDocsUrl);

--- a/packages/manager/cypress/support/constants/dc-specific-pricing.ts
+++ b/packages/manager/cypress/support/constants/dc-specific-pricing.ts
@@ -6,7 +6,7 @@ import { linodeTypeFactory } from '@src/factories';
 
 /** Notice shown to users when selecting a region. */
 export const dcPricingRegionNotice =
-  'Prices for plans, products, and services may vary based on Region.';
+  'Prices for plans, products, and services may vary based on region.';
 
 /** Notice shown to users when selecting a region with a different price structure. */
 export const dcPricingRegionDifferenceNotice =

--- a/packages/manager/src/components/DynamicPriceNotice.tsx
+++ b/packages/manager/src/components/DynamicPriceNotice.tsx
@@ -8,7 +8,7 @@ export const DynamicPriceNotice = (props: NoticeProps) => {
   return (
     <Notice spacingBottom={0} spacingTop={12} variant="info" {...props}>
       <Typography fontWeight="bold">
-        Prices for plans, products, and services may vary based on Region.{' '}
+        Prices for plans, products, and services may vary based on region.{' '}
         <Link to="https://www.linode.com/pricing">Learn more.</Link>
       </Typography>
     </Notice>

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -15,7 +15,7 @@ import { isLinodeTypeDifferentPriceInSelectedRegion } from 'src/utilities/pricin
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 
 import { Box } from '../Box';
-import { DocsLink } from '../DocsLink/DocsLink';
+// import { DocsLink } from '../DocsLink/DocsLink'; //TODO: DC Pricing - M3-7086: Uncomment this once pricing info notice is removed
 import { Link } from '../Link';
 
 interface SelectRegionPanelProps {
@@ -85,12 +85,13 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
         <Typography data-qa-tp="Region" variant="h2">
           Region
         </Typography>
-        {flags.dcSpecificPricing && (
+        {/* TODO: DC Pricing - M3-7086: Uncomment this once pricing info notice is removed */}
+        {/* {flags.dcSpecificPricing && (
           <DocsLink
             href="https://www.linode.com/pricing"
             label="How Data Center Pricing Works"
           />
-        )}
+        )} */}
       </Box>
       <RegionHelperText
         hidePricingNotice={showSelectedRegionHasDifferentPriceWarning}

--- a/packages/manager/src/components/TransferDisplay/TransferDisplayDialog.tsx
+++ b/packages/manager/src/components/TransferDisplay/TransferDisplayDialog.tsx
@@ -70,7 +70,7 @@ export const TransferDisplayDialog = React.memo(
           sx={{ marginBottom: theme.spacing(2), marginTop: theme.spacing(3) }}
         />
         {/**
-         *  Region-specific Transfer Pool Display
+         *  DC-specific Transfer Pool Display
          */}
         {regionTransferPools.length > 0 && (
           <>
@@ -79,7 +79,7 @@ export const TransferDisplayDialog = React.memo(
               fontFamily={theme.font.bold}
               marginBottom={theme.spacing()}
             >
-              Datacenter-specific Network Transfer Pools
+              Data Center Specific Network Transfer Pools
             </Typography>
             <Typography
               marginBottom={theme.spacing()}

--- a/packages/manager/src/components/TransferDisplay/TransferDisplayDialog.tsx
+++ b/packages/manager/src/components/TransferDisplay/TransferDisplayDialog.tsx
@@ -79,7 +79,7 @@ export const TransferDisplayDialog = React.memo(
               fontFamily={theme.font.bold}
               marginBottom={theme.spacing()}
             >
-              Data Center Specific Network Transfer Pools
+              Data Center-Specific Network Transfer Pools
             </Typography>
             <Typography
               marginBottom={theme.spacing()}

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -157,7 +157,7 @@ export const allowedHTMLAttr = ['href', 'lang', 'title', 'align'];
 export const MBpsIntraDC = 200;
 
 /**
- * MBps rate for inter DC migrations (AKA Cross-Datacenter migrations )
+ * MBps rate for inter DC migrations (AKA Cross-Data-Center migrations )
  */
 export const MBpsInterDC = 7.5;
 

--- a/packages/manager/src/features/Kubernetes/CreateCluster/HAControlPlane.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/HAControlPlane.tsx
@@ -55,7 +55,7 @@ export const HAControlPlane = (props: HAControlPlaneProps) => {
           label={`Yes, enable HA control plane. ${
             highAvailabilityPrice
               ? `(${displayPrice(highAvailabilityPrice)}/month)`
-              : '(Select a Region to view price information.)'
+              : '(Select a region to view price information.)'
           }`}
           control={<Radio data-testid="ha-radio-button-yes" />}
           name="yes"

--- a/packages/manager/src/features/Linodes/CloneLanding/Details.tsx
+++ b/packages/manager/src/features/Linodes/CloneLanding/Details.tsx
@@ -197,7 +197,7 @@ export const Details = (props: Props) => {
       )}
 
       <Typography>
-        Current Datacenter: {region?.label ?? thisLinodeRegion}
+        Current Data Center: {region?.label ?? thisLinodeRegion}
       </Typography>
 
       {/* Show the estimated clone time if we're able to submit the form. */}

--- a/packages/manager/src/features/Linodes/LinodesCreate/utilities.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/utilities.tsx
@@ -99,7 +99,7 @@ export const getMonthlyAndHourlyNodePricing = (
 };
 
 export const CROSS_DATA_CENTER_CLONE_WARNING =
-  'Cloning a Powered Off instance across Data Centers may cause long periods of down time.';
+  'Cloning a Powered Off instance across data centers may cause long periods of down time.';
 
 /**
  * Unicode to ASCII (encode data to Base64)

--- a/packages/manager/src/features/Linodes/LinodesCreate/utilities.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/utilities.tsx
@@ -99,7 +99,7 @@ export const getMonthlyAndHourlyNodePricing = (
 };
 
 export const CROSS_DATA_CENTER_CLONE_WARNING =
-  'Cloning a Powered Off instance across data centers may cause long periods of down time.';
+  'Cloning a powered off instance across data centers may cause long periods of down time.';
 
 /**
  * Unicode to ASCII (encode data to Base64)

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/IPSharing.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/IPSharing.tsx
@@ -322,7 +322,7 @@ const IPSharingPanel = (props: Props) => {
                 IP Sharing allows a Linode to share an IP address assignment
                 (one or more additional IP addresses). This can be used to allow
                 one Linode to begin serving requests should another become
-                unresponsive. Only IPs in the same datacenter are offered for
+                unresponsive. Only IPs in the same data center are offered for
                 sharing.
               </Typography>
             </Grid>
@@ -348,7 +348,7 @@ const IPSharingPanel = (props: Props) => {
                     marginTop: theme.spacing(2),
                   }}
                 >
-                  You have no other Linodes in this Linode&rsquo;s datacenter
+                  You have no other Linodes in this Linode&rsquo;s data center
                   with which to share IPs.
                 </Typography>
               ) : (

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
@@ -520,7 +520,7 @@ const LinodeNetworkingIPTransferPanel = (props: Props) => {
                 }}
               >
                 You have no other linodes in this Linode&rsquo;s data center
-                which to transfer IPs.
+                with which to transfer IPs.
               </Typography>
             ) : (
               <Grid container spacing={2} sx={{ width: '100%' }}>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
@@ -519,7 +519,7 @@ const LinodeNetworkingIPTransferPanel = (props: Props) => {
                   marginTop: theme.spacing(2),
                 }}
               >
-                You have no other linodes in this Linode&rsquo;s datacenter with
+                You have no other linodes in this Linode&rsquo;s data center
                 which to transfer IPs.
               </Typography>
             ) : (

--- a/packages/manager/src/features/Linodes/MigrateLinode/MigrateLinode.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/MigrateLinode.tsx
@@ -212,7 +212,7 @@ export const MigrateLinode = React.memo((props: Props) => {
       </Typography>
       {/*
          commenting out for now because we need further clarification from
-         stakeholders about whether or not we want to prevent multiple cross-datacenter migrations.
+         stakeholders about whether or not we want to prevent multiple cross-data-center migrations.
          */}
       {/* <MigrationImminentNotice
         linodeID={props.linodeID}

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -240,7 +240,7 @@ const interceptNotification = (
 
   // Outage interception
   if (notification.type === 'outage') {
-    /** this is an outage to one of the datacenters */
+    /** this is an outage to one of the data centers */
     if (
       notification.type === 'outage' &&
       notification.entity?.type === 'region'

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -283,7 +283,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
                     <span>
                       A single Volume can range from 10 to 10240 GB in size. Up
                       to eight Volumes can be attached to a single Linode.
-                      Select a Region to see cost per GB.
+                      Select a region to see cost per GB.
                     </span>
                   ) : (
                     <span>

--- a/packages/manager/src/features/Volumes/VolumeDrawer/SizeField.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/SizeField.tsx
@@ -89,7 +89,7 @@ const SizeField: React.FC<CombinedProps> = (props) => {
 
   const dynamicPricingHelperText = !resize && (
     <Box marginLeft={'10px'} marginTop={'4px'}>
-      <Typography>Select a Region to see cost per month.</Typography>
+      <Typography>Select a region to see cost per month.</Typography>
     </Box>
   );
 

--- a/packages/manager/src/utilities/pricing/constants.ts
+++ b/packages/manager/src/utilities/pricing/constants.ts
@@ -7,4 +7,4 @@ export const LKE_HA_PRICE = 60;
 export const PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE =
   'Select a region to view plans and prices.';
 export const LKE_CREATE_CLUSTER_CHECKOUT_MESSAGE =
-  'Select a Region, HA choice, and add a Node Pool to view pricing and create a cluster.';
+  'Select a region, HA choice, and add a Node Pool to view pricing and create a cluster.';

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -33,7 +33,7 @@ const priceIncreaseMap = {
  *   flags: { dcSpecificPricing: true },
  *   regionId: 'us-east',
  * });
- * @returns a datacenter specific price
+ * @returns a data center specific price
  */
 export const getDCSpecificPrice = ({
   basePrice,


### PR DESCRIPTION
## Description 📝
This PR does some clean up for DC pricing and attempts to standardize language for "region" and "data center", both of which have been used throughout this project. As a result, it touches a few other components not directly related to DC pricing in order to rename consistently and avoid running into this problem again in another 6 months. 

Changes have been reviewed by UX and Docs.

## Major Changes 🔄
- Use "region" rather than "Region" in notices, since the word is not at the beginning of a sentence or labeling a field.
- Use "data center" rather than "datacenter", since we've previously used both, but "datacenter" was used in copy much less often (only 3 places). 
- Remove the "How Data Center Pricing Works" docs link for now, since it was deemed redundant to display this link while the (temporary) info notice is shown above the Region select.
- Labels some TODOs with project name and ticket number.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-09-13 at 8 50 21 AM](https://github.com/linode/manager/assets/114685994/c00df5a7-5606-4ae3-99f6-5d9bbeff442f) | ![Screenshot 2023-09-13 at 8 39 24 AM](https://github.com/linode/manager/assets/114685994/41ca9499-408c-47b0-9334-7fb68205b843) |
| ![Screenshot 2023-09-13 at 8 50 15 AM](https://github.com/linode/manager/assets/114685994/21ca9aa3-1d31-45f0-a1ce-a4c60d90a7af) | ![Screenshot 2023-09-13 at 8 38 58 AM](https://github.com/linode/manager/assets/114685994/f8ef25eb-92b5-41e7-b6bf-7043c94fcb28) |
| ![Screenshot 2023-09-13 at 8 51 00 AM](https://github.com/linode/manager/assets/114685994/fed7b86e-a42a-4fe6-bb93-927da681244c) | ![Screenshot 2023-09-13 at 8 35 44 AM](https://github.com/linode/manager/assets/114685994/f2fcf6ac-6498-4f46-a58b-2540342f0092) |
| ![Screenshot 2023-09-13 at 8 49 50 AM](https://github.com/linode/manager/assets/114685994/b6a07da4-52eb-4ecd-935a-aa9dc01f8272) |  ![Screenshot 2023-09-13 at 8 25 57 AM](https://github.com/linode/manager/assets/114685994/a86e93c3-3d8d-4c2b-8f0b-b2f4da39e5ba) |
| ![Screenshot 2023-09-13 at 8 50 40 AM](https://github.com/linode/manager/assets/114685994/e1818414-156a-49c9-a994-ef1a250db669) | ![Screenshot 2023-09-13 at 8 16 09 AM](https://github.com/linode/manager/assets/114685994/0cb0f7c3-1362-467c-b9f3-1bfb229ae1cb) |
| ![Screenshot 2023-09-13 at 8 50 01 AM](https://github.com/linode/manager/assets/114685994/80b777c6-804c-4eda-93a7-3e2fba588bd5) | ![Screenshot 2023-09-13 at 8 26 03 AM](https://github.com/linode/manager/assets/114685994/aec187c7-4b1d-4adb-aa4b-b5278e1d31be) |











Not DC-pricing specific: 
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-09-13 at 8 51 45 AM](https://github.com/linode/manager/assets/114685994/b96e5548-e6ab-4c59-8c70-bcc2b4d4b936) | ![Screenshot 2023-09-13 at 8 26 58 AM](https://github.com/linode/manager/assets/114685994/89683577-d264-40fe-897e-d6a4507bd168) |
| ![Screenshot 2023-09-13 at 8 52 26 AM](https://github.com/linode/manager/assets/114685994/99d7a8be-6a1c-4c96-8005-387b5703080b) | ![Screenshot 2023-09-13 at 8 27 30 AM](https://github.com/linode/manager/assets/114685994/6377866b-20e7-420a-b370-2373a97e8b96) |

## How to test 🧪
1. **How to setup test environment?**
- Check out this PR.
- Turn the DC-Specific Pricing flag on and turn the MSW on.
3. **How to verify changes?**
- Go to http://localhost:3000/linodes/create and observe that there is no docs link in the upper right corner of the Region Select panel.
- Observe that "region" in the info notice is not capitalized, matching the "region" in the plans table.
- Go to http://localhost:3000/volumes/create and observe the consistent "region" copy.
- Click on the MNTP modal and observe the consistent "Data Center" copy.
- Go to http://localhost:3000/kubernetes/create and observe the consistent copy.
4. **How to run Unit or E2E tests?**
Make sure all e2es and unit tests pass -- copy changes might affect tests. 