### PR TITLE
test: [M3-7468] - Add Cypress integration test for API maintenance mode handling

### DIFF
--- a/packages/manager/.changeset/pr-9934-tests-1701101589138.md
+++ b/packages/manager/.changeset/pr-9934-tests-1701101589138.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add maintenance mode integration test ([#9934](https://github.com/linode/manager/pull/9934))

--- a/packages/manager/cypress/e2e/core/general/maintenance-mode.spec.ts
+++ b/packages/manager/cypress/e2e/core/general/maintenance-mode.spec.ts
@@ -10,7 +10,7 @@ describe('API maintenance mode', () => {
    */
   it('shows maintenance screen when API is in maintenance mode', () => {
     mockApiMaintenanceMode();
-    cy.visitWithLogin('/linodes');
+    cy.visitWithLogin('/');
 
     // Confirm that maintenance message and link to status page are shown.
     cy.findByText('We are undergoing maintenance.').should('be.visible');

--- a/packages/manager/cypress/e2e/core/general/maintenance-mode.spec.ts
+++ b/packages/manager/cypress/e2e/core/general/maintenance-mode.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * @file Integration tests for Cloud Manager maintenance mode handling.
+ */
+
+import { mockApiMaintenanceMode } from 'support/intercepts/general';
+
+describe('API maintenance mode', () => {
+  /*
+   * - Confirms that maintenance mode screen is shown when API responds with maintenance mode header.
+   */
+  it('shows maintenance screen when API is in maintenance mode', () => {
+    mockApiMaintenanceMode();
+    cy.visitWithLogin('/linodes');
+
+    // Confirm that maintenance message and link to status page are shown.
+    cy.findByText('We are undergoing maintenance.').should('be.visible');
+    cy.contains('status.linode.com').should('be.visible');
+  });
+});

--- a/packages/manager/cypress/support/intercepts/general.ts
+++ b/packages/manager/cypress/support/intercepts/general.ts
@@ -1,0 +1,22 @@
+import { makeErrorResponse } from 'support/util/errors';
+import { apiMatcher } from 'support/util/intercepts';
+
+/**
+ * Intercepts all Linode APIv4 requests and mocks maintenance mode response.
+ *
+ * Maintenance mode mock is achieved by inserting the `x-maintenace-mode` header
+ * into the intercepted response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockApiMaintenanceMode = () => {
+  const errorResponse = makeErrorResponse(
+    'Currently in maintenance mode.',
+    503
+  );
+  errorResponse.headers = {
+    'x-maintenance-mode': 'all,All endpoints are temporarily unavailable.',
+  };
+
+  return cy.intercept(apiMatcher('**'), errorResponse);
+};

--- a/packages/manager/cypress/support/util/paginate.ts
+++ b/packages/manager/cypress/support/util/paginate.ts
@@ -1,6 +1,5 @@
-import { Response } from 'support/util/response';
-
 import type { ResourcePage } from '@linode/api-v4/types';
+import type { StaticResponse } from 'cypress/types/net-stubbing';
 
 /**
  * Paginated data.
@@ -87,7 +86,7 @@ export const paginateResponse = (
   statusCode: number = 200,
   page: number = 1,
   totalPages: number = 1
-): Response => {
+): StaticResponse => {
   const dataArray = Array.isArray(data) ? data : [data];
   return {
     body: {

--- a/packages/manager/cypress/support/util/response.ts
+++ b/packages/manager/cypress/support/util/response.ts
@@ -2,13 +2,7 @@
  * @file Utility functions to easily create HTTP response objects for Cypress tests.
  */
 
-/**
- * Object describing an HTTP response.
- */
-export interface Response {
-  body: any;
-  statusCode: number;
-}
+import type { StaticResponse } from 'cypress/types/net-stubbing';
 
 /**
  * Creates an HTTP response object with the given body data.
@@ -21,7 +15,7 @@ export interface Response {
 export const makeResponse = (
   body: any = {},
   statusCode: number = 200
-): Response => {
+): Partial<StaticResponse> => {
   return {
     body,
     statusCode,


### PR DESCRIPTION
## Description 📝
Adds an integration test for Cloud Manager's handling of the API's maintenance mode. It confirms that the maintenance mode message and link to status page are shown.

## Changes  🔄
- Adds maintenance mode integration test
- Cleans up Cypress response types

## How to test 🧪
We can rely on CI for this, but you can run the new test locally with this command:

`yarn && yarn build && yarn start:manager:ci`, and then:
```bash
yarn cy:run -s "cypress/e2e/core/general/maintenance-mode.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
