### PR TITLE
refactor: [M3-7736] - Clean up `regionDropdown` feature flag

### DIFF
--- a/packages/manager/.changeset/pr-10148-tech-stories-1707231054836.md
+++ b/packages/manager/.changeset/pr-10148-tech-stories-1707231054836.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Clean up `regionDropdown` feature flag ([#10148](https://github.com/linode/manager/pull/10148))

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -62,7 +62,6 @@ export interface Flags {
   promotionalOffers: PromotionalOffer[];
   recharts: boolean;
   referralBannerText: ReferralBannerText;
-  regionDropdown: boolean;
   selfServeBetas: boolean;
   soldOutChips: boolean;
   taxBanner: TaxBanner;

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
@@ -9,7 +9,6 @@ import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
 import { Notice } from 'src/components/Notice/Notice';
 import { TextField } from 'src/components/TextField';
-import { useFlags } from 'src/hooks/useFlags';
 import { useAccount, useMutateAccount } from 'src/queries/account';
 import { useNotificationsQuery } from 'src/queries/accountNotifications';
 import { getErrorMap } from 'src/utilities/errorUtils';
@@ -28,7 +27,6 @@ const UpdateContactInformationForm = ({ focusEmail, onClose }: Props) => {
   const { error, isLoading, mutateAsync } = useMutateAccount();
   const { data: notifications, refetch } = useNotificationsQuery();
   const { classes } = useStyles();
-  const flags = useFlags();
   const emailRef = React.useRef<HTMLInputElement>();
 
   const formik = useFormik({
@@ -241,12 +239,11 @@ const UpdateContactInformationForm = ({ focusEmail, onClose }: Props) => {
             onChange={(item) => formik.setFieldValue('country', item.value)}
             options={countryResults}
             placeholder="Select a Country"
-            required={flags.regionDropdown}
+            required
           />
         </Grid>
         <Grid sm={6} xs={12}>
-          {flags.regionDropdown &&
-          (formik.values.country === 'US' || formik.values.country == 'CA') ? (
+          {formik.values.country === 'US' || formik.values.country == 'CA' ? (
             <EnhancedSelect
               placeholder={
                 formik.values.country === 'US' ? 'state' : 'province'
@@ -266,7 +263,7 @@ const UpdateContactInformationForm = ({ focusEmail, onClose }: Props) => {
               label={`${formik.values.country === 'US' ? 'State' : 'Province'}`}
               onChange={(item) => formik.setFieldValue('state', item.value)}
               options={filteredRegionResults}
-              required={flags.regionDropdown}
+              required
             />
           ) : (
             <TextField
@@ -276,7 +273,7 @@ const UpdateContactInformationForm = ({ focusEmail, onClose }: Props) => {
               name="state"
               onChange={formik.handleChange}
               placeholder="Enter region"
-              required={flags.regionDropdown}
+              required
               value={formik.values.state}
             />
           )}

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
@@ -246,7 +246,9 @@ const UpdateContactInformationForm = ({ focusEmail, onClose }: Props) => {
           {formik.values.country === 'US' || formik.values.country == 'CA' ? (
             <EnhancedSelect
               placeholder={
-                formik.values.country === 'US' ? 'state' : 'province'
+                formik.values.country === 'US'
+                  ? 'Enter state'
+                  : 'Enter province'
               }
               textFieldProps={{
                 dataAttrs: {


### PR DESCRIPTION
## Description 📝

In production, `regionDropdown` has been **enabled** for the last two years and has not changed. I think we can safely remove this flag from the codebase. 🧹

## Preview 📷

<img src="https://github.com/linode/manager/assets/115251059/1e1d3f94-c72f-42b8-a962-4cecc3778682" height="500px" />

## How to test 🧪

- Go to http://localhost:3000/account/billing/edit
- Verify **Country** and **State** are required
- Verify this drawer looks and functions the same locally as it does in production

## As an Author I have considered 🤔

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support