### PR TITLE
fix: [M3-7155] - Link Accessibility & Markup on Billing Detail page

### DIFF
--- a/packages/manager/.changeset/pr-9697-fixed-1695133545193.md
+++ b/packages/manager/.changeset/pr-9697-fixed-1695133545193.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Back link and CSV download button accessibility on Billing Detail page ([#9697](https://github.com/linode/manager/pull/9697))

--- a/packages/manager/cypress/e2e/core/billing/billing-invoices.spec.ts
+++ b/packages/manager/cypress/e2e/core/billing/billing-invoices.spec.ts
@@ -135,15 +135,8 @@ describe('Account invoices', () => {
         cy.findByText(`Invoice #${mockInvoice.id}`).should('be.visible');
         cy.findByText(formatUsd(sumSubtotal + sumTax)).should('be.visible');
 
-        ui.button
-          .findByTitle('Download CSV')
-          .should('be.visible')
-          .should('be.enabled');
-
-        ui.button
-          .findByTitle('Download PDF')
-          .should('be.visible')
-          .should('be.enabled');
+        cy.findByText('Download CSV').should('be.visible');
+        cy.findByText('Download PDF').should('be.visible');
       });
 
     // Confirm that invoice summary displays subtotal, tax subtotal, tax summary entries, and grand total.

--- a/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
+++ b/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
@@ -14,7 +14,7 @@ interface DownloadCSVProps {
   data: unknown[];
   filename: string;
   headers: { key: string; label: string }[];
-  onClick: () => void;
+  onClick?: () => void;
   sx?: SxProps;
   text?: string;
 }

--- a/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
+++ b/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
@@ -40,20 +40,24 @@ export const DownloadCSV = ({
   text = 'Download CSV',
 }: DownloadCSVProps) => {
   return (
-    <>
-      <CSVLink
-        aria-hidden="true"
-        className={className}
-        data={cleanCSVData(data)}
-        filename={filename}
-        headers={headers}
-        ref={csvRef}
-        tabIndex={-1}
-      />
-      <Button buttonType={buttonType} onClick={onClick} sx={sx}>
+    <CSVLink
+      aria-hidden="true"
+      className={className}
+      data={cleanCSVData(data)}
+      filename={filename}
+      headers={headers}
+      ref={csvRef}
+      tabIndex={-1}
+    >
+      <Button
+        buttonType={buttonType}
+        component="span"
+        onClick={onClick}
+        sx={sx}
+      >
         {text}
       </Button>
-    </>
+    </CSVLink>
   );
 };
 

--- a/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
+++ b/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
@@ -41,19 +41,19 @@ export const DownloadCSV = ({
 }: DownloadCSVProps) => {
   return (
     <CSVLink
-      aria-hidden="true"
       className={className}
       data={cleanCSVData(data)}
       filename={filename}
       headers={headers}
       ref={csvRef}
-      tabIndex={-1}
     >
       <Button
         buttonType={buttonType}
         component="span"
+        disableRipple
         onClick={onClick}
         sx={sx}
+        tabIndex={-1}
       >
         {text}
       </Button>

--- a/packages/manager/src/components/Link.tsx
+++ b/packages/manager/src/components/Link.tsx
@@ -67,9 +67,9 @@ export const Link = (props: LinkProps) => {
     className,
     external,
     forceCopyColor,
+    hideIcon,
     onClick,
     to,
-    hideIcon,
   } = props;
   const { classes, cx } = useStyles();
   const sanitizedUrl = () => sanitizeUrl(to);
@@ -77,8 +77,8 @@ export const Link = (props: LinkProps) => {
   const childrenAsAriaLabel = flattenChildrenIntoAriaLabel(children);
   const externalNotice = '- link opens in a new tab';
   const ariaLabel = accessibleAriaLabel
-    ? `${accessibleAriaLabel} ${externalNotice}`
-    : `${childrenAsAriaLabel} ${externalNotice}`;
+    ? `${accessibleAriaLabel} ${shouldOpenInNewTab ? externalNotice : ''}`
+    : `${childrenAsAriaLabel} ${shouldOpenInNewTab ? externalNotice : ''}`;
 
   if (childrenContainsNoText(children) && !accessibleAriaLabel) {
     // eslint-disable-next-line no-console
@@ -122,6 +122,7 @@ export const Link = (props: LinkProps) => {
     </a>
   ) : (
     <RouterLink
+      aria-label={ariaLabel}
       data-testid="internal-link"
       {...routerLinkProps}
       className={cx(

--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -16,7 +16,11 @@ import { useGrants } from 'src/queries/profile';
 
 import AccountLogins from './AccountLogins';
 
-const Billing = React.lazy(() => import('src/features/Billing'));
+const Billing = React.lazy(() =>
+  import('src/features/Billing/BillingDetail').then((module) => ({
+    default: module.BillingDetail,
+  }))
+);
 const EntityTransfersLanding = React.lazy(() =>
   import(
     'src/features/EntityTransfers/EntityTransfersLanding/EntityTransfersLanding'

--- a/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
+++ b/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
@@ -132,7 +132,6 @@ const MaintenanceTable = ({ type }: Props) => {
 
   const downloadCSV = async () => {
     await getCSVData();
-    csvRef.current.link.click();
   };
 
   return (

--- a/packages/manager/src/features/Account/index.tsx
+++ b/packages/manager/src/features/Account/index.tsx
@@ -7,8 +7,10 @@ import { SuspenseLoader } from 'src/components/SuspenseLoader';
 const AccountLanding = React.lazy(
   () => import('src/features/Account/AccountLanding')
 );
-const InvoiceDetail = React.lazy(
-  () => import('src/features/Billing/InvoiceDetail')
+const InvoiceDetail = React.lazy(() =>
+  import('src/features/Billing/InvoiceDetail/InvoiceDetail').then((module) => ({
+    default: module.InvoiceDetail,
+  }))
 );
 const EntityTransfersCreate = React.lazy(() =>
   import(

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -141,7 +141,10 @@ export const InvoiceDetail = () => {
                     padding: 0,
                   }}
                   component="span"
+                  disableFocusRipple
+                  role="none"
                   size="large"
+                  tabIndex={-1}
                 >
                   <KeyboardArrowLeft
                     sx={{

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -129,13 +129,18 @@ export const InvoiceDetail = () => {
     >
       <Grid container rowGap={2}>
         <Grid xs={12}>
-          <Grid container spacing={2} sx={sxGrid} data-qa-invoice-header>
+          <Grid container data-qa-invoice-header spacing={2} sx={sxGrid}>
             <Grid sm={4} sx={sxGrid} xs={12}>
-              <Link to={`/account/billing`} data-qa-back-to-billing>
+              <Link
+                accessibleAriaLabel="Back to Billing"
+                data-qa-back-to-billing
+                to={`/account/billing`}
+              >
                 <IconButton
                   sx={{
                     padding: 0,
                   }}
+                  component="span"
                   size="large"
                 >
                   <KeyboardArrowLeft
@@ -246,5 +251,3 @@ export const InvoiceDetail = () => {
     </Paper>
   );
 };
-
-export default InvoiceDetail;

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -173,7 +173,6 @@ export const InvoiceDetail = () => {
                     data={items}
                     filename={`invoice-${invoice.date}.csv`}
                     headers={csvHeaders}
-                    onClick={() => csvRef.current.link.click()}
                     sx={{ ...sxDownloadButton, marginRight: '8px' }}
                   />
                   <Button

--- a/packages/manager/src/features/Billing/InvoiceDetail/index.ts
+++ b/packages/manager/src/features/Billing/InvoiceDetail/index.ts
@@ -1,2 +1,0 @@
-import InvoiceDetail from './InvoiceDetail';
-export default InvoiceDetail;

--- a/packages/manager/src/features/Billing/index.tsx
+++ b/packages/manager/src/features/Billing/index.tsx
@@ -1,1 +1,0 @@
-export { default } from './BillingDetail';


### PR DESCRIPTION
## Description 📝
Small PR to improve accessibility and markup on the Billing Detail page since those were bothering me and throwing warnings in the console.

![Screenshot 2023-09-19 at 09 54 50](https://github.com/linode/manager/assets/130582365/dfd5d55a-2816-4734-b188-dbb8e92ab8a3)


## Major Changes 🔄
- Provide accessibility to the back button link
- Improve markup of the Download CVS Link
- Update imports/exports

## Preview 📷
This PR should contain no visual regression and should be tested against any.

## How to test 🧪
**Local Setup**:
Pull and run code locally 

**Steps**:
1. Navigate to /account/billing/invoices/{invoiceId}
2. Confirm there's no warning in the console about Link Accessibility
3. Confirm there's no visual regression (no difference from the production page)
4. Confirm the Download CSV link works as expected

