### PR TITLE
fix: [M3-7389] - Add missing region ID param to Linode Detail clone action menu item

### DIFF
--- a/packages/manager/.changeset/pr-9888-fixed-1699476376459.md
+++ b/packages/manager/.changeset/pr-9888-fixed-1699476376459.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Add missing region ID param to Linode Detail clone action menu item ([#9888](https://github.com/linode/manager/pull/9888))

--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -40,9 +40,11 @@ export const buildQueryStringForLinodeClone = (
   types: ExtendedType[] | null | undefined,
   regions: Region[]
 ): string => {
+  const linodeRegionId =
+    regions.find((region) => region.label === linodeRegion)?.id ?? '';
   const params: Record<string, string> = {
     linodeID: String(linodeId),
-    regionID: linodeRegion,
+    regionID: linodeRegionId,
     type: 'Clone Linode',
   };
 

--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -42,6 +42,7 @@ export const buildQueryStringForLinodeClone = (
 ): string => {
   const params: Record<string, string> = {
     linodeID: String(linodeId),
+    regionID: linodeRegion,
     type: 'Clone Linode',
   };
 


### PR DESCRIPTION
## Description 📝
We're missing the URL param on the Linode detail action menu clone item, resulting in the region select not getting the default value.

## Changes  🔄
- Add missing region ID param to Linode Detail clone action menu item

## Preview 📷
**Include a screenshot or screen recording of the change**

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-11-08 at 15 39 21](https://github.com/linode/manager/assets/130582365/a1056469-60cc-47e0-a4a5-b4cf8cfedd7c) | ![Screenshot 2023-11-08 at 15 38 59](https://github.com/linode/manager/assets/130582365/536ee0c0-908f-4a83-b509-237717ef1d30) |

## How to test 🧪

### Prerequisites
- Pull and run code locally

### Reproduction steps
- On production, navigate to a linode detail and click on the "Clone" action menu item in the detail header
- Notice the region select does not get populated with the current linode region

### Verification steps 
(How to verify changes)
- Locally, navigate to a linode detail and click on the "Clone" action menu item in the detail header
- Confirm the region select is getting populated with the current linode region

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
