### PR TITLE
feat: [M3-7235, M3-7236] - VPC UX error feedback

### DIFF
--- a/packages/manager/.changeset/pr-9857-upcoming-features-1698788535458.md
+++ b/packages/manager/.changeset/pr-9857-upcoming-features-1698788535458.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+VPC UX error feedback ([#9857](https://github.com/linode/manager/pull/9857))

--- a/packages/manager/.changeset/pr-9857-upcoming-features-1698788535458.md
+++ b/packages/manager/.changeset/pr-9857-upcoming-features-1698788535458.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-VPC UX error feedback ([#9857](https://github.com/linode/manager/pull/9857))
+Clear subnet errors in Linode Create flow and VPC label errors in VPC Edit flow upon input change ([#9857](https://github.com/linode/manager/pull/9857))

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -38,6 +38,10 @@ import {
   withLinodes,
 } from 'src/containers/withLinodes.container';
 import {
+  WithMarketplaceAppsProps,
+  withMarketplaceApps,
+} from 'src/containers/withMarketplaceApps';
+import {
   WithQueryClientProps,
   withQueryClient,
 } from 'src/containers/withQueryClient.container';
@@ -60,6 +64,7 @@ import {
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { ExtendedType, extendType } from 'src/utilities/extendType';
 import { isEURegion } from 'src/utilities/formatRegion';
+import { UNKNOWN_PRICE } from 'src/utilities/pricing/constants';
 import { getPrice } from 'src/utilities/pricing/linodes';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
@@ -77,11 +82,6 @@ import type {
   LinodeTypeClass,
   PriceObject,
 } from '@linode/api-v4/lib/linodes';
-import {
-  WithMarketplaceAppsProps,
-  withMarketplaceApps,
-} from 'src/containers/withMarketplaceApps';
-import { UNKNOWN_PRICE } from 'src/utilities/pricing/constants';
 
 const DEFAULT_IMAGE = 'linode/debian11';
 
@@ -477,7 +477,12 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
   };
 
   handleSubnetChange = (subnetID: number) => {
-    this.setState({ selectedSubnetId: subnetID });
+    this.setState((prevState) => ({
+      errors: prevState.errors?.filter(
+        (error) => error.field !== 'interfaces[0].subnet_id'
+      ),
+      selectedSubnetId: subnetID,
+    }));
   };
 
   handleVLANChange = (updatedInterface: Interface) => {

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCEditDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCEditDrawer.tsx
@@ -70,6 +70,7 @@ export const VPCEditDrawer = (props: Props) => {
     }
   }, [open]);
 
+  // If there's an error, sync it with formik
   React.useEffect(() => {
     if (error) {
       const errorMap = getErrorMap(['label', 'description'], error);

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCEditDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCEditDrawer.tsx
@@ -1,4 +1,5 @@
 import { UpdateVPCPayload, VPC } from '@linode/api-v4/lib/vpcs/types';
+import { updateVPCSchema } from '@linode/validation/lib/vpcs.schema';
 import { useFormik } from 'formik';
 import * as React from 'react';
 
@@ -41,7 +42,7 @@ export const VPCEditDrawer = (props: Props) => {
     reset,
   } = useUpdateVPCMutation(vpc?.id ?? -1);
 
-  const form = useFormik<UpdateVPCPayload>({
+  const form = useFormik<UpdateVPCPayload & { none?: string }>({
     enableReinitialize: true,
     initialValues: {
       description: vpc?.description,
@@ -51,7 +52,16 @@ export const VPCEditDrawer = (props: Props) => {
       await updateVPC(values);
       onClose();
     },
+    validateOnChange: false,
+    validationSchema: updateVPCSchema,
   });
+
+  const handleFieldChange = (field: string, value: string) => {
+    form.setFieldValue(field, value);
+    if (form.errors[field]) {
+      form.setFieldError(field, undefined);
+    }
+  };
 
   React.useEffect(() => {
     if (open) {
@@ -60,13 +70,21 @@ export const VPCEditDrawer = (props: Props) => {
     }
   }, [open]);
 
-  const { data: regionsData, error: regionsError } = useRegionsQuery();
+  React.useEffect(() => {
+    if (error) {
+      const errorMap = getErrorMap(['label', 'description'], error);
+      for (const [field, reason] of Object.entries(errorMap)) {
+        form.setFieldError(field, reason);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [error]);
 
-  const errorMap = getErrorMap(['label', 'description'], error);
+  const { data: regionsData, error: regionsError } = useRegionsQuery();
 
   return (
     <Drawer onClose={onClose} open={open} title="Edit VPC">
-      {errorMap.none && <Notice text={errorMap.none} variant="error" />}
+      {form.errors.none && <Notice text={form.errors.none} variant="error" />}
       {readOnly && (
         <Notice
           important
@@ -77,18 +95,18 @@ export const VPCEditDrawer = (props: Props) => {
       <form onSubmit={form.handleSubmit}>
         <TextField
           disabled={readOnly}
-          errorText={errorMap.label}
+          errorText={form.errors.label}
           label="Label"
           name="label"
-          onChange={form.handleChange}
+          onChange={(e) => handleFieldChange('label', e.target.value)}
           value={form.values.label}
         />
         <TextField
           disabled={readOnly}
-          errorText={errorMap.description}
+          errorText={form.errors.description}
           label="Description"
           multiline
-          onChange={form.handleChange}
+          onChange={(e) => handleFieldChange('description', e.target.value)}
           rows={1}
           value={form.values.description}
         />


### PR DESCRIPTION
## Description 📝
Clear VPC errors in the Linode Create and VPC Edit drawer flow after the input has changed

## Preview 📷
| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/115299789/0a429b4b-f5d1-4e53-9aff-416a4f6f935e" /> | <video src="https://github.com/linode/manager/assets/115299789/ff973e4d-3fb3-4030-9422-0c05766b25c1" /> |
| <video src="https://github.com/linode/manager/assets/115299789/f6d6e70e-e415-4a0d-94c5-0fdd2049ab5e" /> | <video src="https://github.com/linode/manager/assets/115299789/ea9ecf3a-7204-4d43-9a5f-0a9740400dbc" /> |

## How to test 🧪

### Prerequisites
- Point to the dev env and ensure your account has vpc customer tags
- Create two VPCs if you don't already have one

### Reproduction steps
Linode Create
- Be on the develop branch or go to the remote dev environment
- Go to `/linodes/create` and select a region and VPC, but not a subnet
- Click Create Linode and observe the "Subnet is required" error
- Select a Subnet, the error does not clear

VPC Edit
- Edit a VPC on the landing or details page
- Change the label to the same label as another VPC and click Save, you should see an error about unique labels
- Edit the label again, the error does not clear

### Verification steps 
Linode Create
- Go to `/linodes/create` and select a region and VPC, but not a subnet
- Click Create Linode and observe the "Subnet is required" error
- Select a Subnet, the error should clear

VPC Edit
- Edit a VPC on the landing or details page
- Change the label to the same label as another VPC and click Save, you should see an error about unique labels
- Edit the label again, the error should clear

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support