### PR TITLE
chore: Improve DC Specific Pricing Pricing Links

### DIFF
--- a/packages/manager/src/components/DynamicPriceNotice.tsx
+++ b/packages/manager/src/components/DynamicPriceNotice.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { useRegionsQuery } from 'src/queries/regions';
+import { pricingLinkMap } from 'src/utilities/pricing/dynamicPricing';
 
 import { Link } from './Link';
 import { Notice, NoticeProps } from './Notice/Notice';
@@ -27,7 +28,9 @@ export const DynamicPriceNotice = (props: Props) => {
       <Typography fontWeight="bold">
         Prices for plans, products, and services in {regionLabel} may vary from
         other regions.{' '}
-        <Link to="https://www.linode.com/pricing">Learn more.</Link>
+        <Link to={pricingLinkMap[region] ?? 'https://www.linode.com/pricing'}>
+          Learn more.
+        </Link>
       </Typography>
     </Notice>
   );

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -39,6 +39,11 @@ export const objectStoragePriceIncreaseMap = {
   },
 };
 
+export const pricingLinkMap = {
+  'br-gru': 'https://www.linode.com/pricing/sao-paulo/',
+  'id-cgk': 'https://www.linode.com/pricing/jakarta/',
+};
+
 /**
  * This function is used to calculate the dynamic pricing for a given entity, based on potential region increased costs.
  * @example


### PR DESCRIPTION
## Description 📝
- Links users to more specific pricing pages in the dc specific pricing notice

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-10-05 at 4 22 12 PM](https://github.com/linode/manager/assets/115251059/de468a2d-6ef0-4ae1-a863-0dd6b1dc9f96) | ![Screenshot 2023-10-05 at 4 21 26 PM](https://github.com/linode/manager/assets/115251059/e039d327-6915-4d82-adcc-79182eb8738a) |

## How to test 🧪
- Verify you see the specific pricing link when you select jakarta or sao-paulo