### PR TITLE
fix: [M3-7259] - Fix inconsistent display of % in Linode Details MNTP legend

### DIFF
--- a/packages/manager/.changeset/pr-9780-fixed-1696969213915.md
+++ b/packages/manager/.changeset/pr-9780-fixed-1696969213915.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Inconsistent display of % in Linode Details MNTP legend ([#9780](https://github.com/linode/manager/pull/9780))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferContent.tsx
@@ -106,9 +106,9 @@ export const TransferContent = (props: ContentProps) => {
                 ? `${regionName} Transfer Used (${totalUsedInGB} GB - ${Math.ceil(
                     totalUsagePercent
                   )}%)`
-                : `Global Pool Used (${totalUsedInGB} GB) - ${Math.ceil(
+                : `Global Pool Used (${totalUsedInGB} GB - ${Math.ceil(
                     totalUsagePercent
-                  )}%`}
+                  )}%)`}
             </span>
           </StyledPoolUsage>
           <StyledRemainingPoolUsage>


### PR DESCRIPTION
## Description 📝
Currently, on the Linode Details > Network tab, we display Monthly Network Transfer bar percents, labeled with a legend that looks like the following:

debian-us-sea (0.26 GB - 1%)
Global Pool Used (1 GB) - 1%

We should format these two legend labels consistently:

debian-us-sea (0.26 GB - 1%)
**Global Pool Used (1 GB - 1%)**

## Changes  🔄
- The percentage of the Global/DC-specific pool used is formatted in the same way that the percentage of the pool that the linode has used: [label] ([number] GB - [percent]%)

## Preview 📷
| Before  | After   |
| ------- | ------- |
|![Screenshot 2023-10-10 at 12 50 56 PM](https://github.com/linode/manager/assets/114685994/36326751-306b-4ab4-888b-7a1084dba2d0) | ![Screenshot 2023-10-10 at 1 08 25 PM](https://github.com/linode/manager/assets/114685994/b7cf725f-66cc-4482-a365-dd3a884b49d6)|


## How to test 🧪

### Prerequisites
- Make sure DC-specific pricing feature flag is on.
- If you do not have an existing linode on your account, create one.

### Reproduction steps
- In prod, go to a linode's details page and navigate to the Network tab.
- Observe that the way we format the legend labels in the Monthly Network Transfer section is inconsistent -- in one case, we include the % inside the parentheses, and in another, it is after.
### Verification steps 
- On this branch, go to a linode's details page and navigate to the Network tab.
- Observe that the way we format the legend labels in the Monthly Network Transfer section is consistent.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support
