### PR TITLE
fix: [M3-7177] - Fix MSW not always intercepting API calls

### DIFF
--- a/packages/manager/src/dev-tools/load.ts
+++ b/packages/manager/src/dev-tools/load.ts
@@ -6,8 +6,8 @@ import { ApplicationStore } from 'src/store';
  * are needed.
  * @param store Redux store to control
  */
-export function loadDevTools(store: ApplicationStore) {
-  import('./dev-tools').then((devTools) => devTools.install(store));
+export async function loadDevTools(store: ApplicationStore) {
+  await import('./dev-tools').then((devTools) => devTools.install(store));
 }
 
 /**

--- a/packages/manager/src/index.tsx
+++ b/packages/manager/src/index.tsx
@@ -105,8 +105,13 @@ const Main = () => {
   );
 };
 
-if (shouldEnableDevTools) {
-  loadDevTools(store);
+async function loadApp() {
+  if (shouldEnableDevTools) {
+    // If devtools are enabled, load them before we load the main app.
+    // This ensures the MSW is setup before we start making API calls.
+    await loadDevTools(store);
+  }
+  ReactDOM.render(<Main />, document.getElementById('root'));
 }
 
-ReactDOM.render(<Main />, document.getElementById('root'));
+loadApp();


### PR DESCRIPTION
## Description 📝

Sometimes, with the MSW on, you load the app and some API calls don't get properly intercepted and the real API responds with data. I think this is because the MSW is not always being initialized before our app loads. 

I think this use to not be an issue, but I think https://github.com/linode/manager/pull/9525 made it so that the MSW gets enabled later than it use to, causing this race condition. 

This PR brings back some logic from  https://github.com/linode/manager/pull/9525 (but using async/await instead of a callback) that will load dev tools before we render the app. 

## Major Changes 🔄
- Adjusts dev-tools logic so that the app is rendered **after** dev tools are dynamically imported
  - We use to do this but I changed this in https://github.com/linode/manager/pull/9525 which has possibly caused an issue for us

## How to test 🧪
> [!note]
> This seemed to be like a race condition so it is hard to reproduce the bug or verify the fix works

- Check out this PR
- Turn on the MSW 
- Verify that all API data (like regions, linodes, etc) is coming from the MSW and not the real API
- Refresh the page a few times and confirm that **every time**, data is coming from the MSW and not the real API