### PR TITLE
change: [M3-7715] - Remove `kubernetesDashboardAvailability` feature flag

### DIFF
--- a/packages/manager/.changeset/pr-10121-tech-stories-1706560897746.md
+++ b/packages/manager/.changeset/pr-10121-tech-stories-1706560897746.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Remove `kubernetesDashboardAvailability` feature flag ([#10121](https://github.com/linode/manager/pull/10121))

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -49,7 +49,6 @@ export interface Flags {
   dcGetWell: boolean;
   firewallNodebalancer: boolean;
   ipv6Sharing: boolean;
-  kubernetesDashboardAvailability: boolean;
   linodeCloneUIChanges: boolean;
   linodeCreateWithFirewall: boolean;
   mainContentBanner: MainContentBanner;

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -2,9 +2,9 @@ import { KubernetesCluster } from '@linode/api-v4/lib/kubernetes';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import Grid from '@mui/material/Unstable_Grid2';
 import { Theme } from '@mui/material/styles';
-import { makeStyles } from 'tss-react/mui';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
+import { makeStyles } from 'tss-react/mui';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Button } from 'src/components/Button/Button';
@@ -13,7 +13,6 @@ import { ConfirmationDialog } from 'src/components/ConfirmationDialog/Confirmati
 import { Paper } from 'src/components/Paper';
 import { TagsPanel } from 'src/components/TagsPanel/TagsPanel';
 import KubeClusterSpecs from 'src/features/Kubernetes/KubernetesClusterDetail/KubeClusterSpecs';
-import { useFlags } from 'src/hooks/useFlags';
 import {
   useKubernetesClusterMutation,
   useKubernetesDashboardQuery,
@@ -103,7 +102,6 @@ interface Props {
 export const KubeSummaryPanel = (props: Props) => {
   const { cluster } = props;
   const { classes } = useStyles();
-  const flags = useFlags();
   const { enqueueSnackbar } = useSnackbar();
   const [drawerOpen, setDrawerOpen] = React.useState<boolean>(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
@@ -112,14 +110,10 @@ export const KubeSummaryPanel = (props: Props) => {
     cluster.id
   );
 
-  const isKubeDashboardFeatureEnabled = Boolean(
-    flags.kubernetesDashboardAvailability
-  );
-
   const {
     data: dashboard,
     error: dashboardError,
-  } = useKubernetesDashboardQuery(cluster.id, isKubeDashboardFeatureEnabled);
+  } = useKubernetesDashboardQuery(cluster.id);
 
   const {
     error: resetKubeConfigError,
@@ -173,28 +167,26 @@ export const KubeSummaryPanel = (props: Props) => {
             xs={12}
           >
             <Grid className={classes.actionRow}>
-              {cluster.control_plane.high_availability ? (
+              {cluster.control_plane.high_availability && (
                 <Chip
                   label="HA CLUSTER"
                   outlineColor="green"
                   size="small"
                   variant="outlined"
                 />
-              ) : null}
-              {isKubeDashboardFeatureEnabled ? (
-                <Button
-                  onClick={() => {
-                    window.open(dashboard?.url, '_blank');
-                  }}
-                  buttonType="secondary"
-                  className={classes.dashboard}
-                  compactY
-                  disabled={Boolean(dashboardError) || !dashboard}
-                >
-                  Kubernetes Dashboard
-                  <OpenInNewIcon />
-                </Button>
-              ) : null}
+              )}
+              <Button
+                onClick={() => {
+                  window.open(dashboard?.url, '_blank');
+                }}
+                buttonType="secondary"
+                className={classes.dashboard}
+                compactY
+                disabled={Boolean(dashboardError) || !dashboard}
+              >
+                Kubernetes Dashboard
+                <OpenInNewIcon />
+              </Button>
               <Button
                 buttonType="secondary"
                 className={classes.deleteClusterBtn}

--- a/packages/manager/src/queries/kubernetes.ts
+++ b/packages/manager/src/queries/kubernetes.ts
@@ -233,14 +233,10 @@ export const useAllKubernetesNodePoolQuery = (
   );
 };
 
-export const useKubernetesDashboardQuery = (
-  clusterID: number,
-  enabled: boolean = false
-) => {
+export const useKubernetesDashboardQuery = (clusterId: number) => {
   return useQuery<KubernetesDashboardResponse, APIError[]>(
-    [queryKey, 'cluster', clusterID, 'dashboard'],
-    () => getKubernetesClusterDashboard(clusterID),
-    { enabled }
+    [queryKey, 'cluster', clusterId, 'dashboard'],
+    () => getKubernetesClusterDashboard(clusterId)
   );
 };
 


### PR DESCRIPTION
## Description 📝

Just doing some feature flag clean up. The Kubernetes Dashboard feature has been in production for at least a year or two. I think we can safely clean up this flag! 🧹

As tempting as it is, this PR does not attempt to fix how broken this summary section is.

## Preview 📷

> [!note]
> This should **not** result in UI changes. This feature has been enabled for a long time and should remain enabled.

![Screenshot 2024-01-29 at 3 01 09 PM](https://github.com/linode/manager/assets/115251059/4f8184f9-6bbe-45bd-aebd-61b88fa3bb6b)

## How to test 🧪

- Check out this PR
- Verify you see the `Kubernetes Dashboard` button on the Kubernetes Details page on any LKE cluster

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support