### PR TITLE
fix: [M3-7533] - RegionSelect sorting in Firefox

### DIFF
--- a/packages/manager/.changeset/pr-9971-fixed-1701887926900.md
+++ b/packages/manager/.changeset/pr-9971-fixed-1701887926900.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+RegionSelect sorting in Firefox ([#9971](https://github.com/linode/manager/pull/9971))

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.test.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.test.tsx
@@ -39,12 +39,6 @@ const regions: Region[] = [
 
 const expectedRegions: RegionSelectOption[] = [
   {
-    data: { country: 'ca', region: 'North America' },
-    label: 'CA Location (ca-1)',
-    unavailable: false,
-    value: 'ca-1',
-  },
-  {
     data: {
       country: 'us',
       region: 'North America',
@@ -52,6 +46,12 @@ const expectedRegions: RegionSelectOption[] = [
     label: 'US Location (us-1)',
     unavailable: false,
     value: 'us-1',
+  },
+  {
+    data: { country: 'ca', region: 'North America' },
+    label: 'CA Location (ca-1)',
+    unavailable: false,
+    value: 'ca-1',
   },
   {
     data: { country: 'jp', region: 'Asia' },

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
@@ -77,7 +77,8 @@ export const getRegionOptions = ({
       if (region1.label < region2.label) {
         return -1;
       }
-      return 0;
+
+      return 1;
     });
 };
 

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
@@ -73,7 +73,15 @@ export const getRegionOptions = ({
         return 1;
       }
 
-      // If regions are in the same group, sort alphabetically by label
+      // Then we group by country
+      if (region1.data.country < region2.data.country) {
+        return 1;
+      }
+      if (region1.data.country > region2.data.country) {
+        return -1;
+      }
+
+      // If regions are in the same group or country, sort alphabetically by label
       if (region1.label < region2.label) {
         return -1;
       }


### PR DESCRIPTION
## Description 📝
This **giant** PR fixes a small issue with the region select DCs not being sorted properly in Firefox.

## Changes  🔄
- Adjust RegionSelect sorting util  

## Preview 📷

| Before (Firefox)  | After (Firefox)  |
| ------- | ------- |
| ![Screenshot 2023-12-06 at 13 38 23](https://github.com/linode/manager/assets/130582365/da667f02-5ecd-4ac5-9a32-4d25e6850463) | ![Screenshot 2023-12-06 at 13 33 18](https://github.com/linode/manager/assets/130582365/d5ac5152-2c48-4460-a841-1583208c7195) |

## How to test 🧪

### Reproduction steps
- on develop & while using firefox, go to a create flow featuring the RegionSelect and notice the DCs are not alphabetically sorted.

### Verification steps 
- on this branch & while using firefox, go to a create flow featuring the RegionSelect and notice the DCs are now properly alphabetically sorted.
- Ensure there's no regression in the sorting for other Browsers (chrome & safari most importantly)

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support


