### PR TITLE
feat: [M3-7157] - Only show IPv4s specific to a linode-subnet relationship on VPC details page

### DIFF
--- a/packages/manager/.changeset/pr-9710-upcoming-features-1695410168923.md
+++ b/packages/manager/.changeset/pr-9710-upcoming-features-1695410168923.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Only show IPv4s specific to a linode-subnet relationship in a linode's row on VPC details page ([#9710](https://github.com/linode/manager/pull/9710))

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.test.tsx
@@ -31,7 +31,7 @@ describe('SubnetLinodeRow', () => {
         return res(ctx.json(linodeFactory1));
       }),
       rest.get('*/instances/*/configs', async (req, res, ctx) => {
-        const configs = linodeConfigFactory.buildList(3);
+        const configs = linodeConfigFactory.buildList(1);
         return res(ctx.json(makeResourcePage(configs)));
       })
     );
@@ -42,7 +42,9 @@ describe('SubnetLinodeRow', () => {
       getByTestId,
       getByText,
     } = renderWithTheme(
-      wrapWithTableBody(<SubnetLinodeRow linodeId={linodeFactory1.id} />),
+      wrapWithTableBody(
+        <SubnetLinodeRow linodeId={linodeFactory1.id} subnetId={1} />
+      ),
       {
         queryClient,
       }

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.test.tsx
@@ -31,7 +31,7 @@ describe('SubnetLinodeRow', () => {
         return res(ctx.json(linodeFactory1));
       }),
       rest.get('*/instances/*/configs', async (req, res, ctx) => {
-        const configs = linodeConfigFactory.buildList(1);
+        const configs = linodeConfigFactory.buildList(3);
         return res(ctx.json(makeResourcePage(configs)));
       })
     );
@@ -43,7 +43,7 @@ describe('SubnetLinodeRow', () => {
       getByText,
     } = renderWithTheme(
       wrapWithTableBody(
-        <SubnetLinodeRow linodeId={linodeFactory1.id} subnetId={1} />
+        <SubnetLinodeRow linodeId={linodeFactory1.id} subnetId={0} />
       ),
       {
         queryClient,

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
@@ -169,8 +169,6 @@ const getInterface = (configs: Config[], subnetId: number) => {
   return undefined;
 };
 
-// Realistically at this point, configInterface will not be undefined, but since getInterface
-// technically may return an undefined, we need to include that type here too
 const getIPv4Link = (configInterface: Interface | undefined): JSX.Element => {
   return (
     <>

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
@@ -17,6 +17,7 @@ import { useLinodeFirewallsQuery } from 'src/queries/linodes/firewalls';
 import { useLinodeQuery } from 'src/queries/linodes/linodes';
 import { capitalizeAllWords } from 'src/utilities/capitalize';
 
+import { getSubnetInterfaceFromConfigs } from '../utils';
 import {
   StyledTableCell,
   StyledTableHeadCell,
@@ -153,20 +154,8 @@ const getSubnetLinodeIPv4CellString = (
     return 'None';
   }
 
-  const configInterface = getInterface(configs, subnetId);
+  const configInterface = getSubnetInterfaceFromConfigs(configs, subnetId);
   return getIPv4Link(configInterface);
-};
-
-const getInterface = (configs: Config[], subnetId: number) => {
-  for (const config of configs) {
-    for (const linodeInterface of config.interfaces) {
-      if (linodeInterface.ipv4?.vpc && linodeInterface.subnet_id === subnetId) {
-        return linodeInterface;
-      }
-    }
-  }
-
-  return undefined;
 };
 
 const getIPv4Link = (configInterface: Interface | undefined): JSX.Element => {

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
@@ -154,7 +154,6 @@ const getSubnetLinodeIPv4CellString = (
   }
 
   const configInterface = getInterface(configs, subnetId);
-
   return getIPv4Link(configInterface);
 };
 
@@ -170,6 +169,8 @@ const getInterface = (configs: Config[], subnetId: number) => {
   return undefined;
 };
 
+// Realistically at this point, configInterface will not be undefined, but since getInterface
+// technically may return an undefined, we need to include that type here too
 const getIPv4Link = (configInterface: Interface | undefined): JSX.Element => {
   return (
     <>

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
@@ -186,7 +186,11 @@ export const VPCSubnetsTable = (props: Props) => {
           <TableBody>
             {subnet.linodes.length > 0 ? (
               subnet.linodes.map((linodeId) => (
-                <SubnetLinodeRow key={linodeId} linodeId={linodeId} />
+                <SubnetLinodeRow
+                  key={linodeId}
+                  linodeId={linodeId}
+                  subnetId={subnet.id}
+                />
               ))
             ) : (
               <TableRowEmpty colSpan={5} message={'No Linodes'} />

--- a/packages/manager/src/features/VPCs/utils.test.ts
+++ b/packages/manager/src/features/VPCs/utils.test.ts
@@ -1,6 +1,11 @@
+import { LinodeConfigInterfaceFactoryWithVPC } from 'src/factories/linodeConfigInterfaceFactory';
+import { linodeConfigFactory } from 'src/factories/linodeConfigs';
 import { subnetFactory } from 'src/factories/subnets';
 
-import { getUniqueLinodesFromSubnets } from './utils';
+import {
+  getSubnetInterfaceFromConfigs,
+  getUniqueLinodesFromSubnets,
+} from './utils';
 
 describe('getUniqueLinodesFromSubnets', () => {
   it(`returns the number of unique linodes within a VPC's subnets`, () => {
@@ -18,5 +23,31 @@ describe('getUniqueLinodesFromSubnets', () => {
     expect(getUniqueLinodesFromSubnets(subnets1)).toBe(3);
     expect(getUniqueLinodesFromSubnets(subnets2)).toBe(2);
     expect(getUniqueLinodesFromSubnets(subnets3)).toBe(7);
+  });
+});
+
+describe('getSubnetInterfaceFromConfigs', () => {
+  it('returns the interface associated with the given subnet id', () => {
+    const interfaces = LinodeConfigInterfaceFactoryWithVPC.buildList(5);
+    const singleConfig = linodeConfigFactory.build({ interfaces });
+    const configs = [linodeConfigFactory.build(), singleConfig];
+
+    const subnetInterface1 = getSubnetInterfaceFromConfigs(configs, 1);
+    expect(subnetInterface1).toEqual(interfaces[0]);
+    const subnetInterface2 = getSubnetInterfaceFromConfigs(configs, 2);
+    expect(subnetInterface2).toEqual(interfaces[1]);
+    const subnetInterface3 = getSubnetInterfaceFromConfigs(configs, 3);
+    expect(subnetInterface3).toEqual(interfaces[2]);
+    const subnetInterface4 = getSubnetInterfaceFromConfigs(configs, 4);
+    expect(subnetInterface4).toEqual(interfaces[3]);
+    const subnetInterface5 = getSubnetInterfaceFromConfigs(configs, 5);
+    expect(subnetInterface5).toEqual(interfaces[4]);
+  });
+
+  it('should return undefined if an interface with the given subnet ID is not found', () => {
+    const configs = linodeConfigFactory.buildList(4);
+
+    const subnetInterfaceUndefined = getSubnetInterfaceFromConfigs(configs, 5);
+    expect(subnetInterfaceUndefined).toBeUndefined();
   });
 });

--- a/packages/manager/src/features/VPCs/utils.ts
+++ b/packages/manager/src/features/VPCs/utils.ts
@@ -1,4 +1,4 @@
-import { Subnet } from '@linode/api-v4/lib/vpcs/types';
+import type { Config, Subnet } from '@linode/api-v4';
 
 export const getUniqueLinodesFromSubnets = (subnets: Subnet[]) => {
   const linodes: number[] = [];
@@ -10,4 +10,19 @@ export const getUniqueLinodesFromSubnets = (subnets: Subnet[]) => {
     });
   }
   return linodes.length;
+};
+
+export const getSubnetInterfaceFromConfigs = (
+  configs: Config[],
+  subnetId: number
+) => {
+  for (const config of configs) {
+    for (const linodeInterface of config.interfaces) {
+      if (linodeInterface.ipv4?.vpc && linodeInterface.subnet_id === subnetId) {
+        return linodeInterface;
+      }
+    }
+  }
+
+  return undefined;
 };


### PR DESCRIPTION
## Description 📝
Ensure that a linode row inside the subnets table only shows the IP specific to that subnet

## Major Changes 🔄
Add subnetId to SubnetLinodeRow props, and find the interface associated with that specific subnet

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/139280159/708441ee-b957-45f6-a03f-dfdcdfc5ed32) | ![image](https://github.com/linode/manager/assets/139280159/32dc5dfa-3bdb-4b0d-9e32-2b537f6877a5) |

MSW example: 
![image](https://github.com/linode/manager/assets/139280159/aac87161-e3d9-4091-b520-ade6c93e633d)

## How to test 🧪
**How to verify changes?**
- Using the MSW:
  - Most linodes will have a blank VPC IPv4 column because the mock subnet_id of the mock linode's configs' interfaces don't match the subnet that the linode corresponds to. However, you can go to
    - `packages/manager/src/factories/linodeConfigInterfaceFactory.ts` line 28 and try to put in specific subnet_ids. If the mock subnet_id matches, the IPs will show up (see MSW screenshot example)
- If you are not using the MSW, make sure you're on the dev environment and have the correct VPC flags associated with your account (may need to add them via admin). Navigate to a VPC's detail page and assign a linode to multiple subnets (note -- you'll have to either make the requests directly to the API, or first checkout my branch [feat-m3-6752](https://github.com/linode/manager/pull/9687) to assign linodes from the UI, then switch back to this branch, until that gets merged in 😅)
  - verify that even if a linode is assigned to multiple subnets, only one IPv4 is shown in each row
  - verify that this is the correct IP for the specific linode-subnet relationship 
    - (may need to console.log the configs in `packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx`, and check the interfaces in the configs. The interface with the corresponding subnetId should have the same IPv4 as the one appearing in the row)

 **How to run Unit or E2E tests?**
`yarn test SubnetLinodeRow` (existing test should still pass)
`yarn test 'packages/manager/src/features/VPCs/utils.test.ts'`