### PR TITLE
fix: [M3-7078] codeQL warning with analytics.ts

### DIFF
--- a/packages/manager/.changeset/pr-9700-fixed-1695156150613.md
+++ b/packages/manager/.changeset/pr-9700-fixed-1695156150613.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+codeQL warning with analytics.ts custom event payload ([#9700](https://github.com/linode/manager/pull/9700))

--- a/packages/manager/src/utilities/analytics.ts
+++ b/packages/manager/src/utilities/analytics.ts
@@ -24,9 +24,9 @@ export const sendEvent = (eventPayload: AnalyticsEvent): void => {
   }
 
   // Send a Direct Call Rule if our environment is configured with an Adobe Launch script
-  if ((window as Window)._satellite) {
+  if (window._satellite) {
     // Just don't allow pipes in strings for Adobe Analytics processing.
-    (window as Window)._satellite.track('custom event', {
+    window._satellite.track('custom event', {
       action: eventPayload.action.replace(/\|/g, ''),
       category: eventPayload.category.replace(/\|/g, ''),
       label: eventPayload.label?.replace(/\|/g, ''),

--- a/packages/manager/src/utilities/analytics.ts
+++ b/packages/manager/src/utilities/analytics.ts
@@ -1,5 +1,16 @@
 import { ADOBE_ANALYTICS_URL } from 'src/constants';
 
+// Define a custom type for the _satellite object
+declare global {
+  interface Window {
+    _satellite: DTMSatellite;
+  }
+}
+
+type DTMSatellite = {
+  track: (eventName: string, eventPayload: AnalyticsEvent) => void;
+};
+
 interface AnalyticsEvent {
   action: string;
   category: string;
@@ -13,12 +24,12 @@ export const sendEvent = (eventPayload: AnalyticsEvent): void => {
   }
 
   // Send a Direct Call Rule if our environment is configured with an Adobe Launch script
-  if ((window as any)._satellite) {
+  if ((window as Window)._satellite) {
     // Just don't allow pipes in strings for Adobe Analytics processing.
-    (window as any)._satellite.track('custom event', {
-      action: eventPayload.action.replace('|', ''),
-      category: eventPayload.category.replace('|', ''),
-      label: eventPayload.label?.replace('|', ''),
+    (window as Window)._satellite.track('custom event', {
+      action: eventPayload.action.replace(/\|/g, ''),
+      category: eventPayload.category.replace(/\|/g, ''),
+      label: eventPayload.label?.replace(/\|/g, ''),
       value: eventPayload.value,
     });
   }


### PR DESCRIPTION
## Description 📝
This pr fixes this codeQL warning and type the _satellite object a bit better

## Major Changes 🔄
- Escape expression in `eventPayload` replaced values
- Ensure all occurrences of `|` are replaced (as opposed to one before)

## How to test 🧪
**Setup**:
1. Pull code locally
2. Follow the local analytics [debugging setup](https://github.com/linode/manager/blob/develop/docs/development-guide/13-coding-standards.md#locally-testing-page-views--custom-events-andor-troubleshooting)

**Steps**:
1. Navigate to /linodes
2. Open any action menu and observe the analytic event in the console
3. Modify the [sendLinodeActionEvent](https://github.com/linode/manager/blob/develop/packages/manager/src/utilities/analytics.ts#L30) method to include one or several `|` (pipe) characters
4. Confirm they all get removed from the event payload


