### PR TITLE
fix: [M3-7407]: `TableCell` with `ActionMenu` incorrect size and border placement

### DIFF
--- a/packages/manager/.changeset/pr-9915-fixed-1700235447855.md
+++ b/packages/manager/.changeset/pr-9915-fixed-1700235447855.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+TableCell with ActionMenu incorrect size and border placement ([#9915](https://github.com/linode/manager/pull/9915))

--- a/packages/manager/src/components/TableCell/TableCell.tsx
+++ b/packages/manager/src/components/TableCell/TableCell.tsx
@@ -16,7 +16,6 @@ const useStyles = makeStyles()((theme: Theme) => ({
     },
     alignItems: 'center',
     display: 'flex',
-    height: 40,
     justifyContent: 'flex-end',
     padding: 0,
   },


### PR DESCRIPTION
## Description 📝

Something about our TableCell with an Action Menu is not working well in some tables. The ActionMenu is causing the TableCell to be the wrong size and position the border incorrectly. ☹️

## The Fix 🛠️
- Removes the static `height` assigned to a `TableCell`  with the `actionCell` prop

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![before-zoomed](https://github.com/linode/manager/assets/115251059/4417ca46-3873-41f1-98e8-edc890ff02b7)  | ![after-zoomed](https://github.com/linode/manager/assets/115251059/67acbd13-7735-4bc7-82dd-3245b210c22f) |
| ![before](https://github.com/linode/manager/assets/115251059/21086a6d-5a89-472c-8927-8b6248a157b0)  |  ![after](https://github.com/linode/manager/assets/115251059/a91622c2-de57-4bef-aaa5-affbe407e4c8)  |

## How to test 🧪

### Prerequisites
- Turn on the MSW

### Verification steps 
- Go to `http://localhost:3000/loadbalancers/0/routes`
- Observe that the UI bug shown in the screenshot is resolved
- **Please help me verify this does not cause breaking changes elsewhere in the app**

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support