### PR TITLE
upcoming: [M3-7660] - Cleanup files to use `profile` to get `user_type`

### DIFF
--- a/packages/manager/.changeset/pr-10102-upcoming-features-1706069240239.md
+++ b/packages/manager/.changeset/pr-10102-upcoming-features-1706069240239.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Cleanup files to use profile to get user_type ([#10102](https://github.com/linode/manager/pull/10102))

--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -54,6 +54,8 @@ const AccountLanding = () => {
   const accountAccessGrant = grants?.global?.account_access;
   const readOnlyAccountAccess = accountAccessGrant === 'read_only';
   const isAkamaiAccount = account?.billing_source === 'akamai';
+  const isProxyUser = profile?.user_type === 'proxy';
+  const isParentUser = profile?.user_type === 'parent';
 
   const tabs = [
     {
@@ -115,8 +117,7 @@ const AccountLanding = () => {
 
   const isBillingTabSelected = location.pathname.match(/billing/);
   const canSwitchBetweenParentOrProxyAccount =
-    flags.parentChildAccountAccess &&
-    (profile?.user_type === 'parent' || profile?.user_type === 'proxy');
+    flags.parentChildAccountAccess && (isParentUser || isProxyUser);
 
   const landingHeaderProps: LandingHeaderProps = {
     breadcrumbProps: {
@@ -172,7 +173,7 @@ const AccountLanding = () => {
         </React.Suspense>
       </Tabs>
       <SwitchAccountDrawer
-        isProxyUser={profile?.user_type === 'proxy'}
+        isProxyUser={isProxyUser}
         onClose={() => setIsDrawerOpen(false)}
         open={isDrawerOpen}
       />

--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -13,7 +13,6 @@ import { TabPanels } from 'src/components/Tabs/TabPanels';
 import { Tabs } from 'src/components/Tabs/Tabs';
 import { useFlags } from 'src/hooks/useFlags';
 import { useAccount } from 'src/queries/account';
-import { useAccountUser } from 'src/queries/accountUsers';
 import { useGrants, useProfile } from 'src/queries/profile';
 
 import AccountLogins from './AccountLogins';
@@ -48,7 +47,6 @@ const AccountLanding = () => {
   const { data: account } = useAccount();
   const { data: grants } = useGrants();
   const { data: profile } = useProfile();
-  const { data: user } = useAccountUser(profile?.username ?? '');
 
   const flags = useFlags();
   const [isDrawerOpen, setIsDrawerOpen] = React.useState<boolean>(false);
@@ -118,7 +116,7 @@ const AccountLanding = () => {
   const isBillingTabSelected = location.pathname.match(/billing/);
   const canSwitchBetweenParentOrProxyAccount =
     flags.parentChildAccountAccess &&
-    (user?.user_type === 'parent' || user?.user_type === 'proxy');
+    (profile?.user_type === 'parent' || profile?.user_type === 'proxy');
 
   const landingHeaderProps: LandingHeaderProps = {
     breadcrumbProps: {
@@ -174,7 +172,7 @@ const AccountLanding = () => {
         </React.Suspense>
       </Tabs>
       <SwitchAccountDrawer
-        isProxyUser={user?.user_type === 'proxy'}
+        isProxyUser={profile?.user_type === 'proxy'}
         onClose={() => setIsDrawerOpen(false)}
         open={isDrawerOpen}
       />

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.test.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.test.tsx
@@ -32,7 +32,7 @@ describe('SwitchAccountDrawer', () => {
 
   it('should include a link to switch back to the parent account if the active user is a proxy user', async () => {
     server.use(
-      rest.get('*/account/users/*', (req, res, ctx) => {
+      rest.get('*/account/profile/*', (req, res, ctx) => {
         return res(ctx.json(profileFactory.build({ user_type: 'proxy' })));
       })
     );

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.test.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.test.tsx
@@ -32,7 +32,7 @@ describe('SwitchAccountDrawer', () => {
 
   it('should include a link to switch back to the parent account if the active user is a proxy user', async () => {
     server.use(
-      rest.get('*/account/profile/*', (req, res, ctx) => {
+      rest.get('*/profile/*', (req, res, ctx) => {
         return res(ctx.json(profileFactory.build({ user_type: 'proxy' })));
       })
     );

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.test.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent } from '@testing-library/react';
 import * as React from 'react';
 
-import { accountUserFactory } from 'src/factories/accountUsers';
+import { profileFactory } from 'src/factories/profile';
 import { rest, server } from 'src/mocks/testServer';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
@@ -33,7 +33,7 @@ describe('SwitchAccountDrawer', () => {
   it('should include a link to switch back to the parent account if the active user is a proxy user', async () => {
     server.use(
       rest.get('*/account/users/*', (req, res, ctx) => {
-        return res(ctx.json(accountUserFactory.build({ user_type: 'proxy' })));
+        return res(ctx.json(profileFactory.build({ user_type: 'proxy' })));
       })
     );
 

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.test.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.test.tsx
@@ -32,7 +32,7 @@ describe('SwitchAccountDrawer', () => {
 
   it('should include a link to switch back to the parent account if the active user is a proxy user', async () => {
     server.use(
-      rest.get('*/profile/*', (req, res, ctx) => {
+      rest.get('*/profile', (req, res, ctx) => {
         return res(ctx.json(profileFactory.build({ user_type: 'proxy' })));
       })
     );

--- a/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.test.tsx
+++ b/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.test.tsx
@@ -1,8 +1,7 @@
 import { waitFor, within } from '@testing-library/react';
 import * as React from 'react';
 
-import { accountFactory } from 'src/factories/account';
-import { accountUserFactory } from 'src/factories/accountUsers';
+import { accountFactory, profileFactory } from 'src/factories';
 import { ChildAccountList } from 'src/features/Account/SwitchAccounts/ChildAccountList';
 import { makeResourcePage } from 'src/mocks/serverHandlers';
 import { rest, server } from 'src/mocks/testServer';
@@ -17,8 +16,8 @@ const props = {
 
 it('should display a list of child accounts', async () => {
   server.use(
-    rest.get('*/account/users/*', (req, res, ctx) => {
-      return res(ctx.json(accountUserFactory.build({ user_type: 'parent' })));
+    rest.get('*/profile', (req, res, ctx) => {
+      return res(ctx.json(profileFactory.build({ user_type: 'parent' })));
     }),
     rest.get('*/account/child-accounts', (req, res, ctx) => {
       return res(

--- a/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.test.tsx
+++ b/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.test.tsx
@@ -2,7 +2,7 @@ import { waitFor, within } from '@testing-library/react';
 import * as React from 'react';
 
 import { accountFactory } from 'src/factories/account';
-import { profileFactory } from 'src/factories/profile';
+import { accountUserFactory } from 'src/factories/accountUsers';
 import { ChildAccountList } from 'src/features/Account/SwitchAccounts/ChildAccountList';
 import { makeResourcePage } from 'src/mocks/serverHandlers';
 import { rest, server } from 'src/mocks/testServer';
@@ -18,7 +18,7 @@ const props = {
 it('should display a list of child accounts', async () => {
   server.use(
     rest.get('*/account/users/*', (req, res, ctx) => {
-      return res(ctx.json(profileFactory.build({ user_type: 'parent' })));
+      return res(ctx.json(accountUserFactory.build({ user_type: 'parent' })));
     }),
     rest.get('*/account/child-accounts', (req, res, ctx) => {
       return res(

--- a/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.test.tsx
+++ b/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.test.tsx
@@ -2,7 +2,7 @@ import { waitFor, within } from '@testing-library/react';
 import * as React from 'react';
 
 import { accountFactory } from 'src/factories/account';
-import { accountUserFactory } from 'src/factories/accountUsers';
+import { profileFactory } from 'src/factories/profile';
 import { ChildAccountList } from 'src/features/Account/SwitchAccounts/ChildAccountList';
 import { makeResourcePage } from 'src/mocks/serverHandlers';
 import { rest, server } from 'src/mocks/testServer';
@@ -18,7 +18,7 @@ const props = {
 it('should display a list of child accounts', async () => {
   server.use(
     rest.get('*/account/users/*', (req, res, ctx) => {
-      return res(ctx.json(accountUserFactory.build({ user_type: 'parent' })));
+      return res(ctx.json(profileFactory.build({ user_type: 'parent' })));
     }),
     rest.get('*/account/child-accounts', (req, res, ctx) => {
       return res(

--- a/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.test.tsx
+++ b/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.test.tsx
@@ -3,22 +3,22 @@ import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
 import { appTokenFactory } from 'src/factories';
-import { accountUserFactory } from 'src/factories/accountUsers';
+import { profileFactory } from 'src/factories/profile';
 import { rest, server } from 'src/mocks/testServer';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { CreateAPITokenDrawer } from './CreateAPITokenDrawer';
 
-// Mock the useAccountUser hooks to immediately return the expected data, circumventing the HTTP request and loading state.
+// Mock the useProfile hooks to immediately return the expected data, circumventing the HTTP request and loading state.
 const queryMocks = vi.hoisted(() => ({
-  useAccountUser: vi.fn().mockReturnValue({}),
+  useProfile: vi.fn().mockReturnValue({}),
 }));
 
-vi.mock('src/queries/accountUsers', async () => {
-  const actual = await vi.importActual<any>('src/queries/accountUsers');
+vi.mock('src/queries/profile', async () => {
+  const actual = await vi.importActual<any>('src/queries/profile');
   return {
     ...actual,
-    useAccountUser: queryMocks.useAccountUser,
+    useProfile: queryMocks.useProfile,
   };
 });
 
@@ -88,8 +88,8 @@ describe('Create API Token Drawer', () => {
   });
 
   it('Should show the Child Account Access scope for a parent user account with the parent/child feature flag on', () => {
-    queryMocks.useAccountUser.mockReturnValue({
-      data: accountUserFactory.build({ user_type: 'parent' }),
+    queryMocks.useProfile.mockReturnValue({
+      data: profileFactory.build({ user_type: 'parent' }),
     });
 
     const { getByText } = renderWithTheme(<CreateAPITokenDrawer {...props} />, {
@@ -100,8 +100,8 @@ describe('Create API Token Drawer', () => {
   });
 
   it('Should not show the Child Account Access scope for a non-parent user account with the parent/child feature flag on', () => {
-    queryMocks.useAccountUser.mockReturnValue({
-      data: accountUserFactory.build({ user_type: null }),
+    queryMocks.useProfile.mockReturnValue({
+      data: profileFactory.build({ user_type: null }),
     });
 
     const { queryByText } = renderWithTheme(

--- a/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.tsx
@@ -19,7 +19,6 @@ import { AccessCell } from 'src/features/ObjectStorage/AccessKeyLanding/AccessCe
 import { VPC_READ_ONLY_TOOLTIP } from 'src/features/VPCs/constants';
 import { useFlags } from 'src/hooks/useFlags';
 import { useAccount } from 'src/queries/account';
-import { useAccountUser } from 'src/queries/accountUsers';
 import { useProfile } from 'src/queries/profile';
 import { useCreatePersonalAccessTokenMutation } from 'src/queries/tokens';
 import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
@@ -99,7 +98,6 @@ export const CreateAPITokenDrawer = (props: Props) => {
 
   const { data: profile } = useProfile();
   const { data: account } = useAccount();
-  const { data: user } = useAccountUser(profile?.username ?? '');
 
   const {
     error,
@@ -190,7 +188,7 @@ export const CreateAPITokenDrawer = (props: Props) => {
   const allPermissions = form.values.scopes;
 
   const showFilteredPermissions =
-    (flags.parentChildAccountAccess && user?.user_type !== 'parent') ||
+    (flags.parentChildAccountAccess && profile?.user_type !== 'parent') ||
     Boolean(!flags.parentChildAccountAccess);
 
   const filteredPermissions = allPermissions.filter(

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.test.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent, within } from '@testing-library/react';
 import * as React from 'react';
 
 import { accountFactory, profileFactory } from 'src/factories';
-import { accountUserFactory } from 'src/factories/accountUsers';
 import { rest, server } from 'src/mocks/testServer';
 import { mockMatchMedia, renderWithTheme } from 'src/utilities/testHelpers';
 
@@ -25,10 +24,14 @@ describe('UserMenu', () => {
         );
       }),
       rest.get('*/profile', (req, res, ctx) => {
-        return res(ctx.json(profileFactory.build({ username: 'parent-user' })));
-      }),
-      rest.get('*/account/users/*', (req, res, ctx) => {
-        return res(ctx.json(accountUserFactory.build({ user_type: 'parent' })));
+        return res(
+          ctx.json(
+            profileFactory.build({
+              user_type: 'parent',
+              username: 'parent-user',
+            })
+          )
+        );
       })
     );
 
@@ -48,10 +51,14 @@ describe('UserMenu', () => {
         );
       }),
       rest.get('*/profile', (req, res, ctx) => {
-        return res(ctx.json(profileFactory.build({ username: 'parent-user' })));
-      }),
-      rest.get('*/account/users/*', (req, res, ctx) => {
-        return res(ctx.json(accountUserFactory.build({ user_type: 'proxy' })));
+        return res(
+          ctx.json(
+            profileFactory.build({
+              user_type: 'proxy',
+              username: 'parent-user',
+            })
+          )
+        );
       })
     );
 
@@ -71,10 +78,11 @@ describe('UserMenu', () => {
         );
       }),
       rest.get('*/profile', (req, res, ctx) => {
-        return res(ctx.json(profileFactory.build({ username: 'child-user' })));
-      }),
-      rest.get('*/account/users/*', (req, res, ctx) => {
-        return res(ctx.json(accountUserFactory.build({ user_type: 'child' })));
+        return res(
+          ctx.json(
+            profileFactory.build({ user_type: 'child', username: 'child-user' })
+          )
+        );
       })
     );
 
@@ -93,11 +101,10 @@ describe('UserMenu', () => {
       }),
       rest.get('*/profile', (req, res, ctx) => {
         return res(
-          ctx.json(profileFactory.build({ username: 'regular-user' }))
+          ctx.json(
+            profileFactory.build({ user_type: null, username: 'regular-user' })
+          )
         );
-      }),
-      rest.get('*/account/users/*', (req, res, ctx) => {
-        return res(ctx.json(accountUserFactory.build({ user_type: null })));
       })
     );
 
@@ -116,8 +123,8 @@ describe('UserMenu', () => {
           ctx.json(accountFactory.build({ company: 'Parent Company' }))
         );
       }),
-      rest.get('*/account/users/*', (req, res, ctx) => {
-        return res(ctx.json(accountUserFactory.build({ user_type: 'parent' })));
+      rest.get('*/profile', (req, res, ctx) => {
+        return res(ctx.json(profileFactory.build({ user_type: 'parent' })));
       })
     );
 
@@ -141,8 +148,8 @@ describe('UserMenu', () => {
           ctx.json(accountFactory.build({ company: 'Child Company' }))
         );
       }),
-      rest.get('*/account/users/*', (req, res, ctx) => {
-        return res(ctx.json(accountUserFactory.build({ user_type: 'proxy' })));
+      rest.get('*/profile', (req, res, ctx) => {
+        return res(ctx.json(profileFactory.build({ user_type: 'proxy' })));
       })
     );
 

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -20,7 +20,6 @@ import { SwitchAccountButton } from 'src/features/Account/SwitchAccountButton';
 import { SwitchAccountDrawer } from 'src/features/Account/SwitchAccountDrawer';
 import { useFlags } from 'src/hooks/useFlags';
 import { useAccount } from 'src/queries/account';
-import { useAccountUser } from 'src/queries/accountUsers';
 import { useGrants, useProfile } from 'src/queries/profile';
 import { getStorage } from 'src/utilities/storage';
 
@@ -56,7 +55,6 @@ export const UserMenu = React.memo(() => {
 
   const { data: account } = useAccount();
   const { data: profile } = useProfile();
-  const { data: user } = useAccountUser(profile?.username ?? '');
   const { data: grants } = useGrants();
   const { enqueueSnackbar } = useSnackbar();
   const flags = useFlags();
@@ -67,13 +65,13 @@ export const UserMenu = React.memo(() => {
   const hasAccountAccess = !isRestrictedUser || hasGrant('account_access');
   const hasReadWriteAccountAccess = hasGrant('account_access') === 'read_write';
   const hasParentChildAccountAccess = Boolean(flags.parentChildAccountAccess);
-  const isParentUser = user?.user_type === 'parent';
-  const isProxyUser = user?.user_type === 'proxy';
+  const isParentUser = profile?.user_type === 'parent';
+  const isProxyUser = profile?.user_type === 'proxy';
   const canSwitchBetweenParentOrProxyAccount =
     hasParentChildAccountAccess && (isParentUser || isProxyUser);
   const open = Boolean(anchorEl);
   const id = open ? 'user-menu-popover' : undefined;
-  const companyName = (user?.user_type && account?.company) ?? '';
+  const companyName = (profile?.user_type && account?.company) ?? '';
   const showCompanyName = hasParentChildAccountAccess && companyName;
 
   // Used for fetching parent profile and account data by making a request with the parent's token.

--- a/packages/manager/src/queries/account.ts
+++ b/packages/manager/src/queries/account.ts
@@ -9,7 +9,6 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import { useGrants, useProfile } from 'src/queries/profile';
 
-import { useAccountUser } from './accountUsers';
 import { queryPresets } from './base';
 
 import type {
@@ -54,7 +53,6 @@ export const useChildAccounts = ({
   params,
 }: RequestOptions) => {
   const { data: profile } = useProfile();
-  const { data: user } = useAccountUser(profile?.username ?? '');
   const { data: grants } = useGrants();
   const hasExplicitAuthToken = Boolean(headers?.Authorization);
 
@@ -63,7 +61,7 @@ export const useChildAccounts = ({
     () => getChildAccounts({ filter, headers, params }),
     {
       enabled:
-        (Boolean(user?.user_type === 'parent') && !profile?.restricted) ||
+        (Boolean(profile?.user_type === 'parent') && !profile?.restricted) ||
         Boolean(grants?.global?.child_account_access) ||
         hasExplicitAuthToken,
       keepPreviousData: true,
@@ -73,7 +71,6 @@ export const useChildAccounts = ({
 
 export const useChildAccount = ({ euuid, headers }: ChildAccountPayload) => {
   const { data: profile } = useProfile();
-  const { data: user } = useAccountUser(profile?.username ?? '');
   const { data: grants } = useGrants();
   const hasExplicitAuthToken = Boolean(headers?.Authorization);
 
@@ -82,7 +79,7 @@ export const useChildAccount = ({ euuid, headers }: ChildAccountPayload) => {
     () => getChildAccount({ euuid }),
     {
       enabled:
-        (Boolean(user?.user_type === 'parent') && !profile?.restricted) ||
+        (Boolean(profile?.user_type === 'parent') && !profile?.restricted) ||
         Boolean(grants?.global?.child_account_access) ||
         hasExplicitAuthToken,
     }


### PR DESCRIPTION
## Description 📝
Now that `user_type` is returned from the `/account/profile` endpoint, we can save ourselves some query calls.

## Changes  🔄
- Updated tests and files that didn't need to call `/account/users/`

## Preview 📷
Shouldn't be any visual changes

## How to test 🧪

### Prerequisites
- Run `yarn test` ensure all tests pass
- Run `cyrun cypress/e2e/core/account` ensure all tests pass

### Verification steps 
- Verify user menu still works as intended as with MSW
- Verify we can see `Child Account Access` by [following steps here](https://github.com/linode/manager/pull/10083)

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support