### PR TITLE
upcoming: [M3-7695] - Add new `path_regex` match type to ACLB

### DIFF
--- a/packages/api-v4/src/aglb/types.ts
+++ b/packages/api-v4/src/aglb/types.ts
@@ -45,6 +45,7 @@ type Policy =
 export type MatchField =
   | 'always_match'
   | 'path_prefix'
+  | 'path_regex'
   | 'query'
   | 'header'
   | 'method';

--- a/packages/manager/.changeset/pr-10126-upcoming-features-1706637215176.md
+++ b/packages/manager/.changeset/pr-10126-upcoming-features-1706637215176.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add ACLB rule Path Regex match type ([#10126](https://github.com/linode/manager/pull/10126))

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/MatchTypeInfo.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/MatchTypeInfo.tsx
@@ -15,8 +15,12 @@ export const MatchTypeInfo = () => {
       title: 'HTTP Method',
     },
     {
-      description: 'Match is on a network path.',
-      title: 'Path',
+      description: 'Match is on the prefix of a network path.',
+      title: 'Path Prefix',
+    },
+    {
+      description: '[need copy]',
+      title: 'Path Regex',
     },
     {
       description:

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/MatchTypeInfo.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/MatchTypeInfo.tsx
@@ -19,7 +19,8 @@ export const MatchTypeInfo = () => {
       title: 'Path Prefix',
     },
     {
-      description: '[need copy]',
+      description:
+        'Match is on the prefix of a network path using regular expressions (regex).',
       title: 'Path Regex',
     },
     {

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/MatchTypeInfo.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/MatchTypeInfo.tsx
@@ -20,7 +20,7 @@ export const MatchTypeInfo = () => {
     },
     {
       description:
-        'Match is on the prefix of a network path using regular expressions (regex).',
+        'Match is on a path using regular expression (RE2 syntax). Not applicable for query string parameters.',
       title: 'Path Regex',
     },
     {

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/RuleDrawer.test.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/RuleDrawer.test.tsx
@@ -58,7 +58,7 @@ describe('RuleDrawer', () => {
     );
 
     const matchTypeField = getByLabelText('Match Type');
-    expect(matchTypeField).toHaveDisplayValue('Path');
+    expect(matchTypeField).toHaveDisplayValue('Path Prefix');
 
     const matchValueField = getByLabelText('Match Value');
     expect(matchValueField).toHaveDisplayValue(

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/constants.ts
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/constants.ts
@@ -23,11 +23,11 @@ export const ROUTE_COPY = {
         'For TCP load balancers, a rule consists of service targets and the percentage of incoming requests that should be directed to each target. Add as many service targets as required, but the percentages for all targets must total 100%.',
     },
     MatchValue: {
-      header: 'The format for http header is: X-name=value.',
-      host: '',
+      header: 'The format for http header is: X-name:value.',
       method: 'The request methods include: DELETE, GET, HEAD, POST, and PUT.',
       path_prefix:
         'The format of the path rule is: /pathname1/pathame2. The initial slash is required, but the trailing slash is not.',
+      path_regex: '[need copy]',
       query:
         'The format for query string is: ?name=value. The query string name must be preceded by a question mark (?).',
     },

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/constants.ts
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/constants.ts
@@ -27,7 +27,8 @@ export const ROUTE_COPY = {
       method: 'The request methods include: DELETE, GET, HEAD, POST, and PUT.',
       path_prefix:
         'The format of the path rule is: /pathname1/pathame2. The initial slash is required, but the trailing slash is not.',
-      path_regex: '[need copy]',
+      path_regex:
+        'Match is on a path without any query string, using a regular expression (regex).',
       query:
         'The format for query string is: ?name=value. The query string name must be preceded by a question mark (?).',
     },

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/constants.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/constants.tsx
@@ -1,3 +1,6 @@
+import React from 'react';
+import { Code } from 'src/components/Code/Code';
+
 export const ROUTE_COPY = {
   Description: {
     http:
@@ -27,8 +30,13 @@ export const ROUTE_COPY = {
       method: 'The request methods include: DELETE, GET, HEAD, POST, and PUT.',
       path_prefix:
         'The format of the path rule is: /pathname1/pathame2. The initial slash is required, but the trailing slash is not.',
-      path_regex:
-        'Match is on a path without any query string, using a regular expression (regex).',
+      path_regex: (
+        <>
+          The format for Path Regex is a regular expression in RE2 syntax. An
+          example for any jpg file in the /path/ directory would be
+          <Code>/path/.*[.]jpg</Code>. Initial slash is required.
+        </>
+      ),
       query:
         'The format for query string is: ?name=value. The query string name must be preceded by a question mark (?).',
     },

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/utils.ts
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/utils.ts
@@ -15,7 +15,8 @@ type CustomerFacingMatchFieldOption = Exclude<MatchField, 'always_match'>;
 export const matchFieldMap: Record<CustomerFacingMatchFieldOption, string> = {
   header: 'HTTP Header',
   method: 'HTTP Method',
-  path_prefix: 'Path',
+  path_prefix: 'Path Prefix',
+  path_regex: 'Path Regex',
   query: 'Query String',
 };
 
@@ -23,9 +24,10 @@ export const matchValuePlaceholder: Record<
   CustomerFacingMatchFieldOption,
   string
 > = {
-  header: 'x-my-header=this',
+  header: 'x-my-header:this',
   method: 'POST',
   path_prefix: '/my-path',
+  path_regex: '/static/.*[.](jpg|png)',
   query: '?my-query-param=this',
 };
 

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/utils.ts
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/utils.ts
@@ -27,7 +27,7 @@ export const matchValuePlaceholder: Record<
   header: 'x-my-header:this',
   method: 'POST',
   path_prefix: '/my-path',
-  path_regex: '/static/.*[.](jpg|png)',
+  path_regex: '/my\\-path/.*[.](jpg|png)',
   query: '?my-query-param=this',
 };
 

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/utils.ts
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/utils.ts
@@ -27,7 +27,7 @@ export const matchValuePlaceholder: Record<
   header: 'x-my-header:this',
   method: 'POST',
   path_prefix: '/my-path',
-  path_regex: '/my\\-path/.*[.](jpg|png)',
+  path_regex: '/path/.*[.](jpg)',
   query: '?my-query-param=this',
 };
 

--- a/packages/validation/.changeset/pr-10126-upcoming-features-1706637249025.md
+++ b/packages/validation/.changeset/pr-10126-upcoming-features-1706637249025.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Upcoming Features
+---
+
+Add `path_regex` as a valid ACLB rule match field ([#10126](https://github.com/linode/manager/pull/10126))

--- a/packages/validation/src/loadbalancers.schema.ts
+++ b/packages/validation/src/loadbalancers.schema.ts
@@ -5,6 +5,7 @@ const LABEL_REQUIRED = 'Label is required.';
 const matchFieldOptions = [
   'always_match',
   'path_prefix',
+  'path_regex',
   'query',
   'header',
   'method',


### PR DESCRIPTION
## Description 📝

Adds new `path_regex` Rule match type to ACLB. This will allow users to create rules that match on a path using regex.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-01-30 at 12 48 09 PM](https://github.com/linode/manager/assets/115251059/29f4792a-12fc-45a3-ac37-deffbd520d8a) | ![Screenshot 2024-01-30 at 12 47 53 PM](https://github.com/linode/manager/assets/115251059/c4c7a29e-c9b7-441c-baea-d6b28efa90fa)  |

## How to test 🧪

### Prerequisites
- Check out this PR
- Switch your Cloud Manager to use the dev environemnt 
- Login to `dev-test-aglb` account for testing

### Verification steps 
- On the `aglbsqaMDDA013007` ACLB try to create/edit a rule and choose `Path Regex` as the match type
- Verify the copy for tooltips are updated 

## As an Author I have considered 🤔

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support