### PR TITLE
feat: [M3-7353] - Add AGLB Basic Create Flow

### DIFF
--- a/packages/api-v4/src/aglb/loadbalancers.ts
+++ b/packages/api-v4/src/aglb/loadbalancers.ts
@@ -8,10 +8,12 @@ import Request, {
 import { BETA_API_ROOT } from '../constants';
 import { Filter, Params, ResourcePage } from '../types';
 import type {
+  CreateBasicLoadbalancerPayload,
   CreateLoadbalancerPayload,
   Loadbalancer,
   UpdateLoadbalancerPayload,
 } from './types';
+import { CreateBasicLoadbalancerSchema } from '@linode/validation';
 
 /**
  * getLoadbalancers
@@ -46,6 +48,18 @@ export const createLoadbalancer = (data: CreateLoadbalancerPayload) =>
   Request<Loadbalancer>(
     setURL(`${BETA_API_ROOT}/aglb`),
     setData(data),
+    setMethod('POST')
+  );
+
+/**
+ * createBasicLoadbalancer
+ *
+ * Creates an unconfigured Akamai Global Load Balancer
+ */
+export const createBasicLoadbalancer = (data: CreateBasicLoadbalancerPayload) =>
+  Request<Loadbalancer>(
+    setURL(`${BETA_API_ROOT}/aglb`),
+    setData(data, CreateBasicLoadbalancerSchema),
     setMethod('POST')
   );
 

--- a/packages/api-v4/src/aglb/types.ts
+++ b/packages/api-v4/src/aglb/types.ts
@@ -17,6 +17,13 @@ export interface CreateLoadbalancerPayload {
   configurations?: ConfigurationPayload[];
 }
 
+/**
+ * @TODO AGLB remove when we move to full creation flow
+ */
+export interface CreateBasicLoadbalancerPayload {
+  label: string;
+}
+
 export interface UpdateLoadbalancerPayload {
   label?: string;
   regions?: string[];

--- a/packages/api-v4/src/aglb/types.ts
+++ b/packages/api-v4/src/aglb/types.ts
@@ -18,7 +18,7 @@ export interface CreateLoadbalancerPayload {
 }
 
 /**
- * @TODO AGLB remove when we move to full creation flow
+ * TODO: AGLB - remove when we move to full creation flow
  */
 export interface CreateBasicLoadbalancerPayload {
   label: string;

--- a/packages/manager/.changeset/pr-9856-upcoming-features-1698773808066.md
+++ b/packages/manager/.changeset/pr-9856-upcoming-features-1698773808066.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add basic AGLB create page and feature flag ([#9856](https://github.com/linode/manager/pull/9856))

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -15,6 +15,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'metadata', label: 'Metadata' },
   { flag: 'vpc', label: 'VPC' },
   { flag: 'aglb', label: 'AGLB' },
+  { flag: 'aglbFullCreateFlow', label: 'AGLB Full Create Flow' },
   { flag: 'unifiedMigrations', label: 'Unified Migrations' },
   { flag: 'dcSpecificPricing', label: 'DC-Specific Pricing' },
   { flag: 'objDcSpecificPricing', label: 'OBJ Storage DC-Specific Pricing' },

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -41,6 +41,7 @@ type OneClickApp = Record<string, string>;
 
 export interface Flags {
   aglb: boolean;
+  aglbFullCreateFlow: boolean;
   apiMaintenance: APIMaintenance;
   databaseBeta: boolean;
   databases: boolean;

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerCreate/LoadBalancerBasicCreate.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerCreate/LoadBalancerBasicCreate.tsx
@@ -1,0 +1,93 @@
+import { useFormik } from 'formik';
+import { useSnackbar } from 'notistack';
+import * as React from 'react';
+import { useHistory } from 'react-router-dom';
+
+import { Box } from 'src/components/Box';
+import { Button } from 'src/components/Button/Button';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
+import { LandingHeader } from 'src/components/LandingHeader';
+import { Notice } from 'src/components/Notice/Notice';
+import { Paper } from 'src/components/Paper';
+import { Stack } from 'src/components/Stack';
+import { TextField } from 'src/components/TextField';
+import { useLoadBalancerBasicCreateMutation } from 'src/queries/aglb/loadbalancers';
+import { getFormikErrorsFromAPIErrors } from 'src/utilities/formikErrorUtils';
+
+import { LoadBalancerRegions } from './LoadBalancerRegions';
+import { CreateBasicLoadbalancerSchema } from '@linode/validation';
+
+export const LoadBalancerBasicCreate = () => {
+  const {
+    error,
+    mutateAsync: createLoadbalancer,
+  } = useLoadBalancerBasicCreateMutation();
+
+  const { push } = useHistory();
+  const { enqueueSnackbar } = useSnackbar();
+
+  const formik = useFormik({
+    initialValues: {
+      label: '',
+    },
+    async onSubmit(values, formikHelpers) {
+      try {
+        const loadbalancer = await createLoadbalancer(values);
+        enqueueSnackbar(
+          `Load Balancer ${loadbalancer.label} successfully created.`,
+          { variant: 'success' }
+        );
+        push(`/loadbalancers/${loadbalancer.id}`);
+      } catch (error) {
+        formikHelpers.setErrors(getFormikErrorsFromAPIErrors(error));
+      }
+    },
+    validationSchema: CreateBasicLoadbalancerSchema,
+  });
+
+  const generalError = error
+    ?.filter((e) => !e.field || e.field !== 'label')
+    .map((e) => e.reason)
+    .join(', ');
+
+  return (
+    <form onSubmit={formik.handleSubmit}>
+      <DocumentTitleSegment segment="Create a Load Balancer" />
+      <LandingHeader
+        breadcrumbProps={{
+          crumbOverrides: [
+            {
+              label: 'Global Load Balancers',
+              position: 1,
+            },
+          ],
+          pathname: location.pathname,
+        }}
+        title="Create"
+      />
+      <Stack spacing={3}>
+        {generalError && <Notice text={generalError} variant="error" />}
+        <Paper>
+          <TextField
+            errorText={formik.errors.label}
+            label="Load Balancer Label"
+            name="label"
+            noMarginTop
+            onChange={formik.handleChange}
+            value={formik.values.label}
+          />
+        </Paper>
+        <LoadBalancerRegions />
+        <Box display="flex" justifyContent="flex-end">
+          <Button
+            buttonType="primary"
+            loading={formik.isSubmitting}
+            type="submit"
+          >
+            Create Load Balancer
+          </Button>
+        </Box>
+      </Stack>
+    </form>
+  );
+};

--- a/packages/manager/src/features/LoadBalancers/index.tsx
+++ b/packages/manager/src/features/LoadBalancers/index.tsx
@@ -26,6 +26,9 @@ const LoadBalancer = () => {
     <React.Suspense fallback={<SuspenseLoader />}>
       <ProductInformationBanner bannerLocation="LoadBalancers" />
       <Switch>
+        {/**
+         * TODO: AGLB - remove alternative create flow
+         */}
         <Route
           component={
             flags.aglbFullCreateFlow

--- a/packages/manager/src/features/LoadBalancers/index.tsx
+++ b/packages/manager/src/features/LoadBalancers/index.tsx
@@ -3,6 +3,7 @@ import { Route, Switch } from 'react-router-dom';
 
 import { ProductInformationBanner } from 'src/components/ProductInformationBanner/ProductInformationBanner';
 import { SuspenseLoader } from 'src/components/SuspenseLoader';
+import { useFlags } from 'src/hooks/useFlags';
 
 const LoadBalancerLanding = React.lazy(
   () => import('./LoadBalancerLanding/LoadBalancerLanding')
@@ -13,13 +14,26 @@ const LoadBalancerDetail = React.lazy(
 const LoadBalancerCreate = React.lazy(
   () => import('./LoadBalancerCreate/LoadBalancerCreate')
 );
+const LoadBalancerBasicCreate = React.lazy(() =>
+  import('./LoadBalancerCreate/LoadBalancerBasicCreate').then((module) => ({
+    default: module.LoadBalancerBasicCreate,
+  }))
+);
 
 const LoadBalancer = () => {
+  const flags = useFlags();
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <ProductInformationBanner bannerLocation="LoadBalancers" />
       <Switch>
-        <Route component={LoadBalancerCreate} path="/loadbalancers/create" />
+        <Route
+          component={
+            flags.aglbFullCreateFlow
+              ? LoadBalancerCreate
+              : LoadBalancerBasicCreate
+          }
+          path="/loadbalancers/create"
+        />
         <Route
           component={LoadBalancerDetail}
           path="/loadbalancers/:loadbalancerId"

--- a/packages/manager/src/queries/aglb/loadbalancers.ts
+++ b/packages/manager/src/queries/aglb/loadbalancers.ts
@@ -42,6 +42,7 @@ export const useLoadBalancerMutation = (id: number) => {
     {
       onSuccess(data) {
         queryClient.setQueryData([QUERY_KEY, 'aglb', id], data);
+        queryClient.invalidateQueries([QUERY_KEY, 'paginated']);
       },
     }
   );
@@ -54,6 +55,7 @@ export const useLoadBalancerBasicCreateMutation = () => {
     {
       onSuccess(data) {
         queryClient.setQueryData([QUERY_KEY, 'aglb', data.id], data);
+        queryClient.invalidateQueries([QUERY_KEY, 'paginated']);
       },
     }
   );
@@ -64,6 +66,7 @@ export const useLoadBalancerDeleteMutation = (id: number) => {
   return useMutation<{}, APIError[]>(() => deleteLoadbalancer(id), {
     onSuccess() {
       queryClient.removeQueries([QUERY_KEY, 'aglb', id]);
+      queryClient.invalidateQueries([QUERY_KEY, 'paginated']);
     },
   });
 };

--- a/packages/manager/src/queries/aglb/loadbalancers.ts
+++ b/packages/manager/src/queries/aglb/loadbalancers.ts
@@ -36,34 +36,34 @@ export const useLoadBalancerQuery = (id: number, enabled = true) => {
 };
 
 export const useLoadBalancerMutation = (id: number) => {
-  const queryCleint = useQueryClient();
+  const queryClient = useQueryClient();
   return useMutation<Loadbalancer, APIError[], UpdateLoadbalancerPayload>(
     (data) => updateLoadbalancer(id, data),
     {
       onSuccess(data) {
-        queryCleint.setQueryData([QUERY_KEY, 'aglb', id], data);
+        queryClient.setQueryData([QUERY_KEY, 'aglb', id], data);
       },
     }
   );
 };
 
 export const useLoadBalancerBasicCreateMutation = () => {
-  const queryCleint = useQueryClient();
+  const queryClient = useQueryClient();
   return useMutation<Loadbalancer, APIError[], CreateBasicLoadbalancerPayload>(
     (data) => createBasicLoadbalancer(data),
     {
       onSuccess(data) {
-        queryCleint.setQueryData([QUERY_KEY, 'aglb', data.id], data);
+        queryClient.setQueryData([QUERY_KEY, 'aglb', data.id], data);
       },
     }
   );
 };
 
 export const useLoadBalancerDeleteMutation = (id: number) => {
-  const queryCleint = useQueryClient();
+  const queryClient = useQueryClient();
   return useMutation<{}, APIError[]>(() => deleteLoadbalancer(id), {
     onSuccess() {
-      queryCleint.removeQueries([QUERY_KEY, 'aglb', id]);
+      queryClient.removeQueries([QUERY_KEY, 'aglb', id]);
     },
   });
 };

--- a/packages/manager/src/queries/aglb/loadbalancers.ts
+++ b/packages/manager/src/queries/aglb/loadbalancers.ts
@@ -1,4 +1,5 @@
 import {
+  createBasicLoadbalancer,
   deleteLoadbalancer,
   getLoadbalancer,
   getLoadbalancers,
@@ -8,6 +9,7 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import type {
   APIError,
+  CreateBasicLoadbalancerPayload,
   Filter,
   Loadbalancer,
   Params,
@@ -40,6 +42,18 @@ export const useLoadBalancerMutation = (id: number) => {
     {
       onSuccess(data) {
         queryCleint.setQueryData([QUERY_KEY, 'aglb', id], data);
+      },
+    }
+  );
+};
+
+export const useLoadBalancerBasicCreateMutation = () => {
+  const queryCleint = useQueryClient();
+  return useMutation<Loadbalancer, APIError[], CreateBasicLoadbalancerPayload>(
+    (data) => createBasicLoadbalancer(data),
+    {
+      onSuccess(data) {
+        queryCleint.setQueryData([QUERY_KEY, 'aglb', data.id], data);
       },
     }
   );

--- a/packages/validation/src/loadbalancers.schema.ts
+++ b/packages/validation/src/loadbalancers.schema.ts
@@ -152,6 +152,9 @@ export const UpdateRouteSchema = object({
   }),
 });
 
+/**
+ * TODO: AGLB - remove this create schema
+ */
 export const CreateBasicLoadbalancerSchema = object({
   label: string()
     .min(1, 'Label must not be empty.')

--- a/packages/validation/src/loadbalancers.schema.ts
+++ b/packages/validation/src/loadbalancers.schema.ts
@@ -151,3 +151,9 @@ export const UpdateRouteSchema = object({
     otherwise: (o) => o.of(HTTPRuleSchema),
   }),
 });
+
+export const CreateBasicLoadbalancerSchema = object({
+  label: string()
+    .min(1, 'Label must not be empty.')
+    .required('Label is required'),
+});


### PR DESCRIPTION
## Description 📝

- For AGLB Alpha, users won't be able to configure their AGLB during creation so we must have a "basic" create flow
- This PR adds a _basic_ flow that is controlled by a feature flag. This will allow us to very easily toggle between the create flows for development
- Lots of temporary code is created to support this "basic" creation but it allows us to continue to develop the main product

## Changes  🔄
- Adds new Basic Create Page
- Adds `aglbFullCreateFlow` feature flag

## Preview 📷
![Screenshot 2023-10-31 at 1 18 23 PM](https://github.com/linode/manager/assets/115251059/3c72feef-9495-4e5f-85b0-495b70ff9e7f)

## How to test 🧪

### Prerequisites
- Turn on the MSW

### Verification steps 
- Test that toggling `aglbFullCreateFlow` shows two different create flows
- Verify the only thing in the payload is a `label` for the basic create flow

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support