### PR TITLE
fix: [M3-7405] - Take care of 'oh snap' errors from MSW

### DIFF
--- a/packages/manager/.changeset/pr-9910-fixed-1700149776187.md
+++ b/packages/manager/.changeset/pr-9910-fixed-1700149776187.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+'Oh snap' errors from MSW ([#9910](https://github.com/linode/manager/pull/9910))

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -428,7 +428,7 @@ const aglb = [
 ];
 
 const vpc = [
-  rest.get('*/vpcs', (req, res, ctx) => {
+  rest.get('*/v4beta/vpcs', (req, res, ctx) => {
     const vpcsWithSubnet1 = vpcFactory.buildList(5, {
       subnets: subnetFactory.buildList(Math.floor(Math.random() * 10) + 1),
     });
@@ -447,7 +447,7 @@ const vpc = [
       )
     );
   }),
-  rest.get('*/vpcs/:vpcId', (req, res, ctx) => {
+  rest.get('*/v4beta/vpcs/:vpcId', (req, res, ctx) => {
     return res(
       ctx.json(
         vpcFactory.build({
@@ -457,27 +457,27 @@ const vpc = [
       )
     );
   }),
-  rest.get('*/vpcs/:vpcId/subnets', (req, res, ctx) => {
+  rest.get('*/v4beta/vpcs/:vpcId/subnets', (req, res, ctx) => {
     return res(ctx.json(makeResourcePage(subnetFactory.buildList(30))));
   }),
-  rest.delete('*/vpcs/:vpcId/subnets/:subnetId', (req, res, ctx) => {
+  rest.delete('*/v4beta/vpcs/:vpcId/subnets/:subnetId', (req, res, ctx) => {
     return res(ctx.json({}));
   }),
-  rest.delete('*/vpcs/:vpcId', (req, res, ctx) => {
+  rest.delete('*/v4beta/vpcs/:vpcId', (req, res, ctx) => {
     return res(ctx.json({}));
   }),
-  rest.put('*/vpcs/:vpcId', (req, res, ctx) => {
+  rest.put('*/v4beta/vpcs/:vpcId', (req, res, ctx) => {
     return res(ctx.json(vpcFactory.build({ description: 'testing' })));
   }),
-  rest.get('*/vpcs/:vpcID', (req, res, ctx) => {
+  rest.get('*/v4beta/vpcs/:vpcID', (req, res, ctx) => {
     const id = Number(req.params.id);
     return res(ctx.json(vpcFactory.build({ id })));
   }),
-  rest.post('*/vpcs', (req, res, ctx) => {
+  rest.post('*/v4beta/vpcs', (req, res, ctx) => {
     const vpc = vpcFactory.build({ ...(req.body as any) });
     return res(ctx.json(vpc));
   }),
-  rest.post('*/vpcs/:vpcId/subnets', (req, res, ctx) => {
+  rest.post('*/v4beta/vpcs/:vpcId/subnets', (req, res, ctx) => {
     const subnet = subnetFactory.build({ ...(req.body as any) });
     return res(ctx.json(subnet));
   }),
@@ -678,6 +678,11 @@ export const handlers = [
       )
     );
   }),
+  rest.get('*/linode/instances/:id/firewalls', async (req, res, ctx) => {
+    const firewalls = firewallFactory.buildList(10);
+    firewallFactory.resetSequenceNumber();
+    return res(ctx.json(makeResourcePage(firewalls)));
+  }),
   rest.delete('*/instances/*', async (req, res, ctx) => {
     return res(ctx.json({}));
   }),
@@ -760,20 +765,20 @@ export const handlers = [
   rest.get('*/lke/clusters/*/recycle', async (req, res, ctx) => {
     return res(ctx.json({}));
   }),
-  rest.get('*/firewalls/', (req, res, ctx) => {
+  rest.get('*/v4beta/networking/firewalls', (req, res, ctx) => {
     const firewalls = firewallFactory.buildList(10);
     firewallFactory.resetSequenceNumber();
     return res(ctx.json(makeResourcePage(firewalls)));
   }),
-  rest.get('*/firewalls/*/devices', (req, res, ctx) => {
+  rest.get('*/v4beta/networking/firewalls/*/devices', (req, res, ctx) => {
     const devices = firewallDeviceFactory.buildList(10);
     return res(ctx.json(makeResourcePage(devices)));
   }),
-  rest.get('*/firewalls/:firewallId', (req, res, ctx) => {
+  rest.get('*/v4beta/networking/firewalls/:firewallId', (req, res, ctx) => {
     const firewall = firewallFactory.build();
     return res(ctx.json(firewall));
   }),
-  rest.put('*/firewalls/:firewallId', (req, res, ctx) => {
+  rest.put('*/v4beta/networking/firewalls/:firewallId', (req, res, ctx) => {
     const firewall = firewallFactory.build({
       status: req.body?.['status'] ?? 'disabled',
     });
@@ -782,7 +787,7 @@ export const handlers = [
   // rest.post('*/account/agreements', (req, res, ctx) => {
   //   return res(ctx.status(500), ctx.json({ reason: 'Unknown error' }));
   // }),
-  rest.post('*/firewalls', (req, res, ctx) => {
+  rest.post('*/v4beta/networking/firewalls', (req, res, ctx) => {
     const payload = req.body as any;
     const newFirewall = firewallFactory.build({
       label: payload.label ?? 'mock-firewall',


### PR DESCRIPTION
## Description 📝
During release testing, we ran into a bunch of 'oh snap' popups due to the MSW. This PR should hopefully get rid of them all - the issues seem to stem from VPC and Firewall mock requests.

## Testing
### Prerequisites
(How to setup test environment)
- Use the MSW

### Reproduction steps
(How to reproduce the issue, if applicable)
- Navigate to VPC Landing, Firewall Landing, Linode pages like the Network tab or Configurations tab -- the error pops up on these pages

### Verification steps 
- Perform a general check of CM using the MSW and verify that no 'oh snap' errors appear. Confirm they don't appear on ^ pages

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
