### PR TITLE
ci: Speed Up Code Coverage Github Actions Jobs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,8 +25,11 @@ jobs:
       - name: Install Dependencies
         run: yarn --frozen-lockfile
 
-      - name: Run build
-        run: yarn build
+      - name: Build @linode/validation
+        run: yarn build:validation
+
+      - name: Build @linode/api-v4
+        run: yarn build:sdk
 
       - name: Run Base Branch Coverage
         run: yarn coverage:summary
@@ -65,8 +68,11 @@ jobs:
       - name: Install Dependencies
         run: yarn --frozen-lockfile
 
-      - name: Run Build
-        run: yarn build
+      - name: Build @linode/validation
+        run: yarn build:validation
+
+      - name: Build @linode/api-v4
+        run: yarn build:sdk
 
       - name: Run Current Branch Coverage
         run: yarn coverage:summary

--- a/.github/workflows/coverage_badge.yml
+++ b/.github/workflows/coverage_badge.yml
@@ -27,8 +27,11 @@ jobs:
       - name: Install Dependencies
         run: yarn --frozen-lockfile
 
-      - name: Run Build
-        run: yarn build
+      - name: Build @linode/validation
+        run: yarn build:validation
+
+      - name: Build @linode/api-v4
+        run: yarn build:sdk
 
       - name: Run Base Branch Coverage
         run: yarn coverage:summary

--- a/packages/manager/.changeset/pr-9988-tech-stories-1702336644030.md
+++ b/packages/manager/.changeset/pr-9988-tech-stories-1702336644030.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Speed up code coverage Github Actions jobs by skipping Cloud Manager build ([#9988](https://github.com/linode/manager/pull/9988))


### PR DESCRIPTION
## Description 📝

Slightly speeds up our new code coverage Github Actions jobs by not building a production Cloud Manager bundle 🏎️

We should see an improvement of about 30-60 seconds ⏲️ Nothing groundbreaking, but slightly better. 

## How to test 🧪

- Check the GitHub Actions below this PR and verify that the Code Coverage jobs work as expected

## As an Author I have considered 🤔

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support