### PR TITLE
change: [M3-7755] – Update IPv4 range "Learn more" docs link

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Support for VPC IPv4 Ranges in Linode Create flow and 'VPC IPv4 Ranges' column to inner Subnets table on VPC Detail page ([#10116](https://github.com/linode/manager/pull/10116))
 - Support VPC IPv4 Ranges in Add/Edit Linode Config dialog ([#10170](https://github.com/linode/manager/pull/10170))
 
+### Changed:
+
+- "Learn more" docs link for IPv4 ranges in Add/Edit Linode Config dialog, Linode Create flow, and VPC "Assign Linodes" drawer
+
 ### Fixed:
 
 - Error when enabling backups for Linodes in regions with $0 pricing ([#10153](https://github.com/linode/manager/pull/10153))

--- a/packages/manager/src/features/VPCs/VPCDetail/AssignIPRanges.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/AssignIPRanges.tsx
@@ -9,9 +9,9 @@ import { Notice } from 'src/components/Notice/Notice';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
 import {
+  ASSIGN_COMPUTE_INSTANCE_TO_VPC_LINK,
   ASSIGN_IPV4_RANGES_DESCRIPTION,
   ASSIGN_IPV4_RANGES_TITLE,
-  UNDERSTANDING_IP_ADDRESSES_LINK,
 } from 'src/features/VPCs/constants';
 import { ExtendedIP } from 'src/utilities/ipUtils';
 
@@ -81,6 +81,6 @@ const StyledDescription = styled('span')(() => ({
 const IPv4RangesDescriptionJSX = (
   <>
     <StyledDescription>{ASSIGN_IPV4_RANGES_DESCRIPTION}</StyledDescription>
-    <Link to={UNDERSTANDING_IP_ADDRESSES_LINK}>Learn more</Link>.
+    <Link to={ASSIGN_COMPUTE_INSTANCE_TO_VPC_LINK}>Learn more</Link>.
   </>
 );

--- a/packages/manager/src/features/VPCs/constants.ts
+++ b/packages/manager/src/features/VPCs/constants.ts
@@ -71,5 +71,5 @@ export const VPC_GETTING_STARTED_LINK =
 export const VPC_MULTIPLE_CONFIGURATIONS_LEARN_MORE_LINK =
   'https://www.linode.com/docs/products/compute/compute-instances/guides/configuration-profiles/';
 
-export const UNDERSTANDING_IP_ADDRESSES_LINK =
-  'https://www.linode.com/docs/guides/how-to-understand-ip-addresses/';
+export const ASSIGN_COMPUTE_INSTANCE_TO_VPC_LINK =
+  'https://www.linode.com/docs/products/networking/vpc/guides/assign-services/';


### PR DESCRIPTION
## Description 📝
Updated "Learn more" docs link for IPv4 ranges

## How to test 🧪
### Verification steps 
The "Learn more" link in the "Additional IPv4 ranges" section (in the VPC section of the Linode Create flow, in the Add/Edit Linode Config dialog for VPC interfaces, and in the VPC "Assign Linodes" drawer) should bring you to https://www.linode.com/docs/products/networking/vpc/guides/assign-services/

## As an Author I have considered 🤔
- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support