### PR TITLE
change: [M3-7703] - Hide error message for $0 regions

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed:
 
 - Table CollapsibleRow icon orientation ([#10119](https://github.com/linode/manager/pull/10119))
+- Hide error message for $0 regions ([#10141](https://github.com/linode/manager/pull/10141))
 
 ### Fixed:
 

--- a/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
@@ -60,7 +60,7 @@ const CheckoutBar = (props: CheckoutBarProps) => {
       {children}
       {
         <StyledCheckoutSection data-qa-total-price>
-          {price ? (
+          {price >= 0 || price ? (
             <DisplayPrice interval="mo" price={price} />
           ) : (
             <Typography>{priceSelectionText}</Typography>

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
@@ -72,6 +72,41 @@ describe('KubernetesPlanSelection (table, desktop view)', () => {
     expect(queryByText(regionMonthlyPrice)).toBeInTheDocument();
   });
 
+  it('should not display an error message for $0 regions', () => {
+    const propsWithRegionZeroPrice = {
+      ...props,
+      type: extendedTypeFactory.build({
+        region_prices: [
+          {
+            hourly: 0,
+            id: 'id-cgk',
+            monthly: 0,
+          },
+        ],
+      }),
+    };
+    const { container } = renderWithTheme(
+      wrapWithTableBody(
+        <KubernetesPlanSelection
+          {...propsWithRegionZeroPrice}
+          selectedRegionId={'id-cgk'}
+        />
+      )
+    );
+
+    const monthlyTableCell = container.querySelector('[data-qa-monthly]');
+    const hourlyTableCell = container.querySelector('[data-qa-hourly]');
+    expect(monthlyTableCell).toHaveTextContent('$0');
+    // error tooltip button should not display
+    expect(
+      monthlyTableCell?.querySelector('[data-qa-help-button]')
+    ).not.toBeInTheDocument();
+    expect(hourlyTableCell).toHaveTextContent('$0');
+    expect(
+      hourlyTableCell?.querySelector('[data-qa-help-button]')
+    ).not.toBeInTheDocument();
+  });
+
   describe('KubernetesPlanSelection (cards, mobile view)', () => {
     beforeAll(() => {
       resizeScreenSize(breakpoints.values.sm);

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
@@ -112,14 +112,14 @@ export const KubernetesPlanSelection = (
           </TableCell>
           <TableCell
             data-qa-monthly
-            errorCell={!price?.monthly}
+            errorCell={typeof price?.monthly !== 'number'}
             errorText={!price?.monthly ? PRICE_ERROR_TOOLTIP_TEXT : undefined}
           >
             ${renderMonthlyPriceToCorrectDecimalPlace(price?.monthly)}
           </TableCell>
           <TableCell
             data-qa-hourly
-            errorCell={!price?.hourly}
+            errorCell={typeof price?.hourly !== 'number'}
             errorText={!price?.hourly ? PRICE_ERROR_TOOLTIP_TEXT : undefined}
           >
             ${price?.hourly ?? UNKNOWN_PRICE}

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
@@ -142,7 +142,7 @@ export const KubernetesPlanSelection = (
                   // or there was a pricing data error.
                   (!onAdd && Boolean(selectedId) && type.id !== selectedId) ||
                   disabled ||
-                  !price?.monthly ||
+                  typeof price?.hourly !== 'number' ||
                   isPlanSoldOut
                 }
                 setValue={(newCount: number) =>
@@ -154,7 +154,10 @@ export const KubernetesPlanSelection = (
               {onAdd && (
                 <Button
                   disabled={
-                    count < 1 || disabled || !price?.monthly || isPlanSoldOut
+                    count < 1 ||
+                    disabled ||
+                    typeof price?.hourly !== 'number' ||
+                    isPlanSoldOut
                   }
                   buttonType="primary"
                   onClick={() => onAdd(type.id, count)}

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
@@ -119,6 +119,48 @@ describe('PlanSelection (table, desktop)', () => {
       '1024 GB'
     );
   });
+
+  it('should not display an error message for $0 regions', () => {
+    const propsWithRegionZeroPrice = {
+      ...defaultProps,
+      type: planSelectionTypeFactory.build({
+        heading: 'Dedicated 20 GB',
+        region_prices: [
+          {
+            hourly: 0,
+            id: 'br-gru',
+            monthly: 0,
+          },
+        ],
+        subHeadings: [
+          '$10/mo ($0.015/hr)',
+          '1 CPU, 50 GB Storage, 2 GB RAM',
+          '2 TB Transfer',
+          '40 Gbps In / 2 Gbps Out',
+        ],
+      }),
+    };
+    const { container } = renderWithTheme(
+      wrapWithTableBody(
+        <PlanSelection
+          {...propsWithRegionZeroPrice}
+          selectedRegionId={'br-gru'}
+        />
+      )
+    );
+
+    const monthlyTableCell = container.querySelector('[data-qa-monthly]');
+    const hourlyTableCell = container.querySelector('[data-qa-hourly]');
+    expect(monthlyTableCell).toHaveTextContent('$0');
+    // error tooltip button should not display
+    expect(
+      monthlyTableCell?.querySelector('[data-qa-help-button]')
+    ).not.toBeInTheDocument();
+    expect(hourlyTableCell).toHaveTextContent('$0');
+    expect(
+      hourlyTableCell?.querySelector('[data-qa-help-button]')
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe('PlanSelection (card, mobile)', () => {

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -182,7 +182,7 @@ export const PlanSelection = (props: PlanSelectionProps) => {
           </TableCell>
           <TableCell
             data-qa-monthly
-            errorCell={!price?.monthly}
+            errorCell={typeof price?.monthly !== 'number'}
             errorText={!price?.monthly ? PRICE_ERROR_TOOLTIP_TEXT : undefined}
           >
             {' '}
@@ -190,7 +190,7 @@ export const PlanSelection = (props: PlanSelectionProps) => {
           </TableCell>
           <TableCell
             data-qa-hourly
-            errorCell={!price?.hourly}
+            errorCell={typeof price?.hourly !== 'number'}
             errorText={!price?.hourly ? PRICE_ERROR_TOOLTIP_TEXT : undefined}
           >
             {isGPU ? (

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -64,7 +64,7 @@ export const getDCSpecificPrice = ({
 export const renderMonthlyPriceToCorrectDecimalPlace = (
   monthlyPrice: null | number | undefined
 ) => {
-  if (!monthlyPrice) {
+  if (typeof monthlyPrice !== 'number') {
     return UNKNOWN_PRICE;
   }
   return Number.isInteger(monthlyPrice)


### PR DESCRIPTION
## Description 📝
Hide error message for $0 regions since that is not technically an error. Continue to display the error icon otherwise.

## Changes  🔄
List any change relevant to the reviewer.
- Error message tooltip no longer displayed for $0 region prices in Linode and Kubernetes Create
- Plus and minus and Add buttons are no longer disabled in Kubernetes Create Plan table if the price is $0

## Preview 📷
| Linode Create Before  | Linode Create After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/115299789/a90745c3-48ef-4f47-93f6-65e646ea7ec9) | ![image](https://github.com/linode/manager/assets/115299789/a27826f4-e4f5-46c7-909a-2320b725a9da) |

| Kubernetes Create Before  | Kubernetes Create After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/115299789/bafdc8b2-2582-436a-b25f-8d1869ba1df6" /> | <video src="https://github.com/linode/manager/assets/115299789/426c7b66-0022-449d-8ab1-c71a364889a1" /> |

## How to test 🧪

### Reproduction steps
- On another branch/prod, go to Linode/Kubernetes Create
- Select the Madrid region
- Notice the error icon for both the `$0` hourly price and `$--.--` monthly price
- Notice the disabled plus, minus, add buttons in the Kubernetes Create Plan table

### Verification steps 
- Go to Linode/Kubernetes Create and select the Madrid region
- You should no longer see an error icon for the `$0` hourly price. You should continue to see an error icon for the `$--.--` monthly price
- The plus, minus, add buttons should no longer be disabled in the Kubernetes Create Plan table

```
yarn test KubernetesPlanSelection
yarn test PlanSelection
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support