### PR TITLE
fix: [M3-7196] - Database Access Drawer Incorrect Loading State

### DIFF
--- a/packages/manager/.changeset/pr-9722-fixed-1695762935283.md
+++ b/packages/manager/.changeset/pr-9722-fixed-1695762935283.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Database Access Drawer Broken Loading State ([#9722](https://github.com/linode/manager/pull/9722))

--- a/packages/manager/.changeset/pr-9722-fixed-1695762935283.md
+++ b/packages/manager/.changeset/pr-9722-fixed-1695762935283.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Database Access Drawer Broken Loading State ([#9722](https://github.com/linode/manager/pull/9722))
+"Cancel" button in Database Access Controls drawer incorrectly having a loading state ([#9722](https://github.com/linode/manager/pull/9722))

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -193,14 +193,11 @@ const AddAccessControlDrawer = (props: CombinedProps) => {
               disabled: !formTouched,
               label: 'Update Access Controls',
               loading: isSubmitting,
-              sx: { marginBottom: 8 },
               type: 'submit',
             }}
             secondaryButtonProps={{
               label: 'Cancel',
-              loading: isSubmitting,
               onClick: onClose,
-              sx: { marginBottom: 8 },
             }}
           />
         </form>


### PR DESCRIPTION
## Description 📝
- The loading state is applied to both the primary button and the cancel button. It should only be applied to the primary button
- Caused by https://github.com/linode/manager/pull/9341

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-09-26 at 5 03 15 PM](https://github.com/linode/manager/assets/115251059/f926e7bd-b7ae-47c6-9f69-6c3256070392) | ![Screenshot 2023-09-26 at 5 03 38 PM](https://github.com/linode/manager/assets/115251059/d59630b5-8236-4903-bbc5-9548ad27ae27) |

## How to test 🧪
1. Create a Database (or use an existing one)
2. Go to the Database details page
3. Edit access controls
4. Save Changes and watch closely  👀
5. Verify **only** the `Update Access Controls` button shows a loading spinner, **not both**