### PR TITLE
change: [M3-7668] - Right align chart tooltip data points

### DIFF
--- a/packages/manager/.changeset/pr-10078-changed-1705616003861.md
+++ b/packages/manager/.changeset/pr-10078-changed-1705616003861.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Right align chart tooltip data points ([#10078](https://github.com/linode/manager/pull/10078))

--- a/packages/manager/src/components/AreaChart/AreaChart.tsx
+++ b/packages/manager/src/components/AreaChart/AreaChart.tsx
@@ -15,8 +15,9 @@ import {
 } from 'recharts';
 
 import { AccessibleAreaChart } from 'src/components/AreaChart/AccessibleAreaChart';
-import { MetricsDisplayRow } from 'src/components/LineGraph/MetricsDisplay';
+import { Box } from 'src/components/Box';
 import MetricsDisplay from 'src/components/LineGraph/MetricsDisplay';
+import { MetricsDisplayRow } from 'src/components/LineGraph/MetricsDisplay';
 import { Paper } from 'src/components/Paper';
 import { StyledBottomLegend } from 'src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel';
 
@@ -94,9 +95,18 @@ export const AreaChart = (props: AreaChartProps) => {
         <StyledTooltipPaper>
           <Typography>{tooltipLabelFormatter(label, timezone)}</Typography>
           {payload.map((item) => (
-            <Typography fontFamily={theme.font.bold} key={item.dataKey}>
-              {item.dataKey}: {tooltipValueFormatter(item.value, unit)}
-            </Typography>
+            <Box
+              display="flex"
+              justifyContent="space-between"
+              key={item.dataKey}
+            >
+              <Typography fontFamily={theme.font.bold}>
+                {item.dataKey}
+              </Typography>
+              <Typography fontFamily={theme.font.bold} marginLeft={2}>
+                {tooltipValueFormatter(item.value, unit)}
+              </Typography>
+            </Box>
           ))}
         </StyledTooltipPaper>
       );


### PR DESCRIPTION
## Description 📝
Right justify the chart tooltip datapoints so that they are more discernible as suggested by Kendall/Andrew

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/115299789/1acb4bae-f8bb-4c78-9ae4-4350f5321bed) | ![image](https://github.com/linode/manager/assets/115299789/9aa3ffee-e6f3-4ad7-b16c-5d18d819bc9b) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Have a Linode that's been running for a while

### Verification steps 
(How to verify changes)
- Hover over a chart (like in the Linode Details Analytics tab) to see the tooltip text. Data points should be right aligned

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support