### PR TITLE
fix: [M3-7307] Fix PrimaryNav marketplace navigation within Linode Create

### DIFF
--- a/packages/manager/.changeset/pr-10049-fixed-1704837468392.md
+++ b/packages/manager/.changeset/pr-10049-fixed-1704837468392.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Broken PrimaryNav marketplace navigation within Linode Create ([#10049](https://github.com/linode/manager/pull/10049))

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
@@ -235,6 +235,23 @@ export class LinodeCreate extends React.PureComponent<
     this.props.setTab(getInitialType());
   }
 
+  componentDidUpdate(prevProps: any) {
+    if (this.props.location.search === prevProps.location.search) {
+      return;
+    }
+
+    // This is for the case where a user is already on the create flow and click the "Marketplace" link in the PrimaryNav.
+    // Because it is the same route, the component will not unmount and remount, so we need to manually update the tab state.
+    // This fix provides an isolated solution for this specific case.
+    // Hard to make this dynamic without a larger refactor because the relationship between the tabs and the query params is not straightforward at all.
+    // ex: "One-Click" is `fromApp` creationType, and `fromImage` applies to both "Distributions" and "Images" creation flows so getting the index of the tab
+    // based on the query param is not reliable.
+    // It would be wise to consider rethinking this logic when we refactor the Linode Create flow. (M3-7572)
+    if (getInitialType() === 'fromApp') {
+      this.handleTabChange(1);
+    }
+  }
+
   componentWillUnmount() {
     this.mounted = false;
   }
@@ -434,7 +451,11 @@ export class LinodeCreate extends React.PureComponent<
               variant="error"
             />
           )}
-          <Tabs defaultIndex={selectedTab} onChange={this.handleTabChange}>
+          <Tabs
+            defaultIndex={selectedTab}
+            index={selectedTab}
+            onChange={this.handleTabChange}
+          >
             <TabLinkList tabs={this.tabs} />
             <TabPanels>
               <SafeTabPanel index={0}>


### PR DESCRIPTION
## Description 📝
This PR fixes a small bug in which a user within the linode create flow can't use the "Marketplace" link in the PrimaryNav.
I've left a code comment that explains the problem and why it was fixed this way.

## Changes  🔄
- Add a one time fix to update the selected tab when using the the "Marketplace" primary nav link

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/130582365/4a73f14d-f062-4710-bba3-c9670346b2b2" /> | <video src="https://github.com/linode/manager/assets/130582365/1dad4ffb-2068-49ec-89ab-ca56cff608d7" /> |

## How to test 🧪

### Reproduction steps
- Navigate to https://cloud.linode.com/linodes/create
- Click on the "Marketplace" primary nav item
- Notice nothing happens

### Verification steps 
- Pull code locally and run `yarn up`
- Navigate to http://localhost:3000/linodes/create
- Click on the "Marketplace" primary nav item
- Notice the proper tab being selected

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
