### PR TITLE
test: [M3-7189] - Add assertions for backup prices in Linode Create flow

### DIFF
--- a/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
@@ -134,6 +134,7 @@ describe('create linode', () => {
    * - Confirms DC-specific pricing UI flow works as expected during Linode creation.
    * - Confirms that pricing notice is shown in "Region" section.
    * - Confirms that notice is shown when selecting a region with a different price structure.
+   * - Confirms that backups pricing is correct when selecting a region with a different price structure.
    */
   it('shows DC-specific pricing information during create flow', () => {
     const rootpass = randomString(32);


### PR DESCRIPTION
## Description 📝
Add new cypress assertions for backup prices in Linode create flow.

## Major Changes 🔄
- Add new cypress assertions to check backup prices when creating a Linode.

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/linodes/create-linode.spec.ts"
```
