### PR TITLE
fix: [M3-7340] - Fix error text displaying in Linode Add/Edit config flow and prevent clearing subnet section when clicking on currently assigned VPC

### DIFF
--- a/packages/manager/.changeset/pr-9866-upcoming-features-1698872557988.md
+++ b/packages/manager/.changeset/pr-9866-upcoming-features-1698872557988.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-Fix incorrectly displayed error text and prevent subnet section from incorrectly clearing in Linode Edit/Add Config flow ([#9866](https://github.com/linode/manager/pull/9866))
+Fix incorrectly displayed error text in Linode Edit/Add config flow and prevent subnet section from incorrectly clearing in Linode Edit/Add Config and Linode Create flow ([#9866](https://github.com/linode/manager/pull/9866))

--- a/packages/manager/.changeset/pr-9866-upcoming-features-1698872557988.md
+++ b/packages/manager/.changeset/pr-9866-upcoming-features-1698872557988.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Fix incorrectly displayed error text and prevent subnet section from incorrectly clearing in Linode Edit/Add Config flow ([#9866](https://github.com/linode/manager/pull/9866))

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -488,6 +488,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
   };
 
   handleVPCChange = (vpcId: number) => {
+    // Only clear VPC related fields if VPC selection changes
     if (vpcId !== this.state.selectedVPCId) {
       this.setState({
         selectedSubnetId: undefined, // Ensure the selected subnet is cleared

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -38,6 +38,10 @@ import {
   withLinodes,
 } from 'src/containers/withLinodes.container';
 import {
+  WithMarketplaceAppsProps,
+  withMarketplaceApps,
+} from 'src/containers/withMarketplaceApps';
+import {
   WithQueryClientProps,
   withQueryClient,
 } from 'src/containers/withQueryClient.container';
@@ -60,6 +64,7 @@ import {
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { ExtendedType, extendType } from 'src/utilities/extendType';
 import { isEURegion } from 'src/utilities/formatRegion';
+import { UNKNOWN_PRICE } from 'src/utilities/pricing/constants';
 import { getPrice } from 'src/utilities/pricing/linodes';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
@@ -77,11 +82,6 @@ import type {
   LinodeTypeClass,
   PriceObject,
 } from '@linode/api-v4/lib/linodes';
-import {
-  WithMarketplaceAppsProps,
-  withMarketplaceApps,
-} from 'src/containers/withMarketplaceApps';
-import { UNKNOWN_PRICE } from 'src/utilities/pricing/constants';
 
 const DEFAULT_IMAGE = 'linode/debian11';
 
@@ -488,11 +488,13 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
   };
 
   handleVPCChange = (vpcId: number) => {
-    this.setState({
-      selectedSubnetId: undefined, // Ensure the selected subnet is cleared
-      selectedVPCId: vpcId,
-      vpcIPv4AddressOfLinode: '', // Ensure the VPC IPv4 address is cleared
-    });
+    if (vpcId !== this.state.selectedVPCId) {
+      this.setState({
+        selectedSubnetId: undefined, // Ensure the selected subnet is cleared
+        selectedVPCId: vpcId,
+        vpcIPv4AddressOfLinode: '', // Ensure the VPC IPv4 address is cleared
+      });
+    }
   };
 
   handleVPCIPv4Change = (IPv4: string) => {

--- a/packages/manager/src/features/Linodes/LinodesCreate/VPCPanel.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/VPCPanel.test.tsx
@@ -128,4 +128,61 @@ describe('VPCPanel', () => {
       expect(wrapper.getAllByRole('checkbox')[0]).toBeChecked();
     });
   });
+  it('should display helper text if there are no vpcs in the selected region and "from" is "linodeCreate"', async () => {
+    server.use(
+      rest.get('*/regions', (req, res, ctx) => {
+        const usEast = regionFactory.build({
+          capabilities: ['VPCs'],
+          id: 'us-east',
+        });
+        return res(ctx.json(makeResourcePage([usEast])));
+      }),
+      rest.get('*/vpcs', (req, res, ctx) => {
+        return res(ctx.json(makeResourcePage([])));
+      })
+    );
+
+    const wrapper = renderWithTheme(<VPCPanel {...props} />, {
+      flags: { vpc: true },
+      queryClient,
+    });
+
+    await waitFor(() => {
+      expect(
+        wrapper.queryByText(
+          'No VPCs exist in the selected region. Click Create VPC to create one.'
+        )
+      ).toBeInTheDocument();
+    });
+  });
+  it('should not display helper text if there are no vpcs in the selected region and "from" is "linodeConfig"', async () => {
+    server.use(
+      rest.get('*/regions', (req, res, ctx) => {
+        const usEast = regionFactory.build({
+          capabilities: ['VPCs'],
+          id: 'us-east',
+        });
+        return res(ctx.json(makeResourcePage([usEast])));
+      }),
+      rest.get('*/vpcs', (req, res, ctx) => {
+        return res(ctx.json(makeResourcePage([])));
+      })
+    );
+
+    const wrapper = renderWithTheme(
+      <VPCPanel {...props} from="linodeConfig" />,
+      {
+        flags: { vpc: true },
+        queryClient,
+      }
+    );
+
+    await waitFor(() => {
+      expect(
+        wrapper.queryByText(
+          'No VPCs exist in the selected region. Click Create VPC to create one.'
+        )
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/manager/src/features/Linodes/LinodesCreate/VPCPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/VPCPanel.tsx
@@ -194,7 +194,7 @@ export const VPCPanel = (props: VPCPanelProps) => {
           isClearable={false}
           isLoading={isLoading}
           label={from === 'linodeCreate' ? 'Assign VPC' : 'VPC'}
-          noOptionsMessage={() => 'Create a VPC to assign to this Linode.'}
+          noOptionsMessage={() => `No VPCs exist in this Linode's region.`}
           options={vpcDropdownOptions}
           placeholder={'Select a VPC'}
         />

--- a/packages/manager/src/features/Linodes/LinodesCreate/VPCPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/VPCPanel.tsx
@@ -198,12 +198,15 @@ export const VPCPanel = (props: VPCPanelProps) => {
           options={vpcDropdownOptions}
           placeholder={'Select a VPC'}
         />
-        {vpcDropdownOptions.length <= 1 && regionSupportsVPCs && (
-          <Typography sx={(theme) => ({ paddingTop: theme.spacing(1.5) })}>
-            No VPCs exist in the selected region. Click Create VPC to create
-            one.
-          </Typography>
-        )}
+        {/* todo - Connie - do we want the create VPC link in the add/edit config flow? */}
+        {from === 'linodeCreate' &&
+          vpcDropdownOptions.length <= 1 &&
+          regionSupportsVPCs && (
+            <Typography sx={(theme) => ({ paddingTop: theme.spacing(1.5) })}>
+              No VPCs exist in the selected region. Click Create VPC to create
+              one.
+            </Typography>
+          )}
 
         {from === 'linodeCreate' && (
           <StyledCreateLink to={`${APP_ROOT}/vpcs/create`}>

--- a/packages/manager/src/features/Linodes/LinodesCreate/VPCPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/VPCPanel.tsx
@@ -198,7 +198,6 @@ export const VPCPanel = (props: VPCPanelProps) => {
           options={vpcDropdownOptions}
           placeholder={'Select a VPC'}
         />
-        {/* todo - Connie - do we want the create VPC link in the add/edit config flow? */}
         {from === 'linodeCreate' &&
           vpcDropdownOptions.length <= 1 &&
           regionSupportsVPCs && (

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
@@ -2,7 +2,6 @@ import {
   InterfacePayload,
   InterfacePurpose,
 } from '@linode/api-v4/lib/linodes/types';
-import { Stack } from 'src/components/Stack';
 import Grid from '@mui/material/Unstable_Grid2';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -10,6 +9,7 @@ import * as React from 'react';
 
 import { Divider } from 'src/components/Divider';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
+import { Stack } from 'src/components/Stack';
 import { TextField } from 'src/components/TextField';
 import { VPCPanel } from 'src/features/Linodes/LinodesCreate/VPCPanel';
 import { useFlags } from 'src/hooks/useFlags';
@@ -124,18 +124,21 @@ export const InterfaceSelect = (props: CombinedProps) => {
       purpose,
     });
 
-  const handleVPCLabelChange = (selectedVPCId: number) =>
-    handleChange({
-      ipam_address: null,
-      ipv4: {
-        nat_1_1: autoAssignLinodeIPv4 ? 'any' : undefined,
-        vpc: autoAssignVPCIPv4 ? undefined : vpcIPv4,
-      },
-      label: null,
-      purpose,
-      subnet_id: undefined,
-      vpc_id: selectedVPCId,
-    });
+  const handleVPCLabelChange = (selectedVPCId: number) => {
+    if (selectedVPCId !== vpcId) {
+      handleChange({
+        ipam_address: null,
+        ipv4: {
+          nat_1_1: autoAssignLinodeIPv4 ? 'any' : undefined,
+          vpc: autoAssignVPCIPv4 ? undefined : vpcIPv4,
+        },
+        label: null,
+        purpose,
+        subnet_id: undefined,
+        vpc_id: selectedVPCId,
+      });
+    }
+  };
 
   const handleSubnetChange = (selectedSubnetId: number) =>
     handleChange({

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
@@ -125,6 +125,7 @@ export const InterfaceSelect = (props: CombinedProps) => {
     });
 
   const handleVPCLabelChange = (selectedVPCId: number) => {
+    // Only clear VPC related fields if VPC selection changes
     if (selectedVPCId !== vpcId) {
       handleChange({
         ipam_address: null,


### PR DESCRIPTION
## Description 📝
Fixes some bugs in the Linode Create and Add/Edit Config flows
- fixes error text incorrectly displaying in Linode Add/Edit config flow
- prevents clearing subnet section when clicking on currently assigned VPC

**Note: spoke with UX, we will be hiding the Create VPC link -- as a result, hiding the text in the Add/Edit config flow. Have also changed the copy for the Add/Edit config flow if no VPCs exist in the linode's region -- see comment

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/139280159/c0ffe75e-712a-4a26-9b9f-7d620305a5a8" /> | <video src="https://github.com/linode/manager/assets/139280159/1424e4de-4b04-4ac3-8d8b-daddc0d0e66f" /> |

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/139280159/f5b26fca-ed1a-4d0a-803e-117d70e52eb0) | ![image](https://github.com/linode/manager/assets/139280159/aae9b914-835b-469b-a184-f0a6ebfae597) |

## How to test 🧪

### Prerequisites
- Using either dev or prod environment with vpc admin tags, make sure you have a linode and one vpc, both in the same region

### Reproduction steps
- Bug 1:
  - Navigate to the Add/Edit config flow of a Linode. THE Text 'No VPCs exist in selected region..." shows up, even though you have one VPC in the region (and can select it)
- Bug 2:
  - In the Add/Edit config flow and Create linode flow (video for create linode flow above), select a VPC. Clicking on the same VPC clears the subnet information - it shouldn't

### Verification steps 
- Verify that bug 1 no longer happens for the Add/Edit config flow
- Verify that bug 2 no longer happens for
  - Add/Edit config flow
  - Create Linode flow

`yarn test VPCPanel`

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support

