### PR TITLE
fix: [M3-7260] - Managed Summary layout

### DIFF
--- a/packages/manager/.changeset/pr-10042-fixed-1704748141170.md
+++ b/packages/manager/.changeset/pr-10042-fixed-1704748141170.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Managed Summary layout ([#10042](https://github.com/linode/manager/pull/10042))

--- a/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedChartPanel.styles.tsx
+++ b/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedChartPanel.styles.tsx
@@ -29,6 +29,9 @@ export const StyledGraphControlsDiv = styled('div', {
     top: 52,
     width: 1,
   },
+  alignItems: 'center',
+  display: 'flex',
+  minHeight: 460,
   position: 'relative',
   [theme.breakpoints.up('sm')]: {
     width: '60%',

--- a/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedChartPanel.tsx
+++ b/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedChartPanel.tsx
@@ -275,7 +275,11 @@ export const ManagedChartPanel = () => {
   }
 
   if (isLoading) {
-    return <CircleProgress />;
+    return (
+      <StyledGraphControlsDiv>
+        <CircleProgress />
+      </StyledGraphControlsDiv>
+    );
   }
 
   if (!data) {

--- a/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedDashboardCard.styles.tsx
+++ b/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedDashboardCard.styles.tsx
@@ -15,6 +15,7 @@ export const StyledMonitorStatusOuterGrid = styled(Grid, {
 export const StyledOuterContainerGrid = styled(Grid, {
   label: 'StyledOuterContainerGrid',
 })(({ theme }) => ({
+  background: theme.bg.bgPaper,
   flexDirection: 'column',
   margin: '-8px',
   [theme.breakpoints.up('sm')]: {

--- a/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedDashboardCard.styles.tsx
+++ b/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedDashboardCard.styles.tsx
@@ -15,8 +15,10 @@ export const StyledMonitorStatusOuterGrid = styled(Grid, {
 export const StyledOuterContainerGrid = styled(Grid, {
   label: 'StyledOuterContainerGrid',
 })(({ theme }) => ({
+  flexDirection: 'column',
   margin: '-8px',
   [theme.breakpoints.up('sm')]: {
+    flexDirection: 'row',
     flexWrap: 'nowrap',
     justifyContent: 'space-evenly',
   },


### PR DESCRIPTION
## Description 📝
Fix loading and dark mode styling for the Managed Summary tab

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/115299789/f67fa4ed-7ccd-4e6e-bbef-71c862aa10e3" /> | <video src="https://github.com/linode/manager/assets/115299789/9d76afd6-0c65-4c2f-aef8-c8b8117f1486" /> |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Have an account that's Managed (you can do so via admin)

### Reproduction steps
(How to reproduce the issue, if applicable)
- On another branch, go to `/managed/summary` and observe the styling loading blip
- The container background in dark mode does not match the graph.

### Verification steps 
(How to verify changes)
-  Go to `/managed/summary`, there should no longer be a styling loading blip.
- The container background in dark mode should now match the graph.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support