### PR TITLE
refactor:  Remove unused `tsconfig.test.json`

### DIFF
--- a/packages/manager/tsconfig.test.json
+++ b/packages/manager/tsconfig.test.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "esModuleInterop": true
-  }
-}


### PR DESCRIPTION
## Description 📝

- Deletes an unused `tsconfig` file we no longer need 🎉🗑️
- This tsconfig file was used for our jest tests, but now that we are on Vitest, we don't need it. Thank you Vitest 🙏🏼

## How to test 🧪
- Verify unit tests still run as expected `yarn test`
- Verify all CI passes

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
