### PR TITLE
test: [DBASS1-574] - Adding test coverage for disk metrics added to UI.

### DIFF
--- a/packages/manager/.changeset/pr-9833-tests-1698335199212.md
+++ b/packages/manager/.changeset/pr-9833-tests-1698335199212.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add DBaaS test coverage for disk metrics ([#9833](https://github.com/linode/manager/pull/9833))

--- a/packages/manager/cypress/e2e/core/databases/update-database.spec.ts
+++ b/packages/manager/cypress/e2e/core/databases/update-database.spec.ts
@@ -186,6 +186,8 @@ describe('Update database clusters', () => {
 
           cy.get('[data-qa-cluster-config]').within(() => {
             cy.findByText(configuration.region.label).should('be.visible');
+            cy.findByText(database.used_disk_size_gb + " GB").should('be.visible');
+            cy.findByText(database.total_disk_size_gb + " GB").should('be.visible');
           });
 
           cy.get('[data-qa-connection-details]').within(() => {

--- a/packages/manager/cypress/e2e/core/notificationsAndEvents/events.spec.ts
+++ b/packages/manager/cypress/e2e/core/notificationsAndEvents/events.spec.ts
@@ -16,6 +16,7 @@ const eventActions: RecPartial<EventAction>[] = [
   'disk_duplicate',
   'disk_resize',
   'disk_update',
+  'database_low_disk_space',
   'entity_transfer_accept',
   'entity_transfer_cancel',
   'entity_transfer_create',


### PR DESCRIPTION
## Description 📝
Add test coverage to check disk metrics parameters.  
Add test coverage for low disk size event.

## Changes  🔄
Add new cypress assertions to check disk metrics parameters "Total disk size" and "Used disk size" added to the UI. 
Add test coverage for low disk size event.
- ...
- ...

## Preview 📷
![Screenshot 2023-10-23 at 6 52 53 PM](https://github.com/linode/manager/assets/136849150/5b1593a9-5f3d-434f-83ff-7d141ec387fa)


## How to test 🧪

yarn cy:run -s "cypress/e2e/core/databases/update-database.spec.ts"

yarn cy:run -s "cypress/e2e/core/notificationsAndEvents/events.spec.ts"

