### PR TITLE
chore: [M3-7754] - fix bundle analyse script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:sdk": "yarn workspace @linode/api-v4 build",
     "build:validation": "yarn workspace @linode/validation build",
     "build": "yarn build:validation && yarn build:sdk && yarn workspace linode-manager build",
-    "build:analyze": "yarn build --bundle-analyze",
+    "build:analyze": "yarn workspace linode-manager build:analyze",
     "up": "yarn install:all && yarn build:validation && yarn build:sdk && yarn start:all",
     "up:expose": "yarn install:all && yarn build:validation && yarn build:sdk && yarn start:all:expose",
     "dev": "yarn install:all && yarn start:all",

--- a/packages/manager/.changeset/pr-10175-fixed-1707751671549.md
+++ b/packages/manager/.changeset/pr-10175-fixed-1707751671549.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Bundle analyze script ([#10175](https://github.com/linode/manager/pull/10175))

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -85,6 +85,7 @@
     "start:ci": "yarn serve ./build -p 3000 -s --cors",
     "lint": "yarn run eslint . --ext .js,.ts,.tsx --quiet",
     "build": "node scripts/prebuild.mjs && vite build",
+    "build:analyze": "npx vite-bundle-visualizer",
     "precommit": "lint-staged && yarn typecheck",
     "test": "vitest run",
     "test:debug": "node --inspect-brk scripts/test.js --runInBand",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -85,7 +85,7 @@
     "start:ci": "yarn serve ./build -p 3000 -s --cors",
     "lint": "yarn run eslint . --ext .js,.ts,.tsx --quiet",
     "build": "node scripts/prebuild.mjs && vite build",
-    "build:analyze": "npx vite-bundle-visualizer",
+    "build:analyze": "bunx vite-bundle-visualizer",
     "precommit": "lint-staged && yarn typecheck",
     "test": "vitest run",
     "test:debug": "node --inspect-brk scripts/test.js --runInBand",


### PR DESCRIPTION
## Description 📝
I assume the script was broken since the vite update. This small PR makes it available again via [vite-bunder-visualizer](https://www.npmjs.com/package/vite-bundle-visualizer#vite-bundle-visualizer)

## Changes  🔄
- fix broken bundle analyzer script in package.json

## Preview 📷
![Screenshot 2024-02-12 at 10 22 19](https://github.com/linode/manager/assets/130582365/32af4577-1890-4687-9ed2-3713b79df51c)


## How to test 🧪

### Reproduction steps
- from the root, run `yarn build:analyze`
- see failure

### Verification steps 
(How to verify changes)
- from the root, run `yarn build:analyze`
- confirm report opening in the browser

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support


