### PR TITLE
chore: [M3-7187] - Improvements to Volumes Create

### DIFF
--- a/packages/manager/.changeset/pr-9720-added-1695748436771.md
+++ b/packages/manager/.changeset/pr-9720-added-1695748436771.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Breadcrumb header and other improvements to Volumes Create  ([#9720](https://github.com/linode/manager/pull/9720))

--- a/packages/manager/src/features/Volumes/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate.tsx
@@ -264,16 +264,24 @@ export const VolumeCreate = () => {
                 </span>
               )}
             </Typography>
-            {error && <Notice text={error} variant="error" />}
-            {doesNotHavePermission ? (
+            {error && (
+              <Notice
+                spacingBottom={0}
+                spacingTop={12}
+                text={error}
+                variant="error"
+              />
+            )}
+            {doesNotHavePermission && (
               <Notice
                 text={
                   "You don't have permissions to create a new Volume. Please contact an account administrator for details."
                 }
                 important
+                spacingBottom={0}
                 variant="error"
               />
-            ) : null}
+            )}
             <TextField
               tooltipText="Use only ASCII letters, numbers,
                   underscores, and dashes."

--- a/packages/manager/src/features/Volumes/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate.tsx
@@ -36,8 +36,10 @@ import {
 import { isNilOrEmpty } from 'src/utilities/isNilOrEmpty';
 import { maybeCastToNumber } from 'src/utilities/maybeCastToNumber';
 
-import { ConfigSelect } from '../VolumeDrawer/ConfigSelect';
-import { SizeField } from '../VolumeDrawer/SizeField';
+import { ConfigSelect } from './VolumeDrawer/ConfigSelect';
+import { SizeField } from './VolumeDrawer/SizeField';
+import { LandingHeader } from 'src/components/LandingHeader';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 
 export const SIZE_FIELD_WIDTH = 160;
 
@@ -97,7 +99,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const CreateVolumeForm = () => {
+export const VolumeCreate = () => {
   const theme = useTheme();
   const classes = useStyles();
   const flags = useFlags();
@@ -226,174 +228,189 @@ const CreateVolumeForm = () => {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      {error && <Notice text={error} variant="error" />}
-      {doesNotHavePermission ? (
-        <Notice
-          text={
-            "You don't have permissions to create a new Volume. Please contact an account administrator for details."
-          }
-          important
-          variant="error"
-        />
-      ) : null}
-      <Box display="flex" flexDirection="column">
-        <Paper>
-          <Typography
-            className={classes.copy}
-            data-qa-volume-size-help
-            variant="body1"
-          >
-            {dcSpecificPricing ? (
-              <span>
-                A single Volume can range from 10 to {MAX_VOLUME_SIZE} GB in
-                size. Up to to eight Volumes can be attached to a single Linode.
-                Select a region to see cost per GB.
-              </span>
-            ) : (
-              <span>
-                A single Volume can range from 10 to {MAX_VOLUME_SIZE} GB in
-                size and costs $0.10/GB per month. <br />
-                Up to eight volumes can be attached to a single Linode.
-              </span>
-            )}
-          </Typography>
-          <TextField
-            tooltipText="Use only ASCII letters, numbers,
-                  underscores, and dashes."
-            className={classes.select}
-            data-qa-volume-label
-            disabled={doesNotHavePermission}
-            errorText={touched.label ? errors.label : undefined}
-            label="Label"
-            name="label"
-            onBlur={handleBlur}
-            onChange={handleChange}
-            tooltipClasses={classes.labelTooltip}
-            tooltipPosition="right"
-            value={values.label}
-          />
-          <Box alignItems="flex-end" display="flex">
-            <RegionSelect
-              handleSelection={(value) => {
-                setFieldValue('region', value);
-                setFieldValue('linode_id', null);
-              }}
-              regions={
-                regions?.filter((eachRegion) =>
-                  eachRegion.capabilities.some((eachCape) =>
-                    eachCape.match(/block/i)
-                  )
-                ) ?? []
-              }
-              disabled={doesNotHavePermission}
-              errorText={touched.region ? errors.region : undefined}
-              isClearable
-              label="Region"
-              name="region"
-              onBlur={handleBlur}
-              selectedID={values.region}
-              width={320}
-            />
-            {renderSelectTooltip(
-              'Volumes must be created in a region. You can choose to create a Volume in a region and attach it later to a Linode in the same region.'
-            )}
-          </Box>
-          <Box
-            alignItems="flex-end"
-            className={classes.linodeConfigSelectWrapper}
-            display="flex"
-          >
-            <Box
-              alignItems="flex-end"
-              className={classes.linodeSelect}
-              display="flex"
+    <>
+      <DocumentTitleSegment segment="Create a Volume" />
+      <LandingHeader
+        breadcrumbProps={{
+          crumbOverrides: [
+            {
+              label: 'Volumes',
+              position: 1,
+            },
+          ],
+          pathname: location.pathname,
+        }}
+        title="Create"
+      />
+      <form onSubmit={handleSubmit}>
+        <Box display="flex" flexDirection="column">
+          <Paper>
+            <Typography
+              className={classes.copy}
+              data-qa-volume-size-help
+              variant="body1"
             >
-              <LinodeSelect
-                optionsFilter={(linode: Linode) => {
-                  const linodeRegion = linode.region;
-                  const valuesRegion = values.region;
-
-                  /** When values.region is empty, all Linodes with
-                   * block storage support will be displayed, regardless
-                   * of their region. However, if a region is selected,
-                   * only Linodes from the chosen region with block storage
-                   * support will be shown. */
-                  return isNilOrEmpty(valuesRegion)
-                    ? regionsWithBlockStorage.includes(linodeRegion)
-                    : regionsWithBlockStorage.includes(linodeRegion) &&
-                        linodeRegion === valuesRegion;
-                }}
-                sx={{
-                  width: '320px',
-                }}
-                clearable
-                disabled={doesNotHavePermission}
-                errorText={linodeError}
-                onBlur={handleBlur}
-                onSelectionChange={handleLinodeChange}
-                value={values.linode_id}
-              />
-              {renderSelectTooltip(
-                'If you select a Linode, the Volume will be automatically created in that Linode’s region and attached upon creation.'
+              {dcSpecificPricing ? (
+                <span>
+                  A single Volume can range from 10 to {MAX_VOLUME_SIZE} GB in
+                  size. Up to to eight Volumes can be attached to a single
+                  Linode. Select a region to see cost per GB.
+                </span>
+              ) : (
+                <span>
+                  A single Volume can range from 10 to {MAX_VOLUME_SIZE} GB in
+                  size and costs $0.10/GB per month. <br />
+                  Up to eight volumes can be attached to a single Linode.
+                </span>
               )}
-            </Box>
-            <ConfigSelect
-              disabled={doesNotHavePermission}
-              error={touched.config_id ? errors.config_id : undefined}
-              linodeId={linode_id}
-              name="configId"
-              onBlur={handleBlur}
-              onChange={(id: number) => setFieldValue('config_id', id)}
-              value={config_id}
-              width={320}
-            />
-          </Box>
-          <Box alignItems="flex-end" display="flex" position="relative">
-            <SizeField
-              disabled={doesNotHavePermission}
-              error={touched.size ? errors.size : undefined}
-              hasSelectedRegion={!isNilOrEmpty(values.region)}
-              name="size"
-              onBlur={handleBlur}
-              onChange={handleChange}
-              regionId={values.region}
-              textFieldStyles={classes.size}
-              value={values.size}
-            />
-          </Box>
-          <Box
-            alignItems="center"
-            className={classes.buttonGroup}
-            display="flex"
-            flexWrap="wrap"
-            justifyContent={showAgreement ? 'space-between' : 'flex-end'}
-          >
-            {showAgreement ? (
-              <EUAgreementCheckbox
-                centerCheckbox
-                checked={hasSignedAgreement}
-                className={classes.agreement}
-                onChange={(e) => setHasSignedAgreement(e.target.checked)}
+            </Typography>
+            {error && <Notice text={error} variant="error" />}
+            {doesNotHavePermission ? (
+              <Notice
+                text={
+                  "You don't have permissions to create a new Volume. Please contact an account administrator for details."
+                }
+                important
+                variant="error"
               />
             ) : null}
+            <TextField
+              tooltipText="Use only ASCII letters, numbers,
+                  underscores, and dashes."
+              className={classes.select}
+              data-qa-volume-label
+              disabled={doesNotHavePermission}
+              errorText={touched.label ? errors.label : undefined}
+              label="Label"
+              name="label"
+              onBlur={handleBlur}
+              onChange={handleChange}
+              tooltipClasses={classes.labelTooltip}
+              tooltipPosition="right"
+              value={values.label}
+            />
+            <Box alignItems="flex-end" display="flex">
+              <RegionSelect
+                handleSelection={(value) => {
+                  setFieldValue('region', value);
+                  setFieldValue('linode_id', null);
+                }}
+                regions={
+                  regions?.filter((eachRegion) =>
+                    eachRegion.capabilities.some((eachCape) =>
+                      eachCape.match(/block/i)
+                    )
+                  ) ?? []
+                }
+                disabled={doesNotHavePermission}
+                errorText={touched.region ? errors.region : undefined}
+                isClearable
+                label="Region"
+                name="region"
+                onBlur={handleBlur}
+                selectedID={values.region}
+                width={320}
+              />
+              {renderSelectTooltip(
+                'Volumes must be created in a region. You can choose to create a Volume in a region and attach it later to a Linode in the same region.'
+              )}
+            </Box>
+            <Box
+              alignItems="flex-end"
+              className={classes.linodeConfigSelectWrapper}
+              display="flex"
+            >
+              <Box
+                alignItems="flex-end"
+                className={classes.linodeSelect}
+                display="flex"
+              >
+                <LinodeSelect
+                  optionsFilter={(linode: Linode) => {
+                    const linodeRegion = linode.region;
+                    const valuesRegion = values.region;
+
+                    /** When values.region is empty, all Linodes with
+                     * block storage support will be displayed, regardless
+                     * of their region. However, if a region is selected,
+                     * only Linodes from the chosen region with block storage
+                     * support will be shown. */
+                    return isNilOrEmpty(valuesRegion)
+                      ? regionsWithBlockStorage.includes(linodeRegion)
+                      : regionsWithBlockStorage.includes(linodeRegion) &&
+                          linodeRegion === valuesRegion;
+                  }}
+                  sx={{
+                    width: '320px',
+                  }}
+                  clearable
+                  disabled={doesNotHavePermission}
+                  errorText={linodeError}
+                  onBlur={handleBlur}
+                  onSelectionChange={handleLinodeChange}
+                  value={values.linode_id}
+                />
+                {renderSelectTooltip(
+                  'If you select a Linode, the Volume will be automatically created in that Linode’s region and attached upon creation.'
+                )}
+              </Box>
+              <ConfigSelect
+                disabled={doesNotHavePermission}
+                error={touched.config_id ? errors.config_id : undefined}
+                linodeId={linode_id}
+                name="configId"
+                onBlur={handleBlur}
+                onChange={(id: number) => setFieldValue('config_id', id)}
+                value={config_id}
+                width={320}
+              />
+            </Box>
+            <Box alignItems="flex-end" display="flex" position="relative">
+              <SizeField
+                disabled={doesNotHavePermission}
+                error={touched.size ? errors.size : undefined}
+                hasSelectedRegion={!isNilOrEmpty(values.region)}
+                name="size"
+                onBlur={handleBlur}
+                onChange={handleChange}
+                regionId={values.region}
+                textFieldStyles={classes.size}
+                value={values.size}
+              />
+            </Box>
+            <Box
+              alignItems="center"
+              className={classes.buttonGroup}
+              display="flex"
+              flexWrap="wrap"
+              justifyContent={showAgreement ? 'space-between' : 'flex-end'}
+            >
+              {showAgreement ? (
+                <EUAgreementCheckbox
+                  centerCheckbox
+                  checked={hasSignedAgreement}
+                  className={classes.agreement}
+                  onChange={(e) => setHasSignedAgreement(e.target.checked)}
+                />
+              ) : null}
+            </Box>
+          </Paper>
+          <Box display="flex" justifyContent="flex-end">
+            <Button
+              buttonType="primary"
+              className={classes.button}
+              data-qa-deploy-linode
+              disabled={disabled}
+              loading={isSubmitting}
+              style={{ marginLeft: 12 }}
+              type="submit"
+            >
+              Create Volume
+            </Button>
           </Box>
-        </Paper>
-        <Box display="flex" justifyContent="flex-end">
-          <Button
-            buttonType="primary"
-            className={classes.button}
-            data-qa-deploy-linode
-            disabled={disabled}
-            loading={isSubmitting}
-            style={{ marginLeft: 12 }}
-            type="submit"
-          >
-            Create Volume
-          </Button>
         </Box>
-      </Box>
-    </form>
+      </form>
+    </>
   );
 };
 
@@ -412,5 +429,3 @@ const initialValues: FormState = {
   region: '',
   size: 20,
 };
-
-export default CreateVolumeForm;

--- a/packages/manager/src/features/Volumes/VolumeDrawer/SizeField.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/SizeField.tsx
@@ -9,7 +9,7 @@ import { Typography } from 'src/components/Typography';
 import { MAX_VOLUME_SIZE } from 'src/constants';
 import { useFlags } from 'src/hooks/useFlags';
 import { getDynamicVolumePrice } from 'src/utilities/pricing/dynamicVolumePrice';
-import { SIZE_FIELD_WIDTH } from '../VolumeCreate/CreateVolumeForm';
+import { SIZE_FIELD_WIDTH } from '../VolumeCreate';
 import { makeStyles } from '@mui/styles';
 
 interface Props {

--- a/packages/manager/src/features/Volumes/Volumes.tsx
+++ b/packages/manager/src/features/Volumes/Volumes.tsx
@@ -4,8 +4,11 @@ import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
 import { ProductInformationBanner } from 'src/components/ProductInformationBanner/ProductInformationBanner';
 
 const VolumesLanding = React.lazy(() => import('./VolumesLanding'));
-const VolumeCreate = React.lazy(
-  () => import('./VolumeCreate/CreateVolumeForm')
+
+const VolumeCreate = React.lazy(() =>
+  import('./VolumeCreate').then((module) => ({
+    default: module.VolumeCreate,
+  }))
 );
 
 const Volumes = () => {

--- a/packages/manager/src/features/Volumes/VolumesLandingEmptyState.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLandingEmptyState.tsx
@@ -11,30 +11,34 @@ import {
   linkAnalyticsEvent,
   youtubeLinkData,
 } from './VolumesLandingEmptyStateData';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 
 export const VolumesLandingEmptyState = () => {
   const { push } = useHistory();
 
   return (
-    <ResourcesSection
-      buttonProps={[
-        {
-          children: 'Create Volume',
-          onClick: () => {
-            sendEvent({
-              action: 'Click:button',
-              category: linkAnalyticsEvent.category,
-              label: 'Create Volume',
-            });
-            push('/volumes/create');
+    <>
+      <DocumentTitleSegment segment="Volumes" />
+      <ResourcesSection
+        buttonProps={[
+          {
+            children: 'Create Volume',
+            onClick: () => {
+              sendEvent({
+                action: 'Click:button',
+                category: linkAnalyticsEvent.category,
+                label: 'Create Volume',
+              });
+              push('/volumes/create');
+            },
           },
-        },
-      ]}
-      gettingStartedGuidesData={gettingStartedGuides}
-      headers={headers}
-      icon={StyledVolumeIcon}
-      linkAnalyticsEvent={linkAnalyticsEvent}
-      youtubeLinkData={youtubeLinkData}
-    />
+        ]}
+        gettingStartedGuidesData={gettingStartedGuides}
+        headers={headers}
+        icon={StyledVolumeIcon}
+        linkAnalyticsEvent={linkAnalyticsEvent}
+        youtubeLinkData={youtubeLinkData}
+      />
+    </>
   );
 };


### PR DESCRIPTION
## Description 📝 
- Adds a `LandingHeader` to be consistent with other create pages
- Adds a `DocumentTitleSegement` so that "Create a Volume" shows in the browsers document tab title while on the Volume Create page
- Adds a `DocumentTitleSegement` so that "Volumes" shows  in the browsers document tab title while on the Volumes Landing empty state
- Renames `CreateVolumeForm.tsx` ➡️ `VolumeCreate.tsx` to match our other create pages
- Moves errors notices into the `Paper`

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-09-26 at 10 27 30 AM](https://github.com/linode/manager/assets/115251059/9a2acce7-c65f-4112-9cfc-255024f7073a) | ![Screenshot 2023-09-26 at 10 27 05 AM](https://github.com/linode/manager/assets/115251059/fad42cd4-72cc-4f93-856e-140855f42ad5) |
| ![Screenshot 2023-09-26 at 10 31 24 AM](https://github.com/linode/manager/assets/115251059/bc309e41-d75c-4919-ae5b-36a330a89aa6) | ![Screenshot 2023-09-26 at 10 35 19 AM](https://github.com/linode/manager/assets/115251059/f8562d3d-6d9f-4e50-b9fd-a54e92ce5376) |


## How to test 🧪
- Test general UI and functionality of `http://localhost:3000/volumes/create`
- Verify you see `Create a Volume` in the document title
- Verify the `Volumes / Create` breadcrumb is there and links to the correct place
- To test the placement of the errors, you can manually set one in the code or mock an error with the MSW (see below)

### How to mock an error with the MSW

```ts
rest.post('*/volumes', (req, res, ctx) => {
  return res(ctx.status(500), ctx.json({ errors: [{ reason: "OH NO!" }] }));
}),
```