### PR TITLE
feat: [M3-7168] - Increment Subnet IPv4 value when recommending new subnet range

### DIFF
--- a/packages/manager/.changeset/pr-10010-added-1703035008158.md
+++ b/packages/manager/.changeset/pr-10010-added-1703035008158.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Subnet IPv4 range recommendation in VPC Create flow and Subnet Create Drawer ([#10010](https://github.com/linode/manager/pull/10010))

--- a/packages/manager/src/features/VPCs/VPCCreate/FormComponents/SubnetContent.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/FormComponents/SubnetContent.tsx
@@ -5,13 +5,12 @@ import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
 import { SubnetFieldState } from 'src/utilities/subnets';
 
+import { VPC_CREATE_FORM_SUBNET_HELPER_TEXT } from '../../constants';
 import { MultipleSubnetInput } from '../MultipleSubnetInput';
 import {
   StyledBodyTypography,
   StyledHeaderTypography,
 } from './VPCCreateForm.styles';
-
-import { VPC_CREATE_FORM_SUBNET_HELPER_TEXT } from '../../constants';
 
 interface Props {
   disabled?: boolean;

--- a/packages/manager/src/features/VPCs/VPCCreate/MultipleSubnetInput.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/MultipleSubnetInput.test.tsx
@@ -46,7 +46,7 @@ describe('MultipleSubnetInput', () => {
     expect(props.onChange).toHaveBeenCalledWith([
       ...props.subnets,
       {
-        ip: { availIPv4s: 256, ipv4: '10.0.4.0/24', ipv4Error: '' },
+        ip: { availIPv4s: 256, ipv4: '10.0.1.0/24', ipv4Error: '' },
         label: '',
         labelError: '',
       },

--- a/packages/manager/src/features/VPCs/VPCCreate/MultipleSubnetInput.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/MultipleSubnetInput.tsx
@@ -28,7 +28,7 @@ export const MultipleSubnetInput = (props: Props) => {
   const addSubnet = () => {
     const recommendedIPv4 = getRecommendedSubnetIPv4(
       lastRecommendedIPv4,
-      subnets
+      subnets.map((subnet) => subnet.ip.ipv4 ?? '')
     );
     setLastRecommendedIPv4(recommendedIPv4);
     onChange([

--- a/packages/manager/src/features/VPCs/VPCCreate/MultipleSubnetInput.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/MultipleSubnetInput.tsx
@@ -6,6 +6,7 @@ import { Divider } from 'src/components/Divider';
 import {
   DEFAULT_SUBNET_IPV4_VALUE,
   SubnetFieldState,
+  getRecommendedSubnetIPv4,
 } from 'src/utilities/subnets';
 
 import { SubnetNode } from './SubnetNode';
@@ -20,11 +21,20 @@ interface Props {
 export const MultipleSubnetInput = (props: Props) => {
   const { disabled, isDrawer, onChange, subnets } = props;
 
+  const [lastRecommendedIPv4, setLastRecommendedIPv4] = React.useState(
+    DEFAULT_SUBNET_IPV4_VALUE
+  );
+
   const addSubnet = () => {
+    const recommendedIPv4 = getRecommendedSubnetIPv4(
+      lastRecommendedIPv4,
+      subnets
+    );
+    setLastRecommendedIPv4(recommendedIPv4);
     onChange([
       ...subnets,
       {
-        ip: { availIPv4s: 256, ipv4: DEFAULT_SUBNET_IPV4_VALUE, ipv4Error: '' },
+        ip: { availIPv4s: 256, ipv4: recommendedIPv4, ipv4Error: '' },
         label: '',
         labelError: '',
       },

--- a/packages/manager/src/features/VPCs/VPCCreate/VPCCreate.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/VPCCreate.test.tsx
@@ -104,6 +104,6 @@ describe('VPC create page', () => {
     const { getAllByTestId } = renderWithTheme(<VPCCreate />);
     const subnetIP = getAllByTestId('textfield-input');
     expect(subnetIP[4]).toBeInTheDocument();
-    expect(subnetIP[4]).toHaveValue('10.0.4.0/24');
+    expect(subnetIP[4]).toHaveValue('10.0.0.0/24');
   });
 });

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetCreateDrawer.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetCreateDrawer.test.tsx
@@ -1,9 +1,9 @@
+import { fireEvent } from '@testing-library/react';
 import * as React from 'react';
 
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { SubnetCreateDrawer } from './SubnetCreateDrawer';
-import { fireEvent } from '@testing-library/react';
 
 const props = {
   onClose: vi.fn(),
@@ -13,7 +13,7 @@ const props = {
 
 describe('Create Subnet Drawer', () => {
   it('should render title, label, ipv4 input, ipv4 availability, and action buttons', () => {
-    const { getByTestId, getAllByText, getByText } = renderWithTheme(
+    const { getAllByText, getByTestId, getByText } = renderWithTheme(
       <SubnetCreateDrawer {...props} />
     );
 

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetCreateDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetCreateDrawer.tsx
@@ -6,7 +6,7 @@ import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Drawer } from 'src/components/Drawer';
 import { Notice } from 'src/components/Notice/Notice';
 import { useGrants, useProfile } from 'src/queries/profile';
-import { useAllSubnetsQuery, useCreateSubnetMutation } from 'src/queries/vpcs';
+import { useCreateSubnetMutation, useVPCQuery } from 'src/queries/vpcs';
 import { getErrorMap } from 'src/utilities/errorUtils';
 import {
   DEFAULT_SUBNET_IPV4_VALUE,
@@ -27,13 +27,13 @@ export const SubnetCreateDrawer = (props: Props) => {
 
   const { data: profile } = useProfile();
   const { data: grants } = useGrants();
-  const { data: allSubnets } = useAllSubnetsQuery(vpcId);
+  const { data: vpc } = useVPCQuery(vpcId, open);
 
   const userCannotAddSubnet = profile?.restricted && !grants?.global.add_vpcs;
 
   const recommendedIPv4 = getRecommendedSubnetIPv4(
     DEFAULT_SUBNET_IPV4_VALUE,
-    allSubnets?.map((subnet) => subnet.ipv4 ?? '') ?? []
+    vpc?.subnets?.map((subnet) => subnet.ipv4 ?? '') ?? []
   );
 
   const [errorMap, setErrorMap] = React.useState<

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetCreateDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetCreateDrawer.tsx
@@ -6,11 +6,12 @@ import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Drawer } from 'src/components/Drawer';
 import { Notice } from 'src/components/Notice/Notice';
 import { useGrants, useProfile } from 'src/queries/profile';
-import { useCreateSubnetMutation } from 'src/queries/vpcs';
+import { useAllSubnetsQuery, useCreateSubnetMutation } from 'src/queries/vpcs';
 import { getErrorMap } from 'src/utilities/errorUtils';
 import {
   DEFAULT_SUBNET_IPV4_VALUE,
   SubnetFieldState,
+  getRecommendedSubnetIPv4,
 } from 'src/utilities/subnets';
 
 import { SubnetNode } from '../VPCCreate/SubnetNode';
@@ -26,8 +27,17 @@ export const SubnetCreateDrawer = (props: Props) => {
 
   const { data: profile } = useProfile();
   const { data: grants } = useGrants();
+  const { data: allSubnets } = useAllSubnetsQuery(vpcId);
 
   const userCannotAddSubnet = profile?.restricted && !grants?.global.add_vpcs;
+
+  const recommendedIPv4 =
+    allSubnets && allSubnets.length > 0
+      ? getRecommendedSubnetIPv4(
+          allSubnets[0].ipv4 ?? '',
+          allSubnets.map((subnet) => subnet.ipv4 ?? '')
+        )
+      : DEFAULT_SUBNET_IPV4_VALUE;
 
   const [errorMap, setErrorMap] = React.useState<
     Record<string, string | undefined>
@@ -41,18 +51,18 @@ export const SubnetCreateDrawer = (props: Props) => {
 
   const onCreateSubnet = async () => {
     try {
-      await createSubnet({ label: values.label, ipv4: values.ip.ipv4 });
+      await createSubnet({ ipv4: values.ip.ipv4, label: values.label });
       onClose();
     } catch (errors) {
       const newErrors = getErrorMap(['label', 'ipv4'], errors);
       setErrorMap(newErrors);
       setValues({
-        label: values.label,
-        labelError: newErrors.label,
         ip: {
           ...values.ip,
           ipv4Error: newErrors.ipv4,
         },
+        label: values.label,
+        labelError: newErrors.label,
       });
     }
   };
@@ -60,12 +70,12 @@ export const SubnetCreateDrawer = (props: Props) => {
   const { dirty, handleSubmit, resetForm, setValues, values } = useFormik({
     enableReinitialize: true,
     initialValues: {
+      ip: {
+        availIPv4s: 256,
+        ipv4: recommendedIPv4,
+      },
       // @TODO VPC: add IPv6 when that is supported
       label: '',
-      ip: {
-        ipv4: DEFAULT_SUBNET_IPV4_VALUE,
-        availIPv4s: 256,
-      },
     } as SubnetFieldState,
     onSubmit: onCreateSubnet,
     validateOnBlur: false,
@@ -79,7 +89,7 @@ export const SubnetCreateDrawer = (props: Props) => {
       reset();
       setErrorMap({});
     }
-  }, [open]);
+  }, [open, reset, resetForm]);
 
   return (
     <Drawer onClose={onClose} open={open} title={'Create Subnet'}>
@@ -96,10 +106,10 @@ export const SubnetCreateDrawer = (props: Props) => {
       )}
       <form onSubmit={handleSubmit}>
         <SubnetNode
-          disabled={userCannotAddSubnet}
           onChange={(subnetState) => {
             setValues(subnetState);
           }}
+          disabled={userCannotAddSubnet}
           subnet={values}
         />
         <ActionsPanel
@@ -108,8 +118,8 @@ export const SubnetCreateDrawer = (props: Props) => {
             disabled: !dirty || userCannotAddSubnet,
             label: 'Create Subnet',
             loading: isLoading,
-            type: 'submit',
             onClick: onCreateSubnet,
+            type: 'submit',
           }}
           secondaryButtonProps={{ label: 'Cancel', onClick: onClose }}
         />

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetCreateDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetCreateDrawer.tsx
@@ -31,15 +31,10 @@ export const SubnetCreateDrawer = (props: Props) => {
 
   const userCannotAddSubnet = profile?.restricted && !grants?.global.add_vpcs;
 
-  const recommendedIPv4 =
-    allSubnets && allSubnets.length > 0
-      ? getRecommendedSubnetIPv4(
-          // for simplicity purposes, we take the IPv4 of the last subnet in allSubnets, as
-          // getRecommendedSubnetIPv4 will iterate through potential IPv4s to recommend anyway
-          allSubnets[allSubnets.length - 1].ipv4 ?? '',
-          allSubnets.map((subnet) => subnet.ipv4 ?? '')
-        )
-      : DEFAULT_SUBNET_IPV4_VALUE;
+  const recommendedIPv4 = getRecommendedSubnetIPv4(
+    DEFAULT_SUBNET_IPV4_VALUE,
+    allSubnets?.map((subnet) => subnet.ipv4 ?? '') ?? []
+  );
 
   const [errorMap, setErrorMap] = React.useState<
     Record<string, string | undefined>

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetCreateDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetCreateDrawer.tsx
@@ -34,7 +34,9 @@ export const SubnetCreateDrawer = (props: Props) => {
   const recommendedIPv4 =
     allSubnets && allSubnets.length > 0
       ? getRecommendedSubnetIPv4(
-          allSubnets[0].ipv4 ?? '',
+          // for simplicity purposes, we take the IPv4 of the last subnet in allSubnets, as
+          // getRecommendedSubnetIPv4 will iterate through potential IPv4s to recommend anyway
+          allSubnets[allSubnets.length - 1].ipv4 ?? '',
           allSubnets.map((subnet) => subnet.ipv4 ?? '')
         )
       : DEFAULT_SUBNET_IPV4_VALUE;

--- a/packages/manager/src/queries/vpcs.ts
+++ b/packages/manager/src/queries/vpcs.ts
@@ -24,6 +24,8 @@ import {
 } from '@linode/api-v4/lib/types';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 
+import { getAll } from 'src/utilities/getAll';
+
 export const vpcQueryKey = 'vpcs';
 export const subnetQueryKey = 'subnets';
 
@@ -95,6 +97,18 @@ export const useSubnetsQuery = (
     { enabled, keepPreviousData: true }
   );
 };
+
+export const useAllSubnetsQuery = (vpcID: number, enabled: boolean = true) =>
+  useQuery<Subnet[], APIError[]>(
+    [vpcQueryKey, 'vpc', vpcID, subnetQueryKey, 'unpaginated'],
+    () => getAllSubnetsRequest(vpcID),
+    { enabled, keepPreviousData: true }
+  );
+
+const getAllSubnetsRequest = (vpcID: number) =>
+  getAll<Subnet>((params, filters) =>
+    getSubnets(vpcID, params, filters)
+  )().then((data) => data.data);
 
 export const useSubnetQuery = (vpcID: number, subnetID: number) => {
   return useQuery<Subnet, APIError[]>(

--- a/packages/manager/src/queries/vpcs.ts
+++ b/packages/manager/src/queries/vpcs.ts
@@ -24,8 +24,6 @@ import {
 } from '@linode/api-v4/lib/types';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 
-import { getAll } from 'src/utilities/getAll';
-
 export const vpcQueryKey = 'vpcs';
 export const subnetQueryKey = 'subnets';
 
@@ -97,18 +95,6 @@ export const useSubnetsQuery = (
     { enabled, keepPreviousData: true }
   );
 };
-
-export const useAllSubnetsQuery = (vpcID: number, enabled: boolean = true) =>
-  useQuery<Subnet[], APIError[]>(
-    [vpcQueryKey, 'vpc', vpcID, subnetQueryKey, 'unpaginated'],
-    () => getAllSubnetsRequest(vpcID),
-    { enabled, keepPreviousData: true }
-  );
-
-const getAllSubnetsRequest = (vpcID: number) =>
-  getAll<Subnet>((params, filters) =>
-    getSubnets(vpcID, params, filters)
-  )().then((data) => data.data);
 
 export const useSubnetQuery = (vpcID: number, subnetID: number) => {
   return useQuery<Subnet, APIError[]>(

--- a/packages/manager/src/utilities/subnets.test.ts
+++ b/packages/manager/src/utilities/subnets.test.ts
@@ -121,8 +121,8 @@ describe('getRecommendedSubnetIPv4', () => {
     expect(recommendedIP).toEqual('10.0.7.0/24');
   });
 
-  it('recommends IPs with a /24 mask', () => {
+  it('may recommend valid IPs that cover the same range', () => {
     const recommendedIP = getRecommendedSubnetIPv4('172.16.0.0/16', []);
-    expect(recommendedIP).toEqual('172.16.1.0/24');
+    expect(recommendedIP).toEqual('172.16.1.0/16');
   });
 });

--- a/packages/manager/src/utilities/subnets.test.ts
+++ b/packages/manager/src/utilities/subnets.test.ts
@@ -1,4 +1,8 @@
-import { calculateAvailableIPv4sRFC1918 } from './subnets';
+import {
+  DEFAULT_SUBNET_IPV4_VALUE,
+  calculateAvailableIPv4sRFC1918,
+  getRecommendedSubnetIPv4,
+} from './subnets';
 
 describe('calculateAvailableIPv4s', () => {
   it('should return a number if the input is a valid RFC1918 IPv4 with a mask', () => {
@@ -26,11 +30,11 @@ describe('calculateAvailableIPv4s', () => {
   });
 
   it('should return undefined for valid, non RFC1918 ips', () => {
-    //10.x ips
+    // 10.x ips
     const badIP10 = calculateAvailableIPv4sRFC1918('10.0.0.0/7');
     expect(badIP10).toBeUndefined();
 
-    //172.x ips
+    // 172.x ips
     const badIP17215 = calculateAvailableIPv4sRFC1918('172.15.0.0/24');
     expect(badIP17215).toBeUndefined();
     const badIP17232 = calculateAvailableIPv4sRFC1918('172.32.0.0/24');
@@ -38,13 +42,13 @@ describe('calculateAvailableIPv4s', () => {
     const badIP172Mask = calculateAvailableIPv4sRFC1918('172.16.0.0/11');
     expect(badIP172Mask).toBeUndefined();
 
-    //192.x ips
+    // 192.x ips
     const badIPNot192168 = calculateAvailableIPv4sRFC1918('192.15.0.0/24');
     expect(badIPNot192168).toBeUndefined();
     const badIP192mask = calculateAvailableIPv4sRFC1918('192.168.0.0/15');
     expect(badIP192mask).toBeUndefined();
 
-    //non 10x, 172x, or 168x ips:
+    // non 10x, 172x, or 168x ips:
     const nonRFC1 = calculateAvailableIPv4sRFC1918('145.24.8.0/24');
     expect(nonRFC1).toBeUndefined();
     const nonRFC2 = calculateAvailableIPv4sRFC1918('247.9.82.128/16');
@@ -71,5 +75,54 @@ describe('calculateAvailableIPv4s', () => {
     expect(badMask2).toBe(undefined);
     const badMask3 = calculateAvailableIPv4sRFC1918('10.0.0.0/-100');
     expect(badMask3).toBe(undefined);
+  });
+});
+
+describe('getRecommendedSubnetIPv4', () => {
+  it('should return the default IPv4 address if the calculated recommended IPv4 address is not an RFC1918 ipv4', () => {
+    const recommendedIP1 = getRecommendedSubnetIPv4('10.0.255.0', []);
+    expect(recommendedIP1).toEqual(DEFAULT_SUBNET_IPV4_VALUE);
+
+    const recommendedIP2 = getRecommendedSubnetIPv4('bad ip', []);
+    expect(recommendedIP2).toEqual(DEFAULT_SUBNET_IPV4_VALUE);
+
+    const recommendedIP3 = getRecommendedSubnetIPv4('192.0.0.0/24', []);
+    expect(recommendedIP3).toEqual(DEFAULT_SUBNET_IPV4_VALUE);
+
+    const recommendedIP4 = getRecommendedSubnetIPv4('10.0.0.0/7', []);
+    expect(recommendedIP4).toEqual(DEFAULT_SUBNET_IPV4_VALUE);
+
+    const recommendedIP5 = getRecommendedSubnetIPv4('172.8.0.0/24', []);
+    expect(recommendedIP5).toEqual(DEFAULT_SUBNET_IPV4_VALUE);
+
+    const recommendedIP6 = getRecommendedSubnetIPv4('192.168.0.0/15', []);
+    expect(recommendedIP6).toEqual(DEFAULT_SUBNET_IPV4_VALUE);
+  });
+
+  it('should properly recommend an IPv4 by incrementing the third octet value by 1, if possible', () => {
+    const recommendedIP = getRecommendedSubnetIPv4('10.0.24.0/24', [
+      '10.0.0.0',
+      '10.0.1.0',
+    ]);
+    expect(recommendedIP).toEqual('10.0.25.0/24');
+
+    const recommendedIP2 = getRecommendedSubnetIPv4('192.168.1.0/24', [
+      '10.0.0.0',
+      '192.168.0/24',
+    ]);
+    expect(recommendedIP2).toEqual('192.168.2.0/24');
+  });
+
+  it('should recommend an IPv4 not already in the list of existing IPv4s', () => {
+    const recommendedIP = getRecommendedSubnetIPv4('10.0.5.0/24', [
+      '10.0.6.0/24',
+      '10.0.4.0/24',
+    ]);
+    expect(recommendedIP).toEqual('10.0.7.0/24');
+  });
+
+  it('recommends IPs with a /24 mask', () => {
+    const recommendedIP = getRecommendedSubnetIPv4('172.16.0.0/16', []);
+    expect(recommendedIP).toEqual('172.16.1.0/24');
   });
 });

--- a/packages/manager/src/utilities/subnets.ts
+++ b/packages/manager/src/utilities/subnets.ts
@@ -150,11 +150,12 @@ export const getRecommendedSubnetIPv4 = (
     }.${fourthOctet}`;
   }
 
+  // if the IPv4 we've recommended already exists, we recommend a new IP
   if (
     otherIPv4s.some((ip) => {
       const [_ip] = ip.split('/');
       const [_ipv4ToReturn] = ipv4ToReturn.split('/');
-      return ip === ipv4ToReturn || _ip === _ipv4ToReturn;
+      return _ip === _ipv4ToReturn;
     })
   ) {
     return getRecommendedSubnetIPv4(ipv4ToReturn, otherIPv4s);

--- a/packages/manager/src/utilities/subnets.ts
+++ b/packages/manager/src/utilities/subnets.ts
@@ -109,13 +109,16 @@ export const calculateAvailableIPv4sRFC1918 = (
 };
 
 /**
- * Calculates the next subnet IPv4 address to recommend when creating a subnet, based off of the last recommended ipv4 and already existing IPv4s.
+ * Calculates the next subnet IPv4 address to recommend when creating a subnet, based off of the last recommended ipv4 and already existing IPv4s,
+ * by incrementing the third octet by one.
+ *
  * @param lastRecommendedIPv4 the current IPv4 address to base our recommended IPv4 address off of
  * @param otherIPv4s the other IPv4s to check against
  * @returns the next recommended subnet IPv4 address to use
  *
  * Assumption: if @param lastRecommendedIPv4 is a valid RFC1918 IPv4 and in x.x.x.x/x format, then the output is a valid RFC1918 IPv4 in x.x.x.x/x
- * format and not already in @param otherIPv4s (excluding the default IPv4 case -- see comments below).
+ * format and not already in @param otherIPv4s (excluding the default IPv4 case -- see comments below). HOWEVER, a recommended IP may still cover
+ * the same range as an existing IPv4 (ex 172.16.0.0/16 and 172.16.1.0/16 cover parts of the same range) and therefore not be accepted by the backend.
  */
 export const getRecommendedSubnetIPv4 = (
   lastRecommendedIPv4: string,
@@ -125,9 +128,8 @@ export const getRecommendedSubnetIPv4 = (
     firstOctet,
     secondOctet,
     thirdOctet,
-    fourthOctetAndMask,
+    fourthOctet,
   ] = lastRecommendedIPv4.split('.');
-  const [fourthOctet] = fourthOctetAndMask.split('/');
   const parsedThirdOctet = parseInt(thirdOctet, 10);
   let ipv4ToReturn = '';
 
@@ -143,11 +145,9 @@ export const getRecommendedSubnetIPv4 = (
   ) {
     return DEFAULT_SUBNET_IPV4_VALUE;
   } else {
-    // Automatically adding on a /24 mask to avoid situations where an invalid IP is recommended
-    // For example: 172.16.0.0/
     ipv4ToReturn = `${firstOctet}.${secondOctet}.${
       parsedThirdOctet + 1
-    }.${fourthOctet}/24`;
+    }.${fourthOctet}`;
   }
 
   if (otherIPv4s.some((ip) => ip === ipv4ToReturn)) {

--- a/packages/manager/src/utilities/subnets.ts
+++ b/packages/manager/src/utilities/subnets.ts
@@ -150,7 +150,13 @@ export const getRecommendedSubnetIPv4 = (
     }.${fourthOctet}`;
   }
 
-  if (otherIPv4s.some((ip) => ip === ipv4ToReturn)) {
+  if (
+    otherIPv4s.some((ip) => {
+      const [_ip] = ip.split('/');
+      const [_ipv4ToReturn] = ipv4ToReturn.split('/');
+      return ip === ipv4ToReturn || _ip === _ipv4ToReturn;
+    })
+  ) {
     return getRecommendedSubnetIPv4(ipv4ToReturn, otherIPv4s);
   }
 


### PR DESCRIPTION
## Description 📝
When creating new subnets via both the Create VPC flow and the Create Subnet drawer, we will now be incrementing the subnet range so that the default value is not a static 10.0.4.0/24 value.

Talked with Daniel about this behavior 👍 - 
- For both the VPC Create flows and Subnet Create Drawer, the recommended IP will start at 10.0.0.0/24 or 10.0.1.0/24 and go up to 10.0.1.0/24, 10.0.2.0/24, etc. 10.0.x.0/24 ips will be the only ones recommended. 
  - (There was a previous version that depended more on the user's already existing IPs for the Subnet Create Drawer >> checkout and run [this commit](https://github.com/linode/manager/pull/10010/commits/207c2d4d1efe99d474d0b324877917bfe414af59) - this led to pretty frequent recommendation of "bad IPs" (ips that are technically valid but have overlapping ranges with existing ip addresses, leading to the backend throwing an error), so I switched it to current version 😢)
  - In terms of enough subnets being recommended: since a person can normally have at most 10 subnets to a VPC (special exceptions can occur), for the most part, we should not run out of subnets to recommend 
  - note that due to user input, there's still a chance of a 'bad ip' being recommended (ex. if I have an IP of 10.0.0.0/8, then any 10.0.x.0/24 recommendation is already covered by 10.0.0.0/8...)
- If we want a version where there's more robust ip-recommending, it's going to be a lot more complicated. Since these are just ip recommendations, not what people actually have to choose, this version is a bit better than the previous behavior of just recommending 10.0.4.0/24 though!

## Changes  🔄
List any change relevant to the reviewer.
- Created new helper function to recommend an IPv4 for a subnet (ty to @bnussman for the inspiration in AGLB create flow!) + add relevant tests
- update SubnetCreateDrawer and VPCCreate flows
- added a getAllSubnets request to get around pagination

## Preview 📷

| VPC Create Flow  | Subnet Create Drawer   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/139280159/e44b49e9-4985-40e3-bc85-1b57a524c0bf" /> | <video src="https://github.com/linode/manager/assets/139280159/354d2df1-8afb-4d94-b9a2-e91ef1050bfa" /> |

## How to test 🧪

### Prerequisites
NOTE - there is a separate bug regarding SubnetCreateDrawer erroring when we try to create more than 10 subnets - see internal ticket for details

### Verification steps 
(How to verify changes)
- yarn test subnets.test.ts
- Verify that when creating subnets on VPC Create flows (drawer and page) and Subnet Create Drawer, a new subnet IP that is not in the already existing list of IPs is recommended (note - if you go past 256 subnets though, there will be duplicates)

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
