### PR TITLE
change: [M3-7735] - Improve Linode Graph X Axis Labels when viewing historic data

### DIFF
--- a/packages/manager/.changeset/pr-10186-changed-1707835872709.md
+++ b/packages/manager/.changeset/pr-10186-changed-1707835872709.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Improve Linode Graph X Axis Labels when viewing historic data ([#10186](https://github.com/linode/manager/pull/10186))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -115,6 +115,8 @@ const LinodeSummary: React.FC<Props> = (props) => {
     debouncedRefetchLinodeStats();
   }, [windowWidth, windowHeight, debouncedRefetchLinodeStats]);
 
+  const xAxisTickFormat = isLast24Hours ? 'hh a' : 'LLL dd';
+
   const renderCPUChart = () => {
     const data = stats?.data.cpu ?? [];
     const metrics = getMetrics(data);
@@ -147,7 +149,7 @@ const LinodeSummary: React.FC<Props> = (props) => {
               },
             ]}
             xAxis={{
-              tickFormat: 'hh a',
+              tickFormat: xAxisTickFormat,
               tickGap: 60,
             }}
             ariaLabel="CPU Usage Graph"
@@ -233,7 +235,7 @@ const LinodeSummary: React.FC<Props> = (props) => {
               },
             ]}
             xAxis={{
-              tickFormat: 'hh a',
+              tickFormat: xAxisTickFormat,
               tickGap: 60,
             }}
             ariaLabel="Disk I/O Graph"
@@ -382,7 +384,11 @@ const LinodeSummary: React.FC<Props> = (props) => {
           </StyledGrid>
         </Grid>
       ) : null}
-      <NetworkGraphs stats={stats} {...chartProps} />
+      <NetworkGraphs
+        stats={stats}
+        xAxisTickFormat={xAxisTickFormat}
+        {...chartProps}
+      />
     </Grid>
   );
 };

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -115,6 +115,15 @@ const LinodeSummary: React.FC<Props> = (props) => {
     debouncedRefetchLinodeStats();
   }, [windowWidth, windowHeight, debouncedRefetchLinodeStats]);
 
+  /**
+   * This changes the X-Axis tick labels depending on the selected timeframe.
+   *
+   * This is important because the X-Axis should show dates insted of times
+   * when viewing many days worth of stats.
+   *
+   * @example 'hh a' renders '11am'
+   * @example 'LLL dd' render 'Feb 14'
+   */
   const xAxisTickFormat = isLast24Hours ? 'hh a' : 'LLL dd';
 
   const renderCPUChart = () => {

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -118,11 +118,11 @@ const LinodeSummary: React.FC<Props> = (props) => {
   /**
    * This changes the X-Axis tick labels depending on the selected timeframe.
    *
-   * This is important because the X-Axis should show dates insted of times
-   * when viewing many days worth of stats.
+   * This is important because the X-Axis should show dates instead of times
+   * when viewing many days' worth of stats.
    *
    * @example 'hh a' renders '11am'
-   * @example 'LLL dd' render 'Feb 14'
+   * @example 'LLL dd' renders 'Feb 14'
    */
   const xAxisTickFormat = isLast24Hours ? 'hh a' : 'LLL dd';
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/NetworkGraphs.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/NetworkGraphs.tsx
@@ -44,6 +44,7 @@ interface Props extends ChartProps {
   rangeSelection: string;
   stats?: Stats;
   timezone: string;
+  xAxisTickFormat: string;
 }
 
 interface NetworkMetrics {
@@ -70,7 +71,7 @@ const _getMetrics = (data: NetworkStats) => {
 };
 
 export const NetworkGraphs = (props: Props) => {
-  const { rangeSelection, stats, ...rest } = props;
+  const { rangeSelection, stats, xAxisTickFormat, ...rest } = props;
 
   const theme = useTheme();
   const flags = useFlags();
@@ -137,6 +138,7 @@ export const NetworkGraphs = (props: Props) => {
     rangeSelection,
     theme,
     timezone: props.timezone,
+    xAxisTickFormat,
   };
 
   return (
@@ -187,6 +189,7 @@ interface GraphProps {
   timezone: string;
   totalTraffic: TotalTrafficProps;
   unit: string;
+  xAxisTickFormat: string;
 }
 
 const Graph = (props: GraphProps) => {
@@ -199,6 +202,7 @@ const Graph = (props: GraphProps) => {
     theme,
     timezone,
     unit,
+    xAxisTickFormat,
   } = props;
 
   const flags = useFlags();
@@ -286,7 +290,7 @@ const Graph = (props: GraphProps) => {
             },
           ]}
           xAxis={{
-            tickFormat: 'hh a',
+            tickFormat: xAxisTickFormat,
             tickGap: 60,
           }}
           ariaLabel={ariaLabel}


### PR DESCRIPTION
## Description 📝

Updates the Linode Graph's X Axis to show **days** instead of **hours** on the x-axis when the user select a longer time period 📈

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-02-13 at 9 45 31 AM](https://github.com/linode/manager/assets/115251059/a73ef224-e655-43ae-b554-85c1c855c628) | ![Screenshot 2024-02-13 at 9 45 21 AM](https://github.com/linode/manager/assets/115251059/c9812c3a-ff53-49f6-8e90-e53e8ca0b503) |

## How to test 🧪

### Prerequisites
- Make sure you have the `recharts` flag on

### Verification steps 
- Go to the Analytics tab of on a Linode's details page
- Try viewing the last 30 days or longer of stats
- Verify the X Axis is showing units in days instead of hours
- Verify the X Axis is user friendly

## As an Author I have considered 🤔

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [x] ♿  Providing accessibility support