### PR TITLE
test: [M3-7516] - Cypress tests for Parent → Child account switching flows

### DIFF
--- a/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
+++ b/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
@@ -1,0 +1,137 @@
+import {
+  accountFactory,
+  appTokenFactory,
+  profileFactory,
+} from '@src/factories';
+import { accountUserFactory } from '@src/factories/accountUsers';
+import { DateTime } from 'luxon';
+import {
+  mockCreateChildAccountToken,
+  mockGetAccount,
+  mockGetChildAccounts,
+  mockGetUser,
+} from 'support/intercepts/account';
+import {
+  mockAppendFeatureFlags,
+  mockGetFeatureFlagClientstream,
+} from 'support/intercepts/feature-flags';
+import { mockAllApiRequests } from 'support/intercepts/general';
+import { mockGetProfile } from 'support/intercepts/profile';
+import { ui } from 'support/ui';
+import { makeFeatureFlagData } from 'support/util/feature-flags';
+import { assertLocalStorageValue } from 'support/util/local-storage';
+import { randomLabel, randomNumber, randomString } from 'support/util/random';
+
+describe('Parent/Child account switching', () => {
+  it('can switch from Parent account to Child account', () => {
+    const mockParentAccount = accountFactory.build({
+      company: 'Parent Company',
+    });
+    const mockParentProfile = profileFactory.build({
+      username: randomLabel(),
+      user_type: 'parent',
+    });
+    const mockParentUser = accountUserFactory.build({
+      username: mockParentProfile.username,
+      user_type: 'parent',
+    });
+
+    const mockChildAccount = accountFactory.build({
+      company: 'Child Company',
+    });
+
+    const mockChildAccountToken = appTokenFactory.build({
+      id: randomNumber(),
+      created: DateTime.now().toISO(),
+      expiry: DateTime.now().plus({ hours: 1 }).toISO(),
+      label: `${mockChildAccount.company}_proxy`,
+      scopes: '*',
+      token: randomString(32),
+      website: undefined,
+      thumbnail_url: undefined,
+    });
+
+    mockAppendFeatureFlags({
+      parentChildAccountAccess: makeFeatureFlagData(true),
+    });
+    mockGetFeatureFlagClientstream();
+    mockGetProfile(mockParentProfile);
+    mockGetAccount(mockParentAccount);
+    mockGetChildAccounts([mockChildAccount]);
+    mockGetUser(mockParentUser);
+
+    cy.visitWithLogin('/');
+
+    // Confirm that Parent account username and company name are shown in user
+    // menu button, then click the button.
+    ui.userMenuButton
+      .find()
+      .should('be.visible')
+      .within(() => {
+        cy.findByText(mockParentProfile.username).should('be.visible');
+        cy.findByText(mockParentAccount.company).should('be.visible');
+      })
+      .click();
+
+    // Click "Switch Account" button in user menu.
+    ui.userMenu
+      .find()
+      .should('be.visible')
+      .within(() => {
+        ui.button
+          .findByTitle('Switch Account')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    // Click mock company name in "Switch Account" drawer.
+    mockCreateChildAccountToken(mockChildAccount, mockChildAccountToken).as(
+      'switchAccount'
+    );
+    ui.drawer
+      .findByTitle('Switch Account')
+      .should('be.visible')
+      .within(() => {
+        cy.findByText(mockChildAccount.company).should('be.visible').click();
+      });
+
+    cy.wait('@switchAccount');
+
+    // Confirm that Cloud Manager updates local storage authentication values.
+    assertLocalStorageValue(
+      'authentication/token',
+      mockChildAccountToken.token
+    );
+    assertLocalStorageValue(
+      'authentication/expire',
+      mockChildAccountToken.expiry
+    );
+    assertLocalStorageValue(
+      'authentication/scopes',
+      mockChildAccountToken.scopes
+    );
+
+    // From this point forward, we will not have a valid test account token stored in local storage,
+    // so all non-intercepted API requests will respond with a 401 status code and we will get booted to login.
+    // We'll mitigate this by broadly mocking ALL API-v4 requests, then applying more specific mocks to the
+    // individual requests as needed.
+    mockAllApiRequests();
+    mockGetAccount(mockChildAccount);
+    mockGetProfile(mockParentProfile);
+    mockGetUser(mockParentUser);
+
+    // TODO Remove the call to `cy.reload()` once Cloud Manager automatically updates itself upon account switching.
+    // TODO Add assertions for toast upon account switch.
+    // This probably involves updating the Axios interceptor to use the new auth token, and possibly involves invalidating React Query cache.
+    cy.reload();
+
+    ui.userMenuButton
+      .find()
+      .should('be.visible')
+      .within(() => {
+        cy.findByText(mockParentProfile.username).should('be.visible');
+        cy.findByText(mockChildAccount.company).should('be.visible');
+      });
+  });
+});

--- a/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
+++ b/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
@@ -91,15 +91,23 @@ const mockChildAccountToken = appTokenFactory.build({
 const mockErrorMessage = 'An unknown error has occurred.';
 
 describe('Parent/Child account switching', () => {
+  /*
+   * Tests to confirm that Parent account users can switch to Child accounts as expected.
+   */
   describe('From Parent to Child', () => {
     beforeEach(() => {
-      // @TODO Remove feature flag mocks after feature launch and clean-up.
+      // @TODO M3-7554, M3-7559: Remove feature flag mocks after feature launch and clean-up.
       mockAppendFeatureFlags({
         parentChildAccountAccess: makeFeatureFlagData(true),
       });
       mockGetFeatureFlagClientstream();
     });
 
+    /*
+     * - Confirms that Parent account user can switch to Child account from Account Billing page.
+     * - Confirms that Child account information is displayed in user menu button after switch.
+     * - Confirms that Cloud updates local storage auth values upon account switch.
+     */
     it('can switch from Parent account to Child account from Billing page', () => {
       mockGetProfile(mockParentProfile);
       mockGetAccount(mockParentAccount);
@@ -155,6 +163,12 @@ describe('Parent/Child account switching', () => {
       );
     });
 
+    /*
+     * - Confirms that Parent account user can switch to Child account using the user menu.
+     * - Confirms that Parent account information is initially displayed in user menu button.
+     * - Confirms that Child account information is displayed in user menu button after switch.
+     * - Confirms that Cloud updates local storage auth values upon account switch.
+     */
     it('can switch from Parent account to Child account using user menu', () => {
       mockGetProfile(mockParentProfile);
       mockGetAccount(mockParentAccount);
@@ -228,6 +242,11 @@ describe('Parent/Child account switching', () => {
    * Tests to confirm that Cloud handles account switching errors gracefully.
    */
   describe('Error flows', () => {
+    /*
+     * - Confirms error handling upon failure to fetch child accounts.
+     * - Confirms "Try Again" button can be used to re-fetch child accounts successfully.
+     * - Confirms error handling upon failure to create child account token.
+     */
     it('handles account switching API errors', () => {
       mockGetProfile(mockParentProfile);
       mockGetAccount(mockParentAccount);

--- a/packages/manager/cypress/support/intercepts/account.ts
+++ b/packages/manager/cypress/support/intercepts/account.ts
@@ -500,6 +500,25 @@ export const mockGetChildAccounts = (
 };
 
 /**
+ * Intercepts GET request to fetch child accounts and mocks an error response.
+ *
+ * @param errorMessage - API error message with which to mock response.
+ * @param statusCode - HTTP status code with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetChildAccountsError = (
+  errorMessage: string = 'An unknown error has occurred',
+  statusCode: number = 500
+) => {
+  return cy.intercept(
+    'GET',
+    apiMatcher('account/child-accounts*'),
+    makeErrorResponse(errorMessage, statusCode)
+  );
+};
+
+/**
  * Intercepts POST request to create a child account token and mocks the response.
  *
  * @param childAccount - Child account for which to create a token.
@@ -515,5 +534,26 @@ export const mockCreateChildAccountToken = (
     'POST',
     apiMatcher(`account/child-accounts/${childAccount.euuid}/token`),
     makeResponse(childAccountToken)
+  );
+};
+
+/**
+ * Intercepts POST request to create a child account token and mocks error response.
+ *
+ * @param childAccount - Child account for which to mock error response.
+ * @param errorMessage - API error message with which to mock response.
+ * @param statusCode - HTTP status code with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockCreateChildAccountTokenError = (
+  childAccount: Account,
+  errorMessage: string = 'An unknown error has occurred',
+  statusCode: number = 500
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`account/child-accounts/${childAccount.euuid}/token`),
+    makeErrorResponse(errorMessage, statusCode)
   );
 };

--- a/packages/manager/cypress/support/intercepts/account.ts
+++ b/packages/manager/cypress/support/intercepts/account.ts
@@ -19,6 +19,7 @@ import type {
   InvoiceItem,
   Payment,
   PaymentMethod,
+  Token,
   User,
 } from '@linode/api-v4';
 
@@ -467,6 +468,7 @@ export const mockCancelAccountError = (
 /**
  * Intercepts GET request to fetch the account agreements and mocks the response.
  *
+ * @param agreements - Agreements with which to mock response.
  *
  * @returns Cypress chainable.
  */
@@ -477,5 +479,41 @@ export const mockGetAccountAgreements = (
     'GET',
     apiMatcher(`account/agreements`),
     makeResponse(agreements)
+  );
+};
+
+/**
+ * Intercepts GET request to fetch child accounts and mocks the response.
+ *
+ * @param childAccounts - Child account objects with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetChildAccounts = (
+  childAccounts: Account[]
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher('account/child-accounts*'),
+    paginateResponse(childAccounts)
+  );
+};
+
+/**
+ * Intercepts POST request to create a child account token and mocks the response.
+ *
+ * @param childAccount - Child account for which to create a token.
+ * @param childAccountToken - Token object with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockCreateChildAccountToken = (
+  childAccount: Account,
+  childAccountToken: Token
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`account/child-accounts/${childAccount.euuid}/token`),
+    makeResponse(childAccountToken)
   );
 };

--- a/packages/manager/cypress/support/intercepts/general.ts
+++ b/packages/manager/cypress/support/intercepts/general.ts
@@ -3,6 +3,25 @@ import { apiMatcher } from 'support/util/intercepts';
 import { makeResponse } from 'support/util/response';
 
 /**
+ * Intercepts all requests to Linode API v4 and mocks an HTTP response.
+ *
+ * This is useful to apply a baseline mock on all Linode API v4 requests, e.g.
+ * to prevent 401 responses. More fine-grained mocking can be set up with
+ * subsequent calls to other mock utils.
+ *
+ * @param body - Body data with which to mock response.
+ * @param statusCode - HTTP status code with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockAllApiRequests = (
+  body: any = {},
+  statusCode: number = 200
+) => {
+  return cy.intercept(apiMatcher('**/*'), makeResponse(body, statusCode));
+};
+
+/**
  * Intercepts GET request to given URL and mocks an HTTP 200 response with the given content.
  *
  * This can be used to mock visits to arbitrary webpages.

--- a/packages/manager/cypress/support/util/local-storage.ts
+++ b/packages/manager/cypress/support/util/local-storage.ts
@@ -1,0 +1,30 @@
+/**
+ * @file Utilities to access and validate Local Storage data.
+ */
+
+/**
+ * Asserts that a local storage item has a given value.
+ *
+ * @param key - Local storage item key.
+ * @param value - Local stroage item value to assert.
+ */
+export const assertLocalStorageValue = (key: string, value: any) => {
+  cy.getAllLocalStorage().then((localStorageData: any) => {
+    const origin = Cypress.config('baseUrl');
+    if (!origin) {
+      // This should never happen in practice.
+      throw new Error('Unable to retrieve Cypress base URL configuration');
+    }
+    if (!localStorageData[origin]) {
+      throw new Error(
+        `Unable to retrieve local storage data from origin '${origin}'`
+      );
+    }
+    if (!localStorageData[origin][key]) {
+      throw new Error(
+        `No local storage data exists for key '${key}' and origin '${origin}'`
+      );
+    }
+    expect(localStorageData[origin][key]).equals(value);
+  });
+};


### PR DESCRIPTION
## Description 📝
Adds Cypress integration tests to cover Parent/Child flows involving account switching from a Parent account to a Child account.


## Changes  🔄
- Adds tests to cover Parent/Child account switching flows:
  - Switch from Parent to Child using Account Billing page
  - Switch from Parent to Child using user menu
  - Error flows upon fetching child accounts and switching accounts
- Adds various utilities to support tests
  - Intercept/mock utils for child account API endpoints
  - Util to assert local storage values

## How to test 🧪
We can rely on automated tests for this, but you can also run the test locally:

### Prerequisites
Build and serve Cloud:

```bash
yarn && yarn build && yarn start:manager:ci
```

### Verification steps 

```bash
yarn cy:run -s "cypress/e2e/core/parentChild/account-switching.spec.ts"
```

## As an Author I have considered 🤔

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

