### PR TITLE
feat: [M3-7252] - Only show regions that support VPCs in VPC Create page

### DIFF
--- a/packages/manager/.changeset/pr-9787-upcoming-features-1697145963212.md
+++ b/packages/manager/.changeset/pr-9787-upcoming-features-1697145963212.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Only show regions that support VPCs in VPC Create page ([#9787](https://github.com/linode/manager/pull/9787))

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/disabledRegions.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/disabledRegions.tsx
@@ -58,7 +58,7 @@ interface DisabledRegion {
 export const listOfDisabledRegions: DisabledRegion[] = [
   {
     disabledMessage: tokyoDisabledMessage,
-    excludePaths: ['/object-storage/buckets/create'],
+    excludePaths: ['/object-storage/buckets/create', '/vpcs/create'],
     fakeRegion: fakeTokyo,
     featureFlag: 'soldOutTokyo',
   },

--- a/packages/manager/src/features/VPCs/VPCCreate/VPCCreate.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/VPCCreate.tsx
@@ -43,6 +43,8 @@ const VPCCreate = () => {
   const { data: profile } = useProfile();
   const { data: grants } = useGrants();
   const { data: regions } = useRegionsQuery();
+  const regionsWithVPCCapability =
+    regions?.filter((region) => region.capabilities.includes('VPCs')) ?? [];
   const { isLoading, mutateAsync: createVPC } = useCreateVPCMutation();
   const [
     generalSubnetErrorsFromAPI,
@@ -242,7 +244,7 @@ const VPCCreate = () => {
               disabled={userCannotAddVPC}
               errorText={errors.region}
               isClearable
-              regions={regions ?? []}
+              regions={regionsWithVPCCapability}
               selectedID={values.region}
             />
             <TextField


### PR DESCRIPTION
## Description 📝
- For the VPC Create page, rather than showing all regions, we only show the regions that support VPCs in the region select
- NOTE: Hiding the disabled Tokyo region from this page as well, since 1) Tokyo doesn't support VPCs yet, and 2)  the tooltip for disabled Tokyo region mentions using the Osaka region instead, but Osaka also doesn't support VPCs and doesn't show up

## Preview 📷

| Before  | After   |
| ------- | ------- |
|![image](https://github.com/linode/manager/assets/139280159/9eae0d04-d6a1-4530-868d-e0b2786b0346) |![image](https://github.com/linode/manager/assets/139280159/5eea12cb-e598-4bff-83d3-bc67971b1fe4) |

## How to test 🧪

### Prerequisites
- Using the dev environment, with vpc admin tags, navigate to the VPC Create page

### Verification steps 
- Verify that the region select on the VPC Create page only contains the following regions (these are the ones that have the VPC capability, based on the API return object)
  - Mumbai, India
  - Toronto, Ontario, CAN
  - Sydney, NSW, Australia
  - Newark, NJ, USA
  - London, England, UK

### Tests
- Verify that the vpc-create-spec tests pass:
yarn cy:run -s "cypress/e2e/core/vpc/vpc-create.spec.ts"

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support