### PR TITLE
fix: [OCA-1229] - Correct links to Main Concept and Simplex docs

### DIFF
--- a/packages/manager/.changeset/pr-9854-fixed-1698764756434.md
+++ b/packages/manager/.changeset/pr-9854-fixed-1698764756434.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Docs hyperlink 404s for Main Concept and Simplex Marketplace apps ([#9854](https://github.com/linode/manager/pull/9854))

--- a/packages/manager/.changeset/pr-9854-fixed-1698764756434.md
+++ b/packages/manager/.changeset/pr-9854-fixed-1698764756434.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Docs hyperlink 404s for Main Concept and Simplex Marketplace apps ([#9854](https://github.com/linode/manager/pull/9854))
+Incorrect docs links for Main Concept and Simplex Marketplace apps ([#9854](https://github.com/linode/manager/pull/9854))

--- a/packages/manager/.changeset/pr-9854-fixed.md
+++ b/packages/manager/.changeset/pr-9854-fixed.md
@@ -1,0 +1,9 @@
+```md
+---
+"@linode/manager": Fixed
+---
+
+fixes hyper link 404s in cloud manager marketplace pane for Main Concept and Simplex docs.
+
+([#9854](https://github.com/linode/manager/pull/9854))
+```

--- a/packages/manager/.changeset/pr-9854-fixed.md
+++ b/packages/manager/.changeset/pr-9854-fixed.md
@@ -1,4 +1,4 @@
-```md
+```
 ---
 "@linode/manager": Fixed
 ---

--- a/packages/manager/.changeset/pr-9854-fixed.md
+++ b/packages/manager/.changeset/pr-9854-fixed.md
@@ -1,7 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-fixes hyper link 404s in cloud manager marketplace pane for Main Concept and Simplex docs.
-
-([#9854](https://github.com/linode/manager/pull/9854))

--- a/packages/manager/.changeset/pr-9854-fixed.md
+++ b/packages/manager/.changeset/pr-9854-fixed.md
@@ -1,4 +1,3 @@
-```
 ---
 "@linode/manager": Fixed
 ---
@@ -6,4 +5,3 @@
 fixes hyper link 404s in cloud manager marketplace pane for Main Concept and Simplex docs.
 
 ([#9854](https://github.com/linode/manager/pull/9854))
-```

--- a/packages/manager/src/features/OneClickApps/oneClickApps.ts
+++ b/packages/manager/src/features/OneClickApps/oneClickApps.ts
@@ -1136,7 +1136,7 @@ export const oneClickApps: OCA[] = [
     related_guides: [
       {
         href:
-          'https://www.linode.com/docs/products/tools/marketplace/guides/mcffmpegplugins/',
+          'https://www.linode.com/docs/products/tools/marketplace/guides/mainconcept-ffmpeg-plugins/',
         title:
           'Deploy MainConcept FFmpeg Plugins through the Linode Marketplace',
       },
@@ -1158,7 +1158,7 @@ export const oneClickApps: OCA[] = [
     related_guides: [
       {
         href:
-          'https://www.linode.com/docs/products/tools/marketplace/guides/mcliveencoder/',
+          'https://www.linode.com/docs/products/tools/marketplace/guides/mainconcept-live-encoder/',
         title: 'Deploy MainConcept Live Encoder through the Linode Marketplace',
       },
     ],
@@ -1179,7 +1179,7 @@ export const oneClickApps: OCA[] = [
     related_guides: [
       {
         href:
-          'https://www.linode.com/docs/products/tools/marketplace/guides/mcp2avcultratranscoder/',
+          'https://www.linode.com/docs/products/tools/marketplace/guides/mainconcept-p2-avc-ultra/',
         title:
           'Deploy MainConcept P2 AVC Ultra Transcoder through the Linode Marketplace',
       },
@@ -1202,7 +1202,7 @@ export const oneClickApps: OCA[] = [
     related_guides: [
       {
         href:
-          'https://www.linode.com/docs/products/tools/marketplace/guides/mcp2xavc/',
+          'https://www.linode.com/docs/products/tools/marketplace/guides/mainconcept-xavc-transcoder/',
         title:
           'Deploy MainConcept XAVC Transcoder through the Linode Marketplace',
       },
@@ -1225,7 +1225,7 @@ export const oneClickApps: OCA[] = [
     related_guides: [
       {
         href:
-          'https://www.linode.com/docs/products/tools/marketplace/guides/mcp2xdcam/',
+          'https://www.linode.com/docs/products/tools/marketplace/guides/mainconcept-xdcam-transcoder/',
         title:
           'Deploy MainConcept XDCAM Transcoder through the Linode Marketplace',
       },

--- a/packages/manager/src/features/OneClickApps/oneClickApps.ts
+++ b/packages/manager/src/features/OneClickApps/oneClickApps.ts
@@ -2265,7 +2265,7 @@ export const oneClickApps: OCA[] = [
     related_guides: [
       {
         href:
-          'https://www.linode.com/docs/products/tools/marketplace/guides/simplexchat/',
+          'https://www.linode.com/docs/products/tools/marketplace/guides/simplex/',
         title: 'Deploy SimpleX chat through the Linode Marketplace',
       },
     ],


### PR DESCRIPTION
## Description 📝
fixes hyper link 404s in cloud manager marketplace pane for Main Concept docs.
## Changes  🔄
corrects links to match docs naming scheme here: https://github.com/linode/docs/commit/bd25fe4fbd088c0ca7bf3db3d91f2bffeecdc776
