### PR TITLE
test: Upgrade from Cypress 13.4.0 to Cypress 13.5.0

### DIFF
--- a/packages/manager/.changeset/pr-9892-tests-1699549772226.md
+++ b/packages/manager/.changeset/pr-9892-tests-1699549772226.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Upgrade Cypress from 13.4.0 to 13.5.0 ([#9892](https://github.com/linode/manager/pull/9892))

--- a/packages/manager/Dockerfile
+++ b/packages/manager/Dockerfile
@@ -18,7 +18,7 @@ CMD yarn start:manager:ci
 # `e2e`
 #
 # Runs Cloud Manager Cypress tests.
-FROM cypress/included:12.17.3 as e2e
+FROM cypress/included:13.5.0 as e2e
 WORKDIR /home/node/app
 VOLUME /home/node/app
 USER node

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -166,7 +166,7 @@
     "chai-string": "^1.5.0",
     "chalk": "^5.2.0",
     "css-mediaquery": "^0.1.2",
-    "cypress": "^13.4.0",
+    "cypress": "^13.5.0",
     "cypress-axe": "^1.0.0",
     "cypress-file-upload": "^5.0.7",
     "cypress-real-events": "^1.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6970,10 +6970,10 @@ cypress-vite@^1.4.2:
     chokidar "^3.5.3"
     debug "^4.3.4"
 
-cypress@^13.4.0:
-  version "13.4.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.4.0.tgz#7d91069983ba7c664c505abde84d3e3e20484344"
-  integrity sha512-KeWNC9xSHG/ewZURVbaQsBQg2mOKw4XhjJZFKjWbEjgZCdxpPXLpJnfq5Jns1Gvnjp6AlnIfpZfWFlDgVKXdWQ==
+cypress@^13.5.0:
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.5.0.tgz#8c149074186130972f08b2cdce6ded41f014bacd"
+  integrity sha512-oh6U7h9w8wwHfzNDJQ6wVcAeXu31DlIYlNOBvfd6U4CcB8oe4akawQmH+QJVOMZlM42eBoCne015+svVqdwdRQ==
   dependencies:
     "@cypress/request" "^3.0.0"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
## Description 📝
Upgrades from Cypress 13.4.0 to 13.5.0.

Normally wouldn't update so quickly since we just upgraded to 13.x, but 13.5.0 [includes a lot of bugfixes](https://docs.cypress.io/guides/references/changelog#13-5-0), and I realized I never updated our Dockerfile when we upgraded to 13.4.0 so wanted to take the opportunity to take care of that too.

(This means that at the moment, our GHA tests are using Cypress 13.x, but our Jenkins tests are still using 12.)

## Changes  🔄
List any change relevant to the reviewer.
- Upgrades Cypress from 13.4.0 to 13.5.0
- Updates our Dockerfile for Cypress 13.5.0

## How to test 🧪
We can rely on the automated tests for this, but they can be run locally with `yarn cy:run`.