### PR TITLE
change: [M3-7461] - Update toast notifications for UserPermissions

### DIFF
--- a/packages/manager/.changeset/pr-10011-changed-1703028750129.md
+++ b/packages/manager/.changeset/pr-10011-changed-1703028750129.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Update toast notifications for UserPermissions ([#10011](https://github.com/linode/manager/pull/10011))

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -268,6 +268,9 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           this.getUserGrants();
           // refresh the data on /account/users so it is accurate
           this.props.queryClient.invalidateQueries('account-users');
+          this.props.enqueueSnackbar('User permissions successfully saved.', {
+            variant: 'success',
+          });
         })
         .catch((errResponse) => {
           this.setState({
@@ -658,9 +661,12 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           const { tabs } = this.getTabInformation(grantsResponse);
           this.setState({ isSavingGlobal: false, tabs });
 
-          this.props.enqueueSnackbar('User permissions successfully saved.', {
-            variant: 'success',
-          });
+          this.props.enqueueSnackbar(
+            'General user permissions successfully saved.',
+            {
+              variant: 'success',
+            }
+          );
         })
         .catch((errResponse) => {
           this.setState({
@@ -710,9 +716,12 @@ class UserPermissions extends React.Component<CombinedProps, State> {
         if (updateFns.length) {
           this.setState((compose as any)(...updateFns));
         }
-        this.props.enqueueSnackbar('User permissions successfully saved.', {
-          variant: 'success',
-        });
+        this.props.enqueueSnackbar(
+          'Entity-specific user permissions successfully saved.',
+          {
+            variant: 'success',
+          }
+        );
         // In the chance a new type entity was added to the account, re-calculate what tabs need to be shown.
         const { tabs } = this.getTabInformation(grantsResponse);
         this.setState({ isSavingEntity: false, tabs });

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -658,7 +658,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           const { tabs } = this.getTabInformation(grantsResponse);
           this.setState({ isSavingGlobal: false, tabs });
 
-          this.props.enqueueSnackbar('Successfully saved global permissions', {
+          this.props.enqueueSnackbar('User permissions successfully saved.', {
             variant: 'success',
           });
         })
@@ -710,10 +710,9 @@ class UserPermissions extends React.Component<CombinedProps, State> {
         if (updateFns.length) {
           this.setState((compose as any)(...updateFns));
         }
-        this.props.enqueueSnackbar(
-          'Successfully saved entity-specific permissions',
-          { variant: 'success' }
-        );
+        this.props.enqueueSnackbar('User permissions successfully saved.', {
+          variant: 'success',
+        });
         // In the chance a new type entity was added to the account, re-calculate what tabs need to be shown.
         const { tabs } = this.getTabInformation(grantsResponse);
         this.setState({ isSavingEntity: false, tabs });


### PR DESCRIPTION
## Description 📝
Updated toast notifications in user permissions.

## Changes  🔄
- Updated toast notifications

## Preview 📷
| | 
|---|
| ![Screenshot 2023-12-22 at 2 46 49 PM](https://github.com/linode/manager/assets/139489745/1ae0c537-dacb-4265-9da7-68046f58a2f6) |
| ![Screenshot 2023-12-22 at 2 47 23 PM](https://github.com/linode/manager/assets/139489745/6b707179-119c-4a93-9f30-e31663a07d9a) |
| ![Screenshot 2023-12-22 at 2 47 37 PM](https://github.com/linode/manager/assets/139489745/4c753526-f51c-4038-9ba6-c243d00ec555) |

## How to test 🧪

### Verification steps 
- Ensure that saving full account access, global (soon to be renamed "general"), and entity specific permissions triggers a toast notification. ('User permissions successfully saved.' or '[Entity-specific/general] user permissions successfully saved.')

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support
