### PR TITLE
change: [OCA-1218] - Comment out CS:GO app pending update

### DIFF
--- a/packages/manager/.changeset/pr-9753-changed-1696626338930.md
+++ b/packages/manager/.changeset/pr-9753-changed-1696626338930.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Comment out CS:GO app pending update ([#9753](https://github.com/linode/manager/pull/9753))

--- a/packages/manager/src/features/StackScripts/stackScriptUtils.ts
+++ b/packages/manager/src/features/StackScripts/stackScriptUtils.ts
@@ -115,9 +115,8 @@ export const baseApps = {
   '1008125': 'Easypanel',
   '1017300': 'Kali Linux',
   '1037036': 'Budibase',
-  // uncomment clusters after marketplace release
-  // '1226544': 'HashiCorp Nomad Cluster',
-  // '1226545': 'HashiCorp Nomad Clients Cluster',
+  '1226544': 'HashiCorp Nomad Cluster',
+  '1226545': 'HashiCorp Nomad Clients Cluster',
   '1037037': 'HashiCorp Nomad',
   '1037038': 'HashiCorp Vault',
   '1051714': 'Microweber',

--- a/packages/manager/src/features/StackScripts/stackScriptUtils.ts
+++ b/packages/manager/src/features/StackScripts/stackScriptUtils.ts
@@ -22,7 +22,7 @@ export const baseApps = {
   '401697': 'WordPress - Latest One-Click',
   '401698': 'Drupal - Latest One-Click',
   '401699': 'Ark - Latest One-Click',
-  '401700': 'CS:GO - Latest One-Click',
+  // '401700': 'CS:GO - Latest One-Click',
   '401701': 'LAMP One-Click',
   '401702': 'MERN One-Click',
   '401703': 'Rust - Latest One-Click',

--- a/packages/manager/src/features/StackScripts/stackScriptUtils.ts
+++ b/packages/manager/src/features/StackScripts/stackScriptUtils.ts
@@ -22,7 +22,7 @@ export const baseApps = {
   '401697': 'WordPress - Latest One-Click',
   '401698': 'Drupal - Latest One-Click',
   '401699': 'Ark - Latest One-Click',
-  // '401700': 'CS:GO - Latest One-Click',
+  // '401700': 'CS:GO - Latest One-Click', // CS:GO app is defunct because the sequel is out
   '401701': 'LAMP One-Click',
   '401702': 'MERN One-Click',
   '401703': 'Rust - Latest One-Click',


### PR DESCRIPTION
## Description 📝
We received a report that the CS:GO app is defunct because the sequel is out. removing pending updates. 

## Major Changes 🔄
- comment out CS:GO marketplace app to remove from front-end
