### PR TITLE
fix: [UIE-6952] - DBaaS menu flickers on page load

### DIFF
--- a/packages/manager/.changeset/pr-9808-fixed-1697722511987.md
+++ b/packages/manager/.changeset/pr-9808-fixed-1697722511987.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Primary nav DBaaS menuitem flicker on page load ([#9808](https://github.com/linode/manager/pull/9808))

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -207,7 +207,10 @@ const MainContent = (props: CombinedProps) => {
   const [bannerDismissed, setBannerDismissed] = React.useState<boolean>(false);
 
   const checkRestrictedUser = !Boolean(flags.databases) && !!accountError;
-  const { error: enginesError } = useDatabaseEnginesQuery(checkRestrictedUser);
+  const {
+    error: enginesError,
+    isLoading: enginesLoading,
+  } = useDatabaseEnginesQuery(checkRestrictedUser);
 
   const showDatabases =
     isFeatureEnabled(
@@ -215,7 +218,7 @@ const MainContent = (props: CombinedProps) => {
       Boolean(flags.databases),
       account?.capabilities ?? []
     ) ||
-    (checkRestrictedUser && !enginesError);
+    (checkRestrictedUser && !enginesLoading && !enginesError);
 
   const showVPCs = isFeatureEnabled(
     'VPCs',
@@ -413,8 +416,8 @@ export default compose<CombinedProps, Props>(
 export const checkFlagsForMainContentBanner = (flags: FlagSet) => {
   return Boolean(
     flags.mainContentBanner &&
-    !isEmpty(flags.mainContentBanner) &&
-    flags.mainContentBanner.key
+      !isEmpty(flags.mainContentBanner) &&
+      flags.mainContentBanner.key
   );
 };
 

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -123,7 +123,10 @@ export const PrimaryNav = (props: Props) => {
     !oneClickApps && !oneClickAppsLoading && !oneClickAppsError;
 
   const checkRestrictedUser = !Boolean(flags.databases) && !!accountError;
-  const { error: enginesError } = useDatabaseEnginesQuery(checkRestrictedUser);
+  const {
+    error: enginesError,
+    isLoading: enginesLoading,
+  } = useDatabaseEnginesQuery(checkRestrictedUser);
 
   const showDatabases =
     isFeatureEnabled(
@@ -131,7 +134,7 @@ export const PrimaryNav = (props: Props) => {
       Boolean(flags.databases),
       account?.capabilities ?? []
     ) ||
-    (checkRestrictedUser && !enginesError);
+    (checkRestrictedUser && !enginesLoading && !enginesError);
 
   const showVPCs = isFeatureEnabled(
     'VPCs',

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -46,7 +46,10 @@ export const AddNewMenu = () => {
   const open = Boolean(anchorEl);
 
   const checkRestrictedUser = !Boolean(flags.databases) && !!accountError;
-  const { error: enginesError } = useDatabaseEnginesQuery(checkRestrictedUser);
+  const {
+    error: enginesError,
+    isLoading: enginesLoading,
+  } = useDatabaseEnginesQuery(checkRestrictedUser);
 
   const showDatabases =
     isFeatureEnabled(
@@ -54,7 +57,7 @@ export const AddNewMenu = () => {
       Boolean(flags.databases),
       account?.capabilities ?? []
     ) ||
-    (checkRestrictedUser && !enginesError);
+    (checkRestrictedUser && !enginesLoading && !enginesError);
 
   const showVPCs = isFeatureEnabled(
     'VPCs',


### PR DESCRIPTION
## Description 📝
Fix the Dbaas menu flickering on page load when waiting for API call.

## Changes  🔄
- Wait for API call to finish before checking for error.

## How to test 🧪

### Prerequisites
(How to setup test environment)
- User with restricted access - no billing access

### Reproduction steps
- Login in as restricted user
- Refresh page and see the Dbaas menu appear then disappear on user interaction

### Verification steps 
(How to verify changes)
- Menu does not appear for restricted user during page load

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
