### PR TITLE
fix: [UIE-6977] - Remove sort on region column on DBaaS landing page

### DIFF
--- a/packages/manager/.changeset/pr-9861-fixed-1698947793164.md
+++ b/packages/manager/.changeset/pr-9861-fixed-1698947793164.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Remove region sorting on DBaaS landing page ([#9861](https://github.com/linode/manager/pull/9861))

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -112,6 +112,7 @@ const DatabaseLanding = () => {
               Engine
             </TableSortCell>
             <Hidden mdDown>
+              {/* TODO add back TableSortCell once API is updated to support sort by Region */}
               <TableCell>Region</TableCell>
             </Hidden>
             <Hidden lgDown>

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -9,6 +9,7 @@ import { LandingHeader } from 'src/components/LandingHeader';
 import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFooter';
 import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
+import { TableCell } from 'src/components/TableCell';
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
 import { TableSortCell } from 'src/components/TableSortCell';
@@ -111,14 +112,7 @@ const DatabaseLanding = () => {
               Engine
             </TableSortCell>
             <Hidden mdDown>
-              <TableSortCell
-                active={orderBy === 'region'}
-                direction={order}
-                handleClick={handleOrderChange}
-                label="region"
-              >
-                Region
-              </TableSortCell>
+              <TableCell>Region</TableCell>
             </Hidden>
             <Hidden lgDown>
               <TableSortCell


### PR DESCRIPTION
## Description 📝
Temporarily remove sorting on "Region" column due to API error 400 Bad request. Once the backend is fixed we can add back sorting on "Region" column. All other columns can be sorted without API error.

## Changes  🔄
List any change relevant to the reviewer.
- Change TableSortCell to TableCell on Region column

## How to test 🧪

### Reproduction steps
- Navigate to https://cloud.linode.com/databases and click on the "Region" column to sort.
- To unblock go to https://cloud.linode.com/profile/settings?preferenceEditor=true
and remove "databases-order" from sort keys

### Verification steps 
- Navigate to https://cloud.linode.com/databases the "Region" column is no longer sortable.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
