### PR TITLE
test: [M3-7464] - Add Cypress test FW landing page empty state

### DIFF
--- a/packages/manager/.changeset/pr-10000-tests-1702591069388.md
+++ b/packages/manager/.changeset/pr-10000-tests-1702591069388.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Introduce Cypress test for the Firewalls landing page empty state ([#10000](https://github.com/linode/manager/pull/10000))

--- a/packages/manager/cypress/e2e/core/firewalls/landing-page-empty-state.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/landing-page-empty-state.spec.ts
@@ -1,0 +1,32 @@
+import { ui } from 'support/ui';
+import { mockGetFirewalls } from 'support/intercepts/firewalls';
+
+describe('confirms Firewalls landing page empty state is shown when no Firewalls exist', () => {
+  /*
+   * - Confirms that Getting Started Guides is listed on landing page.
+   * - Confirms that Video Playlist is listed on landing page.
+   * - Confirms that clicking on Create Firewall button navigates user to firewall create page.
+   */
+  it('shows the empty state when no Firewalls exist', () => {
+    mockGetFirewalls([]).as('getFirewalls');
+
+    cy.visitWithLogin('/firewalls');
+    cy.wait(['@getFirewalls']);
+
+    cy.findByText('Secure cloud-based firewall').should('be.visible');
+    cy.findByText(
+      'Control network traffic to and from Linode Compute Instances with a simple management interface'
+    ).should('be.visible');
+    cy.findByText('Getting Started Guides').should('be.visible');
+    cy.findByText('Video Playlist').should('be.visible');
+
+    // Create Firewall button exists and clicking it navigates user to create firewall page.
+    ui.button
+      .findByTitle('Create Firewall')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.url().should('endWith', '/firewalls/create');
+  });
+});


### PR DESCRIPTION
## Description 📝
Introduces Cypress tests for the `Firewalls` landing page in an empty state (no firewalls exist).

## Changes  🔄
- The tests verify that the empty state works as expected.

## Preview 📷
![Screenshot 2023-12-14 at 1 54 48 PM](https://github.com/linode/manager/assets/119514965/ce0f7c52-68ad-4fd8-bbe0-0065577f3d9a)

## How to test 🧪
- Run `yarn cy:run -s "cypress/e2e/core/firewalls/landing-page-empty-state.spec.ts"`

### Verification steps 
- Verify e2e test passes.

## As an Author I have considered 🤔
- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support