### PR TITLE
Release v1.110.0 - `release` → `staging` 

### DIFF
--- a/packages/api-v4/.changeset/pr-10008-added-1704919102710.md
+++ b/packages/api-v4/.changeset/pr-10008-added-1704919102710.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Added
----
-
-AGLB endpoint health endpoints ([#10008](https://github.com/linode/manager/pull/10008))

--- a/packages/api-v4/.changeset/pr-9869-added-1703002185530.md
+++ b/packages/api-v4/.changeset/pr-9869-added-1703002185530.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Added
----
-
-Ability to scale up Database instances ([#9869](https://github.com/linode/manager/pull/9869))

--- a/packages/api-v4/.changeset/pr-9996-changed-1702508393416.md
+++ b/packages/api-v4/.changeset/pr-9996-changed-1702508393416.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Changed
----
-
-Adjusted several OBJ types to accommodate forthcoming API changes ([#9996](https://github.com/linode/manager/pull/9996))

--- a/packages/api-v4/CHANGELOG.md
+++ b/packages/api-v4/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [2024-01-22] - v0.109.0
+
+
+### Added:
+
+- AGLB endpoint health endpoints ([#10008](https://github.com/linode/manager/pull/10008))
+- Ability to scale up Database instances ([#9869](https://github.com/linode/manager/pull/9869))
+
+### Changed:
+
+- Adjusted several OBJ types to accommodate forthcoming API changes ([#9996](https://github.com/linode/manager/pull/9996))
+
 ## [2024-01-08] - v0.107.0
 
 

--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/api-v4",
-  "version": "0.107.0",
+  "version": "0.108.0",
   "homepage": "https://github.com/linode/manager/tree/develop/packages/api-v4",
   "bugs": {
     "url": "https://github.com/linode/manager/issues"

--- a/packages/manager/.changeset/pr-10001-upcoming-features-1702680383371.md
+++ b/packages/manager/.changeset/pr-10001-upcoming-features-1702680383371.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Replace Managed summary charts with Recharts ([#10001](https://github.com/linode/manager/pull/10001))

--- a/packages/manager/.changeset/pr-10008-upcoming-features-1704919046550.md
+++ b/packages/manager/.changeset/pr-10008-upcoming-features-1704919046550.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add AGLB Endpoint Health ([#10008](https://github.com/linode/manager/pull/10008))

--- a/packages/manager/.changeset/pr-10010-added-1703035008158.md
+++ b/packages/manager/.changeset/pr-10010-added-1703035008158.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-Subnet IPv4 range recommendation in VPC Create flow and Subnet Create Drawer ([#10010](https://github.com/linode/manager/pull/10010))

--- a/packages/manager/.changeset/pr-10012-upcoming-features-1703090453195.md
+++ b/packages/manager/.changeset/pr-10012-upcoming-features-1703090453195.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add child account access column and disable delete account button when account has child accounts ([#10012](https://github.com/linode/manager/pull/10012))

--- a/packages/manager/.changeset/pr-10013-added-1703179399644.md
+++ b/packages/manager/.changeset/pr-10013-added-1703179399644.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-Sold out chips for GPU and Premium CPU plans ([#10013](https://github.com/linode/manager/pull/10013))

--- a/packages/manager/.changeset/pr-10016-fixed-1703172060704.md
+++ b/packages/manager/.changeset/pr-10016-fixed-1703172060704.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-AGLB route rules being cleared when updating a route ([#10016](https://github.com/linode/manager/pull/10016))

--- a/packages/manager/.changeset/pr-10016-fixed-1703172108441.md
+++ b/packages/manager/.changeset/pr-10016-fixed-1703172108441.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-AGLB Service Target validation ([#10016](https://github.com/linode/manager/pull/10016))

--- a/packages/manager/.changeset/pr-10020-changed-1704231120228.md
+++ b/packages/manager/.changeset/pr-10020-changed-1704231120228.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Styling of Toggles and Radios in dark mode ([#10020](https://github.com/linode/manager/pull/10020))

--- a/packages/manager/.changeset/pr-10024-upcoming-features-1704317084918.md
+++ b/packages/manager/.changeset/pr-10024-upcoming-features-1704317084918.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Support VPC in Access Token drawers ([#10024](https://github.com/linode/manager/pull/10024))

--- a/packages/manager/.changeset/pr-10026-tech-stories-1704298288134.md
+++ b/packages/manager/.changeset/pr-10026-tech-stories-1704298288134.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Update `react-waypoint` for React 18 ([#10026](https://github.com/linode/manager/pull/10026))

--- a/packages/manager/.changeset/pr-10027-added-1704309699899.md
+++ b/packages/manager/.changeset/pr-10027-added-1704309699899.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-Cloud Manager Documentation microsite with vitepress ([#10027](https://github.com/linode/manager/pull/10027))

--- a/packages/manager/.changeset/pr-10028-tech-stories-1704319234636.md
+++ b/packages/manager/.changeset/pr-10028-tech-stories-1704319234636.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Improve Accessibility of Button Component ([#10028](https://github.com/linode/manager/pull/10028))

--- a/packages/manager/.changeset/pr-10029-tech-stories-1704318402385.md
+++ b/packages/manager/.changeset/pr-10029-tech-stories-1704318402385.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Remove `classnames` and `@types/classnames` ([#10029](https://github.com/linode/manager/pull/10029))

--- a/packages/manager/.changeset/pr-10031-upcoming-features-1704467384095.md
+++ b/packages/manager/.changeset/pr-10031-upcoming-features-1704467384095.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add parent/proxy 'Switch Account' button and drawer to user profile dropdown menu  ([#10031](https://github.com/linode/manager/pull/10031))

--- a/packages/manager/.changeset/pr-10032-tests-1704400629879.md
+++ b/packages/manager/.changeset/pr-10032-tests-1704400629879.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Tests for updating/renaming Linode labels ([#10032](https://github.com/linode/manager/pull/10032))

--- a/packages/manager/.changeset/pr-10033-tests-1704470547191.md
+++ b/packages/manager/.changeset/pr-10033-tests-1704470547191.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-GDPR agreement e2e test ([#10033](https://github.com/linode/manager/pull/10033))

--- a/packages/manager/.changeset/pr-10036-upcoming-features-1704936534931.md
+++ b/packages/manager/.changeset/pr-10036-upcoming-features-1704936534931.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Disable Contact / Billing Info for Restricted Users ([#10036](https://github.com/linode/manager/pull/10036))

--- a/packages/manager/.changeset/pr-10037-upcoming-features-1704490133740.md
+++ b/packages/manager/.changeset/pr-10037-upcoming-features-1704490133740.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Replace Linode details Analytics tab with Recharts ([#10037](https://github.com/linode/manager/pull/10037))

--- a/packages/manager/.changeset/pr-10038-added-1704495369939.md
+++ b/packages/manager/.changeset/pr-10038-added-1704495369939.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-Proper support for OBJ Access Key events ([#10038](https://github.com/linode/manager/pull/10038))

--- a/packages/manager/.changeset/pr-10042-fixed-1704748141170.md
+++ b/packages/manager/.changeset/pr-10042-fixed-1704748141170.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Managed Summary layout ([#10042](https://github.com/linode/manager/pull/10042))

--- a/packages/manager/.changeset/pr-10044-fixed-1704753978034.md
+++ b/packages/manager/.changeset/pr-10044-fixed-1704753978034.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Textfield Label Tooltip Icon elongation/distortion upon focus ([#10044](https://github.com/linode/manager/pull/10044))

--- a/packages/manager/.changeset/pr-10045-tests-1704834823931.md
+++ b/packages/manager/.changeset/pr-10045-tests-1704834823931.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Add test coverage for Billing Access permission for Child accounts ([#10045](https://github.com/linode/manager/pull/10045))

--- a/packages/manager/.changeset/pr-10045-upcoming-features-1704814925607.md
+++ b/packages/manager/.changeset/pr-10045-upcoming-features-1704814925607.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Disable Billing Access user permission for Child accounts ([#10045](https://github.com/linode/manager/pull/10045))

--- a/packages/manager/.changeset/pr-10046-changed-1704923289933.md
+++ b/packages/manager/.changeset/pr-10046-changed-1704923289933.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Deprecate Ark, TF2, Terraria, Percona, Mist, MagicSpam and BitNinja from Markeplace Apps ([#10046](https://github.com/linode/manager/pull/10046))

--- a/packages/manager/.changeset/pr-10048-upcoming-features-1704822100414.md
+++ b/packages/manager/.changeset/pr-10048-upcoming-features-1704822100414.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Fix AGLB Configuration "Save" button remaining disabled when trying to remove a route ([#10048](https://github.com/linode/manager/pull/10048))

--- a/packages/manager/.changeset/pr-10049-fixed-1704837468392.md
+++ b/packages/manager/.changeset/pr-10049-fixed-1704837468392.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Broken PrimaryNav marketplace navigation within Linode Create ([#10049](https://github.com/linode/manager/pull/10049))

--- a/packages/manager/.changeset/pr-10052-upcoming-features-1704993330964.md
+++ b/packages/manager/.changeset/pr-10052-upcoming-features-1704993330964.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add Switch Account button to Account Landing page for parent and proxy users ([#10052](https://github.com/linode/manager/pull/10052))

--- a/packages/manager/.changeset/pr-10054-changed-1704991179381.md
+++ b/packages/manager/.changeset/pr-10054-changed-1704991179381.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Updated user title and emote icons on Support Ticket page ([#10054](https://github.com/linode/manager/pull/10054))

--- a/packages/manager/.changeset/pr-10057-fixed-1704983627685.md
+++ b/packages/manager/.changeset/pr-10057-fixed-1704983627685.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Kubernetes upgrade flow on Kubernetes details page ([#10057](https://github.com/linode/manager/pull/10057))

--- a/packages/manager/.changeset/pr-10057-tests-1704983693919.md
+++ b/packages/manager/.changeset/pr-10057-tests-1704983693919.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Improved Kubernetes version upgrade Cypress test ([#10057](https://github.com/linode/manager/pull/10057))

--- a/packages/manager/.changeset/pr-10059-tech-stories-1704987208139.md
+++ b/packages/manager/.changeset/pr-10059-tech-stories-1704987208139.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Update `axios` to resolve `follow-redirects` dependabot alert ([#10059](https://github.com/linode/manager/pull/10059))

--- a/packages/manager/.changeset/pr-10060-upcoming-features-1704989096198.md
+++ b/packages/manager/.changeset/pr-10060-upcoming-features-1704989096198.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-VM Placement feature flag ([#10060](https://github.com/linode/manager/pull/10060))

--- a/packages/manager/.changeset/pr-10061-tests-1705082473074.md
+++ b/packages/manager/.changeset/pr-10061-tests-1705082473074.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Combine VPC landing page tests for update and delete operations ([#10061](https://github.com/linode/manager/pull/10061))

--- a/packages/manager/.changeset/pr-10062-upcoming-features-1705355996434.md
+++ b/packages/manager/.changeset/pr-10062-upcoming-features-1705355996434.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Placement Groups: Queries, Types, Validation, Factories and Mock Data ([#10062](https://github.com/linode/manager/pull/10062))

--- a/packages/manager/.changeset/pr-10066-upcoming-features-1705422066984.md
+++ b/packages/manager/.changeset/pr-10066-upcoming-features-1705422066984.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Improve AGLB Configuration - Add Certificate Drawer ([#10066](https://github.com/linode/manager/pull/10066))

--- a/packages/manager/.changeset/pr-10067-changed-1705423329479.md
+++ b/packages/manager/.changeset/pr-10067-changed-1705423329479.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Update Cloud Manager LICENCE ([#10067](https://github.com/linode/manager/pull/10067))

--- a/packages/manager/.changeset/pr-10069-upcoming-features-1705512789450.md
+++ b/packages/manager/.changeset/pr-10069-upcoming-features-1705512789450.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-User Permissions: Configure Billing Account Access ([#10069](https://github.com/linode/manager/pull/10069))

--- a/packages/manager/.changeset/pr-10071-fixed-1705522697458.md
+++ b/packages/manager/.changeset/pr-10071-fixed-1705522697458.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-VPC arguments in Linode Create flow CLI ([#10071](https://github.com/linode/manager/pull/10071))

--- a/packages/manager/.changeset/pr-10072-changed-1705529283172.md
+++ b/packages/manager/.changeset/pr-10072-changed-1705529283172.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Clone Linode power-off notice ([#10072](https://github.com/linode/manager/pull/10072))

--- a/packages/manager/.changeset/pr-10073-fixed-1705544271675.md
+++ b/packages/manager/.changeset/pr-10073-fixed-1705544271675.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Standardize Copy Icon Color Variations in CopyableTextField ([#10073](https://github.com/linode/manager/pull/10073))

--- a/packages/manager/.changeset/pr-10074-changed-1705590614132.md
+++ b/packages/manager/.changeset/pr-10074-changed-1705590614132.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Remove unified migrations feature flag ([#10074](https://github.com/linode/manager/pull/10074))

--- a/packages/manager/.changeset/pr-10077-fixed-1705594578246.md
+++ b/packages/manager/.changeset/pr-10077-fixed-1705594578246.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Linode details action button color in dark mode ([#10077](https://github.com/linode/manager/pull/10077))

--- a/packages/manager/.changeset/pr-10078-changed-1705616003861.md
+++ b/packages/manager/.changeset/pr-10078-changed-1705616003861.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Right align chart tooltip data points ([#10078](https://github.com/linode/manager/pull/10078))

--- a/packages/manager/.changeset/pr-9869-added-1699013625860.md
+++ b/packages/manager/.changeset/pr-9869-added-1699013625860.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-Ability to scale up Database instances ([#9869](https://github.com/linode/manager/pull/9869))

--- a/packages/manager/.changeset/pr-9996-changed-1702508487859.md
+++ b/packages/manager/.changeset/pr-9996-changed-1702508487859.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Updated OBJ types used in several Object Storage components ([#9996](https://github.com/linode/manager/pull/9996))

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,72 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2024-01-22] - v1.111.0
+
+
+### Added:
+
+- Subnet IPv4 range recommendation in VPC Create flow and Subnet Create Drawer ([#10010](https://github.com/linode/manager/pull/10010))
+- Sold out chips for GPU and Premium CPU plans ([#10013](https://github.com/linode/manager/pull/10013))
+- Cloud Manager Documentation microsite with vitepress ([#10027](https://github.com/linode/manager/pull/10027))
+- Proper support for OBJ Access Key events ([#10038](https://github.com/linode/manager/pull/10038))
+- Ability to scale up Database instances ([#9869](https://github.com/linode/manager/pull/9869))
+
+### Changed:
+
+- Styling of Toggles and Radios in dark mode ([#10020](https://github.com/linode/manager/pull/10020))
+- Deprecate Ark, TF2, Terraria, Percona, Mist, MagicSpam and BitNinja from Markeplace Apps ([#10046](https://github.com/linode/manager/pull/10046))
+- Updated user title and emote icons on Support Ticket page ([#10054](https://github.com/linode/manager/pull/10054))
+- Update Cloud Manager LICENCE ([#10067](https://github.com/linode/manager/pull/10067))
+- Clone Linode power-off notice ([#10072](https://github.com/linode/manager/pull/10072))
+- Remove unified migrations feature flag ([#10074](https://github.com/linode/manager/pull/10074))
+- Right align chart tooltip data points ([#10078](https://github.com/linode/manager/pull/10078))
+- Updated OBJ types used in several Object Storage components ([#9996](https://github.com/linode/manager/pull/9996))
+
+### Fixed:
+
+- AGLB route rules being cleared when updating a route ([#10016](https://github.com/linode/manager/pull/10016))
+- AGLB Service Target validation ([#10016](https://github.com/linode/manager/pull/10016))
+- Managed Summary layout ([#10042](https://github.com/linode/manager/pull/10042))
+- Textfield Label Tooltip Icon elongation/distortion upon focus ([#10044](https://github.com/linode/manager/pull/10044))
+- Broken PrimaryNav marketplace navigation within Linode Create ([#10049](https://github.com/linode/manager/pull/10049))
+- Kubernetes upgrade flow on Kubernetes details page ([#10057](https://github.com/linode/manager/pull/10057))
+- VPC arguments in Linode Create flow CLI ([#10071](https://github.com/linode/manager/pull/10071))
+- Standardize Copy Icon Color Variations in CopyableTextField ([#10073](https://github.com/linode/manager/pull/10073))
+- Linode details action button color in dark mode ([#10077](https://github.com/linode/manager/pull/10077))
+
+### Tech Stories:
+
+- Update `react-waypoint` for React 18 ([#10026](https://github.com/linode/manager/pull/10026))
+- Improve Accessibility of Button Component ([#10028](https://github.com/linode/manager/pull/10028))
+- Remove `classnames` and `@types/classnames` ([#10029](https://github.com/linode/manager/pull/10029))
+- Update `axios` to resolve `follow-redirects` dependabot alert ([#10059](https://github.com/linode/manager/pull/10059))
+
+### Tests:
+
+- Tests for updating/renaming Linode labels ([#10032](https://github.com/linode/manager/pull/10032))
+- GDPR agreement e2e test ([#10033](https://github.com/linode/manager/pull/10033))
+- Add test coverage for Billing Access permission for Child accounts ([#10045](https://github.com/linode/manager/pull/10045))
+- Improved Kubernetes version upgrade Cypress test ([#10057](https://github.com/linode/manager/pull/10057))
+- Combine VPC landing page tests for update and delete operations ([#10061](https://github.com/linode/manager/pull/10061))
+
+### Upcoming Features:
+
+- Replace Managed summary charts with Recharts ([#10001](https://github.com/linode/manager/pull/10001))
+- Add AGLB Endpoint Health ([#10008](https://github.com/linode/manager/pull/10008))
+- Add child account access column and disable delete account button when account has child accounts ([#10012](https://github.com/linode/manager/pull/10012))
+- Support VPC in Access Token drawers ([#10024](https://github.com/linode/manager/pull/10024))
+- Add parent/proxy 'Switch Account' button and drawer to user profile dropdown menu  ([#10031](https://github.com/linode/manager/pull/10031))
+- Disable Contact / Billing Info for Restricted Users ([#10036](https://github.com/linode/manager/pull/10036))
+- Replace Linode details Analytics tab with Recharts ([#10037](https://github.com/linode/manager/pull/10037))
+- Disable Billing Access user permission for Child accounts ([#10045](https://github.com/linode/manager/pull/10045))
+- Fix AGLB Configuration "Save" button remaining disabled when trying to remove a route ([#10048](https://github.com/linode/manager/pull/10048))
+- Add Switch Account button to Account Landing page for parent and proxy users ([#10052](https://github.com/linode/manager/pull/10052))
+- VM Placement feature flag ([#10060](https://github.com/linode/manager/pull/10060))
+- Placement Groups: Queries, Types, Validation, Factories and Mock Data ([#10062](https://github.com/linode/manager/pull/10062))
+- Improve AGLB Configuration - Add Certificate Drawer ([#10066](https://github.com/linode/manager/pull/10066))
+- User Permissions: Configure Billing Account Access ([#10069](https://github.com/linode/manager/pull/10069))
+
 ## [2024-01-10] - v1.109.1
 
 ### Fixed:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.109.1",
+  "version": "1.110.0",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/validation/.changeset/pr-10063-changed-1705088599651.md
+++ b/packages/validation/.changeset/pr-10063-changed-1705088599651.md
@@ -1,5 +1,0 @@
----
-"@linode/validation": Changed
----
-
-Revised createObjectStorageKeysSchema to include optional 'regions' field ([#10063](https://github.com/linode/manager/pull/10063))

--- a/packages/validation/.changeset/pr-9869-changed-1703002209433.md
+++ b/packages/validation/.changeset/pr-9869-changed-1703002209433.md
@@ -1,5 +1,0 @@
----
-"@linode/validation": Changed
----
-
-Made `allow_list` not required for updateDatabaseSchema and added optional `type` property ([#9869](https://github.com/linode/manager/pull/9869))

--- a/packages/validation/CHANGELOG.md
+++ b/packages/validation/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2024-01-22] - v0.39.0
+
+
+### Changed:
+
+- Revised createObjectStorageKeysSchema to include optional 'regions' field ([#10063](https://github.com/linode/manager/pull/10063))
+- Made `allow_list` not required for updateDatabaseSchema and added optional `type` property ([#9869](https://github.com/linode/manager/pull/9869))
+
 ## [2024-01-08] - v0.37.0
 
 

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/validation",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Yup validation schemas for use with the Linode APIv4",
   "type": "module",
   "main": "lib/index.cjs",


### PR DESCRIPTION
# Cloud Manager
## [2024-01-22] - v1.111.0


### Added:

- Subnet IPv4 range recommendation in VPC Create flow and Subnet Create Drawer ([#10010](https://github.com/linode/manager/pull/10010))
- Sold out chips for GPU and Premium CPU plans ([#10013](https://github.com/linode/manager/pull/10013))
- Cloud Manager Documentation microsite with vitepress ([#10027](https://github.com/linode/manager/pull/10027))
- Proper support for OBJ Access Key events ([#10038](https://github.com/linode/manager/pull/10038))
- Ability to scale up Database instances ([#9869](https://github.com/linode/manager/pull/9869))

### Changed:

- Styling of Toggles and Radios in dark mode ([#10020](https://github.com/linode/manager/pull/10020))
- Deprecate Ark, TF2, Terraria, Percona, Mist, MagicSpam and BitNinja from Markeplace Apps ([#10046](https://github.com/linode/manager/pull/10046))
- Updated user title and emote icons on Support Ticket page ([#10054](https://github.com/linode/manager/pull/10054))
- Update Cloud Manager LICENCE ([#10067](https://github.com/linode/manager/pull/10067))
- Clone Linode power-off notice ([#10072](https://github.com/linode/manager/pull/10072))
- Remove unified migrations feature flag ([#10074](https://github.com/linode/manager/pull/10074))
- Right align chart tooltip data points ([#10078](https://github.com/linode/manager/pull/10078))
- Updated OBJ types used in several Object Storage components ([#9996](https://github.com/linode/manager/pull/9996))

### Fixed:

- AGLB route rules being cleared when updating a route ([#10016](https://github.com/linode/manager/pull/10016))
- AGLB Service Target validation ([#10016](https://github.com/linode/manager/pull/10016))
- Managed Summary layout ([#10042](https://github.com/linode/manager/pull/10042))
- Textfield Label Tooltip Icon elongation/distortion upon focus ([#10044](https://github.com/linode/manager/pull/10044))
- Broken PrimaryNav marketplace navigation within Linode Create ([#10049](https://github.com/linode/manager/pull/10049))
- Kubernetes upgrade flow on Kubernetes details page ([#10057](https://github.com/linode/manager/pull/10057))
- VPC arguments in Linode Create flow CLI ([#10071](https://github.com/linode/manager/pull/10071))
- Standardize Copy Icon Color Variations in CopyableTextField ([#10073](https://github.com/linode/manager/pull/10073))
- Linode details action button color in dark mode ([#10077](https://github.com/linode/manager/pull/10077))

### Tech Stories:

- Update `react-waypoint` for React 18 ([#10026](https://github.com/linode/manager/pull/10026))
- Improve Accessibility of Button Component ([#10028](https://github.com/linode/manager/pull/10028))
- Remove `classnames` and `@types/classnames` ([#10029](https://github.com/linode/manager/pull/10029))
- Update `axios` to resolve `follow-redirects` dependabot alert ([#10059](https://github.com/linode/manager/pull/10059))

### Tests:

- Tests for updating/renaming Linode labels ([#10032](https://github.com/linode/manager/pull/10032))
- GDPR agreement e2e test ([#10033](https://github.com/linode/manager/pull/10033))
- Add test coverage for Billing Access permission for Child accounts ([#10045](https://github.com/linode/manager/pull/10045))
- Improved Kubernetes version upgrade Cypress test ([#10057](https://github.com/linode/manager/pull/10057))
- Combine VPC landing page tests for update and delete operations ([#10061](https://github.com/linode/manager/pull/10061))

### Upcoming Features:

- Replace Managed summary charts with Recharts ([#10001](https://github.com/linode/manager/pull/10001))
- Add AGLB Endpoint Health ([#10008](https://github.com/linode/manager/pull/10008))
- Add child account access column and disable delete account button when account has child accounts ([#10012](https://github.com/linode/manager/pull/10012))
- Support VPC in Access Token drawers ([#10024](https://github.com/linode/manager/pull/10024))
- Add parent/proxy 'Switch Account' button and drawer to user profile dropdown menu  ([#10031](https://github.com/linode/manager/pull/10031))
- Disable Contact / Billing Info for Restricted Users ([#10036](https://github.com/linode/manager/pull/10036))
- Replace Linode details Analytics tab with Recharts ([#10037](https://github.com/linode/manager/pull/10037))
- Disable Billing Access user permission for Child accounts ([#10045](https://github.com/linode/manager/pull/10045))
- Fix AGLB Configuration "Save" button remaining disabled when trying to remove a route ([#10048](https://github.com/linode/manager/pull/10048))
- Add Switch Account button to Account Landing page for parent and proxy users ([#10052](https://github.com/linode/manager/pull/10052))
- VM Placement feature flag ([#10060](https://github.com/linode/manager/pull/10060))
- Placement Groups: Queries, Types, Validation, Factories and Mock Data ([#10062](https://github.com/linode/manager/pull/10062))
- Improve AGLB Configuration - Add Certificate Drawer ([#10066](https://github.com/linode/manager/pull/10066))
- User Permissions: Configure Billing Account Access ([#10069](https://github.com/linode/manager/pull/10069))

# API-v4
## [2024-01-22] - v0.109.0


### Added:

- AGLB endpoint health endpoints ([#10008](https://github.com/linode/manager/pull/10008))
- Ability to scale up Database instances ([#9869](https://github.com/linode/manager/pull/9869))

### Changed:

- Adjusted several OBJ types to accommodate forthcoming API changes ([#9996](https://github.com/linode/manager/pull/9996))

# Validation
## [2024-01-22] - v0.39.0


### Changed:

- Revised createObjectStorageKeysSchema to include optional 'regions' field ([#10063](https://github.com/linode/manager/pull/10063))
- Made `allow_list` not required for updateDatabaseSchema and added optional `type` property ([#9869](https://github.com/linode/manager/pull/9869))
