### PR TITLE
upcoming: [M3-7378] - Add initial account/availability query fetch

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodesLanding.tsx
@@ -1,3 +1,4 @@
+import { AccountAvailability } from '@linode/api-v4';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
@@ -83,6 +84,8 @@ type RouteProps = RouteComponentProps<Params>;
 
 export interface LinodesLandingProps {
   LandingHeader?: React.ReactElement;
+  // See M3-7378 - eventually this data will be moved to the RegionSelect once its refactor is complete
+  accountAvailabilityData?: AccountAvailability[];
   linodesData: LinodeWithMaintenance[];
   linodesRequestError?: APIError[];
   linodesRequestLoading: boolean;

--- a/packages/manager/src/features/Linodes/index.tsx
+++ b/packages/manager/src/features/Linodes/index.tsx
@@ -5,6 +5,9 @@ import { SuspenseLoader } from 'src/components/SuspenseLoader';
 import { useAllAccountMaintenanceQuery } from 'src/queries/accountMaintenance';
 import { useAllLinodesQuery } from 'src/queries/linodes/linodes';
 import { addMaintenanceToLinodes } from 'src/utilities/linodes';
+import { useAccountAvailabilitiesQuery } from 'src/queries/accountAvailability';
+import { usePagination } from 'src/hooks/usePagination';
+import { useFlags } from 'src/hooks/useFlags';
 
 const LinodesLanding = React.lazy(
   () => import('./LinodesLanding/LinodesLanding')
@@ -34,7 +37,16 @@ export default LinodesRoutes;
 // mapStateToProps, but since I wanted to use a query (for accountMaintenance)
 // I needed a Function Component. It seemed safer to do it this way instead of
 // refactoring LinodesLanding.
-const LinodesLandingWrapper: React.FC = React.memo(() => {
+const LinodesLandingWrapper = React.memo(() => {
+  // See M3-7378: we are currently loading this data into the CM so that it's ready to be used
+  const flags = useFlags();
+  const pagination = usePagination(1);
+  const { data: accountAvailability } = useAccountAvailabilitiesQuery(
+    { page: pagination.page },
+    {},
+    flags.dcGetWell
+  );
+
   const { data: accountMaintenanceData } = useAllAccountMaintenanceQuery(
     {},
     { status: { '+or': ['pending, started'] } }
@@ -53,6 +65,7 @@ const LinodesLandingWrapper: React.FC = React.memo(() => {
 
   return (
     <LinodesLanding
+      accountAvailabilityData={accountAvailability?.data}
       someLinodesHaveScheduledMaintenance={Boolean(
         someLinodesHaveScheduledMaintenance
       )}


### PR DESCRIPTION
## Description 📝
- jk we don't need this anymore! Will just be using it inside RegionSelect without any prefetching of data. We'll reevaluate as needed, and if so, then this query should be initially homed in perhaps PrimaryNav or useInitialRequests

## Changes  🔄
- n/a

## Preview 📷
No visual changes

## How to test 🧪

### Verification steps 
- Verify this query is hidden behind a feature flag
- Verify that if the MSW is on, the data has the expected shape ([see this PR and its internal ticket/api spec](https://github.com/linode/manager/pull/9860))

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support