### PR TITLE
change: Update isBeta to use feature flags

### DIFF
--- a/packages/manager/.changeset/pr-10130-changed-1706711108905.md
+++ b/packages/manager/.changeset/pr-10130-changed-1706711108905.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Ensure beta chip is managed by feature flags ([#10130](https://github.com/linode/manager/pull/10130))

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -183,7 +183,7 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
           hide: !flags.vmPlacement,
           href: '/placement-groups',
           icon: <PlacementGroups />,
-          isBeta: true,
+          isBeta: flags.vmPlacement,
         },
         {
           display: 'Volumes',
@@ -196,7 +196,7 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
           hide: !isACLBEnabled,
           href: '/loadbalancers',
           icon: <LoadBalancer />,
-          isBeta: true,
+          isBeta: flags.aclb,
         },
         {
           display: 'NodeBalancers',

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerCreate/LoadBalancerBasicCreate.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerCreate/LoadBalancerBasicCreate.tsx
@@ -13,6 +13,7 @@ import { Paper } from 'src/components/Paper';
 import { Stack } from 'src/components/Stack';
 import { TextField } from 'src/components/TextField';
 import { ACLB_FEEDBACK_FORM_URL } from 'src/features/LoadBalancers/constants';
+import { useFlags } from 'src/hooks/useFlags';
 import { useLoadBalancerBasicCreateMutation } from 'src/queries/aglb/loadbalancers';
 import { getFormikErrorsFromAPIErrors } from 'src/utilities/formikErrorUtils';
 
@@ -26,6 +27,7 @@ export const LoadBalancerBasicCreate = () => {
 
   const { push } = useHistory();
   const { enqueueSnackbar } = useSnackbar();
+  const flags = useFlags();
 
   const formik = useFormik({
     initialValues: {
@@ -64,7 +66,7 @@ export const LoadBalancerBasicCreate = () => {
           ],
           pathname: location.pathname,
         }}
-        betaFeedbackLink={ACLB_FEEDBACK_FORM_URL}
+        betaFeedbackLink={flags.aclb ? ACLB_FEEDBACK_FORM_URL : undefined}
         title="Create"
       />
       <Stack spacing={3}>

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerCreate/LoadBalancerCreate.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerCreate/LoadBalancerCreate.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
 import { LandingHeader } from 'src/components/LandingHeader';
 import { ACLB_FEEDBACK_FORM_URL } from 'src/features/LoadBalancers/constants';
+import { useFlags } from 'src/hooks/useFlags';
 
 import { LoadBalancerActionPanel } from './LoadBalancerActionPanel';
 import { LoadBalancerConfigurations } from './LoadBalancerConfigurations';
@@ -11,6 +12,8 @@ import { LoadBalancerLabel } from './LoadBalancerLabel';
 import { LoadBalancerRegions } from './LoadBalancerRegions';
 
 export const LoadBalancerCreate = () => {
+  const flags = useFlags();
+
   return (
     <>
       <DocumentTitleSegment segment="Create a Load Balancer" />
@@ -24,7 +27,7 @@ export const LoadBalancerCreate = () => {
           ],
           pathname: location.pathname,
         }}
-        betaFeedbackLink={ACLB_FEEDBACK_FORM_URL}
+        betaFeedbackLink={flags.aclb ? ACLB_FEEDBACK_FORM_URL : undefined}
         title="Create"
       />
 

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerDetail.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerDetail.tsx
@@ -18,6 +18,7 @@ import {
   ACLB_DOCS,
   ACLB_FEEDBACK_FORM_URL,
 } from 'src/features/LoadBalancers/constants';
+import { useFlags } from 'src/hooks/useFlags';
 import { useLoadBalancerQuery } from 'src/queries/aglb/loadbalancers';
 
 const LoadBalancerSummary = React.lazy(() =>
@@ -59,6 +60,7 @@ export const LoadBalancerDetail = () => {
   const { loadbalancerId } = useParams<{ loadbalancerId: string }>();
   const location = useLocation();
   const { path, url } = useRouteMatch();
+  const flags = useFlags();
 
   const id = Number(loadbalancerId);
 
@@ -117,7 +119,7 @@ export const LoadBalancerDetail = () => {
           labelOptions: { noCap: true },
           pathname: `/loadbalancers/${loadbalancer?.label}`,
         }}
-        betaFeedbackLink={ACLB_FEEDBACK_FORM_URL}
+        betaFeedbackLink={flags.aclb ? ACLB_FEEDBACK_FORM_URL : undefined}
         docsLabel="Docs"
         docsLink={ACLB_DOCS.GettingStarted}
       />

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerLanding/LoadBalancerLanding.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerLanding/LoadBalancerLanding.tsx
@@ -18,6 +18,7 @@ import {
   ACLB_DOCS,
   ACLB_FEEDBACK_FORM_URL,
 } from 'src/features/LoadBalancers/constants';
+import { useFlags } from 'src/hooks/useFlags';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
 import { useLoadBalancersQuery } from 'src/queries/aglb/loadbalancers';
@@ -32,6 +33,7 @@ const preferenceKey = 'loadbalancers';
 
 export const LoadBalancerLanding = () => {
   const history = useHistory();
+  const flags = useFlags();
 
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
 
@@ -99,7 +101,7 @@ export const LoadBalancerLanding = () => {
       ) : (
         <>
           <LandingHeader
-            betaFeedbackLink={ACLB_FEEDBACK_FORM_URL}
+            betaFeedbackLink={flags.aclb ? ACLB_FEEDBACK_FORM_URL : undefined}
             breadcrumbProps={{ pathname: '/loadbalancers' }}
             createButtonText="Create Load Balancer"
             docsLabel="Docs"


### PR DESCRIPTION
## Description 📝
- Updates the beta chip `isBeta` to use feature flags
- Beta feedback links should also be behind a flag

## How to test 🧪
- Beta chips should still show for ACLB and Placement Groups
- Beta chip for VPC should be removed