### PR TITLE
test: Fix Domains landing page empty state test flake

### DIFF
--- a/packages/manager/.changeset/pr-10094-tests-1705959873279.md
+++ b/packages/manager/.changeset/pr-10094-tests-1705959873279.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Improve Domains landing page empty state test flakiness ([#10094](https://github.com/linode/manager/pull/10094))

--- a/packages/manager/cypress/e2e/core/domains/domains-empty-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/domains/domains-empty-landing-page.spec.ts
@@ -60,7 +60,7 @@ describe('Domains empty landing page', () => {
           .should('be.enabled')
           .click();
       });
-    cy.findByText('Remote Nameserver').should('not.be.visible');
+    cy.findByText('Remote Nameserver').should('not.exist');
 
     // confirms clicking on 'Create Domain' button
     ui.button


### PR DESCRIPTION
## Description 📝
This fixes a flaky test by changing a `should('not.be.visible')` assertion to `should('not.exist')`. This test passes most of the time because the `should('not.be.visible')` assertion passes during a brief moment when the drawer close animation occurs (i.e. the element is still present in the DOM, but not visible). However, every so often this assertion does not occur quickly enough and the element is no longer present in the DOM, and the assertion fails.

This was initially planned to be included in a larger PR containing more fixes, but that's taking longer than I had planned and there's no reason to hold this back in the meantime.

## Changes  🔄
List any change relevant to the reviewer.
- Fix Domains landing page empty state test flake

## How to test 🧪
We can rely on CI, but this test can also be run locally using this command. In its current state, the test seems to fail more often in CI than locally; I was only able to trigger a failure twice out of 100 runs.

```bash
yarn cy:run -s "cypress/e2e/core/domains/domains-empty-landing-page.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

---
