### PR TITLE
change: [M3-7145] - Update DC Specific Pricing Notices

### DIFF
--- a/packages/manager/.changeset/pr-9690-upcoming-features-1695050611174.md
+++ b/packages/manager/.changeset/pr-9690-upcoming-features-1695050611174.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update DC Specific Pricing Notices ([#9690](https://github.com/linode/manager/pull/9690))

--- a/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
@@ -156,10 +156,6 @@ describe('clone linode', () => {
       '@getLinodeTypes',
     ]);
 
-    // TODO: DC Pricing - M3-7073: Move these assertions to end-to-end test once `dcSpecificPricing` flag goes away.
-    // TODO: DC Pricing - M3-7086: Remove this assertion when DC-specific pricing notice goes away.
-    cy.findByText(dcPricingRegionNotice, { exact: false }).should('be.visible');
-
     // TODO: DC Pricing - M3-7086: Uncomment docs link assertion when docs links are added.
     // cy.findByText(dcPricingDocsLabel)
     //   .should('be.visible')

--- a/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
@@ -156,6 +156,8 @@ describe('clone linode', () => {
       '@getLinodeTypes',
     ]);
 
+    cy.findByText(dcPricingRegionNotice, { exact: false }).should('be.visible');
+
     // TODO: DC Pricing - M3-7086: Uncomment docs link assertion when docs links are added.
     // cy.findByText(dcPricingDocsLabel)
     //   .should('be.visible')

--- a/packages/manager/cypress/support/constants/dc-specific-pricing.ts
+++ b/packages/manager/cypress/support/constants/dc-specific-pricing.ts
@@ -5,8 +5,7 @@
 import { linodeTypeFactory } from '@src/factories';
 
 /** Notice shown to users when selecting a region. */
-export const dcPricingRegionNotice =
-  'Prices for plans, products, and services may vary based on region.';
+export const dcPricingRegionNotice = /Prices for plans, products, and services in .* may vary from other regions\./;
 
 /** Notice shown to users when selecting a region with a different price structure. */
 export const dcPricingRegionDifferenceNotice =

--- a/packages/manager/src/components/DynamicPriceNotice.tsx
+++ b/packages/manager/src/components/DynamicPriceNotice.tsx
@@ -1,14 +1,26 @@
 import React from 'react';
 
+import { useRegionsQuery } from 'src/queries/regions';
+
 import { Link } from './Link';
 import { Notice, NoticeProps } from './Notice/Notice';
 import { Typography } from './Typography';
 
-export const DynamicPriceNotice = (props: NoticeProps) => {
+interface Props extends NoticeProps {
+  region: string;
+}
+
+export const DynamicPriceNotice = (props: Props) => {
+  const { data: regions } = useRegionsQuery();
+  const { region, ...rest } = props;
+
+  const regionLabel = regions?.find((r) => r.id === region)?.label ?? region;
+
   return (
-    <Notice spacingBottom={0} spacingTop={12} variant="info" {...props}>
+    <Notice spacingBottom={0} spacingTop={12} variant="warning" {...rest}>
       <Typography fontWeight="bold">
-        Prices for plans, products, and services may vary based on region.{' '}
+        Prices for plans, products, and services in {regionLabel} may vary from
+        other regions.{' '}
         <Link to="https://www.linode.com/pricing">Learn more.</Link>
       </Typography>
     </Notice>

--- a/packages/manager/src/components/SelectRegionPanel/RegionHelperText.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/RegionHelperText.tsx
@@ -2,19 +2,15 @@ import * as React from 'react';
 
 import { Link } from 'src/components/Link';
 import { Typography } from 'src/components/Typography';
-import { useFlags } from 'src/hooks/useFlags';
 
 import { Box, BoxProps } from '../Box';
-import { DynamicPriceNotice } from '../DynamicPriceNotice';
 
 interface RegionHelperTextProps extends BoxProps {
-  hidePricingNotice?: boolean;
   onClick?: () => void;
 }
 
 export const RegionHelperText = (props: RegionHelperTextProps) => {
-  const { hidePricingNotice, onClick, ...rest } = props;
-  const flags = useFlags();
+  const { onClick, ...rest } = props;
 
   return (
     <Box {...rest}>
@@ -27,9 +23,6 @@ export const RegionHelperText = (props: RegionHelperTextProps) => {
         {` `}
         to find the best region for your current location.
       </Typography>
-      {flags.dcSpecificPricing && !hidePricingNotice && (
-        <DynamicPriceNotice spacingBottom={0} spacingTop={8} />
-      )}
     </Box>
   );
 };

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.test.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import { linodeTypeFactory, regionFactory } from 'src/factories';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
+import { rest, server } from 'src/mocks/testServer';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { SelectRegionPanel } from './SelectRegionPanel';
+
+describe('SelectRegionPanel', () => {
+  it('should render a notice when the selected region has unique pricing and the flag is on', async () => {
+    server.use(
+      rest.get('*/linode/types', (req, res, ctx) => {
+        const types = linodeTypeFactory.buildList(1, {
+          region_prices: [
+            {
+              hourly: 2,
+              id: 'id-cgk',
+              monthly: 2,
+            },
+          ],
+        });
+        return res(ctx.json(makeResourcePage(types)));
+      })
+    );
+
+    jest.mock('react-router-dom', () => ({
+      ...jest.requireActual('react-router-dom'),
+      useLocation: () => ({
+        pathname: '/linodes/create',
+      }),
+    }));
+
+    const regions = regionFactory.buildList(1, {
+      id: 'id-cgk',
+      label: 'Jakarta, ID',
+    });
+
+    const { findByText } = renderWithTheme(
+      <SelectRegionPanel
+        handleSelection={jest.fn()}
+        regions={regions}
+        selectedID="id-cgk"
+      />,
+      { flags: { dcSpecificPricing: true } }
+    );
+
+    await findByText(
+      `Prices for plans, products, and services in ${regions[0].label} may vary from other regions.`,
+      { exact: false }
+    );
+  });
+});

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -11,14 +11,14 @@ import { CROSS_DATA_CENTER_CLONE_WARNING } from 'src/features/Linodes/LinodesCre
 import { useFlags } from 'src/hooks/useFlags';
 import { useAllTypes, useTypeQuery } from 'src/queries/types';
 import { sendLinodeCreateDocsEvent } from 'src/utilities/analytics';
+import { priceIncreaseMap } from 'src/utilities/pricing/dynamicPricing';
 import { isLinodeTypeDifferentPriceInSelectedRegion } from 'src/utilities/pricing/linodes';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 
 import { Box } from '../Box';
+import { DynamicPriceNotice } from '../DynamicPriceNotice';
 // import { DocsLink } from '../DocsLink/DocsLink'; //TODO: DC Pricing - M3-7086: Uncomment this once pricing info notice is removed
 import { Link } from '../Link';
-import { DynamicPriceNotice } from '../DynamicPriceNotice';
-import { priceIncreaseMap } from 'src/utilities/pricing/dynamicPricing';
 
 interface SelectRegionPanelProps {
   disabled?: boolean;

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -85,7 +85,7 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
     selectedRegionHasUniquePricing;
 
   // If this component is used in the context of Linodes,
-  // use Linode types from the API to deturmine if the region
+  // use Linode types from the API to determine if the region
   // has specific pricing. Otherwise, check aginst our local pricing map.
   const showRegionPriceNotice = isLinode
     ? showUnqiuePricingNotice

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -79,17 +79,19 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
     types
   );
 
-  const showUnqiuePricingNotice =
+  const showUniquePricingNotice =
     flags.dcSpecificPricing &&
     !showClonePriceWarning && // Don't show both notices at the same time.
     selectedRegionHasUniquePricing;
 
   // If this component is used in the context of Linodes,
   // use Linode types from the API to determine if the region
-  // has specific pricing. Otherwise, check aginst our local pricing map.
-  const showRegionPriceNotice = isLinode
-    ? showUnqiuePricingNotice
-    : selectedID && priceIncreaseMap[selectedID];
+  // has specific pricing. Otherwise, check against our local pricing map.
+  const showRegionPriceNotice = flags.dcSpecificPricing
+    ? isLinode
+      ? showUniquePricingNotice
+      : selectedID && priceIncreaseMap[selectedID]
+    : false;
 
   if (props.regions.length === 0) {
     return null;

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -72,14 +72,21 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
     });
 
   const selectedRegionHasUniquePricing =
-    !showClonePriceWarning &&
     selectedID &&
-    types?.some((type) =>
-      type.region_prices.find((regionPrice) => regionPrice.id === selectedID)
+    types?.some(
+      (type) =>
+        type.region_prices?.find(
+          (regionPrice) => regionPrice.id === selectedID
+        ) ?? false
     );
 
+  const showUnqiuePricingNotice =
+    flags.dcSpecificPricing &&
+    !showClonePriceWarning &&
+    selectedRegionHasUniquePricing;
+
   const showRegionPriceNotice = isLinode
-    ? selectedRegionHasUniquePricing
+    ? showUnqiuePricingNotice
     : selectedID && priceIncreaseMap[selectedID];
 
   if (props.regions.length === 0) {

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -17,6 +17,8 @@ import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 import { Box } from '../Box';
 // import { DocsLink } from '../DocsLink/DocsLink'; //TODO: DC Pricing - M3-7086: Uncomment this once pricing info notice is removed
 import { Link } from '../Link';
+import { DynamicPriceNotice } from '../DynamicPriceNotice';
+import { priceIncreaseMap } from 'src/utilities/pricing/dynamicPricing';
 
 interface SelectRegionPanelProps {
   disabled?: boolean;
@@ -56,7 +58,7 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
   const showCrossDataCenterCloneWarning =
     isCloning && selectedID && params.regionID !== selectedID;
 
-  const showSelectedRegionHasDifferentPriceWarning =
+  const showClonePriceWarning =
     flags.dcSpecificPricing &&
     isCloning &&
     isLinodeTypeDifferentPriceInSelectedRegion({
@@ -64,6 +66,9 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
       regionB: selectedID,
       type,
     });
+
+  const showRegionHasCustomPriceWarning =
+    !showClonePriceWarning && selectedID && priceIncreaseMap[selectedID];
 
   if (props.regions.length === 0) {
     return null;
@@ -94,7 +99,6 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
         )} */}
       </Box>
       <RegionHelperText
-        hidePricingNotice={showSelectedRegionHasDifferentPriceWarning}
         onClick={() => sendLinodeCreateDocsEvent('Speedtest')}
       />
       {showCrossDataCenterCloneWarning ? (
@@ -117,13 +121,16 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
         regions={regions}
         selectedID={selectedID || null}
       />
-      {showSelectedRegionHasDifferentPriceWarning && (
+      {showClonePriceWarning && (
         <Notice spacingBottom={0} spacingTop={12} variant="warning">
           <Typography fontWeight="bold">
             The selected region has a different price structure.{' '}
             <Link to="https://www.linode.com/pricing">Learn more.</Link>
           </Typography>
         </Notice>
+      )}
+      {showRegionHasCustomPriceWarning && (
+        <DynamicPriceNotice region={selectedID} />
       )}
     </Paper>
   );

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -505,7 +505,7 @@ const DatabaseCreate = () => {
             regions={regionsData}
             selectedID={values.region}
           />
-          <RegionHelperText hidePricingNotice mt={1} />
+          <RegionHelperText mt={1} />
         </Grid>
         <Divider spacingBottom={12} spacingTop={38} />
         <Grid>

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -50,6 +50,7 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import KubeCheckoutBar from '../KubeCheckoutBar';
 import { HAControlPlane } from './HAControlPlane';
 import { NodePoolPanel } from './NodePoolPanel';
+import { doesRegionHaveUniquePricing } from 'src/utilities/pricing/linodes';
 
 const useStyles = makeStyles((theme: Theme) => ({
   inner: {
@@ -259,16 +260,9 @@ export const CreateCluster = () => {
     }
   };
 
-  // Show "Prices in region may vary" if
-  // - A region is selected
-  // - Any of the Linode types include a region_price object for the selected region
   const showPricingNotice =
-    selectedRegionID &&
-    typesData.some((type) =>
-      type.region_prices?.find(
-        (regionPrice) => regionPrice.id === selectedRegionID
-      )
-    );
+    flags.dcSpecificPricing &&
+    doesRegionHaveUniquePricing(selectedRegionID, typesData);
 
   const errorMap = getErrorMap(
     ['region', 'node_pools', 'label', 'k8s_version', 'versionLoad'],

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -14,6 +14,7 @@ import { useHistory } from 'react-router-dom';
 
 import { Box } from 'src/components/Box';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import { DynamicPriceNotice } from 'src/components/DynamicPriceNotice';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import { RegionSelect } from 'src/components/EnhancedSelect/variants/RegionSelect';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
@@ -258,6 +259,17 @@ export const CreateCluster = () => {
     }
   };
 
+  // Show "Prices in region may vary" if
+  // - A region is selected
+  // - Any of the Linode types include a region_price object for the selected region
+  const showPricingNotice =
+    selectedRegionID &&
+    typesData.some((type) =>
+      type.region_prices.find(
+        (regionPrice) => regionPrice.id === selectedRegionID
+      )
+    );
+
   const errorMap = getErrorMap(
     ['region', 'node_pools', 'label', 'k8s_version', 'versionLoad'],
     errors
@@ -314,6 +326,12 @@ export const CreateCluster = () => {
               regions={filteredRegions}
               selectedID={selectedID}
             />
+            {showPricingNotice && (
+              <DynamicPriceNotice
+                region={selectedRegionID}
+                spacingBottom={16}
+              />
+            )}
             <Select
               onChange={(selected: Item<string>) => {
                 setVersion(selected);

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -265,7 +265,7 @@ export const CreateCluster = () => {
   const showPricingNotice =
     selectedRegionID &&
     typesData.some((type) =>
-      type.region_prices.find(
+      type.region_prices?.find(
         (regionPrice) => regionPrice.id === selectedRegionID
       )
     );

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -20,7 +20,7 @@ export interface DataCenterPricingOptions {
 }
 
 // The key is a region id and the value is the percentage increase in price.
-const priceIncreaseMap = {
+export const priceIncreaseMap = {
   'br-gru': 0.4, // Sao Paulo
   'id-cgk': 0.2, // Jakarta
 };

--- a/packages/manager/src/utilities/pricing/linodes.test.ts
+++ b/packages/manager/src/utilities/pricing/linodes.test.ts
@@ -281,13 +281,13 @@ describe('doesRegionHaveUniquePricing', () => {
     });
     expect(doesRegionHaveUniquePricing('us-east', types)).toBe(false);
   });
-  it('should return false when no linode type has unique pricing for the specificed region', () => {
+  it('should return false when no linode type has unique pricing for the specified region', () => {
     const types = linodeTypeFactory.buildList(1, {
       region_prices: [{ id: 'id-cgk' }],
     });
     expect(doesRegionHaveUniquePricing('us-east', types)).toBe(false);
   });
-  it('should return true when any linode type has unique pricing for the specificed region', () => {
+  it('should return true when any linode type has unique pricing for the specified region', () => {
     const types = linodeTypeFactory.buildList(1, {
       region_prices: [{ id: 'id-cgk' }],
     });

--- a/packages/manager/src/utilities/pricing/linodes.test.ts
+++ b/packages/manager/src/utilities/pricing/linodes.test.ts
@@ -2,6 +2,7 @@ import { linodeTypeFactory } from 'src/factories';
 
 import { getLinodeBackupPrice } from './backups';
 import {
+  doesRegionHaveUniquePricing,
   getDynamicDCNetworkTransferData,
   getLinodeRegionPrice,
   isLinodeInDynamicPricingDC,
@@ -230,5 +231,66 @@ describe('isLinodeTypeDifferentPriceInSelectedRegion', () => {
 
       expect(result).toEqual({ quota: 0, used: 0 });
     });
+  });
+});
+
+describe('getLinodeRegionPrice', () => {
+  it('gets a linode price without a region override', () => {
+    const type = linodeTypeFactory.build({
+      price: {
+        hourly: 0.1,
+        monthly: 5,
+      },
+      region_prices: [],
+    });
+
+    expect(getLinodeRegionPrice(type, 'us-east')).toEqual({
+      hourly: 0.1,
+      monthly: 5,
+    });
+  });
+  it('gets a linode price with a region override', () => {
+    const type = linodeTypeFactory.build({
+      price: {
+        hourly: 0.1,
+        monthly: 5,
+      },
+      region_prices: [{ hourly: 0.2, id: 'id-cgk', monthly: 29.99 }],
+    });
+
+    expect(getLinodeRegionPrice(type, 'id-cgk')).toEqual({
+      hourly: 0.2,
+      monthly: 29.99,
+    });
+  });
+});
+
+describe('doesRegionHaveUniquePricing', () => {
+  it('should return false when values are undefined', () => {
+    expect(doesRegionHaveUniquePricing(undefined, undefined)).toBe(false);
+  });
+  it('should not error when region_prices is undefined', () => {
+    const types = linodeTypeFactory.buildList(1, {
+      region_prices: undefined,
+    });
+    expect(doesRegionHaveUniquePricing('us-east', types)).toBe(false);
+  });
+  it('should return false when no region has specific pricing', () => {
+    const types = linodeTypeFactory.buildList(1, {
+      region_prices: [],
+    });
+    expect(doesRegionHaveUniquePricing('us-east', types)).toBe(false);
+  });
+  it('should return false when no linode type has unique pricing for the specificed region', () => {
+    const types = linodeTypeFactory.buildList(1, {
+      region_prices: [{ id: 'id-cgk' }],
+    });
+    expect(doesRegionHaveUniquePricing('us-east', types)).toBe(false);
+  });
+  it('should return true when any linode type has unique pricing for the specificed region', () => {
+    const types = linodeTypeFactory.buildList(1, {
+      region_prices: [{ id: 'id-cgk' }],
+    });
+    expect(doesRegionHaveUniquePricing('id-cgk', types)).toBe(true);
   });
 });

--- a/packages/manager/src/utilities/pricing/linodes.ts
+++ b/packages/manager/src/utilities/pricing/linodes.ts
@@ -135,7 +135,7 @@ export const getDynamicDCNetworkTransferData = ({
  * given any number of Linode Types
  * @param regionId the region to check for specific pricing
  * @param types an array of Linode Types
- * @returns true if there is at least one linode type with a DC sprcific price for the provided region
+ * @returns true if there is at least one linode type with a DC specific price for the provided region
  */
 export const doesRegionHaveUniquePricing = (
   regionId: Region['id'] | undefined,

--- a/packages/manager/src/utilities/pricing/linodes.ts
+++ b/packages/manager/src/utilities/pricing/linodes.ts
@@ -129,3 +129,25 @@ export const getDynamicDCNetworkTransferData = ({
     used: networkTransferData.used || 0,
   };
 };
+
+/**
+ * This function is used to determine if specific pricing exists in a region
+ * given any number of Linode Types
+ * @param regionId the region to check for specific pricing
+ * @param types an array of Linode Types
+ * @returns true if there is at least one linode type with a DC sprcific price for the provided region
+ */
+export const doesRegionHaveUniquePricing = (
+  regionId: Region['id'] | undefined,
+  types: LinodeType[] | undefined
+) => {
+  if (!regionId || !types) {
+    return false;
+  }
+
+  return types?.some(
+    (type) =>
+      type.region_prices?.some((regionPrice) => regionPrice.id === regionId) ??
+      false
+  );
+};


### PR DESCRIPTION
## Description 📝

- Updates the DC specific pricing notices on Linode Create, Kubernetes Create, and NodeBalancer Create.

## Major Changes 🔄

- No notice is shown by default (this is new)
- A new **warning** notice shows when you select a region that has DC specific pricing
- No changes to Linode Clone warning (you should see `The selected region has a different price structure` if you clone to a region with different pricing)

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-09-15 at 5 08 04 PM](https://github.com/linode/manager/assets/115251059/b80e9f95-935b-4202-8b99-cbd5ed9ab793) | ![Screenshot 2023-09-15 at 5 07 56 PM](https://github.com/linode/manager/assets/115251059/3d8a85c6-ca2d-412e-bf52-58abe062749d) |
| ![Screenshot 2023-09-15 at 5 07 28 PM](https://github.com/linode/manager/assets/115251059/6d5adc20-1d69-440d-8dd0-96f906551aa4) | ![Screenshot 2023-09-15 at 5 07 19 PM](https://github.com/linode/manager/assets/115251059/64a37c41-aedb-4b2b-8733-bf009607a33a) |
| ![Screenshot 2023-09-15 at 5 07 00 PM](https://github.com/linode/manager/assets/115251059/0f676ee1-c1c2-4949-93d6-f0107f52d303) | ![Screenshot 2023-09-15 at 5 06 39 PM](https://github.com/linode/manager/assets/115251059/cb25f6eb-7fac-46b4-80b4-5002b4a8a6cd) |

## How to test 🧪

### Setup
- Turn on the MSW
- Turn on the DC Specific Pricing Flag

### Linode Create
- Go to `/linodes/create`
- Select `Jakarta, ID (id-cgk)`
- Verify you see a Notice saying `Prices for plans, products, and services in Jakarta, ID may vary from other regions.`
- Select `Sao Paulo, BR (br-gru)`
- Verify you see a Notice saying `Prices for plans, products, and services in Sao Paulo, BR may vary from other regions.`
- Verify that normal regions have no notice

### Linode Clone
- Go to `/linodes/create`
- Go to the Clone tab
- Select a Linode
- Select a region with different pricing
- Verify you see `The selected region has a different price structure. ` when you select a region with different pricing

### NodeBalancer Create
- Go to `/nodebalancers/create`
- Select `Jakarta, ID (id-cgk)`
- Verify you see a Notice saying `Prices for plans, products, and services in Jakarta, ID may vary from other regions.`
- Select `Sao Paulo, BR (br-gru)`
- Verify you see a Notice saying `Prices for plans, products, and services in Sao Paulo, BR may vary from other regions.`
- Verify that normal regions have no notice

### Kubernetes Create
- Go to `/kubernetes/create`
- Select `Jakarta, ID (id-cgk)`
- Verify you see a Notice saying `Prices for plans, products, and services in Jakarta, ID may vary from other regions.`
- Select `Sao Paulo, BR (br-gru)`
- Verify you see a Notice saying `Prices for plans, products, and services in Sao Paulo, BR may vary from other regions.`
- Verify that normal regions have no notice

### Other Testing
- Verify that no DC Specific pricing notices show when the feature flag is off
- Unit tests:
```
yarn test SelectRegionPanel.test.tsx linodes.test.ts 
```