### PR TITLE
fix: [M3-7638] - Standardize Copy Icon Color Variations in CopyableTextField

### DIFF
--- a/packages/manager/.changeset/pr-10073-fixed-1705544271675.md
+++ b/packages/manager/.changeset/pr-10073-fixed-1705544271675.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Review and Standardize Copy Icon Color Variations in CopyableTextField ([#10073](https://github.com/linode/manager/pull/10073))

--- a/packages/manager/.changeset/pr-10073-fixed-1705544271675.md
+++ b/packages/manager/.changeset/pr-10073-fixed-1705544271675.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Review and Standardize Copy Icon Color Variations in CopyableTextField ([#10073](https://github.com/linode/manager/pull/10073))
+Standardize Copy Icon Color Variations in CopyableTextField ([#10073](https://github.com/linode/manager/pull/10073))

--- a/packages/manager/src/components/CopyableTextField/CopyableTextField.tsx
+++ b/packages/manager/src/components/CopyableTextField/CopyableTextField.tsx
@@ -35,7 +35,6 @@ const StyledTextField = styled(TextField)(({ theme }) => ({
   },
   '.copyIcon': {
     '& svg': {
-      color: '#3683dc',
       height: 14,
       top: 1,
     },


### PR DESCRIPTION
## Description 📝
Standardize Copy Icon Color Variations in CopyableTextField.


## Preview 📷

| Before  | After   |
| ------- | ------- |
|![image](https://github.com/linode/manager/assets/119517080/2e9907d1-056d-4424-bf3f-72ceebeec8a2)| ![image](https://github.com/linode/manager/assets/119517080/4226b065-1583-43c5-a417-d0b637338a51) |
|![image](https://github.com/linode/manager/assets/119517080/6c6b3850-d5c2-43df-b455-ba1f292153c1)|![image](https://github.com/linode/manager/assets/119517080/c179cc49-ba6e-4d07-bcee-da284a376ad9) |

## How to test 🧪

### Verification steps 
(How to verify changes)
- Verify all references of CopyableTextField.
- Ensure there is no regression.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support


