### PR TITLE
change: [M3-7731] - Tag breadcrumb label edit icon on Linode Details page for analytics

### DIFF
--- a/packages/manager/.changeset/pr-10183-tech-stories-1707777141390.md
+++ b/packages/manager/.changeset/pr-10183-tech-stories-1707777141390.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Add analytics event for breadcrumb label edit icon on Linode details page ([#10183](https://github.com/linode/manager/pull/10183))

--- a/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
@@ -19,6 +19,7 @@ export const FinalCrumb = React.memo((props: Props) => {
   if (onEditHandlers) {
     return (
       <StyledEditableText
+        analyticsEvent={onEditHandlers.analyticsEvent}
         data-qa-editable-text
         errorText={onEditHandlers.errorText}
         labelLink={labelOptions && labelOptions.linkTo}

--- a/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
@@ -19,9 +19,9 @@ export const FinalCrumb = React.memo((props: Props) => {
   if (onEditHandlers) {
     return (
       <StyledEditableText
-        analyticsEvent={onEditHandlers.analyticsEvent}
         data-qa-editable-text
         errorText={onEditHandlers.errorText}
+        handleAnalyticsEvent={onEditHandlers.handleAnalyticsEvent}
         labelLink={labelOptions && labelOptions.linkTo}
         onCancel={onEditHandlers.onCancel}
         onEdit={onEditHandlers.onEdit}

--- a/packages/manager/src/components/Breadcrumb/types.ts
+++ b/packages/manager/src/components/Breadcrumb/types.ts
@@ -9,10 +9,10 @@ export interface LabelProps {
 }
 
 export interface EditableProps {
-  analyticsEvent?: () => void;
   editableTextTitle: string;
   editableTextTitleSuffix?: string;
   errorText?: string;
+  handleAnalyticsEvent?: () => void;
   onCancel: () => void;
   onEdit: (value: string) => Promise<any>;
 }

--- a/packages/manager/src/components/Breadcrumb/types.ts
+++ b/packages/manager/src/components/Breadcrumb/types.ts
@@ -9,6 +9,7 @@ export interface LabelProps {
 }
 
 export interface EditableProps {
+  analyticsEvent?: () => void;
   editableTextTitle: string;
   editableTextTitleSuffix?: string;
   errorText?: string;

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -102,9 +102,12 @@ const useStyles = makeStyles<void, 'editIcon' | 'icon'>()(
 );
 
 interface Props {
-  analyticsEvent?: () => void;
   className?: string;
   errorText?: string;
+  /**
+   * Send event analytics
+   */
+  handleAnalyticsEvent?: () => void;
   /**
    * Optional link for the text when it is not in editing mode
    */
@@ -135,9 +138,9 @@ export const EditableText = (props: PassThroughProps) => {
   const [isEditing, setIsEditing] = React.useState(Boolean(props.errorText));
   const [text, setText] = React.useState(props.text);
   const {
-    analyticsEvent,
     className,
     errorText,
+    handleAnalyticsEvent,
     labelLink,
     onCancel,
     onEdit,
@@ -161,8 +164,8 @@ export const EditableText = (props: PassThroughProps) => {
 
   const openEdit = () => {
     // Send analytics when pencil icon is clicked.
-    if (analyticsEvent) {
-      analyticsEvent();
+    if (handleAnalyticsEvent) {
+      handleAnalyticsEvent();
     }
     setIsEditing(true);
   };

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -102,6 +102,7 @@ const useStyles = makeStyles<void, 'editIcon' | 'icon'>()(
 );
 
 interface Props {
+  analyticsEvent?: () => void;
   className?: string;
   errorText?: string;
   /**
@@ -134,6 +135,7 @@ export const EditableText = (props: PassThroughProps) => {
   const [isEditing, setIsEditing] = React.useState(Boolean(props.errorText));
   const [text, setText] = React.useState(props.text);
   const {
+    analyticsEvent,
     className,
     errorText,
     labelLink,
@@ -158,6 +160,10 @@ export const EditableText = (props: PassThroughProps) => {
   };
 
   const openEdit = () => {
+    // Send analytics when pencil icon is clicked.
+    if (analyticsEvent) {
+      analyticsEvent();
+    }
     setIsEditing(true);
   };
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsLabelPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsLabelPanel.tsx
@@ -11,6 +11,7 @@ import {
   useLinodeQuery,
   useLinodeUpdateMutation,
 } from 'src/queries/linodes/linodes';
+import { sendUpdateLinodeLabelEvent } from 'src/utilities/analytics';
 import { getErrorMap } from 'src/utilities/errorUtils';
 
 interface Props {
@@ -40,6 +41,7 @@ export const LinodeSettingsLabelPanel = (props: Props) => {
       enqueueSnackbar(`Successfully updated Linode label to ${label}`, {
         variant: 'success',
       });
+      sendUpdateLinodeLabelEvent('Settings');
     },
   });
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -24,6 +24,7 @@ import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 import {
   sendEditBreadcrumbEvent,
   sendLinodeCreateFlowDocsClickEvent,
+  sendUpdateLinodeLabelEvent,
 } from 'src/utilities/analytics';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
@@ -163,6 +164,7 @@ const LinodeDetailHeader = () => {
     return updateLinodeLabel(label)
       .then(() => {
         resetEditableLabel();
+        sendUpdateLinodeLabelEvent('Breadcrumb');
       })
       .catch((updateError) => {
         const errorReasons: string[] = [updateError.message];

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -21,7 +21,10 @@ import {
   useLinodeUpdateMutation,
 } from 'src/queries/linodes/linodes';
 import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
-import { sendLinodeCreateFlowDocsClickEvent } from 'src/utilities/analytics';
+import {
+  sendEditBreadcrumbEvent,
+  sendLinodeCreateFlowDocsClickEvent,
+} from 'src/utilities/analytics';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
@@ -224,6 +227,7 @@ const LinodeDetailHeader = () => {
       <LandingHeader
         breadcrumbProps={{
           onEditHandlers: {
+            analyticsEvent: () => sendEditBreadcrumbEvent(),
             editableTextTitle: linode?.label ?? '',
             errorText: editableLabelError,
             onCancel: resetEditableLabel,

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -229,9 +229,9 @@ const LinodeDetailHeader = () => {
       <LandingHeader
         breadcrumbProps={{
           onEditHandlers: {
-            analyticsEvent: () => sendEditBreadcrumbEvent(),
             editableTextTitle: linode?.label ?? '',
             errorText: editableLabelError,
+            handleAnalyticsEvent: () => sendEditBreadcrumbEvent(),
             onCancel: resetEditableLabel,
             onEdit: handleLinodeLabelUpdate,
           },

--- a/packages/manager/src/utilities/analytics.ts
+++ b/packages/manager/src/utilities/analytics.ts
@@ -443,3 +443,15 @@ export const sendEditBreadcrumbEvent = () => {
     label: 'Edit Breadcrumb',
   });
 };
+
+// LinodeDetailHeader.tsx
+// LinodeSettingsLabelPanel.tsx
+export const sendUpdateLinodeLabelEvent = (
+  label: 'Breadcrumb' | 'Settings'
+) => {
+  sendEvent({
+    action: 'Click:button',
+    category: 'Linode Label',
+    label: `Update linode label from ${label}`,
+  });
+};

--- a/packages/manager/src/utilities/analytics.ts
+++ b/packages/manager/src/utilities/analytics.ts
@@ -434,3 +434,12 @@ export const sendLinodeConfigurationDocsEvent = (label: string) => {
     label,
   });
 };
+
+// LinodeDetailHeader.tsx
+export const sendEditBreadcrumbEvent = () => {
+  sendEvent({
+    action: 'Click:pencil icon',
+    category: 'Breadcrumb',
+    label: 'Edit Breadcrumb',
+  });
+};


### PR DESCRIPTION
## Description 📝
 In the breadcrumb on a Linode detail page, we want a custom event to track the use of the inline edit label feature.

## Changes  🔄
- Adds `sendEditBreadcrumbEvent`, which fires whenever the edit (pencil) icon is clicked on a Linode's details page.
- Adds `sendUpdateLinodeLabelEvent`, which fires when the label is updated in the editable breadcrumb and when the label is updated on the Settings tab. 

## Preview 📷

| Component | Custom Event |
| --- | --- |
| ![image](https://github.com/linode/manager/assets/114685994/a99682f8-b969-4fa6-adf0-932904d96232) | ![image](https://github.com/linode/manager/assets/114685994/a9b69c0d-321e-4a9c-9d6c-d3d9b9d6f446) |
| ![Screenshot 2024-02-13 at 2 46 56 PM](https://github.com/linode/manager/assets/114685994/299c3e0d-8b77-492b-ab04-337a4ea41446) | ![Screenshot 2024-02-13 at 2 46 32 PM](https://github.com/linode/manager/assets/114685994/33f8f11a-abce-4b8a-8407-c843c98980f6) |
| ![Screenshot 2024-02-13 at 2 54 51 PM](https://github.com/linode/manager/assets/114685994/cef46eb3-9c49-44c6-bcdb-9093beef4b84) | ![Screenshot 2024-02-13 at 2 46 17 PM](https://github.com/linode/manager/assets/114685994/383a5207-479b-46d3-84ac-9a48a9e92ae7) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Check out this PR and `yarn dev`
- Go to http://localhost:3000 and turn on analytics logs for Adobe: 
   - In the browser console, type `_satellite.setDebug(true)`
- Have a linode on your account

### Verification steps 
(How to verify changes)
- Go to the details page for a linode
- Click on the edit icon
- Observe the Adobe event above in the browser console log, which confirms the custom event has fired upon icon click
- Confirm the analytics event matches the request in the internal ticket
- See the additional screenshots to test the other events

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support

