### PR TITLE
chore: [M3-7231] - Migrate Filesystem TextField Select to Autocomplete

### DIFF
--- a/packages/manager/.changeset/pr-9752-tech-stories-1696367849962.md
+++ b/packages/manager/.changeset/pr-9752-tech-stories-1696367849962.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Migrate Filesystem TextField Select to Autocomplete ([#9752](https://github.com/linode/manager/pull/9752))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/CreateDiskDrawer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/CreateDiskDrawer.tsx
@@ -153,7 +153,7 @@ export const CreateDiskDrawer = (props: Props) => {
               formik.touched.filesystem ? formik.errors.filesystem : undefined
             }
             onChange={(_, option) =>
-              formik.setFieldValue('filesystem', option?.label)
+              formik.setFieldValue('filesystem', option.label)
             }
             value={fileSystemOptions.find(
               (option) => option.label === formik.values.filesystem

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/CreateDiskDrawer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/CreateDiskDrawer.tsx
@@ -8,11 +8,11 @@ import { useSnackbar } from 'notistack';
 import * as React from 'react';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
+import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
 import { Drawer } from 'src/components/Drawer';
 import { Item } from 'src/components/EnhancedSelect/Select';
 import { FormHelperText } from 'src/components/FormHelperText';
 import { InputAdornment } from 'src/components/InputAdornment';
-import { MenuItem } from 'src/components/MenuItem';
 import { Mode, ModeSelect } from 'src/components/ModeSelect/ModeSelect';
 import { Notice } from 'src/components/Notice/Notice';
 import { TextField } from 'src/components/TextField';
@@ -112,6 +112,14 @@ export const CreateDiskDrawer = (props: Props) => {
     }
   }, [open]);
 
+  const fileSystemOptions = [
+    { label: 'raw' },
+    { label: 'swap' },
+    { label: 'ext3' },
+    { label: 'ext4' },
+    { label: 'initrd' },
+  ];
+
   return (
     <Drawer onClose={onClose} open={open} title="Create Disk">
       <form onSubmit={formik.handleSubmit}>
@@ -140,26 +148,21 @@ export const CreateDiskDrawer = (props: Props) => {
           value={formik.values.label}
         />
         {selectedMode === 'empty' && (
-          <TextField
+          <Autocomplete
             errorText={
               formik.touched.filesystem ? formik.errors.filesystem : undefined
             }
+            onChange={(_, option) =>
+              formik.setFieldValue('filesystem', option?.label)
+            }
+            value={fileSystemOptions.find(
+              (option) => option.label === formik.values.filesystem
+            )}
+            disableClearable
             label="Filesystem"
-            name="filesystem"
             onBlur={formik.handleBlur}
-            onChange={formik.handleChange}
-            select
-            value={formik.values.filesystem}
-          >
-            <MenuItem value="_none_">
-              <em>Select a Filesystem</em>
-            </MenuItem>
-            {['raw', 'swap', 'ext3', 'ext4', 'initrd'].map((fs) => (
-              <MenuItem key={fs} value={fs}>
-                {fs}
-              </MenuItem>
-            ))}
-          </TextField>
+            options={fileSystemOptions}
+          />
         )}
         {selectedMode === 'from_image' && (
           <ImageAndPassword


### PR DESCRIPTION
## Description 📝

In order to fix up our TextField component, we need to **not** allow it to be used as a select component. This PR replaces the TextField Select in CreateDiskDrawer with a modern alternative like Autocomplete

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-10-03 at 5 07 18 PM](https://github.com/linode/manager/assets/115251059/b34177fe-ffc6-4280-aa25-92e7f60b0f2e) | ![Screenshot 2023-10-03 at 5 07 48 PM](https://github.com/linode/manager/assets/115251059/c5e70ea0-a562-476d-b4d9-74fdbd9f1795) |

## How to test 🧪
- Create a Linode
- Go to the Linode's details page
- Go to the `Storage` tab
- Shutdown the Linode
- Delete all of the Linode's disks
- Click `Add Disk`
- Test the `Filesystem` select functionality
- Verify the POST post works and sends the correct filesystem type in the payload