### PR TITLE
fix: [M3-7105] - Highlight.js Theme Switching

### DIFF
--- a/packages/manager/.changeset/pr-9705-fixed-1695242987904.md
+++ b/packages/manager/.changeset/pr-9705-fixed-1695242987904.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fixed theme issues in kubeconfig dialog ([#9705](https://github.com/linode/manager/pull/9705))

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -271,7 +271,7 @@
       "^react-native$": "react-native-web",
       "ramda": "ramda/src/index.js",
       "^src/(.*)": "<rootDir>/src/$1",
-      "\\.css\\?raw$": "<rootDir>/src/components/NullComponent",
+      "(.*)\\.css\\?raw$": "$1.css",
       "@linode/api-v4/lib(.*)$": "<rootDir>/../api-v4/src/$1",
       "@linode/validation/lib(.*)$": "<rootDir>/../validation/src/$1",
       "@linode/api-v4": "<rootDir>/../api-v4/src/index.ts",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -271,6 +271,7 @@
       "^react-native$": "react-native-web",
       "ramda": "ramda/src/index.js",
       "^src/(.*)": "<rootDir>/src/$1",
+      "\\.css\\?raw$": "<rootDir>/src/components/NullComponent",
       "@linode/api-v4/lib(.*)$": "<rootDir>/../api-v4/src/$1",
       "@linode/validation/lib(.*)$": "<rootDir>/../validation/src/$1",
       "@linode/api-v4": "<rootDir>/../api-v4/src/index.ts",

--- a/packages/manager/src/App.test.tsx
+++ b/packages/manager/src/App.test.tsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 import { StaticRouter } from 'react-router-dom';
 
 import { App, hasOauthError } from './App';
-import LinodeThemeWrapper from './LinodeThemeWrapper';
+import { LinodeThemeWrapper } from './LinodeThemeWrapper';
 import { queryClientFactory } from './queries/base';
 import { storeFactory } from './store';
 

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -1,8 +1,6 @@
 import { APIError } from '@linode/api-v4/lib/types';
 import '@reach/tabs/styles.css';
 import { ErrorBoundary } from '@sentry/react';
-import 'highlight.js/styles/a11y-dark.css';
-import 'highlight.js/styles/a11y-light.css';
 import { useSnackbar } from 'notistack';
 import { pathOr } from 'ramda';
 import * as React from 'react';

--- a/packages/manager/src/LinodeThemeWrapper.tsx
+++ b/packages/manager/src/LinodeThemeWrapper.tsx
@@ -1,14 +1,9 @@
-import { StyledEngineProvider } from '@mui/material/styles';
 import { Theme, ThemeProvider } from '@mui/material/styles';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import HLJSDarkTheme from 'highlight.js/styles/a11y-dark.css?raw';
-import HLJSLightTheme from 'highlight.js/styles/a11y-light.css?raw';
+import { StyledEngineProvider } from '@mui/material/styles';
 import * as React from 'react';
 
 import { ThemeName } from './foundations/themes';
-import { useAuthentication } from './hooks/useAuthentication';
-import { usePreferences } from './queries/preferences';
-import { getThemeFromPreferenceValue, themes } from './utilities/theme';
+import { themes, useColorMode } from './utilities/theme';
 
 declare module '@mui/styles/defaultTheme' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -21,47 +16,15 @@ interface Props {
   theme?: ThemeName;
 }
 
-export const LinodeThemeWrapper = ({ children, theme }: Props) => {
-  // fallback to default when rendering themed components pre-authentication
-  const isAuthenticated = !!useAuthentication().token;
-  const { data: preferences } = usePreferences(isAuthenticated);
-  const isSystemInDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
-
-  const selectedTheme =
-    theme ??
-    getThemeFromPreferenceValue(preferences?.theme, isSystemInDarkMode);
-
-  /**
-   * This function exists because we use Hightlight.js and it does not have a built-in
-   * way to programaticly change the theme.
-   *
-   * We must manually switch our Highlight.js theme's CSS when our theme is changed.
-   */
-  const handleHLJSChange = async (theme: ThemeName) => {
-    const THEME_STYLE_ID = 'hljs-theme';
-    const existingStyleTag = document.getElementById(THEME_STYLE_ID);
-
-    if (existingStyleTag) {
-      // If the style tag already exists in the <head>, just update the css content.
-      existingStyleTag.innerHTML =
-        theme === 'light' ? HLJSLightTheme : HLJSDarkTheme;
-    } else {
-      // The page has been loaded and we need to manually append our Hightlight.js
-      // css so we can easily change it later on.
-      const styleTag = document.createElement('style');
-      styleTag.id = THEME_STYLE_ID;
-      styleTag.innerHTML = theme === 'light' ? HLJSLightTheme : HLJSDarkTheme;
-      document.head.appendChild(styleTag);
-    }
-  };
-
-  React.useEffect(() => {
-    handleHLJSChange(selectedTheme);
-  }, [selectedTheme]);
+export const LinodeThemeWrapper = (props: Props) => {
+  const { children, theme: themeOverride } = props;
+  const { colorMode } = useColorMode();
 
   return (
     <StyledEngineProvider injectFirst>
-      <ThemeProvider theme={themes[selectedTheme]}>{children}</ThemeProvider>
+      <ThemeProvider theme={themes[themeOverride ?? colorMode]}>
+        {children}
+      </ThemeProvider>
     </StyledEngineProvider>
   );
 };

--- a/packages/manager/src/components/Button/Button.test.tsx
+++ b/packages/manager/src/components/Button/Button.test.tsx
@@ -1,26 +1,17 @@
 import React from 'react';
 
-import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { Button } from './Button';
 
 describe('Button', () => {
   it('should render', () => {
-    const { getByText } = renderWithTheme(
-      <LinodeThemeWrapper>
-        <Button>Test</Button>
-      </LinodeThemeWrapper>
-    );
+    const { getByText } = renderWithTheme(<Button>Test</Button>);
     getByText('Test');
   });
 
   it('should render the loading state', () => {
-    const { getByTestId } = renderWithTheme(
-      <LinodeThemeWrapper>
-        <Button loading>Test</Button>
-      </LinodeThemeWrapper>
-    );
+    const { getByTestId } = renderWithTheme(<Button loading>Test</Button>);
 
     const loadingIcon = getByTestId('loadingIcon');
     expect(loadingIcon).toBeInTheDocument();
@@ -28,9 +19,7 @@ describe('Button', () => {
 
   it('should render the HelpIcon when tooltipText is true', () => {
     const { getByTestId } = renderWithTheme(
-      <LinodeThemeWrapper>
-        <Button tooltipText="Test">Test</Button>
-      </LinodeThemeWrapper>
+      <Button tooltipText="Test">Test</Button>
     );
 
     const helpIcon = getByTestId('HelpOutlineIcon');

--- a/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.tsx
+++ b/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.tsx
@@ -1,18 +1,20 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-import { Theme, useTheme } from '@mui/material/styles';
 import * as hljs from 'highlight.js/lib/core';
 import apache from 'highlight.js/lib/languages/apache';
 import bash from 'highlight.js/lib/languages/bash';
 import javascript from 'highlight.js/lib/languages/javascript';
 import nginx from 'highlight.js/lib/languages/nginx';
 import yaml from 'highlight.js/lib/languages/yaml';
+import HLJSDarkTheme from 'highlight.js/styles/a11y-dark.css?raw';
+import HLJSLightTheme from 'highlight.js/styles/a11y-light.css?raw';
 import * as React from 'react';
 import sanitize from 'sanitize-html';
 
 import { Typography } from 'src/components/Typography';
 import 'src/formatted-text.css';
+import { ThemeName } from 'src/foundations/themes';
 import { unsafe_MarkdownIt } from 'src/utilities/markdown';
 import { sanitizeHTML } from 'src/utilities/sanitize-html';
+import { useColorMode } from 'src/utilities/theme';
 
 hljs.registerLanguage('apache', apache);
 hljs.registerLanguage('bash', bash);
@@ -37,9 +39,38 @@ export interface HighlightedMarkdownProps {
 }
 
 export const HighlightedMarkdown = (props: HighlightedMarkdownProps) => {
-  const theme = useTheme<Theme>();
   const { className, language, sanitizeOptions, textOrMarkdown } = props;
   const rootRef = React.useRef<HTMLDivElement>(null);
+
+  const { colorMode } = useColorMode();
+
+  /**
+   * This function exists because we use Hightlight.js and it does not have a built-in
+   * way to programaticly change the theme.
+   *
+   * We must manually switch our Highlight.js theme's CSS when our theme is changed.
+   */
+  const handleThemeChange = async (theme: ThemeName) => {
+    const THEME_STYLE_ID = 'hljs-theme';
+    const existingStyleTag = document.getElementById(THEME_STYLE_ID);
+
+    if (existingStyleTag) {
+      // If the style tag already exists in the <head>, just update the css content.
+      existingStyleTag.innerHTML =
+        theme === 'light' ? HLJSLightTheme : HLJSDarkTheme;
+    } else {
+      // The page has been loaded and we need to manually append our Hightlight.js
+      // css so we can easily change it later on.
+      const styleTag = document.createElement('style');
+      styleTag.id = THEME_STYLE_ID;
+      styleTag.innerHTML = theme === 'light' ? HLJSLightTheme : HLJSDarkTheme;
+      document.head.appendChild(styleTag);
+    }
+  };
+
+  React.useEffect(() => {
+    handleThemeChange(colorMode);
+  }, [colorMode]);
 
   /**
    * If the language prop is provided, we'll try to override the language
@@ -79,11 +110,11 @@ export const HighlightedMarkdown = (props: HighlightedMarkdownProps) => {
       dangerouslySetInnerHTML={{
         __html: sanitizedHtml,
       }}
-      sx={{
+      sx={(theme) => ({
         '& .hljs': {
           color: theme.color.offBlack,
         },
-      }}
+      })}
       className={`formatted-text ${className}`}
       ref={rootRef}
     />

--- a/packages/manager/src/components/LandingHeader/LandingHeader.test.tsx
+++ b/packages/manager/src/components/LandingHeader/LandingHeader.test.tsx
@@ -1,29 +1,22 @@
 import * as React from 'react';
 
-import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { LandingHeader } from './LandingHeader';
 
 describe('LandingHeader', () => {
   it('should render a title', () => {
-    const { getByText } = renderWithTheme(
-      <LinodeThemeWrapper>
-        <LandingHeader title="My Title" />
-      </LinodeThemeWrapper>
-    );
+    const { getByText } = renderWithTheme(<LandingHeader title="My Title" />);
     expect(getByText('My Title')).toBeInTheDocument();
   });
 
   it('should render breadcrumbProps pathname', () => {
     renderWithTheme(
-      <LinodeThemeWrapper>
-        <LandingHeader
-          breadcrumbProps={{
-            pathname: '/my/path/to/somewhere',
-          }}
-        />
-      </LinodeThemeWrapper>
+      <LandingHeader
+        breadcrumbProps={{
+          pathname: '/my/path/to/somewhere',
+        }}
+      />
     );
 
     expect(document.body.textContent).toMatch(/my/);
@@ -34,14 +27,12 @@ describe('LandingHeader', () => {
 
   it('should render title over breadcrumb pathname', () => {
     renderWithTheme(
-      <LinodeThemeWrapper>
-        <LandingHeader
-          breadcrumbProps={{
-            pathname: '/my/path/to/somewhere',
-          }}
-          title="My Title"
-        />
-      </LinodeThemeWrapper>
+      <LandingHeader
+        breadcrumbProps={{
+          pathname: '/my/path/to/somewhere',
+        }}
+        title="My Title"
+      />
     );
 
     expect(document.body.textContent).toMatch(/my/);
@@ -53,49 +44,41 @@ describe('LandingHeader', () => {
 
   it('should render a create button', () => {
     const { getByText } = renderWithTheme(
-      <LinodeThemeWrapper>
-        <LandingHeader
-          createButtonText="Create My Entity"
-          onButtonClick={() => null}
-        />
-      </LinodeThemeWrapper>
+      <LandingHeader
+        createButtonText="Create My Entity"
+        onButtonClick={() => null}
+      />
     );
     expect(getByText('Create My Entity')).toBeInTheDocument();
   });
 
   it('should render a docs link', () => {
     const { getByText } = renderWithTheme(
-      <LinodeThemeWrapper>
-        <LandingHeader
-          docsLabel="Docs"
-          docsLink="https://www.linode.com/docs/products/compute/compute-instances/faqs/"
-        />
-      </LinodeThemeWrapper>
+      <LandingHeader
+        docsLabel="Docs"
+        docsLink="https://www.linode.com/docs/products/compute/compute-instances/faqs/"
+      />
     );
     expect(getByText('Docs')).toBeInTheDocument();
   });
 
   it('should render extra actions', () => {
     const { getByText } = renderWithTheme(
-      <LinodeThemeWrapper>
-        <LandingHeader
-          extraActions={<button>Extra Action</button>}
-          onButtonClick={() => null}
-        />
-      </LinodeThemeWrapper>
+      <LandingHeader
+        extraActions={<button>Extra Action</button>}
+        onButtonClick={() => null}
+      />
     );
     expect(getByText('Extra Action')).toBeInTheDocument();
   });
 
   it('should render a disabled create button', () => {
     const { getByText } = renderWithTheme(
-      <LinodeThemeWrapper>
-        <LandingHeader
-          createButtonText="Create My Entity"
-          disabledCreateButton
-          onButtonClick={() => null}
-        />
-      </LinodeThemeWrapper>
+      <LandingHeader
+        createButtonText="Create My Entity"
+        disabledCreateButton
+        onButtonClick={() => null}
+      />
     );
 
     expect(getByText('Create My Entity').closest('button')).toBeDisabled();
@@ -103,14 +86,12 @@ describe('LandingHeader', () => {
 
   it('should render custom crumb path based removeCrumbX prop', () => {
     const { getByText } = renderWithTheme(
-      <LinodeThemeWrapper>
-        <LandingHeader
-          breadcrumbProps={{
-            pathname: '/my/path/to/somewhere',
-          }}
-          removeCrumbX={1}
-        />
-      </LinodeThemeWrapper>
+      <LandingHeader
+        breadcrumbProps={{
+          pathname: '/my/path/to/somewhere',
+        }}
+        removeCrumbX={1}
+      />
     );
 
     expect(document.body.textContent).not.toMatch(/my/);
@@ -124,21 +105,19 @@ describe('LandingHeader', () => {
 
   it('should render custom crumb path based removeCrumbX prop', () => {
     renderWithTheme(
-      <LinodeThemeWrapper>
-        <LandingHeader
-          breadcrumbProps={{
-            crumbOverrides: [
-              {
-                label: 'My First Crumb',
-                linkTo: '/someRoute',
-                noCap: true,
-                position: 1,
-              },
-            ],
-            pathname: '/my/path/to/somewhere',
-          }}
-        />
-      </LinodeThemeWrapper>
+      <LandingHeader
+        breadcrumbProps={{
+          crumbOverrides: [
+            {
+              label: 'My First Crumb',
+              linkTo: '/someRoute',
+              noCap: true,
+              position: 1,
+            },
+          ],
+          pathname: '/my/path/to/somewhere',
+        }}
+      />
     );
 
     expect(document.body.textContent).toMatch(/My First Crumb/);

--- a/packages/manager/src/env.d.ts
+++ b/packages/manager/src/env.d.ts
@@ -40,3 +40,8 @@ declare module '*.svg' {
   const src: ComponentClass<any, any>;
   export default src;
 }
+
+declare module '*.css?raw' {
+  const src: string;
+  export default src;
+}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDrawer.tsx
@@ -83,7 +83,10 @@ export const KubeConfigDrawer = (props: Props) => {
             <CopyTooltip className={classes.tooltip} text={data ?? ''} />
           </Grid>
         </Grid>
-        <HighlightedMarkdown textOrMarkdown={'```\n' + data + '\n```'} />
+        <HighlightedMarkdown
+          language="yaml"
+          textOrMarkdown={'```\n' + data + '\n```'}
+        />
       </DrawerContent>
     </Drawer>
   );

--- a/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
@@ -2,7 +2,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { Provider } from 'react-redux';
 
-import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
+import { LinodeThemeWrapper } from 'src/LinodeThemeWrapper';
 import { queryClientFactory } from 'src/queries/base';
 import { storeFactory } from 'src/store';
 

--- a/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromLinodeContent.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromLinodeContent.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 
 import { linodes } from 'src/__data__/linodes';
-import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
+import { LinodeThemeWrapper } from 'src/LinodeThemeWrapper';
 import { queryClientFactory } from 'src/queries/base';
 import { storeFactory } from 'src/store';
 

--- a/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 
 import { UserDefinedFields as mockUserDefinedFields } from 'src/__data__/UserDefinedFields';
-import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
+import { LinodeThemeWrapper } from 'src/LinodeThemeWrapper';
 import { imageFactory } from 'src/factories/images';
 import { queryClientFactory } from 'src/queries/base';
 import { storeFactory } from 'src/store';

--- a/packages/manager/src/index.tsx
+++ b/packages/manager/src/index.tsx
@@ -1,3 +1,4 @@
+import CssBaseline from '@mui/material/CssBaseline';
 import 'font-logos/assets/font-logos.css';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
@@ -16,11 +17,10 @@ import { setupInterceptors } from 'src/request';
 import { storeFactory } from 'src/store';
 
 import { App } from './App';
-import LinodeThemeWrapper from './LinodeThemeWrapper';
+import { LinodeThemeWrapper } from './LinodeThemeWrapper';
 import { loadDevTools, shouldEnableDevTools } from './dev-tools/load';
 import './index.css';
 import { queryClientFactory } from './queries/base';
-import CssBaseline from '@mui/material/CssBaseline';
 
 const queryClient = queryClientFactory();
 const store = storeFactory(queryClient);

--- a/packages/manager/src/utilities/testHelpers.tsx
+++ b/packages/manager/src/utilities/testHelpers.tsx
@@ -18,7 +18,7 @@ import { DeepPartial } from 'redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
-import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
+import { LinodeThemeWrapper } from 'src/LinodeThemeWrapper';
 import { FlagSet } from 'src/featureFlags';
 import { queryClientFactory } from 'src/queries/base';
 import { setupInterceptors } from 'src/request';

--- a/packages/manager/src/utilities/theme.ts
+++ b/packages/manager/src/utilities/theme.ts
@@ -1,8 +1,11 @@
 import { Theme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 import { dark, light } from 'src/foundations/themes';
 
 import type { ThemeName } from 'src/foundations/themes';
+import { useAuthentication } from 'src/hooks/useAuthentication';
+import { usePreferences } from 'src/queries/preferences';
 
 export type ThemeChoice = 'dark' | 'light' | 'system';
 
@@ -46,4 +49,18 @@ export const getThemeFromPreferenceValue = (
     return value as ThemeName;
   }
   return systemTheme;
+};
+
+export const useColorMode = () => {
+  // Make sure we are authenticated before we fetch preferences.
+  const isAuthenticated = !!useAuthentication().token;
+  const { data: preferences } = usePreferences(isAuthenticated);
+  const isSystemInDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+
+  const colorMode = getThemeFromPreferenceValue(
+    preferences?.theme,
+    isSystemInDarkMode
+  );
+
+  return { colorMode };
 };


### PR DESCRIPTION
## Description 📝

- Fixes bug where Highlight.js theme would not switch
  - The the would not switch because both css files were loaded at the same time. The solution involves switching out the css when the theme is changed.

## Major Changes 🔄
- Made `LinodeThemeWrapper` a named export ✏️
- Moves Highlight.js logic from the `LinodeThemeWrapper` to the `HighlightedMarkdown` so that the css is only imported when `HighlightedMarkdown` is imported. (This helps us seperate concerns and defer loading until it is really needed)
- Removed unnecessary uses of `LinodeThemeWrapper` in some unit tests 🚫
- Removed weird `setTimeout` logic that did nothing 🚫

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-09-20 at 3 30 24 PM](https://github.com/linode/manager/assets/115251059/e0286274-5783-4682-9508-092c5e79a6c3) | ![Screenshot 2023-09-20 at 3 30 29 PM](https://github.com/linode/manager/assets/115251059/0999656b-61c2-47a8-87c3-c5713c6f69c1) |

## How to test 🧪

> [!important]
> Please test locally **and** using the internal preview link! We need to verify this fix works on both **dev** and **production** builds.

- Check out this PR
- Spin up your dev server with `yarn dev`
- Go to a Kubernetes Cluster details page and open the Kubeconfig drawer
- Verify that toggling the theme works
- Verify that, upon refreshing the page, the correct theme is rendered
- Repeat similar steps above with the internal preview link to verify that this fix also works for production builds of the app