### PR TITLE
upcoming: [M3-7611] - Placement Groups Detail Summary

### DIFF
--- a/packages/manager/.changeset/pr-10164-upcoming-features-1707487417041.md
+++ b/packages/manager/.changeset/pr-10164-upcoming-features-1707487417041.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Create PlacementGroups Summary component ([#10164](https://github.com/linode/manager/pull/10164))

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.test.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.test.tsx
@@ -47,6 +47,7 @@ describe('PlacementGroupsLanding', () => {
     queryMocks.usePlacementGroupQuery.mockReturnValue({
       data: placementGroupFactory.build({
         affinity_type: 'anti_affinity',
+        compliant: true,
         id: 1,
         label: 'My first PG',
       }),

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
@@ -1,16 +1,20 @@
 import { AFFINITY_TYPES } from '@linode/api-v4';
+import { useTheme } from '@mui/material';
 import * as React from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import { CircleProgress } from 'src/components/CircleProgress';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { LandingHeader } from 'src/components/LandingHeader';
 import { NotFound } from 'src/components/NotFound';
+import { Notice } from 'src/components/Notice/Notice';
 import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
 import { TabLinkList } from 'src/components/Tabs/TabLinkList';
 import { TabPanels } from 'src/components/Tabs/TabPanels';
 import { Tabs } from 'src/components/Tabs/Tabs';
+import { Typography } from 'src/components/Typography';
 import { useFlags } from 'src/hooks/useFlags';
 import {
   useMutatePlacementGroup,
@@ -19,6 +23,7 @@ import {
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
 import { getPlacementGroupLinodeCount } from '../utils';
+import { getWarningNoticeText } from '../utils';
 import { PlacementGroupsLinodes } from './PlacementGroupsLinodes/PlacementGroupsLinodes';
 import { PlacementGroupsSummary } from './PlacementGroupsSummary/PlacementGroupsSummary';
 
@@ -26,17 +31,21 @@ export const PlacementGroupsDetail = () => {
   const flags = useFlags();
   const { id, tab } = useParams<{ id: string; tab?: string }>();
   const history = useHistory();
+  const theme = useTheme();
   const placementGroupId = Number(id);
+
   const {
     data: placementGroup,
     error: placementGroupError,
     isLoading,
   } = usePlacementGroupQuery(placementGroupId, Boolean(flags.vmPlacement));
+
   const {
     error: updatePlacementGroupError,
     mutateAsync: updatePlacementGroup,
     reset,
   } = useMutatePlacementGroup(placementGroupId);
+
   const errorText = getErrorStringOrDefault(updatePlacementGroupError ?? '');
 
   if (isLoading) {
@@ -110,6 +119,21 @@ export const PlacementGroupsDetail = () => {
         <TabLinkList tabs={tabs} />
         <TabPanels>
           <SafeTabPanel index={0}>
+            {!placementGroup.compliant && (
+              <Notice spacingBottom={20} spacingTop={24} variant="warning">
+                <Typography fontFamily={theme.font.bold}>
+                  {getWarningNoticeText(placementGroup)}
+                  {/* TODO VM_Placement: Get link location */}
+                  <Link
+                    className="secondaryLink"
+                    data-testid="pg-non-compliant-notice-link"
+                    to={'#'}
+                  >
+                    Learn more.
+                  </Link>
+                </Typography>
+              </Notice>
+            )}
             <PlacementGroupsSummary placementGroup={placementGroup} />
           </SafeTabPanel>
           <SafeTabPanel index={1}>

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
@@ -20,6 +20,7 @@ import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
 import { getPlacementGroupLinodeCount } from '../utils';
 import { PlacementGroupsLinodes } from './PlacementGroupsLinodes/PlacementGroupsLinodes';
+import { PlacementGroupsSummary } from './PlacementGroupsSummary/PlacementGroupsSummary';
 
 export const PlacementGroupsDetail = () => {
   const flags = useFlags();
@@ -108,7 +109,9 @@ export const PlacementGroupsDetail = () => {
       >
         <TabLinkList tabs={tabs} />
         <TabPanels>
-          <SafeTabPanel index={0}>TODO VM_Placement: summary</SafeTabPanel>
+          <SafeTabPanel index={0}>
+            <PlacementGroupsSummary placementGroup={placementGroup} />
+          </SafeTabPanel>
           <SafeTabPanel index={1}>
             <PlacementGroupsLinodes placementGroup={placementGroup} />
           </SafeTabPanel>

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
@@ -1,20 +1,16 @@
 import { AFFINITY_TYPES } from '@linode/api-v4';
-import { useTheme } from '@mui/material';
 import * as React from 'react';
 import { useHistory, useParams } from 'react-router-dom';
-import { Link } from 'react-router-dom';
 
 import { CircleProgress } from 'src/components/CircleProgress';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { LandingHeader } from 'src/components/LandingHeader';
 import { NotFound } from 'src/components/NotFound';
-import { Notice } from 'src/components/Notice/Notice';
 import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
 import { TabLinkList } from 'src/components/Tabs/TabLinkList';
 import { TabPanels } from 'src/components/Tabs/TabPanels';
 import { Tabs } from 'src/components/Tabs/Tabs';
-import { Typography } from 'src/components/Typography';
 import { useFlags } from 'src/hooks/useFlags';
 import {
   useMutatePlacementGroup,
@@ -23,7 +19,6 @@ import {
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
 import { getPlacementGroupLinodeCount } from '../utils';
-import { getWarningNoticeText } from '../utils';
 import { PlacementGroupsLinodes } from './PlacementGroupsLinodes/PlacementGroupsLinodes';
 import { PlacementGroupsSummary } from './PlacementGroupsSummary/PlacementGroupsSummary';
 
@@ -31,7 +26,6 @@ export const PlacementGroupsDetail = () => {
   const flags = useFlags();
   const { id, tab } = useParams<{ id: string; tab?: string }>();
   const history = useHistory();
-  const theme = useTheme();
   const placementGroupId = Number(id);
 
   const {
@@ -119,21 +113,6 @@ export const PlacementGroupsDetail = () => {
         <TabLinkList tabs={tabs} />
         <TabPanels>
           <SafeTabPanel index={0}>
-            {!placementGroup.compliant && (
-              <Notice spacingBottom={20} spacingTop={24} variant="warning">
-                <Typography fontFamily={theme.font.bold}>
-                  {getWarningNoticeText(placementGroup)}
-                  {/* TODO VM_Placement: Get link location */}
-                  <Link
-                    className="secondaryLink"
-                    data-testid="pg-non-compliant-notice-link"
-                    to={'#'}
-                  >
-                    Learn more.
-                  </Link>
-                </Typography>
-              </Notice>
-            )}
             <PlacementGroupsSummary placementGroup={placementGroup} />
           </SafeTabPanel>
           <SafeTabPanel index={1}>

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.test.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.test.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+
+import { placementGroupFactory } from 'src/factories';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { PlacementGroupsSummary } from './PlacementGroupsSummary';
+
+const queryMocks = vi.hoisted(() => ({
+  usePlacementGroupQuery: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('src/queries/placementGroups', async () => {
+  const actual = await vi.importActual('src/queries/placementGroups');
+  return {
+    ...actual,
+    usePlacementGroupQuery: queryMocks.usePlacementGroupQuery,
+  };
+});
+
+describe('PlacementGroups Summary', () => {
+  it('renders the placement group detail summary panel', () => {
+    const { getByText } = renderWithTheme(
+      <PlacementGroupsSummary
+        placementGroup={placementGroupFactory.build({
+          affinity_type: 'affinity',
+          capacity: 10,
+          compliant: true,
+          id: 3,
+          label: 'pg-3',
+          linode_ids: [2, 4, 6, 8, 10],
+          region: 'us-east',
+        })}
+      />
+    );
+
+    expect(getByText('Placement Group Configuration')).toBeInTheDocument();
+    expect(getByText('Linodes')).toBeInTheDocument();
+    expect(getByText('Affinity Type')).toBeInTheDocument();
+    expect(getByText('Region')).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.test.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.test.tsx
@@ -5,18 +5,6 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { PlacementGroupsSummary } from './PlacementGroupsSummary';
 
-const queryMocks = vi.hoisted(() => ({
-  usePlacementGroupQuery: vi.fn().mockReturnValue({}),
-}));
-
-vi.mock('src/queries/placementGroups', async () => {
-  const actual = await vi.importActual('src/queries/placementGroups');
-  return {
-    ...actual,
-    usePlacementGroupQuery: queryMocks.usePlacementGroupQuery,
-  };
-});
-
 describe('PlacementGroups Summary', () => {
   it('renders the placement group detail summary panel', () => {
     const { getByText } = renderWithTheme(

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.test.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.test.tsx
@@ -7,7 +7,7 @@ import { PlacementGroupsSummary } from './PlacementGroupsSummary';
 
 describe('PlacementGroups Summary', () => {
   it('renders the placement group detail summary panel', () => {
-    const { getByText } = renderWithTheme(
+    const { getByTestId, getByText } = renderWithTheme(
       <PlacementGroupsSummary
         placementGroup={placementGroupFactory.build({
           affinity_type: 'affinity',
@@ -23,6 +23,7 @@ describe('PlacementGroups Summary', () => {
 
     expect(getByText('Placement Group Configuration')).toBeInTheDocument();
     expect(getByText('Linodes')).toBeInTheDocument();
+    expect(getByTestId('HelpOutlineIcon')).toBeInTheDocument();
     expect(getByText('Affinity Type')).toBeInTheDocument();
     expect(getByText('Region')).toBeInTheDocument();
   });

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
@@ -1,0 +1,81 @@
+import { AFFINITY_TYPES } from '@linode/api-v4';
+import Grid from '@mui/material/Unstable_Grid2';
+import { styled } from '@mui/material/styles';
+import * as React from 'react';
+
+import { Box } from 'src/components/Box';
+import { Paper } from 'src/components/Paper';
+import { TooltipIcon } from 'src/components/TooltipIcon';
+import { Typography } from 'src/components/Typography';
+import { useRegionsQuery } from 'src/queries/regions';
+
+import type { PlacementGroup } from '@linode/api-v4';
+
+const tooltipText = `The Affinity Type and Region determine the maximum number of VMs per group`;
+
+interface Props {
+  placementGroup: PlacementGroup;
+}
+
+export const PlacementGroupsSummary = (props: Props) => {
+  const { placementGroup } = props;
+  const { data: regions } = useRegionsQuery();
+  const regionLabel =
+    regions?.find((region) => region.id === placementGroup.region)?.label ??
+    placementGroup.region;
+
+  return (
+    <Paper>
+      <Typography
+        sx={(theme) => ({ marginBottom: theme.spacing(3) })}
+        variant="h3"
+      >
+        Placement Group Configuration
+      </Typography>
+
+      <Grid container spacing={1}>
+        <Grid md={8} sm={12}>
+          <Box display="flex">
+            <StyledLabel>Linodes</StyledLabel>
+            <Typography sx={{ mx: 8 }}>
+              {`${placementGroup.linode_ids.length} of ${placementGroup.capacity}`}
+              <TooltipIcon
+                sxTooltipIcon={{
+                  marginLeft: '10px',
+                  padding: 0,
+                }}
+                status="help"
+                text={tooltipText}
+                tooltipPosition="right"
+              />
+            </Typography>
+          </Box>
+        </Grid>
+
+        <Grid md={8} sm={12}>
+          <Box display="flex">
+            <StyledLabel>Affinity Type</StyledLabel>
+            <Typography sx={{ mx: 8 }}>
+              {AFFINITY_TYPES[placementGroup?.affinity_type]}
+            </Typography>
+          </Box>
+        </Grid>
+
+        <Grid md={8} sm={12}>
+          <Box display="flex">
+            <StyledLabel>Region</StyledLabel>
+            <Typography sx={{ mx: 8 }}>{regionLabel}</Typography>
+          </Box>
+        </Grid>
+      </Grid>
+    </Paper>
+  );
+};
+
+export const StyledLabel = styled(Typography, {
+  label: 'StyledLabel',
+})(({ theme }) => ({
+  fontFamily: theme.font.bold,
+  marginRight: theme.spacing(8),
+  width: theme.spacing(10),
+}));

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
@@ -27,7 +27,9 @@ export const PlacementGroupsSummary = (props: Props) => {
     regions?.find((region) => region.id === placementGroup.region)?.label ??
     placementGroup.region;
 
-  const warningNoticeText = `Placement Group ${placementGroup.label} (${placementGroup.affinity_type}) is non-compliant.
+  const warningNoticeText = `Placement Group ${placementGroup.label} (${
+    AFFINITY_TYPES[placementGroup?.affinity_type]
+  }) is non-compliant.
   We are working to resolve compliance issues so that you can continue assigning Linodes to this Placement Group.`;
 
   return (

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
@@ -2,18 +2,16 @@ import { AFFINITY_TYPES } from '@linode/api-v4';
 import Grid from '@mui/material/Unstable_Grid2';
 import { styled } from '@mui/material/styles';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 
 import { Box } from 'src/components/Box';
-import { Notice } from 'src/components/Notice/Notice';
 import { Paper } from 'src/components/Paper';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
 import { useRegionsQuery } from 'src/queries/regions';
 
-import type { PlacementGroup } from '@linode/api-v4';
+import { PLACEMENT_GROUP_TOOLTIP_TEXT } from '../../constants';
 
-const tooltipText = `The Affinity Type and Region determine the maximum number of VMs per group`;
+import type { PlacementGroup } from '@linode/api-v4';
 
 interface Props {
   placementGroup: PlacementGroup;
@@ -27,65 +25,48 @@ export const PlacementGroupsSummary = (props: Props) => {
     regions?.find((region) => region.id === placementGroup.region)?.label ??
     placementGroup.region;
 
-  const warningNoticeText = `Placement Group ${placementGroup.label} (${
-    AFFINITY_TYPES[placementGroup?.affinity_type]
-  }) is non-compliant.
-  We are working to resolve compliance issues so that you can continue assigning Linodes to this Placement Group.`;
-
   return (
-    <>
-      {!placementGroup.compliant && (
-        <Notice spacingBottom={0} spacingTop={12} variant="warning">
-          {warningNoticeText}
-          <br />
-          {/* TODO VM_Placement: Get link location */}
-          <Link className="secondaryLink" to={'#'}>
-            Learn more.
-          </Link>
-        </Notice>
-      )}
-      <Paper>
-        <Typography
-          sx={(theme) => ({ marginBottom: theme.spacing(3) })}
-          variant="h3"
-        >
-          Placement Group Configuration
-        </Typography>
-        <Grid container spacing={1}>
-          <Grid md={8} sm={12}>
-            <Box display="flex">
-              <StyledLabel>Linodes</StyledLabel>
-              <Typography sx={{ mx: 8 }}>
-                {`${placementGroup.linode_ids.length} of ${placementGroup.capacity}`}
-                <TooltipIcon
-                  sxTooltipIcon={{
-                    marginLeft: '10px',
-                    padding: 0,
-                  }}
-                  status="help"
-                  text={tooltipText}
-                  tooltipPosition="right"
-                />
-              </Typography>
-            </Box>
-          </Grid>
-          <Grid md={8} sm={12}>
-            <Box display="flex">
-              <StyledLabel>Affinity Type</StyledLabel>
-              <Typography sx={{ mx: 8 }}>
-                {AFFINITY_TYPES[placementGroup?.affinity_type]}
-              </Typography>
-            </Box>
-          </Grid>
-          <Grid md={8} sm={12}>
-            <Box display="flex">
-              <StyledLabel>Region</StyledLabel>
-              <Typography sx={{ mx: 8 }}>{regionLabel}</Typography>
-            </Box>
-          </Grid>
+    <Paper>
+      <Typography
+        sx={(theme) => ({ marginBottom: theme.spacing(3) })}
+        variant="h3"
+      >
+        Placement Group Configuration
+      </Typography>
+      <Grid container spacing={1}>
+        <Grid md={8} sm={12}>
+          <Box display="flex">
+            <StyledLabel>Linodes</StyledLabel>
+            <Typography sx={{ mx: 8 }}>
+              {`${placementGroup.linode_ids.length} of ${placementGroup.capacity}`}
+              <TooltipIcon
+                sxTooltipIcon={{
+                  marginLeft: '10px',
+                  padding: 0,
+                }}
+                status="help"
+                text={PLACEMENT_GROUP_TOOLTIP_TEXT}
+                tooltipPosition="right"
+              />
+            </Typography>
+          </Box>
         </Grid>
-      </Paper>
-    </>
+        <Grid md={8} sm={12}>
+          <Box display="flex">
+            <StyledLabel>Affinity Type</StyledLabel>
+            <Typography sx={{ mx: 8 }}>
+              {AFFINITY_TYPES[placementGroup?.affinity_type]}
+            </Typography>
+          </Box>
+        </Grid>
+        <Grid md={8} sm={12}>
+          <Box display="flex">
+            <StyledLabel>Region</StyledLabel>
+            <Typography sx={{ mx: 8 }}>{regionLabel}</Typography>
+          </Box>
+        </Grid>
+      </Grid>
+    </Paper>
   );
 };
 

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
@@ -44,8 +44,9 @@ export const PlacementGroupsSummary = (props: Props) => {
               data-testid="pg-non-compliant-notice-link"
               to={'#'}
             >
-              Learn more.
+              Learn more
             </Link>
+            .
           </Typography>
         </Notice>
       )}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
@@ -68,6 +68,7 @@ export const PlacementGroupsSummary = (props: Props) => {
                     marginLeft: '10px',
                     padding: 0,
                   }}
+                  // data-testid="help-icon"
                   status="help"
                   text={PLACEMENT_GROUP_TOOLTIP_TEXT}
                   tooltipPosition="right"

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
@@ -1,9 +1,12 @@
 import { AFFINITY_TYPES } from '@linode/api-v4';
+import { useTheme } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
 import { styled } from '@mui/material/styles';
 import * as React from 'react';
 
 import { Box } from 'src/components/Box';
+import { Link } from 'src/components/Link';
+import { Notice } from 'src/components/Notice/Notice';
 import { Paper } from 'src/components/Paper';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
@@ -20,53 +23,74 @@ interface Props {
 export const PlacementGroupsSummary = (props: Props) => {
   const { placementGroup } = props;
   const { data: regions } = useRegionsQuery();
+  const theme = useTheme();
 
-  const regionLabel =
-    regions?.find((region) => region.id === placementGroup.region)?.label ??
-    placementGroup.region;
+  const regionLabel = regions?.find(
+    (region) => region.id === placementGroup.region
+  )?.label;
 
   return (
-    <Paper>
-      <Typography
-        sx={(theme) => ({ marginBottom: theme.spacing(3) })}
-        variant="h3"
-      >
-        Placement Group Configuration
-      </Typography>
-      <Grid container spacing={1}>
-        <Grid md={8} sm={12}>
-          <Box display="flex">
-            <StyledLabel>Linodes</StyledLabel>
-            <Typography sx={{ mx: 8 }}>
-              {`${placementGroup.linode_ids.length} of ${placementGroup.capacity}`}
-              <TooltipIcon
-                sxTooltipIcon={{
-                  marginLeft: '10px',
-                  padding: 0,
-                }}
-                status="help"
-                text={PLACEMENT_GROUP_TOOLTIP_TEXT}
-                tooltipPosition="right"
-              />
-            </Typography>
-          </Box>
+    <>
+      {!placementGroup.compliant && (
+        <Notice spacingBottom={20} spacingTop={24} variant="warning">
+          <Typography fontFamily={theme.font.bold}>
+            {`Placement Group ${placementGroup.label} (${
+              AFFINITY_TYPES[placementGroup.affinity_type]
+            }) is non-compliant.
+          We are working to resolve compliance issues so that you can continue assigning Linodes to this Placement Group. `}
+            {/* TODO VM_Placement: Get link location */}
+            <Link
+              className="secondaryLink"
+              data-testid="pg-non-compliant-notice-link"
+              to={'#'}
+            >
+              Learn more.
+            </Link>
+          </Typography>
+        </Notice>
+      )}
+      <Paper>
+        <Typography
+          sx={(theme) => ({ marginBottom: theme.spacing(3) })}
+          variant="h3"
+        >
+          Placement Group Configuration
+        </Typography>
+        <Grid container spacing={1}>
+          <Grid md={8} sm={12}>
+            <Box display="flex">
+              <StyledLabel>Linodes</StyledLabel>
+              <Typography sx={{ mx: 8 }}>
+                {`${placementGroup.linode_ids.length} of ${placementGroup.capacity}`}
+                <TooltipIcon
+                  sxTooltipIcon={{
+                    marginLeft: '10px',
+                    padding: 0,
+                  }}
+                  status="help"
+                  text={PLACEMENT_GROUP_TOOLTIP_TEXT}
+                  tooltipPosition="right"
+                />
+              </Typography>
+            </Box>
+          </Grid>
+          <Grid md={8} sm={12}>
+            <Box display="flex">
+              <StyledLabel>Affinity Type</StyledLabel>
+              <Typography sx={{ mx: 8 }}>
+                {AFFINITY_TYPES[placementGroup?.affinity_type]}
+              </Typography>
+            </Box>
+          </Grid>
+          <Grid md={8} sm={12}>
+            <Box display="flex">
+              <StyledLabel>Region</StyledLabel>
+              <Typography sx={{ mx: 8 }}>{regionLabel}</Typography>
+            </Box>
+          </Grid>
         </Grid>
-        <Grid md={8} sm={12}>
-          <Box display="flex">
-            <StyledLabel>Affinity Type</StyledLabel>
-            <Typography sx={{ mx: 8 }}>
-              {AFFINITY_TYPES[placementGroup?.affinity_type]}
-            </Typography>
-          </Box>
-        </Grid>
-        <Grid md={8} sm={12}>
-          <Box display="flex">
-            <StyledLabel>Region</StyledLabel>
-            <Typography sx={{ mx: 8 }}>{regionLabel}</Typography>
-          </Box>
-        </Grid>
-      </Grid>
-    </Paper>
+      </Paper>
+    </>
   );
 };
 

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
@@ -2,8 +2,10 @@ import { AFFINITY_TYPES } from '@linode/api-v4';
 import Grid from '@mui/material/Unstable_Grid2';
 import { styled } from '@mui/material/styles';
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 
 import { Box } from 'src/components/Box';
+import { Notice } from 'src/components/Notice/Notice';
 import { Paper } from 'src/components/Paper';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
@@ -20,55 +22,68 @@ interface Props {
 export const PlacementGroupsSummary = (props: Props) => {
   const { placementGroup } = props;
   const { data: regions } = useRegionsQuery();
+
   const regionLabel =
     regions?.find((region) => region.id === placementGroup.region)?.label ??
     placementGroup.region;
 
+  const warningNoticeText = `Placement Group ${placementGroup.label} (${placementGroup.affinity_type}) is non-compliant.
+  We are working to resolve compliance issues so that you can continue assigning Linodes to this Placement Group.`;
+
   return (
-    <Paper>
-      <Typography
-        sx={(theme) => ({ marginBottom: theme.spacing(3) })}
-        variant="h3"
-      >
-        Placement Group Configuration
-      </Typography>
-
-      <Grid container spacing={1}>
-        <Grid md={8} sm={12}>
-          <Box display="flex">
-            <StyledLabel>Linodes</StyledLabel>
-            <Typography sx={{ mx: 8 }}>
-              {`${placementGroup.linode_ids.length} of ${placementGroup.capacity}`}
-              <TooltipIcon
-                sxTooltipIcon={{
-                  marginLeft: '10px',
-                  padding: 0,
-                }}
-                status="help"
-                text={tooltipText}
-                tooltipPosition="right"
-              />
-            </Typography>
-          </Box>
+    <>
+      {!placementGroup.compliant && (
+        <Notice spacingBottom={0} spacingTop={12} variant="warning">
+          {warningNoticeText}
+          <br />
+          {/* TODO VM_Placement: Get link location */}
+          <Link className="secondaryLink" to={'#'}>
+            Learn more.
+          </Link>
+        </Notice>
+      )}
+      <Paper>
+        <Typography
+          sx={(theme) => ({ marginBottom: theme.spacing(3) })}
+          variant="h3"
+        >
+          Placement Group Configuration
+        </Typography>
+        <Grid container spacing={1}>
+          <Grid md={8} sm={12}>
+            <Box display="flex">
+              <StyledLabel>Linodes</StyledLabel>
+              <Typography sx={{ mx: 8 }}>
+                {`${placementGroup.linode_ids.length} of ${placementGroup.capacity}`}
+                <TooltipIcon
+                  sxTooltipIcon={{
+                    marginLeft: '10px',
+                    padding: 0,
+                  }}
+                  status="help"
+                  text={tooltipText}
+                  tooltipPosition="right"
+                />
+              </Typography>
+            </Box>
+          </Grid>
+          <Grid md={8} sm={12}>
+            <Box display="flex">
+              <StyledLabel>Affinity Type</StyledLabel>
+              <Typography sx={{ mx: 8 }}>
+                {AFFINITY_TYPES[placementGroup?.affinity_type]}
+              </Typography>
+            </Box>
+          </Grid>
+          <Grid md={8} sm={12}>
+            <Box display="flex">
+              <StyledLabel>Region</StyledLabel>
+              <Typography sx={{ mx: 8 }}>{regionLabel}</Typography>
+            </Box>
+          </Grid>
         </Grid>
-
-        <Grid md={8} sm={12}>
-          <Box display="flex">
-            <StyledLabel>Affinity Type</StyledLabel>
-            <Typography sx={{ mx: 8 }}>
-              {AFFINITY_TYPES[placementGroup?.affinity_type]}
-            </Typography>
-          </Box>
-        </Grid>
-
-        <Grid md={8} sm={12}>
-          <Box display="flex">
-            <StyledLabel>Region</StyledLabel>
-            <Typography sx={{ mx: 8 }}>{regionLabel}</Typography>
-          </Box>
-        </Grid>
-      </Grid>
-    </Paper>
+      </Paper>
+    </>
   );
 };
 

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
@@ -68,7 +68,6 @@ export const PlacementGroupsSummary = (props: Props) => {
                     marginLeft: '10px',
                     padding: 0,
                   }}
-                  // data-testid="help-icon"
                   status="help"
                   text={PLACEMENT_GROUP_TOOLTIP_TEXT}
                   tooltipPosition="right"

--- a/packages/manager/src/features/PlacementGroups/constants.ts
+++ b/packages/manager/src/features/PlacementGroups/constants.ts
@@ -8,3 +8,5 @@ export const MAX_NUMBER_OF_LINODES_IN_PLACEMENT_GROUP_MESSAGE =
 
 export const PLACEMENT_GROUP_LINODES_ERROR_MESSAGE =
   'There was an error loading Linodes for this Placement Group.';
+
+export const PLACEMENT_GROUP_TOOLTIP_TEXT = `The Affinity Type and Region determine the maximum number of VMs per group`;

--- a/packages/manager/src/features/PlacementGroups/constants.ts
+++ b/packages/manager/src/features/PlacementGroups/constants.ts
@@ -9,4 +9,4 @@ export const MAX_NUMBER_OF_LINODES_IN_PLACEMENT_GROUP_MESSAGE =
 export const PLACEMENT_GROUP_LINODES_ERROR_MESSAGE =
   'There was an error loading Linodes for this Placement Group.';
 
-export const PLACEMENT_GROUP_TOOLTIP_TEXT = `The Affinity Type and Region determine the maximum number of VMs per group`;
+export const PLACEMENT_GROUP_TOOLTIP_TEXT = `The Affinity Type and Region determine the maximum number of VMs per group.`;

--- a/packages/manager/src/features/PlacementGroups/utils.ts
+++ b/packages/manager/src/features/PlacementGroups/utils.ts
@@ -32,13 +32,3 @@ export const affinityTypeOptions = Object.entries(AFFINITY_TYPES).map(
     value: key as CreatePlacementGroupPayload['affinity_type'],
   })
 );
-
-/**
- * Helper to generate the text content of the non-compliant warning notice.
- */
-export const getWarningNoticeText = (placementGroup: PlacementGroup) => {
-  return `Placement Group ${placementGroup.label} (${
-    AFFINITY_TYPES[placementGroup?.affinity_type]
-  }) is non-compliant.
-We are working to resolve compliance issues so that you can continue assigning Linodes to this Placement Group. `;
-};

--- a/packages/manager/src/features/PlacementGroups/utils.ts
+++ b/packages/manager/src/features/PlacementGroups/utils.ts
@@ -32,3 +32,13 @@ export const affinityTypeOptions = Object.entries(AFFINITY_TYPES).map(
     value: key as CreatePlacementGroupPayload['affinity_type'],
   })
 );
+
+/**
+ * Helper to generate the text content of the non-compliant warning notice.
+ */
+export const getWarningNoticeText = (placementGroup: PlacementGroup) => {
+  return `Placement Group ${placementGroup.label} (${
+    AFFINITY_TYPES[placementGroup?.affinity_type]
+  }) is non-compliant.
+We are working to resolve compliance issues so that you can continue assigning Linodes to this Placement Group. `;
+};


### PR DESCRIPTION
## Description 📝
This PR introduces the `PlacementGroupsSummary` component.

## Changes  🔄
- Add Summary panel which displays the Placement Group's configuration details.
- Add logic to display a warning notice in the even the Placement Group is not compliant.
- Add unit testing for component.

## Preview 📷

### Placement Group Summary View
![pg-summary](https://github.com/linode/manager/assets/119514965/152fe64c-a191-4dcb-8b23-25259a56a0b8)

### Tooltip
![pg-summary-tooltip](https://github.com/linode/manager/assets/119514965/67d5041d-2a6e-430f-b7e6-415438f5982b)

### Non-compliant Placement Group Notice
![Screenshot 2024-02-09 at 6 09 41 AM](https://github.com/linode/manager/assets/119514965/b35e882a-6197-439c-8459-da51b8021029)

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Enable the following using the Cloud Manager Dev Tools:
    - Placement Groups feature flag
    - MSW

### Verification steps 
(How to verify changes)
- Navigate to `http://localhost:3000/placement-groups`
- Click on a Placement Group from the table.
- Verify the configuration info to match the info from the Placement Group you clicked.
- Verify that the tooltip is rendered and behaves as expected.
- Run the following unit test: `yarn test PlacementGroupsSummary`

## As an Author I have considered 🤔
*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

