### PR TITLE
change: [M3-7494] – Update copy for Linode "Reboot Needed" tooltip

### DIFF
--- a/packages/manager/.changeset/pr-9966-upcoming-features-1701878955797.md
+++ b/packages/manager/.changeset/pr-9966-upcoming-features-1701878955797.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Updated VPC-related copy for Reboot Needed tooltip ([#9966](https://github.com/linode/manager/pull/9966))

--- a/packages/manager/src/features/VPCs/constants.ts
+++ b/packages/manager/src/features/VPCs/constants.ts
@@ -30,7 +30,7 @@ export const VPC_FEEDBACK_FORM_URL =
   'https://docs.google.com/forms/d/e/1FAIpQLScvWbTupCNsBF5cz5YEsv5oErHM4ONBZodDYi8KuOgC8fyfag/viewform';
 
 export const VPC_REBOOT_MESSAGE =
-  'The VPC configuration has been updated and the Linode needs to be rebooted.';
+  'The VPC configuration has been updated. Reboot the Linode to reflect configuration changes.';
 
 export const NETWORK_INTERFACES_GUIDE_URL =
   'https://www.linode.com/docs/products/compute/compute-instances/guides/configuration-profiles/';


### PR DESCRIPTION
## Description 📝
Update `VPC_REBOOT_MESSAGE` with new copy for "Reboot Needed" tooltip.

## Preview 📷
<details>
<summary>Screenshots</summary>

VPC Details page:
![Screenshot 2023-12-06 at 10 42 20 AM](https://github.com/linode/manager/assets/114682940/473fe7da-77f6-40b4-9d64-a8bf49bd187e)

Linode Details page:
![Screenshot 2023-12-06 at 10 42 02 AM](https://github.com/linode/manager/assets/114682940/cd49e4d5-8e57-407e-9663-e89936cbaaf6)
</details>

## How to test 🧪
### Prerequisites
- Account with proper VPC tags

### Verification steps
The easiest way to test this:
- Assign a Linode to a subnet from the VPC Details page (subnet row --> three-dot menu --> "Assign Linodes")
- Observe: the assigned Linode should appear in the subnet inner table with a status of "Reboot Needed" and a tooltip with the updated copy

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support