### PR TITLE
test: [M3-7482] - Add cypress tests to add users on "Users & Grants" page

### DIFF
--- a/packages/manager/cypress/support/intercepts/account.ts
+++ b/packages/manager/cypress/support/intercepts/account.ts
@@ -92,6 +92,15 @@ export const mockGetUser = (user: User): Cypress.Chainable<null> => {
 };
 
 /**
+ * Intercepts POST request to add an account user.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptAddUser = (): Cypress.Chainable<null> => {
+  return cy.intercept('POST', apiMatcher('account/users'));
+};
+
+/**
  * Intercepts PUT request to update account user information and mocks response.
  *
  * @param username - Username of user to update.

--- a/packages/manager/cypress/support/intercepts/account.ts
+++ b/packages/manager/cypress/support/intercepts/account.ts
@@ -92,12 +92,14 @@ export const mockGetUser = (user: User): Cypress.Chainable<null> => {
 };
 
 /**
- * Intercepts POST request to add an account user.
+ * Intercepts POST request to add an account user and mocks response.
+ *
+ * @param user - New user account info with which to mock response.
  *
  * @returns Cypress chainable.
  */
-export const interceptAddUser = (): Cypress.Chainable<null> => {
-  return cy.intercept('POST', apiMatcher('account/users'));
+export const mockAddUser = (user: User): Cypress.Chainable<null> => {
+  return cy.intercept('POST', apiMatcher('account/users'), makeResponse(user));
 };
 
 /**


### PR DESCRIPTION
## Description 📝
Add regression tests for adding users on `Users & Grants` page.

## Major Changes 🔄
- Add regression tests to add users on `Users & Grants` page.

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/account/user-permissions.spec.ts"
```