### PR TITLE
fix: [M3-7692] - VPC Action Buttons Incorrect Color in Dark Mode

### DIFF
--- a/packages/manager/.changeset/pr-10101-fixed-1706061984923.md
+++ b/packages/manager/.changeset/pr-10101-fixed-1706061984923.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+VPC Action Buttons Incorrect Color in Dark Mode ([#10101](https://github.com/linode/manager/pull/10101))

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.styles.ts
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.styles.ts
@@ -9,8 +9,8 @@ export const StyledActionButton = styled(Button, {
   label: 'StyledActionButton',
 })(({ theme }) => ({
   '&:hover': {
-    backgroundColor: theme.color.blueDTwhite,
-    color: theme.color.white,
+    backgroundColor: theme.color.blue,
+    color: '#fff',
   },
   color: theme.textColors.linkActiveLight,
   fontFamily: theme.font.normal,


### PR DESCRIPTION
## Description 📝

- Fixes button colors of VPC action buttons (`Edit` and `Delete`)
- Relates to https://github.com/linode/manager/pull/10077

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-01-23 at 8 54 50 PM](https://github.com/linode/manager/assets/115251059/a59a30e0-9352-42e1-9c0a-d00b5d29a355) | ![Screenshot 2024-01-23 at 8 54 40 PM](https://github.com/linode/manager/assets/115251059/35382c81-44bb-48e4-90cb-5e057dbb16ee) |

## How to test 🧪

- Go to VPC details page
- Check the colors of the `Edit` and `Delete` buttons in both light ☀️ and dark mode 🌑

## As an Author I have considered 🤔

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support