### PR TITLE
hotfix: [M3-7234] - Disable Tokyo in RegionSelect

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [2023-10-02] - v1.104.1
 
-- Fixed: Add disabled Tokyo RegionSelect menu entry
+### Fixed:
+
+- Add disabled Tokyo RegionSelect menu entry ([#9758](https://github.com/linode/manager/pull/9758))
 
 ## [2023-10-02] - v1.104.0
 

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2023-10-02] - v1.104.1
+
+- Fixed: Add disabled Tokyo RegionSelect menu entry
+
 ## [2023-10-02] - v1.104.0
 
 ### Added:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.104.0",
+  "version": "1.104.1",
   "private": true,
   "bugs": {
     "url": "https://github.com/Linode/manager/issues"

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/DisabledRegions.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/DisabledRegions.tsx
@@ -10,7 +10,10 @@ const tokyoDisabledMessage = (
   <Typography>
     Tokyo is sold out while we expand our capacity. We recommend deploying
     workloads in Osaka.{` `}
-    <Link to="TODO">Learn more</Link>.
+    <Link to="https://www.linode.com/blog/linode/tokyo-region-availability-update/">
+      Learn more
+    </Link>
+    .
   </Typography>
 );
 
@@ -39,7 +42,7 @@ interface DisabledRegion {
   regionId: 'ap-northeast';
 }
 
-export const disabledRegions: DisabledRegion[] = [
+export const listOfDisabledRegions: DisabledRegion[] = [
   {
     disabledMessage: tokyoDisabledMessage,
     fakeRegion: fakeTokyo,

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/DisabledRegions.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/DisabledRegions.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+
+import { Link } from 'src/components/Link';
+import { Typography } from 'src/components/Typography';
+
+import type { Capabilities, Region, RegionStatus } from '@linode/api-v4';
+
+// DATA
+const tokyoDisabledMessage = (
+  <Typography>
+    Tokyo is sold out while we expand our capacity. We recommend deploying
+    workloads in Osaka.{` `}
+    <Link to="TODO">Learn more</Link>.
+  </Typography>
+);
+
+const fakeTokyo: FakeRegion = {
+  capabilities: ['Linodes', 'NodeBalancers'] as Capabilities[],
+  country: 'jp',
+  disabled: true,
+  display: 'Tokyo, JP',
+  id: 'ap-northeast',
+  label: 'Tokyo, JP',
+  resolvers: {
+    ipv4:
+      '173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5',
+    ipv6: '',
+  },
+  status: 'ok' as RegionStatus,
+};
+
+type FakeRegion = Region & { disabled: boolean; display: string };
+
+// UTILS
+interface DisabledRegion {
+  disabledMessage: JSX.Element;
+  fakeRegion: FakeRegion;
+  featureFlag: string;
+  regionId: 'ap-northeast';
+}
+
+export const disabledRegions: DisabledRegion[] = [
+  {
+    disabledMessage: tokyoDisabledMessage,
+    fakeRegion: fakeTokyo,
+    featureFlag: 'soldOutTokyo',
+    regionId: 'ap-northeast',
+  },
+];

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.test.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.test.tsx
@@ -8,7 +8,11 @@ const flags = {};
 describe('Region Select helper functions', () => {
   describe('getRegionOptions', () => {
     it('should return a list of items grouped by continent', () => {
-      const groupedRegions = getRegionOptions(regions, flags);
+      const groupedRegions = getRegionOptions(
+        regions,
+        flags,
+        '/linodes/create'
+      );
       const [r1, r2, r3, r4, r5] = groupedRegions;
       expect(groupedRegions).toHaveLength(8);
       expect(r1.options).toHaveLength(5);
@@ -19,7 +23,11 @@ describe('Region Select helper functions', () => {
     });
 
     it('should group unrecognized regions as Other', () => {
-      const groupedRegions = getRegionOptions([fakeRegion], flags);
+      const groupedRegions = getRegionOptions(
+        [fakeRegion],
+        flags,
+        '/linodes/create'
+      );
       expect(
         groupedRegions.find((group) => group.label === 'Other')
       ).toBeDefined();
@@ -28,7 +36,11 @@ describe('Region Select helper functions', () => {
 
   describe('getSelectedRegionById', () => {
     it('should return the matching Item from a list of GroupedItems', () => {
-      const groupedRegions = getRegionOptions(regions, flags);
+      const groupedRegions = getRegionOptions(
+        regions,
+        flags,
+        '/linodes/create'
+      );
       const selectedID = regions[1].id;
       expect(getSelectedRegionById(selectedID, groupedRegions)).toHaveProperty(
         'value',

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.test.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.test.tsx
@@ -3,11 +3,12 @@ import { regions } from 'src/__data__/regionsData';
 import { getRegionOptions, getSelectedRegionById } from './RegionSelect';
 
 const fakeRegion = { ...regions[0], country: 'fake iso code' };
+const flags = {};
 
 describe('Region Select helper functions', () => {
   describe('getRegionOptions', () => {
     it('should return a list of items grouped by continent', () => {
-      const groupedRegions = getRegionOptions(regions);
+      const groupedRegions = getRegionOptions(regions, flags);
       const [r1, r2, r3, r4, r5] = groupedRegions;
       expect(groupedRegions).toHaveLength(8);
       expect(r1.options).toHaveLength(5);
@@ -18,7 +19,7 @@ describe('Region Select helper functions', () => {
     });
 
     it('should group unrecognized regions as Other', () => {
-      const groupedRegions = getRegionOptions([fakeRegion]);
+      const groupedRegions = getRegionOptions([fakeRegion], flags);
       expect(
         groupedRegions.find((group) => group.label === 'Other')
       ).toBeDefined();
@@ -27,7 +28,7 @@ describe('Region Select helper functions', () => {
 
   describe('getSelectedRegionById', () => {
     it('should return the matching Item from a list of GroupedItems', () => {
-      const groupedRegions = getRegionOptions(regions);
+      const groupedRegions = getRegionOptions(regions, flags);
       const selectedID = regions[1].id;
       expect(getSelectedRegionById(selectedID, groupedRegions)).toHaveProperty(
         'value',

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
@@ -12,8 +12,8 @@ import { Flag } from 'src/components/Flag';
 import { useFlags } from 'src/hooks/useFlags';
 import { getRegionCountryGroup } from 'src/utilities/formatRegion';
 
-import { disabledRegions } from './DisabledRegions';
 import { RegionItem, RegionOption } from './RegionOption';
+import { listOfDisabledRegions } from './disabledRegions';
 import { ContinentNames, Country } from './utils';
 
 import type { FlagSet } from 'src/featureFlags';
@@ -51,12 +51,13 @@ export const getRegionOptions = (regions: Region[], flags: FlagSet) => {
     Other: [],
   };
 
-  const hasUserAccessToDisabledRegions = disabledRegions.some((thisRegion) =>
-    regions.some((region) => region.id === thisRegion.regionId)
+  const hasUserAccessToDisabledRegions = listOfDisabledRegions.some(
+    (disabledRegion) =>
+      regions.some((region) => region.id === disabledRegion.regionId)
   );
   const allRegions = [
     ...regions,
-    ...disabledRegions
+    ...listOfDisabledRegions
       .filter((disabledRegion) => flags[disabledRegion.featureFlag] === true)
       .map((region) => region.fakeRegion)
       .filter(
@@ -71,7 +72,7 @@ export const getRegionOptions = (regions: Region[], flags: FlagSet) => {
       country: region.country,
       disabledMessage: hasUserAccessToDisabledRegions
         ? undefined
-        : disabledRegions.find(
+        : listOfDisabledRegions.find(
             (disabledRegion) => disabledRegion.regionId === region.id
           )?.disabledMessage,
       flag: <Flag country={region.country as Lowercase<Country>} />,

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
@@ -53,7 +53,7 @@ export const getRegionOptions = (regions: Region[], flags: FlagSet) => {
 
   const hasUserAccessToDisabledRegions = listOfDisabledRegions.some(
     (disabledRegion) =>
-      regions.some((region) => region.id === disabledRegion.regionId)
+      regions.some((region) => region.id === disabledRegion.fakeRegion.id)
   );
   const allRegions = [
     ...regions,
@@ -77,7 +77,7 @@ export const getRegionOptions = (regions: Region[], flags: FlagSet) => {
       disabledMessage: hasUserAccessToDisabledRegions
         ? undefined
         : listOfDisabledRegions.find(
-            (disabledRegion) => disabledRegion.regionId === region.id
+            (disabledRegion) => disabledRegion.fakeRegion.id === region.id
           )?.disabledMessage,
       flag: <Flag country={region.country as Lowercase<Country>} />,
       label: `${region.label} (${region.id})`,

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
@@ -58,11 +58,15 @@ export const getRegionOptions = (regions: Region[], flags: FlagSet) => {
   const allRegions = [
     ...regions,
     ...listOfDisabledRegions
-      .filter((disabledRegion) => flags[disabledRegion.featureFlag] === true)
-      .map((region) => region.fakeRegion)
       .filter(
-        (fakeRegion) => !regions.some((region) => region.id === fakeRegion.id)
-      ),
+        (disabledRegion) =>
+          // Only display a fake region if the feature flag for it is enabled
+          // We may want to consider modifying this logic if we end up with disabled regions that don't rely on feature flags
+          flags[disabledRegion.featureFlag] &&
+          // Don't display a fake region if it's included in the real /regions response
+          !regions.some((region) => region.id === disabledRegion.fakeRegion.id)
+      )
+      .map((disabledRegion) => disabledRegion.fakeRegion),
   ];
 
   for (const region of allRegions) {

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/disabledRegions.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/disabledRegions.tsx
@@ -10,6 +10,7 @@ const tokyoDisabledMessage = (
   <Typography>
     Tokyo is sold out while we expand our capacity. We recommend deploying
     workloads in Osaka.{` `}
+    <br />
     <Link to="https://www.linode.com/blog/linode/tokyo-region-availability-update/">
       Learn more
     </Link>

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/disabledRegions.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/disabledRegions.tsx
@@ -37,17 +37,29 @@ type FakeRegion = Region & { disabled: boolean; display: string };
 
 // UTILS
 interface DisabledRegion {
+  /**
+   * The message to display when the region is disabled.
+   */
   disabledMessage: JSX.Element;
+  /**
+   * A list of paths that should not display the fake region.
+   */
+  excludePaths?: string[];
+  /**
+   * The fake region to display.
+   */
   fakeRegion: FakeRegion;
+  /**
+   * The feature flag that controls whether the fake region should be displayed.
+   */
   featureFlag: string;
-  regionId: 'ap-northeast';
 }
 
 export const listOfDisabledRegions: DisabledRegion[] = [
   {
     disabledMessage: tokyoDisabledMessage,
+    excludePaths: ['/object-storage/buckets/create'],
     fakeRegion: fakeTokyo,
     featureFlag: 'soldOutTokyo',
-    regionId: 'ap-northeast',
   },
 ];

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -17,6 +17,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'aglb', label: 'AGLB' },
   { flag: 'dcSpecificPricing', label: 'DC-Specific Pricing' },
   { flag: 'selfServeBetas', label: 'Self Serve Betas' },
+  { flag: 'soldOutTokyo', label: 'Sold Out Tokyo' },
 ];
 
 const FeatureFlagTool: React.FC<{}> = () => {

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -58,6 +58,7 @@ export interface Flags {
   referralBannerText: ReferralBannerText;
   regionDropdown: boolean;
   selfServeBetas: boolean;
+  soldOutTokyo: boolean;
   taxBanner: TaxBanner;
   taxCollectionBanner: TaxCollectionBanner;
   taxes: Taxes;

--- a/packages/manager/src/features/Volumes/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate.tsx
@@ -9,7 +9,9 @@ import { useHistory } from 'react-router-dom';
 
 import { Box } from 'src/components/Box';
 import { Button } from 'src/components/Button/Button';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { RegionSelect } from 'src/components/EnhancedSelect/variants/RegionSelect';
+import { LandingHeader } from 'src/components/LandingHeader';
 import { Notice } from 'src/components/Notice/Notice';
 import { Paper } from 'src/components/Paper';
 import { TextField } from 'src/components/TextField';
@@ -38,8 +40,6 @@ import { maybeCastToNumber } from 'src/utilities/maybeCastToNumber';
 
 import { ConfigSelect } from './VolumeDrawer/ConfigSelect';
 import { SizeField } from './VolumeDrawer/SizeField';
-import { LandingHeader } from 'src/components/LandingHeader';
-import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 
 export const SIZE_FIELD_WIDTH = 160;
 
@@ -86,6 +86,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     lineHeight: '18px',
   },
   select: {
+    [theme.breakpoints.down('sm')]: {
+      width: 320,
+    },
     width: 400,
   },
   size: {
@@ -156,6 +159,7 @@ export const VolumeCreate = () => {
     touched,
     values,
   } = useFormik({
+    initialValues,
     onSubmit: (values, { resetForm, setErrors, setStatus, setSubmitting }) => {
       const { config_id, label, linode_id, region, size } = values;
 
@@ -200,7 +204,6 @@ export const VolumeCreate = () => {
           );
         });
     },
-    initialValues,
     validationSchema: CreateVolumeSchema,
   });
 
@@ -349,6 +352,9 @@ export const VolumeCreate = () => {
                           linodeRegion === valuesRegion;
                   }}
                   sx={{
+                    [theme.breakpoints.down('sm')]: {
+                      width: 320,
+                    },
                     width: '400px',
                   }}
                   clearable
@@ -370,7 +376,7 @@ export const VolumeCreate = () => {
                 onBlur={handleBlur}
                 onChange={(id: number) => setFieldValue('config_id', id)}
                 value={config_id}
-                width={400}
+                width={[theme.breakpoints.down('sm')] ? 320 : 400}
               />
             </Box>
             <Box alignItems="flex-end" display="flex" position="relative">

--- a/packages/manager/src/features/Volumes/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate.tsx
@@ -86,7 +86,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     lineHeight: '18px',
   },
   select: {
-    width: 320,
+    width: 400,
   },
   size: {
     position: 'relative',
@@ -317,7 +317,7 @@ export const VolumeCreate = () => {
                 name="region"
                 onBlur={handleBlur}
                 selectedID={values.region}
-                width={320}
+                width={400}
               />
               {renderSelectTooltip(
                 'Volumes must be created in a region. You can choose to create a Volume in a region and attach it later to a Linode in the same region.'
@@ -349,7 +349,7 @@ export const VolumeCreate = () => {
                           linodeRegion === valuesRegion;
                   }}
                   sx={{
-                    width: '320px',
+                    width: '400px',
                   }}
                   clearable
                   disabled={doesNotHavePermission}
@@ -370,7 +370,7 @@ export const VolumeCreate = () => {
                 onBlur={handleBlur}
                 onChange={(id: number) => setFieldValue('config_id', id)}
                 value={config_id}
-                width={320}
+                width={400}
               />
             </Box>
             <Box alignItems="flex-end" display="flex" position="relative">


### PR DESCRIPTION
## Description 📝
This PR adds a fake Tokyo region menu item with a tooltip to our RegionSelect to show users that Tokyo is now disabled

## Changes 🔄
- Adds a fake menu item with a tooltip if user does not have the `tokyo-enable` flag on their account
- Improve the API for declaring disabled regions
- Puts the change behind the feature flag (`soldOutTokyo`) => currently `off` as a prod flag
- Adds a `Sold Out Tokyo` mock entry in dev settings (can be removed later but helpful to test quickly)

**Note**: the code could be greatly improved given more time. The goal here remains to implement the proper functionality and UI for a hotfix

## Preview 📷
![Screenshot 2023-10-04 at 18 10 58](https://github.com/linode/manager/assets/130582365/c0d2ea01-bcb1-48c7-9b73-a31fe1d09913)


## How to test 🧪

**Note**: OBJ isn't available for **anyone** in Tokyo 

The following scenari should be tested:

### 1. **User has the `tokyo-enable` admin flag** (`soldOutTokyo` `on` or `off`)
- User should see the Tokyo region menu item
- User should not see this option as disabled
- User should not see the fake Tokyo option 
- User should be able to create a resource in Tokyo
- User should not see Tokyo at /object-storage/buckets/create

### 2. **User does not have the `tokyo-enable` admin flag**

flag `off`:
- User should not see the Tokyo option at all
- User should not be able to create a resource in Tokyo
- User should not see Tokyo at /object-storage/buckets/create

flag`on`:
- User should see the fake (disabled) Tokyo menu option 
- User should be able to hover the option and see a tooltip with a description and a link
- User should be able to navigate to https://www.linode.com/blog/linode/tokyo-region-availability-update/ by clicking on a link
- User should not be able to create a resource in Tokyo
- User should not see Tokyo at /object-storage/buckets/create
