### PR TITLE
upcoming: [M3-7365] - New endpoints, query, types and mock data for Sold Out Plans

### DIFF
--- a/packages/api-v4/.changeset/pr-9878-upcoming-features-1699304438796.md
+++ b/packages/api-v4/.changeset/pr-9878-upcoming-features-1699304438796.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Upcoming Features
+---
+
+Add `getRegionAvailabilities` and `getRegionAvailability` endpoints and related types for Sold Out Plans initiative ([#9878](https://github.com/linode/manager/pull/9878))

--- a/packages/api-v4/src/regions/regions.ts
+++ b/packages/api-v4/src/regions/regions.ts
@@ -1,6 +1,6 @@
 import { API_ROOT } from '../constants';
-import Request, { setMethod, setParams, setURL } from '../request';
-import { Params, ResourcePage as Page } from '../types';
+import Request, { setMethod, setParams, setURL, setXFilter } from '../request';
+import { Filter, Params, ResourcePage as Page } from '../types';
 import { Region, RegionAvailability } from './types';
 
 /**
@@ -39,22 +39,27 @@ export const getRegion = (regionId: string) =>
 export { Region };
 
 /**
+ * getRegionAvailabilities
  *
- *
+ * Returns the availability status for all Linode plans for all regions.
  */
-export const getRegionAvailabilities = (params?: Params) =>
+export const getRegionAvailabilities = (params?: Params, filter?: Filter) =>
   Request<Page<RegionAvailability>>(
     setURL(`${API_ROOT}/regions/availability`),
     setMethod('GET'),
-    setParams(params)
+    setParams(params),
+    setXFilter(filter)
   );
 
 /**
+ * getRegionAvailability
  *
+ * Return the availability status of Linode plans for the given region.
  *
+ * @param regionId { string } The region to get the availabilities for
  */
 export const getRegionAvailability = (regionId: string) =>
-  Request<RegionAvailability>(
+  Request<RegionAvailability[]>(
     setURL(`${API_ROOT}/regions/${encodeURIComponent(regionId)}/availability`),
     setMethod('GET')
   );

--- a/packages/api-v4/src/regions/regions.ts
+++ b/packages/api-v4/src/regions/regions.ts
@@ -1,7 +1,7 @@
 import { API_ROOT } from '../constants';
 import Request, { setMethod, setParams, setURL } from '../request';
 import { Params, ResourcePage as Page } from '../types';
-import { Region } from './types';
+import { Region, RegionAvailability } from './types';
 
 /**
  * getRegions
@@ -27,13 +27,34 @@ export const getRegions = (params?: Params) =>
  *
  * Return detailed information about a particular region.
  *
- * @param regionID { string } The region to be retrieved.
+ * @param regionId { string } The region to be retrieved.
  *
  */
-export const getRegion = (regionID: string) =>
+export const getRegion = (regionId: string) =>
   Request<Region>(
-    setURL(`${API_ROOT}/regions/${encodeURIComponent(regionID)}`),
+    setURL(`${API_ROOT}/regions/${encodeURIComponent(regionId)}`),
     setMethod('GET')
   );
 
 export { Region };
+
+/**
+ *
+ *
+ */
+export const getRegionAvailabilities = (params?: Params) =>
+  Request<Page<RegionAvailability>>(
+    setURL(`${API_ROOT}/regions/availability`),
+    setMethod('GET'),
+    setParams(params)
+  );
+
+/**
+ *
+ *
+ */
+export const getRegionAvailability = (regionId: string) =>
+  Request<RegionAvailability>(
+    setURL(`${API_ROOT}/regions/${encodeURIComponent(regionId)}/availability`),
+    setMethod('GET')
+  );

--- a/packages/api-v4/src/regions/types.ts
+++ b/packages/api-v4/src/regions/types.ts
@@ -28,3 +28,9 @@ export interface Region {
   status: RegionStatus;
   resolvers: DNSResolvers;
 }
+
+export interface RegionAvailability {
+  available: boolean;
+  plan: string;
+  region: string;
+}

--- a/packages/manager/.changeset/pr-9878-upcoming-features-1699304466665.md
+++ b/packages/manager/.changeset/pr-9878-upcoming-features-1699304466665.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add RQ queries and mock data for Sold Out Plans ([#9878](https://github.com/linode/manager/pull/9878))

--- a/packages/manager/src/factories/regions.ts
+++ b/packages/manager/src/factories/regions.ts
@@ -44,6 +44,8 @@ export const regionWithDynamicPricingFactory = Factory.Sync.makeFactory<Region>(
 export const regionAvailabilityFactory = Factory.Sync.makeFactory<RegionAvailability>(
   {
     available: false,
+    // TODO SOLD OUT PLANS - Remove this comment once the API is changed: Note that the mock data below doesn't match what the API
+    // currently returns for plans; however, the API will be changing soon to match the below labels (ex: g7-premium-#, g1-gpu-rtx-6000-#)
     plan: Factory.each((id) =>
       pickRandom([`g7-premium-${id}`, `g1-gpu-rtx6000-${id}`])
     ),

--- a/packages/manager/src/factories/regions.ts
+++ b/packages/manager/src/factories/regions.ts
@@ -43,7 +43,7 @@ export const regionWithDynamicPricingFactory = Factory.Sync.makeFactory<Region>(
 
 export const regionAvailabilityFactory = Factory.Sync.makeFactory<RegionAvailability>(
   {
-    available: pickRandom([true, false]),
+    available: false,
     plan: Factory.each((id) =>
       pickRandom([`g7-premium-${id}`, `g1-gpu-rtx6000-${id}`])
     ),

--- a/packages/manager/src/factories/regions.ts
+++ b/packages/manager/src/factories/regions.ts
@@ -1,5 +1,11 @@
-import { DNSResolvers, Region } from '@linode/api-v4/lib/regions/types';
+import {
+  DNSResolvers,
+  Region,
+  RegionAvailability,
+} from '@linode/api-v4/lib/regions/types';
 import * as Factory from 'factory.ts';
+
+import { pickRandom } from 'src/utilities/random';
 
 export const resolverFactory = Factory.Sync.makeFactory<DNSResolvers>({
   ipv4: '1.1.1.1',
@@ -32,5 +38,15 @@ export const regionWithDynamicPricingFactory = Factory.Sync.makeFactory<Region>(
     label: 'Jakarta, ID',
     resolvers: resolverFactory.build(),
     status: 'ok',
+  }
+);
+
+export const regionAvailabilityFactory = Factory.Sync.makeFactory<RegionAvailability>(
+  {
+    available: pickRandom([true, false]),
+    plan: Factory.each((id) =>
+      pickRandom([`g7-premium-${id}`, `g1-gpu-rtx6000-${id}`])
+    ),
+    region: Factory.each((id) => `us-${id}`),
   }
 );

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -78,6 +78,7 @@ import {
   proDedicatedTypeFactory,
   profileFactory,
   promoFactory,
+  regionAvailabilityFactory,
   routeFactory,
   securityQuestionsFactory,
   serviceTargetFactory,
@@ -1060,7 +1061,6 @@ export const handlers = [
     });
     return res(ctx.json(linodeInvoice));
   }),
-
   rest.get('*/account/maintenance', (req, res, ctx) => {
     accountMaintenanceFactory.resetSequenceNumber();
     const page = Number(req.url.searchParams.get('page') || 1);
@@ -1610,6 +1610,16 @@ export const handlers = [
   }),
   rest.get('*/betas', (_req, res, ctx) => {
     return res(ctx.json(makeResourcePage(betaFactory.buildList(5))));
+  }),
+  rest.get('*regions/availability', (_req, res, ctx) => {
+    return res(
+      ctx.json(makeResourcePage(regionAvailabilityFactory.buildList(10)))
+    );
+  }),
+  rest.get('*regions/:regionId/availability', (_req, res, ctx) => {
+    return res(
+      ctx.json(regionAvailabilityFactory.buildList(5, { region: 'us-east' }))
+    );
   }),
   ...entityTransfers,
   ...statusPage,

--- a/packages/manager/src/queries/regions.ts
+++ b/packages/manager/src/queries/regions.ts
@@ -1,5 +1,16 @@
-import { Region, getRegions } from '@linode/api-v4/lib/regions';
-import { APIError } from '@linode/api-v4/lib/types';
+import {
+  Region,
+  RegionAvailability,
+  getRegionAvailabilities,
+  getRegionAvailability,
+  getRegions,
+} from '@linode/api-v4/lib/regions';
+import {
+  APIError,
+  Filter,
+  Params,
+  ResourcePage,
+} from '@linode/api-v4/lib/types';
 import { useQuery } from 'react-query';
 
 import data from 'src/cachedData/regions.json';
@@ -8,6 +19,7 @@ import { getAll } from 'src/utilities/getAll';
 import { queryPresets } from './base';
 
 const cachedData = data.data as Region[];
+const queryKey = 'region-availability';
 
 export const useRegionsQuery = () =>
   useQuery<Region[], APIError[]>('regions', getAllRegionsRequest, {
@@ -17,3 +29,33 @@ export const useRegionsQuery = () =>
 
 const getAllRegionsRequest = () =>
   getAll<Region>((params) => getRegions(params))().then((data) => data.data);
+
+// Region Availability queries
+
+export const useRegionsAvailabilitiesQuery = (
+  params: Params,
+  filter: Filter,
+  enabled: boolean = true
+) => {
+  return useQuery<ResourcePage<RegionAvailability>, APIError[]>(
+    [queryKey, 'paginated', params, filter],
+    () => getRegionAvailabilities(params, filter),
+    {
+      enabled,
+      keepPreviousData: true,
+    }
+  );
+};
+
+export const useRegionsAvailabilityQuery = (
+  id: string,
+  enabled: boolean = true
+) => {
+  return useQuery<RegionAvailability[], APIError[]>(
+    [queryKey, 'regionAvailability', id],
+    () => getRegionAvailability(id),
+    {
+      enabled,
+    }
+  );
+};

--- a/packages/manager/src/queries/regions.ts
+++ b/packages/manager/src/queries/regions.ts
@@ -5,12 +5,7 @@ import {
   getRegionAvailability,
   getRegions,
 } from '@linode/api-v4/lib/regions';
-import {
-  APIError,
-  Filter,
-  Params,
-  ResourcePage,
-} from '@linode/api-v4/lib/types';
+import { APIError } from '@linode/api-v4/lib/types';
 import { useQuery } from 'react-query';
 
 import data from 'src/cachedData/regions.json';
@@ -32,20 +27,16 @@ const getAllRegionsRequest = () =>
 
 // Region Availability queries
 
-export const useRegionsAvailabilitiesQuery = (
-  params: Params,
-  filter: Filter,
-  enabled: boolean = true
-) => {
-  return useQuery<ResourcePage<RegionAvailability>, APIError[]>(
-    [queryKey, 'paginated', params, filter],
-    () => getRegionAvailabilities(params, filter),
-    {
-      enabled,
-      keepPreviousData: true,
-    }
+export const useRegionsAvailabilitiesQuery = () =>
+  useQuery<RegionAvailability[], APIError[]>(
+    queryKey,
+    getAllRegionAvailabilitiesRequest
   );
-};
+
+const getAllRegionAvailabilitiesRequest = () =>
+  getAll<RegionAvailability>((params, filters) =>
+    getRegionAvailabilities(params, filters)
+  )().then((data) => data.data);
 
 export const useRegionsAvailabilityQuery = (
   id: string,


### PR DESCRIPTION
## Description 📝
 - Adds api-v4 endpoints and types for Sold Out Plans
- Adds react queries and mock data for Sold Out Plans

## How to test 🧪
This should have no impact (yet) on customer facing codebase.

Verification steps
- Review endpoints, spelling, and types -- cross reference endpoints and types with these two endpoints: [one](https://www.linode.com/docs/api/regions/#regions-availability-list) and [two](https://www.linode.com/docs/api/regions/#region-availability-view)
- If you'd like to test the MSW, you can use the react queries in some file and check the network calls. You can also cross reference the shape of the data returned by the MSW with the data returned from the actual queries
- Verify `/regions/:regionId` endpoint still works as expected (changed `regionID` to `regionId` for the input name)

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support
