### PR TITLE
fix: [M3-7624] - AGLB Configuration - Save button disabled when trying to remove a route

### DIFF
--- a/packages/manager/.changeset/pr-10048-upcoming-features-1704822100414.md
+++ b/packages/manager/.changeset/pr-10048-upcoming-features-1704822100414.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Fix AGLB Configuration "Save" button remaining disabled when trying to remove a route ([#10048](https://github.com/linode/manager/pull/10048))

--- a/packages/manager/cypress/e2e/core/loadBalancers/load-balancer-configurations.spec.ts
+++ b/packages/manager/cypress/e2e/core/loadBalancers/load-balancer-configurations.spec.ts
@@ -477,15 +477,19 @@ describe('Akamai Global Load Balancer configurations page', () => {
         .should('be.visible')
         .should('be.disabled');
 
-      cy.findByText('route-1')
+      const routeToDelete = routes[1];
+
+      cy.findByText(routeToDelete.label)
         .closest('tr')
         .within(() => {
-          ui.actionMenu.findByTitle('Action Menu for Route route-1').click();
+          ui.actionMenu
+            .findByTitle(`Action Menu for Route ${routeToDelete.label}`)
+            .click();
         });
 
       // Because the route table uses an API filter at all times to show the correct routes,
       // we must simulate the filtering by mocking.
-      const newRoutes = routes.filter((r) => r.label !== 'route-1');
+      const newRoutes = routes.filter((r) => r.label !== routeToDelete.label);
       mockGetLoadBalancerRoutes(loadbalancer.id, newRoutes).as('getRoutes');
 
       ui.actionMenuItem.findByTitle('Remove').click();

--- a/packages/manager/cypress/e2e/core/loadBalancers/load-balancer-configurations.spec.ts
+++ b/packages/manager/cypress/e2e/core/loadBalancers/load-balancer-configurations.spec.ts
@@ -495,6 +495,8 @@ describe('Akamai Global Load Balancer configurations page', () => {
         routes: newRoutes.map((r) => ({ id: r.id, label: r.label })),
       };
 
+      // Beacsue the configruations data will be invalidated and refetched,
+      // we must mock that the route was removed.
       mockGetLoadBalancerConfigurations(loadbalancer.id, [newConfiguration]).as(
         'getConfigurations'
       );

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ConfigurationForm.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ConfigurationForm.tsx
@@ -128,8 +128,9 @@ export const ConfigurationForm = (props: CreateProps | EditProps) => {
     if (!formik.values.route_ids) {
       return;
     }
-    formik.values.route_ids.splice(index, 1);
-    formik.setFieldValue('route_ids', formik.values.route_ids);
+    const newRouteIds = [...formik.values.route_ids];
+    newRouteIds.splice(index, 1);
+    formik.setFieldValue('route_ids', newRouteIds);
   };
 
   const handleAddCerts = (certificates: Configuration['certificates']) => {


### PR DESCRIPTION
## Description 📝
- The AGLB Configuration "Save Changes" button remained disabled even if they tried to remove a route from a configuration

## Preview 📷

| Before  | After   |
| ------- | ------- |
| "Save Changes" never becomes enabled after removing a route | The "Save Changes" button becomes enabled when a change is made | 
|  <video src="https://github.com/linode/manager/assets/115251059/374a5bb3-a4b0-4ec2-a9a5-3128747fd96d" /> | <video src="https://github.com/linode/manager/assets/115251059/870728cf-ad5b-41cb-ae1a-7c92da610a67" /> |

## How to test 🧪

### Prerequisites
- Use the dev environment
- Sign into the `dev-test-aglb` account
- Test using any AGLB on the test account

### Reproduction steps
- Go to the configurations tab on an AGLB
- Remove a route from a configuration using the action menu
- Observe that when you remove the route, you are unable to save changes

### Verification steps 
- Go to the configurations tab on an AGLB
- Remove a route from a configuration using the action menu
- Verify the "Save Changes" button becomes enabled
- Verify clicking Save Changes fires off a PUT, with the correct routes in the payload

> [!Warning]
> Due to an API bug, removing a route on a configuration does not currently work. We can still review this PR by just verifying the "Save Changes" button becomes active when it should

## As an Author I have considered 🤔

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support