### PR TITLE
hotfix: DC-specific pricing -- monthly price decimals and invoice region column

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed:
 
 - Add disabled Tokyo RegionSelect menu entry ([#9758](https://github.com/linode/manager/pull/9758))
+- Display DC-specific monthly prices to two decimal places and hide blank Region column on past invoices ([#9759](https://github.com/linode/manager/pull/9759))
 
 ## [2023-10-02] - v1.104.0
 

--- a/packages/manager/cypress/e2e/core/billing/billing-invoices.spec.ts
+++ b/packages/manager/cypress/e2e/core/billing/billing-invoices.spec.ts
@@ -5,6 +5,7 @@
 import type { InvoiceItem, TaxSummary } from '@linode/api-v4';
 import { invoiceFactory, invoiceItemFactory } from '@src/factories';
 import { DateTime } from 'luxon';
+import { MAGIC_DATE_THAT_DC_SPECIFIC_PRICING_WAS_IMPLEMENTED } from 'support/constants/dc-specific-pricing';
 import {
   mockGetInvoice,
   mockGetInvoiceItems,
@@ -19,6 +20,18 @@ import { formatUsd } from 'support/util/currency';
 import { makeFeatureFlagData } from 'support/util/feature-flags';
 import { randomItem, randomLabel, randomNumber } from 'support/util/random';
 import { chooseRegion, getRegionById } from 'support/util/regions';
+
+/**
+ * Returns a string representation of a region, as shown on the invoice details page.
+ *
+ * @param regionId - ID of region for which to get label.
+ *
+ * @returns Region label in `<label> (<id>)` format.
+ */
+const getRegionLabel = (regionId: string) => {
+  const region = getRegionById(regionId);
+  return `${region.label} (${region.id})`;
+};
 
 describe('Account invoices', () => {
   /*
@@ -106,7 +119,6 @@ describe('Account invoices', () => {
       '@getInvoiceItems',
     ]);
 
-    // TODO: DC Pricing - M3-7073: Remove this and replace with positive assertions when DC pricing goes live.
     // Confirm that "Region" table column is not present.
     cy.findByLabelText('Invoice Details').within(() => {
       cy.get('thead').findByText('Region').should('not.exist');
@@ -171,15 +183,18 @@ describe('Account invoices', () => {
 
   /*
    * - Confirms that invoice item region info is shown when DC-specific pricing is enabled.
-   * - Confirms that table "Region" column is shown when DC-specific pricing is enabled.
+   * - Confirms that table "Region" column is shown when DC-specific pricing is enabled on new invoices.
    * - Confirms that invoice items that do not have a region are displayed as expected.
    * - Confirms that outbound transfer overage items display the associated region when applicable.
    * - Confirms that outbound transfer overage items display "Global" when no region is applicable.
    */
   it('lists invoice item region when DC-specific pricing flag is enabled', () => {
-    // TODO: DC Pricing - M3-7073: Delete this test when DC-specific pricing launches and move assertions to above test.
-    // We don't have to be fancy with the mocks here since we are only concerned with the region.
-    const mockInvoice = invoiceFactory.build({ id: randomNumber() });
+    // TODO: DC Pricing - M3-7073: Delete most of this test when DC-specific pricing launches and move assertions to above test. Use this test for the region invoice column.
+    // We don't have to be fancy with the mocks here since we are only concerned with the region and invoice date.
+    const mockInvoice = invoiceFactory.build({
+      id: randomNumber(),
+      date: MAGIC_DATE_THAT_DC_SPECIFIC_PRICING_WAS_IMPLEMENTED,
+    });
 
     // Regular invoice items.
     const mockInvoiceItemsRegular = [
@@ -208,18 +223,6 @@ describe('Account invoices', () => {
       ...mockInvoiceItemsRegular,
       ...mockInvoiceItemsOverages,
     ];
-
-    /**
-     * Returns a string representation of a region, as shown on the invoice details page.
-     *
-     * @param regionId - ID of region for which to get label.
-     *
-     * @returns Region label in `<label> (<id>)` format.
-     */
-    const getRegionLabel = (regionId: string) => {
-      const region = getRegionById(regionId);
-      return `${region.label} (${region.id})`;
-    };
 
     mockAppendFeatureFlags({
       dcSpecificPricing: makeFeatureFlagData(true),
@@ -288,6 +291,49 @@ describe('Account invoices', () => {
           }
         );
       });
+    });
+  });
+
+  it('does not list the region on past invoices when DC-specific pricing flag is enabled', () => {
+    const mockInvoice = invoiceFactory.build({
+      id: randomNumber(),
+      date: '2023-09-30 00:00:00Z',
+    });
+
+    // Regular invoice items.
+    const mockInvoiceItems = [
+      ...buildArray(10, () => invoiceItemFactory.build({ region: null })),
+    ];
+
+    mockAppendFeatureFlags({
+      dcSpecificPricing: makeFeatureFlagData(true),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientstream');
+    mockGetInvoice(mockInvoice).as('getInvoice');
+    mockGetInvoiceItems(mockInvoice, mockInvoiceItems).as('getInvoiceItems');
+
+    // Visit invoice details page, wait for relevant requests to resolve.
+    cy.visitWithLogin(`/account/billing/invoices/${mockInvoice.id}`);
+    cy.wait([
+      '@getFeatureFlags',
+      '@getClientstream',
+      '@getInvoice',
+      '@getInvoiceItems',
+    ]);
+
+    cy.findByLabelText('Invoice Details').within(() => {
+      // Confirm that "Region" table column is not present in an invoice created before DC-specific pricing was released.
+      cy.get('thead').findByText('Region').should('not.exist');
+    });
+
+    // Confirm that each regular invoice item is shown, and that the region cell is not displayed for each item.
+    mockInvoiceItems.forEach((invoiceItem: InvoiceItem) => {
+      cy.findByText(invoiceItem.label)
+        .should('be.visible')
+        .closest('tr')
+        .within(() => {
+          cy.get('[data-qa-region]').should('not.exist');
+        });
     });
   });
 

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -38,7 +38,7 @@ import { dcPricingMockLinodeTypes } from 'support/constants/dc-specific-pricing'
 
 const mockNodePools = nodePoolFactory.buildList(2);
 
-describe.skip('LKE cluster updates', () => {
+describe('LKE cluster updates', () => {
   /*
    * - Confirms UI flow of upgrading a cluster to high availability control plane using mocked data.
    * - Confirms that user is shown a warning and agrees to billing changes before upgrading.

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -515,9 +515,9 @@ describe('LKE cluster updates', () => {
           .should('be.visible')
           .should('be.disabled');
 
-        cy.findByText('Resized pool: $12/month (1 node at $12/month)').should(
-          'be.visible'
-        );
+        cy.findByText(
+          'Resized pool: $12.00/month (1 node at $12.00/month)'
+        ).should('be.visible');
 
         cy.findByLabelText('Add 1')
           .should('be.visible')
@@ -526,9 +526,9 @@ describe('LKE cluster updates', () => {
           .click();
 
         cy.findByLabelText('Edit Quantity').should('have.value', '3');
-        cy.findByText('Resized pool: $36/month (3 nodes at $12/month)').should(
-          'be.visible'
-        );
+        cy.findByText(
+          'Resized pool: $36.00/month (3 nodes at $12.00/month)'
+        ).should('be.visible');
 
         ui.button
           .findByTitle('Save Changes')
@@ -850,12 +850,12 @@ describe('LKE cluster updates for DC-specific prices', () => {
           .should('be.visible')
           .should('be.disabled');
 
-        cy.findByText('Current pool: $14/month (1 node at $14/month)').should(
-          'be.visible'
-        );
-        cy.findByText('Resized pool: $14/month (1 node at $14/month)').should(
-          'be.visible'
-        );
+        cy.findByText(
+          'Current pool: $14.00/month (1 node at $14.00/month)'
+        ).should('be.visible');
+        cy.findByText(
+          'Resized pool: $14.00/month (1 node at $14.00/month)'
+        ).should('be.visible');
 
         cy.findByLabelText('Add 1')
           .should('be.visible')
@@ -865,12 +865,12 @@ describe('LKE cluster updates for DC-specific prices', () => {
           .click();
 
         cy.findByLabelText('Edit Quantity').should('have.value', '4');
-        cy.findByText('Current pool: $14/month (1 node at $14/month)').should(
-          'be.visible'
-        );
-        cy.findByText('Resized pool: $56/month (4 nodes at $14/month)').should(
-          'be.visible'
-        );
+        cy.findByText(
+          'Current pool: $14.00/month (1 node at $14.00/month)'
+        ).should('be.visible');
+        cy.findByText(
+          'Resized pool: $56.00/month (4 nodes at $14.00/month)'
+        ).should('be.visible');
 
         cy.findByLabelText('Subtract 1')
           .should('be.visible')
@@ -878,9 +878,9 @@ describe('LKE cluster updates for DC-specific prices', () => {
           .click();
 
         cy.findByLabelText('Edit Quantity').should('have.value', '3');
-        cy.findByText('Resized pool: $42/month (3 nodes at $14/month)').should(
-          'be.visible'
-        );
+        cy.findByText(
+          'Resized pool: $42.00/month (3 nodes at $14.00/month)'
+        ).should('be.visible');
 
         ui.button
           .findByTitle('Save Changes')
@@ -961,14 +961,14 @@ describe('LKE cluster updates for DC-specific prices', () => {
           .closest('tr')
           .within(() => {
             // Assert that DC-specific prices are displayed the plan table, then add a node pool with 2 linodes.
-            cy.findByText('$14').should('be.visible');
+            cy.findByText('$14.00').should('be.visible');
             cy.findByText('$0.021').should('be.visible');
             cy.findByLabelText('Add 1').should('be.visible').click().click();
           });
 
         // Assert that DC-specific prices are displayed as helper text.
         cy.contains(
-          'This pool will add $28/month (2 nodes at $14/month) to this cluster.'
+          'This pool will add $28.00/month (2 nodes at $14.00/month) to this cluster.'
         ).should('be.visible');
 
         ui.button

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -38,7 +38,7 @@ import { dcPricingMockLinodeTypes } from 'support/constants/dc-specific-pricing'
 
 const mockNodePools = nodePoolFactory.buildList(2);
 
-describe('LKE cluster updates', () => {
+describe.skip('LKE cluster updates', () => {
   /*
    * - Confirms UI flow of upgrading a cluster to high availability control plane using mocked data.
    * - Confirms that user is shown a warning and agrees to billing changes before upgrading.
@@ -515,9 +515,9 @@ describe('LKE cluster updates', () => {
           .should('be.visible')
           .should('be.disabled');
 
-        cy.findByText(
-          'Resized pool: $12.00/month (1 node at $12.00/month)'
-        ).should('be.visible');
+        cy.findByText('Resized pool: $12/month (1 node at $12/month)').should(
+          'be.visible'
+        );
 
         cy.findByLabelText('Add 1')
           .should('be.visible')
@@ -526,9 +526,9 @@ describe('LKE cluster updates', () => {
           .click();
 
         cy.findByLabelText('Edit Quantity').should('have.value', '3');
-        cy.findByText(
-          'Resized pool: $36.00/month (3 nodes at $12.00/month)'
-        ).should('be.visible');
+        cy.findByText('Resized pool: $36/month (3 nodes at $12/month)').should(
+          'be.visible'
+        );
 
         ui.button
           .findByTitle('Save Changes')
@@ -826,7 +826,7 @@ describe('LKE cluster updates for DC-specific prices', () => {
     });
 
     // Confirm total price is listed in Kube Specs.
-    cy.findByText('$14.00/month').should('be.visible');
+    cy.findByText('$14.40/month').should('be.visible');
 
     // Click "Resize Pool" and increase size to 3 nodes.
     ui.button
@@ -851,10 +851,10 @@ describe('LKE cluster updates for DC-specific prices', () => {
           .should('be.disabled');
 
         cy.findByText(
-          'Current pool: $14.00/month (1 node at $14.00/month)'
+          'Current pool: $14.40/month (1 node at $14.40/month)'
         ).should('be.visible');
         cy.findByText(
-          'Resized pool: $14.00/month (1 node at $14.00/month)'
+          'Resized pool: $14.40/month (1 node at $14.40/month)'
         ).should('be.visible');
 
         cy.findByLabelText('Add 1')
@@ -866,10 +866,10 @@ describe('LKE cluster updates for DC-specific prices', () => {
 
         cy.findByLabelText('Edit Quantity').should('have.value', '4');
         cy.findByText(
-          'Current pool: $14.00/month (1 node at $14.00/month)'
+          'Current pool: $14.40/month (1 node at $14.40/month)'
         ).should('be.visible');
         cy.findByText(
-          'Resized pool: $56.00/month (4 nodes at $14.00/month)'
+          'Resized pool: $57.60/month (4 nodes at $14.40/month)'
         ).should('be.visible');
 
         cy.findByLabelText('Subtract 1')
@@ -879,7 +879,7 @@ describe('LKE cluster updates for DC-specific prices', () => {
 
         cy.findByLabelText('Edit Quantity').should('have.value', '3');
         cy.findByText(
-          'Resized pool: $42.00/month (3 nodes at $14.00/month)'
+          'Resized pool: $43.20/month (3 nodes at $14.40/month)'
         ).should('be.visible');
 
         ui.button
@@ -892,7 +892,7 @@ describe('LKE cluster updates for DC-specific prices', () => {
     cy.wait(['@resizeNodePool', '@getNodePools']);
 
     // Confirm total price updates in Kube Specs.
-    cy.findByText('$42.00/month').should('be.visible');
+    cy.findByText('$43.20/month').should('be.visible');
   });
 
   /*
@@ -939,7 +939,7 @@ describe('LKE cluster updates for DC-specific prices', () => {
     cy.findByText('Linode 0 GB', { selector: 'h2' }).should('be.visible');
 
     // Confirm total price is listed in Kube Specs.
-    cy.findByText('$14.00/month').should('be.visible');
+    cy.findByText('$14.40/month').should('be.visible');
 
     // Add a new node pool, select plan, submit form in drawer.
     ui.button
@@ -961,14 +961,14 @@ describe('LKE cluster updates for DC-specific prices', () => {
           .closest('tr')
           .within(() => {
             // Assert that DC-specific prices are displayed the plan table, then add a node pool with 2 linodes.
-            cy.findByText('$14.00').should('be.visible');
+            cy.findByText('$14.40').should('be.visible');
             cy.findByText('$0.021').should('be.visible');
             cy.findByLabelText('Add 1').should('be.visible').click().click();
           });
 
         // Assert that DC-specific prices are displayed as helper text.
         cy.contains(
-          'This pool will add $28.00/month (2 nodes at $14.00/month) to this cluster.'
+          'This pool will add $28.80/month (2 nodes at $14.40/month) to this cluster.'
         ).should('be.visible');
 
         ui.button
@@ -981,7 +981,7 @@ describe('LKE cluster updates for DC-specific prices', () => {
     // Wait for API responses.
     cy.wait(['@addNodePool', '@getNodePools']);
 
-    // Confirm total price updates in Kube Specs: $14/mo existing pool + $28/mo new pool.
-    cy.findByText('$42.00/month').should('be.visible');
+    // Confirm total price updates in Kube Specs: $14.40/mo existing pool + $28.80/mo new pool.
+    cy.findByText('$43.20/month').should('be.visible');
   });
 });

--- a/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
@@ -183,7 +183,7 @@ describe('create linode', () => {
       const currentPrice = dcPricingMockLinodeTypes[0].region_prices.find(
         (regionPrice) => regionPrice.id === initialRegion.id
       );
-      cy.findByText(`$${currentPrice.monthly}.00/month`).should('be.visible');
+      cy.findByText(`$${currentPrice.monthly}/month`).should('be.visible');
     });
 
     // Confirms that a notice is shown in the "Region" section of the Linode Create form informing the user of tiered pricing
@@ -202,7 +202,7 @@ describe('create linode', () => {
       const currentPrice = dcPricingMockLinodeTypes[1].region_prices.find(
         (regionPrice) => regionPrice.id === newRegion.id
       );
-      cy.findByText(`$${currentPrice.monthly}.00/month`).should('be.visible');
+      cy.findByText(`$${currentPrice.monthly}/month`).should('be.visible');
     });
 
     getClick('#linode-label').clear().type(linodeLabel);

--- a/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
@@ -183,7 +183,7 @@ describe('create linode', () => {
       const currentPrice = dcPricingMockLinodeTypes[0].region_prices.find(
         (regionPrice) => regionPrice.id === initialRegion.id
       );
-      cy.findByText(`$${currentPrice.monthly}/month`).should('be.visible');
+      cy.findByText(`$${currentPrice.monthly}.00/month`).should('be.visible');
     });
 
     // Confirms that a notice is shown in the "Region" section of the Linode Create form informing the user of tiered pricing
@@ -202,7 +202,7 @@ describe('create linode', () => {
       const currentPrice = dcPricingMockLinodeTypes[1].region_prices.find(
         (regionPrice) => regionPrice.id === newRegion.id
       );
-      cy.findByText(`$${currentPrice.monthly}/month`).should('be.visible');
+      cy.findByText(`$${currentPrice.monthly}.00/month`).should('be.visible');
     });
 
     getClick('#linode-label').clear().type(linodeLabel);

--- a/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
@@ -183,7 +183,7 @@ describe('create linode', () => {
       const currentPrice = dcPricingMockLinodeTypes[0].region_prices.find(
         (regionPrice) => regionPrice.id === initialRegion.id
       );
-      cy.findByText(`$${currentPrice.monthly}/month`).should('be.visible');
+      cy.findByText(`$${currentPrice.monthly}0/month`).should('be.visible');
     });
 
     // Confirms that a notice is shown in the "Region" section of the Linode Create form informing the user of tiered pricing
@@ -202,7 +202,7 @@ describe('create linode', () => {
       const currentPrice = dcPricingMockLinodeTypes[1].region_prices.find(
         (regionPrice) => regionPrice.id === newRegion.id
       );
-      cy.findByText(`$${currentPrice.monthly}/month`).should('be.visible');
+      cy.findByText(`$${currentPrice.monthly}0/month`).should('be.visible');
     });
 
     getClick('#linode-label').clear().type(linodeLabel);

--- a/packages/manager/cypress/support/constants/dc-specific-pricing.ts
+++ b/packages/manager/cypress/support/constants/dc-specific-pricing.ts
@@ -63,14 +63,14 @@ export const dcPricingMockLinodeTypes = linodeTypeFactory.buildList(3, {
       // Use `us-east` and `us-west` so we do not have to mock regions request,
       // which otherwise may not include the actual regions which have DC-specific pricing applied.
       id: 'us-east',
-      monthly: 14,
+      monthly: 14.0,
     },
     {
       hourly: 0.018,
       // Use `us-east` and `us-west` so we do not have to mock regions request,
       // which otherwise may not include the actual regions which have DC-specific pricing applied.
       id: 'us-west',
-      monthly: 12,
+      monthly: 12.0,
     },
   ],
 });
@@ -88,3 +88,6 @@ export const dcPricingLkeClusterPlans: LkePlanDescription[] = dcPricingMockLinod
     };
   }
 );
+
+export const MAGIC_DATE_THAT_DC_SPECIFIC_PRICING_WAS_IMPLEMENTED =
+  '2023-10-05 00:00:00Z';

--- a/packages/manager/cypress/support/constants/dc-specific-pricing.ts
+++ b/packages/manager/cypress/support/constants/dc-specific-pricing.ts
@@ -63,14 +63,14 @@ export const dcPricingMockLinodeTypes = linodeTypeFactory.buildList(3, {
       // Use `us-east` and `us-west` so we do not have to mock regions request,
       // which otherwise may not include the actual regions which have DC-specific pricing applied.
       id: 'us-east',
-      monthly: 14.0,
+      monthly: 14.4,
     },
     {
       hourly: 0.018,
       // Use `us-east` and `us-west` so we do not have to mock regions request,
       // which otherwise may not include the actual regions which have DC-specific pricing applied.
       id: 'us-west',
-      monthly: 12.0,
+      monthly: 12.2,
     },
   ],
 });

--- a/packages/manager/src/factories/types.ts
+++ b/packages/manager/src/factories/types.ts
@@ -40,12 +40,12 @@ export const typeFactory = Factory.Sync.makeFactory<LinodeType>({
     {
       hourly: 0.021,
       id: 'br-gru',
-      monthly: 14.0,
+      monthly: 14.4,
     },
     {
       hourly: 0.018,
       id: 'id-cgk',
-      monthly: 12.0,
+      monthly: 12.2,
     },
   ],
   successor: null,

--- a/packages/manager/src/factories/types.ts
+++ b/packages/manager/src/factories/types.ts
@@ -40,12 +40,12 @@ export const typeFactory = Factory.Sync.makeFactory<LinodeType>({
     {
       hourly: 0.021,
       id: 'br-gru',
-      monthly: 14,
+      monthly: 14.0,
     },
     {
       hourly: 0.018,
       id: 'id-cgk',
-      monthly: 12,
+      monthly: 12.0,
     },
   ],
   successor: null,

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -28,6 +28,7 @@ import { useRegionsQuery } from 'src/queries/regions';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getAll } from 'src/utilities/getAll';
 
+import { invoiceCreatedAfterDCPricingLaunch } from '../PdfGenerator/utils';
 import { getShouldUseAkamaiBilling } from '../billingUtils';
 import { InvoiceTable } from './InvoiceTable';
 
@@ -51,6 +52,8 @@ export const InvoiceDetail = () => {
   );
 
   const flags = useFlags();
+
+  const shouldShowRegion = invoiceCreatedAfterDCPricingLaunch(invoice?.date);
 
   const requestData = () => {
     setLoading(true);
@@ -93,7 +96,7 @@ export const InvoiceDetail = () => {
       flags,
       invoice,
       items,
-      regions: regions ?? [],
+      regions: shouldShowRegion && regions ? regions : [],
       taxes,
     });
 
@@ -105,7 +108,9 @@ export const InvoiceDetail = () => {
     { key: 'from', label: 'From' },
     { key: 'to', label: 'To' },
     { key: 'quantity', label: 'Quantity' },
-    ...(flags.dcSpecificPricing ? [{ key: 'region', label: 'Region' }] : []),
+    ...(flags.dcSpecificPricing && shouldShowRegion
+      ? [{ key: 'region', label: 'Region' }]
+      : []),
     { key: 'unit_price', label: 'Unit Price' },
     { key: 'amount', label: 'Amount (USD)' },
     { key: 'tax', label: 'Tax (USD)' },
@@ -206,7 +211,12 @@ export const InvoiceDetail = () => {
           {pdfGenerationError && (
             <Notice variant="error">Failed generating PDF.</Notice>
           )}
-          <InvoiceTable errors={errors} items={items} loading={loading} />
+          <InvoiceTable
+            errors={errors}
+            items={items}
+            loading={loading}
+            shouldShowRegion={shouldShowRegion}
+          />
         </Grid>
         <Grid xs={12}>
           {invoice && (

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -38,13 +38,13 @@ interface Props {
   errors?: APIError[];
   items?: InvoiceItem[];
   loading: boolean;
+  shouldShowRegion: boolean;
 }
 
 export const InvoiceTable = (props: Props) => {
   const { classes } = useStyles();
   const MIN_PAGE_SIZE = 25;
   const flags = useFlags();
-  const NUM_COLUMNS = flags.dcSpecificPricing ? 9 : 8;
 
   const {
     data: regions,
@@ -52,7 +52,8 @@ export const InvoiceTable = (props: Props) => {
     isLoading: regionsLoading,
   } = useRegionsQuery();
 
-  const { errors, items, loading } = props;
+  const { errors, items, loading, shouldShowRegion } = props;
+  const NUM_COLUMNS = flags.dcSpecificPricing && shouldShowRegion ? 9 : 8;
 
   const renderTableContent = () => {
     if (loading || regionsLoading) {
@@ -105,7 +106,7 @@ export const InvoiceTable = (props: Props) => {
                   <TableCell data-qa-quantity parentColumn="Quantity">
                     {renderQuantity(invoiceItem.quantity)}
                   </TableCell>
-                  {flags.dcSpecificPricing && (
+                  {flags.dcSpecificPricing && shouldShowRegion && (
                     <TableCell data-qa-region parentColumn="Region">
                       {getInvoiceRegion(invoiceItem, regions ?? [])}
                     </TableCell>
@@ -165,7 +166,9 @@ export const InvoiceTable = (props: Props) => {
           <TableCell sx={{ minWidth: '125px' }}>From</TableCell>
           <TableCell sx={{ minWidth: '125px' }}>To</TableCell>
           <TableCell>Quantity</TableCell>
-          {flags.dcSpecificPricing && <TableCell>Region</TableCell>}
+          {flags.dcSpecificPricing && shouldShowRegion && (
+            <TableCell>Region</TableCell>
+          )}
           <TableCell noWrap>Unit Price</TableCell>
           <TableCell>Amount (USD)</TableCell>
           <TableCell>Tax (USD)</TableCell>

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -23,6 +23,7 @@ import {
   createPaymentsTable,
   createPaymentsTotalsTable,
   dateConversion,
+  invoiceCreatedAfterDCPricingLaunch,
   pageMargin,
 } from './utils';
 
@@ -288,6 +289,7 @@ export const printInvoice = async (
         flags,
         items: itemsChunk,
         regions,
+        shouldShowRegions: invoiceCreatedAfterDCPricingLaunch(invoice.date),
         startY: titlePosition,
         timezone,
       });

--- a/packages/manager/src/features/Billing/PdfGenerator/utils.test.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/utils.test.ts
@@ -44,17 +44,17 @@ describe('getInvoiceRegion', () => {
 });
 
 describe('invoiceCreatedAfterDCPricingLaunch', () => {
-  it('should return true for a date after 10/05/2023', () => {
+  it('should return true for an invoice date after 10/05/2023', () => {
     const invoiceDate = '2023-10-06T12:00:00';
     expect(invoiceCreatedAfterDCPricingLaunch(invoiceDate)).toBe(true);
   });
 
-  it('should return false for a before 10/05/2023', () => {
+  it('should return false for an invoice date before 10/05/2023', () => {
     const invoiceDate = '2023-10-01T12:00:00';
     expect(invoiceCreatedAfterDCPricingLaunch(invoiceDate)).toBe(false);
   });
 
-  it('should return true for 10/05/2023', () => {
+  it('should return true for an invoice dated 10/05/2023', () => {
     const invoiceDate = '2023-10-05T12:00:00';
     expect(invoiceCreatedAfterDCPricingLaunch(invoiceDate)).toBe(true);
   });

--- a/packages/manager/src/features/Billing/PdfGenerator/utils.test.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/utils.test.ts
@@ -1,6 +1,6 @@
 import { invoiceItemFactory, regionFactory } from 'src/factories';
 
-import { getInvoiceRegion } from './utils';
+import { getInvoiceRegion, invoiceCreatedAfterDCPricingLaunch } from './utils';
 
 describe('getInvoiceRegion', () => {
   it('should get a formatted label given invoice items and regions', () => {
@@ -40,5 +40,22 @@ describe('getInvoiceRegion', () => {
     });
 
     expect(getInvoiceRegion(invoiceItems, regions)).toBe('Global');
+  });
+});
+
+describe('invoiceCreatedAfterDCPricingLaunch', () => {
+  it('should return true for a date after 10/05/2023', () => {
+    const invoiceDate = '2023-10-06T12:00:00';
+    expect(invoiceCreatedAfterDCPricingLaunch(invoiceDate)).toBe(true);
+  });
+
+  it('should return false for a before 10/05/2023', () => {
+    const invoiceDate = '2023-10-01T12:00:00';
+    expect(invoiceCreatedAfterDCPricingLaunch(invoiceDate)).toBe(false);
+  });
+
+  it('should return true for 10/05/2023', () => {
+    const invoiceDate = '2023-10-05T12:00:00';
+    expect(invoiceCreatedAfterDCPricingLaunch(invoiceDate)).toBe(true);
   });
 });

--- a/packages/manager/src/features/Billing/PdfGenerator/utils.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/utils.ts
@@ -11,11 +11,11 @@ import { pathOr } from 'ramda';
 import { ADDRESSES } from 'src/constants';
 import { FlagSet } from 'src/featureFlags';
 import { formatDate } from 'src/utilities/formatDate';
+import { MAGIC_DATE_THAT_DC_SPECIFIC_PRICING_WAS_IMPLEMENTED } from 'src/utilities/pricing/constants';
 
 import { getShouldUseAkamaiBilling } from '../billingUtils';
 
 import type { Region } from '@linode/api-v4';
-import { MAGIC_DATE_THAT_DC_SPECIFIC_PRICING_WAS_IMPLEMENTED } from 'src/utilities/pricing/constants';
 
 /**
  * Margin that has to be applied to every item added to the PDF.

--- a/packages/manager/src/features/Billing/PdfGenerator/utils.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/utils.ts
@@ -15,6 +15,7 @@ import { formatDate } from 'src/utilities/formatDate';
 import { getShouldUseAkamaiBilling } from '../billingUtils';
 
 import type { Region } from '@linode/api-v4';
+import { MAGIC_DATE_THAT_DC_SPECIFIC_PRICING_WAS_IMPLEMENTED } from 'src/utilities/pricing/constants';
 
 /**
  * Margin that has to be applied to every item added to the PDF.
@@ -410,9 +411,10 @@ export interface PdfResult {
 
 export const dateConversion = (str: string): number => Date.parse(str);
 
-export const MAGIC_DATE_THAT_DC_PRICING_WAS_IMPLEMENTED =
-  '2023-10-05 00:00:00Z';
-
+/**
+ * @param _invoiceDate When the invoice was generated
+ * @returns True if invoice is dated on or after the release of DC-specific pricing (10/05/23). From then on, invoice items return a region.
+ */
 export const invoiceCreatedAfterDCPricingLaunch = (_invoiceDate?: string) => {
   // Default to `true` for bad input.
   if (!_invoiceDate) {
@@ -420,7 +422,7 @@ export const invoiceCreatedAfterDCPricingLaunch = (_invoiceDate?: string) => {
   }
 
   const dcPricingDate = new Date(
-    MAGIC_DATE_THAT_DC_PRICING_WAS_IMPLEMENTED
+    MAGIC_DATE_THAT_DC_SPECIFIC_PRICING_WAS_IMPLEMENTED
   ).getTime();
   const invoiceDate = new Date(_invoiceDate).getTime();
 

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.test.tsx
@@ -77,7 +77,7 @@ describe('Database Create', () => {
     // update node pricing if a plan is selected
     const radioBtn = getAllByText('Nanode 1 GB')[0];
     fireEvent.click(radioBtn);
-    expect(nodeRadioBtns).toHaveTextContent('$60/month $0.09/hr');
-    expect(nodeRadioBtns).toHaveTextContent('$140/month $0.21/hr');
+    expect(nodeRadioBtns).toHaveTextContent('$60.00/month $0.09/hr');
+    expect(nodeRadioBtns).toHaveTextContent('$140.00/month $0.21/hr');
   });
 });

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.test.tsx
@@ -77,7 +77,7 @@ describe('Database Create', () => {
     // update node pricing if a plan is selected
     const radioBtn = getAllByText('Nanode 1 GB')[0];
     fireEvent.click(radioBtn);
-    expect(nodeRadioBtns).toHaveTextContent('$60.00/month $0.09/hr');
-    expect(nodeRadioBtns).toHaveTextContent('$140.00/month $0.21/hr');
+    expect(nodeRadioBtns).toHaveTextContent('$60/month $0.09/hr');
+    expect(nodeRadioBtns).toHaveTextContent('$140/month $0.21/hr');
   });
 });

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -338,7 +338,7 @@ const DatabaseCreate = () => {
         monthly: null,
       };
       const subHeadings = [
-        `$${price.monthly}/mo ($${price.hourly}/hr)`,
+        `$${price.monthly?.toFixed(2)}/mo ($${price.hourly}/hr)`,
         typeLabelDetails(type.memory, type.disk, type.vcpus),
       ] as [string, string];
       return {
@@ -375,7 +375,7 @@ const DatabaseCreate = () => {
           1 Node {` `}
           <br />
           <span style={{ fontSize: '12px' }}>
-            {`$${nodePricing?.single?.monthly || 0}/month $${
+            {`$${nodePricing?.single?.monthly.toFixed(2) || 0}/month $${
               nodePricing?.single?.hourly || 0
             }/hr`}
           </span>
@@ -389,7 +389,7 @@ const DatabaseCreate = () => {
           3 Nodes - High Availability (recommended)
           <br />
           <span style={{ fontSize: '12px' }}>
-            {`$${nodePricing?.multi?.monthly || 0}/month $${
+            {`$${nodePricing?.multi?.monthly.toFixed(2) || 0}/month $${
               nodePricing?.multi?.hourly || 0
             }/hr`}
           </span>

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -338,7 +338,7 @@ const DatabaseCreate = () => {
         monthly: null,
       };
       const subHeadings = [
-        `$${price.monthly?.toFixed(2)}/mo ($${price.hourly}/hr)`,
+        `$${price.monthly}/mo ($${price.hourly}/hr)`,
         typeLabelDetails(type.memory, type.disk, type.vcpus),
       ] as [string, string];
       return {
@@ -375,7 +375,7 @@ const DatabaseCreate = () => {
           1 Node {` `}
           <br />
           <span style={{ fontSize: '12px' }}>
-            {`$${nodePricing?.single?.monthly.toFixed(2) || 0}/month $${
+            {`$${nodePricing?.single?.monthly || 0}/month $${
               nodePricing?.single?.hourly || 0
             }/hr`}
           </span>
@@ -389,7 +389,7 @@ const DatabaseCreate = () => {
           3 Nodes - High Availability (recommended)
           <br />
           <span style={{ fontSize: '12px' }}>
-            {`$${nodePricing?.multi?.monthly.toFixed(2) || 0}/month $${
+            {`$${nodePricing?.multi?.monthly || 0}/month $${
               nodePricing?.multi?.hourly || 0
             }/hr`}
           </span>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
@@ -112,12 +112,12 @@ export const AddNodePoolDrawer = (props: Props) => {
 
   const pricePerNode =
     flags.dcSpecificPricing && selectedType
-      ? getLinodeRegionPrice(selectedType, clusterRegionId).monthly
+      ? getLinodeRegionPrice(selectedType, clusterRegionId).monthly?.toFixed(2)
       : selectedType?.price?.monthly;
 
   const totalPrice =
     selectedTypeInfo && pricePerNode
-      ? selectedTypeInfo.count * pricePerNode
+      ? (selectedTypeInfo.count * Number(pricePerNode)).toFixed(2)
       : 0;
 
   React.useEffect(() => {

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
@@ -14,6 +14,7 @@ import { extendType } from 'src/utilities/extendType';
 import { filterCurrentTypes } from 'src/utilities/filterCurrentLinodeTypes';
 import { plansNoticesUtils } from 'src/utilities/planNotices';
 import { pluralize } from 'src/utilities/pluralize';
+import { renderMonthlyPriceToCorrectDecimalPlace } from 'src/utilities/pricing/dynamicPricing';
 import { getLinodeRegionPrice } from 'src/utilities/pricing/linodes';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
@@ -112,12 +113,12 @@ export const AddNodePoolDrawer = (props: Props) => {
 
   const pricePerNode =
     flags.dcSpecificPricing && selectedType
-      ? getLinodeRegionPrice(selectedType, clusterRegionId).monthly?.toFixed(2)
+      ? getLinodeRegionPrice(selectedType, clusterRegionId).monthly
       : selectedType?.price?.monthly;
 
   const totalPrice =
     selectedTypeInfo && pricePerNode
-      ? (selectedTypeInfo.count * Number(pricePerNode)).toFixed(2)
+      ? selectedTypeInfo.count * pricePerNode
       : 0;
 
   React.useEffect(() => {
@@ -221,9 +222,9 @@ export const AddNodePoolDrawer = (props: Props) => {
             <Typography className={classes.priceDisplay}>
               This pool will add{' '}
               <strong>
-                ${totalPrice}/month (
+                ${renderMonthlyPriceToCorrectDecimalPlace(totalPrice)}/month (
                 {pluralize('node', 'nodes', selectedTypeInfo.count)} at $
-                {pricePerNode ?? 0}
+                {renderMonthlyPriceToCorrectDecimalPlace(pricePerNode) ?? 0}
                 /month)
               </strong>{' '}
               to this cluster.

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/ResizeNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/ResizeNodePoolDrawer.tsx
@@ -14,6 +14,7 @@ import { useUpdateNodePoolMutation } from 'src/queries/kubernetes';
 import { useSpecificTypes } from 'src/queries/types';
 import { extendType } from 'src/utilities/extendType';
 import { pluralize } from 'src/utilities/pluralize';
+import { renderMonthlyPriceToCorrectDecimalPlace } from 'src/utilities/pricing/dynamicPricing';
 import { getKubernetesMonthlyPrice } from 'src/utilities/pricing/kubernetes';
 import { getLinodeRegionPrice } from 'src/utilities/pricing/linodes';
 
@@ -99,7 +100,7 @@ export const ResizeNodePoolDrawer = (props: Props) => {
 
   const pricePerNode =
     (flags.dcSpecificPricing && planType
-      ? getLinodeRegionPrice(planType, kubernetesRegionId)?.monthly?.toFixed(2)
+      ? getLinodeRegionPrice(planType, kubernetesRegionId)?.monthly
       : planType?.price.monthly) || 0;
 
   const totalMonthlyPrice =
@@ -110,7 +111,7 @@ export const ResizeNodePoolDrawer = (props: Props) => {
       region: kubernetesRegionId,
       type: nodePool.type,
       types: planType ? [planType] : [],
-    }).toFixed(2);
+    });
 
   return (
     <Drawer
@@ -127,8 +128,10 @@ export const ResizeNodePoolDrawer = (props: Props) => {
       >
         <div className={classes.section}>
           <Typography className={classes.summary}>
-            Current pool: ${totalMonthlyPrice}/month (
-            {pluralize('node', 'nodes', nodePool.count)} at ${pricePerNode}
+            Current pool: $
+            {renderMonthlyPriceToCorrectDecimalPlace(totalMonthlyPrice)}/month (
+            {pluralize('node', 'nodes', nodePool.count)} at $
+            {renderMonthlyPriceToCorrectDecimalPlace(pricePerNode)}
             /month)
           </Typography>
         </div>
@@ -148,9 +151,12 @@ export const ResizeNodePoolDrawer = (props: Props) => {
 
         <div className={classes.section}>
           <Typography className={classes.summary}>
-            Resized pool: ${(updatedCount * Number(pricePerNode)).toFixed(2)}
+            Resized pool: $
+            {renderMonthlyPriceToCorrectDecimalPlace(
+              updatedCount * pricePerNode
+            )}
             /month ({pluralize('node', 'nodes', updatedCount)} at $
-            {pricePerNode}/month)
+            {renderMonthlyPriceToCorrectDecimalPlace(pricePerNode)}/month)
           </Typography>
         </div>
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/ResizeNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/ResizeNodePoolDrawer.tsx
@@ -99,7 +99,7 @@ export const ResizeNodePoolDrawer = (props: Props) => {
 
   const pricePerNode =
     (flags.dcSpecificPricing && planType
-      ? getLinodeRegionPrice(planType, kubernetesRegionId)?.monthly
+      ? getLinodeRegionPrice(planType, kubernetesRegionId)?.monthly?.toFixed(2)
       : planType?.price.monthly) || 0;
 
   const totalMonthlyPrice =
@@ -110,7 +110,7 @@ export const ResizeNodePoolDrawer = (props: Props) => {
       region: kubernetesRegionId,
       type: nodePool.type,
       types: planType ? [planType] : [],
-    });
+    }).toFixed(2);
 
   return (
     <Drawer
@@ -148,8 +148,9 @@ export const ResizeNodePoolDrawer = (props: Props) => {
 
         <div className={classes.section}>
           <Typography className={classes.summary}>
-            Resized pool: ${updatedCount * pricePerNode}/month (
-            {pluralize('node', 'nodes', updatedCount)} at ${pricePerNode}/month)
+            Resized pool: ${(updatedCount * Number(pricePerNode)).toFixed(2)}
+            /month ({pluralize('node', 'nodes', updatedCount)} at $
+            {pricePerNode}/month)
           </Typography>
         </div>
 

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
@@ -16,9 +16,9 @@ import {
 
 const planHeader = 'Dedicated 20 GB';
 const baseHourlyPrice = '$0.015';
-const baseMonthlyPrice = '$10.00';
+const baseMonthlyPrice = '$10';
 const regionHourlyPrice = '$0.018';
-const regionMonthlyPrice = '$12.00';
+const regionMonthlyPrice = '$12.20';
 const ram = '16 GB';
 const cpu = '8';
 const storage = '1024 GB';

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
@@ -16,9 +16,9 @@ import {
 
 const planHeader = 'Dedicated 20 GB';
 const baseHourlyPrice = '$0.015';
-const baseMonthlyPrice = '$10';
+const baseMonthlyPrice = '$10.00';
 const regionHourlyPrice = '$0.018';
-const regionMonthlyPrice = '$12';
+const regionMonthlyPrice = '$12.00';
 const ram = '16 GB';
 const cpu = '8';
 const storage = '1024 GB';

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
@@ -53,7 +53,7 @@ export const KubernetesPlanSelection = (
 
   // We don't want flat-rate pricing or network information for LKE so we select only the second type element.
   const subHeadings = [
-    `$${price.monthly}/mo ($${price.hourly}/hr)`,
+    `$${price.monthly?.toFixed(2)}/mo ($${price.hourly}/hr)`,
     type.subHeadings[1],
   ];
 
@@ -88,7 +88,7 @@ export const KubernetesPlanSelection = (
           key={type.id}
         >
           <TableCell data-qa-plan-name>{type.heading}</TableCell>
-          <TableCell data-qa-monthly> ${price.monthly}</TableCell>
+          <TableCell data-qa-monthly> ${price.monthly?.toFixed(2)}</TableCell>
           <TableCell data-qa-hourly>${price.hourly}</TableCell>
           <TableCell center data-qa-ram>
             {convertMegabytesTo(type.memory, true)}

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
@@ -12,6 +12,7 @@ import { TableCell } from 'src/components/TableCell';
 import { StyledDisabledTableRow } from 'src/features/components/PlansPanel/PlansPanel.styles';
 import { useFlags } from 'src/hooks/useFlags';
 import { ExtendedType } from 'src/utilities/extendType';
+import { renderMonthlyPriceToCorrectDecimalPlace } from 'src/utilities/pricing/dynamicPricing';
 import { getLinodeRegionPrice } from 'src/utilities/pricing/linodes';
 import { convertMegabytesTo } from 'src/utilities/unitConversions';
 
@@ -53,7 +54,9 @@ export const KubernetesPlanSelection = (
 
   // We don't want flat-rate pricing or network information for LKE so we select only the second type element.
   const subHeadings = [
-    `$${price.monthly?.toFixed(2)}/mo ($${price.hourly}/hr)`,
+    `$${renderMonthlyPriceToCorrectDecimalPlace(price.monthly)}/mo ($${
+      price.hourly
+    }/hr)`,
     type.subHeadings[1],
   ];
 
@@ -88,7 +91,10 @@ export const KubernetesPlanSelection = (
           key={type.id}
         >
           <TableCell data-qa-plan-name>{type.heading}</TableCell>
-          <TableCell data-qa-monthly> ${price.monthly?.toFixed(2)}</TableCell>
+          <TableCell data-qa-monthly>
+            {' '}
+            ${renderMonthlyPriceToCorrectDecimalPlace(price.monthly)}
+          </TableCell>
           <TableCell data-qa-hourly>${price.hourly}</TableCell>
           <TableCell center data-qa-ram>
             {convertMegabytesTo(type.memory, true)}

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
@@ -62,6 +62,7 @@ import { getErrorMap } from 'src/utilities/errorUtils';
 import { extendType } from 'src/utilities/extendType';
 import { filterCurrentTypes } from 'src/utilities/filterCurrentLinodeTypes';
 import { getMonthlyBackupsPrice } from 'src/utilities/pricing/backups';
+import { renderMonthlyPriceToCorrectDecimalPlace } from 'src/utilities/pricing/dynamicPricing';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 
 import { SelectFirewallPanel } from '../../../components/SelectFirewallPanel/SelectFirewallPanel';
@@ -319,8 +320,8 @@ export class LinodeCreate extends React.PureComponent<
       const typeDisplayInfoCopy = cloneDeep(typeDisplayInfo);
 
       // Always display monthly cost to two decimals
-      typeDisplayInfoCopy.details = `$${typeDisplayInfo.monthly.toFixed(
-        2
+      typeDisplayInfoCopy.details = `$${renderMonthlyPriceToCorrectDecimalPlace(
+        typeDisplayInfo.monthly
       )}/month`;
 
       if (this.props.createType === 'fromApp' && this.state.numberOfNodes > 0) {

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
@@ -318,6 +318,11 @@ export class LinodeCreate extends React.PureComponent<
     if (typeDisplayInfo) {
       const typeDisplayInfoCopy = cloneDeep(typeDisplayInfo);
 
+      // Always display monthly cost to two decimals
+      typeDisplayInfoCopy.details = `$${typeDisplayInfo.monthly.toFixed(
+        2
+      )}/month`;
+
       if (this.props.createType === 'fromApp' && this.state.numberOfNodes > 0) {
         const { hourlyPrice, monthlyPrice } = getMonthlyAndHourlyNodePricing(
           typeDisplayInfoCopy.monthly,
@@ -325,7 +330,9 @@ export class LinodeCreate extends React.PureComponent<
           this.state.numberOfNodes
         );
 
-        typeDisplayInfoCopy.details = `${this.state.numberOfNodes} Nodes - $${monthlyPrice}/month $${hourlyPrice}/hr`;
+        typeDisplayInfoCopy.details = `${
+          this.state.numberOfNodes
+        } Nodes - $${monthlyPrice.toFixed(2)}/month $${hourlyPrice}/hr`;
       }
 
       displaySections.push(typeDisplayInfoCopy);

--- a/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.test.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.test.tsx
@@ -126,7 +126,7 @@ describe('ConfigureForm component with price comparison', () => {
       '$10.00/month, $0.015/hour | Backups $2.50/month'
     );
     expect(getByTestId(newPricePanel)).toHaveTextContent(
-      '$14.00/month, $0.021/hour | Backups $4.17/month'
+      '$14.40/month, $0.021/hour | Backups $4.17/month'
     );
   });
 
@@ -136,7 +136,7 @@ describe('ConfigureForm component with price comparison', () => {
       '$10.00/month, $0.015/hour'
     );
     expect(getByTestId(newPricePanel)).toHaveTextContent(
-      '$14.00/month, $0.021/hour'
+      '$14.40/month, $0.021/hour'
     );
   });
 

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
@@ -110,7 +110,7 @@ describe('PlanSelection (card, mobile)', () => {
     ).toHaveTextContent('Dedicated 20 GB');
     expect(
       container.querySelector('[data-qa-select-card-subheading="subheading-1"]')
-    ).toHaveTextContent('$10.00/mo ($0.015/hr)');
+    ).toHaveTextContent('$10/mo ($0.015/hr)');
     expect(
       container.querySelector('[data-qa-select-card-subheading="subheading-2"]')
     ).toHaveTextContent('1 CPU, 50 GB Storage, 2 GB RAM');
@@ -153,7 +153,7 @@ describe('PlanSelection (card, mobile)', () => {
     ).toHaveTextContent('Dedicated 20 GB');
     expect(
       container.querySelector('[data-qa-select-card-subheading="subheading-1"]')
-    ).toHaveTextContent('$14.00/mo ($0.021/hr)');
+    ).toHaveTextContent('$14.40/mo ($0.021/hr)');
     expect(
       container.querySelector('[data-qa-select-card-subheading="subheading-2"]')
     ).toHaveTextContent('1 CPU, 50 GB Storage, 2 GB RAM');

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
@@ -110,7 +110,7 @@ describe('PlanSelection (card, mobile)', () => {
     ).toHaveTextContent('Dedicated 20 GB');
     expect(
       container.querySelector('[data-qa-select-card-subheading="subheading-1"]')
-    ).toHaveTextContent('$10/mo ($0.015/hr)');
+    ).toHaveTextContent('$10.00/mo ($0.015/hr)');
     expect(
       container.querySelector('[data-qa-select-card-subheading="subheading-2"]')
     ).toHaveTextContent('1 CPU, 50 GB Storage, 2 GB RAM');
@@ -153,7 +153,7 @@ describe('PlanSelection (card, mobile)', () => {
     ).toHaveTextContent('Dedicated 20 GB');
     expect(
       container.querySelector('[data-qa-select-card-subheading="subheading-1"]')
-    ).toHaveTextContent('$14/mo ($0.021/hr)');
+    ).toHaveTextContent('$14.00/mo ($0.021/hr)');
     expect(
       container.querySelector('[data-qa-select-card-subheading="subheading-2"]')
     ).toHaveTextContent('1 CPU, 50 GB Storage, 2 GB RAM');

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -9,6 +9,7 @@ import { TableCell } from 'src/components/TableCell';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { LINODE_NETWORK_IN } from 'src/constants';
 import { useLinodeQuery } from 'src/queries/linodes/linodes';
+import { renderMonthlyPriceToCorrectDecimalPlace } from 'src/utilities/pricing/dynamicPricing';
 import { getLinodeRegionPrice } from 'src/utilities/pricing/linodes';
 import { convertMegabytesTo } from 'src/utilities/unitConversions';
 
@@ -91,9 +92,9 @@ export const PlanSelection = (props: Props) => {
       ? getLinodeRegionPrice(type, selectedRegionId)
       : type.price;
 
-  type.subHeadings[0] = `$${price.monthly?.toFixed(2)}/mo ($${
-    price.hourly
-  }/hr)`;
+  type.subHeadings[0] = `$${renderMonthlyPriceToCorrectDecimalPlace(
+    price.monthly
+  )}/mo ($${price.hourly}/hr)`;
 
   return (
     <React.Fragment key={`tabbed-panel-${idx}`}>
@@ -153,7 +154,10 @@ export const PlanSelection = (props: Props) => {
               />
             )}
           </TableCell>
-          <TableCell data-qa-monthly> ${price?.monthly?.toFixed(2)}</TableCell>
+          <TableCell data-qa-monthly>
+            {' '}
+            ${renderMonthlyPriceToCorrectDecimalPlace(price?.monthly)}
+          </TableCell>
           <TableCell data-qa-hourly>
             {isGPU ? (
               <Currency quantity={price.hourly ?? 0} />

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -91,7 +91,9 @@ export const PlanSelection = (props: Props) => {
       ? getLinodeRegionPrice(type, selectedRegionId)
       : type.price;
 
-  type.subHeadings[0] = `$${price.monthly}/mo ($${price.hourly}/hr)`;
+  type.subHeadings[0] = `$${price.monthly?.toFixed(2)}/mo ($${
+    price.hourly
+  }/hr)`;
 
   return (
     <React.Fragment key={`tabbed-panel-${idx}`}>
@@ -151,7 +153,7 @@ export const PlanSelection = (props: Props) => {
               />
             )}
           </TableCell>
-          <TableCell data-qa-monthly> ${price?.monthly}</TableCell>
+          <TableCell data-qa-monthly> ${price?.monthly?.toFixed(2)}</TableCell>
           <TableCell data-qa-hourly>
             {isGPU ? (
               <Currency quantity={price.hourly ?? 0} />

--- a/packages/manager/src/utilities/pricing/constants.ts
+++ b/packages/manager/src/utilities/pricing/constants.ts
@@ -23,3 +23,5 @@ export const DIFFERENT_PRICE_STRUCTURE_WARNING =
   'The selected region has a different price structure.';
 export const ENABLE_OBJ_ACCESS_KEYS_MESSAGE =
   'Pricing for monthly rate and overage costs will depend on the data center you select for deployment.';
+export const MAGIC_DATE_THAT_DC_SPECIFIC_PRICING_WAS_IMPLEMENTED =
+  '2023-10-05 00:00:00Z';

--- a/packages/manager/src/utilities/pricing/constants.ts
+++ b/packages/manager/src/utilities/pricing/constants.ts
@@ -13,6 +13,7 @@ export const OBJ_STORAGE_PRICE: ObjStoragePriceObject = {
   storage_overage: 0.02,
   transfer_overage: 0.005,
 };
+export const UNKNOWN_PRICE = '--.--';
 
 // Other constants
 export const PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE =

--- a/packages/manager/src/utilities/pricing/dynamicPricing.test.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.test.ts
@@ -1,4 +1,7 @@
-import { getDCSpecificPrice } from './dynamicPricing';
+import {
+  getDCSpecificPrice,
+  renderMonthlyPriceToCorrectDecimalPlace,
+} from './dynamicPricing';
 import { getDynamicVolumePrice } from './dynamicVolumePrice';
 
 describe('getDCSpecificPricingDisplay', () => {
@@ -58,5 +61,23 @@ describe('getDCSpecificPricingDisplay', () => {
         regionId: 'invalid-region',
       })
     ).toBe('0.00');
+  });
+});
+
+describe('renderMonthlyPriceToCorrectDecimalPlace', () => {
+  it('renders monthly price to two decimal places if the price includes a decimal', () => {
+    expect(renderMonthlyPriceToCorrectDecimalPlace(12.2)).toBe('12.20');
+  });
+
+  it('renders monthly price as an integer if the price does not include a decimal', () => {
+    expect(renderMonthlyPriceToCorrectDecimalPlace(12)).toBe(12);
+  });
+
+  it('renders monthly price as --.-- (unknown price) if the price is undefined', () => {
+    expect(renderMonthlyPriceToCorrectDecimalPlace(undefined)).toBe('--.--');
+  });
+
+  it('renders monthly price as --.-- (unknown price) if the price is null', () => {
+    expect(renderMonthlyPriceToCorrectDecimalPlace(null)).toBe('--.--');
   });
 });

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -1,5 +1,6 @@
 import type { Region } from '@linode/api-v4';
 import type { FlagSet } from 'src/featureFlags';
+import { UNKNOWN_PRICE } from './constants';
 
 export interface DataCenterPricingOptions {
   /**
@@ -75,7 +76,7 @@ export const renderMonthlyPriceToCorrectDecimalPlace = (
   monthlyPrice: null | number | undefined
 ) => {
   if (!monthlyPrice) {
-    return '--.--';
+    return UNKNOWN_PRICE;
   }
   return Number.isInteger(monthlyPrice)
     ? monthlyPrice

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -70,3 +70,14 @@ export const getDCSpecificPrice = ({
 
   return basePrice.toFixed(2);
 };
+
+export const renderMonthlyPriceToCorrectDecimalPlace = (
+  monthlyPrice: null | number | undefined
+) => {
+  if (!monthlyPrice) {
+    return '--.--';
+  }
+  return Number.isInteger(monthlyPrice)
+    ? monthlyPrice
+    : monthlyPrice.toFixed(2);
+};


### PR DESCRIPTION
## Description 📝
There are two issues with DC-specific pricing:
1. on past invoices, the Region column for invoice items is not backfilled due to how this is data is collected and populated on the back-end, which may cause confusion for users who have a region column with no data
2. monthly prices (previously all integers, displayed as `$n/mo`) are now displaying inconsistently -- most often with one decimal place, but in at least one instance (resize node pool drawer, 2GB linode) with way too many decimal places

## Major Changes 🔄
- Fixes issue 1 by hiding the Region column on invoices before DC-specific pricing was implemented. This month's invoice and invoices going forward should include region data for invoice items.
- Fixes issue 2 by displaying monthly prices returned from the API as decimals (at this point, only Jakarta and Sao Paulo) with two decimal places. Monthly prices that are integers (e.g. a 2GB linode at $10/month) should remain integers (not $10.00). We want to avoid adding extra zeroes on the screen (making the price look higher than it is) if it is not necessary. For regions with decimals in their monthly prices, we display to two decimal place rather than rounding or truncating to an integer because prices should be consistent with the prices listed in the linode.com docs.
- Updates unit and cypress tests accordingly for both these fixes.

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-10-04 at 7 46 52 PM](https://github.com/linode/manager/assets/114685994/227479c2-17db-4258-888c-2ea0ba9c59a1) | ![Screenshot 2023-10-04 at 7 46 25 PM](https://github.com/linode/manager/assets/114685994/ddaa99a0-4ed9-4276-8c19-ec6054259723) |
| ![Screenshot 2023-10-04 at 7 47 13 PM](https://github.com/linode/manager/assets/114685994/3f453afb-04bb-45c2-ac1b-84b5f8ae4e29) | ![Screenshot 2023-10-04 at 7 48 21 PM](https://github.com/linode/manager/assets/114685994/1cb7edf0-5a9b-4ddc-8e42-be79f282bfe7) |
| ![Screenshot 2023-10-04 at 9 55 38 PM](https://github.com/linode/manager/assets/114685994/2f571ed6-62f7-4363-991a-f43f5f86ab26) | ![Screenshot 2023-10-04 at 7 48 32 PM](https://github.com/linode/manager/assets/114685994/b259b7d6-c926-4721-a964-e10d9cdb8bac) |
| ![Screenshot 2023-10-04 at 10 00 23 PM](https://github.com/linode/manager/assets/114685994/20b48d6d-db17-4e8a-a88e-1e60b482b959) | ![Screenshot 2023-10-04 at 7 49 21 PM](https://github.com/linode/manager/assets/114685994/8ad8baf0-b89b-419e-bce1-7d5b074b6ab1) |
| ![Screenshot 2023-10-04 at 9 59 56 PM](https://github.com/linode/manager/assets/114685994/46a6a33c-880b-4de3-bc86-0b73d11a214d) | ![Screenshot 2023-10-04 at 7 49 41 PM](https://github.com/linode/manager/assets/114685994/8fc102c3-aaa7-4c68-8d64-e26f878e0c30) |
![Screenshot 2023-10-04 at 7 55 45 PM](https://github.com/linode/manager/assets/114685994/9cd78d5f-2ac6-40e2-a06f-f223e65a60ae) | ![Screenshot 2023-10-04 at 7 55 29 PM](https://github.com/linode/manager/assets/114685994/03ae3e6c-7931-448f-8da9-36128729366f) |
|![Screenshot 2023-10-04 at 10 05 09 PM](https://github.com/linode/manager/assets/114685994/294fc567-7e69-42c8-98fa-fedf4f224183) | ![Screenshot 2023-10-04 at 10 04 48 PM](https://github.com/linode/manager/assets/114685994/05c1133a-18cd-41be-b3a9-2a82c03dc44b) |


## How to test 🧪
1. **How to setup test environment?**
- Check out this PR.
- Have another tab open to compare to prod.
2. **How to reproduce the issue (if applicable)?**
- In prod, through the linode create flow, kube create flow, and kube node pools add/resize pool flows.
- Observe you see monthly prices in the plans tables, summaries, and drawers with a weird number of decimal points.
- Go to your latest account invoice on the billing page.
- Observe you see a regions column but no regions listed.
3. **How to verify changes?**
- On localhost, go through the linode create flow, kube create flow, and kube node pools add/resize pool flows.
- Observe you see monthly prices in the plans tables, summaries, and drawers are unchanged (no decimals) for resources outside of Jakarta or Sao Paulo.
- Observe you see monthly prices in the plans tables, summaries, and drawers with two decimals for resources in Jakarta or Sao Paulo, which have DC-specific pricing.
- Go to your latest account invoice on the billing page.
- Observe you do not see a regions column any of the following: details page (invoice table), csv download, pdf download.
- Edit the regions mock data in serverHandler.ts or the factory to include an invoice with a future date.
- Observe that you do see the regions column in all of the following: details page (invoice table), csv download, pdf 
- If you want to confirm regions will show on a future invoice (like the end of this month) update the existing mock request to include a date of `2023-10-31T18:04:01` and the go to http://localhost:3000/account/billing/invoices/1234:
```
  rest.get('*/account/invoices/:invoiceId', (req, res, ctx) => {
    const linodeInvoice = invoiceFactory.build({
      date: '2022-12-01T18:04:01',
      id: 1234,
      label: 'LinodeInvoice',
    });
    return res(ctx.json(linodeInvoice));
  }),
```

4. **How to run Unit or E2E tests?**
```
yarn test
```
e2es should pass, but I've been seeing issues with the LKE smoke tests locally due to some odd behavior with the region select scrolling out of view and returning `no results` after a selection is made -- that doesn't replicate in the UI, so not sure what is going on here.