### PR TITLE
upcoming: [M3-7413] - Update existing user account endpoints and mocks for Parent/Child Account Switching 

### DIFF
--- a/packages/api-v4/.changeset/pr-9942-upcoming-features-1701206431848.md
+++ b/packages/api-v4/.changeset/pr-9942-upcoming-features-1701206431848.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Upcoming Features
+---
+
+Add `user_type` and `child_account_access` fields for Parent/Child ([#9942](https://github.com/linode/manager/pull/9942))

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -4,19 +4,13 @@ import type { Capabilities, Region } from '../regions';
 export type UserType = 'child' | 'parent' | 'proxy';
 
 export interface User {
-  username: string;
   email: string;
-  restricted: boolean;
-  ssh_keys: string[];
-  tfa_enabled: boolean;
-  verified_phone_number: string | null;
   /**
    * The date of when a password was set on a user.
    * `null` if this user has not created a password yet
    * @example 2022-02-09T16:19:26
    * @example null
    */
-  password_created: string | null;
   /**
    * Information for the most recent login attempt for this User.
    * `null` if no login attempts have been made since creation of this User.
@@ -31,7 +25,13 @@ export interface User {
      */
     status: AccountLoginStatus;
   } | null;
+  password_created: string | null;
+  restricted: boolean;
+  ssh_keys: string[];
+  tfa_enabled: boolean;
+  username: string;
   user_type: UserType | null;
+  verified_phone_number: string | null;
 }
 
 export interface Account {

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -1,6 +1,8 @@
 import { APIWarning } from '../types';
 import type { Capabilities, Region } from '../regions';
 
+export type UserType = 'child' | 'parent' | 'proxy';
+
 export interface User {
   username: string;
   email: string;
@@ -29,6 +31,7 @@ export interface User {
      */
     status: AccountLoginStatus;
   } | null;
+  user_type: UserType | null;
 }
 
 export interface Account {

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -6,12 +6,6 @@ export type UserType = 'child' | 'parent' | 'proxy';
 export interface User {
   email: string;
   /**
-   * The date of when a password was set on a user.
-   * `null` if this user has not created a password yet
-   * @example 2022-02-09T16:19:26
-   * @example null
-   */
-  /**
    * Information for the most recent login attempt for this User.
    * `null` if no login attempts have been made since creation of this User.
    */
@@ -25,6 +19,12 @@ export interface User {
      */
     status: AccountLoginStatus;
   } | null;
+  /**
+   * The date of when a password was set on a user.
+   * `null` if this user has not created a password yet
+   * @example 2022-02-09T16:19:26
+   * @example null
+   */
   password_created: string | null;
   restricted: boolean;
   ssh_keys: string[];

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -172,6 +172,7 @@ export type GlobalGrantTypes =
   | 'add_longview'
   | 'longview_subscription'
   | 'account_access'
+  | 'child_account_access'
   | 'cancel_account'
   | 'add_domains'
   | 'add_stackscripts'

--- a/packages/manager/.changeset/pr-9942-upcoming-features-1701206553615.md
+++ b/packages/manager/.changeset/pr-9942-upcoming-features-1701206553615.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update existing user account and grant factories and mocks for Parent/Child ([#9942](https://github.com/linode/manager/pull/9942))

--- a/packages/manager/src/factories/accountUsers.ts
+++ b/packages/manager/src/factories/accountUsers.ts
@@ -8,6 +8,7 @@ export const accountUserFactory = Factory.Sync.makeFactory<User>({
   restricted: true,
   ssh_keys: [],
   tfa_enabled: false,
+  user_type: null,
   username: 'user',
   verified_phone_number: null,
 });

--- a/packages/manager/src/factories/grants.ts
+++ b/packages/manager/src/factories/grants.ts
@@ -41,6 +41,7 @@ export const grantsFactory = Factory.Sync.makeFactory<Grants>({
     add_volumes: true,
     add_vpcs: true,
     cancel_account: false,
+    child_account_access: false,
     longview_subscription: true,
   },
   image: [

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1125,16 +1125,22 @@ export const handlers = [
   rest.get('*/account/users', (req, res, ctx) => {
     const accountUsers = [
       accountUserFactory.build({
-        last_login: { status: 'failed', login_datetime: '2023-10-16T17:04' },
+        last_login: { login_datetime: '2023-10-16T17:04', status: 'failed' },
         tfa_enabled: true,
       }),
       accountUserFactory.build({
         last_login: {
-          status: 'successful',
           login_datetime: '2023-10-06T12:04',
+          status: 'successful',
         },
       }),
       accountUserFactory.build({ last_login: null }),
+      accountUserFactory.build({
+        email: 'partner@partnercompany.com',
+        last_login: null,
+        user_type: 'proxy',
+        username: 'ParentCompany_a1b2c3d4e5',
+      }),
     ];
     return res(ctx.json(makeResourcePage(accountUsers)));
   }),

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -488,6 +488,27 @@ const standardTypes = linodeTypeFactory.buildList(7);
 const dedicatedTypes = dedicatedTypeFactory.buildList(7);
 const proDedicatedType = proDedicatedTypeFactory.build();
 
+const proxyAccount = accountUserFactory.build({
+  email: 'partner@proxy.com',
+  last_login: null,
+  user_type: 'proxy',
+  username: 'ParentCompany_a1b2c3d4e5',
+});
+const parentAccount = accountUserFactory.build({
+  email: 'parent@acme.com',
+  last_login: null,
+  restricted: false,
+  user_type: 'parent',
+  username: 'ParentUser',
+});
+const childAccount = accountUserFactory.build({
+  email: 'child@linode.com',
+  last_login: null,
+  restricted: false,
+  user_type: 'child',
+  username: 'ChildUser',
+});
+
 export const handlers = [
   rest.get('*/profile', (req, res, ctx) => {
     const profile = profileFactory.build({
@@ -1134,64 +1155,20 @@ export const handlers = [
           status: 'successful',
         },
       }),
-      accountUserFactory.build({
-        email: 'child@linode.com',
-        last_login: null,
-        user_type: 'child',
-        username: 'ChildUser',
-      }),
-      accountUserFactory.build({
-        email: 'partner@partner.com',
-        last_login: null,
-        user_type: 'proxy',
-        username: 'ParentCompany_a1b2c3d4e5',
-      }),
-      accountUserFactory.build({
-        email: 'parent@acme.com',
-        last_login: null,
-        user_type: 'parent',
-        username: 'ParentUser',
-      }),
+      childAccount,
+      parentAccount,
+      proxyAccount,
     ];
     return res(ctx.json(makeResourcePage(accountUsers)));
   }),
   rest.get('*/account/users/ChildUser', (req, res, ctx) => {
-    return res(
-      ctx.json(
-        accountUserFactory.build({
-          email: 'child@linode.com',
-          last_login: null,
-          restricted: false,
-          user_type: 'child',
-          username: 'ChildUser',
-        })
-      )
-    );
+    return res(ctx.json(childAccount));
   }),
   rest.get('*/account/users/ParentCompany_a1b2c3d4e5', (req, res, ctx) => {
-    return res(
-      ctx.json(
-        accountUserFactory.build({
-          email: 'partner@partner.com',
-          last_login: null,
-          user_type: 'proxy',
-          username: 'ParentCompany_a1b2c3d4e5',
-        })
-      )
-    );
+    return res(ctx.json(proxyAccount));
   }),
   rest.get('*/account/users/ParentUser', (req, res, ctx) => {
-    return res(
-      ctx.json(
-        accountUserFactory.build({
-          email: 'parent@acme.com',
-          last_login: null,
-          restricted: false,
-          user_type: 'parent',
-          username: 'ParentUser',
-        })
-      )
-    );
+    return res(ctx.json(parentAccount));
   }),
   rest.get('*/account/users/:user', (req, res, ctx) => {
     return res(ctx.json(accountUserFactory.build()));
@@ -1213,8 +1190,6 @@ export const handlers = [
       return res(
         ctx.json(
           grantsFactory.build({
-            domain: [],
-            firewall: [],
             global: {
               add_domains: false,
               add_firewalls: false,
@@ -1228,12 +1203,6 @@ export const handlers = [
               cancel_account: false,
               longview_subscription: false,
             },
-            image: [],
-            linode: [],
-            longview: [],
-            nodebalancer: [],
-            stackscript: [],
-            volume: [],
           })
         )
       );

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1161,31 +1161,34 @@ export const handlers = [
     ];
     return res(ctx.json(makeResourcePage(accountUsers)));
   }),
-  rest.get('*/account/users/ChildUser', (req, res, ctx) => {
+  rest.get(`*/account/users/${childAccount.username}`, (req, res, ctx) => {
     return res(ctx.json(childAccount));
   }),
-  rest.get('*/account/users/ParentCompany_a1b2c3d4e5', (req, res, ctx) => {
+  rest.get(`*/account/users/${proxyAccount.username}`, (req, res, ctx) => {
     return res(ctx.json(proxyAccount));
   }),
-  rest.get('*/account/users/ParentUser', (req, res, ctx) => {
+  rest.get(`*/account/users/${parentAccount.username}`, (req, res, ctx) => {
     return res(ctx.json(parentAccount));
   }),
   rest.get('*/account/users/:user', (req, res, ctx) => {
     return res(ctx.json(accountUserFactory.build()));
   }),
-  rest.get('*/account/users/ChildUser/grants', (req, res, ctx) => {
-    return res(
-      ctx.json(
-        grantsFactory.build({
-          global: {
-            cancel_account: false,
-          },
-        })
-      )
-    );
-  }),
   rest.get(
-    '*/account/users/ParentCompany_a1b2c3d4e5/grants',
+    `*/account/users/${childAccount.username}/grants`,
+    (req, res, ctx) => {
+      return res(
+        ctx.json(
+          grantsFactory.build({
+            global: {
+              cancel_account: false,
+            },
+          })
+        )
+      );
+    }
+  ),
+  rest.get(
+    `*/account/users/${proxyAccount.username}/grants`,
     (req, res, ctx) => {
       return res(
         ctx.json(
@@ -1208,18 +1211,21 @@ export const handlers = [
       );
     }
   ),
-  rest.get('*/account/users/ParentUser/grants', (req, res, ctx) => {
-    return res(
-      ctx.json(
-        grantsFactory.build({
-          global: {
-            cancel_account: false,
-            child_account_access: true,
-          },
-        })
-      )
-    );
-  }),
+  rest.get(
+    `*/account/users/${parentAccount.username}/grants`,
+    (req, res, ctx) => {
+      return res(
+        ctx.json(
+          grantsFactory.build({
+            global: {
+              cancel_account: false,
+              child_account_access: true,
+            },
+          })
+        )
+      );
+    }
+  ),
   rest.get('*/account/users/:user/grants', (req, res, ctx) => {
     return res(
       ctx.json(

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1134,18 +1134,122 @@ export const handlers = [
           status: 'successful',
         },
       }),
-      accountUserFactory.build({ last_login: null }),
       accountUserFactory.build({
-        email: 'partner@partnercompany.com',
+        email: 'child@linode.com',
+        last_login: null,
+        user_type: 'child',
+        username: 'ChildUser',
+      }),
+      accountUserFactory.build({
+        email: 'partner@partner.com',
         last_login: null,
         user_type: 'proxy',
         username: 'ParentCompany_a1b2c3d4e5',
       }),
+      accountUserFactory.build({
+        email: 'parent@acme.com',
+        last_login: null,
+        user_type: 'parent',
+        username: 'ParentUser',
+      }),
     ];
     return res(ctx.json(makeResourcePage(accountUsers)));
   }),
+  rest.get('*/account/users/ChildUser', (req, res, ctx) => {
+    return res(
+      ctx.json(
+        accountUserFactory.build({
+          email: 'child@linode.com',
+          last_login: null,
+          restricted: false,
+          user_type: 'child',
+          username: 'ChildUser',
+        })
+      )
+    );
+  }),
+  rest.get('*/account/users/ParentCompany_a1b2c3d4e5', (req, res, ctx) => {
+    return res(
+      ctx.json(
+        accountUserFactory.build({
+          email: 'partner@partner.com',
+          last_login: null,
+          user_type: 'proxy',
+          username: 'ParentCompany_a1b2c3d4e5',
+        })
+      )
+    );
+  }),
+  rest.get('*/account/users/ParentUser', (req, res, ctx) => {
+    return res(
+      ctx.json(
+        accountUserFactory.build({
+          email: 'parent@acme.com',
+          last_login: null,
+          restricted: false,
+          user_type: 'parent',
+          username: 'ParentUser',
+        })
+      )
+    );
+  }),
   rest.get('*/account/users/:user', (req, res, ctx) => {
-    return res(ctx.json(profileFactory.build()));
+    return res(ctx.json(accountUserFactory.build()));
+  }),
+  rest.get('*/account/users/ChildUser/grants', (req, res, ctx) => {
+    return res(
+      ctx.json(
+        grantsFactory.build({
+          global: {
+            cancel_account: false,
+          },
+        })
+      )
+    );
+  }),
+  rest.get(
+    '*/account/users/ParentCompany_a1b2c3d4e5/grants',
+    (req, res, ctx) => {
+      return res(
+        ctx.json(
+          grantsFactory.build({
+            domain: [],
+            firewall: [],
+            global: {
+              add_domains: false,
+              add_firewalls: false,
+              add_images: false,
+              add_linodes: false,
+              add_longview: false,
+              add_nodebalancers: false,
+              add_stackscripts: false,
+              add_volumes: false,
+              add_vpcs: false,
+              cancel_account: false,
+              longview_subscription: false,
+            },
+            image: [],
+            linode: [],
+            longview: [],
+            nodebalancer: [],
+            stackscript: [],
+            volume: [],
+          })
+        )
+      );
+    }
+  ),
+  rest.get('*/account/users/ParentUser/grants', (req, res, ctx) => {
+    return res(
+      ctx.json(
+        grantsFactory.build({
+          global: {
+            cancel_account: false,
+            child_account_access: true,
+          },
+        })
+      )
+    );
   }),
   rest.get('*/account/users/:user/grants', (req, res, ctx) => {
     return res(

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1155,6 +1155,7 @@ export const handlers = [
           status: 'successful',
         },
       }),
+      accountUserFactory.build({ last_login: null }),
       childAccount,
       parentAccount,
       proxyAccount,


### PR DESCRIPTION
## Description 📝
`GET /account/users` and `GET /account/users/<username>` requests will return a new `user_type` field to allow us to distinguish between users. 

`GET /account/users/<username>/grants` will return a new grant type: `child_account_access`, which will be true for parent accounts with access to child account endpoints.

These additions to existing endpoints set us up to implement account switching and user permissions flows.

## Changes  🔄
- Updated the `User` interface and factory to include the new `user_type` field
- Updated the `Account` interface and `Grant` factory to include the new `child_account_access` field
- Updated the MSW `account/users` endpoint to include a child, parent, and proxy user
   - IRL, we'd never see all three parent, proxy, and child users on one account, but mocking each user type will allow us to implement the upcoming User & Grants and User Permissions tickets for every user.

## Preview 📷
`GET /account/users` 
![Screenshot 2023-11-28 at 1 35 00 PM](https://github.com/linode/manager/assets/114685994/1ed7081f-4ef3-4bf9-937d-28235572c500)

`GET /account/users/<username>`
![Screenshot 2023-11-28 at 1 45 34 PM](https://github.com/linode/manager/assets/114685994/311911fb-37bb-4730-a1bb-506e503902f6)

`GET /account/users/<username>/grants` 
![Screenshot 2023-11-28 at 1 40 04 PM](https://github.com/linode/manager/assets/114685994/8d4dfc17-278f-436b-ba32-0e41111b0050)


## How to test 🧪

### Prerequisites
(How to setup test environment)
- Check out this branch and `yarn up`.
- Turn the Mock Service Worker on. 

### Verification steps 
(How to verify changes)
- Open the browser dev tools and navigate to the Network tab.
- Go to localhost:3000/accounts/users (the Users & Grants page).
- See the internal ticket for a link to the API spec and verify that section 6.2 (existing endpoints) reflects the changes in this PR. Specifically:
   - Examine the payload of `GET /account/users` and verify the `user_type` field is present and accurate with parent/child/proxy accounts and `null` in all other cases.
   - Visit the ParentUser's permissions page (http://localhost:3000/account/users/ParentUser/permissions) and verify the payload of `GET /account/users/<username>/grants` returns `child_account_access` set to `true`. In all other cases, it should be `false`.
   - Navigate to various users' user/profile or user/permissions pages and verify that `GET /account/users/<username>` returns the expected value for `user_type` in the payload. 

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

