### PR TITLE
fix: CSV Download on Account Maintenance

### DIFF
--- a/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
+++ b/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
@@ -132,6 +132,7 @@ const MaintenanceTable = ({ type }: Props) => {
 
   const downloadCSV = async () => {
     await getCSVData();
+    csvRef.current.link.click();
   };
 
   return (


### PR DESCRIPTION
## Description 📝

- Caused by https://github.com/linode/manager/pull/9697 I think
- Fixes the `Download CSV` button on the `http://localhost:3000/account/maintenance` page
  - This `Download CSV` is unique compared to others because it lazily fetches data when the user presses the button. That's why there is a weird ref involved.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| Clicking download does nothing | Clicking download downloads the CSV |
| <video src="https://github.com/linode/manager/assets/115251059/e47b8976-d752-4943-81c7-38636b3f269e" /> | <video src="https://github.com/linode/manager/assets/115251059/38890e7c-9822-446c-baac-c0f0a0294866" /> |

## How to test 🧪
- Go to `http://localhost:3000/account/maintenance` and test the `Download CSV` functionality
- Turn on the MSW if you need to mock some maintenance events