### PR TITLE
Release v1.105.0 - `release → staging`

### DIFF
--- a/packages/api-v4/.changeset/pr-9677-added-1695693363239.md
+++ b/packages/api-v4/.changeset/pr-9677-added-1695693363239.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Added
----
-
-New payload option `migration_type` in `ResizeLinodePayload` and new event type `linode_resize_warm_create` ([#9677](https://github.com/linode/manager/pull/9677))

--- a/packages/api-v4/CHANGELOG.md
+++ b/packages/api-v4/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2023-10-16] - v0.104.0
+
+
+### Added:
+
+- New payload option `migration_type` in `ResizeLinodePayload` and new event type `linode_resize_warm_create` ([#9677](https://github.com/linode/manager/pull/9677))
+
 ## [2023-10-02] - v0.102.0
 
 ### Upcoming Features:

--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/api-v4",
-  "version": "0.102.0",
+  "version": "0.103.0",
   "homepage": "https://github.com/linode/manager/tree/develop/packages/api-v4",
   "bugs": {
     "url": "https://github.com/linode/manager/issues"

--- a/packages/manager/.changeset/pr-9677-added-1695693479114.md
+++ b/packages/manager/.changeset/pr-9677-added-1695693479114.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-Ability to choose resize types when resizing Linode ([#9677](https://github.com/linode/manager/pull/9677))

--- a/packages/manager/.changeset/pr-9703-upcoming-features-1695751361212.md
+++ b/packages/manager/.changeset/pr-9703-upcoming-features-1695751361212.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Subnet Unassign Linodes Drawer ([#9703](https://github.com/linode/manager/pull/9703))

--- a/packages/manager/.changeset/pr-9725-fixed-1695824674392.md
+++ b/packages/manager/.changeset/pr-9725-fixed-1695824674392.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Add Firewall and Linode Configuration success toast notifications ([#9725](https://github.com/linode/manager/pull/9725))

--- a/packages/manager/.changeset/pr-9728-tests-1696600050126.md
+++ b/packages/manager/.changeset/pr-9728-tests-1696600050126.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Added Cypress integration test for Edit Subnet flow ([#9728](https://github.com/linode/manager/pull/9728))

--- a/packages/manager/.changeset/pr-9730-tests-1696881818677.md
+++ b/packages/manager/.changeset/pr-9730-tests-1696881818677.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Cypress tests for VPC create flows ([#9730](https://github.com/linode/manager/pull/9730))

--- a/packages/manager/.changeset/pr-9731-fixed-1695931370886.md
+++ b/packages/manager/.changeset/pr-9731-fixed-1695931370886.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Long drawer titles overlapping close icon ([#9731](https://github.com/linode/manager/pull/9731))

--- a/packages/manager/.changeset/pr-9732-added-1696340382725.md
+++ b/packages/manager/.changeset/pr-9732-added-1696340382725.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-Statically Cache Marketplace Apps ([#9732](https://github.com/linode/manager/pull/9732))

--- a/packages/manager/.changeset/pr-9735-upcoming-features-1696265642529.md
+++ b/packages/manager/.changeset/pr-9735-upcoming-features-1696265642529.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add AGLB Route Delete Dialog ([#9735](https://github.com/linode/manager/pull/9735))

--- a/packages/manager/.changeset/pr-9736-upcoming-features-1696008733328.md
+++ b/packages/manager/.changeset/pr-9736-upcoming-features-1696008733328.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add Drag and Drop support to the Load Balancer Rules Table ([#9736](https://github.com/linode/manager/pull/9736))

--- a/packages/manager/.changeset/pr-9739-fixed-1696019997998.md
+++ b/packages/manager/.changeset/pr-9739-fixed-1696019997998.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Removed `title` prop forwarding on Modals/Dialogs ([#9739](https://github.com/linode/manager/pull/9739))

--- a/packages/manager/.changeset/pr-9743-upcoming-features-1696347149626.md
+++ b/packages/manager/.changeset/pr-9743-upcoming-features-1696347149626.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Make Reboot Linodes dismissible banner on VPC Details page unique for each VPC ([#9743](https://github.com/linode/manager/pull/9743))

--- a/packages/manager/.changeset/pr-9745-tech-stories-1696272112150.md
+++ b/packages/manager/.changeset/pr-9745-tech-stories-1696272112150.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Disable Sentry Performance Tracing ([#9745](https://github.com/linode/manager/pull/9745))

--- a/packages/manager/.changeset/pr-9746-fixed-1696274683693.md
+++ b/packages/manager/.changeset/pr-9746-fixed-1696274683693.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Fixed the top spacing for the NodeBalancer empty state page ([#9746](https://github.com/linode/manager/pull/9746))

--- a/packages/manager/.changeset/pr-9750-fixed-1696365803471.md
+++ b/packages/manager/.changeset/pr-9750-fixed-1696365803471.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Persistent error messages for Region, Label, and Description fields in VPC Create flow ([#9750](https://github.com/linode/manager/pull/9750))

--- a/packages/manager/.changeset/pr-9751-upcoming-features-1696367790874.md
+++ b/packages/manager/.changeset/pr-9751-upcoming-features-1696367790874.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Showcase VPC feedback ([#9751](https://github.com/linode/manager/pull/9751))

--- a/packages/manager/.changeset/pr-9752-tech-stories-1696367849962.md
+++ b/packages/manager/.changeset/pr-9752-tech-stories-1696367849962.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Migrate Filesystem TextField Select to Autocomplete ([#9752](https://github.com/linode/manager/pull/9752))

--- a/packages/manager/.changeset/pr-9753-changed-1696626338930.md
+++ b/packages/manager/.changeset/pr-9753-changed-1696626338930.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Comment out CS:GO app pending update ([#9753](https://github.com/linode/manager/pull/9753))

--- a/packages/manager/.changeset/pr-9755-fixed-1696437359700.md
+++ b/packages/manager/.changeset/pr-9755-fixed-1696437359700.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Notice scroll-to-view behavior and styling regressions ([#9755](https://github.com/linode/manager/pull/9755))

--- a/packages/manager/.changeset/pr-9762-fixed-1696961275313.md
+++ b/packages/manager/.changeset/pr-9762-fixed-1696961275313.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Display Database menu items in side nav and Create dropdown for permissioned users ([#9762](https://github.com/linode/manager/pull/9762))

--- a/packages/manager/.changeset/pr-9770-changed-1696954786545.md
+++ b/packages/manager/.changeset/pr-9770-changed-1696954786545.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-Link `contact Support` text in notices to support ticket modal ([#9770](https://github.com/linode/manager/pull/9770))

--- a/packages/manager/.changeset/pr-9774-tech-stories-1696952177563.md
+++ b/packages/manager/.changeset/pr-9774-tech-stories-1696952177563.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-MUI v5 Migration - `SRC > Features > Lish` ([#9774](https://github.com/linode/manager/pull/9774))

--- a/packages/manager/.changeset/pr-9776-fixed-1696956017237.md
+++ b/packages/manager/.changeset/pr-9776-fixed-1696956017237.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Customer success Hively overlap issue ([#9776](https://github.com/linode/manager/pull/9776))

--- a/packages/manager/.changeset/pr-9780-fixed-1696969213915.md
+++ b/packages/manager/.changeset/pr-9780-fixed-1696969213915.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Inconsistent display of % in Linode Details MNTP legend ([#9780](https://github.com/linode/manager/pull/9780))

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2023-10-16] - v1.105.0
+
+
+### Added:
+
+- Ability to choose resize types when resizing Linode ([#9677](https://github.com/linode/manager/pull/9677))
+- Statically Cache Marketplace Apps ([#9732](https://github.com/linode/manager/pull/9732))
+- Link `contact Support` text in notices to support ticket modal ([#9770](https://github.com/linode/manager/pull/9770))
+
+### Changed:
+
+- Comment out CS:GO app pending update ([#9753](https://github.com/linode/manager/pull/9753))
+
+### Fixed:
+
+- Add Firewall and Linode Configuration success toast notifications ([#9725](https://github.com/linode/manager/pull/9725))
+- Long drawer titles overlapping close icon ([#9731](https://github.com/linode/manager/pull/9731))
+- Removed `title` prop forwarding on Modals/Dialogs ([#9739](https://github.com/linode/manager/pull/9739))
+- Fixed the top spacing for the NodeBalancer empty state page ([#9746](https://github.com/linode/manager/pull/9746))
+- Persistent error messages for Region, Label, and Description fields in VPC Create flow ([#9750](https://github.com/linode/manager/pull/9750))
+- Notice scroll-to-view behavior and styling regressions ([#9755](https://github.com/linode/manager/pull/9755))
+- Display Database menu items in side nav and Create dropdown for permissioned users ([#9762](https://github.com/linode/manager/pull/9762))
+- Customer success Hively overlap issue ([#9776](https://github.com/linode/manager/pull/9776))
+- Inconsistent display of % in Linode Details MNTP legend ([#9780](https://github.com/linode/manager/pull/9780))
+
+### Tech Stories:
+
+- Disable Sentry Performance Tracing ([#9745](https://github.com/linode/manager/pull/9745))
+- Migrate Filesystem TextField Select to Autocomplete ([#9752](https://github.com/linode/manager/pull/9752))
+- MUI v5 Migration - `SRC > Features > Lish` ([#9774](https://github.com/linode/manager/pull/9774))
+
+### Tests:
+
+- Added Cypress integration test for Edit Subnet flow ([#9728](https://github.com/linode/manager/pull/9728))
+- Cypress tests for VPC create flows ([#9730](https://github.com/linode/manager/pull/9730))
+
+### Upcoming Features:
+
+- Subnet Unassign Linodes Drawer ([#9703](https://github.com/linode/manager/pull/9703))
+- Add AGLB Route Delete Dialog ([#9735](https://github.com/linode/manager/pull/9735))
+- Add Drag and Drop support to the Load Balancer Rules Table ([#9736](https://github.com/linode/manager/pull/9736))
+- Make Reboot Linodes dismissible banner on VPC Details page unique for each VPC ([#9743](https://github.com/linode/manager/pull/9743))
+- Showcase VPC feedback ([#9751](https://github.com/linode/manager/pull/9751))
+
 ## [2023-10-02] - v1.104.1
 
 ### Fixed:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.104.1",
+  "version": "1.105.0",
   "private": true,
   "bugs": {
     "url": "https://github.com/Linode/manager/issues"

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/validation",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Yup validation schemas for use with the Linode APIv4",
   "type": "module",
   "main": "lib/index.cjs",


### PR DESCRIPTION
# Cloud Manager
## [2023-10-16] - v1.105.0

### Added:

- Ability to choose resize types when resizing Linode ([#9677](https://github.com/linode/manager/pull/9677))
- Statically Cache Marketplace Apps ([#9732](https://github.com/linode/manager/pull/9732))
- Link `contact Support` text in notices to support ticket modal ([#9770](https://github.com/linode/manager/pull/9770))

### Changed:

- Comment out CS:GO app pending update ([#9753](https://github.com/linode/manager/pull/9753))

### Fixed:

- Add Firewall and Linode Configuration success toast notifications ([#9725](https://github.com/linode/manager/pull/9725))
- Long drawer titles overlapping close icon ([#9731](https://github.com/linode/manager/pull/9731))
- Removed `title` prop forwarding on Modals/Dialogs ([#9739](https://github.com/linode/manager/pull/9739))
- Fixed the top spacing for the NodeBalancer empty state page ([#9746](https://github.com/linode/manager/pull/9746))
- Persistent error messages for Region, Label, and Description fields in VPC Create flow ([#9750](https://github.com/linode/manager/pull/9750))
- Notice scroll-to-view behavior and styling regressions ([#9755](https://github.com/linode/manager/pull/9755))
- Display Database menu items in side nav and Create dropdown for permissioned users ([#9762](https://github.com/linode/manager/pull/9762))
- Customer success Hively overlap issue ([#9776](https://github.com/linode/manager/pull/9776))
- Inconsistent display of % in Linode Details MNTP legend ([#9780](https://github.com/linode/manager/pull/9780))

### Tech Stories:

- Disable Sentry Performance Tracing ([#9745](https://github.com/linode/manager/pull/9745))
- Migrate Filesystem TextField Select to Autocomplete ([#9752](https://github.com/linode/manager/pull/9752))
- MUI v5 Migration - `SRC > Features > Lish` ([#9774](https://github.com/linode/manager/pull/9774))

### Tests:

- Added Cypress integration test for Edit Subnet flow ([#9728](https://github.com/linode/manager/pull/9728))
- Cypress tests for VPC create flows ([#9730](https://github.com/linode/manager/pull/9730))

### Upcoming Features:

- Subnet Unassign Linodes Drawer ([#9703](https://github.com/linode/manager/pull/9703))
- Add AGLB Route Delete Dialog ([#9735](https://github.com/linode/manager/pull/9735))
- Add Drag and Drop support to the Load Balancer Rules Table ([#9736](https://github.com/linode/manager/pull/9736))
- Make Reboot Linodes dismissible banner on VPC Details page unique for each VPC ([#9743](https://github.com/linode/manager/pull/9743))
- Showcase VPC feedback ([#9751](https://github.com/linode/manager/pull/9751))

# API-v4
## [2023-10-16] - v0.103.0

### Added:

- New payload option `migration_type` in `ResizeLinodePayload` and new event type `linode_resize_warm_create` ([#9677](https://github.com/linode/manager/pull/9677))
