### PR TITLE
change: Remove VPC Banner on Linodes Landing

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodesLanding.tsx
@@ -4,7 +4,6 @@ import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 
 import { CircleProgress } from 'src/components/CircleProgress';
-import { DismissibleBanner } from 'src/components/DismissibleBanner/DismissibleBanner';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { LandingHeader } from 'src/components/LandingHeader';
@@ -13,22 +12,14 @@ import OrderBy from 'src/components/OrderBy';
 import { PreferenceToggle } from 'src/components/PreferenceToggle/PreferenceToggle';
 import { ProductInformationBanner } from 'src/components/ProductInformationBanner/ProductInformationBanner';
 import { TransferDisplay } from 'src/components/TransferDisplay/TransferDisplay';
-import { Typography } from 'src/components/Typography';
-import {
-  WithAccountProps,
-  withAccount,
-} from 'src/containers/account.container';
 import {
   WithProfileProps,
   withProfile,
 } from 'src/containers/profile.container';
-import withFlags, {
-  FeatureFlagConsumerProps,
-} from 'src/containers/withFeatureFlagConsumer.container';
+import withFeatureFlagConsumer from 'src/containers/withFeatureFlagConsumer.container';
 import { BackupsCTA } from 'src/features/Backups/BackupsCTA';
 import { MigrateLinode } from 'src/features/Linodes/MigrateLinode/MigrateLinode';
 import { DialogType } from 'src/features/Linodes/types';
-import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 import {
   sendGroupByTagEnabledEvent,
   sendLinodesViewEvent,
@@ -101,14 +92,11 @@ export interface LinodesLandingProps {
 type CombinedProps = LinodesLandingProps &
   StateProps &
   RouteProps &
-  WithProfileProps &
-  WithAccountProps &
-  FeatureFlagConsumerProps;
+  WithProfileProps;
 
 class ListLinodes extends React.Component<CombinedProps, State> {
   render() {
     const {
-      flags,
       linodesData,
       linodesInTransition,
       linodesRequestError,
@@ -128,12 +116,6 @@ class ListLinodes extends React.Component<CombinedProps, State> {
       someLinodesHaveMaintenance: this.props
         .someLinodesHaveScheduledMaintenance,
     };
-
-    const VPCEnabled = isFeatureEnabled(
-      'VPCs',
-      Boolean(flags.vpc),
-      this.props.account.data?.capabilities ?? []
-    );
 
     if (linodesRequestError) {
       let errorText: JSX.Element | string =
@@ -175,19 +157,6 @@ class ListLinodes extends React.Component<CombinedProps, State> {
 
     return (
       <React.Fragment>
-        {VPCEnabled && (
-          <DismissibleBanner
-            preferenceKey="vpc-linode-ip-config"
-            variant="warning"
-          >
-            <Typography>
-              A Public IP address is provisionally reserved for each Linode, but
-              isn&rsquo;t automatically assigned for Linodes in a VPC. To see
-              whether a Public IPv4 address has been assigned, see the Linode
-              details page.
-            </Typography>
-          </DismissibleBanner>
-        )}
         <LinodeResize
           linodeId={this.state.selectedLinodeID}
           onClose={this.closeDialogs}
@@ -481,8 +450,7 @@ const connected = connect(mapStateToProps, undefined);
 export const enhanced = compose<CombinedProps, LinodesLandingProps>(
   withRouter,
   connected,
-  withAccount,
-  withFlags,
+  withFeatureFlagConsumer,
   withProfile
 );
 


### PR DESCRIPTION
## Description 📝
This PR removes the new VPC-related banner on the Linodes Landing page, currently visible in dev. This was a Product and UX decision based on engineering feedback.

This PR reverts the changes to LinodesLanding in [this PR](https://github.com/linode/manager/pull/9933/files).

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-12-06 at 11 09 23 AM](https://github.com/linode/manager/assets/114753608/b59b0a04-9934-404b-9bdb-0c1d473104e0) | ![Screenshot 2023-12-06 at 10 58 22 AM](https://github.com/linode/manager/assets/114753608/cf23dbe6-ad2d-4071-9e04-ad285930d9f9) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Run this branch locally against the prod API
- Clear any dismissible banners 

### Verification steps 
- Verify the Linodes Landing page works as expected and does not include the VPC banner.l

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support