### PR TITLE
test: [M3-7124] - Add Cypress integration tests for VPC assign/unassign flows

### DIFF
--- a/packages/manager/.changeset/pr-9818-added-1699024035326.md
+++ b/packages/manager/.changeset/pr-9818-added-1699024035326.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Add integration tests for VPC assign/unassign flows ([#9818](https://github.com/linode/manager/pull/9818))

--- a/packages/manager/cypress/e2e/core/volumes/attach-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/attach-volume.spec.ts
@@ -11,7 +11,7 @@ import {
 import { randomLabel, randomString } from 'support/util/random';
 import { ui } from 'support/ui';
 import { chooseRegion } from 'support/util/regions';
-import { interceptGetLinodeConfigs } from 'support/intercepts/linodes';
+import { interceptGetLinodeConfigs } from 'support/intercepts/configs';
 import { cleanUp } from 'support/util/cleanup';
 
 // Local storage override to force volume table to list up to 100 items.

--- a/packages/manager/cypress/e2e/core/vpc/vpc-linodes-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/vpc/vpc-linodes-update.spec.ts
@@ -1,0 +1,331 @@
+/**
+ * @file Integration tests for VPC assign/unassign Linodes flows.
+ */
+
+import {
+  mockAppendFeatureFlags,
+  mockGetFeatureFlagClientstream,
+} from 'support/intercepts/feature-flags';
+import { makeFeatureFlagData } from 'support/util/feature-flags';
+import {
+  mockGetSubnets,
+  mockCreateSubnet,
+  mockGetVPC,
+  mockGetVPCs,
+} from 'support/intercepts/vpc';
+import {
+  subnetFactory,
+  vpcFactory,
+  linodeFactory,
+  linodeConfigFactory,
+  LinodeConfigInterfaceFactoryWithVPC,
+} from '@src/factories';
+import { ui } from 'support/ui';
+import { randomNumber, randomLabel } from 'support/util/random';
+import { mockGetLinodes } from 'support/intercepts/linodes';
+import {
+  mockCreateLinodeConfigInterfaces,
+  mockGetLinodeConfigs,
+  mockDeleteLinodeConfignInterface,
+} from 'support/intercepts/configs';
+import {
+  vpcAssignLinodeRebootNotice,
+  vpcUnassignLinodeRebootNotice,
+} from 'support/constants/vpc';
+import { VPC, Linode, Config } from '@linode/api-v4/types';
+
+describe('VPC assign/unassign flows', () => {
+  let mockVPCs: VPC[];
+  let mockLinode: Linode;
+  let mockConfig: Config;
+
+  before(() => {
+    mockVPCs = vpcFactory.buildList(5);
+
+    mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+    });
+
+    mockConfig = linodeConfigFactory.build({
+      id: randomNumber(),
+    });
+  });
+
+  /*
+   * - Confirms that can assign a Linode to the VPC when feature is enabled.
+   */
+  it('can assign Linode(s) to a VPC', () => {
+    const mockSubnet = subnetFactory.build({
+      id: randomNumber(2),
+      label: randomLabel(),
+    });
+
+    const mockVPC = vpcFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+    });
+
+    const mockVPCAfterSubnetCreation = vpcFactory.build({
+      ...mockVPC,
+      subnets: [mockSubnet],
+    });
+
+    const mockSubnetAfterLinodeAssignment = subnetFactory.build({
+      ...mockSubnet,
+      linodes: [mockLinode],
+    });
+
+    const mockVPCAfterLinodeAssignment = vpcFactory.build({
+      ...mockVPCAfterSubnetCreation,
+      subnets: [mockSubnetAfterLinodeAssignment],
+    });
+
+    mockAppendFeatureFlags({
+      vpc: makeFeatureFlagData(true),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+    mockGetVPCs(mockVPCs).as('getVPCs');
+    mockGetVPC(mockVPC).as('getVPC');
+    mockGetSubnets(mockVPC.id, []).as('getSubnets');
+    mockCreateSubnet(mockVPC.id).as('createSubnet');
+
+    cy.visitWithLogin(`/vpcs/${mockVPC.id}`);
+    cy.wait(['@getFeatureFlags', '@getClientStream', '@getVPC', '@getSubnets']);
+
+    // confirm that vpc and subnet details get displayed
+    cy.findByText(mockVPC.label).should('be.visible');
+    cy.findByText('Subnets (0)');
+    cy.findByText('No Subnets are assigned.');
+
+    ui.button.findByTitle('Create Subnet').should('be.visible').click();
+
+    mockGetVPC(mockVPCAfterSubnetCreation).as('getVPC');
+    mockGetSubnets(mockVPC.id, [mockSubnet]).as('getSubnets');
+
+    ui.drawer
+      .findByTitle('Create Subnet')
+      .should('be.visible')
+      .within(() => {
+        cy.findByText('Subnet Label')
+          .should('be.visible')
+          .click()
+          .type(mockSubnet.label);
+
+        cy.findByTestId('create-subnet-drawer-button')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    cy.wait(['@createSubnet', '@getVPC', '@getSubnets']);
+
+    // confirm that newly created subnet should now appear on VPC's detail page
+    cy.findByText(mockVPC.label).should('be.visible');
+    cy.findByText('Subnets (1)').should('be.visible');
+    cy.findByText(mockSubnet.label).should('be.visible');
+
+    // assign a linode to the subnet
+    ui.actionMenu
+      .findByTitle(`Action menu for Subnet ${mockSubnet.label}`)
+      .should('be.visible')
+      .click();
+
+    mockGetLinodes([mockLinode]).as('getLinodes');
+    ui.actionMenuItem
+      .findByTitle('Assign Linodes')
+      .should('be.visible')
+      .click();
+    cy.wait('@getLinodes');
+
+    ui.drawer
+      .findByTitle(`Assign Linodes to subnet: ${mockSubnet.label} (0.0.0.0/0)`)
+      .should('be.visible')
+      .within(() => {
+        // confirm that the user is warned that a reboot is required
+        cy.findByText(vpcAssignLinodeRebootNotice).should('be.visible');
+
+        ui.button
+          .findByTitle('Assign Linode')
+          .should('be.visible')
+          .should('be.disabled');
+
+        mockGetLinodeConfigs(mockLinode.id, [mockConfig]).as(
+          'getLinodeConfigs'
+        );
+        cy.findByText('Linodes')
+          .should('be.visible')
+          .click()
+          .type(mockLinode.label);
+        cy.findByRole('presentation').should('be.visible').click();
+        cy.wait('@getLinodeConfigs');
+
+        mockCreateLinodeConfigInterfaces(mockLinode.id, mockConfig).as(
+          'createLinodeConfigInterfaces'
+        );
+        mockGetVPC(mockVPCAfterLinodeAssignment).as('getVPCLinodeAssignment');
+        mockGetSubnets(mockVPC.id, [mockSubnetAfterLinodeAssignment]).as(
+          'getSubnetsLinodeAssignment'
+        );
+        ui.button
+          .findByTitle('Assign Linode')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+        cy.wait([
+          '@createLinodeConfigInterfaces',
+          '@getVPCLinodeAssignment',
+          '@getSubnetsLinodeAssignment',
+        ]);
+
+        ui.button
+          .findByTitle('Done')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    cy.get('[aria-label="View Details"]')
+      .closest('tbody')
+      .within(() => {
+        // after assigning Linode(s) to a VPC, VPC page increases number in 'Linodes' column
+        cy.findByText('1').should('be.visible');
+      });
+  });
+
+  /*
+   * - Confirms that can unassign a Linode from the VPC when feature is enabled.
+   */
+  it('can unassign Linode(s) from a VPC', () => {
+    const mockSecondLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+    });
+
+    const mockSubnet = subnetFactory.build({
+      id: randomNumber(2),
+      label: randomLabel(),
+      linodes: [mockLinode, mockSecondLinode],
+    });
+
+    const mockVPC = vpcFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      subnets: [mockSubnet],
+    });
+
+    const mockLinodeConfig = linodeConfigFactory.build({
+      interfaces: [
+        LinodeConfigInterfaceFactoryWithVPC.build({
+          vpc_id: mockVPC.id,
+          subnet_id: mockSubnet.id,
+        }),
+      ],
+    });
+
+    mockAppendFeatureFlags({
+      vpc: makeFeatureFlagData(true),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+    mockGetVPCs(mockVPCs).as('getVPCs');
+    mockGetVPC(mockVPC).as('getVPC');
+    mockGetSubnets(mockVPC.id, [mockSubnet]).as('getSubnets');
+
+    cy.visitWithLogin(`/vpcs/${mockVPC.id}`);
+    cy.wait(['@getFeatureFlags', '@getClientStream', '@getVPC', '@getSubnets']);
+
+    // confirm that subnet should get displayed on VPC's detail page
+    cy.findByText(mockVPC.label).should('be.visible');
+    cy.findByText('Subnets (1)').should('be.visible');
+    cy.findByText(mockSubnet.label).should('be.visible');
+
+    // unassign a linode to the subnet
+    ui.actionMenu
+      .findByTitle(`Action menu for Subnet ${mockSubnet.label}`)
+      .should('be.visible')
+      .click();
+
+    mockGetLinodes([mockLinode, mockSecondLinode]).as('getLinodes');
+    ui.actionMenuItem
+      .findByTitle('Unassign Linodes')
+      .should('be.visible')
+      .click();
+    cy.wait('@getLinodes');
+
+    ui.drawer
+      .findByTitle(
+        `Unassign Linodes from subnet: ${mockSubnet.label} (0.0.0.0/0)`
+      )
+      .should('be.visible')
+      .within(() => {
+        // confirm that the user is warned that a reboot is required
+        cy.findByText(vpcUnassignLinodeRebootNotice).should('be.visible');
+
+        ui.button
+          .findByTitle('Unassign Linodes')
+          .should('be.visible')
+          .should('be.disabled');
+
+        // confirm that unassign a single Linode from the VPC correctly
+        mockGetLinodeConfigs(mockLinode.id, [mockLinodeConfig]).as(
+          'getLinodeConfigs'
+        );
+        cy.findByText('Linodes')
+          .should('be.visible')
+          .click()
+          .type(mockLinode.label);
+        cy.findByRole('presentation').should('be.visible').click();
+        cy.wait('@getLinodeConfigs');
+
+        // the select option won't disappear unless click on somewhere else
+        cy.findByText(vpcUnassignLinodeRebootNotice).click();
+        // confirm that unassigned Linode(s) are displayed on the details page
+        cy.findByText('Linodes to be Unassigned from Subnet (1)').should(
+          'be.visible'
+        );
+        cy.findByText(mockLinode.label).should('be.visible');
+
+        // confirm that unassign multiple Linodes from the VPC correctly
+        mockGetLinodeConfigs(mockSecondLinode.id, [mockLinodeConfig]).as(
+          'getLinodeConfigs'
+        );
+        cy.findByText('Linodes')
+          .should('be.visible')
+          .click()
+          .type(mockSecondLinode.label);
+        cy.findByText(mockSecondLinode.label).should('be.visible').click();
+        cy.wait('@getLinodeConfigs');
+
+        // confirm that unassigned Linode(s) are displayed on the details page
+        cy.findByText(vpcUnassignLinodeRebootNotice).click();
+        cy.findByText('Linodes to be Unassigned from Subnet (2)').should(
+          'be.visible'
+        );
+        cy.findByText(mockSecondLinode.label).should('be.visible');
+
+        mockDeleteLinodeConfignInterface(
+          mockLinode.id,
+          mockLinodeConfig.id,
+          mockLinodeConfig.interfaces[0].id
+        ).as('deleteLinodeConfigInterface1');
+        mockDeleteLinodeConfignInterface(
+          mockSecondLinode.id,
+          mockLinodeConfig.id,
+          mockLinodeConfig.interfaces[0].id
+        ).as('deleteLinodeConfigInterface2');
+        ui.button
+          .findByTitle('Unassign Linodes')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+
+        // Confirm that click on 'Unassign Linodes' button will send request to update the subnet details on the VPC page.
+        cy.wait('@deleteLinodeConfigInterface1')
+          .its('response.statusCode')
+          .should('eq', 200);
+        cy.wait('@deleteLinodeConfigInterface2')
+          .its('response.statusCode')
+          .should('eq', 200);
+      });
+  });
+});

--- a/packages/manager/cypress/e2e/core/vpc/vpc-linodes-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/vpc/vpc-linodes-update.spec.ts
@@ -26,7 +26,7 @@ import { mockGetLinodes } from 'support/intercepts/linodes';
 import {
   mockCreateLinodeConfigInterfaces,
   mockGetLinodeConfigs,
-  mockDeleteLinodeConfignInterface,
+  mockDeleteLinodeConfigInterface,
 } from 'support/intercepts/configs';
 import {
   vpcAssignLinodeRebootNotice,
@@ -303,12 +303,12 @@ describe('VPC assign/unassign flows', () => {
         );
         cy.findByText(mockSecondLinode.label).should('be.visible');
 
-        mockDeleteLinodeConfignInterface(
+        mockDeleteLinodeConfigInterface(
           mockLinode.id,
           mockLinodeConfig.id,
           mockLinodeConfig.interfaces[0].id
         ).as('deleteLinodeConfigInterface1');
-        mockDeleteLinodeConfignInterface(
+        mockDeleteLinodeConfigInterface(
           mockSecondLinode.id,
           mockLinodeConfig.id,
           mockLinodeConfig.interfaces[0].id

--- a/packages/manager/cypress/support/constants/vpc.ts
+++ b/packages/manager/cypress/support/constants/vpc.ts
@@ -1,0 +1,7 @@
+/** Notice shown to users trying to assign a linode to a VPC. */
+export const vpcAssignLinodeRebootNotice =
+  'Assigning a Linode to a subnet requires you to reboot the Linode to update its configuration.';
+
+/** Notice shown to users trying to unassign a linode from a VPC. */
+export const vpcUnassignLinodeRebootNotice =
+  'Unassigning Linodes from a subnet requires you to reboot the Linodes to update its configuration.';

--- a/packages/manager/cypress/support/intercepts/configs.ts
+++ b/packages/manager/cypress/support/intercepts/configs.ts
@@ -3,12 +3,14 @@
  */
 
 import { apiMatcher } from 'support/util/intercepts';
+import { paginateResponse } from 'support/util/paginate';
+import { Config } from '@linode/api-v4/types';
+import { makeResponse } from 'support/util/response';
 
 /**
  * Intercepts GET request to fetch all configs for a given linode.
  *
  * @param linodeId - ID of Linode for intercepted request.
- * @param configId - ID of Linode config for intercepted request.
  *
  * @returns Cypress chainable.
  */
@@ -17,7 +19,7 @@ export const interceptGetLinodeConfigs = (
 ): Cypress.Chainable<null> => {
   return cy.intercept(
     'GET',
-    apiMatcher(`linode/instances/${linodeId}/configs`)
+    apiMatcher(`linode/instances/${linodeId}/configs*`)
   );
 };
 
@@ -70,5 +72,66 @@ export const interceptDeleteLinodeConfig = (
   return cy.intercept(
     'DELETE',
     apiMatcher(`linode/instances/${linodeId}/configs/${configId}`)
+  );
+};
+
+/**
+ * Mocks DELETE request to delete an interface of linode config.
+ *
+ * @param linodeId - ID of Linode for intercepted request.
+ * @param configId - ID of Linode config for intercepted request.
+ * @param interfaceId - ID of Interface in the Linode config.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockDeleteLinodeConfigInterface = (
+  linodeId: number,
+  configId: number,
+  interfaceId: number
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'DELETE',
+    apiMatcher(
+      `linode/instances/${linodeId}/configs/${configId}/interfaces/${interfaceId}`
+    ),
+    makeResponse()
+  );
+};
+
+/**
+ * Mocks GET request to retrieve Linode configs.
+ *
+ * @param linodeId - ID of Linode for mocked request.
+ * @param configs - a list of Linode configswith which to mocked response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetLinodeConfigs = (
+  linodeId: number,
+  configs: Config[]
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher(`linode/instances/${linodeId}/configs*`),
+    paginateResponse(configs)
+  );
+};
+
+/**
+ * Mocks POST request to retrieve interfaces from a given Linode config.
+ *
+ * @param linodeId - ID of Linode for mocked request.
+ * @param config - config data with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockCreateLinodeConfigInterfaces = (
+  linodeId: number,
+  config: Config
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`linode/instances/${linodeId}/configs/${config.id}/interfaces`),
+    config.interfaces
   );
 };

--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -83,22 +83,6 @@ export const interceptGetLinodeDetails = (
 };
 
 /**
- * Intercepts GET request to retrieve Linode configs.
- *
- * @param linodeId - ID of Linode for intercepted request.
- *
- * @returns Cypress chainable.
- */
-export const interceptGetLinodeConfigs = (
-  linodeId: number
-): Cypress.Chainable<null> => {
-  return cy.intercept(
-    'GET',
-    apiMatcher(`linode/instances/${linodeId}/configs*`)
-  );
-};
-
-/**
  * Intercepts GET request to retrieve Linode details and mocks response.
  *
  * @param linodeId - ID of Linode for intercepted request.


### PR DESCRIPTION
## Description 📝
Add new cypress tests for VPC assign/unassign flows.

## Major Changes 🔄
- Add e2e tests to verify assigning/unassigning Linode(s) to/from a VPC.

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/vpc/vpc-linodes-update.spec.ts"
```

## Known Issues
1. When there are multiple Linodes in the select list, users type the label to select one of them, then it will deselect all when users type another label and select it.
1. When users click the `Unassign Linode`  button, it doesn’t send any request to tell the VPC to unassign Linodes.