### PR TITLE
fix: [M3-7191] - Missing primary and secondary action button labels in Delete SSH Key dialog and Clone Domain drawer

### DIFF
--- a/packages/manager/.changeset/pr-9726-fixed-1695827222025.md
+++ b/packages/manager/.changeset/pr-9726-fixed-1695827222025.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Missing button labels in Delete SSH Key dialog and Clone Domain drawer ([#9726](https://github.com/linode/manager/pull/9726))

--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.test.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.test.tsx
@@ -16,7 +16,10 @@ describe('ActionsPanel', () => {
   it('should render render primary button when primaryButtonProps are passed', () => {
     renderWithTheme(
       <ActionsPanel
-        primaryButtonProps={{ 'data-testid': primaryButtonTestId }}
+        primaryButtonProps={{
+          'data-testid': primaryButtonTestId,
+          label: 'Submit',
+        }}
       />
     );
     expect(screen.getByTestId(primaryButtonTestId)).toBeInTheDocument();
@@ -30,13 +33,16 @@ describe('ActionsPanel', () => {
   it('should render secondary button when secondaryButtonProps are passed', () => {
     renderWithTheme(
       <ActionsPanel
-        secondaryButtonProps={{ 'data-testid': secondaryButtonTestId }}
+        secondaryButtonProps={{
+          'data-testid': secondaryButtonTestId,
+          label: 'Cancel',
+        }}
       />
     );
     expect(screen.getByTestId(secondaryButtonTestId)).toBeInTheDocument();
   });
 
-  it('should not render secondary button when  secondaryButtonProps are not passed', () => {
+  it('should not render secondary button when secondaryButtonProps are not passed', () => {
     renderWithTheme(<ActionsPanel secondaryButtonProps={undefined} />);
     expect(screen.queryByTestId(secondaryButtonTestId)).not.toBeInTheDocument();
   });
@@ -47,6 +53,7 @@ describe('ActionsPanel', () => {
       <ActionsPanel
         primaryButtonProps={{
           'data-testid': primaryButtonTestId,
+          label: 'Submit',
           onClick: mockHandler,
         }}
       />
@@ -61,6 +68,7 @@ describe('ActionsPanel', () => {
       <ActionsPanel
         secondaryButtonProps={{
           'data-testid': secondaryButtonTestId,
+          label: 'Cancel',
           onClick: mockHandler,
         }}
       />

--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -10,7 +10,7 @@ import { Box, BoxProps } from '../Box';
 interface ActionButtonsProps extends ButtonProps {
   'data-node-idx'?: number;
   'data-testid'?: string;
-  label?: string;
+  label: string;
 }
 
 interface ActionPanelProps extends BoxProps {
@@ -50,7 +50,7 @@ const ActionsPanelComponent = (props: ActionPanelProps) => {
           data-qa-cancel
           {...secondaryButtonProps}
         >
-          {secondaryButtonProps?.label}
+          {secondaryButtonProps.label}
         </Button>
       ) : null}
       {primaryButtonProps ? (
@@ -59,7 +59,7 @@ const ActionsPanelComponent = (props: ActionPanelProps) => {
           buttonType="primary"
           {...primaryButtonProps}
         >
-          {primaryButtonProps?.label}
+          {primaryButtonProps.label}
         </Button>
       ) : null}
     </StyledBox>

--- a/packages/manager/src/features/Domains/CloneDomainDrawer.tsx
+++ b/packages/manager/src/features/Domains/CloneDomainDrawer.tsx
@@ -97,7 +97,11 @@ export const CloneDomainDrawer = (props: CloneDomainDrawerProps) => {
             loading: formik.isSubmitting,
             type: 'submit',
           }}
-          secondaryButtonProps={{ 'data-testid': 'cancel', onClick: onClose }}
+          secondaryButtonProps={{
+            'data-testid': 'cancel',
+            label: 'Cancel',
+            onClick: onClose,
+          }}
         />
       </form>
     </Drawer>

--- a/packages/manager/src/features/Profile/SSHKeys/DeleteSSHKeyDialog.test.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/DeleteSSHKeyDialog.test.tsx
@@ -1,0 +1,68 @@
+import { act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+
+import { rest, server } from 'src/mocks/testServer';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import DeleteSSHKeyDialog from './DeleteSSHKeyDialog';
+
+const props = {
+  id: 0,
+  onClose: jest.fn(),
+  open: true,
+};
+
+describe('DeleteSSHKeyDialog', () => {
+  it('should display all expected dialog titles, primary, and secondary buttons', async () => {
+    const { getByText } = renderWithTheme(<DeleteSSHKeyDialog {...props} />);
+    // Check for title
+    getByText('Delete SSH Key');
+
+    // Check for buttons
+    getByText('Delete');
+    getByText('Cancel');
+  });
+
+  it('should include the SSH key label when provided', () => {
+    const { getByText } = renderWithTheme(
+      <DeleteSSHKeyDialog {...props} label="my-ssh-key" />
+    );
+
+    getByText(/my-ssh-key/);
+  });
+
+  it('should submit and call onClose', async () => {
+    server.use(
+      rest.delete('*/profile/sshkeys/0', (req, res, ctx) => {
+        return res(ctx.json({}));
+      })
+    );
+
+    const { getByTestId } = renderWithTheme(<DeleteSSHKeyDialog {...props} />);
+
+    const submitButton = getByTestId('confirm-delete');
+
+    act(() => {
+      userEvent.click(submitButton);
+    });
+
+    await waitFor(() => {
+      expect(props.onClose).toBeCalled();
+    });
+  });
+
+  it('should Cancel and call onClose', async () => {
+    const { getByTestId } = renderWithTheme(<DeleteSSHKeyDialog {...props} />);
+
+    const cancelButton = getByTestId('cancel-delete');
+
+    act(() => {
+      userEvent.click(cancelButton);
+    });
+
+    await waitFor(() => {
+      expect(props.onClose).toBeCalled();
+    });
+  });
+});

--- a/packages/manager/src/features/Profile/SSHKeys/DeleteSSHKeyDialog.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/DeleteSSHKeyDialog.tsx
@@ -26,6 +26,7 @@ const DeleteSSHKeyDialog = ({ id, label, onClose, open }: Props) => {
         <ActionsPanel
           primaryButtonProps={{
             'data-testid': 'confirm-delete',
+            label: 'Delete',
             loading: isLoading,
             onClick: onDelete,
           }}


### PR DESCRIPTION
## Description 📝
This PR aimed to fix a bug with a missing button label in the Delete SSH Key dialog and ended up fixing another related bug in the Clone Domain drawer.

## Major Changes 🔄
- Adds the missing `Delete` label to the primary action button in the SSH key delete dialog
- Makes `label` a required, not an optional, prop for `ActionButtonProps`
- Inadvertently fixes another bug, where the `Cancel` button appears invisible in the Clone Domain drawer because it was also missing a label
- Adds unit test for `DeleteSSHKeyDialog` component and updates unit test for `ActionPanel` component.

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/114685994/421f3f63-d72b-493b-b87f-6cfe4ff459d8) | ![image](https://github.com/linode/manager/assets/114685994/f64a99ba-e904-4669-b2d6-910884ced3b1) |
| <video src="https://github.com/linode/manager/assets/114685994/edafc430-bc59-4bff-871c-e03e9992c2fd"/> | <video src="https://github.com/linode/manager/assets/114685994/2458a1b4-da0b-4609-addb-5e61c537dff6" /> |

## How to test 🧪
1. **How to setup test environment?**
- If you do not already have an SSH key on your account, you will need to create one via Profile > `Add an SSH Key`. 
- If you do not already have a domain on your account, you will need to create one via Domains > `Create Domain`. 
- Checkout this PR.
- `yarn dev`
2. **How to reproduce the issue (if applicable)?**
- Go to https://cloud.linode.com/profile/keys.
- Click on the Delete action for your SSH key.
- Observe that the Delete SSH Key dialog will pop up, but it is missing a button label for the primary action button `Delete`.
- Go to https://cloud.linode.com/domains.
- Click on the Clone action for your existing domain.
- Observe in the Clone drawer that the user can hover over the area of the secondary action `Cancel` button and click it to close the drawer, but it is otherwise invisible.
3. **How to verify changes?**
- Go to http://localhost:3000/profile/keys.
- Click on the Delete action for your SSH key.
- Observe that the Delete SSH Key dialog will pop up, and the `Delete` button is labeled accordingly.
- Go to http://localhost:3000/domains.
- Click on the Clone action for your existing domain. 
- Observe in the Clone drawer that a labeled `Cancel` button is visible and clicking it closes the drawer.
4. **How to run Unit or E2E tests?**
```
yarn test DeleteSSHKeyDialog.test.tsx ActionPanel.test.tsx
```