### PR TITLE
upcoming: [M3-7599] - Update AGLB Configuration Ports Copy

### DIFF
--- a/packages/manager/.changeset/pr-10079-upcoming-features-1705615366001.md
+++ b/packages/manager/.changeset/pr-10079-upcoming-features-1705615366001.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update AGLB Configuration Port Copy ([#10079](https://github.com/linode/manager/pull/10079))

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ConfigurationForm.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ConfigurationForm.tsx
@@ -38,6 +38,7 @@ import type {
   CertificateConfig,
   Configuration,
   ConfigurationPayload,
+  Protocol,
 } from '@linode/api-v4';
 
 interface EditProps {
@@ -154,6 +155,33 @@ export const ConfigurationForm = (props: CreateProps | EditProps) => {
     reset();
   };
 
+  const handleProtocolChange = (protocol: Protocol) => {
+    // If the user has changed the port manually, just update the protocol and NOT the port.
+    if (hasChangedPort) {
+      return formik.setFieldValue('protocol', protocol);
+    }
+
+    let newPort = formik.values.port;
+
+    if (protocol === 'http') {
+      newPort = 80;
+    }
+
+    if (protocol === 'https') {
+      newPort = 443;
+    }
+
+    // Update the protocol and port at the same time if the port is unchanged.
+    formik.setFormikState((prev) => ({
+      ...prev,
+      values: {
+        ...prev.values,
+        port: newPort,
+        protocol,
+      },
+    }));
+  };
+
   const generalErrors = error?.reduce((acc, { field, reason }) => {
     if (
       !field ||
@@ -187,28 +215,7 @@ export const ConfigurationForm = (props: CreateProps | EditProps) => {
         <Stack direction="row" spacing={2}>
           <Autocomplete
             onChange={(e, { value }) => {
-              if (hasChangedPort) {
-                return formik.setFieldValue('protocol', value);
-              }
-
-              let newPort = formik.values.port;
-
-              if (value === 'http') {
-                newPort = 80;
-              }
-
-              if (value === 'https') {
-                newPort = 443;
-              }
-
-              formik.setFormikState((prev) => ({
-                ...prev,
-                values: {
-                  ...prev.values,
-                  port: newPort,
-                  protocol: value,
-                },
-              }));
+              handleProtocolChange(value);
             }}
             textFieldProps={{
               labelTooltipText: CONFIGURATION_COPY.Protocol,

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ConfigurationForm.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ConfigurationForm.tsx
@@ -173,9 +173,10 @@ export const ConfigurationForm = (props: CreateProps | EditProps) => {
         />
       )}
       <TextField
-        errorText={formik.errors.label}
+        errorText={formik.touched.label ? formik.errors.label : undefined}
         label="Configuration Label"
         name="label"
+        onBlur={formik.handleBlur}
         onChange={formik.handleChange}
         value={formik.values.label}
       />
@@ -195,10 +196,11 @@ export const ConfigurationForm = (props: CreateProps | EditProps) => {
             options={protocolOptions}
           />
           <TextField
-            errorText={formik.errors.port}
+            errorText={formik.touched.port ? formik.errors.port : undefined}
             label="Port"
             labelTooltipText={CONFIGURATION_COPY.Port}
             name="port"
+            onBlur={formik.handleBlur}
             onChange={formik.handleChange}
             type="number"
             value={formik.values.port}

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ConfigurationForm.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ConfigurationForm.tsx
@@ -65,6 +65,8 @@ export const ConfigurationForm = (props: CreateProps | EditProps) => {
   const [isAddRouteDrawerOpen, setIsAddRouteDrawerOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
+  const [hasChangedPort, setHasChangedPort] = useState(false);
+
   const [routesTableQuery, setRoutesTableQuery] = useState('');
 
   const loadbalancerId = Number(_loadbalancerId);
@@ -148,6 +150,7 @@ export const ConfigurationForm = (props: CreateProps | EditProps) => {
 
   const handleReset = () => {
     formik.resetForm();
+    setHasChangedPort(false);
     reset();
   };
 
@@ -183,6 +186,30 @@ export const ConfigurationForm = (props: CreateProps | EditProps) => {
       <Stack spacing={2}>
         <Stack direction="row" spacing={2}>
           <Autocomplete
+            onChange={(e, { value }) => {
+              if (hasChangedPort) {
+                return formik.setFieldValue('protocol', value);
+              }
+
+              let newPort = formik.values.port;
+
+              if (value === 'http') {
+                newPort = 80;
+              }
+
+              if (value === 'https') {
+                newPort = 443;
+              }
+
+              formik.setFormikState((prev) => ({
+                ...prev,
+                values: {
+                  ...prev.values,
+                  port: newPort,
+                  protocol: value,
+                },
+              }));
+            }}
             textFieldProps={{
               labelTooltipText: CONFIGURATION_COPY.Protocol,
             }}
@@ -192,16 +219,18 @@ export const ConfigurationForm = (props: CreateProps | EditProps) => {
             disableClearable
             errorText={formik.errors.protocol}
             label="Protocol"
-            onChange={(e, { value }) => formik.setFieldValue('protocol', value)}
             options={protocolOptions}
           />
           <TextField
+            onChange={(e) => {
+              formik.handleChange(e);
+              setHasChangedPort(true);
+            }}
             errorText={formik.touched.port ? formik.errors.port : undefined}
             label="Port"
             labelTooltipText={CONFIGURATION_COPY.Port}
             name="port"
             onBlur={formik.handleBlur}
-            onChange={formik.handleChange}
             type="number"
             value={formik.values.port}
           />

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/constants.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/constants.tsx
@@ -31,7 +31,7 @@ export const protocolOptions = [
   { label: 'HTTPS', value: 'https' },
   { label: 'HTTP', value: 'http' },
   { label: 'TCP', value: 'tcp' },
-] as const;
+];
 
 export const CONFIGURATION_COPY = {
   Certificates:

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/constants.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/constants.tsx
@@ -31,7 +31,7 @@ export const protocolOptions = [
   { label: 'HTTPS', value: 'https' },
   { label: 'HTTP', value: 'http' },
   { label: 'TCP', value: 'tcp' },
-];
+] as const;
 
 export const CONFIGURATION_COPY = {
   Certificates:

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/constants.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/constants.tsx
@@ -37,7 +37,7 @@ export const CONFIGURATION_COPY = {
   Certificates:
     'TLS termination certificates create an encrypted link between your clients and Global Load Balancer, and terminate incoming traffic on the load balancer. Once the load balancing policy is applied, traffic is forwarded to your service targets over encrypted TLS connections. Responses from your service targets to your clients are also encrypted.',
   Port:
-    'Set the inbound port value that the load balancer listens on to whichever port the client software will connect to. The port can be 1-65535.',
+    'Set the inbound port value that the load balancer listens on to whichever port the client will connect to. The port can be 1-65535.',
   Protocol: (
     <Typography>
       Set to either TCP, HTTP, or HTTPS. See{' '}

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/constants.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/constants.tsx
@@ -31,13 +31,13 @@ export const protocolOptions = [
   { label: 'HTTPS', value: 'https' },
   { label: 'HTTP', value: 'http' },
   { label: 'TCP', value: 'tcp' },
-];
+] as const;
 
 export const CONFIGURATION_COPY = {
   Certificates:
     'TLS termination certificates create an encrypted link between your clients and Global Load Balancer, and terminate incoming traffic on the load balancer. Once the load balancing policy is applied, traffic is forwarded to your service targets over encrypted TLS connections. Responses from your service targets to your clients are also encrypted.',
   Port:
-    'The inbound port that the load balancer listens on. Enter 80 as the port number for HTTP, 443 for HTTPs, and 0-1023 for TCP.',
+    'Set the inbound port value that the load balancer listens on to whichever port the client software will connect to. The port can be 1-65535.',
   Protocol: (
     <Typography>
       Set to either TCP, HTTP, or HTTPS. See{' '}


### PR DESCRIPTION
## Description 📝
- Updates AGLB Configuration Ports Copy
- Tweaks form error handling so that it matches the behavior of other dynamic forms
- Updates the `port` dynamically if you choose HTTP or HTTPS when you haven't provided a custom port

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-01-18 at 4 59 31 PM](https://github.com/linode/manager/assets/115251059/aa167043-b314-41ed-a9b9-dc69bff3ce1a) | ![Screenshot 2024-01-18 at 4 59 20 PM](https://github.com/linode/manager/assets/115251059/27a2c990-4d36-44b0-a28a-fa1aefec8e2e) |

## How to test 🧪

### Prerequisites
- Use the `dev-test-aglb` account
- Use the dev environment

### Verification steps 
- Go to http://localhost:3000/loadbalancers/13/configurations
- Click `Add Configuration`
- Check the copy on the ports field tooltip

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support