### PR TITLE
test: Fix Database Create e2e test region selection

### DIFF
--- a/packages/manager/cypress/support/constants/databases.ts
+++ b/packages/manager/cypress/support/constants/databases.ts
@@ -61,7 +61,7 @@ export const databaseConfigurations: databaseClusterConfiguration[] = [
     engine: 'MySQL',
     label: randomLabel(),
     linodeType: 'g6-nanode-1',
-    region: chooseRegion(),
+    region: chooseRegion({ capability: 'Managed Databases' }),
     version: '8',
   },
   {
@@ -70,7 +70,7 @@ export const databaseConfigurations: databaseClusterConfiguration[] = [
     engine: 'MySQL',
     label: randomLabel(),
     linodeType: 'g6-dedicated-16',
-    region: chooseRegion(),
+    region: chooseRegion({ capability: 'Managed Databases' }),
     version: '5',
   },
   // {
@@ -89,7 +89,7 @@ export const databaseConfigurations: databaseClusterConfiguration[] = [
     engine: 'PostgreSQL',
     label: randomLabel(),
     linodeType: 'g6-nanode-1',
-    region: chooseRegion(),
+    region: chooseRegion({ capability: 'Managed Databases' }),
     version: '13',
   },
 ];

--- a/packages/manager/cypress/support/util/regions.ts
+++ b/packages/manager/cypress/support/util/regions.ts
@@ -1,6 +1,6 @@
 import { randomItem } from 'support/util/random';
 
-import type { Region } from '@linode/api-v4';
+import type { Capabilities, Region } from '@linode/api-v4';
 
 /**
  * Returns an object describing a Cloud Manager region if specified by the user.
@@ -76,6 +76,14 @@ export const getRegionByLabel = (label: string) => {
   return region;
 };
 
+interface ChooseRegionOptions {
+  /**
+   * If specified, the region returned will support the defined capability
+   * @example 'Managed Databases'
+   */
+  capability?: Capabilities;
+}
+
 /**
  * Returns a known Cloud Manager region at random, or returns a user-chosen
  * region if one was specified.
@@ -86,9 +94,22 @@ export const getRegionByLabel = (label: string) => {
  *
  * @returns Object describing a Cloud Manager region to use during tests.
  */
-export const chooseRegion = (): Region => {
+export const chooseRegion = (options?: ChooseRegionOptions): Region => {
   const overrideRegion = getOverrideRegion();
-  return overrideRegion ? overrideRegion : randomItem(regions);
+
+  if (overrideRegion) {
+    return overrideRegion;
+  }
+
+  if (options?.capability) {
+    const regionsWithCapability = regions.filter((region) =>
+      region.capabilities.includes(options.capability!)
+    );
+
+    return randomItem(regionsWithCapability);
+  }
+
+  return randomItem(regions);
 };
 
 /**


### PR DESCRIPTION
## Description 📝
- Fixes Database Create e2e test now that we filter out some regions in the Database Create Region select
  -  https://github.com/linode/manager/pull/9815
- The fix involves filtering out regions that do not support `Managed Databases` when choosing a region at random
 
## Changes  🔄
- Adds `options` to the `chooseRegion` function

## Preview 📷

![Screenshot 2023-10-19 at 11 58 17 AM](https://github.com/linode/manager/assets/115251059/84c58ada-b268-4f43-903c-7782acef3444)

## How to test 🧪

### Prerequisites
- Verify you have `MANAGER_OAUTH` setup in your `packages/manager/.env`

### Reproduction steps


### Verification steps 
- `yarn cy:debug`
- Run the `create-database.spec.ts` test
- Verify the test passes
- Check CI e2e run for relevant failures

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support