### PR TITLE
feat: [M3-7399] - Linode Details - VPC Subnets Not Associated with VP…

### DIFF
--- a/packages/manager/.changeset/pr-9872-upcoming-features-1699039576510.md
+++ b/packages/manager/.changeset/pr-9872-upcoming-features-1699039576510.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Linode Details: VPC Subnets Not Associated with VPC IP Address Are Displayed ([#9872](https://github.com/linode/manager/pull/9872))

--- a/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
@@ -374,6 +374,12 @@ export const Body = React.memo((props: BodyProps) => {
     );
   });
 
+  // Filter and retrieve subnets associated with a specific Linode ID
+
+  const linodeAssociatedSubnets = vpcLinodeIsAssignedTo?.subnets.filter(
+    (subnet) => subnet.linodes.some((linode) => linode.id === linodeId)
+  );
+
   const { data: configs } = useAllLinodeConfigsQuery(
     linodeId,
     Boolean(vpcLinodeIsAssignedTo) // only grab configs if necessary
@@ -524,7 +530,7 @@ export const Body = React.memo((props: BodyProps) => {
                 <StyledLabelBox component="span" data-testid="subnets-string">
                   Subnets:
                 </StyledLabelBox>{' '}
-                {getSubnetsString(vpcLinodeIsAssignedTo.subnets)}
+                {getSubnetsString(linodeAssociatedSubnets ?? [])}
               </StyledListItem>
             </StyledVPCBox>
             <StyledVPCBox>

--- a/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
@@ -375,7 +375,6 @@ export const Body = React.memo((props: BodyProps) => {
   });
 
   // Filter and retrieve subnets associated with a specific Linode ID
-
   const linodeAssociatedSubnets = vpcLinodeIsAssignedTo?.subnets.filter(
     (subnet) => subnet.linodes.some((linode) => linode.id === linodeId)
   );


### PR DESCRIPTION
## Description 📝
Linode Details: VPC Subnets Not Associated with VPC IP Address Are Displayed.

## Preview 📷
**Include a screenshot or screen recording of the change**

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/119517080/2d5da5ab-b232-4564-b321-6574e8c4c880)|![image](https://github.com/linode/manager/assets/119517080/b13ddffb-1ee1-41ac-9964-e0315b6e8ee9)|

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Checkout PR and run the app.
- Point to dev.

### Reproduction steps
(How to reproduce the issue, if applicable)
- Navigate to https://cloud.dev.linode.com/linodes/24924457
- Notice subnets, displays all the subnets of the VPC.

### Verification steps 
(How to verify changes)
- Navigate to http://localhost:3000/linodes/24924457
- Notice subnets, only displays the subnets of the VPC that are associated to the Linode.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
