### PR TITLE
fix: [M3-7270] - Edit Linode VLAN config interface

### DIFF
--- a/packages/manager/.changeset/pr-9798-upcoming-features-1697553282360.md
+++ b/packages/manager/.changeset/pr-9798-upcoming-features-1697553282360.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Fix Edit Linode VLAN config interface ([#9798](https://github.com/linode/manager/pull/9798))

--- a/packages/manager/.changeset/pr-9798-upcoming-features-1697553282360.md
+++ b/packages/manager/.changeset/pr-9798-upcoming-features-1697553282360.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Fix Edit Linode VLAN config interface ([#9798](https://github.com/linode/manager/pull/9798))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
@@ -368,23 +368,17 @@ export const LinodeConfigDialog = (props: Props) => {
       configData.initrd = finnixDiskID;
     }
 
-    console.log(configData.interfaces)
-
     if (!regionHasVLANS) {
-      console.log('deleting vlan')
       configData.interfaces = configData.interfaces?.filter(
-        (_interface) => _interface.purpose === 'vlan'
+        (_interface) => _interface.purpose !== 'vlan'
       );
     }
 
     if (!regionHasVPCs) {
-      console.log('deleteing vpc')
       configData.interfaces = configData.interfaces?.filter(
-        (_interface) => _interface.purpose === 'vpc'
+        (_interface) => _interface.purpose !== 'vpc'
       );
     }
-
-    console.log(configData.interfaces)
 
     const actionType = Boolean(config) ? 'updated' : 'created';
     const handleSuccess = () => {

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
@@ -368,9 +368,23 @@ export const LinodeConfigDialog = (props: Props) => {
       configData.initrd = finnixDiskID;
     }
 
-    if (!regionHasVLANS || !regionHasVPCs) {
-      delete configData.interfaces;
+    console.log(configData.interfaces)
+
+    if (!regionHasVLANS) {
+      console.log('deleting vlan')
+      configData.interfaces = configData.interfaces?.filter(
+        (_interface) => _interface.purpose === 'vlan'
+      );
     }
+
+    if (!regionHasVPCs) {
+      console.log('deleteing vpc')
+      configData.interfaces = configData.interfaces?.filter(
+        (_interface) => _interface.purpose === 'vpc'
+      );
+    }
+
+    console.log(configData.interfaces)
 
     const actionType = Boolean(config) ? 'updated' : 'created';
     const handleSuccess = () => {


### PR DESCRIPTION
## Description 📝
Bug from https://github.com/linode/manager/pull/9709

On the prod env, we were unable to edit a config due to the config interface being deleted. This was due to the `regionHasVPCs` variable being coupled with `regionHasVLANS` in the if statement to delete config interfaces. The fix was to handle VPCs and VLANs separately.

Note: Linode details have been obfuscated

## Preview 📷
| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/115299789/5d61c3ae-131c-4c66-b5e9-bde536a90bda" /> | <video src="https://github.com/linode/manager/assets/115299789/39d40d03-53b5-4a85-85a8-c8d1aba4a20b" /> |

## How to test 🧪

### Prerequisites
- Point to the prod environment

### Reproduction steps
- Go to a Linode's details page and click on the `Configurations` tab
- Click the edit button and scroll down to the Networking section
- Select a VLAN and save changes

### Verification steps 
- The VLAN changes should be reflected in the Configurations table