### PR TITLE
upcoming: [M3-7463] - Disable Billing access user permission for child users

### DIFF
--- a/packages/manager/.changeset/pr-10045-tests-1704834823931.md
+++ b/packages/manager/.changeset/pr-10045-tests-1704834823931.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add test coverage for Billing Access perms for Child users ([#10045](https://github.com/linode/manager/pull/10045))

--- a/packages/manager/.changeset/pr-10045-tests-1704834823931.md
+++ b/packages/manager/.changeset/pr-10045-tests-1704834823931.md
@@ -2,4 +2,4 @@
 "@linode/manager": Tests
 ---
 
-Add test coverage for Billing Access perms for Child users ([#10045](https://github.com/linode/manager/pull/10045))
+Add test coverage for Billing Access permission for Child accounts ([#10045](https://github.com/linode/manager/pull/10045))

--- a/packages/manager/.changeset/pr-10045-upcoming-features-1704814925607.md
+++ b/packages/manager/.changeset/pr-10045-upcoming-features-1704814925607.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Disable Billing Access user permission for Child accounts ([#10045](https://github.com/linode/manager/pull/10045))

--- a/packages/manager/cypress/e2e/core/account/user-permissions.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/user-permissions.spec.ts
@@ -9,8 +9,13 @@ import {
   mockUpdateUser,
   mockUpdateUserGrants,
 } from 'support/intercepts/account';
+import {
+  mockAppendFeatureFlags,
+  mockGetFeatureFlagClientstream,
+} from 'support/intercepts/feature-flags';
 import { ui } from 'support/ui';
 import { shuffleArray } from 'support/util/arrays';
+import { makeFeatureFlagData } from 'support/util/feature-flags';
 import { randomLabel } from 'support/util/random';
 
 // Message shown when user has unrestricted account acess.
@@ -470,6 +475,82 @@ describe('User permission management', () => {
                 .should('be.visible');
             });
         });
+      });
+  });
+
+  it.only('disables Read-Write and defaults to Read Only Billing Access for child account users with Parent/Child feature flag', () => {
+    const mockActiveUser = accountUserFactory.build({
+      username: 'unrestricted-child-user',
+      restricted: false,
+      user_type: 'child',
+    });
+
+    const mockRestrictedUser = {
+      ...mockActiveUser,
+      restricted: true,
+      username: 'restricted-child-user',
+    };
+
+    const mockUserGrants = grantsFactory.build({
+      global: { account_access: 'read_write' },
+    });
+
+    // TODO: Parent/Child - M3-7559 clean up when feature is live in prod and feature flag is removed.
+    mockAppendFeatureFlags({
+      parentChildAccountAccess: makeFeatureFlagData(true),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+
+    mockGetUsers([mockActiveUser, mockRestrictedUser]).as('getUsers');
+    mockGetUser(mockActiveUser).as('getUser');
+    mockGetUserGrants(mockActiveUser.username, mockUserGrants).as(
+      'getUserGrants'
+    );
+
+    // Navigate to Users & Grants page, find mock restricted user, click its "User Permissions" button.
+    cy.visitWithLogin('/account/users');
+    cy.wait('@getUsers');
+    cy.findByText(mockRestrictedUser.username)
+      .should('be.visible')
+      .closest('tr')
+      .within(() => {
+        ui.button
+          .findByTitle('User Permissions')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    cy.visitWithLogin(
+      `/account/users/${mockRestrictedUser.username}/permissions`
+    );
+    mockGetUser(mockRestrictedUser).as('getUser');
+    mockGetUserGrants(mockRestrictedUser.username, mockUserGrants);
+    cy.wait(['@getClientStream', '@getFeatureFlags']);
+
+    cy.get('[data-qa-global-section]')
+      .should('be.visible')
+      .within(() => {
+        // Confirm that 'Read-Write' Billing Access is disabled and 'Read Only' Billing Access is selected by default.
+        cy.get(`[data-qa-select-card-heading="Read-Write"]`)
+          .closest('[data-qa-selection-card]')
+          .should('be.visible')
+          .should('be.disabled')
+          .should('have.attr', 'data-qa-selection-card-checked', 'false');
+        assertBillingAccessSelected('Read Only');
+
+        // Switch billing access to "None" and confirm that "Read Only" has been deselected.
+        selectBillingAccess('None');
+        cy.get(`[data-qa-select-card-heading="Read Only"]`)
+          .closest('[data-qa-selection-card]')
+          .should('be.visible')
+          .should('have.attr', 'data-qa-selection-card-checked', 'false');
+
+        ui.button
+          .findByTitle('Save')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
       });
   });
 });

--- a/packages/manager/cypress/e2e/core/account/user-permissions.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/user-permissions.spec.ts
@@ -229,13 +229,13 @@ describe('User permission management', () => {
 
     ui.toast.assertMessage('User permissions successfully saved.');
 
-    // Smoke tests to confirm that "Global Permissions" and "Specific Permissions"
+    // Smoke tests to confirm that "General Permissions" and "Specific Permissions"
     // sections are visible.
+    cy.findByText('General Permissions').should('be.visible');
     cy.findByText(unrestrictedAccessMessage).should('not.exist');
     cy.get('[data-qa-global-section]')
       .should('be.visible')
       .within(() => {
-        cy.findByText('General Permissions').should('be.visible');
         cy.contains(
           'Configure the specific rights and privileges this user has within the account.'
         ).should('be.visible');

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -12,7 +12,7 @@ import { APIError } from '@linode/api-v4/lib/types';
 import { Paper } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
 import { WithSnackbarProps, withSnackbar } from 'notistack';
-import { compose, flatten, lensPath, omit, set, view } from 'ramda';
+import { compose, flatten, lensPath, omit, set } from 'ramda';
 import * as React from 'react';
 import { QueryClient } from 'react-query';
 import { compose as recompose } from 'recompose';
@@ -407,13 +407,8 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           <SelectionCard
             checked={
               grants.global.account_access === 'read_only' ||
-              Boolean(
-                this.state.isAccountAccessRestricted &&
-                  view<State, string>(
-                    lensPath(['grants', 'global', 'account_access']),
-                    this.state
-                  )
-              )
+              (this.state.isAccountAccessRestricted &&
+                Boolean(this.state.grants?.global.account_access))
             }
             data-qa-billing-access="Read Only"
             heading="Read Only"

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -407,11 +407,13 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           <SelectionCard
             checked={
               grants.global.account_access === 'read_only' ||
-              (this.state.isAccountAccessRestricted &&
-                view(
-                  lensPath(['grants', 'global', 'account_access']),
-                  this.state
-                ))
+              Boolean(
+                this.state.isAccountAccessRestricted &&
+                  view<State, string>(
+                    lensPath(['grants', 'global', 'account_access']),
+                    this.state
+                  )
+              )
             }
             data-qa-billing-access="Read Only"
             heading="Read Only"

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -157,6 +157,8 @@ class UserPermissions extends React.Component<CombinedProps, State> {
 
   checkAndEnableChildAccountAccess = async () => {
     const { currentUser: currentUsername, flags } = this.props;
+
+    // Current user is the active user on the account.
     if (currentUsername) {
       try {
         const currentUser = await getUser(currentUsername);

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -403,17 +403,23 @@ class UserPermissions extends React.Component<CombinedProps, State> {
             subheadings={['The user cannot view any billing information.']}
           />
           <SelectionCard
-            checked={grants.global.account_access === 'read_only'}
+            checked={
+              grants.global.account_access === 'read_only' ||
+              this.state.isAccountAccessRestricted
+            }
             data-qa-billing-access="Read Only"
             heading="Read Only"
             onClick={this.billingPermOnClick('read_only')}
             subheadings={['Can view invoices and billing info.']}
           />
           <SelectionCard
+            checked={
+              grants.global.account_access === 'read_write' &&
+              !this.state.isAccountAccessRestricted
+            }
             subheadings={[
               'Can make payments, update contact and billing info, and will receive copies of all invoices and payment emails.',
             ]}
-            checked={grants.global.account_access === 'read_write'}
             data-qa-billing-access="Read-Write"
             disabled={this.state.isAccountAccessRestricted}
             heading="Read-Write"

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -165,7 +165,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
         const isParentAccount = currentUser.user_type === 'parent';
         const isFeatureFlagOn = flags.parentChildAccountAccess;
 
-        // An parent user account should have a toggleable `child_account_access` grant for its restricted users.
+        // A parent user account should have a toggleable `child_account_access` grant for its restricted users.
         this.setState({
           childAccountAccessEnabled: Boolean(
             isParentAccount && isFeatureFlagOn

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -12,7 +12,7 @@ import { APIError } from '@linode/api-v4/lib/types';
 import { Paper } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
 import { WithSnackbarProps, withSnackbar } from 'notistack';
-import { compose, flatten, lensPath, omit, set } from 'ramda';
+import { compose, flatten, lensPath, omit, set, view } from 'ramda';
 import * as React from 'react';
 import { QueryClient } from 'react-query';
 import { compose as recompose } from 'recompose';
@@ -405,7 +405,11 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           <SelectionCard
             checked={
               grants.global.account_access === 'read_only' ||
-              this.state.isAccountAccessRestricted
+              (this.state.isAccountAccessRestricted &&
+                view(
+                  lensPath(['grants', 'global', 'account_access']),
+                  this.state
+                ))
             }
             data-qa-billing-access="Read Only"
             heading="Read Only"


### PR DESCRIPTION
## Description 📝
As a child user, the UI of the permissions page will be the same as global or non-parent/child, except for Billing Access. Billing Access will be set to "Read Only" with the option for unrestricted child users to switch it to "None" for other child users. "Read-Write" will always be disabled. In other words, child account users will have no permission greater than "Read Only" billing access.

**Why are we enforcing this in the UI, rather than relying on the `account_access` grant?**
For an unrestricted (admin) child account user's `account_access` (which determines Billing Access), the API will return `read_write` in order for the user to have access to the rest of the user permissions, including managing those of their proxy user. Therefore, we need to make an additional check of the `user_type` to ensure on the front-end that we actually restrict billing access for `child` users.

## Changes  🔄
- The Billing Access default setting is configured to "Read Only" for child users.
- Child users have the option to switch Billing Access to "None."
- The "Read-Write" option is consistently disabled and cannot be selected by child users.
- Adds test coverage for the above to `user-permissions.spec.ts`.

## Preview 📷
![Screenshot 2024-01-08 at 4 19 02 PM](https://github.com/linode/manager/assets/114685994/c7ed5571-4331-4d46-8e45-46652bb1cadd)

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Check out this PR and `yarn dev`.
- In devtools, make sure the feature flag is on and enable the MSW.
- Go to `serverHandlers.ts` and edit the `account/users/:user` request to the following in order to mock a **child** user:
```
  rest.get('*/account/users/:user', (req, res, ctx) => {
  // Parent/Child: switch the `user_type` depending on what account view you need to mock.
  return res(ctx.json(accountUserFactory.build({ user_type: 'child' })));
  }),
```

### Verification steps 
(How to verify changes)
- Go to http://localhost:3000/account/users and navigate to the User Permissions for a mock restricted user.
- Confirm the Changes described above.
- Toggle off the feature flag and confirm that Read-Write billing access is *not* disabled and *is* the default selection.
- Play around with the Billing Access options and make sure there are no regressions in the selected options (e.g. no more than one option can be selected at the same time).
- Verify test passes:
```
yarn cy:run -s "cypress/e2e/core/account/user-permissions.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
