### PR TITLE
feat: [M3-7410] - Add Parent/Child Feature Flag

### DIFF
--- a/packages/manager/.changeset/pr-9919-upcoming-features-1700494666167.md
+++ b/packages/manager/.changeset/pr-9919-upcoming-features-1700494666167.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add `parentChildAccountAccess` feature flag ([#9919](https://github.com/linode/manager/pull/9919))

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -12,13 +12,14 @@ import { getStorage, setStorage } from 'src/utilities/storage';
 const MOCK_FEATURE_FLAGS_STORAGE_KEY = 'devTools/mock-feature-flags';
 
 const options: { flag: keyof Flags; label: string }[] = [
-  { flag: 'metadata', label: 'Metadata' },
-  { flag: 'vpc', label: 'VPC' },
   { flag: 'aglb', label: 'AGLB' },
   { flag: 'aglbFullCreateFlow', label: 'AGLB Full Create Flow' },
-  { flag: 'unifiedMigrations', label: 'Unified Migrations' },
   { flag: 'dcGetWell', label: 'DC Get Well' },
+  { flag: 'metadata', label: 'Metadata' },
+  { flag: 'parentChildAccountAccess', label: 'Parent/Child Account' },
   { flag: 'selfServeBetas', label: 'Self Serve Betas' },
+  { flag: 'unifiedMigrations', label: 'Unified Migrations' },
+  { flag: 'vpc', label: 'VPC' },
 ];
 
 export const FeatureFlagTool = withFeatureFlagProvider(() => {

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -53,6 +53,7 @@ export interface Flags {
   metadata: boolean;
   oneClickApps: OneClickApp;
   oneClickAppsDocsOverride: Record<string, Doc[]>;
+  parentChildAccountAccess: boolean;
   productInformationBanners: ProductInformationBannerFlag[];
   promos: boolean;
   promotionalOffers: PromotionalOffer[];


### PR DESCRIPTION
## Description 📝
Add a new `parentChildAccountAccess` flag and add it to our dev console.

## Preview 📷
![Screenshot 2023-11-20 at 10 35 34 AM](https://github.com/linode/manager/assets/125309814/02ef4b71-dc1e-4d70-878c-c25e16cfbe1e)

## How to test 🧪
- Pull the code 
- Toggle the flag in our developer settings
- use `flags.parentChildAccountAccess` to conditionally render any element