### PR TITLE
upcoming: [M3-7618] - Delete Placement Group Modal

### DIFF
--- a/packages/manager/.changeset/pr-10162-upcoming-features-1708036002117.md
+++ b/packages/manager/.changeset/pr-10162-upcoming-features-1708036002117.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add Delete Placement Group Modal ([#10162](https://github.com/linode/manager/pull/10162))

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.stories.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.stories.tsx
@@ -129,10 +129,20 @@ export const WithReadableRemoveCTA: Story = {
       return (
         <>
           <RemovableSelectionsList
+            RemoveButton={() => (
+              <Button
+                sx={(theme) => ({
+                  fontFamily: theme.font.normal,
+                  fontSize: '0.875rem',
+                })}
+                variant="text"
+              >
+                Remove
+              </Button>
+            )}
             headerText="Linodes to remove"
             noDataText="No Linodes available"
             onRemove={handleRemove}
-            removeButtonText="Remove"
             selectionData={data}
           />
           <Button onClick={resetList} sx={{ marginTop: 2 }}>

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.stories.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.stories.tsx
@@ -113,6 +113,42 @@ export const CustomHeightAndWidth: Story = {
 /**
  * Example of a RemovableSelectionsList with no data to remove
  */
+export const WithReadableRemoveCTA: Story = {
+  render: () => {
+    const SpecifiedLabelWrapper = () => {
+      const [data, setData] = React.useState(diffLabelListItems);
+
+      const handleRemove = (item: RemovableItem) => {
+        setData([...data].filter((data) => data.id !== item.id));
+      };
+
+      const resetList = () => {
+        setData([...diffLabelListItems]);
+      };
+
+      return (
+        <>
+          <RemovableSelectionsList
+            headerText="Linodes to remove"
+            noDataText="No Linodes available"
+            onRemove={handleRemove}
+            removeButtonText="Remove"
+            selectionData={data}
+          />
+          <Button onClick={resetList} sx={{ marginTop: 2 }}>
+            Reset list
+          </Button>
+        </>
+      );
+    };
+
+    return <SpecifiedLabelWrapper />;
+  },
+};
+
+/**
+ * Example of a RemovableSelectionsList with no data to remove
+ */
 export const NoDataExample: Story = {
   args: {
     headerText: 'Linodes to remove',

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.test.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.test.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
+import { Button } from '../Button/Button';
 import { RemovableSelectionsList } from './RemovableSelectionsList';
 
 const defaultList = Array.from({ length: 5 }, (_, index) => {
@@ -94,8 +95,8 @@ describe('Removable Selections List', () => {
     const { queryAllByText } = renderWithTheme(
       <RemovableSelectionsList
         {...props}
+        RemoveButton={() => <Button>Remove Linode</Button>}
         isRemovable
-        removeButtonText="Remove Linode"
       />
     );
     expect(queryAllByText('Remove Linode')).toHaveLength(5);

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.test.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.test.tsx
@@ -89,4 +89,15 @@ describe('Removable Selections List', () => {
     const removeButton = screen.queryByLabelText(`remove my-linode-1`);
     expect(removeButton).not.toBeInTheDocument();
   });
+
+  it('should render the remove button as text when removeButtonText is declared', () => {
+    const { queryAllByText } = renderWithTheme(
+      <RemovableSelectionsList
+        {...props}
+        isRemovable
+        removeButtonText="Remove Linode"
+      />
+    );
+    expect(queryAllByText('Remove Linode')).toHaveLength(5);
+  });
 });

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
@@ -2,7 +2,6 @@ import Close from '@mui/icons-material/Close';
 import * as React from 'react';
 
 import { Box } from 'src/components/Box';
-import { Button } from 'src/components/Button/Button';
 import { IconButton } from 'src/components/IconButton';
 
 import {
@@ -16,6 +15,7 @@ import {
 } from './RemovableSelectionsList.style';
 
 import type { SxProps, Theme } from '@mui/material';
+import type { ButtonProps } from 'src/components/Button/Button';
 
 export type RemovableItem = {
   id: number;
@@ -30,6 +30,11 @@ export interface RemovableSelectionsListProps {
    * The custom label component
    */
   LabelComponent?: React.ComponentType<{ selection: RemovableItem }>;
+  /**
+   * Overrides the render of the X Button
+   * Has no effect if isRemovable is false
+   */
+  RemoveButton?: (props: ButtonProps) => JSX.Element;
   /**
    * The descriptive text to display above the list
    */
@@ -65,11 +70,6 @@ export interface RemovableSelectionsListProps {
    */
   preferredDataLabel?: string;
   /**
-   * Overrides the render of the X Button
-   * Has no effect if isRemovable is false
-   */
-  removeButtonText?: string;
-  /**
    * The data to display in the list
    */
   selectionData: RemovableItem[];
@@ -84,6 +84,7 @@ export const RemovableSelectionsList = (
 ) => {
   const {
     LabelComponent,
+    RemoveButton,
     headerText,
     id,
     isRemovable = true,
@@ -92,7 +93,6 @@ export const RemovableSelectionsList = (
     noDataText,
     onRemove,
     preferredDataLabel,
-    removeButtonText,
     selectionData,
     sx,
   } = props;
@@ -138,17 +138,8 @@ export const RemovableSelectionsList = (
                     )}
                   </StyledLabel>
                   {isRemovable &&
-                    (removeButtonText ? (
-                      <Button
-                        sx={(theme) => ({
-                          fontFamily: theme.font.normal,
-                          fontSize: '0.875rem',
-                        })}
-                        onClick={() => handleOnClick(selection)}
-                        variant="text"
-                      >
-                        {removeButtonText}
-                      </Button>
+                    (RemoveButton ? (
+                      <RemoveButton onClick={() => handleOnClick(selection)} />
                     ) : (
                       <IconButton
                         aria-label={`remove ${

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
@@ -2,6 +2,7 @@ import Close from '@mui/icons-material/Close';
 import * as React from 'react';
 
 import { Box } from 'src/components/Box';
+import { Button } from 'src/components/Button/Button';
 import { IconButton } from 'src/components/IconButton';
 
 import {
@@ -64,6 +65,11 @@ export interface RemovableSelectionsListProps {
    */
   preferredDataLabel?: string;
   /**
+   * Overrides the render of the X Button
+   * Has no effect if isRemovable is false
+   */
+  removeButtonText?: string;
+  /**
    * The data to display in the list
    */
   selectionData: RemovableItem[];
@@ -86,6 +92,7 @@ export const RemovableSelectionsList = (
     noDataText,
     onRemove,
     preferredDataLabel,
+    removeButtonText,
     selectionData,
     sx,
   } = props;
@@ -115,9 +122,9 @@ export const RemovableSelectionsList = (
         >
           <StyledScrollBox maxHeight={maxHeight} maxWidth={maxWidth}>
             <SelectedOptionsList
+              data-qa-selection-list
               isRemovable={isRemovable}
               ref={listRef}
-              data-qa-selection-list
             >
               {selectionData.map((selection) => (
                 <SelectedOptionsListItem alignItems="center" key={selection.id}>
@@ -130,7 +137,18 @@ export const RemovableSelectionsList = (
                       selection.label
                     )}
                   </StyledLabel>
-                  {isRemovable && (
+                  {isRemovable && removeButtonText ? (
+                    <Button
+                      sx={(theme) => ({
+                        fontFamily: theme.font.normal,
+                        fontSize: '0.875rem',
+                      })}
+                      onClick={() => handleOnClick(selection)}
+                      variant="text"
+                    >
+                      {removeButtonText}
+                    </Button>
+                  ) : (
                     <IconButton
                       aria-label={`remove ${
                         preferredDataLabel

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsList.tsx
@@ -137,31 +137,32 @@ export const RemovableSelectionsList = (
                       selection.label
                     )}
                   </StyledLabel>
-                  {isRemovable && removeButtonText ? (
-                    <Button
-                      sx={(theme) => ({
-                        fontFamily: theme.font.normal,
-                        fontSize: '0.875rem',
-                      })}
-                      onClick={() => handleOnClick(selection)}
-                      variant="text"
-                    >
-                      {removeButtonText}
-                    </Button>
-                  ) : (
-                    <IconButton
-                      aria-label={`remove ${
-                        preferredDataLabel
-                          ? selection[preferredDataLabel]
-                          : selection.label
-                      }`}
-                      disableRipple
-                      onClick={() => handleOnClick(selection)}
-                      size="medium"
-                    >
-                      <Close />
-                    </IconButton>
-                  )}
+                  {isRemovable &&
+                    (removeButtonText ? (
+                      <Button
+                        sx={(theme) => ({
+                          fontFamily: theme.font.normal,
+                          fontSize: '0.875rem',
+                        })}
+                        onClick={() => handleOnClick(selection)}
+                        variant="text"
+                      >
+                        {removeButtonText}
+                      </Button>
+                    ) : (
+                      <IconButton
+                        aria-label={`remove ${
+                          preferredDataLabel
+                            ? selection[preferredDataLabel]
+                            : selection.label
+                        }`}
+                        disableRipple
+                        onClick={() => handleOnClick(selection)}
+                        size="medium"
+                      >
+                        <Close />
+                      </IconButton>
+                    ))}
                 </SelectedOptionsListItem>
               ))}
             </SelectedOptionsList>

--- a/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
+++ b/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
@@ -25,7 +25,7 @@ interface EntityInfo {
     | 'Linode'
     | 'Load Balancer'
     | 'NodeBalancer'
-    | 'Placement Groups'
+    | 'Placement Group'
     | 'Subnet'
     | 'VPC'
     | 'Volume';

--- a/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
+++ b/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
@@ -25,6 +25,7 @@ interface EntityInfo {
     | 'Linode'
     | 'Load Balancer'
     | 'NodeBalancer'
+    | 'Placement Group'
     | 'Subnet'
     | 'VPC'
     | 'Volume';

--- a/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
+++ b/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
@@ -50,6 +50,7 @@ export const TypeToConfirmDialog = (props: CombinedProps) => {
     children,
     entity,
     errors,
+    inputProps,
     label,
     loading,
     onClick,
@@ -121,6 +122,7 @@ export const TypeToConfirmDialog = (props: CombinedProps) => {
         data-testid={'dialog-confirm-text-input'}
         expand
         hideInstructions={entity.subType === 'CloseAccount'}
+        inputProps={inputProps}
         label={label}
         placeholder={entity.subType === 'CloseAccount' ? 'Username' : ''}
         textFieldStyle={textFieldStyle}

--- a/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
+++ b/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
@@ -25,7 +25,7 @@ interface EntityInfo {
     | 'Linode'
     | 'Load Balancer'
     | 'NodeBalancer'
-    | 'Placement Group'
+    | 'Placement Groups'
     | 'Subnet'
     | 'VPC'
     | 'Volume';

--- a/packages/manager/src/factories/placementGroups.ts
+++ b/packages/manager/src/factories/placementGroups.ts
@@ -12,7 +12,7 @@ export const placementGroupFactory = Factory.Sync.makeFactory<PlacementGroup>({
   id: Factory.each((id) => id),
   is_compliant: Factory.each(() => pickRandom([true, false])),
   label: Factory.each((id) => `pg-${id}`),
-  linode_ids: [0, 1, 2, 3, 5, 6, 7, 8, 43],
+  linode_ids: [],
   region: 'us-east',
 });
 

--- a/packages/manager/src/factories/placementGroups.ts
+++ b/packages/manager/src/factories/placementGroups.ts
@@ -12,7 +12,7 @@ export const placementGroupFactory = Factory.Sync.makeFactory<PlacementGroup>({
   id: Factory.each((id) => id),
   is_compliant: Factory.each(() => pickRandom([true, false])),
   label: Factory.each((id) => `pg-${id}`),
-  linode_ids: [],
+  linode_ids: [0, 1, 2, 3, 5, 6, 7, 8, 43],
   region: 'us-east',
 });
 

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.test.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent } from '@testing-library/react';
+import * as React from 'react';
+
+import { placementGroupFactory } from 'src/factories';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { PlacementGroupsDeleteModal } from './PlacementGroupsDeleteModal';
+
+const queryMocks = vi.hoisted(() => ({
+  useDeletePlacementGroup: vi.fn().mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+  }),
+}));
+
+vi.mock('src/queries/placementGroups', async () => {
+  const actual = await vi.importActual('src/queries/placementGroups');
+  return {
+    ...actual,
+    useDeletePlacementGroup: queryMocks.useDeletePlacementGroup,
+  };
+});
+
+describe('PlacementGroupsDeleteModal', () => {
+  it('should render the right form elements', () => {
+    const props = {
+      onClose: vi.fn(),
+      open: true,
+      selectedPlacementGroup: placementGroupFactory.build({
+        affinity_type: 'anti_affinity',
+        label: 'PG-to-delete',
+      }),
+    };
+    const { getByRole } = renderWithTheme(
+      <PlacementGroupsDeleteModal {...props} />
+    );
+
+    expect(
+      getByRole('heading', {
+        name: 'Delete Placement Group PG-to-delete (Anti-affinity)',
+      })
+    ).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Close' })).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+
+    const textBox = getByRole('textbox', { name: 'Placement Group' });
+    const deleteButton = getByRole('button', { name: 'Delete' });
+
+    fireEvent.change(textBox, { target: { value: 'PG-to-delete' } });
+
+    expect(deleteButton).toBeEnabled();
+
+    fireEvent.click(deleteButton);
+
+    expect(queryMocks.useDeletePlacementGroup).toHaveBeenCalled();
+  });
+});

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.test.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.test.tsx
@@ -1,36 +1,77 @@
 import { fireEvent } from '@testing-library/react';
 import * as React from 'react';
 
-import { placementGroupFactory } from 'src/factories';
+import { linodeFactory, placementGroupFactory } from 'src/factories';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { PlacementGroupsDeleteModal } from './PlacementGroupsDeleteModal';
 
 const queryMocks = vi.hoisted(() => ({
+  useAllLinodesQuery: vi.fn().mockReturnValue({}),
   useDeletePlacementGroup: vi.fn().mockReturnValue({
     mutateAsync: vi.fn().mockResolvedValue({}),
+    reset: vi.fn(),
   }),
+  useParams: vi.fn().mockReturnValue({}),
+  usePlacementGroupQuery: vi.fn().mockReturnValue({}),
 }));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useParams: queryMocks.useParams,
+  };
+});
 
 vi.mock('src/queries/placementGroups', async () => {
   const actual = await vi.importActual('src/queries/placementGroups');
   return {
     ...actual,
     useDeletePlacementGroup: queryMocks.useDeletePlacementGroup,
+    usePlacementGroupQuery: queryMocks.usePlacementGroupQuery,
   };
 });
 
+vi.mock('src/queries/linodes/linodes', async () => {
+  const actual = await vi.importActual('src/queries/linodes/linodes');
+  return {
+    ...actual,
+    useAllLinodesQuery: queryMocks.useAllLinodesQuery,
+  };
+});
+
+const props = {
+  onClose: vi.fn(),
+  open: true,
+};
+
 describe('PlacementGroupsDeleteModal', () => {
+  beforeAll(() => {
+    queryMocks.useParams.mockReturnValue({
+      id: '1',
+    });
+    queryMocks.useAllLinodesQuery.mockReturnValue({
+      data: [
+        linodeFactory.build({
+          id: 1,
+          label: 'test-linode',
+        }),
+      ],
+    });
+  });
+
   it('should render the right form elements', () => {
-    const props = {
-      onClose: vi.fn(),
-      open: true,
-      selectedPlacementGroup: placementGroupFactory.build({
+    queryMocks.usePlacementGroupQuery.mockReturnValue({
+      data: placementGroupFactory.build({
         affinity_type: 'anti_affinity',
+        id: 1,
         label: 'PG-to-delete',
+        linode_ids: [1],
       }),
-    };
-    const { getByRole } = renderWithTheme(
+    });
+
+    const { getByRole, getByTestId, getByText } = renderWithTheme(
       <PlacementGroupsDeleteModal {...props} />
     );
 
@@ -39,17 +80,44 @@ describe('PlacementGroupsDeleteModal', () => {
         name: 'Delete Placement Group PG-to-delete (Anti-affinity)',
       })
     ).toBeInTheDocument();
+    expect(
+      getByText(
+        'Linodes assigned to Placement Group PG-to-delete (Anti-affinity)'
+      )
+    ).toBeInTheDocument();
+    expect(getByTestId('assigned-linodes')).toContainElement(
+      getByText('test-linode')
+    );
+    expect(getByTestId('textfield-input')).toBeDisabled();
     expect(getByRole('button', { name: 'Close' })).toBeInTheDocument();
     expect(getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
-    expect(getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Delete' })).toBeDisabled();
+  });
 
-    const textBox = getByRole('textbox', { name: 'Placement Group' });
+  it("should be enabled when there's no assigned linodes", () => {
+    queryMocks.usePlacementGroupQuery.mockReturnValue({
+      data: placementGroupFactory.build({
+        affinity_type: 'anti_affinity',
+        id: 1,
+        label: 'PG-to-delete',
+        linode_ids: [],
+      }),
+    });
+    const { getByRole, getByTestId, getByText } = renderWithTheme(
+      <PlacementGroupsDeleteModal {...props} />
+    );
+
+    expect(getByText('No Linodes assigned to this Placement Group.'));
+
+    const textField = getByTestId('textfield-input');
     const deleteButton = getByRole('button', { name: 'Delete' });
 
-    fireEvent.change(textBox, { target: { value: 'PG-to-delete' } });
+    expect(textField).toBeEnabled();
+    expect(deleteButton).toBeDisabled();
+
+    fireEvent.change(textField, { target: { value: 'PG-to-delete' } });
 
     expect(deleteButton).toBeEnabled();
-
     fireEvent.click(deleteButton);
 
     expect(queryMocks.useDeletePlacementGroup).toHaveBeenCalled();

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -33,7 +33,7 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
   );
   const {
     data: assignedLinodes,
-    // error: assignedLinodesError,
+    error: assignedLinodesError,
   } = useAllLinodesQuery(
     {},
     {
@@ -46,20 +46,23 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
     error: deletePlacementError,
     isLoading,
     mutateAsync: deletePlacementGroup,
-    reset,
+    reset: resetDeletePlacementGroup,
   } = useDeletePlacementGroup(selectedPlacementGroup?.id ?? -1);
   const {
     error: unassignLinodeError,
     mutateAsync: unassignLinodes,
+    reset: resetUnassignLinodes,
   } = useUnassignLinodesFromPlacementGroup(selectedPlacementGroup?.id ?? -1);
 
-  const error = deletePlacementError ?? unassignLinodeError;
+  const error =
+    deletePlacementError || unassignLinodeError || assignedLinodesError;
 
   React.useEffect(() => {
     if (open) {
-      reset();
+      resetDeletePlacementGroup();
+      resetUnassignLinodes();
     }
-  }, [open, reset]);
+  }, [open, resetUnassignLinodes, resetDeletePlacementGroup]);
 
   const handleUnassignLinode = async (linode: Linode) => {
     const payload: UnassignLinodesFromPlacementGroupPayload = {

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -1,21 +1,39 @@
 import { AFFINITY_TYPES } from '@linode/api-v4';
 import * as React from 'react';
+import { useParams } from 'react-router-dom';
 
+import { List } from 'src/components/List';
+import { ListItem } from 'src/components/ListItem';
 import { Notice } from 'src/components/Notice/Notice';
+import { RemovableSelectionsList } from 'src/components/RemovableSelectionsList/RemovableSelectionsList';
 import { TypeToConfirmDialog } from 'src/components/TypeToConfirmDialog/TypeToConfirmDialog';
 import { Typography } from 'src/components/Typography';
+import { useAllLinodesQuery } from 'src/queries/linodes/linodes';
 import { useDeletePlacementGroup } from 'src/queries/placementGroups';
-
-import type { PlacementGroup } from '@linode/api-v4';
+import { usePlacementGroupQuery } from 'src/queries/placementGroups';
 
 interface Props {
   onClose: () => void;
   open: boolean;
-  selectedPlacementGroup: PlacementGroup | undefined;
 }
 
 export const PlacementGroupsDeleteModal = (props: Props) => {
-  const { onClose, open, selectedPlacementGroup } = props;
+  const { onClose, open } = props;
+  const { placementGroupId } = useParams<{ placementGroupId: string }>();
+  const { data: selectedPlacementGroup } = usePlacementGroupQuery(
+    +placementGroupId
+  );
+  const {
+    data: assignedLinodes,
+    // error: assignedLinodesError,
+  } = useAllLinodesQuery(
+    {},
+    {
+      '+or': selectedPlacementGroup?.linode_ids.map((id) => ({
+        id,
+      })),
+    }
+  );
   const {
     error,
     isLoading,
@@ -30,11 +48,15 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
   }, [open, reset]);
 
   const onDelete = async () => {
-    try {
-      await deletePlacementGroup();
-      onClose();
-    } catch (e) {}
+    await deletePlacementGroup();
+    onClose();
   };
+
+  const placementGroupLabel = selectedPlacementGroup
+    ? `Placement Group ${selectedPlacementGroup?.label} (${
+        AFFINITY_TYPES[selectedPlacementGroup.affinity_type]
+      })`
+    : 'Placement Group';
 
   return (
     <TypeToConfirmDialog
@@ -49,19 +71,13 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
           ? [{ reason: 'Placement Group not found.' }]
           : undefined
       }
-      title={
-        selectedPlacementGroup
-          ? `Delete Placement Group ${selectedPlacementGroup?.label} (${
-              AFFINITY_TYPES[selectedPlacementGroup?.affinity_type]
-            })`
-          : 'Delete Placement Group'
-      }
       disabled={!selectedPlacementGroup}
       label="Placement Group"
       loading={isLoading}
       onClick={onDelete}
       onClose={onClose}
       open={open}
+      title={`Delete ${placementGroupLabel}`}
     >
       {error && (
         <Notice
@@ -70,12 +86,41 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
           variant="error"
         />
       )}
-      <Notice variant="warning">
+
+      <Notice spacingTop={8} variant="warning">
         <Typography>
-          <strong>Warning:</strong> deleting a placement group is permanent and
-          can’t be undone.
+          <strong>Warning:</strong>
         </Typography>
+        <List
+          sx={(theme) => ({
+            '& > li': {
+              display: 'list-item',
+              fontSize: '0.875rem',
+              pb: theme.spacing(),
+              pl: 0,
+            },
+            listStyle: 'disc',
+            ml: theme.spacing(2),
+            mt: theme.spacing(),
+          })}
+        >
+          <ListItem>
+            deleting a placement group is permanent and can’t be undone.
+          </ListItem>
+          <ListItem>
+            You need to unassign all Linodes before deleting a placement group.
+          </ListItem>
+        </List>
       </Notice>
+      <RemovableSelectionsList
+        headerText={`Linodes assigned to ${placementGroupLabel}`}
+        maxWidth={540}
+        noDataText="No Linodes assigned to this Placement Group."
+        onRemove={() => null}
+        removeButtonText="Unassign"
+        selectionData={assignedLinodes ?? []}
+        sx={{ mb: 3, mt: 1 }}
+      />
     </TypeToConfirmDialog>
   );
 };

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -24,7 +24,7 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
   } = useDeletePlacementGroup(selectedPlacementGroup?.id ?? -1);
 
   React.useEffect(() => {
-    if (!open) {
+    if (open) {
       reset();
     }
   }, [open, reset]);
@@ -44,6 +44,11 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
         primaryBtnText: 'Delete',
         type: 'Placement Groups',
       }}
+      errors={
+        !selectedPlacementGroup
+          ? [{ reason: 'Placement Group not found.' }]
+          : undefined
+      }
       title={
         selectedPlacementGroup
           ? `Delete Placement Group ${selectedPlacementGroup?.label} (${
@@ -51,7 +56,7 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
             })`
           : 'Delete Placement Group'
       }
-      disabled={selectedPlacementGroup === undefined}
+      disabled={!selectedPlacementGroup}
       label="Placement Group"
       loading={isLoading}
       onClick={onDelete}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -1,0 +1,56 @@
+import { AFFINITY_TYPES } from '@linode/api-v4';
+import * as React from 'react';
+
+import { Notice } from 'src/components/Notice/Notice';
+import { TypeToConfirmDialog } from 'src/components/TypeToConfirmDialog/TypeToConfirmDialog';
+import { useDeletePlacementGroup } from 'src/queries/placementGroups';
+
+import type { PlacementGroup } from '@linode/api-v4';
+
+interface Props {
+  onClose: () => void;
+  open: boolean;
+  selectedPlacementGroup: PlacementGroup | undefined;
+}
+
+export const PlacementGroupsDeleteModal = (props: Props) => {
+  const { onClose, open, selectedPlacementGroup } = props;
+  const {
+    error,
+    isLoading,
+    mutateAsync: deletePlacementGroup,
+  } = useDeletePlacementGroup(selectedPlacementGroup?.id ?? -1);
+
+  if (!selectedPlacementGroup) {
+    return null;
+  }
+
+  const onDelete = () => {
+    deletePlacementGroup().then(() => {
+      onClose();
+    });
+  };
+
+  const { affinity_type, label } = selectedPlacementGroup;
+
+  const dialogTitle = `Delete Placement Group ${label} (${AFFINITY_TYPES[affinity_type]})`;
+
+  return (
+    <TypeToConfirmDialog
+      entity={{
+        action: 'deletion',
+        name: label,
+        primaryBtnText: 'Delete',
+        type: 'Placement Group',
+      }}
+      label="Placement Group"
+      loading={isLoading}
+      onClick={onDelete}
+      onClose={onClose}
+      open={open}
+      title={dialogTitle}
+    >
+      {error && <Notice text={error?.[0]?.reason} variant="error" />}
+    </TypeToConfirmDialog>
+  );
+};

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -42,7 +42,7 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
         action: 'deletion',
         name: label,
         primaryBtnText: 'Delete',
-        type: 'Placement Group',
+        type: 'Placement Groups',
       }}
       label="Placement Group"
       loading={isLoading}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -84,7 +84,7 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
         action: 'deletion',
         name: selectedPlacementGroup?.label,
         primaryBtnText: 'Delete',
-        type: 'Placement Groups',
+        type: 'Placement Group',
       }}
       errors={
         !selectedPlacementGroup

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import { Notice } from 'src/components/Notice/Notice';
 import { TypeToConfirmDialog } from 'src/components/TypeToConfirmDialog/TypeToConfirmDialog';
+import { Typography } from 'src/components/Typography';
 import { useDeletePlacementGroup } from 'src/queries/placementGroups';
 
 import type { PlacementGroup } from '@linode/api-v4';
@@ -51,6 +52,12 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
       title={dialogTitle}
     >
       {error && <Notice text={error?.[0]?.reason} variant="error" />}
+      <Notice variant="warning">
+        <Typography>
+          <strong>Warning:</strong> deleting a placement group is permanent and
+          can’t be undone.
+        </Typography>
+      </Notice>
     </TypeToConfirmDialog>
   );
 };

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -20,38 +20,51 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
     error,
     isLoading,
     mutateAsync: deletePlacementGroup,
+    reset,
   } = useDeletePlacementGroup(selectedPlacementGroup?.id ?? -1);
 
-  if (!selectedPlacementGroup) {
-    return null;
-  }
+  React.useEffect(() => {
+    if (!open) {
+      reset();
+    }
+  }, [open, reset]);
 
-  const onDelete = () => {
-    deletePlacementGroup().then(() => {
+  const onDelete = async () => {
+    try {
+      await deletePlacementGroup();
       onClose();
-    });
+    } catch (e) {}
   };
-
-  const { affinity_type, label } = selectedPlacementGroup;
-
-  const dialogTitle = `Delete Placement Group ${label} (${AFFINITY_TYPES[affinity_type]})`;
 
   return (
     <TypeToConfirmDialog
       entity={{
         action: 'deletion',
-        name: label,
+        name: selectedPlacementGroup?.label,
         primaryBtnText: 'Delete',
         type: 'Placement Groups',
       }}
+      title={
+        selectedPlacementGroup
+          ? `Delete Placement Group ${selectedPlacementGroup?.label} (${
+              AFFINITY_TYPES[selectedPlacementGroup?.affinity_type]
+            })`
+          : 'Delete Placement Group'
+      }
+      disabled={selectedPlacementGroup === undefined}
       label="Placement Group"
       loading={isLoading}
       onClick={onDelete}
       onClose={onClose}
       open={open}
-      title={dialogTitle}
     >
-      {error && <Notice text={error?.[0]?.reason} variant="error" />}
+      {error && (
+        <Notice
+          key={selectedPlacementGroup?.id}
+          text={error?.[0]?.reason}
+          variant="error"
+        />
+      )}
       <Notice variant="warning">
         <Typography>
           <strong>Warning:</strong> deleting a placement group is permanent and

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -2,6 +2,7 @@ import { AFFINITY_TYPES } from '@linode/api-v4';
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
 
+import { Button } from 'src/components/Button/Button';
 import { List } from 'src/components/List';
 import { ListItem } from 'src/components/ListItem';
 import { Notice } from 'src/components/Notice/Notice';
@@ -44,6 +45,7 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
   } = useDeletePlacementGroup(selectedPlacementGroup?.id ?? -1);
   const {
     error: unassignLinodeError,
+    isLoading: unassignLinodeLoading,
     mutateAsync: unassignLinodes,
     reset: resetUnassignLinodes,
   } = useUnassignLinodesFromPlacementGroup(selectedPlacementGroup?.id ?? -1);
@@ -128,7 +130,7 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
           })}
         >
           <ListItem>
-            deleting a placement group is permanent and cannot be undone.
+            Deleting a placement group is permanent and cannot be undone.
           </ListItem>
           <ListItem>
             You need to unassign all Linodes before deleting a placement group.
@@ -136,12 +138,23 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
         </List>
       </Notice>
       <RemovableSelectionsList
+        RemoveButton={() => (
+          <Button
+            sx={(theme) => ({
+              fontFamily: theme.font.normal,
+              fontSize: '0.875rem',
+            })}
+            loading={unassignLinodeLoading}
+            variant="text"
+          >
+            Unassign
+          </Button>
+        )}
         headerText={`Linodes assigned to ${placementGroupLabel}`}
         id="assigned-linodes"
         maxWidth={540}
         noDataText="No Linodes assigned to this Placement Group."
         onRemove={handleUnassignLinode}
-        removeButtonText="Unassign"
         selectionData={assignedLinodes ?? []}
         sx={{ mb: 3, mt: 1 }}
       />

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
@@ -26,7 +26,7 @@ export const PlacementGroupsDetail = () => {
   const flags = useFlags();
   const { id, tab } = useParams<{ id: string; tab?: string }>();
   const history = useHistory();
-  const placementGroupId = Number(id);
+  const placementGroupId = +id;
 
   const {
     data: placementGroup,

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLanding.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLanding.tsx
@@ -211,7 +211,6 @@ export const PlacementGroupsLanding = React.memo(() => {
       <PlacementGroupsDeleteModal
         onClose={onClosePlacementGroupDrawer}
         open={isPlacementGroupDeleteModalOpen}
-        selectedPlacementGroup={selectedPlacementGroup}
       />
     </>
   );

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLanding.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLanding.tsx
@@ -81,7 +81,6 @@ export const PlacementGroupsLanding = React.memo(() => {
 
   const onClosePlacementGroupDrawer = () => {
     history.replace('/placement-groups');
-    setSelectedPlacementGroup(undefined);
   };
 
   const isPlacementGroupCreateDrawerOpen = location.pathname.endsWith('create');

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLanding.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLanding.tsx
@@ -22,6 +22,7 @@ import { usePlacementGroupsQuery } from 'src/queries/placementGroups';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 import { PlacementGroupsCreateDrawer } from '../PlacementGroupsCreateDrawer';
+import { PlacementGroupsDeleteModal } from '../PlacementGroupsDeleteModal';
 import { PlacementGroupsRenameDrawer } from '../PlacementGroupsRenameDrawer';
 import { PlacementGroupsLandingEmptyState } from './PlacementGroupsLandingEmptyState';
 import { PlacementGroupsRow } from './PlacementGroupsRow';
@@ -75,6 +76,7 @@ export const PlacementGroupsLanding = React.memo(() => {
 
   const handleDeletePlacementGroup = (placementGroup: PlacementGroup) => {
     setSelectedPlacementGroup(placementGroup);
+    history.replace(`/placement-groups/delete/${placementGroup.id}`);
   };
 
   const onClosePlacementGroupDrawer = () => {
@@ -84,6 +86,7 @@ export const PlacementGroupsLanding = React.memo(() => {
 
   const isPlacementGroupCreateDrawerOpen = location.pathname.endsWith('create');
   const isPlacementGroupRenameDrawerOpen = location.pathname.includes('rename');
+  const isPlacementGroupDeleteModalOpen = location.pathname.includes('delete');
 
   if (isLoading) {
     return <CircleProgress />;
@@ -206,7 +209,11 @@ export const PlacementGroupsLanding = React.memo(() => {
         open={isPlacementGroupRenameDrawerOpen}
         selectedPlacementGroup={selectedPlacementGroup}
       />
-      {/* TODO VM_Placement: add delete dialog */}
+      <PlacementGroupsDeleteModal
+        onClose={onClosePlacementGroupDrawer}
+        open={isPlacementGroupDeleteModalOpen}
+        selectedPlacementGroup={selectedPlacementGroup}
+      />
     </>
   );
 });

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsRow.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsRow.tsx
@@ -1,9 +1,9 @@
 import { AFFINITY_TYPES } from '@linode/api-v4';
 import React from 'react';
-import { Link } from 'react-router-dom';
 
 import { Hidden } from 'src/components/Hidden';
 import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
+import { Link } from 'src/components/Link';
 import { List } from 'src/components/List';
 import { ListItem } from 'src/components/ListItem';
 import { TableCell } from 'src/components/TableCell';

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsUnassignModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsUnassignModal.tsx
@@ -25,11 +25,11 @@ export const PlacementGroupsUnassignModal = (props: Props) => {
     error,
     isLoading,
     mutateAsync: unassignLinodes,
-  } = useUnassignLinodesFromPlacementGroup(Number(placementGroupId) ?? -1);
-  const { data: selectedLinode } = useLinodeQuery(Number(linodeId) ?? -1);
+  } = useUnassignLinodesFromPlacementGroup(+placementGroupId ?? -1);
+  const { data: selectedLinode } = useLinodeQuery(+linodeId ?? -1);
 
   const payload: UnassignLinodesFromPlacementGroupPayload = {
-    linodes: [Number(linodeId) ?? -1],
+    linodes: [+linodeId ?? -1],
   };
 
   const onUnassign = async () => {

--- a/packages/manager/src/features/PlacementGroups/index.tsx
+++ b/packages/manager/src/features/PlacementGroups/index.tsx
@@ -36,7 +36,6 @@ export const PlacementGroups = () => {
             exact
             path={`${path}/rename/:id`}
           />
-
           <Route
             component={PlacementGroupsLanding}
             exact

--- a/packages/manager/src/features/PlacementGroups/index.tsx
+++ b/packages/manager/src/features/PlacementGroups/index.tsx
@@ -36,6 +36,12 @@ export const PlacementGroups = () => {
             exact
             path={`${path}/rename/:id`}
           />
+
+          <Route
+            component={PlacementGroupsLanding}
+            exact
+            path={`${path}/delete/:id`}
+          />
           <Route
             component={PlacementGroupsDetail}
             path={`${path}/:id/:tab?/unassign/:linodeId?`}

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -2069,7 +2069,7 @@ export const handlers = [
     return res(ctx.json(response));
   }),
   rest.delete('*/placement/groups/:placementGroupId', (req, res, ctx) => {
-    if (req.params.placementGroupId === 'undefined') {
+    if (req.params.placementGroupId === '-1') {
       return res(ctx.status(404));
     }
 

--- a/packages/manager/src/queries/placementGroups.ts
+++ b/packages/manager/src/queries/placementGroups.ts
@@ -17,7 +17,6 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import { getAll } from 'src/utilities/getAll';
 
-import { queryKey as LINODES_QUERY_KEY } from './linodes/linodes';
 import { queryKey as PROFILE_QUERY_KEY } from './profile';
 
 import type {
@@ -119,20 +118,15 @@ export const useAssignLinodesToPlacementGroup = (placementGroupId: number) => {
   >({
     mutationFn: (data) => assignLinodesToPlacementGroup(placementGroupId, data),
     onSuccess: (updatedPlacementGroup) => {
+      // Invalidate paginated placement groups
+      queryClient.invalidateQueries([queryKey, 'paginated']);
+
       // Invalidate placement group linodes
       queryClient.invalidateQueries([
         queryKey,
         'placement-group',
         placementGroupId,
-        'linodes',
-      ]);
-
-      // Invalidate linode placement group data
-      queryClient.invalidateQueries([
-        LINODES_QUERY_KEY,
-        'linode',
-        updatedPlacementGroup.linode_ids[0],
-        'placement_groups',
+        'linode_ids',
       ]);
 
       // Set the updated placement group
@@ -156,7 +150,17 @@ export const useUnassignLinodesFromPlacementGroup = (
     mutationFn: (data) =>
       unassignLinodesFromPlacementGroup(placementGroupId, data),
     onSuccess: (updatedPlacementGroup) => {
+      // Invalidate paginated placement groups
       queryClient.invalidateQueries([queryKey, 'paginated']);
+
+      // Invalidate placement group linodes
+      queryClient.invalidateQueries([
+        queryKey,
+        'placement-group',
+        placementGroupId,
+      ]);
+
+      // Set the updated placement group
       queryClient.setQueryData(
         [queryKey, 'placement-group', placementGroupId],
         updatedPlacementGroup

--- a/packages/manager/src/queries/placementGroups.ts
+++ b/packages/manager/src/queries/placementGroups.ts
@@ -17,7 +17,6 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import { getAll } from 'src/utilities/getAll';
 
-import { queryKey as LINODES_QUERY_KEY } from './linodes/linodes';
 import { queryKey as PROFILE_QUERY_KEY } from './profile';
 
 import type {
@@ -118,27 +117,8 @@ export const useAssignLinodesToPlacementGroup = (placementGroupId: number) => {
     AssignLinodesToPlacementGroupPayload
   >({
     mutationFn: (data) => assignLinodesToPlacementGroup(placementGroupId, data),
-    onSuccess: (updatedPlacementGroup, data) => {
-      // Invalidate paginated placement groups
+    onSuccess: (updatedPlacementGroup) => {
       queryClient.invalidateQueries([queryKey, 'paginated']);
-
-      // Invalidate placement group linodes
-      queryClient.invalidateQueries([
-        queryKey,
-        'placement-group',
-        placementGroupId,
-        'linode_ids',
-      ]);
-
-      // Invalidate linode placement group data
-      queryClient.invalidateQueries([
-        LINODES_QUERY_KEY,
-        'linode',
-        data.linodes[0],
-        'placement_groups',
-      ]);
-
-      // Set the updated placement group
       queryClient.setQueryData(
         [queryKey, 'placement-group', placementGroupId],
         updatedPlacementGroup
@@ -158,26 +138,8 @@ export const useUnassignLinodesFromPlacementGroup = (
   >({
     mutationFn: (data) =>
       unassignLinodesFromPlacementGroup(placementGroupId, data),
-    onSuccess: (updatedPlacementGroup, data) => {
-      // Invalidate paginated placement groups
+    onSuccess: (updatedPlacementGroup) => {
       queryClient.invalidateQueries([queryKey, 'paginated']);
-
-      // Invalidate placement group linodes
-      queryClient.invalidateQueries([
-        queryKey,
-        'placement-group',
-        placementGroupId,
-      ]);
-
-      // Invalidate linode placement group data
-      queryClient.invalidateQueries([
-        LINODES_QUERY_KEY,
-        'linode',
-        data.linodes[0],
-        'placement_groups',
-      ]);
-
-      // Set the updated placement group
       queryClient.setQueryData(
         [queryKey, 'placement-group', placementGroupId],
         updatedPlacementGroup

--- a/packages/manager/src/queries/placementGroups.ts
+++ b/packages/manager/src/queries/placementGroups.ts
@@ -17,6 +17,7 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import { getAll } from 'src/utilities/getAll';
 
+import { queryKey as LINODES_QUERY_KEY } from './linodes/linodes';
 import { queryKey as PROFILE_QUERY_KEY } from './profile';
 
 import type {
@@ -117,7 +118,7 @@ export const useAssignLinodesToPlacementGroup = (placementGroupId: number) => {
     AssignLinodesToPlacementGroupPayload
   >({
     mutationFn: (data) => assignLinodesToPlacementGroup(placementGroupId, data),
-    onSuccess: (updatedPlacementGroup) => {
+    onSuccess: (updatedPlacementGroup, data) => {
       // Invalidate paginated placement groups
       queryClient.invalidateQueries([queryKey, 'paginated']);
 
@@ -127,6 +128,14 @@ export const useAssignLinodesToPlacementGroup = (placementGroupId: number) => {
         'placement-group',
         placementGroupId,
         'linode_ids',
+      ]);
+
+      // Invalidate linode placement group data
+      queryClient.invalidateQueries([
+        LINODES_QUERY_KEY,
+        'linode',
+        data.linodes[0],
+        'placement_groups',
       ]);
 
       // Set the updated placement group
@@ -149,7 +158,7 @@ export const useUnassignLinodesFromPlacementGroup = (
   >({
     mutationFn: (data) =>
       unassignLinodesFromPlacementGroup(placementGroupId, data),
-    onSuccess: (updatedPlacementGroup) => {
+    onSuccess: (updatedPlacementGroup, data) => {
       // Invalidate paginated placement groups
       queryClient.invalidateQueries([queryKey, 'paginated']);
 
@@ -158,6 +167,14 @@ export const useUnassignLinodesFromPlacementGroup = (
         queryKey,
         'placement-group',
         placementGroupId,
+      ]);
+
+      // Invalidate linode placement group data
+      queryClient.invalidateQueries([
+        LINODES_QUERY_KEY,
+        'linode',
+        data.linodes[0],
+        'placement_groups',
       ]);
 
       // Set the updated placement group


### PR DESCRIPTION
## Description 📝
This PR adds the delete placement group modal to the PG flow. It also touches a few components for some cleanup or enhancing (non breaking changes)

ℹ️ **CONTEXT**: The reason for adding the removable list in the delete modal is because (not unlike buckets) we can't delete a Placement Group that still has Linodes assigned to it

## Changes  🔄
- Add the PG delete modal and its test
- Make sure inputProps are passed in `TypeToConfirmDialog `
- Allow RemovableSelectionsList to take a readable remove label + test update + story

## Preview 📷
![Screenshot 2024-02-15 at 16 29 03](https://github.com/linode/manager/assets/130582365/1fbb8ef9-18e6-4b36-a097-04893090cacd)

## How to test 🧪

⚠️ NOTE: this is MSW mock data so we won't get the proper UI data changes 👎 

### Prerequisites
- Have the "Placement Group" flag and MSW turned on

### Verification steps 
- Navigate to `http://localhost:3000/placement-groups`
- Click "Delete" for any placement group
- Confirm UI and MSW requests
- change the [factory data](https://github.com/linode/manager/blob/6adb375576d89c9c630547349d1f0ce8092de295/packages/manager/src/factories/placementGroups.ts#L15) to an enabled delete modal

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support


