### PR TITLE
fix: [M3-7313] - Migrated Linode dropdown to Autocomplete in Firewall Landing > Create Firewall drawer

### DIFF
--- a/packages/manager/.changeset/pr-9785-fixed-1697059201989.md
+++ b/packages/manager/.changeset/pr-9785-fixed-1697059201989.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Firewall Create Drawer opens in the same tab in the Linode Create Flow ([#9785](https://github.com/linode/manager/pull/9785))
+Firewall Create Drawer opening in a new tab in the Linode Create Flow ([#9785](https://github.com/linode/manager/pull/9785))

--- a/packages/manager/.changeset/pr-9837-fixed-1698172001079.md
+++ b/packages/manager/.changeset/pr-9837-fixed-1698172001079.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Linode dropdown in Create Firewall drawer using LinodeSelect component instead of the Autocomplete component ([#9837](https://github.com/linode/manager/pull/9837))

--- a/packages/manager/src/components/SelectFirewallPanel/SelectFirewallPanel.tsx
+++ b/packages/manager/src/components/SelectFirewallPanel/SelectFirewallPanel.tsx
@@ -78,7 +78,7 @@ export const SelectFirewallPanel = (props: Props) => {
           Create Firewall
         </LinkButton>
         <CreateFirewallDrawer
-          label={createFirewallLabel}
+          inCreateFlow
           onClose={() => setIsDrawerOpen(false)}
           onFirewallCreated={handleFirewallCreated}
           open={isDrawerOpen}

--- a/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
@@ -176,7 +176,7 @@ export const CreateFirewallDrawer = React.memo(
       const readOnlyIds =
         serviceType === 'linode' ? readOnlyLinodeIds : readOnlyNodebalancerIds;
 
-      return ![...readOnlyIds].includes(id);
+      return !readOnlyIds.includes(id);
     };
 
     const nodebalancers = nodebalancerData?.filter((nb) =>

--- a/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
@@ -275,7 +275,6 @@ export const CreateFirewallDrawer = React.memo(
             })}
             disabled={userCannotAddFirewall || !!linodeError}
             errorText={errors['devices.linodes']}
-            helperText={FIREWALL_HELPER_TEXT}
             label={inCreateFlow ? 'Additional Linodes (Optional)' : 'Linodes'}
             loading={linodeIsLoading}
             multiple

--- a/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
@@ -187,16 +187,14 @@ export const CreateFirewallDrawer = React.memo(
       optionsFilter(linode.id, 'linode')
     );
 
-    const linodeIdSet = new Set(values?.devices?.linodes);
-
     const selectedLinodes: Linode[] =
-      linodes?.filter((linode) => linodeIdSet.has(linode.id)) || [];
-
-    const nodebalancerIdSet = new Set(values?.devices?.nodebalancers);
+      linodes?.filter((linode) =>
+        values.devices?.linodes?.includes(linode.id)
+      ) || [];
 
     const selectedNodeBalancers: NodeBalancer[] =
       nodebalancers?.filter((nodebalancer) =>
-        nodebalancerIdSet.has(nodebalancer.id)
+        values.devices?.nodebalancers?.includes(nodebalancer.id)
       ) || [];
 
     // TODO: NBFW - Placeholder until real link is available

--- a/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
@@ -37,7 +37,7 @@ export const READ_ONLY_DEVICES_HIDDEN_MESSAGE =
   'Only services you have permission to modify are shown.';
 
 export interface CreateFirewallDrawerProps {
-  label?: string;
+  inCreateFlow?: boolean;
   onClose: () => void;
   onFirewallCreated?: (firewall: Firewall) => void;
   open: boolean;
@@ -58,7 +58,7 @@ const initialValues: CreateFirewallPayload = {
 export const CreateFirewallDrawer = React.memo(
   (props: CreateFirewallDrawerProps) => {
     // TODO: NBFW - We'll eventually want to check the read_write firewall grant here too, but it doesn't exist yet.
-    const { label, onClose, onFirewallCreated, open } = props;
+    const { inCreateFlow, onClose, onFirewallCreated, open } = props;
     const { _hasGrant, _isRestrictedUser } = useAccountManagement();
     const { data: grants } = useGrants();
     const { mutateAsync } = useCreateFirewall();
@@ -275,7 +275,7 @@ export const CreateFirewallDrawer = React.memo(
             disabled={userCannotAddFirewall || !!linodeError}
             errorText={errors['devices.linodes']}
             helperText={FIREWALL_HELPER_TEXT}
-            label={label ? label : 'Linodes'}
+            label={inCreateFlow ? 'Additional Linodes (Optional)' : 'Linodes'}
             loading={linodeIsLoading}
             multiple
             noMarginTop={false}
@@ -284,6 +284,11 @@ export const CreateFirewallDrawer = React.memo(
             value={selectedLinodes}
           />
           <Autocomplete
+            label={
+              inCreateFlow
+                ? 'Additional NodeBalancers (Optional)'
+                : 'NodeBalancers'
+            }
             onChange={(_, nodebalancers) => {
               setFieldValue(
                 'devices.nodebalancers',
@@ -296,7 +301,6 @@ export const CreateFirewallDrawer = React.memo(
             })}
             disabled={userCannotAddFirewall || !!nodebalancerError}
             errorText={errors['devices.nodebalancers']}
-            label={label ? label : 'NodeBalancers'}
             loading={nodebalancerIsLoading}
             multiple
             noMarginTop={false}

--- a/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
@@ -268,7 +268,6 @@ export const CreateFirewallDrawer = React.memo(
                 'devices.linodes',
                 linodes.map((linode) => linode.id)
               );
-              setSelectedLinodes(linodes);
             }}
             sx={(theme) => ({
               marginTop: theme.spacing(2),

--- a/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
@@ -176,12 +176,7 @@ export const CreateFirewallDrawer = React.memo(
       const readOnlyIds =
         serviceType === 'linode' ? readOnlyLinodeIds : readOnlyNodebalancerIds;
 
-      const selectedIds =
-        serviceType === 'linode'
-          ? values.devices?.nodebalancers || []
-          : values.devices?.linodes || [];
-
-      return ![...readOnlyIds, ...selectedIds].includes(id);
+      return ![...readOnlyIds].includes(id);
     };
 
     const nodebalancers = nodebalancerData?.filter((nb) =>

--- a/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
@@ -136,6 +136,7 @@ export const CreateFirewallDrawer = React.memo(
     React.useEffect(() => {
       if (open) {
         resetForm();
+        setSelectedLinodes([]);
         setSelectedNodeBalancers([]);
       }
     }, [open, resetForm]);

--- a/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
@@ -136,16 +136,8 @@ export const CreateFirewallDrawer = React.memo(
     React.useEffect(() => {
       if (open) {
         resetForm();
-        setSelectedLinodes([]);
-        setSelectedNodeBalancers([]);
       }
     }, [open, resetForm]);
-
-    const [selectedNodeBalancers, setSelectedNodeBalancers] = React.useState<
-      NodeBalancer[]
-    >([]);
-
-    const [selectedLinodes, setSelectedLinodes] = React.useState<Linode[]>([]);
 
     const {
       data: nodebalancerData,
@@ -186,8 +178,8 @@ export const CreateFirewallDrawer = React.memo(
 
       const selectedIds =
         serviceType === 'linode'
-          ? selectedNodeBalancers.map((nb) => nb.id)
-          : selectedLinodes.map((linode) => linode.id);
+          ? values.devices?.nodebalancers || []
+          : values.devices?.linodes || [];
 
       return ![...readOnlyIds, ...selectedIds].includes(id);
     };
@@ -199,6 +191,18 @@ export const CreateFirewallDrawer = React.memo(
     const linodes = linodeData?.filter((linode) =>
       optionsFilter(linode.id, 'linode')
     );
+
+    const linodeIdSet = new Set(values?.devices?.linodes);
+
+    const selectedLinodes: Linode[] =
+      linodes?.filter((linode) => linodeIdSet.has(linode.id)) || [];
+
+    const nodebalancerIdSet = new Set(values?.devices?.nodebalancers);
+
+    const selectedNodeBalancers: NodeBalancer[] =
+      nodebalancers?.filter((nodebalancer) =>
+        nodebalancerIdSet.has(nodebalancer.id)
+      ) || [];
 
     // TODO: NBFW - Placeholder until real link is available
     const learnMoreLink = <a href="#">Learn more</a>;
@@ -293,7 +297,6 @@ export const CreateFirewallDrawer = React.memo(
                 'devices.nodebalancers',
                 nodebalancers.map((nodebalancer) => nodebalancer.id)
               );
-              setSelectedNodeBalancers(nodebalancers);
             }}
             sx={(theme) => ({
               marginTop: theme.spacing(2),


### PR DESCRIPTION
## Description 📝
Migrated the Linode dropdown in Firewall Landing > Create Firewall drawer from the LinodeSelect component to the Autocomplete component 

## Changes  🔄
- Migrated Linode Dropdown from LinodeSelect to the Autocomplete component
- Fixed NodeBalancer dropdown incorrect highlighted options
- Added successful toast notification for firewall creation

## Preview 📷
| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/139489745/bd2e37c0-6c5e-4493-97df-260dad4647dc" /> | <video src="https://github.com/linode/manager/assets/139489745/ac8bad92-c559-4595-8266-fcf0a8681063" /> |

## How to test 🧪

### Prerequisites

- Checkout the feature branch (feature/firewall-nodebalancer)

### Reproduction steps

- Navigate to http://localhost:3000/firewalls/create
- Select a NodeBalancer, the correct NodeBalancer is created, but all of the options are highlighted as if they were chosen.
- Create the firewall, there should not be a successful toast notification

### Verification steps 

Navigate to http://localhost:3000/firewalls/create
- [ ] Ensure the Linode dropdown and NodeBalancer dropdown are consistent
- [ ] Ensure the dropdowns work as expected
- [ ] Ensure there is a successful toast notification when the Firewall is created
- [ ] Ensure the firewall is assigned to the selected NodeBalancers and Linodes

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support
