### PR TITLE
fix: [M3-7004] - Allow IPv6 ranges transfers

### DIFF
--- a/packages/manager/.changeset/pr-10156-fixed-1707363343774.md
+++ b/packages/manager/.changeset/pr-10156-fixed-1707363343774.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Allow IPv6 ranges transfers ([#10156](https://github.com/linode/manager/pull/10156))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
@@ -1,8 +1,9 @@
 import { IPv6Prefix } from '@linode/api-v4/lib/networking';
-import { useTheme } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import * as React from 'react';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
+import { Box } from 'src/components/Box';
 import { Divider } from 'src/components/Divider';
 import { Drawer } from 'src/components/Drawer';
 import { Item } from 'src/components/EnhancedSelect/Select';
@@ -82,7 +83,6 @@ interface Props {
 
 export const AddIPDrawer = (props: Props) => {
   const { linodeId, onClose, open, readOnly } = props;
-  const theme = useTheme();
 
   const {
     error: ipv4Error,
@@ -166,41 +166,37 @@ export const AddIPDrawer = (props: Props) => {
   return (
     <Drawer onClose={onClose} open={open} title="Add an IP Address">
       <Stack spacing={2}>
-        <Typography variant="h2">IPv4</Typography>
+        <Typography variant="h3">IPv4</Typography>
         {Boolean(ipv4Error) && (
-          <Notice spacingTop={8} text={ipv4Error?.[0].reason} variant="error" />
+          <Notice spacingTop={4} text={ipv4Error?.[0].reason} variant="error" />
         )}
-        <Typography sx={{ marginTop: '1rem' }} variant="h3">
-          Select type
-        </Typography>
-        <RadioGroup
-          aria-label="ip-option"
+
+        <StyledRadioGroup
+          aria-labelledby="ipv4-select-type"
           data-qa-ip-options-radio-group
           name="Select IPv4 type"
           onChange={handleIPv4Change}
-          sx={{ marginTop: '0 !important' }}
           value={selectedIPv4}
         >
-          {ipOptions.map((option, idx) => (
-            <FormControlLabel
-              control={<Radio />}
-              data-qa-radio={option.label}
-              key={idx}
-              label={option.label}
-              value={option.value}
-            />
-          ))}
-        </RadioGroup>
-        {selectedIPv4 && (
-          <Typography sx={{ marginTop: theme.spacing(2) }} variant="body1">
-            {explainerCopy[selectedIPv4]}
-          </Typography>
-        )}
+          <Typography id="ipv4-select-type">Select type</Typography>
+          <Box>
+            {ipOptions.map((option, idx) => (
+              <FormControlLabel
+                control={<Radio />}
+                data-qa-radio={option.label}
+                key={idx}
+                label={option.label}
+                value={option.value}
+              />
+            ))}
+          </Box>
+        </StyledRadioGroup>
+        {selectedIPv4 && <Typography>{explainerCopy[selectedIPv4]}</Typography>}
 
         {_tooltipCopy ? (
           <Tooltip placement="bottom-end" title={_tooltipCopy}>
             <div style={{ display: 'inline' }}>
-              <ActionsPanel
+              <StyledActionsPanel
                 primaryButtonProps={{
                   disabled: disabledIPv4,
                   label: 'Allocate',
@@ -211,7 +207,7 @@ export const AddIPDrawer = (props: Props) => {
             </div>
           </Tooltip>
         ) : (
-          <ActionsPanel
+          <StyledActionsPanel
             primaryButtonProps={{
               disabled: disabledIPv4,
               label: 'Allocate',
@@ -220,38 +216,36 @@ export const AddIPDrawer = (props: Props) => {
             }}
           />
         )}
-        <Divider sx={{ pt: 2 }} />
-        <Typography sx={{ pt: 2 }} variant="h2">
+        <Divider sx={{ pt: 1 }} />
+        <Typography sx={{ pt: 1 }} variant="h3">
           IPv6
         </Typography>
         {Boolean(ipv6Error) && (
-          <Notice spacingTop={8} text={ipv6Error?.[0].reason} variant="error" />
+          <Notice spacingTop={4} text={ipv6Error?.[0].reason} variant="error" />
         )}
-        <Typography sx={{ marginTop: '1rem' }} variant="h3">
-          Select prefix
-        </Typography>
-        <RadioGroup
-          aria-label="prefix-option"
+
+        <StyledRadioGroup
+          aria-labelledby="ipv6-select-type"
           data-qa-ip-options-radio-group
-          name="Select prefix"
+          name="Select IPv6 type"
           onChange={handleIPv6Change}
-          sx={{ marginTop: '0 !important' }}
           value={selectedIPv6Prefix}
         >
-          {prefixOptions.map((option, idx) => (
-            <FormControlLabel
-              control={<Radio />}
-              data-qa-radio={option.label}
-              key={idx}
-              label={option.label}
-              value={option.value}
-            />
-          ))}
-        </RadioGroup>
+          <Typography id="ipv6-select-type">Select prefix</Typography>
+          <Box>
+            {prefixOptions.map((option, idx) => (
+              <FormControlLabel
+                control={<Radio />}
+                data-qa-radio={option.label}
+                key={idx}
+                label={option.label}
+                value={option.value}
+              />
+            ))}
+          </Box>
+        </StyledRadioGroup>
         {selectedIPv6Prefix && (
-          <Typography style={{ marginBottom: '1rem' }} variant="body1">
-            {IPv6ExplanatoryCopy[selectedIPv6Prefix]}
-          </Typography>
+          <Typography>{IPv6ExplanatoryCopy[selectedIPv6Prefix]}</Typography>
         )}
         <Typography>
           IPv6 addresses are allocated as ranges, which you can choose to
@@ -261,16 +255,34 @@ export const AddIPDrawer = (props: Props) => {
           </Link>
           .
         </Typography>
-        <ActionsPanel
+        <StyledActionsPanel
           primaryButtonProps={{
             disabled: disabledIPv6,
             label: 'Allocate',
             loading: ipv6Loading,
             onClick: handleCreateIPv6Range,
-            sx: { marginBottom: 8 },
           }}
         />
       </Stack>
     </Drawer>
   );
 };
+
+const StyledRadioGroup = styled(RadioGroup, {
+  label: 'StyledApiDrawerRadioGroup',
+})(({ theme }) => ({
+  '& label': {
+    minWidth: 100,
+  },
+  '& p': {
+    fontFamily: theme.font.bold,
+    marginTop: theme.spacing(),
+  },
+  marginBottom: '0 !important',
+}));
+
+const StyledActionsPanel = styled(ActionsPanel, {
+  label: 'StyledActionsPanel',
+})(({ theme }) => ({
+  paddingTop: theme.spacing(2),
+}));

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
@@ -3,6 +3,7 @@ import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
+import { Divider } from 'src/components/Divider';
 import { Drawer } from 'src/components/Drawer';
 import { Item } from 'src/components/EnhancedSelect/Select';
 import { FormControlLabel } from 'src/components/FormControlLabel';
@@ -10,6 +11,7 @@ import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
 import { Radio } from 'src/components/Radio/Radio';
 import { RadioGroup } from 'src/components/RadioGroup';
+import { Stack } from 'src/components/Stack';
 import { Tooltip } from 'src/components/Tooltip';
 import { Typography } from 'src/components/Typography';
 import {
@@ -163,7 +165,7 @@ export const AddIPDrawer = (props: Props) => {
 
   return (
     <Drawer onClose={onClose} open={open} title="Add an IP Address">
-      <React.Fragment>
+      <Stack spacing={2}>
         <Typography variant="h2">IPv4</Typography>
         {Boolean(ipv4Error) && (
           <Notice spacingTop={8} text={ipv4Error?.[0].reason} variant="error" />
@@ -204,7 +206,6 @@ export const AddIPDrawer = (props: Props) => {
                   label: 'Allocate',
                   loading: ipv4Loading,
                   onClick: handleAllocateIPv4,
-                  sx: { marginBottom: 8 },
                 }}
               />
             </div>
@@ -216,11 +217,11 @@ export const AddIPDrawer = (props: Props) => {
               label: 'Allocate',
               loading: ipv4Loading,
               onClick: handleAllocateIPv4,
-              sx: { marginBottom: 8 },
             }}
           />
         )}
-        <Typography sx={{ marginTop: theme.spacing(4) }} variant="h2">
+        <Divider sx={{ pt: 2 }} />
+        <Typography sx={{ pt: 2 }} variant="h2">
           IPv6
         </Typography>
         {Boolean(ipv6Error) && (
@@ -269,7 +270,7 @@ export const AddIPDrawer = (props: Props) => {
             sx: { marginBottom: 8 },
           }}
         />
-      </React.Fragment>
+      </Stack>
     </Drawer>
   );
 };

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
@@ -91,7 +91,7 @@ export const getLinodeIPv6Ranges = (
   );
 };
 
-const LinodeNetworkingIPTransferPanel = (props: Props) => {
+export const IPTransfer = (props: Props) => {
   const { linodeId, onClose, open, readOnly } = props;
   const theme = useTheme();
   const { mutateAsync: assignAddresses } = useAssignAdressesMutation();
@@ -100,10 +100,16 @@ const LinodeNetworkingIPTransferPanel = (props: Props) => {
 
   const { data: _ips } = useLinodeIPsQuery(linodeId);
 
-  const publicIPs = _ips?.ipv4.public.map((i) => i.address) ?? [];
-  const privateIPs = _ips?.ipv4.private.map((i) => i.address) ?? [];
+  const publicIPv4Addresses = _ips?.ipv4.public.map((i) => i.address) ?? [];
+  const privateIPv4Addresses = _ips?.ipv4.private.map((i) => i.address) ?? [];
+  const ipv6Addresses =
+    _ips?.ipv6?.global.map((i) => `${i.range}/${i.prefix}`) ?? [];
 
-  const ipAddresses = [...publicIPs, ...privateIPs];
+  const ipAddresses = [
+    ...publicIPv4Addresses,
+    ...privateIPv4Addresses,
+    ...ipv6Addresses,
+  ];
 
   const [ips, setIPs] = React.useState<IPRowState>(
     ipAddresses.reduce(
@@ -252,30 +258,18 @@ const LinodeNetworkingIPTransferPanel = (props: Props) => {
     ];
 
     return (
-      <Grid container key={state.sourceIP} spacing={2} sx={{ width: '100%' }}>
+      <Grid container key={state.sourceIP} spacing={2} xs={12}>
         <Grid
           sx={{
             alignItems: 'center',
             display: 'flex',
-            [theme.breakpoints.down('sm')]: {
-              width: '100%',
-            },
           }}
+          md={3}
+          xs={12}
         >
-          <Typography
-            sx={{
-              marginTop: 0,
-              [theme.breakpoints.up('sm')]: {
-                width: 175,
-              },
-              width: '100%',
-            }}
-            variant="body1"
-          >
-            {state.sourceIP}
-          </Typography>
+          <Typography>{state.sourceIP}</Typography>
         </Grid>
-        <StyledAudoGrid>
+        <StyledAutoGrid md={3} xs={12}>
           <Select
             textFieldProps={{
               dataAttrs: {
@@ -299,7 +293,7 @@ const LinodeNetworkingIPTransferPanel = (props: Props) => {
             overflowPortal
             placeholder="Select Action"
           />
-        </StyledAudoGrid>
+        </StyledAutoGrid>
         {renderLinodeSelect && renderLinodeSelect(state as Move)}
         {renderIPSelect && renderIPSelect(state as Swap)}
       </Grid>
@@ -316,7 +310,7 @@ const LinodeNetworkingIPTransferPanel = (props: Props) => {
     });
 
     return (
-      <StyledAudoGrid xs={12}>
+      <StyledAutoGrid md={3} xs={12}>
         <Select
           textFieldProps={{
             dataAttrs: {
@@ -336,7 +330,7 @@ const LinodeNetworkingIPTransferPanel = (props: Props) => {
           overflowPortal
           value={defaultLinode}
         />
-      </StyledAudoGrid>
+      </StyledAutoGrid>
     );
   };
 
@@ -350,7 +344,7 @@ const LinodeNetworkingIPTransferPanel = (props: Props) => {
     });
 
     return (
-      <StyledAudoGrid xs={12}>
+      <StyledAutoGrid md={3} xs={12}>
         <Select
           textFieldProps={{
             dataAttrs: {
@@ -367,7 +361,7 @@ const LinodeNetworkingIPTransferPanel = (props: Props) => {
           overflowPortal
           value={defaultIP}
         />
-      </StyledAudoGrid>
+      </StyledAutoGrid>
     );
   };
 
@@ -474,7 +468,7 @@ const LinodeNetworkingIPTransferPanel = (props: Props) => {
           the DNS records.
         </Typography>
       </Grid>
-      <Grid container spacing={2} xs={12}>
+      <Grid container xs={12}>
         {!isLoading && !ipv6RangesLoading && ipv6RangesError ? (
           <Notice
             text={'There was an error loading IPv6 Ranges'}
@@ -509,8 +503,8 @@ const LinodeNetworkingIPTransferPanel = (props: Props) => {
                 <Typography>Actions</Typography>
               </Grid>
             </Grid>
-            <Grid sx={{ paddingTop: 0 }} xs={12}>
-              <Divider spacingBottom={0} />
+            <Grid xs={12}>
+              <Divider />
             </Grid>
             {linodes.length === 0 && searchText === '' ? (
               <Typography
@@ -523,33 +517,35 @@ const LinodeNetworkingIPTransferPanel = (props: Props) => {
                 with which to transfer IPs.
               </Typography>
             ) : (
-              <Grid container spacing={2} sx={{ width: '100%' }}>
+              <Grid spacing={2} sx={{ width: '100%' }}>
                 {Object.values(ips).map(ipRow)}
               </Grid>
             )}
           </>
         )}
       </Grid>
-      <ActionsPanel
-        primaryButtonProps={{
-          'data-testid': 'ip-transfer-save',
-          disabled: readOnly || linodes.length === 0,
-          label: 'Save',
-          loading: submitting,
-          onClick: onSubmit,
-        }}
-        secondaryButtonProps={{
-          'data-testid': 'ip-transfer-reset',
-          disabled: submitting || linodes.length === 0,
-          label: 'Reset Form',
-          onClick: onReset,
-        }}
-      />
+      <Grid container justifyContent="flex-end" xs={12}>
+        <ActionsPanel
+          primaryButtonProps={{
+            'data-testid': 'ip-transfer-save',
+            disabled: readOnly || linodes.length === 0,
+            label: 'Save',
+            loading: submitting,
+            onClick: onSubmit,
+          }}
+          secondaryButtonProps={{
+            'data-testid': 'ip-transfer-reset',
+            disabled: submitting || linodes.length === 0,
+            label: 'Reset Form',
+            onClick: onReset,
+          }}
+        />
+      </Grid>
     </Dialog>
   );
 };
 
-const StyledAudoGrid = styled(Grid, { label: 'StyledAutoGrid' })(
+const StyledAutoGrid = styled(Grid, { label: 'StyledAutoGrid' })(
   ({ theme }) => ({
     minWidth: 175,
     [theme.breakpoints.up('sm')]: {
@@ -636,5 +632,3 @@ const createRequestData = (state: IPRowState, region: string) => ({
   assignments: Object.values(state).reduce(stateToAssignmentsReducer, []),
   region,
 });
-
-export default LinodeNetworkingIPTransferPanel;

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
@@ -94,7 +94,9 @@ export const getLinodeIPv6Ranges = (
 export const IPTransfer = (props: Props) => {
   const { linodeId, onClose, open, readOnly } = props;
   const theme = useTheme();
-  const { mutateAsync: assignAddresses } = useAssignAdressesMutation();
+  const { mutateAsync: assignAddresses } = useAssignAdressesMutation({
+    currentLinodeId: linodeId,
+  });
 
   const { data: linode } = useLinodeQuery(linodeId, open);
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
@@ -258,7 +258,18 @@ export const IPTransfer = (props: Props) => {
     ];
 
     return (
-      <Grid container key={state.sourceIP} spacing={2} xs={12}>
+      <Grid
+        sx={{
+          [theme.breakpoints.down('md')]: {
+            backgroundColor: theme.color.grey5,
+            mb: 3,
+          },
+        }}
+        container
+        key={state.sourceIP}
+        spacing={2}
+        xs={12}
+      >
         <Grid
           sx={{
             alignItems: 'center',
@@ -267,7 +278,20 @@ export const IPTransfer = (props: Props) => {
           md={3}
           xs={12}
         >
-          <Typography>{state.sourceIP}</Typography>
+          <Typography>
+            <Typography
+              sx={{
+                [theme.breakpoints.up('md')]: {
+                  display: 'none',
+                },
+              }}
+              component="span"
+              fontFamily={theme.font.bold}
+            >
+              IP address:{' '}
+            </Typography>
+            {state.sourceIP}
+          </Typography>
         </Grid>
         <StyledAutoGrid md={3} xs={12}>
           <Select
@@ -481,21 +505,23 @@ export const IPTransfer = (props: Props) => {
           </div>
         ) : (
           <>
-            <Grid container spacing={2} sx={{ width: '100%' }}>
+            <Grid container xs={12}>
               <Grid
                 sx={{
-                  [theme.breakpoints.up('sm')]: {
-                    width: `calc(175px + ${theme.spacing(2)})`,
+                  [theme.breakpoints.down('md')]: {
+                    display: 'none',
                   },
-                  width: '100%',
                 }}
                 data-qa-transfer-ip-label
+                sm={3}
+                xs={12}
               >
                 <Typography>IP Address</Typography>
               </Grid>
               <Grid
                 sx={{
-                  [theme.breakpoints.down('sm')]: {
+                  pl: 0.5,
+                  [theme.breakpoints.down('md')]: {
                     display: 'none',
                   },
                 }}
@@ -503,7 +529,14 @@ export const IPTransfer = (props: Props) => {
                 <Typography>Actions</Typography>
               </Grid>
             </Grid>
-            <Grid xs={12}>
+            <Grid
+              sx={{
+                [theme.breakpoints.down('md')]: {
+                  visibility: 'hidden',
+                },
+              }}
+              xs={12}
+            >
               <Divider />
             </Grid>
             {linodes.length === 0 && searchText === '' ? (
@@ -517,7 +550,7 @@ export const IPTransfer = (props: Props) => {
                 with which to transfer IPs.
               </Typography>
             ) : (
-              <Grid spacing={2} sx={{ width: '100%' }}>
+              <Grid spacing={2} xs={12}>
                 {Object.values(ips).map(ipRow)}
               </Grid>
             )}

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses.tsx
@@ -27,7 +27,7 @@ import { DeleteRangeDialog } from './DeleteRangeDialog';
 import { EditIPRDNSDrawer } from './EditIPRDNSDrawer';
 import { EditRangeRDNSDrawer } from './EditRangeRDNSDrawer';
 import IPSharing from './IPSharing';
-import IPTransfer from './IPTransfer';
+import { IPTransfer } from './IPTransfer';
 import { IPAddressRowHandlers, LinodeIPAddressRow } from './LinodeIPAddressRow';
 import {
   StyledRootGrid,

--- a/packages/manager/src/queries/linodes/networking.ts
+++ b/packages/manager/src/queries/linodes/networking.ts
@@ -26,6 +26,7 @@ import {
   useQuery,
   useQueryClient,
 } from 'react-query';
+import { useHistory } from 'react-router-dom';
 
 import { queryKey } from './linodes';
 import { getAllIPv6Ranges, getAllIps } from './requests';
@@ -107,6 +108,7 @@ export const useLinodeShareIPMutation = () => {
 
 export const useAssignAdressesMutation = () => {
   const queryClient = useQueryClient();
+  const { location } = useHistory();
   return useMutation<{}, APIError[], IPAssignmentPayload>(assignAddresses, {
     onSuccess(_, variables) {
       for (const { linode_id } of variables.assignments) {
@@ -118,6 +120,13 @@ export const useAssignAdressesMutation = () => {
         ]);
         queryClient.invalidateQueries([queryKey, 'linode', linode_id, 'ips']);
       }
+      const currentLinodeId = location?.pathname?.split('/')?.[2];
+      queryClient.invalidateQueries([
+        queryKey,
+        'linode',
+        Number(currentLinodeId),
+        'ips',
+      ]);
       queryClient.invalidateQueries([queryKey, 'paginated']);
       queryClient.invalidateQueries([queryKey, 'all']);
       queryClient.invalidateQueries([queryKey, 'infinite']);

--- a/packages/manager/src/queries/linodes/networking.ts
+++ b/packages/manager/src/queries/linodes/networking.ts
@@ -123,8 +123,6 @@ export const useAssignAdressesMutation = ({
         ]);
         queryClient.invalidateQueries([queryKey, 'linode', linode_id, 'ips']);
       }
-      // this invalidation will only work when calling this mutation from a Linode detail page.
-      // The mutation is currently only used in the IPTransfer modal, which works.
       queryClient.invalidateQueries([
         queryKey,
         'linode',


### PR DESCRIPTION
## Description 📝
This PR aims to fix a regression where users weren't able to transfer IPv6 ranges in the Linode Network tab.

I am frankly unsure how that was a regression considering we weren't pulling the ranges in the modal whatsoever, but perhaps someone has better context about this. Long story short, I hope my fix is the right one considering my lack of context. One thing I know is that adding those back to the modal works fine, and the transfer goes through.

This component is gross. It is a dirty ramda rat fest and the UI is questionable. While I wanted to only address the problem at heart, I couldn't help but attempt to improve the UI and make things at least look better for our users in the modal and add IP drawer.

## Changes  🔄
- Add (back?) IPvs ranges to the modal
- Improve layout and styling in modal and drawer
- Invalidate an extra query to improve the experience
- Refactor default export

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![localhost_3000_linodes_51692149_networking (1)](https://github.com/linode/manager/assets/130582365/9c547ade-7826-4faf-b4c7-84ebb20acefb) |  ![localhost_3000_linodes_51692149_networking](https://github.com/linode/manager/assets/130582365/1573f31e-37e6-4164-941d-207493932871) |

| Before  | After   |
| ------- | ------- |
| ![cloud linode com_linodes_51692149_networking (2)](https://github.com/linode/manager/assets/130582365/0fd574a6-dc3a-4d44-b947-e797b20587ad) | ![localhost_3000_linodes_51692149_networking (4)](https://github.com/linode/manager/assets/130582365/5806caea-483f-47cf-82cd-f73886cdcf45) | 

| Before  | After   |
| ------- | ------- |
| ![cloud linode com_linodes_51692149_networking (1)](https://github.com/linode/manager/assets/130582365/5f357876-4070-4b42-80ed-b7beee59c938) | ![localhost_3000_linodes_51692149_networking (3)](https://github.com/linode/manager/assets/130582365/15114eb1-a87b-4ea3-aedc-81991748670e) | 

## How to test 🧪

### Prerequisites
- Have two linodes **in the same region** without any extra IP address added (`linode1`, `linode2`)

### Reproduction steps
- Navigate to `/linodes/{linode1.id}/networking`
- Add an IPv6 range (either `/64` or `/56`) 
- Click on the "IP Transfer" Button
- Notice your IPv6 range is not present

### Verification steps 
- Stay on  `/linodes/{linode1.id}/networking`
- Pull code locally
- Click on the "IP Transfer" Button
- Notice your IPv6 range is present and can be transferred to `linode2`
- Verify it gets removed from the IPs table without a refresh

### Overall regression testing
- Verify styling at all breakpoints
- Verify IPv4 can be transferred just the same

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support


