### PR TITLE
change: [M3-7499, M3-7502, M3-7507] – UX copy updates for VPC Panel in Linode Create & Linode Add/Edit Config Dialog

### DIFF
--- a/packages/manager/.changeset/pr-9968-upcoming-features-1701991737243.md
+++ b/packages/manager/.changeset/pr-9968-upcoming-features-1701991737243.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Updated VPC-related UX copy in VPCPanel and Linode Add/Edit Config dialog ([#9968](https://github.com/linode/manager/pull/9968))

--- a/packages/manager/.changeset/pr-9968-upcoming-features-1701991737243.md
+++ b/packages/manager/.changeset/pr-9968-upcoming-features-1701991737243.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Updated VPC-related UX copy in VPCPanel and Linode Add/Edit Config dialog ([#9968](https://github.com/linode/manager/pull/9968))

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -90,6 +90,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Disable Public IP Address for VPC-only Linodes in the Linode's details page ([#9899](https://github.com/linode/manager/pull/9899))
 - Update copy on VPC Create page ([#9962](https://github.com/linode/manager/pull/9962))
 - Update VPC-related copy for Reboot Needed tooltip ([#9966](https://github.com/linode/manager/pull/9966))
+- Update copy for VPC Panel in Linode Create flow and VPC-related copy in Linode Add/Edit Config dialog ([#9968](https://github.com/linode/manager/pull/9968))
 - Create feature flag to support OBJ Multi Cluster UI changes ([#9970](https://github.com/linode/manager/pull/9970))
 - Replace Linode Network Transfer History chart with Recharts ([#9938](https://github.com/linode/manager/pull/9938))
 

--- a/packages/manager/src/features/Linodes/LinodesCreate/VPCPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/VPCPanel.tsx
@@ -152,8 +152,11 @@ export const VPCPanel = (props: VPCPanelProps) => {
 
     return (
       <>
-        {/* @TODO VPC: Update link */}
-        {copy} <Link to="">Learn more</Link>.
+        {copy}{' '}
+        <Link to="https://www.linode.com/docs/products/networking/vpc/guides/assign-services/">
+          Learn more
+        </Link>
+        .
       </>
     );
   };
@@ -309,7 +312,7 @@ export const VPCPanel = (props: VPCPanelProps) => {
                       </Typography>
                       <TooltipIcon
                         text={
-                          'Assign a public IP address for this VPC via 1:1 static NAT.'
+                          'Access the internet through the public IPv4 address using static 1:1 NAT.'
                         }
                         status="help"
                       />

--- a/packages/manager/src/features/Linodes/LinodesCreate/constants.ts
+++ b/packages/manager/src/features/Linodes/LinodesCreate/constants.ts
@@ -2,4 +2,4 @@ export const CROSS_DATA_CENTER_CLONE_WARNING =
   'Cloning a powered off instance across data centers may cause long periods of down time.';
 
 export const REGION_CAVEAT_HELPER_TEXT =
-  'A Linode may only be assigned to a VPC in the same region.';
+  'A Linode may be assigned only to a VPC in the same region.';

--- a/packages/manager/src/features/VPCs/constants.ts
+++ b/packages/manager/src/features/VPCs/constants.ts
@@ -43,10 +43,10 @@ export const WARNING_ICON_UNRECOMMENDED_CONFIG =
 
 // Linode Config dialog helper text for unrecommended configurations
 export const LINODE_UNREACHABLE_HELPER_TEXT =
-  'This network configuration is not recommended. The Linode will not be reachable or be able to reach Linodes in the other subnets of the VPC. We recommend selecting VPC as the primary interface and checking the “Assign a public IPv4 address for this Linode” checkbox.';
+  'This network configuration is not recommended. The Linode will not be reachable or able to reach Linodes in the other subnets of the VPC. We recommend selecting VPC as the primary interface and checking the “Assign a public IPv4 address for this Linode” checkbox.';
 
 export const NATTED_PUBLIC_IP_HELPER_TEXT =
-  "This network configuration is not recommended. The VPC interface with 1:1 NAT will use the Public IP even if it's not on the default network interface. The Linode will lose access to public network connectivity since the default route isn't able to route through the public IPv4 address. We recommend selecting VPC as the primary interface.";
+  'This network configuration is not recommended. The Linode will have no public connectivity as the public IPv4 is assigned to the non-primary VPC interface. We recommend selecting VPC as the primary interface.';
 
 export const NOT_NATTED_HELPER_TEXT =
-  'The Linode will not be able to access the internet. If this Linode needs access to the internet we recommend checking the “Assign a public IPv4 address for this Linode” checkbox to enable 1:1 NAT on the VPC interface.';
+  'The Linode will not be able to access the internet. If this Linode needs access to the internet, we recommend checking the “Assign a public IPv4 address for this Linode” checkbox which will enable 1:1 NAT on the VPC interface.';

--- a/packages/manager/src/features/VPCs/constants.ts
+++ b/packages/manager/src/features/VPCs/constants.ts
@@ -16,7 +16,7 @@ export const SUBNET_UNASSIGN_LINODES_WARNING = `Unassigning Linodes from a subne
 export const VPC_LABEL = 'Virtual Private Cloud (VPC)';
 
 export const VPC_AUTO_ASSIGN_IPV4_TOOLTIP =
-  'A VPC IPv4 is the private IP address for this Linode in the VPC.';
+  'Automatically assigns an IPv4 address as the private IP address for this Linode in the VPC.';
 
 export const CANNOT_CREATE_VPC_MESSAGE = `You don't have permissions to create a new VPC. Please contact an account administrator for details`;
 

--- a/packages/manager/src/features/VPCs/constants.ts
+++ b/packages/manager/src/features/VPCs/constants.ts
@@ -16,7 +16,7 @@ export const SUBNET_UNASSIGN_LINODES_WARNING = `Unassigning Linodes from a subne
 export const VPC_LABEL = 'Virtual Private Cloud (VPC)';
 
 export const VPC_AUTO_ASSIGN_IPV4_TOOLTIP =
-  'Automatically assigns an IPv4 address as the private IP address for this Linode in the VPC.';
+  'Automatically assign an IPv4 address as the private IP address for this Linode in the VPC.';
 
 export const CANNOT_CREATE_VPC_MESSAGE = `You don't have permissions to create a new VPC. Please contact an account administrator for details`;
 


### PR DESCRIPTION
## Description 📝
Update UX copy in the VPCPanel and Linode Add/Edit Config dialog

## Changes  🔄
- UX copy updates and added a docs link

## How to test 🧪
### Prerequisites
- Account with proper VPC tags

### Verification steps
- VPCPanel changes can be verified in the Linode Create flow and/or the Linode Add/Edit Config dialog
  - "Learn more" is hyperlinked to the finalized (but unpublished) doc URL
  - Copy in tooltip for VPC dropdown changed
  - Copy in tooltip for "Assign a public IPv4 address for this Linode" checkbox changed
  - Copy in tooltip for "Auto-assign a VPC IPv4 address for this Linode in the VPC" checkbox changed
- Copy changes for unrecommended configuration notices in Add/Edit Config dialog (instructions for specific configurations/scenarios outlined in "Preview" section in https://github.com/linode/manager/pull/9916)

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support