### PR TITLE
fix: FW NodeBalancer Release Fixes

### DIFF
--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDeleteDialog.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDeleteDialog.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
-import { useQueryClient } from 'react-query';
 import { useHistory } from 'react-router-dom';
 
 import { Notice } from 'src/components/Notice/Notice';
 import { TypeToConfirmDialog } from 'src/components/TypeToConfirmDialog/TypeToConfirmDialog';
 import { Typography } from 'src/components/Typography';
-import { queryKey as firewallsQueryKey } from 'src/queries/firewalls';
 import { useNodebalancerDeleteMutation } from 'src/queries/nodebalancers';
 
 interface Props {
@@ -24,11 +22,8 @@ export const NodeBalancerDeleteDialog = ({
   const { error, isLoading, mutateAsync } = useNodebalancerDeleteMutation(id);
   const { push } = useHistory();
 
-  const queryClient = useQueryClient();
-
   const onDelete = async () => {
     await mutateAsync();
-    queryClient.invalidateQueries([firewallsQueryKey]);
     onClose();
     push('/nodebalancers');
   };

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDeleteDialog.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDeleteDialog.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
+import { useQueryClient } from 'react-query';
 import { useHistory } from 'react-router-dom';
 
 import { Notice } from 'src/components/Notice/Notice';
 import { TypeToConfirmDialog } from 'src/components/TypeToConfirmDialog/TypeToConfirmDialog';
 import { Typography } from 'src/components/Typography';
+import { queryKey as firewallsQueryKey } from 'src/queries/firewalls';
 import { useNodebalancerDeleteMutation } from 'src/queries/nodebalancers';
 
 interface Props {
@@ -22,8 +24,11 @@ export const NodeBalancerDeleteDialog = ({
   const { error, isLoading, mutateAsync } = useNodebalancerDeleteMutation(id);
   const { push } = useHistory();
 
+  const queryClient = useQueryClient();
+
   const onDelete = async () => {
     await mutateAsync();
+    queryClient.invalidateQueries([firewallsQueryKey]);
     onClose();
     push('/nodebalancers');
   };

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings.tsx
@@ -25,7 +25,7 @@ export const NodeBalancerSettings = () => {
   const id = Number(nodeBalancerId);
   const { data: nodebalancer } = useNodeBalancerQuery(id);
   const { data: attachedFirewallData } = useNodeBalancersFirewallsQuery(id);
-  const displayFirewallInfoText = Boolean(attachedFirewallData?.data?.length);
+  const displayFirewallInfoText = !Boolean(attachedFirewallData?.data?.length);
 
   const {
     error: labelError,

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings.tsx
@@ -25,7 +25,7 @@ export const NodeBalancerSettings = () => {
   const id = Number(nodeBalancerId);
   const { data: nodebalancer } = useNodeBalancerQuery(id);
   const { data: attachedFirewallData } = useNodeBalancersFirewallsQuery(id);
-  const displayFirewallInfoText = !Boolean(attachedFirewallData?.data?.length);
+  const displayFirewallInfoText = attachedFirewallData?.results === 0;
 
   const {
     error: labelError,

--- a/packages/manager/src/queries/nodebalancers.ts
+++ b/packages/manager/src/queries/nodebalancers.ts
@@ -32,6 +32,7 @@ import {
 } from 'react-query';
 
 import { EventWithStore } from 'src/events';
+import { queryKey as firewallsQueryKey } from 'src/queries/firewalls';
 import { parseAPIDate } from 'src/utilities/date';
 import { getAll } from 'src/utilities/getAll';
 
@@ -214,6 +215,8 @@ export const nodebalanacerEventHandler = ({
       event.entity!.id,
       'configs',
     ]);
+  } else if (event.action.startsWith('nodebalancer_delete')) {
+    queryClient.invalidateQueries([firewallsQueryKey]);
   } else {
     queryClient.invalidateQueries([queryKey, 'all']);
     queryClient.invalidateQueries([queryKey, 'paginated']);


### PR DESCRIPTION
## Description 📝
FW NodeBalancer Release 1.108.0 fixes

## Changes  🔄
- NodeBalancer Settings tab helper text now shows when the NodeBalancer doe not have an assigned Firewall
- Invalidated Firewall query after NodeBalancer delete

### Prerequisites
- FW-NodeBalancer Feature Flag turned on
- Dev tools > Network > Disable cache

### Verification steps 
- After deleting NodeBalancer, ensure that the Firewall table gets updated
- Make sure helper text in the NodeBalancer's Setting page in the Firewall's panel is visible when there is not an assigned Firewall and not visible when there is.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
