### PR TITLE
fix: [M3-7348] - Only unassign linodes in the 'Linodes to be Unassigned from Subnet' list for Subnet Unassign Drawer

### DIFF
--- a/packages/manager/.changeset/pr-9851-upcoming-features-1698695391804.md
+++ b/packages/manager/.changeset/pr-9851-upcoming-features-1698695391804.md
@@ -1,5 +1,5 @@
 ---
-"@linode/manager": Fixed
+"@linode/manager": Upcoming Features
 ---
 
 Only unassign linodes in the 'Linodes to be Unassigned from Subnet' list for Subnet Unassign Drawer ([#9851](https://github.com/linode/manager/pull/9851))

--- a/packages/manager/.changeset/pr-9851-upcoming-features-1698695391804.md
+++ b/packages/manager/.changeset/pr-9851-upcoming-features-1698695391804.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Fix Subnet Unassign Drawer unassigning linodes it shouldn't be ([#9851](https://github.com/linode/manager/pull/9851))

--- a/packages/manager/.changeset/pr-9851-upcoming-features-1698695391804.md
+++ b/packages/manager/.changeset/pr-9851-upcoming-features-1698695391804.md
@@ -1,5 +1,5 @@
 ---
-"@linode/manager": Upcoming Features
+"@linode/manager": Fixed
 ---
 
-Fix Subnet Unassign Drawer unassigning linodes it shouldn't be ([#9851](https://github.com/linode/manager/pull/9851))
+Only unassign linodes in the 'Linodes to be Unassigned from Subnet' list for Subnet Unassign Drawer ([#9851](https://github.com/linode/manager/pull/9851))

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
@@ -171,6 +171,11 @@ export const SubnetUnassignLinodesDrawer = React.memo(
       setSelectedLinodes((prevSelectedLinodes) =>
         prevSelectedLinodes.filter((option) => option.id !== optionToRemove.id)
       );
+      setConfigInterfacesToDelete((prevInterfacesToDelete) =>
+        prevInterfacesToDelete.filter(
+          (option) => option.linodeId !== optionToRemove.id
+        )
+      );
     };
 
     const processUnassignLinodes = async () => {
@@ -305,7 +310,9 @@ export const SubnetUnassignLinodesDrawer = React.memo(
             <ActionsPanel
               primaryButtonProps={{
                 'data-testid': 'unassign-submit-button',
-                disabled: configInterfacesToDelete.length === 0,
+                disabled:
+                  configInterfacesToDelete.length === 0 ||
+                  selectedLinodes.length === 0,
                 label: 'Unassign Linodes',
                 type: 'submit',
               }}

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
@@ -310,9 +310,7 @@ export const SubnetUnassignLinodesDrawer = React.memo(
             <ActionsPanel
               primaryButtonProps={{
                 'data-testid': 'unassign-submit-button',
-                disabled:
-                  configInterfacesToDelete.length === 0 ||
-                  selectedLinodes.length === 0,
+                disabled: configInterfacesToDelete.length === 0,
                 label: 'Unassign Linodes',
                 type: 'submit',
               }}


### PR DESCRIPTION
## Description 📝
Saw this little bug when looking into Cassie's pr #9818 and thought I'd just put up a quick fix for it. Will create a ticket + add it to this PR's header once I'm done writing this pr

## Changes  🔄
List any change relevant to the reviewer.
- When removing linodes from our 'Linodes to unassign' list, make sure their configs also get removed so that we don't accidentally still unassign them

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/139280159/f1b62a67-2cd6-4de3-9fba-00513d8ca364" /> | <video src="https://github.com/linode/manager/assets/139280159/be0bc4c1-fe2c-47a9-a0ae-a83b1153df34" /> |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Using the dev env and with vpc flags
- OR with vpc flags on the prod account (this should be working now, though it wasn't for me)

### Reproduction steps
(How to reproduce the issue, if applicable)
- Make sure you have 1+ linodes already assigned to a VPC
- Click on the Subnets Unassign Drawer (do not use the inline unassign subnet link)
- Select the linode(s) to unassign, then remove them from the list
- Click the Unassign button
- Note how these linodes are still unassigned, even though we removed them from the list

### Verification steps 
(How to verify changes)
- Repeat the above behavior + confirm that only the linodes you actually want to unassign (the ones in the list) get unassigned
- If there are no linodes in the list, the unassign button should be disabled

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support
