### PR TITLE
test - Fix StackScript Test Failure due to Ubuntu 23.04 Image Deprecation

### DIFF
--- a/packages/manager/.changeset/pr-10091-tests-1705938529204.md
+++ b/packages/manager/.changeset/pr-10091-tests-1705938529204.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix test failure related to Ubuntu 23.04 Image deprecation ([#10091](https://github.com/linode/manager/pull/10091))

--- a/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
@@ -300,7 +300,7 @@ describe('Create stackscripts', () => {
       { label: 'Debian 12', sel: 'linode/debian12' },
       { label: 'Fedora 38', sel: 'linode/fedora38' },
       { label: 'Rocky Linux 9', sel: 'linode/rocky9' },
-      { label: 'Ubuntu 23.04', sel: 'linode/ubuntu23.04' },
+      { label: 'Ubuntu 23.10', sel: 'linode/ubuntu23.10' },
     ];
 
     interceptCreateStackScript().as('createStackScript');


### PR DESCRIPTION
## Description 📝
The Ubuntu 23.04 image was recently marked as deprecated by the API, which impacts the label shown in Cloud and consequently caused the Cloud Manager StackScript test to fail. I updated the test to look for 23.10 instead.

## Changes  🔄
- Replace check for Ubuntu 23.04 with Ubuntu 23.10

## How to test 🧪
We can rely on the automated testing for this.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
