### PR TITLE
test: [M3-7737] - Resolve Billing Contact Cypress failure

### DIFF
--- a/packages/manager/.changeset/pr-10150-tests-1707236804326.md
+++ b/packages/manager/.changeset/pr-10150-tests-1707236804326.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix billing contact Cypress test by narrowing element selection scope ([#10150](https://github.com/linode/manager/pull/10150))

--- a/packages/manager/cypress/e2e/core/billing/billing-contact.spec.ts
+++ b/packages/manager/cypress/e2e/core/billing/billing-contact.spec.ts
@@ -1,6 +1,7 @@
 import { mockGetAccount, mockUpdateAccount } from 'support/intercepts/account';
 import { accountFactory } from 'src/factories/account';
 import type { Account } from '@linode/api-v4';
+import { ui } from 'support/ui';
 
 /* eslint-disable sonarjs/no-duplicate-string */
 const accountData = accountFactory.build({
@@ -66,75 +67,82 @@ describe('Billing Contact', () => {
     // mock the user's account data and confirm that it is displayed correctly upon page load
     mockGetAccount(accountData).as('getAccount');
     cy.visitWithLogin('/account/billing');
-    checkAccountContactDisplay(accountData);
 
     // edit the billing contact information
     mockUpdateAccount(newAccountData).as('updateAccount');
     cy.get('[data-qa-contact-summary]').within((_contact) => {
+      checkAccountContactDisplay(accountData);
       cy.findByText('Edit').should('be.visible').click();
     });
-    // check drawer is visible
-    cy.findByLabelText('First Name')
+
+    ui.drawer
+      .findByTitle('Edit Billing Contact Info')
       .should('be.visible')
-      .click()
-      .clear()
-      .type(newAccountData['first_name']);
-    cy.findByLabelText('Last Name')
-      .should('be.visible')
-      .click()
-      .clear()
-      .type(newAccountData['last_name']);
-    cy.findByLabelText('Company Name')
-      .should('be.visible')
-      .click()
-      .clear()
-      .type(newAccountData['company']);
-    cy.findByLabelText('Address')
-      .should('be.visible')
-      .click()
-      .clear()
-      .type(newAccountData['address_1']);
-    cy.findByLabelText('Address 2')
-      .should('be.visible')
-      .click()
-      .clear()
-      .type(newAccountData['address_2']);
-    cy.findByLabelText('Email (required)')
-      .should('be.visible')
-      .click()
-      .clear()
-      .type(newAccountData['email']);
-    cy.findByLabelText('City')
-      .should('be.visible')
-      .click()
-      .clear()
-      .type(newAccountData['city']);
-    cy.findByLabelText('Postal Code')
-      .should('be.visible')
-      .click()
-      .clear()
-      .type(newAccountData['zip']);
-    cy.findByLabelText('Phone')
-      .should('be.visible')
-      .click()
-      .clear()
-      .type(newAccountData['phone']);
-    cy.get('[data-qa-contact-country]').click().type('United States{enter}');
-    cy.get('[data-qa-contact-state-province]')
-      .should('be.visible')
-      .click()
-      .type(`${newAccountData['state']}{enter}`);
-    cy.findByLabelText('Tax ID')
-      .should('be.visible')
-      .click()
-      .clear()
-      .type(newAccountData['tax_id']);
-    cy.get('[data-qa-save-contact-info="true"]')
-      .click()
-      .then(() => {
-        cy.wait('@updateAccount').then((xhr) => {
-          expect(xhr.response?.body).to.eql(newAccountData);
-        });
+      .within(() => {
+        cy.findByLabelText('First Name')
+          .should('be.visible')
+          .click()
+          .clear()
+          .type(newAccountData['first_name']);
+        cy.findByLabelText('Last Name')
+          .should('be.visible')
+          .click()
+          .clear()
+          .type(newAccountData['last_name']);
+        cy.findByLabelText('Company Name')
+          .should('be.visible')
+          .click()
+          .clear()
+          .type(newAccountData['company']);
+        cy.findByLabelText('Address')
+          .should('be.visible')
+          .click()
+          .clear()
+          .type(newAccountData['address_1']);
+        cy.findByLabelText('Address 2')
+          .should('be.visible')
+          .click()
+          .clear()
+          .type(newAccountData['address_2']);
+        cy.findByLabelText('Email (required)')
+          .should('be.visible')
+          .click()
+          .clear()
+          .type(newAccountData['email']);
+        cy.findByLabelText('City')
+          .should('be.visible')
+          .click()
+          .clear()
+          .type(newAccountData['city']);
+        cy.findByLabelText('Postal Code')
+          .should('be.visible')
+          .click()
+          .clear()
+          .type(newAccountData['zip']);
+        cy.findByLabelText('Phone')
+          .should('be.visible')
+          .click()
+          .clear()
+          .type(newAccountData['phone']);
+        cy.get('[data-qa-contact-country]')
+          .click()
+          .type('United States{enter}');
+        cy.get('[data-qa-contact-state-province]')
+          .should('be.visible')
+          .click()
+          .type(`${newAccountData['state']}{enter}`);
+        cy.findByLabelText('Tax ID')
+          .should('be.visible')
+          .click()
+          .clear()
+          .type(newAccountData['tax_id']);
+        cy.get('[data-qa-save-contact-info="true"]')
+          .click()
+          .then(() => {
+            cy.wait('@updateAccount').then((xhr) => {
+              expect(xhr.response?.body).to.eql(newAccountData);
+            });
+          });
       });
 
     // check the page updates to reflect the edits


### PR DESCRIPTION
## Description 📝
This resolves the Cypress failure in `billing-contact.spec.ts`. The failure stems from the account's company name appearing in the user menu button at the top of the page -- that issue will be handled separately, but this fixes the test in the meantime by searching for the company name only in the billing contact summary section on the billing page.

## Changes  🔄
- Fix `billing-contact.spec.ts` failure

## How to test 🧪
We can rely on CI for this

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

---
## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**
- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

---
