### PR TITLE
test: [M3-7497] - Add tests for child user verification banner

### DIFF
--- a/packages/manager/.changeset/pr-10204-tests-1708976001328.md
+++ b/packages/manager/.changeset/pr-10204-tests-1708976001328.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add tests for child user verification banner ([#10204](https://github.com/linode/manager/pull/10204))

--- a/packages/manager/cypress/e2e/core/account/user-verification-banner.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/user-verification-banner.spec.ts
@@ -14,6 +14,7 @@ import {
 import { ui } from 'support/ui';
 import { mockGetProfile } from 'support/intercepts/profile';
 import { makeFeatureFlagData } from 'support/util/feature-flags';
+import { verificationBannerNotice } from 'support/constants/user';
 
 describe('User verification banner', () => {
   /*
@@ -62,35 +63,23 @@ describe('User verification banner', () => {
     cy.visitWithLogin('/account/users');
 
     // A banner is displayed and prompts users to set up phone numbers or security questions.
-    cy.findByText(
-      'Add verification details to enhance account security and ensure prompt assistance when needed.'
-    ).should('be.visible');
+    cy.findByText(verificationBannerNotice).should('be.visible');
 
     // The banner should be present across all other pages
     cy.visitWithLogin('/account/billings');
-    cy.findByText(
-      'Add verification details to enhance account security and ensure prompt assistance when needed.'
-    ).should('be.visible');
+    cy.findByText(verificationBannerNotice).should('be.visible');
 
     cy.visitWithLogin('/account/login-history');
-    cy.findByText(
-      'Add verification details to enhance account security and ensure prompt assistance when needed.'
-    ).should('be.visible');
+    cy.findByText(verificationBannerNotice).should('be.visible');
 
     cy.visitWithLogin('/account/service-transfers');
-    cy.findByText(
-      'Add verification details to enhance account security and ensure prompt assistance when needed.'
-    ).should('be.visible');
+    cy.findByText(verificationBannerNotice).should('be.visible');
 
     cy.visitWithLogin('/account/maintenance');
-    cy.findByText(
-      'Add verification details to enhance account security and ensure prompt assistance when needed.'
-    ).should('be.visible');
+    cy.findByText(verificationBannerNotice).should('be.visible');
 
     cy.visitWithLogin('/account/settings');
-    cy.findByText(
-      'Add verification details to enhance account security and ensure prompt assistance when needed.'
-    ).should('be.visible');
+    cy.findByText(verificationBannerNotice).should('be.visible');
 
     // "Add verification details" button should redirect to url '/profile/auth'
     ui.button
@@ -129,14 +118,14 @@ describe('User verification banner', () => {
       global: { account_access: 'read_write' },
     });
 
-    const securityQuestions = securityQuestionsFactory.build();
-    const securityQuestionAnswers = ['Answer 1', 'Answer 2', 'Answer 3'];
-    securityQuestions.security_questions[0].response =
-      securityQuestionAnswers[0];
-    securityQuestions.security_questions[1].response =
-      securityQuestionAnswers[1];
-    securityQuestions.security_questions[2].response =
-      securityQuestionAnswers[2];
+    const mockSecurityQuestions = securityQuestionsFactory.build();
+    const mockSecurityQuestionAnswers = ['Answer 1', 'Answer 2', 'Answer 3'];
+    mockSecurityQuestions.security_questions[0].response =
+      mockSecurityQuestionAnswers[0];
+    mockSecurityQuestions.security_questions[1].response =
+      mockSecurityQuestionAnswers[1];
+    mockSecurityQuestions.security_questions[2].response =
+      mockSecurityQuestionAnswers[2];
 
     // TODO: Parent/Child - M3-7559 clean up when feature is live in prod and feature flag is removed.
     mockAppendFeatureFlags({
@@ -150,16 +139,14 @@ describe('User verification banner', () => {
     mockGetProfile(mockChildProfile);
     mockGetUser(mockRestrictedProxyUser);
     mockGetUserGrants(mockRestrictedProxyUser.username, mockUserGrants);
-    mockGetSecurityQuestions(securityQuestions).as('getSecurityQuestions');
+    mockGetSecurityQuestions(mockSecurityQuestions).as('getSecurityQuestions');
 
     // Navigate to Users & Grants page and confirm "Business partner settings" and "User settings" sections are visible.
     cy.visitWithLogin('/account/users');
     cy.wait(['@getUsers', '@getSecurityQuestions']);
 
     // The banner should not show up.
-    cy.findByText(
-      'Add verification details to enhance account security and ensure prompt assistance when needed.'
-    ).should('not.exist');
+    cy.findByText(verificationBannerNotice).should('not.exist');
     cy.get('[data-testid="confirmButton"]').should('not.exist');
   });
 });

--- a/packages/manager/cypress/e2e/core/account/user-verification-banner.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/user-verification-banner.spec.ts
@@ -18,7 +18,7 @@ import { verificationBannerNotice } from 'support/constants/user';
 
 describe('User verification banner', () => {
   /*
-   * - Confirms that a banner is present the child users do not have a phone number or security questions.
+   * - Confirms that a banner is present when child users do not have a phone number or security questions.
    * - Confirms that the "Add Verification Details" button redirects the user to /profile/auth.
    */
   it('can show up when a child user has not associated a phone number or set up security questions for their account', () => {
@@ -50,9 +50,9 @@ describe('User verification banner', () => {
     mockAppendFeatureFlags({
       parentChildAccountAccess: makeFeatureFlagData(true),
     }).as('getFeatureFlags');
-    mockGetFeatureFlagClientstream().as('getClientStream');
+    mockGetFeatureFlagClientstream();
 
-    mockGetUsers([mockRestrictedProxyUser]).as('getUsers');
+    mockGetUsers([mockRestrictedProxyUser]);
     mockGetUser(mockChildUser);
     mockGetUserGrants(mockChildUser.username, mockUserGrants);
     mockGetProfile(mockChildProfile);
@@ -91,7 +91,7 @@ describe('User verification banner', () => {
   });
 
   /*
-   * - Confirms that a banner is present the child users set up security questions but not have a phone number.
+   * - Confirms that a banner is present when child users set up security questions but not a phone number.
    * - Confirms that the "Add Verification Details" button redirects the user to /profile/auth.
    */
   it('can show up when a child user has set up security questions but not a phone number for their account', () => {
@@ -175,9 +175,9 @@ describe('User verification banner', () => {
   });
 
   /*
-   * - Confirms that a banner is not shown when the child user sets up security questions.
+   * - Confirms that a banner is not shown when the child user sets up both phone number and security questions.
    */
-  it('does not show up when a child user adds a phone number or set up security questions', () => {
+  it('does not show up when a child user adds a phone number and sets up security questions', () => {
     const mockChildProfile = profileFactory.build({
       username: 'child-user',
       user_type: 'child',

--- a/packages/manager/cypress/support/constants/user.ts
+++ b/packages/manager/cypress/support/constants/user.ts
@@ -1,0 +1,3 @@
+/** Notice shown to users not setting up security questions. */
+export const verificationBannerNotice =
+  'Add verification details to enhance account security and ensure prompt assistance when needed.';


### PR DESCRIPTION
## Description 📝
Add regression tests for checking child user verification banner

## Major Changes 🔄
- Add regression tests to check child user verification banner

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/account/user-verification-banner.spec.ts"
```