### PR TITLE
fix: [M3-7285] – Tweak when and where `public` interfaces are included in Linode Create payload

### DIFF
--- a/packages/manager/.changeset/pr-9834-changed-1698111109868.md
+++ b/packages/manager/.changeset/pr-9834-changed-1698111109868.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Logic governing inclusion of public interfaces in Linode Create payload ([#9834](https://github.com/linode/manager/pull/9834))

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
@@ -858,8 +858,11 @@ export class LinodeCreate extends React.PureComponent<
         interfaces.push(defaultPublicInterface);
       }
 
-      // Case 3: VPC and VLAN assigned + Private IP enabled
-      if (vpcAssigned && vlanAssigned && this.props.privateIPEnabled) {
+      /*
+        Case 3: VPC and VLAN assigned (this is inclusive
+        of whether the user enables "Private IP" or not)
+      */
+      if (vpcAssigned && vlanAssigned) {
         interfaces.push(defaultPublicInterface);
       }
 

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
@@ -853,16 +853,13 @@ export class LinodeCreate extends React.PureComponent<
         interfaces.unshift(defaultPublicInterface);
       }
 
-      // Case 2: VPC assigned, no VLAN assigned, "Private IP" enabled
+      // Case 2: VPC assigned, no VLAN assigned, Private IP enabled
       if (!vlanAssigned && this.props.privateIPEnabled) {
         interfaces.push(defaultPublicInterface);
       }
 
-      /*
-        Case 3: VPC and VLAN assigned (this is inclusive
-        of whether the user enables "Private IP" or not)
-      */
-      if (vpcAssigned && vlanAssigned) {
+      // Case 3: VPC and VLAN assigned + Private IP enabled
+      if (vpcAssigned && vlanAssigned && this.props.privateIPEnabled) {
         interfaces.push(defaultPublicInterface);
       }
 


### PR DESCRIPTION
## Description 📝
Based on conversations with a couple of stakeholders (see ticket), it was pointed out that some tweaks needed to be made with regards to when and where `public` interfaces are included in the Linode Create payload based on the various configurations of VPC, VLAN, and Private IP a user might choose in the Create flow.

This PR makes changes so that:

1. VPC assigned (no VLAN) + "Private IP" add-on is selected --> a `public` interface is added into the `interfaces[1]` slot
2. VLAN assigned (no VPC) --> retain existing behavior (`public` interface added in the `interfaces[0]` slot)
3. VPC and VLAN assigned + "Private IP" add-on selected --> a `public` interface is added into the `interfaces[2]` slot

If a VPC is assigned, the VPC interface will always occupy the `interfaces[0]` slot. 

## Changes  🔄
- Tweak when and where `public` interfaces are included in the Linode Create payload

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Account with the appropriate VPC tags
- Point at `dev` environment

### Verification steps 
With your Dev Tools open, check the Network tab for the POST requests to `/instances` when you create a linode with each of these configurations:
- No VPC, no VLAN, no Private IP: the `interfaces` array should not be in the payload
- Just a VLAN: `public` interface in `interfaces[0]`, VLAN interface in `interfaces[1]`
- Just a VPC: VPC interface in `interfaces[0]`
- A VPC + a Private IP: VPC interface in `interfaces[0]`, `public` interface in `interfaces[1]`
- VPC + VLAN + Private IP: VPC interface in `interfaces[0]`, VLAN interface in `interfaces[1]`, `public` interface in `interfaces[2]`

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support