### PR TITLE
test: Mock DBaaS feature flag in Cypress tests

### DIFF
--- a/packages/manager/cypress/e2e/core/databases/create-database.spec.ts
+++ b/packages/manager/cypress/e2e/core/databases/create-database.spec.ts
@@ -8,9 +8,14 @@ import {
   mockCreateDatabase,
   mockGetDatabases,
 } from 'support/intercepts/databases';
+import {
+  mockAppendFeatureFlags,
+  mockGetFeatureFlagClientstream,
+} from 'support/intercepts/feature-flags';
 import { mockGetEvents } from 'support/intercepts/events';
 import { getRegionById } from 'support/util/regions';
 import { ui } from 'support/ui';
+import { makeFeatureFlagData } from 'support/util/feature-flags';
 
 describe('create a database cluster, mocked data', () => {
   databaseConfigurations.forEach(
@@ -62,10 +67,16 @@ describe('create a database cluster, mocked data', () => {
             ? 'Dedicated CPU'
             : 'Shared CPU';
 
+        mockAppendFeatureFlags({
+          databases: makeFeatureFlagData(true),
+        }).as('getFeatureFlags');
+        mockGetFeatureFlagClientstream().as('getClientstream');
         mockCreateDatabase(databaseMock).as('createDatabase');
         mockGetDatabases([databaseMock]).as('getDatabases');
 
         cy.visitWithLogin('/databases/create');
+        cy.wait(['@getFeatureFlags', '@getClientstream']);
+
         ui.entityHeader
           .find()
           .should('be.visible')

--- a/packages/manager/cypress/e2e/core/databases/delete-database.spec.ts
+++ b/packages/manager/cypress/e2e/core/databases/delete-database.spec.ts
@@ -9,11 +9,16 @@ import {
   mockDeleteProvisioningDatabase,
   mockGetDatabase,
 } from 'support/intercepts/databases';
+import {
+  mockAppendFeatureFlags,
+  mockGetFeatureFlagClientstream,
+} from 'support/intercepts/feature-flags';
 import { ui } from 'support/ui';
 import {
   databaseClusterConfiguration,
   databaseConfigurations,
 } from 'support/constants/databases';
+import { makeFeatureFlagData } from 'support/util/feature-flags';
 
 describe('Delete database clusters', () => {
   databaseConfigurations.forEach(
@@ -36,13 +41,17 @@ describe('Delete database clusters', () => {
             allow_list: [allowedIp],
           });
 
+          mockAppendFeatureFlags({
+            databases: makeFeatureFlagData(true),
+          }).as('getFeatureFlags');
+          mockGetFeatureFlagClientstream().as('getClientstream');
           mockGetDatabase(database).as('getDatabase');
           mockDeleteDatabase(database.id, database.engine).as('deleteDatabase');
 
           cy.visitWithLogin(
             `/databases/${database.engine}/${database.id}/settings`
           );
-          cy.wait('@getDatabase');
+          cy.wait(['@getFeatureFlags', '@getClientstream', '@getDatabase']);
 
           // Click "Delete Cluster" button.
           ui.button
@@ -92,6 +101,10 @@ describe('Delete database clusters', () => {
           const errorMessage =
             'Your database is provisioning; please wait until provisioning is complete to perform this operation.';
 
+          mockAppendFeatureFlags({
+            databases: makeFeatureFlagData(true),
+          }).as('getFeatureFlags');
+          mockGetFeatureFlagClientstream().as('getClientstream');
           mockGetDatabase(database).as('getDatabase');
           mockDeleteProvisioningDatabase(
             database.id,
@@ -102,7 +115,7 @@ describe('Delete database clusters', () => {
           cy.visitWithLogin(
             `/databases/${database.engine}/${database.id}/settings`
           );
-          cy.wait('@getDatabase');
+          cy.wait(['@getFeatureFlags', '@getClientstream', '@getDatabase']);
 
           // Click "Delete Cluster" button.
           ui.button


### PR DESCRIPTION
## Description 📝
This mocks the `databases` feature flag in our DBaaS tests so that the state of the Launch Darkly flag does not impact the tests. This should fix the failures we've been getting since this value changed in the Development environment.

## Major Changes 🔄
- Mock `databases` feature flag in Cypress DBaaS tests

## How to test 🧪
We can rely on the automated tests for this. If the DBaaS tests pass, then we know this PR will accomplish its purpose.