### PR TITLE
change: Remove Databases feature flag

### DIFF
--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -196,12 +196,6 @@ const MainContent = (props: CombinedProps) => {
 
   const [bannerDismissed, setBannerDismissed] = React.useState<boolean>(false);
 
-  const showDatabases = isFeatureEnabled(
-    'Managed Databases',
-    Boolean(flags.databases),
-    account?.capabilities ?? []
-  );
-
   const showVPCs = isFeatureEnabled(
     'VPCs',
     Boolean(flags.vpc),
@@ -357,9 +351,7 @@ const MainContent = (props: CombinedProps) => {
                             <Route component={SearchLanding} path="/search" />
                             <Route component={EventsLanding} path="/events" />
                             <Route component={Firewalls} path="/firewalls" />
-                            {showDatabases ? (
-                              <Route component={Databases} path="/databases" />
-                            ) : null}
+                            <Route component={Databases} path="/databases" />
                             {flags.selfServeBetas ? (
                               <Route component={BetaRoutes} path="/betas" />
                             ) : null}

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -121,12 +121,6 @@ export const PrimaryNav = (props: Props) => {
   const allowMarketplacePrefetch =
     !oneClickApps && !oneClickAppsLoading && !oneClickAppsError;
 
-  const showDatabases = isFeatureEnabled(
-    'Managed Databases',
-    Boolean(flags.databases),
-    account?.capabilities ?? []
-  );
-
   const showVPCs = isFeatureEnabled(
     'VPCs',
     Boolean(flags.vpc),
@@ -216,10 +210,8 @@ export const PrimaryNav = (props: Props) => {
         },
         {
           display: 'Databases',
-          hide: !showDatabases,
           href: '/databases',
           icon: <Database />,
-          isBeta: flags.databaseBeta,
         },
         {
           activeLinks: ['/kubernetes/create'],
@@ -273,11 +265,9 @@ export const PrimaryNav = (props: Props) => {
     ],
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
-      showDatabases,
       _isManagedAccount,
       allowObjPrefetch,
       allowMarketplacePrefetch,
-      flags.databaseBeta,
       flags.aglb,
       showVPCs,
     ]

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -20,7 +20,6 @@ import { makeStyles } from 'tss-react/mui';
 import MongoDBIcon from 'src/assets/icons/mongodb.svg';
 import MySQLIcon from 'src/assets/icons/mysql.svg';
 import PostgreSQLIcon from 'src/assets/icons/postgresql.svg';
-import { BetaChip } from 'src/components/BetaChip/BetaChip';
 import { Button } from 'src/components/Button/Button';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { Divider } from 'src/components/Divider';
@@ -45,7 +44,6 @@ import { databaseEngineMap } from 'src/features/Databases/DatabaseLanding/Databa
 import { enforceIPMasks } from 'src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.utils';
 import { typeLabelDetails } from 'src/features/Linodes/presentation';
 import { PlansPanel } from 'src/features/components/PlansPanel/PlansPanel';
-import { useFlags } from 'src/hooks/useFlags';
 import {
   useCreateDatabaseMutation,
   useDatabaseEnginesQuery,
@@ -193,7 +191,6 @@ interface NodePricing {
 const DatabaseCreate = () => {
   const { classes } = useStyles();
   const history = useHistory();
-  const flags = useFlags();
 
   const {
     data: regionsData,
@@ -453,11 +450,6 @@ const DatabaseCreate = () => {
               position: 1,
             },
           ],
-          labelOptions: {
-            suffixComponent: flags.databaseBeta ? (
-              <BetaChip className={classes.chip} component="span" />
-            ) : null,
-          },
           pathname: location.pathname,
         }}
         title="Create"
@@ -560,21 +552,6 @@ const DatabaseCreate = () => {
               ))}
             </RadioGroup>
           </FormControl>
-          <Grid md={8} xs={12}>
-            {flags.databaseBeta ? (
-              <Notice className={classes.notice} variant="info">
-                <strong>
-                  Notice: There is no charge for database clusters during beta.
-                </strong>{' '}
-                Database clusters will be subject to charges when the beta
-                period ends on May 2nd, 2022.{' '}
-                <Link to="https://www.linode.com/pricing/#databases">
-                  View pricing
-                </Link>
-                .
-              </Notice>
-            ) : undefined}
-          </Grid>
         </Grid>
         <Divider spacingBottom={12} spacingTop={26} />
         <Grid>

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -44,12 +44,6 @@ export const AddNewMenu = () => {
   const flags = useFlags();
   const open = Boolean(anchorEl);
 
-  const showDatabases = isFeatureEnabled(
-    'Managed Databases',
-    Boolean(flags.databases),
-    account?.capabilities ?? []
-  );
-
   const showVPCs = isFeatureEnabled(
     'VPCs',
     Boolean(flags.vpc),
@@ -114,7 +108,6 @@ export const AddNewMenu = () => {
     {
       description: 'High-performance managed database clusters',
       entity: 'Database',
-      hide: !showDatabases,
       icon: DatabaseIcon,
       link: '/databases/create',
     },


### PR DESCRIPTION
## Description 📝
Databases has been released for over a year now so we no longer need the feature flag. The DBaaS team will also be disabling the feature flag for production on Monday so we need to ensure that Databases still show without the flag on.

## How to test 🧪
- Check that Databases is visible in the Primary Navigation menu and Create dropdown menu
- `/databases` should load and display databases
- Database details page should load
- Ensure you can still create a Database
