### PR TITLE
fix: `ScheduleSettings.test.tsx` failing due to daylight savings time ending

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/ScheduleSettings.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/ScheduleSettings.test.tsx
@@ -98,7 +98,7 @@ describe('ScheduleSettings', () => {
     const offset = DateTime.now().setZone('America/New_York').offset / 60;
 
     // W10 indicates that your backups should be taken between 10:00 and 12:00 UTC.
-    // W10 in America/New_York will be 06:00 - 08:00 EDT (UTC-5) or 05:00 - 07:00 EST (UTC-4).
+    // W10 in America/New_York will be 06:00 - 08:00 EDT (UTC-4) or 05:00 - 07:00 EST (UTC-5).
     await findByText(`0${10 + offset}:00 - 0${10 + 2 + offset}:00`);
 
     await findByText('Time displayed in America/New York');

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/ScheduleSettings.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/ScheduleSettings.test.tsx
@@ -6,6 +6,7 @@ import { rest, server } from 'src/mocks/testServer';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { ScheduleSettings } from './ScheduleSettings';
+import { DateTime } from 'luxon';
 
 describe('ScheduleSettings', () => {
   it('renders heading and copy', async () => {
@@ -27,7 +28,7 @@ describe('ScheduleSettings', () => {
     );
   });
 
-  it('renders with the linode schedule taking into account the user timezone', async () => {
+  it('renders with the linode schedule taking into account the user timezone (UTC)', async () => {
     server.use(
       rest.get('*/linode/instances/1', (req, res, ctx) => {
         return res(
@@ -60,5 +61,46 @@ describe('ScheduleSettings', () => {
     await findByText('10:00 - 12:00');
 
     await findByText('Time displayed in utc');
+  });
+
+  it('renders with the linode schedule taking into account the user timezone (America/New_York)', async () => {
+    server.use(
+      rest.get('*/linode/instances/1', (req, res, ctx) => {
+        return res(
+          ctx.json(
+            linodeFactory.build({
+              backups: {
+                enabled: true,
+                schedule: {
+                  day: 'Wednesday',
+                  window: 'W10',
+                },
+              },
+              id: 1,
+            })
+          )
+        );
+      }),
+      rest.get('*/profile', (req, res, ctx) => {
+        return res(
+          ctx.json(profileFactory.build({ timezone: 'America/New_York' }))
+        );
+      })
+    );
+
+    const { findByText } = renderWithTheme(
+      <ScheduleSettings isReadOnly={false} linodeId={1} />
+    );
+
+    await findByText('Wednesday');
+
+    // Because of Daylight savings time, offset will be -4 or -5.
+    const offset = DateTime.now().setZone('America/New_York').offset / 60;
+
+    // W10 indicates that your backups should be taken between 10:00 and 12:00 UTC.
+    // W10 in America/New_York will be 06:00 - 08:00 EDT (UTC-5) or 05:00 - 07:00 EST (UTC-4).
+    await findByText(`0${10 + offset}:00 - 0${10 + 2 + offset}:00`);
+
+    await findByText('Time displayed in America/New York');
   });
 });

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/ScheduleSettings.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/ScheduleSettings.test.tsx
@@ -37,7 +37,7 @@ describe('ScheduleSettings', () => {
                 enabled: true,
                 schedule: {
                   day: 'Monday',
-                  window: 'W4',
+                  window: 'W10',
                 },
               },
               id: 1,
@@ -46,9 +46,7 @@ describe('ScheduleSettings', () => {
         );
       }),
       rest.get('*/profile', (req, res, ctx) => {
-        return res(
-          ctx.json(profileFactory.build({ timezone: 'America/New_York' }))
-        );
+        return res(ctx.json(profileFactory.build({ timezone: 'utc' })));
       })
     );
 
@@ -57,8 +55,10 @@ describe('ScheduleSettings', () => {
     );
 
     await findByText('Monday');
-    await findByText('00:00 - 02:00');
 
-    await findByText('America/New York', { exact: false });
+    // W10 indicates that your backups should be taken between 10:00 and 12:00
+    await findByText('10:00 - 12:00');
+
+    await findByText('UTC', { exact: false });
   });
 });

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/ScheduleSettings.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/ScheduleSettings.test.tsx
@@ -1,3 +1,4 @@
+import { Settings } from 'luxon';
 import * as React from 'react';
 
 import { profileFactory } from 'src/factories';
@@ -6,7 +7,6 @@ import { rest, server } from 'src/mocks/testServer';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { ScheduleSettings } from './ScheduleSettings';
-import { DateTime } from 'luxon';
 
 describe('ScheduleSettings', () => {
   it('renders heading and copy', async () => {
@@ -63,7 +63,7 @@ describe('ScheduleSettings', () => {
     await findByText('Time displayed in utc');
   });
 
-  it('renders with the linode schedule taking into account the user timezone (America/New_York)', async () => {
+  it('renders with the linode schedule taking into account the user timezone (America/New_York) (EDT)', async () => {
     server.use(
       rest.get('*/linode/instances/1', (req, res, ctx) => {
         return res(
@@ -88,18 +88,59 @@ describe('ScheduleSettings', () => {
       })
     );
 
+    // Mock that today's date is May 25th, 2018 so that it is daylight savings time
+    Settings.now = () => new Date(2018, 4, 25).valueOf();
+
     const { findByText } = renderWithTheme(
       <ScheduleSettings isReadOnly={false} linodeId={1} />
     );
 
     await findByText('Wednesday');
 
-    // Because of Daylight savings time, offset will be -4 or -5.
-    const offset = DateTime.now().setZone('America/New_York').offset / 60;
+    // W10 indicates that your backups should be taken between 10:00 and 12:00 UTC.
+    // W10 in America/New_York during daylight savings is 06:00 - 08:00 EDT (UTC-4).
+    await findByText(`06:00 - 08:00`);
+
+    await findByText('Time displayed in America/New York');
+  });
+
+  it('renders with the linode schedule taking into account the user timezone (America/New_York) (EST)', async () => {
+    server.use(
+      rest.get('*/linode/instances/1', (req, res, ctx) => {
+        return res(
+          ctx.json(
+            linodeFactory.build({
+              backups: {
+                enabled: true,
+                schedule: {
+                  day: 'Wednesday',
+                  window: 'W10',
+                },
+              },
+              id: 1,
+            })
+          )
+        );
+      }),
+      rest.get('*/profile', (req, res, ctx) => {
+        return res(
+          ctx.json(profileFactory.build({ timezone: 'America/New_York' }))
+        );
+      })
+    );
+
+    // Mock that today's date is Nov 7th, 2023 so that it is *not* daylight savings time
+    Settings.now = () => new Date(2023, 11, 7).valueOf();
+
+    const { findByText } = renderWithTheme(
+      <ScheduleSettings isReadOnly={false} linodeId={1} />
+    );
+
+    await findByText('Wednesday');
 
     // W10 indicates that your backups should be taken between 10:00 and 12:00 UTC.
-    // W10 in America/New_York will be 06:00 - 08:00 EDT (UTC-4) or 05:00 - 07:00 EST (UTC-5).
-    await findByText(`0${10 + offset}:00 - 0${10 + 2 + offset}:00`);
+    // W10 in America/New_York when it is not daylight savings is 05:00 - 07:00 EST (UTC-5).
+    await findByText(`05:00 - 07:00`);
 
     await findByText('Time displayed in America/New York');
   });

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/ScheduleSettings.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/ScheduleSettings.test.tsx
@@ -59,6 +59,6 @@ describe('ScheduleSettings', () => {
     // W10 indicates that your backups should be taken between 10:00 and 12:00
     await findByText('10:00 - 12:00');
 
-    await findByText('UTC', { exact: false });
+    await findByText('Time displayed in utc');
   });
 });


### PR DESCRIPTION
## Description 📝
- Fixes `ScheduleSettings.test.tsx`  that broken due to Daylight savings time ending

## Changes  🔄
- Makes the unit test use `utc` for asserting the time
- Adds a DST-compatible unit test for `America/New_York`

## How to test 🧪

### Verification steps 
- `yarn test ScheduleSettings.test.tsx`
- Or verify Github Actions passes

## As an Author I have considered 🤔

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support