### PR TITLE
upcoming, change: [M3-7524] - Add child_account OAuth scope to Create and View PAT drawers

### DIFF
--- a/packages/manager/.changeset/pr-9992-changed-1703028128822.md
+++ b/packages/manager/.changeset/pr-9992-changed-1703028128822.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Default access to `None` for all scopes when creating Personal Access Tokens ([#9992](https://github.com/linode/manager/pull/9992))

--- a/packages/manager/.changeset/pr-9992-upcoming-features-1702939785550.md
+++ b/packages/manager/.changeset/pr-9992-upcoming-features-1702939785550.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add `child_account` oauth scope to Personal Access Token drawers ([#9992](https://github.com/linode/manager/pull/9992))

--- a/packages/manager/src/factories/oauth.ts
+++ b/packages/manager/src/factories/oauth.ts
@@ -13,7 +13,6 @@ export const appTokenFactory = Factory.Sync.makeFactory<Token>({
 
 export interface Access {
   Account: number;
-  // 'Child Account': number;
   Databases: number;
   Domains: number;
   Events: number;
@@ -31,7 +30,6 @@ export interface Access {
 
 export const accessFactory = Factory.Sync.makeFactory<Access>({
   Account: 0,
-  // 'Child Account': 0,
   Databases: 0,
   Domains: 0,
   Events: 0,

--- a/packages/manager/src/factories/oauth.ts
+++ b/packages/manager/src/factories/oauth.ts
@@ -13,6 +13,7 @@ export const appTokenFactory = Factory.Sync.makeFactory<Token>({
 
 export interface Access {
   Account: number;
+  // 'Child Account': number;
   Databases: number;
   Domains: number;
   Events: number;
@@ -30,6 +31,7 @@ export interface Access {
 
 export const accessFactory = Factory.Sync.makeFactory<Access>({
   Account: 0,
+  // 'Child Account': 0,
   Databases: 0,
   Domains: 0,
   Events: 0,

--- a/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.test.tsx
+++ b/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.test.tsx
@@ -88,7 +88,7 @@ describe('Create API Token Drawer', () => {
 
   it('Should show the Child Account Access scope for a parent user account with the parent/child feature flag on', async () => {
     server.use(
-      rest.get('*/account/users/parent-user', (req, res, ctx) => {
+      rest.get('*/account/users/*', (req, res, ctx) => {
         return res(ctx.json(accountUserFactory.build({ user_type: 'parent' })));
       })
     );
@@ -103,21 +103,20 @@ describe('Create API Token Drawer', () => {
     expect(childScope).toBeInTheDocument();
   });
 
-  // TODO: fix failing test
-  it('Should not show the Child Account Access scope for a non-parent user account with the parent/child feature flag on', async () => {
+  it('Should not show the Child Account Access scope for a non-parent user account with the parent/child feature flag on', () => {
     server.use(
-      rest.get('*/account/users/test-user', (req, res, ctx) => {
+      rest.get('*/account/users/*', (req, res, ctx) => {
         return res(ctx.json(accountUserFactory.build({ user_type: null })));
       })
     );
 
-    const { findByText } = renderWithTheme(
+    const { queryByText } = renderWithTheme(
       <CreateAPITokenDrawer {...props} />,
       {
         flags: { parentChildAccountAccess: true },
       }
     );
-    const childScope = await findByText('Child Account Access');
+    const childScope = queryByText('Child Account Access');
     expect(childScope).not.toBeInTheDocument();
   });
 

--- a/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.test.tsx
+++ b/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.test.tsx
@@ -86,35 +86,39 @@ describe('Create API Token Drawer', () => {
     getByText('In 6 months');
   });
 
-  // TODO: fix - cannot find text
-  it.skip('Should show the Child Account Access scope for a parent user account with the parent/child feature flag on', () => {
+  it('Should show the Child Account Access scope for a parent user account with the parent/child feature flag on', async () => {
     server.use(
-      // rest.get('*/profile', (req, res, ctx) => {
-      //   return res(ctx.json(profileFactory.build({ username: 'parent-user' })));
-      // }),
       rest.get('*/account/users/parent-user', (req, res, ctx) => {
         return res(ctx.json(accountUserFactory.build({ user_type: 'parent' })));
       })
     );
 
-    const { getByText } = renderWithTheme(<CreateAPITokenDrawer {...props} />, {
-      flags: { parentChildAccountAccess: true },
-    });
-    expect(getByText('Child Account Access')).toBeInTheDocument();
+    const { findByText } = renderWithTheme(
+      <CreateAPITokenDrawer {...props} />,
+      {
+        flags: { parentChildAccountAccess: true },
+      }
+    );
+    const childScope = await findByText('Child Account Access');
+    expect(childScope).toBeInTheDocument();
   });
 
   // TODO: fix - cannot find text
-  it.skip('Should not show the Child Account Access scope for a non-parent user account with the parent/child feature flag on', () => {
+  it('Should not show the Child Account Access scope for a non-parent user account with the parent/child feature flag on', async () => {
     server.use(
       rest.get('*/account/users/test-user', (req, res, ctx) => {
         return res(ctx.json(accountUserFactory.build({ user_type: null })));
       })
     );
 
-    const { getByText } = renderWithTheme(<CreateAPITokenDrawer {...props} />, {
-      flags: { parentChildAccountAccess: true },
-    });
-    expect(getByText('Child Account Access')).not.toBeInTheDocument();
+    const { findByText } = renderWithTheme(
+      <CreateAPITokenDrawer {...props} />,
+      {
+        flags: { parentChildAccountAccess: true },
+      }
+    );
+    const childScope = await findByText('Child Account Access');
+    expect(childScope).not.toBeInTheDocument();
   });
 
   it('Should close when Cancel is pressed', () => {

--- a/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.test.tsx
+++ b/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.test.tsx
@@ -74,21 +74,9 @@ describe('Create API Token Drawer', () => {
     );
   });
 
-  // TODO: Parent/Child - remove this test when Parent/Child feature is released.
-  it('Should default to read/write for all scopes', () => {
+  it('Should default to None for all scopes', () => {
     const { getByLabelText } = renderWithTheme(
       <CreateAPITokenDrawer {...props} />
-    );
-    const selectAllReadWritePermRadioButton = getByLabelText(
-      'Select read/write for all'
-    );
-    expect(selectAllReadWritePermRadioButton).toBeChecked();
-  });
-
-  it('Should default to None for all scopes with the parent/child feature flag on', () => {
-    const { getByLabelText } = renderWithTheme(
-      <CreateAPITokenDrawer {...props} />,
-      { flags: { parentChildAccountAccess: true } }
     );
     const selectAllNonePermRadioButton = getByLabelText('Select none for all');
     expect(selectAllNonePermRadioButton).toBeChecked();

--- a/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.test.tsx
+++ b/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.test.tsx
@@ -99,18 +99,15 @@ describe('Create API Token Drawer', () => {
     getByText('In 6 months');
   });
 
-  it('Should show the Child Account Access scope for a parent user account with the parent/child feature flag on', async () => {
+  it('Should show the Child Account Access scope for a parent user account with the parent/child feature flag on', () => {
     queryMocks.useAccountUser.mockReturnValue({
       data: accountUserFactory.build({ user_type: 'parent' }),
     });
 
-    const { findByText } = renderWithTheme(
-      <CreateAPITokenDrawer {...props} />,
-      {
-        flags: { parentChildAccountAccess: true },
-      }
-    );
-    const childScope = await findByText('Child Account Access');
+    const { getByText } = renderWithTheme(<CreateAPITokenDrawer {...props} />, {
+      flags: { parentChildAccountAccess: true },
+    });
+    const childScope = getByText('Child Account Access');
     expect(childScope).toBeInTheDocument();
   });
 

--- a/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.test.tsx
+++ b/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.test.tsx
@@ -87,7 +87,7 @@ describe('Create API Token Drawer', () => {
   });
 
   // TODO: fix - cannot find text
-  it.skip('Should show the Child Account scope for a parent user account with the parent/child feature flag on', () => {
+  it.skip('Should show the Child Account Access scope for a parent user account with the parent/child feature flag on', () => {
     server.use(
       // rest.get('*/profile', (req, res, ctx) => {
       //   return res(ctx.json(profileFactory.build({ username: 'parent-user' })));
@@ -100,11 +100,11 @@ describe('Create API Token Drawer', () => {
     const { getByText } = renderWithTheme(<CreateAPITokenDrawer {...props} />, {
       flags: { parentChildAccountAccess: true },
     });
-    expect(getByText('Child Account')).toBeInTheDocument();
+    expect(getByText('Child Account Access')).toBeInTheDocument();
   });
 
   // TODO: fix - cannot find text
-  it.skip('Should not show the Child Account scope for a non-parent user account with the parent/child feature flag on', () => {
+  it.skip('Should not show the Child Account Access scope for a non-parent user account with the parent/child feature flag on', () => {
     server.use(
       rest.get('*/account/users/test-user', (req, res, ctx) => {
         return res(ctx.json(accountUserFactory.build({ user_type: null })));
@@ -114,7 +114,7 @@ describe('Create API Token Drawer', () => {
     const { getByText } = renderWithTheme(<CreateAPITokenDrawer {...props} />, {
       flags: { parentChildAccountAccess: true },
     });
-    expect(getByText('Child Account')).not.toBeInTheDocument();
+    expect(getByText('Child Account Access')).not.toBeInTheDocument();
   });
 
   it('Should close when Cancel is pressed', () => {

--- a/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.test.tsx
+++ b/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.test.tsx
@@ -9,6 +9,19 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { CreateAPITokenDrawer } from './CreateAPITokenDrawer';
 
+// Mock the useAccountUser hooks to immediately return the expected data, circumventing the HTTP request and loading state.
+const queryMocks = vi.hoisted(() => ({
+  useAccountUser: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('src/queries/accountUsers', async () => {
+  const actual = await vi.importActual<any>('src/queries/accountUsers');
+  return {
+    ...actual,
+    useAccountUser: queryMocks.useAccountUser,
+  };
+});
+
 const props = {
   onClose: vi.fn(),
   open: true,
@@ -87,11 +100,9 @@ describe('Create API Token Drawer', () => {
   });
 
   it('Should show the Child Account Access scope for a parent user account with the parent/child feature flag on', async () => {
-    server.use(
-      rest.get('*/account/users/*', (req, res, ctx) => {
-        return res(ctx.json(accountUserFactory.build({ user_type: 'parent' })));
-      })
-    );
+    queryMocks.useAccountUser.mockReturnValue({
+      data: accountUserFactory.build({ user_type: 'parent' }),
+    });
 
     const { findByText } = renderWithTheme(
       <CreateAPITokenDrawer {...props} />,
@@ -104,11 +115,9 @@ describe('Create API Token Drawer', () => {
   });
 
   it('Should not show the Child Account Access scope for a non-parent user account with the parent/child feature flag on', () => {
-    server.use(
-      rest.get('*/account/users/*', (req, res, ctx) => {
-        return res(ctx.json(accountUserFactory.build({ user_type: null })));
-      })
-    );
+    queryMocks.useAccountUser.mockReturnValue({
+      data: accountUserFactory.build({ user_type: null }),
+    });
 
     const { queryByText } = renderWithTheme(
       <CreateAPITokenDrawer {...props} />,
@@ -116,6 +125,7 @@ describe('Create API Token Drawer', () => {
         flags: { parentChildAccountAccess: true },
       }
     );
+
     const childScope = queryByText('Child Account Access');
     expect(childScope).not.toBeInTheDocument();
   });

--- a/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.test.tsx
+++ b/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.test.tsx
@@ -103,7 +103,7 @@ describe('Create API Token Drawer', () => {
     expect(childScope).toBeInTheDocument();
   });
 
-  // TODO: fix - cannot find text
+  // TODO: fix failing test
   it('Should not show the Child Account Access scope for a non-parent user account with the parent/child feature flag on', async () => {
     server.use(
       rest.get('*/account/users/test-user', (req, res, ctx) => {

--- a/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.tsx
@@ -249,12 +249,13 @@ export const CreateAPITokenDrawer = (props: Props) => {
               return null;
             }
             return (
-              // When the feature flag is on, display the Child Account scope for parent user accounts only.
+              // When the feature flag is on, display the Child Account Access scope for parent user accounts only.
               (!flags.parentChildAccountAccess &&
-                basePermNameMap[scopeTup[0]] === 'Child Account') ||
+                basePermNameMap[scopeTup[0]] === 'Child Account Access') ||
                 (flags.parentChildAccountAccess &&
                   user?.user_type !== 'parent' &&
-                  basePermNameMap[scopeTup[0]] === 'Child Account') ? null : (
+                  basePermNameMap[scopeTup[0]] ===
+                    'Child Account Access') ? null : (
                 <TableRow
                   data-qa-row={basePermNameMap[scopeTup[0]]}
                   key={scopeTup[0]}

--- a/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.tsx
@@ -90,7 +90,7 @@ export const CreateAPITokenDrawer = (props: Props) => {
   const initialValues = {
     expiry: expiryTups[0][1],
     label: '',
-    scopes: scopeStringToPermTuples(flags.parentChildAccountAccess ? '' : '*'),
+    scopes: scopeStringToPermTuples(''),
   };
 
   const { data: profile } = useProfile();

--- a/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.tsx
@@ -160,6 +160,15 @@ export const CreateAPITokenDrawer = (props: Props) => {
     return { label: expiryTup[0], value: expiryTup[1] };
   });
 
+  // Filter permissions for all users except parent user accounts.
+  const allPermissions = form.values.scopes;
+  const showFilteredPermissions =
+    (flags.parentChildAccountAccess && user?.user_type !== 'parent') ||
+    Boolean(!flags.parentChildAccountAccess);
+  const filteredPermissions = allPermissions.filter(
+    (scopeTup) => basePermNameMap[scopeTup[0]] !== 'Child Account Access'
+  );
+
   return (
     <Drawer onClose={onClose} open={open} title="Add Personal Access Token">
       {errorMap.none && <Notice text={errorMap.none} variant="error" />}
@@ -244,18 +253,12 @@ export const CreateAPITokenDrawer = (props: Props) => {
               />
             </StyledPermissionsCell>
           </TableRow>
-          {form.values.scopes.map((scopeTup) => {
-            if (!basePermNameMap[scopeTup[0]]) {
-              return null;
-            }
-            return (
-              // When the feature flag is on, display the Child Account Access scope for parent user accounts only.
-              (!flags.parentChildAccountAccess &&
-                basePermNameMap[scopeTup[0]] === 'Child Account Access') ||
-                (flags.parentChildAccountAccess &&
-                  user?.user_type !== 'parent' &&
-                  basePermNameMap[scopeTup[0]] ===
-                    'Child Account Access') ? null : (
+          {(showFilteredPermissions ? filteredPermissions : allPermissions).map(
+            (scopeTup) => {
+              if (!basePermNameMap[scopeTup[0]]) {
+                return null;
+              }
+              return (
                 <TableRow
                   data-qa-row={basePermNameMap[scopeTup[0]]}
                   key={scopeTup[0]}
@@ -300,9 +303,9 @@ export const CreateAPITokenDrawer = (props: Props) => {
                     />
                   </StyledPermissionsCell>
                 </TableRow>
-              )
-            );
-          })}
+              );
+            }
+          )}
         </TableBody>
       </StyledPermsTable>
       {errorMap.scopes && (

--- a/packages/manager/src/features/Profile/APITokens/ViewAPITokenDrawer.test.tsx
+++ b/packages/manager/src/features/Profile/APITokens/ViewAPITokenDrawer.test.tsx
@@ -6,7 +6,13 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 import { ViewAPITokenDrawer } from './ViewAPITokenDrawer';
 import { basePerms } from './utils';
 
+const nonParentPerms = basePerms.filter((value) => value !== 'child_account');
+
 const token = appTokenFactory.build({ label: 'my-token', scopes: '*' });
+const limitedToken = appTokenFactory.build({
+  label: 'my-limited-token',
+  scopes: '',
+});
 
 const props = {
   onClose: vi.fn(),
@@ -21,9 +27,25 @@ describe('View API Token Drawer', () => {
     expect(getByText(token.label)).toBeVisible();
   });
 
-  it('should all permissions as read/write with wildcard scopes', () => {
-    const { getByTestId } = renderWithTheme(<ViewAPITokenDrawer {...props} />);
-    for (const permissionName of basePerms) {
+  it('should show all permissions as none with no scopes', () => {
+    const { getByTestId } = renderWithTheme(
+      <ViewAPITokenDrawer {...props} token={limitedToken} />,
+      { flags: { parentChildAccountAccess: false } }
+    );
+    for (const permissionName of nonParentPerms) {
+      expect(getByTestId(`perm-${permissionName}`)).toHaveAttribute(
+        'aria-label',
+        `This token has 0 access for ${permissionName}`
+      );
+    }
+  });
+
+  it('should show all permissions as read/write with wildcard scopes', () => {
+    const { getByTestId } = renderWithTheme(
+      <ViewAPITokenDrawer {...props} />,
+      {}
+    );
+    for (const permissionName of nonParentPerms) {
       expect(getByTestId(`perm-${permissionName}`)).toHaveAttribute(
         'aria-label',
         `This token has 2 access for ${permissionName}`
@@ -38,7 +60,7 @@ describe('View API Token Drawer', () => {
         token={appTokenFactory.build({ scopes: 'account:read_write' })}
       />
     );
-    for (const permissionName of basePerms) {
+    for (const permissionName of nonParentPerms) {
       // We only expect account to have read/write for this test
       const expectedScopeLevel = permissionName === 'account' ? 2 : 0;
       expect(getByTestId(`perm-${permissionName}`)).toHaveAttribute(
@@ -76,12 +98,16 @@ describe('View API Token Drawer', () => {
       volumes: 1,
     } as const;
 
-    for (const permissionName of basePerms) {
+    for (const permissionName of nonParentPerms) {
       const expectedScopeLevel = expectedScopeLevels[permissionName];
       expect(getByTestId(`perm-${permissionName}`)).toHaveAttribute(
         'aria-label',
         `This token has ${expectedScopeLevel} access for ${permissionName}`
       );
     }
+  });
+
+  it('shows the child account perm in the table for a parent user account', () => {
+    // TODO: test child_account perm; use basePerms
   });
 });

--- a/packages/manager/src/features/Profile/APITokens/ViewAPITokenDrawer.test.tsx
+++ b/packages/manager/src/features/Profile/APITokens/ViewAPITokenDrawer.test.tsx
@@ -1,10 +1,24 @@
 import * as React from 'react';
 
 import { appTokenFactory } from 'src/factories';
+import { accountUserFactory } from 'src/factories/accountUsers';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { ViewAPITokenDrawer } from './ViewAPITokenDrawer';
 import { basePerms } from './utils';
+
+// Mock the useAccountUser hooks to immediately return the expected data, circumventing the HTTP request and loading state.
+const queryMocks = vi.hoisted(() => ({
+  useAccountUser: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('src/queries/accountUsers', async () => {
+  const actual = await vi.importActual<any>('src/queries/accountUsers');
+  return {
+    ...actual,
+    useAccountUser: queryMocks.useAccountUser,
+  };
+});
 
 const nonParentPerms = basePerms.filter((value) => value !== 'child_account');
 
@@ -27,19 +41,6 @@ describe('View API Token Drawer', () => {
     expect(getByText(token.label)).toBeVisible();
   });
 
-  it('should show all permissions as none with no scopes', () => {
-    const { getByTestId } = renderWithTheme(
-      <ViewAPITokenDrawer {...props} token={limitedToken} />,
-      { flags: { parentChildAccountAccess: false } }
-    );
-    for (const permissionName of nonParentPerms) {
-      expect(getByTestId(`perm-${permissionName}`)).toHaveAttribute(
-        'aria-label',
-        `This token has 0 access for ${permissionName}`
-      );
-    }
-  });
-
   it('should show all permissions as read/write with wildcard scopes', () => {
     const { getByTestId } = renderWithTheme(
       <ViewAPITokenDrawer {...props} />,
@@ -49,6 +50,19 @@ describe('View API Token Drawer', () => {
       expect(getByTestId(`perm-${permissionName}`)).toHaveAttribute(
         'aria-label',
         `This token has 2 access for ${permissionName}`
+      );
+    }
+  });
+
+  it('should show all permissions as none with no scopes', () => {
+    const { getByTestId } = renderWithTheme(
+      <ViewAPITokenDrawer {...props} token={limitedToken} />,
+      { flags: { parentChildAccountAccess: false } }
+    );
+    for (const permissionName of nonParentPerms) {
+      expect(getByTestId(`perm-${permissionName}`)).toHaveAttribute(
+        'aria-label',
+        `This token has 0 access for ${permissionName}`
       );
     }
   });
@@ -107,7 +121,46 @@ describe('View API Token Drawer', () => {
     }
   });
 
-  it('shows the child account perm in the table for a parent user account', () => {
-    // TODO: test child_account perm; use basePerms
+  it('should show Child Account Access scope with read/write perms for a parent user account with the parent/child feature flag on', async () => {
+    queryMocks.useAccountUser.mockReturnValue({
+      data: accountUserFactory.build({ user_type: 'parent' }),
+    });
+
+    const { findByText, getByTestId } = renderWithTheme(
+      <ViewAPITokenDrawer
+        {...props}
+        token={appTokenFactory.build({
+          scopes: 'child_account:read_write',
+        })}
+      />,
+      {
+        flags: { parentChildAccountAccess: true },
+      }
+    );
+
+    const childScope = await findByText('Child Account Access');
+    const expectedScopeLevels = {
+      child_account: 2,
+    } as const;
+    const childPermissionName = 'child_account';
+
+    expect(childScope).toBeInTheDocument();
+    expect(getByTestId(`perm-${childPermissionName}`)).toHaveAttribute(
+      'aria-label',
+      `This token has ${expectedScopeLevels[childPermissionName]} access for ${childPermissionName}`
+    );
+  });
+
+  it('should not show the Child Account Access scope for a non-parent user account with the parent/child feature flag on', () => {
+    queryMocks.useAccountUser.mockReturnValue({
+      data: accountUserFactory.build({ user_type: null }),
+    });
+
+    const { queryByText } = renderWithTheme(<ViewAPITokenDrawer {...props} />, {
+      flags: { parentChildAccountAccess: true },
+    });
+
+    const childScope = queryByText('Child Account Access');
+    expect(childScope).not.toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/Profile/APITokens/ViewAPITokenDrawer.test.tsx
+++ b/packages/manager/src/features/Profile/APITokens/ViewAPITokenDrawer.test.tsx
@@ -42,10 +42,7 @@ describe('View API Token Drawer', () => {
   });
 
   it('should show all permissions as read/write with wildcard scopes', () => {
-    const { getByTestId } = renderWithTheme(
-      <ViewAPITokenDrawer {...props} />,
-      {}
-    );
+    const { getByTestId } = renderWithTheme(<ViewAPITokenDrawer {...props} />);
     for (const permissionName of nonParentPerms) {
       expect(getByTestId(`perm-${permissionName}`)).toHaveAttribute(
         'aria-label',
@@ -121,12 +118,12 @@ describe('View API Token Drawer', () => {
     }
   });
 
-  it('should show Child Account Access scope with read/write perms for a parent user account with the parent/child feature flag on', async () => {
+  it('should show Child Account Access scope with read/write perms for a parent user account with the parent/child feature flag on', () => {
     queryMocks.useAccountUser.mockReturnValue({
       data: accountUserFactory.build({ user_type: 'parent' }),
     });
 
-    const { findByText, getByTestId } = renderWithTheme(
+    const { getByTestId, getByText } = renderWithTheme(
       <ViewAPITokenDrawer
         {...props}
         token={appTokenFactory.build({
@@ -138,7 +135,7 @@ describe('View API Token Drawer', () => {
       }
     );
 
-    const childScope = await findByText('Child Account Access');
+    const childScope = getByText('Child Account Access');
     const expectedScopeLevels = {
       child_account: 2,
     } as const;

--- a/packages/manager/src/features/Profile/APITokens/ViewAPITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/ViewAPITokenDrawer.tsx
@@ -61,12 +61,13 @@ export const ViewAPITokenDrawer = (props: Props) => {
               return null;
             }
             return (
-              // When the feature flag is on, display the Child Account scope for parent user accounts only.
+              // When the feature flag is on, display the Child Account Access scope for parent user accounts only.
               (!flags.parentChildAccountAccess &&
-                basePermNameMap[scopeTup[0]] === 'Child Account') ||
+                basePermNameMap[scopeTup[0]] === 'Child Account Access') ||
                 (flags.parentChildAccountAccess &&
                   user?.user_type !== 'parent' &&
-                  basePermNameMap[scopeTup[0]] === 'Child Account') ? null : (
+                  basePermNameMap[scopeTup[0]] ===
+                    'Child Account Access') ? null : (
                 <TableRow
                   data-qa-row={basePermNameMap[scopeTup[0]]}
                   key={scopeTup[0]}

--- a/packages/manager/src/features/Profile/APITokens/utils.test.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.test.ts
@@ -26,6 +26,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('*');
       const expected = [
         ['account', 2],
+        ['child_account', 2],
         ['databases', 2],
         ['domains', 2],
         ['events', 2],
@@ -49,6 +50,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('');
       const expected = [
         ['account', 0],
+        ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
         ['events', 0],
@@ -73,6 +75,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:none');
       const expected = [
         ['account', 0],
+        ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
         ['events', 0],
@@ -97,6 +100,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:read_only');
       const expected = [
         ['account', 1],
+        ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
         ['events', 0],
@@ -121,6 +125,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:read_write');
       const expected = [
         ['account', 2],
+        ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
         ['events', 0],
@@ -147,6 +152,7 @@ describe('APIToken utils', () => {
       );
       const expected = [
         ['account', 0],
+        ['child_account', 0],
         ['databases', 0],
         ['domains', 1],
         ['events', 0],
@@ -175,6 +181,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:none,tokens:read_write');
       const expected = [
         ['account', 2],
+        ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
         ['events', 0],
@@ -203,6 +210,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:read_only,tokens:none');
       const expected = [
         ['account', 1],
+        ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
         ['events', 0],
@@ -227,6 +235,7 @@ describe('APIToken utils', () => {
       it('should return 0 if all scopes are 0', () => {
         const scopes: Permission[] = [
           ['account', 0],
+          ['child_account', 0],
           ['databases', 0],
           ['domains', 0],
           ['events', 0],
@@ -246,6 +255,7 @@ describe('APIToken utils', () => {
       it('should return 1 if all scopes are 1', () => {
         const scopes: Permission[] = [
           ['account', 1],
+          ['child_account', 1],
           ['databases', 1],
           ['domains', 1],
           ['events', 1],
@@ -265,6 +275,7 @@ describe('APIToken utils', () => {
       it('should return 2 if all scopes are 2', () => {
         const scopes: Permission[] = [
           ['account', 2],
+          ['child_account', 2],
           ['databases', 2],
           ['domains', 2],
           ['events', 2],
@@ -284,6 +295,7 @@ describe('APIToken utils', () => {
       it('should return null if all scopes are different', () => {
         const scopes: Permission[] = [
           ['account', 1],
+          ['child_account', 0],
           ['databases', 0],
           ['domains', 2],
           ['events', 0],

--- a/packages/manager/src/features/Profile/APITokens/utils.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.ts
@@ -24,7 +24,7 @@ export const basePerms = [
 
 export const basePermNameMap: Record<string, string> = {
   account: 'Account',
-  child_account: 'Child Account',
+  child_account: 'Child Account Access',
   databases: 'Databases',
   domains: 'Domains',
   events: 'Events',

--- a/packages/manager/src/features/Profile/APITokens/utils.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.ts
@@ -6,6 +6,7 @@ export type Permission = [string, number];
 
 export const basePerms = [
   'account',
+  'child_account',
   'databases',
   'domains',
   'events',
@@ -23,6 +24,7 @@ export const basePerms = [
 
 export const basePermNameMap: Record<string, string> = {
   account: 'Account',
+  child_account: 'Child Account',
   databases: 'Databases',
   domains: 'Domains',
   events: 'Events',


### PR DESCRIPTION
## Description 📝
New Scope:
Introduce a new OAuth scope named "child_account" for all users, but visible only to "Parent" accounts. As per API spec: its purpose is to allow Parent Account Users with the `child_account_access` grant to specify a Token with less permission than their User, i.e. a Token that is unable to list and/or create Tokens for the Child Account(s).

Token Configuration:
Default all scopes to `none` for users. Users should enable scopes as needed, contrary to having the initial state set to `read_write`. 

## Changes  🔄
- In the Create PAT drawer, a new "Child Account Access" scope is visible for **parent** users.
- In the View PAT drawer, a new "Child Account Access" scope is visible for **parent** users.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-12-13 at 4 01 40 PM](https://github.com/linode/manager/assets/114685994/690a6749-904c-4eba-a2ff-70ba2e03de27) | ![Screenshot 2023-12-13 at 4 00 48 PM](https://github.com/linode/manager/assets/114685994/33e3d5cd-4291-45eb-98e2-b329b97a94de) |
| ![Screenshot 2023-12-13 at 4 02 58 PM](https://github.com/linode/manager/assets/114685994/093b6d55-6f52-4d57-8c78-79c3b6f04baa) | ![Screenshot 2023-12-13 at 4 03 14 PM](https://github.com/linode/manager/assets/114685994/4e5f4e70-5554-42ea-aca0-98cf1a9a877d) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Check out this PR and `yarn dev`.
- In the dev tools:
   - Make sure the Parent/Child Account Switching feature flag is on.
   - Turn mocks on.

### Verification steps 
(How to verify changes)
- Go to http://localhost:3000/profile/tokens and click the Create a Personal Access Token button.
- Observe that "Child Account Access" is visible as a new scope and all scopes default to None.
- On the tokens landing page, click the View Scope button for any mock PAT.
- Observe that the "Child Account Access" scope is visible in the table.
- Toggle the feature flag off and observe that the Child Account Access token is not visible in the Create or View drawers and all scopes default to Read/Write.
- Toggle the feature flag back on.
- Go to `serverHandler.ts` and edit the following request to change the user_type to `null`, `child`, or `proxy`:
```
  rest.get('*/account/users/:user', (req, res, ctx) => {
    // Parent/Child: switch the `user_type` depending on what account view you need to mock.
    return res(ctx.json(accountUserFactory.build({ user_type: 'parent' })));
  }),
```
- Observe that the Child Account Access token is not visible in the Create or View drawers.
- Verify tests pass:
```
yarn test utils CreateAPITokenDrawer ViewAPITokenDrawer

```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
