### PR TITLE
fix: [M3-7331] - VPC and StackScript details overflow

### DIFF
--- a/packages/manager/.changeset/pr-9887-fixed-1699470171696.md
+++ b/packages/manager/.changeset/pr-9887-fixed-1699470171696.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Fix overflow for VPC and StackScript detail descriptions and prevent VPC searchbar placeholder text from being cut off ([#9887](https://github.com/linode/manager/pull/9887))
+Overflow for VPC and StackScript detail descriptions and cut off placeholder text in VPC search bar ([#9887](https://github.com/linode/manager/pull/9887))

--- a/packages/manager/.changeset/pr-9887-fixed-1699470171696.md
+++ b/packages/manager/.changeset/pr-9887-fixed-1699470171696.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fix overflow for VPC and StackScript detail descriptions and prevent VPC searchbar placeholder text from being cut off ([#9887](https://github.com/linode/manager/pull/9887))

--- a/packages/manager/src/components/DebouncedSearchTextField/DebouncedSearchTextField.tsx
+++ b/packages/manager/src/components/DebouncedSearchTextField/DebouncedSearchTextField.tsx
@@ -76,14 +76,6 @@ const DebouncedSearch = (props: DebouncedSearchProps) => {
         ),
         ...InputProps,
       }}
-      sx={{
-        '& input::placeholder': {
-          color: 'green',
-        },
-        '& input': {
-          color: 'green',
-        },
-      }}
       className={className}
       data-qa-debounced-search
       defaultValue={defaultValue}

--- a/packages/manager/src/components/DebouncedSearchTextField/DebouncedSearchTextField.tsx
+++ b/packages/manager/src/components/DebouncedSearchTextField/DebouncedSearchTextField.tsx
@@ -76,6 +76,14 @@ const DebouncedSearch = (props: DebouncedSearchProps) => {
         ),
         ...InputProps,
       }}
+      sx={{
+        '& input::placeholder': {
+          color: 'green',
+        },
+        '& input': {
+          color: 'green',
+        },
+      }}
       className={className}
       data-qa-debounced-search
       defaultValue={defaultValue}

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -49,9 +49,9 @@ const useStyles = makeStyles()((theme: Theme) => ({
     marginTop: theme.spacing(1),
   },
   description: {
-    overflowWrap: 'break-word',
+    overflowWrap: 'anywhere',
     whiteSpace: 'pre-wrap',
-    wordBreak: 'break-word',
+    wordBreak: 'normal',
   },
   descriptionText: {
     marginBottom: theme.spacing(2),

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -49,6 +49,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     marginTop: theme.spacing(1),
   },
   description: {
+    overflowWrap: 'break-word',
     whiteSpace: 'pre-wrap',
     wordBreak: 'break-word',
   },

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -87,7 +87,7 @@ interface StackScriptImages {
   deprecated: JSX.Element[];
 }
 
-export const StackScript = (props: StackScriptProps) => {
+export const StackScript = React.memo((props: StackScriptProps) => {
   const {
     data: {
       deployments_active,
@@ -277,6 +277,4 @@ export const StackScript = (props: StackScriptProps) => {
       <ScriptCode script={script} />
     </div>
   );
-};
-
-export default React.memo(StackScript);
+});

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -1,10 +1,10 @@
 import { StackScript as StackScriptType } from '@linode/api-v4/lib/stackscripts';
-import { Box } from 'src/components/Box';
 import { Theme, useTheme } from '@mui/material/styles';
 import * as React from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { makeStyles } from 'tss-react/mui';
 
+import { Box } from 'src/components/Box';
 import { Button } from 'src/components/Button/Button';
 import { Chip } from 'src/components/Chip';
 import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
@@ -50,6 +50,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
   },
   description: {
     whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
   },
   descriptionText: {
     marginBottom: theme.spacing(2),

--- a/packages/manager/src/components/StackScript/index.ts
+++ b/packages/manager/src/components/StackScript/index.ts
@@ -1,4 +1,0 @@
-import StackScript, { StackScriptProps } from './StackScript';
-export default StackScript;
-/* tslint:disable */
-export type Props = StackScriptProps;

--- a/packages/manager/src/features/StackScripts/StackScriptDialog.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptDialog.tsx
@@ -6,7 +6,7 @@ import { MapDispatchToProps, connect } from 'react-redux';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { Dialog } from 'src/components/Dialog/Dialog';
 import { Notice } from 'src/components/Notice/Notice';
-import _StackScript from 'src/components/StackScript';
+import { StackScript as _StackScript } from 'src/components/StackScript/StackScript';
 import { ApplicationState } from 'src/store';
 import { closeStackScriptDialog } from 'src/store/stackScriptDialog';
 import { MapState } from 'src/store/types';

--- a/packages/manager/src/features/StackScripts/StackScriptsDetail.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsDetail.tsx
@@ -10,7 +10,7 @@ import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { LandingHeader } from 'src/components/LandingHeader';
 import { NotFound } from 'src/components/NotFound';
-import _StackScript from 'src/components/StackScript';
+import { StackScript as _StackScript } from 'src/components/StackScript/StackScript';
 import { useAccountManagement } from 'src/hooks/useAccountManagement';
 import { useGrants } from 'src/queries/profile';
 import { getAPIErrorOrDefault, getErrorMap } from 'src/utilities/errorUtils';

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.tsx
@@ -161,9 +161,7 @@ const VPCDetail = () => {
                 Description
               </span>{' '}
             </Typography>
-            <Typography
-              sx={{ overflowWrap: 'break-word', wordBreak: 'break-word' }}
-            >
+            <Typography sx={{ overflowWrap: 'anywhere', wordBreak: 'normal' }}>
               {description}{' '}
               {description.length > 150 && (
                 <StyledLinkButton

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.tsx
@@ -161,7 +161,9 @@ const VPCDetail = () => {
                 Description
               </span>{' '}
             </Typography>
-            <Typography sx={{ wordBreak: 'break-word' }}>
+            <Typography
+              sx={{ overflowWrap: 'break-word', wordBreak: 'break-word' }}
+            >
               {description}{' '}
               {description.length > 150 && (
                 <StyledLinkButton

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { useParams } from 'react-router-dom';
 
 import { Box } from 'src/components/Box';
+import { StyledLinkButton } from 'src/components/Button/StyledLinkButton';
 import { CircleProgress } from 'src/components/CircleProgress/CircleProgress';
 import { DismissibleBanner } from 'src/components/DismissibleBanner';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
@@ -160,15 +161,15 @@ const VPCDetail = () => {
                 Description
               </span>{' '}
             </Typography>
-            <Typography>
+            <Typography sx={{ wordBreak: 'break-word' }}>
               {description}{' '}
               {description.length > 150 && (
-                <button
+                <StyledLinkButton
                   onClick={() => setShowFullDescription((show) => !show)}
-                  style={{ ...theme.applyLinkStyles, fontSize: '0.875rem' }}
+                  sx={{ fontSize: '0.875rem' }}
                 >
                   Read {showFullDescription ? 'Less' : 'More'}
-                </button>
+                </StyledLinkButton>
               )}
             </Typography>
           </StyledDescriptionBox>

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
@@ -259,6 +259,7 @@ export const VPCSubnetsTable = (props: Props) => {
     <>
       <Box
         display="flex"
+        flexWrap="wrap"
         justifyContent="space-between"
         paddingBottom={theme.spacing(2)}
       >
@@ -267,6 +268,7 @@ export const VPCSubnetsTable = (props: Props) => {
             [theme.breakpoints.up('sm')]: {
               width: '416px',
             },
+            width: '250px',
           }}
           debounceTime={250}
           hideLabel

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
@@ -257,14 +257,10 @@ export const VPCSubnetsTable = (props: Props) => {
 
   return (
     <>
-      <Box
-        display="flex"
-        flexWrap="wrap"
-        justifyContent="space-between"
-        paddingBottom={theme.spacing(2)}
-      >
+      <Box display="flex" flexWrap="wrap" justifyContent="space-between">
         <DebouncedSearchTextField
           sx={{
+            marginBottom: theme.spacing(2),
             [theme.breakpoints.up('sm')]: {
               width: '416px',
             },
@@ -278,6 +274,9 @@ export const VPCSubnetsTable = (props: Props) => {
           placeholder="Filter Subnets by label or id"
         />
         <Button
+          sx={{
+            marginBottom: theme.spacing(2),
+          }}
           buttonType="primary"
           onClick={() => setSubnetCreateDrawerOpen(true)}
         >


### PR DESCRIPTION
## Description + notes on some changes 📝
- Fixes the overflow bug on the VPC and StackScript details page
- Fixes cutoff searchbar on VPC details page 
  - note: placeholder text so far still gets larger when the screen gets smaller (consistent across all searchbars) -- currently forcing a default width of the searchbar on the VPC details page as a result + Also updated the margin for the searchbar and Create Subnet button in the VPCSubnetsTable, due to adding the flex-wrap property so that the search bar and button don't squash each other on smaller screens. this is an alternate fix compared to trying to decrease the placeholder text font (think I just need to target the correct mui classes, but was having trouble with it -- will still look into it)

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/139280159/8fe53420-063e-48fe-98fd-95cdeb04155d) | ![image](https://github.com/linode/manager/assets/139280159/0f69ba3a-1bf4-479a-bd63-795313ea6815) |

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/139280159/dadfdd96-09d2-4f34-880c-ae238ef06b78) | ![image](https://github.com/linode/manager/assets/139280159/0d8753ce-0beb-42d0-9a88-bb033a2ec0e1) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- With VPC admin tags, using the prod env (or dev env), make sure you have a VPC. Give it a long, one word description
- Create a stackscript and also give it a long description

### Reproduction steps
- Notice how the description overflows for both VPC and StackScript
- Notice how the searchbar placeholder text gets cutoff

### Verification steps 
- Confirm description text is now broken up for VPC and StackScript description for a very long single word
- Confirm VPC and StackScript description work normally without a single very long word
- Confirm search bar text no longer gets cutoff on small screens

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
