### PR TITLE
Release v1.110.1 - `staging` → `master` 

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2024-01-31] - v1.110.1
+### Changed:
+- Updated VPC flag for primary navigation
+
 ## [2024-01-22] - v1.110.0
 
 

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.110.0",
+  "version": "1.110.1",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -195,7 +195,7 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
           hide: !showVPCs,
           href: '/vpcs',
           icon: <VPC />,
-          isBeta: true,
+          isBeta: flags.vpc,
         },
         {
           display: 'Firewalls',


### PR DESCRIPTION
## [2024-01-31] - v1.110.1
### Changed:
- Updated VPC flag for primary navigation