### PR TITLE
refactor: [M3-7672] – Use feature flag to govern display of beta chip for VPC in PrimaryNav

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -205,7 +205,7 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
           hide: !showVPCs,
           href: '/vpcs',
           icon: <VPC />,
-          isBeta: true,
+          isBeta: flags.vpc, // @TODO VPC: after VPC enters GA, remove this property entirely
         },
         {
           display: 'Firewalls',


### PR DESCRIPTION
## Description 📝
Instead of hard-coding `true` for `isBeta` (which determines whether the beta chip is displayed or not), we can rely on the feature flag.

As of the open beta, the API returns `VPCs` in `account.capabilities` for all users, so our feature flag does not actually control access to VPC features in Cloud at this time. Once VPC enters GA, we can safely turn off the feature flag, making this a good case for using it.

I don't think a changeset is needed here, but I can add one if there's disagreement on that.

## How to test 🧪
Two options:

1) Using our DevTool, toggle the checkbox for the VPC feature flag and refresh the page. Observe: the presence of the beta chip for VPC in the PrimaryNav should reflect the current state of that checkbox (unchecked --> no beta chip, checked --> beta chip)

2) Add `vpc: false` in the return object in `useFlags.ts`. Observe: the beta chip does not display for VPC in the PrimaryNav

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support