### PR TITLE
change: [M3-7250] – Properly surface VPC interface errors

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesCreate/VPCPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/VPCPanel.tsx
@@ -304,16 +304,16 @@ export const VPCPanel = (props: VPCPanelProps) => {
                   </Box>
                 }
               />
-              {assignPublicIPv4Address && publicIPv4Error && (
-                <Typography
-                  sx={(theme) => ({
-                    color: theme.color.red,
-                  })}
-                >
-                  {publicIPv4Error}
-                </Typography>
-              )}
             </Box>
+            {assignPublicIPv4Address && publicIPv4Error && (
+              <Typography
+                sx={(theme) => ({
+                  color: theme.color.red,
+                })}
+              >
+                {publicIPv4Error}
+              </Typography>
+            )}
           </Stack>
         )}
       </Stack>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
@@ -425,20 +425,9 @@ export const LinodeConfigDialog = (props: Props) => {
         });
       };
 
-      // @TODO VPC: Remove this override and surface the field errors appropriately
-      // once API fixes interface index bug for ipv4.vpc & ipv4.nat_1_1 errors
-      const overrideFieldForIPv4 = (error: APIError[]) => {
-        error.forEach((err) => {
-          if (err.field && ['ipv4.nat_1_1', 'ipv4.vpc'].includes(err.field)) {
-            err.field = 'interfaces';
-          }
-        });
-      };
-
       formik.setSubmitting(false);
 
       overrideFieldForDevices(error);
-      overrideFieldForIPv4(error);
 
       handleFieldErrors(formik.setErrors, error);
 


### PR DESCRIPTION
## Description 📝
There was an API bug for API endpoints that take a list of interfaces where, if there was an error for one of the interfaces, the `field` of the error didn't indicate which interface index it applied to. This presented difficulties for surfacing the errors in the UI. Temporary code was added in https://github.com/linode/manager/pull/9709 to surface the errors in a general way just so that they wouldn't stay submerged, but since the API fix has been merged in, that temporary code is being removed so the errors surface and map to the appropriate interfaces.

## Changes  🔄
- Remove temporary code in `LinodeConfigDialog.tsx`
- Move `publicIPv4Error` outside of `<Box />` in `VPCPanel.tsx` to avoid odd formatting of error in the Add/Edit Linode Config dialog

## Preview 📷
(for the `publicIPv4Error` error change -- this error is only really possible to get back in the Linode Config flow, not the Linode Create flow)
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-10-24 at 4 22 12 PM](https://github.com/linode/manager/assets/114682940/996c0154-c8ce-40b6-92ae-f248b0066adf) | ![Screenshot 2023-10-24 at 4 21 57 PM](https://github.com/linode/manager/assets/114682940/737c030e-02d3-464d-94e2-0716d6a6e7d8) |

## How to test 🧪

### Prerequisites
- Account with proper VPC tags
- Point at `dev` environment

### Verification steps 
Try adding a Linode config or editing an existing config:
- Choose a VPC interface, uncheck the "Auto-assign a VPC IPv4 address for this Linode in the VPC" checkbox, and input a reserved IP in the "VPC IPv4" field (example: if the subnet's range is 10.0.4.0/24, you can input 10.0.4.0 in that field).
  - Observe: when you submit the form, you should see a field error: "The provided IP is reserved"
- Try adding two VPC interfaces and check the "Assign a public IPv4 address for this Linode" checkbox for both of them
  - Observe: the second one should get a "Linode has no public IP to use for 1:1 NAT" error

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support