### PR TITLE
upcoming: [M3-7481] - Disable creating and editing API tokens for proxy users

### DIFF
--- a/packages/manager/.changeset/pr-10109-upcoming-features-1706136926455.md
+++ b/packages/manager/.changeset/pr-10109-upcoming-features-1706136926455.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Disable adding and editing API tokens for proxy users ([#10109](https://github.com/linode/manager/pull/10109))

--- a/packages/manager/cypress/e2e/core/account/personal-access-tokens.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/personal-access-tokens.spec.ts
@@ -272,13 +272,9 @@ describe('Personal access tokens', () => {
       .should('be.disabled')
       .click();
 
-    cy.findByRole('tooltip')
-      .should('be.visible')
-      .within(() => {
-        cy.findByText(
-          'You can only create tokens for your own company.'
-        ).should('be.visible');
-      });
+    ui.tooltip
+      .findByText('You can only create tokens for your own company.')
+      .should('be.visible');
 
     // Find token in list, confirm "Rename" is disabled and tooltip displays.
     cy.findByText(proxyToken.label)
@@ -292,13 +288,9 @@ describe('Personal access tokens', () => {
           .click();
       });
 
-    cy.findByRole('tooltip')
-      .should('be.visible')
-      .within(() => {
-        cy.findByText('Only company users can edit API tokens.').should(
-          'be.visible'
-        );
-      });
+    ui.tooltip
+      .findByText('Only company users can edit API tokens.')
+      .should('be.visible');
 
     // Confirm that token has not been renamed, initiate revocation.
     cy.findByText(proxyToken.label)

--- a/packages/manager/cypress/e2e/core/account/personal-access-tokens.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/personal-access-tokens.spec.ts
@@ -249,7 +249,7 @@ describe('Personal access tokens', () => {
     cy.visitWithLogin('/profile/tokens');
     cy.wait(['@getTokens', '@getAppTokens']);
 
-    // Find 'Create a Personal Access Token' button, confirm it is disabled, and tooltip displays.
+    // Find 'Create a Personal Access Token' button, confirm it is disabled and tooltip displays.
     ui.button
       .findByTitle('Create a Personal Access Token')
       .should('be.visible')
@@ -264,7 +264,7 @@ describe('Personal access tokens', () => {
         ).should('be.visible');
       });
 
-    // Find token in list, confirm "Rename" is disabled, and tooltip displays.
+    // Find token in list, confirm "Rename" is disabled and tooltip displays.
     cy.findByText(proxyToken.label)
       .should('be.visible')
       .closest('tr')
@@ -284,7 +284,7 @@ describe('Personal access tokens', () => {
         );
       });
 
-    // Confirm that token has been renamed, initiate revocation.
+    // Confirm that token has not been renamed, initiate revocation.
     cy.findByText(proxyToken.label)
       .should('be.visible')
       .closest('tr')

--- a/packages/manager/cypress/e2e/core/account/personal-access-tokens.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/personal-access-tokens.spec.ts
@@ -4,10 +4,12 @@
 
 import { Token } from '@linode/api-v4/types';
 import { appTokenFactory } from 'src/factories/oauth';
+import { profileFactory } from 'src/factories/profile';
 import {
   mockCreatePersonalAccessToken,
   mockGetAppTokens,
   mockGetPersonalAccessTokens,
+  mockGetProfile,
   mockRevokePersonalAccessToken,
   mockUpdatePersonalAccessToken,
 } from 'support/intercepts/profile';
@@ -221,6 +223,98 @@ describe('Personal access tokens', () => {
       .should('be.visible')
       .within(() => {
         cy.findByText(newToken.label).should('not.exist');
+        cy.findByText('No items to display.').should('be.visible');
+      });
+  });
+
+  /*
+   * - Uses mocked API requests to confirm disabled states for proxy users
+   * - Confirms that a proxy user cannot create an API token
+   * - Confirms that a proxy user cannot edit (rename) an API token
+   * - Confirms that a proxy user can revoke an API token created for them
+   * - Confirms that token is removed from list after revoking it
+   */
+  it('disables API token creation and editing for a proxy user', () => {
+    const proxyToken: Token = appTokenFactory.build({
+      label: randomLabel(),
+      token: randomString(64),
+    });
+    const proxyUserProfile = profileFactory.build({ user_type: 'proxy' });
+
+    mockGetProfile(proxyUserProfile);
+    mockGetPersonalAccessTokens([proxyToken]).as('getTokens');
+    mockGetAppTokens([]).as('getAppTokens');
+    mockRevokePersonalAccessToken(proxyToken.id).as('revokeToken');
+
+    cy.visitWithLogin('/profile/tokens');
+    cy.wait(['@getTokens', '@getAppTokens']);
+
+    // Find 'Create a Personal Access Token' button, confirm it is disabled, and tooltip displays.
+    ui.button
+      .findByTitle('Create a Personal Access Token')
+      .should('be.visible')
+      .should('be.disabled')
+      .click();
+
+    cy.findByRole('tooltip')
+      .should('be.visible')
+      .within(() => {
+        cy.findByText(
+          'You can only create tokens for your own company.'
+        ).should('be.visible');
+      });
+
+    // Find token in list, confirm "Rename" is disabled, and tooltip displays.
+    cy.findByText(proxyToken.label)
+      .should('be.visible')
+      .closest('tr')
+      .within(() => {
+        ui.button
+          .findByTitle('Rename')
+          .should('be.visible')
+          .should('be.disabled')
+          .click();
+      });
+
+    cy.findByRole('tooltip')
+      .should('be.visible')
+      .within(() => {
+        cy.findByText('Only company users can edit API tokens.').should(
+          'be.visible'
+        );
+      });
+
+    // Confirm that token has been renamed, initiate revocation.
+    cy.findByText(proxyToken.label)
+      .should('be.visible')
+      .closest('tr')
+      .within(() => {
+        ui.button
+          .findByTitle('Revoke')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    mockGetPersonalAccessTokens([]).as('getTokens');
+    ui.dialog
+      .findByTitle(`Revoke ${proxyToken.label}?`)
+      .should('be.visible')
+      .within(() => {
+        ui.buttonGroup
+          .findButtonByTitle('Revoke')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    // Confirm that token is removed from list after revoking.
+    cy.wait(['@revokeToken', '@getTokens']);
+    ui.toast.assertMessage(`Successfully revoked ${proxyToken.label}`);
+    cy.findByLabelText('List of Personal Access Tokens')
+      .should('be.visible')
+      .within(() => {
+        cy.findByText(proxyToken.label).should('not.exist');
         cy.findByText('No items to display.').should('be.visible');
       });
   });

--- a/packages/manager/src/features/Profile/APITokens/APITokenMenu.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenMenu.tsx
@@ -7,6 +7,7 @@ import { Action, ActionMenu } from 'src/components/ActionMenu/ActionMenu';
 import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
 
 interface Props {
+  isProxyUser: boolean;
   isThirdPartyAccessToken: boolean;
   openEditDrawer: (token: Token) => void;
   openRevokeDialog: (token: Token, type: string) => void;
@@ -20,6 +21,7 @@ export const APITokenMenu = (props: Props) => {
   const matchesSmDown = useMediaQuery(theme.breakpoints.down('md'));
 
   const {
+    isProxyUser,
     isThirdPartyAccessToken,
     openEditDrawer,
     openRevokeDialog,
@@ -37,10 +39,12 @@ export const APITokenMenu = (props: Props) => {
     },
     !isThirdPartyAccessToken
       ? {
+          disabled: isProxyUser,
           onClick: () => {
             openEditDrawer(token);
           },
           title: 'Rename',
+          tooltip: 'Only company users can edit API tokens.',
         }
       : null,
     {
@@ -65,8 +69,10 @@ export const APITokenMenu = (props: Props) => {
       {actions.map((action) => (
         <InlineMenuAction
           actionText={action.title}
+          disabled={action.disabled}
           key={action.title}
           onClick={action.onClick}
+          tooltip={action.tooltip}
         />
       ))}
     </>

--- a/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
@@ -18,6 +18,7 @@ import { StyledTableSortCell } from 'src/components/TableSortCell/StyledTableSor
 import { TableSortCell } from 'src/components/TableSortCell/TableSortCell';
 import { Typography } from 'src/components/Typography';
 import { SecretTokenDialog } from 'src/features/Profile/SecretTokenDialog/SecretTokenDialog';
+import { useFlags } from 'src/hooks/useFlags';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
 import { useProfile } from 'src/queries/profile';
@@ -54,6 +55,7 @@ const PREFERENCE_KEY = 'api-tokens';
 export const APITokenTable = (props: Props) => {
   const { title, type } = props;
 
+  const flags = useFlags();
   const { data: profile } = useProfile();
   const { handleOrderChange, order, orderBy } = useOrder(
     {
@@ -80,7 +82,9 @@ export const APITokenTable = (props: Props) => {
     { '+order': order, '+order_by': orderBy }
   );
 
-  const isProxyUser = profile?.user_type === 'proxy';
+  const isProxyUser = Boolean(
+    flags.parentChildAccountAccess && profile?.user_type === 'proxy'
+  );
 
   const [isCreateOpen, setIsCreateOpen] = React.useState<boolean>(false);
   const [isRevokeOpen, setIsRevokeOpen] = React.useState<boolean>(false);

--- a/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
@@ -20,6 +20,7 @@ import { Typography } from 'src/components/Typography';
 import { SecretTokenDialog } from 'src/features/Profile/SecretTokenDialog/SecretTokenDialog';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
+import { useProfile } from 'src/queries/profile';
 import {
   useAppTokensQuery,
   usePersonalAccessTokensQuery,
@@ -53,6 +54,7 @@ const PREFERENCE_KEY = 'api-tokens';
 export const APITokenTable = (props: Props) => {
   const { title, type } = props;
 
+  const { data: profile } = useProfile();
   const { handleOrderChange, order, orderBy } = useOrder(
     {
       order: 'desc',
@@ -77,6 +79,8 @@ export const APITokenTable = (props: Props) => {
     },
     { '+order': order, '+order_by': orderBy }
   );
+
+  const isProxyUser = profile?.user_type === 'proxy';
 
   const [isCreateOpen, setIsCreateOpen] = React.useState<boolean>(false);
   const [isRevokeOpen, setIsRevokeOpen] = React.useState<boolean>(false);
@@ -169,6 +173,7 @@ export const APITokenTable = (props: Props) => {
         </TableCell>
         <TableCell actionCell>
           <APITokenMenu
+            isProxyUser={isProxyUser}
             isThirdPartyAccessToken={title === 'Third Party Access Tokens'}
             openEditDrawer={openEditDrawer}
             openRevokeDialog={openRevokeDialog}
@@ -197,6 +202,12 @@ export const APITokenTable = (props: Props) => {
         <StyledAddNewWrapper>
           {type === 'Personal Access Token' && (
             <AddNewLink
+              disabledReason={
+                isProxyUser
+                  ? 'You can only create tokens for your own company.'
+                  : undefined
+              }
+              disabled={isProxyUser}
               label="Create a Personal Access Token"
               onClick={() => setIsCreateOpen(true)}
             />


### PR DESCRIPTION
## Description 📝
According to the API spec:

Proxy users may not generate additional tokens for themselves.
Proxy users will be able to view the tokens provisioned for them, but will not be able to modify them.
Proxy users should still be able to revoke their own PAT.

## Changes  🔄

- The "Create A Personal Access Token" button is disabled for proxy users.
- The disabled button has a tooltip that reads: "You can only create API tokens for your own company."
- Proxy users can view the tokens provisioned for them but cannot modify them.
- The disabled Rename action has a tooltip that reads: "Only company users can edit API tokens."
- Added Cypress test coverage for proxy user disabled PAT states.

## Preview 📷

| Description  | Screenshot   |
| ------- | ------- |
| Disabled Edit action button |![Screenshot 2024-01-24 at 3 40 29 PM](https://github.com/linode/manager/assets/114685994/c703c3f2-6b97-41f8-8d51-7b59d678cd8f) |
| Disabled Create button |![Screenshot 2024-01-24 at 3 40 09 PM](https://github.com/linode/manager/assets/114685994/7f07a16b-4032-4f19-8013-d3c6ffc451cc) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Check out this PR.
- Make sure the Parent/Child feature flag is on and change `user_type` to `proxy` in [`serverHandlers.ts`](https://github.com/linode/manager/blob/develop/packages/manager/src/mocks/serverHandlers.ts#L554).

### Verification steps 
(How to verify changes)
- As a proxy user, go to http://localhost:3000/profile/tokens.
- Confirm that the `Create a Personal Access Token` is disabled and hovering over the button displays a tooltip explaining the reason for disabling.
- Confirm that the edit action (`Rename`) is disabled and hovering over the help tooltip displays a message explaining the reason for disabling.
- Confirm that API tokens are editable and creatable for non proxy users (e.g. other user_types; feature flag off).
- Confirm test passes:
```
yarn cy:run -s "cypress/e2e/core/account/personal-access-tokens.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support
