### PR TITLE
fix: [M3-7638] - VPC arguments in Linode Create flow CLI

### DIFF
--- a/packages/manager/.changeset/pr-10071-fixed-1705522697458.md
+++ b/packages/manager/.changeset/pr-10071-fixed-1705522697458.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+VPC arguments in Linode Create flow CLI ([#10071](https://github.com/linode/manager/pull/10071))

--- a/packages/manager/src/utilities/generate-cli.test.ts
+++ b/packages/manager/src/utilities/generate-cli.test.ts
@@ -8,6 +8,20 @@ const linodeData = {
   ...linodeRequest,
   authorized_users: ['Linny', 'Gritty'],
   backup_id: undefined,
+  interfaces: [
+    {
+      ipam_address: null,
+      ipv4: {
+        nat_1_1: 'any',
+        vpc: '123',
+      },
+      label: null,
+      primary: true,
+      purpose: 'vpc',
+      subnet_id: 8296,
+      vpc_id: 7403,
+    },
+  ],
   metadata: {
     user_data: 'cmVrbmpnYmloZXVma2xkbQpqZXZia2Y=',
   },
@@ -27,6 +41,7 @@ const linodeDataForCLI = `
   --type ${linodeRequest.type} \\
   --authorized_users Linny \\
   --authorized_users Gritty \\
+  --interfaces.ipam_address null  --interfaces.ipv4.nat_1_1 \"any\" --interfaces.ipv4.vpc \"123\" --interfaces.label null --interfaces.primary true --interfaces.purpose \"vpc\" --interfaces.subnet_id 8296 \\
   --metadata.user_data="cmVrbmpnYmloZXVma2xkbQpqZXZia2Y=" \\
   --stackscript_data '{"gh_username": "linode"}' \\
   --stackscript_id 10079

--- a/packages/manager/src/utilities/generate-cli.test.ts
+++ b/packages/manager/src/utilities/generate-cli.test.ts
@@ -41,7 +41,7 @@ const linodeDataForCLI = `
   --type ${linodeRequest.type} \\
   --authorized_users Linny \\
   --authorized_users Gritty \\
-  --interfaces.ipam_address null  --interfaces.ipv4.nat_1_1 \"any\" --interfaces.ipv4.vpc \"123\" --interfaces.label null --interfaces.primary true --interfaces.purpose \"vpc\" --interfaces.subnet_id 8296 \\
+  --interfaces.ipam_address null --interfaces.ipv4.nat_1_1 \"any\" --interfaces.ipv4.vpc \"123\" --interfaces.label null --interfaces.primary true --interfaces.purpose \"vpc\" --interfaces.subnet_id 8296 \\
   --metadata.user_data="cmVrbmpnYmloZXVma2xkbQpqZXZia2Y=" \\
   --stackscript_data '{"gh_username": "linode"}' \\
   --stackscript_id 10079

--- a/packages/manager/src/utilities/generate-cli.ts
+++ b/packages/manager/src/utilities/generate-cli.ts
@@ -22,17 +22,18 @@ const convertObjectToCLIArg = (data: {} | null) => {
 
 const parseObject = (key: string, value: {}) => {
   const parseIpv4Object = (_key: string, _value: ConfigInterfaceIPv4) => {
-    let ipv4ValueString = '';
+    const ipv4ValueStrings = [];
     if (_value.nat_1_1) {
-      ipv4ValueString =
-        ipv4ValueString +
-        ` --${key}.${_key}.nat_1_1 ${JSON.stringify(_value.nat_1_1)}`;
+      ipv4ValueStrings.push(
+        `--${key}.${_key}.nat_1_1 ${JSON.stringify(_value.nat_1_1)}`
+      );
     }
     if (_value.vpc) {
-      ipv4ValueString =
-        ipv4ValueString + ` --${key}.${_key}.vpc ${JSON.stringify(_value.vpc)}`;
+      ipv4ValueStrings.push(
+        `--${key}.${_key}.vpc ${JSON.stringify(_value.vpc)}`
+      );
     }
-    return ipv4ValueString.replace(/\s+/g, ' ');
+    return ipv4ValueStrings.join(' ');
   };
 
   const result = Object.entries(value)

--- a/packages/manager/src/utilities/generate-cli.ts
+++ b/packages/manager/src/utilities/generate-cli.ts
@@ -21,6 +21,7 @@ const convertObjectToCLIArg = (data: {} | null) => {
 };
 
 const parseObject = (key: string, value: {}) => {
+  // M3-7638: The Linode CLI does not currently accept interfaces.ipv4 as an object so we need to make them separate arguments
   const parseIpv4Object = (_key: string, _value: ConfigInterfaceIPv4) => {
     const ipv4ValueStrings = [];
     if (_value.nat_1_1) {
@@ -54,6 +55,7 @@ const parseArray = (key: string, value: any[]) => {
     results.push(
       value
         .map((item) => {
+          // M3-7638: vpc_id is not a valid argument. The subnet_id will be used in the backend to implicitly determine the VPC ID
           delete item.vpc_id;
           return parseObject('interfaces', item);
         })

--- a/packages/manager/src/utilities/generate-cli.ts
+++ b/packages/manager/src/utilities/generate-cli.ts
@@ -43,6 +43,7 @@ const parseObject = (key: string, value: {}) => {
       }
       return `--${key}.${_key} ${JSON.stringify(_value)}`;
     })
+    .filter((string) => string.length > 0)
     .join(' ');
   return result.padStart(result.length + 2);
 };


### PR DESCRIPTION
## Description 📝
The Linode CLI doesn't accept `interfaces.ipv4` as an object. Instead, it should be configured individually as `interfaces.ipv4.vpc` and `interfaces.ipv4.nat_1_1`. `interfaces.vpc_id` is also not a valid argument.

## Changes  🔄
- `interfaces.ipv4` object -> individual arguments 
- Removed `interfaces.vpc_id` from the Linode CLI command

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/115299789/2bfefd9b-eefc-41bc-be64-f7b95c980b23) | ![image](https://github.com/linode/manager/assets/115299789/17861307-0d7d-449e-bc01-f8f58d6ece72) |

## How to test 🧪

### Prerequisites
### Reproduction steps
(How to reproduce the issue, if applicable)
- On a different branch, go to `/linodes/create`. Fill out the form, add a VPC, and click the `Create Using Command Line` button. Notice how `--interfaces.ipv4` is an object.

### Verification steps 
(How to verify changes)
- Go to `/linodes/create`, fill out the form, add a VPC, and click the `Create Using Command Line` button. Notice how `--interfaces.ipv4` is no longer an object but separate arguments depending on the checkboxes selected
- There should be no regressions in terms of the data displayed (`nat_1_1` and `vpc`)

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support