### PR TITLE
fix: [M3-7746] - Fix $0 region price error in "Enable All Backups" drawer

### DIFF
--- a/packages/manager/.changeset/pr-10161-fixed-1707341493849.md
+++ b/packages/manager/.changeset/pr-10161-fixed-1707341493849.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Error in Enable All Backups drawer when one or more Linode is in a $0 region ([#10161](https://github.com/linode/manager/pull/10161))

--- a/packages/manager/cypress/e2e/core/linodes/backup-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/backup-linode.spec.ts
@@ -270,15 +270,21 @@ describe('"Enable Linode Backups" banner', () => {
       // See `dcPricingMockLinodeTypes` exported from `support/constants/dc-specific-pricing.ts`.
       linodeFactory.build({
         label: randomLabel(),
-        region: 'us-east',
+        region: 'us-ord',
         backups: { enabled: false },
         type: dcPricingMockLinodeTypesForBackups[0].id,
       }),
       linodeFactory.build({
         label: randomLabel(),
-        region: 'us-west',
+        region: 'us-east',
         backups: { enabled: false },
         type: dcPricingMockLinodeTypesForBackups[1].id,
+      }),
+      linodeFactory.build({
+        label: randomLabel(),
+        region: 'us-west',
+        backups: { enabled: false },
+        type: dcPricingMockLinodeTypesForBackups[2].id,
       }),
       linodeFactory.build({
         label: randomLabel(),
@@ -317,6 +323,7 @@ describe('"Enable Linode Backups" banner', () => {
 
     // The expected backup price for each Linode, as shown in backups drawer table.
     const expectedPrices = [
+      '$0.00/mo', // us-ord mocked price.
       '$3.57/mo', // us-east mocked price.
       '$4.17/mo', // us-west mocked price.
       '$2.00/mo', // regular price.
@@ -377,6 +384,10 @@ describe('"Enable Linode Backups" banner', () => {
             .closest('tr')
             .within(() => {
               cy.findByText(expectedPrice).should('be.visible');
+              // Confirm no error indicator appears for $0.00 prices.
+              cy.findByLabelText(
+                'There was an error loading the price.'
+              ).should('not.exist');
             });
         });
 

--- a/packages/manager/cypress/e2e/core/linodes/backup-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/backup-linode.spec.ts
@@ -365,7 +365,7 @@ describe('"Enable Linode Backups" banner', () => {
         );
 
         // Confirm that expected total cost is shown.
-        cy.contains(`Total for 3 Linodes: ${expectedTotal}`).should(
+        cy.contains(`Total for 4 Linodes: ${expectedTotal}`).should(
           'be.visible'
         );
 
@@ -409,7 +409,7 @@ describe('"Enable Linode Backups" banner', () => {
     cy.wait([...enableBackupAliases, '@updateAccountSettings']);
 
     ui.toast.assertMessage(
-      '3 Linodes have been enrolled in automatic backups, and all new Linodes will automatically be backed up.'
+      '4 Linodes have been enrolled in automatic backups, and all new Linodes will automatically be backed up.'
     );
   });
 });

--- a/packages/manager/cypress/support/constants/dc-specific-pricing.ts
+++ b/packages/manager/cypress/support/constants/dc-specific-pricing.ts
@@ -93,6 +93,11 @@ export const dcPricingMockLinodeTypesForBackups = linodeTypeFactory.buildList(
         },
         region_prices: [
           {
+            hourly: 0,
+            id: 'us-ord',
+            monthly: 0,
+          },
+          {
             hourly: 0.0048,
             id: 'us-east',
             monthly: 3.57,

--- a/packages/manager/src/factories/index.ts
+++ b/packages/manager/src/factories/index.ts
@@ -41,6 +41,7 @@ export * from './statusPage';
 export * from './subnets';
 export * from './support';
 export * from './tags';
+export * from './types';
 export * from './volume';
 export * from './vlans';
 export * from './vpcs';

--- a/packages/manager/src/features/Backups/BackupDrawer.test.tsx
+++ b/packages/manager/src/features/Backups/BackupDrawer.test.tsx
@@ -1,0 +1,172 @@
+import * as React from 'react';
+import {
+  accountSettingsFactory,
+  linodeFactory,
+  typeFactory,
+} from 'src/factories';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { BackupDrawer } from './BackupDrawer';
+
+const queryMocks = vi.hoisted(() => ({
+  useAllLinodesQuery: vi.fn().mockReturnValue({
+    data: undefined,
+  }),
+  useAllTypes: vi.fn().mockReturnValue({
+    data: undefined,
+  }),
+  useTypeQuery: vi.fn().mockReturnValue({
+    data: undefined,
+  }),
+  useAccountSettings: vi.fn().mockReturnValue({
+    data: undefined,
+  }),
+}));
+
+vi.mock('src/queries/linodes/linodes', async () => {
+  const actual = await vi.importActual('src/queries/linodes/linodes');
+  return {
+    ...actual,
+    useAllLinodesQuery: queryMocks.useAllLinodesQuery,
+  };
+});
+
+vi.mock('src/queries/types', async () => {
+  const actual = await vi.importActual('src/queries/types');
+  return {
+    ...actual,
+    useAllTypes: queryMocks.useAllTypes,
+    useTypeQuery: queryMocks.useTypeQuery,
+  };
+});
+
+vi.mock('src/queries/accountSettings', async () => {
+  const actual = await vi.importActual('src/queries/accountSettings');
+  return {
+    ...actual,
+    useAccountSettings: queryMocks.useAccountSettings,
+  };
+});
+
+describe('BackupDrawer', () => {
+  beforeEach(() => {
+    const mockType = typeFactory.build({
+      id: 'mock-linode-type',
+      label: 'Mock Linode Type',
+      addons: {
+        backups: {
+          price: {
+            hourly: 0.004,
+            monthly: 2.5,
+          },
+          region_prices: [
+            {
+              hourly: 0,
+              id: 'es-mad',
+              monthly: 0,
+            },
+          ],
+        },
+      },
+    });
+    queryMocks.useAccountSettings.mockReturnValue({
+      data: accountSettingsFactory.build({
+        backups_enabled: false,
+      }),
+    });
+    queryMocks.useAllTypes.mockReturnValue({
+      data: [mockType],
+    });
+    queryMocks.useTypeQuery.mockReturnValue({
+      data: mockType,
+    });
+  });
+
+  describe('Total price display', () => {
+    it('displays total backup price', async () => {
+      queryMocks.useAllLinodesQuery.mockReturnValue({
+        data: [
+          linodeFactory.build({
+            region: 'es-mad',
+            type: 'mock-linode-type',
+            backups: { enabled: false },
+          }),
+          ...linodeFactory.buildList(5, {
+            region: 'us-east',
+            type: 'mock-linode-type',
+            backups: { enabled: false },
+          }),
+        ],
+      });
+
+      const { findByText } = renderWithTheme(
+        <BackupDrawer open={true} onClose={vi.fn()} />
+      );
+      expect(await findByText('Total for 6 Linodes:')).toBeVisible();
+      expect(await findByText('$12.50')).toBeVisible();
+    });
+
+    it('displays total backup price when total is $0', async () => {
+      queryMocks.useAllLinodesQuery.mockReturnValue({
+        data: [
+          linodeFactory.build({
+            region: 'es-mad',
+            type: 'mock-linode-type',
+            backups: { enabled: false },
+          }),
+        ],
+      });
+
+      const { findByText } = renderWithTheme(
+        <BackupDrawer open={true} onClose={vi.fn()} />
+      );
+      expect(await findByText('Total for 1 Linode:')).toBeVisible();
+      expect(await findByText('$0.00')).toBeVisible();
+    });
+
+    it('displays placeholder when total backup price cannot be determined', async () => {
+      queryMocks.useAllTypes.mockReturnValue({
+        data: undefined,
+      });
+
+      queryMocks.useAllLinodesQuery.mockReturnValue({
+        data: [linodeFactory.build({ backups: { enabled: false } })],
+      });
+
+      const { findByText } = renderWithTheme(
+        <BackupDrawer open={true} onClose={vi.fn()} />
+      );
+      expect(await findByText('Total for 1 Linode:')).toBeVisible();
+      expect(await findByText('$--.--')).toBeVisible();
+    });
+  });
+
+  describe('Linode list', () => {
+    it('Only lists Linodes that do not have backups enabled', async () => {
+      const mockLinodesWithBackups = linodeFactory.buildList(3, {
+        backups: { enabled: true },
+      });
+
+      const mockLinodesWithoutBackups = linodeFactory.buildList(3, {
+        backups: { enabled: false },
+      });
+
+      queryMocks.useAllLinodesQuery.mockReturnValue({
+        data: [...mockLinodesWithBackups, ...mockLinodesWithoutBackups],
+      });
+
+      const { findByText, queryByText } = renderWithTheme(
+        <BackupDrawer open={true} onClose={vi.fn()} />
+      );
+      // Confirm that Linodes without backups are listed in table.
+      /* eslint-disable no-await-in-loop */
+      for (const mockLinode of mockLinodesWithoutBackups) {
+        expect(await findByText(mockLinode.label)).toBeVisible();
+      }
+      // Confirm that Linodes with backups are not listed in table.
+      for (const mockLinode of mockLinodesWithBackups) {
+        expect(queryByText(mockLinode.label)).toBeNull();
+      }
+    });
+  });
+});

--- a/packages/manager/src/features/Backups/BackupDrawer.tsx
+++ b/packages/manager/src/features/Backups/BackupDrawer.tsx
@@ -181,9 +181,7 @@ all new Linodes will automatically be backed up.`
           &nbsp;
           <DisplayPrice
             price={
-              totalBackupsPrice && isNumber(totalBackupsPrice)
-                ? totalBackupsPrice
-                : UNKNOWN_PRICE
+              isNumber(totalBackupsPrice) ? totalBackupsPrice : UNKNOWN_PRICE
             }
             interval="mo"
           />

--- a/packages/manager/src/features/Backups/BackupLinodeRow.tsx
+++ b/packages/manager/src/features/Backups/BackupLinodeRow.tsx
@@ -32,7 +32,7 @@ export const BackupLinodeRow = (props: Props) => {
   const regionLabel =
     regions?.find((r) => r.id === linode.region)?.label ?? linode.region;
 
-  const hasErrorCell =
+  const hasInvalidPrice =
     backupsMonthlyPrice === null || backupsMonthlyPrice === undefined;
 
   return (
@@ -56,8 +56,8 @@ export const BackupLinodeRow = (props: Props) => {
       </TableCell>
       <TableCell parentColumn="Region">{regionLabel ?? 'Unknown'}</TableCell>
       <TableCell
-        errorCell={hasErrorCell}
-        errorText={hasErrorCell ? PRICE_ERROR_TOOLTIP_TEXT : undefined}
+        errorCell={hasInvalidPrice}
+        errorText={hasInvalidPrice ? PRICE_ERROR_TOOLTIP_TEXT : undefined}
         parentColumn="Price"
       >
         {`$${backupsMonthlyPrice?.toFixed(2) ?? UNKNOWN_PRICE}/mo`}

--- a/packages/manager/src/features/Backups/BackupLinodeRow.tsx
+++ b/packages/manager/src/features/Backups/BackupLinodeRow.tsx
@@ -32,6 +32,9 @@ export const BackupLinodeRow = (props: Props) => {
   const regionLabel =
     regions?.find((r) => r.id === linode.region)?.label ?? linode.region;
 
+  const hasErrorCell =
+    backupsMonthlyPrice === null || backupsMonthlyPrice === undefined;
+
   return (
     <TableRow key={`backup-linode-${linode.id}`}>
       <TableCell parentColumn="Label">
@@ -53,8 +56,8 @@ export const BackupLinodeRow = (props: Props) => {
       </TableCell>
       <TableCell parentColumn="Region">{regionLabel ?? 'Unknown'}</TableCell>
       <TableCell
-        errorCell={!Boolean(backupsMonthlyPrice)}
-        errorText={!backupsMonthlyPrice ? PRICE_ERROR_TOOLTIP_TEXT : undefined}
+        errorCell={hasErrorCell}
+        errorText={hasErrorCell ? PRICE_ERROR_TOOLTIP_TEXT : undefined}
         parentColumn="Price"
       >
         {`$${backupsMonthlyPrice?.toFixed(2) ?? UNKNOWN_PRICE}/mo`}

--- a/packages/manager/src/utilities/pricing/backups.test.tsx
+++ b/packages/manager/src/utilities/pricing/backups.test.tsx
@@ -100,4 +100,37 @@ describe('getTotalBackupsPrice', () => {
       })
     ).toBe(8.57);
   });
+
+  it('correctly calculates the total price with $0 DC-specific pricing for Linode backups', () => {
+    const basePriceLinodes = linodeFactory.buildList(2, { type: 'my-type' });
+    const zeroPriceLinode = linodeFactory.build({
+      region: 'es-mad',
+      type: 'my-type',
+    });
+    const linodes = [...basePriceLinodes, zeroPriceLinode];
+    const types = linodeTypeFactory.buildList(1, {
+      addons: {
+        backups: {
+          price: {
+            hourly: 0.004,
+            monthly: 2.5,
+          },
+          region_prices: [
+            {
+              hourly: 0,
+              id: 'es-mad',
+              monthly: 0,
+            },
+          ],
+        },
+      },
+      id: 'my-type',
+    });
+    expect(
+      getTotalBackupsPrice({
+        linodes,
+        types,
+      })
+    ).toBe(5);
+  });
 });

--- a/packages/manager/src/utilities/pricing/backups.ts
+++ b/packages/manager/src/utilities/pricing/backups.ts
@@ -75,11 +75,12 @@ export const getTotalBackupsPrice = ({
       return undefined;
     }
 
-    const backupsMonthlyPrice: PriceObject['monthly'] | undefined =
-      getMonthlyBackupsPrice({
-        region: linode.region,
-        type,
-      }) || undefined;
+    const backupsMonthlyPrice:
+      | PriceObject['monthly']
+      | undefined = getMonthlyBackupsPrice({
+      region: linode.region,
+      type,
+    });
 
     if (backupsMonthlyPrice === null || backupsMonthlyPrice === undefined) {
       return undefined;


### PR DESCRIPTION
## Description 📝
This fixes a couple issues in the "Enable All Backups" drawer when one or more Linodes are in a $0-priced region.

- Fixes calculation of total backup cost
- Removes error indicator

## Changes  🔄
List any change relevant to the reviewer.
- Fixes calculation of total backup price when one or more Linodes is in a $0 region
- Removes error indicator from backup rows for Linodes in $0 regions
- Adds and updates tests to account for these states

## Preview 📷
**Include a screenshot or screen recording of the change**

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| <img width="1048" alt="Screenshot 2024-02-07 at 1 33 36 PM" src="https://github.com/linode/manager/assets/97627410/06488726-0d30-4e72-8337-6344c71e0880"> | <img width="1194" alt="Screenshot 2024-02-07 at 4 18 30 PM" src="https://github.com/linode/manager/assets/97627410/141d6881-e537-4b41-9189-4a697ac00417"> |

## How to test 🧪
We should be able to rely on the unit tests and Cypress tests to cover this, since getting the "Enable All Linode Backups" drawer to appear can be difficult depending on the state of your account.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
