### PR TITLE
fix: Custom breadcrumb for NodeBalancers details page

### DIFF
--- a/packages/manager/.changeset/pr-10127-fixed-1706638177404.md
+++ b/packages/manager/.changeset/pr-10127-fixed-1706638177404.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Breadcrumb label in NodeBalancers details page ([#10127](https://github.com/linode/manager/pull/10127))

--- a/packages/manager/.changeset/pr-10127-fixed-1706638177404.md
+++ b/packages/manager/.changeset/pr-10127-fixed-1706638177404.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Breadcrumb label in NodeBalancers details page ([#10127](https://github.com/linode/manager/pull/10127))
+Breadcrumb label in NodeBalancers details & create pages ([#10127](https://github.com/linode/manager/pull/10127))

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -453,6 +453,7 @@ const NodeBalancerCreate = () => {
           breadcrumbDataAttrs: {
             'data-qa-create-nodebalancer-header': true,
           },
+          crumbOverrides: [{ label: 'NodeBalancers', position: 1 }],
           pathname: '/nodebalancers/create',
         }}
         title="Create"

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -93,6 +93,7 @@ export const NodeBalancerDetail = () => {
     <React.Fragment>
       <LandingHeader
         breadcrumbProps={{
+          crumbOverrides: [{ label: 'NodeBalancers', position: 1 }],
           firstAndLastOnly: true,
           onEditHandlers: {
             editableTextTitle: nodeBalancerLabel,


### PR DESCRIPTION
## Description 📝
Adds a custom label to the `NodeBalancerDetail` & `NodeBalancerCreate` breadcrumb labels. This eliminates the inconsistent capitalization between "Nodebalancers" and "NodeBalancers".

## Changes  🔄
- "Nodebalancers" ➡️ "NodeBalancers" in the NodeBalancers details & create breadcrumb labels

## Preview 📷
**Include a screenshot or screen recording of the change**

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-01-30 at 1 06 34 PM](https://github.com/linode/manager/assets/122488130/88bf6098-4b9c-4154-97d9-a45b7366ca88) | ![Screenshot 2024-01-30 at 1 06 42 PM](https://github.com/linode/manager/assets/122488130/2c1974bd-52e0-48dd-87c6-2b05d90dbbde) |
| ![Screenshot 2024-01-30 at 1 29 19 PM](https://github.com/linode/manager/assets/122488130/823cc026-05fe-4b06-88ab-57783ef7e894) | ![Screenshot 2024-01-30 at 1 29 30 PM](https://github.com/linode/manager/assets/122488130/8c6e5ca4-a192-4fa6-90c4-3393e9c844be) |

## How to test 🧪

### Verification steps 
- Navigate to the details page for a NodeBalancer
- Verify the word NodeBalancers appears with the correct capitalization in the breadcrumb
- Repeat for the create page for a NodeBalancer

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support
