### PR TITLE
upcoming: [M3-7647] - Update logic for child_account PAT

### DIFF
--- a/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.tsx
@@ -35,7 +35,7 @@ import {
   basePermNameMap as _basePermNameMap,
   Permission,
   allScopesAreTheSame,
-  getPermsNameMap,
+  filterPermsNameMap,
   permTuplesToScopeString,
   scopeStringToPermTuples,
 } from './utils';
@@ -113,12 +113,20 @@ export const CreateAPITokenDrawer = (props: Props) => {
     account?.capabilities ?? []
   );
 
-  // @TODO VPC: once VPC enters GA, remove _basePermNameMap logic and references.
+  const hasParentChildAccountAccess = Boolean(flags.parentChildAccountAccess);
+
+  // @TODO: VPC & Parent/Child - once these are in GA, remove _basePermNameMap logic and references.
   // Just use the basePermNameMap import directly w/o any manipulation.
-  const basePermNameMap = getPermsNameMap(_basePermNameMap, {
-    name: 'vpc',
-    shouldBeIncluded: showVPCs,
-  });
+  const basePermNameMap = filterPermsNameMap(_basePermNameMap, [
+    {
+      name: 'vpc',
+      shouldBeIncluded: showVPCs,
+    },
+    {
+      name: 'child_account',
+      shouldBeIncluded: hasParentChildAccountAccess,
+    },
+  ]);
 
   const form = useFormik<{
     expiry: string;
@@ -180,24 +188,14 @@ export const CreateAPITokenDrawer = (props: Props) => {
 
   // Filter permissions for all users except parent user accounts.
   const allPermissions = form.values.scopes;
+
   const showFilteredPermissions =
     (flags.parentChildAccountAccess && user?.user_type !== 'parent') ||
     Boolean(!flags.parentChildAccountAccess);
+
   const filteredPermissions = allPermissions.filter(
     (scopeTup) => basePermNameMap[scopeTup[0]] !== 'Child Account Access'
   );
-  // TODO: Parent/Child - remove this conditional once code is in prod.
-  // Note: We couldn't include 'child_account' in our list of permissions in utils
-  // because it needs to be feature-flagged. Therefore, we're manually adding it here.
-  if (flags.parentChildAccountAccess && user?.user_type !== null) {
-    const childAccountIndex = allPermissions.findIndex(
-      ([scope]) => scope === 'child_account'
-    );
-    if (childAccountIndex === -1) {
-      allPermissions.push(['child_account', 0]);
-    }
-    basePermNameMap.child_account = 'Child Account Access';
-  }
 
   return (
     <Drawer onClose={onClose} open={open} title="Add Personal Access Token">

--- a/packages/manager/src/features/Profile/APITokens/ViewAPITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/ViewAPITokenDrawer.tsx
@@ -20,7 +20,7 @@ import {
 } from './APITokenDrawer.styles';
 import {
   basePermNameMap as _basePermNameMap,
-  getPermsNameMap,
+  filterPermsNameMap,
   scopeStringToPermTuples,
 } from './utils';
 
@@ -45,12 +45,20 @@ export const ViewAPITokenDrawer = (props: Props) => {
     account?.capabilities ?? []
   );
 
-  // @TODO VPC: once VPC enters GA, remove _basePermNameMap logic and references.
+  const hasParentChildAccountAccess = Boolean(flags.parentChildAccountAccess);
+
+  // @TODO: VPC & Parent/Child - once these are in GA, remove _basePermNameMap logic and references.
   // Just use the basePermNameMap import directly w/o any manipulation.
-  const basePermNameMap = getPermsNameMap(_basePermNameMap, {
-    name: 'vpc',
-    shouldBeIncluded: showVPCs,
-  });
+  const basePermNameMap = filterPermsNameMap(_basePermNameMap, [
+    {
+      name: 'vpc',
+      shouldBeIncluded: showVPCs,
+    },
+    {
+      name: 'child_account',
+      shouldBeIncluded: hasParentChildAccountAccess,
+    },
+  ]);
 
   const allPermissions = scopeStringToPermTuples(token?.scopes ?? '');
 
@@ -58,21 +66,10 @@ export const ViewAPITokenDrawer = (props: Props) => {
   const showFilteredPermissions =
     (flags.parentChildAccountAccess && user?.user_type !== 'parent') ||
     Boolean(!flags.parentChildAccountAccess);
+
   const filteredPermissions = allPermissions.filter(
     (scopeTup) => basePermNameMap[scopeTup[0]] !== 'Child Account Access'
   );
-  // TODO: Parent/Child - remove this conditional once code is in prod.
-  // Note: We couldn't include 'child_account' in our list of permissions in utils
-  // because it needs to be feature-flagged. Therefore, we're manually adding it here.
-  if (flags.parentChildAccountAccess && user?.user_type !== null) {
-    const childAccountIndex = allPermissions.findIndex(
-      ([scope]) => scope === 'child_account'
-    );
-    if (childAccountIndex === -1) {
-      allPermissions.push(['child_account', 0]);
-    }
-    basePermNameMap.child_account = 'Child Account Access';
-  }
 
   return (
     <Drawer onClose={onClose} open={open} title={token?.label ?? 'Token'}>

--- a/packages/manager/src/features/Profile/APITokens/utils.test.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.test.ts
@@ -26,8 +26,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('*');
       const expected = [
         ['account', 2],
-        // TODO: Parent/Child - add this scope once code is in prod.
-        // ['child_account', 2],
+        ['child_account', 2],
         ['databases', 2],
         ['domains', 2],
         ['events', 2],
@@ -52,8 +51,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('');
       const expected = [
         ['account', 0],
-        // TODO: Parent/Child - add this scope once code is in prod.
-        // ['child_account', 0],
+        ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
         ['events', 0],
@@ -79,8 +77,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:none');
       const expected = [
         ['account', 0],
-        // TODO: Parent/Child - add this scope once code is in prod.
-        // ['child_account', 0],
+        ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
         ['events', 0],
@@ -106,8 +103,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:read_only');
       const expected = [
         ['account', 1],
-        // TODO: Parent/Child - add this scope once code is in prod.
-        // ['child_account', 0],
+        ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
         ['events', 0],
@@ -133,8 +129,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:read_write');
       const expected = [
         ['account', 2],
-        // TODO: Parent/Child - add this scope once code is in prod.
-        // ['child_account', 0],
+        ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
         ['events', 0],
@@ -162,8 +157,7 @@ describe('APIToken utils', () => {
       );
       const expected = [
         ['account', 0],
-        // TODO: Parent/Child - add this scope once code is in prod.
-        // ['child_account', 0],
+        ['child_account', 0],
         ['databases', 0],
         ['domains', 1],
         ['events', 0],
@@ -193,8 +187,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:none,tokens:read_write');
       const expected = [
         ['account', 2],
-        // TODO: Parent/Child - add this scope once code is in prod.
-        // ['child_account', 0],
+        ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
         ['events', 0],
@@ -224,8 +217,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:read_only,tokens:none');
       const expected = [
         ['account', 1],
-        // TODO: Parent/Child - add this scope once code is in prod.
-        // ['child_account', 0],
+        ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
         ['events', 0],
@@ -251,8 +243,7 @@ describe('APIToken utils', () => {
       it('should return 0 if all scopes are 0', () => {
         const scopes: Permission[] = [
           ['account', 0],
-          // TODO: Parent/Child - add this scope once code is in prod.
-          // ['child_account', 0],
+          ['child_account', 0],
           ['databases', 0],
           ['domains', 0],
           ['events', 0],
@@ -273,8 +264,7 @@ describe('APIToken utils', () => {
       it('should return 1 if all scopes are 1', () => {
         const scopes: Permission[] = [
           ['account', 1],
-          // TODO: Parent/Child - add this scope once code is in prod.
-          // ['child_account', 1],
+          ['child_account', 1],
           ['databases', 1],
           ['domains', 1],
           ['events', 1],
@@ -294,8 +284,7 @@ describe('APIToken utils', () => {
       it('should return 2 if all scopes are 2', () => {
         const scopes: Permission[] = [
           ['account', 2],
-          // TODO: Parent/Child - add this scope once code is in prod.
-          // ['child_account', 2],
+          ['child_account', 2],
           ['databases', 2],
           ['domains', 2],
           ['events', 2],
@@ -316,8 +305,7 @@ describe('APIToken utils', () => {
       it('should return null if all scopes are different', () => {
         const scopes: Permission[] = [
           ['account', 1],
-          // TODO: Parent/Child - add this scope once code is in prod.
-          // ['child_account', 0],
+          ['child_account', 0],
           ['databases', 0],
           ['domains', 2],
           ['events', 0],

--- a/packages/manager/src/features/Profile/APITokens/utils.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.ts
@@ -6,8 +6,7 @@ export type Permission = [string, number];
 
 export const basePerms = [
   'account',
-  // TODO: Parent/Child - add this scope once API code is in prod.
-  // 'child_account',
+  'child_account',
   'databases',
   'domains',
   'events',
@@ -26,8 +25,7 @@ export const basePerms = [
 
 export const basePermNameMap: Record<string, string> = {
   account: 'Account',
-  // TODO: Parent/Child - add this scope once API code is in prod.
-  // child_account: 'Child Account Access',
+  child_account: 'Child Account Access',
   databases: 'Databases',
   domains: 'Domains',
   events: 'Events',
@@ -197,21 +195,23 @@ export const isWayInTheFuture = (time: string) => {
 };
 
 /**
- * Used to remove a permission
- * @param basePermNameMap an object consisting of API perm keys and their
- * corresponding names in Cloud
- * @param perm an object consisting of a perm name and a boolean indicating
- * whether it should be included in basePermNameMap or not
- * @returns a copy of basePermNameMap (either unedited or with the specified perm removed)
+ * Filters permissions from the base permission name map.
+ * @param basePermNameMap An object consisting of API perm keys and their corresponding names in Cloud.
+ * @param perm A collection of objects, each comprising a name and a boolean value indicating whether
+ * the permission should be included in the basePermNameMap.
+ * @returns A copy of basePermNameMap, either unedited or with the specified permissions removed.
  */
-export const getPermsNameMap = (
+export const filterPermsNameMap = (
   basePermNameMap: Record<string, string>,
-  perm: { name: string; shouldBeIncluded: boolean }
-) => {
-  const basePermNameMapCopy = { ...basePermNameMap };
-  if (basePermNameMapCopy[perm.name] && !perm.shouldBeIncluded) {
-    delete basePermNameMapCopy[perm.name];
+  perm: { name: string; shouldBeIncluded: boolean }[]
+): Record<string, string> => {
+  const filteredPermNameMap = { ...basePermNameMap };
+
+  for (const { name, shouldBeIncluded } of perm) {
+    if (!shouldBeIncluded && filteredPermNameMap[name]) {
+      delete filteredPermNameMap[name];
+    }
   }
 
-  return basePermNameMapCopy;
+  return filteredPermNameMap;
 };


### PR DESCRIPTION
## Description 📝
Used our approach from https://github.com/linode/manager/pull/10024 to cleanup Parent/Child scopes.

Nothing should change in terms of what we see from the original PR: https://github.com/linode/manager/pull/9992

## Changes  🔄
- Changed `getPermsNameMap` to `filterPermsNameMap` and now it accepts an array of perms
- Enabled `child_account` perms and removed our old approach
- Update tests

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Check out this PR and `yarn dev`.
- In the dev tools:
   - Make sure the Parent/Child Account Switching feature flag is on.
   - Turn mocks on.

### Verification steps 
(How to verify changes)
- Go to http://localhost:3000/profile/tokens and click the Create a Personal Access Token button.
- Observe that "Child Account Access" is visible as a new scope and all scopes default to None.
- On the tokens landing page, click the View Scope button for any mock PAT.
- Observe that the "Child Account Access" scope is visible in the table.
- Toggle the feature flag off and observe that the Child Account Access token is not visible in the Create or View drawers and all scopes default to Read/Write.
- Toggle the feature flag back on.
- Go to `serverHandler.ts` and edit the following request to change the user_type to `null`, `child`, or `proxy`:
```
  rest.get('*/account/users/:user', (req, res, ctx) => {
    // Parent/Child: switch the `user_type` depending on what account view you need to mock.
    return res(ctx.json(accountUserFactory.build({ user_type: 'parent' })));
  }),
```
- Observe that the Child Account Access token is not visible in the Create or View drawers.
- Verify tests pass:
```
yarn test utils CreateAPITokenDrawer ViewAPITokenDrawer

```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support