### PR TITLE
upcoming: [M3-7475] - Add Switch Account button to Account Landing page

### DIFF
--- a/packages/manager/.changeset/pr-10052-upcoming-features-1704993330964.md
+++ b/packages/manager/.changeset/pr-10052-upcoming-features-1704993330964.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add Switch Account button to Account Landing page for parent and proxy users ([#10052](https://github.com/linode/manager/pull/10052))

--- a/packages/manager/src/components/LandingHeader/LandingHeader.tsx
+++ b/packages/manager/src/components/LandingHeader/LandingHeader.tsx
@@ -61,6 +61,12 @@ export const LandingHeader = ({
   const labelTitle = title?.toString();
 
   const xsDown = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
+  const customXsDownBreakpoint = useMediaQuery((theme: Theme) =>
+    theme.breakpoints.down(636)
+  );
+  const customSmMdBetweenBreakpoint = useMediaQuery((theme: Theme) =>
+    theme.breakpoints.between(636, 'md')
+  );
 
   const docsAnalyticsLabel = analyticsLabel
     ? analyticsLabel
@@ -90,7 +96,11 @@ export const LandingHeader = ({
           <Grid
             sx={{
               flex: '1 1 auto',
-              marginLeft: xsDown ? theme.spacing(1) : undefined,
+              marginLeft: customSmMdBetweenBreakpoint
+                ? theme.spacing(2)
+                : customXsDownBreakpoint
+                ? theme.spacing(1)
+                : undefined,
             }}
             alignItems="center"
             display="flex"

--- a/packages/manager/src/components/LandingHeader/LandingHeader.tsx
+++ b/packages/manager/src/components/LandingHeader/LandingHeader.tsx
@@ -93,7 +93,6 @@ export const LandingHeader = ({
               marginLeft: xsDown ? theme.spacing(1) : undefined,
             }}
             alignItems="center"
-            data-qa-entity-header
             display="flex"
             flexWrap={xsDown ? 'wrap' : 'nowrap'}
             gap={3}

--- a/packages/manager/src/components/LandingHeader/LandingHeader.tsx
+++ b/packages/manager/src/components/LandingHeader/LandingHeader.tsx
@@ -140,5 +140,6 @@ export const LandingHeader = ({
 };
 
 const Actions = styled('div')(({ theme }) => ({
-  marginLeft: `${theme.spacing(2)}`,
+  display: 'flex',
+  marginLeft: theme.spacing(2),
 }));

--- a/packages/manager/src/components/LandingHeader/LandingHeader.tsx
+++ b/packages/manager/src/components/LandingHeader/LandingHeader.tsx
@@ -66,10 +66,6 @@ export const LandingHeader = ({
     ? analyticsLabel
     : `${title} Landing`;
 
-  const sxButton = {
-    marginLeft: theme.spacing(1),
-  };
-
   return (
     <Grid
       alignItems="center"
@@ -91,7 +87,18 @@ export const LandingHeader = ({
       </Grid>
       {!shouldHideDocsAndCreateButtons && (
         <Grid>
-          <Grid alignItems="center" container justifyContent="flex-end">
+          <Grid
+            sx={{
+              flex: '1 1 auto',
+              marginLeft: xsDown ? theme.spacing(1) : undefined,
+            }}
+            alignItems="center"
+            data-qa-entity-header
+            display="flex"
+            flexWrap={xsDown ? 'wrap' : 'nowrap'}
+            gap={3}
+            justifyContent="flex-end"
+          >
             {betaFeedbackLink && (
               <span
                 style={{
@@ -124,7 +131,6 @@ export const LandingHeader = ({
                     loading={loading}
                     onClick={onButtonClick}
                     onKeyPress={onButtonKeyPress}
-                    sx={sxButton}
                     {...buttonDataAttrs}
                   >
                     {createButtonText ?? `Create ${entity}`}
@@ -139,7 +145,7 @@ export const LandingHeader = ({
   );
 };
 
-const Actions = styled('div')(({ theme }) => ({
+const Actions = styled('div')(() => ({
   display: 'flex',
-  marginLeft: theme.spacing(2),
+  justifyContent: 'flex-end',
 }));

--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -116,7 +116,7 @@ const AccountLanding = () => {
   let idx = 0;
 
   const isBillingTabSelected = location.pathname.match(/billing/);
-  const isAccountSwitchable =
+  const canSwitchBetweenParentOrProxyAccount =
     flags.parentChildAccountAccess &&
     (user?.user_type === 'parent' || user?.user_type === 'proxy');
 
@@ -137,7 +137,7 @@ const AccountLanding = () => {
         history.replace('/account/billing/make-payment');
     }
     landingHeaderProps.disabledCreateButton = readOnlyAccountAccess;
-    landingHeaderProps.extraActions = isAccountSwitchable ? (
+    landingHeaderProps.extraActions = canSwitchBetweenParentOrProxyAccount ? (
       <SwitchAccountButton onClick={() => setIsDrawerOpen(true)} />
     ) : undefined;
   }

--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -118,7 +118,7 @@ const AccountLanding = () => {
   const isBillingTabSelected = location.pathname.match(/billing/);
   const isAccountSwitchable =
     flags.parentChildAccountAccess &&
-    (user?.user_type === 'parent' || user?.user_type === 'child');
+    (user?.user_type === 'parent' || user?.user_type === 'proxy');
 
   const landingHeaderProps: LandingHeaderProps = {
     breadcrumbProps: {

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.test.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.test.tsx
@@ -55,6 +55,9 @@ describe('SwitchAccountDrawer', () => {
 
   it('should display a list of child accounts', async () => {
     server.use(
+      rest.get('*/account/users/*', (req, res, ctx) => {
+        return res(ctx.json(accountUserFactory.build({ user_type: 'parent' })));
+      }),
       rest.get('*/account/child-accounts', (req, res, ctx) => {
         return res(
           ctx.json(

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
@@ -10,6 +10,7 @@ import { Stack } from 'src/components/Stack';
 import { useFlags } from 'src/hooks/useFlags';
 import { useChildAccounts } from 'src/queries/account';
 import { useAccountUser } from 'src/queries/accountUsers';
+import { useProfile } from 'src/queries/profile';
 import { authentication } from 'src/utilities/storage';
 
 interface Props {
@@ -19,7 +20,7 @@ interface Props {
 }
 
 export const SwitchAccountDrawer = (props: Props) => {
-  const { onClose, open, username } = props;
+  const { onClose, open } = props;
 
   const flags = useFlags();
 
@@ -27,7 +28,8 @@ export const SwitchAccountDrawer = (props: Props) => {
     onClose();
   };
 
-  const { data: user } = useAccountUser(username ?? '');
+  const { data: profile } = useProfile();
+  const { data: user } = useAccountUser(profile?.username ?? '');
 
   // From proxy accounts, make a request on behalf of the parent account to fetch child accounts.
   const headers =

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
@@ -10,7 +10,6 @@ import { Stack } from 'src/components/Stack';
 import { useFlags } from 'src/hooks/useFlags';
 import { useChildAccounts } from 'src/queries/account';
 import { useAccountUser } from 'src/queries/accountUsers';
-import { useProfile } from 'src/queries/profile';
 import { authentication } from 'src/utilities/storage';
 
 interface Props {
@@ -20,7 +19,7 @@ interface Props {
 }
 
 export const SwitchAccountDrawer = (props: Props) => {
-  const { onClose, open } = props;
+  const { onClose, open, username } = props;
 
   const flags = useFlags();
 
@@ -28,8 +27,7 @@ export const SwitchAccountDrawer = (props: Props) => {
     onClose();
   };
 
-  const { data: profile } = useProfile();
-  const { data: user } = useAccountUser(profile?.username ?? '');
+  const { data: user } = useAccountUser(username ?? '');
 
   // From proxy accounts, make a request on behalf of the parent account to fetch child accounts.
   const headers =


### PR DESCRIPTION
## Description 📝
This PR adds a convenient "Switch Account" button to the Account Landing page to allow an alternative and efficient way (aside from the user menu) to access the account switching drawer.

## Changes  🔄
- A 'Switch Account' button is now visible on the Billing Info tab of the Account Landing page for parent and proxy users

## Preview 📷

<details>
<summary>
Video
</summary>

https://github.com/linode/manager/assets/114685994/fac2174a-c225-46de-81cb-142cfbb92f20
</details>

![Screenshot 2024-01-10 at 10 48 33 AM](https://github.com/linode/manager/assets/114685994/ddd675e6-bd82-4dce-9269-96b11008f550)

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Check out this PR and `yarn dev`.
- Turn the parent/child feature flag and mocks on. 

### Verification steps 
(How to verify changes)
- Go to http://localhost:3000/account/billing and observe the Switch Account button.
- Click the button and observe that it opens and displays a list of child accounts. (By default, `user_type` is parent.)
- Go to `serverHandlers.ts` and edit the `account/users/:user` request to the following in order to mock a proxy user:
```
  rest.get('*/account/users/:user', (req, res, ctx) => {
  // Parent/Child: switch the `user_type` depending on what account view you need to mock.
  return res(ctx.json(accountUserFactory.build({ user_type: 'proxy' })));
  }),
```
- Confirm that clicking the button opens the drawer for a proxy user, and text includes a link back to parent account.
- Toggle off feature flag and confirm parity with prod.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

