### PR TITLE
fix: [M3-7008] - Invoice and Payment `id` wrapping in generated PDFs

### DIFF
--- a/packages/manager/.changeset/pr-9702-fixed-1695158299608.md
+++ b/packages/manager/.changeset/pr-9702-fixed-1695158299608.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Payment confirmation number covered in Payment Receipts ([#9702](https://github.com/linode/manager/pull/9702))

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -163,9 +163,12 @@ const addTitle = (doc: jsPDF, y: number, ...textStrings: Title[]) => {
     doc.text(eachString.text, eachString.leftMargin || pageMargin, y, {
       charSpace: 0.75,
     });
+    y += 12;
   });
   // reset text format
   doc.setFont(baseFont, 'normal');
+
+  return y;
 };
 
 // M3-6177 only make one request to get the logo
@@ -272,15 +275,20 @@ export const printInvoice = async (
       );
       const rightHeaderYPosition = addRightHeader(doc, account);
 
-      addTitle(doc, Math.max(leftHeaderYPosition, rightHeaderYPosition) + 4, {
-        text: `Invoice: #${invoiceId}`,
-      });
+      const titlePosition = addTitle(
+        doc,
+        Math.max(leftHeaderYPosition, rightHeaderYPosition) + 12,
+        {
+          text: `Invoice: #${invoiceId}`,
+        }
+      );
 
       createInvoiceItemsTable({
         doc,
         flags,
         items: itemsChunk,
         regions,
+        startY: titlePosition,
         timezone,
       });
 
@@ -335,11 +343,16 @@ export const printPayment = (
       countryTax
     );
     const rightHeaderYPosition = addRightHeader(doc, account);
-    addTitle(doc, Math.max(leftHeaderYPosition, rightHeaderYPosition) + 12, {
-      text: `Receipt for Payment #${payment.id}`,
-    });
 
-    createPaymentsTable(doc, payment, timezone);
+    const titleYPosition = addTitle(
+      doc,
+      Math.max(leftHeaderYPosition, rightHeaderYPosition) + 12,
+      {
+        text: `Receipt for Payment #${payment.id}`,
+      }
+    );
+
+    createPaymentsTable(doc, payment, titleYPosition, timezone);
     createFooter(doc, baseFont, account.country, payment.date);
     createPaymentsTotalsTable(doc, payment);
 

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -162,7 +162,6 @@ const addTitle = (doc: jsPDF, y: number, ...textStrings: Title[]) => {
   textStrings.forEach((eachString) => {
     doc.text(eachString.text, eachString.leftMargin || pageMargin, y, {
       charSpace: 0.75,
-      maxWidth: 100,
     });
   });
   // reset text format

--- a/packages/manager/src/features/Billing/PdfGenerator/utils.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/utils.ts
@@ -44,6 +44,7 @@ const formatDateForTable = (
 export const createPaymentsTable = (
   doc: JSPDF,
   payment: Payment,
+  startY: number,
   timezone?: string
 ) => {
   autoTable(doc, {
@@ -63,7 +64,7 @@ export const createPaymentsTable = (
     headStyles: {
       fillColor: '#444444',
     },
-    startY: 165,
+    startY,
     styles: {
       lineWidth: 1,
     },
@@ -95,6 +96,10 @@ interface CreateInvoiceItemsTableOptions {
    * Used to add Region labels to the `Region` column
    */
   regions: Region[];
+  /**
+   * The start position of the table on the Y axis
+   */
+  startY: number;
   timezone?: string;
 }
 
@@ -104,7 +109,7 @@ interface CreateInvoiceItemsTableOptions {
 export const createInvoiceItemsTable = (
   options: CreateInvoiceItemsTableOptions
 ) => {
-  const { doc, flags, items, regions, timezone } = options;
+  const { doc, flags, items, regions, timezone, startY } = options;
 
   autoTable(doc, {
     body: items.map((item) => {
@@ -182,7 +187,7 @@ export const createInvoiceItemsTable = (
     headStyles: {
       fillColor: '#444444',
     },
-    startY: 165,
+    startY,
     styles: {
       lineWidth: 1,
     },

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -977,8 +977,9 @@ export const handlers = [
     return res(ctx.delay(5000), ctx.json(transfer));
   }),
   rest.get('*/account/payments', (req, res, ctx) => {
+    const paymentWithLargeId = paymentFactory.build({ id: 15106536 });
     const payments = paymentFactory.buildList(5);
-    return res(ctx.json(makeResourcePage(payments)));
+    return res(ctx.json(makeResourcePage([paymentWithLargeId, ...payments])));
   }),
   rest.get('*/account/invoices', (req, res, ctx) => {
     const linodeInvoice = invoiceFactory.build({
@@ -989,7 +990,15 @@ export const handlers = [
       date: '2022-12-16T18:04:01',
       label: 'AkamaiInvoice',
     });
-    return res(ctx.json(makeResourcePage([linodeInvoice, akamaiInvoice])));
+    const invoiceWithLargerId = invoiceFactory.build({
+      id: 23974531,
+      label: 'Invoice with Large ID',
+    });
+    return res(
+      ctx.json(
+        makeResourcePage([linodeInvoice, akamaiInvoice, invoiceWithLargerId])
+      )
+    );
   }),
   rest.get('*/account/invoices/:invoiceId', (req, res, ctx) => {
     const linodeInvoice = invoiceFactory.build({

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -977,7 +977,9 @@ export const handlers = [
     return res(ctx.delay(5000), ctx.json(transfer));
   }),
   rest.get('*/account/payments', (req, res, ctx) => {
-    const paymentWithLargeId = paymentFactory.build({ id: 15106536 });
+    const paymentWithLargeId = paymentFactory.build({
+      id: 123_456_789_123_456,
+    });
     const payments = paymentFactory.buildList(5);
     return res(ctx.json(makeResourcePage([paymentWithLargeId, ...payments])));
   }),
@@ -991,7 +993,7 @@ export const handlers = [
       label: 'AkamaiInvoice',
     });
     const invoiceWithLargerId = invoiceFactory.build({
-      id: 23974531,
+      id: 123_456_789_123_456,
       label: 'Invoice with Large ID',
     });
     return res(


### PR DESCRIPTION
## Description 📝

> [!important]
> I recommend checking the internal ticket to see context of this 🪲

Fixes unnecessary wrap in invoice and payment PDFs that caused some `id` numbers to be partially cut off and improves general positioning

## Major Changes 🔄
- Do not enforce a maxWidth in the `addTitle` function
- Replaced hard-coded table start position with dynamic start position 🎉

## Preview 📷

| Before  | After   |
| ------- | ------- |
|   ![Screenshot 2023-09-19 at 4 49 28 PM](https://github.com/linode/manager/assets/115251059/7bac73b4-fc9e-4a21-9bb5-e310464f6a23)  |  ![Screenshot 2023-09-19 at 5 01 32 PM](https://github.com/linode/manager/assets/115251059/799fc9e7-4174-4874-9fd2-70e5934b3827) |
|  ![Screenshot 2023-09-19 at 4 49 17 PM](https://github.com/linode/manager/assets/115251059/72f980d9-9c11-411d-901a-bd539f028e16)   |   ![Screenshot 2023-09-19 at 5 02 38 PM](https://github.com/linode/manager/assets/115251059/78724a4b-10d0-4286-a8ee-080ceb163d25) |

## How to test 🧪
- Turn on the MSW
- Go to `http://localhost:3000/account/billing`
- Check the PDF of the invoice called `Invoice with Large ID` and verify the text `Invoice: #123456789123456` is positioned correctly and is not overlapping anything
- Check the PDF of the payment called `Payment #123456789123456` and verify the text `Receipt for Payment #123456789123456` is positioned correctly and is not overlapping anything
- Continue to test on a variety of different invoices and payment PDFs