### PR TITLE
changed: [M3-7663] - Remove unified migrations feature flag

### DIFF
--- a/packages/manager/.changeset/pr-10074-changed-1705590614132.md
+++ b/packages/manager/.changeset/pr-10074-changed-1705590614132.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Remove unified migrations feature flag ([#10074](https://github.com/linode/manager/pull/10074))

--- a/packages/manager/cypress/e2e/core/linodes/resize-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/resize-linode.spec.ts
@@ -17,9 +17,6 @@ describe('resize linode', () => {
   });
 
   it('resizes a linode by increasing size: warm migration', () => {
-    mockAppendFeatureFlags({
-      unifiedMigrations: makeFeatureFlagData(true),
-    }).as('getFeatureFlags');
     mockGetFeatureFlagClientstream().as('getClientStream');
 
     createLinode().then((linode) => {
@@ -44,9 +41,6 @@ describe('resize linode', () => {
   });
 
   it('resizes a linode by increasing size: cold migration', () => {
-    mockAppendFeatureFlags({
-      unifiedMigrations: makeFeatureFlagData(true),
-    }).as('getFeatureFlags');
     mockGetFeatureFlagClientstream().as('getClientStream');
     createLinode().then((linode) => {
       cy.intercept(
@@ -71,9 +65,6 @@ describe('resize linode', () => {
   });
 
   it('resizes a linode by increasing size when offline: cold migration', () => {
-    mockAppendFeatureFlags({
-      unifiedMigrations: makeFeatureFlagData(true),
-    }).as('getFeatureFlags');
     mockGetFeatureFlagClientstream().as('getClientStream');
     createLinode().then((linode) => {
       cy.visitWithLogin(`/linodes/${linode.id}`);

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -18,7 +18,6 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'metadata', label: 'Metadata' },
   { flag: 'parentChildAccountAccess', label: 'Parent/Child Account' },
   { flag: 'selfServeBetas', label: 'Self Serve Betas' },
-  { flag: 'unifiedMigrations', label: 'Unified Migrations' },
   { flag: 'vpc', label: 'VPC' },
   { flag: 'firewallNodebalancer', label: 'Firewall NodeBalancer' },
   { flag: 'recharts', label: 'Recharts' },

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -69,7 +69,6 @@ export interface Flags {
   taxCollectionBanner: TaxCollectionBanner;
   taxes: Taxes;
   tpaProviders: Provider[];
-  unifiedMigrations: boolean;
   vmPlacement: boolean;
   vpc: boolean;
 }

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -20,7 +20,6 @@ import { Typography } from 'src/components/Typography';
 import { resetEventsPolling } from 'src/eventsPolling';
 import { linodeInTransition } from 'src/features/Linodes/transitions';
 import { PlansPanel } from 'src/features/components/PlansPanel/PlansPanel';
-import { useFlags } from 'src/hooks/useFlags';
 import { useAllLinodeDisksQuery } from 'src/queries/linodes/disks';
 import {
   useLinodeQuery,
@@ -59,7 +58,6 @@ const migrationTypeOptions: { [key in MigrationTypes]: key } = {
 
 export const LinodeResize = (props: Props) => {
   const { linodeId, onClose, open } = props;
-  const flags = useFlags();
   const theme = useTheme();
 
   const { data: linode } = useLinodeQuery(
@@ -99,9 +97,7 @@ export const LinodeResize = (props: Props) => {
   const formik = useFormik<ResizeLinodePayload>({
     initialValues: {
       allow_auto_disk_resize: shouldEnableAutoResizeDiskOption(disks ?? [])[1],
-      migration_type: flags.unifiedMigrations
-        ? migrationTypeOptions.warm
-        : undefined,
+      migration_type: migrationTypeOptions.warm,
       type: '',
     },
     async onSubmit(values) {
@@ -118,9 +114,7 @@ export const LinodeResize = (props: Props) => {
        */
       await resizeLinode({
         allow_auto_disk_resize: values.allow_auto_disk_resize && !isSmaller,
-        migration_type: flags.unifiedMigrations
-          ? values.migration_type
-          : undefined,
+        migration_type: values.migration_type,
         type: values.type,
       });
       resetEventsPolling();
@@ -188,9 +182,7 @@ export const LinodeResize = (props: Props) => {
   const error = getError(resizeError);
 
   const resizeButtonProps: ButtonProps =
-    flags.unifiedMigrations &&
-    formik.values.migration_type === 'warm' &&
-    !isLinodeOffline
+    formik.values.migration_type === 'warm' && !isLinodeOffline
       ? {
           onClick: () => formik.handleSubmit(),
         }
@@ -247,14 +239,11 @@ export const LinodeResize = (props: Props) => {
             types={currentTypes.map(extendType)}
           />
         </Box>
-
-        {flags.unifiedMigrations && (
-          <UnifiedMigrationPanel
-            formik={formik}
-            isLinodeOffline={isLinodeOffline}
-            migrationTypeOptions={migrationTypeOptions}
-          />
-        )}
+        <UnifiedMigrationPanel
+          formik={formik}
+          isLinodeOffline={isLinodeOffline}
+          migrationTypeOptions={migrationTypeOptions}
+        />
         <Typography
           sx={{ alignItems: 'center', display: 'flex', minHeight: '44px' }}
           variant="h2"

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -42,8 +42,6 @@ import {
 } from './LinodeResize.utils';
 import { UnifiedMigrationPanel } from './LinodeResizeUnifiedMigrationPanel';
 
-import type { ButtonProps } from 'src/components/Button/Button';
-
 interface Props {
   linodeId?: number;
   linodeLabel?: string;
@@ -180,16 +178,6 @@ export const LinodeResize = (props: Props) => {
     types?.filter((thisType) => !Boolean(thisType.successor)) ?? [];
 
   const error = getError(resizeError);
-
-  const resizeButtonProps: ButtonProps =
-    formik.values.migration_type === 'warm' && !isLinodeOffline
-      ? {
-          onClick: () => formik.handleSubmit(),
-        }
-      : {
-          loading: isLoading,
-          type: 'submit',
-        };
 
   return (
     <Dialog
@@ -333,7 +321,8 @@ export const LinodeResize = (props: Props) => {
             }
             buttonType="primary"
             data-qa-resize
-            {...resizeButtonProps}
+            loading={isLoading}
+            type="submit"
           >
             Resize Linode
           </Button>


### PR DESCRIPTION
## Description 📝
Removed the Unified Migrations feature flag since the feature has been released.

## Changes  🔄
- Removed feature flag in E2E and Linode Resize
- Added loading state to submit button

## How to test 🧪

### Verification steps 
(How to verify changes)
- Attempt to resize a linode
- Observe resize panel is still showing
- Observe warm resizes still work