### PR TITLE
upcoming: [M3-7214 - M3-7216, M3-7219, M3-7221, M3-7222] - Add DC Get Well logic to various user flows pt1

### DIFF
--- a/packages/manager/.changeset/pr-9943-upcoming-features-1701209599920.md
+++ b/packages/manager/.changeset/pr-9943-upcoming-features-1701209599920.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-Add DC Get Well logic to various user flows pt1 ([#9943](https://github.com/linode/manager/pull/9943))
+Add logic to prevent new customers in regions to various user flows for DC Get Well initiative pt1 ([#9943](https://github.com/linode/manager/pull/9943))

--- a/packages/manager/.changeset/pr-9943-upcoming-features-1701209599920.md
+++ b/packages/manager/.changeset/pr-9943-upcoming-features-1701209599920.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add DC Get Well logic to various user flows pt1 ([#9943](https://github.com/linode/manager/pull/9943))

--- a/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
@@ -33,20 +33,24 @@ import { makeFeatureFlagData } from 'support/util/feature-flags';
 
 const mockRegions: Region[] = [
   regionFactory.build({
+    capabilities: ['Linodes'],
     country: 'uk',
     id: 'eu-west',
     label: 'London, UK',
   }),
   regionFactory.build({
+    capabilities: ['Linodes'],
     country: 'sg',
     id: 'ap-south',
     label: 'Singapore, SG',
   }),
   regionFactory.build({
+    capabilities: ['Linodes'],
     id: 'us-east',
     label: 'Newark, NJ',
   }),
   regionFactory.build({
+    capabilities: ['Linodes'],
     id: 'us-central',
     label: 'Dallas, TX',
   }),

--- a/packages/manager/cypress/e2e/core/objectStorage/enable-object-storage.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/enable-object-storage.spec.ts
@@ -72,9 +72,21 @@ describe('Object Storage enrollment', () => {
     };
 
     const mockRegions: Region[] = [
-      regionFactory.build({ label: 'Newark, NJ', id: 'us-east' }),
-      regionFactory.build({ label: 'Sao Paulo, BR', id: 'br-gru' }),
-      regionFactory.build({ label: 'Jakarta, ID', id: 'id-cgk' }),
+      regionFactory.build({
+        capabilities: ['Object Storage'],
+        label: 'Newark, NJ',
+        id: 'us-east',
+      }),
+      regionFactory.build({
+        capabilities: ['Object Storage'],
+        label: 'Sao Paulo, BR',
+        id: 'br-gru',
+      }),
+      regionFactory.build({
+        capabilities: ['Object Storage'],
+        label: 'Jakarta, ID',
+        id: 'id-cgk',
+      }),
     ];
 
     // Clusters with special pricing are currently hardcoded rather than

--- a/packages/manager/src/components/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.tsx
@@ -100,6 +100,9 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
             Boolean(flags.dcGetWell) && Boolean(option.unavailable);
           return (
             <Tooltip
+              PopperProps={{
+                sx: { '& .MuiTooltip-tooltip': { minWidth: 215 } },
+              }}
               title={
                 isDisabledMenuItem ? (
                   <>

--- a/packages/manager/src/components/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.tsx
@@ -101,11 +101,13 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
           return (
             <Tooltip
               title={
-                // TODO DC_GET_WELL: add proper link to status page when available
                 isDisabledMenuItem ? (
                   <>
-                    For more information about regional availability, please see
-                    our new <Link to="https://linode.com">status page</Link>.
+                    There may be limited capacity in this region.{' '}
+                    <Link to="https://www.linode.com/global-infrastructure/availability">
+                      Learn more
+                    </Link>
+                    .
                   </>
                 ) : (
                   ''
@@ -133,7 +135,7 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
                     <StyledFlagContainer>
                       <Flag country={option.data.country} />
                     </StyledFlagContainer>
-                    {option.label} {isDisabledMenuItem && ' (Not available)'}
+                    {option.label}
                   </Box>
                   {selected && <SelectedIcon visible={selected} />}
                 </>

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.test.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.test.tsx
@@ -53,7 +53,6 @@ const expectedRegions: RegionSelectOption[] = [
     unavailable: false,
     value: 'us-1',
   },
-
   {
     data: { country: 'jp', region: 'Asia' },
     label: 'JP Location (jp-1)',

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.test.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.test.tsx
@@ -18,20 +18,48 @@ const accountAvailabilityData = [
 
 const regions: Region[] = [
   regionFactory.build({
+    capabilities: ['Linodes'],
     country: 'us',
     id: 'us-1',
     label: 'US Location',
   }),
   regionFactory.build({
+    capabilities: ['Linodes'],
     country: 'ca',
     id: 'ca-1',
     label: 'CA Location',
   }),
   regionFactory.build({
+    capabilities: ['Linodes'],
     country: 'jp',
     id: 'jp-1',
     label: 'JP Location',
   }),
+];
+
+const expectedRegions: RegionSelectOption[] = [
+  {
+    data: { country: 'ca', region: 'North America' },
+    label: 'CA Location (ca-1)',
+    unavailable: false,
+    value: 'ca-1',
+  },
+  {
+    data: {
+      country: 'us',
+      region: 'North America',
+    },
+    label: 'US Location (us-1)',
+    unavailable: false,
+    value: 'us-1',
+  },
+
+  {
+    data: { country: 'jp', region: 'Asia' },
+    label: 'JP Location (jp-1)',
+    unavailable: false,
+    value: 'jp-1',
+  },
 ];
 
 describe('getRegionOptions', () => {
@@ -53,33 +81,27 @@ describe('getRegionOptions', () => {
       regions,
     });
 
-    // Expected result
-    const expected: RegionSelectOption[] = [
-      {
-        data: { country: 'ca', region: 'North America' },
-        label: 'CA Location (ca-1)',
-        unavailable: false,
-        value: 'ca-1',
-      },
-      {
-        data: {
-          country: 'us',
-          region: 'North America',
-        },
-        label: 'US Location (us-1)',
-        unavailable: false,
-        value: 'us-1',
-      },
+    expect(result).toEqual(expectedRegions);
+  });
 
-      {
-        data: { country: 'jp', region: 'Asia' },
-        label: 'JP Location (jp-1)',
-        unavailable: false,
-        value: 'jp-1',
-      },
+  it('should filter out regions that do not have the currentCapability if currentCapability is provided', () => {
+    const regionsToFilter: Region[] = [
+      ...regions,
+      regionFactory.build({
+        capabilities: ['Object Storage'],
+        country: 'pe',
+        id: 'peru-1',
+        label: 'Peru Location',
+      }),
     ];
 
-    expect(result).toEqual(expected);
+    const result: RegionSelectOption[] = getRegionOptions({
+      accountAvailabilityData,
+      currentCapability: 'Linodes',
+      regions: regionsToFilter,
+    });
+
+    expect(result).toEqual(expectedRegions);
   });
 });
 

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
@@ -26,7 +26,7 @@ export const getRegionOptions = ({
   currentCapability,
   regions,
 }: GetRegionOptions): RegionSelectOption[] => {
-  // TODO DC_GET_WELL - when currentCapability becomes a requiredProp, we can remove the extra `filteredRegions` constant and filter directly on `regions`
+  // TODO DC_GET_WELL - when currentCapability becomes a required prop (M3-7355), we can remove the extra `filteredRegions` constant and filter directly on `regions`
   const filteredRegions = currentCapability
     ? regions.filter((region) =>
         region.capabilities.includes(currentCapability)

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
@@ -26,7 +26,14 @@ export const getRegionOptions = ({
   currentCapability,
   regions,
 }: GetRegionOptions): RegionSelectOption[] => {
-  return regions
+  // TODO DC_GET_WELL - when currentCapability becomes a requiredProp, we can remove the extra `filteredRegions` constant and filter directly on `regions`
+  const filteredRegions = currentCapability
+    ? regions.filter((region) =>
+        region.capabilities.includes(currentCapability)
+      )
+    : regions;
+
+  return filteredRegions
     .map((region: Region) => {
       const group = getRegionCountryGroup(region);
 

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
@@ -26,7 +26,6 @@ export const getRegionOptions = ({
   currentCapability,
   regions,
 }: GetRegionOptions): RegionSelectOption[] => {
-  // TODO DC_GET_WELL - when currentCapability becomes a required prop (M3-7355), we can remove the extra `filteredRegions` constant and filter directly on `regions`
   const filteredRegions = currentCapability
     ? regions.filter((region) =>
         region.capabilities.includes(currentCapability)

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -25,7 +25,6 @@ import { DynamicPriceNotice } from '../DynamicPriceNotice';
 import { Link } from '../Link';
 
 interface SelectRegionPanelProps {
-  // TODO DC_GET_WELL: eventually we will make this prop required M3-7355
   currentCapability?: Capabilities | undefined;
   disabled?: boolean;
   error?: string;

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -25,7 +25,7 @@ import { DynamicPriceNotice } from '../DynamicPriceNotice';
 import { Link } from '../Link';
 
 interface SelectRegionPanelProps {
-  // TODO DC_GET_WELL: eventually we will make this prop required M3-7360
+  // TODO DC_GET_WELL: eventually we will make this prop required M3-7355
   currentCapability?: Capabilities | undefined;
   disabled?: boolean;
   error?: string;

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -1,4 +1,4 @@
-import { Region } from '@linode/api-v4/lib/regions';
+import { Capabilities, Region } from '@linode/api-v4/lib/regions';
 import { useTheme } from '@mui/material';
 import * as React from 'react';
 import { useLocation } from 'react-router-dom';
@@ -25,6 +25,8 @@ import { DynamicPriceNotice } from '../DynamicPriceNotice';
 import { Link } from '../Link';
 
 interface SelectRegionPanelProps {
+  // TODO DC_GET_WELL: eventually we will make this prop required M3-7360
+  currentCapability?: Capabilities | undefined;
   disabled?: boolean;
   error?: string;
   handleSelection: (id: string) => void;
@@ -39,6 +41,7 @@ interface SelectRegionPanelProps {
 
 export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
   const {
+    currentCapability,
     disabled,
     error,
     handleSelection,
@@ -134,6 +137,7 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
         </Notice>
       ) : null}
       <RegionSelect
+        currentCapability={currentCapability}
         disabled={disabled}
         errorText={error}
         handleSelection={handleSelection}

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -52,7 +52,6 @@ import {
   useDatabaseTypesQuery,
 } from 'src/queries/databases';
 import { useRegionsQuery } from 'src/queries/regions';
-import { regionsWithFeature } from 'src/utilities/doesRegionSupportFeature';
 import { formatStorageUnits } from 'src/utilities/formatStorageUnits';
 import { handleAPIErrors } from 'src/utilities/formikErrorUtils';
 import { getSelectedOptionFromGroupedOptions } from 'src/utilities/getSelectedOptionFromGroupedOptions';
@@ -201,11 +200,6 @@ const DatabaseCreate = () => {
     error: regionsError,
     isLoading: regionsLoading,
   } = useRegionsQuery();
-
-  const regionsThatSupportDbaas = regionsWithFeature(
-    regionsData ?? [],
-    'Managed Databases'
-  );
 
   const {
     data: engines,
@@ -507,8 +501,9 @@ const DatabaseCreate = () => {
             handleSelection={(selected: string) =>
               setFieldValue('region', selected)
             }
+            currentCapability="Managed Databases"
             errorText={errors.region}
-            regions={regionsThatSupportDbaas}
+            regions={regionsData}
             selectedId={values.region}
           />
           <RegionHelperText mt={1} />

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
@@ -545,6 +545,7 @@ export class LinodeCreate extends React.PureComponent<
 
           {this.props.createType !== 'fromBackup' && (
             <SelectRegionPanel
+              currentCapability="Linodes"
               data-qa-select-region-panel
               disabled={userCannotCreateLinode}
               error={hasErrorFor.region}

--- a/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
@@ -127,6 +127,7 @@ export const ConfigureForm = React.memo((props: Props) => {
             textFieldProps={{
               helperText,
             }}
+            currentCapability="Linodes"
             errorText={errorText}
             handleSelection={handleSelectRegion}
             label="New Region"

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -479,6 +479,7 @@ const NodeBalancerCreate = () => {
         />
       </Paper>
       <SelectRegionPanel
+        currentCapability="NodeBalancers"
         disabled={disabled}
         error={hasErrorFor('region')}
         handleSelection={regionChange}

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.tsx
@@ -44,6 +44,7 @@ export const ClusterSelect: React.FC<Props> = (props) => {
 
   return (
     <RegionSelect
+      currentCapability="Object Storage"
       data-qa-select-cluster
       disabled={disabled}
       errorText={errorText}

--- a/packages/manager/src/features/Volumes/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate.tsx
@@ -297,18 +297,13 @@ export const VolumeCreate = () => {
                   setFieldValue('region', value);
                   setFieldValue('linode_id', null);
                 }}
-                regions={
-                  regions?.filter((eachRegion) =>
-                    eachRegion.capabilities.some((eachCape) =>
-                      eachCape.match(/block/i)
-                    )
-                  ) ?? []
-                }
+                currentCapability="Block Storage"
                 disabled={doesNotHavePermission}
                 errorText={touched.region ? errors.region : undefined}
                 isClearable
                 label="Region"
                 onBlur={handleBlur}
+                regions={regions ?? []}
                 selectedId={values.region}
                 width={400}
               />

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1020,7 +1020,7 @@ export const handlers = [
   rest.get('*/account/availability', (req, res, ctx) => {
     const newarkStorage = accountAvailabilityFactory.build({
       id: 'us-east-0',
-      unavailable: ['Block Storage'],
+      unavailable: ['Object Storage'],
     });
     const atlanta = accountAvailabilityFactory.build({
       id: 'us-southeast',

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1024,7 +1024,7 @@ export const handlers = [
     });
     const atlanta = accountAvailabilityFactory.build({
       id: 'us-southeast',
-      unavailable: ['Block Storage'],
+      unavailable: ['Block Storage', 'Managed Databases'],
     });
     const singapore = accountAvailabilityFactory.build({
       id: 'ap-south',


### PR DESCRIPTION
## Description 📝
- The bulk of the logic for disabling regions was implemented [here](https://github.com/linode/manager/pull/9909)! 🎉 This PR adds some additional logic to disable regions when creating various entities:
  - Linodes/Migrating Linodes
  - Volumes
  - Nodebalancers
  - Managed Databases
  - Object Storage

There will be a part 2 PR for additional stuff later - definitely Kubernetes, potentially Service Transfers

## Changes  🔄
- Updated `getRegionOptions` in `RegionSelect` to filter regions based on capability - only show the regions that actually support whichever capability we pass in + added relevant test
- Update MSW so that we can see a disabled region in Object Storage & Databases
- Add logic for disabled regions in Linodes/Migrate Linodes, Volume, Nodebalancers, Managed Databases, Object Storage
- update tooltip copy & link

## Preview 📷

| MSW - Linodes  | MSW - volumes   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/139280159/823b2a04-f21b-47d5-a334-d9210f041c4d) | ![image](https://github.com/linode/manager/assets/139280159/989c80b9-4ece-4744-85d2-ad439201cd79) |

## How to test 🧪
### Verification steps 
- Without the MSW (and with/without the DC get well feature flag), for each flow listed above
  - Verify that the creation (or migration) flow for each entity still works as expected
  - Verify that this PR still has the same regions as prod
    - ** Tokyo no longer appears in this PR bc we've removed fake regions
    - ** order of continent/regions may not be the same, we've alphabetized everything
- With the MSW + dc get well feature flag, for each flow
  - Verify that disabled regions appear as expected for each entity/capability (see mock data for `account/availability` endpoint in `serverHandlers.ts`)
  - Verify that if a region doesn't have a capability for some entity, that region doesn't appear. You can do this by adding or removing capabilities in `regions.json` 
  - clicking on the "learn more" link takes you to https://www.linode.com/global-infrastructure/availability (page does not yet exist but will soon)
- `yarn test components/RegionSelect`

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
