### PR TITLE
tests: [M3-6219] - Clean up Cypress Firewall tests

### DIFF
--- a/packages/manager/.changeset/pr-9807-tests-1697570775779.md
+++ b/packages/manager/.changeset/pr-9807-tests-1697570775779.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Refactor Cypress Firewall migration tests ([#9807](https://github.com/linode/manager/pull/9807))

--- a/packages/manager/cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts
@@ -265,48 +265,4 @@ describe('Migrate Linode With Firewall', () => {
       validateMigration();
     });
   });
-
-  it('adds linode to firewall - real data', () => {
-    const firewallLabel = `cy-test-firewall-${randomString(5)}`;
-    // intercept firewall requests
-    cy.intercept('POST', apiMatcher('networking/firewalls')).as(
-      'createFirewall'
-    );
-    cy.intercept(apiMatcher('networking/firewalls*')).as('getFirewall');
-
-    cy.visitWithLogin('/firewalls');
-    createLinode().then((linode) => {
-      const linodeLabel = linode.label;
-      cy.wait('@getFirewall').then(() => {
-        getVisible('[data-qa-header]').within(() => {
-          fbtVisible('Firewalls');
-        });
-        fbtClick('Create Firewall');
-      });
-
-      cy.get('[data-testid="textfield-input"]:first')
-        .should('be.visible')
-        .type(firewallLabel);
-
-      cy.get('[data-testid="textfield-input"]:last')
-        .should('be.visible')
-        .click()
-        .type(linodeLabel);
-
-      cy.get('[data-qa-autocomplete-popper]')
-        .findByText(linode.label)
-        .should('be.visible')
-        .click();
-
-      cy.get('[data-testid="textfield-input"]:last')
-        .should('be.visible')
-        .click();
-
-      cy.findByText(linodeLabel).should('be.visible');
-
-      getClick('[data-qa-submit="true"]');
-      cy.wait('@createFirewall').its('response.statusCode').should('eq', 200);
-      fbtVisible(linodeLabel);
-    });
-  });
 });

--- a/packages/manager/cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts
@@ -59,10 +59,10 @@ describe('Migrate Linode With Firewall', () => {
     cleanUp('firewalls');
   });
 
+  /*
+   * - Tests Linode migration flow for Linodes with Firewalls using mock API data.
+   */
   it('test migrate flow - mocking all data', () => {
-    // const fakeLinodeId = 9999;
-    // const fakeFirewallId = 6666;
-
     const mockLinode = linodeFactory.build({
       id: randomNumber(),
       label: randomLabel(),
@@ -96,7 +96,9 @@ describe('Migrate Linode With Firewall', () => {
     cy.wait('@migrateReq').its('response.statusCode').should('eq', 200);
   });
 
-  // create linode w/ firewall region then add firewall to it then attempt to migrate linode to non firewall region, should fail
+  /*
+   * - Uses real API data to create a Firewall, attach a Linode to it, then migrate the Linode.
+   */
   it('migrates linode with firewall - real data', () => {
     const [migrationRegionStart, migrationRegionEnd] = chooseRegions(2);
     const firewallLabel = randomLabel();

--- a/packages/manager/cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts
@@ -1,52 +1,57 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import { linodeFactory } from '@src/factories';
-import { authenticate } from 'support/api/authentication';
-import { createLinode } from 'support/api/linodes';
 import {
-  getClick,
-  containsClick,
-  fbtClick,
-  getVisible,
-  fbtVisible,
-  containsVisible,
-} from 'support/helpers';
-import { mockGetLinodeDetails } from 'support/intercepts/linodes';
+  createLinodeRequestFactory,
+  firewallFactory,
+  linodeFactory,
+  regionFactory,
+} from '@src/factories';
+import { authenticate } from 'support/api/authentication';
+import { createLinode } from '@linode/api-v4';
+import {
+  interceptCreateFirewall,
+  interceptGetFirewalls,
+  mockGetFirewalls,
+} from 'support/intercepts/firewalls';
+import {
+  interceptMigrateLinode,
+  mockGetLinodeDetails,
+  mockMigrateLinode,
+} from 'support/intercepts/linodes';
+import { mockGetRegions } from 'support/intercepts/regions';
 import { ui } from 'support/ui';
 import { selectRegionString } from 'support/ui/constants';
 import { cleanUp } from 'support/util/cleanup';
-import { apiMatcher } from 'support/util/intercepts';
-import { randomString } from 'support/util/random';
+import { randomLabel, randomNumber } from 'support/util/random';
+import type { Linode, Region } from '@linode/api-v4';
+import { chooseRegion } from 'support/util/regions';
 
-const fakeRegionsData = {
-  data: [
-    {
-      capabilities: ['Linodes', 'NodeBalancers', 'Block Storage'],
-      country: 'us',
-      id: 'us-central',
-      status: 'ok',
-      label: 'Dallas, TX',
-    },
-    {
-      capabilities: ['Linodes', 'NodeBalancers', 'Block Storage'],
-      country: 'uk',
-      id: 'eu-west',
-      status: 'ok',
-      label: 'London, UK',
-    },
-    {
-      capabilities: [
-        'Linodes',
-        'NodeBalancers',
-        'Block Storage',
-        'Cloud Firewall',
-      ],
-      country: 'sg',
-      id: 'ap-south',
-      status: 'ok',
-      label: 'Singapore, SG',
-    },
-  ],
-};
+const mockRegions: Region[] = [
+  regionFactory.build({
+    capabilities: ['Linodes', 'NodeBalancers', 'Block Storage'],
+    id: 'us-central',
+    status: 'ok',
+    label: 'Dallas, TX',
+  }),
+  regionFactory.build({
+    capabilities: ['Linodes', 'NodeBalancers', 'Block Storage'],
+    country: 'uk',
+    id: 'eu-west',
+    status: 'ok',
+    label: 'London, UK',
+  }),
+  regionFactory.build({
+    capabilities: [
+      'Linodes',
+      'NodeBalancers',
+      'Block Storage',
+      'Cloud Firewall',
+    ],
+    country: 'sg',
+    id: 'ap-south',
+    status: 'ok',
+    label: 'Singapore, SG',
+  }),
+];
 
 authenticate();
 describe('Migrate Linode With Firewall', () => {
@@ -55,168 +60,71 @@ describe('Migrate Linode With Firewall', () => {
   });
 
   it('test migrate flow - mocking all data', () => {
-    const fakeLinodeId = 9999;
-    const fakeFirewallId = 6666;
+    // const fakeLinodeId = 9999;
+    // const fakeFirewallId = 6666;
 
-    // modify incoming response
-    cy.intercept(apiMatcher('networking/firewalls*'), (req) => {
-      req.reply((res) => {
-        res.send({
-          data: [
-            {
-              id: fakeFirewallId,
-              label: 'test',
-              created: '2020-08-03T15:49:50',
-              updated: '2020-08-03T15:49:50',
-              status: 'enabled',
-              rules: {
-                inbound: [
-                  {
-                    ports: '80',
-                    protocol: 'TCP',
-                    addresses: { ipv4: ['0.0.0.0/0'], ipv6: ['::/0'] },
-                  },
-                ],
-                outbound: [
-                  {
-                    ports: '80',
-                    protocol: 'TCP',
-                    addresses: { ipv4: ['0.0.0.0/0'], ipv6: ['::/0'] },
-                  },
-                ],
-              },
-              tags: [],
-              devices: { linodes: [fakeLinodeId] },
-            },
-          ],
-          page: 1,
-          pages: 1,
-          results: 1,
-        });
-      });
-    }).as('getFirewalls');
-
-    const fakeLinodeData = linodeFactory.build({
-      id: fakeLinodeId,
-      label: 'debian-us-central',
-      group: '',
-      status: 'running',
-      created: '2020-06-23T16:02:14',
-      updated: '2020-06-23T16:05:23',
-      type: 'g6-standard-1',
-      ipv4: ['104.237.129.173'],
-      ipv6: '2600:3c00::f03c:92ff:feeb:98f9/64',
-      image: 'linode/debian10',
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
       region: 'us-central',
-      specs: {
-        disk: 51200,
-        memory: 2048,
-        vcpus: 1,
-        gpus: 0,
-        transfer: 2000,
-      },
-      alerts: {
-        cpu: 90,
-        network_in: 10,
-        network_out: 10,
-        transfer_quota: 80,
-        io: 10000,
-      },
-      backups: {
-        enabled: true,
-        schedule: { day: 'Scheduling', window: 'Scheduling' },
-        last_successful: '2020-08-02T22:26:19',
-      },
-      hypervisor: 'kvm',
-      watchdog_enabled: true,
-      tags: [],
     });
 
-    // modify incoming response
-    cy.intercept(apiMatcher('regions*'), (req) => {
-      req.reply((res) => {
-        res.send(fakeRegionsData);
-      });
-    }).as('getRegions');
+    const mockFirewall = firewallFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      status: 'enabled',
+      devices: {
+        linodes: [mockLinode.id],
+      },
+    });
 
-    // intercept request and stub it, respond with 200
-    cy.intercept(
-      'POST',
-      apiMatcher(`linode/instances/${fakeLinodeId}/migrate`),
-      {
-        statusCode: 200,
-      }
-    ).as('migrateReq');
+    mockGetFirewalls([mockFirewall]).as('getFirewalls');
+    mockGetLinodeDetails(mockLinode.id, mockLinode).as('getLinode');
+    mockGetRegions(mockRegions).as('getRegions');
+    mockMigrateLinode(mockLinode.id).as('migrateReq');
 
-    // modify incoming response
-    mockGetLinodeDetails(fakeLinodeId, fakeLinodeData).as('getLinode');
-
-    // modify incoming response
-    cy.intercept(
-      'GET',
-      apiMatcher(`linode/instances/${fakeLinodeId}/migrate`),
-      (req) => {
-        req.reply((res) => {
-          res.send(fakeLinodeData);
-        });
-      }
-    ).as('getLinode');
-
-    cy.visitWithLogin(`/linodes/${fakeLinodeId}/migrate`);
-    cy.wait('@getLinode');
-    cy.wait('@getRegions');
+    cy.visitWithLogin(`/linodes/${mockLinode.id}/migrate`);
+    cy.wait(['@getLinode', '@getRegions']);
     cy.findByText('Dallas, TX').should('be.visible');
-    getClick('[data-qa-checked="false"]');
+    cy.get('[data-qa-checked="false"]').click();
     cy.findByText(`North America: Dallas, TX`).should('be.visible');
-    containsClick(selectRegionString);
+    cy.contains(selectRegionString).click();
 
     ui.regionSelect.findItemByRegionLabel('Singapore, SG').click();
 
-    fbtClick('Enter Migration Queue');
+    cy.findByText('Enter Migration Queue').click();
     cy.wait('@migrateReq').its('response.statusCode').should('eq', 200);
   });
 
   // create linode w/ firewall region then add firewall to it then attempt to migrate linode to non firewall region, should fail
   it('migrates linode with firewall - real data', () => {
-    const validateMigration = () => {
-      ui.button
-        .findByTitle('Enter Migration Queue')
-        .should('be.visible')
-        .should('be.enabled')
-        .click();
+    const firewallLabel = randomLabel();
+    const linodePayload = createLinodeRequestFactory.build({
+      label: randomLabel(),
+      region: chooseRegion().id,
+    });
 
-      cy.wait('@migrateLinode').its('response.statusCode').should('eq', 200);
-    };
+    interceptCreateFirewall().as('createFirewall');
+    interceptGetFirewalls().as('getFirewalls');
 
-    const firewallLabel = `cy-test-firewall-${randomString(5)}`;
-    // intercept create firewall request
-    cy.intercept('POST', apiMatcher('networking/firewalls')).as(
-      'createFirewall'
-    );
-    // modify incoming response
-    cy.intercept(apiMatcher('networking/firewalls*')).as('getFirewalls');
-
-    cy.visitWithLogin('/firewalls');
-
-    createLinode({ region: 'ap-southeast' }).then((linode) => {
+    cy.defer(createLinode(linodePayload)).then((linode: Linode) => {
+      interceptMigrateLinode(linode.id).as('migrateLinode');
+      cy.visitWithLogin('/firewalls');
       // intercept migrate linode request
-      cy.intercept(
-        'POST',
-        apiMatcher(`linode/instances/${linode.id}/migrate`)
-      ).as('migrateLinode');
 
-      getVisible('[data-qa-header]').within(() => {
-        fbtVisible('Firewalls');
-      });
-
-      cy.wait('@getFirewalls').then(({ response }) => {
-        const length = response?.body.data['length'];
-        console.log(`THIS: ${length}`);
-        getVisible('[data-qa-header]').within(() => {
-          fbtVisible('Firewalls');
+      cy.get('[data-qa-header]')
+        .should('be.visible')
+        .within(() => {
+          cy.findByText('Firewalls').should('be.visible');
         });
-        fbtClick('Create Firewall');
-      });
+
+      cy.wait('@getFirewalls');
+      cy.get('[data-qa-header]')
+        .should('be.visible')
+        .within(() => {
+          cy.findByText('Firewalls').should('be.visible');
+        });
+      cy.findByText('Create Firewall').click();
 
       cy.get('[data-testid="textfield-input"]:first')
         .should('be.visible')
@@ -238,12 +146,14 @@ describe('Migrate Linode With Firewall', () => {
 
       cy.findByText(linode.label).should('be.visible');
 
-      getClick('[data-qa-submit="true"]');
+      cy.get('[data-qa-submit="true"]').click();
       cy.wait('@createFirewall');
-      cy.visit(`/linodes/${linode.id}`);
-      getVisible('[data-qa-link-text="true"]').within(() => {
-        fbtVisible('linodes');
-      });
+      cy.visitWithLogin(`/linodes/${linode.id}`);
+      cy.get('[data-qa-link-text="true"]')
+        .should('be.visible')
+        .within(() => {
+          cy.findByText('linodes').should('be.visible');
+        });
 
       // Make sure Linode is running before attempting to migrate.
       cy.get('[data-qa-linode-status]').within(() => {
@@ -257,12 +167,18 @@ describe('Migrate Linode With Firewall', () => {
 
       ui.actionMenuItem.findByTitle('Migrate').should('be.visible').click();
 
-      containsVisible(`Migrate Linode ${linode.label}`);
-      getClick('[data-qa-checked="false"]');
-      fbtClick(selectRegionString);
+      cy.contains(`Migrate Linode ${linode.label}`).should('be.visible');
+      cy.get('[data-qa-checked="false"]').click();
+      cy.findByText(selectRegionString).click();
 
       ui.regionSelect.findItemByRegionLabel('Toronto, CA').click();
-      validateMigration();
+      ui.button
+        .findByTitle('Enter Migration Queue')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+
+      cy.wait('@migrateLinode').its('response.statusCode').should('eq', 200);
     });
   });
 });

--- a/packages/manager/cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts
@@ -23,7 +23,7 @@ import { selectRegionString } from 'support/ui/constants';
 import { cleanUp } from 'support/util/cleanup';
 import { randomLabel, randomNumber } from 'support/util/random';
 import type { Linode, Region } from '@linode/api-v4';
-import { chooseRegion } from 'support/util/regions';
+import { chooseRegions } from 'support/util/regions';
 
 const mockRegions: Region[] = [
   regionFactory.build({
@@ -98,10 +98,11 @@ describe('Migrate Linode With Firewall', () => {
 
   // create linode w/ firewall region then add firewall to it then attempt to migrate linode to non firewall region, should fail
   it('migrates linode with firewall - real data', () => {
+    const [migrationRegionStart, migrationRegionEnd] = chooseRegions(2);
     const firewallLabel = randomLabel();
     const linodePayload = createLinodeRequestFactory.build({
       label: randomLabel(),
-      region: chooseRegion().id,
+      region: migrationRegionStart.id,
     });
 
     interceptCreateFirewall().as('createFirewall');
@@ -171,7 +172,7 @@ describe('Migrate Linode With Firewall', () => {
       cy.get('[data-qa-checked="false"]').click();
       cy.findByText(selectRegionString).click();
 
-      ui.regionSelect.findItemByRegionLabel('Toronto, CA').click();
+      ui.regionSelect.findItemByRegionLabel(migrationRegionEnd.label).click();
       ui.button
         .findByTitle('Enter Migration Queue')
         .should('be.visible')

--- a/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
@@ -12,9 +12,8 @@ import {
   linodeFactory,
 } from 'src/factories';
 import { authenticate } from 'support/api/authentication';
-import { containsClick, getClick } from 'support/helpers';
+import { containsClick } from 'support/helpers';
 import {
-  interceptCreateFirewall,
   interceptUpdateFirewallLinodes,
   interceptUpdateFirewallRules,
 } from 'support/intercepts/firewalls';

--- a/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
@@ -1,10 +1,11 @@
-import {
-  createLinode,
-  createFirewall,
+import type {
   Linode,
   Firewall,
   FirewallRuleType,
+  CreateLinodeRequest,
+  CreateFirewallPayload,
 } from '@linode/api-v4';
+import { createLinode, createFirewall } from '@linode/api-v4';
 import {
   createLinodeRequestFactory,
   firewallFactory,
@@ -43,10 +44,6 @@ const outboundRule = firewallRuleFactory.build({
   description: randomString(),
   action: 'Drop',
   ports: randomItem(Object.keys(portPresetMap)),
-});
-
-const firewall = firewallFactory.build({
-  label: randomLabel(),
 });
 
 /**
@@ -153,8 +150,8 @@ const addLinodesToFirewall = (firewall: Firewall, linode: Linode) => {
 };
 
 const createLinodeAndFirewall = async (
-  linodeRequestPayload,
-  firewallRequestPayload
+  linodeRequestPayload: CreateLinodeRequest,
+  firewallRequestPayload: CreateFirewallPayload
 ) => {
   return Promise.all([
     createLinode(linodeRequestPayload),

--- a/packages/manager/cypress/support/intercepts/firewalls.ts
+++ b/packages/manager/cypress/support/intercepts/firewalls.ts
@@ -1,8 +1,35 @@
 /**
- * @files Cypress intercepts and mocks for Firewall API requests.
+ * @file Cypress intercepts and mocks for Firewall API requests.
  */
-
+import type { Firewall } from '@linode/api-v4';
 import { apiMatcher } from 'support/util/intercepts';
+import { paginateResponse } from 'support/util/paginate';
+
+/**
+ * Intercepts GET request to fetch Firewalls.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptGetFirewalls = (): Cypress.Chainable<null> => {
+  return cy.intercept('GET', apiMatcher('networking/firewalls*'));
+};
+
+/**
+ * Intercepts GET request to fetch Firewalls and mocks response.
+ *
+ * @param firewalls - Array of Firewalls with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetFirewalls = (
+  firewalls: Firewall[]
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher('networking/firewalls*'),
+    paginateResponse(firewalls)
+  );
+};
 
 /**
  * Intercepts POST request to create a Firewall.

--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -302,6 +302,22 @@ export const interceptCreateLinodeSnapshot = (
 /**
  * Intercepts POST request to migrate a Linode.
  *
+ * @param linodeId - ID of Linode being migrated.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptMigrateLinode = (
+  linodeId: number
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`linode/instances/${linodeId}/migrate`)
+  );
+};
+
+/**
+ * Intercepts POST request to migrate a Linode.
+ *
  * @param linodeId - Linode ID for which to mock migration.
  *
  * @returns Cypress chainable.

--- a/packages/manager/cypress/support/util/regions.ts
+++ b/packages/manager/cypress/support/util/regions.ts
@@ -80,9 +80,9 @@ export const getRegionByLabel = (label: string) => {
  * Returns a known Cloud Manager region at random, or returns a user-chosen
  * region if one was specified.
  *
- * Region selection can be configured via the `CY_TEST_REGION_ID` and
- * `CY_TEST_REGION_NAME` environment variables. Both must be specified in
- * order to override the region that is returned by this function.
+ * Region selection can be configured via the `CY_TEST_REGION` environment
+ * variable. If defined, the region returned by this function will be
+ * overridden using the chosen region.
  *
  * @returns Object describing a Cloud Manager region to use during tests.
  */


### PR DESCRIPTION
## Description 📝
This cleans up the Cypress Firewall tests by implementing newer testing patterns.

## Changes  🔄
- Remove calls to `cy.intercept`, replacing them with calls intercept and mocking utils
- Use `ui` helpers where applicable, reduce number of calls to `cy.get()`
- Adds a couple assertions related to migration warnings shown to and accepted by the user

## How to test 🧪

### Prerequisites
```bash
yarn && yarn build && yarn start:manager:ci
```

### Test Command
```bash
yarn cy:run -s "cypress/e2e/core/firewalls/create-firewall.spec.ts,cypress/e2e/core/firewalls/delete-firewall.spec.ts,cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts,cypress/e2e/core/firewalls/update-firewall.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support
