### PR TITLE
Feat: [M3-7195] - Marketplace OCA loading pattern POC

### DIFF
--- a/packages/manager/.changeset/pr-9724-tech-stories-1695847434977.md
+++ b/packages/manager/.changeset/pr-9724-tech-stories-1695847434977.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Improve loading patterns on Marketplace page ([#9724](https://github.com/linode/manager/pull/9724))

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -84,7 +84,6 @@ export const PrimaryNav = (props: Props) => {
   const location = useLocation();
 
   const [enableObjectPrefetch, setEnableObjectPrefetch] = React.useState(false);
-
   const [
     enableMarketplacePrefetch,
     setEnableMarketplacePrefetch,
@@ -92,11 +91,7 @@ export const PrimaryNav = (props: Props) => {
 
   const { _isManagedAccount, account } = useAccountManagement();
 
-  const {
-    data: oneClickApps,
-    error: oneClickAppsError,
-    isLoading: oneClickAppsLoading,
-  } = useStackScriptsOCA(enableMarketplacePrefetch);
+  const { prefetchStackScriptsOCA } = useStackScriptsOCA();
 
   const {
     data: clusters,
@@ -117,9 +112,6 @@ export const PrimaryNav = (props: Props) => {
     !bucketsLoading &&
     !clustersError &&
     !bucketsError;
-
-  const allowMarketplacePrefetch =
-    !oneClickApps && !oneClickAppsLoading && !oneClickAppsError;
 
   const showDatabases = isFeatureEnabled(
     'Managed Databases',
@@ -144,6 +136,12 @@ export const PrimaryNav = (props: Props) => {
       setEnableMarketplacePrefetch(true);
     }
   };
+
+  React.useEffect(() => {
+    if (enableMarketplacePrefetch) {
+      prefetchStackScriptsOCA();
+    }
+  }, [enableMarketplacePrefetch, prefetchStackScriptsOCA]);
 
   const primaryLinkGroups: PrimaryLink[][] = React.useMemo(
     () => [
@@ -248,7 +246,7 @@ export const PrimaryNav = (props: Props) => {
           display: 'Marketplace',
           href: '/linodes/create?type=One-Click',
           icon: <OCA />,
-          prefetchRequestCondition: allowMarketplacePrefetch,
+          prefetchRequestCondition: true,
           prefetchRequestFn: prefetchMarketplace,
         },
       ],
@@ -276,7 +274,6 @@ export const PrimaryNav = (props: Props) => {
       showDatabases,
       _isManagedAccount,
       allowObjPrefetch,
-      allowMarketplacePrefetch,
       flags.databaseBeta,
       flags.aglb,
       showVPCs,

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -84,6 +84,7 @@ export const PrimaryNav = (props: Props) => {
   const location = useLocation();
 
   const [enableObjectPrefetch, setEnableObjectPrefetch] = React.useState(false);
+
   const [
     enableMarketplacePrefetch,
     setEnableMarketplacePrefetch,
@@ -91,7 +92,11 @@ export const PrimaryNav = (props: Props) => {
 
   const { _isManagedAccount, account } = useAccountManagement();
 
-  const { prefetchStackScriptsOCA } = useStackScriptsOCA();
+  const {
+    data: oneClickApps,
+    error: oneClickAppsError,
+    isLoading: oneClickAppsLoading,
+  } = useStackScriptsOCA(enableMarketplacePrefetch);
 
   const {
     data: clusters,
@@ -112,6 +117,9 @@ export const PrimaryNav = (props: Props) => {
     !bucketsLoading &&
     !clustersError &&
     !bucketsError;
+
+  const allowMarketplacePrefetch =
+    !oneClickApps && !oneClickAppsLoading && !oneClickAppsError;
 
   const showDatabases = isFeatureEnabled(
     'Managed Databases',
@@ -136,12 +144,6 @@ export const PrimaryNav = (props: Props) => {
       setEnableMarketplacePrefetch(true);
     }
   };
-
-  React.useEffect(() => {
-    if (enableMarketplacePrefetch) {
-      prefetchStackScriptsOCA();
-    }
-  }, [enableMarketplacePrefetch, prefetchStackScriptsOCA]);
 
   const primaryLinkGroups: PrimaryLink[][] = React.useMemo(
     () => [
@@ -246,7 +248,7 @@ export const PrimaryNav = (props: Props) => {
           display: 'Marketplace',
           href: '/linodes/create?type=One-Click',
           icon: <OCA />,
-          prefetchRequestCondition: true,
+          prefetchRequestCondition: allowMarketplacePrefetch,
           prefetchRequestFn: prefetchMarketplace,
         },
       ],
@@ -274,6 +276,7 @@ export const PrimaryNav = (props: Props) => {
       showDatabases,
       _isManagedAccount,
       allowObjPrefetch,
+      allowMarketplacePrefetch,
       flags.databaseBeta,
       flags.aglb,
       showVPCs,

--- a/packages/manager/src/features/Linodes/LinodesCreate/LoadingAppPanelSection.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LoadingAppPanelSection.tsx
@@ -1,0 +1,51 @@
+import Grid from '@mui/material/Unstable_Grid2';
+import { styled } from '@mui/material/styles';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import * as React from 'react';
+
+import { Divider } from 'src/components/Divider';
+import { Skeleton } from 'src/components/Skeleton';
+import { Typography } from 'src/components/Typography';
+
+interface Props {
+  desktopCount: number;
+  heading: string;
+  mobileCount: number;
+}
+
+export const LoadingAppPanelSection = (props: Props) => {
+  const { desktopCount, heading, mobileCount } = props;
+  const theme = useTheme();
+  const matchesSmDown = useMediaQuery(theme.breakpoints.down('md'));
+  const count = matchesSmDown ? mobileCount : desktopCount;
+
+  return (
+    <>
+      <Typography variant="h2">{heading}</Typography>
+      <Divider spacingBottom={16} spacingTop={16} />
+      <AppPanelGrid container spacing={2}>
+        {Array(count)
+          .fill(0)
+          .map((_, idx) => (
+            <Grid key={idx} md={4} sm={6} xs={12}>
+              <StyledSkeleton />
+            </Grid>
+          ))}
+      </AppPanelGrid>
+    </>
+  );
+};
+
+const AppPanelGrid = styled(Grid)(({ theme }) => ({
+  marginBottom: theme.spacing(),
+  marginTop: theme.spacing(2),
+  padding: `${theme.spacing(1)} 0`,
+}));
+
+const StyledSkeleton = styled(Skeleton, {
+  label: 'StyledSkeleton',
+})(({ theme }) => ({
+  height: 60,
+  transform: 'none',
+}));

--- a/packages/manager/src/features/Linodes/LinodesCreate/SelectAppPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/SelectAppPanel.tsx
@@ -4,12 +4,12 @@ import * as React from 'react';
 import { compose } from 'recompose';
 
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
-import { LandingLoading } from 'src/components/LandingLoading/LandingLoading';
 import { Notice } from 'src/components/Notice/Notice';
 import { Paper } from 'src/components/Paper';
 import { AppPanelSection } from 'src/features/Linodes/LinodesCreate/AppPanelSection';
 import { getQueryParamFromQueryString } from 'src/utilities/queryParams';
 
+import { LoadingAppPanelSection } from './LoadingAppPanelSection';
 import { Panel } from './Panel';
 import { AppsData } from './types';
 
@@ -68,12 +68,25 @@ class SelectAppPanel extends React.PureComponent<Props> {
     }
 
     if (appInstancesLoading || !appInstances) {
+      // if (true === true) {
       return (
-        <StyledPanel error={error} title="Select App">
-          <StyledLoadingSpan>
-            <LandingLoading />
-          </StyledLoadingSpan>
-        </StyledPanel>
+        <StyledPaper error={error} title="Select App">
+          <LoadingAppPanelSection
+            desktopCount={3}
+            heading="New apps"
+            mobileCount={2}
+          />
+          <LoadingAppPanelSection
+            desktopCount={6}
+            heading="Popular apps"
+            mobileCount={4}
+          />
+          <LoadingAppPanelSection
+            desktopCount={9}
+            heading="All apps"
+            mobileCount={6}
+          />
+        </StyledPaper>
       );
     }
 
@@ -190,11 +203,5 @@ const StyledPanel = styled(Panel, { label: 'StyledPanel' })(({ theme }) => ({
 const StyledPaper = styled(Paper, { label: 'StyledPaper' })(({ theme }) => ({
   ...commonStyling(theme),
 }));
-
-const StyledLoadingSpan = styled('span', { label: 'StyledLoadingSpan' })({
-  '& >div:first-of-type': {
-    height: 450,
-  },
-});
 
 export default compose<Props, Props>(React.memo)(SelectAppPanel);

--- a/packages/manager/src/features/Linodes/LinodesCreate/SelectAppPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/SelectAppPanel.tsx
@@ -13,6 +13,10 @@ import { LoadingAppPanelSection } from './LoadingAppPanelSection';
 import { Panel } from './Panel';
 import { AppsData } from './types';
 
+const NEW_APPS_HEADER = 'New apps';
+const POPULAR_APPS_HEADER = 'Popular apps';
+const ALL_APPS_HEADER = 'All apps';
+
 interface Props extends AppsData {
   disabled: boolean;
   error?: string;
@@ -68,22 +72,21 @@ class SelectAppPanel extends React.PureComponent<Props> {
     }
 
     if (appInstancesLoading || !appInstances) {
-      // if (true === true) {
       return (
         <StyledPaper error={error} title="Select App">
           <LoadingAppPanelSection
             desktopCount={3}
-            heading="New apps"
+            heading={NEW_APPS_HEADER}
             mobileCount={2}
           />
           <LoadingAppPanelSection
             desktopCount={6}
-            heading="Popular apps"
+            heading={POPULAR_APPS_HEADER}
             mobileCount={4}
           />
           <LoadingAppPanelSection
             desktopCount={9}
-            heading="All apps"
+            heading={ALL_APPS_HEADER}
             mobileCount={6}
           />
         </StyledPaper>
@@ -118,7 +121,7 @@ class SelectAppPanel extends React.PureComponent<Props> {
             apps={newApps}
             disabled={disabled}
             handleClick={handleClick}
-            heading="New apps"
+            heading={NEW_APPS_HEADER}
             openDrawer={openDrawer}
             selectedStackScriptID={selectedStackScriptID}
           />
@@ -128,7 +131,7 @@ class SelectAppPanel extends React.PureComponent<Props> {
             apps={popularApps}
             disabled={disabled}
             handleClick={handleClick}
-            heading="Popular apps"
+            heading={POPULAR_APPS_HEADER}
             openDrawer={openDrawer}
             selectedStackScriptID={selectedStackScriptID}
           />
@@ -137,7 +140,7 @@ class SelectAppPanel extends React.PureComponent<Props> {
           apps={allApps}
           disabled={disabled}
           handleClick={handleClick}
-          heading={isFilteringOrSearching ? '' : 'All apps'}
+          heading={isFilteringOrSearching ? '' : ALL_APPS_HEADER}
           openDrawer={openDrawer}
           searchValue={searchValue}
           selectedStackScriptID={selectedStackScriptID}

--- a/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -229,6 +229,7 @@ export class FromAppsContent extends React.Component<CombinedProps, State> {
                       ? {
                           endAdornment: (
                             <IconButton
+                              aria-label="Clear search"
                               onClick={handleClearSearch}
                               sx={{ padding: '2px 4px' }}
                             >
@@ -431,8 +432,8 @@ export class FromAppsContent extends React.Component<CombinedProps, State> {
     });
   };
 
-  //
-  percentageCounter = initializePercentageCounter(7000);
+  // Based on average API response time
+  percentageCounter = initializePercentageCounter(8000);
 
   state: State = {
     categoryFilter: null,

--- a/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -1,14 +1,15 @@
 import { Image } from '@linode/api-v4/lib/images';
 import { StackScript, UserDefinedField } from '@linode/api-v4/lib/stackscripts';
-import { styled } from '@mui/material/styles';
+import Close from '@mui/icons-material/Close';
+import Grid from '@mui/material/Unstable_Grid2';
 import compact from 'lodash/compact';
 import curry from 'lodash/curry';
 import { assocPath } from 'ramda';
 import * as React from 'react';
 
-import { Box } from 'src/components/Box';
 import { DebouncedSearchTextField } from 'src/components/DebouncedSearchTextField';
 import Select, { Item } from 'src/components/EnhancedSelect';
+import { IconButton } from 'src/components/IconButton';
 import { ImageSelect } from 'src/components/ImageSelect/ImageSelect';
 import { Paper } from 'src/components/Paper';
 import { Typography } from 'src/components/Typography';
@@ -178,6 +179,13 @@ export class FromAppsContent extends React.Component<CombinedProps, State> {
       sendMarketplaceSearchEvent('Search Field');
     };
 
+    const handleClearSearch = () => {
+      this.setState({
+        isSearching: false,
+        query: '',
+      });
+    };
+
     const logoUrl = appInstances?.find(
       (app) => app.id === selectedStackScriptID
     )?.logo_url;
@@ -200,9 +208,36 @@ export class FromAppsContent extends React.Component<CombinedProps, State> {
         <StyledGrid>
           <Paper>
             <Typography variant="h2">Select an App</Typography>
-            <StyledSearchFilterBox>
-              <StyledSearchBox>
+            <Grid
+              sx={{
+                marginTop: 0.5,
+              }}
+              container
+              spacing={2}
+            >
+              <Grid
+                sx={{
+                  '& .MuiInputBase-root': {
+                    maxWidth: '100%',
+                  },
+                  flexGrow: 1,
+                }}
+              >
                 <DebouncedSearchTextField
+                  InputProps={
+                    isSearching
+                      ? {
+                          endAdornment: (
+                            <IconButton
+                              onClick={handleClearSearch}
+                              sx={{ padding: '2px 4px' }}
+                            >
+                              <Close />
+                            </IconButton>
+                          ),
+                        }
+                      : undefined
+                  }
                   placeholder={
                     appInstancesLoading
                       ? `Loading... ${percentageCounter.toFixed(0)}%`
@@ -211,6 +246,9 @@ export class FromAppsContent extends React.Component<CombinedProps, State> {
                   sx={
                     appInstancesLoading
                       ? {
+                          '& .MuiInput-input::placeholder': {
+                            opacity: 1,
+                          },
                           '& input': {
                             cursor: 'not-allowed',
                           },
@@ -220,6 +258,7 @@ export class FromAppsContent extends React.Component<CombinedProps, State> {
                         }
                       : null
                   }
+                  debounceTime={250}
                   disabled={appInstancesLoading}
                   fullWidth
                   hideLabel
@@ -228,8 +267,8 @@ export class FromAppsContent extends React.Component<CombinedProps, State> {
                   onSearch={this.onSearch}
                   value={query}
                 />
-              </StyledSearchBox>
-              <StyledFilterBox>
+              </Grid>
+              <Grid sx={{ minWidth: 225 }}>
                 <Select
                   placeholder={
                     appInstancesLoading ? 'Loading...' : 'Select category'
@@ -241,8 +280,8 @@ export class FromAppsContent extends React.Component<CombinedProps, State> {
                   options={appCategoryOptions}
                   value={categoryFilter}
                 />
-              </StyledFilterBox>
-            </StyledSearchFilterBox>
+              </Grid>
+            </Grid>
           </Paper>
           <SelectAppPanel
             appInstances={
@@ -392,7 +431,8 @@ export class FromAppsContent extends React.Component<CombinedProps, State> {
     });
   };
 
-  percentageCounter = initializePercentageCounter(6000);
+  //
+  percentageCounter = initializePercentageCounter(7000);
 
   state: State = {
     categoryFilter: null,
@@ -409,26 +449,3 @@ export class FromAppsContent extends React.Component<CombinedProps, State> {
     this.setState({ percentageCounter: newPercentage });
   };
 }
-
-const StyledSearchFilterBox = styled(Box, { label: 'StyledSearchFilterBox' })(
-  ({ theme }) => ({
-    '& > h2': {
-      width: '100%',
-    },
-    display: 'flex',
-    gap: theme.spacing(),
-    justifyContent: 'space-between',
-    marginTop: theme.spacing(),
-  })
-);
-
-const StyledFilterBox = styled(Box, { label: 'StyledFilterBox' })({
-  flexGrow: 1.5,
-});
-
-const StyledSearchBox = styled(Box, { label: 'StyledSearchBox' })({
-  '& .input': {
-    maxWidth: 'none',
-  },
-  flexGrow: 10,
-});

--- a/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -10,8 +10,8 @@ import { Box } from 'src/components/Box';
 import { DebouncedSearchTextField } from 'src/components/DebouncedSearchTextField';
 import Select, { Item } from 'src/components/EnhancedSelect';
 import { ImageSelect } from 'src/components/ImageSelect/ImageSelect';
-import { Typography } from 'src/components/Typography';
 import { Paper } from 'src/components/Paper';
+import { Typography } from 'src/components/Typography';
 import { APP_ROOT } from 'src/constants';
 import { ImageEmptyState } from 'src/features/Linodes/LinodesCreate/TabbedContent/ImageEmptyState';
 import { AppDetailDrawer } from 'src/features/OneClickApps';
@@ -22,6 +22,7 @@ import {
 import UserDefinedFieldsPanel from 'src/features/StackScripts/UserDefinedFieldsPanel';
 import { sendMarketplaceSearchEvent } from 'src/utilities/analytics';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
+import { initializePercentageCounter } from 'src/utilities/percentageCounter';
 
 import SelectAppPanel from '../SelectAppPanel';
 import {
@@ -30,8 +31,8 @@ import {
   StackScriptFormStateHandlers,
   WithTypesRegionsAndImages,
 } from '../types';
-import { filterUDFErrors } from './formUtilities';
 import { StyledGrid } from './CommonTabbedContent.styles';
+import { filterUDFErrors } from './formUtilities';
 
 const appCategories = [
   'Control Panels',
@@ -80,6 +81,7 @@ interface State {
   filteredApps: CombinedProps['appInstances'];
   isFiltering: boolean;
   isSearching: boolean;
+  percentageCounter: number;
   query: string;
   selectedScriptForDrawer: string;
 }
@@ -136,6 +138,14 @@ const renderLogo = (selectedStackScriptLabel?: string, logoUrl?: string) => {
 const curriedHandleSelectStackScript = curry(handleSelectStackScript);
 
 export class FromAppsContent extends React.Component<CombinedProps, State> {
+  componentDidMount() {
+    this.percentageCounter.startAnimation(this.updatePercentage);
+  }
+
+  componentWillUnmount() {
+    this.percentageCounter.stopAnimation();
+  }
+
   render() {
     const {
       appInstances,
@@ -179,6 +189,7 @@ export class FromAppsContent extends React.Component<CombinedProps, State> {
       filteredApps,
       isFiltering,
       isSearching,
+      percentageCounter,
       query,
     } = this.state;
 
@@ -193,7 +204,9 @@ export class FromAppsContent extends React.Component<CombinedProps, State> {
               <StyledSearchBox>
                 <DebouncedSearchTextField
                   placeholder={
-                    appInstancesLoading ? 'Loading...' : 'Search for app name'
+                    appInstancesLoading
+                      ? `Loading... ${percentageCounter.toFixed(0)}%`
+                      : 'Search for app name'
                   }
                   sx={
                     appInstancesLoading
@@ -379,14 +392,21 @@ export class FromAppsContent extends React.Component<CombinedProps, State> {
     });
   };
 
+  percentageCounter = initializePercentageCounter(6000);
+
   state: State = {
     categoryFilter: null,
     detailDrawerOpen: false,
     filteredApps: [],
     isFiltering: false,
     isSearching: false,
+    percentageCounter: 0,
     query: '',
     selectedScriptForDrawer: '',
+  };
+
+  updatePercentage = (newPercentage: number) => {
+    this.setState({ percentageCounter: newPercentage });
   };
 }
 

--- a/packages/manager/src/queries/stackscripts.ts
+++ b/packages/manager/src/queries/stackscripts.ts
@@ -1,6 +1,6 @@
 import { StackScript } from '@linode/api-v4/lib/stackscripts';
 import { APIError, Params } from '@linode/api-v4/lib/types';
-import { useQuery } from 'react-query';
+import { useQueryClient } from 'react-query';
 
 import { getOneClickApps } from 'src/features/StackScripts/stackScriptUtils';
 import { getAll } from 'src/utilities/getAll';
@@ -9,15 +9,22 @@ import { queryPresets } from './base';
 
 export const queryKey = 'stackscripts';
 
-export const useStackScriptsOCA = (enabled: boolean, params: Params = {}) => {
-  return useQuery<StackScript[], APIError[]>(
-    [`${queryKey}-oca-all`, params],
-    () => getAllOCAsRequest(params),
-    {
-      enabled,
-      ...queryPresets.oneTimeFetch,
-    }
-  );
+export const useStackScriptsOCA = (params: Params = {}) => {
+  const queryClient = useQueryClient();
+
+  const prefetchStackScriptsOCA = async () => {
+    await queryClient.prefetchQuery<StackScript[], APIError[]>(
+      `${queryKey}-oca-all`,
+      () => getAllOCAsRequest(params),
+      {
+        ...queryPresets.oneTimeFetch,
+      }
+    );
+  };
+
+  return {
+    prefetchStackScriptsOCA,
+  };
 };
 
 export const getAllOCAsRequest = (passedParams: Params = {}) =>

--- a/packages/manager/src/queries/stackscripts.ts
+++ b/packages/manager/src/queries/stackscripts.ts
@@ -11,7 +11,7 @@ export const queryKey = 'stackscripts';
 
 export const useStackScriptsOCA = (enabled: boolean, params: Params = {}) => {
   return useQuery<StackScript[], APIError[]>(
-    [`${queryKey}-oca-all`, params],
+    `${queryKey}-oca-all`,
     () => getAllOCAsRequest(params),
     {
       enabled,

--- a/packages/manager/src/queries/stackscripts.ts
+++ b/packages/manager/src/queries/stackscripts.ts
@@ -1,6 +1,6 @@
 import { StackScript } from '@linode/api-v4/lib/stackscripts';
 import { APIError, Params } from '@linode/api-v4/lib/types';
-import { useQueryClient } from 'react-query';
+import { useQuery } from 'react-query';
 
 import { getOneClickApps } from 'src/features/StackScripts/stackScriptUtils';
 import { getAll } from 'src/utilities/getAll';
@@ -9,22 +9,15 @@ import { queryPresets } from './base';
 
 export const queryKey = 'stackscripts';
 
-export const useStackScriptsOCA = (params: Params = {}) => {
-  const queryClient = useQueryClient();
-
-  const prefetchStackScriptsOCA = async () => {
-    await queryClient.prefetchQuery<StackScript[], APIError[]>(
-      `${queryKey}-oca-all`,
-      () => getAllOCAsRequest(params),
-      {
-        ...queryPresets.oneTimeFetch,
-      }
-    );
-  };
-
-  return {
-    prefetchStackScriptsOCA,
-  };
+export const useStackScriptsOCA = (enabled: boolean, params: Params = {}) => {
+  return useQuery<StackScript[], APIError[]>(
+    [`${queryKey}-oca-all`, params],
+    () => getAllOCAsRequest(params),
+    {
+      enabled,
+      ...queryPresets.oneTimeFetch,
+    }
+  );
 };
 
 export const getAllOCAsRequest = (passedParams: Params = {}) =>

--- a/packages/manager/src/utilities/percentageCounter.test.ts
+++ b/packages/manager/src/utilities/percentageCounter.test.ts
@@ -1,0 +1,85 @@
+import { initializePercentageCounter } from './percentageCounter';
+
+describe('initializePercentageCounter', () => {
+  let animationFrameSpy: jest.SpyInstance<number, [FrameRequestCallback]>;
+  let cancelAnimationFrameSpy: jest.SpyInstance<void, [number]>;
+  let requestAnimationFrameSpy: jest.SpyInstance<
+    number,
+    [FrameRequestCallback]
+  >;
+
+  beforeEach(() => {
+    animationFrameSpy = jest.spyOn(window, 'requestAnimationFrame');
+    cancelAnimationFrameSpy = jest.spyOn(window, 'cancelAnimationFrame');
+    requestAnimationFrameSpy = jest.spyOn(window, 'requestAnimationFrame');
+  });
+
+  afterEach(() => {
+    animationFrameSpy.mockRestore();
+    cancelAnimationFrameSpy.mockRestore();
+    requestAnimationFrameSpy.mockRestore();
+  });
+
+  it('should start and stop animation correctly', () => {
+    const duration = 2000;
+    const onUpdateMock = jest.fn();
+
+    const { startAnimation, stopAnimation } = initializePercentageCounter(
+      duration
+    );
+
+    // Start animation
+    startAnimation(onUpdateMock);
+
+    // Ensure requestAnimationFrame was called
+    expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1);
+
+    // Manually trigger the animation frame callback
+    const frameCallback = requestAnimationFrameSpy.mock.calls[0][0];
+    frameCallback(performance.now()); // Simulate a frame update
+
+    // Check if onUpdate was called with an updated percentage
+    expect(onUpdateMock).toHaveBeenCalledWith(expect.any(Number));
+
+    // Stop animation
+    stopAnimation();
+
+    // Ensure cancelAnimationFrame was called
+    expect(cancelAnimationFrameSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not exceed 99% during animation', () => {
+    const duration = 10000; // 10 seconds
+    const onUpdateMock = jest.fn();
+
+    const { startAnimation, stopAnimation } = initializePercentageCounter(
+      duration
+    );
+
+    // Start animation
+    startAnimation(onUpdateMock);
+
+    // Manually trigger the animation frame callback for the entire duration
+    const frameCallback = requestAnimationFrameSpy.mock.calls[0][0];
+    for (let time = 0; time < duration; time += 1000) {
+      frameCallback(performance.now() + time); // Simulate frame updates
+    }
+
+    // Ensure percentage never exceeded 99
+    expect(onUpdateMock).toHaveBeenCalledTimes(10);
+    onUpdateMock.mock.calls.forEach(([percentage]) => {
+      expect(percentage).toBeLessThanOrEqual(99);
+    });
+
+    // Stop animation
+    stopAnimation();
+  });
+});
+
+beforeAll(() => {
+  jest.useFakeTimers();
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});

--- a/packages/manager/src/utilities/percentageCounter.ts
+++ b/packages/manager/src/utilities/percentageCounter.ts
@@ -1,0 +1,33 @@
+export const initializePercentageCounter = (duration: number) => {
+  let startTimestamp: number;
+  let animationFrameId: number;
+  let percentage: number = 0;
+  let onUpdate: (percentage: number) => void;
+
+  const animatePercentage = (timestamp: number) => {
+    if (!startTimestamp) {
+      startTimestamp = timestamp;
+    }
+
+    const progress = timestamp - startTimestamp;
+    percentage = Math.min(100, (progress / duration) * 100);
+    onUpdate(percentage);
+
+    if (percentage < 100) {
+      animationFrameId = requestAnimationFrame(animatePercentage);
+    }
+  };
+
+  const startAnimation = (updateCallback: (percentage: number) => void) => {
+    onUpdate = updateCallback;
+    animationFrameId = requestAnimationFrame(animatePercentage);
+  };
+
+  const stopAnimation = () => {
+    if (animationFrameId) {
+      cancelAnimationFrame(animationFrameId);
+    }
+  };
+
+  return { startAnimation, stopAnimation };
+};

--- a/packages/manager/src/utilities/percentageCounter.ts
+++ b/packages/manager/src/utilities/percentageCounter.ts
@@ -1,3 +1,19 @@
+/**
+ * This function provides a mechanism to display a percentage based progress.
+ * It helps the user with a better visual indication that an action is still processing.
+ * It could be used for instance to display a percentage progress or fill a progress bar.
+ *
+ * It accepts an arbitrary timer, based on a either a time based action or an estimation a task may take.
+ *
+ * In the case of an API request, it should only be used for requests that takes a long time, such as One Click Apps StackScripts.
+ * The idea behind it is that if the request takes shorter than the timer, then great, otherwise it may stay at 99% a tad longer till resolved.
+ * In this case it is purely an approximate visual aid.
+ *
+ * For the purpose of it being versatile, it avoids hooks so it can be used in any component.
+ *
+ * @param duration {number}
+ * @returns {startAnimation, stopAnimation}
+ */
 export const initializePercentageCounter = (duration: number) => {
   let startTimestamp: number;
   let animationFrameId: number;
@@ -10,10 +26,15 @@ export const initializePercentageCounter = (duration: number) => {
     }
 
     const progress = timestamp - startTimestamp;
-    percentage = Math.min(100, (progress / duration) * 100);
+    // Here we're upping the percentage to 99 max
+    // It provides an indication the request isn't fully complete
+    // Since it's an arbitrary timer, we don't want to show 100% while not complete
+    // It will appear "Stuck" at 99% till resolved
+    const stopAtPercentage = 99;
+    percentage = Math.min(stopAtPercentage, (progress / duration) * 100);
     onUpdate(percentage);
 
-    if (percentage < 100) {
+    if (percentage < stopAtPercentage) {
       animationFrameId = requestAnimationFrame(animatePercentage);
     }
   };


### PR DESCRIPTION
## Description 📝
As a follow up to https://github.com/linode/manager/pull/9704, I noticed a few issues and room for improving the visual loading pattern (long query, prefetching issue, multiple circular loaders).

Apart from the prefetching issue, this PR offers improvements as a proof of concept to visually help the user while the page is loading. Those changes will be submitted to UX as well for approval.

## Major Changes 🔄
- Fixes the prefetching pattern from the navbar (was fetching twice: once from menu entry hover prefetch, twice when navigating to the page). There should be only one request.
- Adds a clearable field to the App Search textfield. Small improvement but mirror the Category selection next to it and makes it easier to get the full list back
- Replace the second circular loading pattern with our skeleton loader (App grid). Two circular loaders is not very friendly and seems to indicate something is wrong. Using the skeletons helps pre-shaping the content while announcing categories early (previously obfuscated by the loader)
- Adds a "fake" loading percentage to the search bar. This is more the POC part. The code is commented but the gist of it is to provide an indication to the user this request will take longer (it is an anomaly within CM). While not being based on a true API roundtrip, I believe it to be helpful and potentially relieve some frustration waiting for the request to complete. All in all it is an inoffensive distraction pattern. The value of the counter is based on an average API response time. Note: whatever we do with it the util could be useful for other purposes. 

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-09-27 at 16 03 55](https://github.com/linode/manager/assets/130582365/55dc6236-6dce-4a20-a648-6cf5ec9ade65) | ![Screenshot 2023-09-27 at 16 06 08](https://github.com/linode/manager/assets/130582365/3208f2cf-0364-4bdb-b1e9-69970ee20212) |

## How to test 🧪
**Requisites**: pull code locally

**Refetching fix**
1. While you network console is open (and use a XHR "strackscript" filter), navigate to /linodes - should notice no request
2. Hover "Marketplace" - notice one request
3. Click on "Marketplace" - notice no new request
4. Reload Marketplace page - notice one request
5. Navigate through site and come back to Marketplace - no new request and data should be loaded immediately
6. You can also verify other scenari: hover over item for 4s then click, request should take about half time when landing on the marketplace page

**Compare this behaviours with production and confirm fix + no regression**

**Visual fixes**
1. Use search and confirm filtering and clearing filtering
2. Assert percentage count is not too far off (it may be if on a very slow connection)
3. Confirm experience is isn't degraded, if not bettered by these changes


