### PR TITLE
feat: [M3-7373] - Sold Out Chips

### DIFF
--- a/packages/manager/.changeset/pr-10013-added-1703179399644.md
+++ b/packages/manager/.changeset/pr-10013-added-1703179399644.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Sold out chips for GPU and Premium CPU plans ([#10013](https://github.com/linode/manager/pull/10013))

--- a/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
@@ -75,7 +75,7 @@ describe('create linode', () => {
 
     cy.visitWithLogin('linodes/create');
 
-    cy.wait(['@getClientStream', '@getFeatureFlags', '@getRegions']);
+    cy.wait(['@getRegions']);
 
     // Confirm that region select dropdown is visible and interactive.
     ui.regionSelect.find().click();

--- a/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
@@ -73,11 +73,6 @@ describe('create linode', () => {
   it('region select', () => {
     mockGetRegions(mockRegions).as('getRegions');
 
-    mockAppendFeatureFlags({
-      soldOutTokyo: makeFeatureFlagData(true),
-    }).as('getFeatureFlags');
-    mockGetFeatureFlagClientstream().as('getClientStream');
-
     cy.visitWithLogin('linodes/create');
 
     cy.wait(['@getClientStream', '@getFeatureFlags', '@getRegions']);

--- a/packages/manager/src/components/SelectionCard/CardBase.tsx
+++ b/packages/manager/src/components/SelectionCard/CardBase.tsx
@@ -16,7 +16,7 @@ export interface CardBaseProps {
   headingDecoration?: JSX.Element;
   renderIcon?: () => JSX.Element;
   renderVariant?: () => JSX.Element | null;
-  subheadings: (string | undefined)[];
+  subheadings: (JSX.Element | string | undefined)[];
   sx?: SxProps;
   sxHeading?: SxProps;
   sxIcon?: SxProps;

--- a/packages/manager/src/components/SelectionCard/SelectionCard.tsx
+++ b/packages/manager/src/components/SelectionCard/SelectionCard.tsx
@@ -54,7 +54,7 @@ export interface SelectionCardProps {
    * An array of subheadings to display below the heading.
    * @example ['Linode 1GB', 'Linode 2GB', 'Linode 4GB']
    */
-  subheadings: (string | undefined)[];
+  subheadings: (JSX.Element | string | undefined)[];
   /**
    * Optional styles to apply to the root element.
    */

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -275,3 +275,7 @@ export const FIREWALL_GET_STARTED_LINK =
   'https://www.linode.com/docs/products/networking/cloud-firewall/get-started/';
 export const FIREWALL_LIMITS_CONSIDERATIONS_LINK =
   'https://www.linode.com/docs/products/networking/cloud-firewall/#limits-and-considerations';
+
+// Sold Out plans
+export const PLAN_IS_SOLD_OUT_COPY =
+  'This plan has no availability for the selected region. Please select a smaller plan or the same plan in another region.';

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -278,4 +278,4 @@ export const FIREWALL_LIMITS_CONSIDERATIONS_LINK =
 
 // Sold Out plans
 export const PLAN_IS_SOLD_OUT_COPY =
-  'This plan has no availability for the selected region. Please select a smaller plan or the same plan in another region.';
+  'This plan has no availability for the selected region. Please select a different plan or the same plan in another region.';

--- a/packages/manager/src/factories/regions.ts
+++ b/packages/manager/src/factories/regions.ts
@@ -6,8 +6,6 @@ import {
 } from '@linode/api-v4/lib/regions/types';
 import * as Factory from 'factory.ts';
 
-import { pickRandom } from 'src/utilities/random';
-
 export const resolverFactory = Factory.Sync.makeFactory<DNSResolvers>({
   ipv4: '1.1.1.1',
   ipv6: '2600:3c03::',
@@ -45,11 +43,7 @@ export const regionWithDynamicPricingFactory = Factory.Sync.makeFactory<Region>(
 export const regionAvailabilityFactory = Factory.Sync.makeFactory<RegionAvailability>(
   {
     available: false,
-    // TODO SOLD OUT PLANS - Remove this comment once the API is changed: Note that the mock data below doesn't match what the API
-    // currently returns for plans; however, the API will be changing soon to match the below labels (ex: g7-premium-#, g1-gpu-rtx-6000-#)
-    plan: Factory.each((id) =>
-      pickRandom([`g7-premium-${id}`, `g1-gpu-rtx6000-${id}`])
-    ),
-    region: Factory.each((id) => `us-${id}`),
+    plan: 'g6-standard-7',
+    region: 'us-east',
   }
 );

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -63,8 +63,7 @@ export interface Flags {
   referralBannerText: ReferralBannerText;
   regionDropdown: boolean;
   selfServeBetas: boolean;
-  soldOutSingapore: boolean;
-  soldOutTokyo: boolean;
+  soldOutChips: boolean;
   taxBanner: TaxBanner;
   taxCollectionBanner: TaxCollectionBanner;
   taxes: Taxes;

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -103,7 +103,7 @@ const Panel: React.FunctionComponent<NodePoolPanelProps> = (props) => {
           regionsData={regionsData}
           resetValues={() => null} // In this flow we don't want to clear things on tab changes
           selectedId={selectedType}
-          selectedRegionID={selectedRegionId}
+          selectedRegionId={selectedRegionId}
           updatePlanCount={updatePlanCount}
         />
       </Grid>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
@@ -1,6 +1,6 @@
 import { Theme } from '@mui/material/styles';
-import { makeStyles } from 'tss-react/mui';
 import * as React from 'react';
+import { makeStyles } from 'tss-react/mui';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Box } from 'src/components/Box';
@@ -149,13 +149,13 @@ export const AddNodePoolDrawer = (props: Props) => {
 
   return (
     <Drawer
-      wide
       PaperProps={{
         sx: { maxWidth: '790px !important' },
       }}
       onClose={onClose}
       open={open}
       title={`Add a Node Pool: ${clusterLabel}`}
+      wide
     >
       {error && (
         <Notice
@@ -184,7 +184,7 @@ export const AddNodePoolDrawer = (props: Props) => {
           regionsData={regionsData}
           resetValues={resetDrawer}
           selectedId={selectedTypeInfo?.planId}
-          selectedRegionID={clusterRegionId}
+          selectedRegionId={clusterRegionId}
           updatePlanCount={updatePlanCount}
         />
         {selectedTypeInfo &&

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.test.tsx
@@ -15,7 +15,7 @@ const props: KubernetesPlanContainerProps = {
   getTypeCount: vi.fn(),
   onSelect: vi.fn(),
   plans,
-  selectedRegionID: undefined,
+  selectedRegionId: undefined,
   updatePlanCount: vi.fn(),
 };
 

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
@@ -11,7 +11,7 @@ import { TableRow } from 'src/components/TableRow';
 import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
 import { getIsPlanSoldOut } from 'src/features/components/PlansPanel/utils';
 import { useFlags } from 'src/hooks/useFlags';
-import { useRegionsAvailabilitiesQuery } from 'src/queries/regions';
+import { useRegionsAvailabilityQuery } from 'src/queries/regions';
 import { ExtendedType } from 'src/utilities/extendType';
 import { PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE } from 'src/utilities/pricing/constants';
 
@@ -53,8 +53,9 @@ export const KubernetesPlanContainer = (
   } = props;
   const flags = useFlags();
 
-  const { data: regionAvailabilities } = useRegionsAvailabilitiesQuery(
-    Boolean(flags.soldOutChips)
+  const { data: regionAvailabilities } = useRegionsAvailabilityQuery(
+    selectedRegionId || '',
+    Boolean(flags.soldOutChips) && selectedRegionId !== undefined
   );
   const shouldDisplayNoRegionSelectedMessage = !selectedRegionId;
 

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
@@ -65,12 +65,13 @@ export const KubernetesPlanContainer = (
         regionAvailabilities,
         selectedRegionId,
       });
+
       return (
         <KubernetesPlanSelection
           disabled={disabled}
           getTypeCount={getTypeCount}
           idx={id}
-          isPlanSoldOut={isPlanSoldOut}
+          isPlanSoldOut={disabled ? false : isPlanSoldOut} // no need to add sold out chip if the whole panel is disabled (meaning that the plan isn't available for the selected region)
           key={id}
           onAdd={onAdd}
           onSelect={onSelect}

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
@@ -9,6 +9,9 @@ import { TableCell } from 'src/components/TableCell';
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
 import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
+import { getPlanSoldOutStatus } from 'src/features/components/PlansPanel/utils';
+import { useFlags } from 'src/hooks/useFlags';
+import { useRegionsAvailabilitiesQuery } from 'src/queries/regions';
 import { ExtendedType } from 'src/utilities/extendType';
 import { PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE } from 'src/utilities/pricing/constants';
 
@@ -31,7 +34,7 @@ export interface KubernetesPlanContainerProps {
   onSelect: (key: string) => void;
   plans: ExtendedType[];
   selectedId?: string;
-  selectedRegionID?: string;
+  selectedRegionId?: string;
   updatePlanCount: (planId: string, newCount: number) => void;
 }
 
@@ -45,27 +48,39 @@ export const KubernetesPlanContainer = (
     onSelect,
     plans,
     selectedId,
-    selectedRegionID,
+    selectedRegionId,
     updatePlanCount,
   } = props;
+  const flags = useFlags();
 
-  const shouldDisplayNoRegionSelectedMessage = !selectedRegionID;
+  const { data: regionAvailabilities } = useRegionsAvailabilitiesQuery(
+    Boolean(flags.soldOutChips)
+  );
+  const shouldDisplayNoRegionSelectedMessage = !selectedRegionId;
 
   const renderPlanSelection = React.useCallback(() => {
-    return plans.map((plan, id) => (
-      <KubernetesPlanSelection
-        disabled={disabled}
-        getTypeCount={getTypeCount}
-        idx={id}
-        key={id}
-        onAdd={onAdd}
-        onSelect={onSelect}
-        selectedId={selectedId}
-        selectedRegionID={selectedRegionID}
-        type={plan}
-        updatePlanCount={updatePlanCount}
-      />
-    ));
+    return plans.map((plan, id) => {
+      const isPlanSoldOut = getPlanSoldOutStatus({
+        plan,
+        regionAvailabilities,
+        selectedRegionId,
+      });
+      return (
+        <KubernetesPlanSelection
+          disabled={disabled}
+          getTypeCount={getTypeCount}
+          idx={id}
+          isPlanSoldOut={isPlanSoldOut}
+          key={id}
+          onAdd={onAdd}
+          onSelect={onSelect}
+          selectedId={selectedId}
+          selectedRegionID={selectedRegionId}
+          type={plan}
+          updatePlanCount={updatePlanCount}
+        />
+      );
+    });
   }, [
     disabled,
     getTypeCount,
@@ -73,7 +88,7 @@ export const KubernetesPlanContainer = (
     onSelect,
     plans,
     selectedId,
-    selectedRegionID,
+    selectedRegionId,
     updatePlanCount,
   ]);
 

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
@@ -75,7 +75,7 @@ export const KubernetesPlanContainer = (
           onAdd={onAdd}
           onSelect={onSelect}
           selectedId={selectedId}
-          selectedRegionID={selectedRegionId}
+          selectedRegionId={selectedRegionId}
           type={plan}
           updatePlanCount={updatePlanCount}
         />

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
@@ -88,6 +88,7 @@ export const KubernetesPlanContainer = (
     onAdd,
     onSelect,
     plans,
+    regionAvailabilities,
     selectedId,
     selectedRegionId,
     updatePlanCount,

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
@@ -9,7 +9,7 @@ import { TableCell } from 'src/components/TableCell';
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
 import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
-import { getPlanSoldOutStatus } from 'src/features/components/PlansPanel/utils';
+import { getIsPlanSoldOut } from 'src/features/components/PlansPanel/utils';
 import { useFlags } from 'src/hooks/useFlags';
 import { useRegionsAvailabilitiesQuery } from 'src/queries/regions';
 import { ExtendedType } from 'src/utilities/extendType';
@@ -60,7 +60,7 @@ export const KubernetesPlanContainer = (
 
   const renderPlanSelection = React.useCallback(() => {
     return plans.map((plan, id) => {
-      const isPlanSoldOut = getPlanSoldOutStatus({
+      const isPlanSoldOut = getIsPlanSoldOut({
         plan,
         regionAvailabilities,
         selectedRegionId,

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
 
+import { PLAN_IS_SOLD_OUT_COPY } from 'src/constants';
 import { extendedTypeFactory } from 'src/factories/types';
 import { breakpoints } from 'src/foundations/breakpoints';
 import {
@@ -31,7 +32,7 @@ const props: KubernetesPlanSelectionProps = {
   isPlanSoldOut: false,
   onAdd: vi.fn(),
   onSelect: vi.fn(),
-  selectedRegionID: 'us-east',
+  selectedRegionId: 'us-east',
   type: extendedType,
   updatePlanCount: vi.fn(),
 };
@@ -63,7 +64,7 @@ describe('KubernetesPlanSelection (table, desktop view)', () => {
   it('displays DC-specific prices in a region with a price increase', async () => {
     const { queryByText } = render(
       wrapWithTableBody(
-        <KubernetesPlanSelection {...props} selectedRegionID="id-cgk" />
+        <KubernetesPlanSelection {...props} selectedRegionId="id-cgk" />
       )
     );
 
@@ -97,7 +98,7 @@ describe('KubernetesPlanSelection (table, desktop view)', () => {
 
     it('displays DC-specific prices in a region with a price increase', async () => {
       const { getByText } = renderWithTheme(
-        <KubernetesPlanSelection {...props} selectedRegionID="id-cgk" />
+        <KubernetesPlanSelection {...props} selectedRegionId="id-cgk" />
       );
 
       expect(
@@ -106,6 +107,18 @@ describe('KubernetesPlanSelection (table, desktop view)', () => {
       expect(
         getByText(`${regionHourlyPrice}/hr`, { exact: false })
       ).toBeInTheDocument();
+    });
+
+    it('shows a chip if plan is sold out', () => {
+      const { getByLabelText } = renderWithTheme(
+        <KubernetesPlanSelection
+          {...props}
+          isPlanSoldOut={true}
+          selectedRegionId={'us-east'}
+        />
+      );
+
+      expect(getByLabelText(PLAN_IS_SOLD_OUT_COPY)).toBeInTheDocument();
     });
   });
 });

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
@@ -28,6 +28,7 @@ const extendedType = extendedTypeFactory.build();
 const props: KubernetesPlanSelectionProps = {
   getTypeCount: vi.fn(),
   idx: 0,
+  isPlanSoldOut: false,
   onAdd: vi.fn(),
   onSelect: vi.fn(),
   selectedRegionID: 'us-east',

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
@@ -97,7 +97,7 @@ export const KubernetesPlanSelection = (
           key={type.id}
         >
           <TableCell data-qa-plan-name>
-            {type.heading}{' '}
+            {type.heading} &nbsp;
             {isPlanSoldOut && (
               <Tooltip
                 data-testid="sold-out-chip"

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
@@ -5,10 +5,13 @@ import { styled } from '@mui/material/styles';
 import * as React from 'react';
 
 import { Button } from 'src/components/Button/Button';
+import { Chip } from 'src/components/Chip';
 import { EnhancedNumberInput } from 'src/components/EnhancedNumberInput/EnhancedNumberInput';
 import { Hidden } from 'src/components/Hidden';
 import { SelectionCard } from 'src/components/SelectionCard/SelectionCard';
 import { TableCell } from 'src/components/TableCell';
+import { TooltipIcon } from 'src/components/TooltipIcon';
+import { PLAN_IS_SOLD_OUT_COPY } from 'src/constants';
 import { StyledDisabledTableRow } from 'src/features/components/PlansPanel/PlansPanel.styles';
 import { ExtendedType } from 'src/utilities/extendType';
 import {
@@ -23,6 +26,7 @@ export interface KubernetesPlanSelectionProps {
   disabled?: boolean;
   getTypeCount: (planId: string) => number;
   idx: number;
+  isPlanSoldOut: boolean;
   onAdd?: (key: string, value: number) => void;
   onSelect: (key: string) => void;
   selectedId?: string;
@@ -38,6 +42,7 @@ export const KubernetesPlanSelection = (
     disabled,
     getTypeCount,
     idx,
+    isPlanSoldOut,
     onAdd,
     onSelect,
     selectedId,
@@ -88,10 +93,20 @@ export const KubernetesPlanSelection = (
       <Hidden mdDown>
         <StyledDisabledTableRow
           data-qa-plan-row={type.formattedLabel}
-          disabled={disabled}
+          disabled={disabled || isPlanSoldOut}
           key={type.id}
         >
-          <TableCell data-qa-plan-name>{type.heading}</TableCell>
+          <TableCell data-qa-plan-name>
+            {type.heading}{' '}
+            {isPlanSoldOut && (
+              <TooltipIcon
+                data-testid="sold-out-chip"
+                icon={<Chip label="Sold Out" />}
+                status="other"
+                text={PLAN_IS_SOLD_OUT_COPY}
+              />
+            )}
+          </TableCell>
           <TableCell
             data-qa-monthly
             errorCell={!price?.monthly}
@@ -149,13 +164,24 @@ export const KubernetesPlanSelection = (
       {/* Displays SelectionCard for small screens */}
       <Hidden mdUp>
         <SelectionCard
+          subheadings={[
+            ...subHeadings,
+            isPlanSoldOut ? (
+              <TooltipIcon
+                icon={<Chip label="Sold Out" sx={{ ml: -1.5 }} />}
+                status="other"
+                text={PLAN_IS_SOLD_OUT_COPY}
+              />
+            ) : (
+              ''
+            ),
+          ]}
           checked={type.id === String(selectedId)}
-          disabled={disabled}
+          disabled={disabled || isPlanSoldOut}
           heading={type.heading}
           key={type.id}
           onClick={() => onSelect(type.id)}
           renderVariant={renderVariant}
-          subheadings={subHeadings}
         />
       </Hidden>
     </React.Fragment>

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
@@ -30,7 +30,7 @@ export interface KubernetesPlanSelectionProps {
   onAdd?: (key: string, value: number) => void;
   onSelect: (key: string) => void;
   selectedId?: string;
-  selectedRegionID?: Region['id'];
+  selectedRegionId?: Region['id'];
   type: ExtendedType;
   updatePlanCount: (planId: string, newCount: number) => void;
 }
@@ -46,7 +46,7 @@ export const KubernetesPlanSelection = (
     onAdd,
     onSelect,
     selectedId,
-    selectedRegionID,
+    selectedRegionId,
     type,
     updatePlanCount,
   } = props;
@@ -55,7 +55,7 @@ export const KubernetesPlanSelection = (
 
   const price: PriceObject | undefined = getLinodeRegionPrice(
     type,
-    selectedRegionID
+    selectedRegionId
   );
 
   // We don't want flat-rate pricing or network information for LKE so we select only the second type element.

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
@@ -103,6 +103,7 @@ export const KubernetesPlanSelection = (
                 data-testid="sold-out-chip"
                 icon={<Chip label="Sold Out" />}
                 status="other"
+                sxTooltipIcon={{ padding: 0 }}
                 text={PLAN_IS_SOLD_OUT_COPY}
               />
             )}
@@ -139,7 +140,8 @@ export const KubernetesPlanSelection = (
                   // or there was a pricing data error.
                   (!onAdd && Boolean(selectedId) && type.id !== selectedId) ||
                   disabled ||
-                  !price?.monthly
+                  !price?.monthly ||
+                  isPlanSoldOut
                 }
                 setValue={(newCount: number) =>
                   updatePlanCount(type.id, newCount)
@@ -149,8 +151,10 @@ export const KubernetesPlanSelection = (
               />
               {onAdd && (
                 <Button
+                  disabled={
+                    count < 1 || disabled || !price?.monthly || isPlanSoldOut
+                  }
                   buttonType="primary"
-                  disabled={count < 1 || disabled || !price?.monthly}
                   onClick={() => onAdd(type.id, count)}
                   sx={{ marginLeft: '10px', minWidth: '85px' }}
                 >

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
@@ -10,7 +10,7 @@ import { EnhancedNumberInput } from 'src/components/EnhancedNumberInput/Enhanced
 import { Hidden } from 'src/components/Hidden';
 import { SelectionCard } from 'src/components/SelectionCard/SelectionCard';
 import { TableCell } from 'src/components/TableCell';
-import { TooltipIcon } from 'src/components/TooltipIcon';
+import { Tooltip } from 'src/components/Tooltip';
 import { PLAN_IS_SOLD_OUT_COPY } from 'src/constants';
 import { StyledDisabledTableRow } from 'src/features/components/PlansPanel/PlansPanel.styles';
 import { ExtendedType } from 'src/utilities/extendType';
@@ -70,14 +70,14 @@ export const KubernetesPlanSelection = (
     <Grid xs={12}>
       <StyledInputOuter>
         <EnhancedNumberInput
-          disabled={disabled}
+          disabled={disabled || isPlanSoldOut}
           setValue={(newCount: number) => updatePlanCount(type.id, newCount)}
           value={count}
         />
         {onAdd && (
           <Button
             buttonType="primary"
-            disabled={count < 1 || disabled}
+            disabled={count < 1 || disabled || isPlanSoldOut}
             onClick={() => onAdd(type.id, count)}
             sx={{ marginLeft: '10px', minWidth: '85px' }}
           >
@@ -99,13 +99,15 @@ export const KubernetesPlanSelection = (
           <TableCell data-qa-plan-name>
             {type.heading}{' '}
             {isPlanSoldOut && (
-              <TooltipIcon
+              <Tooltip
                 data-testid="sold-out-chip"
-                icon={<Chip label="Sold Out" />}
-                status="other"
-                sxTooltipIcon={{ padding: 0 }}
-                text={PLAN_IS_SOLD_OUT_COPY}
-              />
+                placement="right-start"
+                title={PLAN_IS_SOLD_OUT_COPY}
+              >
+                <span>
+                  <Chip label="Sold Out" />
+                </span>
+              </Tooltip>
             )}
           </TableCell>
           <TableCell
@@ -170,15 +172,7 @@ export const KubernetesPlanSelection = (
         <SelectionCard
           subheadings={[
             ...subHeadings,
-            isPlanSoldOut ? (
-              <TooltipIcon
-                icon={<Chip label="Sold Out" sx={{ ml: -1.5 }} />}
-                status="other"
-                text={PLAN_IS_SOLD_OUT_COPY}
-              />
-            ) : (
-              ''
-            ),
+            isPlanSoldOut ? <Chip label="Sold Out" /> : '',
           ]}
           checked={type.id === String(selectedId)}
           disabled={disabled || isPlanSoldOut}
@@ -186,6 +180,7 @@ export const KubernetesPlanSelection = (
           key={type.id}
           onClick={() => onSelect(type.id)}
           renderVariant={renderVariant}
+          tooltip={isPlanSoldOut ? PLAN_IS_SOLD_OUT_COPY : undefined}
         />
       </Hidden>
     </React.Fragment>

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
@@ -31,7 +31,7 @@ interface Props {
   regionsData: Region[];
   resetValues: () => void;
   selectedId?: string;
-  selectedRegionID?: Region['id'] | string;
+  selectedRegionId?: Region['id'] | string;
   types: ExtendedType[];
   updatePlanCount: (planId: string, newCount: number) => void;
 }
@@ -52,7 +52,7 @@ export const KubernetesPlansPanel = (props: Props) => {
     regionsData,
     resetValues,
     selectedId,
-    selectedRegionID,
+    selectedRegionId,
     types,
     updatePlanCount,
   } = props;
@@ -79,7 +79,7 @@ export const KubernetesPlansPanel = (props: Props) => {
               onSelect={onSelect}
               plans={plans[plan]}
               selectedId={selectedId}
-              selectedRegionID={selectedRegionID}
+              selectedRegionId={selectedRegionId}
               updatePlanCount={updatePlanCount}
             />
           </>

--- a/packages/manager/src/features/components/PlansPanel/PlanContainer.styles.ts
+++ b/packages/manager/src/features/components/PlansPanel/PlanContainer.styles.ts
@@ -10,15 +10,9 @@ type StyledTableCellPropsProps = TableCellProps & {
 
 export const StyledTable = styled(Table, {
   label: 'StyledTable',
-  shouldForwardProp: omittedProps(['isDisabled']),
-})<{ isDisabled?: boolean }>(({ isDisabled, theme }) => ({
-  '& tr ': {
-    opacity: isDisabled ? 0.4 : 1,
-  },
+})(({ theme }) => ({
   borderLeft: `1px solid ${theme.borderColors.borderTable}`,
   borderRight: `1px solid ${theme.borderColors.borderTable}`,
-  cursor: isDisabled ? 'not-allowed' : 'inherit',
-  opacity: isDisabled ? 0.5 : 1,
   overflowX: 'hidden',
 }));
 

--- a/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
@@ -101,7 +101,7 @@ export const PlanContainer = (props: Props) => {
           disabledClasses={disabledClasses}
           idx={id}
           isCreate={isCreate}
-          isPlanSoldOut={isPlanSoldOut}
+          isPlanSoldOut={disabled ? false : isPlanSoldOut} // no need to add sold out chip if the whole panel is disabled (meaning that the plan isn't available for the selected region)
           key={id}
           linodeID={linodeID}
           onSelect={onSelect}

--- a/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
@@ -145,11 +145,7 @@ export const PlanContainer = (props: Props) => {
       </Hidden>
       <Hidden lgDown={isCreate} mdDown={!isCreate}>
         <Grid xs={12}>
-          <StyledTable
-            aria-label="List of Linode Plans"
-            isDisabled={disabled}
-            spacingBottom={16}
-          >
+          <StyledTable aria-label="List of Linode Plans" spacingBottom={16}>
             <TableHead>
               <TableRow>
                 {tableCells.map(({ cellName, center, noWrap, testId }) => {

--- a/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
@@ -16,7 +16,7 @@ import { PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE } from 'src/utilities/pricing
 
 import { StyledTable, StyledTableCell } from './PlanContainer.styles';
 import { PlanSelection } from './PlanSelection';
-import { getPlanSoldOutStatus } from './utils';
+import { getIsPlanSoldOut } from './utils';
 
 import type { PlanSelectionType } from './types';
 import type { Region } from '@linode/api-v4';
@@ -88,7 +88,7 @@ export const PlanContainer = (props: Props) => {
 
   const renderPlanSelection = React.useCallback(() => {
     return plans.map((plan, id) => {
-      const isPlanSoldOut = getPlanSoldOutStatus({
+      const isPlanSoldOut = getIsPlanSoldOut({
         plan,
         regionAvailabilities,
         selectedRegionId,

--- a/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
@@ -10,7 +10,7 @@ import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
 import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
 import { useFlags } from 'src/hooks/useFlags';
-import { useRegionsAvailabilitiesQuery } from 'src/queries/regions';
+import { useRegionsAvailabilityQuery } from 'src/queries/regions';
 import { ExtendedType } from 'src/utilities/extendType';
 import { PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE } from 'src/utilities/pricing/constants';
 
@@ -69,8 +69,9 @@ export const PlanContainer = (props: Props) => {
   const location = useLocation();
   const flags = useFlags();
 
-  const { data: regionAvailabilities } = useRegionsAvailabilitiesQuery(
-    Boolean(flags.soldOutChips)
+  const { data: regionAvailabilities } = useRegionsAvailabilityQuery(
+    selectedRegionId || '',
+    Boolean(flags.soldOutChips) && selectedRegionId !== undefined
   );
 
   // Show the Transfer column if, for any plan, the api returned data and we're not in the Database Create flow

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
@@ -1,13 +1,13 @@
 import { fireEvent } from '@testing-library/react';
 import React from 'react';
 
+import { PLAN_IS_SOLD_OUT_COPY } from 'src/constants';
 import { planSelectionTypeFactory } from 'src/factories/types';
 import { breakpoints } from 'src/foundations/breakpoints';
-import { renderWithTheme } from 'src/utilities/testHelpers';
 import { wrapWithTableBody } from 'src/utilities/testHelpers';
+import { renderWithTheme } from 'src/utilities/testHelpers';
 import { resizeScreenSize } from 'src/utilities/testHelpers';
 
-import { PLAN_IS_SOLD_OUT_COPY } from './PlanSelection';
 import { PlanSelection } from './PlanSelection';
 
 import type { PlanSelectionProps } from './PlanSelection';

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
@@ -3,12 +3,14 @@ import React from 'react';
 
 import { planSelectionTypeFactory } from 'src/factories/types';
 import { breakpoints } from 'src/foundations/breakpoints';
-import { resizeScreenSize } from 'src/utilities/testHelpers';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 import { wrapWithTableBody } from 'src/utilities/testHelpers';
+import { resizeScreenSize } from 'src/utilities/testHelpers';
 
+import { PLAN_IS_SOLD_OUT_COPY } from './PlanSelection';
 import { PlanSelection } from './PlanSelection';
 
+import type { PlanSelectionProps } from './PlanSelection';
 import type { PlanSelectionType } from './types';
 
 const mockPlan: PlanSelectionType = planSelectionTypeFactory.build({
@@ -21,20 +23,25 @@ const mockPlan: PlanSelectionType = planSelectionTypeFactory.build({
   ],
 });
 
+const defaultProps: PlanSelectionProps = {
+  idx: 0,
+  isPlanSoldOut: false,
+  onSelect: () => vi.fn(),
+  type: mockPlan,
+};
+
 describe('PlanSelection (table, desktop)', () => {
   beforeAll(() => {
     resizeScreenSize(breakpoints.values.lg);
   });
 
   it('renders the table row', () => {
-    const { container } = renderWithTheme(
+    const { container, queryByLabelText } = renderWithTheme(
       wrapWithTableBody(
         <PlanSelection
-          idx={0}
+          {...defaultProps}
           isCreate={true}
-          onSelect={() => vi.fn()}
           selectedRegionId={'us-east'}
-          type={mockPlan}
         />
       )
     );
@@ -54,18 +61,12 @@ describe('PlanSelection (table, desktop)', () => {
     expect(container.querySelector('[data-qa-storage]')).toHaveTextContent(
       '1024 GB'
     );
+    expect(queryByLabelText(PLAN_IS_SOLD_OUT_COPY)).toBeNull();
   });
 
   it('renders the table row with unknown prices if a region is not selected', () => {
     const { container } = renderWithTheme(
-      wrapWithTableBody(
-        <PlanSelection
-          idx={0}
-          isCreate={true}
-          onSelect={() => vi.fn()}
-          type={mockPlan}
-        />
-      )
+      wrapWithTableBody(<PlanSelection {...defaultProps} isCreate={true} />)
     );
 
     expect(container.querySelector('[data-qa-plan-row]')).toBeInTheDocument();
@@ -85,7 +86,7 @@ describe('PlanSelection (table, desktop)', () => {
 
     const { getByRole } = renderWithTheme(
       wrapWithTableBody(
-        <PlanSelection idx={0} onSelect={mockOnSelect} type={mockPlan} />
+        <PlanSelection {...defaultProps} onSelect={mockOnSelect} />
       )
     );
 
@@ -98,12 +99,7 @@ describe('PlanSelection (table, desktop)', () => {
   it('shows the dynamic prices for a region with DC-specific pricing', () => {
     const { container } = renderWithTheme(
       wrapWithTableBody(
-        <PlanSelection
-          idx={0}
-          onSelect={() => {}}
-          selectedRegionId={'br-gru'}
-          type={mockPlan}
-        />
+        <PlanSelection {...defaultProps} selectedRegionId={'br-gru'} />
       )
     );
 
@@ -132,12 +128,7 @@ describe('PlanSelection (card, mobile)', () => {
 
   it('renders the table row', () => {
     const { container } = renderWithTheme(
-      <PlanSelection
-        idx={0}
-        onSelect={() => {}}
-        selectedRegionId={'us-east'}
-        type={mockPlan}
-      />
+      <PlanSelection {...defaultProps} selectedRegionId={'us-east'} />
     );
 
     expect(
@@ -161,9 +152,7 @@ describe('PlanSelection (card, mobile)', () => {
   });
 
   it('renders the table row with unknown prices if a region is not selected', () => {
-    const { container } = renderWithTheme(
-      <PlanSelection idx={0} onSelect={() => {}} type={mockPlan} />
-    );
+    const { container } = renderWithTheme(<PlanSelection {...defaultProps} />);
 
     expect(
       container.querySelector('[data-qa-selection-card]')
@@ -180,7 +169,7 @@ describe('PlanSelection (card, mobile)', () => {
     const mockOnSelect = vi.fn();
 
     const { container } = renderWithTheme(
-      <PlanSelection idx={0} onSelect={mockOnSelect} type={mockPlan} />
+      <PlanSelection {...defaultProps} onSelect={mockOnSelect} />
     );
 
     fireEvent.click(container.querySelector('[data-qa-selection-card]')!);
@@ -190,12 +179,7 @@ describe('PlanSelection (card, mobile)', () => {
 
   it('shows the dynamic prices for a region with DC-specific pricing', () => {
     const { container } = renderWithTheme(
-      <PlanSelection
-        idx={0}
-        onSelect={() => {}}
-        selectedRegionId={'br-gru'}
-        type={mockPlan}
-      />
+      <PlanSelection {...defaultProps} selectedRegionId={'br-gru'} />
     );
 
     expect(
@@ -216,5 +200,17 @@ describe('PlanSelection (card, mobile)', () => {
     expect(
       container.querySelector('[data-qa-select-card-subheading="subheading-4"]')
     ).toHaveTextContent('40 Gbps In / 2 Gbps Out');
+  });
+
+  it('shows a chip if plan is sold out', () => {
+    const { getByLabelText } = renderWithTheme(
+      <PlanSelection
+        {...defaultProps}
+        isPlanSoldOut={true}
+        selectedRegionId={'us-east'}
+      />
+    );
+
+    expect(getByLabelText(PLAN_IS_SOLD_OUT_COPY)).toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -145,7 +145,7 @@ export const PlanSelection = (props: PlanSelectionProps) => {
             )}
           </StyledRadioCell>
           <TableCell data-qa-plan-name>
-            {type.heading}{' '}
+            {type.heading} &nbsp;
             {isPlanSoldOut && (
               <Tooltip
                 data-testid="sold-out-chip"

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { Chip } from 'src/components/Chip';
 import { Currency } from 'src/components/Currency';
 import { FormControlLabel } from 'src/components/FormControlLabel';
 import { Hidden } from 'src/components/Hidden';
@@ -22,6 +23,9 @@ import { StyledDisabledTableRow } from './PlansPanel.styles';
 
 import type { PlanSelectionType } from './types';
 import type { LinodeTypeClass, PriceObject, Region } from '@linode/api-v4';
+
+const PLAN_IS_SOLD_OUT_COPY =
+  'This plan has no availability for the selected region. Please select a smaller plan or the same plan in another region.';
 
 export interface PlanSelectionProps {
   currentPlanHeading?: string;
@@ -99,17 +103,22 @@ export const PlanSelection = (props: PlanSelectionProps) => {
   return (
     <React.Fragment key={`tabbed-panel-${idx}`}>
       {/* Displays Table Row for larger screens */}
+
       <Hidden lgDown={isCreate} mdDown={!isCreate}>
         <StyledDisabledTableRow
+          aria-disabled={
+            isSamePlan || planTooSmall || isPlanSoldOut || isDisabledClass
+          }
+          disabled={
+            isSamePlan || planTooSmall || isPlanSoldOut || isDisabledClass
+          }
           onClick={() =>
-            !isSamePlan && !disabled && !isDisabledClass
+            !isSamePlan && !disabled && !isPlanSoldOut && !isDisabledClass
               ? onSelect(type.id)
               : undefined
           }
-          aria-disabled={isSamePlan || planTooSmall || isDisabledClass}
           aria-label={rowAriaLabel}
           data-qa-plan-row={type.formattedLabel}
-          disabled={isSamePlan || planTooSmall || isDisabledClass}
           key={type.id}
         >
           <StyledRadioCell>
@@ -122,7 +131,12 @@ export const PlanSelection = (props: PlanSelectionProps) => {
                       !planTooSmall &&
                       type.id === String(selectedId)
                     }
-                    disabled={planTooSmall || disabled || isDisabledClass}
+                    disabled={
+                      planTooSmall ||
+                      disabled ||
+                      isPlanSoldOut ||
+                      isDisabledClass
+                    }
                     id={type.id}
                     onChange={() => onSelect(type.id)}
                   />
@@ -134,7 +148,14 @@ export const PlanSelection = (props: PlanSelectionProps) => {
             )}
           </StyledRadioCell>
           <TableCell data-qa-plan-name>
-            {type.heading} {isPlanSoldOut && '(Sold Out)'}
+            {type.heading}{' '}
+            {isPlanSoldOut && (
+              <TooltipIcon
+                icon={<Chip label="Sold Out" />}
+                status="other"
+                text={PLAN_IS_SOLD_OUT_COPY}
+              />
+            )}
             {(isSamePlan || type.id === selectedLinodePlanType) && (
               <StyledChip
                 aria-label="This is your current plan"
@@ -200,12 +221,29 @@ export const PlanSelection = (props: PlanSelectionProps) => {
       {/* Displays SelectionCard for small screens */}
       <Hidden lgUp={isCreate} mdUp={!isCreate}>
         <SelectionCard
+          disabled={
+            planTooSmall ||
+            isSamePlan ||
+            disabled ||
+            isPlanSoldOut ||
+            isDisabledClass
+          }
+          subheadings={[
+            ...type.subHeadings,
+            isPlanSoldOut ? (
+              <TooltipIcon
+                icon={<Chip label="Sold Out" sx={{ ml: -1.5 }} />}
+                status="other"
+                text={PLAN_IS_SOLD_OUT_COPY}
+              />
+            ) : (
+              ''
+            ),
+          ]}
           checked={type.id === String(selectedId)}
-          disabled={planTooSmall || isSamePlan || disabled || isDisabledClass}
           heading={type.heading}
           key={type.id}
           onClick={() => onSelect(type.id)}
-          subheadings={type.subHeadings}
           tooltip={tooltip}
         />
       </Hidden>

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -24,7 +24,7 @@ import { StyledDisabledTableRow } from './PlansPanel.styles';
 import type { PlanSelectionType } from './types';
 import type { LinodeTypeClass, PriceObject, Region } from '@linode/api-v4';
 
-const PLAN_IS_SOLD_OUT_COPY =
+export const PLAN_IS_SOLD_OUT_COPY =
   'This plan has no availability for the selected region. Please select a smaller plan or the same plan in another region.';
 
 export interface PlanSelectionProps {
@@ -34,7 +34,7 @@ export interface PlanSelectionProps {
   header?: string;
   idx: number;
   isCreate?: boolean;
-  isPlanSoldOut?: boolean;
+  isPlanSoldOut: boolean;
   linodeID?: number | undefined;
   onSelect: (key: string) => void;
   selectedDiskSize?: number;
@@ -103,7 +103,6 @@ export const PlanSelection = (props: PlanSelectionProps) => {
   return (
     <React.Fragment key={`tabbed-panel-${idx}`}>
       {/* Displays Table Row for larger screens */}
-
       <Hidden lgDown={isCreate} mdDown={!isCreate}>
         <StyledDisabledTableRow
           aria-disabled={
@@ -151,6 +150,7 @@ export const PlanSelection = (props: PlanSelectionProps) => {
             {type.heading}{' '}
             {isPlanSoldOut && (
               <TooltipIcon
+                data-testid="sold-out-chip"
                 icon={<Chip label="Sold Out" />}
                 status="other"
                 text={PLAN_IS_SOLD_OUT_COPY}

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -21,16 +21,16 @@ import { StyledChip, StyledRadioCell } from './PlanSelection.styles';
 import { StyledDisabledTableRow } from './PlansPanel.styles';
 
 import type { PlanSelectionType } from './types';
-import type { PriceObject, Region } from '@linode/api-v4';
-import type { LinodeTypeClass } from '@linode/api-v4/lib/linodes';
+import type { LinodeTypeClass, PriceObject, Region } from '@linode/api-v4';
 
-interface Props {
+export interface PlanSelectionProps {
   currentPlanHeading?: string;
   disabled?: boolean;
   disabledClasses?: LinodeTypeClass[];
   header?: string;
   idx: number;
   isCreate?: boolean;
+  isPlanSoldOut?: boolean;
   linodeID?: number | undefined;
   onSelect: (key: string) => void;
   selectedDiskSize?: number;
@@ -47,13 +47,14 @@ const getDisabledClass = (
   return disabledClasses.includes(typeClass);
 };
 
-export const PlanSelection = (props: Props) => {
+export const PlanSelection = (props: PlanSelectionProps) => {
   const {
     currentPlanHeading,
     disabled,
     disabledClasses,
     idx,
     isCreate,
+    isPlanSoldOut,
     linodeID,
     onSelect,
     selectedDiskSize,
@@ -133,7 +134,7 @@ export const PlanSelection = (props: Props) => {
             )}
           </StyledRadioCell>
           <TableCell data-qa-plan-name>
-            {type.heading}{' '}
+            {type.heading} {isPlanSoldOut && '(Sold Out)'}
             {(isSamePlan || type.id === selectedLinodePlanType) && (
               <StyledChip
                 aria-label="This is your current plan"

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -8,6 +8,7 @@ import { Radio } from 'src/components/Radio/Radio';
 import { SelectionCard } from 'src/components/SelectionCard/SelectionCard';
 import { TableCell } from 'src/components/TableCell';
 import { TooltipIcon } from 'src/components/TooltipIcon';
+import { PLAN_IS_SOLD_OUT_COPY } from 'src/constants';
 import { LINODE_NETWORK_IN } from 'src/constants';
 import { useLinodeQuery } from 'src/queries/linodes/linodes';
 import {
@@ -23,10 +24,6 @@ import { StyledDisabledTableRow } from './PlansPanel.styles';
 
 import type { PlanSelectionType } from './types';
 import type { LinodeTypeClass, PriceObject, Region } from '@linode/api-v4';
-
-export const PLAN_IS_SOLD_OUT_COPY =
-  'This plan has no availability for the selected region. Please select a smaller plan or the same plan in another region.';
-
 export interface PlanSelectionProps {
   currentPlanHeading?: string;
   disabled?: boolean;

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -7,9 +7,10 @@ import { Hidden } from 'src/components/Hidden';
 import { Radio } from 'src/components/Radio/Radio';
 import { SelectionCard } from 'src/components/SelectionCard/SelectionCard';
 import { TableCell } from 'src/components/TableCell';
+import { Tooltip } from 'src/components/Tooltip';
 import { TooltipIcon } from 'src/components/TooltipIcon';
-import { PLAN_IS_SOLD_OUT_COPY } from 'src/constants';
 import { LINODE_NETWORK_IN } from 'src/constants';
+import { PLAN_IS_SOLD_OUT_COPY } from 'src/constants';
 import { useLinodeQuery } from 'src/queries/linodes/linodes';
 import {
   PRICE_ERROR_TOOLTIP_TEXT,
@@ -146,12 +147,15 @@ export const PlanSelection = (props: PlanSelectionProps) => {
           <TableCell data-qa-plan-name>
             {type.heading}{' '}
             {isPlanSoldOut && (
-              <TooltipIcon
+              <Tooltip
                 data-testid="sold-out-chip"
-                icon={<Chip label="Sold Out" />}
-                status="other"
-                text={PLAN_IS_SOLD_OUT_COPY}
-              />
+                placement="right-start"
+                title={PLAN_IS_SOLD_OUT_COPY}
+              >
+                <span>
+                  <Chip label="Sold Out" />
+                </span>
+              </Tooltip>
             )}
             {(isSamePlan || type.id === selectedLinodePlanType) && (
               <StyledChip
@@ -227,21 +231,13 @@ export const PlanSelection = (props: PlanSelectionProps) => {
           }
           subheadings={[
             ...type.subHeadings,
-            isPlanSoldOut ? (
-              <TooltipIcon
-                icon={<Chip label="Sold Out" sx={{ ml: -1.5 }} />}
-                status="other"
-                text={PLAN_IS_SOLD_OUT_COPY}
-              />
-            ) : (
-              ''
-            ),
+            isPlanSoldOut ? <Chip label="Sold Out" /> : '',
           ]}
           checked={type.id === String(selectedId)}
           heading={type.heading}
           key={type.id}
           onClick={() => onSelect(type.id)}
-          tooltip={tooltip}
+          tooltip={isPlanSoldOut ? PLAN_IS_SOLD_OUT_COPY : tooltip}
         />
       </Hidden>
     </React.Fragment>

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.styles.ts
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.styles.ts
@@ -28,7 +28,7 @@ export const StyledDisabledTableRow = styled(TableRow, {
   ...(props.disabled && {
     backgroundColor: theme.bg.tableHeader,
     cursor: 'not-allowed',
-    opacity: 0.4,
+    opacity: 0.5,
   }),
   '&:focus-within': {
     backgroundColor: theme.bg.lightBlue1,

--- a/packages/manager/src/features/components/PlansPanel/utils.test.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.test.ts
@@ -4,7 +4,7 @@ import { planSelectionTypeFactory, typeFactory } from 'src/factories/types';
 import {
   determineInitialPlanCategoryTab,
   getPlanSelectionsByPlanType,
-  getPlanSoldOutStatus,
+  getIsPlanSoldOut,
   planTypeOrder,
 } from './utils';
 
@@ -145,12 +145,12 @@ describe('determineInitialPlanCategoryTab', () => {
   });
 });
 
-describe('getPlanSoldOutStatus', () => {
+describe('getIsPlanSoldOut', () => {
   const mockPlan: PlanSelectionType = planSelectionTypeFactory.build();
   const mockSelectedRegionId = 'us-east-1';
 
   it('should return false if regionAvailabilities is falsy', () => {
-    const result = getPlanSoldOutStatus({
+    const result = getIsPlanSoldOut({
       plan: mockPlan,
       regionAvailabilities: undefined,
       selectedRegionId: mockSelectedRegionId,
@@ -160,7 +160,7 @@ describe('getPlanSoldOutStatus', () => {
   });
 
   it('should return false if no matching regionAvailability is found (based on planId)', () => {
-    const result = getPlanSoldOutStatus({
+    const result = getIsPlanSoldOut({
       plan: mockPlan,
       regionAvailabilities: [
         { available: true, plan: 'fakeplan', region: 'us-east-1' },
@@ -172,7 +172,7 @@ describe('getPlanSoldOutStatus', () => {
   });
 
   it('should return false if selectedRegionId is falsy', () => {
-    const result = getPlanSoldOutStatus({
+    const result = getIsPlanSoldOut({
       plan: mockPlan,
       regionAvailabilities: [
         { available: false, plan: mockPlan.id, region: 'us-east-1' },
@@ -184,7 +184,7 @@ describe('getPlanSoldOutStatus', () => {
   });
 
   it('should return false if no matching regionAvailability is found', () => {
-    const result = getPlanSoldOutStatus({
+    const result = getIsPlanSoldOut({
       plan: mockPlan,
       regionAvailabilities: [
         { available: false, plan: mockPlan.id, region: 'us-west-2' },
@@ -196,7 +196,7 @@ describe('getPlanSoldOutStatus', () => {
   });
 
   it('should return true if matching regionAvailability is found with available set to false', () => {
-    const result = getPlanSoldOutStatus({
+    const result = getIsPlanSoldOut({
       plan: mockPlan,
       regionAvailabilities: [
         { available: false, plan: mockPlan.id, region: 'us-east-1' },
@@ -208,7 +208,7 @@ describe('getPlanSoldOutStatus', () => {
   });
 
   it('should return false if matching regionAvailability is found with available set to true', () => {
-    const result = getPlanSoldOutStatus({
+    const result = getIsPlanSoldOut({
       plan: mockPlan,
       regionAvailabilities: [
         { available: true, plan: mockPlan.id, region: 'us-east-1' },

--- a/packages/manager/src/features/components/PlansPanel/utils.test.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.test.ts
@@ -159,7 +159,19 @@ describe('getPlanSoldOutStatus', () => {
     expect(result).toBe(false);
   });
 
-  it('should return false if plan or selectedRegionId is falsy', () => {
+  it('should return false if no matching regionAvailability is found (based on planId)', () => {
+    const result = getPlanSoldOutStatus({
+      plan: mockPlan,
+      regionAvailabilities: [
+        { available: true, plan: 'fakeplan', region: 'us-east-1' },
+      ],
+      selectedRegionId: mockSelectedRegionId,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false if selectedRegionId is falsy', () => {
     const result = getPlanSoldOutStatus({
       plan: mockPlan,
       regionAvailabilities: [

--- a/packages/manager/src/features/components/PlansPanel/utils.test.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.test.ts
@@ -1,11 +1,14 @@
 import { extendedTypes } from 'src/__data__/ExtendedType';
-import { typeFactory } from 'src/factories/types';
+import { planSelectionTypeFactory, typeFactory } from 'src/factories/types';
 
 import {
   determineInitialPlanCategoryTab,
   getPlanSelectionsByPlanType,
+  getPlanSoldOutStatus,
   planTypeOrder,
 } from './utils';
+
+import type { PlanSelectionType } from './types';
 
 const standard = typeFactory.build({ class: 'standard', id: 'g6-standard-1' });
 const metal = typeFactory.build({ class: 'metal', id: 'g6-metal-alpha-2' });
@@ -132,11 +135,75 @@ describe('determineInitialPlanCategoryTab', () => {
 
     expect(initialTab).toBe(2);
   });
+
   it('should return the correct initial tab when gpu plan is selected', () => {
     const selectedId = 'g1-gpu-rtx6000-2';
 
     const initialTab = determineInitialPlanCategoryTab(types, selectedId);
 
     expect(initialTab).toBe(3);
+  });
+});
+
+describe('getPlanSoldOutStatus', () => {
+  const mockPlan: PlanSelectionType = planSelectionTypeFactory.build();
+  const mockSelectedRegionId = 'us-east-1';
+
+  it('should return false if regionAvailabilities is falsy', () => {
+    const result = getPlanSoldOutStatus({
+      plan: mockPlan,
+      regionAvailabilities: undefined,
+      selectedRegionId: mockSelectedRegionId,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false if plan or selectedRegionId is falsy', () => {
+    const result = getPlanSoldOutStatus({
+      plan: mockPlan,
+      regionAvailabilities: [
+        { available: false, plan: mockPlan.id, region: 'us-east-1' },
+      ],
+      selectedRegionId: undefined,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false if no matching regionAvailability is found', () => {
+    const result = getPlanSoldOutStatus({
+      plan: mockPlan,
+      regionAvailabilities: [
+        { available: false, plan: mockPlan.id, region: 'us-west-2' },
+      ],
+      selectedRegionId: mockSelectedRegionId,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return true if matching regionAvailability is found with available set to false', () => {
+    const result = getPlanSoldOutStatus({
+      plan: mockPlan,
+      regionAvailabilities: [
+        { available: false, plan: mockPlan.id, region: 'us-east-1' },
+      ],
+      selectedRegionId: mockSelectedRegionId,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false if matching regionAvailability is found with available set to true', () => {
+    const result = getPlanSoldOutStatus({
+      plan: mockPlan,
+      regionAvailabilities: [
+        { available: true, plan: mockPlan.id, region: 'us-east-1' },
+      ],
+      selectedRegionId: mockSelectedRegionId,
+    });
+
+    expect(result).toBe(false);
   });
 });

--- a/packages/manager/src/features/components/PlansPanel/utils.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.ts
@@ -111,7 +111,7 @@ export const getRegionsWithCapability = (
   return arrayToList(withCapability ?? []);
 };
 
-interface PlanSoldOutStatus {
+interface PlanSoldOutStatusOptions {
   plan: PlanSelectionType;
   regionAvailabilities: RegionAvailability[] | undefined;
   selectedRegionId: Region['id'] | undefined;
@@ -124,7 +124,7 @@ export const getIsPlanSoldOut = ({
   plan,
   regionAvailabilities,
   selectedRegionId,
-}: PlanSoldOutStatus): boolean => {
+}: PlanSoldOutStatusOptions): boolean => {
   if (!regionAvailabilities || !selectedRegionId) {
     return false;
   }

--- a/packages/manager/src/features/components/PlansPanel/utils.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.ts
@@ -118,9 +118,9 @@ interface PlanSoldOutStatus {
 }
 
 /**
- * Utility to map Premium & GPU plans to a selected region's availability.
+ * Utility to determine if a plan is sold out based on a region's availability.
  */
-export const getPlanSoldOutStatus = ({
+export const getIsPlanSoldOut = ({
   plan,
   regionAvailabilities,
   selectedRegionId,

--- a/packages/manager/src/features/components/PlansPanel/utils.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.ts
@@ -1,12 +1,14 @@
-import { Region } from '@linode/api-v4/lib/regions';
-import { Capabilities } from '@linode/api-v4/lib/regions/types';
-
 import { arrayToList } from 'src/utilities/arrayToList';
 import { ExtendedType } from 'src/utilities/extendType';
 
 import { PlanSelectionType } from './types';
 
-import type { LinodeTypeClass } from '@linode/api-v4';
+import type {
+  Capabilities,
+  LinodeTypeClass,
+  Region,
+  RegionAvailability,
+} from '@linode/api-v4';
 
 export type PlansTypes<T> = Record<LinodeTypeClass, T[]>;
 
@@ -107,6 +109,41 @@ export const getRegionsWithCapability = (
     )
     .map((thisRegion: Region) => thisRegion.label);
   return arrayToList(withCapability ?? []);
+};
+
+interface PlanSoldOutStatus {
+  plan: PlanSelectionType;
+  regionAvailabilities: RegionAvailability[] | undefined;
+  selectedRegionId: Region['id'] | undefined;
+}
+
+/**
+ * Utility to map Premium & GPU plans to a selected region's availability.
+ */
+export const getPlanSoldOutStatus = ({
+  plan,
+  regionAvailabilities,
+  selectedRegionId,
+}: PlanSoldOutStatus): boolean => {
+  if (!regionAvailabilities || !selectedRegionId) {
+    return false;
+  }
+
+  const availability = regionAvailabilities?.find((regionAvailability) => {
+    const regionMatch = regionAvailability?.region === selectedRegionId;
+
+    if (!regionMatch) {
+      return false;
+    }
+
+    if (regionAvailability.plan === plan.id) {
+      return regionAvailability.available === false;
+    }
+
+    return false;
+  });
+
+  return !!availability;
 };
 
 export const planTabInfoContent = {

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1827,7 +1827,16 @@ export const handlers = [
   }),
   rest.get('*regions/:regionId/availability', (_req, res, ctx) => {
     return res(
-      ctx.json(regionAvailabilityFactory.buildList(5, { region: 'us-east' }))
+      ctx.json([
+        regionAvailabilityFactory.build({
+          plan: 'g6-standard-6',
+          region: 'us-east',
+        }),
+        regionAvailabilityFactory.build({
+          plan: 'g6-standard-7',
+          region: 'us-east',
+        }),
+      ])
     );
   }),
   ...entityTransfers,

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1803,7 +1803,14 @@ export const handlers = [
   }),
   rest.get('*regions/availability', (_req, res, ctx) => {
     return res(
-      ctx.json(makeResourcePage(regionAvailabilityFactory.buildList(10)))
+      ctx.json(
+        makeResourcePage([
+          regionAvailabilityFactory.build(),
+          regionAvailabilityFactory.build({
+            plan: 'g6-standard-6',
+          }),
+        ])
+      )
     );
   }),
   rest.get('*regions/:regionId/availability', (_req, res, ctx) => {

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1805,9 +1805,21 @@ export const handlers = [
     return res(
       ctx.json(
         makeResourcePage([
-          regionAvailabilityFactory.build(),
           regionAvailabilityFactory.build({
             plan: 'g6-standard-6',
+            region: 'us-east',
+          }),
+          regionAvailabilityFactory.build({
+            plan: 'g6-standard-7',
+            region: 'us-east',
+          }),
+          regionAvailabilityFactory.build({
+            plan: 'g6-dedicated-5',
+            region: 'us-central',
+          }),
+          regionAvailabilityFactory.build({
+            plan: 'g6-dedicated-6',
+            region: 'us-central',
           }),
         ])
       )

--- a/packages/manager/src/queries/regions.ts
+++ b/packages/manager/src/queries/regions.ts
@@ -27,10 +27,13 @@ const getAllRegionsRequest = () =>
 
 // Region Availability queries
 
-export const useRegionsAvailabilitiesQuery = () =>
+export const useRegionsAvailabilitiesQuery = (enabled: boolean = true) =>
   useQuery<RegionAvailability[], APIError[]>(
     queryKey,
-    getAllRegionAvailabilitiesRequest
+    getAllRegionAvailabilitiesRequest,
+    {
+      enabled,
+    }
   );
 
 const getAllRegionAvailabilitiesRequest = () =>


### PR DESCRIPTION
## Description 📝
This PR implements sold out chips to our `PlanSelection` components (both Linode and Kubernetes). It helps our users with picking a `GPU` or `Premium CPU` plan by showing them plans that are actually available to them instead of trying to select unavailable plans that would lead to an API error upon submission.

It utilizes the new regions/availability endpoint which only returns availability for `GPU` or `Premium CPU` plans (it may be expanded later on). In the background, the endpoint gets refreshed at 15m via a cron job checking available resources in our DCs.

⚠️: While the endpoint is already live in production, we're waiting for an API update that will convert the `plan` value to our regular plan Ids. This is why this PR is to be tested with mock data.

⚠️: The feature flag is currently turned on for testing, but will be off in production till the fix above is completed. The flag controls the enabling of the API query so when `off` and no data is returned no plans will be shown as sold out. 

## Changes  🔄
- Implement logic to add the sold out chip to `GPU` or `Premium CPU` plans
- Add test coverage for new feature
- Modify the `useRegionsAvailabilitiesQuery` to be abled to be disabled
- Add ability to pass JSX element to `subheadings` mobile selection cards
- Get rid of obsolete `soldOutSingapore` & `soldOutTokyo` flags
- Replace instances of `selectedRegionID` with `selectedRegionId`


## Preview 📷

### Linode Creation Flow

| Mobile  | Desktop   |
| ------- | ------- |
| ![Screenshot 2023-12-21 at 11 58 57](https://github.com/linode/manager/assets/130582365/c7f8323e-e852-4b43-947e-44969904e008) | ![Screenshot 2023-12-21 at 11 59 04](https://github.com/linode/manager/assets/130582365/b19f5825-398a-48d9-953f-f7469efe1486) |

### Kubernetes Creation Flow
| Mobile  | Desktop   |
| ------- | ------- |
| ![Screenshot 2023-12-21 at 12 00 07](https://github.com/linode/manager/assets/130582365/92529529-8c2a-4ec4-bced-13faf08ed932) | ![Screenshot 2023-12-21 at 12 00 14](https://github.com/linode/manager/assets/130582365/984bff1b-770b-42fd-975b-71401b722fb1) |

## How to test 🧪

### Prerequisites
- pull and run code locally
- turn on MSW

### Verification steps 
for both the Linode and Kubernetes creation flows: 
- select either Newark, NJ (us-east) or Dallas, TX (us-central)
- confirm sold out chips in either the Dedicated CPU or Shared CPU tabs (those plans are not representative of what is returned by the API but what was mocked for testing purposes)
- Confirm mobile and desktop styling
- Confirm light and dark mode (ignore known visual defect for disabled radios which will be released at the same time)
- Confirm chip doesn't show if panel is disabled (you can do that by making [this prop](https://github.com/linode/manager/blob/develop/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx#L85) `true`)

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support