### PR TITLE
change: [SD-449] - update support error links

### DIFF
--- a/packages/manager/src/components/SupportError.tsx
+++ b/packages/manager/src/components/SupportError.tsx
@@ -12,7 +12,9 @@ interface Props {
 export const SupportError = (props: Props) => {
   const theme = useTheme();
   const { errors } = props;
-  const errorMsg = errors[0].reason.split(/(open a support ticket)/i);
+  const errorMsg = errors[0].reason.split(
+    /(open a support ticket|contact support)/i
+  );
 
   return (
     <Typography
@@ -24,6 +26,7 @@ export const SupportError = (props: Props) => {
     >
       {errorMsg.map((substring: string, idx) => {
         const openTicket = substring.match(/open a support ticket/i);
+        const contact = substring.match(/contact support/i);
         if (openTicket) {
           return (
             <SupportLink
@@ -31,6 +34,17 @@ export const SupportError = (props: Props) => {
                 substring.match(/Open.*/)
                   ? 'Open a support ticket'
                   : 'open a support ticket'
+              }
+              key={`${substring}-${idx}`}
+            />
+          );
+        } else if (contact) {
+          return (
+            <SupportLink
+              text={
+                substring.match(/Contact.*/)
+                  ? 'Contact support'
+                  : 'contact support'
               }
               key={`${substring}-${idx}`}
             />


### PR DESCRIPTION
* added ticket page link to errors containing the string "contact support"

## Description 📝

This PR updates `SupportError.tsx` to split out on "contact support" found with error messages returned via API, allowing links to the support ticket page of Cloud to be inserted. This is needed after language updates to some error messages were modified, using this wording rather than "open a support ticket". 
