### PR TITLE
feat: [M3-7563] – Add proper support for OBJ Access Key events

### DIFF
--- a/packages/manager/.changeset/pr-10038-added-1704495369939.md
+++ b/packages/manager/.changeset/pr-10038-added-1704495369939.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Proper support for OBJ Access Key events ([#10038](https://github.com/linode/manager/pull/10038))

--- a/packages/manager/src/features/Events/eventMessageGenerator.ts
+++ b/packages/manager/src/features/Events/eventMessageGenerator.ts
@@ -666,6 +666,15 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   oauth_client_update: {
     notification: (e) => `OAuth App ${e.entity!.label} has been updated.`,
   },
+  obj_access_key_create: {
+    notification: (e) => `Access Key ${e.entity!.label} has been created.`,
+  },
+  obj_access_key_delete: {
+    notification: (e) => `Access Key ${e.entity!.label} has been deleted.`,
+  },
+  obj_access_key_update: {
+    notification: (e) => `Access Key ${e.entity!.label} has been updated.`,
+  },
   password_reset: {
     failed: (e) => `Password reset failed for Linode ${e.entity!.label}.`,
     finished: (e) => `Password has been reset on Linode ${e.entity!.label}.`,


### PR DESCRIPTION
## Description 📝
Add support for `obj_access_key_create`, `obj_access_key_delete`, and `obj_access_key_update` events so that they are properly formatted in the Events dropdown and Events landing page.

## Changes  🔄
- Add OBJ Access Key events to `eventMessageGenerator.ts`

## Preview 📷
<details>
<summary>Screenshot</summary>

![Screenshot 2024-01-05 at 5 51 26 PM](https://github.com/linode/manager/assets/114682940/e4bde24e-2a36-481c-a511-a6326b2521a9)
</details>

## How to test 🧪
### Verification steps 
- Create, edit, and delete an OBJ Access Key
- Observe: OBJ Access Key events should be properly formatted as shown in the screenshot in the Preview section

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support