### PR TITLE
change: [M3-7359] - Move Linode Details Add/Edit Config button alignment to the right

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.styles.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.styles.ts
@@ -1,0 +1,46 @@
+import { styled } from '@mui/material/styles';
+
+import { Divider } from 'src/components/Divider';
+import { FormControl } from 'src/components/FormControl';
+import { FormControlLabel } from 'src/components/FormControlLabel';
+import { FormGroup } from 'src/components/FormGroup';
+import { RadioGroup } from 'src/components/RadioGroup';
+
+const formGroupStyling = () => ({
+  '&.MuiFormGroup-root[role="radiogroup"]': {
+    marginBottom: 0,
+  },
+  alignItems: 'flex-start',
+});
+
+export const StyledRadioGroup = styled(RadioGroup, {
+  label: 'StyledRadioGroup',
+})({
+  ...formGroupStyling(),
+});
+
+export const StyledFormControl = styled(FormControl, {
+  label: 'StyledFormControl',
+})({
+  ...formGroupStyling(),
+});
+
+export const StyledFormGroup = styled(FormGroup, { label: 'StyledFormGroup' })({
+  ...formGroupStyling(),
+});
+
+export const StyledDivider = styled(Divider, { label: 'StyledDivider' })(
+  ({ theme }) => ({
+    margin: '36px 8px 12px',
+    width: `calc(100% - ${theme.spacing(2)})`,
+  })
+);
+
+export const StyledFormControlLabel = styled(FormControlLabel, {
+  label: 'StyledFormControlLabel',
+})(({ theme }) => ({
+  '& button': {
+    color: theme.textColors.tableHeader,
+    order: 3,
+  },
+}));

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
@@ -5,7 +5,7 @@ import {
 } from '@linode/api-v4/lib/linodes';
 import { APIError } from '@linode/api-v4/lib/types';
 import Grid from '@mui/material/Unstable_Grid2';
-import { styled, useTheme } from '@mui/material/styles';
+import { useTheme } from '@mui/material/styles';
 import { useFormik } from 'formik';
 import { useSnackbar } from 'notistack';
 import { equals, pathOr, repeat } from 'ramda';
@@ -22,13 +22,11 @@ import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { FormControl } from 'src/components/FormControl';
 import { FormControlLabel } from 'src/components/FormControlLabel';
-import { FormGroup } from 'src/components/FormGroup';
 import { FormHelperText } from 'src/components/FormHelperText';
 import { FormLabel } from 'src/components/FormLabel';
 import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
 import { Radio } from 'src/components/Radio/Radio';
-import { RadioGroup } from 'src/components/RadioGroup';
 import { TextField } from 'src/components/TextField';
 import { Toggle } from 'src/components/Toggle/Toggle';
 import { TooltipIcon } from 'src/components/TooltipIcon';
@@ -68,6 +66,13 @@ import {
   InterfaceSelect,
 } from '../LinodeSettings/InterfaceSelect';
 import { KernelSelect } from '../LinodeSettings/KernelSelect';
+import {
+  StyledDivider,
+  StyledFormControl,
+  StyledFormControlLabel,
+  StyledFormGroup,
+  StyledRadioGroup,
+} from './LinodeConfigDialog.styles';
 
 interface Helpers {
   devtmpfs_automount: boolean;
@@ -1114,41 +1119,6 @@ export const LinodeConfigDialog = (props: Props) => {
     </Dialog>
   );
 };
-
-const formGroupStyling = () => ({
-  '&.MuiFormGroup-root[role="radiogroup"]': {
-    marginBottom: 0,
-  },
-  alignItems: 'flex-start',
-});
-
-const StyledRadioGroup = styled(RadioGroup, { label: 'StyledRadioGroup' })({
-  ...formGroupStyling(),
-});
-
-const StyledFormControl = styled(FormControl, { label: 'StyledFormControl' })({
-  ...formGroupStyling(),
-});
-
-const StyledFormGroup = styled(FormGroup, { label: 'StyledFormGroup' })({
-  ...formGroupStyling(),
-});
-
-const StyledDivider = styled(Divider, { label: 'StyledDivider' })(
-  ({ theme }) => ({
-    margin: '36px 8px 12px',
-    width: `calc(100% - ${theme.spacing(2)})`,
-  })
-);
-
-const StyledFormControlLabel = styled(FormControlLabel, {
-  label: 'StyledFormControlLabel',
-})(({ theme }) => ({
-  '& button': {
-    color: theme.textColors.tableHeader,
-    order: 3,
-  },
-}));
 
 interface ConfigFormProps {
   children: JSX.Element;

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
@@ -1115,6 +1115,7 @@ export const LinodeConfigDialog = (props: Props) => {
           onClick: formik.submitForm,
         }}
         secondaryButtonProps={{ label: 'Cancel', onClick: onClose }}
+        sx={{ display: 'flex', justifySelf: 'flex-end' }}
       />
     </Dialog>
   );


### PR DESCRIPTION
## Description 📝
- Moves the edit/add config action panel's buttons to the right to be more consistent
- also moved config's styles to a separate file to be in line with our styling guidelines (since file is >100 lines)

## Preview 📷

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- ...
- ...

### Reproduction steps
(How to reproduce the issue, if applicable)
- ...
- ...

### Verification steps 
(How to verify changes)
- ...
- ...

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
