### PR TITLE
test: [M3-7698] - Add test to check proxy user disabled username/email field

### DIFF
--- a/packages/manager/.changeset/pr-10139-tests-1707331596288.md
+++ b/packages/manager/.changeset/pr-10139-tests-1707331596288.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add test to check proxy user disabled username/email field ([#10139](https://github.com/linode/manager/pull/10139))

--- a/packages/manager/cypress/e2e/core/account/change-username.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/change-username.spec.ts
@@ -1,3 +1,17 @@
+import { profileFactory } from '@src/factories';
+import { accountUserFactory } from '@src/factories/accountUsers';
+import { grantsFactory } from '@src/factories/grants';
+import {
+  mockGetUser,
+  mockGetUserGrants,
+  mockGetUsers,
+} from 'support/intercepts/account';
+import {
+  mockAppendFeatureFlags,
+  mockGetFeatureFlagClientstream,
+} from 'support/intercepts/feature-flags';
+import { makeFeatureFlagData } from 'support/util/feature-flags';
+import { mockGetProfile } from 'support/intercepts/profile';
 import { getProfile } from 'support/api/account';
 import { interceptGetProfile } from 'support/intercepts/profile';
 import {
@@ -95,5 +109,58 @@ describe('username', () => {
 
       cy.findByText('Username updated successfully.').should('be.visible');
     });
+  });
+
+  it('disables username/email fields for proxy user', () => {
+    const mockRestrictedProxyUser = accountUserFactory.build({
+      restricted: true,
+      user_type: 'proxy',
+      username: 'restricted-proxy-user',
+    });
+
+    const mockRestrictedProxyProfile = profileFactory.build({
+      username: 'restricted-proxy-user',
+      user_type: 'proxy',
+    });
+
+    const mockUserGrants = grantsFactory.build({
+      global: { account_access: 'read_write' },
+    });
+
+    // TODO: Parent/Child - M3-7559 clean up when feature is live in prod and feature flag is removed.
+    mockAppendFeatureFlags({
+      parentChildAccountAccess: makeFeatureFlagData(true),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+
+    mockGetUsers([mockRestrictedProxyUser]).as('getUsers');
+    mockGetProfile(mockRestrictedProxyProfile);
+    mockGetUser(mockRestrictedProxyUser);
+    mockGetUserGrants(mockRestrictedProxyUser.username, mockUserGrants);
+
+    // Navigate to User Profile page
+    cy.visitWithLogin('/profile/display');
+
+    // Confirm the username and email address fields are disabled, as well their respective save buttons
+    cy.get('[id="username"]').should('be.disabled');
+    ui.button
+      .findByTitle('Update Username')
+      .should('be.visible')
+      .should('be.disabled')
+      .click();
+    // Click the button first, then confirm the tooltip is shown:
+    ui.tooltip
+      .findByText('This account type cannot update this field.')
+      .should('be.visible');
+    cy.get('[id="email"]').should('be.disabled');
+    ui.button
+      .findByTitle('Update Email')
+      .should('be.visible')
+      .should('be.disabled')
+      .click();
+    // Click the button first, then confirm the tooltip is shown:
+    ui.tooltip
+      .findByText('This account type cannot update this field.')
+      .should('be.visible');
   });
 });

--- a/packages/manager/cypress/e2e/core/account/user-permissions.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/user-permissions.spec.ts
@@ -1007,47 +1007,4 @@ describe('User permission management', () => {
     );
     cy.findByText(additionalUser.username).should('not.exist');
   });
-
-  it('disables username/email fields for proxy user', () => {
-    const mockRestrictedProxyUser = accountUserFactory.build({
-      restricted: true,
-      user_type: 'proxy',
-      username: 'restricted-proxy-user',
-    });
-
-    const mockRestrictedProxyProfile = profileFactory.build({
-      username: 'restricted-proxy-user',
-      user_type: 'proxy',
-    });
-
-    const mockUserGrants = grantsFactory.build({
-      global: { account_access: 'read_write' },
-    });
-
-    // TODO: Parent/Child - M3-7559 clean up when feature is live in prod and feature flag is removed.
-    mockAppendFeatureFlags({
-      parentChildAccountAccess: makeFeatureFlagData(true),
-    }).as('getFeatureFlags');
-    mockGetFeatureFlagClientstream().as('getClientStream');
-
-    mockGetUsers([mockRestrictedProxyUser]).as('getUsers');
-    mockGetProfile(mockRestrictedProxyProfile);
-    mockGetUser(mockRestrictedProxyUser);
-    mockGetUserGrants(mockRestrictedProxyUser.username, mockUserGrants);
-
-    // Navigate to User Profile page
-    cy.visitWithLogin('/profile/display');
-
-    // Confirm the username and email address fields are disabled, as well their respective save buttons
-    cy.get('[id="username"]').should('be.disabled');
-    ui.button
-      .findByTitle('Update Username')
-      .should('be.visible')
-      .should('be.disabled');
-    cy.get('[id="email"]').should('be.disabled');
-    ui.button
-      .findByTitle('Update Email')
-      .should('be.visible')
-      .should('be.disabled');
-  });
 });

--- a/packages/manager/cypress/e2e/core/account/user-permissions.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/user-permissions.spec.ts
@@ -1007,4 +1007,47 @@ describe('User permission management', () => {
     );
     cy.findByText(additionalUser.username).should('not.exist');
   });
+
+  it('disables username/email fields for proxy user', () => {
+    const mockRestrictedProxyUser = accountUserFactory.build({
+      restricted: true,
+      user_type: 'proxy',
+      username: 'restricted-proxy-user',
+    });
+
+    const mockRestrictedProxyProfile = profileFactory.build({
+      username: 'restricted-proxy-user',
+      user_type: 'proxy',
+    });
+
+    const mockUserGrants = grantsFactory.build({
+      global: { account_access: 'read_write' },
+    });
+
+    // TODO: Parent/Child - M3-7559 clean up when feature is live in prod and feature flag is removed.
+    mockAppendFeatureFlags({
+      parentChildAccountAccess: makeFeatureFlagData(true),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+
+    mockGetUsers([mockRestrictedProxyUser]).as('getUsers');
+    mockGetProfile(mockRestrictedProxyProfile);
+    mockGetUser(mockRestrictedProxyUser);
+    mockGetUserGrants(mockRestrictedProxyUser.username, mockUserGrants);
+
+    // Navigate to User Profile page
+    cy.visitWithLogin('/profile/display');
+
+    // Confirm the username and email address fields are disabled, as well their respective save buttons
+    cy.get('[id="username"]').should('be.disabled');
+    ui.button
+      .findByTitle('Update Username')
+      .should('be.visible')
+      .should('be.disabled');
+    cy.get('[id="email"]').should('be.disabled');
+    ui.button
+      .findByTitle('Update Email')
+      .should('be.visible')
+      .should('be.disabled');
+  });
 });


### PR DESCRIPTION
## Description 📝
Add regression tests for checking proxy user disabled username/email field

## Major Changes 🔄
- Add regression tests to check proxy user disabled username/email field
## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/account/change-username.spec.ts"
```