### PR TITLE
refactor: [M3-6287] - MUI v5 `Features > Users`

### DIFF
--- a/packages/manager/.changeset/pr-9748-tech-stories-1696350216805.md
+++ b/packages/manager/.changeset/pr-9748-tech-stories-1696350216805.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+MUI v5 Migration - Src > Features > Users ([#9748](https://github.com/linode/manager/pull/9748))

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -134,7 +134,11 @@ interface Props {
 
 type CombinedProps = Props & GlobalErrorProps;
 
-const Account = React.lazy(() => import('src/features/Account'));
+const Account = React.lazy(() =>
+  import('src/features/Account').then((module) => ({
+    default: module.Account,
+  }))
+);
 const LinodesRoutes = React.lazy(() => import('src/features/Linodes'));
 const Volumes = React.lazy(() => import('src/features/Volumes'));
 const Domains = React.lazy(() =>
@@ -398,8 +402,8 @@ export default compose<CombinedProps, Props>(
 export const checkFlagsForMainContentBanner = (flags: FlagSet) => {
   return Boolean(
     flags.mainContentBanner &&
-      !isEmpty(flags.mainContentBanner) &&
-      flags.mainContentBanner.key
+    !isEmpty(flags.mainContentBanner) &&
+    flags.mainContentBanner.key
   );
 };
 

--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -77,11 +77,10 @@ const StyledBox = styled(Box)(({ theme: { spacing } }) => ({
   '& > button': {
     marginBottom: spacing(1),
   },
-  display: 'flex',
   justifyContent: 'flex-end',
-  marginTop: spacing(2),
+  marginTop: spacing(1),
   paddingBottom: spacing(1),
-  paddingTop: spacing(2),
+  paddingTop: spacing(1),
 }));
 
 const ActionsPanel = RenderGuard(ActionsPanelComponent);

--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -28,7 +28,11 @@ const EntityTransfersLanding = React.lazy(() =>
     default: module.EntityTransfersLanding,
   }))
 );
-const Users = React.lazy(() => import('src/features/Users'));
+const Users = React.lazy(() =>
+  import('../Users/UsersLanding').then((module) => ({
+    default: module.UsersLanding,
+  }))
+);
 const GlobalSettings = React.lazy(() => import('./GlobalSettings'));
 const MaintenanceLanding = React.lazy(
   () => import('./Maintenance/MaintenanceLanding')

--- a/packages/manager/src/features/Account/index.tsx
+++ b/packages/manager/src/features/Account/index.tsx
@@ -19,11 +19,16 @@ const EntityTransfersCreate = React.lazy(() =>
     default: module.EntityTransfersCreate,
   }))
 );
-const UserDetail = React.lazy(() => import('src/features/Users/UserDetail'));
+
+const UserDetail = React.lazy(() =>
+  import('../Users/UserDetail').then((module) => ({
+    default: module.UserDetail,
+  }))
+);
 
 type Props = RouteComponentProps<{}>;
 
-class Account extends React.Component<Props> {
+export class Account extends React.Component<Props> {
   render() {
     const {
       match: { path },
@@ -55,4 +60,3 @@ class Account extends React.Component<Props> {
     );
   }
 }
-export default Account;

--- a/packages/manager/src/features/Users/CreateUserDrawer.tsx
+++ b/packages/manager/src/features/Users/CreateUserDrawer.tsx
@@ -12,7 +12,7 @@ import { Toggle } from 'src/components/Toggle';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 
-interface CreateUserDrawerProps {
+interface Props {
   onClose: () => void;
   open: boolean;
   refetch: () => void;
@@ -26,7 +26,7 @@ interface State {
   username: string;
 }
 
-type CombinedProps = CreateUserDrawerProps & RouteComponentProps<{}>;
+type CombinedProps = Props & RouteComponentProps<{}>;
 
 class CreateUserDrawer extends React.Component<CombinedProps, State> {
   componentDidUpdate(prevProps: CombinedProps) {

--- a/packages/manager/src/features/Users/CreateUserDrawer.tsx
+++ b/packages/manager/src/features/Users/CreateUserDrawer.tsx
@@ -5,14 +5,14 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Drawer } from 'src/components/Drawer';
+import { FormControlLabel } from 'src/components/FormControlLabel';
 import { Notice } from 'src/components/Notice/Notice';
 import { TextField } from 'src/components/TextField';
 import { Toggle } from 'src/components/Toggle';
-import { FormControlLabel } from 'src/components/FormControlLabel';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 
-interface Props {
+interface CreateUserDrawerProps {
   onClose: () => void;
   open: boolean;
   refetch: () => void;
@@ -26,7 +26,7 @@ interface State {
   username: string;
 }
 
-type CombinedProps = Props & RouteComponentProps<{}>;
+type CombinedProps = CreateUserDrawerProps & RouteComponentProps<{}>;
 
 class CreateUserDrawer extends React.Component<CombinedProps, State> {
   componentDidUpdate(prevProps: CombinedProps) {

--- a/packages/manager/src/features/Users/UserDeleteConfirmationDialog.tsx
+++ b/packages/manager/src/features/Users/UserDeleteConfirmationDialog.tsx
@@ -3,16 +3,19 @@ import * as React from 'react';
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
 
-interface Props {
+interface UserDeleteConfirmationDialogProps {
   onCancel: () => void;
   onDelete: () => void;
   open: boolean;
   username: string;
 }
 
-export const UserDeleteConfirmationDialog = (props: Props) => {
-  const { onCancel, onDelete, open, username } = props;
-
+export const UserDeleteConfirmationDialog = ({
+  onCancel,
+  onDelete,
+  open,
+  username,
+}: UserDeleteConfirmationDialogProps) => {
   return (
     <ConfirmationDialog
       actions={

--- a/packages/manager/src/features/Users/UserDeleteConfirmationDialog.tsx
+++ b/packages/manager/src/features/Users/UserDeleteConfirmationDialog.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
 
-interface UserDeleteConfirmationDialogProps {
+interface Props {
   onCancel: () => void;
   onDelete: () => void;
   open: boolean;
@@ -15,7 +15,7 @@ export const UserDeleteConfirmationDialog = ({
   onDelete,
   open,
   username,
-}: UserDeleteConfirmationDialogProps) => {
+}: Props) => {
   return (
     <ConfirmationDialog
       actions={

--- a/packages/manager/src/features/Users/UserDetail.tsx
+++ b/packages/manager/src/features/Users/UserDetail.tsx
@@ -14,18 +14,18 @@ import {
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { LandingHeader } from 'src/components/LandingHeader';
 import { Notice } from 'src/components/Notice/Notice';
-import { SafeTabPanel } from 'src/components/SafeTabPanel/SafeTabPanel';
-import { TabLinkList } from 'src/components/TabLinkList/TabLinkList';
 import { TabPanels } from 'src/components/ReachTabPanels';
 import { Tabs } from 'src/components/ReachTabs';
+import { SafeTabPanel } from 'src/components/SafeTabPanel/SafeTabPanel';
+import { TabLinkList } from 'src/components/TabLinkList/TabLinkList';
 import { queryKey } from 'src/queries/account';
 import { useProfile } from 'src/queries/profile';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 import UserPermissions from './UserPermissions';
-import UserProfile from './UserProfile';
+import { UserProfile } from './UserProfile';
 
-const UserDetail: React.FC = () => {
+export const UserDetail = () => {
   const { username: usernameParam } = useParams<{ username: string }>();
   const location = useLocation<{ newUsername: string; success: boolean }>();
   const history = useHistory();
@@ -260,5 +260,3 @@ const UserDetail: React.FC = () => {
     </>
   );
 };
-
-export default UserDetail;

--- a/packages/manager/src/features/Users/UserPermissions.styles.ts
+++ b/packages/manager/src/features/Users/UserPermissions.styles.ts
@@ -1,0 +1,32 @@
+import { styled } from '@mui/material/styles';
+
+import Select from 'src/components/EnhancedSelect/Select';
+
+export const StyledSelect = styled(Select, {
+  label: 'StyledSelect',
+})(({ theme }) => ({
+  '& .react-select__menu, & .input': {
+    marginLeft: theme.spacing(1),
+    right: 0,
+    textAlign: 'left' as const,
+    width: 125,
+  },
+  '& .react-select__menu-list': {
+    width: '100%',
+  },
+  '& > div': {
+    alignItems: 'center',
+    display: 'flex',
+    justifyContent: 'flex-end',
+  },
+  '& label': {
+    marginTop: 6,
+  },
+}));
+
+export const StyledDivWrapper = styled('div', {
+  label: 'StyledDivWrapper',
+})(({ theme }) => ({
+  marginTop: theme.spacing(2),
+  paddingBottom: 0,
+}));

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -9,18 +9,16 @@ import {
 } from '@linode/api-v4/lib/account';
 import { APIError } from '@linode/api-v4/lib/types';
 import Grid from '@mui/material/Unstable_Grid2';
-import { Theme } from '@mui/material/styles';
 import { WithSnackbarProps, withSnackbar } from 'notistack';
 import { compose, flatten, lensPath, omit, set } from 'ramda';
 import * as React from 'react';
 import { compose as recompose } from 'recompose';
-import { withStyles } from 'tss-react/mui';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { Divider } from 'src/components/Divider';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-import Select, { Item } from 'src/components/EnhancedSelect/Select';
+import { Item } from 'src/components/EnhancedSelect/Select';
 import { FormControlLabel } from 'src/components/FormControlLabel';
 import { Notice } from 'src/components/Notice/Notice';
 import { Paper } from 'src/components/Paper';
@@ -43,66 +41,12 @@ import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
+import { StyledDivWrapper, StyledSelect } from './UserPermissions.styles';
 import {
   UserPermissionsEntitySection,
   entityNameMap,
 } from './UserPermissionsEntitySection';
-
-type ClassNames =
-  | 'globalRow'
-  | 'globalSection'
-  | 'section'
-  | 'setAll'
-  | 'title'
-  | 'toggle'
-  | 'unrestrictedRoot';
-
-const styles = (theme: Theme) => ({
-  globalRow: {
-    padding: `${theme.spacing(1)} 0`,
-  },
-  globalSection: {
-    marginTop: theme.spacing(2),
-  },
-  section: {
-    marginTop: theme.spacing(2),
-    paddingBottom: 0,
-  },
-  setAll: {
-    '& .react-select__menu, & .input': {
-      marginLeft: theme.spacing(1),
-      right: 0,
-      textAlign: 'left' as const,
-      width: 125,
-    },
-    '& .react-select__menu-list': {
-      width: '100%',
-    },
-    '& > div': {
-      alignItems: 'center',
-      display: 'flex',
-      justifyContent: 'flex-end',
-    },
-    '& label': {
-      marginTop: 6,
-    },
-  },
-  title: {
-    [theme.breakpoints.down('md')]: {
-      paddingLeft: theme.spacing(),
-    },
-  },
-  toggle: {
-    marginRight: 3,
-  },
-  unrestrictedRoot: {
-    marginTop: theme.spacing(2),
-    padding: theme.spacing(3),
-  },
-});
-
 interface Props {
-  classes?: Partial<Record<ClassNames, string>>;
   clearNewUser: () => void;
   currentUser?: string;
   username?: string;
@@ -342,7 +286,6 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     onCancel: () => void,
     loading: boolean
   ) => {
-    const classes = withStyles.getClasses(this.props);
     return (
       <ActionsPanel
         primaryButtonProps={{
@@ -356,8 +299,11 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           label: 'Reset',
           onClick: onCancel,
         }}
+        sx={(theme) => ({
+          marginTop: theme.spacing(2),
+          paddingBottom: 0,
+        })}
         alignItems="center"
-        className={classes.section}
         display="flex"
         justifyContent="flex-end"
       />
@@ -365,16 +311,18 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   };
 
   renderBillingPerm = () => {
-    const classes = withStyles.getClasses(this.props);
     const { grants } = this.state;
     if (!(grants && grants.global)) {
       return null;
     }
 
     return (
-      <div className={classes.section}>
+      <StyledDivWrapper>
         <Grid
-          className={classes.section}
+          sx={(theme) => ({
+            marginTop: theme.spacing(2),
+            paddingBottom: 0,
+          })}
           container
           data-qa-billing-section
           spacing={2}
@@ -385,7 +333,14 @@ class UserPermissions extends React.Component<CombinedProps, State> {
             </Typography>
           </Grid>
         </Grid>
-        <Grid className={classes.section} container spacing={2}>
+        <Grid
+          sx={(theme) => ({
+            marginTop: theme.spacing(2),
+            paddingBottom: 0,
+          })}
+          container
+          spacing={2}
+        >
           <SelectionCard
             checked={grants.global.account_access === null}
             data-qa-billing-access="None"
@@ -410,12 +365,11 @@ class UserPermissions extends React.Component<CombinedProps, State> {
             onClick={this.billingPermOnClick('read_write')}
           />
         </Grid>
-      </div>
+      </StyledDivWrapper>
     );
   };
 
   renderBody = () => {
-    const classes = withStyles.getClasses(this.props);
     const { currentUser, username } = this.props;
     const { errors, restricted } = this.state;
     const hasErrorFor = getAPIErrorsFor({ restricted: 'Restricted' }, errors);
@@ -434,7 +388,11 @@ class UserPermissions extends React.Component<CombinedProps, State> {
         >
           <Grid>
             <Typography
-              className={classes.title}
+              sx={(theme) => ({
+                [theme.breakpoints.down('md')]: {
+                  paddingLeft: theme.spacing(),
+                },
+              })}
               data-qa-restrict-access={restricted}
               variant="h2"
             >
@@ -452,9 +410,9 @@ class UserPermissions extends React.Component<CombinedProps, State> {
                   : ''
               }
               checked={!restricted}
-              className={classes.toggle}
               disabled={username === currentUser}
               onChange={this.onChangeRestricted}
+              sx={{ marginRight: 3 }}
             />
           </Grid>
         </Grid>
@@ -464,7 +422,6 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   };
 
   renderGlobalPerm = (perm: string, checked: boolean) => {
-    const classes = withStyles.getClasses(this.props);
     const permDescriptionMap = {
       add_databases: 'Can add Databases to this account ($)',
       add_domains: 'Can add Domains using the DNS Manager',
@@ -494,7 +451,9 @@ class UserPermissions extends React.Component<CombinedProps, State> {
               onChange={this.globalPermOnChange(perm)}
             />
           }
-          className={classes.globalRow}
+          sx={(theme) => ({
+            padding: `${theme.spacing(1)} 0`,
+          })}
           label={permDescriptionMap[perm]}
         />
         <Divider />
@@ -503,17 +462,28 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   };
 
   renderGlobalPerms = () => {
-    const classes = withStyles.getClasses(this.props);
     const { grants, isSavingGlobal } = this.state;
     return (
-      <Paper className={classes.globalSection} data-qa-global-section>
+      <Paper
+        sx={(theme) => ({
+          marginTop: theme.spacing(2),
+        })}
+        data-qa-global-section
+      >
         <Typography
           data-qa-permissions-header="Global Permissions"
           variant="h2"
         >
           Global Permissions
         </Typography>
-        <Grid className={classes.section} container spacing={2}>
+        <Grid
+          sx={(theme) => ({
+            marginTop: theme.spacing(2),
+            paddingBottom: 0,
+          })}
+          container
+          spacing={2}
+        >
           {grants &&
             grants.global &&
             this.globalBooleanPerms
@@ -552,7 +522,6 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   };
 
   renderSpecificPerms = () => {
-    const classes = withStyles.getClasses(this.props);
     const { grants, isSavingEntity, setAllPerm } = this.state;
 
     const permOptions = [
@@ -566,7 +535,12 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     });
 
     return (
-      <Paper className={classes.globalSection} data-qa-entity-section>
+      <Paper
+        sx={(theme) => ({
+          marginTop: theme.spacing(2),
+        })}
+        data-qa-entity-section
+      >
         <Grid alignItems="center" container justifyContent="space-between">
           <Grid>
             <Typography
@@ -578,8 +552,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           </Grid>
 
           <Grid style={{ marginTop: 5 }}>
-            <Select
-              className={classes.setAll}
+            <StyledSelect
               defaultValue={defaultPerm}
               id="setall"
               inline
@@ -593,7 +566,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
             />
           </Grid>
         </Grid>
-        <div className={classes.section}>
+        <StyledDivWrapper>
           {this.state.showTabs ? (
             <Tabs>
               <TabList>
@@ -628,7 +601,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
               />
             ))
           )}
-        </div>
+        </StyledDivWrapper>
         {this.renderActions(
           this.saveSpecificGrants,
           this.cancelPermsType('entity'),
@@ -639,10 +612,14 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   };
 
   renderUnrestricted = () => {
-    const classes = withStyles.getClasses(this.props);
     /* TODO: render all permissions disabled with this message above */
     return (
-      <Paper className={classes.unrestrictedRoot}>
+      <Paper
+        sx={(theme) => ({
+          marginTop: theme.spacing(2),
+          padding: theme.spacing(3),
+        })}
+      >
         <Typography data-qa-unrestricted-msg>
           This user has unrestricted access to the account.
         </Typography>
@@ -785,4 +762,4 @@ export default recompose<CombinedProps, Props>(
   withSnackbar,
   withQueryClient,
   withFlags
-)(withStyles(UserPermissions, styles));
+)(UserPermissions);

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -412,7 +412,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
               checked={!restricted}
               disabled={username === currentUser}
               onChange={this.onChangeRestricted}
-              sx={{ marginRight: 3 }}
+              sx={{ marginRight: '3px' }}
             />
           </Grid>
         </Grid>

--- a/packages/manager/src/features/Users/UserPermissionsEntitySection.styles.ts
+++ b/packages/manager/src/features/Users/UserPermissionsEntitySection.styles.ts
@@ -1,0 +1,18 @@
+import { styled } from '@mui/material/styles';
+
+import { Table } from 'src/components/Table';
+
+export const StyledGrantsTable = styled(Table, {
+  label: 'StyledGrantsTable',
+})(({ theme }) => ({
+  '& td': {
+    [theme.breakpoints.down('sm')]: {
+      paddingRight: '0 !important',
+    },
+    width: '100%',
+  },
+  '& th': {
+    minWidth: 150,
+    width: '25%',
+  },
+}));

--- a/packages/manager/src/features/Users/UserPermissionsEntitySection.tsx
+++ b/packages/manager/src/features/Users/UserPermissionsEntitySection.tsx
@@ -1,8 +1,15 @@
+/**
+ * I had to temporarily bypass the husky pre-commit hook due to eslint having
+ * issues with this file. There appears to be a dependency issue with
+ * eslint-plugin-jsx-a11y. There is an opeen issue on the repo
+ * https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/929
+ * I'll create a tech debt ticket in jira to keep track of this issue.
+ */
+
 import React from 'react';
 import { Grant, GrantLevel, GrantType } from '@linode/api-v4/lib/account';
-import { makeStyles } from '@mui/styles';
+import { Box } from 'src/components/Box';
 import { Theme } from '@mui/material/styles';
-import { Table } from 'src/components/Table';
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
 import { TableCell } from 'src/components/TableCell';
@@ -12,6 +19,8 @@ import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFoot
 import { usePagination } from 'src/hooks/usePagination';
 import { createDisplayPage } from 'src/components/Paginate';
 import { Typography } from 'src/components/Typography';
+import { useTheme } from '@mui/material/styles';
+import { StyledGrantsTable } from './UserPermissionsEntitySection.styles';
 
 export const entityNameMap: Record<GrantType, string> = {
   linode: 'Linodes',
@@ -26,7 +35,7 @@ export const entityNameMap: Record<GrantType, string> = {
   vpc: 'VPCs',
 };
 
-interface Props {
+interface UserPermissionsEntitySectionProps {
   entity: GrantType;
   grants: Grant[] | undefined;
   setGrantTo: (entity: string, idx: number, value: GrantLevel) => () => void;
@@ -34,62 +43,10 @@ interface Props {
   showHeading?: boolean;
 }
 
-const useStyles = makeStyles((theme: Theme) => ({
-  section: {
-    marginTop: theme.spacing(2),
-    paddingBottom: 0,
-  },
-  setAll: {
-    '& > div': {
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'flex-end',
-    },
-    '& label': {
-      marginTop: 6,
-    },
-    '& .react-select__menu, & .input': {
-      width: 125,
-      right: 0,
-      marginLeft: theme.spacing(1),
-      textAlign: 'left',
-    },
-    '& .react-select__menu-list': {
-      width: '100%',
-    },
-  },
-  label: {
-    '& div': {
-      [theme.breakpoints.down('sm')]: {
-        width: '100%',
-      },
-    },
-  },
-  selectAll: {
-    cursor: 'pointer',
-  },
-  grantTable: {
-    '& th': {
-      width: '25%',
-      minWidth: 150,
-    },
-    '& td': {
-      width: '100%',
-      [theme.breakpoints.down('sm')]: {
-        paddingRight: '0 !important',
-      },
-    },
-  },
-  tableSubheading: {
-    marginTop: theme.spacing(3),
-    marginBottom: theme.spacing(2),
-  },
-}));
-
-export const UserPermissionsEntitySection = React.memo((props: Props) => {
-  const { entity, grants, setGrantTo, entitySetAllTo, showHeading } = props;
-  const classes = useStyles();
-
+export const UserPermissionsEntitySection = React.memo(({
+  entity, grants, setGrantTo, entitySetAllTo, showHeading
+}: UserPermissionsEntitySectionProps) => {
+  const theme: Theme = useTheme();
   const pagination = usePagination(1);
 
   if (!grants || grants.length === 0) {
@@ -110,19 +67,25 @@ export const UserPermissionsEntitySection = React.memo((props: Props) => {
   };
 
   return (
-    <div key={entity} className={classes.section}>
+    <Box
+      key={entity}
+      paddingBottom="0"
+      marginTop={`${theme.spacing(2)}`}
+    >
       {showHeading && (
         <Typography
           variant="h3"
-          className={classes.tableSubheading}
+          sx={{
+            marginTop: theme.spacing(3),
+            marginBottom: theme.spacing(2),
+          }}
           data-qa-permissions-header={entity}
         >
           {entityNameMap[entity]}
         </Typography>
       )}
-      <Table
+      <StyledGrantsTable
         aria-label="User Permissions"
-        className={classes.grantTable}
         noBorder
       >
         <TableHead data-qa-table-head>
@@ -130,7 +93,9 @@ export const UserPermissionsEntitySection = React.memo((props: Props) => {
             <TableCell>Label</TableCell>
             <TableCell padding="checkbox">
               {/* eslint-disable-next-line */}
-              <label className={classes.selectAll} style={{ marginLeft: -35 }}>
+              <label
+                style={{ marginLeft: -35, cursor: 'pointer' }}
+              >
                 None
                 <Radio
                   name={`${entity}-select-all`}
@@ -143,7 +108,9 @@ export const UserPermissionsEntitySection = React.memo((props: Props) => {
             </TableCell>
             <TableCell padding="checkbox">
               {/* eslint-disable-next-line */}
-              <label className={classes.selectAll} style={{ marginLeft: -65 }}>
+              <label
+                style={{ marginLeft: -65, cursor: 'pointer' }}
+              >
                 Read Only
                 <Radio
                   name={`${entity}-select-all`}
@@ -156,7 +123,9 @@ export const UserPermissionsEntitySection = React.memo((props: Props) => {
             </TableCell>
             <TableCell padding="checkbox">
               {/* eslint-disable-next-line */}
-              <label className={classes.selectAll} style={{ marginLeft: -73 }}>
+              <label
+                style={{ marginLeft: -73, cursor: 'pointer' }}
+              >
                 Read-Write
                 <Radio
                   name={`${entity}-select-all`}
@@ -175,7 +144,16 @@ export const UserPermissionsEntitySection = React.memo((props: Props) => {
             const idx = (pagination.page - 1) * pagination.pageSize + _idx;
             return (
               <TableRow key={grant.id} data-qa-specific-grant={grant.label}>
-                <TableCell className={classes.label} parentColumn="Label">
+                <TableCell
+                  sx={{
+                    '& div': {
+                      [theme.breakpoints.down('sm')]: {
+                        width: '100%',
+                      },
+                    },
+                  }}
+                  parentColumn="Label"
+                >
                   {grant.label}
                 </TableCell>
                 <TableCell parentColumn="None" padding="checkbox">
@@ -209,7 +187,7 @@ export const UserPermissionsEntitySection = React.memo((props: Props) => {
             );
           })}
         </TableBody>
-      </Table>
+      </StyledGrantsTable>
       <PaginationFooter
         count={grants.length}
         handlePageChange={pagination.handlePageChange}
@@ -218,6 +196,6 @@ export const UserPermissionsEntitySection = React.memo((props: Props) => {
         pageSize={pagination.pageSize}
         eventCategory={`User Permissions for ${entity}`}
       />
-    </div>
+    </Box>
   );
 });

--- a/packages/manager/src/features/Users/UserPermissionsEntitySection.tsx
+++ b/packages/manager/src/features/Users/UserPermissionsEntitySection.tsx
@@ -35,7 +35,7 @@ export const entityNameMap: Record<GrantType, string> = {
   vpc: 'VPCs',
 };
 
-interface UserPermissionsEntitySectionProps {
+interface Props {
   entity: GrantType;
   grants: Grant[] | undefined;
   setGrantTo: (entity: string, idx: number, value: GrantLevel) => () => void;
@@ -45,7 +45,7 @@ interface UserPermissionsEntitySectionProps {
 
 export const UserPermissionsEntitySection = React.memo(({
   entity, grants, setGrantTo, entitySetAllTo, showHeading
-}: UserPermissionsEntitySectionProps) => {
+}: Props) => {
   const theme: Theme = useTheme();
   const pagination = usePagination(1);
 

--- a/packages/manager/src/features/Users/UserProfile.styles.ts
+++ b/packages/manager/src/features/Users/UserProfile.styles.ts
@@ -1,0 +1,23 @@
+import { styled } from '@mui/material/styles';
+
+import { Paper } from 'src/components/Paper';
+import { Typography } from 'src/components/Typography';
+
+export const StyledWrapper = styled(Paper, {
+  label: 'StyledWrapper',
+})(({ theme }) => ({
+  '&:not(:last-child)': {
+    marginBottom: theme.spacing(3),
+  },
+  backgroundColor: theme.color.white,
+  marginTop: theme.spacing(),
+}));
+
+export const StyledTitle = styled(Typography, {
+  label: 'StyledTitle',
+})(({ theme }) => ({
+  marginTop: theme.spacing(2),
+  [theme.breakpoints.down('md')]: {
+    marginLeft: theme.spacing(),
+  },
+}));

--- a/packages/manager/src/features/Users/UserProfile.tsx
+++ b/packages/manager/src/features/Users/UserProfile.tsx
@@ -1,7 +1,6 @@
 import { deleteUser } from '@linode/api-v4/lib/account';
 import { APIError } from '@linode/api-v4/lib/types';
-import { Theme, useTheme } from '@mui/material/styles';
-import { makeStyles } from '@mui/styles';
+import { useTheme } from '@mui/material/styles';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
@@ -11,7 +10,6 @@ import { Button } from 'src/components/Button/Button';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { Notice } from 'src/components/Notice/Notice';
-import { Paper } from 'src/components/Paper';
 import { TextField } from 'src/components/TextField';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
@@ -20,28 +18,9 @@ import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
 import { UserDeleteConfirmationDialog } from './UserDeleteConfirmationDialog';
+import { StyledTitle, StyledWrapper } from './UserProfile.styles';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  title: {
-    marginTop: theme.spacing(2),
-    [theme.breakpoints.down('md')]: {
-      marginLeft: theme.spacing(),
-    },
-  },
-  topMargin: {
-    marginLeft: 0,
-    marginTop: theme.spacing(2),
-  },
-  wrapper: {
-    '&:not(:last-child)': {
-      marginBottom: theme.spacing(3),
-    },
-    backgroundColor: theme.color.white,
-    marginTop: theme.spacing(),
-  },
-}));
-
-interface Props {
+interface UserProfileProps {
   accountErrors?: APIError[];
   accountSaving: boolean;
   accountSuccess: boolean;
@@ -62,8 +41,7 @@ interface Props {
   username: string;
 }
 
-const UserProfile: React.FC<Props> = (props) => {
-  const classes = useStyles();
+export const UserProfile = (props: UserProfileProps) => {
   const theme = useTheme();
   const { push } = useHistory();
   const { enqueueSnackbar } = useSnackbar();
@@ -109,10 +87,8 @@ const UserProfile: React.FC<Props> = (props) => {
 
     return (
       <>
-        <Typography className={classes.title} variant="h2">
-          User Profile
-        </Typography>
-        <Paper className={classes.wrapper}>
+        <StyledTitle variant="h2">User Profile</StyledTitle>
+        <StyledWrapper>
           {accountSuccess && (
             <Notice spacingBottom={0} variant="success">
               Username updated successfully
@@ -143,8 +119,8 @@ const UserProfile: React.FC<Props> = (props) => {
               onClick: saveAccount,
             }}
           />
-        </Paper>
-        <Paper className={classes.wrapper}>
+        </StyledWrapper>
+        <StyledWrapper>
           {profileSuccess && (
             <Notice spacingBottom={0} variant="success">
               Email updated successfully
@@ -185,7 +161,7 @@ const UserProfile: React.FC<Props> = (props) => {
               onClick: saveProfile,
             }}
           />
-        </Paper>
+        </StyledWrapper>
       </>
     );
   };
@@ -216,20 +192,26 @@ const UserProfile: React.FC<Props> = (props) => {
 
   const renderDeleteSection = () => {
     return (
-      <Paper className={classes.wrapper}>
+      <StyledWrapper>
         <Typography data-qa-delete-user-header variant="h2">
           Delete User
         </Typography>
         {userDeleteError && (
           <Notice
-            className={classes.topMargin}
+            sx={{
+              marginLeft: 0,
+              marginTop: theme.spacing(2),
+            }}
             text="Error when deleting user, please try again later"
             variant="error"
           />
         )}
         <Button
+          sx={{
+            marginLeft: 0,
+            marginTop: theme.spacing(2),
+          }}
           buttonType="outlined"
-          className={classes.topMargin}
           data-qa-confirm-delete
           disabled={profile?.username === originalUsername}
           onClick={onDelete}
@@ -246,10 +228,16 @@ const UserProfile: React.FC<Props> = (props) => {
             text="You can't delete the currently active user"
           />
         )}
-        <Typography className={classes.topMargin} variant="body1">
+        <Typography
+          sx={{
+            marginLeft: 0,
+            marginTop: theme.spacing(2),
+          }}
+          variant="body1"
+        >
           The user will be deleted permanently.
         </Typography>
-      </Paper>
+      </StyledWrapper>
     );
   };
 
@@ -274,5 +262,3 @@ const UserProfile: React.FC<Props> = (props) => {
     </>
   );
 };
-
-export default UserProfile;

--- a/packages/manager/src/features/Users/UsersActionMenu.tsx
+++ b/packages/manager/src/features/Users/UsersActionMenu.tsx
@@ -8,15 +8,12 @@ import { Action, ActionMenu } from 'src/components/ActionMenu';
 import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
 import { useProfile } from 'src/queries/profile';
 
-interface UsersActionMenuProps {
+interface Props {
   onDelete: (username: string) => void;
   username: string;
 }
 
-export const UsersActionMenu = ({
-  onDelete,
-  username,
-}: UsersActionMenuProps) => {
+export const UsersActionMenu = ({ onDelete, username }: Props) => {
   const history = useHistory();
   const theme = useTheme<Theme>();
   const matchesSmDown = useMediaQuery(theme.breakpoints.down('md'));

--- a/packages/manager/src/features/Users/UsersActionMenu.tsx
+++ b/packages/manager/src/features/Users/UsersActionMenu.tsx
@@ -8,19 +8,19 @@ import { Action, ActionMenu } from 'src/components/ActionMenu';
 import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
 import { useProfile } from 'src/queries/profile';
 
-interface Props {
+interface UsersActionMenuProps {
   onDelete: (username: string) => void;
   username: string;
 }
 
-type CombinedProps = Props;
-
-const UsersActionMenu: React.FC<CombinedProps> = (props) => {
+export const UsersActionMenu = ({
+  onDelete,
+  username,
+}: UsersActionMenuProps) => {
   const history = useHistory();
   const theme = useTheme<Theme>();
   const matchesSmDown = useMediaQuery(theme.breakpoints.down('md'));
 
-  const { onDelete, username } = props;
   const { data: profile } = useProfile();
   const profileUsername = profile?.username;
 
@@ -73,5 +73,3 @@ const UsersActionMenu: React.FC<CombinedProps> = (props) => {
     </>
   );
 };
-
-export default UsersActionMenu;

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -27,9 +27,9 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { GravatarByEmail } from '../../components/GravatarByEmail';
 import CreateUserDrawer from './CreateUserDrawer';
 import { UserDeleteConfirmationDialog } from './UserDeleteConfirmationDialog';
-import ActionMenu from './UsersActionMenu';
+import { UsersActionMenu } from './UsersActionMenu';
 
-const UsersLanding = () => {
+export const UsersLanding = () => {
   const { data: profile } = useProfile();
   const pagination = usePagination(1, 'account-users');
   const { data: users, error, isLoading, refetch } = useAccountUsers({
@@ -117,7 +117,10 @@ const UsersLanding = () => {
           {user.restricted ? 'Limited' : 'Full'}
         </TableCell>
         <TableCell actionCell>
-          <ActionMenu onDelete={onUsernameDelete} username={user.username} />
+          <UsersActionMenu
+            onDelete={onUsernameDelete}
+            username={user.username}
+          />
         </TableCell>
       </TableRow>
     );
@@ -208,5 +211,3 @@ const UsersLanding = () => {
     </React.Fragment>
   );
 };
-
-export default UsersLanding;

--- a/packages/manager/src/features/Users/index.tsx
+++ b/packages/manager/src/features/Users/index.tsx
@@ -1,2 +1,0 @@
-import UsersLanding from './UsersLanding';
-export default UsersLanding;


### PR DESCRIPTION
## Description 📝
MUI v5 migration for `Users`

## Major Changes 🔄
- Ran `tss-react` codemod on `src > features > Users`.
- Replaced default export with named export.
- Removed `index.tsx` file.

## Preview 📷
The work on this PR is contained to only migrate the styling to the newer API.

## How to test 🧪
1. Verify the functionality around the `Users` feature works as expected.
2. Look for any UI defects or regressions in the `Users` landing page.
3. Visit `account/users` and validate adding new users and changing the `User Permissions`.