### PR TITLE
fix: [M3-7400] - Linode Network Transfer History - Back button incorrectly disabled

### DIFF
--- a/packages/manager/.changeset/pr-9900-fixed-1699974142591.md
+++ b/packages/manager/.changeset/pr-9900-fixed-1699974142591.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Linode Network Transfer History graph back button incorrectly appearing to be disabled ([#9900](https://github.com/linode/manager/pull/9900))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.tsx
@@ -1,12 +1,13 @@
 import { Stats } from '@linode/api-v4/lib/linodes';
 import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
-import { Theme, styled, useTheme } from '@mui/material/styles';
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import { IconButton } from '@mui/material';
+import { styled, useTheme } from '@mui/material/styles';
 import { DateTime, Interval } from 'luxon';
 import * as React from 'react';
 
 import PendingIcon from 'src/assets/icons/pending.svg';
 import { Box } from 'src/components/Box';
-import { StyledLinkButton } from 'src/components/Button/StyledLinkButton';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { LineGraph } from 'src/components/LineGraph/LineGraph';
@@ -200,40 +201,31 @@ export const TransferHistory = React.memo((props: Props) => {
           flexDirection="row"
           justifyContent="space-between"
         >
-          <StyledButton
+          <IconButton
             aria-label={`Show Network Transfer History for ${decrementLabel}`}
+            color="primary"
+            disableRipple
             disabled={monthOffset === maxMonthOffset}
             onClick={decrementOffset}
+            sx={{ padding: 0 }}
           >
-            <ArrowBackIosIcon
-              sx={{
-                ...(monthOffset === maxMonthOffset
-                  ? sxArrowIconDisabled(theme)
-                  : {}),
-                fontSize: '1rem',
-              }}
-            />
-          </StyledButton>
+            <ArrowBackIosIcon sx={{ fontSize: '1rem' }} />
+          </IconButton>
           {/* Give this a min-width so it doesn't change widths between displaying
           the month and "Last 30 Days" */}
           <span style={{ minWidth: 80, textAlign: 'center' }}>
             <Typography>{humanizedDate}</Typography>
           </span>
-          <StyledButton
+          <IconButton
             aria-label={`Show Network Transfer History for ${incrementLabel}`}
+            color="primary"
+            disableRipple
             disabled={monthOffset === minMonthOffset}
             onClick={incrementOffset}
+            sx={{ padding: 0 }}
           >
-            <ArrowBackIosIcon
-              sx={{
-                ...(monthOffset === minMonthOffset
-                  ? sxArrowIconDisabled(theme)
-                  : {}),
-                fontSize: '1rem',
-                transform: 'rotate(180deg)',
-              }}
-            />
-          </StyledButton>
+            <ArrowForwardIosIcon sx={{ fontSize: '1rem' }} />
+          </IconButton>
         </Box>
       </Box>
       {renderStatsGraph()}
@@ -241,20 +233,11 @@ export const TransferHistory = React.memo((props: Props) => {
   );
 });
 
-const sxArrowIconDisabled = (theme: Theme) => ({
-  cursor: 'not-allowed',
-  fill: theme.color.grey1,
-});
-
 const StyledDiv = styled('div', { label: 'StyledDiv' })({
   alignItems: 'center',
   display: 'flex',
   height: 100,
   justifyContent: 'center',
-});
-
-const StyledButton = styled(StyledLinkButton, { label: 'StyledButton' })({
-  display: 'flex',
 });
 
 // =============================================================================

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.tsx
@@ -207,7 +207,7 @@ export const TransferHistory = React.memo((props: Props) => {
           >
             <ArrowBackIosIcon
               sx={{
-                ...(monthOffset === minMonthOffset
+                ...(monthOffset === maxMonthOffset
                   ? sxArrowIconDisabled(theme)
                   : {}),
                 fontSize: '1rem',


### PR DESCRIPTION
## Description 📝
 
Fixes back button disabled state on the Linode Details network tab

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-11-14 at 9 51 10 AM](https://github.com/linode/manager/assets/115251059/9d63b752-428e-4875-a80d-dfa0bb09c29d) | ![Screenshot 2023-11-14 at 9 57 07 AM](https://github.com/linode/manager/assets/115251059/0f90c8fd-8d64-42a1-99c1-463c8bbf00b8) |

## How to test 🧪

### Prerequisites
- You must have a Linode that has > 1 month of network data to show on the graph

### Reproduction steps
- Go to http://localhost:3000/linodes/:id/networking
- Observe that the back button appears to be disabled even though clicking it goes back a month

### Verification steps 
- Verify the button appears to be enabled when there is past network history to be viewed

## As an Author I have considered 🤔

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support