### PR TITLE
fix: [M3-7747] - Fix Linode Migration dialog hidden $0 price

### DIFF
--- a/packages/manager/.changeset/pr-10166-fixed-1707414781493.md
+++ b/packages/manager/.changeset/pr-10166-fixed-1707414781493.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Display $0.00 prices in Linode Migration dialog ([#10166](https://github.com/linode/manager/pull/10166))

--- a/packages/manager/src/features/Linodes/MigrateLinode/MigrationPricing.test.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/MigrationPricing.test.tsx
@@ -111,7 +111,6 @@ describe('MigrationPricing component', () => {
       );
       expect(await findByText('| Backups', { exact: false })).toBeVisible();
       expect(await findByText('$2.50')).toBeVisible();
-      // expect(await findByTestId('migration-pricing')).not.toBeNull();
     });
 
     it('shows $0 backup prices', async () => {

--- a/packages/manager/src/features/Linodes/MigrateLinode/MigrationPricing.test.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/MigrationPricing.test.tsx
@@ -1,0 +1,170 @@
+import * as React from 'react';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { MigrationPricing } from './MigrationPricing';
+
+const backupPricesNull = {
+  monthly: null,
+  hourly: null,
+};
+
+const backupPricesZero = {
+  monthly: 0,
+  hourly: 0,
+};
+
+const backupPricesRegular = {
+  hourly: 0.004,
+  monthly: 2.5,
+};
+
+describe('MigrationPricing component', () => {
+  describe('render condition', () => {
+    it('does not render when prices are not specified', async () => {
+      // Some combinations of props that should prevent component rendering.
+      const propCombinations = [
+        { backups: 'disabled' as const, hourly: undefined, monthly: 0 },
+        { backups: backupPricesNull, hourly: null, monthly: 0.1 },
+        { backups: backupPricesRegular, hourly: null, monthly: null },
+        { backups: backupPricesZero, hourly: undefined, monthly: 1 },
+        { backups: undefined, hourly: 0, monthly: 0 },
+        { backups: undefined, hourly: 1, monthly: undefined },
+        { backups: undefined, hourly: null, monthly: null },
+      ];
+
+      propCombinations.forEach((props) => {
+        const { queryByTestId, unmount } = renderWithTheme(
+          <MigrationPricing panelType="current" {...props} />
+        );
+        expect(queryByTestId('migration-pricing')).toBeNull();
+        unmount();
+      });
+    });
+
+    it('renders when prices are specified', async () => {
+      const props = {
+        backups: 'disabled' as const,
+        hourly: 0.004,
+        monthly: 2.5,
+      };
+
+      const { findByTestId } = renderWithTheme(
+        <MigrationPricing panelType="current" {...props} />
+      );
+      expect(await findByTestId('migration-pricing')).not.toBeNull();
+    });
+
+    it('renders when $0 prices are specified', async () => {
+      const props = {
+        backups: 'disabled' as const,
+        hourly: 0,
+        monthly: 0,
+      };
+
+      const { findByTestId } = renderWithTheme(
+        <MigrationPricing panelType="current" {...props} />
+      );
+      expect(await findByTestId('migration-pricing')).not.toBeNull();
+    });
+  });
+
+  describe('price display', () => {
+    it('displays prices', async () => {
+      const props = {
+        backups: 'disabled' as const,
+        hourly: 0.004,
+        monthly: 2.5,
+      };
+
+      const { findByText } = renderWithTheme(
+        <MigrationPricing panelType="current" {...props} />
+      );
+      expect(await findByText('$0.004')).toBeVisible();
+      expect(await findByText('$2.50')).toBeVisible();
+    });
+
+    it('displays $0 prices', async () => {
+      const props = {
+        backups: 'disabled' as const,
+        hourly: 0,
+        monthly: 0,
+      };
+
+      const { findByText } = renderWithTheme(
+        <MigrationPricing panelType="current" {...props} />
+      );
+      expect(await findByText('$0.000')).toBeVisible();
+      expect(await findByText('$0.00')).toBeVisible();
+    });
+  });
+
+  describe('backup price display', () => {
+    it('shows backup prices', async () => {
+      const props = {
+        backups: backupPricesRegular,
+        hourly: 0.001,
+        monthly: 1.5,
+      };
+
+      const { findByText } = renderWithTheme(
+        <MigrationPricing panelType="current" {...props} />
+      );
+      expect(await findByText('| Backups', { exact: false })).toBeVisible();
+      expect(await findByText('$2.50')).toBeVisible();
+      // expect(await findByTestId('migration-pricing')).not.toBeNull();
+    });
+
+    it('shows $0 backup prices', async () => {
+      const props = {
+        backups: backupPricesZero,
+        hourly: 0.001,
+        monthly: 1.5,
+      };
+
+      const { findByText } = renderWithTheme(
+        <MigrationPricing panelType="current" {...props} />
+      );
+      expect(await findByText('| Backups', { exact: false })).toBeVisible();
+      expect(await findByText('$0.00')).toBeVisible();
+    });
+
+    it('hides backup prices when backups are disabled', () => {
+      const props = {
+        backups: 'disabled' as const,
+        hourly: 0.001,
+        monthly: 1.5,
+      };
+
+      const { queryByText } = renderWithTheme(
+        <MigrationPricing panelType="current" {...props} />
+      );
+      expect(queryByText('| Backups', { exact: false })).toBeNull();
+    });
+
+    it('hides backup prices when backups are undefined', () => {
+      const props = {
+        backups: undefined,
+        hourly: 0.001,
+        monthly: 1.5,
+      };
+
+      const { queryByText } = renderWithTheme(
+        <MigrationPricing panelType="current" {...props} />
+      );
+      expect(queryByText('| Backups', { exact: false })).toBeNull();
+    });
+
+    it('hides backup prices when backup prices are null', () => {
+      const props = {
+        backups: backupPricesNull,
+        hourly: 0.001,
+        monthly: 1.5,
+      };
+
+      const { queryByText } = renderWithTheme(
+        <MigrationPricing panelType="current" {...props} />
+      );
+      expect(queryByText('| Backups', { exact: false })).toBeNull();
+    });
+  });
+});

--- a/packages/manager/src/features/Linodes/MigrateLinode/MigrationPricing.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/MigrationPricing.tsx
@@ -1,6 +1,7 @@
 import { PriceObject } from '@linode/api-v4';
 import { styled } from '@mui/material/styles';
 import { useTheme } from '@mui/material';
+import { isNumber } from 'lodash';
 import * as React from 'react';
 
 import { Box } from 'src/components/Box';
@@ -25,11 +26,7 @@ export const MigrationPricing = (props: MigrationPricingProps) => {
   const priceFontSize = `${theme.typography.body1.fontSize}`;
 
   const shouldShowPrice =
-    monthly !== undefined &&
-    monthly !== null &&
-    hourly !== undefined &&
-    hourly !== null &&
-    backups !== undefined;
+    isNumber(monthly) && isNumber(hourly) && backups !== undefined;
 
   const shouldShowBackupsPrice =
     backups && backups !== 'disabled' && backups.monthly !== null;

--- a/packages/manager/src/features/Linodes/MigrateLinode/MigrationPricing.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/MigrationPricing.tsx
@@ -24,8 +24,21 @@ export const MigrationPricing = (props: MigrationPricingProps) => {
   const theme = useTheme();
   const priceFontSize = `${theme.typography.body1.fontSize}`;
 
-  return monthly && hourly && backups ? (
-    <StyledMigrationPricingContainer panelType={panelType}>
+  const shouldShowPrice =
+    monthly !== undefined &&
+    monthly !== null &&
+    hourly !== undefined &&
+    hourly !== null &&
+    backups !== undefined;
+
+  const shouldShowBackupsPrice =
+    backups && backups !== 'disabled' && backups.monthly !== null;
+
+  return shouldShowPrice ? (
+    <StyledMigrationPricingContainer
+      panelType={panelType}
+      data-testid="migration-pricing"
+    >
       <StyledSpan>{currentPanel ? 'Current' : 'New'} Price</StyledSpan>
       <Box
         alignItems="baseline"
@@ -44,7 +57,7 @@ export const MigrationPricing = (props: MigrationPricingProps) => {
           interval="hour"
           price={hourly}
         />
-        {backups !== 'disabled' && backups?.monthly && (
+        {shouldShowBackupsPrice && (
           <>
             &nbsp;
             <Typography fontFamily={theme.font.bold} fontSize={priceFontSize}>
@@ -53,7 +66,7 @@ export const MigrationPricing = (props: MigrationPricingProps) => {
             <DisplayPrice
               fontSize={priceFontSize}
               interval="month"
-              price={backups.monthly}
+              price={backups.monthly ?? '--.--'}
             />
           </>
         )}


### PR DESCRIPTION
## Description 📝
When migrating to or from a region with $0 pricing, the Linode migrate dialog hides the $0.00 price. This fixes the issue and adds some unit tests.

## Changes  🔄
List any change relevant to the reviewer.
- Adds unit tests for MigrationPricing component
- Updates MigrationPricing logic to account for $0 pricing

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img width="956" alt="To Zero Region" src="https://github.com/linode/manager/assets/97627410/a7bfe71f-b452-4730-88c8-23017ac302b9"> | <img width="947" alt="Screenshot 2024-02-08 at 12 24 28 PM" src="https://github.com/linode/manager/assets/97627410/4d76e05f-87ab-40df-bab8-80c7e6d9eaa0"> |

## How to test 🧪
To run the new unit tests:
```bash
yarn test MigrationPricing.test
```

To run related Cypress tests:

`yarn && yarn build && yarn start:manager:ci` and then

```bash
yarn cy:run -s "cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts,cypress/e2e/core/linodes/migrate-linode.spec.ts"
```

### Manual verification:
Using an account with access to `es-mad`, create a Linode in `es-mad`, wait for it to provision and boot, and then open the Migration dialog (via either the Linode landing page or details page). Confirm that after selecting a new region, the $0 price is displayed for Madrid.

Similarly, you can create a Linode in another region, open the Migration dialog, select Madrid for the new region, and confirm that $0 appears.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

