### PR TITLE
feat: [M3-7335] - Add codeowners for Cypress tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,5 @@
 # Default code owners
 * @linode/frontend
+
+# Frontend SDET code owners for Cypress tests
+/packages/manager/cypress/ @linode/frontend-sdets

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 * @linode/frontend
 
 # Frontend SDET code owners for Cypress tests
-/packages/manager/cypress/ @linode/frontend-sdets
+/packages/manager/cypress/ @linode/frontend-sdet


### PR DESCRIPTION
## Description 📝
Adds a rule to the `CODEOWNERS` file to assign ownership of the Cypress code to the `frontend-sdet` team so that Cassie and I get added to PRs that include test changes and additions.

I'm not too familiar with the `CODEOWNERS` file syntax, and used [this example from GitHub's docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#:~:text=%23%20In%20this%20example%2C%20%40doctocat%20owns%20any%20file%20in%20the%20%60/docs%60%0A%23%20directory%20in%20the%20root%20of%20your%20repository%20and%20any%20of%20its%0A%23%20subdirectories.%0A/docs/%20%40doctocat) as the basis for this change.

## Changes  🔄
- Added rule to assign code ownership of Cypress tests to `frontend-sdet` team

## How to test 🧪
`undefined`

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
