### PR TITLE
Release v1.103.0 - release → staging

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2023-09-22] - v1.102.1
+## [2023-09-22] - v1.103.0
 
-### Fixed:
+### Change:
 
 - Remove Beta chip from Add User Data accordion ([#9712](https://github.com/linode/manager/pull/9712))
 

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2023-09-22] - v1.102.1
+
+### Fixed:
+
+- Remove Beta chip from Add User Data accordion ([#9712](https://github.com/linode/manager/pull/9712))
+
 ## [2023-09-18] - v1.102.0
 
 ### Added:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.102.1",
+  "version": "1.103.0",
   "private": true,
   "bugs": {
     "url": "https://github.com/Linode/manager/issues"

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.102.0",
+  "version": "1.102.1",
   "private": true,
   "bugs": {
     "url": "https://github.com/Linode/manager/issues"

--- a/packages/manager/src/features/Linodes/LinodesCreate/UserDataAccordion/UserDataAccordionHeading.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/UserDataAccordion/UserDataAccordionHeading.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import { BetaChip } from 'src/components/BetaChip/BetaChip';
 import { Box } from 'src/components/Box';
 import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
@@ -28,7 +27,7 @@ export const UserDataAccordionHeading = (props: Props) => {
   return (
     <>
       <Box display="flex">
-        Add User Data <BetaChip component="span" />
+        Add User Data
         <TooltipIcon
           text={
             <>


### PR DESCRIPTION
## Description 📝
Metadata is now in General Availability so we need to remove the beta chip from the Add User Data accordion

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/115299789/56d844ed-8321-438f-bebd-063282cded99) | ![image](https://github.com/linode/manager/assets/115299789/126a1844-733e-403a-a3a1-1207671a028d) |

## How to test 🧪
- Go to `/linodes/create`
- Select a cloud-init compatible image (there will be a note icon to the right)
- Select a region that supports Metadata (e.g. Washington, DC)
- Scroll down to the bottom and check the Add User Data accordion
