### PR TITLE
feat: [M3-7109] - Add AGLB Delete Route Dialog 

### DIFF
--- a/packages/manager/.changeset/pr-9735-upcoming-features-1696265642529.md
+++ b/packages/manager/.changeset/pr-9735-upcoming-features-1696265642529.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add AGLB Route Delete Dialog ([#9735](https://github.com/linode/manager/pull/9735))

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/DeleteRouteDialog.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/DeleteRouteDialog.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
+import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
+import { useLoadBalancerRouteDeleteMutation } from 'src/queries/aglb/routes';
+
+import type { Route } from '@linode/api-v4';
+
+interface Props {
+  loadbalancerId: number;
+  onClose: () => void;
+  open: boolean;
+  route: Route | undefined;
+}
+
+export const DeleteRouteDialog = (props: Props) => {
+  const { loadbalancerId, onClose, open, route } = props;
+
+  const { error, isLoading, mutateAsync } = useLoadBalancerRouteDeleteMutation(
+    loadbalancerId,
+    route?.id ?? -1
+  );
+
+  const onDelete = async () => {
+    await mutateAsync();
+    onClose();
+  };
+
+  return (
+    <ConfirmationDialog
+      actions={
+        <ActionsPanel
+          primaryButtonProps={{
+            label: 'Delete',
+            loading: isLoading,
+            onClick: onDelete,
+          }}
+          secondaryButtonProps={{
+            label: 'Cancel',
+            onClick: onClose,
+          }}
+        />
+      }
+      error={error?.[0]?.reason}
+      onClose={onClose}
+      open={open}
+      title={`Delete Route ${route?.label}?`}
+    >
+      Are you sure you want to delete this route?
+    </ConfirmationDialog>
+  );
+};

--- a/packages/manager/src/queries/aglb/routes.ts
+++ b/packages/manager/src/queries/aglb/routes.ts
@@ -1,5 +1,5 @@
-import { getLoadbalancerRoutes } from '@linode/api-v4';
-import { useQuery } from 'react-query';
+import { deleteLoadbalancerRoute, getLoadbalancerRoutes } from '@linode/api-v4';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import { QUERY_KEY } from './loadbalancers';
 
@@ -20,5 +20,25 @@ export const useLoadBalancerRoutesQuery = (
     [QUERY_KEY, 'loadbalancer', id, 'routes', params, filter],
     () => getLoadbalancerRoutes(id, params, filter),
     { keepPreviousData: true }
+  );
+};
+
+export const useLoadBalancerRouteDeleteMutation = (
+  loadbalancerId: number,
+  routeId: number
+) => {
+  const queryClient = useQueryClient();
+  return useMutation<{}, APIError[]>(
+    () => deleteLoadbalancerRoute(loadbalancerId, routeId),
+    {
+      onSuccess() {
+        queryClient.invalidateQueries([
+          QUERY_KEY,
+          'loadbalancer',
+          loadbalancerId,
+          'routes',
+        ]);
+      },
+    }
   );
 };


### PR DESCRIPTION
## Description 📝
- Adds a basic AGLB Route Delete Dialog

## Preview 📷

![Screenshot 2023-09-29 at 12 35 29 PM](https://github.com/linode/manager/assets/115251059/d5f5c5b8-7023-497c-a96c-e5247a860d8b)

## How to test 🧪
- Check out this PR
- Turn the MSW **on**
- Go to `http://localhost:3000/loadbalancers/0/routes`
- Test the Delete Dialog
  - Check spelling ✏️
  - Check styles 🎨
  - Check functionality 🎮
- Verify a `DELETE https://api.linode.com/v4beta/aglb/0/routes/24` API call happens on delete
- Verify existing routes get invalidated upon delete (You should see a `GET https://api.linode.com/v4beta/aglb/0/routes?page=1&page_size=25` API call)