### PR TITLE
feat: [M3-6973] - Add DC-specific pricing Object Storage overages

### DIFF
--- a/packages/manager/.changeset/pr-9813-added-1697655032681.md
+++ b/packages/manager/.changeset/pr-9813-added-1697655032681.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Helper text for DC-specific pricing Object Storage overages ([#9813](https://github.com/linode/manager/pull/9813))

--- a/packages/manager/cypress/e2e/core/objectStorage/enable-object-storage.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/enable-object-storage.spec.ts
@@ -32,8 +32,7 @@ import { mockGetAccessKeys } from 'support/intercepts/object-storage';
 // under different circumstances.
 const objNotes = {
   // When enabling OBJ using a region with a regular pricing structure, when OBJ DC-specific pricing is disabled.
-  regularPricing:
-    "Linode Object Storage costs a flat rate of $5/month, and includes 250 GB of storage and 1 TB of outbound data transfer. Beyond that, it's $0.02 per GB per month.",
+  regularPricing: /Linode Object Storage costs a flat rate of \$5\/month, and includes 250 GB of storage and 1 TB of outbound data transfer. Beyond that, it.*s \$0.02 per GB per month./,
 
   // When enabling OBJ using a region with special pricing during the free beta period (OBJ DC-specific pricing is disabled).
   dcSpecificBetaPricing: /Object Storage for .* is currently in beta\. During the beta period, Object Storage in these regions is free\. After the beta period, customers will be notified before charges for this service begin./,

--- a/packages/manager/cypress/e2e/core/objectStorage/enable-object-storage.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/enable-object-storage.spec.ts
@@ -296,6 +296,13 @@ describe('Object Storage enrollment', () => {
     cy.findByText('Enable Object Storage').should('not.exist');
   });
 
+  /*
+   * - Confirms that Object Storage can be enabled using mock API data.
+   * - Confirms that pricing information link is present in enrollment dialog.
+   * - Confirms that cancellation explanation is present in enrollment dialog.
+   * - Confirms that DC-specific overage pricing is explained for regions in the Create Bucket drawer.
+   * - Confirms that consistent pricing information is shown for all regions in the enable modal.
+   */
   // TODO: DC Pricing - M3-7073: Remove feature flag mocks once feature flags are cleaned up.
   it('can enroll in Object Storage with OBJ DC-specific pricing', () => {
     const mockAccountSettings = accountSettingsFactory.build({

--- a/packages/manager/cypress/e2e/core/objectStorage/enable-object-storage.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/enable-object-storage.spec.ts
@@ -31,24 +31,26 @@ import { mockGetAccessKeys } from 'support/intercepts/object-storage';
 // Various messages, notes, and warnings that may be shown when enabling Object Storage
 // under different circumstances.
 const objNotes = {
-  // When enabling OBJ using a region with a regular pricing structure, or when
-  // DC-specific pricing is disabled.
+  // When enabling OBJ using a region with a regular pricing structure, when OBJ DC-specific pricing is disabled.
   regularPricing:
     "Linode Object Storage costs a flat rate of $5/month, and includes 250 GB of storage and 1 TB of outbound data transfer. Beyond that, it's $0.02 per GB per month.",
 
-  // When enabling OBJ using a region with special pricing during the free beta period.
+  // When enabling OBJ using a region with special pricing during the free beta period (OBJ DC-specific pricing is disabled).
   dcSpecificBetaPricing: /Object Storage for .* is currently in beta\. During the beta period, Object Storage in these regions is free\. After the beta period, customers will be notified before charges for this service begin./,
 
-  // When enabling OBJ without having selected a region.
+  // When enabling OBJ without having selected a region, when OBJ DC-specific pricing is disabled.
   dcPricingGenericExplanation:
     'Pricing for monthly rate and overage costs will depend on the data center you select for deployment.',
 
-  // Link to further DC-specific pricing information when DC-specific pricing is enabled.
+  // When enabling OBJ, in both the Access Key flow and Create Bucket flow, when OBJ DC-specific pricing is enabled.
+  objDCPricing:
+    'Object Storage costs a flat rate of $5/month, and includes 250 GB of storage. When you enable Object Storage, 1 TB of outbound data transfer will be added to your global network transfer pool.',
+
+  // Link to further DC-specific pricing information.
   dcPricingLearnMoreNote: 'Learn more about pricing and specifications.',
 
   // Information regarding the Object Storage cancellation process.
-  cancellationExplanation:
-    "To discontinue billing, you'll need to cancel Object Storage in your Account Settings.",
+  cancellationExplanation: /To discontinue billing, you.*ll need to cancel Object Storage in your Account Settings./,
 };
 
 describe('Object Storage enrollment', () => {
@@ -60,8 +62,8 @@ describe('Object Storage enrollment', () => {
    * - Confirms that regular pricing information is shown for regions with regular price structures.
    * - Confirms that generic pricing information is shown when no region is selected.
    */
-  it('can enroll in Object Storage', () => {
-    // TODO: DC Pricing - M3-7073: Delete feature flag mocks when DC-specific pricing goes live.
+  // TODO: DC Pricing - M3-7073: Delete test when cleaning up feature flag.
+  it('can enroll in Object Storage with free beta DC-specific pricing', () => {
     const mockAccountSettings = accountSettingsFactory.build({
       managed: false,
       object_storage: 'disabled',
@@ -101,9 +103,8 @@ describe('Object Storage enrollment', () => {
     const mockAccessKey = objectStorageKeyFactory.build({
       label: randomLabel(),
     });
-
     mockAppendFeatureFlags({
-      dcSpecificPricing: makeFeatureFlagData(true),
+      objDcSpecificPricing: makeFeatureFlagData(false),
     }).as('getFeatureFlags');
     mockGetFeatureFlagClientstream().as('getClientStream');
     mockGetAccountSettings(mockAccountSettings).as('getAccountSettings');
@@ -149,7 +150,7 @@ describe('Object Storage enrollment', () => {
     // Confirm dialog contents shows the expected information for regions
     // with special pricing during beta period, then cancel.
     ui.dialog
-      .findByTitle('Just to confirm...')
+      .findByTitle('Enable Object Storage')
       .should('be.visible')
       .within(() => {
         // Confirm that DC-specific beta pricing notes are shown, as well as
@@ -182,7 +183,7 @@ describe('Object Storage enrollment', () => {
     });
 
     ui.dialog
-      .findByTitle('Just to confirm...')
+      .findByTitle('Enable Object Storage')
       .should('be.visible')
       .within(() => {
         // Confirm that regular pricing information is shown, as well as
@@ -235,7 +236,7 @@ describe('Object Storage enrollment', () => {
     mockGetAccessKeys([mockAccessKey]).as('getAccessKey');
     mockGetAccountSettings(mockAccountSettingsEnabled).as('getAccountSettings');
     ui.dialog
-      .findByTitle('Just to confirm...')
+      .findByTitle('Enable Object Storage')
       .should('be.visible')
       .within(() => {
         // Confirm that DC-specific generic pricing notes are shown, as well as
@@ -251,7 +252,7 @@ describe('Object Storage enrollment', () => {
 
         // Click "Enable Object Storage".
         ui.button
-          .findByTitle('Enable Object Storage')
+          .findByAttribute('data-qa-enable-obj', 'true')
           .should('be.visible')
           .should('be.enabled')
           .click();
@@ -292,55 +293,75 @@ describe('Object Storage enrollment', () => {
           .click();
       });
 
-    cy.findByText('Just to confirm...').should('not.exist');
+    cy.findByText('Enable Object Storage').should('not.exist');
   });
 
-  /*
-   * - Confirms Object Storage enrollment dialog contents when DC-specific pricing is disabled.
-   * - Confirms expected dialog language is shown when enrolling by creating a bucket.
-   * - Confirms expected dialog language is shown when enrolling by creating an access key.
-   * - Confirms that "Create a Bucket" dialog cannot be submitted without selecting a region.
-   */
-  it('can enroll in Object Storage without DC-specific pricing', () => {
-    // TODO: DC Pricing - M3-7073: Delete this test when DC-specific pricing feature goes live.
+  // TODO: DC Pricing - M3-7073: Remove feature flag mocks once feature flags are cleaned up.
+  it('can enroll in Object Storage with OBJ DC-specific pricing', () => {
     const mockAccountSettings = accountSettingsFactory.build({
       managed: false,
       object_storage: 'disabled',
     });
 
-    const mockRegion = regionFactory.build({
-      label: 'Newark, NJ',
-      id: 'us-east',
+    const mockAccountSettingsEnabled = {
+      ...mockAccountSettings,
+      object_storage: 'active',
+    };
+
+    const mockRegions: Region[] = [
+      regionFactory.build({ label: 'Newark, NJ', id: 'us-east' }),
+      regionFactory.build({ label: 'Sao Paulo, BR', id: 'br-gru' }),
+      regionFactory.build({ label: 'Jakarta, ID', id: 'id-cgk' }),
+    ];
+
+    // Clusters with special pricing are currently hardcoded rather than
+    // retrieved via API, so we have to mock the cluster API request to correspond
+    // with that hardcoded data.
+    const mockClusters = [
+      // Regions with special pricing.
+      objectStorageClusterFactory.build({
+        id: 'br-gru-0',
+        region: 'br-gru',
+      }),
+      objectStorageClusterFactory.build({
+        id: 'id-cgk-1',
+        region: 'id-cgk',
+      }),
+      // A region that does not have special pricing.
+      objectStorageClusterFactory.build({
+        id: 'us-east-1',
+        region: 'us-east',
+      }),
+    ];
+
+    const mockAccessKey = objectStorageKeyFactory.build({
+      label: randomLabel(),
     });
 
     mockAppendFeatureFlags({
-      dcSpecificPricing: makeFeatureFlagData(false),
+      objDcSpecificPricing: makeFeatureFlagData(true),
     }).as('getFeatureFlags');
     mockGetFeatureFlagClientstream().as('getClientStream');
     mockGetAccountSettings(mockAccountSettings).as('getAccountSettings');
+    mockGetClusters(mockClusters).as('getClusters');
     mockGetBuckets([]).as('getBuckets');
+    mockGetRegions(mockRegions).as('getRegions');
     mockGetAccessKeys([]);
-    mockGetRegions([mockRegion]).as('getRegions');
 
-    const confirmModalContents = () => {
-      // Confirm that pricing and cancellation explanations are present.
-      cy.contains(objNotes.regularPricing).should('be.visible');
-      cy.contains(objNotes.cancellationExplanation).should('be.visible');
-
-      // Confirm that DC-specific pricing learn more CTA is not present.
-      cy.contains(objNotes.dcPricingLearnMoreNote).should('not.exist');
-    };
-
-    // Navigate to Object Storage Buckets page and click "Create Bucket".
     cy.visitWithLogin('/object-storage/buckets');
     cy.wait([
       '@getFeatureFlags',
       '@getClientStream',
       '@getAccountSettings',
+      '@getClusters',
       '@getBuckets',
       '@getRegions',
     ]);
 
+    // Confirm that empty-state message is shown before proceeding.
+    cy.findByText('S3-compatible storage solution').should('be.visible');
+
+    // Click create button, select a region with special pricing, and submit.
     ui.button
       .findByTitle('Create Bucket')
       .should('be.visible')
@@ -351,16 +372,16 @@ describe('Object Storage enrollment', () => {
       .findByTitle('Create Bucket')
       .should('be.visible')
       .within(() => {
-        // Confirm that "Create Bucket" button is disabled until region is selected.
-        ui.buttonGroup
-          .findButtonByTitle('Create Bucket')
-          .should('be.visible')
-          .should('be.disabled');
+        // Select a region with special pricing structure.
+        cy.findByText('Region').click().type('Jakarta, ID{enter}');
 
-        cy.findByText('Region')
-          .should('be.visible')
-          .click()
-          .type(`Newark, NJ{enter}`);
+        // Confirm DC-specific overage prices are shown in the drawer.
+        cy.contains(
+          'For this region, additional storage costs $0.024 per GB.'
+        ).should('be.visible');
+        cy.contains(
+          'Outbound transfer will cost $0.015 per GB if it exceeds the network transfer pool for this region.'
+        ).should('be.visible');
 
         ui.buttonGroup
           .findButtonByTitle('Create Bucket')
@@ -369,14 +390,22 @@ describe('Object Storage enrollment', () => {
           .click();
       });
 
-    // Confirm dialog contents, then cancel.
+    // Confirm dialog contents shows the expected information, then cancel.
     ui.dialog
-      .findByTitle('Just to confirm...')
+      .findByTitle('Enable Object Storage')
       .should('be.visible')
       .within(() => {
-        // Confirm that pricing and cancellation explanations are present, but
-        // DC-specific information is hidden.
-        confirmModalContents();
+        // Confirm that regular pricing and DC-specific OBJ pricing notes are shown, as well as
+        // additional pricing explanation link and cancellation information.
+        cy.contains(
+          'To create your first bucket, you need to enable Object Storage.'
+        );
+        cy.contains(objNotes.objDCPricing).should('be.visible');
+        cy.contains(objNotes.dcPricingLearnMoreNote).should('be.visible');
+        cy.contains(objNotes.cancellationExplanation).should('be.visible');
+
+        // Confirm that DC-specific beta pricing information is not shown.
+        cy.contains(objNotes.dcSpecificBetaPricing).should('not.exist');
 
         ui.button
           .findByTitle('Cancel')
@@ -385,16 +414,120 @@ describe('Object Storage enrollment', () => {
           .click();
       });
 
-    // Close "Create Bucket" drawer.
-    ui.drawer
-      .findByTitle('Create Bucket')
+    // Initiate bucket create flow again, and this time select a region with
+    // regular pricing structure.
+    ui.drawer.findByTitle('Create Bucket').within(() => {
+      // Select a region with regular pricing structure.
+      cy.findByText('Region').click().type('Newark, NJ{enter}');
+
+      // Confirm regular overage prices are shown in the drawer.
+      cy.contains(
+        'For this region, additional storage costs $0.02 per GB.'
+      ).should('be.visible');
+      cy.contains(
+        'Outbound transfer will cost $0.005 per GB if it exceeds your global network transfer pool.'
+      ).should('be.visible');
+
+      ui.buttonGroup
+        .findButtonByTitle('Create Bucket')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+    });
+
+    ui.dialog
+      .findByTitle('Enable Object Storage')
       .should('be.visible')
       .within(() => {
-        ui.drawerCloseButton.find().click();
+        // Confirm that regular pricing information is shown, as well as
+        // additional pricing explanation link and cancellation information.
+        cy.contains(objNotes.objDCPricing).should('be.visible');
+        cy.contains(objNotes.dcPricingLearnMoreNote).should('be.visible');
+        cy.contains(objNotes.cancellationExplanation).should('be.visible');
+
+        // Confirm that DC-specific beta pricing information is not shown.
+        // TODO: DC Pricing - M3-7073: Delete next line once feature flags are cleaned up.
+        cy.contains(objNotes.dcSpecificBetaPricing).should('not.exist');
+
+        ui.button
+          .findByTitle('Cancel')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
       });
 
-    // Switch to "Access Keys" tab and create an access key.
+    // Close the "Create Bucket" drawer, and navigate to the "Access Keys" tab.
+    ui.drawer.findByTitle('Create Bucket').within(() => {
+      ui.drawerCloseButton.find().should('be.visible').click();
+    });
+
     ui.tabList.findTabByTitle('Access Keys').should('be.visible').click();
+
+    ui.button
+      .findByTitle('Create Access Key')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    // Fill out "Create Access Key" form, then submit.
+    ui.drawer
+      .findByTitle('Create Access Key')
+      .should('be.visible')
+      .within(() => {
+        cy.findByLabelText('Label')
+          .should('be.visible')
+          .type(mockAccessKey.label);
+
+        ui.buttonGroup
+          .findButtonByTitle('Create Access Key')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    // Confirm dialog contents shows the expected information.
+    mockCreateAccessKey(mockAccessKey).as('createAccessKey');
+    mockGetAccessKeys([mockAccessKey]).as('getAccessKey');
+    mockGetAccountSettings(mockAccountSettingsEnabled).as('getAccountSettings');
+    ui.dialog
+      .findByTitle('Enable Object Storage')
+      .should('be.visible')
+      .within(() => {
+        // Confirm that DC-specific generic pricing notes are shown, as well as
+        // additional pricing explanation link and cancellation information.
+        cy.contains(
+          'To create your first access key, you need to enable Object Storage.'
+        );
+        cy.contains(objNotes.objDCPricing).should('be.visible');
+        cy.contains(objNotes.dcPricingLearnMoreNote).should('be.visible');
+        cy.contains(objNotes.cancellationExplanation).should('be.visible');
+
+        // Confirm that DC-specific beta pricing information is not shown.
+        // TODO: DC Pricing - M3-7073: Delete next line once feature flags are cleaned up.
+        cy.contains(objNotes.dcSpecificBetaPricing).should('not.exist');
+
+        // Click "Enable Object Storage".
+        ui.button
+          .findByAttribute('data-qa-enable-obj', 'true')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    cy.wait(['@createAccessKey', '@getAccessKey', '@getAccountSettings']);
+    cy.findByText(mockAccessKey.label).should('be.visible');
+
+    // Click through the "Access Keys" dialog which displays the new access key.
+    ui.dialog
+      .findByTitle('Access Keys')
+      .should('be.visible')
+      .within(() => {
+        ui.button
+          .findByTitle('I Have Saved My Secret Key')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
 
     ui.button
       .findByTitle('Create Access Key')
@@ -416,15 +549,7 @@ describe('Object Storage enrollment', () => {
           .click();
       });
 
-    // Confirm dialog contents shows the expected information.
-    ui.dialog
-      .findByTitle('Just to confirm...')
-      .should('be.visible')
-      .within(() => {
-        // Confirm that pricing and cancellation explanations are present, but
-        // DC-specific information is hidden.
-        confirmModalContents();
-      });
+    cy.findByText('Enable Object Storage').should('not.exist');
   });
 
   /*

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -17,6 +17,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'aglb', label: 'AGLB' },
   { flag: 'unifiedMigrations', label: 'Unified Migrations' },
   { flag: 'dcSpecificPricing', label: 'DC-Specific Pricing' },
+  { flag: 'objDCSpecificPricing', label: 'OBJ Storage DC-Specific Pricing' },
   { flag: 'selfServeBetas', label: 'Self Serve Betas' },
   { flag: 'soldOutTokyo', label: 'Sold Out Tokyo' },
 ];

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -17,7 +17,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'aglb', label: 'AGLB' },
   { flag: 'unifiedMigrations', label: 'Unified Migrations' },
   { flag: 'dcSpecificPricing', label: 'DC-Specific Pricing' },
-  { flag: 'objDCSpecificPricing', label: 'OBJ Storage DC-Specific Pricing' },
+  { flag: 'objDcSpecificPricing', label: 'OBJ Storage DC-Specific Pricing' },
   { flag: 'selfServeBetas', label: 'Self Serve Betas' },
   { flag: 'soldOutTokyo', label: 'Sold Out Tokyo' },
 ];

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -50,6 +50,7 @@ export interface Flags {
   linodeCreateWithFirewall: boolean;
   mainContentBanner: MainContentBanner;
   metadata: boolean;
+  objDCSpecificPricing: boolean;
   oneClickApps: OneClickApp;
   oneClickAppsDocsOverride: Record<string, Doc[]>;
   productInformationBanners: ProductInformationBannerFlag[];

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -50,7 +50,7 @@ export interface Flags {
   linodeCreateWithFirewall: boolean;
   mainContentBanner: MainContentBanner;
   metadata: boolean;
-  objDCSpecificPricing: boolean;
+  objDcSpecificPricing: boolean;
   oneClickApps: OneClickApp;
   oneClickAppsDocsOverride: Record<string, Doc[]>;
   productInformationBanners: ProductInformationBannerFlag[];

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.test.tsx
@@ -88,7 +88,7 @@ describe('CreateBucketDrawer', () => {
       getByTestId,
     } = renderWithTheme(<CreateBucketDrawer {...props} />, { queryClient });
 
-    userEvent.type(getByLabelText('Label'), 'my-test-bucket');
+    userEvent.type(getByLabelText('Label', { exact: false }), 'my-test-bucket');
 
     // We must waitFor because we need to load region and cluster data from the API
     await waitFor(() =>

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.tsx
@@ -144,7 +144,7 @@ export const CreateBucketDrawer = (props: Props) => {
           required
           selectedCluster={formik.values.cluster}
         />
-        {flags.objDCSpecificPricing && (
+        {flags.objDcSpecificPricing && clusterRegion?.[0]?.id && (
           <OveragePricing regionId={clusterRegion?.[0]?.id} />
         )}
         {showAgreement ? (

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.tsx
@@ -133,6 +133,7 @@ export const CreateBucketDrawer = (props: Props) => {
           name="label"
           onBlur={formik.handleBlur}
           onChange={formik.handleChange}
+          required
           value={formik.values.label}
         />
         <ClusterSelect

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.tsx
@@ -7,6 +7,7 @@ import { Drawer } from 'src/components/Drawer';
 import { Notice } from 'src/components/Notice/Notice';
 import { TextField } from 'src/components/TextField';
 import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
+import { useFlags } from 'src/hooks/useFlags';
 import {
   useAccountAgreements,
   useMutateAccountAgreements,
@@ -25,6 +26,7 @@ import { isEURegion } from 'src/utilities/formatRegion';
 
 import { EnableObjectStorageModal } from '../EnableObjectStorageModal';
 import ClusterSelect from './ClusterSelect';
+import { OveragePricing } from './OveragePricing';
 
 interface Props {
   isOpen: boolean;
@@ -50,6 +52,8 @@ export const CreateBucketDrawer = (props: Props) => {
   const [isEnableObjDialogOpen, setIsEnableObjDialogOpen] = React.useState(
     false
   );
+
+  const flags = useFlags();
 
   const formik = useFormik({
     initialValues: {
@@ -140,6 +144,9 @@ export const CreateBucketDrawer = (props: Props) => {
           required
           selectedCluster={formik.values.cluster}
         />
+        {flags.objDCSpecificPricing && (
+          <OveragePricing regionId={clusterRegion?.[0]?.id} />
+        )}
         {showAgreement ? (
           <StyledEUAgreementCheckbox
             onChange={(e) =>

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.test.tsx
@@ -11,8 +11,6 @@ import {
   OveragePricing,
 } from './OveragePricing';
 
-jest.mock('src/components/EnhancedSelect/Select');
-
 describe('OveragePricing', () => {
   it('Renders base overage pricing for a region without price increases', () => {
     const { getByText } = renderWithTheme(

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { OBJ_STORAGE_PRICE } from 'src/utilities/pricing/constants';
+import { objectStoragePriceIncreaseMap } from 'src/utilities/pricing/dynamicPricing';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import {
+  DC_SPECIFIC_TRANSFER_POOLS_TOOLTIP_TEXT,
+  GLOBAL_TRANSFER_POOL_TOOLTIP_TEXT,
+  OveragePricing,
+} from './OveragePricing';
+
+jest.mock('src/components/EnhancedSelect/Select');
+
+describe('OveragePricing', () => {
+  it('Renders base overage pricing for a region without price increases', () => {
+    const { getByText } = renderWithTheme(
+      <OveragePricing regionId="us-east" />
+    );
+    getByText(`$${OBJ_STORAGE_PRICE.storage_overage} per GB`, { exact: false });
+    getByText(`$${OBJ_STORAGE_PRICE.transfer_overage} per GB`, {
+      exact: false,
+    });
+  });
+
+  it('Renders DC-specific overage pricing for a region with price increases', () => {
+    const { getByText } = renderWithTheme(<OveragePricing regionId="br-gru" />);
+    getByText(
+      `$${objectStoragePriceIncreaseMap['br-gru'].storage_overage} per GB`,
+      { exact: false }
+    );
+    getByText(
+      `$${objectStoragePriceIncreaseMap['br-gru'].transfer_overage} per GB`,
+      { exact: false }
+    );
+  });
+
+  it('Renders a tooltip for DC-specific transfer pools for a region with price increases', async () => {
+    const { findByRole, getByText } = renderWithTheme(
+      <OveragePricing regionId="br-gru" />
+    );
+
+    fireEvent.mouseEnter(getByText('network transfer pool for this region'));
+
+    const tooltip = await findByRole(/tooltip/);
+
+    expect(tooltip).toBeInTheDocument();
+    expect(getByText(DC_SPECIFIC_TRANSFER_POOLS_TOOLTIP_TEXT)).toBeVisible();
+  });
+
+  it('Renders a tooltip for global network transfer pools for a region without price increases', async () => {
+    const { findByRole, getByText } = renderWithTheme(
+      <OveragePricing regionId="us-east" />
+    );
+
+    fireEvent.mouseEnter(getByText('global network transfer pool'));
+
+    const tooltip = await findByRole(/tooltip/);
+
+    expect(tooltip).toBeInTheDocument();
+    expect(getByText(GLOBAL_TRANSFER_POOL_TOOLTIP_TEXT)).toBeVisible();
+  });
+});

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.tsx
@@ -11,9 +11,9 @@ interface Props {
   regionId: Region['id'];
 }
 
-const DC_SPECIFIC_TRANSFER_POOLS_TOOLTIP_TEXT =
+export const DC_SPECIFIC_TRANSFER_POOLS_TOOLTIP_TEXT =
   'For this region, monthly network transfer is calculated and tracked independently and is not part of your global network transfer pool.';
-const GLOBAL_TRANSFER_POOL_TOOLTIP_TEXT =
+export const GLOBAL_TRANSFER_POOL_TOOLTIP_TEXT =
   'Your global network transfer pool adds up all the included transfer associated with active Linode services on your account and is prorated based on service creation.';
 
 export const OveragePricing = (props: Props) => {

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.tsx
@@ -1,4 +1,5 @@
 import { Region } from '@linode/api-v4';
+import { styled } from '@mui/material/styles';
 import React from 'react';
 
 import { TextTooltip } from 'src/components/TextTooltip';
@@ -13,7 +14,7 @@ interface Props {
 const DC_SPECIFIC_TRANSFER_POOLS_TOOLTIP_TEXT =
   'For this region, monthly network transfer is calculated and tracked independently and is not part of your global network transfer pool.';
 const GLOBAL_TRANSFER_POOL_TOOLTIP_TEXT =
-  'Your global network transfer pool adds up all the included transfer associated with active Linode services on our account and is prorated based on service creation.';
+  'Your global network transfer pool adds up all the included transfer associated with active Linode services on your account and is prorated based on service creation.';
 
 export const OveragePricing = (props: Props) => {
   const { regionId } = props;
@@ -22,7 +23,7 @@ export const OveragePricing = (props: Props) => {
 
   return regionId ? (
     <>
-      <Typography sx={{ marginTop: '12px' }}>
+      <StyledTypography>
         For this region, additional storage costs{' '}
         <strong>
           $
@@ -32,8 +33,8 @@ export const OveragePricing = (props: Props) => {
           per GB
         </strong>
         .
-      </Typography>
-      <Typography>
+      </StyledTypography>
+      <StyledTypography>
         Outbound transfer will cost{' '}
         <strong>
           $
@@ -61,7 +62,13 @@ export const OveragePricing = (props: Props) => {
           </>
         )}
         .
-      </Typography>
+      </StyledTypography>
     </>
   ) : null;
 };
+
+const StyledTypography = styled(Typography, {
+  label: 'StyledTypography',
+})(({ theme }) => ({
+  margin: `${theme.spacing(2)} 0`,
+}));

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.tsx
@@ -8,7 +8,7 @@ import { OBJ_STORAGE_PRICE } from 'src/utilities/pricing/constants';
 import { objectStoragePriceIncreaseMap } from 'src/utilities/pricing/dynamicPricing';
 
 interface Props {
-  regionId?: Region['id'];
+  regionId: Region['id'];
 }
 
 const DC_SPECIFIC_TRANSFER_POOLS_TOOLTIP_TEXT =
@@ -18,10 +18,11 @@ const GLOBAL_TRANSFER_POOL_TOOLTIP_TEXT =
 
 export const OveragePricing = (props: Props) => {
   const { regionId } = props;
-  const isDcSpecificPricingRegion =
-    regionId && objectStoragePriceIncreaseMap.hasOwnProperty(regionId);
+  const isDcSpecificPricingRegion = objectStoragePriceIncreaseMap.hasOwnProperty(
+    regionId
+  );
 
-  return regionId ? (
+  return (
     <>
       <StyledTypography>
         For this region, additional storage costs{' '}
@@ -64,7 +65,7 @@ export const OveragePricing = (props: Props) => {
         .
       </StyledTypography>
     </>
-  ) : null;
+  );
 };
 
 const StyledTypography = styled(Typography, {

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.tsx
@@ -1,0 +1,67 @@
+import { Region } from '@linode/api-v4';
+import React from 'react';
+
+import { TextTooltip } from 'src/components/TextTooltip';
+import { Typography } from 'src/components/Typography';
+import { OBJ_STORAGE_PRICE } from 'src/utilities/pricing/constants';
+import { objectStoragePriceIncreaseMap } from 'src/utilities/pricing/dynamicPricing';
+
+interface Props {
+  regionId?: Region['id'];
+}
+
+const DC_SPECIFIC_TRANSFER_POOLS_TOOLTIP_TEXT =
+  'For this region, monthly network transfer is calculated and tracked independently and is not part of your global network transfer pool.';
+const GLOBAL_TRANSFER_POOL_TOOLTIP_TEXT =
+  'Your global network transfer pool adds up all the included transfer associated with active Linode services on our account and is prorated based on service creation.';
+
+export const OveragePricing = (props: Props) => {
+  const { regionId } = props;
+  const isDcSpecificPricingRegion =
+    regionId && objectStoragePriceIncreaseMap.hasOwnProperty(regionId);
+
+  return regionId ? (
+    <>
+      <Typography sx={{ marginTop: '12px' }}>
+        For this region, additional storage costs{' '}
+        <strong>
+          $
+          {isDcSpecificPricingRegion
+            ? objectStoragePriceIncreaseMap[regionId].storage_overage
+            : OBJ_STORAGE_PRICE.storage_overage}{' '}
+          per GB
+        </strong>
+        .
+      </Typography>
+      <Typography>
+        Outbound transfer will cost{' '}
+        <strong>
+          $
+          {isDcSpecificPricingRegion
+            ? objectStoragePriceIncreaseMap[regionId].transfer_overage
+            : OBJ_STORAGE_PRICE.transfer_overage}{' '}
+          per GB
+        </strong>{' '}
+        if it exceeds{' '}
+        {isDcSpecificPricingRegion ? (
+          <>
+            the{' '}
+            <TextTooltip
+              displayText="network transfer pool for this region"
+              tooltipText={DC_SPECIFIC_TRANSFER_POOLS_TOOLTIP_TEXT}
+            />
+          </>
+        ) : (
+          <>
+            your{' '}
+            <TextTooltip
+              displayText="global network transfer pool"
+              tooltipText={GLOBAL_TRANSFER_POOL_TOOLTIP_TEXT}
+            />
+          </>
+        )}
+        .
+      </Typography>
+    </>
+  ) : null;
+};

--- a/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.test.tsx
@@ -6,12 +6,13 @@ import {
   ENABLE_OBJ_ACCESS_KEYS_MESSAGE,
   OBJ_STORAGE_PRICE,
 } from 'src/utilities/pricing/constants';
-import { objectStoragePriceIncreaseMap } from 'src/utilities/pricing/dynamicPricing';
 import { wrapWithTheme } from 'src/utilities/testHelpers';
 
 import {
   EnableObjectStorageModal,
   EnableObjectStorageProps,
+  OBJ_STORAGE_NETWORK_TRANSFER_AMT,
+  OBJ_STORAGE_STORAGE_AMT,
 } from './EnableObjectStorageModal';
 
 const DC_SPECIFIC_PRICING_REGION_LABEL = 'Jakarta, ID';
@@ -28,14 +29,14 @@ const props: EnableObjectStorageProps = {
 };
 
 describe('EnableObjectStorageModal', () => {
-  it('includes a header', () => {
+  // TODO: fix failing test
+  it.skip('includes a header', () => {
     const { getByText } = render(
       wrapWithTheme(<EnableObjectStorageModal {...props} />)
     );
-    getByText('Just to confirm...');
+    getByText('Enable Object Storage');
   });
 
-  // TODO: DC Pricing - M3-7073: Remove this test once dcSpecificPricing flag is cleaned up
   it('displays base prices for a region without price increases when the DC-specific pricing feature flag is off', () => {
     const { getByText } = render(
       wrapWithTheme(
@@ -93,8 +94,7 @@ describe('EnableObjectStorageModal', () => {
     );
   });
 
-  // TODO: DC Pricing - M3-6973: Unskip this test when beta pricing ends.
-  it.skip('displays DC-specific pricing  for a region with price increases when the DC-specific pricing flag is on', () => {
+  it('displays flat rate pricing, storage, and network transfer amounts when OBJ DC-specific pricing flag is on', () => {
     const { getByText } = render(
       wrapWithTheme(
         <EnableObjectStorageModal
@@ -102,24 +102,13 @@ describe('EnableObjectStorageModal', () => {
           regionId={DC_SPECIFIC_PRICING_REGION}
         />,
         {
-          flags: { dcSpecificPricing: true },
+          flags: { objDCSpecificPricing: true },
         }
       )
     );
-    getByText(
-      `$${objectStoragePriceIncreaseMap[DC_SPECIFIC_PRICING_REGION].monthly}/month`,
-      {
-        exact: false,
-      }
-    );
-    getByText(
-      `$${objectStoragePriceIncreaseMap[DC_SPECIFIC_PRICING_REGION].storage_overage} per GB`,
-      { exact: false }
-    );
-    getByText(
-      `$${objectStoragePriceIncreaseMap[DC_SPECIFIC_PRICING_REGION].transfer_overage} per GB`,
-      { exact: false }
-    );
+    getByText(`$${OBJ_STORAGE_PRICE.monthly}/month`, { exact: false });
+    getByText(OBJ_STORAGE_STORAGE_AMT, { exact: false });
+    getByText(OBJ_STORAGE_NETWORK_TRANSFER_AMT, { exact: false });
   });
 
   it('displays a message without pricing if no region exists (e.g. access key flow) when the DC-specific pricing flag is on', () => {
@@ -168,11 +157,12 @@ describe('EnableObjectStorageModal', () => {
     expect(props.onClose).toHaveBeenCalled();
   });
 
-  it('calls the handleSubmit prop/handler when the Enable Object Storage button is clicked', () => {
-    const { getByText } = render(
+  // TODO: fix failing test
+  it.skip('calls the handleSubmit prop/handler when the Enable Object Storage button is clicked', () => {
+    const { getByLabelText } = render(
       wrapWithTheme(<EnableObjectStorageModal {...props} />)
     );
-    fireEvent.click(getByText('Enable Object Storage'));
+    fireEvent.click(getByLabelText('Enable Object Storage'));
     expect(props.handleSubmit).toHaveBeenCalled();
   });
 });

--- a/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.test.tsx
@@ -29,55 +29,29 @@ const props: EnableObjectStorageProps = {
 };
 
 describe('EnableObjectStorageModal', () => {
-  // TODO: fix failing test
-  it.skip('includes a header', () => {
-    const { getByText } = render(
+  it('includes a header', () => {
+    const { getAllByText } = render(
       wrapWithTheme(<EnableObjectStorageModal {...props} />)
     );
-    getByText('Enable Object Storage');
+    getAllByText('Enable Object Storage');
   });
 
-  it('displays base prices for a region without price increases when the DC-specific pricing feature flag is off', () => {
+  // TODO: DC Pricing - M3-7063: Delete this test when feature flags are cleaned up.
+  it('displays flat rate pricing and storage for a region without price increases with the OBJ DC-specific pricing flag off', () => {
     const { getByText } = render(
       wrapWithTheme(
         <EnableObjectStorageModal {...props} regionId={BASE_PRICING_REGION} />,
-        { flags: { dcSpecificPricing: false } }
-      )
-    );
-    getByText(`$${OBJ_STORAGE_PRICE.monthly}/month`, { exact: false });
-    getByText(`$${OBJ_STORAGE_PRICE.storage_overage} per GB`, { exact: false });
-  });
-
-  // TODO: DC Pricing - M3-7073: Remove this test once dcSpecificPricing flag is cleaned up
-  it('displays base prices for a region with price increases when the DC-specific pricing feature flag is off', () => {
-    const { getByText } = render(
-      wrapWithTheme(
-        <EnableObjectStorageModal
-          {...props}
-          regionId={DC_SPECIFIC_PRICING_REGION}
-        />,
         {
-          flags: { dcSpecificPricing: false },
+          flags: { objDcSpecificPricing: false },
         }
       )
     );
-    getByText(`${OBJ_STORAGE_PRICE.monthly}/month`, { exact: false });
-    getByText(`$${OBJ_STORAGE_PRICE.storage_overage} per GB`, { exact: false });
-  });
-
-  it('displays base prices for a region without price increases when the DC-specific pricing feature flag is on', () => {
-    const { getByText } = render(
-      wrapWithTheme(
-        <EnableObjectStorageModal {...props} regionId={BASE_PRICING_REGION} />,
-        { flags: { dcSpecificPricing: true } }
-      )
-    );
     getByText(`$${OBJ_STORAGE_PRICE.monthly}/month`, { exact: false });
     getByText(`$${OBJ_STORAGE_PRICE.storage_overage} per GB`, { exact: false });
   });
 
-  // TODO: DC Pricing - M3-6973: delete this test and replace it with the one below it when beta pricing ends.
-  it('displays beta message with region label for a region with price increases when the DC-specific pricing flag is on', () => {
+  // TODO: DC Pricing - M3-7063: Delete this test when feature flags are cleaned up.
+  it('displays beta message with region label for a region with price increases when the OBJ DC-specific pricing flag is off', () => {
     const { getByText } = render(
       wrapWithTheme(
         <EnableObjectStorageModal
@@ -85,7 +59,7 @@ describe('EnableObjectStorageModal', () => {
           regionId={DC_SPECIFIC_PRICING_REGION}
         />,
         {
-          flags: { dcSpecificPricing: true },
+          flags: { objDcSpecificPricing: false },
         }
       )
     );
@@ -94,7 +68,7 @@ describe('EnableObjectStorageModal', () => {
     );
   });
 
-  it('displays flat rate pricing, storage, and network transfer amounts when OBJ DC-specific pricing flag is on', () => {
+  it('displays flat rate pricing, storage, and network transfer amounts in a region without price increases with the OBJ DC-specific pricing flag on', () => {
     const { getByText } = render(
       wrapWithTheme(
         <EnableObjectStorageModal
@@ -102,7 +76,7 @@ describe('EnableObjectStorageModal', () => {
           regionId={DC_SPECIFIC_PRICING_REGION}
         />,
         {
-          flags: { objDCSpecificPricing: true },
+          flags: { objDcSpecificPricing: true },
         }
       )
     );
@@ -111,20 +85,47 @@ describe('EnableObjectStorageModal', () => {
     getByText(OBJ_STORAGE_NETWORK_TRANSFER_AMT, { exact: false });
   });
 
-  it('displays a message without pricing if no region exists (e.g. access key flow) when the DC-specific pricing flag is on', () => {
+  it('displays flat rate pricing, storage, and network transfer amounts in a price increase region with the OBJ DC-specific pricing flag on', () => {
+    const { getByText } = render(
+      wrapWithTheme(
+        <EnableObjectStorageModal
+          {...props}
+          regionId={DC_SPECIFIC_PRICING_REGION}
+        />,
+        {
+          flags: { objDcSpecificPricing: true },
+        }
+      )
+    );
+    getByText(`$${OBJ_STORAGE_PRICE.monthly}/month`, { exact: false });
+    getByText(OBJ_STORAGE_STORAGE_AMT, { exact: false });
+    getByText(OBJ_STORAGE_NETWORK_TRANSFER_AMT, { exact: false });
+  });
+
+  // TODO: DC Pricing - M3-7063: Delete this test when feature flags are cleaned up.
+  it('displays a message without pricing if no region exists (e.g. access key flow) when the OBJ DC-specific pricing flag is off', () => {
     const { getByText } = render(
       wrapWithTheme(<EnableObjectStorageModal {...props} />, {
-        flags: { dcSpecificPricing: true },
+        flags: { objDcSpecificPricing: false },
       })
     );
     getByText(ENABLE_OBJ_ACCESS_KEYS_MESSAGE);
   });
 
-  it('includes a link to linode.com/pricing when the DC-specific pricing flag is on', () => {
+  it('displays flat rate pricing, storage, and network transfer amounts when a regionId is not defined and OBJ DC-specific pricing flag is on', () => {
     const { getByText } = render(
       wrapWithTheme(<EnableObjectStorageModal {...props} />, {
-        flags: { dcSpecificPricing: true },
+        flags: { objDcSpecificPricing: true },
       })
+    );
+    getByText(`$${OBJ_STORAGE_PRICE.monthly}/month`, { exact: false });
+    getByText(OBJ_STORAGE_STORAGE_AMT, { exact: false });
+    getByText(OBJ_STORAGE_NETWORK_TRANSFER_AMT, { exact: false });
+  });
+
+  it('includes a link to linode.com/pricing', () => {
+    const { getByText } = render(
+      wrapWithTheme(<EnableObjectStorageModal {...props} />)
     );
     const link = getByText('Learn more');
     expect(link.closest('a')).toHaveAttribute(
@@ -158,11 +159,11 @@ describe('EnableObjectStorageModal', () => {
   });
 
   // TODO: fix failing test
-  it.skip('calls the handleSubmit prop/handler when the Enable Object Storage button is clicked', () => {
-    const { getByLabelText } = render(
+  it('calls the handleSubmit prop/handler when the Enable Object Storage button is clicked', () => {
+    const { getByTestId } = render(
       wrapWithTheme(<EnableObjectStorageModal {...props} />)
     );
-    fireEvent.click(getByLabelText('Enable Object Storage'));
+    fireEvent.click(getByTestId('enable-obj'));
     expect(props.handleSubmit).toHaveBeenCalled();
   });
 });

--- a/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.test.tsx
@@ -158,7 +158,6 @@ describe('EnableObjectStorageModal', () => {
     expect(props.onClose).toHaveBeenCalled();
   });
 
-  // TODO: fix failing test
   it('calls the handleSubmit prop/handler when the Enable Object Storage button is clicked', () => {
     const { getByTestId } = render(
       wrapWithTheme(<EnableObjectStorageModal {...props} />)

--- a/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
+++ b/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
@@ -41,7 +41,7 @@ export const EnableObjectStorageModal = React.memo(
      * @returns Dynamic modal text dependent on the existence and selection of a region
      */
     const renderRegionPricingText = (regionLabel: string) => {
-      if (flags.objDCSpecificPricing) {
+      if (flags.objDcSpecificPricing) {
         return (
           <>
             <StyledTypography>
@@ -59,23 +59,19 @@ export const EnableObjectStorageModal = React.memo(
         );
       }
 
-      if (flags.dcSpecificPricing) {
-        if (!regionId) {
-          return (
-            <StyledTypography>
-              {ENABLE_OBJ_ACCESS_KEYS_MESSAGE}
-            </StyledTypography>
-          );
-        } else if (isObjBetaPricingRegion) {
-          return (
-            <StyledTypography>
-              Object Storage for {regionLabel} is currently in beta. During the
-              beta period, Object Storage in these regions is free. After the
-              beta period, customers will be notified before charges for this
-              service begin.
-            </StyledTypography>
-          );
-        }
+      if (!regionId) {
+        return (
+          <StyledTypography>{ENABLE_OBJ_ACCESS_KEYS_MESSAGE}</StyledTypography>
+        );
+      } else if (isObjBetaPricingRegion) {
+        return (
+          <StyledTypography>
+            Object Storage for {regionLabel} is currently in beta. During the
+            beta period, Object Storage in these regions is free. After the beta
+            period, customers will be notified before charges for this service
+            begin.
+          </StyledTypography>
+        );
       }
 
       return (
@@ -88,11 +84,6 @@ export const EnableObjectStorageModal = React.memo(
           <strong>
             ${OBJ_STORAGE_PRICE.storage_overage} per GB per month.
           </strong>{' '}
-          {!flags.dcSpecificPricing && (
-            <Link to="https://www.linode.com/docs/products/storage/object-storage/#pricing">
-              Learn more.
-            </Link>
-          )}
         </StyledTypography>
       );
     };
@@ -102,6 +93,7 @@ export const EnableObjectStorageModal = React.memo(
         actions={() => (
           <ActionsPanel
             primaryButtonProps={{
+              'data-testid': 'enable-obj',
               label: 'Enable Object Storage',
               onClick: () => {
                 onClose();
@@ -120,14 +112,12 @@ export const EnableObjectStorageModal = React.memo(
         title="Enable Object Storage"
       >
         {renderRegionPricingText(regionLabel ?? 'this region')}
-        {flags.dcSpecificPricing && (
-          <StyledTypography>
-            <Link to="https://www.linode.com/pricing/#object-storage">
-              Learn more
-            </Link>{' '}
-            about pricing and specifications.
-          </StyledTypography>
-        )}
+        <StyledTypography>
+          <Link to="https://www.linode.com/pricing/#object-storage">
+            Learn more
+          </Link>{' '}
+          about pricing and specifications.
+        </StyledTypography>
         <Notice spacingBottom={0} variant="warning">
           To discontinue billing, you&rsquo;ll need to cancel Object Storage in
           your &nbsp;

--- a/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
+++ b/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
@@ -32,10 +32,6 @@ export const EnableObjectStorageModal = React.memo(
 
     const regionLabel =
       regions?.find((r) => r.id === regionId)?.label ?? regionId;
-    // TODO: DC Pricing - M3-6973: Uncomment to calculate `objStoragePrices` based on region map rather than OBJ_STORAGE_PRICE constant
-    //   regionId && flags.dcSpecificPricing
-    //     ? objectStoragePriceIncreaseMap[regionId] ?? OBJ_STORAGE_PRICE
-    //     : OBJ_STORAGE_PRICE;
     const isObjBetaPricingRegion =
       regionId && objectStoragePriceIncreaseMap.hasOwnProperty(regionId);
 

--- a/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
+++ b/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
@@ -4,18 +4,18 @@ import * as React from 'react';
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
 import { Link } from 'src/components/Link';
+import { Notice } from 'src/components/Notice/Notice';
 import { Typography } from 'src/components/Typography';
 import { useFlags } from 'src/hooks/useFlags';
 import { useRegionsQuery } from 'src/queries/regions';
 import {
   ENABLE_OBJ_ACCESS_KEYS_MESSAGE,
   OBJ_STORAGE_PRICE,
-  ObjStoragePriceObject,
 } from 'src/utilities/pricing/constants';
 import { objectStoragePriceIncreaseMap } from 'src/utilities/pricing/dynamicPricing';
 
-const OBJ_STORAGE_STORAGE_AMT = '250 GB';
-const OBJ_STORAGE_NETWORK_TRANSFER_AMT = '1 TB';
+export const OBJ_STORAGE_STORAGE_AMT = '250 GB';
+export const OBJ_STORAGE_NETWORK_TRANSFER_AMT = '1 TB';
 export interface EnableObjectStorageProps {
   handleSubmit: () => void;
   onClose: () => void;
@@ -32,7 +32,6 @@ export const EnableObjectStorageModal = React.memo(
 
     const regionLabel =
       regions?.find((r) => r.id === regionId)?.label ?? regionId;
-    const objStoragePrices: ObjStoragePriceObject = OBJ_STORAGE_PRICE;
     // TODO: DC Pricing - M3-6973: Uncomment to calculate `objStoragePrices` based on region map rather than OBJ_STORAGE_PRICE constant
     //   regionId && flags.dcSpecificPricing
     //     ? objectStoragePriceIncreaseMap[regionId] ?? OBJ_STORAGE_PRICE
@@ -45,13 +44,35 @@ export const EnableObjectStorageModal = React.memo(
      * @returns Dynamic modal text dependent on the existence and selection of a region
      */
     const renderRegionPricingText = (regionLabel: string) => {
+      if (flags.objDCSpecificPricing) {
+        return (
+          <>
+            <Typography sx={{ fontSize: '1rem', marginBottom: '12px' }}>
+              To create your first {regionId ? 'bucket' : 'access key'}, you
+              need to enable Object Storage.{' '}
+            </Typography>
+            <Typography sx={{ fontSize: '1rem' }}>
+              Object Storage costs a flat rate of{' '}
+              <strong>${OBJ_STORAGE_PRICE.monthly}/month</strong>, and includes{' '}
+              {OBJ_STORAGE_STORAGE_AMT} of storage. When you enable Object
+              Storage, {OBJ_STORAGE_NETWORK_TRANSFER_AMT} of outbound data
+              transfer will be added to your global network transfer pool.
+            </Typography>
+          </>
+        );
+      }
+
       if (flags.dcSpecificPricing) {
         if (!regionId) {
-          return <Typography>{ENABLE_OBJ_ACCESS_KEYS_MESSAGE}</Typography>;
+          return (
+            <Typography sx={{ fontSize: '1rem' }}>
+              {ENABLE_OBJ_ACCESS_KEYS_MESSAGE}
+            </Typography>
+          );
         } else if (isObjBetaPricingRegion) {
           // TODO: DC Pricing - M3-6973: Remove this case once beta pricing ends.
           return (
-            <Typography>
+            <Typography sx={{ fontSize: '1rem' }}>
               Object Storage for {regionLabel} is currently in beta. During the
               beta period, Object Storage in these regions is free. After the
               beta period, customers will be notified before charges for this
@@ -62,13 +83,15 @@ export const EnableObjectStorageModal = React.memo(
       }
 
       return (
-        <Typography>
+        <Typography sx={{ fontSize: '1rem' }}>
           Linode Object Storage costs a flat rate of{' '}
-          <strong>${objStoragePrices.monthly}/month</strong>, and includes{' '}
+          <strong>${OBJ_STORAGE_PRICE.monthly}/month</strong>, and includes{' '}
           {OBJ_STORAGE_STORAGE_AMT} of storage and{' '}
           {OBJ_STORAGE_NETWORK_TRANSFER_AMT} of outbound data transfer. Beyond
-          that, it's{' '}
-          <strong>${objStoragePrices.storage_overage} per GB per month.</strong>{' '}
+          that, it&rsquo;s{' '}
+          <strong>
+            ${OBJ_STORAGE_PRICE.storage_overage} per GB per month.
+          </strong>{' '}
           {!flags.dcSpecificPricing && (
             <Link to="https://www.linode.com/docs/products/storage/object-storage/#pricing">
               Learn more.
@@ -98,21 +121,22 @@ export const EnableObjectStorageModal = React.memo(
         )}
         onClose={onClose}
         open={open}
-        title="Just to confirm..."
+        title="Enable Object Storage"
       >
         {renderRegionPricingText(regionLabel ?? 'this region')}
         {flags.dcSpecificPricing && (
-          <Typography style={{ marginTop: 12 }}>
+          <Typography style={{ fontSize: '1rem', marginTop: 12 }}>
             <Link to="https://www.linode.com/pricing/#object-storage">
               Learn more
             </Link>{' '}
             about pricing and specifications.
           </Typography>
         )}
-        <Typography style={{ marginTop: 12 }}>
-          To discontinue billing, you'll need to cancel Object Storage in your{' '}
+        <Notice spacingTop={12} spacingBottom={0} variant="warning">
+          To discontinue billing, you&rsquo;ll need to cancel Object Storage in
+          your &nbsp;
           <Link to="/account/settings">Account Settings</Link>.
-        </Typography>
+        </Notice>
       </ConfirmationDialog>
     );
   }

--- a/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
+++ b/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
@@ -1,4 +1,5 @@
 import { Region } from '@linode/api-v4';
+import { styled } from '@mui/material/styles';
 import * as React from 'react';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
@@ -43,17 +44,17 @@ export const EnableObjectStorageModal = React.memo(
       if (flags.objDCSpecificPricing) {
         return (
           <>
-            <Typography sx={{ fontSize: '1rem', marginBottom: '12px' }}>
+            <StyledTypography>
               To create your first {regionId ? 'bucket' : 'access key'}, you
               need to enable Object Storage.{' '}
-            </Typography>
-            <Typography sx={{ fontSize: '1rem' }}>
+            </StyledTypography>
+            <StyledTypography>
               Object Storage costs a flat rate of{' '}
               <strong>${OBJ_STORAGE_PRICE.monthly}/month</strong>, and includes{' '}
               {OBJ_STORAGE_STORAGE_AMT} of storage. When you enable Object
               Storage, {OBJ_STORAGE_NETWORK_TRANSFER_AMT} of outbound data
               transfer will be added to your global network transfer pool.
-            </Typography>
+            </StyledTypography>
           </>
         );
       }
@@ -61,25 +62,24 @@ export const EnableObjectStorageModal = React.memo(
       if (flags.dcSpecificPricing) {
         if (!regionId) {
           return (
-            <Typography sx={{ fontSize: '1rem' }}>
+            <StyledTypography>
               {ENABLE_OBJ_ACCESS_KEYS_MESSAGE}
-            </Typography>
+            </StyledTypography>
           );
         } else if (isObjBetaPricingRegion) {
-          // TODO: DC Pricing - M3-6973: Remove this case once beta pricing ends.
           return (
-            <Typography sx={{ fontSize: '1rem' }}>
+            <StyledTypography>
               Object Storage for {regionLabel} is currently in beta. During the
               beta period, Object Storage in these regions is free. After the
               beta period, customers will be notified before charges for this
               service begin.
-            </Typography>
+            </StyledTypography>
           );
         }
       }
 
       return (
-        <Typography sx={{ fontSize: '1rem' }}>
+        <StyledTypography>
           Linode Object Storage costs a flat rate of{' '}
           <strong>${OBJ_STORAGE_PRICE.monthly}/month</strong>, and includes{' '}
           {OBJ_STORAGE_STORAGE_AMT} of storage and{' '}
@@ -93,7 +93,7 @@ export const EnableObjectStorageModal = React.memo(
               Learn more.
             </Link>
           )}
-        </Typography>
+        </StyledTypography>
       );
     };
 
@@ -121,14 +121,14 @@ export const EnableObjectStorageModal = React.memo(
       >
         {renderRegionPricingText(regionLabel ?? 'this region')}
         {flags.dcSpecificPricing && (
-          <Typography style={{ fontSize: '1rem', marginTop: 12 }}>
+          <StyledTypography>
             <Link to="https://www.linode.com/pricing/#object-storage">
               Learn more
             </Link>{' '}
             about pricing and specifications.
-          </Typography>
+          </StyledTypography>
         )}
-        <Notice spacingTop={12} spacingBottom={0} variant="warning">
+        <Notice spacingBottom={0} variant="warning">
           To discontinue billing, you&rsquo;ll need to cancel Object Storage in
           your &nbsp;
           <Link to="/account/settings">Account Settings</Link>.
@@ -137,3 +137,10 @@ export const EnableObjectStorageModal = React.memo(
     );
   }
 );
+
+const StyledTypography = styled(Typography, {
+  label: 'StyledTypography',
+})(({ theme }) => ({
+  fontSize: '1rem',
+  marginBottom: theme.spacing(2),
+}));

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -1,6 +1,7 @@
+import { UNKNOWN_PRICE } from './constants';
+
 import type { Region } from '@linode/api-v4';
 import type { FlagSet } from 'src/featureFlags';
-import { UNKNOWN_PRICE } from './constants';
 
 export interface DataCenterPricingOptions {
   /**
@@ -26,17 +27,14 @@ export const priceIncreaseMap = {
   'id-cgk': 0.2, // Jakarta
 };
 
-// TODO: DC Pricing - M3-6973: Update these values when beta pricing ends.
 export const objectStoragePriceIncreaseMap = {
   'br-gru': {
-    monthly: 0.0,
-    storage_overage: 0.0,
-    transfer_overage: 0.0,
+    storage_overage: 0.028,
+    transfer_overage: 0.007,
   },
   'id-cgk': {
-    monthly: 0.0,
-    storage_overage: 0.0,
-    transfer_overage: 0.0,
+    storage_overage: 0.024,
+    transfer_overage: 0.015,
   },
 };
 


### PR DESCRIPTION
## Description 📝
Object storage has hardcoded prices throughout the codebase. The service is a flat $5/month. Beyond the first 250GB storage and 1TB outbound transfer, it's and $0.02/GB/month. We need to update this due to pricing changes for DC-specific overage rates and clarification that outbound transfer is *not* added to DC-specific pools, only the global pool.

The only time a user sees the Enable Object Storage notice is the first time they create a bucket or access key and must opt-in to the service. 
- For this reason, we are adding region-specific overage pricing to the Create Bucket drawer.

Note: Access keys are not currently tied to regions.

## Changes  🔄
- Overage prices on the Create Bucket drawer reflect accurate prices for dynamic region pricing.
- Copy updates are made in the Enable Object Storage modal to match the mocks for enabling via both bucket and key.
- Cleaned up `dcSpecificPricing` feature flag in the Enable OBJ Modal and related tests, since initial DC-specific pricing work has been released, to avoid extra conditional logic. DC-specific pricing behavior is now the default.
- Updated tests and added a new unit test for a new component.

## Preview 📷
| Description | Prod | This Branch |
| ---- | ---- | ---- |
| Enable Object Modal | ![Screenshot 2023-10-18 at 11 26 56 AM](https://github.com/linode/manager/assets/114685994/297cb31e-0412-4f02-a07c-a22007dd292d) ![Screenshot 2023-10-18 at 11 16 30 AM](https://github.com/linode/manager/assets/114685994/acefa512-98bd-465d-af51-a73621a268e5) ![Screenshot 2023-10-18 at 11 17 49 AM](https://github.com/linode/manager/assets/114685994/b47be026-ae63-4165-9c2e-2a90b5685bc5) | ![Screenshot 2023-10-18 at 11 16 54 AM](https://github.com/linode/manager/assets/114685994/483f7362-5cde-4e1f-94d2-9e5a7aec14a5) ![Screenshot 2023-10-18 at 11 17 33 AM](https://github.com/linode/manager/assets/114685994/905097c9-b1d4-4a2c-b161-6ac5d6a6ad9e) |
| Create Bucket Drawer | ![Screenshot 2023-10-18 at 11 14 25 AM](https://github.com/linode/manager/assets/114685994/1f09d949-1322-41fb-aad5-069122935eb5) | ![Screenshot 2023-10-18 at 11 02 18 AM](https://github.com/linode/manager/assets/114685994/25f983a6-1fce-440f-b694-600b8dd2059d) ![Screenshot 2023-10-18 at 11 02 26 AM](https://github.com/linode/manager/assets/114685994/454fc522-836f-4c18-b90b-8d053cb5654d)  ![Screenshot 2023-10-18 at 11 02 34 AM](https://github.com/linode/manager/assets/114685994/ad6ac4bd-53b3-4d7f-9116-68ec0d16cd95)|
| Create Bucket Drawer Tooltip | N/A | ![Screenshot 2023-10-18 at 11 02 44 AM](https://github.com/linode/manager/assets/114685994/80403bcc-0b41-4a3d-93c4-8ce8305519c0) ![Screenshot 2023-10-18 at 11 02 56 AM](https://github.com/linode/manager/assets/114685994/cb574db4-eb76-4498-84ff-0bfd1a3b59c6) ![Screenshot 2023-10-18 at 1 07 51 PM](https://github.com/linode/manager/assets/114685994/4d3f224e-6a99-4444-9ddd-61fb976d4fe0)|

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Check out this PR.
- Turn on the `objDCSpecificPricing` feature flag.
- If Object Storage already enabled, go to /account/settings and cancel it.

### Verification steps 
- With the feature flags on:
   - Confirm that the copy of the modal matches the copy in the screenshots above for each scenario, which matches the mocks attached to the internal ticket.
   - [ ] Create your first access key and enable OBJ.
   - [ ] Create your first bucket and enable OBJ.
   - Confirm that overage pricing displays in the Create Bucket drawer, matches the mocks attached to the internal ticket, and updates dynamically depending on cluster region selection.
   - [ ] Create Bucket in Sao Paulo.
   - [ ] Create Bucket in Jakarta.
   - [ ] Create Bucket in any other region (will use base pricing).

Verify unit tests pass:
```
yarn test EnableObjectStorageModal OveragePricing CreateBucketDrawer
```
Verify Cypress test passes:
```
yarn cy:run -s "cypress/e2e/core/objectStorage/enable-object-storage.spec.ts"
```
   
## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support
