### PR TITLE
chore: [M3-7224] - Disable Sentry Performance Tracing

### DIFF
--- a/packages/manager/.changeset/pr-9745-tech-stories-1696272112150.md
+++ b/packages/manager/.changeset/pr-9745-tech-stories-1696272112150.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Disable Sentry Performance Tracing ([#9745](https://github.com/linode/manager/pull/9745))

--- a/packages/manager/src/initSentry.ts
+++ b/packages/manager/src/initSentry.ts
@@ -78,7 +78,7 @@ export const initSentry = () => {
       /**
        * Uncomment the 3 lines below to enable Sentry's "Performance" feature.
        * We're disabling it October 2nd 2023 because we are running into plan limits
-       * and this Sentry feature isn't crutial to our workflow.
+       * and this Sentry feature isn't crucial to our workflow.
        */
       // enableTracing: true,
       // integrations: [new BrowserTracing()],

--- a/packages/manager/src/initSentry.ts
+++ b/packages/manager/src/initSentry.ts
@@ -1,9 +1,4 @@
-import {
-  BrowserOptions,
-  BrowserTracing,
-  Event as SentryEvent,
-  init,
-} from '@sentry/react';
+import { BrowserOptions, Event as SentryEvent, init } from '@sentry/react';
 
 import { APP_ROOT, SENTRY_URL } from 'src/constants';
 import { deepStringTransform } from 'src/utilities/deepStringTransform';
@@ -31,7 +26,6 @@ export const initSentry = () => {
         /^chrome:\/\//i,
       ],
       dsn: SENTRY_URL,
-      enableTracing: true,
       environment,
       ignoreErrors: [
         // Random plugins/extensions
@@ -80,9 +74,15 @@ export const initSentry = () => {
         // This is apparently a benign error: https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded
         'ResizeObserver loop limit exceeded',
       ],
-      integrations: [new BrowserTracing()],
       release: packageJson.version,
-      tracesSampleRate: environment === 'production' ? 0.025 : 1,
+      /**
+       * Uncomment the 3 lines below to enable Sentry's "Performance" feature.
+       * We're disabling it October 2nd 2023 because we are running into plan limits
+       * and this Sentry feature isn't crutial to our workflow.
+       */
+      // enableTracing: true,
+      // integrations: [new BrowserTracing()],
+      // tracesSampleRate: environment === 'production' ? 0.025 : 1,
     });
   }
 };


### PR DESCRIPTION
## Description 📝
- We're disabling Sentry performance tracing because we are running into plan limits and this Sentry feature isn't crucial to our workflow.

(We still use Sentry for logging errors)

## How to test 🧪

> [!NOTE]
> These steps just confirm error reporting is still working as expected

- Check out this PR
- Make sure you have `REACT_APP_SENTRY_URL` defined in your env
- Throw an error in a component
- Go to that component and make Cloud Manager crash 
- Verify you see the error in sentry

![Screenshot 2023-10-02 at 2 39 13 PM](https://github.com/linode/manager/assets/115251059/73b40275-fb58-49f2-9a46-510bcd1b47a0)

![Screenshot 2023-10-02 at 2 38 19 PM](https://github.com/linode/manager/assets/115251059/3c23d5c9-fb9f-48e9-bfdc-679abfb9a230)
