### PR TITLE
fix: [UIE-6961]: Only show regions that support Databases on the Database Create page

### DIFF
--- a/packages/api-v4/src/regions/types.ts
+++ b/packages/api-v4/src/regions/types.ts
@@ -5,6 +5,7 @@ export type Capabilities =
   | 'GPU Linodes'
   | 'Kubernetes'
   | 'Linodes'
+  | 'Managed Databases'
   | 'Metadata'
   | 'NodeBalancers'
   | 'Object Storage'

--- a/packages/manager/.changeset/pr-9815-fixed-1697665414544.md
+++ b/packages/manager/.changeset/pr-9815-fixed-1697665414544.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Only show regions that support Databases on the Database Create page ([#9815](https://github.com/linode/manager/pull/9815))

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -52,6 +52,7 @@ import {
   useDatabaseTypesQuery,
 } from 'src/queries/databases';
 import { useRegionsQuery } from 'src/queries/regions';
+import { regionsWithFeature } from 'src/utilities/doesRegionSupportFeature';
 import { formatStorageUnits } from 'src/utilities/formatStorageUnits';
 import { handleAPIErrors } from 'src/utilities/formikErrorUtils';
 import getSelectedOptionFromGroupedOptions from 'src/utilities/getSelectedOptionFromGroupedOptions';
@@ -200,6 +201,11 @@ const DatabaseCreate = () => {
     error: regionsError,
     isLoading: regionsLoading,
   } = useRegionsQuery();
+
+  const regionsThatSupportDbaas = regionsWithFeature(
+    regionsData ?? [],
+    'Managed Databases'
+  );
 
   const {
     data: engines,
@@ -502,7 +508,7 @@ const DatabaseCreate = () => {
               setFieldValue('region', selected)
             }
             errorText={errors.region}
-            regions={regionsData}
+            regions={regionsThatSupportDbaas}
             selectedID={values.region}
           />
           <RegionHelperText mt={1} />


### PR DESCRIPTION
## Description 📝
Filter regions selection on database create by capability to prevent user selecting a region that doesn't support dbaas.

## Changes  🔄
- Add capability "Managed Databases" to list of capabilities
- Filter the regions by the "Managed Databases" capability.

## How to test 🧪

### Verification steps 
- Go to create a database and verify Chennai and Osaka are not listed in the regions selection

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
