### PR TITLE
feat: [M3-7564] – Update OBJ validation

### DIFF
--- a/packages/validation/.changeset/pr-10063-changed-1705088599651.md
+++ b/packages/validation/.changeset/pr-10063-changed-1705088599651.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Changed
+---
+
+Revised createObjectStorageKeysSchema to include optional 'regions' field ([#10063](https://github.com/linode/manager/pull/10063))

--- a/packages/validation/src/objectStorageKeys.schema.ts
+++ b/packages/validation/src/objectStorageKeys.schema.ts
@@ -1,4 +1,4 @@
-import { object, string } from 'yup';
+import { object, string, array } from 'yup';
 
 export const createObjectStorageKeysSchema = object({
   label: string()
@@ -6,4 +6,8 @@ export const createObjectStorageKeysSchema = object({
     .min(3, 'Label must be between 3 and 50 characters.')
     .max(50, 'Label must be between 3 and 50 characters.')
     .trim(),
+  regions: array()
+    .of(string())
+    .min(1, 'Regions must include at least one region')
+    .notRequired(),
 });


### PR DESCRIPTION
## Description 📝
Update OBJ validation to reflect the upcoming OBJ Multi-Cluster changes.

Changes to _createBucketSchema_, which were in scope for this ticket, were already made in https://github.com/linode/manager/pull/9976.

## Changes  🔄
- Add optional `regions` property in `createObjectStorageKeysSchema` (it cannot be an empty array nor null)

## How to test 🧪
### Verification steps
At this stage, the main concern is verifying that this change does not break existing functionality: you should still be able to create Access Keys as you can currently, with no unexpected errors in the UI or in the console.

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support