### PR TITLE
fix: Failing `CreditCard.test.tsx` Unit Test

### DIFF
--- a/packages/manager/.changeset/pr-10023-tests-1704213295558.md
+++ b/packages/manager/.changeset/pr-10023-tests-1704213295558.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix `CreditCard.test.tsx` failing unit test ([#10023](https://github.com/linode/manager/pull/10023))

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.test.tsx
@@ -1,4 +1,5 @@
 import { CreditCardData } from '@linode/api-v4';
+import { Settings } from 'luxon';
 import * as React from 'react';
 
 import { renderWithTheme } from 'src/utilities/testHelpers';
@@ -20,6 +21,8 @@ it('Displays credit card type and last four digits', () => {
 });
 
 it('Displays formatted expiration date for cards with expiration', () => {
+  Settings.now = () => new Date(2023, 11, 7).valueOf();
+
   const creditCardData: CreditCardData = {
     card_type: 'Visa',
     expiry: '12/2023',

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.test.tsx
@@ -21,6 +21,7 @@ it('Displays credit card type and last four digits', () => {
 });
 
 it('Displays formatted expiration date for cards with expiration', () => {
+  // Mock that the current date is in 2023 so that the card is not expired.
   Settings.now = () => new Date(2023, 11, 7).valueOf();
 
   const creditCardData: CreditCardData = {

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.tsx
@@ -11,7 +11,7 @@ import MastercardIcon from 'src/assets/icons/payment/mastercard.svg';
 import VisaIcon from 'src/assets/icons/payment/visa.svg';
 import { Box } from 'src/components/Box';
 import { Typography } from 'src/components/Typography';
-import { formatExpiry, hasExpirationPassedFor } from 'src/utilities/creditCard';
+import { formatExpiry, isCreditCardExpired } from 'src/utilities/creditCard';
 
 const useStyles = makeStyles()((theme: Theme) => ({
   card: {
@@ -87,7 +87,7 @@ export const CreditCard = (props: Props) => {
           {`${type || 'Card ending in'} ****${lastFour}`}
         </Typography>
         <Typography data-qa-contact-cc-exp-date>
-          {expiry && hasExpirationPassedFor(expiry) ? (
+          {expiry && isCreditCardExpired(expiry) ? (
             <span className={classes.expired}>{`Expired ${formatExpiry(
               expiry
             )}`}</span>

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.tsx
@@ -1,5 +1,4 @@
 import { CardType, CreditCardData } from '@linode/api-v4/lib/account/types';
-import { Box } from 'src/components/Box';
 import { Theme } from '@mui/material/styles';
 import * as React from 'react';
 import { makeStyles } from 'tss-react/mui';
@@ -10,8 +9,9 @@ import DiscoverIcon from 'src/assets/icons/payment/discover.svg';
 import JCBIcon from 'src/assets/icons/payment/jcb.svg';
 import MastercardIcon from 'src/assets/icons/payment/mastercard.svg';
 import VisaIcon from 'src/assets/icons/payment/visa.svg';
+import { Box } from 'src/components/Box';
 import { Typography } from 'src/components/Typography';
-import isCreditCardExpired, { formatExpiry } from 'src/utilities/creditCard';
+import { formatExpiry, hasExpirationPassedFor } from 'src/utilities/creditCard';
 
 const useStyles = makeStyles()((theme: Theme) => ({
   card: {
@@ -87,7 +87,7 @@ export const CreditCard = (props: Props) => {
           {`${type || 'Card ending in'} ****${lastFour}`}
         </Typography>
         <Typography data-qa-contact-cc-exp-date>
-          {expiry && isCreditCardExpired(expiry) ? (
+          {expiry && hasExpirationPassedFor(expiry) ? (
             <span className={classes.expired}>{`Expired ${formatExpiry(
               expiry
             )}`}</span>

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -30,7 +30,7 @@ import PayPalButton from './PayPalButton';
 import CreditCardDialog from './PaymentBits/CreditCardDialog';
 import { PaymentMethodCard } from './PaymentMethodCard';
 import { SetSuccess } from './types';
-import { hasExpirationPassedFor } from 'src/utilities/creditCard';
+import { isCreditCardExpired } from 'src/utilities/creditCard';
 
 const useStyles = makeStyles()(() => ({
   button: {
@@ -130,7 +130,7 @@ export const PaymentDrawer = (props: Props) => {
         setSelectedCardExpired(
           Boolean(
             selectedPaymentMethod.data.expiry &&
-              hasExpirationPassedFor(selectedPaymentMethod.data.expiry)
+              isCreditCardExpired(selectedPaymentMethod.data.expiry)
           )
         );
       }

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -22,7 +22,6 @@ import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
 import { useAccount } from 'src/queries/account';
 import { queryKey } from 'src/queries/accountBilling';
-import isCreditCardExpired from 'src/utilities/creditCard';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 import { PayPalErrorBoundary } from '../../PaymentInfoPanel/PayPalErrorBoundary';
@@ -31,6 +30,7 @@ import PayPalButton from './PayPalButton';
 import CreditCardDialog from './PaymentBits/CreditCardDialog';
 import { PaymentMethodCard } from './PaymentMethodCard';
 import { SetSuccess } from './types';
+import { hasExpirationPassedFor } from 'src/utilities/creditCard';
 
 const useStyles = makeStyles()(() => ({
   button: {
@@ -130,7 +130,7 @@ export const PaymentDrawer = (props: Props) => {
         setSelectedCardExpired(
           Boolean(
             selectedPaymentMethod.data.expiry &&
-              isCreditCardExpired(selectedPaymentMethod.data.expiry)
+              hasExpirationPassedFor(selectedPaymentMethod.data.expiry)
           )
         );
       }

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
@@ -10,7 +10,7 @@ import {
 } from 'src/components/PaymentMethodRow/ThirdPartyPayment';
 import { SelectionCard } from 'src/components/SelectionCard/SelectionCard';
 import { getIcon as getCreditCardIcon } from 'src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard';
-import isCreditCardExpired, { formatExpiry } from 'src/utilities/creditCard';
+import { formatExpiry, hasExpirationPassedFor } from 'src/utilities/creditCard';
 
 interface Props {
   handlePaymentMethodChange: (id: number, cardExpired: boolean) => void;
@@ -23,7 +23,8 @@ const getIsCardExpired = (paymentMethod: PaymentMethod) => {
     return false;
   }
   return Boolean(
-    paymentMethod.data.expiry && isCreditCardExpired(paymentMethod.data.expiry)
+    paymentMethod.data.expiry &&
+      hasExpirationPassedFor(paymentMethod.data.expiry)
   );
 };
 

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
@@ -10,7 +10,7 @@ import {
 } from 'src/components/PaymentMethodRow/ThirdPartyPayment';
 import { SelectionCard } from 'src/components/SelectionCard/SelectionCard';
 import { getIcon as getCreditCardIcon } from 'src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard';
-import { formatExpiry, hasExpirationPassedFor } from 'src/utilities/creditCard';
+import { formatExpiry, isCreditCardExpired } from 'src/utilities/creditCard';
 
 interface Props {
   handlePaymentMethodChange: (id: number, cardExpired: boolean) => void;
@@ -23,8 +23,7 @@ const getIsCardExpired = (paymentMethod: PaymentMethod) => {
     return false;
   }
   return Boolean(
-    paymentMethod.data.expiry &&
-      hasExpirationPassedFor(paymentMethod.data.expiry)
+    paymentMethod.data.expiry && isCreditCardExpired(paymentMethod.data.expiry)
   );
 };
 

--- a/packages/manager/src/utilities/creditCard.test.ts
+++ b/packages/manager/src/utilities/creditCard.test.ts
@@ -4,7 +4,7 @@ import { take, takeLast } from 'ramda';
 
 import {
   formatExpiry,
-  hasExpirationPassedFor,
+  isCreditCardExpired,
   parseExpiryYear,
 } from './creditCard';
 
@@ -12,9 +12,9 @@ const currentYear = new Date().getFullYear();
 const currentYearFirstTwoDigits = take(2, String(currentYear));
 
 describe('isCreditCardExpired', () => {
-  describe('give today is 01/01/2019', () => {
-    // Mock that the current date
-    Settings.now = () => new Date(2019, 1, 1).valueOf();
+  describe('given today is 01/01/2019', () => {
+    // Mock that the current date is 1/1/2019
+    Settings.now = () => new Date(2019, 0, 1).valueOf();
 
     [
       ['01/2018', true],
@@ -29,7 +29,7 @@ describe('isCreditCardExpired', () => {
       ['10/2018', true],
       ['11/2018', true],
       ['12/2018', true],
-      ['01/2019', true],
+      ['01/2019', false], // A card is still valid until the end of the month
       ['02/2019', false],
       ['03/2019', false],
       ['04/2019', false],
@@ -44,7 +44,7 @@ describe('isCreditCardExpired', () => {
     ].forEach(([expiration, result]: [string, boolean]) => {
       describe(`and a expiration date of ${expiration}`, () => {
         it(`should return ${result}`, () => {
-          expect(hasExpirationPassedFor(expiration)).toBe(result);
+          expect(isCreditCardExpired(expiration)).toBe(result);
         });
       });
     });

--- a/packages/manager/src/utilities/creditCard.test.ts
+++ b/packages/manager/src/utilities/creditCard.test.ts
@@ -13,6 +13,7 @@ const currentYearFirstTwoDigits = take(2, String(currentYear));
 
 describe('isCreditCardExpired', () => {
   describe('give today is 01/01/2019', () => {
+    // Mock that the current date
     Settings.now = () => new Date(2019, 1, 1).valueOf();
 
     [

--- a/packages/manager/src/utilities/creditCard.test.ts
+++ b/packages/manager/src/utilities/creditCard.test.ts
@@ -1,5 +1,5 @@
 import { CreditCardSchema } from '@linode/validation';
-import { DateTime } from 'luxon';
+import { Settings } from 'luxon';
 import { take, takeLast } from 'ramda';
 
 import {
@@ -13,9 +13,7 @@ const currentYearFirstTwoDigits = take(2, String(currentYear));
 
 describe('isCreditCardExpired', () => {
   describe('give today is 01/01/2019', () => {
-    const date = DateTime.fromObject({ day: 1, month: 1, year: 2019 });
-
-    const isCreditCardExpired = hasExpirationPassedFor(date);
+    Settings.now = () => new Date(2019, 1, 1).valueOf();
 
     [
       ['01/2018', true],
@@ -30,7 +28,7 @@ describe('isCreditCardExpired', () => {
       ['10/2018', true],
       ['11/2018', true],
       ['12/2018', true],
-      ['01/2019', false],
+      ['01/2019', true],
       ['02/2019', false],
       ['03/2019', false],
       ['04/2019', false],
@@ -45,7 +43,7 @@ describe('isCreditCardExpired', () => {
     ].forEach(([expiration, result]: [string, boolean]) => {
       describe(`and a expiration date of ${expiration}`, () => {
         it(`should return ${result}`, () => {
-          expect(isCreditCardExpired(expiration)).toBe(result);
+          expect(hasExpirationPassedFor(expiration)).toBe(result);
         });
       });
     });

--- a/packages/manager/src/utilities/creditCard.ts
+++ b/packages/manager/src/utilities/creditCard.ts
@@ -1,8 +1,12 @@
 import { DateTime } from 'luxon';
 import { take, takeLast } from 'ramda';
 /**
- * Expiration is the beginning of the day of the first day of the month.
- * Expiration: yyyy-MM-01 00:00:00
+ * Credit cards generally are valid through the expiry month (inclusive).
+ *
+ * For example,
+ * A credit card with an expiry of 01/2019 expires the last day of January.
+ *
+ * @param expDate The expiry date in the format MM/YYYY
  */
 const expirationDateFromString = (expDate: string /* MM/YYYY */) => {
   const pattern = /^((0[1-9])|(1[0-2]))\/(\d{4})$/i;
@@ -11,13 +15,21 @@ const expirationDateFromString = (expDate: string /* MM/YYYY */) => {
   }
 
   // month are 1 based in luxon
-  const month = +expDate.substr(0, 2);
-  const year = +expDate.substr(3, 8);
+  const month = +expDate.substring(0, 2);
+  const year = +expDate.substring(3, 8);
 
-  return DateTime.fromObject({ day: 1, month, year }).endOf('month');
+  return DateTime.fromObject({ month, year }).endOf('month');
 };
 
-export const hasExpirationPassedFor = (expDate: string /** MM/YYYY */) => {
+/**
+ * Returns true if a credit card is expired.
+ *
+ * For example, if a card has an expiry of 1/1/2023 and the current date is
+ * 1/1/2023, the card is is not expired.
+ *
+ * @param expDate The expiry date in the format MM/YYYY
+ */
+export const isCreditCardExpired = (expDate: string) => {
   return DateTime.local() > expirationDateFromString(expDate);
 };
 

--- a/packages/manager/src/utilities/creditCard.ts
+++ b/packages/manager/src/utilities/creditCard.ts
@@ -17,10 +17,8 @@ const expirationDateFromString = (expDate: string /* MM/YYYY */) => {
   return DateTime.fromObject({ day: 1, month, year }).endOf('month');
 };
 
-export const hasExpirationPassedFor = (today: DateTime = DateTime.local()) => (
-  expDate: string /** MM/YYYY */
-) => {
-  return today > expirationDateFromString(expDate);
+export const hasExpirationPassedFor = (expDate: string /** MM/YYYY */) => {
+  return DateTime.local() > expirationDateFromString(expDate);
 };
 
 /**
@@ -48,5 +46,3 @@ export const parseExpiryYear = (
 
   return take(2, String(new Date().getFullYear())) + expiryYear;
 };
-
-export default hasExpirationPassedFor();


### PR DESCRIPTION
## Description 📝
- Fixes failing unit test caused by the New Year (`2023` ➡️ `2024`) 🎆

## Changes  🔄
- Mocks dates by changing Luxon's settings 📅
- Simplifies function and naming ✏️
- Removes default exports ❌

## How to test 🧪

This is the test that needed to be fixed.
```sh
yarn test CreditCard
```

Check this for good measure because it contains the expiry logic
```sh
yarn test creditCard
```

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support