### PR TITLE
test: [M3-7409] - Add GDPR agreement e2e

### DIFF
--- a/packages/manager/.changeset/pr-10033-tests-1704470547191.md
+++ b/packages/manager/.changeset/pr-10033-tests-1704470547191.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+GDPR agreement e2e test ([#10033](https://github.com/linode/manager/pull/10033))

--- a/packages/manager/cypress/e2e/core/general/gdpr-agreement.spec.ts
+++ b/packages/manager/cypress/e2e/core/general/gdpr-agreement.spec.ts
@@ -1,0 +1,96 @@
+import { ui } from 'support/ui';
+import { regionFactory } from '@src/factories';
+import { authenticate } from 'support/api/authentication';
+import { cleanUp } from 'support/util/cleanup';
+import { mockGetRegions } from 'support/intercepts/regions';
+import { mockGetAccountAgreements } from 'support/intercepts/account';
+
+import type { Region } from '@linode/api-v4';
+
+const mockRegions: Region[] = [
+  regionFactory.build({
+    capabilities: ['Linodes'],
+    country: 'fr',
+    id: 'fr-par',
+    label: 'Paris, FR',
+  }),
+  regionFactory.build({
+    capabilities: ['Linodes'],
+    country: 'sg',
+    id: 'ap-south',
+    label: 'Singapore, SG',
+  }),
+  regionFactory.build({
+    capabilities: ['Linodes'],
+    country: 'us',
+    id: 'us-east',
+    label: 'Newark, NJ',
+  }),
+  regionFactory.build({
+    capabilities: ['Linodes'],
+    country: 'us',
+    id: 'us-central',
+    label: 'Dallas, TX',
+  }),
+  regionFactory.build({
+    capabilities: ['Linodes'],
+    country: 'gb',
+    id: 'eu-west',
+    label: 'London, UK',
+  }),
+];
+
+authenticate();
+describe('GDPR agreement', () => {
+  it('displays the GDPR agreement based on region, if user has not agreed yet', () => {
+    mockGetRegions(mockRegions).as('getRegions');
+    mockGetAccountAgreements({
+      privacy_policy: false,
+      eu_model: false,
+    }).as('getAgreements');
+
+    cy.visitWithLogin('/linodes/create');
+    cy.wait(['@getAgreements', '@getRegions']);
+
+    // Paris should have the agreement
+    ui.regionSelect.find().click();
+    ui.regionSelect.findItemByRegionId('fr-par').click();
+    cy.get('[data-testid="eu-agreement-checkbox"]').should('be.visible');
+
+    // London should have the agreement
+    ui.regionSelect.find().click();
+    ui.regionSelect.findItemByRegionId('eu-west').click();
+    cy.get('[data-testid="eu-agreement-checkbox"]').should('be.visible');
+
+    // Newark should not have the agreement
+    ui.regionSelect.find().click();
+    ui.regionSelect.findItemByRegionId('us-east').click();
+    cy.get('[data-testid="eu-agreement-checkbox"]').should('not.exist');
+  });
+
+  it('does not display the GDPR agreement based on any region, if user has already agreed', () => {
+    mockGetRegions(mockRegions).as('getRegions');
+    mockGetAccountAgreements({
+      privacy_policy: false,
+      eu_model: true,
+    }).as('getAgreements');
+
+    cy.visitWithLogin('/linodes/create');
+    cy.wait(['@getAgreements', '@getRegions']);
+
+    // Paris should not have the agreement
+    ui.regionSelect.find().click();
+    ui.regionSelect.findItemByRegionId('fr-par').click();
+    cy.get('[data-testid="eu-agreement-checkbox"]').should('not.exist');
+
+    // London should not have the agreement
+    ui.regionSelect.find().click();
+    ui.regionSelect.findItemByRegionId('eu-west').click();
+    cy.get('[data-testid="eu-agreement-checkbox"]').should('not.exist');
+
+    // Newark should not have the agreement
+    ui.regionSelect.find().click();
+    ui.regionSelect.findItemByRegionId('us-east').click();
+    cy.get('[data-testid="eu-agreement-checkbox"]').should('not.exist');
+  });
+});

--- a/packages/manager/cypress/e2e/core/general/gdpr-agreement.spec.ts
+++ b/packages/manager/cypress/e2e/core/general/gdpr-agreement.spec.ts
@@ -1,7 +1,6 @@
 import { ui } from 'support/ui';
 import { regionFactory } from '@src/factories';
 import { authenticate } from 'support/api/authentication';
-import { cleanUp } from 'support/util/cleanup';
 import { mockGetRegions } from 'support/intercepts/regions';
 import { mockGetAccountAgreements } from 'support/intercepts/account';
 

--- a/packages/manager/cypress/e2e/core/general/gdpr-agreement.spec.ts
+++ b/packages/manager/cypress/e2e/core/general/gdpr-agreement.spec.ts
@@ -93,7 +93,7 @@ describe('GDPR agreement', () => {
     cy.get('[data-testid="eu-agreement-checkbox"]').should('not.exist');
   });
 
-  it.only('needs the agreement checked to validate the form', () => {
+  it('needs the agreement checked to validate the form', () => {
     mockGetRegions(mockRegions).as('getRegions');
     mockGetAccountAgreements({
       privacy_policy: false,

--- a/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
@@ -26,11 +26,6 @@ import {
 } from 'support/intercepts/linodes';
 
 import type { Region } from '@linode/api-v4';
-import {
-  mockAppendFeatureFlags,
-  mockGetFeatureFlagClientstream,
-} from 'support/intercepts/feature-flags';
-import { makeFeatureFlagData } from 'support/util/feature-flags';
 
 const mockRegions: Region[] = [
   regionFactory.build({

--- a/packages/manager/cypress/support/intercepts/account.ts
+++ b/packages/manager/cypress/support/intercepts/account.ts
@@ -11,14 +11,15 @@ import { makeResponse } from 'support/util/response';
 import type {
   Account,
   AccountSettings,
+  Agreements,
   CancelAccount,
   EntityTransfer,
+  Grants,
   Invoice,
   InvoiceItem,
   Payment,
   PaymentMethod,
   User,
-  Grants,
 } from '@linode/api-v4';
 
 /**
@@ -449,5 +450,21 @@ export const mockCancelAccountError = (
     'POST',
     apiMatcher('account/cancel'),
     makeErrorResponse(errorMessage, status)
+  );
+};
+
+/**
+ * Intercepts GET request to fetch the account agreements and mocks the response.
+ *
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetAccountAgreements = (
+  agreements: Agreements
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher(`account/agreements`),
+    makeResponse(agreements)
   );
 };

--- a/packages/manager/src/features/Account/Agreements/EUAgreementCheckbox.tsx
+++ b/packages/manager/src/features/Account/Agreements/EUAgreementCheckbox.tsx
@@ -47,8 +47,17 @@ export const EUAgreementCheckbox = (props: Props) => {
       display="flex"
       flexDirection="row"
     >
-      <Checkbox checked={checked} onChange={onChange} sx={checkboxStyle} />
-      <Typography style={{ marginLeft: 4 }}>
+      <Checkbox
+        checked={checked}
+        id="gdpr-checkbox"
+        onChange={onChange}
+        sx={checkboxStyle}
+      />
+      <Typography
+        component={'label'}
+        htmlFor="gdpr-checkbox"
+        style={{ marginLeft: 4 }}
+      >
         I have read and agree to the{' '}
         <Link to="https://www.linode.com/legal-privacy/">
           Linode Privacy Policy

--- a/packages/manager/src/features/Account/Agreements/EUAgreementCheckbox.tsx
+++ b/packages/manager/src/features/Account/Agreements/EUAgreementCheckbox.tsx
@@ -54,7 +54,7 @@ export const EUAgreementCheckbox = (props: Props) => {
         sx={checkboxStyle}
       />
       <Typography
-        component={'label'}
+        component="label"
         htmlFor="gdpr-checkbox"
         style={{ marginLeft: 4 }}
       >


### PR DESCRIPTION
## Description 📝
Small PR to add e2e coverage for the GDPR agreement panel.

Since we are using existing test accounts it is preferable to mock the response from `account/agreements`.

## Changes  🔄
- Add a new `gdpr-agreement.spec.ts`
- Add a new util to mock the response from `account/agreements`

### Reproduction steps

### Verification steps 
- pull code locally, run `yarn up` and `yarn cy:debug`, pick the `gdpr-agreement` test and run it

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [x] ♿  Providing accessibility support
