### PR TITLE
fix: [M3-7138] - Fix Create Volume Drawer static pricing copy and misplaced helper text

### DIFF
--- a/packages/manager/.changeset/pr-9683-fixed-1694731625764.md
+++ b/packages/manager/.changeset/pr-9683-fixed-1694731625764.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Misplaced helper text and static copy in Linode Create Volume drawer ([#9683](https://github.com/linode/manager/pull/9683))

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -281,9 +281,9 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
                 >
                   {dcSpecificPricing ? (
                     <span>
-                      A single Volume can range from 10 to 10240 GB in size. Up
-                      to eight Volumes can be attached to a single Linode.
-                      Select a region to see cost per GB.
+                      A single Volume can range from 10 to {MAX_VOLUME_SIZE} GB
+                      in size. Up to to eight Volumes can be attached to a
+                      single Linode. Select a region to see cost per GB.
                     </span>
                   ) : (
                     <span>

--- a/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
@@ -197,9 +197,18 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
               data-qa-volume-size-help
               variant="body1"
             >
-              A single Volume can range from 10 to {MAX_VOLUME_SIZE} gigabytes
-              in size and costs $0.10/GB per month. Up to eight volumes can be
-              attached to a single Linode.
+              {flags.dcSpecificPricing ? (
+                <span>
+                  A single Volume can range from 10 to {MAX_VOLUME_SIZE} GB in
+                  size. Up to eight Volumes can be attached to a single Linode.
+                </span>
+              ) : (
+                <span>
+                  A single Volume can range from 10 to {MAX_VOLUME_SIZE} GB in
+                  size and costs $0.10/GB per month. <br />
+                  Up to eight volumes can be attached to a single Linode.
+                </span>
+              )}
             </Typography>
 
             <LabelField

--- a/packages/manager/src/features/Volumes/VolumeDrawer/SizeField.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/SizeField.tsx
@@ -79,15 +79,13 @@ const SizeField: React.FC<CombinedProps> = (props) => {
 
   const legacyHelperText = (
     <FormHelperText>
-      {resize || isFromLinode ? (
-        'The size of the new volume in GB.'
-      ) : (
+      {resize || isFromLinode ? null : (
         <span className={classes.createVolumeText}>${price}/month</span>
       )}
     </FormHelperText>
   );
 
-  const dynamicPricingHelperText = !resize && (
+  const dynamicPricingHelperText = !resize && !isFromLinode && (
     <Box marginLeft={'10px'} marginTop={'4px'}>
       <Typography>Select a region to see cost per month.</Typography>
     </Box>

--- a/packages/manager/src/features/Volumes/VolumeDrawer/SizeField.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/SizeField.tsx
@@ -77,7 +77,7 @@ const SizeField: React.FC<CombinedProps> = (props) => {
     size: value,
   });
 
-  const legacyHelperText = (
+  const priceDisplayText = (
     <FormHelperText>
       {resize || isFromLinode ? null : (
         <span className={classes.createVolumeText}>${price}/month</span>
@@ -113,9 +113,9 @@ const SizeField: React.FC<CombinedProps> = (props) => {
       <div className={classes.priceDisplay}>
         {dcSpecificPricing
           ? hasSelectedRegion
-            ? legacyHelperText
+            ? priceDisplayText
             : dynamicPricingHelperText
-          : legacyHelperText}
+          : priceDisplayText}
       </div>
     </>
   );


### PR DESCRIPTION
## Description 📝
This PR cleans up some copy for static Volume pricing ($0.10/GB per month) that was previously missed when creating a volume from a Linode's Storage tab. It also corrects a bug with the size field helper text related to when it should display.

These issues were found/fixed in #9601, but due to that PR's size and amount of refactoring, should be fixed in their own PR.  

## Preview 📷
| Prod  | This Branch   |
| ------- | ------- |
| ![Screenshot 2023-09-14 at 3 21 40 PM](https://github.com/linode/manager/assets/114685994/b2063822-0a90-4a59-a4ad-82a85dc88328) ![image](https://github.com/linode/manager/assets/114685994/8cda9896-671f-40aa-bbf2-de76c1d75cf3) | ![Screenshot 2023-09-14 at 3 30 01 PM](https://github.com/linode/manager/assets/114685994/c61180e6-f844-4eb2-bf99-ec4e4308a551) ![Screenshot 2023-09-14 at 3 29 07 PM](https://github.com/linode/manager/assets/114685994/fb4e67e4-5faa-43de-8ce5-2abb9b47c775) |
| ![Screenshot 2023-09-14 at 3 21 21 PM](https://github.com/linode/manager/assets/114685994/24afff0d-1ae3-4e5d-8ad5-f28bb8f228d2) | ![Screenshot 2023-09-14 at 3 30 15 PM](https://github.com/linode/manager/assets/114685994/ebfec778-a10a-4930-9322-734abf0b76aa) |

## How to test 🧪
1. **How to setup test environment?**
Check out this PR.
3. **How to reproduce the issue (if applicable)?**
- Go to `http://localhost:3000/linodes/{id}/storage` and click the Create Volume button. 
- Observe the hardcoded pricing ($0.10/GB) in the helper text.
- Toggle the DC pricing feature flag on. 
- Observe the hardcoded pricing ($0.10/GB) in the helper text.
- Observe the floating size field helper text "The size of the new volume in GB".
- Observe the floating size field helper text prompting region selection, which should not display at all in this drawer (we already have the linode's region).
- Create a volume and observe this floating helper text is also present when resizing a volume.
4. **How to verify changes?**
- Go to `http://localhost:3000/linodes/{id}/storage`.
- Click the Create Volume button.
- Notice that the floating helper text is gone.
- Observe the hardcoded pricing ($0.10/GB) in the helper text.
- Toggle the DC pricing feature flag on. 
- Observe there is *not* hardcoded pricing ($0.10/GB) in the helper text.
- Create a volume and observe this floating helper text is *not* present when resizing a volume.
- Check http://localhost:3000/volumes/create and confirm that the size field helper text displays a price when the feature flag is off or once a region has been selected. When the DC pricing feature flag is *on* and a region is *not* selected, confirm text is "Select a region to see cost per month.".
6. **How to run Unit or E2E tests?**
The Create Volume Drawer relies on `getDynamicVolumePrice`, which already has a unit test. (`yarn test getDynamicVolumePrice`)
