### PR TITLE
test: [M3-7470] - Cypress test for Volumes landing page empty state

### DIFF
--- a/packages/manager/.changeset/pr-9995-tests-1702420300908.md
+++ b/packages/manager/.changeset/pr-9995-tests-1702420300908.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Introduce Cypress test for the Volumes landing page empty state ([#9995](https://github.com/linode/manager/pull/9995))

--- a/packages/manager/cypress/e2e/core/volumes/landing-page-empty-state.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/landing-page-empty-state.spec.ts
@@ -1,0 +1,29 @@
+import { ui } from 'support/ui';
+import { mockGetVolumes } from 'support/intercepts/volumes';
+
+describe('confirms Volumes landing page empty state is shown when no Volumes exist', () => {
+  /*
+   * - Confirms that Getting Started Guides is listed on landing page.
+   * - Confirms that Video Playlist is listed on landing page.
+   * - Confirms that clicking on Create Volume button navigates user to volume create page.
+   */
+  it('shows the empty state when no Volumes exist', () => {
+    mockGetVolumes([]).as('getVolumes');
+
+    cy.visitWithLogin('/volumes');
+    cy.wait(['@getVolumes']);
+
+    cy.findByText('NVMe block storage service').should('be.visible');
+    cy.findByText('Getting Started Guides').should('be.visible');
+    cy.findByText('Video Playlist').should('be.visible');
+
+    // Create Volume button exists and clicking it navigates user to create volume page.
+    ui.button
+      .findByTitle('Create Volume')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.url().should('endWith', '/volumes/create');
+  });
+});


### PR DESCRIPTION
## Description 📝
This PR introduces Cypress tests for the `Volumes` landing page in an empty state (no volumes exists).

## Changes  🔄
- The tests verify that the empty state works as expected.

## Preview 📷
![Screenshot 2023-12-12 at 2 21 32 PM](https://github.com/linode/manager/assets/119514965/57e5dadd-d98f-4917-9caa-4a197ad4d37f)

## How to test 🧪
- Run `yarn cy:run -s "/Users/ecarrill/Desktop/manager/packages/manager/cypress/e2e/core/volumes/landing-page-empty-state.spec.ts"`

### Verification steps 
- Verify e2e test passes.

## As an Author I have considered 🤔

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
