### PR TITLE
fix: [M3-7630] - Fix Kubernetes Upgrade Flow

### DIFF
--- a/packages/manager/.changeset/pr-10057-fixed-1704983627685.md
+++ b/packages/manager/.changeset/pr-10057-fixed-1704983627685.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Kubernetes upgrade flow on Kubernetes details page ([#10057](https://github.com/linode/manager/pull/10057))

--- a/packages/manager/.changeset/pr-10057-tests-1704983693919.md
+++ b/packages/manager/.changeset/pr-10057-tests-1704983693919.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Improved Kubernetes version upgrade Cypress test ([#10057](https://github.com/linode/manager/pull/10057))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -112,7 +112,7 @@ describe('LKE cluster updates', () => {
    * - Confirms that Kubernetes upgrade prompt is shown when not up-to-date.
    * - Confirms that Kubernetes upgrade prompt is hidden when up-to-date.
    */
-  it.only('can upgrade Kubernetes engine version', () => {
+  it('can upgrade Kubernetes engine version', () => {
     const oldVersion = '1.25';
     const newVersion = '1.26';
 

--- a/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx
+++ b/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx
@@ -49,11 +49,11 @@ export const UpgradeDialog = (props: Props) => {
     }
   }, [isOpen]);
 
-  if (nextVersion === null) {
-    return null;
-  }
-
   const onSubmitUpgradeDialog = () => {
+    if (!nextVersion) {
+      setError('Your Kubernetes Cluster is already on the latest version.');
+      return;
+    }
     setSubmitting(true);
     setError(undefined);
     updateKubernetesCluster({


### PR DESCRIPTION
## Description 📝
- Fixes the Kubernetes Upgrade Flow
- This bug was not caught by our automated testing because we did not have full coverage for the upgrade flow 

## The Bug 🐛

- On the Kubernetes Upgrade flow on the Kubernetes Details page, users were not able to reach step 2 of the upgrade flow. The Upgrade dialog would close after submitting step 1. 
  - This was caused by us rendering `null` in our upgrade component when we still need to render step 2  
- **This bug only applies to the details page**
  - This was the case because on the details page, we passed the version of the cluster to the upgrade dialog from the React Query store, which caused the dialog to close immediately when the version updated. The reason this did not happen to the landing page is because the cluster's current version was stored in an intermediary state that was not reactive to the React Query cache.  

## The Solution 🔧

- Don't render `null` if the Kubernetes version is up to date. We must continue to render the component so that the user can reach step 2, which is recycling the nodes.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/115251059/4ffbb280-9414-4931-b79a-aad73a892bc3" /> | <video src="https://github.com/linode/manager/assets/115251059/59f29c86-8939-4b14-aa08-cd7500b1a4b7" /> |


## How to test 🧪

### Reproduction steps
- Create a Kubernetes Cluster with version 1.27
- Go to the details page for that Kubernetes cluster
- Try to upgrade the Kubernetes cluster to 1.28
- Observe that when you click "Upgrade Version", the dialog closes and no step 2 shows up ☹️

### Verification steps 
- Create a Kubernetes Cluster with version 1.27
- Go to the details page for that Kubernetes cluster
- Try to upgrade the Kubernetes cluster to 1.28
- Verify you can complete both step 1 and step 2 successfully 🎉

## As an Author I have considered 🤔

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support