### PR TITLE
fix: [M3-6931] - Fixed top spacing for NodeBalancer empty state

### DIFF
--- a/packages/manager/.changeset/pr-9746-fixed-1696274683693.md
+++ b/packages/manager/.changeset/pr-9746-fixed-1696274683693.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fixed the top spacing for the NodeBalancer empty state page ([#9746](https://github.com/linode/manager/pull/9746))

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingEmptyState.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingEmptyState.tsx
@@ -45,5 +45,5 @@ const StyledPlaceholder = styled(Placeholder, {
 })(({ theme }) => ({
   // this important rules can be removed when Placeholder is refactored
   // and we can just use sx={{ paddingBottom: 0 }} on placeholder
-  padding: `${theme.spacing(2)} 0 0 0 !important`,
+  padding: `${theme.spacing(10)} 0 0 0 !important`,
 }));


### PR DESCRIPTION
## Description 📝
Fixed the top spacing for the NodeBalancer empty state

## Major Changes 🔄
- Added top padding to NodeBalancer empty state

## Preview 📷
</details>

<details>
<summary>Before</summary>

| Domains  | NodeBalancer   |
| ------- | ------- |
| ![Screenshot 2023-10-02 at 3 21 57 PM](https://github.com/linode/manager/assets/139489745/f052977d-ab75-487b-ad8a-29fd00a1966b) | ![Screenshot 2023-10-02 at 3 22 22 PM](https://github.com/linode/manager/assets/139489745/0aaa1129-201b-47ea-b4e0-614bd8e51cae) |

</details>

<details>
<summary>After</summary>

| Domains  | NodeBalancer   |
| ------- | ------- |
| ![Screenshot 2023-10-02 at 3 20 07 PM](https://github.com/linode/manager/assets/139489745/48c0f0a5-25c3-4af4-8052-2e2488ca04aa) | ![Screenshot 2023-10-02 at 3 20 30 PM](https://github.com/linode/manager/assets/139489745/14feb808-9772-4aad-be5d-93d25810c6f6) |

</details>

## How to test 🧪
1. Turn on MSW and ensure there are 0 active NodeBalancers
2. Navigate to http://localhost:3000/nodebalancers
3. Ensure the spacing is consistent with the other empty state pages (ex. Volumes, Domains, Kubernetes, etc.)

<!-- My private comment -->
