### PR TITLE
change: [M3-7492] – VPC Landing page empty state resource links & copy updates

### DIFF
--- a/packages/manager/.changeset/pr-9951-upcoming-features-1701454182728.md
+++ b/packages/manager/.changeset/pr-9951-upcoming-features-1701454182728.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Tweaked VPC landing page empty state copy and added resource links ([#9951](https://github.com/linode/manager/pull/9951))

--- a/packages/manager/cypress/e2e/core/vpc/vpc-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/vpc/vpc-landing-page.spec.ts
@@ -71,7 +71,6 @@ describe('VPC landing page', () => {
     cy.findByText(VPC_LABEL).should('be.visible');
     cy.findByText('Create a private and isolated network').should('be.visible');
     cy.findByText('Getting Started Guides').should('be.visible');
-    cy.findByText('Video Playlist').should('be.visible');
 
     // Create button exists and navigates user to create page.
     ui.button

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCEmptyState.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCEmptyState.tsx
@@ -3,10 +3,7 @@ import { useHistory } from 'react-router-dom';
 
 import VPC from 'src/assets/icons/entityIcons/vpc.svg';
 import { ResourcesSection } from 'src/components/EmptyLandingPageResources/ResourcesSection';
-import {
-  gettingStartedGuides,
-  youtubeLinkData,
-} from 'src/features/Linodes/LinodesLanding/LinodesLandingEmptyStateData';
+import { gettingStartedGuides } from 'src/features/VPCs/VPCLanding/VPCLandingEmptyStateData';
 import { sendEvent } from 'src/utilities/analytics';
 
 import { headers, linkAnalyticsEvent } from './VPCEmptyStateData';
@@ -33,7 +30,6 @@ export const VPCEmptyState = () => {
       headers={headers}
       icon={VPC}
       linkAnalyticsEvent={linkAnalyticsEvent}
-      youtubeLinkData={youtubeLinkData}
     />
   );
 };

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCEmptyStateData.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCEmptyStateData.tsx
@@ -7,7 +7,7 @@ import type {
 
 export const headers: ResourcesHeaders = {
   description:
-    'Enable cloud resources to privately and securely communicate with each other, the internet, and other private networks.',
+    'Enable cloud resources to privately communicate with each other, the internet, and other private networks.',
   subtitle: 'Create a private and isolated network',
   title: VPC_LABEL,
 };

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCLandingEmptyStateData.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCLandingEmptyStateData.tsx
@@ -1,0 +1,48 @@
+import type {
+  ResourcesHeaders,
+  ResourcesLinkSection,
+  ResourcesLinks,
+} from 'src/components/EmptyLandingPageResources/ResourcesLinksTypes';
+
+export const headers: ResourcesHeaders = {
+  description:
+    'Host your websites, applications, or any other Cloud-based workloads on a scalable and reliable platform.',
+  subtitle: 'Cloud-based virtual machines',
+  title: 'Linodes',
+};
+
+export const gettingStartedGuides: ResourcesLinkSection = {
+  links: [
+    {
+      text: 'Overview of Virtual Private Clouds (VPCs)',
+      to: 'https://www.linode.com/docs/products/networking/vpc/',
+    },
+    {
+      text: 'Getting Started with VPCs',
+      to: 'https://www.linode.com/docs/products/networking/vpc/get-started/',
+    },
+    {
+      text: 'Create a VPC',
+      to: 'https://www.linode.com/docs/products/networking/vpc/guides/create/',
+    },
+    {
+      text: 'Manage VPC Subnets',
+      to: 'https://www.linode.com/docs/products/networking/vpc/guides/subnets/',
+    },
+    {
+      text: 'Assign (and Remove) Services',
+      to:
+        'https://www.linode.com/docs/products/networking/vpc/guides/assign-services/',
+    },
+  ],
+  moreInfo: {
+    text: 'View additional VPC guides',
+    to: 'https://www.linode.com/docs/products/networking/vpc/guides/',
+  },
+  title: 'Getting Started Guides',
+};
+
+export const linkAnalyticsEvent: ResourcesLinks['linkAnalyticsEvent'] = {
+  action: 'Click:link',
+  category: 'VPCs landing page empty',
+};


### PR DESCRIPTION
## Description 📝
Update copy and resource links for the empty state VPC landing page.

## Changes  🔄
- Minor copy tweaks
- Resource links added (links have not yet been published yet so the hyperlinks won't work at this point, but the URLs have been finalized)

## Preview 📷
![Screenshot 2023-12-01 at 12 55 27 PM](https://github.com/linode/manager/assets/114682940/2e977b13-d8fb-4e94-a95b-973709c68411)

## How to test 🧪

### Prerequisites
- MSW

### Verification steps
If you have VPCs on your account already, the easiest way to test this would be turning the MSW, commenting these lines out in `serverHandlers.ts`, and refreshing the page:

https://github.com/linode/manager/blob/1141d10c3801992fe07f114280250150bc737738/packages/manager/src/mocks/serverHandlers.ts#L443-L445

Confirm that:
- Copy matches the ticket/mockup
- Links match what's listed in the ticket

## As an Author I have considered 🤔
- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support