### PR TITLE
fix: [M3-7451] - Replace Images landing page section title with "Getting Started Guides"

### DIFF
--- a/packages/manager/.changeset/pr-9930-fixed-1700680496652.md
+++ b/packages/manager/.changeset/pr-9930-fixed-1700680496652.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Images landing page guide section title ([#9930](https://github.com/linode/manager/pull/9930))

--- a/packages/manager/src/features/Images/ImagesLandingEmptyStateData.ts
+++ b/packages/manager/src/features/Images/ImagesLandingEmptyStateData.ts
@@ -41,7 +41,7 @@ export const gettingStartedGuides: ResourcesLinkSection = {
     text: 'View additional Images guides',
     to: 'https://www.linode.com/docs/products/tools/images/guides/',
   },
-  title: 'DNS Manager Guides',
+  title: 'Getting Started Guides',
 };
 
 export const youtubeLinkData: ResourcesLinkSection = {


### PR DESCRIPTION
## Description 📝
Fixes a typo on the Images landing page empty state by replacing "DNS Manager Guides" with "Getting Started Guides"

## Changes  🔄
- Just replaces "DNS Manager Guides" with "Getting Started Guides"

## Preview 📷
**Include a screenshot or screen recording of the change**

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪
Not covered by any E2E tests right now (see M3-7452, however). Can be tested manually by navigating to `/images` and confirming page title. This may require deleting the images on your test account, or using MSW to mock your images request to force the empty state.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

