### PR TITLE
[Fix]: Invoice detail CSV button

### DIFF
--- a/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
+++ b/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
@@ -16,7 +16,7 @@ interface DownloadCSVProps {
   data: unknown[];
   filename: string;
   headers: { key: string; label: string }[];
-  onClick?: () => void;
+  onClick: () => void;
   sx?: SxProps;
   text?: string;
 }
@@ -48,14 +48,7 @@ export const DownloadCSV = ({
         {text}
       </StyledLinkButton>
     ) : (
-      <Button
-        buttonType={buttonType}
-        component="span"
-        disableRipple
-        onClick={onClick}
-        sx={sx}
-        tabIndex={-1}
-      >
+      <Button buttonType={buttonType} onClick={onClick} sx={sx}>
         {text}
       </Button>
     );
@@ -63,11 +56,15 @@ export const DownloadCSV = ({
   return (
     <>
       <CSVLink
+        // This is a visually hidden link that is controlled by the button below.
+        // It should not be focusable or visible to screen readers either.
+        aria-hidden={true}
         className={className}
         data={cleanCSVData(data)}
         filename={filename}
         headers={headers}
         ref={csvRef}
+        tabIndex={-1}
       />
       {renderButton}
     </>

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -176,6 +176,7 @@ export const InvoiceDetail = () => {
                     data={items}
                     filename={`invoice-${invoice.date}.csv`}
                     headers={csvHeaders}
+                    onClick={() => csvRef.current.link.click()}
                     sx={{ ...sxDownloadButton, marginRight: '8px' }}
                   />
                   <Button


### PR DESCRIPTION
## Description 📝
This PR fixes the download CSV button on the invoice detail page. 

Two different PRs touched this file for this release: https://github.com/linode/manager/pull/9697 & https://github.com/linode/manager/pull/9687

My initial fix had wrapped the Download button as a span inside the CSVLink (slightly better semantically) but https://github.com/linode/manager/pull/9687/files#diff-8d0889ab4c29796d8405ff92e8a926c9b6d672b073b7703931ee9cbdcdf97a91L42 broke that by removing the wrapping. 

Since it seems clearer to everyone to use the ref and the onClick behaviour I reverted to the original implementation which allowed to require the onClick prop to be passed.

## How to test 🧪
1. Navigate to /account/billing/invoices/{invoice-Id}
2. Confirm the "Download CSV" **button** downloads the file properly and is accessible and tabulable
3. Confirm the CVS **link** itself (a tag) is properly hidden and not tabulable. 

No need for a changeset, this did not hit production yet
