### PR TITLE
change: [M3-7493] – Update UX copy on VPC Create page

### DIFF
--- a/packages/manager/.changeset/pr-9962-upcoming-features-1701804783926.md
+++ b/packages/manager/.changeset/pr-9962-upcoming-features-1701804783926.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Updated copy on VPC Create page ([#9962](https://github.com/linode/manager/pull/9962))

--- a/packages/manager/src/features/VPCs/VPCCreate/FormComponents/SubnetContent.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/FormComponents/SubnetContent.tsx
@@ -30,9 +30,11 @@ export const SubnetContent = (props: Props) => {
         Subnets
       </StyledHeaderTypography>
       <StyledBodyTypography isDrawer={isDrawer} variant="body1">
-        {VPC_CREATE_FORM_SUBNET_HELPER_TEXT}
-        <Link to="#"> Learn more</Link>.
-        {/* @TODO VPC: subnet learn more link here */}
+        {VPC_CREATE_FORM_SUBNET_HELPER_TEXT}{' '}
+        <Link to="https://www.linode.com/docs/products/networking/vpc/guides/subnets/">
+          Learn more
+        </Link>
+        .
       </StyledBodyTypography>
       {subnetErrors
         ? subnetErrors.map((apiError: APIError) => (

--- a/packages/manager/src/features/VPCs/VPCCreate/FormComponents/VPCTopSectionContent.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/FormComponents/VPCTopSectionContent.tsx
@@ -24,8 +24,11 @@ export const VPCTopSectionContent = (props: Props) => {
   return (
     <>
       <StyledBodyTypography isDrawer={isDrawer} variant="body1">
-        {VPC_CREATE_FORM_VPC_HELPER_TEXT}
-        <Link to="#"> Learn more</Link>.{/* @TODO VPC: learn more link here */}
+        {VPC_CREATE_FORM_VPC_HELPER_TEXT}{' '}
+        <Link to="https://www.linode.com/docs/products/networking/vpc/">
+          Learn more
+        </Link>
+        .
       </StyledBodyTypography>
       <RegionSelect
         aria-label="Choose a region"

--- a/packages/manager/src/features/VPCs/constants.ts
+++ b/packages/manager/src/features/VPCs/constants.ts
@@ -20,10 +20,11 @@ export const VPC_AUTO_ASSIGN_IPV4_TOOLTIP =
 
 export const CANNOT_CREATE_VPC_MESSAGE = `You don't have permissions to create a new VPC. Please contact an account administrator for details`;
 
-export const VPC_CREATE_FORM_SUBNET_HELPER_TEXT = `A subnet divides a VPC into multiple logically defined networks to allow for controlled access to VPC resources. Subnets within a VPC are routable regardless of the address spaces they are in.`;
+export const VPC_CREATE_FORM_SUBNET_HELPER_TEXT =
+  'Each VPC can further segment itself into distinct networks through the use of multiple subnets. These subnets can isolate various functionality of an application.';
 
 export const VPC_CREATE_FORM_VPC_HELPER_TEXT =
-  'A virtual private cloud (VPC) is an isolated network which allows for control over how resources are networked and can communicate.';
+  'A VPC is an isolated network that enables private communication between Compute Instances within the same data center.';
 
 export const VPC_FEEDBACK_FORM_URL =
   'https://docs.google.com/forms/d/e/1FAIpQLScvWbTupCNsBF5cz5YEsv5oErHM4ONBZodDYi8KuOgC8fyfag/viewform';


### PR DESCRIPTION
## Description 📝
Update the copy and "Learn more" links on the VPC Create page

## Preview 📷
<details>
<summary>Screenshot</summary>

![Screenshot 2023-12-05 at 2 18 34 PM](https://github.com/linode/manager/assets/114682940/0fc026fb-7131-471d-a3d9-62891dc14dec)
</details>

## How to test 🧪
### Prerequisites
- An account with the proper VPC tags

### Verification steps 
- Ensure the copy and links on the VPC Create page match the ticket (note: the docs have not been published yet so the links will not go to an actual guide, but the URLs have been finalized)

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support