### PR TITLE
upcoming: [M3-7131] - Add AGLB Configuration Edit Tests & General Bug Fixes

### DIFF
--- a/packages/api-v4/src/aglb/types.ts
+++ b/packages/api-v4/src/aglb/types.ts
@@ -177,7 +177,7 @@ type CertificateType = 'ca' | 'downstream';
 export interface Certificate {
   id: number;
   label: string;
-  certificate: string;
+  certificate?: string; // Not returned for Alpha
   type: CertificateType;
 }
 

--- a/packages/manager/.changeset/pr-9941-upcoming-features-1701203325929.md
+++ b/packages/manager/.changeset/pr-9941-upcoming-features-1701203325929.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add AGLB Configuration e2e tests, improve error handling, and improve UX ([#9941](https://github.com/linode/manager/pull/9941))

--- a/packages/manager/cypress/support/intercepts/load-balancers.ts
+++ b/packages/manager/cypress/support/intercepts/load-balancers.ts
@@ -120,6 +120,45 @@ export const mockCreateLoadBalancerConfiguration = (
 };
 
 /**
+ * Intercepts PUT request to update an AGLB configuration.
+ *
+ * @param loadBalancerId - ID of load balancer for which to update the configuration.
+ * @param configuration - The AGLB configuration being updated.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockUpdateLoadBalancerConfiguration = (
+  loadBalancerId: number,
+  configuration: Configuration
+) => {
+  return cy.intercept(
+    'PUT',
+    apiMatcher(`/aglb/${loadBalancerId}/configurations/${configuration.id}`),
+    makeResponse(configuration)
+  );
+};
+
+/**
+ * Intercepts PUT request to update an AGLB configuration.
+ *
+ * @param loadBalancerId - ID of load balancer for which to update the configuration.
+ * @param configuration - The AGLB configuration being updated.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockUpdateLoadBalancerConfigurationError = (
+  loadBalancerId: number,
+  configurationId: number,
+  errors: APIError[]
+) => {
+  return cy.intercept(
+    'PUT',
+    apiMatcher(`/aglb/${loadBalancerId}/configurations/${configurationId}`),
+    makeResponse({ errors }, 400)
+  );
+};
+
+/**
  * Intercepts POST request to create an AGLB configuration and returns an error.
  *
  * @param loadBalancerId - ID of load balancer for which to create the configuration.

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.test.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.test.tsx
@@ -1,4 +1,3 @@
-import { Certificate } from '@linode/api-v4';
 import { act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -8,18 +7,19 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { EditCertificateDrawer } from './EditCertificateDrawer';
 
-const mockTLSCertificate: Certificate = {
+const mockTLSCertificate = {
   certificate: mockCertificate,
   id: 0,
   label: 'test-tls-cert',
   type: 'downstream',
-};
-const mockCACertificate: Certificate = {
+} as const;
+
+const mockCACertificate = {
   certificate: mockCertificate,
   id: 0,
   label: 'test-ca-cert',
   type: 'ca',
-};
+} as const;
 
 describe('EditCertificateDrawer', () => {
   it('should contain the name of the cert in the drawer title and label field', () => {

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Certificates/EditCertificateDrawer.tsx
@@ -35,7 +35,7 @@ export const EditCertificateDrawer = (props: Props) => {
   const formik = useFormik<UpdateCertificatePayload>({
     enableReinitialize: true,
     initialValues: {
-      certificate: certificate?.certificate.trim(),
+      certificate: certificate?.certificate?.trim(),
       key: '',
       label: certificate?.label ?? '',
       type: certificate?.type,
@@ -43,7 +43,7 @@ export const EditCertificateDrawer = (props: Props) => {
     async onSubmit(values) {
       // The user has not edited their cert or the private key, so we exclude both cert and key from the request.
       const shouldIgnoreField =
-        certificate?.certificate.trim() === values.certificate &&
+        certificate?.certificate?.trim() === values.certificate &&
         values.key === '';
 
       try {

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ApplyCertificatesDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ApplyCertificatesDrawer.tsx
@@ -85,6 +85,7 @@ export const ApplyCertificatesDrawer = (props: Props) => {
                 )
               }
               errorText={formik.errors.certificates?.[index]?.['id']}
+              filter={{ type: 'downstream' }}
               loadbalancerId={loadbalancerId}
               value={id}
             />

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/CertificateTable.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/CertificateTable.tsx
@@ -8,18 +8,21 @@ import { TableCell } from 'src/components/TableCell';
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
 import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
+import { Typography } from 'src/components/Typography';
 import { useLoadBalancerCertificatesQuery } from 'src/queries/aglb/certificates';
 
-import type { Configuration } from '@linode/api-v4';
+import type { CertificateConfig, Configuration } from '@linode/api-v4';
+import type { FormikErrors } from 'formik';
 
 interface Props {
   certificates: Configuration['certificates'];
+  errors: FormikErrors<CertificateConfig>[] | string[];
   loadbalancerId: number;
   onRemove: (index: number) => void;
 }
 
 export const CertificateTable = (props: Props) => {
-  const { certificates, loadbalancerId, onRemove } = props;
+  const { certificates, errors, loadbalancerId, onRemove } = props;
 
   const { data } = useLoadBalancerCertificatesQuery(
     loadbalancerId,
@@ -40,10 +43,27 @@ export const CertificateTable = (props: Props) => {
         {certificates.length === 0 && <TableRowEmpty colSpan={3} />}
         {certificates.map((cert, idx) => {
           const certificate = data?.data.find((c) => c.id === cert.id);
+          const error = errors[idx];
+          const hostnameError =
+            typeof error !== 'string' ? error?.hostname : undefined;
+          const idError = typeof error !== 'string' ? error?.id : undefined;
+
+          const generalRowError = typeof error === 'string' ? error : idError;
+
           return (
             <TableRow key={idx}>
-              <TableCell>{certificate?.label ?? cert.id}</TableCell>
-              <TableCell>{cert.hostname}</TableCell>
+              <TableCell>
+                {certificate?.label ?? cert.id}
+                {generalRowError && (
+                  <Typography color="error">{generalRowError}</Typography>
+                )}
+              </TableCell>
+              <TableCell>
+                {cert.hostname}
+                {hostnameError && (
+                  <Typography color="error">{hostnameError}</Typography>
+                )}
+              </TableCell>
               <TableCell actionCell>
                 <IconButton
                   aria-label={`Remove Certificate ${

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ConfigurationForm.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ConfigurationForm.tsx
@@ -2,7 +2,7 @@ import {
   CreateConfigurationSchema,
   UpdateConfigurationSchema,
 } from '@linode/validation';
-import { useFormik } from 'formik';
+import { useFormik, yupToFormErrors } from 'formik';
 import React, { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -101,10 +101,20 @@ export const ConfigurationForm = (props: CreateProps | EditProps) => {
         helpers.setErrors(getFormikErrorsFromAPIErrors(error));
       }
     },
+    validate(values) {
+      // We must use `validate` insted of validationSchema because Formik decided to convert
+      // "" to undefined before passing the values to yup. This makes it hard to validate `label`.
+      // See https://github.com/jaredpalmer/formik/issues/805
+      try {
+        validationSchema.validateSync(values, { abortEarly: false });
+        return {};
+      } catch (error) {
+        return yupToFormErrors(error);
+      }
+    },
     // Prevent errors from being cleared when we show API errors
     validateOnBlur: !error,
     validateOnChange: !error,
-    validationSchema,
   });
 
   const protocolOptions = [

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ConfigurationForm.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ConfigurationForm.tsx
@@ -73,7 +73,7 @@ export const ConfigurationForm = (props: CreateProps | EditProps) => {
       ? useLoadBalancerConfigurationMutation
       : useLoadBalancerConfigurationCreateMutation;
 
-  const { error, isLoading, mutateAsync } = useMutation(
+  const { error, isLoading, mutateAsync, reset } = useMutation(
     loadbalancerId,
     configuration?.id ?? -1
   );
@@ -143,6 +143,11 @@ export const ConfigurationForm = (props: CreateProps | EditProps) => {
       ...formik.values.certificates,
       ...certificates,
     ]);
+  };
+
+  const handleReset = () => {
+    formik.resetForm();
+    reset();
   };
 
   const generalErrors = error?.reduce((acc, { field, reason }) => {
@@ -269,7 +274,7 @@ export const ConfigurationForm = (props: CreateProps | EditProps) => {
       <Divider spacingBottom={16} spacingTop={16} />
       <Stack direction="row" flexWrap="wrap" gap={2} justifyContent="flex-end">
         {mode === 'edit' && formik.dirty && (
-          <Button buttonType="secondary" onClick={() => formik.resetForm()}>
+          <Button buttonType="secondary" onClick={handleReset}>
             Reset
           </Button>
         )}

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ConfigurationForm.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ConfigurationForm.tsx
@@ -101,6 +101,7 @@ export const ConfigurationForm = (props: CreateProps | EditProps) => {
         helpers.setErrors(getFormikErrorsFromAPIErrors(error));
       }
     },
+    // Prevent errors from being cleared when we show API errors
     validateOnBlur: !error,
     validateOnChange: !error,
     validationSchema,
@@ -257,14 +258,24 @@ export const ConfigurationForm = (props: CreateProps | EditProps) => {
       </Stack>
       <Divider spacingBottom={16} spacingTop={16} />
       <Stack direction="row" flexWrap="wrap" gap={2} justifyContent="flex-end">
-        <Button
-          onClick={
-            mode === 'edit' ? () => setIsDeleteDialogOpen(true) : onCancel
-          }
-          buttonType="secondary"
-        >
-          {mode === 'edit' ? 'Delete' : 'Cancel'}
-        </Button>
+        {mode === 'edit' && formik.dirty && (
+          <Button buttonType="secondary" onClick={() => formik.resetForm()}>
+            Reset
+          </Button>
+        )}
+        {mode === 'edit' && (
+          <Button
+            buttonType="secondary"
+            onClick={() => setIsDeleteDialogOpen(true)}
+          >
+            Delete
+          </Button>
+        )}
+        {mode === 'create' && (
+          <Button buttonType="secondary" onClick={onCancel}>
+            Cancel
+          </Button>
+        )}
         <Button
           buttonType="primary"
           disabled={mode === 'edit' && !formik.dirty}

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerServiceTargets.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerServiceTargets.tsx
@@ -148,10 +148,10 @@ export const LoadBalancerServiceTargets = () => {
             </TableSortCell>
             <Hidden smDown>
               <TableSortCell
-                active={orderBy === 'algorithm'}
+                active={orderBy === 'load_balancing_policy'}
                 direction={order}
                 handleClick={handleOrderChange}
-                label="algorithm"
+                label="load_balancing_policy"
               >
                 Algorithm
               </TableSortCell>

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerServiceTargets.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerServiceTargets.tsx
@@ -1,7 +1,7 @@
 import { ServiceTarget } from '@linode/api-v4';
 import CloseIcon from '@mui/icons-material/Close';
 import { Hidden, IconButton } from '@mui/material';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { Button } from 'src/components/Button/Button';
@@ -65,13 +65,6 @@ export const LoadBalancerServiceTargets = () => {
     setIsDeleteDialogOpen(true);
     setSelectedServiceTarget(serviceTarget);
   };
-
-  // Once the drawer is closed, clear the selected service target for the correct add/edit drawer data.
-  useEffect(() => {
-    if (!isDrawerOpen) {
-      setSelectedServiceTarget(undefined);
-    }
-  }, [isDrawerOpen]);
 
   // If the user types in a search query, filter results by label.
   if (query) {
@@ -197,8 +190,11 @@ export const LoadBalancerServiceTargets = () => {
         pageSize={pagination.pageSize}
       />
       <ServiceTargetDrawer
+        onClose={() => {
+          setIsDrawerOpen(false);
+          setSelectedServiceTarget(undefined);
+        }}
         loadbalancerId={Number(loadbalancerId)}
-        onClose={() => setIsDrawerOpen(false)}
         open={isDrawerOpen}
         serviceTarget={selectedServiceTarget}
       />

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/RuleDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/RuleDrawer.tsx
@@ -89,6 +89,7 @@ export const RuleDrawer = (props: Props) => {
         }
 
         await updateRoute({
+          label: route?.label,
           protocol: route?.protocol,
           // If we are editing, send the updated rules, otherwise
           // append a new rule to the end.

--- a/packages/manager/src/queries/aglb/serviceTargets.ts
+++ b/packages/manager/src/queries/aglb/serviceTargets.ts
@@ -97,7 +97,7 @@ export const useLoadBalancerServiceTargetsInfiniteQuery = (
   filter: Filter = {}
 ) => {
   return useInfiniteQuery<ResourcePage<ServiceTarget>, APIError[]>(
-    [QUERY_KEY, 'loadbalancer', id, 'service-targets', 'infinite', filter],
+    [QUERY_KEY, 'aglb', id, 'service-targets', 'infinite', filter],
     ({ pageParam }) =>
       getLoadbalancerServiceTargets(
         id,

--- a/packages/validation/src/loadbalancers.schema.ts
+++ b/packages/validation/src/loadbalancers.schema.ts
@@ -134,6 +134,7 @@ const BaseRuleSchema = object({
         return sum === 100;
       }
     )
+    .min(1, 'Rules must have at least 1 Service Target.')
     .required(),
 });
 


### PR DESCRIPTION
## Description 📝
- Adds AGLB e2es for updating configurations using only **mock data** 🧪
- Also improves **error handling** for AGLB configurations 🚫
- Disabled the "Save Configuration" button if no changes have been made ⏹️
- Fixed bug where a rule would not be creatable (we pass `label` to fix this) 🐛
- Only shows `downstream` certificates when configuring a Configuration 🔐
- Handles the certificates endpoint not returning `certificate` for alpha 🚫

## Preview 📷

### Shows button behavior when editing 👁️

https://github.com/linode/manager/assets/115251059/bbe2b4ed-2ff7-45b9-8ac8-a202aefefdc7

### Example of how complex API errors will be shown 👁️
![Screenshot 2023-11-28 at 3 13 46 PM](https://github.com/linode/manager/assets/115251059/825392d4-55e0-4751-a41d-9193a02d933e)

## How to test 🧪

### Verification steps 
- Run `yarn cy:debug`
- Run the `load-balancer-configurations.spec.ts` tests
- Manually test the Configurations tab with the MSW **on** for any regressions

## As an Author I have considered 🤔

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support