### PR TITLE
fix: [M3-7079] - Resolve "Incomplete string escape or encoding" alert in changeset.mjs

### DIFF
--- a/scripts/changelog/changeset.mjs
+++ b/scripts/changelog/changeset.mjs
@@ -101,7 +101,7 @@ async function generateChangeset() {
 
   try {
     const addCmd = `git add ${changesetFile}`;
-    // escape \ characters in input and allow backticks in commit message 
+    // allow backticks in commit message, making sure to remove \ characters before any backticks  
     const escapedDescription = description.replace(/\\*`/g, "\\`"); 
     const commitCmd = `git commit -m "Added changeset: ${escapedDescription}"`;
     execSync(addCmd);

--- a/scripts/changelog/changeset.mjs
+++ b/scripts/changelog/changeset.mjs
@@ -101,7 +101,8 @@ async function generateChangeset() {
 
   try {
     const addCmd = `git add ${changesetFile}`;
-    const escapedDescription = description.replace(/`/g, "\\`"); // Allow backticks in commit message
+    // I don't know if this would actually get rid of the code quality error though...
+    const escapedDescription = description.replace(/\\/g, '').replace(/`/g, "\\`"); // Allow backticks in commit message
     const commitCmd = `git commit -m "Added changeset: ${escapedDescription}"`;
     execSync(addCmd);
     execSync(commitCmd);

--- a/scripts/changelog/changeset.mjs
+++ b/scripts/changelog/changeset.mjs
@@ -101,8 +101,8 @@ async function generateChangeset() {
 
   try {
     const addCmd = `git add ${changesetFile}`;
-    // First sanitize against any \, then allow backticks in commit message
-    const escapedDescription = description.replace(/\\/g, '').replace(/`/g, "\\`"); 
+    // escape \ characters in input and allow backticks in commit message 
+    const escapedDescription = description.replace(/\\*`/g, "\\`"); 
     const commitCmd = `git commit -m "Added changeset: ${escapedDescription}"`;
     execSync(addCmd);
     execSync(commitCmd);

--- a/scripts/changelog/changeset.mjs
+++ b/scripts/changelog/changeset.mjs
@@ -101,7 +101,9 @@ async function generateChangeset() {
 
   try {
     const addCmd = `git add ${changesetFile}`;
-    // allow backticks in commit message, making sure to remove \ characters before any backticks  
+    // This allows backticks in the commit message. We first need to sanitize against any number of backslashes 
+    // that appear before backtick in description, to avoid having unescaped characters. Then we can add back 
+    // two backslashes before the backtick to make sure backticks show up in the commit message.
     const escapedDescription = description.replace(/\\*`/g, "\\`"); 
     const commitCmd = `git commit -m "Added changeset: ${escapedDescription}"`;
     execSync(addCmd);

--- a/scripts/changelog/changeset.mjs
+++ b/scripts/changelog/changeset.mjs
@@ -101,8 +101,8 @@ async function generateChangeset() {
 
   try {
     const addCmd = `git add ${changesetFile}`;
-    // I don't know if this would actually get rid of the code quality error though...
-    const escapedDescription = description.replace(/\\/g, '').replace(/`/g, "\\`"); // Allow backticks in commit message
+    // First sanitize against any \, then allow backticks in commit message
+    const escapedDescription = description.replace(/\\/g, '').replace(/`/g, "\\`"); 
     const commitCmd = `git commit -m "Added changeset: ${escapedDescription}"`;
     execSync(addCmd);
     execSync(commitCmd);


### PR DESCRIPTION
## Description 📝
Resolve codeQL alert due to not escaping backslashes

## Major Changes 🔄
- Updated regex pattern to check for any number of backslashes before a \` when replacing instances

## Preview 📷

looks like the alert for the changeset script (last alert in the before picture) is gone! (I installed the codeQL extension on VSCode + set it up and ran it). Note: the other alerts aren't part of this PR. They aren't showing up in the Security tab, and seem to be for build files, so I'm unsure if we'll need to create tickets for them (?)

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/139280159/262f0552-19d6-4378-ad64-6b3c87f3421e) | ![image](https://github.com/linode/manager/assets/139280159/08677180-80fd-4496-a11a-0f2989b90d18) |

(this doesn't actually affect the changeset, just the commit message if you're committing the changeset)
![image](https://github.com/linode/manager/assets/139280159/0330e89a-d310-4bed-a7a8-d21a825e422e)
![image](https://github.com/linode/manager/assets/139280159/f16c339c-48e5-492a-a2f4-45bc2a453509)


## How to test 🧪
- If you have the codeQL extension on VSCode, you can set up a codeQL database for the manager repo and run the IncompleteSanitization.ql query (from the [codeql repo](https://github.com/github/codeql) - `javascript >> ql >> src >> Security >> CWE-116 >> IncompleteSanitization.ql`) on the manager database. Instructions for setting up the extension here: https://codeql.github.com/docs/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code/ (+ I also installed the CLI). I found [this guide](https://luisrangelc.medium.com/analyze-vulnerabilities-in-your-code-with-codeql-locally-3e5d31f8ed2) pretty helpful for setting up the db too
- If you don't have the codeQL extension, you can try running the changeset script and inputing \ with \` characters into the description, and then committing those files. You may need to log the `escapedDescription` to verify that the \` characters are correctly escaped there or push the commits to verify the commit message

