### PR TITLE
feat: [M3-7141] Add codeowner file to monorepo root

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default code owners
-* @frontend
+* @linode/frontend

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners
+* @frontend


### PR DESCRIPTION
## Description 📝
Small PR to add a CODEOWNER file needed for the auto assignment of PRs

There's not much to test, once merged it should trigger the rules configured in the repo's settings.

No need for a changeset here either.