### PR TITLE
test: [M3-7483] - Add test to delete users on "Users & Grants" page

### DIFF
--- a/packages/manager/.changeset/pr-10093-tests-1706031852395.md
+++ b/packages/manager/.changeset/pr-10093-tests-1706031852395.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add regression tests for deleting users on Users & Grants page. ([#10093](https://github.com/linode/manager/pull/10093))

--- a/packages/manager/cypress/e2e/core/account/user-permissions.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/user-permissions.spec.ts
@@ -10,6 +10,7 @@ import {
   mockGetUsers,
   mockUpdateUser,
   mockUpdateUserGrants,
+  mockDeleteUser,
 } from 'support/intercepts/account';
 import {
   mockAppendFeatureFlags,
@@ -903,5 +904,96 @@ describe('User permission management', () => {
 
     // redirects to the new user's "User Permissions" page
     cy.url().should('endWith', `/users/${newUser.username}/permissions`);
+  });
+
+  it('can delete users', () => {
+    const mockUser = accountUserFactory.build({
+      username: randomLabel(),
+      restricted: false,
+    });
+
+    const username = randomLabel();
+    const additionalUser = accountUserFactory.build({
+      username: username,
+      email: `${username}@test.com`,
+      restricted: false,
+    });
+
+    const mockUserGrantsUpdated = grantsFactory.build();
+    const mockUserGrants = {
+      ...mockUserGrantsUpdated,
+      global: undefined,
+    };
+
+    mockGetUsers([mockUser, additionalUser]).as('getUsers');
+    mockGetUser(mockUser);
+    mockGetUserGrants(mockUser.username, mockUserGrants);
+    mockGetUserGrants(additionalUser.username, mockUserGrants);
+    mockDeleteUser(additionalUser.username).as('deleteUser');
+
+    // Navigate to Users & Grants page, find mock user, click its "User Permissions" button.
+    cy.visitWithLogin('/account/users');
+    cy.wait('@getUsers');
+
+    mockGetUsers([mockUser]).as('getUsers');
+
+    // Confirm that the "Users & Grants" page initially lists the main and additional users
+    cy.findByText(mockUser.username).should('be.visible');
+    cy.findByText(additionalUser.username)
+      .should('be.visible')
+      .closest('tr')
+      .within(() => {
+        ui.button
+          .findByTitle('Delete')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    // the "Confirm Deletion" dialog opens
+    ui.dialog.findByTitle('Confirm Deletion').within(() => {
+      ui.button.findByTitle('Cancel').should('be.visible').click();
+    });
+    // click the "Cancel" button will do nothing
+    cy.findByText(mockUser.username).should('be.visible');
+    cy.findByText(additionalUser.username).should('be.visible');
+
+    // clickl the "x" button will dismiss the dialog and do nothing
+    cy.findByText(additionalUser.username)
+      .should('be.visible')
+      .closest('tr')
+      .within(() => {
+        ui.button
+          .findByTitle('Delete')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+    ui.dialog.findByTitle('Confirm Deletion').within(() => {
+      cy.get('[data-testid="CloseIcon"]').should('be.visible').click();
+    });
+    cy.findByText(mockUser.username).should('be.visible');
+    cy.findByText(additionalUser.username).should('be.visible');
+
+    // delete the user
+    cy.findByText(additionalUser.username)
+      .should('be.visible')
+      .closest('tr')
+      .within(() => {
+        ui.button
+          .findByTitle('Delete')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    // the "Confirm Deletion" dialog opens
+    ui.dialog.findByTitle('Confirm Deletion').within(() => {
+      ui.button.findByTitle('Delete').should('be.visible').click();
+    });
+    cy.wait(['@deleteUser', '@getUsers']);
+
+    // the user is deleted
+    cy.findByText(additionalUser.username).should('not.exist');
   });
 });

--- a/packages/manager/cypress/e2e/core/account/user-permissions.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/user-permissions.spec.ts
@@ -925,6 +925,12 @@ describe('User permission management', () => {
       global: undefined,
     };
 
+    // TODO: Parent/Child - M3-7559 clean up when feature is live in prod and feature flag is removed.
+    mockAppendFeatureFlags({
+      parentChildAccountAccess: makeFeatureFlagData(false),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+
     mockGetUsers([mockUser, additionalUser]).as('getUsers');
     mockGetUser(mockUser);
     mockGetUserGrants(mockUser.username, mockUserGrants);
@@ -958,7 +964,7 @@ describe('User permission management', () => {
     cy.findByText(mockUser.username).should('be.visible');
     cy.findByText(additionalUser.username).should('be.visible');
 
-    // clickl the "x" button will dismiss the dialog and do nothing
+    // clicking the "x" button will dismiss the dialog and do nothing
     cy.findByText(additionalUser.username)
       .should('be.visible')
       .closest('tr')
@@ -994,6 +1000,9 @@ describe('User permission management', () => {
     cy.wait(['@deleteUser', '@getUsers']);
 
     // the user is deleted
+    ui.toast.assertMessage(
+      `User ${additionalUser.username} has been deleted successfully.`
+    );
     cy.findByText(additionalUser.username).should('not.exist');
   });
 });

--- a/packages/manager/cypress/support/intercepts/account.ts
+++ b/packages/manager/cypress/support/intercepts/account.ts
@@ -122,6 +122,21 @@ export const mockUpdateUser = (
 };
 
 /**
+ * Intercepts DELETE request to remove account user.
+ *
+ * @param username - Username of user to delete.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockDeleteUser = (username: string): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'DELETE',
+    apiMatcher(`account/users/${username}`),
+    makeResponse()
+  );
+};
+
+/**
  * Intercepts GET request to fetch account user grants and mocks response.
  *
  * @param username - Username of user for which to fetch grants.


### PR DESCRIPTION
## Description 📝
Add regression tests for deleting users on `Users & Grants` page.

## Major Changes 🔄
- Add regression tests to delete users on `Users & Grants` page.

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/account/user-permissions.spec.ts"
```