### PR TITLE
feat: [M3-7644] - Add VPC IPv4 address and range to Linode IP Address Table

### DIFF
--- a/packages/api-v4/src/networking/types.ts
+++ b/packages/api-v4/src/networking/types.ts
@@ -10,6 +10,11 @@ export interface IPAddress {
   region: string;
 }
 
+export interface VPCIPAddress {
+  address: string;
+  type: string;
+}
+
 export interface IPRangeBaseData {
   range: string;
   region: string;

--- a/packages/api-v4/src/networking/types.ts
+++ b/packages/api-v4/src/networking/types.ts
@@ -10,11 +10,6 @@ export interface IPAddress {
   region: string;
 }
 
-export interface VPCIPAddress {
-  address: string;
-  type: string;
-}
-
 export interface IPRangeBaseData {
   range: string;
   region: string;

--- a/packages/manager/.changeset/pr-10108-added-1706218083195.md
+++ b/packages/manager/.changeset/pr-10108-added-1706218083195.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+VPC IPv4 address and range to Linode IP Address Table ([#10108](https://github.com/linode/manager/pull/10108))

--- a/packages/manager/src/factories/linodeConfigInterfaceFactory.ts
+++ b/packages/manager/src/factories/linodeConfigInterfaceFactory.ts
@@ -15,7 +15,7 @@ export const LinodeConfigInterfaceFactoryWithVPC = Factory.Sync.makeFactory<Inte
   {
     active: false,
     id: Factory.each((i) => i),
-    ip_ranges: ['192.0.2.0/24'],
+    ip_ranges: ['192.0.2.0/24', '192.0.3.0/24'],
     ipam_address: '10.0.0.1/24',
     ipv4: {
       nat_1_1: 'some nat',

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddressRow.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddressRow.test.tsx
@@ -53,12 +53,9 @@ describe('LinodeIPAddressRow', () => {
     const { getAllByText, queryByText } = renderWithTheme(
       wrapWithTableBody(
         <LinodeIPAddressRow
-          gateway={''}
           isVPCOnlyLinode={false}
           linodeId={1}
-          rdns={''}
           readOnly={false}
-          subnetMask={''}
           {...handlers}
           {...ipDisplayVPC}
         />

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddressRow.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddressRow.test.tsx
@@ -1,8 +1,12 @@
 import { fireEvent } from '@testing-library/react';
 import * as React from 'react';
 
+import { LinodeConfigInterfaceFactoryWithVPC } from 'src/factories/linodeConfigInterfaceFactory';
 import { linodeIPFactory } from 'src/factories/linodes';
-import { ipResponseToDisplayRows } from 'src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses';
+import {
+  ipResponseToDisplayRows,
+  vpcConfigInterfaceToDisplayRows,
+} from 'src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses';
 import { PUBLIC_IPS_UNASSIGNED_TOOLTIP_TEXT } from 'src/features/Linodes/PublicIpsUnassignedTooltip';
 import { renderWithTheme, wrapWithTableBody } from 'src/utilities/testHelpers';
 
@@ -10,6 +14,9 @@ import { IPAddressRowHandlers, LinodeIPAddressRow } from './LinodeIPAddressRow';
 
 const ips = linodeIPFactory.build();
 const ipDisplay = ipResponseToDisplayRows(ips)[0];
+const ipDisplayVPC = vpcConfigInterfaceToDisplayRows(
+  LinodeConfigInterfaceFactoryWithVPC.build()
+)[0];
 
 const handlers: IPAddressRowHandlers = {
   handleOpenEditRDNS: vi.fn(),
@@ -41,6 +48,28 @@ describe('LinodeIPAddressRow', () => {
     // Check if actions were rendered
     getAllByText('Delete');
     getAllByText('Edit RDNS');
+  });
+  it('should render a VPC IP Address row', () => {
+    const { getAllByText, queryByText } = renderWithTheme(
+      wrapWithTableBody(
+        <LinodeIPAddressRow
+          gateway={''}
+          isVPCOnlyLinode={false}
+          linodeId={1}
+          rdns={''}
+          readOnly={false}
+          subnetMask={''}
+          {...handlers}
+          {...ipDisplayVPC}
+        />
+      )
+    );
+
+    getAllByText(ipDisplayVPC.address);
+    getAllByText(ipDisplayVPC.type);
+    // No actions should be rendered
+    expect(queryByText('Delete')).not.toBeInTheDocument();
+    expect(queryByText('Edit RDNS')).not.toBeInTheDocument();
   });
 
   it('should disable the row if disabled is true and display a tooltip', async () => {

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddressRow.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddressRow.test.tsx
@@ -122,3 +122,19 @@ describe('LinodeIPAddressRow', () => {
     expect(editRDNSBtn).not.toHaveAttribute('aria-disabled', 'true');
   });
 });
+
+describe('ipResponseToDisplayRows', () => {
+  it('should not return a Public IPv4 row if there is a VPC interface with 1:1 NAT', () => {
+    const ipDisplays = ipResponseToDisplayRows(
+      ips,
+      LinodeConfigInterfaceFactoryWithVPC.build()
+    );
+
+    expect(
+      ipDisplays.find((ipDisplay) => ipDisplay.type === 'IPv4 – Public')
+    ).toBeUndefined();
+    expect(
+      ipDisplays.find((ipDisplay) => ipDisplay.type === 'VPC IPv4 – NAT')
+    ).toBeDefined();
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddressRow.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddressRow.tsx
@@ -72,7 +72,11 @@ export const LinodeIPAddressRow = (props: CombinedProps) => {
         <CopyTooltip copyableText disabled={isVPCOnlyLinode} text={address} />
         {!isVPCOnlyLinode && <StyledCopyToolTip text={address} />}
       </TableCell>
-      <TableCell data-qa-ip-address parentColumn="Type">
+      <TableCell
+        data-qa-ip-address
+        parentColumn="Type"
+        sx={{ whiteSpace: 'nowrap' }}
+      >
         {type}
       </TableCell>
       <TableCell parentColumn="Default Gateway">{gateway}</TableCell>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses.tsx
@@ -301,7 +301,9 @@ interface VPCIPAddress {
   type: IPTypes;
 }
 
-const vpcConfigInterfaceToDisplayRows = (configInterfaceWithVPC: Interface) => {
+export const vpcConfigInterfaceToDisplayRows = (
+  configInterfaceWithVPC: Interface
+) => {
   const ipDisplay: VPCIPAddress[] = [];
 
   if (configInterfaceWithVPC.ipv4?.vpc) {

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses.tsx
@@ -1,9 +1,5 @@
 import { Interface, LinodeIPsResponse } from '@linode/api-v4/lib/linodes';
-import {
-  IPAddress,
-  IPRange,
-  VPCIPAddress,
-} from '@linode/api-v4/lib/networking';
+import { IPAddress, IPRange } from '@linode/api-v4/lib/networking';
 import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 
@@ -300,6 +296,11 @@ export interface IPDisplay {
   type: IPTypes;
 }
 
+interface VPCIPAddress {
+  address: string;
+  type: IPTypes;
+}
+
 const vpcConfigInterfaceToDisplayRows = (configInterfaceWithVPC: Interface) => {
   const ipDisplay: VPCIPAddress[] = [];
 
@@ -314,6 +315,15 @@ const vpcConfigInterfaceToDisplayRows = (configInterfaceWithVPC: Interface) => {
     ipDisplay.push({
       address: configInterfaceWithVPC.ipv4.nat_1_1,
       type: 'VPC IPv4 – NAT',
+    });
+  }
+
+  if (configInterfaceWithVPC.ip_ranges) {
+    configInterfaceWithVPC.ip_ranges.forEach((ip_range) => {
+      ipDisplay.push({
+        address: ip_range,
+        type: 'IPv4 – VPC – Range',
+      });
     });
   }
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses.tsx
@@ -202,7 +202,7 @@ export const LinodeIPAddresses = (props: LinodeIPAddressesProps) => {
                         isVPCOnlyLinode={
                           isVPCOnlyLinode && ipDisplay.type === 'IPv4 – Public'
                         }
-                        key={ipDisplay.address}
+                        key={`${ipDisplay.address}-${ipDisplay.type}`}
                         linodeId={linodeID}
                         readOnly={readOnly}
                       />

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses.tsx
@@ -357,7 +357,7 @@ export const ipResponseToDisplayRows = (
 
   if (configInterfaceWithVPC) {
     if (configInterfaceWithVPC.ipv4?.nat_1_1) {
-      // Hide the Public IPv4 row as the address will only be usable on the VPC interface with 1:1 NAT
+      // If there is a VPC interface with 1:1 NAT, hide the Public IPv4 IP address row
       ipDisplay.shift();
     }
     ipDisplay.push(...vpcConfigInterfaceToDisplayRows(configInterfaceWithVPC));

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses.tsx
@@ -356,6 +356,10 @@ export const ipResponseToDisplayRows = (
   }
 
   if (configInterfaceWithVPC) {
+    if (configInterfaceWithVPC.ipv4?.nat_1_1) {
+      // Hide the Public IPv4 row as the address will only be usable on the VPC interface with 1:1 NAT
+      ipDisplay.shift();
+    }
     ipDisplay.push(...vpcConfigInterfaceToDisplayRows(configInterfaceWithVPC));
   }
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses.tsx
@@ -326,6 +326,25 @@ export const ipResponseToDisplayRows = (
     );
   }
 
+  if (configInterfaceWithVPC && configInterfaceWithVPC.ipv4?.nat_1_1) {
+    ipDisplay.push(
+      ipToDisplay(
+        {
+          address: configInterfaceWithVPC.ipv4.nat_1_1,
+          gateway: '',
+          linode_id: 10,
+          prefix: 10,
+          public: false,
+          rdns: '',
+          region: '',
+          subnet_mask: '',
+          type: 'ipv4',
+        },
+        'VPC_NAT'
+      )
+    );
+  }
+
   if (ipv6?.slaac) {
     ipDisplay.push(ipToDisplay(ipv6.slaac, 'SLAAC'));
   }
@@ -373,7 +392,8 @@ type ipKey =
   | 'Reserved'
   | 'SLAAC'
   | 'Shared'
-  | 'VPC';
+  | 'VPC'
+  | 'VPC_NAT';
 
 const mapIPv4Display = (ips: IPAddress[], key: ipKey): IPDisplay[] => {
   return ips.map((ip) => ipToDisplay(ip, key));
@@ -398,6 +418,8 @@ export const createType = (ip: IPAddress, key: ipKey) => {
 
   if (key === 'Reserved') {
     type += ip.public ? 'Reserved (public)' : 'Reserved (private)';
+  } else if (key === 'VPC_NAT') {
+    type = `VPC ${type}NAT`;
   } else {
     type += key;
   }

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
@@ -41,7 +41,8 @@ export const LinodeNetworkingActionMenu = (props: Props) => {
     ipType !== 'IPv4 – Private' &&
     ipType !== 'IPv6 – Link Local' &&
     ipType !== 'IPv4 – Reserved (public)' &&
-    ipType !== 'IPv4 – Reserved (private)';
+    ipType !== 'IPv4 – Reserved (private)' &&
+    ipType !== 'IPv4 – VPC';
 
   const deletableIPTypes = ['IPv4 – Public', 'IPv4 – Private', 'IPv6 – Range'];
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
@@ -37,13 +37,14 @@ export const LinodeNetworkingActionMenu = (props: Props) => {
     readOnly,
   } = props;
 
-  const showEdit =
-    ipType !== 'IPv4 – Private' &&
-    ipType !== 'IPv6 – Link Local' &&
-    ipType !== 'IPv4 – Reserved (public)' &&
-    ipType !== 'IPv4 – Reserved (private)' &&
-    ipType !== 'IPv4 – VPC' &&
-    ipType !== 'VPC IPv4 – NAT';
+  const showEdit = ![
+    'IPv4 – Private',
+    'IPv4 – Reserved (private)',
+    'IPv4 – Reserved (public)',
+    'IPv4 – VPC',
+    'IPv6 – Link Local',
+    'VPC IPv4 – NAT',
+  ].includes(ipType);
 
   const deletableIPTypes = ['IPv4 – Public', 'IPv4 – Private', 'IPv6 – Range'];
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
@@ -42,7 +42,8 @@ export const LinodeNetworkingActionMenu = (props: Props) => {
     ipType !== 'IPv6 – Link Local' &&
     ipType !== 'IPv4 – Reserved (public)' &&
     ipType !== 'IPv4 – Reserved (private)' &&
-    ipType !== 'IPv4 – VPC';
+    ipType !== 'IPv4 – VPC' &&
+    ipType !== 'VPC IPv4 – NAT';
 
   const deletableIPTypes = ['IPv4 – Public', 'IPv4 – Private', 'IPv6 – Range'];
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/types.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/types.ts
@@ -9,4 +9,4 @@ export type IPTypes =
   | 'IPv6 – Link Local'
   | 'IPv6 – Range'
   | 'IPv6 – SLAAC'
-  | 'VPC IPv4 - NAT';
+  | 'VPC IPv4 – NAT';

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/types.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/types.ts
@@ -4,6 +4,9 @@ export type IPTypes =
   | 'IPv4 – Reserved (private)'
   | 'IPv4 – Reserved (public)'
   | 'IPv4 – Shared'
+  | 'IPv4 – VPC - Range'
+  | 'IPv4 – VPC'
   | 'IPv6 – Link Local'
   | 'IPv6 – Range'
-  | 'IPv6 – SLAAC';
+  | 'IPv6 – SLAAC'
+  | 'VPC IPv4 - NAT';

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/types.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/types.ts
@@ -4,7 +4,7 @@ export type IPTypes =
   | 'IPv4 – Reserved (private)'
   | 'IPv4 – Reserved (public)'
   | 'IPv4 – Shared'
-  | 'IPv4 – VPC - Range'
+  | 'IPv4 – VPC – Range'
   | 'IPv4 – VPC'
   | 'IPv6 – Link Local'
   | 'IPv6 – Range'


### PR DESCRIPTION
## Description 📝
Add support for displaying VPC IPv4 addresses and ranges in the Linode Details -> Network tab -> "IP Addresses" table

## Changes  🔄
List any change relevant to the reviewer.
- Add Support for VPC IPv4 addresses and ranges to the Linode IP Address table
  - If there is a VPC interface with 1:1 NAT, hide the Public IPv4 IP address row
- Improve mobile text display of the Type column

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![ip address table before](https://github.com/linode/manager/assets/115299789/da3851c5-6040-4361-8446-512a87fefcd8) | ![image](https://github.com/linode/manager/assets/115299789/13f23888-972a-4d78-8433-df3585281fef) |

| Mobile before  | Mobile after   |
| ------- | ------- |
| ![mobile before](https://github.com/linode/manager/assets/115299789/b35299fc-058c-4a1b-8c46-3174810a2ef5) | ![image](https://github.com/linode/manager/assets/115299789/365f36c9-9a76-4784-8e9b-5b8424f20761) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Have the `vpc-extra-beta` tag on your account and a VPC with at least one Subnet
- Assign a Linode to the Subnet and check both the checkboxes (Auto-assign a VPC IPv4 address & Assign a public IPv4 address)
- To add `ip_ranges`, check out https://github.com/linode/manager/pull/10089

### Verification steps 
(How to verify changes)
- Go to the Linode Details -> Network tab of the assigned Linode and check the IP Addresses table
- You should see IP Address rows for `IPv4 – VPC`, `VPC IPv4 – NAT`, and `IPv4 – VPC – Range` for each range
- You should _not_ see an IP address row for the type `IPv4 - Public`
```
yarn test LinodeIPAddressRow
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support