### PR TITLE
change: [M3-7710] - Table Collapsible row icon orientation

### DIFF
--- a/packages/manager/.changeset/pr-10119-changed-1706549896002.md
+++ b/packages/manager/.changeset/pr-10119-changed-1706549896002.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Table Collapsible row icon orientation ([#10119](https://github.com/linode/manager/pull/10119))

--- a/packages/manager/cypress/e2e/core/loadBalancers/load-balancer-routes.spec.ts
+++ b/packages/manager/cypress/e2e/core/loadBalancers/load-balancer-routes.spec.ts
@@ -527,7 +527,7 @@ describe('Akamai Global Load Balancer routes page', () => {
         '@getRoutes',
       ]);
 
-      cy.findByLabelText(`route-${routes[0].id} expand row`).click();
+      cy.findByLabelText(`expand route-${routes[0].id} row`).click();
 
       ui.actionMenu.findByTitle('Action Menu for Rule 0').click();
 
@@ -600,7 +600,7 @@ describe('Akamai Global Load Balancer routes page', () => {
       ]);
 
       // Expand the route table
-      cy.findByLabelText(`route-${routes[0].id} expand row`).click();
+      cy.findByLabelText(`expand route-${routes[0].id} row`).click();
 
       // Verify all rules are shown
       for (const rule of routes[0].rules) {

--- a/packages/manager/src/components/CollapsibleTable/CollapsibleRow.tsx
+++ b/packages/manager/src/components/CollapsibleTable/CollapsibleRow.tsx
@@ -1,5 +1,5 @@
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import Box from '@mui/material/Box';
 import Collapse from '@mui/material/Collapse';
 import IconButton from '@mui/material/IconButton';
@@ -25,12 +25,12 @@ export const CollapsibleRow = (props: Props) => {
       <StyledOuterTableRow>
         <TableCell component="th" scope="row">
           <IconButton
-            aria-label={`${label} expand row`}
+            aria-label={`expand ${label} row`}
             onClick={() => setOpen(!open)}
             size="small"
             sx={{ padding: 1 }}
           >
-            {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+            {open ? <KeyboardArrowDownIcon /> : <KeyboardArrowRightIcon />}
           </IconButton>
           {label}
         </TableCell>


### PR DESCRIPTION
## Description 📝
Small PR to rectify the orientation of the Collapsible TableRow icon

## Preview 📷

| Before (closed)  | After (closed)  |
| ------- | ------- |
| ![localhost_3000_vpcs_19662 (2)](https://github.com/linode/manager/assets/130582365/3f54c5ab-bbd7-47ea-9275-282b7c740295) | ![localhost_3000_vpcs_19662](https://github.com/linode/manager/assets/130582365/af639afc-b162-4809-95fe-096c0fa3f9b0) |

| Before (open)  | After (open)  |
| ------- | ------- |
| ![localhost_3000_vpcs_19662 (3)](https://github.com/linode/manager/assets/130582365/7645d344-f033-4c03-8e99-46b8eaaf47c5) | ![localhost_3000_vpcs_19662 (1)](https://github.com/linode/manager/assets/130582365/da037d26-639a-4141-940e-af9d8f1363fb) |

## How to test 🧪

### Prerequisites
- Have a VPC and subnet

### Reproduction steps


### Verification steps 
- Navigate to http://localhost:3000/vpcs/{id}
- Observe the new orientation of the  Collapsible TableRow icon

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support


