### PR TITLE
feat: [M3-7017] - Update firewall events

### DIFF
--- a/packages/manager/.changeset/pr-9693-upcoming-features-1695157943571.md
+++ b/packages/manager/.changeset/pr-9693-upcoming-features-1695157943571.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update Firewall events messages ([#9693](https://github.com/linode/manager/pull/9693))

--- a/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
@@ -128,7 +128,7 @@ const removeFirewallRules = (ruleLabel: string) => {
  */
 const addLinodesToFirewall = (firewall: Firewall, linode: Linode) => {
   // Go to Linodes tab
-  ui.tabList.findTabByTitle('Linodes').should('be.visible').click();
+  ui.tabList.findTabByTitle('Linodes (0)').should('be.visible').click();
 
   ui.button.findByTitle('Add Linodes to Firewall').should('be.visible').click();
 

--- a/packages/manager/src/features/Events/eventMessageGenerator.ts
+++ b/packages/manager/src/features/Events/eventMessageGenerator.ts
@@ -7,6 +7,7 @@ import {
   formatEventWithAppendedText,
   formatEventWithUsername,
 } from 'src/features/Events/Event.helpers';
+import { capitalize } from 'src/utilities/capitalize';
 import { escapeRegExp } from 'src/utilities/escapeRegExp';
 import { getLinkForEvent } from 'src/utilities/getEventsActionLink';
 
@@ -257,12 +258,26 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     notification: (e) => `Firewall ${e.entity?.label ?? ''} has been deleted.`,
   },
   firewall_device_add: {
-    notification: (e) =>
-      `A device has been added to Firewall ${e.entity?.label ?? ''}.`,
+    notification: (e) => {
+      const secondaryEntityName = e.secondary_entity?.type
+        ? capitalize(e.secondary_entity.type)
+        : e.secondary_entity?.type;
+
+      return `${secondaryEntityName} ${
+        e.secondary_entity?.label
+      } has been added to Firewall ${e.entity?.label ?? ''}.`;
+    },
   },
   firewall_device_remove: {
-    notification: (e) =>
-      `A device has been removed from Firewall ${e.entity?.label ?? ''}.`,
+    notification: (e) => {
+      const secondaryEntityName = e.secondary_entity?.type
+        ? capitalize(e.secondary_entity.type)
+        : e.secondary_entity?.type;
+
+      return `${secondaryEntityName} ${
+        e.secondary_entity?.label
+      } has been removed from Firewall ${e.entity?.label ?? ''}.`;
+    },
   },
   firewall_disable: {
     notification: (e) => `Firewall ${e.entity?.label ?? ''} has been disabled.`,

--- a/packages/manager/src/features/Events/eventMessageGenerator.ts
+++ b/packages/manager/src/features/Events/eventMessageGenerator.ts
@@ -7,7 +7,6 @@ import {
   formatEventWithAppendedText,
   formatEventWithUsername,
 } from 'src/features/Events/Event.helpers';
-import { capitalize } from 'src/utilities/capitalize';
 import { escapeRegExp } from 'src/utilities/escapeRegExp';
 import { getLinkForEvent } from 'src/utilities/getEventsActionLink';
 
@@ -28,6 +27,11 @@ export const safeSecondaryEntityLabel = (
 ) => {
   const label = e?.secondary_entity?.label;
   return label ? `${text} ${label}` : fallback;
+};
+
+const secondaryEntityTypeObj = {
+  linode: 'Linode',
+  nodebalancer: 'NodeBalancer',
 };
 
 export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
@@ -259,24 +263,28 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   },
   firewall_device_add: {
     notification: (e) => {
-      const secondaryEntityName = e.secondary_entity?.type
-        ? capitalize(e.secondary_entity.type)
-        : e.secondary_entity?.type;
-
-      return `${secondaryEntityName} ${
-        e.secondary_entity?.label
-      } has been added to Firewall ${e.entity?.label ?? ''}.`;
+      if (e.secondary_entity?.type) {
+        const secondaryEntityName =
+          secondaryEntityTypeObj[e.secondary_entity.type];
+        return `${secondaryEntityName} ${
+          e.secondary_entity?.label
+        } has been added to Firewall ${e.entity?.label ?? ''}.`;
+      }
+      return `A device has been added to Firewall ${e.entity?.label ?? ''}.`;
     },
   },
   firewall_device_remove: {
     notification: (e) => {
-      const secondaryEntityName = e.secondary_entity?.type
-        ? capitalize(e.secondary_entity.type)
-        : e.secondary_entity?.type;
-
-      return `${secondaryEntityName} ${
-        e.secondary_entity?.label
-      } has been removed from Firewall ${e.entity?.label ?? ''}.`;
+      if (e.secondary_entity?.type) {
+        const secondaryEntityName =
+          secondaryEntityTypeObj[e.secondary_entity.type];
+        return `${secondaryEntityName} ${
+          e.secondary_entity?.label
+        } has been removed from Firewall ${e.entity?.label ?? ''}.`;
+      }
+      return `A device has been removed from Firewall ${
+        e.entity?.label ?? ''
+      }.`;
     },
   },
   firewall_disable: {


### PR DESCRIPTION
## Description 📝
Changes the copy of the notification message in the `Events` landing page to account for the ability to add `NodeBalancers` to `Firewalls`. 

## Major Changes 🔄
- Replaces `device` for the appropriate device type (`Linode` or `NodeBalancer`) in the message displayed in the `Events` landing page.

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![m3-7017-before](https://github.com/linode/manager/assets/119514965/ae5708cf-385c-4919-9f09-bb27c26cd8f7) | ![m3-7017-after](https://github.com/linode/manager/assets/119514965/5ee485d4-b763-465c-9171-1e3db74889f6) |

## How to test 🧪
1. On you `localhost` instance, switch over to the `Dev` environment via the CloudManager dev tools.
2. On a existing `Firewall` entity add at least one instance of both `Linode` and `NodeBalancer`.
3. Validate the event notification messages in the `Events` landing page.
4. On the same `Firewall` instance remove the `Linode` and `NodeBalancer` instances that you added in step 2.
5. Validate the event notification messages in the `Events` landing page. 