### PR TITLE
fix: [M3-7104] - Images create > upload image > reduce space above and below Linode CLI help text

### DIFF
--- a/packages/manager/.changeset/pr-9812-fixed-1697639234272.md
+++ b/packages/manager/.changeset/pr-9812-fixed-1697639234272.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Images create > upload image > reduced space above and below Linode CLI help text ([#9812](https://github.com/linode/manager/pull/9812))

--- a/packages/manager/.changeset/pr-9812-fixed-1697639234272.md
+++ b/packages/manager/.changeset/pr-9812-fixed-1697639234272.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Images create > upload image > reduced space above and below Linode CLI help text ([#9812](https://github.com/linode/manager/pull/9812))
+Excess spacing above and below Linode CLI help text in Upload Image form ([#9812](https://github.com/linode/manager/pull/9812))

--- a/packages/manager/src/features/Images/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImageUpload.tsx
@@ -309,7 +309,7 @@ export const ImageUpload: React.FC<Props> = (props) => {
             setCancelFn={setCancelFn}
             setErrors={setErrors}
           />
-          <Typography sx={{ paddingBottom: 8, paddingTop: 16 }}>
+          <Typography sx={{ paddingBottom: 1, paddingTop: 2 }}>
             Or, upload an image using the{' '}
             <button
               className={classes.cliModalButton}


### PR DESCRIPTION
## Description 📝
- In Images Create > Upload Image (http://localhost:3000/images/create/upload), reduce the spacing above and below the Linode CLI help text

## Changes  🔄
List any change relevant to the reviewer.
- Decreased spacing above and below the Linode CLI help text

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-10-18 at 10 31 52 AM](https://github.com/linode/manager/assets/139489745/c31e32ba-16bb-44fb-a459-cb8669e1a745) | ![Screenshot 2023-10-18 at 10 28 38 AM](https://github.com/linode/manager/assets/139489745/9bd08d57-8e39-494a-93b8-298b49c57c09) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- There are no prerequisites

### Reproduction steps
(How to reproduce the issue, if applicable)
- Navigate to https://cloud.linode.com/images/create/upload
- Scroll down to the bottom of the page and confirm the spacing above and below the Linode CLI help text matches the before screenshot

### Verification steps 
(How to verify changes)
- Navigate to http://localhost:3000/images/create/upload
- Scroll to the bottom of the page and confirm the spacing of the Linode CLI help text matches the mockups spacing:
![Screenshot 2023-10-18 at 10 39 02 AM](https://github.com/linode/manager/assets/139489745/9132a044-aaac-4b61-a9be-5d340d78ed1e)

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support
