### PR TITLE
feat: [M3-7642] – Support IPv4 Ranges data in "Unassign Linodes" drawer

### DIFF
--- a/packages/manager/.changeset/pr-10089-added-1706135120889.md
+++ b/packages/manager/.changeset/pr-10089-added-1706135120889.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Support for IPv4 Ranges in VPC 'Assign Linodes to subnet' drawer ([#10089](https://github.com/linode/manager/pull/10089))

--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
@@ -56,9 +56,11 @@ const useStyles = makeStyles()((theme: Theme) => ({
 }));
 
 interface Props {
+  buttonText?: string;
   className?: string;
   error?: string;
   forDatabaseAccessControls?: boolean;
+  forVPCIPv4Ranges?: boolean;
   helperText?: string;
   inputProps?: InputBaseProps;
   ips: ExtendedIP[];
@@ -72,9 +74,11 @@ interface Props {
 
 export const MultipleIPInput = React.memo((props: Props) => {
   const {
+    buttonText,
     className,
     error,
     forDatabaseAccessControls,
+    forVPCIPv4Ranges,
     helperText,
     ips,
     onBlur,
@@ -177,16 +181,18 @@ export const MultipleIPInput = React.memo((props: Props) => {
               value={thisIP.address}
             />
           </Grid>
-          {/** Don't show the button for the first input since it won't do anything, unless this component is used in DBaaS */}
+          {/** Don't show the button for the first input since it won't do anything, unless this component is
+           * used in DBaaS or for Linode VPC interfaces
+           */}
           <Grid xs={1}>
-            {idx > 0 || forDatabaseAccessControls ? (
+            {(idx > 0 || forDatabaseAccessControls || forVPCIPv4Ranges) && (
               <Button
                 className={classes.button}
                 onClick={() => removeInput(idx)}
               >
                 <Close data-testid={`delete-ip-${idx}`} />
               </Button>
-            ) : null}
+            )}
           </Grid>
         </Grid>
       ))}
@@ -196,7 +202,7 @@ export const MultipleIPInput = React.memo((props: Props) => {
         compactX
         onClick={addNewInput}
       >
-        Add an IP
+        {buttonText ?? 'Add an IP'}
       </Button>
     </div>
   );

--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
@@ -7,7 +7,9 @@ import { makeStyles } from 'tss-react/mui';
 
 import { Button } from 'src/components/Button/Button';
 import { InputLabel } from 'src/components/InputLabel';
+import { LinkButton } from 'src/components/LinkButton';
 import { Notice } from 'src/components/Notice/Notice';
+import { StyledLinkButtonBox } from 'src/components/SelectFirewallPanel/SelectFirewallPanel';
 import { TextField } from 'src/components/TextField';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
@@ -126,6 +128,21 @@ export const MultipleIPInput = React.memo((props: Props) => {
     return null;
   }
 
+  const addIPButton = forVPCIPv4Ranges ? (
+    <StyledLinkButtonBox>
+      <LinkButton onClick={addNewInput}>{buttonText}</LinkButton>
+    </StyledLinkButtonBox>
+  ) : (
+    <Button
+      buttonType="secondary"
+      className={classes.addIP}
+      compactX
+      onClick={addNewInput}
+    >
+      {buttonText ?? 'Add an IP'}
+    </Button>
+  );
+
   return (
     <div className={cx(classes.root, className)}>
       {tooltip ? (
@@ -196,14 +213,7 @@ export const MultipleIPInput = React.memo((props: Props) => {
           </Grid>
         </Grid>
       ))}
-      <Button
-        buttonType="secondary"
-        className={classes.addIP}
-        compactX
-        onClick={addNewInput}
-      >
-        {buttonText ?? 'Add an IP'}
-      </Button>
+      {addIPButton}
     </div>
   );
 });

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -195,7 +195,7 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
           hide: !showVPCs,
           href: '/vpcs',
           icon: <VPC />,
-          isBeta: true,
+          isBeta: flags.vpc, // @TODO VPC: after VPC enters GA, remove this property entirely
         },
         {
           display: 'Firewalls',

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.style.ts
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.style.ts
@@ -88,3 +88,10 @@ export const StyledScrollBox = styled(Box, {
   maxWidth: `${maxWidth}px`,
   overflow: 'auto',
 }));
+
+export const StyledItemWithPlusChip = styled('span', {
+  label: 'ItemWithPlusChip',
+})({
+  alignItems: 'center',
+  display: 'inline-flex',
+});

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
@@ -18,6 +18,7 @@ import {
   StyledNoAssignedLinodesBox,
   StyledScrollBox,
 } from './RemovableSelectionsList.style';
+import { Chip } from '../Chip';
 
 export type RemovableItem = {
   id: number;
@@ -227,11 +228,11 @@ const determineNoneSingleOrMultipleWithChip = (
   ));
 
   return (
-    <>
+    <span style={{ alignItems: 'center', display: 'inline-flex' }}>
       {dataArray[0]}{' '}
       <Tooltip placement="bottom" title={remainingData}>
-        <span>+{remainingData.length}</span>
+        <Chip clickable inTable label={`+${remainingData.length}`} />
       </Tooltip>
-    </>
+    </span>
   );
 };

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
@@ -1,6 +1,7 @@
 import Close from '@mui/icons-material/Close';
 import * as React from 'react';
 
+import { Chip } from 'src/components/Chip';
 import { IconButton } from 'src/components/IconButton';
 import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
@@ -14,11 +15,11 @@ import {
   SelectedOptionsList,
   SelectedOptionsListItem,
   StyledBoxShadowWrapper,
+  StyledItemWithPlusChip,
   StyledLabel,
   StyledNoAssignedLinodesBox,
   StyledScrollBox,
 } from './RemovableSelectionsList.style';
-import { Chip } from '../Chip';
 
 export type RemovableItem = {
   id: number;
@@ -228,11 +229,11 @@ const determineNoneSingleOrMultipleWithChip = (
   ));
 
   return (
-    <span style={{ alignItems: 'center', display: 'inline-flex' }}>
+    <StyledItemWithPlusChip>
       {dataArray[0]}{' '}
       <Tooltip placement="bottom" title={remainingData}>
         <Chip clickable inTable label={`+${remainingData.length}`} />
       </Tooltip>
-    </span>
+    </StyledItemWithPlusChip>
   );
 };

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
@@ -1,21 +1,19 @@
 import Close from '@mui/icons-material/Close';
 import * as React from 'react';
 
-import { Chip } from 'src/components/Chip';
 import { IconButton } from 'src/components/IconButton';
 import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
 import { TableCell } from 'src/components/TableCell';
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
-import { Tooltip } from 'src/components/Tooltip';
+import { determineNoneSingleOrMultipleWithChip } from 'src/utilities/noneSingleOrMultipleWithChip';
 
 import {
   SelectedOptionsHeader,
   SelectedOptionsList,
   SelectedOptionsListItem,
   StyledBoxShadowWrapper,
-  StyledItemWithPlusChip,
   StyledLabel,
   StyledNoAssignedLinodesBox,
   StyledScrollBox,
@@ -205,35 +203,5 @@ export const RemovableSelectionsList = (
         </StyledNoAssignedLinodesBox>
       )}
     </>
-  );
-};
-
-const determineNoneSingleOrMultipleWithChip = (
-  dataArray: string[]
-): JSX.Element | string => {
-  if (dataArray.length === 0) {
-    return 'None';
-  }
-
-  if (dataArray.length === 1) {
-    return dataArray[0];
-  }
-
-  const allDataExceptFirstElement = dataArray.slice(1);
-
-  const remainingData = allDataExceptFirstElement.map((datum) => (
-    <>
-      <span key={datum}>{datum}</span>
-      <br />
-    </>
-  ));
-
-  return (
-    <StyledItemWithPlusChip>
-      {dataArray[0]}{' '}
-      <Tooltip placement="bottom" title={remainingData}>
-        <Chip clickable inTable label={`+${remainingData.length}`} />
-      </Tooltip>
-    </StyledItemWithPlusChip>
   );
 };

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
@@ -2,14 +2,7 @@ import Close from '@mui/icons-material/Close';
 import * as React from 'react';
 
 import { IconButton } from 'src/components/IconButton';
-import { Table } from 'src/components/Table';
-import { TableBody } from 'src/components/TableBody';
-import { TableCell } from 'src/components/TableCell';
-import { TableHead } from 'src/components/TableHead';
-import { TableRow } from 'src/components/TableRow';
-import { determineNoneSingleOrMultipleWithChip } from 'src/utilities/noneSingleOrMultipleWithChip';
 
-import { TableRowEmpty } from '../TableRowEmpty/TableRowEmpty';
 import {
   SelectedOptionsHeader,
   SelectedOptionsList,
@@ -63,10 +56,6 @@ export interface RemovableSelectionsListProps {
    * The data to display in the list
    */
   selectionData: RemovableItem[];
-  /**
-   * Headers for the table containing the list of selected options
-   */
-  tableHeaders?: string[];
 }
 
 export const RemovableSelectionsList = (
@@ -81,7 +70,6 @@ export const RemovableSelectionsList = (
     onRemove,
     preferredDataLabel,
     selectionData,
-    tableHeaders,
   } = props;
 
   // used to determine when to display a box-shadow to indicate scrollability
@@ -98,128 +86,46 @@ export const RemovableSelectionsList = (
     onRemove(selection);
   };
 
-  // Used for non-table version
-  const selectedOptionsJSX = (
-    <StyledBoxShadowWrapper
-      displayShadow={listHeight > maxHeight}
-      maxWidth={maxWidth}
-    >
-      <StyledScrollBox maxHeight={maxHeight} maxWidth={maxWidth}>
-        <SelectedOptionsList isRemovable={isRemovable} ref={listRef}>
-          {selectionData.map((selection) => (
-            <SelectedOptionsListItem alignItems="center" key={selection.id}>
-              <StyledLabel>
-                {preferredDataLabel
-                  ? selection[preferredDataLabel]
-                  : selection.label}
-              </StyledLabel>
-              {isRemovable && (
-                <IconButton
-                  aria-label={`remove ${
-                    preferredDataLabel
-                      ? selection[preferredDataLabel]
-                      : selection.label
-                  }`}
-                  disableRipple
-                  onClick={() => handleOnClick(selection)}
-                  size="medium"
-                >
-                  <Close />
-                </IconButton>
-              )}
-            </SelectedOptionsListItem>
-          ))}
-        </SelectedOptionsList>
-      </StyledScrollBox>
-    </StyledBoxShadowWrapper>
-  );
-
-  // Used for table version
-  const selectedOptionsJSXForTable = (
-    <>
-      {selectionData.map((selection) => (
-        <TableRow key={selection.id}>
-          <TableCell>
-            <StyledLabel>
-              {preferredDataLabel
-                ? selection[preferredDataLabel]
-                : selection.label}
-            </StyledLabel>
-          </TableCell>
-          <TableCell>{selection.interfaceData?.ipv4?.vpc ?? null}</TableCell>
-          <TableCell>
-            {determineNoneSingleOrMultipleWithChip(
-              selection.interfaceData?.ip_ranges ?? []
-            )}
-          </TableCell>
-          <TableCell>
-            {isRemovable && (
-              <IconButton
-                aria-label={`remove ${
-                  preferredDataLabel
-                    ? selection[preferredDataLabel]
-                    : selection.label
-                }`}
-                disableRipple
-                onClick={() => handleOnClick(selection)}
-                size="medium"
-              >
-                <Close />
-              </IconButton>
-            )}
-          </TableCell>
-        </TableRow>
-      ))}
-    </>
-  );
-
-  const tableOfSelectedOptions = (
-    <Table>
-      <TableHead>
-        <TableRow>
-          {tableHeaders?.map((thisHeader) => (
-            <TableCell key={`removable-selections-list-header-${thisHeader}`}>
-              {thisHeader}
-            </TableCell>
-          ))}
-          <TableCell />
-        </TableRow>
-      </TableHead>
-      <TableBody>{selectedOptionsJSXForTable}</TableBody>
-    </Table>
-  );
-
-  const tableWithoutData = (
-    <Table>
-      <TableHead>
-        <TableRow>
-          {tableHeaders?.map((thisHeader) => (
-            <TableCell key={`removable-selections-list-header-${thisHeader}`}>
-              {thisHeader}
-            </TableCell>
-          ))}
-          <TableCell />
-        </TableRow>
-      </TableHead>
-      <TableRowEmpty colSpan={4} message={noDataText} />
-    </Table>
-  );
-
   return (
     <>
       <SelectedOptionsHeader>{headerText}</SelectedOptionsHeader>
       {selectionData.length > 0 ? (
-        !tableHeaders ? (
-          selectedOptionsJSX
-        ) : (
-          tableOfSelectedOptions
-        )
-      ) : !tableHeaders ? (
+        <StyledBoxShadowWrapper
+          displayShadow={listHeight > maxHeight}
+          maxWidth={maxWidth}
+        >
+          <StyledScrollBox maxHeight={maxHeight} maxWidth={maxWidth}>
+            <SelectedOptionsList isRemovable={isRemovable} ref={listRef}>
+              {selectionData.map((selection) => (
+                <SelectedOptionsListItem alignItems="center" key={selection.id}>
+                  <StyledLabel>
+                    {preferredDataLabel
+                      ? selection[preferredDataLabel]
+                      : selection.label}
+                  </StyledLabel>
+                  {isRemovable && (
+                    <IconButton
+                      aria-label={`remove ${
+                        preferredDataLabel
+                          ? selection[preferredDataLabel]
+                          : selection.label
+                      }`}
+                      disableRipple
+                      onClick={() => handleOnClick(selection)}
+                      size="medium"
+                    >
+                      <Close />
+                    </IconButton>
+                  )}
+                </SelectedOptionsListItem>
+              ))}
+            </SelectedOptionsList>
+          </StyledScrollBox>
+        </StyledBoxShadowWrapper>
+      ) : (
         <StyledNoAssignedLinodesBox maxWidth={maxWidth}>
           <StyledLabel>{noDataText}</StyledLabel>
         </StyledNoAssignedLinodesBox>
-      ) : (
-        tableWithoutData
       )}
     </>
   );

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
@@ -9,6 +9,7 @@ import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
 import { determineNoneSingleOrMultipleWithChip } from 'src/utilities/noneSingleOrMultipleWithChip';
 
+import { TableRowEmpty } from '../TableRowEmpty/TableRowEmpty';
 import {
   SelectedOptionsHeader,
   SelectedOptionsList,
@@ -188,19 +189,37 @@ export const RemovableSelectionsList = (
     </Table>
   );
 
+  const tableWithoutData = (
+    <Table>
+      <TableHead>
+        <TableRow>
+          {tableHeaders?.map((thisHeader) => (
+            <TableCell key={`removable-selections-list-header-${thisHeader}`}>
+              {thisHeader}
+            </TableCell>
+          ))}
+          <TableCell />
+        </TableRow>
+      </TableHead>
+      <TableRowEmpty colSpan={4} message={noDataText} />
+    </Table>
+  );
+
   return (
     <>
       <SelectedOptionsHeader>{headerText}</SelectedOptionsHeader>
       {selectionData.length > 0 ? (
-        !tableHeaders || tableHeaders.length === 0 ? (
+        !tableHeaders ? (
           selectedOptionsJSX
         ) : (
           tableOfSelectedOptions
         )
-      ) : (
+      ) : !tableHeaders ? (
         <StyledNoAssignedLinodesBox maxWidth={maxWidth}>
           <StyledLabel>{noDataText}</StyledLabel>
         </StyledNoAssignedLinodesBox>
+      ) : (
+        tableWithoutData
       )}
     </>
   );

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsListTable.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsListTable.tsx
@@ -1,0 +1,133 @@
+import Close from '@mui/icons-material/Close';
+import * as React from 'react';
+
+import { IconButton } from 'src/components/IconButton';
+import { Table } from 'src/components/Table';
+import { TableBody } from 'src/components/TableBody';
+import { TableCell } from 'src/components/TableCell';
+import { TableHead } from 'src/components/TableHead';
+import { TableRow } from 'src/components/TableRow';
+import { determineNoneSingleOrMultipleWithChip } from 'src/utilities/noneSingleOrMultipleWithChip';
+
+import { TableRowEmpty } from '../TableRowEmpty/TableRowEmpty';
+import {
+  SelectedOptionsHeader,
+  StyledLabel,
+} from './RemovableSelectionsList.style';
+
+export type RemovableItem = {
+  id: number;
+  label: string;
+  // The remaining key-value pairs must have their values typed
+  // as 'any' because we do not know what types they could be.
+  // Trying to type them as 'unknown' led to type errors.
+} & { [key: string]: any };
+
+export interface RemovableSelectionsListTableProps {
+  /**
+   * The descriptive text to display above the list
+   */
+  headerText: string;
+  /**
+   * If false, hide the remove button
+   */
+  isRemovable?: boolean;
+  /**
+   * The text to display if there is no data
+   */
+  noDataText: string;
+  /**
+   * The action to perform when a data item is clicked
+   */
+  onRemove: (data: RemovableItem) => void;
+  /**
+   * Assumes the passed in prop is a key within the selectionData, and that the
+   * value of this key is a string.
+   * Displays the value of this key as the label of the data item, rather than data.label
+   */
+  preferredDataLabel?: string;
+  /**
+   * The data to display in the list
+   */
+  selectionData: RemovableItem[];
+  /**
+   * Headers for the table containing the list of selected options
+   */
+  tableHeaders: string[];
+}
+
+export const RemovableSelectionsListTable = (
+  props: RemovableSelectionsListTableProps
+) => {
+  const {
+    headerText,
+    isRemovable = true,
+    noDataText,
+    onRemove,
+    preferredDataLabel,
+    selectionData,
+    tableHeaders,
+  } = props;
+
+  const handleOnClick = (selection: RemovableItem) => {
+    onRemove(selection);
+  };
+
+  const selectedOptionsJSX =
+    selectionData.length === 0 ? (
+      <TableRowEmpty colSpan={4} message={noDataText} />
+    ) : (
+      selectionData.map((selection) => (
+        <TableRow key={selection.id}>
+          <TableCell>
+            <StyledLabel>
+              {preferredDataLabel
+                ? selection[preferredDataLabel]
+                : selection.label}
+            </StyledLabel>
+          </TableCell>
+          <TableCell>{selection.interfaceData?.ipv4?.vpc ?? null}</TableCell>
+          <TableCell>
+            {determineNoneSingleOrMultipleWithChip(
+              selection.interfaceData?.ip_ranges ?? []
+            )}
+          </TableCell>
+          <TableCell>
+            {isRemovable && (
+              <IconButton
+                aria-label={`remove ${
+                  preferredDataLabel
+                    ? selection[preferredDataLabel]
+                    : selection.label
+                }`}
+                disableRipple
+                onClick={() => handleOnClick(selection)}
+                size="medium"
+              >
+                <Close />
+              </IconButton>
+            )}
+          </TableCell>
+        </TableRow>
+      ))
+    );
+
+  return (
+    <>
+      <SelectedOptionsHeader>{headerText}</SelectedOptionsHeader>
+      <Table>
+        <TableHead>
+          <TableRow>
+            {tableHeaders.map((thisHeader) => (
+              <TableCell key={`removable-selections-list-header-${thisHeader}`}>
+                {thisHeader}
+              </TableCell>
+            ))}
+            <TableCell />
+          </TableRow>
+        </TableHead>
+        <TableBody>{selectedOptionsJSX}</TableBody>
+      </Table>
+    </>
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeSelect/LinodeSelect.tsx
+++ b/packages/manager/src/features/Linodes/LinodeSelect/LinodeSelect.tsx
@@ -161,6 +161,7 @@ export const LinodeSelect = (
       helperText={helperText}
       id={id}
       inputValue={inputValue}
+      isOptionEqualToValue={(option, value) => option.id === value.id}
       label={label ? label : multiple ? 'Linodes' : 'Linode'}
       loading={isLoading || loading}
       multiple={multiple}

--- a/packages/manager/src/features/VPCs/VPCDetail/AssignIPRanges.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/AssignIPRanges.tsx
@@ -37,11 +37,11 @@ export const AssignIPRanges = (props: Props) => {
         .
       </Typography>
       <MultipleIPInput
-        buttonText="Add IPv4 Ranges"
+        buttonText="Add IPv4 Range"
         forVPCIPv4Ranges
         ips={ipRanges}
         onChange={handleIPRangeChange}
-        placeholder="IPv4 range address format, e.g. 10.0.0.0/24"
+        placeholder="10.0.0.0/24"
         title=""
       />
     </>

--- a/packages/manager/src/features/VPCs/VPCDetail/AssignIPRanges.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/AssignIPRanges.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+
+import { Divider } from 'src/components/Divider';
+import { Link } from 'src/components/Link';
+import { MultipleIPInput } from 'src/components/MultipleIPInput/MultipleIPInput';
+import { Notice } from 'src/components/Notice/Notice';
+import { Typography } from 'src/components/Typography';
+import {
+  ASSIGN_IPV4_RANGES_DESCRIPTION,
+  ASSIGN_IPV4_RANGES_TITLE,
+} from 'src/features/VPCs/constants';
+import { ExtendedIP } from 'src/utilities/ipUtils';
+
+interface Props {
+  handleIPRangeChange: (ips: ExtendedIP[]) => void;
+  ipRanges: ExtendedIP[];
+  ipRangesError?: string;
+}
+
+export const AssignIPRanges = (props: Props) => {
+  const { handleIPRangeChange, ipRanges, ipRangesError } = props;
+
+  return (
+    <>
+      <Divider />
+      {ipRangesError && (
+        <Notice important text={ipRangesError} variant="error" />
+      )}
+      <Typography sx={(theme) => ({ fontFamily: theme.font.bold })}>
+        {ASSIGN_IPV4_RANGES_TITLE}
+      </Typography>
+      <Typography variant="body1">
+        {ASSIGN_IPV4_RANGES_DESCRIPTION}{' '}
+        <Link to="https://www.linode.com/docs/guides/how-to-understand-ip-addresses/">
+          Learn more
+        </Link>
+        .
+      </Typography>
+      <MultipleIPInput
+        buttonText="Add IPv4 Ranges"
+        forVPCIPv4Ranges
+        ips={ipRanges}
+        onChange={handleIPRangeChange}
+        placeholder="IPv4 range address format, e.g. 10.0.0.0/24"
+        title=""
+      />
+    </>
+  );
+};

--- a/packages/manager/src/features/VPCs/VPCDetail/AssignIPRanges.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/AssignIPRanges.tsx
@@ -11,18 +11,21 @@ import {
 } from 'src/features/VPCs/constants';
 import { ExtendedIP } from 'src/utilities/ipUtils';
 
+import type { SxProps } from '@mui/material/styles';
+
 interface Props {
   handleIPRangeChange: (ips: ExtendedIP[]) => void;
   ipRanges: ExtendedIP[];
   ipRangesError?: string;
+  sx?: SxProps;
 }
 
 export const AssignIPRanges = (props: Props) => {
-  const { handleIPRangeChange, ipRanges, ipRangesError } = props;
+  const { handleIPRangeChange, ipRanges, ipRangesError, sx } = props;
 
   return (
     <>
-      <Divider />
+      <Divider sx={{ ...sx }} />
       {ipRangesError && (
         <Notice important text={ipRangesError} variant="error" />
       )}

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.test.tsx
@@ -42,7 +42,7 @@ describe('Subnet Assign Linodes Drawer', () => {
   );
 
   it('should render a subnet assign linodes drawer', () => {
-    const { getByText } = renderWithTheme(
+    const { getByText, queryAllByText } = renderWithTheme(
       <SubnetAssignLinodesDrawer {...props} />,
       {
         queryClient,
@@ -61,7 +61,7 @@ describe('Subnet Assign Linodes Drawer', () => {
       `Select the Linodes you would like to assign to this subnet. Only Linodes in this VPC's region are displayed.`
     );
     expect(helperText).toBeVisible();
-    const linodeSelect = getByText('Linode');
+    const linodeSelect = queryAllByText('Linode')[0];
     expect(linodeSelect).toBeVisible();
 
     const assignButton = getByText('Assign Linode');

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.test.tsx
@@ -1,10 +1,21 @@
 import { Subnet } from '@linode/api-v4';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import * as React from 'react';
+import { QueryClient } from 'react-query';
 
-import { renderWithTheme } from 'src/utilities/testHelpers';
+import { linodeFactory } from 'src/factories';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
+import { rest, server } from 'src/mocks/testServer';
+import { mockMatchMedia, renderWithTheme } from 'src/utilities/testHelpers';
 
 import { SubnetAssignLinodesDrawer } from './SubnetAssignLinodesDrawer';
+
+const queryClient = new QueryClient();
+
+beforeAll(() => mockMatchMedia());
+afterEach(() => {
+  queryClient.clear();
+});
 
 const props = {
   onClose: vi.fn(),
@@ -15,13 +26,27 @@ const props = {
     label: 'subnet-1',
   } as Subnet,
   vpcId: 1,
-  vpcRegion: '',
+  vpcRegion: 'us-east',
 };
 
 describe('Subnet Assign Linodes Drawer', () => {
+  const linode = linodeFactory.build({
+    label: 'this-linode',
+    region: props.vpcRegion,
+  });
+
+  server.use(
+    rest.get('*/linode/instances', (req, res, ctx) => {
+      return res(ctx.json(makeResourcePage([linode])));
+    })
+  );
+
   it('should render a subnet assign linodes drawer', () => {
-    const { getByText, queryByText } = renderWithTheme(
-      <SubnetAssignLinodesDrawer {...props} />
+    const { getByText } = renderWithTheme(
+      <SubnetAssignLinodesDrawer {...props} />,
+      {
+        queryClient,
+      }
     );
 
     const header = getByText(
@@ -36,14 +61,9 @@ describe('Subnet Assign Linodes Drawer', () => {
       `Select the Linodes you would like to assign to this subnet. Only Linodes in this VPC's region are displayed.`
     );
     expect(helperText).toBeVisible();
-    const linodeSelect = getByText('Linodes');
+    const linodeSelect = getByText('Linode');
     expect(linodeSelect).toBeVisible();
-    const checkbox = getByText(
-      'Auto-assign a VPC IPv4 address for this Linode'
-    );
-    expect(checkbox).toBeVisible();
-    const ipv4Textbox = queryByText('VPC IPv4');
-    expect(ipv4Textbox).toBeNull();
+
     const assignButton = getByText('Assign Linode');
     expect(assignButton).toBeVisible();
     const alreadyAssigned = getByText('Linodes Assigned to Subnet (0)');
@@ -52,19 +72,26 @@ describe('Subnet Assign Linodes Drawer', () => {
     expect(doneButton).toBeVisible();
   });
 
-  it('should show the IPv4 textbox when the checkmark is clicked', () => {
-    const { getByText } = renderWithTheme(
-      <SubnetAssignLinodesDrawer {...props} />
+  it.skip('should show the IPv4 textbox when the checkmark is clicked', async () => {
+    const { findByText, getByLabelText } = renderWithTheme(
+      <SubnetAssignLinodesDrawer {...props} />,
+      {
+        queryClient,
+      }
     );
 
-    const checkbox = getByText(
+    const selectField = getByLabelText('Linode');
+    fireEvent.change(selectField, { target: { value: 'this-linode' } });
+
+    const checkbox = await findByText(
       'Auto-assign a VPC IPv4 address for this Linode'
     );
-    expect(checkbox).toBeVisible();
+
+    await waitFor(() => expect(checkbox).toBeVisible());
     fireEvent.click(checkbox);
 
-    const ipv4Textbox = getByText('VPC IPv4');
-    expect(ipv4Textbox).toBeVisible();
+    const ipv4Textbox = await findByText('VPC IPv4');
+    await waitFor(() => expect(ipv4Textbox).toBeVisible());
   });
 
   it('should close the drawer', () => {

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.tsx
@@ -157,7 +157,9 @@ export const SubnetAssignLinodesDrawer = (
     );
 
     const interfacePayload: InterfacePayload = {
-      ip_ranges: ipRanges.map((ipRange) => ipRange.address),
+      ip_ranges: ipRanges
+        .map((ipRange) => ipRange.address)
+        .filter((ipRange) => ipRange !== ''),
       ipam_address: null,
       ipv4: {
         nat_1_1: 'any', // 'any' in all cases here to help the user towards a functional configuration & hide complexity per stakeholder feedback

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.tsx
@@ -398,37 +398,41 @@ export const SubnetAssignLinodesDrawer = (
           sx={{ marginBottom: '8px' }}
           value={values.selectedLinode?.id || null}
         />
-        <Box alignItems="center" display="flex" flexDirection="row">
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={autoAssignIPv4}
-                onChange={handleAutoAssignIPv4Change}
+        {values.selectedLinode?.id && (
+          <>
+            <Box alignItems="center" display="flex" flexDirection="row">
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={autoAssignIPv4}
+                    onChange={handleAutoAssignIPv4Change}
+                  />
+                }
+                label={
+                  <Typography>
+                    Auto-assign a VPC IPv4 address for this Linode
+                  </Typography>
+                }
+                data-testid="vpc-ipv4-checkbox"
+                disabled={userCannotAssignLinodes}
+                sx={{ marginRight: 0 }}
               />
-            }
-            label={
-              <Typography>
-                Auto-assign a VPC IPv4 address for this Linode
-              </Typography>
-            }
-            data-testid="vpc-ipv4-checkbox"
-            disabled={userCannotAssignLinodes}
-            sx={{ marginRight: 0 }}
-          />
-          <TooltipIcon status="help" text={VPC_AUTO_ASSIGN_IPV4_TOOLTIP} />
-        </Box>
-        {!autoAssignIPv4 && (
-          <TextField
-            onChange={(e) => {
-              setFieldValue('chosenIP', e.target.value);
-              setAssignLinodesErrors({});
-            }}
-            disabled={userCannotAssignLinodes}
-            errorText={assignLinodesErrors['ipv4.vpc']}
-            label={'VPC IPv4'}
-            sx={{ marginBottom: '8px' }}
-            value={values.chosenIP}
-          />
+              <TooltipIcon status="help" text={VPC_AUTO_ASSIGN_IPV4_TOOLTIP} />
+            </Box>
+            {!autoAssignIPv4 && (
+              <TextField
+                onChange={(e) => {
+                  setFieldValue('chosenIP', e.target.value);
+                  setAssignLinodesErrors({});
+                }}
+                disabled={userCannotAssignLinodes}
+                errorText={assignLinodesErrors['ipv4.vpc']}
+                label={'VPC IPv4'}
+                sx={{ marginBottom: '8px' }}
+                value={values.chosenIP}
+              />
+            )}
+          </>
         )}
         {linodeConfigs.length > 1 && (
           <>

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.tsx
@@ -1,4 +1,5 @@
 import { appendConfigInterface } from '@linode/api-v4';
+import { useTheme } from '@mui/material/styles';
 import { useFormik } from 'formik';
 import * as React from 'react';
 
@@ -78,6 +79,7 @@ export const SubnetAssignLinodesDrawer = (
   const newInterface = React.useRef<Interface>();
   const removedLinodeId = React.useRef<number>(-1);
   const formattedDate = useFormattedDate();
+  const theme = useTheme();
 
   const [assignLinodesErrors, setAssignLinodesErrors] = React.useState<
     Record<string, string | undefined>
@@ -131,7 +133,7 @@ export const SubnetAssignLinodesDrawer = (
 
   // Moved the list of linodes that are currently assignable to a subnet into a state variable (linodeOptionsToAssign)
   // and update that list whenever this subnet or the list of all linodes in this subnet's region changes. This takes
-  // care of the MUI invalid value warning that was occuring before in the Linodes autocomplete [M3-6752]
+  // care of the MUI invalid value warning that was occurring before in the Linodes autocomplete [M3-6752]
   React.useEffect(() => {
     if (linodes) {
       setLinodeOptionsToAssign(findUnassignedLinodes() ?? []);
@@ -503,6 +505,13 @@ export const SubnetAssignLinodesDrawer = (
             {((linodeConfigs.length > 1 && values.selectedConfig) ||
               linodeConfigs.length === 1) && (
               <AssignIPRanges
+                sx={{
+                  marginBottom: theme.spacing(),
+                  marginTop:
+                    linodeConfigs.length > 1
+                      ? theme.spacing(2)
+                      : theme.spacing(),
+                }}
                 handleIPRangeChange={handleIPRangeChange}
                 ipRanges={values.ipRanges}
                 ipRangesError={assignLinodesErrors['ip_ranges']}

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.tsx
@@ -13,7 +13,7 @@ import { FormControlLabel } from 'src/components/FormControlLabel';
 import { FormHelperText } from 'src/components/FormHelperText';
 import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
-import { RemovableSelectionsList } from 'src/components/RemovableSelectionsList/RemovableSelectionsList';
+import { RemovableSelectionsListTable } from 'src/components/RemovableSelectionsList/RemovableSelectionsListTable';
 import { TextField } from 'src/components/TextField';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
@@ -544,7 +544,7 @@ export const SubnetAssignLinodesDrawer = (
             />
           ))
         : null}
-      <RemovableSelectionsList
+      <RemovableSelectionsListTable
         onRemove={(data) => {
           handleUnassignLinode(data as LinodeAndConfigData);
           setUnassignLinodesErrors([]);

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.tsx
@@ -61,7 +61,7 @@ interface SubnetAssignLinodesDrawerProps {
 
 type LinodeAndConfigData = Linode & {
   configId: number;
-  interfaceId: number;
+  interfaceData: Interface | undefined;
   linodeConfigLabel: string;
 };
 
@@ -193,7 +193,7 @@ export const SubnetAssignLinodesDrawer = (
 
       // We're storing this in a ref to access this later in order
       // to update `assignedLinodesAndConfigData` with the new
-      // interfaceId without causing a re-render
+      // interface data without causing a re-render
       newInterface.current = _newInterface;
 
       await invalidateQueries({
@@ -236,12 +236,12 @@ export const SubnetAssignLinodesDrawer = (
   };
 
   const handleUnassignLinode = async (data: LinodeAndConfigData) => {
-    const { configId, id: linodeId, interfaceId } = data;
+    const { configId, id: linodeId, interfaceData } = data;
     removedLinodeId.current = linodeId;
     try {
       await unassignLinode({
         configId,
-        interfaceId,
+        interfaceId: interfaceData?.id ?? -1,
         linodeId,
         subnetId: subnet?.id ?? -1,
         vpcId,
@@ -312,7 +312,6 @@ export const SubnetAssignLinodesDrawer = (
         ...values.selectedLinode,
         configId,
         interfaceData: newInterface?.current,
-        interfaceId: newInterface?.current?.id ?? -1,
         // Create a label that combines Linode label and configuration label (if available)
         linodeConfigLabel: `${values.selectedLinode.label}${
           values.selectedConfig?.label

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
@@ -10,7 +10,7 @@ import { Box } from 'src/components/Box';
 import { DownloadCSV } from 'src/components/DownloadCSV/DownloadCSV';
 import { Drawer } from 'src/components/Drawer';
 import { Notice } from 'src/components/Notice/Notice';
-import { RemovableSelectionsList } from 'src/components/RemovableSelectionsList/RemovableSelectionsList';
+import { RemovableSelectionsListTable } from 'src/components/RemovableSelectionsList/RemovableSelectionsListTable';
 import { SUBNET_UNASSIGN_LINODES_WARNING } from 'src/features/VPCs/constants';
 import { useFormattedDate } from 'src/hooks/useFormattedDate';
 import { useUnassignLinode } from 'src/hooks/useUnassignLinode';
@@ -25,6 +25,7 @@ import { SUBNET_LINODE_CSV_HEADERS } from 'src/utilities/subnets';
 import type {
   APIError,
   DeleteLinodeConfigInterfacePayload,
+  Interface,
   Linode,
   UpdateConfigInterfacePayload,
 } from '@linode/api-v4';
@@ -36,6 +37,14 @@ interface Props {
   subnet?: Subnet;
   vpcId: number;
 }
+
+type ConfigInterfaceAndLinodeData = { id: number } & {
+  configId: number;
+  interfaceData: Interface;
+  interfaceId: number;
+  label: string;
+  linodeId: number;
+};
 
 export const SubnetUnassignLinodesDrawer = React.memo(
   ({ onClose, open, singleLinodeToBeUnassigned, subnet, vpcId }: Props) => {
@@ -53,9 +62,15 @@ export const SubnetUnassignLinodesDrawer = React.memo(
 
     const csvRef = React.useRef<any>();
     const formattedDate = useFormattedDate();
+
     const [selectedLinodes, setSelectedLinodes] = React.useState<Linode[]>(
       singleLinodeToBeUnassigned ? [singleLinodeToBeUnassigned] : []
     );
+    const [
+      selectedLinodesAndConfigData,
+      setSelectedLinodesAndConfigData,
+    ] = React.useState<ConfigInterfaceAndLinodeData[]>([]);
+
     const hasError = React.useRef(false); // This flag is used to prevent the drawer from closing if an error occurs.
 
     const [
@@ -127,7 +142,10 @@ export const SubnetUnassignLinodesDrawer = React.memo(
 
                 return {
                   configId: configWithVpcInterface.id,
+                  id: linode.id,
+                  interfaceData: vpcInterface,
                   interfaceId: vpcInterface.id,
+                  label: linode.label,
                   linodeId: linode.id,
                 };
               }
@@ -136,12 +154,26 @@ export const SubnetUnassignLinodesDrawer = React.memo(
           );
 
           // Filter out any null values and ensure item conforms to type using `is` type guard.
-          const filteredConfigInterfaces = updatedConfigInterfaces.filter(
+          const _selectedLinodesAndConfigData = updatedConfigInterfaces.filter(
+            (item): item is ConfigInterfaceAndLinodeData => item !== null
+          );
+
+          // Remove interface property for the DeleteLinodeConfigInterfacePayload data
+          const _updatedConfigInterfaces = updatedConfigInterfaces.map(
+            (item) => ({
+              configId: item?.configId,
+              interfaceId: item?.interfaceId,
+              linodeId: item?.linodeId,
+            })
+          );
+
+          const filteredConfigInterfaces = _updatedConfigInterfaces.filter(
             (item): item is DeleteLinodeConfigInterfacePayload => item !== null
           );
 
           // Update the state with the new data
           setConfigInterfacesToDelete([...filteredConfigInterfaces]);
+          setSelectedLinodesAndConfigData([..._selectedLinodesAndConfigData]);
         } catch (error) {
           // Capture errors if the promise.all fails
           hasError.current = true;
@@ -168,13 +200,22 @@ export const SubnetUnassignLinodesDrawer = React.memo(
       csvRef.current.link.click();
     };
 
-    const handleRemoveLinode = (optionToRemove: Linode) => {
+    const handleRemoveLinode = (
+      optionToRemove: ConfigInterfaceAndLinodeData
+    ) => {
       setSelectedLinodes((prevSelectedLinodes) =>
         prevSelectedLinodes.filter((option) => option.id !== optionToRemove.id)
       );
+
       setConfigInterfacesToDelete((prevInterfacesToDelete) =>
         prevInterfacesToDelete.filter(
           (option) => option.linodeId !== optionToRemove.id
+        )
+      );
+
+      setSelectedLinodesAndConfigData((prevSelectedLinodesAndConfigData) =>
+        prevSelectedLinodesAndConfigData.filter(
+          (option) => option.id !== optionToRemove.id
         )
       );
     };
@@ -284,12 +325,13 @@ export const SubnetUnassignLinodesDrawer = React.memo(
               />
             )}
             <Box sx={(theme) => ({ marginTop: theme.spacing(2) })}>
-              <RemovableSelectionsList
+              <RemovableSelectionsListTable
                 headerText={`Linodes to be Unassigned from Subnet (${selectedLinodes.length})`}
                 isRemovable={!Boolean(singleLinodeToBeUnassigned)}
-                noDataText={'Select Linodes to be Unassigned from Subnet.'}
+                noDataText="Select Linodes to be Unassigned from Subnet."
                 onRemove={handleRemoveLinode}
-                selectionData={selectedLinodes}
+                selectionData={selectedLinodesAndConfigData}
+                tableHeaders={['Linode', 'VPC IPv4', 'VPC IPv4 Ranges']}
               />
             </Box>
             {selectedLinodes.length > 0 && (

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.tsx
@@ -16,6 +16,7 @@ import {
   VPC_FEEDBACK_FORM_URL,
   VPC_LABEL,
 } from 'src/features/VPCs/constants';
+import { useFlags } from 'src/hooks/useFlags';
 import { useRegionsQuery } from 'src/queries/regions';
 import { useVPCQuery } from 'src/queries/vpcs';
 import { truncate } from 'src/utilities/truncate';
@@ -39,6 +40,7 @@ const VPCDetail = () => {
 
   const { data: vpc, error, isLoading } = useVPCQuery(+vpcId);
   const { data: regions } = useRegionsQuery();
+  const flags = useFlags();
 
   const [editVPCDrawerOpen, setEditVPCDrawerOpen] = React.useState(false);
   const [deleteVPCDialogOpen, setDeleteVPCDialogOpen] = React.useState(false);
@@ -112,7 +114,7 @@ const VPCDetail = () => {
           labelOptions: { noCap: true },
           pathname: `/vpcs/${vpc.label}`,
         }}
-        betaFeedbackLink={VPC_FEEDBACK_FORM_URL}
+        betaFeedbackLink={flags.vpc ? VPC_FEEDBACK_FORM_URL : undefined} // @TODO VPC: remove this once VPC goes into GA
         docsLabel="Docs"
         docsLink={VPC_DOCS_LINK}
       />

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCLanding.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCLanding.tsx
@@ -18,6 +18,7 @@ import {
   VPC_FEEDBACK_FORM_URL,
   VPC_LABEL,
 } from 'src/features/VPCs/constants';
+import { useFlags } from 'src/hooks/useFlags';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
 import { useVPCsQuery } from 'src/queries/vpcs';
@@ -55,6 +56,7 @@ const VPCLanding = () => {
   );
 
   const history = useHistory();
+  const flags = useFlags();
 
   const [selectedVPC, setSelectedVPC] = React.useState<VPC | undefined>();
 
@@ -96,7 +98,7 @@ const VPCLanding = () => {
   return (
     <>
       <LandingHeader
-        betaFeedbackLink={VPC_FEEDBACK_FORM_URL}
+        betaFeedbackLink={flags.vpc ? VPC_FEEDBACK_FORM_URL : undefined} // @TODO VPC: remove this once VPC goes into GA
         createButtonText="Create VPC"
         docsLink={VPC_DOCS_LINK}
         onButtonClick={createVPC}

--- a/packages/manager/src/features/VPCs/constants.ts
+++ b/packages/manager/src/features/VPCs/constants.ts
@@ -40,6 +40,11 @@ export const VPC_REBOOT_MESSAGE =
 
 export const VPC_READ_ONLY_TOOLTIP = 'VPC does not support Read Only access';
 
+export const ASSIGN_IPV4_RANGES_TITLE = 'Assign additional IPv4 ranges';
+
+export const ASSIGN_IPV4_RANGES_DESCRIPTION =
+  'Assign additional IPv4 address ranges that the VPC can use to reach services running on this Linode.';
+
 // Linode Config dialog helper text for unrecommended configurations
 export const LINODE_UNREACHABLE_HELPER_TEXT =
   'This network configuration is not recommended. The Linode will not be reachable or able to reach Linodes in the other subnets of the VPC. We recommend selecting VPC as the primary interface and checking the “Assign a public IPv4 address for this Linode” checkbox.';

--- a/packages/manager/src/utilities/noneSingleOrMultipleWithChip.test.tsx
+++ b/packages/manager/src/utilities/noneSingleOrMultipleWithChip.test.tsx
@@ -1,0 +1,22 @@
+import { determineNoneSingleOrMultipleWithChip } from './noneSingleOrMultipleWithChip';
+
+describe('determineNoneSingleOrMultipleWithChip', () => {
+  it('should return None for empty arrays', () => {
+    expect(determineNoneSingleOrMultipleWithChip([])).toEqual('None');
+  });
+
+  it('should return the element if the array only consists of one element', () => {
+    const array = ['Test'];
+
+    expect(determineNoneSingleOrMultipleWithChip(array)).toEqual(array[0]);
+  });
+
+  it('should not return "None" nor equal the first element of the array if the array contains multiple elements', () => {
+    const array = ['Test', 'Test 2', 'Test 3', 'Test 4'];
+
+    const returned = determineNoneSingleOrMultipleWithChip(array);
+
+    expect(returned).not.toEqual('None');
+    expect(returned).not.toEqual('Test');
+  });
+});

--- a/packages/manager/src/utilities/noneSingleOrMultipleWithChip.tsx
+++ b/packages/manager/src/utilities/noneSingleOrMultipleWithChip.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+
+import { Chip } from 'src/components/Chip';
+import { StyledItemWithPlusChip } from 'src/components/RemovableSelectionsList/RemovableSelectionsList.style';
+import { Tooltip } from 'src/components/Tooltip';
+
+export const remainingDataLengthChip = 'remaining-data-length-chip';
+
+export const determineNoneSingleOrMultipleWithChip = (
+  dataArray: string[]
+): JSX.Element | string => {
+  if (dataArray.length === 0) {
+    return 'None';
+  }
+
+  if (dataArray.length === 1) {
+    return dataArray[0];
+  }
+
+  const allDataExceptFirstElement = dataArray.slice(1);
+
+  const remainingData = allDataExceptFirstElement.map((datum) => (
+    <>
+      <span key={datum}>{datum}</span>
+      <br />
+    </>
+  ));
+
+  return (
+    <StyledItemWithPlusChip>
+      {dataArray[0]}{' '}
+      <Tooltip placement="bottom" title={remainingData}>
+        <Chip
+          clickable
+          data-testid={remainingDataLengthChip}
+          inTable
+          label={`+${remainingData.length}`}
+        />
+      </Tooltip>
+    </StyledItemWithPlusChip>
+  );
+};

--- a/packages/validation/.changeset/pr-10089-changed-1706135447361.md
+++ b/packages/validation/.changeset/pr-10089-changed-1706135447361.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Changed
+---
+
+ip_ranges field in LinodeInterfaceSchema no longer limited to 1 element ([#10089](https://github.com/linode/manager/pull/10089))

--- a/packages/validation/src/linodes.schema.ts
+++ b/packages/validation/src/linodes.schema.ts
@@ -195,7 +195,7 @@ export const LinodeInterfaceSchema = object().shape({
     .of(string())
     .when('purpose', {
       is: 'vpc',
-      then: array().of(string().test(validateIP)).max(1).notRequired(),
+      then: array().of(string().test(validateIP)).notRequired(),
       otherwise: array().test({
         name: testnameDisallowedBasedOnPurpose('VPC'),
         message: testmessageDisallowedBasedOnPurpose('vpc', 'ip_ranges'),


### PR DESCRIPTION
## Description 📝
(opened in lieu of https://github.com/linode/manager/pull/10111 being closed due to git history issues)

> [!NOTE] 
> This branches off from https://github.com/linode/manager/pull/10089 -- the diff should be reduced down to two files (`SubnetUnassignLinodesDrawer.tsx` and the changeset) once that PR is merged into the release branch (`staging-off-release`).

Support IPv4 Ranges data in "Unassign Linodes" drawer.

## Changes  🔄
- Use `RemovableSelectionsListTable` in Unassign drawer to display VPC IPv4 and VPC IPv4 Ranges data

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-01-26 at 12 03 01 PM](https://github.com/linode/manager/assets/114682940/1e8b016c-f56a-4d10-9e3c-7e0b56245725) | ![Screenshot 2024-01-26 at 12 02 38 PM](https://github.com/linode/manager/assets/114682940/cde2449d-0719-4e0e-92ed-43a25e1e15af) |

## How to test 🧪
### Verification steps 
Have the `vpc-extra-beta` tag on your account and a VPC containing at least one subnet with a linode assigned to it. Confirm that:

- You see a table in the "Linodes to be Unassigned from Subnet" section
- When you select a linode, the table is populated with its data
  - If you select one with no IPv4 Ranges, you should see "None" in that cell
 - Clicking the "X" for that table row removes it (and clicking "X" in the LinodeSelect should clear all selections from the table)

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support