### PR TITLE
fix: N/A - Correct closing tag typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <br />
   <br />
   Akamai Connected Cloud Manager
-</h2>
+</h3>
 
 <p align="center">
   <img alt="Linode Manager Code Coverage" src="https://cloud-manager-coverage.us-east-1.linodeobjects.com/badges.svg?v=1" />


### PR DESCRIPTION
## Description 📝
I noticed a typo in the README.md file where the closing tag for the header was incorrectly written as `</h2>` instead of `</h3>`. 

## Changes  🔄
List any change relevant to the reviewer.
- Corrected the closing tag for the header from `</h2>` to `</h3>`.

## Preview 📷
**Include a screenshot or screen recording of the change**

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| <img src="https://i.imgur.com/6W8drUu.png" /> | <img src="https://i.imgur.com/WybyOYg.png" /> |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- ...
- ...

### Reproduction steps
(How to reproduce the issue, if applicable)
- ...
- ...

### Verification steps 
(How to verify changes)
- ...
- ...

## As an Author I have considered 🤔

*Check all that apply*

- [X] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
