### PR TITLE
fix: [M3-7256] - Added spacing for Hively external link

### DIFF
--- a/packages/manager/.changeset/pr-9776-fixed-1696956017237.md
+++ b/packages/manager/.changeset/pr-9776-fixed-1696956017237.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Customer success Hivelyoverlap issue ([#9776](https://github.com/linode/manager/pull/9776))

--- a/packages/manager/.changeset/pr-9776-fixed-1696956017237.md
+++ b/packages/manager/.changeset/pr-9776-fixed-1696956017237.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Customer success Hivelyoverlap issue ([#9776](https://github.com/linode/manager/pull/9776))
+Customer success Hively overlap issue ([#9776](https://github.com/linode/manager/pull/9776))

--- a/packages/manager/src/features/Support/Hively.stories.tsx
+++ b/packages/manager/src/features/Support/Hively.stories.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { Hively } from './Hively';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof Hively> = {
+  args: {
+    linodeUsername: 'linodeuser',
+    replyId: '123',
+    ticketId: '123',
+  },
+  component: Hively,
+  title: 'Components/Hively',
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Hively>;
+
+export const Default: Story = {
+  args: {},
+  render: (args) => <Hively {...args} />,
+};

--- a/packages/manager/src/features/Support/Hively.tsx
+++ b/packages/manager/src/features/Support/Hively.tsx
@@ -51,7 +51,11 @@ export const Hively = (props: Props) => {
     <>
       <Divider />
       <Stack alignItems="center" direction="row" pl={1} spacing={1.5}>
-        <Typography pr={2.5}>
+        <Typography
+          sx={{
+            paddingRight: 2.5,
+          }}
+        >
           <Link external to={href + '3'}>
             How did I do?
           </Link>

--- a/packages/manager/src/features/Support/Hively.tsx
+++ b/packages/manager/src/features/Support/Hively.tsx
@@ -51,7 +51,7 @@ export const Hively = (props: Props) => {
     <>
       <Divider />
       <Stack alignItems="center" direction="row" pl={1} spacing={1.5}>
-        <Typography pr={3}>
+        <Typography pr={2.5}>
           <Link external to={href + '3'}>
             How did I do?
           </Link>

--- a/packages/manager/src/features/Support/Hively.tsx
+++ b/packages/manager/src/features/Support/Hively.tsx
@@ -53,7 +53,7 @@ export const Hively = (props: Props) => {
       <Stack alignItems="center" direction="row" pl={1} spacing={1.5}>
         <Typography
           sx={{
-            paddingRight: 2.5,
+            padding: '2px 20px 2px 0',
           }}
         >
           <Link external to={href + '3'}>

--- a/packages/manager/src/features/Support/Hively.tsx
+++ b/packages/manager/src/features/Support/Hively.tsx
@@ -10,8 +10,11 @@ import { parseAPIDate } from 'src/utilities/date';
 import { OFFICIAL_USERNAMES } from './ticketUtils';
 
 interface Props {
+  /** The username of the Linode user who created the ticket. */
   linodeUsername: string;
+  /** The ID of the reply. */
   replyId: string;
+  /** The ID of the ticket. */
   ticketId: string;
 }
 
@@ -48,7 +51,7 @@ export const Hively = (props: Props) => {
     <>
       <Divider />
       <Stack alignItems="center" direction="row" pl={1} spacing={1.5}>
-        <Typography mr={3}>
+        <Typography pr={3}>
           <Link external to={href + '3'}>
             How did I do?
           </Link>


### PR DESCRIPTION
## Description 📝
Feedback Smiley Ratings should be easily clickable, however it overlaps with the "How did I do?" link

## Changes  🔄
- `margin` is overwritten due to being in a `Stack`, so switching to `padding` which is the more better approach.
- Added Storybook

## Preview 📷
| Before  | After   |
| ------- | ------- |
| <img width="246" alt="Screenshot 2023-10-10 at 12 31 40 PM" src="https://github.com/linode/manager/assets/125309814/5a291cb3-cc2e-4184-ac60-909904e56145"> | <img width="400" alt="Screenshot 2023-10-10 at 12 36 54 PM" src="https://github.com/linode/manager/assets/125309814/009211d6-8b44-44c2-a529-37a3350cfcb7"> |

<img width="1019" alt="Screenshot 2023-10-10 at 12 37 26 PM" src="https://github.com/linode/manager/assets/125309814/c5b6d60d-387a-47b7-a878-8bd9151ec9d0">


## How to test 🧪

### Prerequisites
- Run storybook `yarn storybook`

### Reproduction steps
- Go to http://localhost:6006/?path=/docs/components-hively--documentation

### Verification steps 
- Observe that there's no more overlapping happening in component

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support