### PR TITLE
change: [M3-7182] - Update RemovableSelectionsList default maximum height to cut off the last list item

### DIFF
--- a/packages/manager/.changeset/pr-9827-upcoming-features-1698091273479.md
+++ b/packages/manager/.changeset/pr-9827-upcoming-features-1698091273479.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update `RemovableSelectionsList` default maximum height to cut off last list item and indicate scrolling ([#9827](https://github.com/linode/manager/pull/9827))

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.style.ts
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.style.ts
@@ -1,0 +1,90 @@
+import { styled } from '@mui/material/styles';
+
+import { Box } from 'src/components/Box';
+import { List } from 'src/components/List';
+import { ListItem } from 'src/components/ListItem';
+import { omittedProps } from 'src/utilities/omittedProps';
+
+import type { RemovableSelectionsListProps } from './RemovableSelectionsList';
+
+export const StyledNoAssignedLinodesBox = styled(Box, {
+  label: 'StyledNoAssignedLinodesBox',
+  shouldForwardProp: omittedProps(['maxWidth']),
+})(({ maxWidth, theme }) => ({
+  background: theme.name === 'light' ? theme.bg.main : theme.bg.app,
+  display: 'flex',
+  flexDirection: 'column',
+  height: '52px',
+  justifyContent: 'center',
+  maxWidth: maxWidth ? `${maxWidth}px` : '416px',
+  paddingLeft: theme.spacing(2),
+  width: '100%',
+}));
+
+export const SelectedOptionsHeader = styled('h4', {
+  label: 'SelectedOptionsHeader',
+})(({ theme }) => ({
+  color: theme.color.headline,
+  fontFamily: theme.font.bold,
+  fontSize: '14px',
+  textTransform: 'initial',
+}));
+
+export const SelectedOptionsList = styled(List, {
+  label: 'SelectedOptionsList',
+  shouldForwardProp: omittedProps(['isRemovable']),
+})<{ isRemovable?: boolean }>(({ isRemovable, theme }) => ({
+  background: theme.name === 'light' ? theme.bg.main : theme.bg.app,
+  padding: !isRemovable ? `${theme.spacing(2)} 0` : '5px 0',
+  width: '100%',
+}));
+
+export const SelectedOptionsListItem = styled(ListItem, {
+  label: 'SelectedOptionsListItem',
+})(() => ({
+  justifyContent: 'space-between',
+  paddingBottom: 0,
+  paddingRight: 4,
+  paddingTop: 0,
+}));
+
+export const StyledLabel = styled('span', { label: 'StyledLabel' })(
+  ({ theme }) => ({
+    color: theme.color.label,
+    fontFamily: theme.font.semiBold,
+    fontSize: '14px',
+  })
+);
+
+type StyledBoxShadowWrapperBoxProps = Pick<
+  RemovableSelectionsListProps,
+  'maxHeight' | 'maxWidth'
+>;
+
+export const StyledBoxShadowWrapper = styled(Box, {
+  label: 'StyledBoxShadowWrapper',
+  shouldForwardProp: omittedProps(['displayShadow']),
+})<{ displayShadow: boolean; maxWidth: number }>(
+  ({ displayShadow, maxWidth, theme }) => ({
+    '&:after': {
+      bottom: 0,
+      content: '""',
+      height: '15px',
+      position: 'absolute',
+      width: '100%',
+      ...(displayShadow && {
+        boxShadow: `${theme.color.boxShadow} 0px -15px 10px -10px inset`,
+      }),
+    },
+    maxWidth: `${maxWidth}px`,
+    position: 'relative',
+  })
+);
+
+export const StyledScrollBox = styled(Box, {
+  label: 'StyledScrollBox',
+})<StyledBoxShadowWrapperBoxProps>(({ maxHeight, maxWidth }) => ({
+  maxHeight: `${maxHeight}px`,
+  maxWidth: `${maxWidth}px`,
+  overflow: 'auto',
+}));

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.test.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.test.tsx
@@ -81,4 +81,12 @@ describe('Removable Selections List', () => {
     fireEvent.click(removeButton);
     expect(props.onRemove).toHaveBeenCalled();
   });
+
+  it('should not display the remove button for a list item', () => {
+    const screen = renderWithTheme(
+      <RemovableSelectionsList {...props} isRemovable={false} />
+    );
+    const removeButton = screen.queryByLabelText(`remove my-linode-1`);
+    expect(removeButton).not.toBeInTheDocument();
+  });
 });

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
@@ -25,6 +25,10 @@ interface Props {
    */
   headerText: string;
   /**
+   * Hides the drop shadow when the list is <= given list size
+   */
+  hideShadowOnListSizeOrLess?: number;
+  /**
    * If false, hide the remove button
    */
   isRemovable?: boolean;
@@ -59,6 +63,9 @@ interface Props {
 export const RemovableSelectionsList = (props: Props) => {
   const {
     headerText,
+    // Defaulting this value to 10: With the default height of 427px, a list of size 10 or
+    // less does not scroll, so it doesn't yet need the drop-shadow to indicate scrollability.
+    hideShadowOnListSizeOrLess = 10,
     isRemovable = true,
     maxHeight,
     maxWidth,
@@ -77,6 +84,10 @@ export const RemovableSelectionsList = (props: Props) => {
       <SelectedOptionsHeader>{headerText}</SelectedOptionsHeader>
       {selectionData.length > 0 ? (
         <SelectedOptionsList
+          hideShadow={
+            hideShadowOnListSizeOrLess !== undefined &&
+            selectionData.length < hideShadowOnListSizeOrLess
+          }
           sx={{
             maxHeight: maxHeight
               ? `${maxHeight}px`
@@ -143,13 +154,18 @@ const SelectedOptionsHeader = styled('h4', {
 
 const SelectedOptionsList = styled(List, {
   label: 'SelectedOptionsList',
-  shouldForwardProp: omittedProps(['isRemovable']),
-})<{ isRemovable?: boolean }>(({ isRemovable, theme }) => ({
-  background: theme.name === 'light' ? theme.bg.main : theme.bg.app,
-  overflow: 'auto',
-  padding: !isRemovable ? '16px 0' : '5px 0',
-  width: '100%',
-}));
+  shouldForwardProp: omittedProps(['hideShadowOnListSize', 'isRemovable']),
+})<{ hideShadow?: boolean; isRemovable?: boolean }>(
+  ({ hideShadow, isRemovable, theme }) => ({
+    background: theme.name === 'light' ? theme.bg.main : theme.bg.app,
+    overflow: 'auto',
+    padding: !isRemovable ? '16px 0' : '5px 0',
+    width: '100%',
+    ...(!hideShadow && {
+      boxShadow: `${theme.color.boxShadow} 0px -15px 10px -10px inset`,
+    }),
+  })
+);
 
 const SelectedOptionsListItem = styled(ListItem, {
   label: 'SelectedOptionsListItem',

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
@@ -8,6 +8,9 @@ import { List } from 'src/components/List';
 import { ListItem } from 'src/components/ListItem';
 import { omittedProps } from 'src/utilities/omittedProps';
 
+const DEFAULT_LIST_HEIGHT = 427;
+const DEFAULT_LIST_WIDTH = 416;
+
 export type RemovableItem = {
   id: number;
   label: string;
@@ -75,8 +78,10 @@ export const RemovableSelectionsList = (props: Props) => {
       {selectionData.length > 0 ? (
         <SelectedOptionsList
           sx={{
-            maxHeight: maxHeight ? `${maxHeight}px` : '450px',
-            maxWidth: maxWidth ? `${maxWidth}px` : '416px',
+            maxHeight: maxHeight
+              ? `${maxHeight}px`
+              : `${DEFAULT_LIST_HEIGHT}px`,
+            maxWidth: maxWidth ? `${maxWidth}px` : `${DEFAULT_LIST_WIDTH}px`,
           }}
           isRemovable={isRemovable}
         >

--- a/packages/manager/src/features/Linodes/LinodesCreate/SelectAppPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/SelectAppPanel.tsx
@@ -182,7 +182,6 @@ class SelectAppPanel extends React.PureComponent<Props> {
 }
 
 const commonStyling = (theme: Theme) => ({
-  boxShadow: `${theme.color.boxShadow} 0px -15px 10px -10px inset`,
   height: 450,
   marginBottom: theme.spacing(3),
   overflowY: 'auto' as const,

--- a/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -233,22 +233,24 @@ export class FromAppsContent extends React.Component<CombinedProps, State> {
               </StyledFilterBox>
             </StyledSearchFilterBox>
           </Paper>
-          <SelectAppPanel
-            appInstances={
-              isSearching || isFiltering ? filteredApps : appInstances
-            }
-            appInstancesError={appInstancesError}
-            appInstancesLoading={appInstancesLoading}
-            disabled={userCannotCreateLinode}
-            error={hasErrorFor('stackscript_id')}
-            flags={flags}
-            handleClick={handleSelectStackScript}
-            isFiltering={isFiltering}
-            isSearching={isSearching}
-            openDrawer={this.openDrawer}
-            searchValue={query}
-            selectedStackScriptID={selectedStackScriptID}
-          />
+          <StyledBoxShadowWrapper>
+            <SelectAppPanel
+              appInstances={
+                isSearching || isFiltering ? filteredApps : appInstances
+              }
+              appInstancesError={appInstancesError}
+              appInstancesLoading={appInstancesLoading}
+              disabled={userCannotCreateLinode}
+              error={hasErrorFor('stackscript_id')}
+              flags={flags}
+              handleClick={handleSelectStackScript}
+              isFiltering={isFiltering}
+              isSearching={isSearching}
+              openDrawer={this.openDrawer}
+              searchValue={query}
+              selectedStackScriptID={selectedStackScriptID}
+            />
+          </StyledBoxShadowWrapper>
           {!userCannotCreateLinode && selectedStackScriptLabel ? (
             <UserDefinedFieldsPanel
               updateFor={[
@@ -415,3 +417,18 @@ const StyledSearchBox = styled(Box, { label: 'StyledSearchBox' })({
   },
   flexGrow: 10,
 });
+
+const StyledBoxShadowWrapper = styled('div', {
+  label: 'StyledBoxShadowWrapper',
+})(({ theme }) => ({
+  '&:after': {
+    content: '""',
+    width: '100%',
+    height: '15px',
+    boxShadow: `${theme.color.boxShadow} 0px -15px 10px -10px inset`,
+    position: 'absolute',
+    bottom: 0,
+  },
+  position: 'relative',
+  //marginBottom: theme.spacing(3),
+}));

--- a/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -422,13 +422,12 @@ const StyledBoxShadowWrapper = styled('div', {
   label: 'StyledBoxShadowWrapper',
 })(({ theme }) => ({
   '&:after': {
-    content: '""',
-    width: '100%',
-    height: '15px',
-    boxShadow: `${theme.color.boxShadow} 0px -15px 10px -10px inset`,
-    position: 'absolute',
     bottom: 0,
+    boxShadow: `${theme.color.boxShadow} 0px -15px 10px -10px inset`,
+    content: '""',
+    height: '15px',
+    position: 'absolute',
+    width: '100%',
   },
   position: 'relative',
-  //marginBottom: theme.spacing(3),
 }));


### PR DESCRIPTION
## Description 📝
- Add dropshadow and update maxHeight to list to indicate scrolling is necessary
- Fix dropshadow UI bug on Safari for market place apps

#### some background
- See [this comment here](https://github.com/linode/manager/pull/9687#discussion_r1335967787) for some background behind this issue

## Preview 📷

| Before  | After   |
| ------- | ------- |
|![image](https://github.com/linode/manager/assets/139280159/07e30b69-fdc1-4147-b6d6-c2915fb9d132) |![image](https://github.com/linode/manager/assets/139280159/396d723d-0e20-4f34-9dec-9768daa8fed7) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- checkout this branch
- yarn storybook --> RemovableSelectionsList

- Marketplace fix: navigate to the marketplace apps on **safari**

### Verification steps 
- For the removable selections list
  - verify that the default example now cuts off the 11th item in the list. 
  - verify that there is a drop shadow if the list can be scrolled
  - Alternatively, if you want to test this with the SubnetAssignLinodesDrawer, make sure you're on the dev environment with the vpc tags, and you can assign 11+ linodes to a subnet

- for the Marketplace apps, verify that the drop shadow appears above the individual apps (it should now mirror chrome's behavior)

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support

