### PR TITLE
test: [M3-7183] - Account for Managed test acccounts in Linode Backup tests

### DIFF
--- a/.github/workflows/e2e_schedule_and_push.yml
+++ b/.github/workflows/e2e_schedule_and_push.yml
@@ -6,6 +6,7 @@ env:
   USER_3: ${{ secrets.USER_3 }}
   USER_4: ${{ secrets.USER_4 }}
   CLIENT_ID: ${{ secrets.REACT_APP_CLIENT_ID }}
+  CY_TEST_FAIL_ON_MANAGED: 1
 on:
   schedule:
     - cron: "0 13 * * 1-5"

--- a/docs/development-guide/08-testing.md
+++ b/docs/development-guide/08-testing.md
@@ -211,6 +211,7 @@ Environment variables related to Cypress logging and reporting, as well as repor
 | `CY_TEST_USER_REPORT`           | Log test account information when tests begin | `1`       | Unset; disabled by default |
 | `CY_TEST_JUNIT_REPORT`          | Enable JUnit reporting                        | `1`       | Unset; disabled by default |
 | `CY_TEST_DISABLE_FILE_WATCHING` | Disable file watching in Cypress UI           | `1`       | Unset; disabled by default |
+| `CY_TEST_FAIL_ON_MANAGED`       | Fail affected tests when Managed is enabled   | `1`       | Unset; disabled by default |
 
 ### Writing End-to-End Tests
 

--- a/packages/manager/cypress/e2e/core/linodes/backup-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/backup-linode.spec.ts
@@ -201,6 +201,11 @@ describe('"Enable Linode Backups" banner', () => {
     const enableBackupsMessage =
       'Enable Linode Backups to protect your data and recover quickly in an emergency.';
 
+    const mockAccountSettings = accountSettingsFactory.build({
+      backups_enabled: false,
+      managed: false,
+    });
+
     // Mock Linodes that do not have backups enabled.
     const mockLinodes = linodeFactory.buildList(2, {
       backups: { enabled: false },
@@ -217,12 +222,13 @@ describe('"Enable Linode Backups" banner', () => {
     // Confirm notice appears when Linodes do not have backups enabled,
     // and confirm that the notice can be dismissed.
     mockGetLinodes(mockLinodes).as('getLinodes');
+    mockGetAccountSettings(mockAccountSettings).as('getAccountSettings');
     cy.visitWithLogin('/linodes', {
       preferenceOverrides: {
         backups_cta_dismissed: false,
       },
     });
-    cy.wait('@getLinodes');
+    cy.wait(['@getLinodes', '@getAccountSettings']);
     cy.contains(enableBackupsMessage).should('be.visible');
 
     // Click dismiss button.
@@ -277,6 +283,7 @@ describe('"Enable Linode Backups" banner', () => {
     // Mock account settings before and after enabling auto backup enrollment.
     const mockInitialAccountSettings = accountSettingsFactory.build({
       backups_enabled: false,
+      managed: false,
     });
 
     const mockUpdatedAccountSettings = {
@@ -368,6 +375,11 @@ describe('"Enable Linode Backups" banner', () => {
    * - Confirms that DC-specific pricing information is displayed in backups drawer when feature is enabled.
    */
   it('displays DC-specific pricing information when feature flag is enabled', () => {
+    const mockAccountSettings = accountSettingsFactory.build({
+      backups_enabled: false,
+      managed: false,
+    });
+
     // TODO: DC Pricing - M3-7073: Move assertions involving pricing to above test when DC-specific pricing goes live.
     // TODO: DC Pricing - M3-7073: Remove this test when DC-specific pricing goes live.
     const mockLinodes = [
@@ -414,6 +426,7 @@ describe('"Enable Linode Backups" banner', () => {
     }).as('getFeatureFlags');
     mockGetFeatureFlagClientstream().as('getClientstream');
     mockGetLinodes(mockLinodes).as('getLinodes');
+    mockGetAccountSettings(mockAccountSettings).as('getAccountSettings');
 
     cy.visitWithLogin('/linodes', {
       preferenceOverrides: {
@@ -421,7 +434,12 @@ describe('"Enable Linode Backups" banner', () => {
       },
     });
 
-    cy.wait(['@getFeatureFlags', '@getClientstream', '@getLinodes']);
+    cy.wait([
+      '@getFeatureFlags',
+      '@getClientstream',
+      '@getLinodes',
+      '@getAccountSettings',
+    ]);
 
     // Click "Enable Linode Backups" link within backups notice.
     cy.findByText('Enable Linode Backups').should('be.visible').click();

--- a/packages/manager/cypress/e2e/core/linodes/backup-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/backup-linode.spec.ts
@@ -31,6 +31,7 @@ import { makeFeatureFlagData } from 'support/util/feature-flags';
 import { randomLabel } from 'support/util/random';
 import { dcPricingMockLinodeTypes } from 'support/constants/dc-specific-pricing';
 import { chooseRegion } from 'support/util/regions';
+import { expectManagedDisabled } from 'support/api/managed';
 
 authenticate();
 describe('linode backups', () => {
@@ -45,6 +46,10 @@ describe('linode backups', () => {
    * - Confirms that Linode details page updates to reflect that backups are enabled.
    */
   it('can enable backups', () => {
+    // Skip or optionally fail if test account has Managed enabled.
+    // This is necessary because Managed accounts have backups enabled implicitly.
+    expectManagedDisabled();
+
     // Create a Linode that is not booted and which does not have backups enabled.
     const createLinodeRequest = createLinodeRequestFactory.build({
       label: randomLabel(),

--- a/packages/manager/cypress/support/api/managed.ts
+++ b/packages/manager/cypress/support/api/managed.ts
@@ -3,8 +3,9 @@
  */
 
 import { mockGetAccountSettings } from 'support/intercepts/account';
-
+import { skip } from 'support/util/skip';
 import { accountSettingsFactory } from 'src/factories/accountSettings';
+import type { AccountSettings } from '@linode/api-v4';
 
 // / Account object with Managed enabled for mocking API requests.
 export const managedAccount = accountSettingsFactory.build({
@@ -15,6 +16,37 @@ export const managedAccount = accountSettingsFactory.build({
 export const nonManagedAccount = accountSettingsFactory.build({
   managed: false,
 });
+
+/**
+ * Skips the test if Linode Managed is enabled on the test account.
+ *
+ * Certain tests only function correctly if Managed is disabled, and this function
+ * can be used to skip such tests when Managed is enabled.
+ *
+ * Optionally, if the `CY_TEST_FAIL_ON_MANAGED` environment variable is defined,
+ * the test will fail rather than being skipped. This is useful in environments
+ * where Managed is not expected to be enabled (e.g. when being run via CI).
+ */
+export const expectManagedDisabled = () => {
+  const accountSettings = Cypress.env('cloudManagerAccountSettings') as
+    | AccountSettings
+    | undefined;
+  const failOnManaged = Cypress.env('CY_TEST_FAIL_ON_MANAGED');
+
+  if (!accountSettings) {
+    throw new Error('Unable to retrieve cached account settings');
+  }
+
+  if (accountSettings.managed) {
+    if (failOnManaged) {
+      throw new Error(
+        'Test failed because Managed is enabled on the test account. This test expects Managed to be disabled.'
+      );
+    }
+    cy.log('Skipping test because Managed is enabled on test account');
+    skip();
+  }
+};
 
 /**
  * Visits the given Manager URL with account settings mocked to enable Managed.

--- a/packages/manager/cypress/support/index.d.ts
+++ b/packages/manager/cypress/support/index.d.ts
@@ -23,8 +23,6 @@ declare global {
           | string
       ): Chainable<>;
 
-      // mockCommonRequests(options?: CommonRequestMockOptions | undefined): Chainable<>;
-
       /**
        * Custom command to select DOM element by data-cy attribute.
        * @example cy.dataCy('greeting')

--- a/packages/manager/cypress/support/index.d.ts
+++ b/packages/manager/cypress/support/index.d.ts
@@ -34,6 +34,11 @@ declare global {
         linodeOptions?: LinodeVisitOptions,
         cypressOptions?: Partial<Cypress.VisitOptions>
       ): Chainable<any>;
+
+      /**
+       * Internal Cypress command to retrieve test state.
+       */
+      state(state: string): any;
     }
   }
 }

--- a/packages/manager/cypress/support/index.d.ts
+++ b/packages/manager/cypress/support/index.d.ts
@@ -37,6 +37,8 @@ declare global {
 
       /**
        * Internal Cypress command to retrieve test state.
+       *
+       * @param state - Cypress internal state to retrieve.
        */
       state(state: string): any;
     }

--- a/packages/manager/cypress/support/plugins/fetch-account.ts
+++ b/packages/manager/cypress/support/plugins/fetch-account.ts
@@ -1,17 +1,24 @@
 import type { CypressPlugin } from './plugin';
-import { getAccountInfo } from '@linode/api-v4';
+import { getAccountInfo, getAccountSettings } from '@linode/api-v4';
 
 /**
- * Fetches Linode account info and stores data in Cypress `cloudManagerAccount` env.
+ * Fetches and caches Linode account info and settings.
+ *
+ * Cached account data is stored in Cypress's `cloudManagerAccount` and
+ * `cloudManagerAccountSettings` env, respectively.
  */
 export const fetchAccount: CypressPlugin = async (_on, config) => {
-  const account = await getAccountInfo();
+  const [account, accountSettings] = await Promise.all([
+    getAccountInfo(),
+    getAccountSettings(),
+  ]);
 
   return {
     ...config,
     env: {
       ...config.env,
       cloudManagerAccount: account,
+      cloudManagerAccountSettings: accountSettings,
     },
   };
 };

--- a/packages/manager/cypress/support/util/skip.ts
+++ b/packages/manager/cypress/support/util/skip.ts
@@ -10,8 +10,6 @@ export const skip = () => {
   // Implementation taken from `cypress-skip-test`:
   // https://github.com/cypress-io/cypress-skip-test
   //
-  /* eslint-disable @typescript-eslint/ban-ts-comment */
-  // @ts-ignore "cy.state" is not in the "cy" type
   const mochaContext = cy.state('runnable').ctx as Context;
   return mochaContext.skip();
 };

--- a/packages/manager/cypress/support/util/skip.ts
+++ b/packages/manager/cypress/support/util/skip.ts
@@ -1,0 +1,17 @@
+import type { Context } from 'mocha';
+
+/**
+ * Skips the running test.
+ */
+export const skip = () => {
+  // `cy.state()` is intended to be used by Cypress internally, and the API
+  // is not guaranteed to be stable.
+  //
+  // Implementation taken from `cypress-skip-test`:
+  // https://github.com/cypress-io/cypress-skip-test
+  //
+  /* eslint-disable @typescript-eslint/ban-ts-comment */
+  // @ts-ignore "cy.state" is not in the "cy" type
+  const mochaContext = cy.state('runnable').ctx as Context;
+  return mochaContext.skip();
+};

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -138,6 +138,7 @@
     "@types/luxon": "^3.2.0",
     "@types/markdown-it": "^10.0.2",
     "@types/md5": "^2.1.32",
+    "@types/mocha": "^10.0.2",
     "@types/node": "^12.7.1",
     "@types/qrcode.react": "^0.8.0",
     "@types/ramda": "0.25.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4212,6 +4212,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
+"@types/mocha@^10.0.2":
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.2.tgz#96d63314255540a36bf24da094cce7a13668d73b"
+  integrity sha512-NaHL0+0lLNhX6d9rs+NSt97WH/gIlRHmszXbQ/8/MV/eVcFNdeJ/GYhrFuUc8K7WuPhRhTSdMkCp8VMzhUq85w==
+
 "@types/node-fetch@^2.5.7":
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"


### PR DESCRIPTION
## Description 📝
This allows the Cypress backup tests to more gracefully handle cases where the test account has Managed.

- By default, tests that are impacted by Managed will be skipped if the test account has Managed enabled
  - At the moment only the Linode Backup tests are affected
- If the `CY_TEST_FAIL_ON_MANAGED` environment variable is defined, the tests will fail instead. This is intended for CI environments where Managed should never be enabled on test accounts.

See this discussion for more context: https://github.com/linode/manager/pull/9699#pullrequestreview-1635928325

## Changes  🔄
- Fetch and cache test account settings when Cypress launches to detect whether or not Managed is enabled
- Adds utilities to skip Cypress tests
- Adds `CY_TEST_FAIL_ON_MANAGED` environment variable to control test behavior on Managed accounts
- Skip/fail Linode Backup tests when test account has Managed enabled
- Fixes one of the backup integration tests by mocking account settings

## How to test 🧪
- We can rely on the automated tests to ensure that tests work as expected when test accounts do not have Managed enabled

### Prerequisites
- Enable Managed on your test account through Cloud Manager
  - (Feel free to reach out on Slack if you have any questions about enabling or disabling Managed)
- Run `yarn && yarn build && yarn start:manager:ci`

### Verification steps 
- Run `yarn cy:run -s "cypress/e2e/core/linodes/backup-linode.spec.ts"` and confirm that the "can enable backups" test is skipped and the rest of the tests pass
- Run `CY_TEST_FAIL_ON_MANAGED=1 yarn cy:run -s "cypress/e2e/core/linodes/backup-linode.spec.ts"` and confirm that the "can enable backups" test fails and the rest of the tests pass

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support
