### PR TITLE
fix: [M3-7722] - Adjust EditableText styling to prevent pixel shift

### DIFF
--- a/packages/manager/.changeset/pr-10132-fixed-1706715510568.md
+++ b/packages/manager/.changeset/pr-10132-fixed-1706715510568.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+EditableText interaction styling ([#10132](https://github.com/linode/manager/pull/10132))

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -9,7 +9,6 @@ import { makeStyles } from 'tss-react/mui';
 import { Button } from 'src/components/Button/Button';
 import { ClickAwayListener } from 'src/components/ClickAwayListener';
 import { H1Header } from 'src/components/H1Header/H1Header';
-import { fadeIn } from 'src/styles/keyframes';
 
 import { TextField, TextFieldProps } from '../TextField';
 
@@ -63,7 +62,7 @@ const useStyles = makeStyles<void, 'editIcon' | 'icon'>()(
           color: theme.color.grey1,
         },
       },
-      border: '1px solid transparent',
+      borderLeft: '1px solid transparent',
     },
     input: {
       fontFamily: theme.font.bold,
@@ -92,7 +91,6 @@ const useStyles = makeStyles<void, 'editIcon' | 'icon'>()(
       wordBreak: 'break-all',
     },
     textField: {
-      animation: `${fadeIn} .3s ease-in-out forwards`,
       margin: 0,
     },
     underlineOnHover: {


### PR DESCRIPTION
## Description 📝
This is a tiny PR to fix a small pixel shift when switching on the editable breadcrumb.

Currently, when clicking on the pencil icon to edit the final breadcrumb (title), we can see the whole breadcrumb shift two pixels and make the content underneath shift as well (see **before** video).

## Changes  🔄
- Remove unnecessary initial vertical borders
- Remove fade-in animation (I don't think it adds anything? - makes it looks" buggy")

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/130582365/a823cf9f-09d0-4a64-ad24-6b32469f0d59" /> | <video src="https://github.com/linode/manager/assets/130582365/4f8ca504-3232-479c-a124-05d40e30cf2f" /> |

## How to test 🧪

### Verification steps 
- Test editable breadcrumbs for various entity details (firewall, linode etc)

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
