### PR TITLE
refactor: [M3-6964] - MUI v5 Migration - `SRC > Components > EditableInput`

### DIFF
--- a/packages/manager/.changeset/pr-9884-tech-stories-1699542889621.md
+++ b/packages/manager/.changeset/pr-9884-tech-stories-1699542889621.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+MUI v5 Migration - `SRC > Components > EditableInput` ([#9884](https://github.com/linode/manager/pull/9884))

--- a/packages/manager/src/components/EditableEntityLabel/EditableEntityLabel.tsx
+++ b/packages/manager/src/components/EditableEntityLabel/EditableEntityLabel.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { EntityIcon } from 'src/components/EntityIcon/EntityIcon';
 import { Typography } from 'src/components/Typography';
 
-import EditableInput from './EditableInput';
+import { EditableInput } from './EditableInput';
 
 import type { EntityVariants } from 'src/components/EntityIcon/EntityIcon';
 

--- a/packages/manager/src/components/EditableEntityLabel/EditableInput.styles.tsx
+++ b/packages/manager/src/components/EditableEntityLabel/EditableInput.styles.tsx
@@ -1,0 +1,102 @@
+import Edit from '@mui/icons-material/Edit';
+import { styled } from '@mui/material/styles';
+
+import { Box } from 'src/components/Box';
+import { Button } from 'src/components/Button/Button';
+import { TextField, TextFieldProps } from 'src/components/TextField';
+import { Typography } from 'src/components/Typography';
+import { fadeIn } from 'src/styles/keyframes';
+
+import { EditableInputProps } from './EditableInput';
+
+export const StyledTypography = styled(Typography)(({ theme, ...props }) => ({
+  ...(!props.className && {
+    display: 'inline-block',
+    lineHeight: 1,
+    padding: '5px 8px',
+    textDecoration: 'inherit',
+    transition: theme.transitions.create(['opacity']),
+    wordBreak: 'break-all',
+  }),
+}));
+
+export const StyledTextContainer = styled(Box)(({ theme }) => ({
+  '& svg': {
+    [theme.breakpoints.up('sm')]: {
+      opacity: 0,
+    },
+  },
+  '&:hover, &:focus': {
+    '& svg': {
+      '&:hover': {
+        color: theme.color.black,
+      },
+      color: theme.color.grey1,
+      opacity: 1,
+    },
+  },
+  alignItems: 'center',
+  display: 'flex',
+  justifyContent: 'flex-start',
+  position: 'relative',
+}));
+
+export const StyledButton = styled(Button)(() => ({
+  height: 24,
+  marginTop: 0,
+  minHeight: 'auto',
+  minWidth: 'auto',
+  padding: 0,
+  position: 'absolute',
+  right: 10,
+  width: 24,
+}));
+
+export const StyledEdit = styled(Edit)(({ theme }) => ({
+  '&:hover, &:focus': {
+    color: theme.palette.primary.light,
+  },
+  border: '1px solid transparent',
+  color: theme.palette.text.primary,
+  fontSize: 22,
+  margin: '0 10px',
+}));
+
+export const StyledEditingContainer = styled(Box)(() => ({
+  alignItems: 'center',
+  border: '1px solid transparent',
+  display: 'flex',
+  fontSize: 22,
+  gap: 2,
+  justifyContent: 'flex-start',
+  position: 'relative',
+}));
+
+export const StyledTextField = styled(TextField)<
+  Partial<EditableInputProps> & TextFieldProps
+>(({ theme, ...props }) => ({
+  '& .MuiInputBase-input': {
+    padding: '5px 8px',
+    ...theme.typography.body1,
+    ...(props.typeVariant === 'h1' && {
+      ...theme.typography.h1,
+    }),
+    ...(props.typeVariant === 'h2' && {
+      ...theme.typography.h2,
+    }),
+  },
+  '& .MuiInputBase-root': {
+    backgroundColor: 'transparent',
+    borderColor: `${theme.palette.primary.main} !important`,
+    boxShadow: 'none',
+    maxWidth: 170,
+    minHeight: 40,
+    [theme.breakpoints.up('md')]: {
+      maxWidth: 415,
+      width: '100%',
+    },
+  },
+  animation: `${fadeIn} .3s ease-in-out forwards`,
+  margin: 0,
+  opacity: 0,
+}));

--- a/packages/manager/src/components/EditableEntityLabel/EditableInput.styles.tsx
+++ b/packages/manager/src/components/EditableEntityLabel/EditableInput.styles.tsx
@@ -3,11 +3,7 @@ import { styled } from '@mui/material/styles';
 
 import { Box } from 'src/components/Box';
 import { Button } from 'src/components/Button/Button';
-import { TextField, TextFieldProps } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
-import { fadeIn } from 'src/styles/keyframes';
-
-import { EditableInputProps } from './EditableInput';
 
 export const StyledTypography = styled(Typography)(({ theme, ...props }) => ({
   ...(!props.className && {
@@ -70,33 +66,4 @@ export const StyledEditingContainer = styled(Box)(() => ({
   gap: 2,
   justifyContent: 'flex-start',
   position: 'relative',
-}));
-
-export const StyledTextField = styled(TextField)<
-  Partial<EditableInputProps> & TextFieldProps
->(({ theme, ...props }) => ({
-  '& .MuiInputBase-input': {
-    padding: '5px 8px',
-    ...theme.typography.body1,
-    ...(props.typeVariant === 'h1' && {
-      ...theme.typography.h1,
-    }),
-    ...(props.typeVariant === 'h2' && {
-      ...theme.typography.h2,
-    }),
-  },
-  '& .MuiInputBase-root': {
-    backgroundColor: 'transparent',
-    borderColor: `${theme.palette.primary.main} !important`,
-    boxShadow: 'none',
-    maxWidth: 170,
-    minHeight: 40,
-    [theme.breakpoints.up('md')]: {
-      maxWidth: 415,
-      width: '100%',
-    },
-  },
-  animation: `${fadeIn} .3s ease-in-out forwards`,
-  margin: 0,
-  opacity: 0,
 }));

--- a/packages/manager/src/components/EditableEntityLabel/EditableInput.styles.tsx
+++ b/packages/manager/src/components/EditableEntityLabel/EditableInput.styles.tsx
@@ -5,7 +5,9 @@ import { Box } from 'src/components/Box';
 import { Button } from 'src/components/Button/Button';
 import { Typography } from 'src/components/Typography';
 
-export const StyledTypography = styled(Typography)(({ theme, ...props }) => ({
+export const StyledTypography = styled(Typography, {
+  label: 'EditableInput__StyledTypography',
+})(({ theme, ...props }) => ({
   ...(!props.className && {
     display: 'inline-block',
     lineHeight: 1,
@@ -16,7 +18,9 @@ export const StyledTypography = styled(Typography)(({ theme, ...props }) => ({
   }),
 }));
 
-export const StyledTextContainer = styled(Box)(({ theme }) => ({
+export const StyledTextContainer = styled(Box, {
+  label: 'EditableInput__StyledTextContainer',
+})(({ theme }) => ({
   '& svg': {
     [theme.breakpoints.up('sm')]: {
       opacity: 0,
@@ -37,7 +41,9 @@ export const StyledTextContainer = styled(Box)(({ theme }) => ({
   position: 'relative',
 }));
 
-export const StyledButton = styled(Button)(() => ({
+export const StyledButton = styled(Button, {
+  label: 'EditableInput__StyledButton',
+})(() => ({
   height: 24,
   marginTop: 0,
   minHeight: 'auto',
@@ -48,7 +54,9 @@ export const StyledButton = styled(Button)(() => ({
   width: 24,
 }));
 
-export const StyledEdit = styled(Edit)(({ theme }) => ({
+export const StyledEdit = styled(Edit, {
+  label: 'EditableInput__StyledEdit',
+})(({ theme }) => ({
   '&:hover, &:focus': {
     color: theme.palette.primary.light,
   },
@@ -58,7 +66,9 @@ export const StyledEdit = styled(Edit)(({ theme }) => ({
   margin: '0 10px',
 }));
 
-export const StyledEditingContainer = styled(Box)(() => ({
+export const StyledEditingContainer = styled(Box, {
+  label: 'EditableInput__StyledEditingContainer',
+})(() => ({
   alignItems: 'center',
   border: '1px solid transparent',
   display: 'flex',

--- a/packages/manager/src/components/EditableEntityLabel/EditableInput.styles.tsx
+++ b/packages/manager/src/components/EditableEntityLabel/EditableInput.styles.tsx
@@ -3,7 +3,11 @@ import { styled } from '@mui/material/styles';
 
 import { Box } from 'src/components/Box';
 import { Button } from 'src/components/Button/Button';
+import { TextField, TextFieldProps } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
+import { fadeIn } from 'src/styles/keyframes';
+
+import { EditableTextVariant } from './EditableInput';
 
 export const StyledTypography = styled(Typography, {
   label: 'EditableInput__StyledTypography',
@@ -76,4 +80,37 @@ export const StyledEditingContainer = styled(Box, {
   gap: 2,
   justifyContent: 'flex-start',
   position: 'relative',
+}));
+
+type ExpandedTextField = TextFieldProps & {
+  typeVariant: EditableTextVariant;
+};
+
+export const StyledTextField = styled(TextField, {
+  label: 'EditableInput__StyledTextField',
+})<ExpandedTextField>(({ theme, ...props }) => ({
+  '& .MuiInputBase-input': {
+    padding: '5px 8px',
+    ...theme.typography.body1,
+    ...(props.typeVariant === 'h1' && {
+      ...theme.typography.h1,
+    }),
+    ...(props.typeVariant === 'h2' && {
+      ...theme.typography.h2,
+    }),
+  },
+  '& .MuiInputBase-root': {
+    backgroundColor: 'transparent',
+    borderColor: `${theme.palette.primary.main} !important`,
+    boxShadow: 'none',
+    maxWidth: 170,
+    minHeight: 40,
+    [theme.breakpoints.up('md')]: {
+      maxWidth: 415,
+      width: '100%',
+    },
+  },
+  animation: `${fadeIn} .3s ease-in-out forwards`,
+  margin: 0,
+  opacity: 0,
 }));

--- a/packages/manager/src/components/EditableEntityLabel/EditableInput.tsx
+++ b/packages/manager/src/components/EditableEntityLabel/EditableInput.tsx
@@ -13,7 +13,6 @@ import {
   StyledEdit,
   StyledEditingContainer,
   StyledTextContainer,
-  // StyledTextField,
   StyledTypography,
 } from './EditableInput.styles';
 

--- a/packages/manager/src/components/EditableEntityLabel/EditableInput.tsx
+++ b/packages/manager/src/components/EditableEntityLabel/EditableInput.tsx
@@ -1,17 +1,19 @@
 import Check from '@mui/icons-material/Check';
 import Close from '@mui/icons-material/Close';
+import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 
 import { ClickAwayListener } from 'src/components/ClickAwayListener';
 import { IconButton } from 'src/components/IconButton';
-import { TextFieldProps } from 'src/components/TextField';
+import { TextField, TextFieldProps } from 'src/components/TextField';
+import { fadeIn } from 'src/styles/keyframes';
 
 import {
   StyledButton,
   StyledEdit,
   StyledEditingContainer,
   StyledTextContainer,
-  StyledTextField,
+  // StyledTextField,
   StyledTypography,
 } from './EditableInput.styles';
 
@@ -51,6 +53,8 @@ export const EditableInput = (props: FilteredEditableInputProps) => {
     ...rest
   } = props;
 
+  const theme = useTheme();
+
   /** confirm or cancel edits if the enter or escape keys are pressed, respectively */
   const handleKeyPress = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
@@ -72,6 +76,35 @@ export const EditableInput = (props: FilteredEditableInputProps) => {
     </StyledTypography>
   );
 
+  const textFieldStyles = {
+    '& .MuiInputBase-input': {
+      padding: '5px 8px',
+      ...theme.typography.body1,
+      ...(props.typeVariant === 'h1' && {
+        ...theme.typography.h1,
+        color: 'red',
+      }),
+      ...(props.typeVariant === 'h2' && {
+        ...theme.typography.h2,
+        color: 'blue',
+      }),
+    },
+    '& .MuiInputBase-root': {
+      backgroundColor: 'transparent',
+      borderColor: `${theme.palette.primary.main} !important`,
+      boxShadow: 'none',
+      maxWidth: 170,
+      minHeight: 40,
+      [theme.breakpoints.up('md')]: {
+        maxWidth: 415,
+        width: '100%',
+      },
+    },
+    animation: `${fadeIn} .3s ease-in-out forwards`,
+    margin: 0,
+    opacity: 0,
+  };
+
   return !isEditing && !errorText ? (
     <StyledTextContainer className={className} data-testid={'editable-text'}>
       {labelText}
@@ -87,7 +120,7 @@ export const EditableInput = (props: FilteredEditableInputProps) => {
   ) : (
     <ClickAwayListener mouseEvent="onMouseDown" onClickAway={cancelEdit}>
       <StyledEditingContainer className={className} data-qa-edit-field>
-        <StyledTextField
+        <TextField
           {...rest}
           // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus={true}
@@ -98,6 +131,7 @@ export const EditableInput = (props: FilteredEditableInputProps) => {
           loading={loading}
           onChange={(e: any) => onInputChange(e.target.value)}
           onKeyDown={handleKeyPress}
+          sx={textFieldStyles}
           type="text"
           value={inputText}
         />

--- a/packages/manager/src/components/EditableEntityLabel/EditableInput.tsx
+++ b/packages/manager/src/components/EditableEntityLabel/EditableInput.tsx
@@ -1,130 +1,23 @@
 import Check from '@mui/icons-material/Check';
 import Close from '@mui/icons-material/Close';
-import Edit from '@mui/icons-material/Edit';
-import { Theme } from '@mui/material/styles';
-import { makeStyles } from '@mui/styles';
-import classNames from 'classnames';
 import * as React from 'react';
 
-import { Button } from 'src/components/Button/Button';
 import { ClickAwayListener } from 'src/components/ClickAwayListener';
-import { TextField, TextFieldProps } from 'src/components/TextField';
-import { Typography } from 'src/components/Typography';
+import { IconButton } from 'src/components/IconButton';
+import { TextFieldProps } from 'src/components/TextField';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  '@keyframes fadeIn': {
-    from: {
-      opacity: 0,
-    },
-    to: {
-      opacity: 1,
-    },
-  },
-  button: {
-    background: 'transparent !important',
-    height: 24,
-    marginTop: 5,
-    minHeight: 'auto',
-    minWidth: 'auto',
-    padding: 0,
-    width: 24,
-  },
-  close: {
-    fontSize: 26,
-  },
-  container: {
-    alignItems: 'center',
-    display: 'flex',
-    justifyContent: 'flex-start',
-    position: 'relative',
-  },
-  containerEditing: {
-    alignItems: 'flex-start',
-    display: 'flex',
-    justifyContent: 'flex-start',
-    position: 'relative',
-  },
-  edit: {
-    border: '1px solid transparent',
-    fontSize: 22,
-  },
-  editIcon: {
-    marginTop: '0 !important',
-    position: 'absolute',
-    right: 10,
-    [theme.breakpoints.up('sm')]: {
-      '&:focus': {
-        opacity: 1,
-      },
-      opacity: 0,
-    },
-  },
-  headline: {
-    ...theme.typography.h1,
-  },
-  icon: {
-    '&:hover, &:focus': {
-      color: theme.palette.primary.light,
-    },
-    color: theme.palette.text.primary,
-    margin: '0 10px',
-  },
-  initial: {
-    '&:hover, &:focus': {
-      '& $editIcon': {
-        opacity: 1,
-      },
-      '& $icon': {
-        '&:hover': {
-          color: theme.color.black,
-        },
-        color: theme.color.grey1,
-      },
-    },
-  },
-  input: {
-    padding: '5px 8px',
-    ...theme.typography.body1,
-  },
-  inputRoot: {
-    backgroundColor: 'transparent',
-    borderColor: `${theme.palette.primary.main} !important`,
-    boxShadow: 'none',
-    maxWidth: 170,
-    minHeight: 40,
-    [theme.breakpoints.up('md')]: {
-      maxWidth: 415,
-      width: '100%',
-    },
-  },
-  root: {
-    display: 'inline-block',
-    lineHeight: 1,
-    padding: '5px 8px',
-    textDecoration: 'inherit',
-    transition: theme.transitions.create(['opacity']),
-    wordBreak: 'break-all',
-  },
-  save: {
-    fontSize: 26,
-  },
-  saveButton: {
-    marginLeft: 8,
-    marginRight: 8,
-  },
-  textField: {
-    animation: '$fadeIn .3s ease-in-out forwards',
-    margin: 0,
-    opacity: 0,
-  },
-  title: {
-    ...theme.typography.h1,
-  },
-}));
+import {
+  StyledButton,
+  StyledEdit,
+  StyledEditingContainer,
+  StyledTextContainer,
+  StyledTextField,
+  StyledTypography,
+} from './EditableInput.styles';
 
 export type EditableTextVariant = 'h1' | 'h2' | 'table-cell';
 
-interface Props {
+export interface EditableInputProps {
   cancelEdit: () => void;
   className?: string;
   editable?: boolean;
@@ -139,15 +32,13 @@ interface Props {
   typeVariant: EditableTextVariant;
 }
 
-type PassThroughProps = Props & Omit<TextFieldProps, 'label'>;
+type FilteredEditableInputProps = EditableInputProps &
+  Omit<TextFieldProps, 'label'>;
 
-type FinalProps = PassThroughProps;
-
-export const EditableInput: React.FC<FinalProps> = (props) => {
+export const EditableInput = (props: FilteredEditableInputProps) => {
   const {
     cancelEdit,
     className,
-    editable,
     errorText,
     inputText,
     isEditing,
@@ -170,54 +61,36 @@ export const EditableInput: React.FC<FinalProps> = (props) => {
     }
   };
 
-  const classes = useStyles();
-
   const labelText = (
-    <Typography
+    <StyledTypography
       aria-label={text}
-      className={className ? className : classes.root}
+      className={className}
       data-qa-editable-text
       variant={typeVariant === 'table-cell' ? 'body1' : 'h1'}
     >
       <strong>{text}</strong>
-    </Typography>
+    </StyledTypography>
   );
 
   return !isEditing && !errorText ? (
-    <div
-      className={`${classes.initial} ${className} ${classes.container}`}
-      data-testid={'editable-text'}
-    >
+    <StyledTextContainer className={className} data-testid={'editable-text'}>
       {labelText}
       {/** pencil icon */}
-      <Button
+      <StyledButton
         aria-label={`Edit ${text}`}
-        className={`${classes.button} ${classes.editIcon}`}
         data-qa-edit-button
         onClick={openForEdit}
       >
-        <Edit className={`${classes.icon} ${classes.edit}`} />
-      </Button>
-    </div>
+        <StyledEdit />
+      </StyledButton>
+    </StyledTextContainer>
   ) : (
     <ClickAwayListener mouseEvent="onMouseDown" onClickAway={cancelEdit}>
-      <div
-        className={`${classes.containerEditing} ${classes.edit} ${className}`}
-        data-qa-edit-field
-      >
-        <TextField
+      <StyledEditingContainer className={className} data-qa-edit-field>
+        <StyledTextField
           {...rest}
-          inputProps={{
-            className: classNames({
-              [classes.headline]: typeVariant === 'h1',
-              [classes.input]: true,
-              [classes.title]: typeVariant === 'h2',
-            }),
-          }}
-          InputProps={{ className: classes.inputRoot }}
           // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus={true}
-          className={classes.textField}
           editable
           errorText={errorText}
           hideLabel
@@ -230,27 +103,25 @@ export const EditableInput: React.FC<FinalProps> = (props) => {
         />
         {!loading && (
           <>
-            <Button
+            <IconButton
               aria-label="Save new label"
-              className={`${classes.button} ${classes.saveButton}`}
               data-qa-save-edit
               onClick={() => onEdit()}
+              size="small"
             >
-              <Check className={`${classes.icon} ${classes.save}`} />
-            </Button>
-            <Button
+              <Check />
+            </IconButton>
+            <IconButton
               aria-label="Cancel label edit"
-              className={classes.button}
               data-qa-cancel-edit
               onClick={cancelEdit}
+              size="small"
             >
-              <Close className={`${classes.icon} ${classes.close}`} />
-            </Button>
+              <Close />
+            </IconButton>
           </>
         )}
-      </div>
+      </StyledEditingContainer>
     </ClickAwayListener>
   );
 };
-
-export default EditableInput;

--- a/packages/manager/src/components/EditableEntityLabel/EditableInput.tsx
+++ b/packages/manager/src/components/EditableEntityLabel/EditableInput.tsx
@@ -1,18 +1,17 @@
 import Check from '@mui/icons-material/Check';
 import Close from '@mui/icons-material/Close';
-import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 
 import { ClickAwayListener } from 'src/components/ClickAwayListener';
 import { IconButton } from 'src/components/IconButton';
-import { TextField, TextFieldProps } from 'src/components/TextField';
-import { fadeIn } from 'src/styles/keyframes';
+import { TextFieldProps } from 'src/components/TextField';
 
 import {
   StyledButton,
   StyledEdit,
   StyledEditingContainer,
   StyledTextContainer,
+  StyledTextField,
   StyledTypography,
 } from './EditableInput.styles';
 
@@ -52,8 +51,6 @@ export const EditableInput = (props: FilteredEditableInputProps) => {
     ...rest
   } = props;
 
-  const theme = useTheme();
-
   /** confirm or cancel edits if the enter or escape keys are pressed, respectively */
   const handleKeyPress = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
@@ -75,35 +72,6 @@ export const EditableInput = (props: FilteredEditableInputProps) => {
     </StyledTypography>
   );
 
-  const textFieldStyles = {
-    '& .MuiInputBase-input': {
-      padding: '5px 8px',
-      ...theme.typography.body1,
-      ...(props.typeVariant === 'h1' && {
-        ...theme.typography.h1,
-        color: 'red',
-      }),
-      ...(props.typeVariant === 'h2' && {
-        ...theme.typography.h2,
-        color: 'blue',
-      }),
-    },
-    '& .MuiInputBase-root': {
-      backgroundColor: 'transparent',
-      borderColor: `${theme.palette.primary.main} !important`,
-      boxShadow: 'none',
-      maxWidth: 170,
-      minHeight: 40,
-      [theme.breakpoints.up('md')]: {
-        maxWidth: 415,
-        width: '100%',
-      },
-    },
-    animation: `${fadeIn} .3s ease-in-out forwards`,
-    margin: 0,
-    opacity: 0,
-  };
-
   return !isEditing && !errorText ? (
     <StyledTextContainer className={className} data-testid={'editable-text'}>
       {labelText}
@@ -119,7 +87,7 @@ export const EditableInput = (props: FilteredEditableInputProps) => {
   ) : (
     <ClickAwayListener mouseEvent="onMouseDown" onClickAway={cancelEdit}>
       <StyledEditingContainer className={className} data-qa-edit-field>
-        <TextField
+        <StyledTextField
           {...rest}
           // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus={true}
@@ -130,8 +98,8 @@ export const EditableInput = (props: FilteredEditableInputProps) => {
           loading={loading}
           onChange={(e: any) => onInputChange(e.target.value)}
           onKeyDown={handleKeyPress}
-          sx={textFieldStyles}
           type="text"
+          typeVariant={typeVariant}
           value={inputText}
         />
         {!loading && (


### PR DESCRIPTION
## Description 📝
Refactors on `SRC > Components > EditableInput` for MUI v5 migration

## Changes  🔄
- Converts `makeStyles` to `styled` API
- Moved styles to separate file
- Buttons "x" and checkmark have been converted to IconButton and look nicer

## Preview 📷
> [!note]
> Gif below has been slowed down and is a little pixelated compared to what you'll actually see.

![editablelabel](https://github.com/linode/manager/assets/125309814/a0b7ee97-5d94-47b3-9bdf-1fe829087657)


## How to test 🧪

### Prerequisites
- Pull down branch

### Reproduction steps
- Go to any longview page with a client

### Verification steps 
- There should be no visual changes except for the icon buttons
- Observe changing `typeVariant` in the `EditableEntityLabel` file to `h1/h2/table-cell` work

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support