### PR TITLE
feat: [M3-7021] - Added Firewall panel to create NodeBalancer flow

### DIFF
--- a/packages/api-v4/src/nodebalancers/types.ts
+++ b/packages/api-v4/src/nodebalancers/types.ts
@@ -106,9 +106,7 @@ export interface CreateNodeBalancerConfigNode {
   weight?: number;
 }
 
-export type UpdateNodeBalancerConfigNode = Partial<
-  CreateNodeBalancerConfigNode
->;
+export type UpdateNodeBalancerConfigNode = Partial<CreateNodeBalancerConfigNode>;
 
 export interface NodeBalancerConfigNode {
   address: string;
@@ -119,6 +117,7 @@ export interface NodeBalancerConfigNode {
   nodebalancer_id: number;
   status: 'unknown' | 'UP' | 'DOWN';
   weight: number;
+  firewall_id?: number;
 }
 
 export interface NodeBalancerConfigNodeWithPort extends NodeBalancerConfigNode {

--- a/packages/manager/.changeset/pr-9733-upcoming-features-1697041470658.md
+++ b/packages/manager/.changeset/pr-9733-upcoming-features-1697041470658.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Added Firewall Panel to NodeBalancer Create flow ([#9733](https://github.com/linode/manager/pull/9733))

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -21,8 +21,10 @@ import { CheckoutSummary } from 'src/components/CheckoutSummary/CheckoutSummary'
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { LandingHeader } from 'src/components/LandingHeader';
+import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
 import { Paper } from 'src/components/Paper';
+import { SelectFirewallPanel } from 'src/components/SelectFirewallPanel/SelectFirewallPanel';
 import { SelectRegionPanel } from 'src/components/SelectRegionPanel/SelectRegionPanel';
 import { Tag, TagsInput } from 'src/components/TagsInput/TagsInput';
 import { TextField } from 'src/components/TextField';
@@ -56,6 +58,7 @@ import type { APIError } from '@linode/api-v4/lib/types';
 
 interface NodeBalancerFieldsState {
   configs: (NodeBalancerConfigFieldsWithStatus & { errors?: any })[];
+  firewall_id?: number;
   label?: string;
   region?: string;
   tags?: string[];
@@ -399,17 +402,28 @@ const NodeBalancerCreate = () => {
     regionId: nodeBalancerFields.region,
   });
 
-  const summaryItems = [
-    { title: regionLabel },
-    { details: nodeBalancerFields.configs.length, title: 'Configs' },
-    {
-      details: nodeBalancerFields.configs.reduce(
-        (acc, config) => acc + config.nodes.length,
-        0
-      ),
-      title: 'Nodes',
-    },
-  ].filter((item) => Boolean(item.title));
+  const summaryItems = [];
+
+  if (regionLabel) {
+    summaryItems.push({ title: regionLabel });
+  }
+
+  if (nodeBalancerFields.firewall_id) {
+    summaryItems.push({ title: 'Firewall Assigned' });
+  }
+
+  summaryItems.push({
+    details: nodeBalancerFields.configs.length,
+    title: 'Configs',
+  });
+
+  summaryItems.push({
+    details: nodeBalancerFields.configs.reduce(
+      (acc, config) => acc + config.nodes.length,
+      0
+    ),
+    title: 'Nodes',
+  });
 
   if (nodeBalancerFields.region) {
     summaryItems.unshift({ title: `$${price}/month` });
@@ -471,6 +485,23 @@ const NodeBalancerCreate = () => {
         handleSelection={regionChange}
         regions={regions ?? []}
         selectedID={nodeBalancerFields.region}
+      />
+      <SelectFirewallPanel
+        handleFirewallChange={(firewallId: number) => {
+          setNodeBalancerFields((prev) => ({
+            ...prev,
+            firewall_id: firewallId > 0 ? firewallId : undefined,
+          }));
+        }}
+        helperText={
+          <Typography>
+            Assign an existing Firewall to this NodeBalancer to control inbound
+            network traffic. If you want to assign a new Firewall to this
+            NodeBalancer, go to <Link to="/firewalls">Firewalls</Link>.{' '}
+            {/* @TODO Firewall-NodeBalancer: Update link */}
+            <Link to="">Learn more about creating Firewalls</Link>.
+          </Typography>
+        }
       />
       <Box marginBottom={2} marginTop={2}>
         {nodeBalancerFields.configs.map((nodeBalancerConfig, idx) => {


### PR DESCRIPTION
## Description 📝
- Added the firewall panel to the create NodeBalancer flow so users can assign a firewall as soon as a NodeBalancer is created.

## Major Changes 🔄
- Added the firewall panel to the create NodeBalancer flow
- Added helper text to the firewall panel
- Cleaned up and added "Firewall Assigned" to Checkout Summary

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-09-29 at 10 17 12 AM](https://github.com/linode/manager/assets/139489745/c28b6a04-f8c4-463d-9f2c-41228049645e) | ![Screenshot 2023-09-29 at 10 18 34 AM](https://github.com/linode/manager/assets/139489745/9ae0aa5c-acab-4ad5-a1be-84396cb5f071) |
| ![Screenshot 2023-09-29 at 10 20 18 AM](https://github.com/linode/manager/assets/139489745/fc525519-1dfa-407b-a149-f146ace3042f) | ![Screenshot 2023-09-29 at 10 20 49 AM](https://github.com/linode/manager/assets/139489745/5c855aeb-3d48-496e-b702-0bb3c209ca48) |

## How to test 🧪
Navigate to http://localhost:3000/nodebalancers/create and ensure that:
- [ ] The firewall options in the dropdown match your account firewalls
- [ ] When assigning a firewall, the summary in the bottom of the page should be updated
- [ ] The summary items are still accurate (region, firewall assigned, configs nodes)
- [ ] You can successfully create a NodeBalancer
- [ ] The selected firewall is assigned to the NodeBalancer
