### PR TITLE
fix: [M3-7174] - Fix `BarPercent` console errors and other improvements

### DIFF
--- a/packages/manager/src/components/BarPercent/BarPercent.tsx
+++ b/packages/manager/src/components/BarPercent/BarPercent.tsx
@@ -26,7 +26,7 @@ export interface BarPercentProps {
 /**
  * Determinate indicator that displays how long a process will take.
  */
-export const BarPercent = (props: BarPercentProps) => {
+export const BarPercent = React.memo((props: BarPercentProps) => {
   const {
     className,
     isFetchingValue,
@@ -56,7 +56,7 @@ export const BarPercent = (props: BarPercentProps) => {
       />
     </StyledDiv>
   );
-};
+});
 
 export const getPercentage = (value: number, max: number) =>
   (value / max) * 100;

--- a/packages/manager/src/components/BarPercent/BarPercent.tsx
+++ b/packages/manager/src/components/BarPercent/BarPercent.tsx
@@ -39,7 +39,7 @@ export const BarPercent = (props: BarPercentProps) => {
   } = props;
 
   return (
-    <StyledDiv className={`${className}`}>
+    <StyledDiv className={className}>
       <StyledLinearProgress
         variant={
           isFetchingValue
@@ -58,8 +58,6 @@ export const BarPercent = (props: BarPercentProps) => {
   );
 };
 
-export default React.memo(BarPercent);
-
 export const getPercentage = (value: number, max: number) =>
   (value / max) * 100;
 
@@ -71,7 +69,7 @@ const StyledDiv = styled('div')({
 
 const StyledLinearProgress = styled(LinearProgress, {
   label: 'StyledLinearProgress',
-  shouldForwardProp: (prop) => isPropValid(['rounded'], prop),
+  shouldForwardProp: (prop) => isPropValid(['rounded', 'narrow'], prop),
 })<Partial<BarPercentProps>>(({ theme, ...props }) => ({
   '& .MuiLinearProgress-bar2Buffer': {
     backgroundColor: '#5ad865',

--- a/packages/manager/src/components/BarPercent/index.ts
+++ b/packages/manager/src/components/BarPercent/index.ts
@@ -1,1 +1,2 @@
-export { default } from './BarPercent';
+export { BarPercent } from './BarPercent';
+export type { BarPercentProps } from './BarPercent';

--- a/packages/manager/src/components/TransferDisplay/LegacyTransferDisplay.tsx
+++ b/packages/manager/src/components/TransferDisplay/LegacyTransferDisplay.tsx
@@ -10,7 +10,7 @@ import { DateTime } from 'luxon';
 import * as React from 'react';
 import { makeStyles } from 'tss-react/mui';
 
-import BarPercent from 'src/components/BarPercent';
+import { BarPercent } from 'src/components/BarPercent';
 import { Dialog } from 'src/components/Dialog/Dialog';
 import { Link } from 'src/components/Link';
 import { Typography } from 'src/components/Typography';

--- a/packages/manager/src/components/TransferDisplay/TransferDisplayUsage.tsx
+++ b/packages/manager/src/components/TransferDisplay/TransferDisplayUsage.tsx
@@ -1,7 +1,7 @@
 import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 
-import BarPercent from 'src/components/BarPercent';
+import { BarPercent } from 'src/components/BarPercent';
 import { Typography } from 'src/components/Typography';
 
 import { formatPoolUsagePct } from './utils';

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferContent.tsx
@@ -2,7 +2,7 @@ import Grid from '@mui/material/Unstable_Grid2';
 import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 
-import BarPercent from 'src/components/BarPercent';
+import { BarPercent } from 'src/components/BarPercent';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { Notice } from 'src/components/Notice/Notice';
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeDiskRow.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeDiskRow.tsx
@@ -2,7 +2,7 @@ import { Disk } from '@linode/api-v4/lib/linodes';
 import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 
-import BarPercent from 'src/components/BarPercent';
+import { BarPercent } from 'src/components/BarPercent';
 import { DateTimeDisplay } from 'src/components/DateTimeDisplay';
 import { Hidden } from 'src/components/Hidden';
 import { TableCell } from 'src/components/TableCell';

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderProgressEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderProgressEvent.tsx
@@ -2,7 +2,7 @@ import { Event } from '@linode/api-v4/lib/account/types';
 import { Duration } from 'luxon';
 import * as React from 'react';
 
-import BarPercent from 'src/components/BarPercent';
+import { BarPercent } from 'src/components/BarPercent';
 import { Box } from 'src/components/Box';
 import { Divider } from 'src/components/Divider';
 import { Typography } from 'src/components/Typography';


### PR DESCRIPTION
## Description 📝
- Fix some console errors and general issues with our `BarPercent` component 🛠️

## Major Changes 🔄
- Fix `narrow` prop getting passed to the underlying component
- Fixed `undefined` className
- Use **named exports** instead of default exports ✏️

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-09-25 at 10 47 49 AM](https://github.com/linode/manager/assets/115251059/893676fb-8d99-4939-8c1b-61d1f336f982)  | ![Screenshot 2023-09-25 at 10 48 31 AM](https://github.com/linode/manager/assets/115251059/8f496fd8-c94a-416d-8c26-0cbd5c8f0ac6) |
| ![Screenshot 2023-09-25 at 10 47 18 AM](https://github.com/linode/manager/assets/115251059/e1b3035b-9235-4bba-be8d-cd63b17397f4) | ![Screenshot 2023-09-25 at 10 46 55 AM](https://github.com/linode/manager/assets/115251059/06455332-6bda-4de1-9612-3a00f267508c) |

## How to test 🧪
- You can check storybook to verify the changes are okay
- Alternatively, you can turn on the MSW and look in the notification menu (the component is used here) 
- Verify you don't see the console error shown in the screenshot above
- Verify you don't see a `undefined` className
- Verify the component works as expected (functionality should not have changed)