### PR TITLE
upcoming: [M3-7530] - Restrict proxy users from updating username/email

### DIFF
--- a/packages/manager/.changeset/pr-10103-upcoming-features-1706069199851.md
+++ b/packages/manager/.changeset/pr-10103-upcoming-features-1706069199851.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Restrict proxy users from updating username/email ([#10103](https://github.com/linode/manager/pull/10103))

--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -8,8 +8,8 @@ import { Box, BoxProps } from '../Box';
 
 interface ActionButtonsProps extends ButtonProps {
   'data-node-idx'?: number;
-  'data-testid'?: string;
   'data-qa-form-data-loading'?: boolean;
+  'data-testid'?: string;
   label: string;
 }
 
@@ -77,9 +77,6 @@ const StyledBox = styled(Box)(({ theme: { spacing } }) => ({
   },
   '& > :only-child': {
     marginRight: 0,
-  },
-  '& > button': {
-    marginBottom: spacing(1),
   },
   justifyContent: 'flex-end',
   marginTop: spacing(1),

--- a/packages/manager/src/components/SingleTextFieldForm/SingleTextFieldForm.tsx
+++ b/packages/manager/src/components/SingleTextFieldForm/SingleTextFieldForm.tsx
@@ -78,12 +78,11 @@ export const SingleTextFieldForm = React.memo((props: Props) => {
       >
         <TextField
           {...textFieldProps}
-          sx={(theme) => ({
-            minWidth: 415,
-            [theme.breakpoints.down('md')]: {
-              minWidth: 'auto',
+          containerProps={{
+            sx: {
+              width: '100%',
             },
-          })}
+          }}
           disabled={disabled}
           errorText={fieldError}
           label={label}
@@ -108,6 +107,7 @@ export const SingleTextFieldForm = React.memo((props: Props) => {
                 : undefined,
           }}
           sx={{
+            flexShrink: 0,
             padding: 0,
           }}
         />

--- a/packages/manager/src/components/SingleTextFieldForm/SingleTextFieldForm.tsx
+++ b/packages/manager/src/components/SingleTextFieldForm/SingleTextFieldForm.tsx
@@ -98,10 +98,10 @@ export const SingleTextFieldForm = React.memo((props: Props) => {
             label: `Update ${label}`,
             loading: submitting,
             onClick: handleSubmit,
-            sx: () => ({
+            sx: {
               margin: '0',
               minWidth: 180,
-            }),
+            },
             tooltipText:
               tooltipText && typeof tooltipText === 'string'
                 ? tooltipText

--- a/packages/manager/src/components/SingleTextFieldForm/SingleTextFieldForm.tsx
+++ b/packages/manager/src/components/SingleTextFieldForm/SingleTextFieldForm.tsx
@@ -1,5 +1,4 @@
 import { APIError } from '@linode/api-v4/lib/types';
-import { Theme } from '@mui/material/styles';
 import * as React from 'react';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
@@ -69,9 +68,11 @@ export const SingleTextFieldForm = React.memo((props: Props) => {
       <Box
         sx={(theme) => ({
           [theme.breakpoints.down('md')]: {
+            alignItems: 'flex-start',
             flexDirection: 'column',
           },
         })}
+        alignItems="flex-end"
         display="flex"
         justifyContent="space-between"
       >
@@ -88,7 +89,6 @@ export const SingleTextFieldForm = React.memo((props: Props) => {
           label={label}
           onBlur={(e) => setValue(e.target.value)}
           onChange={(e) => setValue(e.target.value)}
-          tooltipText={tooltipText ? tooltipText : undefined}
           trimmed={trimmed}
           value={value}
         />
@@ -98,12 +98,17 @@ export const SingleTextFieldForm = React.memo((props: Props) => {
             label: `Update ${label}`,
             loading: submitting,
             onClick: handleSubmit,
-            sx: (theme: Theme) => ({
+            sx: () => ({
+              margin: '0 !important', // Investigate why I can't override with `!important`
               minWidth: 180,
-              [theme.breakpoints.up('md')]: {
-                marginTop: 2,
-              },
             }),
+            tooltipText:
+              tooltipText && typeof tooltipText === 'string'
+                ? tooltipText
+                : undefined,
+          }}
+          sx={{
+            padding: 0,
           }}
         />
       </Box>

--- a/packages/manager/src/components/SingleTextFieldForm/SingleTextFieldForm.tsx
+++ b/packages/manager/src/components/SingleTextFieldForm/SingleTextFieldForm.tsx
@@ -99,7 +99,7 @@ export const SingleTextFieldForm = React.memo((props: Props) => {
             loading: submitting,
             onClick: handleSubmit,
             sx: () => ({
-              margin: '0 !important', // Investigate why I can't override with `!important`
+              margin: '0 !important', // Investigate why I can't override without `!important`
               minWidth: 180,
             }),
             tooltipText:

--- a/packages/manager/src/components/SingleTextFieldForm/SingleTextFieldForm.tsx
+++ b/packages/manager/src/components/SingleTextFieldForm/SingleTextFieldForm.tsx
@@ -99,7 +99,7 @@ export const SingleTextFieldForm = React.memo((props: Props) => {
             loading: submitting,
             onClick: handleSubmit,
             sx: () => ({
-              margin: '0 !important', // TODO: Investigate why I can't override without `!important`
+              margin: '0',
               minWidth: 180,
             }),
             tooltipText:

--- a/packages/manager/src/components/SingleTextFieldForm/SingleTextFieldForm.tsx
+++ b/packages/manager/src/components/SingleTextFieldForm/SingleTextFieldForm.tsx
@@ -99,7 +99,7 @@ export const SingleTextFieldForm = React.memo((props: Props) => {
             loading: submitting,
             onClick: handleSubmit,
             sx: () => ({
-              margin: '0 !important', // Investigate why I can't override without `!important`
+              margin: '0 !important', // TODO: Investigate why I can't override without `!important`
               minWidth: 180,
             }),
             tooltipText:

--- a/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.test.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.test.tsx
@@ -1,0 +1,35 @@
+import { screen } from '@testing-library/react';
+import React from 'react';
+
+import { profileFactory } from 'src/factories/profile';
+import { DisplaySettings } from 'src/features/Profile/DisplaySettings/DisplaySettings';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+// Mock the useProfile hooks to immediately return the expected data, circumventing the HTTP request and loading state.
+const queryMocks = vi.hoisted(() => ({
+  useProfile: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('src/queries/profile', async () => {
+  const actual = await vi.importActual('src/queries/profile');
+  return {
+    ...actual,
+    useProfile: queryMocks.useProfile,
+  };
+});
+
+describe('DisplaySettings component', () => {
+  it('should disable SingleTextFieldForm components based on isProxyUser', () => {
+    queryMocks.useProfile.mockReturnValue({
+      data: profileFactory.build({ user_type: 'proxy' }),
+    });
+
+    renderWithTheme(<DisplaySettings />);
+
+    const usernameInput = screen.getByLabelText('Username');
+    expect(usernameInput).toHaveAttribute('disabled');
+
+    const emailInput = screen.getByLabelText('Email');
+    expect(emailInput).toHaveAttribute('disabled');
+  });
+});

--- a/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.test.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.test.tsx
@@ -31,4 +31,42 @@ describe('DisplaySettings component', () => {
     const emailInput = screen.getByLabelText('Email');
     expect(emailInput).toHaveAttribute('disabled');
   });
+
+  it('Should only disable the SingleTextFieldForm components if the user is not a proxy user.', () => {
+    queryMocks.useProfile.mockReturnValue({
+      data: profileFactory.build({ user_type: 'child' }),
+    });
+
+    renderWithTheme(<DisplaySettings />);
+
+    const usernameInput = screen.getByLabelText('Username');
+    expect(usernameInput).not.toHaveAttribute('disabled');
+
+    const emailInput = screen.getByLabelText('Email');
+    expect(emailInput).not.toHaveAttribute('disabled');
+  });
+
+  it('should disable the "Update Username" and "Update Email" buttons if the user is a proxy user.', async () => {
+    queryMocks.useProfile.mockReturnValue({
+      data: profileFactory.build({ user_type: 'proxy' }),
+    });
+
+    renderWithTheme(<DisplaySettings />);
+
+    const updateUsernameButton = screen
+      .getByText('Update Username')
+      .closest('button');
+
+    const updateEmailButton = screen
+      .getByText('Update Email')
+      .closest('button');
+
+    expect(updateUsernameButton).not.toHaveAttribute('disabled');
+    expect(updateUsernameButton).toHaveAttribute('aria-disabled', 'true');
+    expect(updateEmailButton).toHaveAttribute('data-qa-tooltip');
+
+    expect(updateEmailButton).not.toHaveAttribute('disabled');
+    expect(updateEmailButton).toHaveAttribute('aria-disabled', 'true');
+    expect(updateEmailButton).toHaveAttribute('data-qa-tooltip');
+  });
 });

--- a/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.test.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.test.tsx
@@ -5,7 +5,6 @@ import { profileFactory } from 'src/factories/profile';
 import { DisplaySettings } from 'src/features/Profile/DisplaySettings/DisplaySettings';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
-// Mock the useProfile hooks to immediately return the expected data, circumventing the HTTP request and loading state.
 const queryMocks = vi.hoisted(() => ({
   useProfile: vi.fn().mockReturnValue({}),
 }));

--- a/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.tsx
@@ -30,6 +30,8 @@ export const DisplaySettings = () => {
   const location = useLocation<{ focusEmail: boolean }>();
   const emailRef = React.createRef<HTMLInputElement>();
 
+  const isProxyUser = profile?.user_type === 'proxy';
+
   React.useEffect(() => {
     if (location.state?.focusEmail && emailRef.current) {
       emailRef.current.focus();
@@ -62,6 +64,8 @@ export const DisplaySettings = () => {
       automatically linked.
     </>
   );
+
+  const restrictedProxyUserTooltip = 'Proxy users cannot update this field.';
 
   return (
     <Paper>
@@ -102,9 +106,11 @@ export const DisplaySettings = () => {
         tooltipText={
           profile?.restricted
             ? 'Restricted users cannot update their username. Please contact an account administrator.'
+            : isProxyUser
+            ? restrictedProxyUserTooltip
             : undefined
         }
-        disabled={profile?.restricted}
+        disabled={profile?.restricted || isProxyUser}
         initialValue={profile?.username}
         key={usernameResetToken}
         label="Username"
@@ -125,11 +131,13 @@ export const DisplaySettings = () => {
             refetch();
           }
         }}
+        disabled={isProxyUser}
         initialValue={profile?.email}
         inputRef={emailRef}
         key={emailResetToken}
         label="Email"
         submitForm={updateEmail}
+        tooltipText={isProxyUser ? restrictedProxyUserTooltip : undefined}
         trimmed
         type="email"
       />

--- a/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.tsx
@@ -65,7 +65,8 @@ export const DisplaySettings = () => {
     </>
   );
 
-  const restrictedProxyUserTooltip = 'Proxy users cannot update this field.';
+  const restrictedProxyUserTooltip =
+    'This account type cannot update this field.';
 
   return (
     <Paper>

--- a/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -86,7 +86,11 @@ export const TimezoneForm = (props: Props) => {
           </Typography>
         </StyledLoggedInAsCustomerNotice>
       ) : null}
-      <StyledRootContainer display="flex" justifyContent="space-between">
+      <StyledRootContainer
+        alignItems="flex-end"
+        display="flex"
+        justifyContent="space-between"
+      >
         <Select
           data-qa-tz-select
           defaultValue={defaultTimeZone}
@@ -104,9 +108,14 @@ export const TimezoneForm = (props: Props) => {
             loading: isLoading,
             onClick: onSubmit,
             sx: {
+              margin: '0 !important', // Investigate why I can't override without `!important`
               marginTop: (theme: Theme) => (theme.breakpoints.up('md') ? 2 : 0),
               minWidth: 180,
             },
+          }}
+          sx={{
+            margin: 0,
+            padding: 0,
           }}
         />
       </StyledRootContainer>

--- a/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -114,7 +114,7 @@ export const TimezoneForm = (props: Props) => {
             loading: isLoading,
             onClick: onSubmit,
             sx: {
-              margin: '0 !important', // Investigate why I can't override without `!important`
+              margin: '0 !important', // TODO: Investigate why I can't override without `!important`
               marginTop: (theme: Theme) => (theme.breakpoints.up('md') ? 2 : 0),
               minWidth: 180,
             },

--- a/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -1,4 +1,4 @@
-import { Theme, styled } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import { DateTime } from 'luxon';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
@@ -115,7 +115,6 @@ export const TimezoneForm = (props: Props) => {
             onClick: onSubmit,
             sx: {
               margin: '0',
-              marginTop: (theme: Theme) => (theme.breakpoints.up('md') ? 2 : 0),
               minWidth: 180,
             },
           }}

--- a/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -114,7 +114,7 @@ export const TimezoneForm = (props: Props) => {
             loading: isLoading,
             onClick: onSubmit,
             sx: {
-              margin: '0 !important', // TODO: Investigate why I can't override without `!important`
+              margin: '0',
               marginTop: (theme: Theme) => (theme.breakpoints.up('md') ? 2 : 0),
               minWidth: 180,
             },

--- a/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -87,6 +87,12 @@ export const TimezoneForm = (props: Props) => {
         </StyledLoggedInAsCustomerNotice>
       ) : null}
       <StyledRootContainer
+        sx={(theme) => ({
+          [theme.breakpoints.down('md')]: {
+            alignItems: 'flex-start',
+            flexDirection: 'column',
+          },
+        })}
         alignItems="flex-end"
         display="flex"
         justifyContent="space-between"
@@ -114,7 +120,6 @@ export const TimezoneForm = (props: Props) => {
             },
           }}
           sx={{
-            margin: 0,
             padding: 0,
           }}
         />

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -551,7 +551,7 @@ export const handlers = [
     const profile = profileFactory.build({
       restricted: false,
       // Parent/Child: switch the `user_type` depending on what account view you need to mock.
-      user_type: 'parent',
+      user_type: 'proxy',
     });
     return res(ctx.json(profile));
   }),


### PR DESCRIPTION
## Description 📝
As a parent user logged into a proxy account, I should not be able to change the email address or username set by the provisioning API.  

## Changes  🔄
- Fixed alignment of input fields and buttons at `/profile/display` page.
- Added unit tests for disabling `Username` and `Email`
- As proxy user: added tooltip text to buttons to disabled buttons for context

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-01-23 at 10 41 23 PM](https://github.com/linode/manager/assets/125309814/cea5d150-0917-49e3-bbaf-80ffadd254cb) | ![Screenshot 2024-01-23 at 10 51 06 PM](https://github.com/linode/manager/assets/125309814/79c08fc4-4b11-4ba9-b35b-f87dbeae3a06) |

## How to test 🧪

### Prerequisites
- Turn on MSW and Parent/Child feature flag
- Set `user_type` to `proxy` in [serverHandlers](https://github.com/linode/manager/blob/develop/packages/manager/src/mocks/serverHandlers.ts#L554)

### Reproduction steps
- Go to http://localhost:3000/profile/display

### Verification steps 
- Observe disabled fields
- Change `user_type` to something else, observe fields are editable

## As an Author I have considered 🤔

*Check all that apply*
- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support