### PR TITLE
docs: [CT-3888] - Update API docs endpoint links to style matching linode/linode-docs-theme#400

### DIFF
--- a/packages/manager/cypress/e2e/region/images/update-delete-machine-image.spec.ts
+++ b/packages/manager/cypress/e2e/region/images/update-delete-machine-image.spec.ts
@@ -18,7 +18,7 @@ import { testRegions } from 'support/util/regions';
  *
  * See Linode API v4 documentation for more information.
  *
- * @link https://www.linode.com/docs/api/images/#image-upload
+ * @link https://www.linode.com/docs/api/images/image-upload/
  *
  * @param region - Image upload region.
  * @param data - Data to upload.


### PR DESCRIPTION
## Description 📝
https://github.com/linode/linode-docs-theme/pull/400 will update the API docs so that every endpoint is rendered to its own page, instead of an endpoint collection rendering all of its endpoints to a single page. URLs for API docs will change like so:

Before:
https://www.linode.com/docs/api/images/#image-upload
After:
https://www.linode.com/docs/api/images/image-upload/

This manager PR updates the one API docs link I could find that links to an individual endpoint within a collection.

Note that if a user visits one of the old-style anchor links for endpoint, there is client-side logic to refresh the page to show the new URL. This uses some JS to update the page's contents and the URL of the browser, instead of performing an actual page reload.

**Please do not merge until we push the API docs changes to production.**

## Major Changes 🔄
Just the one URL change noted in the description

## Preview 📷
No visual changes

## How to test 🧪
Doesn't seem like testing is needed