### PR TITLE
test, upcoming: [M3-7134, M3-7314] - Add integration test for AGLB Edit Certificate flow and improve form validation

### DIFF
--- a/packages/manager/.changeset/pr-9880-tests-1699311124062.md
+++ b/packages/manager/.changeset/pr-9880-tests-1699311124062.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add integration tests for AGLB Edit Certificate flow ([#9880](https://github.com/linode/manager/pull/9880))

--- a/packages/manager/.changeset/pr-9880-upcoming-features-1699311064702.md
+++ b/packages/manager/.changeset/pr-9880-upcoming-features-1699311064702.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add missing label field validation in AGLB Edit Certificate drawer ([#9880](https://github.com/linode/manager/pull/9880))

--- a/packages/manager/cypress/e2e/core/loadBalancers/load-balancer-certificates.spec.ts
+++ b/packages/manager/cypress/e2e/core/loadBalancers/load-balancer-certificates.spec.ts
@@ -321,9 +321,8 @@ describe('Akamai Global Load Balancer certificates page', () => {
           .invoke('attr', 'placeholder')
           .should('contain', 'Private key is redacted for security.');
 
-        // Confirm that validation errors appear when drawer is not filled out correctly.
+        // Attempt to submit an incorrect form without a label or a new cert key.
         cy.findByLabelText('Certificate Label').clear();
-
         cy.findByLabelText('TLS Certificate').clear().type('my-new-cert');
 
         ui.buttonGroup
@@ -333,6 +332,8 @@ describe('Akamai Global Load Balancer certificates page', () => {
           .should('be.enabled')
           .click();
 
+        // Confirm that validation errors appear when drawer is not filled out correctly.
+        cy.findAllByText('Label must not be empty.').should('be.visible');
         cy.findAllByText('Private Key is required').should('be.visible');
 
         // Fix errors.
@@ -391,7 +392,7 @@ describe('Akamai Global Load Balancer certificates page', () => {
       '@getCertificates',
     ]);
 
-    // Edit a TLS certificate.
+    // Edit a CA certificate.
     ui.actionMenu
       .findByTitle(
         `Action Menu for certificate ${mockLoadBalancerCertServiceTarget.label}`
@@ -425,7 +426,7 @@ describe('Akamai Global Load Balancer certificates page', () => {
         cy.findByLabelText('Private Key').should('not.exist');
 
         // Confirm that validation errors appear when drawer is not filled out correctly.
-        cy.findByLabelText('Certificate Label').clear();
+        // cy.findByLabelText('Certificate Label').clear();
 
         ui.buttonGroup
           .findButtonByTitle('Update Certificate')

--- a/packages/manager/cypress/e2e/core/loadBalancers/load-balancer-certificates.spec.ts
+++ b/packages/manager/cypress/e2e/core/loadBalancers/load-balancer-certificates.spec.ts
@@ -251,7 +251,6 @@ describe('Akamai Global Load Balancer certificates page', () => {
    * - Confirms that TLS and Service Target certificates can be edited.
    * - Confirms that certificates table updates to reflect edited certificates.
    */
-
   it('can update a TLS certificate', () => {
     const mockLoadBalancer = loadbalancerFactory.build();
     const mockLoadBalancerCertTls = certificateFactory.build({
@@ -425,8 +424,8 @@ describe('Akamai Global Load Balancer certificates page', () => {
 
         cy.findByLabelText('Private Key').should('not.exist');
 
-        // Confirm that validation errors appear when drawer is not filled out correctly.
-        // cy.findByLabelText('Certificate Label').clear();
+        // Attempt to submit an incorrect form without a label.
+        cy.findByLabelText('Certificate Label').clear();
 
         ui.buttonGroup
           .findButtonByTitle('Update Certificate')
@@ -435,22 +434,23 @@ describe('Akamai Global Load Balancer certificates page', () => {
           .should('be.enabled')
           .click();
 
-        // TODO: label error
-        //cy.findAllByText('Label is required').should('be.visible');
+        // Confirm that validation error appears when drawer is not filled out correctly.
+        cy.findAllByText('Label must not be empty.').should('be.visible');
 
-        // Fix errors.
-        // cy.findByLabelText('Certificate Label')
-        //   .click()
-        //   .type(mockNewLoadBalancerCertServiceTarget.label);
+        // Fix error.
+        cy.findByLabelText('Certificate Label')
+          .click()
+          .type(mockNewLoadBalancerCertServiceTarget.label);
 
-        // cy.findByLabelText('TLS Certificate')
-        //   .click()
-        //   .type(mockNewLoadBalancerCertServiceTarget.certificate);
+        // Update certificate.
+        cy.findByLabelText('Server Certificate')
+          .click()
+          .type(mockNewLoadBalancerCertServiceTarget.certificate);
 
-        // ui.buttonGroup
-        //   .findButtonByTitle('Update Certificate')
-        //   .scrollIntoView()
-        //   .click();
+        ui.buttonGroup
+          .findButtonByTitle('Update Certificate')
+          .scrollIntoView()
+          .click();
       });
 
     cy.wait(['@updateCertificate', '@getCertificates']);
@@ -461,13 +461,13 @@ describe('Akamai Global Load Balancer certificates page', () => {
     );
   });
 
-   /*
+  /*
    * - Confirms Load Balancer certificate delete UI flow using mocked API requests.
    * - Confirms that TLS and Service Target certificates can be deleted.
    * - Confirms that certificates table update to reflects deleted certificates.
    * - Confirms that the last certificate can be deleted.
    */
-   it('can delete a TLS certificate', () => {
+  it('can delete a TLS certificate', () => {
     const mockLoadBalancerCertsTls = certificateFactory.buildList(5, {
       type: 'downstream',
     });

--- a/packages/manager/cypress/e2e/core/loadBalancers/load-balancer-certificates.spec.ts
+++ b/packages/manager/cypress/e2e/core/loadBalancers/load-balancer-certificates.spec.ts
@@ -7,7 +7,11 @@ import {
   mockGetFeatureFlagClientstream,
 } from 'support/intercepts/feature-flags';
 import { makeFeatureFlagData } from 'support/util/feature-flags';
-import { loadbalancerFactory, certificateFactory } from '@src/factories';
+import {
+  loadbalancerFactory,
+  certificateFactory,
+  mockCertificate,
+} from '@src/factories';
 import { ui } from 'support/ui';
 import { randomItem, randomLabel, randomString } from 'support/util/random';
 import {
@@ -15,6 +19,7 @@ import {
   mockDeleteLoadBalancerCertificateError,
   mockGetLoadBalancer,
   mockGetLoadBalancerCertificates,
+  mockUpdateLoadBalancerCertificate,
   mockUploadLoadBalancerCertificate,
 } from 'support/intercepts/load-balancers';
 import { Loadbalancer, Certificate } from '@linode/api-v4/types';
@@ -242,12 +247,226 @@ describe('Akamai Global Load Balancer certificates page', () => {
   });
 
   /*
+   * - Confirms Load Balancer certificate edit UI flow using mocked API requests.
+   * - Confirms that TLS and Service Target certificates can be edited.
+   * - Confirms that certificates table updates to reflect edited certificates.
+   */
+
+  it('can update a TLS certificate', () => {
+    const mockLoadBalancer = loadbalancerFactory.build();
+    const mockLoadBalancerCertTls = certificateFactory.build({
+      label: randomLabel(),
+      type: 'downstream',
+      certificate: mockCertificate.trim(),
+    });
+    const mockNewLoadBalancerCertTls = certificateFactory.build({
+      label: 'my-updated-tls-cert',
+      certificate: 'mock-new-cert',
+      key: 'mock-new-key',
+      type: 'downstream',
+    });
+
+    mockAppendFeatureFlags({
+      aglb: makeFeatureFlagData(true),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+    mockGetLoadBalancer(mockLoadBalancer).as('getLoadBalancer');
+    mockGetLoadBalancerCertificates(
+      mockLoadBalancer.id,
+      mockLoadBalancerCertTls
+    ).as('getCertificates');
+
+    cy.visitWithLogin(`/loadbalancers/${mockLoadBalancer.id}/certificates`);
+    cy.wait([
+      '@getFeatureFlags',
+      '@getClientStream',
+      '@getLoadBalancer',
+      '@getCertificates',
+    ]);
+
+    // Edit a TLS certificate.
+    ui.actionMenu
+      .findByTitle(
+        `Action Menu for certificate ${mockLoadBalancerCertTls.label}`
+      )
+      .should('be.visible')
+      .click();
+    ui.actionMenuItem.findByTitle('Edit').should('be.visible').click();
+
+    mockUpdateLoadBalancerCertificate(
+      mockLoadBalancer.id,
+      mockLoadBalancerCertTls
+    ).as('updateCertificate');
+
+    mockGetLoadBalancerCertificates(mockLoadBalancer.id, [
+      mockNewLoadBalancerCertTls,
+    ]).as('getCertificates');
+
+    ui.drawer
+      .findByTitle(`Edit ${mockLoadBalancerCertTls.label}`)
+      .should('be.visible')
+      .within(() => {
+        // Confirm that drawer displays certificate data or indicates where data is redacted for security.
+        cy.findByLabelText('Certificate Label')
+          .should('be.visible')
+          .should('have.value', mockLoadBalancerCertTls.label);
+
+        cy.findByLabelText('TLS Certificate')
+          .should('be.visible')
+          .should('have.value', mockLoadBalancerCertTls.certificate);
+
+        cy.findByLabelText('Private Key')
+          .should('be.visible')
+          .should('have.value', '')
+          .invoke('attr', 'placeholder')
+          .should('contain', 'Private key is redacted for security.');
+
+        // Confirm that validation errors appear when drawer is not filled out correctly.
+        cy.findByLabelText('Certificate Label').clear();
+
+        cy.findByLabelText('TLS Certificate').clear().type('my-new-cert');
+
+        ui.buttonGroup
+          .findButtonByTitle('Update Certificate')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+
+        cy.findAllByText('Private Key is required').should('be.visible');
+
+        // Fix errors.
+        cy.findByLabelText('Certificate Label')
+          .click()
+          .type(mockNewLoadBalancerCertTls.label);
+
+        cy.findByLabelText('TLS Certificate')
+          .click()
+          .type(mockNewLoadBalancerCertTls.certificate);
+
+        cy.findByLabelText('Private Key')
+          .click()
+          .type(mockNewLoadBalancerCertTls.key);
+
+        ui.buttonGroup
+          .findButtonByTitle('Update Certificate')
+          .scrollIntoView()
+          .click();
+      });
+
+    cy.wait(['@updateCertificate', '@getCertificates']);
+
+    // Confirm that new certificate is listed in the table with expected info.
+    cy.findByText(mockNewLoadBalancerCertTls.label).should('be.visible');
+  });
+
+  it('can update a service target certificate', () => {
+    const mockLoadBalancer = loadbalancerFactory.build();
+    const mockLoadBalancerCertServiceTarget = certificateFactory.build({
+      label: randomLabel(),
+      type: 'ca',
+      certificate: mockCertificate.trim(),
+    });
+    const mockNewLoadBalancerCertServiceTarget = certificateFactory.build({
+      label: 'my-updated-ca-cert',
+      certificate: 'mock-new-cert',
+      type: 'ca',
+    });
+
+    mockAppendFeatureFlags({
+      aglb: makeFeatureFlagData(true),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+    mockGetLoadBalancer(mockLoadBalancer).as('getLoadBalancer');
+    mockGetLoadBalancerCertificates(
+      mockLoadBalancer.id,
+      mockLoadBalancerCertServiceTarget
+    ).as('getCertificates');
+
+    cy.visitWithLogin(`/loadbalancers/${mockLoadBalancer.id}/certificates`);
+    cy.wait([
+      '@getFeatureFlags',
+      '@getClientStream',
+      '@getLoadBalancer',
+      '@getCertificates',
+    ]);
+
+    // Edit a TLS certificate.
+    ui.actionMenu
+      .findByTitle(
+        `Action Menu for certificate ${mockLoadBalancerCertServiceTarget.label}`
+      )
+      .should('be.visible')
+      .click();
+    ui.actionMenuItem.findByTitle('Edit').should('be.visible').click();
+
+    mockUpdateLoadBalancerCertificate(
+      mockLoadBalancer.id,
+      mockLoadBalancerCertServiceTarget
+    ).as('updateCertificate');
+
+    mockGetLoadBalancerCertificates(mockLoadBalancer.id, [
+      mockNewLoadBalancerCertServiceTarget,
+    ]).as('getCertificates');
+
+    ui.drawer
+      .findByTitle(`Edit ${mockLoadBalancerCertServiceTarget.label}`)
+      .should('be.visible')
+      .within(() => {
+        // Confirm that drawer displays certificate data or indicates where data is redacted for security.
+        cy.findByLabelText('Certificate Label')
+          .should('be.visible')
+          .should('have.value', mockLoadBalancerCertServiceTarget.label);
+
+        cy.findByLabelText('Server Certificate')
+          .should('be.visible')
+          .should('have.value', mockLoadBalancerCertServiceTarget.certificate);
+
+        cy.findByLabelText('Private Key').should('not.exist');
+
+        // Confirm that validation errors appear when drawer is not filled out correctly.
+        cy.findByLabelText('Certificate Label').clear();
+
+        ui.buttonGroup
+          .findButtonByTitle('Update Certificate')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+
+        // TODO: label error
+        //cy.findAllByText('Label is required').should('be.visible');
+
+        // Fix errors.
+        // cy.findByLabelText('Certificate Label')
+        //   .click()
+        //   .type(mockNewLoadBalancerCertServiceTarget.label);
+
+        // cy.findByLabelText('TLS Certificate')
+        //   .click()
+        //   .type(mockNewLoadBalancerCertServiceTarget.certificate);
+
+        // ui.buttonGroup
+        //   .findButtonByTitle('Update Certificate')
+        //   .scrollIntoView()
+        //   .click();
+      });
+
+    cy.wait(['@updateCertificate', '@getCertificates']);
+
+    // Confirm that new certificate is listed in the table with expected info.
+    cy.findByText(mockNewLoadBalancerCertServiceTarget.label).should(
+      'be.visible'
+    );
+  });
+
+   /*
    * - Confirms Load Balancer certificate delete UI flow using mocked API requests.
    * - Confirms that TLS and Service Target certificates can be deleted.
    * - Confirms that certificates table update to reflects deleted certificates.
    * - Confirms that the last certificate can be deleted.
    */
-  it('can delete a TLS certificate', () => {
+   it('can delete a TLS certificate', () => {
     const mockLoadBalancerCertsTls = certificateFactory.buildList(5, {
       type: 'downstream',
     });

--- a/packages/manager/cypress/support/intercepts/load-balancers.ts
+++ b/packages/manager/cypress/support/intercepts/load-balancers.ts
@@ -140,6 +140,24 @@ export const mockDeleteLoadBalancerCertificateError = (
 };
 
 /**
+ * Intercepts PUT request to update an AGLB load balancer certificate and mocks a success response.
+ *
+ * @param loadBalancerId - ID of load balancer for which to mock certificates.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockUpdateLoadBalancerCertificate = (
+  loadBalancerId: number,
+  certificate: Certificate
+) => {
+  return cy.intercept(
+    'PUT',
+    apiMatcher(`/aglb/${loadBalancerId}/certificates/${certificate.id}`),
+    makeResponse(certificate)
+  );
+};
+
+/**
  * Intercepts GET request to retrieve AGLB service targets and mocks response.
  *
  * @param serviceTargets - Service targets with which to mock response.

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/CreateCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/CreateCertificateDrawer.tsx
@@ -7,7 +7,6 @@ import { Notice } from 'src/components/Notice/Notice';
 import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
 import { useLoadBalancerCertificateCreateMutation } from 'src/queries/aglb/certificates';
-import { getErrorMap } from 'src/utilities/errorUtils';
 import { getFormikErrorsFromAPIErrors } from 'src/utilities/formikErrorUtils';
 import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
 

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
@@ -9,7 +9,7 @@ import { Notice } from 'src/components/Notice/Notice';
 import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
 import { useLoadBalancerCertificateMutation } from 'src/queries/aglb/certificates';
-import { getErrorMap } from 'src/utilities/errorUtils';
+import { getFormikErrorsFromAPIErrors } from 'src/utilities/formikErrorUtils';
 
 interface Props {
   certificate: Certificate | undefined;
@@ -55,26 +55,28 @@ export const EditCertificateDrawer = (props: Props) => {
         certificate?.certificate.trim() === values.certificate &&
         values.key === '';
 
-      await updateCertificate({
-        certificate:
-          values.certificate && !shouldIgnoreField
-            ? values.certificate
-            : undefined,
-        key: values.key && !shouldIgnoreField ? values.key : undefined,
-        label: values.label,
-        type: values.type,
-      });
-      onClose();
+      try {
+        await updateCertificate({
+          certificate:
+            values.certificate && !shouldIgnoreField
+              ? values.certificate
+              : undefined,
+          key: values.key && !shouldIgnoreField ? values.key : undefined,
+          label: values.label,
+          type: values.type,
+        });
+        onClose();
+      } catch (errors) {
+        formik.setErrors(getFormikErrorsFromAPIErrors(errors));
+      }
     },
+    // Disabling validateOnBlur and validateOnChange when an API error is shown prevents
+    // all API errors from disappearing when one field is changed.
+    validateOnBlur: !error,
+    validateOnChange: !error,
   });
 
-  const errorFields = ['label', 'certificate'];
-
-  if (certificate?.type === 'downstream') {
-    errorFields.push('key');
-  }
-
-  const errorMap = getErrorMap(errorFields, error);
+  const generalError = error?.find((e) => !e.field)?.reason;
 
   const onClose = () => {
     formik.resetForm();
@@ -89,16 +91,16 @@ export const EditCertificateDrawer = (props: Props) => {
       title={`Edit ${certificate?.label ?? 'Certificate'}`}
       wide
     >
+      {generalError && <Notice variant="error">{generalError}</Notice>}
       {!certificate ? (
         <Notice variant="error">Error loading certificate.</Notice>
       ) : (
         <form onSubmit={formik.handleSubmit}>
-          {errorMap.none && <Notice text={errorMap.none} variant="error" />}
           <Typography sx={{ marginBottom: theme.spacing(2) }}>
             {descriptionMap[certificate.type]}
           </Typography>
           <TextField
-            errorText={errorMap.label}
+            errorText={formik.errors.label}
             expand
             label="Certificate Label"
             name="label"
@@ -106,7 +108,7 @@ export const EditCertificateDrawer = (props: Props) => {
             value={formik.values.label}
           />
           <TextField
-            errorText={errorMap.certificate}
+            errorText={formik.errors.certificate}
             expand
             label={labelMap[certificate.type]}
             labelTooltipText="TODO: AGLB"
@@ -118,7 +120,7 @@ export const EditCertificateDrawer = (props: Props) => {
           />
           {certificate?.type === 'downstream' && (
             <TextField
-              errorText={errorMap.key}
+              errorText={formik.errors.key}
               expand
               label="Private Key"
               labelTooltipText="TODO: AGLB"

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
@@ -89,7 +89,6 @@ export const EditCertificateDrawer = (props: Props) => {
       title={`Edit ${certificate?.label ?? 'Certificate'}`}
       wide
     >
-      {errorMap.none && <Notice variant="error">{errorMap.none}</Notice>}
       {!certificate ? (
         <Notice variant="error">Error loading certificate.</Notice>
       ) : (

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
@@ -10,6 +10,7 @@ import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
 import { useLoadBalancerCertificateMutation } from 'src/queries/aglb/certificates';
 import { getFormikErrorsFromAPIErrors } from 'src/utilities/formikErrorUtils';
+import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
 
 interface Props {
   certificate: Certificate | undefined;
@@ -68,6 +69,7 @@ export const EditCertificateDrawer = (props: Props) => {
         onClose();
       } catch (errors) {
         formik.setErrors(getFormikErrorsFromAPIErrors(errors));
+        scrollErrorIntoView();
       }
     },
     // Disabling validateOnBlur and validateOnChange when an API error is shown prevents

--- a/packages/validation/.changeset/pr-9880-upcoming-features-1699311177462.md
+++ b/packages/validation/.changeset/pr-9880-upcoming-features-1699311177462.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Upcoming Features
+---
+
+Add missing label validation to `UpdateCertificateSchema` ([#9880](https://github.com/linode/manager/pull/9880))

--- a/packages/validation/src/loadbalancers.schema.ts
+++ b/packages/validation/src/loadbalancers.schema.ts
@@ -20,7 +20,7 @@ export const UpdateCertificateSchema = object().shape(
         type === 'downstream' && certificate,
       then: string().required('Private Key is required'),
     }),
-    label: string(),
+    label: string().min(1, 'Label must not be empty.'),
     type: string().oneOf(['downstream', 'ca']),
   },
   [['certificate', 'key']]


### PR DESCRIPTION
## Description 📝
This PR does two things, because fixing the validation was necessary for writing a complete integration test that confirmed all input errors were handled gracefully.

1. Add Cypress integration tests to confirm the UI flow for AGLB certification editing works as expected.
2. Provide form validation to prevent a user from being able to edit a certificate and provide a blank label.

## Changes  🔄
Integration tests in `load-balancer-certificates.spec.ts` test the following:
- User can edit certificates from the AGLB certificate page (route: /loadbalancers/:id/certificates)
- Certificates page updates to reflect edited certificates
- Cloud Manager handles user input errors (e.g. empty or invalid fields/selections) gracefully
- Cloud Manager handles server errors (e.g. HTTP 500 responses from the API) gracefully

In the Cloud Manager UI:
- A validation error ("Label must not be empty.") is provided when a user attempts to submit the Edit Certificate drawer with a blank label field. 

## Preview 📷
| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/114685994/aabf207c-6bf0-451c-8d0a-c580143f7ba1" /> | <video src="https://github.com/linode/manager/assets/114685994/94143886-e6f4-459e-bc30-d6bc79ce10c6" /> |

![Screenshot 2023-11-06 at 2 39 18 PM](https://github.com/linode/manager/assets/114685994/25c1b7a7-3f93-4d2c-ac20-0da6d3a28ea1)

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Checkout this PR.
- Make sure the `aglb` feature flag is on and **turn mocks on**. 

### Reproduction steps
(How to reproduce the issue, if applicable)
- Checkout `develop`.
- Go to http://localhost:3000/loadbalancers/0/certificates.
- Use the action menu (`...`) to select the Edit action and open the Edit Certificate drawer.
- Clear the pre-populated `label` field.
- Submit the form.
- Observe there is no validation error and in the request payload, the blank label is submitted. (Due to the mocks, this isn't visible in the UI.)

### Verification steps 
(How to verify changes)
- On this branch, go to http://localhost:3000/loadbalancers/0/certificates.
- Use the action menu (`...`) to select the Edit action and open the Edit Certificate drawer.
- Clear the pre-populated `label` field.
- Submit the form.
- Observe there is a validation error `Label must not be empty` and the form will not submit until a label is provided.

Also confirm the following validation still works as expected by checking the request payload:
- When editing a TLS certificate:
   - A user can edit just the form label, and the form will submit. The certificate will be excluded from the payload since it has not changed.
   - A user can edit just the key, and the form will submit. The existing certificate will be included in the payload, since updating a key requires a cert.
   - A user _cannot_ edit just the cert and will see a validation error on Private Key. This is invalid because updating a cert requires a key, and API does not return the key for security. 
   - A user can edit both the cert and the key, and the form will submit. Both the edited cert and edited key will be in the payload.

Confirm the integration test passes:
```
yarn cy:run -s "cypress/e2e/core/loadBalancers/load-balancer-certificates.spec.ts"
```
## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

