### PR TITLE
test: [M3-7101] - Add integration tests for Kubernetes Create DC-specific pricing

### DIFF
--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -17,17 +17,14 @@ import {
 } from 'support/intercepts/feature-flags';
 import { makeFeatureFlagData } from 'support/util/feature-flags';
 import {
-  dcPricingKubernetesCheckoutSummaryPlaceholder,
-  dcPricingKubernetesHAPlaceholder,
+  dcPricingLkeCheckoutSummaryPlaceholder,
+  dcPricingLkeHAPlaceholder,
   dcPricingLkeClusterPlans,
   dcPricingMockLinodeTypes,
   dcPricingPlanPlaceholder,
   dcPricingRegionNotice,
 } from 'support/constants/dc-specific-pricing';
-import {
-  mockGetLinodeType,
-  mockGetLinodeTypes,
-} from 'support/intercepts/linodes';
+import { mockGetLinodeTypes } from 'support/intercepts/linodes';
 
 /**
  * Gets the label for an LKE plan as shown in creation plan table.
@@ -77,7 +74,7 @@ authenticate();
 describe('LKE Cluster Creation', () => {
   before(() => {
     cleanUp('lke-clusters');
-    //TODO: DC Pricing - M3-7073: Remove feature flag mocks when DC specific pricing goes live.
+    // TODO: DC Pricing - M3-7073: Remove feature flag mocks when DC specific pricing goes live.
     mockAppendFeatureFlags({
       dcSpecificPricing: makeFeatureFlagData(false),
     }).as('getFeatureFlags');
@@ -224,7 +221,7 @@ describe('LKE Cluster Creation', () => {
   });
 });
 
-//TODO: DC Pricing - M3-7073: Delete test and add commented pieces of it above.
+// TODO: DC Pricing - M3-7073: Delete test and add commented pieces of it above.
 describe('LKE Cluster Creation with DC-specific pricing', () => {
   before(() => {
     cleanUp('lke-clusters');
@@ -265,13 +262,11 @@ describe('LKE Cluster Creation with DC-specific pricing', () => {
     mockGetLinodeTypes(dcPricingMockLinodeTypes).as('getLinodeTypes');
     cy.wait(['@getLinodeTypes']);
 
-    //TODO: DC Pricing - M3-7073: Add to test above.
+    // TODO: DC Pricing - M3-7073: Add to test above.
     // Confirm that, without a region selected, no pricing information is displayed.
 
     // Confirm checkout summary displays helper text and disabled create button.
-    cy.findByText(dcPricingKubernetesCheckoutSummaryPlaceholder).should(
-      'be.visible'
-    );
+    cy.findByText(dcPricingLkeCheckoutSummaryPlaceholder).should('be.visible');
     cy.get('[data-qa-deploy-linode]')
       .should('contain.text', 'Create Cluster')
       .should('be.disabled');
@@ -280,7 +275,7 @@ describe('LKE Cluster Creation with DC-specific pricing', () => {
     cy.contains(dcPricingPlanPlaceholder).should('be.visible');
 
     // Confirm that HA pricing displays helper text instead of price.
-    cy.contains(dcPricingKubernetesHAPlaceholder).should('be.visible');
+    cy.contains(dcPricingLkeHAPlaceholder).should('be.visible');
 
     // Fill out LKE creation form label, region, and Kubernetes version fields.
     cy.findByLabelText('Cluster Label')
@@ -301,7 +296,7 @@ describe('LKE Cluster Creation with DC-specific pricing', () => {
       .type(`${dcSpecificPricingRegion.label}{enter}`);
     cy.findByText(dcPricingRegionNotice).should('be.visible');
 
-    //TODO: DC Pricing - M3-7073: Add to test above.
+    // TODO: DC Pricing - M3-7073: Add to test above.
     // Confirm that HA price updates dynamically once region selection is made.
     cy.contains(/\(\$.*\/month\)/).should('be.visible');
 
@@ -312,7 +307,7 @@ describe('LKE Cluster Creation with DC-specific pricing', () => {
       .click()
       .type(`${clusterVersion}{enter}`);
 
-    //TODO: DC Pricing - M3-7073: Add to test above.
+    // TODO: DC Pricing - M3-7073: Add to test above.
     // Confirm that with region and HA selections, create button is still disabled until plan selection is made.
     cy.get('[data-qa-deploy-linode]')
       .should('contain.text', 'Create Cluster')

--- a/packages/manager/cypress/support/constants/dc-specific-pricing.ts
+++ b/packages/manager/cypress/support/constants/dc-specific-pricing.ts
@@ -3,6 +3,7 @@
  */
 
 import { linodeTypeFactory } from '@src/factories';
+import { LkePlanDescription } from 'support/api/lke';
 
 /** Notice shown to users when selecting a region. */
 export const dcPricingRegionNotice = /Prices for plans, products, and services in .* may vary from other regions\./;
@@ -16,10 +17,10 @@ export const dcPricingPlanPlaceholder =
   'Select a region to view plans and prices.';
 
 /** Helper text shown to users users trying to create an LKE cluster before selecting both a region and plan. */
-export const dcPricingKubernetesCheckoutSummaryPlaceholder =
+export const dcPricingLkeCheckoutSummaryPlaceholder =
   'Select a region, HA choice, and add a Node Pool to view pricing and create a cluster.';
 
-export const dcPricingKubernetesHAPlaceholder =
+export const dcPricingLkeHAPlaceholder =
   'Select a region to view price information.';
 
 /** DC-specific pricing docs link label. */

--- a/packages/manager/cypress/support/constants/dc-specific-pricing.ts
+++ b/packages/manager/cypress/support/constants/dc-specific-pricing.ts
@@ -1,5 +1,5 @@
 /**
- * @file Constants related to tiered pricing.
+ * @file Constants related to DC-specific pricing.
  */
 
 import { linodeTypeFactory } from '@src/factories';
@@ -14,6 +14,13 @@ export const dcPricingRegionDifferenceNotice =
 /** Notice shown to users trying to choose a plan before selecting a region. */
 export const dcPricingPlanPlaceholder =
   'Select a region to view plans and prices.';
+
+/** Helper text shown to users users trying to create an LKE cluster before selecting both a region and plan. */
+export const dcPricingKubernetesCheckoutSummaryPlaceholder =
+  'Select a region, HA choice, and add a Node Pool to view pricing and create a cluster.';
+
+export const dcPricingKubernetesHAPlaceholder =
+  'Select a region to view price information.';
 
 /** DC-specific pricing docs link label. */
 export const dcPricingDocsLabel = 'How Data Center Pricing Works';

--- a/packages/manager/cypress/support/constants/dc-specific-pricing.ts
+++ b/packages/manager/cypress/support/constants/dc-specific-pricing.ts
@@ -57,7 +57,7 @@ export const dcPricingMockLinodeTypes = linodeTypeFactory.buildList(3, {
 
 /**
  * Subset of LKE cluster plans as shown on Cloud Manager, mapped from DC-specific pricing mock linode
- * types to ensure size is consistent ids in the types factory.
+ * types to ensure size is consistent with ids in the types factory.
  */
 export const dcPricingLkeClusterPlans: LkePlanDescription[] = dcPricingMockLinodeTypes.map(
   (type) => {

--- a/packages/manager/cypress/support/constants/dc-specific-pricing.ts
+++ b/packages/manager/cypress/support/constants/dc-specific-pricing.ts
@@ -56,10 +56,15 @@ export const dcPricingMockLinodeTypes = linodeTypeFactory.buildList(3, {
 });
 
 /**
- * Subset of LKE cluster plans as shown on Cloud Manager.
+ * Subset of LKE cluster plans as shown on Cloud Manager, mapped from DC-specific pricing mock linode
+ * types to ensure size is consistent ids in the types factory.
  */
-export const dcPricingLkeClusterPlans: LkePlanDescription[] = [
-  { size: 8, tab: 'Shared CPU', type: 'Linode' },
-  { size: 9, tab: 'Shared CPU', type: 'Linode' },
-  { size: 10, tab: 'Shared CPU', type: 'Linode' },
-];
+export const dcPricingLkeClusterPlans: LkePlanDescription[] = dcPricingMockLinodeTypes.map(
+  (type) => {
+    return {
+      size: type.id.split('-')[2],
+      tab: 'Shared CPU',
+      type: 'Linode',
+    };
+  }
+);

--- a/packages/manager/cypress/support/constants/dc-specific-pricing.ts
+++ b/packages/manager/cypress/support/constants/dc-specific-pricing.ts
@@ -53,3 +53,12 @@ export const dcPricingMockLinodeTypes = linodeTypeFactory.buildList(3, {
     },
   ],
 });
+
+/**
+ * Subset of LKE cluster plans as shown on Cloud Manager.
+ */
+export const dcPricingLkeClusterPlans: LkePlanDescription[] = [
+  { size: 8, tab: 'Shared CPU', type: 'Linode' },
+  { size: 9, tab: 'Shared CPU', type: 'Linode' },
+  { size: 10, tab: 'Shared CPU', type: 'Linode' },
+];


### PR DESCRIPTION
## Description 📝
Add Cypress integration tests for Cloud Manager to confirm DC-specific pricing UX when creating a Kubernetes cluster.

## Major Changes 🔄
 - Confirms that DC-specific pricing notices and prices are present in the LKE create form when the feature flag is on.
 - Confirms that the plan table shows a message in place of plans when a region is not selected.
 - Confirms that the cluster summary create button is disabled until a plan and region selection are made.
- Confirms that HA helper text updates dynamically to display pricing when a region is selected.
- Confirms that the pricing warning notice is visible for a region with DC-specific pricing and not visible otherwise.

## How to test 🧪
1. **How to run Unit or E2E tests?**
```
yarn cy:run -s "cypress/e2e/core/kubernetes/lke-create.spec.ts"
```