### PR TITLE
upcoming: [M3-7707] - Change AGLB Rule Execution Order Column Header and Values

### DIFF
--- a/packages/manager/.changeset/pr-10112-upcoming-features-1706218217394.md
+++ b/packages/manager/.changeset/pr-10112-upcoming-features-1706218217394.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Change ACLB Rule Execution Order Column ([#10112](https://github.com/linode/manager/pull/10112))

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/RuleRow.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/RuleRow.tsx
@@ -30,15 +30,6 @@ interface RuleRowProps {
   totalRules: number;
 }
 
-const getExecutionLabel = (index: number, total: number) => {
-  if (index === 0) {
-    return 'First';
-  } else if (index === total - 1) {
-    return 'Last';
-  }
-  return index + 1;
-};
-
 export const RuleRow = (props: RuleRowProps) => {
   const {
     index,
@@ -77,7 +68,7 @@ export const RuleRow = (props: RuleRowProps) => {
               }}
             >
               <StyledDragIndicator aria-label="Drag indicator icon" />
-              {getExecutionLabel(index, totalRules)}
+              {index + 1}
             </Box>
             <Box
               sx={{

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/RulesTable.test.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/RulesTable.test.tsx
@@ -30,7 +30,7 @@ describe('RulesTable', () => {
         route={mockRoute}
       />
     );
-    expect(getByText('Execution')).toBeInTheDocument();
+    expect(getByText('Execution Order')).toBeInTheDocument();
     expect(getByText('Match Value')).toBeInTheDocument();
   });
 
@@ -56,7 +56,7 @@ describe('RulesTable', () => {
       />
     );
 
-    expect(getByText('First')).toBeInTheDocument();
+    expect(getByText('1')).toBeInTheDocument();
     expect(getByText('/images/*')).toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/RulesTable.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/RulesTable.tsx
@@ -93,7 +93,7 @@ export const RulesTable = (props: Props) => {
               width: xsDown ? '50%' : '15%',
             }}
           >
-            Execution
+            Execution Order
           </Box>
           <Box sx={{ ...sxItemSpacing, width: xsDown ? '45%' : '20%' }}>
             Match Value


### PR DESCRIPTION
## Description 📝

- Changes ACLB Rule table column  `Execution` ➡️ `Execution Order`
- Changes the values `First 2 3 Last` to `1 2 3 4`
- This is a change requested by UX

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-01-25 at 4 09 38 PM](https://github.com/linode/manager/assets/115251059/0fb56ecb-74e2-49cc-a845-9868f52d9687)  | ![Screenshot 2024-01-25 at 4 08 54 PM](https://github.com/linode/manager/assets/115251059/a2a32167-01ef-4c9a-ac1b-28a39d788826) |

## How to test 🧪

### Prerequisites
- Login to `dev-test-aglb` account using the dev API **or** use the MSW to test this

### Verification steps 
- Go to an AGLB
- View rules on any route
- Verify the rules has an `Execution Order` column
- Verify the rules `Execution Order` column has numeric values `1 2 3 4`

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support