### PR TITLE
upcoming: [M3-7527] - Improve Login History restricted and child user experience

### DIFF
--- a/packages/manager/.changeset/pr-10125-tests-1707232650553.md
+++ b/packages/manager/.changeset/pr-10125-tests-1707232650553.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add integration test coverage for Account Login History ([#10125](https://github.com/linode/manager/pull/10125))

--- a/packages/manager/.changeset/pr-10125-upcoming-features-1707232753513.md
+++ b/packages/manager/.changeset/pr-10125-upcoming-features-1707232753513.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Improve restricted access Login History experience for child and restricted users ([#10125](https://github.com/linode/manager/pull/10125))

--- a/packages/manager/cypress/e2e/core/account/account-login-history.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/account-login-history.spec.ts
@@ -4,28 +4,44 @@
 
 import { accountFactory, profileFactory } from 'src/factories';
 import { accountLoginFactory } from 'src/factories/accountLogin';
+import { grantsFactory } from 'src/factories/grants';
+import { formatDate } from 'src/utilities/formatDate';
 import {
   mockGetAccount,
   mockGetAccountLogins,
 } from 'support/intercepts/account';
-import { mockGetProfile } from 'support/intercepts/profile';
+import {
+  mockAppendFeatureFlags,
+  mockGetFeatureFlagClientstream,
+} from 'support/intercepts/feature-flags';
+import {
+  mockGetProfile,
+  mockGetProfileGrants,
+} from 'support/intercepts/profile';
+import { makeFeatureFlagData } from 'support/util/feature-flags';
 
 describe('Account login history', () => {
   /*
    * - Confirms that a user can navigate to and view the login history page.
-   * - Confirms that login table displays the expected columns.
-   * - Confirms that the login table displays mocked failed and successful logins.
+   * - Confirms that login table displays the expected column headers.
+   * - Confirms that the login table displays a mocked failed restricted user login.
+   * - Confirm that the login table displays a mocked successful unrestricted user login.
    */
-  it.only('users can view the login history table', () => {
+  it('users can view the login history table', () => {
     const mockAccount = accountFactory.build();
     const mockProfile = profileFactory.build({
       username: 'mock-user',
       restricted: false,
       user_type: null,
     });
-    const mockFailedLogin = accountLoginFactory.build({ status: 'failed' });
+    const mockFailedLogin = accountLoginFactory.build({
+      status: 'failed',
+      username: 'mock-restricted-user',
+      restricted: true,
+    });
     const mockSuccessfulLogin = accountLoginFactory.build({
       status: 'successful',
+      restricted: false,
     });
 
     mockGetAccount(mockAccount).as('getAccount');
@@ -34,20 +50,155 @@ describe('Account login history', () => {
       'getAccountLogins'
     );
 
+    // TODO: Parent/Child - M3-7559 clean up when feature is live in prod and feature flag is removed.
+    mockAppendFeatureFlags({
+      parentChildAccountAccess: makeFeatureFlagData(false),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+
     // Navigate to Account Login History page.
     cy.visitWithLogin('/account/login-history');
-    cy.wait(['@getAccount', '@getProfile', '@getAccountLogins']);
+    cy.wait([
+      '@getAccount',
+      '@getClientStream',
+      '@getFeatureFlags',
+      '@getProfile',
+    ]);
 
     // Confirm helper text above table is visible.
     cy.findByText(
       'Logins across all users on your account over the last 90 days.'
     ).should('be.visible');
 
-    // Confirm the mocked logins are visible in table.
-    // TODO
+    // Confirm the login table includes the expected column headers and mocked logins are visible in table.
+    cy.findByLabelText('Account Logins').within(() => {
+      cy.get('thead').findByText('Date').should('be.visible');
+      cy.get('thead').findByText('Username').should('be.visible');
+      cy.get('thead').findByText('IP').should('be.visible');
+      cy.get('thead').findByText('Permission Level').should('be.visible');
+      cy.get('thead').findByText('Access').should('be.visible');
+
+      // Confirm that restricted user's failed login and status icon display in table.
+      cy.findByText(mockFailedLogin.username)
+        .should('be.visible')
+        .closest('tr')
+        .within(() => {
+          cy.findByText(mockFailedLogin.status, { exact: false }).should(
+            'be.visible'
+          );
+          cy.findAllByLabelText(`Status is ${mockFailedLogin.status}`);
+          cy.findByText('Restricted').should('be.visible');
+        });
+
+      // Confirm that unrestricted user login displays in table.
+      cy.findByText(mockSuccessfulLogin.username)
+        .should('be.visible')
+        .closest('tr')
+        .within(() => {
+          // Confirm that successful login and status icon display in table.
+          cy.findByText(mockSuccessfulLogin.status, { exact: false }).should(
+            'be.visible'
+          );
+          cy.findAllByLabelText(`Status is ${mockSuccessfulLogin.status}`);
+
+          // Confirm all other fields display in table.
+          cy.findByText(
+            formatDate(mockSuccessfulLogin.datetime, {
+              timezone: mockProfile.timezone,
+            })
+          ).should('be.visible');
+          cy.findByText(mockSuccessfulLogin.ip).should('be.visible');
+          cy.findByText('Unrestricted').should('be.visible');
+        });
+    });
   });
 
-  it('child users cannot view login history and see a warning', () => {});
+  /**
+   * - Confirms that a child user can navigate to the Login History page.
+   * - Confirms that a child user cannot see login history data.
+   * - Confirms that a child user sees a notice instead.
+   */
+  it('child users cannot view login history', () => {
+    const mockAccount = accountFactory.build();
+    const mockProfile = profileFactory.build({
+      username: 'mock-child-user',
+      restricted: false,
+      user_type: 'child',
+    });
 
-  it('restricted users without `read_write` account_access cannot view login history and see a warning', () => {});
+    mockGetAccount(mockAccount).as('getAccount');
+    mockGetProfile(mockProfile).as('getProfile');
+
+    // TODO: Parent/Child - M3-7559 clean up when feature is live in prod and feature flag is removed.
+    mockAppendFeatureFlags({
+      parentChildAccountAccess: makeFeatureFlagData(true),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+
+    // Navigate to Account Login History page.
+    cy.visitWithLogin('/account/login-history');
+    cy.wait([
+      '@getAccount',
+      '@getClientStream',
+      '@getFeatureFlags',
+      '@getProfile',
+    ]);
+
+    // Confirm helper text above table and table are not visible.
+    cy.findByText(
+      'Logins across all users on your account over the last 90 days.'
+    ).should('not.exist');
+    cy.findByLabelText('Account Logins').should('not.exist');
+
+    cy.findByText(
+      'Access restricted. Please contact your business partner to request the necessary permission.'
+    );
+  });
+
+  /**
+   * - Confirms that a restricted user with "read-only" account access can navigate to the Login History page.
+   * - Confirms that the user cannot see login history data.
+   * - Confirms that the user sees a notice instead.
+   */
+  it('restricted users without `read_write` account_access cannot view login history', () => {
+    const mockAccount = accountFactory.build();
+    const mockGrants = grantsFactory.build({
+      global: { account_access: 'read_only' },
+    });
+    const mockProfile = profileFactory.build({
+      username: 'mock-restricted-user',
+      restricted: true,
+      user_type: null,
+    });
+
+    mockGetProfile(mockProfile).as('getProfile');
+    mockGetAccount(mockAccount).as('getAccount');
+    mockGetProfileGrants(mockGrants).as('getProfileGrants');
+
+    // TODO: Parent/Child - M3-7559 clean up when feature is live in prod and feature flag is removed.
+    mockAppendFeatureFlags({
+      parentChildAccountAccess: makeFeatureFlagData(true),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+
+    // Navigate to Account Login History page.
+    cy.visitWithLogin('/account/login-history');
+    cy.wait([
+      '@getAccount',
+      '@getClientStream',
+      '@getFeatureFlags',
+      '@getProfile',
+      '@getProfileGrants',
+    ]);
+
+    // Confirm helper text above table and table are not visible.
+    cy.findByText(
+      'Logins across all users on your account over the last 90 days.'
+    ).should('not.exist');
+    cy.findByLabelText('Account Logins').should('not.exist');
+
+    cy.findByText(
+      'Access restricted. Please contact your account administrator to request the necessary permission.'
+    );
+  });
 });

--- a/packages/manager/cypress/e2e/core/account/account-login-history.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/account-login-history.spec.ts
@@ -4,7 +4,6 @@
 
 import { accountFactory, profileFactory } from 'src/factories';
 import { accountLoginFactory } from 'src/factories/accountLogin';
-import { grantsFactory } from 'src/factories/grants';
 import { formatDate } from 'src/utilities/formatDate';
 import {
   mockGetAccount,
@@ -14,10 +13,7 @@ import {
   mockAppendFeatureFlags,
   mockGetFeatureFlagClientstream,
 } from 'support/intercepts/feature-flags';
-import {
-  mockGetProfile,
-  mockGetProfileGrants,
-} from 'support/intercepts/profile';
+import { mockGetProfile } from 'support/intercepts/profile';
 import { makeFeatureFlagData } from 'support/util/feature-flags';
 
 describe('Account login history', () => {
@@ -156,15 +152,12 @@ describe('Account login history', () => {
   });
 
   /**
-   * - Confirms that a restricted user with "read-only" account access can navigate to the Login History page.
-   * - Confirms that the user cannot see login history data.
-   * - Confirms that the user sees a notice instead.
+   * - Confirms that a restricted user can navigate to the Login History page.
+   * - Confirms that a restricted user cannot see login history data.
+   * - Confirms that a restricted user sees a notice instead.
    */
-  it('restricted users without `read_write` account_access cannot view login history', () => {
+  it('restricted users cannot view login history', () => {
     const mockAccount = accountFactory.build();
-    const mockGrants = grantsFactory.build({
-      global: { account_access: 'read_only' },
-    });
     const mockProfile = profileFactory.build({
       username: 'mock-restricted-user',
       restricted: true,
@@ -173,7 +166,6 @@ describe('Account login history', () => {
 
     mockGetProfile(mockProfile).as('getProfile');
     mockGetAccount(mockAccount).as('getAccount');
-    mockGetProfileGrants(mockGrants).as('getProfileGrants');
 
     // TODO: Parent/Child - M3-7559 clean up when feature is live in prod and feature flag is removed.
     mockAppendFeatureFlags({
@@ -188,7 +180,6 @@ describe('Account login history', () => {
       '@getClientStream',
       '@getFeatureFlags',
       '@getProfile',
-      '@getProfileGrants',
     ]);
 
     // Confirm helper text above table and table are not visible.

--- a/packages/manager/cypress/e2e/core/account/account-login-history.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/account-login-history.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * @file Integration tests for Cloud Manager account login history flows.
+ */
+
+import { accountFactory, profileFactory } from 'src/factories';
+import { accountLoginFactory } from 'src/factories/accountLogin';
+import {
+  mockGetAccount,
+  mockGetAccountLogins,
+} from 'support/intercepts/account';
+import { mockGetProfile } from 'support/intercepts/profile';
+
+describe('Account login history', () => {
+  /*
+   * - Confirms that a user can navigate to and view the login history page.
+   * - Confirms that login table displays the expected columns.
+   * - Confirms that the login table displays mocked failed and successful logins.
+   */
+  it.only('users can view the login history table', () => {
+    const mockAccount = accountFactory.build();
+    const mockProfile = profileFactory.build({
+      username: 'mock-user',
+      restricted: false,
+      user_type: null,
+    });
+    const mockFailedLogin = accountLoginFactory.build({ status: 'failed' });
+    const mockSuccessfulLogin = accountLoginFactory.build({
+      status: 'successful',
+    });
+
+    mockGetAccount(mockAccount).as('getAccount');
+    mockGetProfile(mockProfile).as('getProfile');
+    mockGetAccountLogins([mockFailedLogin, mockSuccessfulLogin]).as(
+      'getAccountLogins'
+    );
+
+    // Navigate to Account Login History page.
+    cy.visitWithLogin('/account/login-history');
+    cy.wait(['@getAccount', '@getProfile', '@getAccountLogins']);
+
+    // Confirm helper text above table is visible.
+    cy.findByText(
+      'Logins across all users on your account over the last 90 days.'
+    ).should('be.visible');
+
+    // Confirm the mocked logins are visible in table.
+    // TODO
+  });
+
+  it('child users cannot view login history and see a warning', () => {});
+
+  it('restricted users without `read_write` account_access cannot view login history and see a warning', () => {});
+});

--- a/packages/manager/cypress/support/intercepts/account.ts
+++ b/packages/manager/cypress/support/intercepts/account.ts
@@ -10,6 +10,7 @@ import { makeResponse } from 'support/util/response';
 
 import type {
   Account,
+  AccountLogin,
   AccountSettings,
   Agreements,
   CancelAccount,
@@ -512,5 +513,21 @@ export const mockGetAccountAgreements = (
     'GET',
     apiMatcher(`account/agreements`),
     makeResponse(agreements)
+  );
+};
+
+/**
+ * Intercepts GET request to fetch the account logins and mocks the response.
+ *
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetAccountLogins = (
+  accountLogins: AccountLogin[]
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher(`account/logins*`),
+    paginateResponse(accountLogins)
   );
 };

--- a/packages/manager/src/factories/accountLogin.ts
+++ b/packages/manager/src/factories/accountLogin.ts
@@ -1,0 +1,11 @@
+import { AccountLogin } from '@linode/api-v4';
+import * as Factory from 'factory.ts';
+
+export const accountLoginFactory = Factory.Sync.makeFactory<AccountLogin>({
+  datetime: '2021-05-21T14:27:51',
+  id: Factory.each((id) => id),
+  ip: '1.127.0.0.1',
+  restricted: false,
+  status: 'successful',
+  username: 'mock-user',
+});

--- a/packages/manager/src/factories/accountLogin.ts
+++ b/packages/manager/src/factories/accountLogin.ts
@@ -4,7 +4,7 @@ import * as Factory from 'factory.ts';
 export const accountLoginFactory = Factory.Sync.makeFactory<AccountLogin>({
   datetime: '2021-05-21T14:27:51',
   id: Factory.each((id) => id),
-  ip: '1.127.0.0.1',
+  ip: '127.0.0.1',
   restricted: false,
   status: 'successful',
   username: 'mock-user',

--- a/packages/manager/src/features/Account/AccountLogins.tsx
+++ b/packages/manager/src/features/Account/AccountLogins.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { makeStyles } from 'tss-react/mui';
 
 import { Hidden } from 'src/components/Hidden';
+import { Notice } from 'src/components/Notice/Notice';
 import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFooter';
 import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
@@ -15,11 +16,14 @@ import { TableRowError } from 'src/components/TableRowError/TableRowError';
 import { TableRowLoading } from 'src/components/TableRowLoading/TableRowLoading';
 import { TableSortCell } from 'src/components/TableSortCell';
 import { Typography } from 'src/components/Typography';
+import { useFlags } from 'src/hooks/useFlags';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
 import { useAccountLoginsQuery } from 'src/queries/accountLogins';
+import { useGrants, useProfile } from 'src/queries/profile';
 
 import AccountLoginsTableRow from './AccountLoginsTableRow';
+import { getAccessRestrictedText } from './utils';
 
 const preferenceKey = 'account-logins';
 
@@ -40,6 +44,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
 const AccountLogins = () => {
   const { classes } = useStyles();
   const pagination = usePagination(1, preferenceKey);
+  const flags = useFlags();
 
   const { handleOrderChange, order, orderBy } = useOrder(
     {
@@ -61,6 +66,13 @@ const AccountLogins = () => {
     },
     filter
   );
+  const { data: profile } = useProfile();
+  const { data: grants } = useGrants();
+
+  const isRestrictedChildUser =
+    flags.parentChildAccountAccess && profile?.user_type === 'child';
+  const isAccountAccessRestricted =
+    isRestrictedChildUser || grants?.global.account_access !== 'read_write';
 
   const renderTableContent = () => {
     if (isLoading) {
@@ -90,7 +102,7 @@ const AccountLogins = () => {
     return null;
   };
 
-  return (
+  return !isAccountAccessRestricted ? (
     <>
       <Typography className={classes.copy} variant="body1">
         Logins across all users on your account over the last 90 days.
@@ -152,6 +164,10 @@ const AccountLogins = () => {
         pageSize={pagination.pageSize}
       />
     </>
+  ) : (
+    <Notice important variant="warning">
+      {getAccessRestrictedText(profile?.user_type ?? null)}
+    </Notice>
   );
 };
 

--- a/packages/manager/src/features/Account/AccountLogins.tsx
+++ b/packages/manager/src/features/Account/AccountLogins.tsx
@@ -20,7 +20,7 @@ import { useFlags } from 'src/hooks/useFlags';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
 import { useAccountLoginsQuery } from 'src/queries/accountLogins';
-import { useGrants, useProfile } from 'src/queries/profile';
+import { useProfile } from 'src/queries/profile';
 
 import AccountLoginsTableRow from './AccountLoginsTableRow';
 import { getAccessRestrictedText } from './utils';
@@ -67,14 +67,12 @@ const AccountLogins = () => {
     filter
   );
   const { data: profile } = useProfile();
-  const { data: grants } = useGrants();
 
   const isRestrictedChildUser = Boolean(
     flags.parentChildAccountAccess && profile?.user_type === 'child'
   );
   const isAccountAccessRestricted =
-    isRestrictedChildUser ||
-    (profile?.restricted && grants?.global.account_access !== 'read_write');
+    isRestrictedChildUser || profile?.restricted;
 
   const renderTableContent = () => {
     if (isLoading) {

--- a/packages/manager/src/features/Account/AccountLogins.tsx
+++ b/packages/manager/src/features/Account/AccountLogins.tsx
@@ -109,7 +109,7 @@ const AccountLogins = () => {
       <Typography className={classes.copy} variant="body1">
         Logins across all users on your account over the last 90 days.
       </Typography>
-      <Table>
+      <Table aria-label="Account Logins">
         <TableHead>
           <TableRow>
             <TableSortCell

--- a/packages/manager/src/features/Account/AccountLogins.tsx
+++ b/packages/manager/src/features/Account/AccountLogins.tsx
@@ -69,10 +69,12 @@ const AccountLogins = () => {
   const { data: profile } = useProfile();
   const { data: grants } = useGrants();
 
-  const isRestrictedChildUser =
-    flags.parentChildAccountAccess && profile?.user_type === 'child';
+  const isRestrictedChildUser = Boolean(
+    flags.parentChildAccountAccess && profile?.user_type === 'child'
+  );
   const isAccountAccessRestricted =
-    isRestrictedChildUser || grants?.global.account_access !== 'read_write';
+    isRestrictedChildUser ||
+    (profile?.restricted && grants?.global.account_access !== 'read_write');
 
   const renderTableContent = () => {
     if (isLoading) {

--- a/packages/manager/src/features/Account/AccountLoginsTableRow.tsx
+++ b/packages/manager/src/features/Account/AccountLoginsTableRow.tsx
@@ -41,7 +41,11 @@ const AccountLoginsTableRow = (props: AccountLogin) => {
         </TableCell>
       </Hidden>
       <TableCell statusCell>
-        <StatusIcon pulse={false} status={accessIconMap[status] ?? 'other'} />
+        <StatusIcon
+          ariaLabel={`Status is ${status}`}
+          pulse={false}
+          status={accessIconMap[status] ?? 'other'}
+        />
         {capitalize(status)}
       </TableCell>
     </TableRow>

--- a/packages/manager/src/features/Account/utils.ts
+++ b/packages/manager/src/features/Account/utils.ts
@@ -1,6 +1,12 @@
 import { getStorage, setStorage } from 'src/utilities/storage';
 
-import type { GlobalGrantTypes, Grants, Profile, Token } from '@linode/api-v4';
+import type {
+  GlobalGrantTypes,
+  Grants,
+  Profile,
+  Token,
+  UserType,
+} from '@linode/api-v4';
 import type { GrantTypeMap } from 'src/features/Account/types';
 
 type ActionType = 'create' | 'delete' | 'edit' | 'view';
@@ -10,6 +16,10 @@ interface GetRestrictedResourceText {
   isSingular?: boolean;
   resourceType: GrantTypeMap;
 }
+
+/**
+ * Get a resource restricted message based on action and resource type.
+ */
 export const getRestrictedResourceText = ({
   action = 'edit',
   isSingular = true,
@@ -20,6 +30,15 @@ export const getRestrictedResourceText = ({
     : resourceType;
 
   return `You don't have permissions to ${action} ${resource}. Please contact your account administrator to request the necessary permissions.`;
+};
+
+/**
+ * Get an 'access restricted' message based on user type.
+ */
+export const getAccessRestrictedText = (userType: UserType | null) => {
+  return `Access restricted. Please contact your ${
+    userType === 'child' ? 'business partner' : 'account administrator'
+  } to request the necessary permission.`;
 };
 
 export const isRestrictedGlobalGrantType = ({

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -99,6 +99,7 @@ import {
   vpcFactory,
 } from 'src/factories';
 import { accountAgreementsFactory } from 'src/factories/accountAgreements';
+import { accountLoginFactory } from 'src/factories/accountLogin';
 import { accountUserFactory } from 'src/factories/accountUsers';
 import { grantFactory, grantsFactory } from 'src/factories/grants';
 import { pickRandom } from 'src/utilities/random';
@@ -1417,6 +1418,22 @@ export const handlers = [
           stackscript: grantFactory.buildList(30),
           volume: grantFactory.buildList(100),
         })
+      )
+    );
+  }),
+  rest.get('*/account/logins', (req, res, ctx) => {
+    const failedRestrictedAccountLogin = accountLoginFactory.build({
+      restricted: true,
+      status: 'failed',
+    });
+    const successfulAccountLogins = accountLoginFactory.buildList(25);
+
+    return res(
+      ctx.json(
+        makeResourcePage([
+          failedRestrictedAccountLogin,
+          ...successfulAccountLogins,
+        ])
       )
     );
   }),


### PR DESCRIPTION
## Description 📝
Currently, all restricted users receive an unauthorized message (see Before screenshot) after the table data fails to populate when they access the Login History tab. In the case of a child user (user_type: child), who is unrestricted by the API (account_access: read_write), but should be restricted in the UI, we must manually restrict the child user from viewing this page.

This PR updates the child view to not show login history information and display a warning notice to convey unauthorized access. For consistency, we will also make these changes for restricted users.

> [!NOTE] 
The API has recently changed from `user_type: null` to `user_type: "default"`. This is not reflected in this PR at this time because I didn't want to duplicate the work we'll need to make these changes on the front end, which will be done in another ticket.

## Changes  🔄
- Provides an informational warning notice to the child user and users with restricted `account_access` and does not display the login history table.
- Adds an AccountLogin factory and `account/logins` endpoint to the MSW so we can now mock that page.
- Adds integration test spec for the Login History page (`account/account-login-history.spec.ts`).
- A couple of aria-label accessibility improvements (account logins table, status icon)

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-11-27 at 12 02 30 PM](https://github.com/linode/manager/assets/114685994/55de9d38-2b8c-486d-812e-93e6e925c97d) | |
| Child view | ![Screenshot 2024-02-05 at 4 36 35 PM](https://github.com/linode/manager/assets/114685994/d9a1857d-4d87-41dd-bd1a-46786b815d34) |
| Regular restricted user view  | ![Screenshot 2024-02-05 at 4 26 39 PM](https://github.com/linode/manager/assets/114685994/c2aeeef0-87ad-4a61-9914-c8839764ac43) |
| Added mocks | ![localhost_3000_account_login-history (1)](https://github.com/linode/manager/assets/114685994/aca4bb6c-4342-42eb-bcd8-5bd617ed161d) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Turn on the Parent/Child feature flag and turn on the mock data.

### Reproduction steps
(How to reproduce the issue, if applicable)
- Have a restricted user that has billing access (the `account_access` grant) set to either `Read-Only` or `None`.
- Go to http://localhost:3000/account/login-history and observe the table loading and then eventually displaying an "Unauthorized" error.

### Verification steps 
(How to verify changes)
- Confirm that child "restricted" users see the warning notice pictured above:
   - Change the MSW `user_type` to `"child"` and  make sure `restricted` is`false` in [`*/profile`](https://github.com/linode/manager/blob/5354baeb5ea850c3722342f46e5d21ee7fd43ab4/packages/manager/src/mocks/serverHandlers.ts#L553-L555).
   - Go to http://localhost:3000/account/login-history and observe the notice.
   - Confirm that notice for the child user is feature flagged by toggling it off.
- Confirm that regular restricted users see the warning notice pictured above:
   - Change the MSW `user_type` to `null` and `restricted` to `true` in [`*/profile`](https://github.com/linode/manager/blob/5354baeb5ea850c3722342f46e5d21ee7fd43ab4/packages/manager/src/mocks/serverHandlers.ts#L553-L555).
   - Go to http://localhost:3000/account/login-history and observe the notice.
- Confirm no regressions to the login history page for a *non*-restricted user.
- Confirm integration test passes:
```
yarn cy:run -s "cypress/e2e/core/account/account-login-history.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [x] ♿  Providing accessibility support
