### PR TITLE
fix: [M3-7728] - Token issues when account switching

### DIFF
--- a/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
@@ -62,7 +62,7 @@ export const SwitchAccountDrawer = (props: Props) => {
           headers:
             userType === 'proxy'
               ? {
-                  Authorization: `Bearer ${token}`,
+                  Authorization: token,
                 }
               : undefined,
         });
@@ -105,8 +105,8 @@ export const SwitchAccountDrawer = (props: Props) => {
         // We don't need to worry about this if we're a proxy user.
         if (!isProxyUser) {
           const parentToken = {
-            expiry: getStorage('authenication/expire'),
-            scopes: getStorage('authenication/scopes'),
+            expiry: getStorage('authentication/expire'),
+            scopes: getStorage('authentication/scopes'),
             token: currentTokenWithBearer ?? '',
           };
 

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -552,7 +552,7 @@ export const handlers = [
     const profile = profileFactory.build({
       restricted: false,
       // Parent/Child: switch the `user_type` depending on what account view you need to mock.
-      user_type: 'proxy',
+      user_type: 'parent',
     });
     return res(ctx.json(profile));
   }),


### PR DESCRIPTION
## Description 📝
This PR fixes a couple of issues impacting account switching:
1. Fixes a typo introduced [here](https://github.com/linode/manager/pull/10064#discussion_r1459818274) that was causing a parent token's `scopes` and `expiry` to not be fetched and then stored correctly from local storage, causing the "switch" back to a parent account (which relies on the stored parent's token in local storage) to fail.
2. Fixes a [bug](https://github.com/linode/manager/pull/10110#discussion_r1474686256) where "Bearer" would have been included twice in an auth token.

This PR also changes the `user_type` back to `parent` in the MSW. This doesn't really matter, but we've used a default of `parent` throughout this project so it's helpful to keep it the same default for consistency.


## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/114685994/49d2595b-56d9-4f85-8e1e-07650b5070fc) | ![Screenshot 2024-02-01 at 10 54 14 AM](https://github.com/linode/manager/assets/114685994/a8ff56c6-125d-4f7f-b2e1-89d2778ef844) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Check out this PR.
- Turn the Parent/Child feature flag on and MSW on.

### Reproduction steps
(How to reproduce the issue, if applicable)
- On develop, try to account switch from a proxy account back to a parent account and observe the error and lack of parent's auth token data stored in local storage.

### Verification steps 
(How to verify changes)
- Follow the testing steps [here](https://github.com/linode/manager/pull/10064) to confirm that token swapping is behaving as expected.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

