### PR TITLE
fix: [M3-7298] - Improve Footer Styles

### DIFF
--- a/packages/manager/.changeset/pr-9823-fixed-1697820563300.md
+++ b/packages/manager/.changeset/pr-9823-fixed-1697820563300.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Footer styles on small viewports ([#9823](https://github.com/linode/manager/pull/9823))

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -18,7 +18,7 @@ import withGlobalErrors, {
   Props as GlobalErrorProps,
 } from 'src/containers/globalErrors.container';
 import { useDialogContext } from 'src/context/useDialogContext';
-import { Footer } from 'src/features/Footer/Footer';
+import { Footer } from 'src/features/Footer';
 import { GlobalNotifications } from 'src/features/GlobalNotifications/GlobalNotifications';
 import {
   notificationContext,
@@ -155,7 +155,9 @@ const LoadBalancers = React.lazy(() => import('src/features/LoadBalancers'));
 const NodeBalancers = React.lazy(
   () => import('src/features/NodeBalancers/NodeBalancers')
 );
-const StackScripts = React.lazy(() => import('src/features/StackScripts/StackScripts'));
+const StackScripts = React.lazy(
+  () => import('src/features/StackScripts/StackScripts')
+);
 const SupportTickets = React.lazy(
   () => import('src/features/Support/SupportTickets')
 );

--- a/packages/manager/src/components/SideMenu.tsx
+++ b/packages/manager/src/components/SideMenu.tsx
@@ -7,6 +7,7 @@ import { Hidden } from 'src/components/Hidden';
 import PrimaryNav from './PrimaryNav/PrimaryNav';
 
 export const SIDEBAR_WIDTH = 190;
+export const SIDEBAR_COLLAPSED_WIDTH = 52;
 
 export interface Props {
   closeMenu: () => void;
@@ -70,7 +71,7 @@ const StyledDrawer = styled(Drawer, {
         [theme.breakpoints.up('sm')]: {
           overflowY: 'hidden',
         },
-        width: '52px',
+        width: `${SIDEBAR_COLLAPSED_WIDTH}px`,
       },
       '&.MuiDrawer-docked': {
         height: '100%',

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -255,3 +255,7 @@ export const ACCESS_LEVELS = {
 
 // Linode Community URL accessible from the TopMenu Community icon
 export const LINODE_COMMUNITY_URL = 'https://linode.com/community';
+
+export const FEEDBACK_LINK = 'https://www.linode.com/feedback/';
+
+export const DEVELOPERS_LINK = 'https://developers.linode.com';

--- a/packages/manager/src/features/Footer.tsx
+++ b/packages/manager/src/features/Footer.tsx
@@ -6,14 +6,13 @@ import {
   SIDEBAR_COLLAPSED_WIDTH,
   SIDEBAR_WIDTH,
 } from 'src/components/SideMenu';
+import { DEVELOPERS_LINK, FEEDBACK_LINK } from 'src/constants';
 
 import packageJson from '../../package.json';
 
 interface Props {
   desktopMenuIsOpen: boolean;
 }
-
-const FEEDBACK_LINK = 'https://www.linode.com/feedback/';
 
 export const Footer = React.memo((props: Props) => {
   const { desktopMenuIsOpen } = props;
@@ -31,7 +30,7 @@ export const Footer = React.memo((props: Props) => {
             xs: 2,
           },
           paddingY: theme.spacing(2.5),
-          transition: 'all .1s linear', // match the sidebar transition speed
+          transition: 'padding-left .1s linear', // match the sidebar transition speed
         })}
         direction={{ sm: 'row', xs: 'column' }}
         spacing={{ sm: 4, xs: 1 }}
@@ -42,7 +41,7 @@ export const Footer = React.memo((props: Props) => {
         >
           v{packageJson.version}
         </Link>
-        <Link forceCopyColor to="https://developers.linode.com">
+        <Link forceCopyColor to={DEVELOPERS_LINK}>
           API Reference
         </Link>
         <Link forceCopyColor to={FEEDBACK_LINK}>

--- a/packages/manager/src/features/Footer.tsx
+++ b/packages/manager/src/features/Footer.tsx
@@ -7,7 +7,7 @@ import {
   SIDEBAR_WIDTH,
 } from 'src/components/SideMenu';
 
-import packageJson from '../../../package.json';
+import packageJson from '../../package.json';
 
 interface Props {
   desktopMenuIsOpen: boolean;

--- a/packages/manager/src/features/Footer/Footer.tsx
+++ b/packages/manager/src/features/Footer/Footer.tsx
@@ -1,9 +1,11 @@
-import Grid from '@mui/material/Unstable_Grid2';
-import { Theme } from '@mui/material/styles';
+import Stack from '@mui/material/Stack';
 import * as React from 'react';
-import { makeStyles } from 'tss-react/mui';
 
 import { Link } from 'src/components/Link';
+import {
+  SIDEBAR_COLLAPSED_WIDTH,
+  SIDEBAR_WIDTH,
+} from 'src/components/SideMenu';
 
 import packageJson from '../../../package.json';
 
@@ -11,118 +13,42 @@ interface Props {
   desktopMenuIsOpen: boolean;
 }
 
-const useStyles = makeStyles()((theme: Theme) => ({
-  container: {
-    backgroundColor: theme.bg.main,
-    fontSize: '1rem',
-    margin: 0,
-    padding: '4px 0px',
-    [theme.breakpoints.down('sm')]: {
-      alignItems: 'flex-start',
-      flexDirection: 'column',
-    },
-    [theme.breakpoints.up('md')]: {
-      paddingLeft: 200,
-    },
-    width: '100%',
-  },
-  desktopMenuIsOpen: {
-    paddingLeft: 0,
-    [theme.breakpoints.up('md')]: {
-      paddingLeft: 52,
-    },
-  },
-  feedbackLink: {
-    [theme.breakpoints.down('sm')]: {
-      marginBottom: theme.spacing(1),
-    },
-    [theme.breakpoints.up('xs')]: {
-      '&.MuiGrid-item': {
-        paddingRight: 0,
-      },
-    },
-  },
-  link: {
-    fontSize: '90%',
-    [theme.breakpoints.down('lg')]: {
-      marginRight: theme.spacing(1),
-    },
-  },
-  linkContainer: {
-    [theme.breakpoints.down('sm')]: {
-      padding: '0 8px !important',
-    },
-  },
-  version: {
-    '&.MuiGrid-item': {
-      paddingLeft: 0,
-    },
-    [theme.breakpoints.down('md')]: {
-      marginLeft: theme.spacing(),
-    },
-  },
-}));
-
 const FEEDBACK_LINK = 'https://www.linode.com/feedback/';
 
 export const Footer = React.memo((props: Props) => {
-  const { classes, cx } = useStyles();
-
   const { desktopMenuIsOpen } = props;
 
   return (
     <footer role="contentinfo">
-      <Grid
-        className={cx({
-          [classes.container]: true,
-          [classes.desktopMenuIsOpen]: desktopMenuIsOpen,
+      <Stack
+        sx={(theme) => ({
+          backgroundColor: theme.bg.main,
+          paddingLeft: {
+            md: desktopMenuIsOpen
+              ? `${SIDEBAR_COLLAPSED_WIDTH + 16}px`
+              : `${SIDEBAR_WIDTH + 16}px`,
+            sm: 2,
+            xs: 2,
+          },
+          paddingY: theme.spacing(2.5),
+          transition: 'all .1s linear', // match the sidebar transition speed
         })}
-        alignItems="center"
-        container
-        spacing={4}
+        direction={{ sm: 'row', xs: 'column' }}
+        spacing={{ sm: 4, xs: 1 }}
       >
-        <Grid className={classes.version}>{renderVersion(classes.link)}</Grid>
-        <Grid
-          className={cx({
-            [classes.linkContainer]: true,
-          })}
+        <Link
+          forceCopyColor
+          to={`https://github.com/linode/manager/releases/tag/linode-manager@v${packageJson.version}`}
         >
-          <Link
-            className={classes.link}
-            forceCopyColor
-            to="https://developers.linode.com"
-          >
-            API Reference
-          </Link>
-        </Grid>
-        <Grid
-          className={cx({
-            [classes.feedbackLink]: true,
-            [classes.linkContainer]: true,
-          })}
-        >
-          <Link className={classes.link} forceCopyColor to={FEEDBACK_LINK}>
-            Provide Feedback
-          </Link>
-        </Grid>
-      </Grid>
+          v{packageJson.version}
+        </Link>
+        <Link forceCopyColor to="https://developers.linode.com">
+          API Reference
+        </Link>
+        <Link forceCopyColor to={FEEDBACK_LINK}>
+          Provide Feedback
+        </Link>
+      </Stack>
     </footer>
   );
 });
-
-const renderVersion = (className: string) => {
-  const VERSION = packageJson.version;
-  if (!VERSION) {
-    return null;
-  }
-
-  return (
-    <Link
-      className={className}
-      forceCopyColor
-      to={`https://github.com/linode/manager/releases/tag/linode-manager@v${VERSION}`}
-    >
-      v{VERSION}
-    </Link>
-  );
-};


### PR DESCRIPTION
## Description 📝

- Cleans up and fixes our Footer styles 🎨

## Changes  🔄
- Fixes footer for `xs` viewports
- Uses less `Grid`
- Cleans up unnecessarily complex styles 
- Added nice animation

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-10-20 at 12 37 54 PM](https://github.com/linode/manager/assets/115251059/649f2db0-66bb-448e-b9b9-30b75500c31a) | ![Screenshot 2023-10-20 at 12 37 47 PM](https://github.com/linode/manager/assets/115251059/b6846895-f6aa-4cc6-9c43-64a5067d3751) |
| ![Screenshot 2023-10-20 at 12 37 33 PM](https://github.com/linode/manager/assets/115251059/7a606d58-84b1-4c31-8470-c70246d203d6) | ![Screenshot 2023-10-20 at 12 37 20 PM](https://github.com/linode/manager/assets/115251059/d90d7545-ea41-4884-afba-dd644e6da806) |

### New Animation ✨

https://github.com/linode/manager/assets/115251059/7c70cad1-1432-4998-9421-3c7d2322e390

## How to test 🧪

### Reproduction steps
- On mobile viewport sizes, the Cloud Manager version was spaced differently than the other links ⁉️

### Verification steps 
- Check out this PR
- Verify that the footer looks better on mobile viewport sizes
- Verify that the footer looks nearly identical to production on other screen sizes

## As an Author I have considered 🤔

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support