### PR TITLE
fix: [M3-7766] - Account Maintenance `Pending` Table - Incorrect `X-Filter`

### DIFF
--- a/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
+++ b/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import { AccountMaintenance } from '@linode/api-v4/lib/account/types';
 import { Theme } from '@mui/material/styles';
 import * as React from 'react';
 import { makeStyles } from 'tss-react/mui';
@@ -27,6 +26,8 @@ import {
 } from 'src/queries/accountMaintenance';
 
 import { MaintenanceTableRow } from './MaintenanceTableRow';
+
+import type { AccountMaintenance, Filter } from '@linode/api-v4';
 
 const preferenceKey = 'account-maintenance';
 
@@ -73,15 +74,11 @@ const MaintenanceTable = ({ type }: Props) => {
     type
   );
 
-  const filters: Record<'completed' | 'pending', any> = {
-    completed: 'completed',
-    pending: { '+or': ['pending, started'] },
-  };
-
-  const filter = {
+  const filter: Filter = {
     '+order': order,
     '+order_by': orderBy,
-    status: filters[type],
+    status:
+      type === 'completed' ? 'completed' : { '+or': ['pending', 'started'] },
   };
 
   const { data: csv, refetch: getCSVData } = useAllAccountMaintenanceQuery(


### PR DESCRIPTION
## Description 📝
Someone internal notified us about an incorrect X-Filter on the Account Maintenance Table. 
 
### Current 
```json
"status":{"+or":["pending, started"]} 
```

### Expected 

```json
"status":{"+or":["pending","started"]} 
 ```
 
> [!note]
> Notice how the current header is missing a `"` between `pending, started`

## Preview 📷

> [!warning]
> Work in progress

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites

> [!warning]
> Work in progress

### Reproduction steps
- Go to https://cloud.linode.com/account/maintenance
- Observe that the incorrect header (shown in the description) is sent 

### Verification steps
- Go to http://localhost:3000/account/maintenance
- Observe that the correct header (shown in the description) is sent 

> [!warning]
> Work in progress


## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support