### PR TITLE
test: [M3-6750] - VPC Delete tests

### DIFF
--- a/packages/manager/.changeset/pr-9920-tests-1700498392893.md
+++ b/packages/manager/.changeset/pr-9920-tests-1700498392893.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add unit tests and additional integration test for VPC delete dialog ([#9920](https://github.com/linode/manager/pull/9920))

--- a/packages/manager/cypress/e2e/core/vpc/vpc-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/vpc/vpc-landing-page.spec.ts
@@ -8,6 +8,7 @@ import {
   mockDeleteVPC,
   mockDeleteVPCError,
   mockUpdateVPC,
+  MOCK_DELETE_VPC_ERROR,
 } from 'support/intercepts/vpc';
 import { subnetFactory, vpcFactory } from '@src/factories';
 import { ui } from 'support/ui';
@@ -274,7 +275,7 @@ describe('VPC landing page', () => {
   /**
    * Confirms UI handles errors gracefully when attempting to delete a VPC
    */
-  it.only('cannot delete a VPC with linodes assigned to it', () => {
+  it('cannot delete a VPC with linodes assigned to it', () => {
     const subnet = subnetFactory.build();
     const mockVPCs = [
       vpcFactory.build({
@@ -329,9 +330,7 @@ describe('VPC landing page', () => {
 
     // Confirm that VPC doesn't get deleted and that an error appears
     cy.wait(['@deleteVPCError']);
-    cy.findByText(
-      'Before deleting this VPC, you must remove all of its Linodes'
-    ).should('be.visible');
+    cy.findByText(MOCK_DELETE_VPC_ERROR).should('be.visible');
 
     // close Delete dialog for this VPC and open it up for the second VPC to confirm that error message does not persist
     ui.dialog
@@ -356,9 +355,7 @@ describe('VPC landing page', () => {
           .click();
       });
 
-    cy.findByText(
-      'Before deleting this VPC, you must remove all of its Linodes'
-    ).should('not.exist');
+    cy.findByText(MOCK_DELETE_VPC_ERROR).should('not.exist');
   });
 
   /*

--- a/packages/manager/cypress/e2e/core/vpc/vpc-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/vpc/vpc-landing-page.spec.ts
@@ -9,7 +9,7 @@ import {
   mockDeleteVPCError,
   mockUpdateVPC,
 } from 'support/intercepts/vpc';
-import { vpcFactory } from '@src/factories';
+import { subnetFactory, vpcFactory } from '@src/factories';
 import { ui } from 'support/ui';
 import { randomLabel, randomPhrase } from 'support/util/random';
 import { chooseRegion, getRegionById } from 'support/util/regions';
@@ -274,11 +274,13 @@ describe('VPC landing page', () => {
   /**
    * Confirms UI handles errors gracefully when attempting to delete a VPC
    */
-  it('cannot delete a VPC with linodes assigned to it', () => {
+  it.only('cannot delete a VPC with linodes assigned to it', () => {
+    const subnet = subnetFactory.build();
     const mockVPCs = [
       vpcFactory.build({
         label: randomLabel(),
         region: chooseRegion().id,
+        subnets: [subnet],
       }),
       vpcFactory.build({
         label: randomLabel(),

--- a/packages/manager/cypress/support/intercepts/vpc.ts
+++ b/packages/manager/cypress/support/intercepts/vpc.ts
@@ -9,6 +9,9 @@ import { makeResponse } from 'support/util/response';
 
 import type { Subnet, VPC } from '@linode/api-v4';
 
+export const MOCK_DELETE_VPC_ERROR =
+  'Before deleting this VPC, you must remove all of its Linodes';
+
 /**
  * Intercepts GET request to fetch a VPC and mocks response.
  *
@@ -100,7 +103,7 @@ export const mockDeleteVPC = (vpcId: number): Cypress.Chainable<null> => {
  */
 export const mockDeleteVPCError = (
   vpcId: number,
-  errorMessage: string = 'Before deleting this VPC, you must remove all of its Linodes',
+  errorMessage: string = MOCK_DELETE_VPC_ERROR,
   errorCode: number = 400
 ): Cypress.Chainable<null> => {
   return cy.intercept(

--- a/packages/manager/cypress/support/intercepts/vpc.ts
+++ b/packages/manager/cypress/support/intercepts/vpc.ts
@@ -90,7 +90,7 @@ export const mockDeleteVPC = (vpcId: number): Cypress.Chainable<null> => {
 };
 
 /**
- * Intercepts DELETE request to delete a VPC and mocks response.
+ * Intercepts DELETE request to delete a VPC and mocks an HTTP error response.
  *
  * @param vpcId - ID of deleted VPC for which to mock response.
  * @param errorMessage - Optional error message with which to mock response.

--- a/packages/manager/cypress/support/intercepts/vpc.ts
+++ b/packages/manager/cypress/support/intercepts/vpc.ts
@@ -2,12 +2,12 @@
  * @files Cypress intercepts and mocks for VPC API requests.
  */
 
+import { makeErrorResponse } from 'support/util/errors';
 import { apiMatcher } from 'support/util/intercepts';
 import { paginateResponse } from 'support/util/paginate';
+import { makeResponse } from 'support/util/response';
 
 import type { Subnet, VPC } from '@linode/api-v4';
-import { makeResponse } from 'support/util/response';
-import { makeErrorResponse } from 'support/util/errors';
 
 /**
  * Intercepts GET request to fetch a VPC and mocks response.
@@ -87,6 +87,27 @@ export const mockUpdateVPC = (
  */
 export const mockDeleteVPC = (vpcId: number): Cypress.Chainable<null> => {
   return cy.intercept('DELETE', apiMatcher(`vpcs/${vpcId}`), {});
+};
+
+/**
+ * Intercepts DELETE request to delete a VPC and mocks response.
+ *
+ * @param vpcId - ID of deleted VPC for which to mock response.
+ * @param errorMessage - Optional error message with which to mock response.
+ * @param errorCode - Optional error code with which to mock response. Default is `500`.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockDeleteVPCError = (
+  vpcId: number,
+  errorMessage: string = 'Before deleting this VPC, you must remove all of its Linodes',
+  errorCode: number = 400
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'DELETE',
+    apiMatcher(`/vpcs/${vpcId}`),
+    makeErrorResponse(errorMessage, errorCode)
+  );
 };
 
 /**

--- a/packages/manager/cypress/support/intercepts/vpc.ts
+++ b/packages/manager/cypress/support/intercepts/vpc.ts
@@ -94,7 +94,7 @@ export const mockDeleteVPC = (vpcId: number): Cypress.Chainable<null> => {
  *
  * @param vpcId - ID of deleted VPC for which to mock response.
  * @param errorMessage - Optional error message with which to mock response.
- * @param errorCode - Optional error code with which to mock response. Default is `500`.
+ * @param errorCode - Optional error code with which to mock response. Default is `400`.
  *
  * @returns Cypress chainable.
  */

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetDeleteDialog.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetDeleteDialog.tsx
@@ -19,7 +19,14 @@ export const SubnetDeleteDialog = (props: Props) => {
     error,
     isLoading,
     mutateAsync: deleteSubnet,
+    reset,
   } = useDeleteSubnetMutation(vpcId, subnet?.id ?? -1);
+
+  React.useEffect(() => {
+    if (open) {
+      reset();
+    }
+  }, [open, reset]);
 
   const onDeleteSubnet = async () => {
     await deleteSubnet();

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCDeleteDialog.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCDeleteDialog.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent } from '@testing-library/react';
+import * as React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { VPCDeleteDialog } from './VPCDeleteDialog';
+
+describe('VPC Delete Dialog', () => {
+  const props = {
+    id: 1,
+    label: 'vpc-1',
+    onClose: vi.fn(),
+    open: true,
+  };
+
+  it('renders a VPC delete dialog correctly', () => {
+    const screen = renderWithTheme(<VPCDeleteDialog {...props} />);
+    const vpcTitle = screen.getByText('Delete VPC vpc-1');
+    expect(vpcTitle).toBeVisible();
+
+    const cancelButton = screen.getByText('Cancel');
+    expect(cancelButton).toBeVisible();
+
+    const deleteButton = screen.getByText('Delete');
+    expect(deleteButton).toBeVisible();
+  });
+  it('closes the VPC delete dialog as expected', () => {
+    const screen = renderWithTheme(<VPCDeleteDialog {...props} />);
+    const cancelButton = screen.getByText('Cancel');
+    expect(cancelButton).toBeVisible();
+    fireEvent.click(cancelButton);
+    expect(props.onClose).toBeCalled();
+  });
+});

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCDeleteDialog.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCDeleteDialog.tsx
@@ -15,10 +15,19 @@ interface Props {
 export const VPCDeleteDialog = (props: Props) => {
   const { id, label, onClose, open } = props;
   const { enqueueSnackbar } = useSnackbar();
-  const { error, isLoading, mutateAsync: deleteVPC } = useDeleteVPCMutation(
-    id ?? -1
-  );
+  const {
+    error,
+    isLoading,
+    mutateAsync: deleteVPC,
+    reset,
+  } = useDeleteVPCMutation(id ?? -1);
   const history = useHistory();
+
+  React.useEffect(() => {
+    if (open) {
+      reset();
+    }
+  }, [open, reset]);
 
   const onDeleteVPC = () => {
     deleteVPC().then(() => {


### PR DESCRIPTION
## Description 📝
- Add unit tests for VPC Delete component
- Add additional integration test to confirm error handling for VPC deletion
- Small bug fix for VPC delete error state (make sure error doesn't persist when opening up the delete dialog)

## Preview 📷

Bug fix: 
| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/139280159/1ca5ee48-5d0f-40e2-8eb4-bc56b67849b4" /> | <video src="https://github.com/linode/manager/assets/139280159/0b88e51d-5e65-4467-8480-e2e915b4eafe" /> |

## How to test 🧪

### Prerequisites
For testing the bug
(How to setup test environment)
- With VPC account tags, set up two vpcs:
  - one VPC with at least one linode assigned to it
  - some other VPC
- Navigate to VPC landing page

### Reproduction steps
(How to reproduce the issue, if applicable)
- Try to delete the VPC with a linode assigned to it (you shouldn't be able to, and you should see an error message pop up)
- Close the VPC delete dialog and open dialog up for other VPC - the error message still persists

### Verification steps 
(How to verify changes)
- Confirm error message no longer persists for VPC delete dialog
- `yarn test VPCDeleteDialog`
- `yarn cy:run -s "cypress/e2e/core/vpc/vpc-landing-page.spec.ts"`

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
