### PR TITLE
upcoming: [M3-7414] - Add mocks and update queries for new Parent/Child endpoints

### DIFF
--- a/packages/manager/.changeset/pr-9977-upcoming-features-1701987666651.md
+++ b/packages/manager/.changeset/pr-9977-upcoming-features-1701987666651.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add mocks and update queries for new Parent/Child endpoints ([#9977](https://github.com/linode/manager/pull/9977))

--- a/packages/manager/src/env.d.ts
+++ b/packages/manager/src/env.d.ts
@@ -27,6 +27,7 @@ interface ImportMetaEnv {
   REACT_APP_MOCK_SERVICE_WORKER?: string;
   REACT_APP_PAYPAL_CLIENT_ID?: string;
   REACT_APP_PAYPAL_ENV?: string;
+  REACT_APP_PROXY_PAT?: string;
   REACT_APP_SENTRY_URL?: string;
   REACT_APP_STATUS_PAGE_URL?: string;
   SSR: boolean;

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -1,9 +1,10 @@
+import { APIError } from '@linode/api-v4';
 import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUp from '@mui/icons-material/KeyboardArrowUp';
 import { Theme, styled, useMediaQuery } from '@mui/material';
 import Popover from '@mui/material/Popover';
-import { Stack } from 'src/components/Stack';
 import Grid from '@mui/material/Unstable_Grid2';
+import { AxiosHeaders } from 'axios';
 import * as React from 'react';
 
 import { Box } from 'src/components/Box';
@@ -12,10 +13,17 @@ import { Divider } from 'src/components/Divider';
 import { GravatarByEmail } from 'src/components/GravatarByEmail';
 import { Hidden } from 'src/components/Hidden';
 import { Link } from 'src/components/Link';
+import { Stack } from 'src/components/Stack';
 import { Tooltip } from 'src/components/Tooltip';
 import { Typography } from 'src/components/Typography';
 import { useAccountManagement } from 'src/hooks/useAccountManagement';
+import {
+  // useChildAccount,
+  // useChildAccounts,
+  useCreateChildAccountPersonalAccessTokenMutation,
+} from 'src/queries/account';
 import { useGrants } from 'src/queries/profile';
+import { getStorage } from 'src/utilities/storage';
 
 interface MenuLink {
   display: string;
@@ -48,6 +56,22 @@ export const UserMenu = React.memo(() => {
     profile,
   } = useAccountManagement();
 
+  // Parent/Child - For testing purposes only:
+  const config = {
+    headers: {
+      Authorization: `Bearer ${getStorage('authentication/token')}`,
+    },
+  };
+  const headers = new AxiosHeaders(config.headers);
+
+  // TODO: figure out why this request isn't working when `headers` are removed, even though we're mocking the grants and it includes `child_account_access` as true
+  // const { data: childAccounts } = useChildAccounts({ headers });
+
+  // const { data: childAccount } = useChildAccount({ euuid: '1', headers });
+  const {
+    mutateAsync: fetchProxyToken,
+  } = useCreateChildAccountPersonalAccessTokenMutation({ euuid: '1', headers });
+
   const matchesSmDown = useMediaQuery((theme: Theme) =>
     theme.breakpoints.down('sm')
   );
@@ -58,6 +82,16 @@ export const UserMenu = React.memo(() => {
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
+    // Parent/Child - For testing purposes only:
+    fetchProxyToken({ euuid: '1', headers })
+      .then((data) => {
+        //console.log({ data });
+      })
+      .catch((errorResponse: APIError[]) => {
+        //console.log({ errorResponse });
+      });
+    //console.log({ childAccounts });
+    //console.log({ childAccount });
   };
 
   const handleClose = () => {

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -4,7 +4,6 @@ import KeyboardArrowUp from '@mui/icons-material/KeyboardArrowUp';
 import { Theme, styled, useMediaQuery } from '@mui/material';
 import Popover from '@mui/material/Popover';
 import Grid from '@mui/material/Unstable_Grid2';
-import { AxiosHeaders } from 'axios';
 import * as React from 'react';
 
 import { Box } from 'src/components/Box';
@@ -23,7 +22,6 @@ import {
   useCreateChildAccountPersonalAccessTokenMutation,
 } from 'src/queries/account';
 import { useGrants } from 'src/queries/profile';
-import { getStorage } from 'src/utilities/storage';
 
 interface MenuLink {
   display: string;
@@ -57,20 +55,11 @@ export const UserMenu = React.memo(() => {
   } = useAccountManagement();
 
   // Parent/Child - For testing purposes only:
-  const config = {
-    headers: {
-      Authorization: `Bearer ${getStorage('authentication/token')}`,
-    },
-  };
-  const headers = new AxiosHeaders(config.headers);
-
-  // TODO: figure out why this request isn't working when `headers` are removed, even though we're mocking the grants and it includes `child_account_access` as true
-  // const { data: childAccounts } = useChildAccounts({ headers });
-
-  // const { data: childAccount } = useChildAccount({ euuid: '1', headers });
+  // const { data: childAccounts } = useChildAccounts({});
+  // const { data: childAccount } = useChildAccount({ euuid: '1'});
   const {
     mutateAsync: fetchProxyToken,
-  } = useCreateChildAccountPersonalAccessTokenMutation({ euuid: '1', headers });
+  } = useCreateChildAccountPersonalAccessTokenMutation({ euuid: '1' });
 
   const matchesSmDown = useMediaQuery((theme: Theme) =>
     theme.breakpoints.down('sm')
@@ -83,15 +72,15 @@ export const UserMenu = React.memo(() => {
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
     // Parent/Child - For testing purposes only:
-    fetchProxyToken({ euuid: '1', headers })
+    fetchProxyToken({ euuid: '1' })
       .then((data) => {
-        //console.log({ data });
+        // console.log({ data });
       })
       .catch((errorResponse: APIError[]) => {
-        //console.log({ errorResponse });
+        // console.log({ errorResponse });
       });
-    //console.log({ childAccounts });
-    //console.log({ childAccount });
+    // console.log({ childAccounts });
+    // console.log({ childAccount });
   };
 
   const handleClose = () => {

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -1,4 +1,3 @@
-import { APIError } from '@linode/api-v4';
 import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUp from '@mui/icons-material/KeyboardArrowUp';
 import { Theme, styled, useMediaQuery } from '@mui/material';
@@ -16,11 +15,6 @@ import { Stack } from 'src/components/Stack';
 import { Tooltip } from 'src/components/Tooltip';
 import { Typography } from 'src/components/Typography';
 import { useAccountManagement } from 'src/hooks/useAccountManagement';
-import {
-  // useChildAccount,
-  // useChildAccounts,
-  useCreateChildAccountPersonalAccessTokenMutation,
-} from 'src/queries/account';
 import { useGrants } from 'src/queries/profile';
 
 interface MenuLink {
@@ -54,13 +48,6 @@ export const UserMenu = React.memo(() => {
     profile,
   } = useAccountManagement();
 
-  // Parent/Child - For testing purposes only:
-  // const { data: childAccounts } = useChildAccounts({});
-  // const { data: childAccount } = useChildAccount({ euuid: '1'});
-  const {
-    mutateAsync: fetchProxyToken,
-  } = useCreateChildAccountPersonalAccessTokenMutation({ euuid: '1' });
-
   const matchesSmDown = useMediaQuery((theme: Theme) =>
     theme.breakpoints.down('sm')
   );
@@ -71,16 +58,6 @@ export const UserMenu = React.memo(() => {
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
-    // Parent/Child - For testing purposes only:
-    fetchProxyToken({ euuid: '1' })
-      .then((data) => {
-        // console.log({ data });
-      })
-      .catch((errorResponse: APIError[]) => {
-        // console.log({ errorResponse });
-      });
-    // console.log({ childAccounts });
-    // console.log({ childAccount });
   };
 
   const handleClose = () => {

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -523,7 +523,7 @@ export const handlers = [
     return res(
       // Parent/Child: switch out the return statement if you want to mock a restricted parent user with access to child accounts.
       // ctx.json(grantsFactory.build({ global: { child_account_access: true } }))
-      ctx.json(grantsFactory.build({}))
+      ctx.json(grantsFactory.build())
     );
   }),
   rest.get('*/profile/apps', (req, res, ctx) => {

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1178,7 +1178,12 @@ export const handlers = [
     return res(ctx.json(childAccount));
   }),
   rest.post('*/account/child-accounts/:euuid/token', (req, res, ctx) => {
+    // Proxy tokens expire in 15 minutes.
+    const now = new Date();
+    const expiry = new Date(now.setMinutes(now.getMinutes() + 15));
+
     const proxyToken = appTokenFactory.build({
+      expiry: expiry.toISOString(),
       token: `Bearer ${import.meta.env.REACT_APP_PROXY_PAT}`,
     });
     return res(ctx.json(proxyToken));

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1156,28 +1156,24 @@ export const handlers = [
   rest.get('*/account/child-accounts', (req, res, ctx) => {
     const childAccounts = [
       accountFactory.build({
+        company: 'Child Company 0',
         euuid: '0',
-        first_name: 'Child',
-        last_name: 'User 0',
       }),
       accountFactory.build({
+        company: 'Child Company 1',
         euuid: '1',
-        first_name: 'Child',
-        last_name: 'User 1',
       }),
       accountFactory.build({
+        company: 'Child Company 2',
         euuid: '2',
-        first_name: 'Child',
-        last_name: 'User 2',
       }),
     ];
     return res(ctx.json(makeResourcePage(childAccounts)));
   }),
   rest.get('*/account/child-accounts/:euuid', (req, res, ctx) => {
     const childAccount = accountFactory.build({
+      company: 'Child Company 1',
       euuid: '1',
-      first_name: 'Child',
-      last_name: 'User 1',
     });
     return res(ctx.json(childAccount));
   }),

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -521,7 +521,9 @@ export const handlers = [
   }),
   rest.get('*/profile/grants', (req, res, ctx) => {
     return res(
-      ctx.json(grantsFactory.build({ global: { child_account_access: true } }))
+      // Parent/Child: switch out the return statement if you want to mock a restricted parent user with access to child accounts.
+      // ctx.json(grantsFactory.build({ global: { child_account_access: true } }))
+      ctx.json(grantsFactory.build({}))
     );
   }),
   rest.get('*/profile/apps', (req, res, ctx) => {
@@ -1182,7 +1184,6 @@ export const handlers = [
   rest.post('*/account/child-accounts/:euuid/token', (req, res, ctx) => {
     const proxyToken = appTokenFactory.build({
       token: `Bearer ${import.meta.env.REACT_APP_PROXY_PAT}`,
-      // TODO: Set expiry for 15 minutes from now
     });
     return res(ctx.json(proxyToken));
   }),
@@ -1279,7 +1280,6 @@ export const handlers = [
           firewall: [],
           global: {
             cancel_account: true,
-            child_account_access: true,
           },
           image: [],
           linode: grantFactory.buildList(6000),

--- a/packages/manager/src/queries/account.ts
+++ b/packages/manager/src/queries/account.ts
@@ -9,6 +9,7 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import { useGrants, useProfile } from 'src/queries/profile';
 
+import { useAccountUser } from './accountUsers';
 import { queryPresets } from './base';
 
 import type {
@@ -52,6 +53,8 @@ export const useChildAccounts = ({
   headers,
   params,
 }: RequestOptions) => {
+  const { data: profile } = useProfile();
+  const { data: user } = useAccountUser(profile?.username ?? '');
   const { data: grants } = useGrants();
   const hasExplicitAuthToken = Boolean(headers?.Authorization);
 
@@ -60,13 +63,17 @@ export const useChildAccounts = ({
     () => getChildAccounts({ filter, headers, params }),
     {
       enabled:
-        Boolean(grants?.global?.child_account_access) || hasExplicitAuthToken,
+        (Boolean(user?.user_type === 'parent') && !profile?.restricted) ||
+        Boolean(grants?.global?.child_account_access) ||
+        hasExplicitAuthToken,
       keepPreviousData: true,
     }
   );
 };
 
 export const useChildAccount = ({ euuid, headers }: ChildAccountPayload) => {
+  const { data: profile } = useProfile();
+  const { data: user } = useAccountUser(profile?.username ?? '');
   const { data: grants } = useGrants();
   const hasExplicitAuthToken = Boolean(headers?.Authorization);
 
@@ -75,7 +82,9 @@ export const useChildAccount = ({ euuid, headers }: ChildAccountPayload) => {
     () => getChildAccount({ euuid }),
     {
       enabled:
-        Boolean(grants?.global?.child_account_access) || hasExplicitAuthToken,
+        (Boolean(user?.user_type === 'parent') && !profile?.restricted) ||
+        Boolean(grants?.global?.child_account_access) ||
+        hasExplicitAuthToken,
     }
   );
 };


### PR DESCRIPTION
## Description 📝
This PR adds Mock Service Worker (MSW) endpoints for all new "Parent/Child" API calls. (Updates to all existing endpoints were previously done in #9942.) These changes will enable us to mock the Parent/Child API interactions, ensuring our development remains unimpeded and independent of ongoing API changes. 

## Changes  🔄
- Added endpoints to the MSW for new Parent/Child endpoints.
- Updated the queries for `useChildAccounts` and `useChildAccount` to allow an unrestricted parent account to be able to reach these endpoints. (They will have `child_account_access` by default, but we can't check grants on an unrestricted user, which was relied upon in the initial implementation of the queries.)

## Preview 📷
|   |   |
| --- | --- |
| ![Screenshot 2023-12-08 at 10 05 53 AM](https://github.com/linode/manager/assets/114685994/40d9fdd1-0646-4893-bfd5-bb4da964044c)  | ![Screenshot 2023-12-08 at 10 06 19 AM](https://github.com/linode/manager/assets/114685994/02875c62-b97f-47ab-a728-93734f90e3ae)|
|![Screenshot 2023-12-08 at 10 05 45 AM](https://github.com/linode/manager/assets/114685994/1abe9053-3c3c-40dd-900e-32584f2a931e) | ![Screenshot 2023-12-08 at 10 06 04 AM](https://github.com/linode/manager/assets/114685994/fa5581e4-410f-4f32-900e-6c2e35374c26)|
![Screenshot 2023-12-08 at 10 08 04 AM](https://github.com/linode/manager/assets/114685994/bb7a29aa-2b50-41c1-9fbb-906736a5307a) | ![Screenshot 2023-12-08 at 10 08 57 AM](https://github.com/linode/manager/assets/114685994/b631a622-fb57-4302-a1e2-5748bc5e5898) |

## How to test 🧪

### Prerequisites
(How to setup test environment)

- Check out this PR and add a new `REACT_APP_PROXY_PAT` to your `.env` with any token to test. We'll need to store a mock "proxy" token to log into a child account somewhere until the API returns it. 
- Start the dev server: `yarn dev`.
- In dev tools:
   - Turn on the MSW.
   - Make sure the Parent/Child feature flag is on.
  
### Verification steps 
(How to verify changes)
- Take a look at the [removed lines of code in UserMenu.tsx](https://github.com/linode/manager/pull/9977/commits/e129bf078f0a58c431d86d2c43af6aa76cf2609a#diff-bbc007980e447b77254be68318934de3f8109be20948e1aa9f9321a534a517d0) in the commit [e129bf0](https://github.com/linode/manager/pull/9977/commits/e129bf078f0a58c431d86d2c43af6aa76cf2609a).
You will need:
```
  const { data: childAccounts } = useChildAccounts({});
  const { data: childAccount } = useChildAccount({ euuid: '1' });
  const {
    mutateAsync: fetchProxyToken,
  } = useCreateChildAccountPersonalAccessTokenMutation({ euuid: '1' });

  fetchProxyToken({ euuid: '1' })
      .then((data) => {
        console.log({ data });
      })
```
- To test the mocked queries, add the code to a component (UserMenu makes sense for our purposes) and verify in the dev console log and/or through the network request and response payload that the mocked requests to `GET /account/child-accounts`, `GET /account/child-accounts/<euuid>`, and `POST /account/child-accounts/<euuid>/token` are all executing and returning the expected data.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

