### PR TITLE
test: Fix DBaaS tests after API update

### DIFF
--- a/packages/manager/.changeset/pr-9801-tests-1697547109194.md
+++ b/packages/manager/.changeset/pr-9801-tests-1697547109194.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix DBaaS UI test failures stemming from API update ([#9801](https://github.com/linode/manager/pull/9801))

--- a/packages/manager/cypress/e2e/core/databases/create-database.spec.ts
+++ b/packages/manager/cypress/e2e/core/databases/create-database.spec.ts
@@ -4,11 +4,13 @@ import {
   databaseClusterConfiguration,
   databaseConfigurations,
   mockDatabaseEngineTypes,
+  mockDatabaseNodeTypes,
 } from 'support/constants/databases';
 import {
   mockCreateDatabase,
   mockGetDatabases,
   mockGetDatabaseEngines,
+  mockGetDatabaseTypes,
 } from 'support/intercepts/databases';
 import { mockGetEvents } from 'support/intercepts/events';
 import { getRegionById } from 'support/util/regions';
@@ -71,9 +73,10 @@ describe('create a database cluster, mocked data', () => {
         );
         mockCreateDatabase(databaseMock).as('createDatabase');
         mockGetDatabases([databaseMock]).as('getDatabases');
+        mockGetDatabaseTypes(mockDatabaseNodeTypes).as('getDatabaseTypes');
 
         cy.visitWithLogin('/databases/create');
-        cy.wait(['@getAccount', '@getDatabaseEngines']);
+        cy.wait(['@getAccount', '@getDatabaseEngines', '@getDatabaseTypes']);
 
         ui.entityHeader
           .find()

--- a/packages/manager/cypress/e2e/core/databases/delete-database.spec.ts
+++ b/packages/manager/cypress/e2e/core/databases/delete-database.spec.ts
@@ -9,11 +9,13 @@ import {
   mockDeleteDatabase,
   mockDeleteProvisioningDatabase,
   mockGetDatabase,
+  mockGetDatabaseTypes,
 } from 'support/intercepts/databases';
 import { ui } from 'support/ui';
 import {
   databaseClusterConfiguration,
   databaseConfigurations,
+  mockDatabaseNodeTypes,
 } from 'support/constants/databases';
 
 describe('Delete database clusters', () => {
@@ -40,12 +42,13 @@ describe('Delete database clusters', () => {
           // Mock account to ensure 'Managed Databases' capability.
           mockGetAccount(accountFactory.build()).as('getAccount');
           mockGetDatabase(database).as('getDatabase');
+          mockGetDatabaseTypes(mockDatabaseNodeTypes).as('getDatabaseTypes');
           mockDeleteDatabase(database.id, database.engine).as('deleteDatabase');
 
           cy.visitWithLogin(
             `/databases/${database.engine}/${database.id}/settings`
           );
-          cy.wait(['@getAccount', '@getDatabase']);
+          cy.wait(['@getAccount', '@getDatabase', '@getDatabaseTypes']);
 
           // Click "Delete Cluster" button.
           ui.button
@@ -97,6 +100,7 @@ describe('Delete database clusters', () => {
 
           mockGetAccount(accountFactory.build()).as('getAccount');
           mockGetDatabase(database).as('getDatabase');
+          mockGetDatabaseTypes(mockDatabaseNodeTypes).as('getDatabaseTypes');
           mockDeleteProvisioningDatabase(
             database.id,
             database.engine,
@@ -106,7 +110,7 @@ describe('Delete database clusters', () => {
           cy.visitWithLogin(
             `/databases/${database.engine}/${database.id}/settings`
           );
-          cy.wait(['@getAccount', '@getDatabase']);
+          cy.wait(['@getAccount', '@getDatabase', '@getDatabaseTypes']);
 
           // Click "Delete Cluster" button.
           ui.button

--- a/packages/manager/cypress/e2e/core/databases/update-database.spec.ts
+++ b/packages/manager/cypress/e2e/core/databases/update-database.spec.ts
@@ -8,12 +8,13 @@ import {
   randomIp,
   randomString,
 } from 'support/util/random';
-import { databaseFactory } from 'src/factories/databases';
+import { databaseFactory, databaseTypeFactory } from 'src/factories/databases';
 import { ui } from 'support/ui';
 import { mockGetAccount } from 'support/intercepts/account';
 import {
   mockGetDatabase,
   mockGetDatabaseCredentials,
+  mockGetDatabaseTypes,
   mockResetPassword,
   mockResetPasswordProvisioningDatabase,
   mockUpdateDatabase,
@@ -22,6 +23,7 @@ import {
 import {
   databaseClusterConfiguration,
   databaseConfigurations,
+  mockDatabaseNodeTypes,
 } from 'support/constants/databases';
 import { accountFactory } from '@src/factories';
 
@@ -169,6 +171,7 @@ describe('Update database clusters', () => {
           // Mock account to ensure 'Managed Databases' capability.
           mockGetAccount(accountFactory.build()).as('getAccount');
           mockGetDatabase(database).as('getDatabase');
+          mockGetDatabaseTypes(mockDatabaseNodeTypes).as('getDatabaseTypes');
           mockResetPassword(database.id, database.engine).as(
             'resetRootPassword'
           );
@@ -179,7 +182,7 @@ describe('Update database clusters', () => {
           ).as('getCredentials');
 
           cy.visitWithLogin(`/databases/${database.engine}/${database.id}`);
-          cy.wait(['@getAccount', '@getDatabase']);
+          cy.wait(['@getAccount', '@getDatabase', '@getDatabaseTypes']);
 
           cy.get('[data-qa-cluster-config]').within(() => {
             cy.findByText(configuration.region.label).should('be.visible');
@@ -282,6 +285,7 @@ describe('Update database clusters', () => {
 
           mockGetAccount(accountFactory.build()).as('getAccount');
           mockGetDatabase(database).as('getDatabase');
+          mockGetDatabaseTypes(mockDatabaseNodeTypes).as('getDatabaseTypes');
 
           mockUpdateProvisioningDatabase(
             database.id,
@@ -296,7 +300,7 @@ describe('Update database clusters', () => {
           ).as('resetRootPassword');
 
           cy.visitWithLogin(`/databases/${database.engine}/${database.id}`);
-          cy.wait(['@getAccount', '@getDatabase']);
+          cy.wait(['@getAccount', '@getDatabase', '@getDatabaseTypes']);
 
           // Cannot update database label.
           updateDatabaseLabel(initialLabel, updateAttemptLabel);

--- a/packages/manager/cypress/support/constants/databases.ts
+++ b/packages/manager/cypress/support/constants/databases.ts
@@ -44,9 +44,11 @@ export const mockDatabaseEngineTypes: DatabaseEngine[] = [
 // `linodeType` values used by the tests.
 export const mockDatabaseNodeTypes: DatabaseType[] = [
   databaseTypeFactory.build({
+    class: 'nanode',
     id: 'g6-nanode-1',
   }),
   databaseTypeFactory.build({
+    class: 'dedicated',
     id: 'g6-dedicated-16',
   }),
 ];

--- a/packages/manager/cypress/support/constants/databases.ts
+++ b/packages/manager/cypress/support/constants/databases.ts
@@ -1,12 +1,13 @@
-import {
+import type {
   ClusterSize,
   Engine,
   Region,
   DatabaseEngine,
+  DatabaseType,
 } from '@linode/api-v4/types';
 import { randomLabel } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
-import { databaseEngineFactory } from '@src/factories';
+import { databaseEngineFactory, databaseTypeFactory } from '@src/factories';
 
 export interface databaseClusterConfiguration {
   clusterSize: ClusterSize;
@@ -36,6 +37,17 @@ export const mockDatabaseEngineTypes: DatabaseEngine[] = [
     engine: 'postgresql',
     version: '13',
     deprecated: false,
+  }),
+];
+
+// The database type IDs in this array should correspond to the DBaaS cluster
+// `linodeType` values used by the tests.
+export const mockDatabaseNodeTypes: DatabaseType[] = [
+  databaseTypeFactory.build({
+    id: 'g6-nanode-1',
+  }),
+  databaseTypeFactory.build({
+    id: 'g6-dedicated-16',
   }),
 ];
 

--- a/packages/manager/cypress/support/intercepts/databases.ts
+++ b/packages/manager/cypress/support/intercepts/databases.ts
@@ -2,10 +2,11 @@
  * @file Cypress intercepts and mocks for Cloud Manager DBaaS operations.
  */
 
-import {
+import type {
   Database,
   DatabaseCredentials,
   DatabaseEngine,
+  DatabaseType,
 } from '@linode/api-v4/types';
 import { makeErrorResponse } from 'support/util/errors';
 import { apiMatcher } from 'support/util/intercepts';
@@ -232,6 +233,23 @@ export const mockDeleteProvisioningDatabase = (
     'DELETE',
     apiMatcher(`databases/${engine}/instances/${id}`),
     error
+  );
+};
+
+/**
+ * Intercepts GET request to fetch DBaaS node types and mocks response.
+ *
+ * @param databaseTypes - Database node types.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetDatabaseTypes = (
+  databaseTypes: DatabaseType[]
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher('databases/types*'),
+    paginateResponse(databaseTypes)
   );
 };
 


### PR DESCRIPTION
## Description 📝
This fixes the DBaaS tests by mocking the request to the DBaaS node types endpoint.

## How to test 🧪
We can rely on the automated tests, but to run the tests locally you can use this command:

```bash
yarn cy:run -s "cypress/e2e/core/databases/create-database.spec.ts,cypress/e2e/core/databases/update-database.spec.ts,cypress/e2e/core/databases/delete-database.spec.ts"
```
