### PR TITLE
fix: [M3-7072] - Long drawer titles overlapping close icon

### DIFF
--- a/packages/manager/.changeset/pr-9731-fixed-1695931370886.md
+++ b/packages/manager/.changeset/pr-9731-fixed-1695931370886.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Long drawer titles overlapping close icon ([#9731](https://github.com/linode/manager/pull/9731))

--- a/packages/manager/src/components/Drawer.tsx
+++ b/packages/manager/src/components/Drawer.tsx
@@ -132,7 +132,6 @@ export const Drawer = (props: Props) => {
         <Grid>
           <IconButton
             sx={{
-              position: 'absolute',
               right: '-12px',
               top: '-12px',
             }}

--- a/packages/manager/src/components/Drawer.tsx
+++ b/packages/manager/src/components/Drawer.tsx
@@ -15,7 +15,7 @@ interface Props extends DrawerProps {
    */
   title: string;
   /**
-   * Increaces the Drawers width from 480px to 700px on desktop-sized viewports
+   * Increases the Drawers width from 480px to 700px on desktop-sized viewports
    * @default false
    */
   wide?: boolean;

--- a/packages/manager/src/components/Drawer.tsx
+++ b/packages/manager/src/components/Drawer.tsx
@@ -62,6 +62,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     },
   },
   title: {
+    // paddingRight: theme.spacing(4),
     wordBreak: 'break-word',
   },
   wide: {
@@ -132,6 +133,7 @@ export const Drawer = (props: Props) => {
         <Grid>
           <IconButton
             sx={{
+              // position: 'absolute',
               right: '-12px',
               top: '-12px',
             }}

--- a/packages/manager/src/components/Drawer.tsx
+++ b/packages/manager/src/components/Drawer.tsx
@@ -62,7 +62,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     },
   },
   title: {
-    // paddingRight: theme.spacing(4),
+    paddingRight: theme.spacing(4),
     wordBreak: 'break-word',
   },
   wide: {
@@ -133,7 +133,7 @@ export const Drawer = (props: Props) => {
         <Grid>
           <IconButton
             sx={{
-              // position: 'absolute',
+              position: 'absolute',
               right: '-12px',
               top: '-12px',
             }}

--- a/packages/manager/src/components/Drawer.tsx
+++ b/packages/manager/src/components/Drawer.tsx
@@ -62,7 +62,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     },
   },
   title: {
-    paddingRight: theme.spacing(4),
+    marginRight: theme.spacing(4),
     wordBreak: 'break-word',
   },
   wide: {

--- a/packages/manager/src/components/Drawer.tsx
+++ b/packages/manager/src/components/Drawer.tsx
@@ -34,11 +34,6 @@ const useStyles = makeStyles()((theme: Theme) => ({
     minWidth: 'auto',
     padding: 0,
   },
-  drawerHeader: {
-    '&&': {
-      marginBottom: theme.spacing(2),
-    },
-  },
   common: {
     '& .actionPanel': {
       display: 'flex',
@@ -55,10 +50,15 @@ const useStyles = makeStyles()((theme: Theme) => ({
     },
   },
   default: {
-    width: 480,
     [theme.breakpoints.down('sm')]: {
       maxWidth: 445,
       width: '100%',
+    },
+    width: 480,
+  },
+  drawerHeader: {
+    '&&': {
+      marginBottom: theme.spacing(2),
     },
   },
   title: {
@@ -90,18 +90,18 @@ export const Drawer = (props: Props) => {
 
   return (
     <_Drawer
-      onClose={(event, reason) => {
-        if (onClose && reason !== 'backdropClick') {
-          onClose(event, reason);
-        }
-      }}
-      anchor="right"
       classes={{
         paper: cx(classes.common, {
           [classes.default]: !wide,
           [classes.wide]: wide,
         }),
       }}
+      onClose={(event, reason) => {
+        if (onClose && reason !== 'backdropClick') {
+          onClose(event, reason);
+        }
+      }}
+      anchor="right"
       {...rest}
       aria-labelledby={titleID}
       data-qa-drawer


### PR DESCRIPTION
## Description 📝
This PR fixes an edge case where very long `Drawer` titles (in this case, due to long firewall names) overlap the `Drawer` close (X) icon.

Note: we fixed a similar issue before with Dialogs, not Drawers.

## Major Changes 🔄
**List highlighting major changes**
- Adds right margin to the drawer title to prevent overlap with close icon
- Reorders props to resolve eslint perfectionist warnings
- Fixes a typo that appears in the component's Storybook documentation

## Preview 📷

| Before | After |
| ---- | ---- |
| ![longdrawertitle_prod](https://github.com/linode/manager/assets/114685994/0fd5e514-92c0-4ac3-9594-9e303feaddcd) | ![Screenshot 2023-10-04 at 6 56 05 AM](https://github.com/linode/manager/assets/114685994/3574a681-fd39-4757-8b02-30be3fe6e0a3) |


## How to test 🧪
1. **How to setup test environment?**
- Create a firewall with a long label (max is 32 characters) at https://cloud.linode.com/firewalls/create with word breaks that get as close as possible to the close button. (e.g. `test-this-re-l-y-l-o-n-gf-ir-e-w`)
- Check out this PR.
- `yarn dev`
2. **How to reproduce the issue (if applicable)?**
- Go to https://cloud.linode.com/firewalls and visit the details page for your new firewall with a really long name.
- Select the `Linodes` tab and click the button to `Add Linodes to Firewall`.
- Observe the AddDeviceDrawer that opens and has a long title that overlaps the close icon. 
3. **How to verify changes?**
- Go to http://localhost:3000/firewalls and visit the details page for your new firewall with a really long name.
- Select the `Linodes` tab and click the button to `Add Linodes to Firewall`.
- Observe the AddDeviceDrawer that opens and has a long title that *does not* overlap the close icon.
- Check a few other drawers throughout the app to ensure there have been no unintended styling regressions from eslint reordering by comparing to prod. 
4. **How to run Unit or E2E tests?**
This was a styling regression. 