### PR TITLE
fix: [M3-7664] - Linode Action Buttons Incorrect Color in Dark Mode

### DIFF
--- a/packages/manager/.changeset/pr-10077-fixed-1705594578246.md
+++ b/packages/manager/.changeset/pr-10077-fixed-1705594578246.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Linode details action button color in dark mode ([#10077](https://github.com/linode/manager/pull/10077))

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailHeader.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailHeader.tsx
@@ -124,8 +124,8 @@ export const LinodeEntityDetailHeader = (
 
   const sxActionItem = {
     '&:hover': {
-      backgroundColor: theme.color.blueDTwhite,
-      color: theme.color.white,
+      backgroundColor: theme.color.blue,
+      color: '#fff',
     },
     color: theme.textColors.linkActiveLight,
     fontFamily: theme.font.normal,


### PR DESCRIPTION
## Description 📝

Fixes a dark mode bug for some Linode action buttons on the Linodes details page 🎨
I think this bug has been around for a few months.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-01-18 at 11 10 02 AM](https://github.com/linode/manager/assets/115251059/596d8f66-16b3-4cd5-b96e-d7e7874b88b5) | ![Screenshot 2024-01-18 at 11 10 08 AM](https://github.com/linode/manager/assets/115251059/bec8f231-0641-42a7-9dbc-14655baae06f)  |

## How to test 🧪

- Switch to Dark Mode 🌚
- Go to the Linodes details page on any Linode 
- Hover over one of the action buttons "Power off", "Reboot", or "Launch LISH Console"
- Verify that these buttons are the correct color
- Verify light mode is still the correct color ☀️

## As an Author I have considered 🤔

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support