### PR TITLE
chore: [M3-7140] - Improve Type-safety of the `Paginate` component

### DIFF
--- a/packages/manager/src/components/OrderBy.tsx
+++ b/packages/manager/src/components/OrderBy.tsx
@@ -234,9 +234,7 @@ export const OrderBy = <T extends unknown>(props: CombinedProps<T>) => {
 
 const Memoized = React.memo(OrderBy);
 
-export default <T extends unknown>(props: CombinedProps<T>) => (
-  <Memoized {...props} />
-);
+export default <T,>(props: CombinedProps<T>) => <Memoized {...props} />;
 
 const isValidDate = (date: any) => {
   return DateTime.fromISO(date).isValid;

--- a/packages/manager/src/components/Paginate.ts
+++ b/packages/manager/src/components/Paginate.ts
@@ -4,10 +4,9 @@ import * as React from 'react';
 import scrollTo from 'src/utilities/scrollTo';
 import { storage } from 'src/utilities/storage';
 
-export const createDisplayPage = <T extends any>(
-  page: number,
-  pageSize: number
-) => (list: T[]): T[] => {
+export const createDisplayPage = <T>(page: number, pageSize: number) => (
+  list: T[]
+): T[] => {
   const count = list.length;
   if (count === 0) {
     return list;
@@ -25,9 +24,9 @@ export const createDisplayPage = <T extends any>(
   return slice(startIndex, endIndex + 1, list);
 };
 
-export interface PaginationProps extends State {
+export interface PaginationProps<T> extends State {
   count: number;
-  data: any[];
+  data: T[];
   handlePageChange: (page: number) => void;
   handlePageSizeChange: (pageSize: number) => void;
 }
@@ -37,9 +36,9 @@ interface State {
   pageSize: number;
 }
 
-interface Props {
-  children: (p: PaginationProps) => React.ReactNode;
-  data: any[];
+interface Props<T> {
+  children: (p: PaginationProps<T>) => React.ReactNode;
+  data: T[];
   page?: number;
   pageSize?: number;
   pageSizeSetter?: (v: number) => void;
@@ -48,9 +47,9 @@ interface Props {
   updatePageUrl?: (page: number) => void;
 }
 
-export default class Paginate extends React.Component<Props, State> {
+export default class Paginate<T> extends React.Component<Props<T>, State> {
   render() {
-    let view;
+    let view: (data: T[]) => T[];
     // update view based on page url
     if (this.props.updatePageUrl) {
       view = createDisplayPage(this.props.page || 1, this.state.pageSize);

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -404,101 +404,85 @@ export const BillingActivityPanel = (props: Props) => {
           order={'desc'}
           orderBy={'date'}
         >
-          {React.useCallback(
-            ({ data: orderedData }) => (
-              <Paginate data={orderedData} pageSize={25} shouldScroll={false}>
-                {({
-                  count,
-                  data: paginatedAndOrderedData,
-                  handlePageChange,
-                  handlePageSizeChange,
-                  page,
-                  pageSize,
-                }) => (
-                  <>
-                    <Table aria-label="List of Invoices and Payments">
-                      <TableHead>
-                        <TableRow>
-                          <TableCell className={classes.descriptionColumn}>
-                            Description
-                          </TableCell>
-                          <TableCell className={classes.dateColumn}>
-                            Date
-                          </TableCell>
-                          <TableCell className={classes.totalColumn}>
-                            Amount
-                          </TableCell>
-                          <TableCell className={classes.pdfDownloadColumn} />
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        <TableContentWrapper
-                          error={
-                            accountPaymentsError || accountInvoicesError
-                              ? [
-                                  {
-                                    reason:
-                                      'There was an error retrieving your billing activity.',
-                                  },
-                                ]
-                              : undefined
-                          }
-                          loading={
-                            accountPaymentsLoading || accountInvoicesLoading
-                          }
-                          loadingProps={{
-                            columns: 4,
-                          }}
-                          length={paginatedAndOrderedData.length}
-                        >
-                          {paginatedAndOrderedData.map((thisItem) => {
-                            return (
-                              <ActivityFeedItem
-                                downloadPDF={
-                                  thisItem.type === 'invoice'
-                                    ? downloadInvoicePDF
-                                    : downloadPaymentPDF
-                                }
-                                hasError={pdfErrors.has(
-                                  `${thisItem.type}-${thisItem.id}`
-                                )}
-                                isLoading={pdfLoading.has(
-                                  `${thisItem.type}-${thisItem.id}`
-                                )}
-                                key={`${thisItem.type}-${thisItem.id}`}
-                                {...thisItem}
-                              />
-                            );
-                          })}
-                        </TableContentWrapper>
-                      </TableBody>
-                    </Table>
-                    <PaginationFooter
-                      count={count}
-                      eventCategory="Billing Activity Table"
-                      handlePageChange={handlePageChange}
-                      handleSizeChange={handlePageSizeChange}
-                      page={page}
-                      pageSize={pageSize}
-                    />
-                  </>
-                )}
-              </Paginate>
-            ),
-            [
-              classes.descriptionColumn,
-              classes.dateColumn,
-              classes.totalColumn,
-              classes.pdfDownloadColumn,
-              accountPaymentsLoading,
-              accountInvoicesLoading,
-              accountPaymentsError,
-              accountInvoicesError,
-              downloadInvoicePDF,
-              downloadPaymentPDF,
-              pdfErrors,
-              pdfLoading,
-            ]
+          {({ data: orderedData }) => (
+            <Paginate data={orderedData} pageSize={25} shouldScroll={false}>
+              {({
+                count,
+                data: paginatedAndOrderedData,
+                handlePageChange,
+                handlePageSizeChange,
+                page,
+                pageSize,
+              }) => (
+                <>
+                  <Table aria-label="List of Invoices and Payments">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell className={classes.descriptionColumn}>
+                          Description
+                        </TableCell>
+                        <TableCell className={classes.dateColumn}>
+                          Date
+                        </TableCell>
+                        <TableCell className={classes.totalColumn}>
+                          Amount
+                        </TableCell>
+                        <TableCell className={classes.pdfDownloadColumn} />
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      <TableContentWrapper
+                        error={
+                          accountPaymentsError || accountInvoicesError
+                            ? [
+                                {
+                                  reason:
+                                    'There was an error retrieving your billing activity.',
+                                },
+                              ]
+                            : undefined
+                        }
+                        loading={
+                          accountPaymentsLoading || accountInvoicesLoading
+                        }
+                        loadingProps={{
+                          columns: 4,
+                        }}
+                        length={paginatedAndOrderedData.length}
+                      >
+                        {paginatedAndOrderedData.map((thisItem) => {
+                          return (
+                            <ActivityFeedItem
+                              downloadPDF={
+                                thisItem.type === 'invoice'
+                                  ? downloadInvoicePDF
+                                  : downloadPaymentPDF
+                              }
+                              hasError={pdfErrors.has(
+                                `${thisItem.type}-${thisItem.id}`
+                              )}
+                              isLoading={pdfLoading.has(
+                                `${thisItem.type}-${thisItem.id}`
+                              )}
+                              key={`${thisItem.type}-${thisItem.id}`}
+                              {...thisItem}
+                            />
+                          );
+                        })}
+                      </TableContentWrapper>
+                    </TableBody>
+                  </Table>
+                  <PaginationFooter
+                    count={count}
+                    eventCategory="Billing Activity Table"
+                    handlePageChange={handlePageChange}
+                    handleSizeChange={handlePageSizeChange}
+                    page={page}
+                    pageSize={pageSize}
+                  />
+                </>
+              )}
+            </Paginate>
           )}
         </OrderBy>
       </div>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDevicesTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDevicesTable.tsx
@@ -67,7 +67,7 @@ export const FirewallDevicesTable = React.memo((props: Props) => {
                   >
                     {paginatedAndOrderedData.map((thisDevice) => (
                       <FirewallDeviceRow
-                        deviceEntityID={thisDevice.entity.id}
+                        deviceEntityID={String(thisDevice.entity.id)}
                         deviceID={thisDevice.id}
                         deviceLabel={thisDevice.entity.label}
                         disabled={disabled}

--- a/packages/manager/src/features/Linodes/LinodesLanding/DisplayLinodes.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/DisplayLinodes.tsx
@@ -24,7 +24,8 @@ import TableWrapper from './TableWrapper';
 
 import type { Config } from '@linode/api-v4/lib/linodes';
 
-export interface RenderLinodesProps extends PaginationProps {
+export interface RenderLinodesProps
+  extends PaginationProps<LinodeWithMaintenance> {
   data: Props['data'];
   openDialog: Props['openDialog'];
   openPowerActionDialog: Props['openPowerActionDialog'];


### PR DESCRIPTION
## Description 📝
- `Paginate` is not typesafe. Improving the type-safety will help us prevent bugs

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-09-15 at 1 26 41 PM](https://github.com/linode/manager/assets/115251059/90f86d34-3e01-4823-bc6c-7ecd3801034d) | ![Screenshot 2023-09-15 at 1 26 30 PM](https://github.com/linode/manager/assets/115251059/dd476505-a749-4f83-8f21-9cac53f84475) |

## How to test 🧪
- Observe how `data` is now properly typed (as shown in the example above)
- Test the `BillingActivityPanel` (where invoices and payments are shown) on `http://localhost:3000/account/billing` and verify that removing the `useCallback` had no effect on the table
- Test the `FirewallDevicesTable` because a potential bug was found there by this fix