### PR TITLE
change: [M3-7651] - Add Clone Linode power-off notice

### DIFF
--- a/packages/manager/.changeset/pr-10072-changed-1705529283172.md
+++ b/packages/manager/.changeset/pr-10072-changed-1705529283172.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Clone Linode power-off notice ([#10072](https://github.com/linode/manager/pull/10072))

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -15,6 +15,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'aglb', label: 'AGLB' },
   { flag: 'aglbFullCreateFlow', label: 'AGLB Full Create Flow' },
   { flag: 'dcGetWell', label: 'DC Get Well' },
+  { flag: 'linodeCloneUIChanges', label: 'Linode Clone UI Changes' },
   { flag: 'metadata', label: 'Metadata' },
   { flag: 'parentChildAccountAccess', label: 'Parent/Child Account' },
   { flag: 'selfServeBetas', label: 'Self Serve Betas' },

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -50,6 +50,7 @@ export interface Flags {
   firewallNodebalancer: boolean;
   ipv6Sharing: boolean;
   kubernetesDashboardAvailability: boolean;
+  linodeCloneUIChanges: boolean;
   linodeCreateWithFirewall: boolean;
   mainContentBanner: MainContentBanner;
   metadata: boolean;

--- a/packages/manager/src/features/Linodes/LinodesCreate/SelectLinodePanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/SelectLinodePanel.tsx
@@ -10,6 +10,7 @@ import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFoot
 import { Paper } from 'src/components/Paper';
 import { RenderGuard } from 'src/components/RenderGuard';
 import { SelectionCard } from 'src/components/SelectionCard/SelectionCard';
+import { Stack } from 'src/components/Stack';
 import { Typography } from 'src/components/Typography';
 
 export interface ExtendedLinode extends Linode {
@@ -71,12 +72,27 @@ const SelectLinodePanel = (props: Props) => {
         return (
           <>
             <StyledPaper data-qa-select-linode-panel>
-              {error && <Notice text={error} variant="error" />}
-              {notices &&
-                !disabled &&
-                notices.map((notice, i) => (
-                  <Notice key={i} text={notice.text} variant={notice.level} />
-                ))}
+              <Stack gap={0.5} mb={2}>
+                {error && (
+                  <Notice
+                    spacingBottom={0}
+                    spacingTop={0}
+                    text={error}
+                    variant="error"
+                  />
+                )}
+                {notices &&
+                  !disabled &&
+                  notices.map((notice, i) => (
+                    <Notice
+                      key={i}
+                      spacingBottom={0}
+                      spacingTop={0}
+                      text={notice.text}
+                      variant={notice.level}
+                    />
+                  ))}
+              </Stack>
               <Typography data-qa-select-linode-header variant="h2">
                 {!!header ? header : 'Select Linode'}
               </Typography>

--- a/packages/manager/src/features/Linodes/LinodesCreate/SelectLinodePanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/SelectLinodePanel.tsx
@@ -28,7 +28,7 @@ interface Props {
   handleSelection: (id: number, type: null | string, diskSize?: number) => void;
   header?: string;
   linodes: ExtendedLinode[];
-  notice?: Notice;
+  notices?: Notice[];
   selectedLinodeID?: number;
 }
 
@@ -39,7 +39,7 @@ const SelectLinodePanel = (props: Props) => {
     handleSelection,
     header,
     linodes,
-    notice,
+    notices,
     selectedLinodeID,
   } = props;
 
@@ -72,9 +72,11 @@ const SelectLinodePanel = (props: Props) => {
           <>
             <StyledPaper data-qa-select-linode-panel>
               {error && <Notice text={error} variant="error" />}
-              {notice && !disabled && (
-                <Notice text={notice.text} variant={notice.level} />
-              )}
+              {notices &&
+                !disabled &&
+                notices.map((notice, i) => (
+                  <Notice key={i} text={notice.text} variant={notice.level} />
+                ))}
               <Typography data-qa-select-linode-header variant="h2">
                 {!!header ? header : 'Select Linode'}
               </Typography>

--- a/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -120,13 +120,15 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
                   ),
                 filterLinodesWithBackups
               )(linodesData)}
-              notice={{
-                level: 'warning',
-                text: `This newly created Linode will be created with
+              notices={[
+                {
+                  level: 'warning',
+                  text: `This newly created Linode will be created with
                           the same password and SSH Keys (if any) as the original Linode.
                           Also note that this Linode will need to be manually booted after it finishes
                           provisioning.`,
-              }}
+                },
+              ]}
               disabled={disabled}
               error={hasErrorFor('linode_id')}
               handleSelection={this.handleLinodeSelect}

--- a/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -5,6 +5,7 @@ import VolumeIcon from 'src/assets/icons/entityIcons/volume.svg';
 import { Paper } from 'src/components/Paper';
 import { Placeholder } from 'src/components/Placeholder/Placeholder';
 import { buildQueryStringForLinodeClone } from 'src/features/Linodes/LinodesLanding/LinodeActionMenu';
+import { useFlags } from 'src/hooks/useFlags';
 import { extendType } from 'src/utilities/extendType';
 import { getAPIErrorFor } from 'src/utilities/getAPIErrorFor';
 
@@ -46,6 +47,8 @@ export const FromLinodeContent = (props: CombinedProps) => {
   const hasErrorFor = getAPIErrorFor(errorResources, errors);
 
   const history = useHistory();
+
+  const flags = useFlags();
 
   const updateSearchParams = (search: string) => {
     history.replace({ search });
@@ -105,11 +108,15 @@ export const FromLinodeContent = (props: CombinedProps) => {
                 text:
                   'This newly created Linode will be created with the same password and SSH Keys (if any) as the original Linode.',
               },
-              {
-                level: 'warning',
-                text:
-                  'To help avoid data corruption during the cloning process, we recommend powering off your Compute Instance prior to cloning.',
-              },
+              ...(flags.linodeCloneUIChanges
+                ? [
+                    {
+                      level: 'warning' as const,
+                      text:
+                        'To help avoid data corruption during the cloning process, we recommend powering off your Compute Instance prior to cloning.',
+                    },
+                  ]
+                : []),
             ]}
             data-qa-linode-panel
             disabled={userCannotCreateLinode}

--- a/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -2,12 +2,11 @@ import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 
 import VolumeIcon from 'src/assets/icons/entityIcons/volume.svg';
-import { Placeholder } from 'src/components/Placeholder/Placeholder';
 import { Paper } from 'src/components/Paper';
+import { Placeholder } from 'src/components/Placeholder/Placeholder';
 import { buildQueryStringForLinodeClone } from 'src/features/Linodes/LinodesLanding/LinodeActionMenu';
 import { extendType } from 'src/utilities/extendType';
 import { getAPIErrorFor } from 'src/utilities/getAPIErrorFor';
-import { StyledGrid } from './CommonTabbedContent.styles';
 
 import SelectLinodePanel from '../SelectLinodePanel';
 import {
@@ -16,6 +15,7 @@ import {
   WithLinodesTypesRegionsAndImages,
 } from '../types';
 import { extendLinodes } from '../utilities';
+import { StyledGrid } from './CommonTabbedContent.styles';
 
 const errorResources = {
   label: 'A label',
@@ -99,10 +99,18 @@ export const FromLinodeContent = (props: CombinedProps) => {
               extendedTypes,
               regionsData
             )}
-            notice={{
-              level: 'warning',
-              text: `This newly created Linode will be created with the same password and SSH Keys (if any) as the original Linode.`,
-            }}
+            notices={[
+              {
+                level: 'warning',
+                text:
+                  'This newly created Linode will be created with the same password and SSH Keys (if any) as the original Linode.',
+              },
+              {
+                level: 'warning',
+                text:
+                  'To help avoid data corruption during the cloning process, we recommend powering off your Compute Instance prior to cloning.',
+              },
+            ]}
             data-qa-linode-panel
             disabled={userCannotCreateLinode}
             error={hasErrorFor('linode_id')}


### PR DESCRIPTION
## Description 📝
This PR address sub-task 1 of M3-7580 Updates to Linode Clone UI.

I plan to release each sub-task directly to develop under a new feature flag, `linodeCloneUIChanges`.

## Changes  🔄
- Adds a new notice to the Clone Linodes flow recommending users power off their Linode before cloning

## Preview 📷

| Before  | After   |
| ------- | ------- |
|  ![Screenshot 2024-01-17 at 4 59 40 PM](https://github.com/linode/manager/assets/122488130/8ec559f5-fd1a-4b9e-ba97-700e86bd3cb8) |  ![Screenshot 2024-01-17 at 4 59 25 PM](https://github.com/linode/manager/assets/122488130/e7849b73-9ba7-4897-909d-b206fb35ccc4) |

## How to test 🧪

### Prerequisites
- Enable the "Linode Clone UI Changes" feature flag
- Navigate to the Create Linode flow
- Click on the "Clone Linode" tab
- Verify a notice appears recommending users power off their Linode before cloning

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
