### PR TITLE
feat: [M3-7160] - Add AGLB "Edit Certificate" drawer

### DIFF
--- a/packages/api-v4/src/aglb/certificates.ts
+++ b/packages/api-v4/src/aglb/certificates.ts
@@ -67,7 +67,7 @@ export const createLoadbalancerCertificate = (
 /**
  * updateLoadbalancerCertificate
  *
- * Creates an Akamai Global Load Balancer certificate
+ * Updates an Akamai Global Load Balancer certificate
  */
 export const updateLoadbalancerCertificate = (
   loadbalancerId: number,

--- a/packages/api-v4/src/aglb/certificates.ts
+++ b/packages/api-v4/src/aglb/certificates.ts
@@ -7,8 +7,15 @@ import Request, {
 } from '../request';
 import { BETA_API_ROOT } from '../constants';
 import { Filter, Params, ResourcePage } from '../types';
-import { Certificate, CreateCertificatePayload } from './types';
-import { CreateCertificateSchema } from '@linode/validation';
+import {
+  Certificate,
+  CreateCertificatePayload,
+  UpdateCertificatePayload,
+} from './types';
+import {
+  CreateCertificateSchema,
+  UpdateCertificateSchema,
+} from '@linode/validation';
 
 /**
  * getLoadbalancerCertificates
@@ -72,7 +79,7 @@ export const createLoadbalancerCertificate = (
 export const updateLoadbalancerCertificate = (
   loadbalancerId: number,
   certificateId: number,
-  data: Partial<CreateCertificatePayload>
+  data: Partial<UpdateCertificatePayload>
 ) =>
   Request<Certificate>(
     setURL(
@@ -81,7 +88,7 @@ export const updateLoadbalancerCertificate = (
       )}/certificates/${encodeURIComponent(certificateId)}`
     ),
     setMethod('PUT'),
-    setData(data)
+    setData(data, UpdateCertificateSchema)
   );
 
 /**

--- a/packages/api-v4/src/aglb/types.ts
+++ b/packages/api-v4/src/aglb/types.ts
@@ -141,6 +141,7 @@ type CertificateType = 'ca' | 'downstream';
 export interface Certificate {
   id: number;
   label: string;
+  certificate: string;
   type: CertificateType;
 }
 

--- a/packages/api-v4/src/aglb/types.ts
+++ b/packages/api-v4/src/aglb/types.ts
@@ -150,3 +150,10 @@ export interface CreateCertificatePayload {
   label: string;
   type: CertificateType;
 }
+
+export interface UpdateCertificatePayload {
+  key?: string;
+  certificate?: string;
+  label?: string;
+  type?: CertificateType;
+}

--- a/packages/manager/cypress/e2e/core/loadBalancers/load-balancer-certificates.spec.ts
+++ b/packages/manager/cypress/e2e/core/loadBalancers/load-balancer-certificates.spec.ts
@@ -145,7 +145,7 @@ describe('Akamai Global Load Balancer certificates page', () => {
           .should('be.visible')
           .type(mockLoadBalancerCertServiceTarget.label);
 
-        cy.findByLabelText('TLS Certificate')
+        cy.findByLabelText('Server Certificate')
           .should('be.visible')
           .type(randomString(32));
 

--- a/packages/manager/src/factories/aglb.ts
+++ b/packages/manager/src/factories/aglb.ts
@@ -13,7 +13,7 @@ import {
 } from '@linode/api-v4/lib/aglb/types';
 import * as Factory from 'factory.ts';
 
-const certificate = `
+export const mockCertificate = `
 -----BEGIN CERTIFICATE-----
 MIID0DCCArigAwIBAgIBATANBgkqhkiG9w0BAQUFADB/MQswCQYDVQQGEwJGUjET
 MBEGA1UECAwKU29tZS1TdGF0ZTEOMAwGA1UEBwwFUGFyaXMxDTALBgNVBAoMBERp
@@ -39,7 +39,7 @@ cbTV5RDkrlaYwm5yqlTIglvCv7o=
 -----END CERTIFICATE-----
 `;
 
-const key = `
+const mockKey = `
 -----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAvpnaPKLIKdvx98KW68lz8pGaRRcYersNGqPjpifMVjjE8LuC
 oXgPU0HePnNTUjpShBnynKCvrtWhN+haKbSp+QWXSxiTrW99HBfAl1MDQyWcukoE
@@ -275,6 +275,7 @@ export const createServiceTargetFactory = Factory.Sync.makeFactory<ServiceTarget
 // Certificate endpoints
 // *********************
 export const certificateFactory = Factory.Sync.makeFactory<Certificate>({
+  certificate: mockCertificate,
   id: Factory.each((i) => i),
   label: Factory.each((i) => `certificate-${i}`),
   type: 'ca',
@@ -282,8 +283,8 @@ export const certificateFactory = Factory.Sync.makeFactory<Certificate>({
 
 export const createCertificateFactory = Factory.Sync.makeFactory<CreateCertificatePayload>(
   {
-    certificate,
-    key,
+    certificate: mockCertificate,
+    key: mockKey,
     label: 'my-cert',
     type: 'downstream',
   }

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/Certificates.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/Certificates.tsx
@@ -22,6 +22,7 @@ import { useLoadBalancerCertificatesQuery } from 'src/queries/aglb/certificates'
 
 import { CreateCertificateDrawer } from './CreateCertificateDrawer';
 import { DeleteCertificateDialog } from './DeleteCertificateDialog';
+import { EditCertificateDrawer } from './EditCertificateDrawer';
 
 import type { Certificate, Filter } from '@linode/api-v4';
 
@@ -40,6 +41,7 @@ export const Certificates = () => {
   const history = useHistory();
 
   const isCreateDrawerOpen = location.pathname.endsWith('/create');
+  const [isEditDrawerOpen, setIsEditDrawerOpen] = useState(false);
   const [isDeleteDrawerOpen, setIsDeleteDrawerOpen] = useState(false);
 
   const [selectedCertificateId, setSelectedCertificateId] = useState<number>();
@@ -147,7 +149,7 @@ export const Certificates = () => {
               <TableCell actionCell>
                 <ActionMenu
                   actionsList={[
-                    { onClick: () => null, title: 'Edit' },
+                    { onClick: () => setIsEditDrawerOpen(true), title: 'Edit' },
                     {
                       onClick: () => onDeleteCertificate(certificate),
                       title: 'Delete',
@@ -174,6 +176,12 @@ export const Certificates = () => {
         loadbalancerId={id}
         open={isCreateDrawerOpen}
         type={certType}
+      />
+      <EditCertificateDrawer
+        certificateId={selectedCertificateId}
+        loadbalancerId={id}
+        onClose={() => setIsEditDrawerOpen(false)}
+        open={isEditDrawerOpen}
       />
       <DeleteCertificateDialog
         certificate={selectedCertificate}

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/Certificates.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/Certificates.tsx
@@ -71,6 +71,11 @@ export const Certificates = () => {
     filter
   );
 
+  const onEditCertificate = (certificate: Certificate) => {
+    setIsEditDrawerOpen(true);
+    setSelectedCertificateId(certificate.id);
+  };
+
   const onDeleteCertificate = (certificate: Certificate) => {
     setIsDeleteDrawerOpen(true);
     setSelectedCertificateId(certificate.id);
@@ -149,7 +154,10 @@ export const Certificates = () => {
               <TableCell actionCell>
                 <ActionMenu
                   actionsList={[
-                    { onClick: () => setIsEditDrawerOpen(true), title: 'Edit' },
+                    {
+                      onClick: () => onEditCertificate(certificate),
+                      title: 'Edit',
+                    },
                     {
                       onClick: () => onDeleteCertificate(certificate),
                       title: 'Delete',
@@ -178,7 +186,7 @@ export const Certificates = () => {
         type={certType}
       />
       <EditCertificateDrawer
-        certificateId={selectedCertificateId}
+        certificate={selectedCertificate}
         loadbalancerId={id}
         onClose={() => setIsEditDrawerOpen(false)}
         open={isEditDrawerOpen}

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/CreateCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/CreateCertificateDrawer.tsx
@@ -9,6 +9,8 @@ import { Typography } from 'src/components/Typography';
 import { useLoadBalancerCertificateCreateMutation } from 'src/queries/aglb/certificates';
 import { getErrorMap } from 'src/utilities/errorUtils';
 
+import { labelMap } from './EditCertificateDrawer';
+
 import type { Certificate, CreateCertificatePayload } from '@linode/api-v4';
 
 interface Props {
@@ -91,7 +93,7 @@ export const CreateCertificateDrawer = (props: Props) => {
         />
         <TextField
           errorText={errorMap.certificate}
-          label="TLS Certificate"
+          label={labelMap[type]}
           labelTooltipText="TODO"
           multiline
           name="certificate"

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.test.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.test.tsx
@@ -36,7 +36,8 @@ describe('EditCertificateDrawer', () => {
     );
   });
 
-  it('should display pre-populated fields for a TLS cert type when opened', async () => {
+  // TODO: update and unskip this test before merging
+  it.skip('should display pre-populated fields for a TLS cert type when opened', async () => {
     const onClose = jest.fn();
 
     const { getByLabelText } = renderWithTheme(
@@ -57,6 +58,7 @@ describe('EditCertificateDrawer', () => {
     expect(keyInput).not.toHaveDisplayValue('');
   });
 
+  // TODO: update and unskip this test before merging
   it.skip('should display pre-populated fields for a CA cert type when opened', async () => {
     const onClose = jest.fn();
 
@@ -76,7 +78,7 @@ describe('EditCertificateDrawer', () => {
     expect(certInput).not.toHaveDisplayValue('');
   });
 
-  it.skip('should have editable fields and be submittable when filled out correctly', async () => {
+  it('should have editable fields and be submittable when filled out correctly', async () => {
     const onClose = jest.fn();
 
     const { getByLabelText, getByTestId } = renderWithTheme(

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.test.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.test.tsx
@@ -19,28 +19,10 @@ const mockCACertificate: Certificate = {
 };
 
 describe('EditCertificateDrawer', () => {
-  it('should contain the name of the cert in the drawer title', () => {
+  it('should contain the name of the cert in the drawer title and label field', () => {
     const onClose = jest.fn();
 
-    const { getByTestId } = renderWithTheme(
-      <EditCertificateDrawer
-        certificate={mockTLSCertificate}
-        loadbalancerId={0}
-        onClose={onClose}
-        open
-      />
-    );
-
-    expect(getByTestId('drawer-title')).toHaveTextContent(
-      `Edit ${mockTLSCertificate.label}`
-    );
-  });
-
-  // TODO: update and unskip this test before merging
-  it.skip('should display pre-populated fields for a TLS cert type when opened', async () => {
-    const onClose = jest.fn();
-
-    const { getByLabelText } = renderWithTheme(
+    const { getByTestId, getByLabelText } = renderWithTheme(
       <EditCertificateDrawer
         certificate={mockTLSCertificate}
         loadbalancerId={0}
@@ -50,19 +32,17 @@ describe('EditCertificateDrawer', () => {
     );
 
     const labelInput = getByLabelText('Certificate Label');
-    const certInput = getByLabelText('TLS Certificate');
-    const keyInput = getByLabelText('Private Key');
 
+    expect(getByTestId('drawer-title')).toHaveTextContent(
+      `Edit ${mockTLSCertificate.label}`
+    );
     expect(labelInput).toHaveDisplayValue(mockTLSCertificate.label);
-    expect(certInput).not.toHaveDisplayValue('');
-    expect(keyInput).not.toHaveDisplayValue('');
   });
 
-  // TODO: update and unskip this test before merging
-  it.skip('should display pre-populated fields for a CA cert type when opened', async () => {
+  it('should submit and close drawer when only the label of the certificate is edited', async () => {
     const onClose = jest.fn();
 
-    const { getByLabelText } = renderWithTheme(
+    const { getByLabelText, getByTestId } = renderWithTheme(
       <EditCertificateDrawer
         certificate={mockCACertificate}
         loadbalancerId={0}
@@ -75,10 +55,17 @@ describe('EditCertificateDrawer', () => {
     const certInput = getByLabelText('Server Certificate');
 
     expect(labelInput).toHaveDisplayValue(mockCACertificate.label);
-    expect(certInput).not.toHaveDisplayValue('');
+    expect(certInput).toHaveDisplayValue('');
+
+    act(() => {
+      userEvent.type(labelInput, 'my-updated-cert-0');
+      userEvent.click(getByTestId('submit'));
+    });
+
+    await waitFor(() => expect(onClose).toBeCalled());
   });
 
-  it('should have editable fields and be submittable when filled out correctly', async () => {
+  it('should submit and close drawer when both a certificate and key are included', async () => {
     const onClose = jest.fn();
 
     const { getByLabelText, getByTestId } = renderWithTheme(

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.test.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.test.tsx
@@ -3,16 +3,19 @@ import { act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
+import { mockCertificate } from 'src/factories';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { EditCertificateDrawer } from './EditCertificateDrawer';
 
 const mockTLSCertificate: Certificate = {
+  certificate: mockCertificate,
   id: 0,
   label: 'test-tls-cert',
   type: 'downstream',
 };
 const mockCACertificate: Certificate = {
+  certificate: mockCertificate,
   id: 0,
   label: 'test-ca-cert',
   type: 'ca',
@@ -22,7 +25,7 @@ describe('EditCertificateDrawer', () => {
   it('should contain the name of the cert in the drawer title and label field', () => {
     const onClose = jest.fn();
 
-    const { getByTestId, getByLabelText } = renderWithTheme(
+    const { getByLabelText, getByTestId } = renderWithTheme(
       <EditCertificateDrawer
         certificate={mockTLSCertificate}
         loadbalancerId={0}

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.test.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.test.tsx
@@ -1,3 +1,4 @@
+import { Certificate } from '@linode/api-v4';
 import { act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -6,20 +7,87 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { EditCertificateDrawer } from './EditCertificateDrawer';
 
-describe.skip('CreateCertificateDrawer', () => {
-  it('should be submittable when form is filled out correctly', async () => {
+const mockTLSCertificate: Certificate = {
+  id: 0,
+  label: 'test-tls-cert',
+  type: 'downstream',
+};
+const mockCACertificate: Certificate = {
+  id: 0,
+  label: 'test-ca-cert',
+  type: 'ca',
+};
+
+describe('EditCertificateDrawer', () => {
+  it('should contain the name of the cert in the drawer title', () => {
     const onClose = jest.fn();
 
-    const { getByLabelText, getByTestId } = renderWithTheme(
+    const { getByTestId } = renderWithTheme(
       <EditCertificateDrawer
-        certificateId={0}
+        certificate={mockTLSCertificate}
         loadbalancerId={0}
         onClose={onClose}
         open
       />
     );
 
-    const labelInput = getByLabelText('Label');
+    expect(getByTestId('drawer-title')).toHaveTextContent(
+      `Edit ${mockTLSCertificate.label}`
+    );
+  });
+
+  it('should display pre-populated fields for a TLS cert type when opened', async () => {
+    const onClose = jest.fn();
+
+    const { getByLabelText } = renderWithTheme(
+      <EditCertificateDrawer
+        certificate={mockTLSCertificate}
+        loadbalancerId={0}
+        onClose={onClose}
+        open
+      />
+    );
+
+    const labelInput = getByLabelText('Certificate Label');
+    const certInput = getByLabelText('TLS Certificate');
+    const keyInput = getByLabelText('Private Key');
+
+    expect(labelInput).toHaveDisplayValue(mockTLSCertificate.label);
+    expect(certInput).not.toHaveDisplayValue('');
+    expect(keyInput).not.toHaveDisplayValue('');
+  });
+
+  it.skip('should display pre-populated fields for a CA cert type when opened', async () => {
+    const onClose = jest.fn();
+
+    const { getByLabelText } = renderWithTheme(
+      <EditCertificateDrawer
+        certificate={mockCACertificate}
+        loadbalancerId={0}
+        onClose={onClose}
+        open
+      />
+    );
+
+    const labelInput = getByLabelText('Certificate Label');
+    const certInput = getByLabelText('Server Certificate');
+
+    expect(labelInput).toHaveDisplayValue(mockCACertificate.label);
+    expect(certInput).not.toHaveDisplayValue('');
+  });
+
+  it.skip('should have editable fields and be submittable when filled out correctly', async () => {
+    const onClose = jest.fn();
+
+    const { getByLabelText, getByTestId } = renderWithTheme(
+      <EditCertificateDrawer
+        certificate={mockTLSCertificate}
+        loadbalancerId={0}
+        onClose={onClose}
+        open
+      />
+    );
+    const labelInput = getByLabelText('Certificate Label');
     const certInput = getByLabelText('TLS Certificate');
     const keyInput = getByLabelText('Private Key');
 

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.test.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.test.tsx
@@ -42,6 +42,28 @@ describe('EditCertificateDrawer', () => {
     expect(labelInput).toHaveDisplayValue(mockTLSCertificate.label);
   });
 
+  it('should contain the cert in the cert field and placeholder text in the private key for a downstream cert', () => {
+    const onClose = jest.fn();
+
+    const { getByLabelText } = renderWithTheme(
+      <EditCertificateDrawer
+        certificate={mockTLSCertificate}
+        loadbalancerId={0}
+        onClose={onClose}
+        open
+      />
+    );
+
+    const certInput = getByLabelText('TLS Certificate');
+    const keyInput = getByLabelText('Private Key');
+
+    expect(certInput).toHaveDisplayValue(mockTLSCertificate.certificate.trim());
+    expect(keyInput).toHaveAttribute(
+      'placeholder',
+      'Private key is redacted for security.'
+    );
+  });
+
   it('should submit and close drawer when only the label of the certificate is edited', async () => {
     const onClose = jest.fn();
 
@@ -58,7 +80,7 @@ describe('EditCertificateDrawer', () => {
     const certInput = getByLabelText('Server Certificate');
 
     expect(labelInput).toHaveDisplayValue(mockCACertificate.label);
-    expect(certInput).toHaveDisplayValue('');
+    expect(certInput).toHaveDisplayValue(mockCACertificate.certificate.trim());
 
     act(() => {
       userEvent.type(labelInput, 'my-updated-cert-0');

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.test.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.test.tsx
@@ -1,0 +1,36 @@
+import { act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { EditCertificateDrawer } from './EditCertificateDrawer';
+
+describe.skip('CreateCertificateDrawer', () => {
+  it('should be submittable when form is filled out correctly', async () => {
+    const onClose = jest.fn();
+
+    const { getByLabelText, getByTestId } = renderWithTheme(
+      <EditCertificateDrawer
+        certificateId={0}
+        loadbalancerId={0}
+        onClose={onClose}
+        open
+      />
+    );
+
+    const labelInput = getByLabelText('Label');
+    const certInput = getByLabelText('TLS Certificate');
+    const keyInput = getByLabelText('Private Key');
+
+    act(() => {
+      userEvent.type(labelInput, 'my-cert-0');
+      userEvent.type(certInput, 'massive cert');
+      userEvent.type(keyInput, 'massive key');
+
+      userEvent.click(getByTestId('submit'));
+    });
+
+    await waitFor(() => expect(onClose).toBeCalled());
+  });
+});

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
@@ -1,4 +1,4 @@
-import { Certificate, CreateCertificatePayload } from '@linode/api-v4';
+import { Certificate, UpdateCertificatePayload } from '@linode/api-v4';
 import { useTheme } from '@mui/material/styles';
 import { useFormik } from 'formik';
 import React from 'react';
@@ -37,20 +37,20 @@ export const EditCertificateDrawer = (props: Props) => {
 
   const {
     error,
-    mutateAsync: editCertificate,
+    mutateAsync: updateCertificate,
     reset,
   } = useLoadBalancerCertificateMutation(loadbalancerId, certificate?.id ?? -1);
 
-  const formik = useFormik<CreateCertificatePayload>({
+  const formik = useFormik<UpdateCertificatePayload>({
     enableReinitialize: true,
     initialValues: {
       certificate: '',
       key: '',
       label: certificate?.label ?? '',
-      type: certificate?.type ?? 'downstream',
+      type: certificate?.type,
     },
     async onSubmit(values) {
-      await editCertificate(values);
+      await updateCertificate(values);
       onClose();
     },
   });

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
@@ -18,7 +18,7 @@ interface Props {
   open: boolean;
 }
 
-const labelMap: Record<Certificate['type'], string> = {
+export const labelMap: Record<Certificate['type'], string> = {
   ca: 'Server Certificate',
   downstream: 'TLS Certificate',
 };
@@ -92,23 +92,27 @@ export const EditCertificateDrawer = (props: Props) => {
             value={formik.values.label}
           />
           <TextField
+            disabled
             errorText={errorMap.certificate}
             label={labelMap[certificate.type]}
             labelTooltipText="TODO: AGLB"
             multiline
             name="certificate"
             onChange={formik.handleChange}
+            placeholder={certificate.certificate ?? ''}
             trimmed
             value={formik.values.certificate}
           />
           {certificate?.type === 'downstream' && (
             <TextField
+              disabled
               errorText={errorMap.key}
               label="Private Key"
               labelTooltipText="TODO: AGLB"
               multiline
               name="key"
               onChange={formik.handleChange}
+              placeholder="Key is concealed."
               trimmed
               value={formik.values.key}
             />

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
@@ -1,0 +1,98 @@
+import { CreateCertificatePayload } from '@linode/api-v4';
+import { useTheme } from '@mui/material/styles';
+import { useFormik } from 'formik';
+import React from 'react';
+
+import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
+import { Drawer } from 'src/components/Drawer';
+import { Notice } from 'src/components/Notice/Notice';
+import { TextField } from 'src/components/TextField';
+import { Typography } from 'src/components/Typography';
+import { useLoadBalancerCertificateMutation } from 'src/queries/aglb/certificates';
+import { getErrorMap } from 'src/utilities/errorUtils';
+
+interface Props {
+  certificateId: number | undefined;
+  loadbalancerId: number;
+  onClose: () => void;
+  open: boolean;
+}
+
+export const EditCertificateDrawer = (props: Props) => {
+  const { certificateId, loadbalancerId, onClose: _onClose, open } = props;
+
+  const theme = useTheme();
+
+  const onClose = () => {
+    formik.resetForm();
+    _onClose();
+    reset();
+  };
+
+  const {
+    error,
+    mutateAsync: editCertificate,
+    reset,
+  } = useLoadBalancerCertificateMutation(loadbalancerId, certificateId ?? -1);
+
+  const formik = useFormik<CreateCertificatePayload>({
+    initialValues: {
+      certificate: '',
+      key: '',
+      label: '',
+      type: 'downstream',
+    },
+    async onSubmit(values) {
+      await editCertificate(values);
+      onClose();
+    },
+  });
+
+  const errorMap = getErrorMap(['label', 'key', 'certificate'], error);
+
+  return (
+    <Drawer onClose={onClose} open={open} title="Edit Certificate">
+      <form onSubmit={formik.handleSubmit}>
+        {errorMap.none && <Notice text={errorMap.none} variant="error" />}
+        <Typography sx={{ marginBottom: theme.spacing(2) }}>
+          {/* TODO: AGLB - Update with final copy. */}
+          You can edit this cert here. Maybe something about service targets.
+        </Typography>
+        <TextField
+          errorText={errorMap.label}
+          label="Certificate Label"
+          name="label"
+          onChange={formik.handleChange}
+          value={formik.values.label}
+        />
+        <TextField
+          errorText={errorMap.certificate}
+          label="TLS Certificate"
+          labelTooltipText="TODO: AGLB"
+          multiline
+          name="certificate"
+          onChange={formik.handleChange}
+          trimmed
+          value={formik.values.certificate}
+        />
+        <TextField
+          errorText={errorMap.key}
+          label="Private Key"
+          labelTooltipText="TODO: AGLB"
+          multiline
+          name="key"
+          onChange={formik.handleChange}
+          trimmed
+          value={formik.values.key}
+        />
+        <ActionsPanel
+          primaryButtonProps={{
+            'data-testid': 'submit',
+            label: 'Update Certificate',
+            type: 'submit',
+          }}
+        />
+      </form>
+    </Drawer>
+  );
+};

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
@@ -110,6 +110,7 @@ export const EditCertificateDrawer = (props: Props) => {
               multiline
               name="key"
               onChange={formik.handleChange}
+              placeholder="Private key is redacted for security reasons."
               trimmed
               value={formik.values.key}
             />

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
@@ -92,7 +92,6 @@ export const EditCertificateDrawer = (props: Props) => {
             value={formik.values.label}
           />
           <TextField
-            disabled
             errorText={errorMap.certificate}
             label={labelMap[certificate.type]}
             labelTooltipText="TODO: AGLB"
@@ -105,14 +104,12 @@ export const EditCertificateDrawer = (props: Props) => {
           />
           {certificate?.type === 'downstream' && (
             <TextField
-              disabled
               errorText={errorMap.key}
               label="Private Key"
               labelTooltipText="TODO: AGLB"
               multiline
               name="key"
               onChange={formik.handleChange}
-              placeholder="Key is concealed."
               trimmed
               value={formik.values.key}
             />

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
@@ -55,7 +55,13 @@ export const EditCertificateDrawer = (props: Props) => {
     },
   });
 
-  const errorMap = getErrorMap(['label', 'key', 'certificate'], error);
+  const errorFields = ['label', 'certificate'];
+
+  if (certificate?.type === 'downstream') {
+    errorFields.push('key');
+  }
+
+  const errorMap = getErrorMap(errorFields, error);
 
   const onClose = () => {
     formik.resetForm();

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
@@ -50,7 +50,11 @@ export const EditCertificateDrawer = (props: Props) => {
       type: certificate?.type,
     },
     async onSubmit(values) {
-      await updateCertificate(values);
+      await updateCertificate({
+        certificate: values.certificate !== '' ? values.certificate : undefined,
+        key: values.key !== '' ? values.key : undefined,
+        label: values.label,
+      });
       onClose();
     },
   });

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
@@ -44,15 +44,23 @@ export const EditCertificateDrawer = (props: Props) => {
   const formik = useFormik<UpdateCertificatePayload>({
     enableReinitialize: true,
     initialValues: {
-      certificate: '',
+      certificate: certificate?.certificate.trim(),
       key: '',
       label: certificate?.label ?? '',
       type: certificate?.type,
     },
     async onSubmit(values) {
+      // The user has not edited their cert or the private key, so we exclude both cert and key from the request.
+      const shouldIgnoreField =
+        certificate?.certificate.trim() === values.certificate &&
+        values.key === '';
+
       await updateCertificate({
-        certificate: values.certificate !== '' ? values.certificate : undefined,
-        key: values.key !== '' ? values.key : undefined,
+        certificate:
+          values.certificate && !shouldIgnoreField
+            ? values.certificate
+            : undefined,
+        key: values.key && !shouldIgnoreField ? values.key : undefined,
         label: values.label,
         type: values.type,
       });
@@ -106,7 +114,6 @@ export const EditCertificateDrawer = (props: Props) => {
             multiline
             name="certificate"
             onChange={formik.handleChange}
-            placeholder={certificate.certificate.trim() ?? ''}
             trimmed
             value={formik.values.certificate}
           />
@@ -119,7 +126,7 @@ export const EditCertificateDrawer = (props: Props) => {
               multiline
               name="key"
               onChange={formik.handleChange}
-              placeholder="Private key is redacted for security reasons."
+              placeholder="Private key is redacted for security."
               trimmed
               value={formik.values.key}
             />

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
@@ -54,6 +54,7 @@ export const EditCertificateDrawer = (props: Props) => {
         certificate: values.certificate !== '' ? values.certificate : undefined,
         key: values.key !== '' ? values.key : undefined,
         label: values.label,
+        type: values.type,
       });
       onClose();
     },

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
@@ -74,6 +74,7 @@ export const EditCertificateDrawer = (props: Props) => {
       onClose={onClose}
       open={open}
       title={`Edit ${certificate?.label ?? 'Certificate'}`}
+      wide
     >
       {errorMap.none && <Notice variant="error">{errorMap.none}</Notice>}
       {!certificate ? (
@@ -86,6 +87,7 @@ export const EditCertificateDrawer = (props: Props) => {
           </Typography>
           <TextField
             errorText={errorMap.label}
+            expand
             label="Certificate Label"
             name="label"
             onChange={formik.handleChange}
@@ -93,18 +95,20 @@ export const EditCertificateDrawer = (props: Props) => {
           />
           <TextField
             errorText={errorMap.certificate}
+            expand
             label={labelMap[certificate.type]}
             labelTooltipText="TODO: AGLB"
             multiline
             name="certificate"
             onChange={formik.handleChange}
-            placeholder={certificate.certificate ?? ''}
+            placeholder={certificate.certificate.trim() ?? ''}
             trimmed
             value={formik.values.certificate}
           />
           {certificate?.type === 'downstream' && (
             <TextField
               errorText={errorMap.key}
+              expand
               label="Private Key"
               labelTooltipText="TODO: AGLB"
               multiline

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -391,8 +391,12 @@ const aglb = [
   ),
   // Certificates
   rest.get('*/v4beta/aglb/:id/certificates', (req, res, ctx) => {
+    const tlsCertificate = certificateFactory.build({
+      label: 'tls-certificate',
+      type: 'downstream',
+    });
     const certificates = certificateFactory.buildList(3);
-    return res(ctx.json(makeResourcePage(certificates)));
+    return res(ctx.json(makeResourcePage([tlsCertificate, ...certificates])));
   }),
   rest.post('*/v4beta/aglb/:id/certificates', (req, res, ctx) => {
     return res(ctx.json(certificateFactory.build()));

--- a/packages/manager/src/queries/aglb/certificates.ts
+++ b/packages/manager/src/queries/aglb/certificates.ts
@@ -20,6 +20,7 @@ import type {
   Filter,
   Params,
   ResourcePage,
+  UpdateCertificatePayload,
 } from '@linode/api-v4';
 
 export const useLoadBalancerCertificatesQuery = (
@@ -66,7 +67,7 @@ export const useLoadBalancerCertificateMutation = (
   certificateId: number
 ) => {
   const queryClient = useQueryClient();
-  return useMutation<Certificate, APIError[], CreateCertificatePayload>(
+  return useMutation<Certificate, APIError[], UpdateCertificatePayload>(
     (data) =>
       updateLoadbalancerCertificate(loadbalancerId, certificateId, data),
     {

--- a/packages/manager/src/queries/aglb/certificates.ts
+++ b/packages/manager/src/queries/aglb/certificates.ts
@@ -2,6 +2,7 @@ import {
   createLoadbalancerCertificate,
   deleteLoadbalancerCertificate,
   getLoadbalancerCertificates,
+  updateLoadbalancerCertificate,
 } from '@linode/api-v4';
 import {
   useInfiniteQuery,
@@ -47,6 +48,27 @@ export const useLoadBalancerCertificateCreateMutation = (
   const queryClient = useQueryClient();
   return useMutation<Certificate, APIError[], CreateCertificatePayload>(
     (data) => createLoadbalancerCertificate(loadbalancerId, data),
+    {
+      onSuccess() {
+        queryClient.invalidateQueries([
+          QUERY_KEY,
+          'loadbalancer',
+          loadbalancerId,
+          'certificates',
+        ]);
+      },
+    }
+  );
+};
+
+export const useLoadBalancerCertificateMutation = (
+  loadbalancerId: number,
+  certificateId: number
+) => {
+  const queryClient = useQueryClient();
+  return useMutation<Certificate, APIError[], CreateCertificatePayload>(
+    (data) =>
+      updateLoadbalancerCertificate(loadbalancerId, certificateId, data),
     {
       onSuccess() {
         queryClient.invalidateQueries([

--- a/packages/validation/src/loadbalancers.schema.ts
+++ b/packages/validation/src/loadbalancers.schema.ts
@@ -14,7 +14,7 @@ export const UpdateCertificateSchema = object({
   certificate: string(),
   key: string().when(['type', 'certificate'], {
     is: (type: string, certificate: string) =>
-      type === 'downstream' && certificate === '',
+      type === 'downstream' && certificate,
     then: string().required('Private Key is required'),
   }),
   label: string(),

--- a/packages/validation/src/loadbalancers.schema.ts
+++ b/packages/validation/src/loadbalancers.schema.ts
@@ -15,7 +15,7 @@ export const UpdateCertificateSchema = object().shape(
     certificate: string(),
     key: string().when(['type', 'certificate'], {
       is: (type: string, certificate: string) =>
-        undefined && type === 'downstream' && certificate, // This doesn't actually work, though
+        type === 'downstream' && certificate,
       then: string().required('Private Key is required'),
     }),
     label: string(),

--- a/packages/validation/src/loadbalancers.schema.ts
+++ b/packages/validation/src/loadbalancers.schema.ts
@@ -10,16 +10,22 @@ export const CreateCertificateSchema = object({
   type: string().oneOf(['downstream', 'ca']).required('Type is required.'),
 });
 
-export const UpdateCertificateSchema = object({
-  certificate: string(),
-  key: string().when(['type', 'certificate'], {
-    is: (type: string, certificate: string) =>
-      type === 'downstream' && certificate,
-    then: string().required('Private Key is required'),
-  }),
-  label: string(),
-  type: string().oneOf(['downstream', 'ca']),
-});
+export const UpdateCertificateSchema = object().shape(
+  {
+    certificate: string().when(['type', 'key'], {
+      is: (type: string, key: string) => type === 'downstream' && key,
+      then: string().required('Certificate is required'),
+    }),
+    key: string().when(['type', 'certificate'], {
+      is: (type: string, certificate: string) =>
+        type === 'downstream' && certificate,
+      then: string().required('Private Key is required'),
+    }),
+    label: string(),
+    type: string().oneOf(['downstream', 'ca']),
+  },
+  [['certificate', 'key']]
+);
 
 export const certificateConfigSchema = object({
   certificates: array(

--- a/packages/validation/src/loadbalancers.schema.ts
+++ b/packages/validation/src/loadbalancers.schema.ts
@@ -10,6 +10,17 @@ export const CreateCertificateSchema = object({
   type: string().oneOf(['downstream', 'ca']).required('Type is required.'),
 });
 
+export const UpdateCertificateSchema = object({
+  certificate: string(),
+  key: string().when(['type', 'certificate'], {
+    is: (type: string, certificate: string) =>
+      type === 'downstream' && certificate === '',
+    then: string().required('Private Key is required'),
+  }),
+  label: string(),
+  type: string().oneOf(['downstream', 'ca']),
+});
+
 export const certificateConfigSchema = object({
   certificates: array(
     object({

--- a/packages/validation/src/loadbalancers.schema.ts
+++ b/packages/validation/src/loadbalancers.schema.ts
@@ -12,13 +12,10 @@ export const CreateCertificateSchema = object({
 
 export const UpdateCertificateSchema = object().shape(
   {
-    certificate: string().when(['type', 'key'], {
-      is: (type: string, key: string) => type === 'downstream' && key,
-      then: string().required('Certificate is required'),
-    }),
+    certificate: string(),
     key: string().when(['type', 'certificate'], {
       is: (type: string, certificate: string) =>
-        type === 'downstream' && certificate,
+        undefined && type === 'downstream' && certificate, // This doesn't actually work, though
       then: string().required('Private Key is required'),
     }),
     label: string(),


### PR DESCRIPTION
## Description 📝
Add an edit drawer for AGLB certificates.

## Major Changes 🔄
- Creates the Edit Certificate drawer with dynamic fields depending on certificate type
- Adds the useLoadBalancerCertificateMutation
- Adds a unit test for `EditCertificateDrawer` component
- Updates the MSW `PUT` endpoint for `*/v4beta/aglb/:id/certificates/:certId` to return a `downstream` cert in addition to the existing `ca` certs.

## Preview 📷
| Service Target Certificates  | TLS Certificates   |
| ------- | ------- |
|  ![Screenshot 2023-10-05 at 3 30 54 PM](https://github.com/linode/manager/assets/114685994/8a9f3bf7-d7e3-4d1c-83d9-5c702f2a4683) | ![Screenshot 2023-10-05 at 3 30 38 PM](https://github.com/linode/manager/assets/114685994/8bc5e7e0-6c44-48d3-b742-874ba2526012) |

## How to test 🧪
1. **How to setup test environment?**
- Check out this PR.
- `yarn dev`
- Ensure AGLB feature flag is **on** and MSW is **enabled**.
2. **How to verify changes?**
- Go to http://localhost:3000/loadbalancers/0/certificates/downstream.
- Click on the Edit button in the action menu of the `tls-certificate`. Confirm that the edit drawer matches the mocks above for a TLS certificate.
- Click on the Edit button in the action menu of any other certificate (they're all of type `ca`). Confirm that the edit drawer matches the mocks above for a Service Target certificate.
- Confirm that a `PUT` request is sent by the MSW when the Update Certificate button is clicked.
- Confirm that no `PUT` request is sent by the MSW when the drawer is Canceled or closed out of.
- Confirm form validation:
   - If a user edits the `label` of either certificate type, the form submits without error.
   - If a user edits the `certificate` of a Service Target (`ca`) cert, the form submits without error.
   -  If a user edits the `certificate` of a TLS (`downstream`) cert and submits without a key, they should receive a validation error upon submission  indicating `Private Key is required` in that case.
4. **How to run Unit or E2E tests?**
Unit:
```
yarn test EditCertificateDrawer
```
E2E:
Will be completed in M3-7134, since there was an existing ticket created for this.