### PR TITLE
upcoming: [M3-7775] - Disable ability to edit or delete a proxy user via User Profile page

### DIFF
--- a/packages/manager/.changeset/pr-10202-tests-1708119481596.md
+++ b/packages/manager/.changeset/pr-10202-tests-1708119481596.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Improve User Profile integration test coverage and separate from Display Settings coverage ([#10202](https://github.com/linode/manager/pull/10202))

--- a/packages/manager/.changeset/pr-10202-upcoming-features-1708119409383.md
+++ b/packages/manager/.changeset/pr-10202-upcoming-features-1708119409383.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Disable ability to edit or delete a proxy user via User Profile page ([#10202](https://github.com/linode/manager/pull/10202))

--- a/packages/manager/cypress/e2e/core/account/display-settings.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/display-settings.spec.ts
@@ -8,10 +8,7 @@ import { makeFeatureFlagData } from 'support/util/feature-flags';
 import { mockGetProfile } from 'support/intercepts/profile';
 import { getProfile } from 'support/api/account';
 import { interceptGetProfile } from 'support/intercepts/profile';
-import {
-  interceptGetUser,
-  mockUpdateUsername,
-} from 'support/intercepts/account';
+import { mockUpdateUsername } from 'support/intercepts/account';
 import { ui } from 'support/ui';
 import { randomString } from 'support/util/random';
 
@@ -59,54 +56,7 @@ const verifyUsernameAndEmail = (
   }
 };
 
-describe('username', () => {
-  /*
-   * - Validates username update flow via the user profile page using mocked data.
-   */
-  it('can change username via user profile page', () => {
-    const newUsername = randomString(12);
-
-    getProfile().then((profile) => {
-      const username = profile.body.username;
-
-      interceptGetUser(username).as('getUser');
-      mockUpdateUsername(username, newUsername).as('updateUsername');
-
-      cy.visitWithLogin(`account/users/${username}`);
-      cy.wait('@getUser');
-
-      cy.findByText('Username').should('be.visible');
-      cy.findByText('Email').should('be.visible');
-      cy.findByText('Delete User').should('be.visible');
-
-      cy.get('[id="username"]')
-        .should('be.visible')
-        .should('have.value', username)
-        .clear()
-        .type(newUsername);
-
-      cy.get('[data-qa-textfield-label="Username"]')
-        .parent()
-        .parent()
-        .parent()
-        .within(() => {
-          ui.button
-            .findByTitle('Save')
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-        });
-
-      cy.wait('@updateUsername');
-
-      // No confirmation gets shown on this page when changes are saved.
-      // Confirm that the text field has the correct value instead.
-      cy.get('[id="username"]')
-        .should('be.visible')
-        .should('have.value', newUsername);
-    });
-  });
-
+describe('Display Settings', () => {
   /*
    * - Validates username update flow via the profile display page using mocked data.
    */

--- a/packages/manager/cypress/e2e/core/account/user-profile.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/user-profile.spec.ts
@@ -276,7 +276,7 @@ describe('User Profile', () => {
         .trigger('mouseover');
       // Click the button first, then confirm the tooltip is shown.
       ui.tooltip
-        .findByText('You can\u{2019}t delete the proxy user.')
+        .findByText('You can\u{2019}t delete a business partner user.')
         .should('be.visible');
     });
   });

--- a/packages/manager/cypress/e2e/core/account/user-profile.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/user-profile.spec.ts
@@ -8,30 +8,73 @@ import {
 } from 'support/intercepts/account';
 import { randomString } from 'support/util/random';
 import { ui } from 'support/ui';
+import { mockUpdateProfile } from 'support/intercepts/profile';
 
 describe('User Profile', () => {
   /*
-   * - Validates username update flow via the user profile page using mocked data.
+   * - Validates the flow of updating the username and email of the active account user via the User Profile page using mocked data.
    */
-  it('can change username', () => {
+  it('can change email and username of the active account', () => {
     const newUsername = randomString(12);
+    const newEmail = `${newUsername}@example.com`;
 
     getProfile().then((profile) => {
-      const username = profile.body.username;
+      const activeUsername = profile.body.username;
+      const activeEmail = profile.body.email;
 
-      interceptGetUser(username).as('getUser');
-      mockUpdateUsername(username, newUsername).as('updateUsername');
+      interceptGetUser(activeUsername).as('getUser');
+      mockUpdateUsername(activeUsername, newUsername).as('updateUsername');
+      mockUpdateProfile({
+        ...profile.body,
+        email: newEmail,
+      }).as('updateEmail');
 
-      cy.visitWithLogin(`account/users/${username}`);
+      cy.visitWithLogin(`account/users/${activeUsername}`);
       cy.wait('@getUser');
 
       cy.findByText('Username').should('be.visible');
       cy.findByText('Email').should('be.visible');
       cy.findByText('Delete User').should('be.visible');
 
+      // Confirm the currently active user cannot be deleted.
+      ui.button
+        .findByTitle('Delete')
+        .should('be.visible')
+        .should('be.disabled')
+        .trigger('mouseover');
+      // Click the button first, then confirm the tooltip is shown.
+      ui.tooltip
+        .findByText('You can\u{2019}t delete the currently active user.')
+        .should('be.visible');
+
+      // Confirm user can update their email before updating the username, since you cannot update a different user's (as determined by username) email.
+      cy.get('[id="email"]')
+        .should('be.visible')
+        .should('have.value', activeEmail)
+        .clear()
+        .type(newEmail);
+
+      cy.get('[data-qa-textfield-label="Email"]')
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          ui.button
+            .findByTitle('Save')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      cy.wait('@updateEmail');
+
+      // Confirm success notice displays.
+      cy.findByText('Email updated successfully').should('be.visible');
+
+      // Confirm user can update their username.
       cy.get('[id="username"]')
         .should('be.visible')
-        .should('have.value', username)
+        .should('have.value', activeUsername)
         .clear()
         .type(newUsername);
 
@@ -58,7 +101,95 @@ describe('User Profile', () => {
   });
 
   /*
-   * - Validates disabled username and email flow for a proxy user profile using mocked data.
+   * - Validates the flow of updating the username and email of another user via the User Profile page using mocked data.
+   */
+  it('can change the username but not email of another user account', () => {
+    const newUsername = randomString(12);
+
+    getProfile().then((profile) => {
+      const additionalUsername = 'mock_user2';
+      const mockAccountUsers = accountUserFactory.buildList(1, {
+        username: additionalUsername,
+      });
+      const additionalUser = mockAccountUsers[0];
+
+      mockGetUsers(mockAccountUsers).as('getUsers');
+      mockGetUser(additionalUser).as('getUser');
+      mockUpdateUsername(additionalUsername, newUsername).as('updateUsername');
+
+      cy.visitWithLogin(`account/users/${additionalUsername}`);
+
+      cy.wait('@getUser');
+
+      cy.findByText('Username').should('be.visible');
+      cy.findByText('Email').should('be.visible');
+      cy.findByText('Delete User').should('be.visible');
+      ui.button.findByTitle('Delete').should('be.visible').should('be.enabled');
+
+      // Confirm email of another user cannot be updated.
+      cy.get('[id="email"]')
+        .should('be.visible')
+        .should('have.value', additionalUser.email)
+        .should('be.disabled')
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          ui.button
+            .findByAttribute('data-qa-help-button', 'true')
+            .should('be.visible')
+            .trigger('mouseover');
+          // Click the button first, then confirm the tooltip is shown.
+          ui.tooltip
+            .findByText(
+              'You can\u{2019}t change another user\u{2019}s email address.'
+            )
+            .should('be.visible');
+        });
+
+      cy.get('[data-qa-textfield-label="Email"]')
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          ui.button
+            .findByTitle('Save')
+            .should('be.visible')
+            .should('be.disabled')
+            .click();
+        });
+
+      // Confirm username of another user can be updated.
+      cy.get('[id="username"]')
+        .should('be.visible')
+        .should('have.value', additionalUsername)
+        .clear()
+        .type(newUsername);
+
+      cy.get('[data-qa-textfield-label="Username"]')
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          ui.button
+            .findByTitle('Save')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      cy.wait('@updateUsername');
+
+      // No confirmation gets shown on this page when changes are saved.
+      // Confirm that the text field has the correct value instead.
+      cy.get('[id="username"]')
+        .should('be.visible')
+        .should('have.value', newUsername);
+    });
+  });
+
+  /*
+   * - Validates disabled username and email flow for a proxy user via the User Profile page using mocked data.
    */
   it('cannot change username or email for a proxy user or delete the proxy user', () => {
     getProfile().then((profile) => {
@@ -81,6 +212,7 @@ describe('User Profile', () => {
 
       cy.get('[id="username"]')
         .should('be.visible')
+        .should('have.value', proxyUsername)
         .should('be.disabled')
         .parent()
         .parent()
@@ -144,7 +276,7 @@ describe('User Profile', () => {
         .trigger('mouseover');
       // Click the button first, then confirm the tooltip is shown.
       ui.tooltip
-        .findByText("You can't delete the proxy user.")
+        .findByText('You can\u{2019}t delete the proxy user.')
         .should('be.visible');
     });
   });

--- a/packages/manager/cypress/e2e/core/account/user-profile.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/user-profile.spec.ts
@@ -1,0 +1,151 @@
+import { accountUserFactory } from 'src/factories/accountUsers';
+import { getProfile } from 'support/api/account';
+import {
+  interceptGetUser,
+  mockGetUser,
+  mockGetUsers,
+  mockUpdateUsername,
+} from 'support/intercepts/account';
+import { randomString } from 'support/util/random';
+import { ui } from 'support/ui';
+
+describe('User Profile', () => {
+  /*
+   * - Validates username update flow via the user profile page using mocked data.
+   */
+  it('can change username', () => {
+    const newUsername = randomString(12);
+
+    getProfile().then((profile) => {
+      const username = profile.body.username;
+
+      interceptGetUser(username).as('getUser');
+      mockUpdateUsername(username, newUsername).as('updateUsername');
+
+      cy.visitWithLogin(`account/users/${username}`);
+      cy.wait('@getUser');
+
+      cy.findByText('Username').should('be.visible');
+      cy.findByText('Email').should('be.visible');
+      cy.findByText('Delete User').should('be.visible');
+
+      cy.get('[id="username"]')
+        .should('be.visible')
+        .should('have.value', username)
+        .clear()
+        .type(newUsername);
+
+      cy.get('[data-qa-textfield-label="Username"]')
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          ui.button
+            .findByTitle('Save')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      cy.wait('@updateUsername');
+
+      // No confirmation gets shown on this page when changes are saved.
+      // Confirm that the text field has the correct value instead.
+      cy.get('[id="username"]')
+        .should('be.visible')
+        .should('have.value', newUsername);
+    });
+  });
+
+  /*
+   * - Validates disabled username and email flow for a proxy user profile using mocked data.
+   */
+  it('cannot change username or email for a proxy user or delete the proxy user', () => {
+    getProfile().then((profile) => {
+      const proxyUsername = 'proxy_user';
+      const mockAccountUsers = accountUserFactory.buildList(1, {
+        username: proxyUsername,
+        user_type: 'proxy',
+      });
+
+      mockGetUsers(mockAccountUsers).as('getUsers');
+      mockGetUser(mockAccountUsers[0]).as('getUser');
+
+      cy.visitWithLogin(`account/users/${proxyUsername}`);
+
+      cy.wait('@getUser');
+
+      cy.findByText('Username').should('be.visible');
+      cy.findByText('Email').should('be.visible');
+      cy.findByText('Delete User').should('be.visible');
+
+      cy.get('[id="username"]')
+        .should('be.visible')
+        .should('be.disabled')
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          ui.button
+            .findByAttribute('data-qa-help-button', 'true')
+            .should('be.visible')
+            .trigger('mouseover');
+          // Click the button first, then confirm the tooltip is shown.
+          ui.tooltip
+            .findByText('This account type cannot update this field.')
+            .should('be.visible');
+        });
+
+      cy.get('[data-qa-textfield-label="Username"]')
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          ui.button
+            .findByTitle('Save')
+            .should('be.visible')
+            .should('be.disabled');
+        });
+
+      cy.get('[id="email"]')
+        .should('be.visible')
+        .should('be.disabled')
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          ui.button
+            .findByAttribute('data-qa-help-button', 'true')
+            .should('be.visible')
+            .trigger('mouseover');
+          // Click the button first, then confirm the tooltip is shown.
+          ui.tooltip
+            .findByText('This account type cannot update this field.')
+            .should('be.visible');
+        });
+
+      cy.get('[data-qa-textfield-label="Email"]')
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          ui.button
+            .findByTitle('Save')
+            .should('be.visible')
+            .should('be.disabled')
+            .click();
+        });
+
+      // Confirms the proxy user cannot be deleted.
+      ui.button
+        .findByTitle('Delete')
+        .should('be.visible')
+        .should('be.disabled')
+        .trigger('mouseover');
+      // Click the button first, then confirm the tooltip is shown.
+      ui.tooltip
+        .findByText("You can't delete the proxy user.")
+        .should('be.visible');
+    });
+  });
+});

--- a/packages/manager/src/features/Account/constants.ts
+++ b/packages/manager/src/features/Account/constants.ts
@@ -22,3 +22,6 @@ export const CHILD_USER_CLOSE_ACCOUNT_TOOLTIP_TEXT =
 // TODO: Parent/Child: Requires updated copy...
 export const PARENT_SESSION_EXPIRED =
   'Session expired. Please log in again to your business partner account.';
+
+export const RESTRICTED_FIELD_TOOLTIP =
+  'This account type cannot update this field.';

--- a/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.tsx
@@ -17,8 +17,8 @@ import { useNotificationsQuery } from 'src/queries/accountNotifications';
 import { useMutateProfile, useProfile } from 'src/queries/profile';
 import { ApplicationState } from 'src/store';
 
-import { restrictedProxyUserTooltip } from '../constants';
 import { TimezoneForm } from './TimezoneForm';
+import { RESTRICTED_FIELD_TOOLTIP } from 'src/features/Account/constants';
 
 export const DisplaySettings = () => {
   const theme = useTheme();
@@ -106,7 +106,7 @@ export const DisplaySettings = () => {
           profile?.restricted
             ? 'Restricted users cannot update their username. Please contact an account administrator.'
             : isProxyUser
-            ? restrictedProxyUserTooltip
+            ? RESTRICTED_FIELD_TOOLTIP
             : undefined
         }
         disabled={profile?.restricted || isProxyUser}
@@ -136,7 +136,7 @@ export const DisplaySettings = () => {
         key={emailResetToken}
         label="Email"
         submitForm={updateEmail}
-        tooltipText={isProxyUser ? restrictedProxyUserTooltip : undefined}
+        tooltipText={isProxyUser ? RESTRICTED_FIELD_TOOLTIP : undefined}
         trimmed
         type="email"
       />

--- a/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.tsx
@@ -17,6 +17,7 @@ import { useNotificationsQuery } from 'src/queries/accountNotifications';
 import { useMutateProfile, useProfile } from 'src/queries/profile';
 import { ApplicationState } from 'src/store';
 
+import { restrictedProxyUserTooltip } from '../constants';
 import { TimezoneForm } from './TimezoneForm';
 
 export const DisplaySettings = () => {
@@ -64,9 +65,6 @@ export const DisplaySettings = () => {
       automatically linked.
     </>
   );
-
-  const restrictedProxyUserTooltip =
-    'This account type cannot update this field.';
 
   return (
     <Paper>

--- a/packages/manager/src/features/Profile/constants.ts
+++ b/packages/manager/src/features/Profile/constants.ts
@@ -1,0 +1,2 @@
+export const restrictedProxyUserTooltip =
+  'This account type cannot update this field.';

--- a/packages/manager/src/features/Profile/constants.ts
+++ b/packages/manager/src/features/Profile/constants.ts
@@ -1,2 +1,0 @@
-export const restrictedProxyUserTooltip =
-  'This account type cannot update this field.';

--- a/packages/manager/src/features/Users/UserProfile.tsx
+++ b/packages/manager/src/features/Users/UserProfile.tsx
@@ -9,11 +9,12 @@ import { CircleProgress } from 'src/components/CircleProgress';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { Notice } from 'src/components/Notice/Notice';
 import { TextField } from 'src/components/TextField';
-import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
+import { useAccountUser } from 'src/queries/accountUsers';
 import { useProfile } from 'src/queries/profile';
 import { getAPIErrorFor } from 'src/utilities/getAPIErrorFor';
 
+import { restrictedProxyUserTooltip } from '../Profile/constants';
 import { UserDeleteConfirmationDialog } from './UserDeleteConfirmationDialog';
 import { StyledTitle, StyledWrapper } from './UserProfile.styles';
 
@@ -59,11 +60,14 @@ export const UserProfile = (props: UserProfileProps) => {
   } = props;
 
   const { data: profile } = useProfile();
+  const { data: currentUser } = useAccountUser(username);
 
   const [
     deleteConfirmDialogOpen,
     setDeleteConfirmDialogOpen,
   ] = React.useState<boolean>(false);
+
+  const isProxyUserProfile = currentUser?.user_type === 'proxy';
 
   const renderProfileSection = () => {
     const hasAccountErrorFor = getAPIErrorFor(
@@ -97,7 +101,11 @@ export const UserProfile = (props: UserProfileProps) => {
             />
           )}
           <TextField
+            tooltipText={
+              isProxyUserProfile ? restrictedProxyUserTooltip : undefined
+            }
             data-qa-username
+            disabled={isProxyUserProfile}
             errorText={hasAccountErrorFor('username')}
             label="Username"
             onBlur={changeUsername}
@@ -129,14 +137,18 @@ export const UserProfile = (props: UserProfileProps) => {
             />
           )}
           <TextField
+            // This should be disabled if this is NOT the current user or if the proxy user is viewing their own profile.
+            disabled={
+              profile?.username !== originalUsername || isProxyUserProfile
+            }
             tooltipText={
-              profile?.username !== originalUsername
-                ? "You can't change another user\u{2019}s email address"
-                : ''
+              isProxyUserProfile
+                ? restrictedProxyUserTooltip
+                : profile?.username !== originalUsername
+                ? "You can't change another user\u{2019}s email address."
+                : undefined
             }
             data-qa-email
-            // This should be disabled if this is NOT the current user.
-            disabled={profile?.username !== originalUsername}
             errorText={hasProfileErrorFor('email')}
             label="Email"
             onChange={changeEmail}
@@ -176,27 +188,26 @@ export const UserProfile = (props: UserProfileProps) => {
           Delete User
         </Typography>
         <Button
+          disabled={
+            profile?.username === originalUsername || isProxyUserProfile
+          }
           sx={{
             marginLeft: 0,
             marginTop: theme.spacing(2),
           }}
+          tooltipText={
+            profile?.username === originalUsername
+              ? "You can't delete the currently active user."
+              : isProxyUserProfile
+              ? "You can't delete the proxy user."
+              : undefined
+          }
           buttonType="outlined"
           data-qa-confirm-delete
-          disabled={profile?.username === originalUsername}
           onClick={onDelete}
         >
           Delete
         </Button>
-        {profile?.username === originalUsername && (
-          <TooltipIcon
-            sxTooltipIcon={{
-              marginLeft: 0,
-              marginTop: theme.spacing(2),
-            }}
-            status="help"
-            text="You can't delete the currently active user"
-          />
-        )}
         <Typography
           sx={{
             marginLeft: 0,

--- a/packages/manager/src/features/Users/UserProfile.tsx
+++ b/packages/manager/src/features/Users/UserProfile.tsx
@@ -14,9 +14,9 @@ import { useAccountUser } from 'src/queries/accountUsers';
 import { useProfile } from 'src/queries/profile';
 import { getAPIErrorFor } from 'src/utilities/getAPIErrorFor';
 
-import { restrictedProxyUserTooltip } from '../Profile/constants';
 import { UserDeleteConfirmationDialog } from './UserDeleteConfirmationDialog';
 import { StyledTitle, StyledWrapper } from './UserProfile.styles';
+import { RESTRICTED_FIELD_TOOLTIP } from '../Account/constants';
 
 interface UserProfileProps {
   accountErrors?: APIError[];
@@ -102,7 +102,7 @@ export const UserProfile = (props: UserProfileProps) => {
           )}
           <TextField
             tooltipText={
-              isProxyUserProfile ? restrictedProxyUserTooltip : undefined
+              isProxyUserProfile ? RESTRICTED_FIELD_TOOLTIP : undefined
             }
             data-qa-username
             disabled={isProxyUserProfile}
@@ -143,7 +143,7 @@ export const UserProfile = (props: UserProfileProps) => {
             }
             tooltipText={
               isProxyUserProfile
-                ? restrictedProxyUserTooltip
+                ? RESTRICTED_FIELD_TOOLTIP
                 : profile?.username !== originalUsername
                 ? 'You can\u{2019}t change another user\u{2019}s email address.'
                 : undefined

--- a/packages/manager/src/features/Users/UserProfile.tsx
+++ b/packages/manager/src/features/Users/UserProfile.tsx
@@ -145,7 +145,7 @@ export const UserProfile = (props: UserProfileProps) => {
               isProxyUserProfile
                 ? restrictedProxyUserTooltip
                 : profile?.username !== originalUsername
-                ? "You can't change another user\u{2019}s email address."
+                ? 'You can\u{2019}t change another user\u{2019}s email address.'
                 : undefined
             }
             data-qa-email
@@ -197,9 +197,9 @@ export const UserProfile = (props: UserProfileProps) => {
           }}
           tooltipText={
             profile?.username === originalUsername
-              ? "You can't delete the currently active user."
+              ? 'You can\u{2019}t delete the currently active user.'
               : isProxyUserProfile
-              ? "You can't delete the proxy user."
+              ? 'You can\u{2019}t delete the proxy user.'
               : undefined
           }
           buttonType="outlined"

--- a/packages/manager/src/features/Users/UserProfile.tsx
+++ b/packages/manager/src/features/Users/UserProfile.tsx
@@ -199,7 +199,7 @@ export const UserProfile = (props: UserProfileProps) => {
             profile?.username === originalUsername
               ? 'You can\u{2019}t delete the currently active user.'
               : isProxyUserProfile
-              ? 'You can\u{2019}t delete the proxy user.'
+              ? 'You can\u{2019}t delete a business partner user.'
               : undefined
           }
           buttonType="outlined"


### PR DESCRIPTION
## Description 📝
In Cloud Manager, a proxy user cannot be deleted, nor can its email address or username be edited once it is provisioned. 

This PR is a follow up from #10103 which restricted proxy users from updating their username or email on the Display Settings page (http://localhost:3000/profile/display). There is one additional place that a proxy user could be edited, which is by visiting the User Profile page for the proxy user via URL. (The User Profile button is not visible for a proxy user on the Users & Grants page, http://localhost:3000/account/users.)

## Changes  🔄
List any change relevant to the reviewer.
- Disables the username and email fields and the buttons on the proxy user's profile. Displays tooltips with reason for disabling.
- Separates out tests in `change-username.spec.ts` into two different files: one for the Display Settings section (`display-settings.spec.ts`) and another for the User Profile page (`user-profile.spec.ts`). This was suggested a while ago and included in the AC of another ticket in the backlog, but it was cleaner to make the switch now rather than shoehorn additional test coverage into where it didn't really belong.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/114685994/9e498eb9-06c3-455e-9acf-ae96fed2d72b"/>  | <video src="https://github.com/linode/manager/assets/114685994/7e3c8f8b-04f2-496c-86d8-53799cf27eb0"/> |
| <video src="https://github.com/linode/manager/assets/114685994/97126ac0-5ea5-459f-a9b6-49500766eb1b"/> | <video src="https://github.com/linode/manager/assets/114685994/a80534cf-2535-4d11-aac7-8dec80f11eb0"/> |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Check out this PR and `yarn dev`.
- Make sure Parent/Child feature flag and mocks are on.

### Reproduction steps
(How to reproduce the issue, if applicable)
- Go to http://localhost:3000/account/users/ParentCompany_a1b2c3d4e5 and observe you can edit the username, email and have the ability to delete the account.
- See also: videos.

### Verification steps
(How to verify changes)
- Change the MSW `*/profile` endpoint to mock the proxy user as the current active user.
```
const profile = profileFactory.build({
      restricted: false,
      // Parent/Child: switch the `user_type` depending on what account view you need to mock.
      user_type: 'proxy',
      username: 'ParentCompany_a1b2c3d4e5',
    });
```
- Go to http://localhost:3000/account/users/ParentCompany_a1b2c3d4e5) and confirm the username, email, and ability to delete the account are disabled.
- Change the MSW `*/profile` endpoint to mock a child user
```
const profile = profileFactory.build({
      restricted: false,
      // Parent/Child: switch the `user_type` depending on what account view you need to mock.
      user_type: 'child',
    });
```
- Go to http://localhost:3000/account/users/ParentCompany_a1b2c3d4e5) and confirm the username, email, and ability to delete the account are disabled.
- Confirm no regressions to User Profile page for other users (default, restricted, current active user). 
- Confirm tests pass:
```
yarn cy:run -s "cypress/e2e/core/account/user-profile.spec.ts, cypress/e2e/core/account/display-settings.spec.ts"
```


## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

