### PR TITLE
test: Fix Cypress LKE create test failures stemming from reset mocks

### DIFF
--- a/packages/manager/.changeset/pr-9782-tests-1697147463647.md
+++ b/packages/manager/.changeset/pr-9782-tests-1697147463647.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Improve LKE create test reattempt stability ([#9782](https://github.com/linode/manager/pull/9782))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -73,12 +73,7 @@ const getSimilarPlans = (
 authenticate();
 describe('LKE Cluster Creation', () => {
   before(() => {
-    cleanUp('lke-clusters');
-    // TODO: DC Pricing - M3-7073: Remove feature flag mocks when DC specific pricing goes live.
-    mockAppendFeatureFlags({
-      dcSpecificPricing: makeFeatureFlagData(false),
-    }).as('getFeatureFlags');
-    mockGetFeatureFlagClientstream().as('getClientStream');
+    cleanUp(['linodes', 'lke-clusters']);
   });
 
   /*
@@ -96,6 +91,11 @@ describe('LKE Cluster Creation', () => {
       .fill(null)
       .map(() => randomItem(lkeClusterPlans));
 
+    // TODO: DC Pricing - M3-7073: Remove feature flag mocks when DC specific pricing goes live.
+    mockAppendFeatureFlags({
+      dcSpecificPricing: makeFeatureFlagData(false),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
     interceptCreateCluster().as('createCluster');
 
     cy.visitWithLogin('/kubernetes/clusters');
@@ -225,10 +225,6 @@ describe('LKE Cluster Creation', () => {
 describe('LKE Cluster Creation with DC-specific pricing', () => {
   before(() => {
     cleanUp('lke-clusters');
-    mockAppendFeatureFlags({
-      dcSpecificPricing: makeFeatureFlagData(true),
-    }).as('getFeatureFlags');
-    mockGetFeatureFlagClientstream().as('getClientStream');
   });
 
   /*
@@ -247,6 +243,10 @@ describe('LKE Cluster Creation with DC-specific pricing', () => {
       .fill(null)
       .map(() => randomItem(dcPricingLkeClusterPlans));
 
+    mockAppendFeatureFlags({
+      dcSpecificPricing: makeFeatureFlagData(true),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
     interceptCreateCluster().as('createCluster');
 
     cy.visitWithLogin('/kubernetes/clusters');

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -91,7 +91,7 @@ describe('LKE Cluster Creation', () => {
   it('can create an LKE cluster', () => {
     const clusterLabel = randomLabel();
     const clusterRegion = chooseRegion();
-    const clusterVersion = '1.26';
+    const clusterVersion = '1.27';
     const clusterPlans = new Array(2)
       .fill(null)
       .map(() => randomItem(lkeClusterPlans));
@@ -242,7 +242,7 @@ describe('LKE Cluster Creation with DC-specific pricing', () => {
     const clusterRegion = getRegionById('us-southeast');
     const dcSpecificPricingRegion = getRegionById('us-east');
     const clusterLabel = randomLabel();
-    const clusterVersion = '1.26';
+    const clusterVersion = '1.27';
     const clusterPlans = new Array(2)
       .fill(null)
       .map(() => randomItem(dcPricingLkeClusterPlans));


### PR DESCRIPTION
## Description 📝
This fixes a consistent failure that occurs upon any re-attempt of the LKE create tests. If the LKE test fails on its first attempt for any reason, the Launch Darkly feature flag mocks will fail to be set in any of the reattempts, leading the tests to fail each time. This addresses the issue by setting up the mocks inside of the test instead of in a `before` hook.

Additionally, I set the tests to use Kubernetes v1.27 and clean up Linodes in addition to LKE clusters prior to running the tests, but the mock changes are the real fix here.

## Changes  🔄
List any change relevant to the reviewer.
- Move LKE feature flag mocks to resolve failure on reattempts
- Use Kubernetes 1.27 for LKE create E2E tests
- Clean up Linodes before running LKE create test

## How to test 🧪
This is challenging to reproduce because the failure only occurs when the test fails on its first attempt. We can smoke test the changes by running the test and making sure there aren't any new failures:

`yarn && yarn build && yarn start:manager:ci` and then:
```bash
yarn cy:run -s "cypress/e2e/core/kubernetes/lke-create.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support
