### PR TITLE
fix: [M3-7081] - Quote variable in changeset shell command

### DIFF
--- a/packages/manager/.changeset/pr-9791-fixed-1697461463011.md
+++ b/packages/manager/.changeset/pr-9791-fixed-1697461463011.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Quote variable in changeset shell command ([#9791](https://github.com/linode/manager/pull/9791))

--- a/scripts/changelog/changeset.mjs
+++ b/scripts/changelog/changeset.mjs
@@ -100,7 +100,7 @@ async function generateChangeset() {
   }
 
   try {
-    const addCmd = `git add ${changesetFile}`;
+    const addCmd = `git add "${changesetFile}"`;
     // This allows backticks in the commit message. We first need to sanitize against any number of backslashes 
     // that appear before backtick in description, to avoid having unescaped characters. Then we can add back 
     // two backslashes before the backtick to make sure backticks show up in the commit message.


### PR DESCRIPTION
## Description 📝
We're getting a [codeQL warning](https://github.com/linode/manager/security/code-scanning/30) for "Shell command built from environment values" for not properly handling the variable in the shell command. 

> Dynamically constructing a shell command with values from the local environment, such as file paths, may inadvertently change the meaning of the shell command. Such changes can occur when an environment value contains characters that the shell interprets in a special way, for instance quotes and spaces. This can result in the shell command misbehaving, or even allowing a malicious user to execute arbitrary commands on the system.

> **Recommendation**
> If possible, use hard-coded string literals to specify the shell command to run, and provide the dynamic arguments to the shell command separately to avoid interpretation by the shell.

## Changes  🔄
- Add quotes to the git add shell command in the changeset job

## Preview 📷
No visual change

## How to test 🧪

If you have the codeQL extension on VSCode, you can set up a codeQL database for the manager repo and run the IncompleteSanitization.ql query (from the [codeql repo](https://github.com/github/codeql) - javascript >> ql >> src >> Security >> CWE-78 >> ShellCommandInjectionFromEnvironment.ql) on the manager database. Instructions for setting up the extension here: https://codeql.github.com/docs/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code/ (+ I also installed the CLI). [guide](https://luisrangelc.medium.com/analyze-vulnerabilities-in-your-code-with-codeql-locally-3e5d31f8ed2)

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support

---
## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**
- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

---
