### PR TITLE
upcoming: [M3-7610] - Placement Groups Detail

### DIFF
--- a/packages/manager/.changeset/pr-10096-upcoming-features-1706030600745.md
+++ b/packages/manager/.changeset/pr-10096-upcoming-features-1706030600745.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Placement Groups Detail Page ([#10096](https://github.com/linode/manager/pull/10096))

--- a/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
@@ -24,6 +24,7 @@ export const FinalCrumb = React.memo((props: Props) => {
         labelLink={labelOptions && labelOptions.linkTo}
         onCancel={onEditHandlers.onCancel}
         onEdit={onEditHandlers.onEdit}
+        onOpenEdit={onEditHandlers.onOpenEdit}
         text={onEditHandlers.editableTextTitle}
       />
     );

--- a/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
@@ -24,8 +24,8 @@ export const FinalCrumb = React.memo((props: Props) => {
         labelLink={labelOptions && labelOptions.linkTo}
         onCancel={onEditHandlers.onCancel}
         onEdit={onEditHandlers.onEdit}
-        onOpenEdit={onEditHandlers.onOpenEdit}
         text={onEditHandlers.editableTextTitle}
+        textSuffix={onEditHandlers.editableTextTitleSuffix}
       />
     );
   }

--- a/packages/manager/src/components/Breadcrumb/types.ts
+++ b/packages/manager/src/components/Breadcrumb/types.ts
@@ -10,8 +10,8 @@ export interface LabelProps {
 
 export interface EditableProps {
   editableTextTitle: string;
+  editableTextTitleSuffix?: string;
   errorText?: string;
   onCancel: () => void;
   onEdit: (value: string) => Promise<any>;
-  onOpenEdit?: () => void;
 }

--- a/packages/manager/src/components/Breadcrumb/types.ts
+++ b/packages/manager/src/components/Breadcrumb/types.ts
@@ -13,4 +13,5 @@ export interface EditableProps {
   errorText?: string;
   onCancel: () => void;
   onEdit: (value: string) => Promise<any>;
+  onOpenEdit?: () => void;
 }

--- a/packages/manager/src/components/EditableText/EditableText.stories.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.stories.tsx
@@ -24,6 +24,24 @@ export const Default: Story = {
   },
 };
 
+export const WithSuffix: Story = {
+  args: {
+    onCancel: action('onCancel'),
+    text: 'I have a suffix',
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [, setLocalArgs] = useArgs();
+    const onEdit = (updatedText: string) => {
+      return Promise.resolve(setLocalArgs({ text: updatedText }));
+    };
+
+    return (
+      <EditableText {...args} onEdit={onEdit} textSuffix=" (I am the suffix)" />
+    );
+  },
+};
+
 const meta: Meta<typeof EditableText> = {
   component: EditableText,
   title: 'Components/Editable Text',

--- a/packages/manager/src/components/EditableText/EditableText.test.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.test.tsx
@@ -108,4 +108,26 @@ describe('Editable Text', () => {
     fireEvent.click(saveButton);
     expect(props.onEdit).toHaveBeenCalled();
   });
+
+  it('appends a suffix to the text when provided', () => {
+    const { getByRole, getByTestId, getByText } = renderWithTheme(
+      <EditableText {...props} textSuffix="suffix" />
+    );
+
+    const text = getByText('Edit this suffix');
+    expect(text).toBeVisible();
+
+    const editButton = getByRole('button', { name: BUTTON_LABEL });
+    expect(editButton).toBeInTheDocument();
+
+    fireEvent.click(editButton);
+    const textfield = getByTestId('textfield-input');
+
+    expect(textfield).toHaveValue('Edit this');
+
+    const closeButton = getByTestId(CLOSE_BUTTON_ICON);
+    fireEvent.click(closeButton);
+
+    expect(getByText('Edit this suffix')).toBeVisible();
+  });
 });

--- a/packages/manager/src/components/EditableText/EditableText.test.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.test.tsx
@@ -111,7 +111,7 @@ describe('Editable Text', () => {
 
   it('appends a suffix to the text when provided', () => {
     const { getByRole, getByTestId, getByText } = renderWithTheme(
-      <EditableText {...props} textSuffix="suffix" />
+      <EditableText {...props} textSuffix=" suffix" />
     );
 
     const text = getByText('Edit this suffix');

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -200,7 +200,7 @@ export const EditableText = (props: PassThroughProps) => {
     <H1Header
       className={classes.root}
       data-qa-editable-text
-      title={`${text}${textSuffix ? textSuffix : ''}`}
+      title={`${text}${textSuffix ?? ''}`}
     />
   );
 

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -200,7 +200,7 @@ export const EditableText = (props: PassThroughProps) => {
     <H1Header
       className={classes.root}
       data-qa-editable-text
-      title={`${text} ${textSuffix || ''}`}
+      title={`${text}${textSuffix ? textSuffix : ''}`}
     />
   );
 

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -119,13 +119,13 @@ interface Props {
    */
   onEdit: (text: string) => Promise<any>;
   /**
-   * Additional function to run when the pencil icon is clicked (won't change default behavior)
-   */
-  onOpenEdit?: () => void;
-  /**
    * The text inside the textbox
    */
   text: string;
+  /**
+   * Optional suffix to append to the text when it is not in editing mode
+   */
+  textSuffix?: string;
 }
 
 type PassThroughProps = Props & Omit<TextFieldProps, 'label'>;
@@ -141,8 +141,8 @@ export const EditableText = (props: PassThroughProps) => {
     labelLink,
     onCancel,
     onEdit,
-    onOpenEdit,
     text: propText,
+    textSuffix,
     ...rest
   } = props;
 
@@ -164,9 +164,6 @@ export const EditableText = (props: PassThroughProps) => {
 
   const openEdit = () => {
     setIsEditing(true);
-    if (onOpenEdit) {
-      onOpenEdit();
-    }
   };
 
   const finishEditing = () => {
@@ -203,7 +200,11 @@ export const EditableText = (props: PassThroughProps) => {
     }
   };
   const labelText = (
-    <H1Header className={classes.root} data-qa-editable-text title={text} />
+    <H1Header
+      className={classes.root}
+      data-qa-editable-text
+      title={`${text} ${textSuffix || ''}`}
+    />
   );
 
   return !isEditing && !errorText ? (

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -151,10 +151,7 @@ export const EditableText = (props: PassThroughProps) => {
   }, [propText]);
 
   React.useEffect(() => {
-    if (!isEditing) {
-      onCancel();
-    }
-
+    onCancel();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isEditing]);
 

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -119,6 +119,10 @@ interface Props {
    */
   onEdit: (text: string) => Promise<any>;
   /**
+   * Additional function to run when the pencil icon is clicked (won't change default behavior)
+   */
+  onOpenEdit?: () => void;
+  /**
    * The text inside the textbox
    */
   text: string;
@@ -137,6 +141,7 @@ export const EditableText = (props: PassThroughProps) => {
     labelLink,
     onCancel,
     onEdit,
+    onOpenEdit,
     text: propText,
     ...rest
   } = props;
@@ -146,7 +151,10 @@ export const EditableText = (props: PassThroughProps) => {
   }, [propText]);
 
   React.useEffect(() => {
-    onCancel();
+    if (!isEditing) {
+      onCancel();
+    }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isEditing]);
 
@@ -156,6 +164,9 @@ export const EditableText = (props: PassThroughProps) => {
 
   const openEdit = () => {
     setIsEditing(true);
+    if (onOpenEdit) {
+      onOpenEdit();
+    }
   };
 
   const finishEditing = () => {

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -251,6 +251,7 @@ export const EditableText = (props: PassThroughProps) => {
           value={text}
         />
         <Button
+          aria-label="Save"
           className={classes.button}
           data-qa-save-edit
           onClick={finishEditing}
@@ -258,6 +259,7 @@ export const EditableText = (props: PassThroughProps) => {
           <Check className={classes.icon} />
         </Button>
         <Button
+          aria-label="Cancel"
           className={classes.button}
           data-qa-cancel-edit
           onClick={cancelEditing}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.test.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.test.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+
+import { placementGroupFactory } from 'src/factories';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { PlacementGroupsDetail } from './PlacementGroupsDetail';
+
+const queryMocks = vi.hoisted(() => ({
+  usePlacementGroupQuery: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('src/queries/placementGroups', async () => {
+  const actual = await vi.importActual('src/queries/placementGroups');
+  return {
+    ...actual,
+    usePlacementGroupQuery: queryMocks.usePlacementGroupQuery,
+  };
+});
+
+describe('PlacementGroupsLanding', () => {
+  it('renders a error page', () => {
+    const { getByText } = renderWithTheme(<PlacementGroupsDetail />);
+
+    expect(getByText('Not Found')).toBeInTheDocument();
+  });
+
+  it('renders a loading state', () => {
+    queryMocks.usePlacementGroupQuery.mockReturnValue({
+      data: {
+        data: placementGroupFactory.build({
+          id: 1,
+        }),
+      },
+      isLoading: true,
+    });
+
+    const { getByRole } = renderWithTheme(<PlacementGroupsDetail />, {
+      MemoryRouter: {
+        initialEntries: [{ pathname: '/placement-groups/1' }],
+      },
+    });
+
+    expect(getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('renders breadcrumbs, docs link and tabs', () => {
+    queryMocks.usePlacementGroupQuery.mockReturnValue({
+      data: placementGroupFactory.build({
+        affinity_type: 'anti_affinity',
+        id: 1,
+        label: 'My first PG',
+      }),
+    });
+
+    const { getByRole, getByText } = renderWithTheme(
+      <PlacementGroupsDetail />,
+      {
+        MemoryRouter: {
+          initialEntries: [{ pathname: '/placement-groups/1' }],
+        },
+      }
+    );
+
+    expect(getByText(/my first pg \(Anti-affinity\)/i)).toBeInTheDocument();
+    expect(getByText(/docs/i)).toBeInTheDocument();
+    expect(getByRole('tab', { name: 'Summary' })).toBeInTheDocument();
+    expect(getByRole('tab', { name: 'Linodes (3)' })).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
@@ -82,6 +82,12 @@ export const PlacementGroupsDetail = () => {
       <DocumentTitleSegment segment={label} />
       <LandingHeader
         breadcrumbProps={{
+          crumbOverrides: [
+            {
+              label: 'Placement Groups',
+              position: 1,
+            },
+          ],
           onEditHandlers: {
             editableTextTitle: label,
             editableTextTitleSuffix: ` (${affinityLabel})`,

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+import { useHistory, useParams } from 'react-router-dom';
+
+import { CircleProgress } from 'src/components/CircleProgress';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import { ErrorState } from 'src/components/ErrorState/ErrorState';
+import { LandingHeader } from 'src/components/LandingHeader';
+import { NotFound } from 'src/components/NotFound';
+import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
+import { TabLinkList } from 'src/components/Tabs/TabLinkList';
+import { TabPanels } from 'src/components/Tabs/TabPanels';
+import { Tabs } from 'src/components/Tabs/Tabs';
+import { useFlags } from 'src/hooks/useFlags';
+import {
+  useMutatePlacementGroup,
+  usePlacementGroupQuery,
+} from 'src/queries/placementGroups';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
+
+import { getAffinityLabel, getPlacementGroupLinodeCount } from '../utils';
+
+export const PlacementGroupsDetail = () => {
+  const flags = useFlags();
+  const { id, tab } = useParams<{ id: string; tab?: string }>();
+  const history = useHistory();
+  const placementGroupId = Number(id);
+  const {
+    data: placementGroup,
+    error: placementGroupError,
+    isLoading,
+  } = usePlacementGroupQuery(placementGroupId, Boolean(flags.vmPlacement));
+  const {
+    error: updatePlacementGroupError,
+    mutateAsync: updatePlacementGroup,
+    reset,
+  } = useMutatePlacementGroup(placementGroupId);
+  const errorText = getErrorStringOrDefault(updatePlacementGroupError ?? '');
+
+  if (!placementGroup) {
+    return <NotFound />;
+  }
+
+  if (placementGroupError) {
+    return (
+      <ErrorState errorText="There was a problem retrieving your Placement Group. Please try again." />
+    );
+  }
+
+  if (isLoading) {
+    return <CircleProgress />;
+  }
+
+  const linodeCount = getPlacementGroupLinodeCount(placementGroup);
+  const tabs = [
+    {
+      routeName: `/placement-groups/${id}`,
+      title: 'Summary',
+    },
+    {
+      routeName: `/placement-groups/${id}/linodes`,
+      title: `Linodes (${linodeCount})`,
+    },
+  ];
+
+  const handleLabelChange = (newLabel: string) => {
+    if (updatePlacementGroupError) {
+      reset();
+    }
+    return updatePlacementGroup({ label: newLabel });
+  };
+
+  const resetEditableLabel = () => {
+    return placementGroup.label;
+  };
+
+  const { affinity_type, label } = placementGroup;
+  const affinityLabel = getAffinityLabel(affinity_type);
+  const tabIndex = tab ? tabs.findIndex((t) => t.routeName.endsWith(tab)) : -1;
+
+  return (
+    <React.Fragment>
+      <DocumentTitleSegment segment={label} />
+      <LandingHeader
+        breadcrumbProps={{
+          onEditHandlers: {
+            editableTextTitle: `${placementGroup?.label} (${affinityLabel})`,
+            errorText,
+            onCancel: resetEditableLabel,
+            onEdit: handleLabelChange,
+          },
+          pathname: `/placement-groups/${placementGroup.label}`,
+        }}
+        docsLabel="Docs"
+        docsLink=""
+        title="Placement Group Details"
+      />
+      <Tabs
+        index={tabIndex === -1 ? 0 : tabIndex}
+        onChange={(i) => history.push(tabs[i].routeName)}
+      >
+        <TabLinkList tabs={tabs} />
+
+        <TabPanels>
+          <SafeTabPanel index={0}>
+            <>{/* something */}</>
+          </SafeTabPanel>
+          <SafeTabPanel index={1}>
+            <>{/* something */}</>
+          </SafeTabPanel>
+        </TabPanels>
+      </Tabs>
+    </React.Fragment>
+  );
+};

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
@@ -35,7 +35,6 @@ export const PlacementGroupsDetail = () => {
     reset,
   } = useMutatePlacementGroup(placementGroupId);
   const errorText = getErrorStringOrDefault(updatePlacementGroupError ?? '');
-  const [isEditingLabel, setIsEditingLabel] = React.useState<boolean>(false);
 
   if (!placementGroup) {
     return <NotFound />;
@@ -67,14 +66,10 @@ export const PlacementGroupsDetail = () => {
   const tabIndex = tab ? tabs.findIndex((t) => t.routeName.endsWith(tab)) : -1;
 
   const resetEditableLabel = () => {
-    setIsEditingLabel(false);
-
     return `${label} (${affinityLabel})`;
   };
 
   const handleLabelEdit = (newLabel: string) => {
-    setIsEditingLabel(false);
-
     if (updatePlacementGroupError) {
       reset();
     }
@@ -88,13 +83,11 @@ export const PlacementGroupsDetail = () => {
       <LandingHeader
         breadcrumbProps={{
           onEditHandlers: {
-            editableTextTitle: isEditingLabel
-              ? label
-              : `${label} (${affinityLabel})`,
+            editableTextTitle: label,
+            editableTextTitleSuffix: `(${affinityLabel})`,
             errorText,
             onCancel: resetEditableLabel,
             onEdit: handleLabelEdit,
-            onOpenEdit: () => setIsEditingLabel(true),
           },
           pathname: `/placement-groups/${label}`,
         }}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
@@ -84,7 +84,7 @@ export const PlacementGroupsDetail = () => {
         breadcrumbProps={{
           onEditHandlers: {
             editableTextTitle: label,
-            editableTextTitleSuffix: `(${affinityLabel})`,
+            editableTextTitleSuffix: ` (${affinityLabel})`,
             errorText,
             onCancel: resetEditableLabel,
             onEdit: handleLabelEdit,

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
@@ -35,6 +35,7 @@ export const PlacementGroupsDetail = () => {
     reset,
   } = useMutatePlacementGroup(placementGroupId);
   const errorText = getErrorStringOrDefault(updatePlacementGroupError ?? '');
+  const [isEditingLabel, setIsEditingLabel] = React.useState<boolean>(false);
 
   if (!placementGroup) {
     return <NotFound />;
@@ -61,38 +62,45 @@ export const PlacementGroupsDetail = () => {
       title: `Linodes (${linodeCount})`,
     },
   ];
-
-  const handleLabelChange = (newLabel: string) => {
-    if (updatePlacementGroupError) {
-      reset();
-    }
-    return updatePlacementGroup({ label: newLabel });
-  };
-
-  const resetEditableLabel = () => {
-    return placementGroup.label;
-  };
-
   const { affinity_type, label } = placementGroup;
   const affinityLabel = getAffinityLabel(affinity_type);
   const tabIndex = tab ? tabs.findIndex((t) => t.routeName.endsWith(tab)) : -1;
 
+  const resetEditableLabel = () => {
+    setIsEditingLabel(false);
+
+    return `${label} (${affinityLabel})`;
+  };
+
+  const handleLabelEdit = (newLabel: string) => {
+    setIsEditingLabel(false);
+
+    if (updatePlacementGroupError) {
+      reset();
+    }
+
+    return updatePlacementGroup({ label: newLabel });
+  };
+
   return (
-    <React.Fragment>
+    <>
       <DocumentTitleSegment segment={label} />
       <LandingHeader
         breadcrumbProps={{
           onEditHandlers: {
-            editableTextTitle: `${placementGroup?.label} (${affinityLabel})`,
+            editableTextTitle: isEditingLabel
+              ? label
+              : `${label} (${affinityLabel})`,
             errorText,
             onCancel: resetEditableLabel,
-            onEdit: handleLabelChange,
+            onEdit: handleLabelEdit,
+            onOpenEdit: () => setIsEditingLabel(true),
           },
-          pathname: `/placement-groups/${placementGroup.label}`,
+          pathname: `/placement-groups/${label}`,
         }}
         docsLabel="Docs"
-        docsLink=""
-        title="Placement Group Details"
+        docsLink="TODO VM_Placement: add doc link"
+        title="Placement Group Detail"
       />
       <Tabs
         index={tabIndex === -1 ? 0 : tabIndex}
@@ -101,14 +109,10 @@ export const PlacementGroupsDetail = () => {
         <TabLinkList tabs={tabs} />
 
         <TabPanels>
-          <SafeTabPanel index={0}>
-            <>{/* something */}</>
-          </SafeTabPanel>
-          <SafeTabPanel index={1}>
-            <>{/* something */}</>
-          </SafeTabPanel>
+          <SafeTabPanel index={0}>TODO VM_Placement: summary</SafeTabPanel>
+          <SafeTabPanel index={1}>TODO VM_Placement: linode list</SafeTabPanel>
         </TabPanels>
       </Tabs>
-    </React.Fragment>
+    </>
   );
 };

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsRow.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsRow.tsx
@@ -12,6 +12,7 @@ import { Typography } from 'src/components/Typography';
 import { useLinodesQuery } from 'src/queries/linodes/linodes';
 import { useRegionsQuery } from 'src/queries/regions';
 
+import { getAffinityLabel, getPlacementGroupLinodeCount } from '../utils';
 import { StyledWarningIcon } from './PlacementGroupsRow.styles';
 
 import type { PlacementGroup } from '@linode/api-v4';
@@ -42,12 +43,12 @@ export const PlacementGroupsRow = React.memo(
     const regionLabel =
       regions?.find((region) => region.id === placementGroup.region)?.label ??
       placementGroup.region;
-    const numberOfAssignedLinodesAsString = linode_ids.length.toString() ?? '';
+    const linodeCount = getPlacementGroupLinodeCount(placementGroup);
     const listOfAssignedLinodes = linodes?.data.filter((linode) =>
       linode_ids.includes(linode.id)
     );
-    const affinityType =
-      affinity_type === 'affinity' ? 'Affinity' : 'Anti-affinity';
+    const affinityLabel = getAffinityLabel(affinity_type);
+
     const actions: Action[] = [
       {
         onClick: handleRenamePlacementGroup,
@@ -62,14 +63,14 @@ export const PlacementGroupsRow = React.memo(
     return (
       <TableRow
         ariaLabel={`Placement Group ${label}`}
-        data-testid={`placement-group-${id}`}
+        data-testid={`placement-groups-${id}`}
       >
         <TableCell>
           <Link
             data-testid={`link-to-placement-group-${id}`}
             to={`/placement-groups/${id}`}
           >
-            {label} ({affinityType}) &nbsp;
+            {label} ({affinityLabel}) &nbsp;
           </Link>
           {!compliant && (
             <Typography component="span" sx={{ whiteSpace: 'nowrap' }}>
@@ -87,7 +88,7 @@ export const PlacementGroupsRow = React.memo(
                 ))}
               </List>
             }
-            displayText={numberOfAssignedLinodesAsString}
+            displayText={`${linodeCount}`}
             minWidth={200}
           />
           &nbsp; of {limits}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsRow.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsRow.tsx
@@ -63,7 +63,7 @@ export const PlacementGroupsRow = React.memo(
     return (
       <TableRow
         ariaLabel={`Placement Group ${label}`}
-        data-testid={`placement-groups-${id}`}
+        data-testid={`placement-group-${id}`}
       >
         <TableCell>
           <Link

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsRow.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsRow.tsx
@@ -68,9 +68,10 @@ export const PlacementGroupsRow = React.memo(
         <TableCell>
           <Link
             data-testid={`link-to-placement-group-${id}`}
+            style={{ marginRight: 8 }}
             to={`/placement-groups/${id}`}
           >
-            {label} ({affinityLabel}) &nbsp;
+            {label} ({affinityLabel})
           </Link>
           {!compliant && (
             <Typography component="span" sx={{ whiteSpace: 'nowrap' }}>

--- a/packages/manager/src/features/PlacementGroups/index.tsx
+++ b/packages/manager/src/features/PlacementGroups/index.tsx
@@ -11,12 +11,11 @@ const PlacementGroupsLanding = React.lazy(() =>
   }))
 );
 
-// TODO VM_Placement: add <PlacementGroupsDetail />
-// const PlacementGroupDetail = React.lazy(() =>
-//   import('./PlacementGroupDetail/PlacementGroupDetail').then((module) => ({
-//     default: module.PlacementGroupsDetail,
-//   }))
-// );
+const PlacementGroupsDetail = React.lazy(() =>
+  import('./PlacementGroupsDetail/PlacementGroupsDetail').then((module) => ({
+    default: module.PlacementGroupsDetail,
+  }))
+);
 
 export const PlacementGroups = () => {
   const { path } = useRouteMatch();
@@ -32,10 +31,7 @@ export const PlacementGroups = () => {
             exact
             path={`${path}/create`}
           />
-          {/*
-            // TODO VM_Placement: add <PlacementGroupsDetail />
-            <Route component={FirewallDetail} path={`${path}/:id/:tab?`} />
-          */}
+          <Route component={PlacementGroupsDetail} path={`${path}/:id/:tab?`} />
           <Route component={PlacementGroupsLanding} />
         </Switch>
       </React.Fragment>

--- a/packages/manager/src/features/PlacementGroups/utils.test.ts
+++ b/packages/manager/src/features/PlacementGroups/utils.test.ts
@@ -1,0 +1,21 @@
+import { getAffinityLabel, getPlacementGroupLinodeCount } from './utils';
+
+describe('getAffinityLabel', () => {
+  it('returns "Affinity" for "affinity" type', () => {
+    expect(getAffinityLabel('affinity')).toBe('Affinity');
+  });
+
+  it('returns "Anti-Affinity" for "anti-affinity" type', () => {
+    expect(getAffinityLabel('anti_affinity')).toBe('Anti-Affinity');
+  });
+});
+
+describe('getPlacementGroupLinodeCount', () => {
+  it('returns the length of the linode_ids array', () => {
+    expect(
+      getPlacementGroupLinodeCount({
+        linode_ids: [1, 2, 3],
+      } as any)
+    ).toBe(3);
+  });
+});

--- a/packages/manager/src/features/PlacementGroups/utils.test.ts
+++ b/packages/manager/src/features/PlacementGroups/utils.test.ts
@@ -5,8 +5,8 @@ describe('getAffinityLabel', () => {
     expect(getAffinityLabel('affinity')).toBe('Affinity');
   });
 
-  it('returns "Anti-Affinity" for "anti-affinity" type', () => {
-    expect(getAffinityLabel('anti_affinity')).toBe('Anti-Affinity');
+  it('returns "Anti-affinity" for "anti_affinity" type', () => {
+    expect(getAffinityLabel('anti_affinity')).toBe('Anti-affinity');
   });
 });
 

--- a/packages/manager/src/features/PlacementGroups/utils.ts
+++ b/packages/manager/src/features/PlacementGroups/utils.ts
@@ -1,0 +1,19 @@
+import { PlacementGroup } from '@linode/api-v4';
+
+/**
+ * Helper to get the human readable label for a Placement Group affinity type.
+ */
+export const getAffinityLabel = (
+  affinityType: PlacementGroup['affinity_type']
+): string => {
+  return affinityType === 'affinity' ? 'Affinity' : 'Anti-Affinity';
+};
+
+/**
+ * Helper to get the number of Linodes in a Placement Group.
+ */
+export const getPlacementGroupLinodeCount = (
+  placementGroup: PlacementGroup
+): number => {
+  return placementGroup.linode_ids.length;
+};

--- a/packages/manager/src/features/PlacementGroups/utils.ts
+++ b/packages/manager/src/features/PlacementGroups/utils.ts
@@ -6,7 +6,7 @@ import { PlacementGroup } from '@linode/api-v4';
 export const getAffinityLabel = (
   affinityType: PlacementGroup['affinity_type']
 ): string => {
-  return affinityType === 'affinity' ? 'Affinity' : 'Anti-Affinity';
+  return affinityType === 'affinity' ? 'Affinity' : 'Anti-affinity';
 };
 
 /**

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1937,7 +1937,13 @@ export const handlers = [
       return res(ctx.status(404));
     }
 
-    return res(ctx.json(placementGroupFactory.build()));
+    return res(
+      ctx.json(
+        placementGroupFactory.build({
+          id: 1,
+        })
+      )
+    );
   }),
   rest.post('*/placement/groups', (req, res, ctx) => {
     return res(

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1954,7 +1954,7 @@ export const handlers = [
       )
     );
   }),
-  rest.post('*/placement/groups/:placementGroupId', (req, res, ctx) => {
+  rest.put('*/placement/groups/:placementGroupId', (req, res, ctx) => {
     if (req.params.placementGroupId === 'undefined') {
       return res(ctx.status(404));
     }


### PR DESCRIPTION
## Description 📝
This PR implements the Placement Groups Detail page and associated routing. It does not implement tabs content (summary & linodes list) which are left for subsequent tickets.

## Changes  🔄
- Implement the detail page and its routing
- Add a couple simple utils and their tests
- Make the `EditableTextField` take a  new `textSuffix` prop to manage the breadcrumb suffix
- Add test and a story for ☝️ 
- Fix the HTTP method for placement group query MSW

## Preview 📷
![Screenshot 2024-01-23 at 12 15 58](https://github.com/linode/manager/assets/130582365/b3a3f552-4f75-49a7-bd17-e41026bafd74)


![Screenshot 2024-01-24 at 09 23 40](https://github.com/linode/manager/assets/130582365/213f8bc4-c238-4e64-b9c8-81c5e348f787)


## How to test 🧪

### Verification steps 
- Pull and run code locally
- Turn on the "Placement Group" dev setting and MSW
- Navigate to http://localhost:3000/placement-groups
- Click on a placement group in the table
- Confirm the Placement Group Detail page and its content (breadcrumb w/ editint label, docs link, tabs without content) 

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [x] ♿  Providing accessibility support


