### PR TITLE
feat: [M3-7119] - Showcase VPC feedback

### DIFF
--- a/packages/manager/.changeset/pr-9751-upcoming-features-1696367790874.md
+++ b/packages/manager/.changeset/pr-9751-upcoming-features-1696367790874.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Showcase VPC feedback ([#9751](https://github.com/linode/manager/pull/9751))

--- a/packages/manager/cypress/e2e/core/vpc/vpc-details-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/vpc/vpc-details-page.spec.ts
@@ -188,7 +188,7 @@ describe('VPC details page', () => {
     // confirm there are no remaining subnets
     cy.url().should('endWith', `/${mockVPC.id}`);
     cy.findByText('Subnets (0)');
-    cy.findByText('No Subnets');
+    cy.findByText('No Subnets are assigned.');
     cy.findByText(mockSubnet.label).should('not.exist');
   });
 
@@ -226,7 +226,7 @@ describe('VPC details page', () => {
     // confirm that vpc and subnet details get displayed
     cy.findByText(mockVPC.label).should('be.visible');
     cy.findByText('Subnets (0)');
-    cy.findByText('No Subnets');
+    cy.findByText('No Subnets are assigned.');
 
     ui.button.findByTitle('Create Subnet').should('be.visible').click();
 

--- a/packages/manager/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/manager/src/components/Autocomplete/Autocomplete.tsx
@@ -65,6 +65,7 @@ export const Autocomplete = <
     disablePortal = true,
     errorText = '',
     helperText,
+    isOptionEqualToValue,
     label,
     limitTags = 2,
     loading = false,
@@ -132,6 +133,7 @@ export const Autocomplete = <
       defaultValue={defaultValue}
       disableCloseOnSelect={multiple}
       disablePortal={disablePortal}
+      isOptionEqualToValue={isOptionEqualToValue}
       limitTags={limitTags}
       loading={loading}
       loadingText={loadingText || 'Loading...'}

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
@@ -22,6 +22,10 @@ interface Props {
    */
   headerText: string;
   /**
+   * If false, hide the remove button
+   */
+  isRemovable?: boolean;
+  /**
    * The maxHeight of the list component, in px
    */
   maxHeight?: number;
@@ -52,6 +56,7 @@ interface Props {
 export const RemovableSelectionsList = (props: Props) => {
   const {
     headerText,
+    isRemovable,
     maxHeight,
     maxWidth,
     noDataText,
@@ -73,6 +78,7 @@ export const RemovableSelectionsList = (props: Props) => {
             maxHeight: maxHeight ? `${maxHeight}px` : '450px',
             maxWidth: maxWidth ? `${maxWidth}px` : '416px',
           }}
+          isRemovable={isRemovable}
         >
           {selectionData.map((selection) => (
             <SelectedOptionsListItem alignItems="center" key={selection.id}>
@@ -81,18 +87,20 @@ export const RemovableSelectionsList = (props: Props) => {
                   ? selection[preferredDataLabel]
                   : selection.label}
               </StyledLabel>
-              <IconButton
-                aria-label={`remove ${
-                  preferredDataLabel
-                    ? selection[preferredDataLabel]
-                    : selection.label
-                }`}
-                disableRipple
-                onClick={() => handleOnClick(selection)}
-                size="medium"
-              >
-                <Close />
-              </IconButton>
+              {isRemovable && (
+                <IconButton
+                  aria-label={`remove ${
+                    preferredDataLabel
+                      ? selection[preferredDataLabel]
+                      : selection.label
+                  }`}
+                  disableRipple
+                  onClick={() => handleOnClick(selection)}
+                  size="medium"
+                >
+                  <Close />
+                </IconButton>
+              )}
             </SelectedOptionsListItem>
           ))}
         </SelectedOptionsList>
@@ -130,10 +138,11 @@ const SelectedOptionsHeader = styled('h4', {
 
 const SelectedOptionsList = styled(List, {
   label: 'SelectedOptionsList',
-})(({ theme }) => ({
+  shouldForwardProp: (prop) => isPropValid(['isRemovable'], prop),
+})<{ isRemovable?: boolean }>(({ isRemovable, theme }) => ({
   background: theme.name === 'light' ? theme.bg.main : theme.bg.app,
   overflow: 'auto',
-  padding: '5px 0',
+  padding: !isRemovable ? '16px 0' : '5px 0',
   width: '100%',
 }));
 
@@ -142,6 +151,7 @@ const SelectedOptionsListItem = styled(ListItem, {
 })(() => ({
   justifyContent: 'space-between',
   paddingBottom: 0,
+  paddingRight: 4,
   paddingTop: 0,
 }));
 

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
@@ -56,7 +56,7 @@ interface Props {
 export const RemovableSelectionsList = (props: Props) => {
   const {
     headerText,
-    isRemovable,
+    isRemovable = true,
     maxHeight,
     maxWidth,
     noDataText,

--- a/packages/manager/src/features/VPCs/VPCCreate/MultipleSubnetInput.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/MultipleSubnetInput.test.tsx
@@ -41,24 +41,24 @@ describe('MultipleSubnetInput', () => {
 
   it('should add a subnet to the array when the Add Subnet button is clicked', () => {
     const { getByText } = renderWithTheme(<MultipleSubnetInput {...props} />);
-    const addButton = getByText('Add a Subnet');
+    const addButton = getByText('Add another Subnet');
     fireEvent.click(addButton);
     expect(props.onChange).toHaveBeenCalledWith([
       ...props.subnets,
       {
-        ip: { ipv4: '10.0.4.0/24', ipv4Error: '', availIPv4s: 256 },
+        ip: { availIPv4s: 256, ipv4: '10.0.4.0/24', ipv4Error: '' },
         label: '',
         labelError: '',
       },
     ]);
   });
 
-  it('all inputs after the first should have a close button (X)', () => {
+  it('all inputs should have a close button (X)', () => {
     const { queryAllByTestId } = renderWithTheme(
       <MultipleSubnetInput {...props} />
     );
     expect(queryAllByTestId(/delete-subnet/)).toHaveLength(
-      props.subnets.length - 1
+      props.subnets.length
     );
   });
 

--- a/packages/manager/src/features/VPCs/VPCCreate/MultipleSubnetInput.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/MultipleSubnetInput.tsx
@@ -50,7 +50,6 @@ export const MultipleSubnetInput = (props: Props) => {
     <Grid>
       {subnets.map((subnet, subnetIdx) => (
         <Grid key={`subnet-${subnetIdx}`}>
-          {subnetIdx !== 0 && <Divider sx={{ marginTop: theme.spacing(3) }} />}
           <SubnetNode
             onChange={(subnet, subnetIdx, removable) =>
               handleSubnetChange(subnet, subnetIdx ?? 0, !!removable)
@@ -60,9 +59,9 @@ export const MultipleSubnetInput = (props: Props) => {
             isRemovable={true}
             subnet={subnet}
           />
+          <Divider sx={{ marginTop: theme.spacing(3) }} />
         </Grid>
       ))}
-      <Divider sx={{ marginTop: theme.spacing(3) }} />
       <Button
         buttonType="outlined"
         disabled={disabled}

--- a/packages/manager/src/features/VPCs/VPCCreate/MultipleSubnetInput.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/MultipleSubnetInput.tsx
@@ -62,13 +62,14 @@ export const MultipleSubnetInput = (props: Props) => {
           />
         </Grid>
       ))}
+      <Divider sx={{ marginTop: theme.spacing(3) }} />
       <Button
         buttonType="outlined"
         disabled={disabled}
         onClick={addSubnet}
-        sx={{ marginTop: theme.spacing(3) }}
+        sx={{ marginTop: theme.spacing(2) }}
       >
-        Add a Subnet
+        Add {subnets.length > 0 ? 'another' : 'a'} Subnet
       </Button>
     </Grid>
   );

--- a/packages/manager/src/features/VPCs/VPCCreate/SubnetNode.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/SubnetNode.test.tsx
@@ -60,7 +60,7 @@ describe('SubnetNode', () => {
     expect(ipAddress).toBeInTheDocument();
   });
 
-  it('should show a removable button if isRemovable is true and subnet idx exists and is > 0', () => {
+  it('should show a removable button if isRemovable is true', () => {
     renderWithTheme(
       <SubnetNode
         disabled={false}
@@ -73,20 +73,5 @@ describe('SubnetNode', () => {
 
     const removableButton = screen.getByTestId('delete-subnet-1');
     expect(removableButton).toBeInTheDocument();
-  });
-
-  it('should not show a removable button for a subnet with idx 0', () => {
-    renderWithTheme(
-      <SubnetNode
-        disabled={false}
-        idx={0}
-        isRemovable={true}
-        onChange={() => {}}
-        subnet={{ ip: { ipv4: '' }, label: '' }}
-      />
-    );
-
-    const removableButton = screen.queryByTestId('delete-subnet-0');
-    expect(removableButton).not.toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/VPCs/VPCCreate/SubnetNode.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/SubnetNode.tsx
@@ -7,9 +7,9 @@ import { Button } from 'src/components/Button/Button';
 import { FormHelperText } from 'src/components/FormHelperText';
 import { TextField } from 'src/components/TextField';
 import {
-  calculateAvailableIPv4sRFC1918,
-  SubnetFieldState,
   RESERVED_IP_NUMBER,
+  SubnetFieldState,
+  calculateAvailableIPv4sRFC1918,
 } from 'src/utilities/subnets';
 
 interface Props {
@@ -56,8 +56,8 @@ export const SubnetNode = (props: Props) => {
     <Grid key={idx} sx={{ maxWidth: 460 }}>
       <Grid container direction="row" spacing={2}>
         <Grid
-          xs={isRemovable ? 11 : 12}
           sx={{ ...(!isRemovable && { width: '100%' }) }}
+          xs={isRemovable ? 11 : 12}
         >
           <TextField
             disabled={disabled}
@@ -69,13 +69,11 @@ export const SubnetNode = (props: Props) => {
             value={subnet.label}
           />
         </Grid>
-        {isRemovable && !!idx && (
-          <Grid xs={1}>
-            <StyledButton onClick={removeSubnet}>
-              <Close data-testid={`delete-subnet-${idx}`} />
-            </StyledButton>
-          </Grid>
-        )}
+        <Grid xs={1}>
+          <StyledButton onClick={removeSubnet}>
+            <Close data-testid={`delete-subnet-${idx}`} />
+          </StyledButton>
+        </Grid>
       </Grid>
       <Grid xs={isRemovable ? 11 : 12}>
         <TextField

--- a/packages/manager/src/features/VPCs/VPCCreate/SubnetNode.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/SubnetNode.tsx
@@ -69,11 +69,13 @@ export const SubnetNode = (props: Props) => {
             value={subnet.label}
           />
         </Grid>
-        <Grid xs={1}>
-          <StyledButton onClick={removeSubnet}>
-            <Close data-testid={`delete-subnet-${idx}`} />
-          </StyledButton>
-        </Grid>
+        {isRemovable && (
+          <Grid xs={1}>
+            <StyledButton onClick={removeSubnet}>
+              <Close data-testid={`delete-subnet-${idx}`} />
+            </StyledButton>
+          </Grid>
+        )}
       </Grid>
       <Grid xs={isRemovable ? 11 : 12}>
         <TextField

--- a/packages/manager/src/features/VPCs/VPCCreate/VPCCreate.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/VPCCreate.test.tsx
@@ -25,7 +25,7 @@ describe('VPC create page', () => {
     getAllByText('Subnets');
     getAllByText('Subnet label');
     getAllByText('Subnet IP Address Range');
-    getAllByText('Add a Subnet');
+    getAllByText('Add another Subnet');
     getAllByText('Create VPC');
   });
 
@@ -55,7 +55,7 @@ describe('VPC create page', () => {
 
   it('should add and delete subnets correctly', async () => {
     renderWithTheme(<VPCCreate />);
-    const addSubnet = screen.getByText('Add a Subnet');
+    const addSubnet = screen.getByText('Add another Subnet');
     expect(addSubnet).toBeInTheDocument();
     await act(async () => {
       userEvent.click(addSubnet);

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.tsx
@@ -346,6 +346,7 @@ export const SubnetAssignLinodesDrawer = (
         <Notice text={assignLinodesErrors.none} variant="error" />
       )}
       <Notice
+        spacingBottom={16}
         text={`${ASSIGN_LINODES_DRAWER_REBOOT_MESSAGE}`}
         variant="warning"
       />

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.styles.ts
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.styles.ts
@@ -22,6 +22,12 @@ export const StyledTableCell = styled(TableCell, {
   border: 'none',
 }));
 
+export const StyledActionTableCell = styled(TableCell, {
+  label: 'StyledActionTableCell',
+})(() => ({
+  border: 'none',
+}));
+
 export const StyledTableHeadCell = styled(TableCell, {
   label: 'StyledTableHeadCell',
 })(({ theme }) => ({

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.test.tsx
@@ -43,7 +43,11 @@ describe('SubnetLinodeRow', () => {
       getByText,
     } = renderWithTheme(
       wrapWithTableBody(
-        <SubnetLinodeRow linodeId={linodeFactory1.id} subnetId={0} />
+        <SubnetLinodeRow
+          handleUnassignLinode={jest.fn()}
+          linodeId={linodeFactory1.id}
+          subnetId={0}
+        />
       ),
       {
         queryClient,

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/react';
 import { waitForElementToBeRemoved } from '@testing-library/react';
 import * as React from 'react';
 import { QueryClient } from 'react-query';
@@ -24,7 +25,7 @@ afterEach(() => {
 const loadingTestId = 'circle-progress';
 
 describe('SubnetLinodeRow', () => {
-  it('should display linode label, status, id, vpc ipv4 address, and associated firewalls', async () => {
+  it('should display linode label, status, id, vpc ipv4 address, associated firewalls and unassign button', async () => {
     const linodeFactory1 = linodeFactory.build({ id: 1, label: 'linode-1' });
     server.use(
       rest.get('*/linodes/instances/:linodeId', (req, res, ctx) => {
@@ -36,6 +37,8 @@ describe('SubnetLinodeRow', () => {
       })
     );
 
+    const handleUnassignLinode = jest.fn();
+
     const {
       getAllByRole,
       getAllByText,
@@ -44,7 +47,7 @@ describe('SubnetLinodeRow', () => {
     } = renderWithTheme(
       wrapWithTableBody(
         <SubnetLinodeRow
-          handleUnassignLinode={jest.fn()}
+          handleUnassignLinode={handleUnassignLinode}
           linodeId={linodeFactory1.id}
           subnetId={0}
         />
@@ -64,8 +67,14 @@ describe('SubnetLinodeRow', () => {
       'href',
       `/linodes/${linodeFactory1.id}`
     );
+
     getAllByText(linodeFactory1.id);
     getAllByText('10.0.0.0');
     getByText('mock-firewall-0');
+
+    const unassignLinodeButton = getAllByRole('button')[0];
+    expect(unassignLinodeButton).toHaveTextContent('Unassign Linode');
+    fireEvent.click(unassignLinodeButton);
+    expect(handleUnassignLinode).toHaveBeenCalled();
   });
 });

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
@@ -20,6 +20,7 @@ import { capitalizeAllWords } from 'src/utilities/capitalize';
 
 import { getSubnetInterfaceFromConfigs } from '../utils';
 import {
+  StyledActionTableCell,
   StyledTableCell,
   StyledTableHeadCell,
   StyledTableRow,
@@ -117,12 +118,12 @@ export const SubnetLinodeRow = (props: Props) => {
           )}
         </StyledTableCell>
       </Hidden>
-      <TableCell actionCell>
+      <StyledActionTableCell actionCell>
         <InlineMenuAction
           actionText="Unassign Linode"
           onClick={() => handleUnassignLinode(subnet, linode)}
         />
-      </TableCell>
+      </StyledActionTableCell>
     </StyledTableRow>
   );
 };

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
@@ -219,6 +219,6 @@ export const SubnetLinodeTableRowHead = (
     <Hidden smDown>
       <StyledTableHeadCell>Firewalls</StyledTableHeadCell>
     </Hidden>
-    <StyledTableHeadCell sx={{ width: '11%' }}></StyledTableHeadCell>
+    <StyledTableHeadCell></StyledTableHeadCell>
   </TableRow>
 );

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
@@ -206,9 +206,7 @@ const getFirewallLinks = (data: Firewall[]): JSX.Element => {
 
 export const SubnetLinodeTableRowHead = (
   <TableRow>
-    <StyledTableHeadCell sx={{ width: '24%' }}>
-      Linode Label
-    </StyledTableHeadCell>
+    <StyledTableHeadCell>Linode Label</StyledTableHeadCell>
     <StyledTableHeadCell sx={{ width: '14%' }}>Status</StyledTableHeadCell>
     <Hidden lgDown>
       <StyledTableHeadCell sx={{ width: '10%' }}>Linode ID</StyledTableHeadCell>

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { Box } from 'src/components/Box';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { Hidden } from 'src/components/Hidden';
+import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
 import { Link } from 'src/components/Link';
 import { StatusIcon } from 'src/components/StatusIcon/StatusIcon';
 import { TableCell } from 'src/components/TableCell';
@@ -24,13 +25,17 @@ import {
   StyledTableRow,
 } from './SubnetLinodeRow.styles';
 
+import type { Subnet } from '@linode/api-v4/lib/vpcs/types';
+
 interface Props {
+  handleUnassignLinode: any;
   linodeId: number;
+  subnet?: Subnet;
   subnetId: number;
 }
 
 export const SubnetLinodeRow = (props: Props) => {
-  const { linodeId, subnetId } = props;
+  const { handleUnassignLinode, linodeId, subnet, subnetId } = props;
 
   const {
     data: linode,
@@ -112,6 +117,12 @@ export const SubnetLinodeRow = (props: Props) => {
           )}
         </StyledTableCell>
       </Hidden>
+      <TableCell actionCell>
+        <InlineMenuAction
+          actionText="Unassign Linode"
+          onClick={() => handleUnassignLinode(subnet, linode)}
+        />
+      </TableCell>
     </StyledTableRow>
   );
 };
@@ -202,10 +213,11 @@ export const SubnetLinodeTableRowHead = (
       <StyledTableHeadCell sx={{ width: '10%' }}>Linode ID</StyledTableHeadCell>
     </Hidden>
     <Hidden smDown>
-      <StyledTableHeadCell sx={{ width: '20%' }}>VPC IPv4</StyledTableHeadCell>
+      <StyledTableHeadCell>VPC IPv4</StyledTableHeadCell>
     </Hidden>
     <Hidden smDown>
       <StyledTableHeadCell>Firewalls</StyledTableHeadCell>
     </Hidden>
+    <StyledTableHeadCell sx={{ width: '11%' }}></StyledTableHeadCell>
   </TableRow>
 );

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
@@ -1,5 +1,5 @@
 import { Subnet } from '@linode/api-v4/lib/vpcs/types';
-import { Stack } from '@mui/material';
+import { Stack, Typography } from '@mui/material';
 import { useFormik } from 'formik';
 import * as React from 'react';
 import { useQueryClient } from 'react-query';
@@ -284,19 +284,27 @@ export const SubnetUnassignLinodesDrawer = React.memo(
           <Notice text={unassignLinodesErrors[0].reason} variant="error" />
         )}
         <Notice text={SUBNET_UNASSIGN_LINODES_WARNING} variant="warning" />
+        {!selectedLinode && (
+          <Typography>
+            Select the Linodes you would like to unassign from this subnet. Only
+            Linodes in this VPC&rsquo;s region are displayed.
+          </Typography>
+        )}
         <form onSubmit={handleSubmit}>
           <Stack>
-            <Autocomplete
-              disabled={userCannotUnassignLinodes}
-              errorText={linodesError ? linodesError[0].reason : undefined}
-              label="Linodes"
-              multiple
-              onChange={(_, value) => setSelectedLinodes(value)}
-              options={linodeOptionsToUnassign}
-              placeholder="Select Linodes or type to search"
-              renderTags={() => null}
-              value={selectedLinodes}
-            />
+            {!selectedLinode && (
+              <Autocomplete
+                disabled={userCannotUnassignLinodes}
+                errorText={linodesError ? linodesError[0].reason : undefined}
+                label="Linodes"
+                multiple
+                onChange={(_, value) => setSelectedLinodes(value)}
+                options={linodeOptionsToUnassign}
+                placeholder="Select Linodes or type to search"
+                renderTags={() => null}
+                value={selectedLinodes}
+              />
+            )}
             <RemovableSelectionsList
               headerText={`Linodes to be Unassigned from Subnet (${selectedLinodes.length})`}
               noDataText={'Select Linodes to be Unassigned from Subnet.'}

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
@@ -33,12 +33,13 @@ import type {
 interface Props {
   onClose: () => void;
   open: boolean;
+  selectedLinode?: Linode;
   subnet?: Subnet;
   vpcId: number;
 }
 
 export const SubnetUnassignLinodesDrawer = React.memo(
-  ({ onClose, open, subnet, vpcId }: Props) => {
+  ({ onClose, open, selectedLinode, subnet, vpcId }: Props) => {
     const { data: profile } = useProfile();
     const { data: grants } = useGrants();
     const vpcPermissions = grants?.vpc.find((v) => v.id === vpcId);
@@ -52,7 +53,9 @@ export const SubnetUnassignLinodesDrawer = React.memo(
 
     const csvRef = React.useRef<any>();
     const formattedDate = useFormattedDate();
-    const [selectedLinodes, setSelectedLinodes] = React.useState<Linode[]>([]);
+    const [selectedLinodes, setSelectedLinodes] = React.useState<Linode[]>(
+      selectedLinode ? [selectedLinode] : []
+    );
     const prevSelectedLinodes = usePrevious(selectedLinodes);
     const hasError = React.useRef(false); // This flag is used to prevent the drawer from closing if an error occurs.
 

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
@@ -300,6 +300,7 @@ export const SubnetUnassignLinodesDrawer = React.memo(
               <Autocomplete
                 disabled={userCannotUnassignLinodes}
                 errorText={linodesError ? linodesError[0].reason : undefined}
+                isOptionEqualToValue={() => true} // Ignore the multi-select warning since it isn't helpful https://github.com/mui/material-ui/issues/29727
                 label="Linodes"
                 multiple
                 onChange={(_, value) => setSelectedLinodes(value)}

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
@@ -92,6 +92,9 @@ export const SubnetUnassignLinodesDrawer = React.memo(
       if (linodes) {
         setLinodeOptionsToUnassign(findAssignedLinodes() ?? []);
       }
+      return () => {
+        setLinodeOptionsToUnassign([]);
+      };
     }, [linodes, setLinodeOptionsToUnassign, findAssignedLinodes]);
 
     // 3. Everytime our selection changes, we need to either add or remove the linode from the configInterfacesToDelete state.

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
@@ -283,7 +283,11 @@ export const SubnetUnassignLinodesDrawer = React.memo(
         {unassignLinodesErrors.length > 0 && (
           <Notice text={unassignLinodesErrors[0].reason} variant="error" />
         )}
-        <Notice text={SUBNET_UNASSIGN_LINODES_WARNING} variant="warning" />
+        <Notice
+          spacingBottom={selectedLinode ? 0 : 16}
+          text={SUBNET_UNASSIGN_LINODES_WARNING}
+          variant="warning"
+        />
         {!selectedLinode && (
           <Typography>
             Select the Linodes you would like to unassign from this subnet. Only
@@ -307,6 +311,7 @@ export const SubnetUnassignLinodesDrawer = React.memo(
             )}
             <RemovableSelectionsList
               headerText={`Linodes to be Unassigned from Subnet (${selectedLinodes.length})`}
+              isRemovable={selectedLinode ? false : true}
               noDataText={'Select Linodes to be Unassigned from Subnet.'}
               onRemove={handleRemoveLinode}
               selectionData={selectedLinodes}

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
@@ -240,7 +240,7 @@ export const VPCSubnetsTable = (props: Props) => {
                 />
               ))
             ) : (
-              <TableRowEmpty colSpan={5} message={'No Linodes'} />
+              <TableRowEmpty colSpan={6} message={'No Linodes'} />
             )}
           </TableBody>
         </Table>

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
@@ -276,8 +276,10 @@ export const VPCSubnetsTable = (props: Props) => {
         vpcId={vpcId}
       />
       <CollapsibleTable
+        TableRowEmpty={
+          <TableRowEmpty colSpan={5} message={'No Subnets are assigned.'} />
+        }
         TableItems={getTableItems()}
-        TableRowEmpty={<TableRowEmpty colSpan={5} message={'No Subnets'} />}
         TableRowHead={SubnetTableRowHead}
       />
       <PaginationFooter

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
@@ -31,6 +31,7 @@ import { SubnetEditDrawer } from './SubnetEditDrawer';
 import { SubnetLinodeRow, SubnetLinodeTableRowHead } from './SubnetLinodeRow';
 import { SubnetUnassignLinodesDrawer } from './SubnetUnassignLinodesDrawer';
 
+import type { Linode } from '@linode/api-v4/lib/linodes/types';
 import type { Subnet } from '@linode/api-v4/lib/vpcs/types';
 
 interface Props {
@@ -46,6 +47,9 @@ export const VPCSubnetsTable = (props: Props) => {
   const [subnetsFilterText, setSubnetsFilterText] = React.useState('');
   const [selectedSubnet, setSelectedSubnet] = React.useState<
     Subnet | undefined
+  >();
+  const [selectedLinode, setSelectedLinode] = React.useState<
+    Linode | undefined
   >();
   const [deleteSubnetDialogOpen, setDeleteSubnetDialogOpen] = React.useState(
     false
@@ -125,6 +129,12 @@ export const VPCSubnetsTable = (props: Props) => {
 
   const handleSubnetUnassignLinodes = (subnet: Subnet) => {
     setSelectedSubnet(subnet);
+    setSubnetUnassignLinodesDrawerOpen(true);
+  };
+
+  const handleSubnetUnassignLinode = (subnet: Subnet, linode: Linode) => {
+    setSelectedSubnet(subnet);
+    setSelectedLinode(linode);
     setSubnetUnassignLinodesDrawerOpen(true);
   };
 
@@ -222,8 +232,10 @@ export const VPCSubnetsTable = (props: Props) => {
             {subnet.linodes.length > 0 ? (
               subnet.linodes.map((linodeId) => (
                 <SubnetLinodeRow
+                  handleUnassignLinode={handleSubnetUnassignLinode}
                   key={linodeId}
                   linodeId={linodeId}
+                  subnet={subnet}
                   subnetId={subnet.id}
                 />
               ))
@@ -293,8 +305,10 @@ export const VPCSubnetsTable = (props: Props) => {
         <SubnetUnassignLinodesDrawer
           onClose={() => {
             setSubnetUnassignLinodesDrawerOpen(false);
+            setSelectedLinode(undefined);
           }}
           open={subnetUnassignLinodesDrawerOpen}
+          selectedLinode={selectedLinode}
           subnet={selectedSubnet}
           vpcId={vpcId}
         />


### PR DESCRIPTION
## Description 📝
Address Showcase feedback

VPC Create
- Added remove X icon to default subnet label input.
- Changed button text from “Add Subnet” to “Add Another Subnet”.
- Button text is “Add a Subnet” when there are no subnets added.

VPC Details - Subnets
- Added `Unassign Linode` inline button to the Subnets table row which will open the Unassign Linodes drawer with the Linode pre-selected and the Linode select hidden.
  - Added helper text to the Unassign Linode drawer per the UX mocks and hide the helper text if the drawer is opened via inline Unassign Linode
- Updated Subnets table empty state text
- Pluralize Subnet action menu item text “Assign Linode” -> “Assign Linodes” and “Unassign Linode” -> “Unassign Linodes”.

## Preview 📷
| VPC Create  | VPC Details - Subnets  |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/115299789/e6fe14a0-a4de-447b-8e99-dd6886a3530c" /> | <video src="https://github.com/linode/manager/assets/115299789/1c105033-0f73-49a9-a0ad-8f611951b9c8" /> |

## How to test 🧪
With a properly-tagged account or with the VPC feature flag on:
- Go to `/vpcs/create` and check the Subnets flow
  - You should be able to delete the first Subnet now
- Go to a VPC's details page
  - Create a Subnet and assign Linodes to it if you don't already have one
- Expand the collapsible table row and you should see `Unassign Linode` in the row
- Clicking that should bring up the Unassign Linodes drawer with that Linode pre-selected
- Unassign the Linode and ensure the Subnets table updates as normal

```
yarn test MultipleSubnetInput
yarn test SubnetNode
yarn test VPCCreate
yarn test SubnetLinodeRow
```
