### PR TITLE
fix: [M3-7208] Prevent forwarding the title prop to the markup

### DIFF
--- a/packages/manager/.changeset/pr-9739-fixed-1696019997998.md
+++ b/packages/manager/.changeset/pr-9739-fixed-1696019997998.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Removed `title` prop forwarding on Modals/Dialogs ([#9739](https://github.com/linode/manager/pull/9739))

--- a/packages/manager/src/components/Dialog/Dialog.tsx
+++ b/packages/manager/src/components/Dialog/Dialog.tsx
@@ -95,7 +95,8 @@ export const Dialog = (props: DialogProps) => {
 };
 
 const StyledDialog = styled(_Dialog, {
-  shouldForwardProp: (prop) => isPropValid(['fullHeight'], prop),
+  shouldForwardProp: (prop) =>
+    isPropValid(['fullHeight'], prop) && prop !== 'title',
 })<DialogProps>(({ theme, ...props }) => ({
   '& .MuiDialog-paper': {
     height: props.fullHeight ? '100vh' : undefined,

--- a/packages/manager/src/components/Dialog/Dialog.tsx
+++ b/packages/manager/src/components/Dialog/Dialog.tsx
@@ -95,8 +95,7 @@ export const Dialog = (props: DialogProps) => {
 };
 
 const StyledDialog = styled(_Dialog, {
-  shouldForwardProp: (prop) =>
-    isPropValid(['fullHeight'], prop) && prop !== 'title',
+  shouldForwardProp: (prop) => isPropValid(['fullHeight', 'title'], prop),
 })<DialogProps>(({ theme, ...props }) => ({
   '& .MuiDialog-paper': {
     height: props.fullHeight ? '100vh' : undefined,


### PR DESCRIPTION
## Description 📝

You've been annoyed by this on our modals?

![Screenshot 2023-09-29 at 10 57 00](https://github.com/linode/manager/assets/130582365/4346137f-8e37-46ec-b3ad-43e9cfecf5a9)

Look no further, this fix is for you.

The title prop on our modals creates more trouble than it's worth. It adds html tooltip (a proper HTML `title` feature) that follows you around and often obfuscate content or distracts the user.

It does not add any particular accessibility feature (known to me) and does not seem to be standard at all:
https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/dialog/

We already have the necessary features described in the [accessibility standards docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) so there's no need to continue defining them and require them on those components.

## Major Changes 🔄
**List highlighting major changes**
- Prevent forwarding the title prop to the html

## How to test 🧪
1. Open any modal/dialog in CM - example Linode resize
2. Confirm the `title` tooltip is gone (usually after mouse pointing in the same spot for a couple seconds
3. Confirm the title is removed from the markup
4. Confirm the title is still being used wherever it should be (aria tags, modal title etc)
