### PR TITLE
fix: Restore `nattedIPv4Address` prop passed from `LinodeConfigDialog` --> `InterfaceSelect`

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
@@ -1005,15 +1005,16 @@ export const LinodeConfigDialog = (props: Props) => {
                     ipamAddress={thisInterface.ipam_address}
                     key={`eth${idx}-interface`}
                     label={thisInterface.label}
+                    nattedIPv4Address={thisInterface.ipv4?.nat_1_1}
                     purpose={thisInterface.purpose}
                     readOnly={isReadOnly}
                     region={linode?.region}
+                    regionHasVLANs={regionHasVLANS}
+                    regionHasVPCs={regionHasVPCs}
                     slotNumber={idx}
                     subnetId={thisInterface.subnet_id}
                     vpcIPv4={thisInterface.ipv4?.vpc}
                     vpcId={thisInterface.vpc_id}
-                    regionHasVLANs={regionHasVLANS}
-                    regionHasVPCs={regionHasVPCs}
                   />
                 );
               })}


### PR DESCRIPTION
## Description 📝
We lost a one-liner added in https://github.com/linode/manager/pull/9865 that checks off the "Assign a public IPv4 address for this Linode" checkbox in the Edit Linode Config dialog when the `ipv4.nat_1_1` property is populated. This PR restores it.

## How to test 🧪
### Prerequisites
- Account with proper VPC tags

### Reproduction steps
On the release branch:
- In the Linode Create flow, assign a VPC and check off the "Assign a public IPv4 address for this Linode" checkbox. Proceed with creation
- (with your DevTools > Network tab open filtered for `configs`) On the newly-created Linode, go to the Configurations tab, edit the config, scroll down the Edit Config dialog to the "Networking" section and observe: the VPC interface's "Assign a public IPv4 address for this Linode" checkbox is unchecked, despite the network request showing `ipv4.nat_1_1` being populated

### Verification steps 
On this branch:
- Do the 2nd step from above and observe: the checkbox is properly checked off