### PR TITLE
test: Improve Cypress error messages when Linode API errors occur

### DIFF
--- a/packages/manager/.changeset/pr-9777-tests-1696958372039.md
+++ b/packages/manager/.changeset/pr-9777-tests-1696958372039.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Improve error message display when Linode API error occurs in Cypress test ([#9777](https://github.com/linode/manager/pull/9777))

--- a/packages/manager/cypress/support/setup/defer-command.ts
+++ b/packages/manager/cypress/support/setup/defer-command.ts
@@ -135,7 +135,7 @@ const enhanceError = (e: any) => {
           )
           .join('\n');
 
-    return `${summary}\n${validationErrorMessage}`;
+    return new Error(`${summary}\n${validationErrorMessage}`);
   }
   // Return `e` unmodified if it's not handled by any of the above cases.
   return e;

--- a/packages/manager/cypress/support/setup/defer-command.ts
+++ b/packages/manager/cypress/support/setup/defer-command.ts
@@ -84,11 +84,12 @@ const enhanceError = (e: any) => {
         : `- ${error.reason}`;
     });
 
-    const requestUrl = !!e.request?.responseURL
-      ? `\nRequest URL: ${e.request.responseURL}`
-      : '';
+    const requestInfo =
+      !!e.request?.responseURL && !!e.config.method
+        ? `\nRequest: ${e.config.method.toUpperCase()} ${e.request.responseURL}`
+        : '';
 
-    return new Error(`${summary}\n${errorDetails.join('\n')}${requestUrl}`);
+    return new Error(`${summary}\n${errorDetails.join('\n')}${requestInfo}`);
   }
 
   if (isAxiosError(e)) {
@@ -98,11 +99,12 @@ const enhanceError = (e: any) => {
       ? `Request failed with status code ${e.response.status}`
       : `Request failed`;
 
-    const requestUrl = !!e.request?.responseURL
-      ? `\nRequest URL: ${e.request.responseURL}`
-      : '';
+    const requestInfo =
+      !!e.request?.responseURL && !!e.config.method
+        ? `\nRequest: ${e.config.method.toUpperCase()} ${e.request.responseURL}`
+        : '';
 
-    return new Error(`${summary}${requestUrl}`);
+    return new Error(`${summary}${requestInfo}`);
   }
 
   // Handle cases where a validation error is thrown.

--- a/packages/manager/cypress/support/setup/defer-command.ts
+++ b/packages/manager/cypress/support/setup/defer-command.ts
@@ -1,28 +1,143 @@
-// ***********************************************
-// This example commands.js shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add("login", (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+import type { AxiosError } from 'axios';
+import type { APIError } from '@linode/api-v4';
+
+type LinodeApiV4Error = {
+  errors: APIError[];
+};
+
+/**
+ * Returns `true` if the given error is a Linode API schema validation error.
+ *
+ * Type guards `e` as an array of `APIError` objects.
+ *
+ * @param e - Error.
+ *
+ * @returns `true` if `e` is a Linode API schema validation error.
+ */
+const isValidationError = (e: any): e is APIError[] => {
+  // When a Linode APIv4 schema validation error occurs, an array of `APIError`
+  // objects is thrown rather than a typical `Error` type.
+  return (
+    Array.isArray(e) &&
+    e.every((item: any) => {
+      return 'reason' in item;
+    })
+  );
+};
+
+/**
+ * Returns `true` if the given error is an Axios error.
+ *
+ * Type guards `e` as an `AxiosError` instance.
+ *
+ * @param e - Error.
+ *
+ * @returns `true` if `e` is an `AxiosError`.
+ */
+const isAxiosError = (e: any): e is AxiosError => {
+  return !!e.isAxiosError;
+};
+
+/**
+ * Returns `true` if the given error is a Linode API v4 request error.
+ *
+ * Type guards `e` as an `AxiosError<LinodeApiV4Error>` instance.
+ *
+ * @param e - Error.
+ *
+ * @returns `true` if `e` is a Linode API v4 request error.
+ */
+const isLinodeApiError = (e: any): e is AxiosError<LinodeApiV4Error> => {
+  if (isAxiosError(e)) {
+    const errorData = e.response?.data?.errors;
+    return (
+      Array.isArray(errorData) &&
+      errorData.every((item: any) => {
+        return 'reason' in item;
+      })
+    );
+  }
+  return false;
+};
+
+/**
+ * Detects known error types and returns a new Error with more detailed message.
+ *
+ * Unknown error types are returned without modification.
+ *
+ * @param e - Error.
+ *
+ * @returns A new error with added information in message, or `e`.
+ */
+const enhanceError = (e: any) => {
+  // Check for most specific error types first.
+  if (isLinodeApiError(e)) {
+    // If `e` is a Linode APIv4 error response, show the status code, error messages,
+    // and request URL when applicable.
+    const summary = !!e.response?.status
+      ? `Linode APIv4 request failed with status code ${e.response.status}`
+      : `Linode APIv4 request failed`;
+
+    const errorDetails = e.response!.data.errors.map((error: APIError) => {
+      return error.field
+        ? `- ${error.reason} (field '${error.field}')`
+        : `- ${error.reason}`;
+    });
+
+    const requestUrl = !!e.request?.responseURL
+      ? `\nRequest URL: ${e.request.responseURL}`
+      : '';
+
+    return new Error(`${summary}\n${errorDetails.join('\n')}${requestUrl}`);
+  }
+
+  if (isAxiosError(e)) {
+    // If `e` is an Axios error (but not a Linode API error specifically), show the
+    // status code, error messages, and request URL when applicable.
+    const summary = !!e.response?.status
+      ? `Request failed with status code ${e.response.status}`
+      : `Request failed`;
+
+    const requestUrl = !!e.request?.responseURL
+      ? `\nRequest URL: ${e.request.responseURL}`
+      : '';
+
+    return new Error(`${summary}${requestUrl}`);
+  }
+
+  // Handle cases where a validation error is thrown.
+  // These are arrays containing `APIError` objects; no additional request context
+  // is included so we only have the validation error messages themselves to work with.
+  if (isValidationError(e)) {
+    // Validation errors do not contain any additional context (request URL, payload, etc.).
+    // Show the validation error messages instead.
+    const multipleErrors = e.length > 1;
+    const summary = multipleErrors
+      ? 'Request failed with Linode schema validation errors'
+      : 'Request failed with Linode schema validation error';
+
+    // Format, accounting for 0, 1, or more errors.
+    const validationErrorMessage = multipleErrors
+      ? e
+          .map((error) =>
+            error.field
+              ? `- ${error.reason} (field '${error.field}')`
+              : `- ${error.reason}`
+          )
+          .join('\n')
+      : e
+          .map((error) =>
+            error.field
+              ? `${error.reason} (field '${error.field}')`
+              : `${error.reason}`
+          )
+          .join('\n');
+
+    return `${summary}\n${validationErrorMessage}`;
+  }
+  // Return `e` unmodified if it's not handled by any of the above cases.
+  return e;
+};
 
 /**
  * Describes an object which can contain a label.
@@ -87,9 +202,9 @@ Cypress.Commands.add(
       let result: T;
       try {
         result = await promise;
-      } catch (e) {
-        commandLog.end();
-        throw e;
+      } catch (e: any) {
+        commandLog.error(e);
+        throw enhanceError(e);
       }
       commandLog.end();
       return result;


### PR DESCRIPTION
## Description 📝
This improves error handling when a Linode API error or validation error occurs during a Cypress test by adding additional information to the command log. This is intended to help troubleshoot test failures.

(Meta: Not sure if this is better suited as `test` or `refactor` type, happy to change this to `refactor` if we think that's more applicable)

## Changes  🔄
- Detect common error types (Linode API error, generic Axios error, Linode schema validation error) and add additional information to the error message when Promise rejects in `cy.defer`

## Preview 📷

| Before  | After   |
| ------- | ------- |
| **Linode API error:** | |
| <img width="391" alt="Linode API Error Before" src="https://github.com/linode/manager/assets/97627410/1337fdc4-0b9d-4762-9ee9-29f15007031c"> | <img width="375" alt="Linode API Error After (2)" src="https://github.com/linode/manager/assets/97627410/f03f6fa5-c979-455e-aa54-823c547f9c83"> |
| **Linode schema validation error:** | |
| <img width="381" alt="Schema Validation Error Before" src="https://github.com/linode/manager/assets/97627410/512e53a1-b022-411e-b0d5-1981e80a8689"> | <img width="403" alt="Schema Validation Error After" src="https://github.com/linode/manager/assets/97627410/ee54024a-a665-409d-bd48-59ac357c17a1"> |

## How to test 🧪
* If any of the automated tests fail during a before hook (which has been happening a lot lately), we can rely on the archived screenshots and videos to confirm that this change works.
* Otherwise, the easiest thing to do is to force a test to make an invalid request and observe the error using `yarn cy:debug`:
  1. Modify `linodeRequest` in `cypress/support/util/linode-utils.ts` (line 10) to contain a short/weak `root_pass` property
  2. Run `yarn cy:debug` and select `rescue-linode.spec.ts` in the UI
  3. Observe that the API responds with a 400 and confirm that detailed messaging is shown in the Cypress UI

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support

