### PR TITLE
fix: [M3-7725] - Unit tests button enabled assertions

### DIFF
--- a/packages/manager/.changeset/pr-10142-fixed-1707158870254.md
+++ b/packages/manager/.changeset/pr-10142-fixed-1707158870254.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Unit tests Button enabled assertions ([#10142](https://github.com/linode/manager/pull/10142))

--- a/packages/manager/src/testSetup.ts
+++ b/packages/manager/src/testSetup.ts
@@ -1,9 +1,8 @@
+import matchers from '@testing-library/jest-dom/matchers';
 import Enzyme from 'enzyme';
 // @ts-expect-error not a big deal, we can suffer
 import Adapter from 'enzyme-adapter-react-16';
-
 import { expect } from 'vitest';
-import matchers from '@testing-library/jest-dom/matchers';
 
 // // Enzyme React 17 adapter.
 // Enzyme.configure({ adapter: new Adapter() });
@@ -60,3 +59,73 @@ vi.mock('highlight.js/lib/highlight', () => ({
     registerLanguage: vi.fn(),
   },
 }));
+
+/**
+ ***************************************
+ *  Custom matchers & matchers overrides
+ ***************************************
+ */
+
+/**
+ * Matcher override for toBeDisabled and toBeEnabled
+ */
+const ariaDisabled = 'aria-disabled';
+expect.extend({
+  toBeDisabled(element: HTMLElement) {
+    const isAriaDisabled = element.getAttribute(ariaDisabled) === 'true';
+    const disabledMessage = `expected ${element?.tagName} to be disabled`;
+
+    if (element?.tagName.toLowerCase() === 'input') {
+      return isAriaDisabled
+        ? {
+            message: () => disabledMessage,
+            pass: true,
+          }
+        : {
+            message: () => disabledMessage,
+            pass: false,
+          };
+    } else {
+      const isDisabled = element.hasAttribute('disabled');
+      return isDisabled
+        ? {
+            message: () => disabledMessage,
+            pass: true,
+          }
+        : {
+            message: () => disabledMessage,
+            pass: false,
+          };
+    }
+  },
+  toBeEnabled(element) {
+    const isAriaEnabled = !(
+      element.getAttribute(ariaDisabled) &&
+      element.getAttribute(ariaDisabled) === 'true'
+    );
+    const enabledMessage = `expected ${element.tagName} to be enabled`;
+
+    if (element.tagName.toLowerCase() === 'button') {
+      return isAriaEnabled
+        ? {
+            message: () => enabledMessage,
+            pass: true,
+          }
+        : {
+            message: () => enabledMessage,
+            pass: false,
+          };
+    } else {
+      const isEnabled = !element.hasAttribute('disabled');
+      return isEnabled
+        ? {
+            message: () => enabledMessage,
+            pass: true,
+          }
+        : {
+            message: () => enabledMessage,
+            pass: false,
+          };
+    }
+  },
+});


### PR DESCRIPTION
## Description 📝
Since we changed our buttons to feature an aria tag VS using a `disabled` attribute, both `toBeEnabled` & `toBeDisabled` can lead to false positives.

The reason is, the `jest-dom` assertion for `toBeEnabled` will look for a `disabled` attribute which isn't going to be present since we've altered our Button to feature an `aria-disabled` tag instead, leading to a false positive.

We've applied the fix for our e2e but the unit suite configuration needed to be handled as well.

## Changes  🔄
- Add an interceptor for `toBeEnabled` & `toBeDisabled` assertions (for buttons only) that checks for `aria-disabled` tags as well

## How to test 🧪

### Reproduction steps
- An easy to reproduce the initial issue is to use an existing assertion such as the `CloseAccountSetting` component locally (**on develop branch**)
  -  hardcode this [value](https://github.com/linode/manager/blob/develop/packages/manager/src/features/Account/CloseAccountSetting.tsx#L38) to `true`
  - run `yarn test CloseAccountSetting.test.tsx` -  this [assertion](https://github.com/linode/manager/blob/develop/packages/manager/src/features/Account/CloseAccountSetting.test.tsx#L41) will still pass, which is a false positive

### Verification steps 
- Pull code locally and reproduce the steps above, make sure the assertion now fails
- run `yarn test` and Make sure the whole suite runs 

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

