### PR TITLE
change: [M3-7505] – Update copy for Private IP add-on in Linode Create flow

### DIFF
--- a/packages/manager/.changeset/pr-9990-upcoming-features-1702400746535.md
+++ b/packages/manager/.changeset/pr-9990-upcoming-features-1702400746535.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Revised copy for Private IP add-on in Linode Create flow ([#9990](https://github.com/linode/manager/pull/9990))

--- a/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.tsx
@@ -250,8 +250,8 @@ export const AddonsPanel = React.memo((props: AddonsPanelProps) => {
             data-testid="private-ip-contextual-copy"
             variant="body1"
           >
-            Use this for a backend node to a NodeBalancer. Use VPC instead for
-            private communication between your Linodes.
+            Use Private IP for a backend node to a NodeBalancer. Use VPC instead
+            for private communication between your Linodes.
           </StyledTypography>
         )}
       </Paper>


### PR DESCRIPTION
## Description 📝
Update the descriptive copy for the Private IP add-on in the Linode Create flow.

## Changes  🔄
- Copy change for Private IP add-on in Linode Create flow

## How to test 🧪
### Prerequisites
- An account with the proper VPC tags

### Verification steps 
- On an account with the proper VPC tags or with the VPC feature flag on, you should see the text for the Private IP add-on in the Linode Create flow

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support