### PR TITLE
upcoming: [M3-7699] - Put newly created ACLB Rules at the top of the table upon creation

### DIFF
--- a/packages/manager/.changeset/pr-10107-upcoming-features-1706135635175.md
+++ b/packages/manager/.changeset/pr-10107-upcoming-features-1706135635175.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Put newly created ACLB Rules at the top of the table upon creation ([#10107](https://github.com/linode/manager/pull/10107))

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/RuleDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/RuleDrawer.tsx
@@ -97,7 +97,7 @@ export const RuleDrawer = (props: Props) => {
           label: route?.label,
           protocol: route?.protocol,
           // If we are editing, send the updated rules, otherwise
-          // append a new rule to the end.
+          // append a new rule to the beginning.
           rules: isEditMode
             ? existingRules
             : [normalizedRule, ...existingRules],

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/RuleDrawer.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/RuleDrawer.tsx
@@ -100,7 +100,7 @@ export const RuleDrawer = (props: Props) => {
           // append a new rule to the end.
           rules: isEditMode
             ? existingRules
-            : [...existingRules, normalizedRule],
+            : [normalizedRule, ...existingRules],
         });
         onClose();
       } catch (errors) {


### PR DESCRIPTION
## Description 📝

- Puts ACLB rules at the top of the table / array when the rule is created

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/115251059/bf69b633-99b0-4298-a7ae-a8f553e18ec1"/> | <video src="https://github.com/linode/manager/assets/115251059/3e326b7d-87bb-476e-aef7-11a4a0dbf6ee" /> |


## How to test 🧪

### Prerequisites
- Have the AGLB flag on
- Use the dev environment
- Login to the `dev-test-aglb` account


### Verification steps 
- Verify that when you create a new rule, it is placed at the **top** of the rules table.

## As an Author I have considered 🤔

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support