### PR TITLE
fix: [M3-7741] - Hide error notices for $0 regions in Resize Pool and Add a Node Pool drawers

### DIFF
--- a/packages/manager/.changeset/pr-10157-fixed-1707328749030.md
+++ b/packages/manager/.changeset/pr-10157-fixed-1707328749030.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Hide error notices for $0 regions for LKE Resize and Add Node Pools ([#10157](https://github.com/linode/manager/pull/10157))
+Error notices for $0 regions in LKE Resize and Add Node Pools drawers ([#10157](https://github.com/linode/manager/pull/10157))

--- a/packages/manager/.changeset/pr-10157-fixed-1707328749030.md
+++ b/packages/manager/.changeset/pr-10157-fixed-1707328749030.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Hide error notices for $0 regions for LKE Resize and Add Node Pools ([#10157](https://github.com/linode/manager/pull/10157))

--- a/packages/manager/cypress/support/constants/dc-specific-pricing.ts
+++ b/packages/manager/cypress/support/constants/dc-specific-pricing.ts
@@ -75,9 +75,10 @@ export const dcPricingMockLinodeTypes = linodeTypeFactory.buildList(3, {
       monthly: 12.2,
     },
     {
-      hourly: 0.006,
+      // Mock a DC with $0 region prices, which is possible in some circumstances (e.g. Limited Availability).
+      hourly: 0.0,
       id: 'us-southeast',
-      monthly: 4.67,
+      monthly: 0.0,
     },
   ],
 });

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
@@ -100,11 +100,13 @@ export const AddNodePoolDrawer = (props: Props) => {
 
   const pricePerNode = getLinodeRegionPrice(selectedType, clusterRegionId)
     ?.monthly;
+  const isInvalidPricePerNode = !pricePerNode && pricePerNode !== 0;
 
   const totalPrice =
-    selectedTypeInfo && pricePerNode
+    selectedTypeInfo && !isInvalidPricePerNode
       ? selectedTypeInfo.count * pricePerNode
       : undefined;
+  const isInvalidTotalPrice = !totalPrice && totalPrice !== 0;
 
   React.useEffect(() => {
     if (open) {
@@ -199,7 +201,7 @@ export const AddNodePoolDrawer = (props: Props) => {
             />
           )}
 
-        {selectedTypeInfo && !totalPrice && !pricePerNode && (
+        {selectedTypeInfo && isInvalidPricePerNode && isInvalidTotalPrice && (
           <Notice
             spacingBottom={16}
             spacingTop={8}
@@ -229,7 +231,10 @@ export const AddNodePoolDrawer = (props: Props) => {
           )}
           <ActionsPanel
             primaryButtonProps={{
-              disabled: !selectedTypeInfo,
+              disabled:
+                !selectedTypeInfo ||
+                isInvalidTotalPrice ||
+                isInvalidPricePerNode,
               label: 'Add pool',
               loading: isLoading,
               onClick: handleAdd,

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
@@ -201,7 +201,7 @@ export const AddNodePoolDrawer = (props: Props) => {
             />
           )}
 
-        {selectedTypeInfo && isInvalidPricePerNode && isInvalidTotalPrice && (
+        {selectedTypeInfo && (isInvalidPricePerNode || isInvalidTotalPrice) && (
           <Notice
             spacingBottom={16}
             spacingTop={8}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
@@ -1,4 +1,5 @@
 import { Theme } from '@mui/material/styles';
+import { isNumber } from 'lodash';
 import * as React from 'react';
 import { makeStyles } from 'tss-react/mui';
 
@@ -20,6 +21,7 @@ import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
 
 import { KubernetesPlansPanel } from '../../KubernetesPlansPanel/KubernetesPlansPanel';
 import { nodeWarning } from '../../kubeUtils';
+import { hasInvalidNodePoolPrice } from './utils';
 
 import type { Region } from '@linode/api-v4';
 
@@ -100,13 +102,13 @@ export const AddNodePoolDrawer = (props: Props) => {
 
   const pricePerNode = getLinodeRegionPrice(selectedType, clusterRegionId)
     ?.monthly;
-  const isInvalidPricePerNode = !pricePerNode && pricePerNode !== 0;
 
   const totalPrice =
-    selectedTypeInfo && !isInvalidPricePerNode
+    selectedTypeInfo && isNumber(pricePerNode)
       ? selectedTypeInfo.count * pricePerNode
       : undefined;
-  const isInvalidTotalPrice = !totalPrice && totalPrice !== 0;
+
+  const hasInvalidPrice = hasInvalidNodePoolPrice(pricePerNode, totalPrice);
 
   React.useEffect(() => {
     if (open) {
@@ -201,7 +203,7 @@ export const AddNodePoolDrawer = (props: Props) => {
             />
           )}
 
-        {selectedTypeInfo && (isInvalidPricePerNode || isInvalidTotalPrice) && (
+        {selectedTypeInfo && hasInvalidPrice && (
           <Notice
             spacingBottom={16}
             spacingTop={8}
@@ -231,10 +233,7 @@ export const AddNodePoolDrawer = (props: Props) => {
           )}
           <ActionsPanel
             primaryButtonProps={{
-              disabled:
-                !selectedTypeInfo ||
-                isInvalidTotalPrice ||
-                isInvalidPricePerNode,
+              disabled: !selectedTypeInfo || hasInvalidPrice,
               label: 'Add pool',
               loading: isLoading,
               onClick: handleAdd,

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/ResizeNodePoolDrawer.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/ResizeNodePoolDrawer.test.tsx
@@ -26,18 +26,19 @@ describe('ResizeNodePoolDrawer', () => {
     await findByText(/linode 1 GB/i);
   });
 
-  it('should display a warning if the user tries to resize a node pool to < 3 nodes', () => {
-    const { getByText } = renderWithTheme(
+  it('should display a warning if the user tries to resize a node pool to < 3 nodes', async () => {
+    const { findByText } = renderWithTheme(
       <ResizeNodePoolDrawer {...props} nodePool={smallPool} />
     );
-    expect(getByText(/minimum of 3 nodes/i));
+    expect(await findByText(/minimum of 3 nodes/i));
   });
 
-  it('should display a warning if the user tries to resize to a smaller node count', () => {
-    const { getByTestId, getByText } = renderWithTheme(
+  it('should display a warning if the user tries to resize to a smaller node count', async () => {
+    const { findByTestId, getByText } = renderWithTheme(
       <ResizeNodePoolDrawer {...props} />
     );
-    const decrement = getByTestId('decrement-button');
+
+    const decrement = await findByTestId('decrement-button');
     fireEvent.click(decrement);
     expect(getByText(/resizing to fewer nodes/i));
   });

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/ResizeNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/ResizeNodePoolDrawer.tsx
@@ -117,79 +117,82 @@ export const ResizeNodePoolDrawer = (props: Props) => {
       open={open}
       title={`Resize Pool: ${planType?.formattedLabel ?? 'Unknown'} Plan`}
     >
-      {isLoadingTypes && <CircleProgress />}
-      <form
-        onSubmit={(e: React.ChangeEvent<HTMLFormElement>) => {
-          e.preventDefault();
-          handleSubmit();
-        }}
-      >
-        <div className={classes.section}>
-          <Typography className={classes.summary}>
-            Current pool: $
-            {renderMonthlyPriceToCorrectDecimalPlace(totalMonthlyPrice)}
-            /month ({pluralize('node', 'nodes', nodePool.count)} at $
-            {renderMonthlyPriceToCorrectDecimalPlace(pricePerNode)}
-            /month)
-          </Typography>
-        </div>
+      {isLoadingTypes ? (
+        <CircleProgress />
+      ) : (
+        <form
+          onSubmit={(e: React.ChangeEvent<HTMLFormElement>) => {
+            e.preventDefault();
+            handleSubmit();
+          }}
+        >
+          <div className={classes.section}>
+            <Typography className={classes.summary}>
+              Current pool: $
+              {renderMonthlyPriceToCorrectDecimalPlace(totalMonthlyPrice)}
+              /month ({pluralize('node', 'nodes', nodePool.count)} at $
+              {renderMonthlyPriceToCorrectDecimalPlace(pricePerNode)}
+              /month)
+            </Typography>
+          </div>
 
-        {error && <Notice text={error?.[0].reason} variant="error" />}
+          {error && <Notice text={error?.[0].reason} variant="error" />}
 
-        <div className={classes.section}>
-          <Typography className={classes.helperText}>
-            Enter the number of nodes you'd like in this pool:
-          </Typography>
-          <EnhancedNumberInput
-            min={1}
-            setValue={handleChange}
-            value={updatedCount}
-          />
-        </div>
-
-        <div className={classes.section}>
-          {/* Renders total pool price/month for N nodes at price per node/month. */}
-          <Typography className={classes.summary}>
-            {`Resized pool: $${renderMonthlyPriceToCorrectDecimalPlace(
-              !isInvalidPricePerNode ? updatedCount * pricePerNode : undefined
-            )}/month`}{' '}
-            ({pluralize('node', 'nodes', updatedCount)} at $
-            {renderMonthlyPriceToCorrectDecimalPlace(pricePerNode)}
-            /month)
-          </Typography>
-        </div>
-
-        {updatedCount < nodePool.count && (
-          <Notice important text={resizeWarning} variant="warning" />
-        )}
-
-        {updatedCount < 3 && (
-          <Notice important text={nodeWarning} variant="warning" />
-        )}
-
-        {nodePool.count &&
-          (isInvalidPricePerNode || isInvalidTotalMonthlyPrice) && (
-            <Notice
-              spacingBottom={16}
-              spacingTop={8}
-              text={PRICES_RELOAD_ERROR_NOTICE_TEXT}
-              variant="error"
+          <div className={classes.section}>
+            <Typography className={classes.helperText}>
+              Enter the number of nodes you'd like in this pool:
+            </Typography>
+            <EnhancedNumberInput
+              min={1}
+              setValue={handleChange}
+              value={updatedCount}
             />
+          </div>
+
+          <div className={classes.section}>
+            {/* Renders total pool price/month for N nodes at price per node/month. */}
+            <Typography className={classes.summary}>
+              {`Resized pool: $${renderMonthlyPriceToCorrectDecimalPlace(
+                !isInvalidPricePerNode ? updatedCount * pricePerNode : undefined
+              )}/month`}{' '}
+              ({pluralize('node', 'nodes', updatedCount)} at $
+              {renderMonthlyPriceToCorrectDecimalPlace(pricePerNode)}
+              /month)
+            </Typography>
+          </div>
+
+          {updatedCount < nodePool.count && (
+            <Notice important text={resizeWarning} variant="warning" />
           )}
 
-        <ActionsPanel
-          primaryButtonProps={{
-            'data-testid': 'submit',
-            disabled:
-              updatedCount === nodePool.count ||
-              isInvalidPricePerNode ||
-              isInvalidTotalMonthlyPrice,
-            label: 'Save Changes',
-            loading: isLoading,
-            onClick: handleSubmit,
-          }}
-        />
-      </form>
+          {updatedCount < 3 && (
+            <Notice important text={nodeWarning} variant="warning" />
+          )}
+
+          {nodePool.count &&
+            (isInvalidPricePerNode || isInvalidTotalMonthlyPrice) && (
+              <Notice
+                spacingBottom={16}
+                spacingTop={8}
+                text={PRICES_RELOAD_ERROR_NOTICE_TEXT}
+                variant="error"
+              />
+            )}
+
+          <ActionsPanel
+            primaryButtonProps={{
+              'data-testid': 'submit',
+              disabled:
+                updatedCount === nodePool.count ||
+                isInvalidPricePerNode ||
+                isInvalidTotalMonthlyPrice,
+              label: 'Save Changes',
+              loading: isLoading,
+              onClick: handleSubmit,
+            }}
+          />
+        </form>
+      )}
     </Drawer>
   );
 };

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/utils.test.ts
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/utils.test.ts
@@ -1,0 +1,19 @@
+import { hasInvalidNodePoolPrice } from './utils';
+
+describe('hasInvalidNodePoolPrice', () => {
+  it('returns false if the prices are both zero, which is valid', () => {
+    expect(hasInvalidNodePoolPrice(0, 0)).toBe(false);
+  });
+
+  it('returns true if at least one of the prices is undefined', () => {
+    expect(hasInvalidNodePoolPrice(0, undefined)).toBe(true);
+    expect(hasInvalidNodePoolPrice(undefined, 0)).toBe(true);
+    expect(hasInvalidNodePoolPrice(undefined, undefined)).toBe(true);
+  });
+
+  it('returns true if at least one of the prices is null', () => {
+    expect(hasInvalidNodePoolPrice(0, null)).toBe(true);
+    expect(hasInvalidNodePoolPrice(null, 0)).toBe(true);
+    expect(hasInvalidNodePoolPrice(null, null)).toBe(true);
+  });
+});

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/utils.ts
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/utils.ts
@@ -1,0 +1,13 @@
+/**
+ * Checks whether prices are valid - 0 is valid, but undefined and null prices are invalid.
+ * @returns true if either value is null or undefined
+ */
+export const hasInvalidNodePoolPrice = (
+  pricePerNode: null | number | undefined,
+  totalPrice: null | number | undefined
+) => {
+  const isInvalidPricePerNode = !pricePerNode && pricePerNode !== 0;
+  const isInvalidTotalPrice = !totalPrice && totalPrice !== 0;
+
+  return isInvalidPricePerNode || isInvalidTotalPrice;
+};


### PR DESCRIPTION
## Description 📝
This PR supports $0 region pricing by correctly showing pricing without errors on the LKE Details page. It also fixes the UI for invalid (`null` or `undefined`) prices in the Resize Pool drawer.

Currently, once a user creates a LKE cluster in a region where pricing is $0 (currently: Madrid, which is in LA):

When trying to **resize pool**, the UI displays a confusing `0` in place of the "Current pool" and "Resized pool" calculations, the pricing error is displayed, but a user is actually still able to complete the resize because the enhanced number input is still clickable and can be incremented, at which point the user can save changes.

When trying to **add a node pool**, after adding at lease one node, the UI displays a pricing error and pricing display text with $--.-- placeholder pricing in it. The user can still save changes.

## Changes  🔄

Resize Pool:

- The user is able to resize pool for an LKE cluster in a region where pricing is $0 and sees no error notice.
- The user is not able to resize pool for an LKE cluster with pricing that is null or undefined.
- If pricing is null or undefined, correctly display placeholder copy
   - Current pool: $--.–-/month (`N` node(s) at $--.--/month)
   - Resized pool: $--.–-/month (`N` node(s) at $--.--/month)
and the pricing error rather than just `0`.

Add a Node Pool:

- The user is able to add nodes to an LKE cluster in a region where pricing is $0 and sees no error notice.
- The user is not able to add nodes to an LKE cluster with pricing that is null or undefined.
- If pricing is null or undefined, correctly display placeholder copy
   - This pool will add $--.--/month (`N` node(s) at $--.--/month) to this cluster.
  
## Preview 📷

| Description | Before  | After   |
| ------- | ------- | ------- |
| Resize Pool: Region with $0 pricing (currently `Madrid`) | ![Screenshot 2024-02-06 at 3 04 04 PM](https://github.com/linode/manager/assets/114685994/40d3eaac-624c-4c59-9275-ddfce2e920b3) | ![Screenshot 2024-02-07 at 8 19 57 AM](https://github.com/linode/manager/assets/114685994/63f41b15-9b07-4c52-b533-23e0d89f51e2) |
| Resize Pool: `undefined` or `null` pricing | ![Screenshot 2024-02-07 at 9 28 16 AM](https://github.com/linode/manager/assets/114685994/e99181c6-73d0-41ec-9f65-9e06fa49dc49) |  ![Screenshot 2024-02-07 at 9 28 57 AM](https://github.com/linode/manager/assets/114685994/cc81b249-e017-498e-b7eb-c783c550373b) |
| Add a Node Pool: Region with $0 pricing (currently `Madrid`) | ![Screenshot 2024-02-06 at 5 18 32 PM](https://github.com/linode/manager/assets/114685994/72f3130b-bca5-4b4e-9e33-6e83901e7179) | ![Screenshot 2024-02-07 at 8 20 11 AM](https://github.com/linode/manager/assets/114685994/cb9263e6-eeb5-4787-afc3-06fe46f5324c) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Check out this PR and `yarn dev`.
- Create a LKE cluster with `es-madrid` as its region.

### Reproduction steps
(How to reproduce the issue, if applicable)

Resize Pool:
- Navigate to the cluster's details page and click Resize Pool.
- Observe the described/screenshotted issues with the drawer.

Add a Node Pool:
- Navigate to the cluster's details page and click Add a Node Pool.
- Add at least one node to the pool (press the + icon)
- Observe the described/screenshotted issues with the drawer.

### Verification steps 
(How to verify changes)
- On this branch, follow the repro steps and observe that there are no errors for a region with $0 pricing when Resizing Pool or Adding a Node Pool.
- To test behavior with pricing that is `undefined` (same behavior as `null`), block network requests to the linode type (example: `v4/linode/types/g6-standard-1`) or manually edit the values of `pricePerNode` and `totalMonthlyPrice` ([here](https://github.com/linode/manager/pull/10157/files#diff-4aa000018d57c7b8f63c48250b5ceed1226b865b8f94c646e13be0ea80a9212fR101-R108), [here](https://github.com/linode/manager/pull/10157/files#diff-5b950e50fea1b821958b0b26e5096df0cd8a67318b9e288dbdbf81e8f04eb3b1R98-R108)).
- Confirm test passes with added coverage for resizing and adding to node pool in $0 regions:
```
yarn cy:run -s "cypress/e2e/core/kubernetes/lke-update.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
