### PR TITLE
test: [M3-7452] - Add Cypress test to check empty state in Images landing page

### DIFF
--- a/packages/manager/.changeset/pr-10167-tests-1709236661581.md
+++ b/packages/manager/.changeset/pr-10167-tests-1709236661581.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add Cypress test to check empty state in Images landing page ([#10167](https://github.com/linode/manager/pull/10167))

--- a/packages/manager/cypress/e2e/core/images/images-empty-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/images-empty-landing-page.spec.ts
@@ -1,8 +1,6 @@
 import { ui } from 'support/ui';
 import { mockGetAllImages } from 'support/intercepts/images';
-import { authenticate } from 'support/api/authentication';
 
-authenticate();
 describe('Images empty landing page', () => {
   /**
    * - Confirms Images landing page empty state is shown when no Images are present:

--- a/packages/manager/cypress/e2e/core/images/images-empty-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/images-empty-landing-page.spec.ts
@@ -1,0 +1,51 @@
+import { ui } from 'support/ui';
+import { mockGetAllImages } from 'support/intercepts/images';
+import { authenticate } from 'support/api/authentication';
+
+authenticate();
+describe('Images empty landing page', () => {
+  /**
+   * - Confirms Images landing page empty state is shown when no Images are present:
+   * - Confirms that "Getting Started Guides" and "Video Playlist" are listed on landing page.
+   * - Confirms that clicking "Create Image" navigates user to image create page.
+   */
+  it('shows the empty state when there are no images', () => {
+    mockGetAllImages([]).as('getImages');
+
+    cy.visitWithLogin('/images');
+    cy.wait(['@getImages']);
+
+    // confirms helper text
+    cy.findByText(
+      'Store your own custom Linux images, enabling you to rapidly deploy Linode Compute Instances preconfigured with the software and settings you require.'
+    ).should('be.visible');
+
+    // checks that guides are visible
+    cy.findByText('Getting Started Guides').should('be.visible');
+    cy.findByText('Overview of Custom Images').should('be.visible');
+    cy.findByText('Getting Started with Custom Images').should('be.visible');
+    cy.findByText('Capture an Image from a Linode').should('be.visible');
+    cy.findByText('Upload a Custom Image').should('be.visible');
+    cy.findByText('View additional Images guides').should('be.visible');
+
+    // checks that videos are visible
+    cy.findByText('Video Playlist').should('be.visible');
+    cy.findByText(
+      'How to use Linode Images | Learn how to Create, Upload, and Deploy Custom Images on Linode'
+    ).should('be.visible');
+    cy.findByText(
+      'Custom Images on Linode | Create, Upload, and Deploy Custom iso Images to Deploy on Linode'
+    ).should('be.visible');
+    cy.findByText('Using Images and Backups on Linode').should('be.visible');
+    cy.findByText('View our YouTube channel').should('be.visible');
+
+    // confirms clicking on 'Create Image' button
+    ui.button
+      .findByTitle('Create Image')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.url().should('endWith', '/images/create');
+  });
+});


### PR DESCRIPTION
## Description 📝
Add regression tests to check Images landing page empty state.

## Major Changes 🔄
- Add regression tests to check the empty state in Images landing page.

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/images/images-empty-landing-page.spec.ts"
```