### PR TITLE
change: [M3-7485] - Revert Disable Public IP for Linodes Landing

### DIFF
--- a/packages/manager/.changeset/pr-9899-upcoming-features-1699911388781.md
+++ b/packages/manager/.changeset/pr-9899-upcoming-features-1699911388781.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-Disable Public IP Address for VPC-only Linodes in the Linode's details page ([#9899](https://github.com/linode/manager/pull/9899))
+Disable Public IP Address for VPC-only Linodes in the Linode's details page and add warning banner to Linode landing ([#9899](https://github.com/linode/manager/pull/9899))

--- a/packages/manager/.changeset/pr-9899-upcoming-features-1699911388781.md
+++ b/packages/manager/.changeset/pr-9899-upcoming-features-1699911388781.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-Disable Public IP Address for VPC-only Linodes ([#9899](https://github.com/linode/manager/pull/9899))
+Disable Public IP Address for VPC-only Linodes in the Linode's details page ([#9899](https://github.com/linode/manager/pull/9899))

--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -17,7 +17,6 @@ import {
   transitionText,
 } from 'src/features/Linodes/transitions';
 import { notificationContext as _notificationContext } from 'src/features/NotificationCenter/NotificationContext';
-import { useVPCConfigInterface } from 'src/hooks/useVPCConfigInterface';
 import { useTypeQuery } from 'src/queries/types';
 import { useRecentEventForLinode } from 'src/store/selectors/recentEventForLinode';
 import { capitalizeAllWords } from 'src/utilities/capitalize';
@@ -55,8 +54,6 @@ export const LinodeRow = (props: Props) => {
   const { data: linodeType } = useTypeQuery(type ?? '', type !== null);
 
   const recentEvent = useRecentEventForLinode(id);
-
-  const { isVPCOnlyLinode } = useVPCConfigInterface(id);
 
   const isBareMetalInstance = linodeType?.class === 'metal';
 
@@ -144,11 +141,7 @@ export const LinodeRow = (props: Props) => {
           {linodeType ? formatStorageUnits(linodeType.label) : type}
         </TableCell>
         <StyledIpTableCell data-qa-ips>
-          <IPAddress
-            disabled={isVPCOnlyLinode}
-            ips={ipv4}
-            isHovered={isHovered}
-          />
+          <IPAddress ips={ipv4} isHovered={isHovered} />
         </StyledIpTableCell>
         <Hidden lgDown>
           <TableCell data-qa-region>

--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodesLanding.tsx
@@ -4,6 +4,7 @@ import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 
 import { CircleProgress } from 'src/components/CircleProgress';
+import { DismissibleBanner } from 'src/components/DismissibleBanner/DismissibleBanner';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { LandingHeader } from 'src/components/LandingHeader';
@@ -12,14 +13,22 @@ import OrderBy from 'src/components/OrderBy';
 import { PreferenceToggle } from 'src/components/PreferenceToggle/PreferenceToggle';
 import { ProductInformationBanner } from 'src/components/ProductInformationBanner/ProductInformationBanner';
 import { TransferDisplay } from 'src/components/TransferDisplay/TransferDisplay';
+import { Typography } from 'src/components/Typography';
+import {
+  WithAccountProps,
+  withAccount,
+} from 'src/containers/account.container';
 import {
   WithProfileProps,
   withProfile,
 } from 'src/containers/profile.container';
-import withFeatureFlagConsumer from 'src/containers/withFeatureFlagConsumer.container';
+import withFlags, {
+  FeatureFlagConsumerProps,
+} from 'src/containers/withFeatureFlagConsumer.container';
 import { BackupsCTA } from 'src/features/Backups/BackupsCTA';
 import { MigrateLinode } from 'src/features/Linodes/MigrateLinode/MigrateLinode';
 import { DialogType } from 'src/features/Linodes/types';
+import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 import {
   sendGroupByTagEnabledEvent,
   sendLinodesViewEvent,
@@ -92,11 +101,14 @@ export interface LinodesLandingProps {
 type CombinedProps = LinodesLandingProps &
   StateProps &
   RouteProps &
-  WithProfileProps;
+  WithProfileProps &
+  WithAccountProps &
+  FeatureFlagConsumerProps;
 
 class ListLinodes extends React.Component<CombinedProps, State> {
   render() {
     const {
+      flags,
       linodesData,
       linodesInTransition,
       linodesRequestError,
@@ -116,6 +128,12 @@ class ListLinodes extends React.Component<CombinedProps, State> {
       someLinodesHaveMaintenance: this.props
         .someLinodesHaveScheduledMaintenance,
     };
+
+    const VPCEnabled = isFeatureEnabled(
+      'VPCs',
+      Boolean(flags.vpc),
+      this.props.account.data?.capabilities ?? []
+    );
 
     if (linodesRequestError) {
       let errorText: JSX.Element | string =
@@ -157,6 +175,19 @@ class ListLinodes extends React.Component<CombinedProps, State> {
 
     return (
       <React.Fragment>
+        {VPCEnabled && (
+          <DismissibleBanner
+            preferenceKey="vpc-linode-ip-config"
+            variant="warning"
+          >
+            <Typography>
+              A Public IP address is provisionally reserved for each Linode, but
+              isn&rsquo;t automatically assigned for Linodes in a VPC. To see
+              whether a Public IPv4 address has been assigned, see the Linode
+              details page.
+            </Typography>
+          </DismissibleBanner>
+        )}
         <LinodeResize
           linodeId={this.state.selectedLinodeID}
           onClose={this.closeDialogs}
@@ -450,7 +481,8 @@ const connected = connect(mapStateToProps, undefined);
 export const enhanced = compose<CombinedProps, LinodesLandingProps>(
   withRouter,
   connected,
-  withFeatureFlagConsumer,
+  withAccount,
+  withFlags,
   withProfile
 );
 


### PR DESCRIPTION
## Description 📝
We are grabbing configs for every Linode in the Linodes landing page to check if it is a VPC-only Linode which does not scale well (same problem as the VPC Linodes landing column). This PR reverts the Linodes landing portion of https://github.com/linode/manager/pull/9899 and adds a warning banner

## Changes  🔄
- Revert disabling of the Public IP Address column in the Linodes landing table for VPC-only Linodes
- Add warning banner to the Linodes landing page

## Preview 📷
![image](https://github.com/linode/manager/assets/115299789/4a09b380-c5c1-4b48-ac49-fc8926e81436)

## How to test 🧪

### Prerequisites
- Ensure your account has vpc customer tags

### Reproduction steps
- Go to `/linodes` and filter your Network tab by `configs`. You should see a configs request for each Linode you have

### Verification steps 
- Go to `/linodes` and filter your Network tab by `configs`
  - You should no longer see a configs request for each Linode you have
  - You should see a warning banner

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support