### PR TITLE
test: [M3-7322] - Add Cypress test to confirm Linode Config VPC assignment

### DIFF
--- a/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
@@ -3,22 +3,79 @@ import { containsVisible } from 'support/helpers';
 import { ui } from 'support/ui';
 import { authenticate } from 'support/api/authentication';
 import { cleanUp } from 'support/util/cleanup';
-import { interceptRebootLinode } from 'support/intercepts/linodes';
+import {
+  mockAppendFeatureFlags,
+  mockGetFeatureFlagClientstream,
+} from 'support/intercepts/feature-flags';
+import { makeFeatureFlagData } from 'support/util/feature-flags';
+import { mockGetVPC, mockGetVPCs } from 'support/intercepts/vpc';
+import { dcPricingMockLinodeTypes } from 'support/constants/dc-specific-pricing';
+import { getRegionById } from 'support/util/regions';
+import { mockGetVLANs } from 'support/intercepts/vlans';
+import {
+  interceptRebootLinode,
+  mockGetLinodeDetails,
+  mockGetLinodeDisks,
+  mockGetLinodeVolumes,
+} from 'support/intercepts/linodes';
 import {
   interceptDeleteLinodeConfig,
   interceptCreateLinodeConfigs,
   interceptUpdateLinodeConfigs,
+  mockGetLinodeConfigs,
+  mockCreateLinodeConfigs,
+  mockUpdateLinodeConfigs,
 } from 'support/intercepts/configs';
 import {
   createLinodeAndGetConfig,
   createAndBootLinode,
 } from 'support/util/linodes';
+import {
+  vpcFactory,
+  linodeFactory,
+  linodeConfigFactory,
+  subnetFactory,
+  VLANFactory,
+} from '@src/factories';
+import { randomNumber, randomLabel } from 'support/util/random';
 
-import type { Config, Linode } from '@linode/api-v4';
+import type { Config, Linode, VLAN, VPC, Disk, Region } from '@linode/api-v4';
 
 authenticate();
 
 describe('Linode Config', () => {
+  const region: Region = getRegionById('us-southeast');
+  const diskLabel: string = 'Debian 10 Disk';
+  const mockConfig: Config = linodeConfigFactory.build({
+    id: randomNumber(),
+  });
+  const mockDisks: Disk[] = [
+    {
+      id: 44311273,
+      status: 'ready',
+      label: diskLabel,
+      created: '2020-08-21T17:26:14',
+      updated: '2020-08-21T17:26:30',
+      filesystem: 'ext4',
+      size: 81408,
+    },
+    {
+      id: 44311274,
+      status: 'ready',
+      label: '512 MB Swap Image',
+      created: '2020-08-21T17:26:14',
+      updated: '2020-08-21T17:26:31',
+      filesystem: 'swap',
+      size: 512,
+    },
+  ];
+  const mockVLANs: VLAN[] = VLANFactory.buildList(2);
+  const mockVPCs: VPC[] = vpcFactory.buildList(5);
+
+  before(() => {
+    mockConfig.interfaces.splice(2, 1);
+  });
+
   beforeEach(() => {
     cleanUp(['linodes']);
   });
@@ -59,6 +116,109 @@ describe('Linode Config', () => {
         );
         containsVisible('eth0 – Public Internet');
       });
+    });
+  });
+
+  it('Creates a new config and assigns a VPC as a network interface', () => {
+    const mockLinode = linodeFactory.build({
+      region: region.id,
+      type: dcPricingMockLinodeTypes[0].id,
+    });
+
+    const mockVPC = vpcFactory.build({
+      id: 1,
+      label: randomLabel(),
+    });
+
+    mockGetLinodeDetails(mockLinode.id, mockLinode).as('getLinode');
+    mockAppendFeatureFlags({
+      vpc: makeFeatureFlagData(true),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+
+    mockGetVPCs(mockVPCs).as('getVPCs');
+    mockGetLinodeDisks(mockLinode.id, mockDisks).as('getDisks');
+    mockGetLinodeConfigs(mockLinode.id, []);
+    mockGetVPC(mockVPC).as('getVPC');
+    mockGetLinodeVolumes(mockLinode.id, []).as('getVolumes');
+
+    cy.visitWithLogin(`/linodes/${mockLinode.id}/configurations`);
+    cy.wait([
+      '@getClientStream',
+      '@getFeatureFlags',
+      '@getLinode',
+      '@getVPCs',
+      '@getDisks',
+      '@getVolumes',
+    ]);
+
+    // Confirm that there is no configuration yet.
+    cy.findByLabelText('List of Configurations').within(() => {
+      cy.contains(`${mockConfig.label} – GRUB 2`).should('not.exist');
+    });
+
+    mockGetVLANs(mockVLANs);
+    mockGetVPC(mockVPC).as('getVPC');
+    mockCreateLinodeConfigs(mockLinode.id, mockConfig).as('createLinodeConfig');
+    mockGetLinodeConfigs(mockLinode.id, [mockConfig]).as('getLinodeConfigs');
+    cy.findByText('Add Configuration').click();
+    ui.dialog
+      .findByTitle('Add Configuration')
+      .should('be.visible')
+      .within(() => {
+        cy.get('#label').type(`${mockConfig.label}`);
+        // Confirm that "VPC" can be selected for either "eth0", "eth1", or "eth2".
+        // Add VPC to eth0
+        cy.get('[data-qa-textfield-label="eth0"]')
+          .scrollIntoView()
+          .parent()
+          .parent()
+          .within(() => {
+            ui.select
+              .findByText('Public Internet')
+              .should('be.visible')
+              .click()
+              .type('VPC{enter}');
+          });
+        // Add VPC to eth1
+        cy.get('[data-qa-textfield-label="eth1"]')
+          .scrollIntoView()
+          .parent()
+          .parent()
+          .within(() => {
+            ui.select
+              .findByText('None')
+              .should('be.visible')
+              .click()
+              .type('VPC{enter}');
+          });
+        // Add VPC to eth2
+        cy.get('[data-qa-textfield-label="eth2"]')
+          .scrollIntoView()
+          .parent()
+          .parent()
+          .within(() => {
+            ui.select
+              .findByText('None')
+              .should('be.visible')
+              .click()
+              .type('VPC{enter}');
+          });
+        ui.buttonGroup
+          .findButtonByTitle('Add Configuration')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+    cy.wait(['@createLinodeConfig', '@getLinodeConfigs', '@getVPC']);
+
+    // Confirm that VLAN and VPC have been assigned.
+    cy.findByLabelText('List of Configurations').within(() => {
+      cy.get('tr').should('have.length', 2);
+      containsVisible(`${mockConfig.label} – GRUB 2`);
+      containsVisible('eth0 – Public Internet');
+      containsVisible(`eth2 – VPC: ${mockVPC.label}`);
     });
   });
 
@@ -110,6 +270,109 @@ describe('Linode Config', () => {
         containsVisible('eth0 – Public Internet');
         containsVisible('eth1 – VLAN: testvlan (192.0.2.0/25)');
       });
+    });
+  });
+
+  it('Edits an existing config and assigns a VPC as a network interface', () => {
+    const mockLinode = linodeFactory.build({
+      region: region.id,
+      type: dcPricingMockLinodeTypes[0].id,
+    });
+
+    const mockVPC = vpcFactory.build({
+      id: 1,
+      label: randomLabel(),
+    });
+
+    mockGetLinodeDetails(mockLinode.id, mockLinode).as('getLinode');
+    mockAppendFeatureFlags({
+      vpc: makeFeatureFlagData(true),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+
+    mockGetVPCs(mockVPCs).as('getVPCs');
+    mockGetLinodeDisks(mockLinode.id, mockDisks).as('getDisks');
+    mockGetLinodeConfigs(mockLinode.id, [mockConfig]).as('getConfig');
+    mockGetVPC(mockVPC).as('getVPC');
+    mockGetLinodeVolumes(mockLinode.id, []).as('getVolumes');
+
+    cy.visitWithLogin(`/linodes/${mockLinode.id}/configurations`);
+    cy.wait([
+      '@getClientStream',
+      '@getFeatureFlags',
+      '@getLinode',
+      '@getConfig',
+      '@getVPCs',
+      '@getDisks',
+      '@getVolumes',
+    ]);
+
+    cy.findByLabelText('List of Configurations').within(() => {
+      containsVisible(`${mockConfig.label} – GRUB 2`);
+    });
+    cy.findByText('Edit').click();
+
+    mockGetVLANs(mockVLANs);
+    mockGetVPC(mockVPC).as('getVPC');
+    mockUpdateLinodeConfigs(mockLinode.id, mockConfig).as(
+      'updateLinodeConfigs'
+    );
+    mockGetLinodeConfigs(mockLinode.id, [mockConfig]).as('getLinodeConfigs');
+    ui.dialog
+      .findByTitle('Edit Configuration')
+      .should('be.visible')
+      .within(() => {
+        // Change eth0 to VPC
+        cy.get('[data-qa-textfield-label="eth0"]')
+          .scrollIntoView()
+          .parent()
+          .parent()
+          .within(() => {
+            ui.select
+              .findByText('Public Internet')
+              .should('be.visible')
+              .click()
+              .type('VPC{enter}');
+          });
+        // Change eth1 to VPC
+        cy.get('[data-qa-textfield-label="eth1"]')
+          .scrollIntoView()
+          .parent()
+          .parent()
+          .within(() => {
+            ui.select
+              .findByText('VLAN')
+              .should('be.visible')
+              .click()
+              .type('VPC{enter}');
+          });
+        // Change eth2 to VPC
+        cy.get('[data-qa-textfield-label="eth2"]')
+          .scrollIntoView()
+          .parent()
+          .parent()
+          .within(() => {
+            ui.select
+              .findByText('VPC')
+              .should('be.visible')
+              .click()
+              .type('VPC{enter}');
+          });
+        ui.button
+          .findByTitle('Save Changes')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+    cy.wait(['@updateLinodeConfigs', '@getLinodeConfigs', '@getVPC']);
+
+    // Confirm that VLAN and VPC have been assigned.
+    cy.findByLabelText('List of Configurations').within(() => {
+      cy.get('tr').should('have.length', 2);
+      containsVisible(`${mockConfig.label} – GRUB 2`);
+      containsVisible('eth0 – Public Internet');
+      containsVisible(`eth2 – VPC: ${mockVPC.label}`);
     });
   });
 

--- a/packages/manager/cypress/support/intercepts/configs.ts
+++ b/packages/manager/cypress/support/intercepts/configs.ts
@@ -118,6 +118,44 @@ export const mockGetLinodeConfigs = (
 };
 
 /**
+ * Mocks PUT request to update a linode config.
+ *
+ * @param linodeId - ID of Linode for mock request.
+ * @param config - config data with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockUpdateLinodeConfigs = (
+  linodeId: number,
+  config: Config
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'PUT',
+    apiMatcher(`linode/instances/${linodeId}/configs/${config.id}`),
+    config
+  );
+};
+
+/**
+ * Mocks POST request to create a Linode config.
+ *
+ * @param linodeId - ID of Linode for mocked request.
+ * @param config - config data with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockCreateLinodeConfigs = (
+  linodeId: number,
+  config: Config
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`linode/instances/${linodeId}/configs`),
+    config
+  );
+};
+
+/**
  * Mocks POST request to retrieve interfaces from a given Linode config.
  *
  * @param linodeId - ID of Linode for mocked request.

--- a/packages/manager/cypress/support/intercepts/vlans.ts
+++ b/packages/manager/cypress/support/intercepts/vlans.ts
@@ -1,0 +1,22 @@
+/**
+ * @files Cypress intercepts and mocks for VLAN API requests.
+ */
+
+import { apiMatcher } from 'support/util/intercepts';
+import { paginateResponse } from 'support/util/paginate';
+
+import type { VLAN } from '@linode/api-v4';
+/**
+ * Intercepts GET request to fetch VLANs and mocks response.
+ *
+ * @param vlans - Array of VLANs with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetVLANs = (vlans: VLAN[]): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher('networking/vlans*'),
+    paginateResponse(vlans)
+  );
+};


### PR DESCRIPTION
## Description 📝
Add regression tests to verify Linode Config VPC assignment to interface.

## Major Changes 🔄
- Add new tests to assign VPC to the interface in Linode Config page.

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/linodes/linode-config.spec.ts"
```