### PR TITLE
upcoming: [M3-7300] - Replace Linode details Analytics tab with Recharts

### DIFF
--- a/packages/manager/src/components/AreaChart/AreaChart.tsx
+++ b/packages/manager/src/components/AreaChart/AreaChart.tsx
@@ -18,6 +18,9 @@ import { AccessibleAreaChart } from 'src/components/AreaChart/AccessibleAreaChar
 import { Paper } from 'src/components/Paper';
 
 import { tooltipLabelFormatter, tooltipValueFormatter } from './utils';
+import MetricsDisplay from 'src/components/LineGraph/MetricsDisplay';
+import { StyledBottomLegend } from 'src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel';
+import { MetricsDisplayRow } from 'src/components/LineGraph/MetricsDisplay';
 
 interface AreaProps {
   color: string;
@@ -38,6 +41,7 @@ interface AreaChartProps {
   timezone: string;
   unit: string;
   xAxis: XAxisProps;
+  legendRows?: MetricsDisplayRow[];
 }
 
 const humanizeLargeData = (value: number) => {
@@ -60,6 +64,7 @@ export const AreaChart = (props: AreaChartProps) => {
     timezone,
     unit,
     xAxis,
+    legendRows,
   } = props;
 
   const theme = useTheme();
@@ -100,6 +105,14 @@ export const AreaChart = (props: AreaChartProps) => {
     return null;
   };
 
+  const CustomLegend = () => {
+    return legendRows ? (
+      <StyledBottomLegend>
+        <MetricsDisplay rows={legendRows} />
+      </StyledBottomLegend>
+    ) : null;
+  };
+
   const accessibleDataKeys = areas.map((area) => area.dataKey);
 
   return (
@@ -132,7 +145,7 @@ export const AreaChart = (props: AreaChartProps) => {
             }}
             content={<CustomTooltip />}
           />
-          {showLegend && (
+          {showLegend && !legendRows && (
             <Legend
               formatter={(value) => (
                 <span style={{ color: theme.color.label, cursor: 'pointer' }}>
@@ -144,6 +157,14 @@ export const AreaChart = (props: AreaChartProps) => {
               }}
               iconType="square"
               onClick={(props) => handleLegendClick(props.dataKey)}
+            />
+          )}
+          {showLegend && legendRows && (
+            <Legend
+              content={<CustomLegend />}
+              wrapperStyle={{
+                left: 20,
+              }}
             />
           )}
           {areas.map(({ color, dataKey }) => (

--- a/packages/manager/src/components/AreaChart/AreaChart.tsx
+++ b/packages/manager/src/components/AreaChart/AreaChart.tsx
@@ -41,7 +41,7 @@ interface AreaChartProps {
   timezone: string;
   unit: string;
   xAxis: XAxisProps;
-  legendRows?: MetricsDisplayRow[];
+  legendRows?: Omit<MetricsDisplayRow[], 'handleLegendClick'>;
 }
 
 const humanizeLargeData = (value: number) => {
@@ -106,11 +106,19 @@ export const AreaChart = (props: AreaChartProps) => {
   };
 
   const CustomLegend = () => {
-    return legendRows ? (
-      <StyledBottomLegend>
-        <MetricsDisplay rows={legendRows} />
-      </StyledBottomLegend>
-    ) : null;
+    if (legendRows) {
+      const legendRowsWithClickHandler = legendRows.map((legendRow) => ({
+        ...legendRow,
+        handleLegendClick: () => handleLegendClick(legendRow.legendTitle),
+      }));
+
+      return (
+        <StyledBottomLegend>
+          <MetricsDisplay rows={legendRowsWithClickHandler} />
+        </StyledBottomLegend>
+      );
+    }
+    return null;
   };
 
   const accessibleDataKeys = areas.map((area) => area.dataKey);

--- a/packages/manager/src/components/AreaChart/AreaChart.tsx
+++ b/packages/manager/src/components/AreaChart/AreaChart.tsx
@@ -114,7 +114,10 @@ export const AreaChart = (props: AreaChartProps) => {
 
       return (
         <StyledBottomLegend>
-          <MetricsDisplay rows={legendRowsWithClickHandler} />
+          <MetricsDisplay
+            rows={legendRowsWithClickHandler}
+            hiddenRows={activeSeries}
+          />
         </StyledBottomLegend>
       );
     }

--- a/packages/manager/src/components/LineGraph/MetricDisplay.styles.ts
+++ b/packages/manager/src/components/LineGraph/MetricDisplay.styles.ts
@@ -1,7 +1,7 @@
 import { Theme } from '@mui/material/styles';
 import { makeStyles } from 'tss-react/mui';
 
-export const useMetricsDiaplyStyles = makeStyles()((theme: Theme) => ({
+export const useMetricsDisplayStyles = makeStyles()((theme: Theme) => ({
   blue: {
     '&:before': {
       backgroundColor: theme.graphs.blue,
@@ -18,7 +18,7 @@ export const useMetricsDiaplyStyles = makeStyles()((theme: Theme) => ({
     },
   },
   legend: {
-    '& > div': {
+    '& > button': {
       '&:before': {
         content: '""',
         display: 'inline-block',

--- a/packages/manager/src/components/LineGraph/MetricDisplay.styles.ts
+++ b/packages/manager/src/components/LineGraph/MetricDisplay.styles.ts
@@ -1,60 +1,51 @@
-import { Theme } from '@mui/material/styles';
-import { makeStyles } from 'tss-react/mui';
+import { styled } from '@mui/material/styles';
 
-export const useMetricsDisplayStyles = makeStyles()((theme: Theme) => ({
-  blue: {
+import { Button } from 'src/components/Button/Button';
+import { Table } from 'src/components/Table';
+import { TableCell } from 'src/components/TableCell';
+import { omittedProps } from 'src/utilities/omittedProps';
+
+export const StyledTable = styled(Table, {
+  label: 'StyledTable',
+})(({ theme }) => ({
+  border: `1px solid ${theme.borderColors.borderTable}`,
+}));
+
+export const StyledTableCell = styled(TableCell, {
+  label: 'StyledTableCell',
+})(({ theme }) => ({
+  '& > button': {
     '&:before': {
-      backgroundColor: theme.graphs.blue,
+      content: '""',
+      display: 'inline-block',
+      height: 20,
+      marginRight: theme.spacing(1),
+      width: 20,
+    },
+    alignItems: 'center',
+    display: 'flex',
+    justifyContent: 'flex-start',
+    [theme.breakpoints.down('sm')]: {
+      padding: 0,
     },
   },
-  darkGreen: {
+}));
+
+export const StyledButton = styled(Button, {
+  label: 'StyledButton',
+  shouldForwardProp: omittedProps(['legendColor', 'hidden']),
+})<{ legendColor?: string }>(({ hidden, legendColor, theme }) => ({
+  ...(hidden && {
+    '&hover, &:focus': {
+      color: theme.textColors.tableStatic,
+      textDecoration: 'line-through',
+    },
+    color: theme.textColors.tableStatic,
+    textDecoration: 'line-through',
+  }),
+  ...(legendColor && {
     '&:before': {
-      backgroundColor: theme.graphs.network.inbound,
+      backgroundColor: theme.graphs[legendColor],
     },
-  },
-  green: {
-    '&:before': {
-      backgroundColor: theme.graphs.green,
-    },
-  },
-  legend: {
-    '& > button': {
-      '&:before': {
-        content: '""',
-        display: 'inline-block',
-        height: 20,
-        marginRight: theme.spacing(1),
-        width: 20,
-      },
-      alignItems: 'center',
-      display: 'flex',
-      justifyContent: 'flex-start',
-      [theme.breakpoints.down('sm')]: {
-        padding: 0,
-      },
-    },
-  },
-  lightGreen: {
-    '&:before': {
-      backgroundColor: theme.graphs.network.outbound,
-    },
-  },
-  purple: {
-    '&:before': {
-      backgroundColor: theme.graphs.purple,
-    },
-  },
-  red: {
-    '&:before': {
-      backgroundColor: theme.graphs.red,
-    },
-  },
-  root: {
-    border: `1px solid ${theme.borderColors.borderTable}`,
-  },
-  yellow: {
-    '&:before': {
-      backgroundColor: theme.graphs.yellow,
-    },
-  },
+  }),
 }));

--- a/packages/manager/src/components/LineGraph/MetricDisplay.styles.ts
+++ b/packages/manager/src/components/LineGraph/MetricDisplay.styles.ts
@@ -28,6 +28,10 @@ export const useMetricsDisplayStyles = makeStyles()((theme: Theme) => ({
       },
       alignItems: 'center',
       display: 'flex',
+      justifyContent: 'flex-start',
+      [theme.breakpoints.down('sm')]: {
+        padding: 0,
+      },
     },
   },
   lightGreen: {

--- a/packages/manager/src/components/LineGraph/MetricsDisplay.test.tsx
+++ b/packages/manager/src/components/LineGraph/MetricsDisplay.test.tsx
@@ -23,6 +23,7 @@ describe('CPUMetrics', () => {
           {
             data: mockMetrics,
             format: formatPercentage,
+            handleLegendClick: vi.fn(),
             legendColor: 'blue',
             legendTitle: 'Legend Title',
           },
@@ -40,6 +41,7 @@ describe('CPUMetrics', () => {
           {
             data: mockMetrics,
             format: formatPercentage,
+            handleLegendClick: vi.fn(),
             legendColor: 'blue',
             legendTitle: 'Legend Title',
           },
@@ -59,6 +61,7 @@ describe('CPUMetrics', () => {
           {
             data: mockMetrics,
             format: formatPercentage,
+            handleLegendClick: vi.fn(),
             legendColor: 'blue',
             legendTitle: 'Legend Title',
           },
@@ -77,6 +80,7 @@ describe('CPUMetrics', () => {
           {
             data: mockMetrics,
             format: formatPercentage,
+            handleLegendClick: vi.fn(),
             legendColor: 'blue',
             legendTitle: 'Legend Title',
           },
@@ -96,12 +100,14 @@ describe('CPUMetrics', () => {
           {
             data: mockMetrics,
             format: formatPercentage,
+            handleLegendClick: vi.fn(),
             legendColor: 'blue',
             legendTitle: 'Legend Title 1',
           },
           {
             data: { average: 90, last: 100, length: 0, max: 80, total: 110 },
             format: formatPercentage,
+            handleLegendClick: vi.fn(),
             legendColor: 'red',
             legendTitle: 'Legend Title 2',
           },

--- a/packages/manager/src/components/LineGraph/MetricsDisplay.tsx
+++ b/packages/manager/src/components/LineGraph/MetricsDisplay.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 
-import { Button } from 'src/components/Button/Button';
-import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
 import { TableCell } from 'src/components/TableCell';
 import { TableHead } from 'src/components/TableHead';
@@ -9,9 +7,14 @@ import { TableRow } from 'src/components/TableRow';
 import { Typography } from 'src/components/Typography';
 import { Metrics } from 'src/utilities/statMetrics';
 
-import { useMetricsDisplayStyles } from './MetricDisplay.styles';
+import {
+  StyledButton,
+  StyledTable,
+  StyledTableCell,
+} from './MetricDisplay.styles';
 
 interface Props {
+  hiddenRows?: string[];
   rows: MetricsDisplayRow[];
 }
 
@@ -30,21 +33,19 @@ export interface MetricsDisplayRow {
   legendTitle: string;
 }
 
-export const MetricsDisplay = ({ rows }: Props) => {
+export const MetricsDisplay = ({ hiddenRows, rows }: Props) => {
   const rowHeaders = ['Max', 'Avg', 'Last'];
-  const { classes } = useMetricsDisplayStyles();
+  const sxProps = {
+    borderTop: 'none !important',
+  };
 
   return (
-    <Table aria-label="Stats and metrics" className={classes.root}>
-      <TableHead sx={{ borderTop: 'none !important' }}>
-        <TableRow sx={{ borderTop: 'none !important' }}>
-          <TableCell sx={{ borderTop: 'none !important' }}>{''}</TableCell>
+    <StyledTable aria-label="Stats and metrics">
+      <TableHead sx={sxProps}>
+        <TableRow sx={sxProps}>
+          <TableCell sx={sxProps}>{''}</TableCell>
           {rowHeaders.map((section, idx) => (
-            <TableCell
-              data-qa-header-cell
-              key={idx}
-              sx={{ borderTop: 'none !important' }}
-            >
+            <TableCell data-qa-header-cell key={idx} sx={sxProps}>
               {section}
             </TableCell>
           ))}
@@ -59,17 +60,20 @@ export const MetricsDisplay = ({ rows }: Props) => {
             legendColor,
             legendTitle,
           } = row;
+          const hidden = hiddenRows?.includes(legendTitle);
+
           return (
             <TableRow data-qa-metric-row key={legendTitle}>
-              <TableCell className={classes.legend}>
-                <Button
-                  className={classes[legendColor]}
+              <StyledTableCell>
+                <StyledButton
                   data-testid="legend-title"
+                  hidden={hidden}
+                  legendColor={legendColor}
                   onClick={handleLegendClick}
                 >
                   <Typography component="span">{legendTitle}</Typography>
-                </Button>
-              </TableCell>
+                </StyledButton>
+              </StyledTableCell>
               {metricsBySection(data).map((section, idx) => {
                 return (
                   <TableCell
@@ -85,7 +89,7 @@ export const MetricsDisplay = ({ rows }: Props) => {
           );
         })}
       </TableBody>
-    </Table>
+    </StyledTable>
   );
 };
 

--- a/packages/manager/src/components/LineGraph/MetricsDisplay.tsx
+++ b/packages/manager/src/components/LineGraph/MetricsDisplay.tsx
@@ -13,7 +13,7 @@ interface Props {
   rows: MetricsDisplayRow[];
 }
 
-interface MetricsDisplayRow {
+export interface MetricsDisplayRow {
   data: Metrics;
   format: (n: number) => string;
   legendColor:

--- a/packages/manager/src/components/LineGraph/MetricsDisplay.tsx
+++ b/packages/manager/src/components/LineGraph/MetricsDisplay.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { Button } from 'src/components/Button/Button';
 import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
 import { TableCell } from 'src/components/TableCell';
@@ -7,7 +8,8 @@ import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
 import { Typography } from 'src/components/Typography';
 import { Metrics } from 'src/utilities/statMetrics';
-import { useMetricsDiaplyStyles } from './MetricDisplay.styles';
+
+import { useMetricsDisplayStyles } from './MetricDisplay.styles';
 
 interface Props {
   rows: MetricsDisplayRow[];
@@ -16,6 +18,7 @@ interface Props {
 export interface MetricsDisplayRow {
   data: Metrics;
   format: (n: number) => string;
+  handleLegendClick?: () => void;
   legendColor:
     | 'blue'
     | 'darkGreen'
@@ -29,7 +32,7 @@ export interface MetricsDisplayRow {
 
 export const MetricsDisplay = ({ rows }: Props) => {
   const rowHeaders = ['Max', 'Avg', 'Last'];
-  const { classes } = useMetricsDiaplyStyles();
+  const { classes } = useMetricsDisplayStyles();
 
   return (
     <Table aria-label="Stats and metrics" className={classes.root}>
@@ -49,16 +52,23 @@ export const MetricsDisplay = ({ rows }: Props) => {
       </TableHead>
       <TableBody>
         {rows.map((row) => {
-          const { data, format, legendColor, legendTitle } = row;
+          const {
+            data,
+            format,
+            handleLegendClick,
+            legendColor,
+            legendTitle,
+          } = row;
           return (
             <TableRow data-qa-metric-row key={legendTitle}>
               <TableCell className={classes.legend}>
-                <div
+                <Button
                   className={classes[legendColor]}
                   data-testid="legend-title"
+                  onClick={handleLegendClick}
                 >
                   <Typography component="span">{legendTitle}</Typography>
-                </div>
+                </Button>
               </TableCell>
               {metricsBySection(data).map((section, idx) => {
                 return (

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -125,7 +125,7 @@ const LinodeSummary: React.FC<Props> = (props) => {
       }, []);
 
       return (
-        <Box marginLeft={-4} marginTop={2}>
+        <Box marginLeft={-5} marginTop={2}>
           <AreaChart
             areas={[
               {
@@ -188,6 +188,59 @@ const LinodeSummary: React.FC<Props> = (props) => {
       io: stats?.data.io.io ?? [],
       swap: stats?.data.io.swap ?? [],
     };
+    const timeData = [];
+
+    // @TODO recharts: remove conditional code and delete old chart when we decide recharts is stable
+    if (flags.recharts) {
+      for (let i = 0; i < data.io.length; i++) {
+        timeData.push({
+          'I/O Rate': data.io[i][1],
+          'Swap Rate': data.swap[i][1],
+          timestamp: data.io[i][0],
+        });
+      }
+
+      return (
+        <Box marginLeft={-4} marginTop={2}>
+          <AreaChart
+            areas={[
+              {
+                color: theme.graphs.diskIO.read,
+                dataKey: 'I/O Rate',
+              },
+              {
+                color: theme.graphs.diskIO.swap,
+                dataKey: 'Swap Rate',
+              },
+            ]}
+            legendRows={[
+              {
+                data: getMetrics(data.io),
+                format: formatNumber,
+                legendColor: 'yellow',
+                legendTitle: 'I/O Rate',
+              },
+              {
+                data: getMetrics(data.swap),
+                format: formatNumber,
+                legendColor: 'red',
+                legendTitle: 'Swap Rate',
+              },
+            ]}
+            xAxis={{
+              tickFormat: 'hh a',
+              tickGap: 60,
+            }}
+            ariaLabel="Network Traffic Graph"
+            data={timeData}
+            height={342}
+            showLegend
+            timezone={timezone}
+            unit={' blocks/s'}
+          />
+        </Box>
+      );
+    }
 
     return (
       <LineGraph
@@ -315,7 +368,7 @@ const LinodeSummary: React.FC<Props> = (props) => {
                 {...chartProps}
               />
             </StyledGrid>
-            <StyledGrid xs={12}>
+            <StyledGrid recharts={flags.recharts} xs={12}>
               <StatsPanel
                 renderBody={renderDiskIOChart}
                 title="Disk I/O (blocks/s)"

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -125,7 +125,7 @@ const LinodeSummary: React.FC<Props> = (props) => {
       }, []);
 
       return (
-        <Box marginLeft={-5} marginTop={2}>
+        <Box marginLeft={-4} marginTop={2}>
           <AreaChart
             areas={[
               {
@@ -231,7 +231,7 @@ const LinodeSummary: React.FC<Props> = (props) => {
               tickFormat: 'hh a',
               tickGap: 60,
             }}
-            ariaLabel="Network Traffic Graph"
+            ariaLabel="Disk I/O Graph"
             data={timeData}
             height={342}
             showLegend

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -44,7 +44,7 @@ interface Props {
 }
 
 const chartHeight = 160;
-const rechartsHeight = 260;
+const rechartsHeight = 300;
 
 const LinodeSummary: React.FC<Props> = (props) => {
   const { isBareMetalInstance, linodeCreated } = props;
@@ -125,7 +125,7 @@ const LinodeSummary: React.FC<Props> = (props) => {
       }, []);
 
       return (
-        <Box marginLeft={-4} marginTop={3}>
+        <Box marginLeft={-4} marginTop={2}>
           <AreaChart
             areas={[
               {
@@ -308,7 +308,7 @@ const LinodeSummary: React.FC<Props> = (props) => {
             spacing={4}
             xs={12}
           >
-            <StyledGrid xs={12}>
+            <StyledGrid recharts={flags.recharts} xs={12}>
               <StatsPanel
                 renderBody={renderCPUChart}
                 title="CPU (%)"
@@ -334,14 +334,17 @@ const StyledSelect = styled(Select, { label: 'StyledSelect' })({
   maxWidth: 150,
 });
 
-const StyledGrid = styled(Grid, { label: 'StyledGrid' })(({ theme }) => ({
+const StyledGrid = styled(Grid, {
+  label: 'StyledGrid',
+  shouldForwardProp: (prop) => prop !== 'recharts',
+})<{ recharts?: boolean }>(({ recharts, theme }) => ({
   '& h2': {
     fontSize: '1rem',
   },
   '&.MuiGrid-item': {
     padding: theme.spacing(2),
   },
-  backgroundColor: theme.bg.offWhite,
+  backgroundColor: recharts ? 'transparent' : theme.bg.offWhite,
   border: `solid 1px ${theme.borderColors.divider}`,
   marginBottom: theme.spacing(2),
   [theme.breakpoints.up(1100)]: {

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/NetworkGraphs.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/NetworkGraphs.tsx
@@ -1,9 +1,11 @@
 import { Stats } from '@linode/api-v4/lib/linodes';
 import Grid from '@mui/material/Unstable_Grid2';
-import { styled, useTheme, Theme } from '@mui/material/styles';
+import { Theme, styled, useTheme } from '@mui/material/styles';
 import { map, pathOr } from 'ramda';
 import * as React from 'react';
 
+import { AreaChart } from 'src/components/AreaChart/AreaChart';
+import { Box } from 'src/components/Box';
 import { LineGraph } from 'src/components/LineGraph/LineGraph';
 import {
   convertNetworkToUnit,
@@ -11,12 +13,14 @@ import {
   formatNetworkTooltip,
   generateNetworkUnits,
 } from 'src/features/Longview/shared/utilities';
+import { useFlags } from 'src/hooks/useFlags';
 import {
   Metrics,
   getMetrics,
   getTotalTraffic,
 } from 'src/utilities/statMetrics';
 import { readableBytes } from 'src/utilities/unitConversions';
+
 import { StatsPanel } from './StatsPanel';
 
 export interface TotalTrafficProps {
@@ -68,6 +72,7 @@ export const NetworkGraphs = (props: Props) => {
   const { rangeSelection, stats, ...rest } = props;
 
   const theme = useTheme();
+  const flags = useFlags();
 
   const v4Data: NetworkStats = {
     privateIn: pathOr([], ['data', 'netv4', 'private_in'], stats),
@@ -135,7 +140,7 @@ export const NetworkGraphs = (props: Props) => {
 
   return (
     <StyledGraphGrid container spacing={4} xs={12}>
-      <StyledGrid xs={12}>
+      <StyledGrid recharts={flags.recharts} xs={12}>
         <StatsPanel
           renderBody={() => (
             <Graph
@@ -151,7 +156,7 @@ export const NetworkGraphs = (props: Props) => {
           {...rest}
         />
       </StyledGrid>
-      <StyledGrid xs={12}>
+      <StyledGrid recharts={flags.recharts} xs={12}>
         <StatsPanel
           renderBody={() => (
             <Graph
@@ -195,6 +200,8 @@ const Graph = (props: GraphProps) => {
     unit,
   } = props;
 
+  const flags = useFlags();
+
   const format = formatBitsPerSecond;
 
   const convertNetworkData = (value: number) => {
@@ -216,6 +223,81 @@ const Graph = (props: GraphProps) => {
   const convertedPublicOut = data.publicOut;
   const convertedPrivateIn = data.privateIn;
   const convertedPrivateOut = data.privateOut;
+  const timeData = [];
+
+  for (let i = 0; i < data.publicIn.length; i++) {
+    timeData.push({
+      'Private In': convertNetworkData(data.privateIn[i][1]),
+      'Private Out': convertNetworkData(data.privateOut[i][1]),
+      'Public In': convertNetworkData(data.publicIn[i][1]),
+      'Public Out': convertNetworkData(data.publicOut[i][1]),
+      timestamp: data.publicIn[i][0],
+    });
+  }
+
+  // @TODO recharts: remove conditional code and delete old chart when we decide recharts is stable
+  if (flags.recharts) {
+    return (
+      <Box marginLeft={-4} marginTop={2}>
+        <AreaChart
+          areas={[
+            {
+              color: theme.graphs.network.inbound,
+              dataKey: 'Public In',
+            },
+            {
+              color: theme.graphs.network.outbound,
+              dataKey: 'Public Out',
+            },
+            {
+              color: theme.graphs.purple,
+              dataKey: 'Private In',
+            },
+            {
+              color: theme.graphs.yellow,
+              dataKey: 'Private Out',
+            },
+          ]}
+          legendRows={[
+            {
+              data: metrics.publicIn,
+              format,
+              legendColor: 'darkGreen',
+              legendTitle: 'Public In',
+            },
+            {
+              data: metrics.publicOut,
+              format,
+              legendColor: 'green',
+              legendTitle: 'Public Out',
+            },
+            {
+              data: metrics.privateIn,
+              format,
+              legendColor: 'purple',
+              legendTitle: 'Private In',
+            },
+            {
+              data: metrics.privateOut,
+              format,
+              legendColor: 'yellow',
+              legendTitle: 'Private Out',
+            },
+          ]}
+          xAxis={{
+            tickFormat: 'hh a',
+            tickGap: 60,
+          }}
+          ariaLabel={ariaLabel}
+          data={timeData}
+          height={442}
+          showLegend
+          timezone={timezone}
+          unit={' Kb/s'}
+        />
+      </Box>
+    );
+  }
 
   return (
     <LineGraph
@@ -275,14 +357,17 @@ const Graph = (props: GraphProps) => {
   );
 };
 
-const StyledGrid = styled(Grid, { label: 'StyledGrid' })(({ theme }) => ({
+const StyledGrid = styled(Grid, {
+  label: 'StyledGrid',
+  shouldForwardProp: (prop) => prop !== 'recharts',
+})<{ recharts?: boolean }>(({ recharts, theme }) => ({
   '& h2': {
     fontSize: '1rem',
   },
   '&.MuiGrid-item': {
     padding: theme.spacing(2),
   },
-  backgroundColor: theme.bg.offWhite,
+  backgroundColor: recharts ? 'transparent' : theme.bg.offWhite,
   border: `solid 1px ${theme.borderColors.divider}`,
   [theme.breakpoints.down(1100)]: {
     '&:first-of-type': {

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/NetworkGraphs.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/NetworkGraphs.tsx
@@ -242,11 +242,11 @@ const Graph = (props: GraphProps) => {
         <AreaChart
           areas={[
             {
-              color: theme.graphs.network.inbound,
+              color: theme.graphs.darkGreen,
               dataKey: 'Public In',
             },
             {
-              color: theme.graphs.network.outbound,
+              color: theme.graphs.lightGreen,
               dataKey: 'Public Out',
             },
             {
@@ -268,7 +268,7 @@ const Graph = (props: GraphProps) => {
             {
               data: metrics.publicOut,
               format,
-              legendColor: 'green',
+              legendColor: 'lightGreen',
               legendTitle: 'Public Out',
             },
             {
@@ -303,13 +303,13 @@ const Graph = (props: GraphProps) => {
     <LineGraph
       data={[
         {
-          backgroundColor: theme.graphs.network.inbound,
+          backgroundColor: theme.graphs.darkGreen,
           borderColor: 'transparent',
           data: convertedPublicIn,
           label: 'Public In',
         },
         {
-          backgroundColor: theme.graphs.network.outbound,
+          backgroundColor: theme.graphs.lightGreen,
           borderColor: 'transparent',
           data: convertedPublicOut,
           label: 'Public Out',

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Apache/ApacheGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Apache/ApacheGraphs.tsx
@@ -113,7 +113,7 @@ export const ApacheGraphs = React.memo((props: Props) => {
               <LongviewLineGraph
                 data={[
                   {
-                    backgroundColor: theme.graphs.network.outbound,
+                    backgroundColor: theme.graphs.lightGreen,
                     borderColor: 'transparent',
                     data: _convertData(
                       totalKBytes,

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/MySQL/MySQLGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/MySQL/MySQLGraphs.tsx
@@ -111,13 +111,13 @@ export const MySQLGraphs = (props: Props) => {
               <LongviewLineGraph
                 data={[
                   {
-                    backgroundColor: theme.graphs.network.inbound,
+                    backgroundColor: theme.graphs.darkGreen,
                     borderColor: 'transparent',
                     data: _convertData(inbound, start, end),
                     label: 'Inbound',
                   },
                   {
-                    backgroundColor: theme.graphs.network.outbound,
+                    backgroundColor: theme.graphs.lightGreen,
                     borderColor: 'transparent',
                     data: _convertData(outbound, start, end),
                     label: 'Outbound',

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Network/NetworkGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Network/NetworkGraphs.tsx
@@ -78,13 +78,13 @@ export const NetworkGraphs = (props: Props) => {
               <LongviewLineGraph
                 data={[
                   {
-                    backgroundColor: theme.graphs.network.inbound,
+                    backgroundColor: theme.graphs.darkGreen,
                     borderColor: 'transparent',
                     data: _convertData(rx_bytes, start, end),
                     label: 'Inbound',
                   },
                   {
-                    backgroundColor: theme.graphs.network.outbound,
+                    backgroundColor: theme.graphs.lightGreen,
                     borderColor: 'transparent',
                     data: _convertData(tx_bytes, start, end),
                     label: 'Outbound',

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
@@ -55,13 +55,13 @@ export const NetworkGraph = React.memo((props: GraphProps) => {
     <LongviewLineGraph
       data={[
         {
-          backgroundColor: theme.graphs.network.inbound,
+          backgroundColor: theme.graphs.darkGreen,
           borderColor: 'transparent',
           data: _convertData(rx_bytes, start, end),
           label: 'Inbound',
         },
         {
-          backgroundColor: theme.graphs.network.outbound,
+          backgroundColor: theme.graphs.lightGreen,
           borderColor: 'transparent',
           data: _convertData(tx_bytes, start, end),
           label: 'Outbound',

--- a/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedChartPanel.tsx
+++ b/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedChartPanel.tsx
@@ -148,11 +148,11 @@ const createTabs = (
                 <AreaChart
                   areas={[
                     {
-                      color: theme.graphs.network.inbound,
+                      color: theme.graphs.darkGreen,
                       dataKey: 'Network Traffic In',
                     },
                     {
-                      color: theme.graphs.network.outbound,
+                      color: theme.graphs.lightGreen,
                       dataKey: 'Network Traffic Out',
                     },
                   ]}
@@ -173,13 +173,13 @@ const createTabs = (
                 <LineGraph
                   data={[
                     {
-                      backgroundColor: theme.graphs.network.inbound,
+                      backgroundColor: theme.graphs.darkGreen,
                       borderColor: 'transparent',
                       data: formatData(data.net_in),
                       label: 'Network Traffic In',
                     },
                     {
-                      backgroundColor: theme.graphs.network.outbound,
+                      backgroundColor: theme.graphs.lightGreen,
                       borderColor: 'transparent',
                       data: formatData(data.net_out),
                       label: 'Network Traffic Out',

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -211,7 +211,7 @@ export const TablesPanel = () => {
 
     if (flags.recharts) {
       return (
-        <Box marginLeft={-4}>
+        <Box marginLeft={-3}>
           <AreaChart
             areas={[
               {

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -95,48 +95,57 @@ export const TablesPanel = () => {
         });
         return acc;
       }, []);
+
+      return (
+        <Box marginLeft={-3}>
+          <AreaChart
+            areas={[
+              {
+                color: theme.graphs.purple,
+                dataKey: 'Connections',
+              },
+            ]}
+            legendRows={[
+              {
+                data: metrics,
+                format: formatNumber,
+                legendColor: 'purple',
+                legendTitle: 'Connections',
+              },
+            ]}
+            xAxis={{
+              tickFormat: 'hh a',
+              tickGap: 60,
+            }}
+            ariaLabel="Connections Graph"
+            data={timeData}
+            height={412}
+            showLegend
+            timezone={timezone}
+            unit={' CXN/s'}
+          />
+        </Box>
+      );
     }
 
     return (
-      <React.Fragment>
-        {flags.recharts ? (
-          <Box marginLeft={-3}>
-            <AreaChart
-              areas={[
-                {
-                  color: theme.graphs.purple,
-                  dataKey: 'Connections',
-                },
-              ]}
-              xAxis={{
-                tickFormat: 'hh a',
-                tickGap: 60,
-              }}
-              ariaLabel="Connections Graph"
-              data={timeData}
-              height={300}
-              timezone={timezone}
-              unit={' CXN/s'}
-            />
-          </Box>
-        ) : (
-          <StyledChart>
-            <LineGraph
-              data={[
-                {
-                  backgroundColor: theme.graphs.purple,
-                  borderColor: 'transparent',
-                  data,
-                  label: 'Connections',
-                },
-              ]}
-              accessibleDataTable={{ unit: 'CXN/s' }}
-              ariaLabel="Connections Graph"
-              showToday={true}
-              timezone={timezone}
-            />
-          </StyledChart>
-        )}
+      <>
+        <StyledChart>
+          <LineGraph
+            data={[
+              {
+                backgroundColor: theme.graphs.purple,
+                borderColor: 'transparent',
+                data,
+                label: 'Connections',
+              },
+            ]}
+            accessibleDataTable={{ unit: 'CXN/s' }}
+            ariaLabel="Connections Graph"
+            showToday={true}
+            timezone={timezone}
+          />
+        </StyledChart>
         <StyledBottomLegend>
           <MetricsDisplay
             rows={[
@@ -149,7 +158,7 @@ export const TablesPanel = () => {
             ]}
           />
         </StyledBottomLegend>
-      </React.Fragment>
+      </>
     );
   };
 
@@ -200,55 +209,72 @@ export const TablesPanel = () => {
       return <Loading />;
     }
 
+    if (flags.recharts) {
+      return (
+        <Box marginLeft={-4}>
+          <AreaChart
+            areas={[
+              {
+                color: theme.graphs.network.inbound,
+                dataKey: 'Traffic In',
+              },
+              {
+                color: theme.graphs.network.outbound,
+                dataKey: 'Traffic Out',
+              },
+            ]}
+            legendRows={[
+              {
+                data: getMetrics(trafficIn),
+                format: formatBitsPerSecond,
+                legendColor: 'darkGreen',
+                legendTitle: 'Traffic In',
+              },
+              {
+                data: getMetrics(trafficOut),
+                format: formatBitsPerSecond,
+                legendColor: 'lightGreen',
+                legendTitle: 'Traffic Out',
+              },
+            ]}
+            xAxis={{
+              tickFormat: 'hh a',
+              tickGap: 60,
+            }}
+            ariaLabel="Network Traffic Graph"
+            data={timeData}
+            height={412}
+            showLegend
+            timezone={timezone}
+            unit={' bits/s'}
+          />
+        </Box>
+      );
+    }
+
     return (
       <React.Fragment>
         <StyledChart>
-          {flags.recharts ? (
-            <Box marginLeft={-4}>
-              <AreaChart
-                areas={[
-                  {
-                    color: theme.graphs.network.inbound,
-                    dataKey: 'Traffic In',
-                  },
-                  {
-                    color: theme.graphs.network.outbound,
-                    dataKey: 'Traffic Out',
-                  },
-                ]}
-                xAxis={{
-                  tickFormat: 'hh a',
-                  tickGap: 60,
-                }}
-                ariaLabel="Traffic Graph"
-                data={timeData}
-                height={300}
-                timezone={timezone}
-                unit={' bits/s'}
-              />
-            </Box>
-          ) : (
-            <LineGraph
-              data={[
-                {
-                  backgroundColor: theme.graphs.network.inbound,
-                  borderColor: 'transparent',
-                  data: trafficIn,
-                  label: 'Traffic In',
-                },
-                {
-                  backgroundColor: theme.graphs.network.outbound,
-                  borderColor: 'transparent',
-                  data: trafficOut,
-                  label: 'Traffic Out',
-                },
-              ]}
-              accessibleDataTable={{ unit: 'bits/s' }}
-              ariaLabel="Traffic Graph"
-              showToday={true}
-              timezone={timezone}
-            />
-          )}
+          <LineGraph
+            data={[
+              {
+                backgroundColor: theme.graphs.network.inbound,
+                borderColor: 'transparent',
+                data: trafficIn,
+                label: 'Traffic In',
+              },
+              {
+                backgroundColor: theme.graphs.network.outbound,
+                borderColor: 'transparent',
+                data: trafficOut,
+                label: 'Traffic Out',
+              },
+            ]}
+            accessibleDataTable={{ unit: 'bits/s' }}
+            ariaLabel="Traffic Graph"
+            showToday={true}
+            timezone={timezone}
+          />
         </StyledChart>
         <StyledBottomLegend>
           <MetricsDisplay

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -215,11 +215,11 @@ export const TablesPanel = () => {
           <AreaChart
             areas={[
               {
-                color: theme.graphs.network.inbound,
+                color: theme.graphs.darkGreen,
                 dataKey: 'Traffic In',
               },
               {
-                color: theme.graphs.network.outbound,
+                color: theme.graphs.lightGreen,
                 dataKey: 'Traffic Out',
               },
             ]}
@@ -258,13 +258,13 @@ export const TablesPanel = () => {
           <LineGraph
             data={[
               {
-                backgroundColor: theme.graphs.network.inbound,
+                backgroundColor: theme.graphs.darkGreen,
                 borderColor: 'transparent',
                 data: trafficIn,
                 label: 'Traffic In',
               },
               {
-                backgroundColor: theme.graphs.network.outbound,
+                backgroundColor: theme.graphs.lightGreen,
                 borderColor: 'transparent',
                 data: trafficOut,
                 label: 'Traffic Out',

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -316,7 +316,7 @@ const StyledChart = styled('div', {
   width: '100%',
 }));
 
-const StyledBottomLegend = styled('div', {
+export const StyledBottomLegend = styled('div', {
   label: 'StyledBottomLegend',
 })(({ theme }) => ({
   backgroundColor: theme.bg.offWhite,

--- a/packages/manager/src/foundations/themes/dark.ts
+++ b/packages/manager/src/foundations/themes/dark.ts
@@ -542,15 +542,13 @@ export const darkTheme: ThemeOptions = {
       user: `rgb(81, 166, 245)`,
       wait: `rgb(145, 199, 237)`,
     },
+    darkGreen: `rgb(16, 162, 29)`,
     diskIO: {
       read: `rgb(255, 196, 105)`,
       swap: `rgb(238, 44, 44)`,
       write: `rgb(255, 179, 77)`,
     },
-    network: {
-      inbound: `rgb(16, 162, 29)`,
-      outbound: `rgb(49, 206, 62)`,
-    },
+    lightGreen: `rgb(49, 206, 62)`,
     purple: `rgb(217, 176, 217)`,
     red: `rgb(255, 99, 60)`,
     yellow: `rgb(255, 220, 125)`,

--- a/packages/manager/src/foundations/themes/light.ts
+++ b/packages/manager/src/foundations/themes/light.ts
@@ -1382,6 +1382,7 @@ export const lightTheme: ThemeOptions = {
       user: `rgba(81, 166, 245, ${graphTransparency})`,
       wait: `rgba(145, 199, 237, ${graphTransparency})`,
     },
+    darkGreen: `rgba(16, 162, 29, ${graphTransparency})`,
     diskIO: {
       read: `rgba(255, 196, 105, ${graphTransparency})`,
       swap: `rgba(238, 44, 44, ${graphTransparency})`,
@@ -1389,16 +1390,13 @@ export const lightTheme: ThemeOptions = {
     },
     green: `rgba(91, 215, 101, ${graphTransparency})`,
     inodes: `rgba(224, 138, 146, ${graphTransparency})`,
+    lightGreen: `rgba(49, 206, 62, ${graphTransparency})`,
     load: `rgba(255, 220, 77, ${graphTransparency})`,
     memory: {
       buffers: `rgba(142, 56, 142, ${graphTransparency})`,
       cache: `rgba(205, 150, 205, ${graphTransparency})`,
       swap: `rgba(238, 44, 44, ${graphTransparency})`,
       used: `rgba(236, 200, 236, ${graphTransparency})`,
-    },
-    network: {
-      inbound: `rgba(16, 162, 29, ${graphTransparency})`,
-      outbound: `rgba(49, 206, 62, ${graphTransparency})`,
     },
     orange: `rgba(255, 179, 77, ${graphTransparency})`,
     processCount: `rgba(113, 86, 245, ${graphTransparency})`,


### PR DESCRIPTION
## Description 📝
Replace Linode details Analytics charts with Recharts

- CPU % chart
- Disk I/O chart
- Network Transfer charts (IPv4 & IPv6)

## Changes  🔄
List any change relevant to the reviewer.
- Updated UI charts for the Linode details Analytics tab
- Added custom legend logic to AreaChart
- Migrate MetricDisplay styles to styled components

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/115299789/5e693603-afde-4945-9cf8-36fcd497e73a) | ![image](https://github.com/linode/manager/assets/115299789/ead68364-91c3-44d9-b59e-8d22b4f75f76) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Have a Linode that's been running for a while

### Verification steps 
(How to verify changes)
- Go to a Linode's details page. On the Analytics tab, verify the updated UI and that there are no regressions in the graph, units, functionality, etc.
  - Note: X and Y axis labels will not match exactly but the graph data is still the same

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support