### PR TITLE
fix: [M3-7117] - Fix style consistency issues with NodeBalancer create flow panels

### DIFF
--- a/packages/manager/.changeset/pr-9673-fixed-1694628742725.md
+++ b/packages/manager/.changeset/pr-9673-fixed-1694628742725.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Panels alignment in NB create flow ([#9673](https://github.com/linode/manager/pull/9673))

--- a/packages/manager/.changeset/pr-9673-fixed-1694628742725.md
+++ b/packages/manager/.changeset/pr-9673-fixed-1694628742725.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Panels alignment in NB create flow ([#9673](https://github.com/linode/manager/pull/9673))
+Panels alignment in NodeBalancer create flow ([#9673](https://github.com/linode/manager/pull/9673))

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerActiveCheck.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerActiveCheck.tsx
@@ -123,7 +123,7 @@ export const ActiveCheck = (props: ActiveCheckProps) => {
           </FormHelperText>
         </Grid>
         {healthCheckType !== 'none' && (
-          <React.Fragment>
+          <Grid container>
             <Grid xs={12}>
               <TextField
                 InputProps={{
@@ -212,7 +212,7 @@ export const ActiveCheck = (props: ActiveCheckProps) => {
                 />
               </Grid>
             )}
-          </React.Fragment>
+          </Grid>
         )}
       </Grid>
     </Grid>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerActiveCheck.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerActiveCheck.tsx
@@ -2,10 +2,10 @@ import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 
 import Select from 'src/components/EnhancedSelect/Select';
-import { TextField } from 'src/components/TextField';
-import { Typography } from 'src/components/Typography';
 import { FormHelperText } from 'src/components/FormHelperText';
 import { InputAdornment } from 'src/components/InputAdornment';
+import { TextField } from 'src/components/TextField';
+import { Typography } from 'src/components/Typography';
 
 import { setErrorMap } from './utils';
 
@@ -91,8 +91,8 @@ export const ActiveCheck = (props: ActiveCheckProps) => {
   });
 
   return (
-    <Grid md={6} sx={{ padding: 0 }} xs={12}>
-      <Grid container spacing={2}>
+    <Grid md={6} xs={12}>
+      <Grid container spacing={2} sx={{ padding: 1 }}>
         <Grid xs={12}>
           <Typography data-qa-active-checks-header variant="h2">
             Active Health Checks

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerActiveCheck.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerActiveCheck.tsx
@@ -200,7 +200,7 @@ export const ActiveCheck = (props: ActiveCheckProps) => {
               </Grid>
             )}
             {healthCheckType === 'http_body' && (
-              <Grid md={4} xs={12}>
+              <Grid md={12} xs={12}>
                 <TextField
                   disabled={disabled}
                   errorGroup={forEdit ? `${configIdx}` : undefined}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
@@ -61,7 +61,7 @@ export const NodeBalancerConfigNode = React.memo(
 
     return (
       <React.Fragment>
-        <Grid data-qa-node sx={{ padding: 0 }} xs={12}>
+        <Grid data-qa-node sx={{ padding: 1 }} xs={12}>
           {idx !== 0 && (
             <Grid xs={12}>
               <Divider
@@ -112,7 +112,7 @@ export const NodeBalancerConfigNode = React.memo(
             )}
           </Grid>
         </Grid>
-        <Grid sx={{ padding: 0 }} xs={12}>
+        <Grid sx={{ padding: 1 }} xs={12}>
           <Grid container data-qa-node key={idx} spacing={2}>
             <Grid lg={forEdit ? 2 : 4} sm={3} xs={12}>
               <ConfigNodeIPSelect

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
@@ -86,7 +86,7 @@ export const NodeBalancerConfigNode = React.memo(
               }}
               lg={forEdit ? 2 : 4}
               sm={forEdit ? 4 : 6}
-              xs={6}
+              xs={12}
             >
               <TextField
                 data-qa-backend-ip-label

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -6,11 +6,11 @@ import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Button } from 'src/components/Button/Button';
 import { Divider } from 'src/components/Divider';
 import Select from 'src/components/EnhancedSelect/Select';
+import { FormHelperText } from 'src/components/FormHelperText';
 import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
 import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
-import { FormHelperText } from 'src/components/FormHelperText';
 
 import { ActiveCheck } from './NodeBalancerActiveCheck';
 import { NodeBalancerConfigNode } from './NodeBalancerConfigNode';

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -259,7 +259,7 @@ export const NodeBalancerConfigPanel = (
         )}
 
         {tcpSelected && (
-          <Grid md={3} xs={6}>
+          <Grid md={6} xs={12}>
             <Select
               textFieldProps={{
                 dataAttrs: {

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -225,8 +225,8 @@ export const NodeBalancerConfigPanel = (
 
         {protocol === 'https' && (
           <Grid xs={12}>
-            <Grid container spacing={2}>
-              <Grid xs={12}>
+            <Grid columns={12} container spacing={2}>
+              <Grid md={5} sm={6} xs={12}>
                 <TextField
                   data-qa-cert-field
                   disabled={disabled}
@@ -240,7 +240,7 @@ export const NodeBalancerConfigPanel = (
                   value={sslCertificate || ''}
                 />
               </Grid>
-              <Grid xs={12}>
+              <Grid md={5} sm={6} xs={12}>
                 <TextField
                   data-qa-private-key-field
                   disabled={disabled}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -224,36 +224,34 @@ export const NodeBalancerConfigPanel = (
         </Grid>
 
         {protocol === 'https' && (
-          <Grid xs={12}>
-            <Grid columns={12} container spacing={2}>
-              <Grid md={5} sm={6} xs={12}>
-                <TextField
-                  data-qa-cert-field
-                  disabled={disabled}
-                  errorGroup={forEdit ? `${configIdx}` : undefined}
-                  errorText={errorMap.ssl_cert}
-                  label="SSL Certificate"
-                  multiline
-                  onChange={onSslCertificateChange}
-                  required={protocol === 'https'}
-                  rows={3}
-                  value={sslCertificate || ''}
-                />
-              </Grid>
-              <Grid md={5} sm={6} xs={12}>
-                <TextField
-                  data-qa-private-key-field
-                  disabled={disabled}
-                  errorGroup={forEdit ? `${configIdx}` : undefined}
-                  errorText={errorMap.ssl_key}
-                  label="Private Key"
-                  multiline
-                  onChange={onPrivateKeyChange}
-                  required={protocol === 'https'}
-                  rows={3}
-                  value={privateKey || ''}
-                />
-              </Grid>
+          <Grid container spacing={2} xs={12}>
+            <Grid md={5} sm={6} xs={12}>
+              <TextField
+                data-qa-cert-field
+                disabled={disabled}
+                errorGroup={forEdit ? `${configIdx}` : undefined}
+                errorText={errorMap.ssl_cert}
+                label="SSL Certificate"
+                multiline
+                onChange={onSslCertificateChange}
+                required={protocol === 'https'}
+                rows={3}
+                value={sslCertificate || ''}
+              />
+            </Grid>
+            <Grid md={5} sm={6} xs={12}>
+              <TextField
+                data-qa-private-key-field
+                disabled={disabled}
+                errorGroup={forEdit ? `${configIdx}` : undefined}
+                errorText={errorMap.ssl_key}
+                label="Private Key"
+                multiline
+                onChange={onPrivateKeyChange}
+                required={protocol === 'https'}
+                rows={3}
+                value={privateKey || ''}
+              />
             </Grid>
           </Grid>
         )}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -27,6 +27,7 @@ import { SelectRegionPanel } from 'src/components/SelectRegionPanel/SelectRegion
 import { Tag, TagsInput } from 'src/components/TagsInput/TagsInput';
 import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
+import { useFlags } from 'src/hooks/useFlags';
 import {
   useAccountAgreements,
   useMutateAccountAgreements,
@@ -38,6 +39,8 @@ import { sendCreateNodeBalancerEvent } from 'src/utilities/analytics';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { isEURegion } from 'src/utilities/formatRegion';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
+import { NODEBALANCER_PRICE } from 'src/utilities/pricing/constants';
+import { getDCSpecificPrice } from 'src/utilities/pricing/dynamicPricing';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
 import EUAgreementCheckbox from '../Account/Agreements/EUAgreementCheckbox';
@@ -50,9 +53,6 @@ import {
 
 import type { NodeBalancerConfigFieldsWithStatus } from './types';
 import type { APIError } from '@linode/api-v4/lib/types';
-import { getDCSpecificPrice } from 'src/utilities/pricing/dynamicPricing';
-import { NODEBALANCER_PRICE } from 'src/utilities/pricing/constants';
-import { useFlags } from 'src/hooks/useFlags';
 
 interface NodeBalancerFieldsState {
   configs: (NodeBalancerConfigFieldsWithStatus & { errors?: any })[];
@@ -483,6 +483,9 @@ const NodeBalancerCreate = () => {
               heading={`Configuration - Port ${
                 nodeBalancerFields.configs[idx].port ?? ''
               }`}
+              sx={{
+                padding: 1,
+              }}
               defaultExpanded
               key={idx}
             >

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerPassiveCheck.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerPassiveCheck.tsx
@@ -1,10 +1,10 @@
 import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 
-import { Toggle } from 'src/components/Toggle';
-import { Typography } from 'src/components/Typography';
 import { FormControlLabel } from 'src/components/FormControlLabel';
 import { FormHelperText } from 'src/components/FormHelperText';
+import { Toggle } from 'src/components/Toggle';
+import { Typography } from 'src/components/Typography';
 
 import type { NodeBalancerConfigPanelProps } from './types';
 
@@ -17,7 +17,7 @@ export const PassiveCheck = (props: NodeBalancerConfigPanelProps) => {
   ) => props.onCheckPassiveChange(value);
 
   return (
-    <Grid md={6} sx={{ padding: 0 }} xs={12}>
+    <Grid md={6} sx={{ padding: 1 }} xs={12}>
       <Grid container spacing={2}>
         <Grid xs={12}>
           <Typography data-qa-passive-checks-header variant="h2">


### PR DESCRIPTION
## Description 📝
This PR fixes the alignment of the NB create flow panels and accordions. This one has bothered me for a while!

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-09-13 at 13 30 52](https://github.com/linode/manager/assets/130582365/9bda7e9c-cf2f-4970-bb68-bf8f92e9c1cc)| ![Screenshot 2023-09-13 at 14 07 00](https://github.com/linode/manager/assets/130582365/b0b902cd-bed2-4b78-9a73-2c961d7932b5) |

## How to test 🧪
1. Navigate to nodebalancers/create
2. Check the alignment of all visible panels on desktop and mobile
3. Check the alignment of all conditionally rendered panels on desktop and mobile (toggle `Protocol` in Configurations &  `Type` in Active Health Checks etc)
