### PR TITLE
upcoming: [M3-7462] - User Permissions: Configure Billing Account Access

### DIFF
--- a/packages/manager/.changeset/pr-10069-upcoming-features-1705512789450.md
+++ b/packages/manager/.changeset/pr-10069-upcoming-features-1705512789450.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+User Permissions: Configure Billing Account Access ([#10069](https://github.com/linode/manager/pull/10069))

--- a/packages/manager/cypress/e2e/core/account/user-permissions.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/user-permissions.spec.ts
@@ -590,6 +590,8 @@ describe('User permission management', () => {
     mockGetUser(mockActiveUser);
     mockGetUserGrants(mockActiveUser.username, mockUserGrants);
     mockGetProfile(mockProfile);
+    mockGetUser(mockRestrictedUser);
+    mockGetUserGrants(mockRestrictedUser.username, mockUserGrants);
 
     // Navigate to Users & Grants page, find mock restricted user, click its "User Permissions" button.
     cy.visitWithLogin('/account/users');
@@ -605,11 +607,10 @@ describe('User permission management', () => {
           .click();
       });
 
-    cy.visitWithLogin(
+    cy.url().should(
+      'endWith',
       `/account/users/${mockRestrictedUser.username}/permissions`
     );
-    mockGetUser(mockRestrictedUser);
-    mockGetUserGrants(mockRestrictedUser.username, mockUserGrants);
     cy.wait(['@getClientStream', '@getFeatureFlags']);
 
     cy.get('[data-qa-global-section]')

--- a/packages/manager/cypress/e2e/core/account/user-permissions.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/user-permissions.spec.ts
@@ -622,7 +622,7 @@ describe('User permission management', () => {
           .should('be.enabled');
         assertBillingAccessSelected('Read-Write');
 
-        // Confirm that 'Read Only' and 'None' Billing Access is disabled
+        // Confirm that 'Read Only' and 'None' Billing Access are disabled
         cy.get(`[data-qa-select-card-heading="Read Only"]`)
           .closest('[data-qa-selection-card]')
           .should('be.visible')

--- a/packages/manager/cypress/e2e/core/account/user-permissions.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/user-permissions.spec.ts
@@ -559,7 +559,7 @@ describe('User permission management', () => {
       });
   });
 
-  it.only('disables "Ready Only" and "None" and defaults to "Read Write" Billing Access for "Proxy" account users with Parent/Child feature flag', () => {
+  it('disables "Read Only" and "None" and defaults to "Read Write" Billing Access for "Proxy" account users with Parent/Child feature flag', () => {
     const mockProfile = profileFactory.build({
       username: 'proxy-user',
     });

--- a/packages/manager/src/features/Users/UserDetail.tsx
+++ b/packages/manager/src/features/Users/UserDetail.tsx
@@ -250,10 +250,10 @@ export const UserDetail = () => {
           </SafeTabPanel>
           <SafeTabPanel index={1}>
             <UserPermissions
+              accountUsername={profile?.username}
               clearNewUser={clearNewUser}
-              currentUser={profile?.username}
+              currentUsername={username}
               queryClient={queryClient}
-              username={username}
             />
           </SafeTabPanel>
         </TabPanels>

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -248,7 +248,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   getUserType = async () => {
     const { currentUsername } = this.props;
 
-    // Current user is the active user on the account.
+    // Current user is the user whose permissions are currently being viewed.
     if (currentUsername) {
       try {
         const user = await getUser(currentUsername);

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -59,10 +59,10 @@ import {
   entityNameMap,
 } from './UserPermissionsEntitySection';
 interface Props {
+  accountUsername?: string;
   clearNewUser: () => void;
-  currentUser?: string;
+  currentUsername?: string;
   queryClient: QueryClient;
-  username?: string;
 }
 
 interface TabInfo {
@@ -71,10 +71,8 @@ interface TabInfo {
 }
 
 interface State {
-  childAccountAccessEnabled: boolean;
   errors?: APIError[];
   grants?: Grants;
-  isAccountAccessRestricted: boolean;
   isSavingEntity: boolean;
   isSavingGlobal: boolean;
   loading: boolean;
@@ -87,6 +85,7 @@ interface State {
   /* Large Account Support */
   showTabs?: boolean;
   tabs?: string[];
+  userType: null | string;
   vpcEnabled: boolean;
 }
 
@@ -98,7 +97,7 @@ type CombinedProps = Props &
 class UserPermissions extends React.Component<CombinedProps, State> {
   componentDidMount() {
     this.getUserGrants();
-    this.checkAndEnableChildAccountAccess();
+    this.getUserType();
 
     if (this.props.flags.vpc) {
       this.setState({ vpcEnabled: true });
@@ -108,19 +107,19 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   }
 
   componentDidUpdate(prevProps: CombinedProps) {
-    if (prevProps.username !== this.props.username) {
+    if (prevProps.currentUsername !== this.props.currentUsername) {
       this.getUserGrants();
-      this.checkAndEnableChildAccountAccess();
+      this.getUserType();
     }
   }
 
   render() {
     const { loading } = this.state;
-    const { username } = this.props;
+    const { currentUsername } = this.props;
 
     return (
       <React.Fragment>
-        <DocumentTitleSegment segment={`${username} - Permissions`} />
+        <DocumentTitleSegment segment={`${currentUsername} - Permissions`} />
         {loading ? <CircleProgress /> : this.renderBody()}
       </React.Fragment>
     );
@@ -151,42 +150,6 @@ class UserPermissions extends React.Component<CombinedProps, State> {
       /* apply all of them at once */
       if (updateFns.length) {
         this.setState((compose as any)(...updateFns));
-      }
-    }
-  };
-
-  checkAndEnableChildAccountAccess = async () => {
-    const { currentUser: currentUsername, flags } = this.props;
-
-    // Current user is the active user on the account.
-    if (currentUsername) {
-      try {
-        const currentUser = await getUser(currentUsername);
-
-        const isChildAccount = currentUser.user_type === 'child';
-        const isParentAccount = currentUser.user_type === 'parent';
-        const isFeatureFlagOn = flags.parentChildAccountAccess;
-
-        // A parent user account should have a toggleable `child_account_access` grant for its restricted users.
-        this.setState({
-          childAccountAccessEnabled: Boolean(
-            isParentAccount && isFeatureFlagOn
-          ),
-        });
-
-        // A child user account should have no more than `read_only` billing (account) access.
-        // Since API returns `read_write` for child users' `account_access` grant, we must manually disable the `read_write` Billing Access permission.
-        this.setState({
-          isAccountAccessRestricted: Boolean(isChildAccount && isFeatureFlagOn),
-        });
-      } catch (error) {
-        this.setState({
-          errors: getAPIErrorOrDefault(
-            error,
-            'Unknown error occurred while fetching user permissions. Try again later.'
-          ),
-        });
-        scrollErrorIntoView();
       }
     }
   };
@@ -245,9 +208,9 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     );
 
   getUserGrants = () => {
-    const { username } = this.props;
-    if (username) {
-      getGrants(username)
+    const { currentUsername } = this.props;
+    if (currentUsername) {
+      getGrants(currentUsername)
         .then((grants) => {
           if (grants.global) {
             const { showTabs, tabs } = this.getTabInformation(grants);
@@ -282,6 +245,29 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     }
   };
 
+  getUserType = async () => {
+    const { currentUsername } = this.props;
+
+    // Current user is the active user on the account.
+    if (currentUsername) {
+      try {
+        const user = await getUser(currentUsername);
+
+        this.setState({
+          userType: user.user_type,
+        });
+      } catch (error) {
+        this.setState({
+          errors: getAPIErrorOrDefault(
+            error,
+            'Unknown error occurred while fetching user permissions. Try again later.'
+          ),
+        });
+        scrollErrorIntoView();
+      }
+    }
+  };
+
   globalBooleanPerms = [
     'add_linodes',
     'add_nodebalancers',
@@ -304,13 +290,13 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   };
 
   onChangeRestricted = () => {
-    const { username } = this.props;
+    const { currentUsername } = this.props;
     this.setState({
       errors: [],
       loadingGrants: true,
     });
-    if (username) {
-      updateUser(username, { restricted: !this.state.restricted })
+    if (currentUsername) {
+      updateUser(currentUsername, { restricted: !this.state.restricted })
         .then((user) => {
           this.setState({
             restricted: user.restricted,
@@ -368,7 +354,10 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   };
 
   renderBillingPerm = () => {
-    const { grants } = this.state;
+    const { grants, userType } = this.state;
+    const isChildUser = userType === 'child';
+    const isProxyUser = userType === 'proxy';
+
     if (!(grants && grants.global)) {
       return null;
     }
@@ -400,6 +389,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           <SelectionCard
             checked={grants.global.account_access === null}
             data-qa-billing-access="None"
+            disabled={isProxyUser}
             heading="None"
             onClick={this.billingPermOnClick(null)}
             subheadings={['The user cannot view any billing information.']}
@@ -407,24 +397,23 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           <SelectionCard
             checked={
               grants.global.account_access === 'read_only' ||
-              (this.state.isAccountAccessRestricted &&
-                Boolean(this.state.grants?.global.account_access))
+              (isChildUser && Boolean(this.state.grants?.global.account_access))
             }
             data-qa-billing-access="Read Only"
+            disabled={isProxyUser}
             heading="Read Only"
             onClick={this.billingPermOnClick('read_only')}
             subheadings={['Can view invoices and billing info.']}
           />
           <SelectionCard
             checked={
-              grants.global.account_access === 'read_write' &&
-              !this.state.isAccountAccessRestricted
+              grants.global.account_access === 'read_write' && !isChildUser
             }
             subheadings={[
               'Can make payments, update contact and billing info, and will receive copies of all invoices and payment emails.',
             ]}
             data-qa-billing-access="Read-Write"
-            disabled={this.state.isAccountAccessRestricted}
+            disabled={isChildUser}
             heading="Read-Write"
             onClick={this.billingPermOnClick('read_write')}
           />
@@ -434,7 +423,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   };
 
   renderBody = () => {
-    const { currentUser, username } = this.props;
+    const { accountUsername, currentUsername } = this.props;
     const { errors, restricted } = this.state;
     const hasErrorFor = getAPIErrorFor({ restricted: 'Restricted' }, errors);
     const generalError = hasErrorFor('none');
@@ -459,13 +448,13 @@ class UserPermissions extends React.Component<CombinedProps, State> {
             <StyledSubHeaderGrid>
               <Toggle
                 tooltipText={
-                  username === currentUser
+                  currentUsername === accountUsername
                     ? 'You cannot restrict the current active user.'
                     : ''
                 }
                 aria-label="Toggle Full Account Access"
                 checked={!restricted}
-                disabled={username === currentUser}
+                disabled={currentUsername === accountUsername}
                 onChange={this.onChangeRestricted}
               />
             </StyledSubHeaderGrid>
@@ -504,7 +493,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
       permDescriptionMap['add_vpcs'] = 'Can add VPCs to this account';
     }
 
-    if (this.state.childAccountAccessEnabled) {
+    if (this.state.userType === 'parent') {
       permDescriptionMap['child_account_access'] =
         'Enable child account access';
     }
@@ -531,7 +520,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   renderGlobalPerms = () => {
     const { grants, isSavingGlobal } = this.state;
     if (
-      this.state.childAccountAccessEnabled &&
+      this.state.userType === 'parent' &&
       !this.globalBooleanPerms.includes('child_account_access')
     ) {
       this.globalBooleanPerms.push('child_account_access');
@@ -698,9 +687,9 @@ class UserPermissions extends React.Component<CombinedProps, State> {
 
   savePermsType = (type: string) => () => {
     this.setState({ errors: undefined });
-    const { clearNewUser, username } = this.props;
+    const { clearNewUser, currentUsername } = this.props;
     const { grants } = this.state;
-    if (!username || !(grants && grants[type])) {
+    if (!currentUsername || !(grants && grants[type])) {
       return this.setState({
         errors: [
           {
@@ -714,7 +703,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
 
     if (type === 'global') {
       this.setState({ isSavingGlobal: true });
-      updateGrants(username, { global: grants.global })
+      updateGrants(currentUsername, { global: grants.global })
         .then((grantsResponse) => {
           this.setState(
             compose<State, State, State>(
@@ -751,9 +740,9 @@ class UserPermissions extends React.Component<CombinedProps, State> {
 
   saveSpecificGrants = () => {
     this.setState({ errors: undefined, isSavingEntity: true });
-    const { username } = this.props;
+    const { currentUsername } = this.props;
     const { grants } = this.state;
-    if (!username || !grants) {
+    if (!currentUsername || !grants) {
       return this.setState({
         errors: [
           {
@@ -766,7 +755,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
 
     // You would think ramda could do a TS omit, but I guess not
     const requestPayload = omit(['global'], grants) as Omit<Grants, 'global'>;
-    updateGrants(username, requestPayload)
+    updateGrants(currentUsername, requestPayload)
       .then((grantsResponse) => {
         /* build array of update fns */
         let updateFns = this.entityPerms.map((entity) => {
@@ -823,13 +812,12 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   };
 
   state: State = {
-    childAccountAccessEnabled: false,
-    isAccountAccessRestricted: false,
     isSavingEntity: false,
     isSavingGlobal: false,
     loading: true,
     loadingGrants: false,
     setAllPerm: 'null',
+    userType: null,
     vpcEnabled: false,
   };
 }

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1283,6 +1283,9 @@ export const handlers = [
         ctx.json(
           grantsFactory.build({
             global: {
+              // The API returns 'read_write' for child account users' account access,
+              // On the frontend, we display 'read_only' and restrict child users from billing actions.
+              account_access: 'read_write',
               cancel_account: false,
             },
           })
@@ -1297,6 +1300,7 @@ export const handlers = [
         ctx.json(
           grantsFactory.build({
             global: {
+              account_access: 'read_write', // This is immutable for proxy users
               add_domains: false,
               add_firewalls: false,
               add_images: false,


### PR DESCRIPTION
## Description 📝
Depending on the type of user managing the account, we want to restrict account access to billing.
- Regular/Parent Account Users: No change, they can configure `None | Read Only | Read Write`.
- Child Account Users: Can configure `None | Read Only`, `Read Write` is disabled.
- Proxy Users: `Read Write` is enabled and immutable, `None | Read Only` are disabled. 

## Changes  🔄
- `currentUser` and `username` created ambiguity as to what user we're actually dealing with for permissions, so to provide clarity:
    - `currentUser` is now `accountUsername`
    - `username` is now `currentUsername` 
- Removed `checkAndEnableChildAccountAccess` and it's accompanying state properties since we can infer all this based on `user_type`.
    -  Removed from state: `childAccountAccessEnabled` and `isAccountAccessRestricted`
- Added `userType` to state
- Updated E2E tests to account for Proxy user Billing Access perms

## Preview 📷
**Include a screenshot or screen recording of the change**

| User Type  | Screenshot   |
| ------- | ------- |
| Normal / Parent | ![Screenshot 2024-01-17 at 11 58 58 AM](https://github.com/linode/manager/assets/125309814/52cacf9a-9617-4390-ac9d-16401b94d10c) |
| Child | ![Screenshot 2024-01-17 at 11 58 00 AM](https://github.com/linode/manager/assets/125309814/bde7c5e9-cc41-46d7-aad0-829547c58419) |
| Proxy | ![Screenshot 2024-01-17 at 11 58 32 AM](https://github.com/linode/manager/assets/125309814/d07fe4fc-a329-494a-9107-2fd5cfe76192) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Enable Parent / Child Account feature flag
- Turn on Mock Service Worker (MSW)
- Ensure that { user_type: 'parent' } in [serverHandlers.ts](https://github.com/linode/manager/blob/develop/packages/manager/src/mocks/serverHandlers.ts#L1267)

### Reproduction steps
(How to reproduce the issue, if applicable)
- Go to http://localhost:3000/account/users
- Go through all 4 user types: ChildUser, ParentUser, ParentCompany (Proxy), NonAdminUser (Normal Users)

### Verification steps 
(How to verify changes)
- Ensure as a Parent/NonAdminUser you can enable any billing account access perms
- Ensure as a Child user that `Read Write` is disabled, but other two perms are selectable.
- Ensure as a Proxy user that `Read Write` is enabled, but other two perms are disabled.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support