### PR TITLE
change: [M3-7437] - Update Profile Queries to use Query Key Factory

### DIFF
--- a/packages/manager/cypress/e2e/core/account/personal-access-tokens.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/personal-access-tokens.spec.ts
@@ -196,8 +196,10 @@ describe('Personal access tokens', () => {
           .click();
       });
 
+    mockGetPersonalAccessTokens([newToken]).as('getTokens');
     // Confirm that token has been renamed, initiate revocation.
-    cy.wait('@updateToken');
+    cy.wait(['@updateToken', '@getTokens']);
+
     cy.findByText(newToken.label)
       .should('be.visible')
       .closest('tr')

--- a/packages/manager/src/features/Profile/AuthenticationSettings/PhoneVerification/PhoneVerification.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/PhoneVerification/PhoneVerification.tsx
@@ -12,7 +12,7 @@ import { LinkButton } from 'src/components/LinkButton';
 import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
 import {
-  queryKey,
+  profileQueries,
   updateProfileData,
   useProfile,
   useSendPhoneVerificationCodeMutation,
@@ -98,7 +98,7 @@ export const PhoneVerification = ({
       );
     } else {
       // Cloud Manager does not know about the country, so lets refetch the user's phone number so we know it's displaying correctly
-      queryClient.invalidateQueries(queryKey);
+      queryClient.invalidateQueries(profileQueries.profile().queryKey);
     }
 
     // reset form states

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
@@ -6,7 +6,7 @@ import { useQueryClient } from 'react-query';
 import { StyledLinkButton } from 'src/components/Button/StyledLinkButton';
 import { Notice } from 'src/components/Notice/Notice';
 import { Typography } from 'src/components/Typography';
-import { queryKey } from 'src/queries/profile';
+import { profileQueries } from 'src/queries/profile';
 import { useSecurityQuestions } from 'src/queries/securityQuestions';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getAPIErrorFor } from 'src/utilities/getAPIErrorFor';
@@ -61,7 +61,7 @@ export const TwoFactor = (props: TwoFactorProps) => {
    */
   const handleEnableSuccess = (scratchCode: string) => {
     // Refetch Profile with React Query so profile is up to date
-    queryClient.invalidateQueries(queryKey);
+    queryClient.invalidateQueries(profileQueries.profile().queryKey);
     setSuccess('Two-factor authentication has been enabled.');
     setShowQRCode(false);
     setTwoFactorEnabled(true);

--- a/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -33,11 +33,11 @@ import {
   withQueryClient,
 } from 'src/containers/withQueryClient.container';
 import { StackScriptForm } from 'src/features/StackScripts/StackScriptForm/StackScriptForm';
-import { queryKey } from 'src/queries/profile';
 import { filterImagesByType } from 'src/store/image/image.helpers';
 import { getAPIErrorFor } from 'src/utilities/getAPIErrorFor';
 import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
 import { storage } from 'src/utilities/storage';
+import { profileQueries } from 'src/queries/profile';
 
 interface State {
   apiResponse?: StackScript;
@@ -359,7 +359,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
           return;
         }
         if (profile.data?.restricted) {
-          queryClient.invalidateQueries([queryKey, 'grants']);
+          queryClient.invalidateQueries(profileQueries.grants.queryKey);
         }
         this.setState({ isSubmitting: false });
         this.resetAllFields();

--- a/packages/manager/src/hooks/useInitialRequests.ts
+++ b/packages/manager/src/hooks/useInitialRequests.ts
@@ -1,11 +1,12 @@
 import { getAccountInfo, getAccountSettings } from '@linode/api-v4/lib/account';
-import { getProfile, getUserPreferences } from '@linode/api-v4/lib/profile';
+import { getUserPreferences } from '@linode/api-v4/lib/profile';
 import * as React from 'react';
 import { useQueryClient } from 'react-query';
 
 import { useAuthentication } from 'src/hooks/useAuthentication';
 import { usePendingUpload } from 'src/hooks/usePendingUpload';
 import { queryKey as accountQueryKey } from 'src/queries/account';
+import { profileQueries } from 'src/queries/profile';
 import { redirectToLogin } from 'src/session';
 
 /**
@@ -66,10 +67,7 @@ export const useInitialRequests = () => {
       }),
 
       // Username and whether a user is restricted
-      queryClient.prefetchQuery({
-        queryFn: () => getProfile(),
-        queryKey: 'profile',
-      }),
+      queryClient.prefetchQuery(profileQueries.profile()),
 
       // Is a user managed
       queryClient.prefetchQuery({

--- a/packages/manager/src/queries/databases.ts
+++ b/packages/manager/src/queries/databases.ts
@@ -41,7 +41,7 @@ import { EventHandlerData } from 'src/hooks/useEventHandlers';
 import { getAll } from 'src/utilities/getAll';
 
 import { queryPresets, updateInPaginatedStore } from './base';
-import { queryKey as PROFILE_QUERY_KEY } from './profile';
+import { profileQueries } from './profile';
 
 export const queryKey = 'databases';
 
@@ -116,7 +116,7 @@ export const useCreateDatabaseMutation = () => {
         // Add database to the cache
         queryClient.setQueryData([queryKey, data.id], data);
         // If a restricted user creates an entity, we must make sure grants are up to date.
-        queryClient.invalidateQueries([PROFILE_QUERY_KEY, 'grants']);
+        queryClient.invalidateQueries(profileQueries.grants.queryKey);
       },
     }
   );

--- a/packages/manager/src/queries/domains.ts
+++ b/packages/manager/src/queries/domains.ts
@@ -24,8 +24,8 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import { getAll } from 'src/utilities/getAll';
 
-import { queryKey as PROFILE_QUERY_KEY } from './profile';
 import { EventHandlerData } from 'src/hooks/useEventHandlers';
+import { profileQueries } from './profile';
 
 export const queryKey = 'domains';
 
@@ -57,7 +57,7 @@ export const useCreateDomainMutation = () => {
       queryClient.invalidateQueries([queryKey, 'paginated']);
       queryClient.setQueryData([queryKey, 'domain', domain.id], domain);
       // If a restricted user creates an entity, we must make sure grants are up to date.
-      queryClient.invalidateQueries([PROFILE_QUERY_KEY, 'grants']);
+      queryClient.invalidateQueries(profileQueries.grants.queryKey);
     },
   });
 };

--- a/packages/manager/src/queries/firewalls.ts
+++ b/packages/manager/src/queries/firewalls.ts
@@ -27,7 +27,7 @@ import { queryKey as linodesQueryKey } from 'src/queries/linodes/linodes';
 import { getAll } from 'src/utilities/getAll';
 
 import { updateInPaginatedStore } from './base';
-import { queryKey as PROFILE_QUERY_KEY } from './profile';
+import { profileQueries } from './profile';
 
 export const queryKey = 'firewall';
 
@@ -123,7 +123,7 @@ export const useCreateFirewall = () => {
         queryClient.invalidateQueries([queryKey, 'paginated']);
         queryClient.setQueryData([queryKey, 'firewall', firewall.id], firewall);
         // If a restricted user creates an entity, we must make sure grants are up to date.
-        queryClient.invalidateQueries([PROFILE_QUERY_KEY, 'grants']);
+        queryClient.invalidateQueries(profileQueries.grants.queryKey);
       },
     }
   );

--- a/packages/manager/src/queries/images.ts
+++ b/packages/manager/src/queries/images.ts
@@ -26,8 +26,8 @@ import {
 import { getAll } from 'src/utilities/getAll';
 
 import { doesItemExistInPaginatedStore, updateInPaginatedStore } from './base';
-import { queryKey as PROFILE_QUERY_KEY } from './profile';
 import { EventHandlerData } from 'src/hooks/useEventHandlers';
+import { profileQueries } from './profile';
 
 export const queryKey = 'images';
 
@@ -55,7 +55,7 @@ export const useCreateImageMutation = () => {
       onSuccess() {
         queryClient.invalidateQueries(`${queryKey}-list`);
         // If a restricted user creates an entity, we must make sure grants are up to date.
-        queryClient.invalidateQueries([PROFILE_QUERY_KEY, 'grants']);
+        queryClient.invalidateQueries(profileQueries.grants.queryKey);
       },
     }
   );

--- a/packages/manager/src/queries/kubernetes.ts
+++ b/packages/manager/src/queries/kubernetes.ts
@@ -36,7 +36,7 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { getAll } from 'src/utilities/getAll';
 
 import { queryPresets, updateInPaginatedStore } from './base';
-import { queryKey as PROFILE_QUERY_KEY } from './profile';
+import { profileQueries } from './profile';
 
 export const queryKey = `kubernetes`;
 
@@ -141,7 +141,7 @@ export const useCreateKubernetesClusterMutation = () => {
       onSuccess() {
         queryClient.invalidateQueries([`${queryKey}-list`]);
         // If a restricted user creates an entity, we must make sure grants are up to date.
-        queryClient.invalidateQueries([PROFILE_QUERY_KEY, 'grants']);
+        queryClient.invalidateQueries(profileQueries.grants.queryKey);
       },
     }
   );

--- a/packages/manager/src/queries/linodes/linodes.ts
+++ b/packages/manager/src/queries/linodes/linodes.ts
@@ -40,7 +40,7 @@ import { manuallySetVPCConfigInterfacesToActive } from 'src/utilities/configs';
 
 import { queryKey as accountNotificationsQueryKey } from '../accountNotifications';
 import { queryPresets } from '../base';
-import { queryKey as PROFILE_QUERY_KEY } from '../profile';
+import { profileQueries } from '../profile';
 import { getAllLinodeKernelsRequest, getAllLinodesRequest } from './requests';
 
 export const queryKey = 'linodes';
@@ -159,7 +159,7 @@ export const useCreateLinodeMutation = () => {
         linode
       );
       // If a restricted user creates an entity, we must make sure grants are up to date.
-      queryClient.invalidateQueries([PROFILE_QUERY_KEY, 'grants']);
+      queryClient.invalidateQueries(profileQueries.grants.queryKey);
     },
   });
 };

--- a/packages/manager/src/queries/nodebalancers.ts
+++ b/packages/manager/src/queries/nodebalancers.ts
@@ -38,7 +38,7 @@ import { getAll } from 'src/utilities/getAll';
 
 import { queryPresets } from './base';
 import { itemInListCreationHandler, itemInListMutationHandler } from './base';
-import { queryKey as PROFILE_QUERY_KEY } from './profile';
+import { profileQueries } from './profile';
 
 export const queryKey = 'nodebalancers';
 
@@ -114,7 +114,7 @@ export const useNodebalancerCreateMutation = () => {
         queryClient.invalidateQueries([queryKey]);
         queryClient.setQueryData([queryKey, 'nodebalancer', data.id], data);
         // If a restricted user creates an entity, we must make sure grants are up to date.
-        queryClient.invalidateQueries([PROFILE_QUERY_KEY, 'grants']);
+        queryClient.invalidateQueries(profileQueries.grants.queryKey);
       },
     }
   );

--- a/packages/manager/src/queries/placementGroups.ts
+++ b/packages/manager/src/queries/placementGroups.ts
@@ -17,8 +17,6 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import { getAll } from 'src/utilities/getAll';
 
-import { queryKey as PROFILE_QUERY_KEY } from './profile';
-
 import type {
   AssignLinodesToPlacementGroupPayload,
   CreatePlacementGroupPayload,
@@ -26,6 +24,7 @@ import type {
   RenamePlacementGroupPayload,
   UnassignLinodesFromPlacementGroupPayload,
 } from '@linode/api-v4';
+import { profileQueries } from './profile';
 
 export const queryKey = 'placement-groups';
 
@@ -76,7 +75,7 @@ export const useCreatePlacementGroup = () => {
         placementGroup
       );
       // If a restricted user creates an entity, we must make sure grants are up to date.
-      queryClient.invalidateQueries([PROFILE_QUERY_KEY, 'grants']);
+      queryClient.invalidateQueries(profileQueries.grants.queryKey);
     },
   });
 };

--- a/packages/manager/src/queries/profile.ts
+++ b/packages/manager/src/queries/profile.ts
@@ -57,6 +57,7 @@ export const { profile: profileQueries } = getQueryKeys({
     }),
     profile: (options: RequestOptions = {}) => ({
       queryFn: () => getProfile(options),
+      queryKey: [options],
     }),
     sshKeys: (params: Params = {}, filter: Filter = {}) => ({
       queryFn: () => getSSHKeys(params, filter),

--- a/packages/manager/src/queries/profile.ts
+++ b/packages/manager/src/queries/profile.ts
@@ -8,6 +8,8 @@ import {
   deleteSSHKey,
   deleteTrustedDevice,
   disableTwoFactor,
+  getAppTokens,
+  getPersonalAccessTokens,
   getProfile,
   getSSHKeys,
   getTrustedDevices,
@@ -17,8 +19,6 @@ import {
   updateProfile,
   updateSSHKey,
   verifyPhoneNumberCode,
-  getAppTokens,
-  getPersonalAccessTokens,
 } from '@linode/api-v4/lib/profile';
 import {
   APIError,

--- a/packages/manager/src/queries/profile.ts
+++ b/packages/manager/src/queries/profile.ts
@@ -69,7 +69,7 @@ export const { profile: profileQueries } = getQueryKeys({
   },
 });
 
-export const useProfile = (options?: RequestOptions) => {
+export const useProfile = (options: RequestOptions = {}) => {
   return useQuery<Profile, APIError[]>({
     ...profileQueries.profile(options),
     ...queryPresets.oneTimeFetch,

--- a/packages/manager/src/queries/volumes.ts
+++ b/packages/manager/src/queries/volumes.ts
@@ -24,11 +24,11 @@ import {
   useQueryClient,
 } from 'react-query';
 
+import { EventHandlerData } from 'src/hooks/useEventHandlers';
 import { getAll } from 'src/utilities/getAll';
 
 import { updateInPaginatedStore } from './base';
-import { queryKey as PROFILE_QUERY_KEY } from './profile';
-import { EventHandlerData } from 'src/hooks/useEventHandlers';
+import { profileQueries } from './profile';
 
 export const queryKey = 'volumes';
 
@@ -127,7 +127,7 @@ export const useCreateVolumeMutation = () => {
     onSuccess() {
       queryClient.invalidateQueries([queryKey]);
       // If a restricted user creates an entity, we must make sure grants are up to date.
-      queryClient.invalidateQueries([PROFILE_QUERY_KEY, 'grants']);
+      queryClient.invalidateQueries(profileQueries.grants.queryKey);
     },
   });
 };

--- a/packages/manager/src/utilities/queryKeys.test.ts
+++ b/packages/manager/src/utilities/queryKeys.test.ts
@@ -226,3 +226,18 @@ test("can passthrough options", async () => {
   expect(queries.linode("test").enabled).toBe(true);
   expect(queries.volumes.onSuccess()).toBe(true);
 });
+
+test("training undefined", async () => {
+  const queries = getQueryKeys({
+    linode: (id: { label?: string } = {}) => ({
+      queryFn: () => Promise.resolve(id),
+      queryKey: [id],
+    }),
+  });
+
+  // expect(queries.linode({ label: 'test' }).queryKey).toStrictEqual([
+  //   'linode',
+  //   { label: test },
+  // ]);
+  expect(queries.linode().queryKey).toStrictEqual(['linode', {}]);
+});

--- a/packages/manager/src/utilities/queryKeys.test.ts
+++ b/packages/manager/src/utilities/queryKeys.test.ts
@@ -1,0 +1,228 @@
+import { expect, expectTypeOf, test } from "vitest";
+import { getQueryKeys } from "./queryKeys";
+
+test("should handle functions", async () => {
+  const queries = getQueryKeys({
+    agreements: {},
+    avilability: {
+      all: {
+        queryFn: () => Promise.resolve("all"),
+      },
+      paginated: (params: string, filters: number) => ({
+        queryFn: () => Promise.resolve(params),
+        queryKey: [params, filters],
+      }),
+    },
+    info: {
+      queryFn: () => Promise.resolve("info"),
+    },
+    details: (id: number, label: string) => ({
+      queryFn: () => Promise.resolve({ id, label }),
+    }),
+  });
+
+  expect(queries.avilability.paginated("test", 1).queryKey).toStrictEqual(["avilability", "paginated", "test", 1]);
+  expect(queries.avilability.paginated.queryKey).toStrictEqual(["avilability", "paginated"]);
+  expect((await queries.avilability.paginated("test", 1).queryFn())).toEqual("test");
+
+  expectTypeOf(queries.info.queryFn).toBeFunction()
+  expectTypeOf(queries.info).toMatchTypeOf<{ queryFn: () => Promise<string>, queryKey: ["info"] }>()
+
+  expectTypeOf(queries.details).toBeFunction()
+  expectTypeOf(queries.details(1, "test").queryFn).toBeFunction()
+  expect((await queries.details(1, "test").queryFn())).toEqual({ id: 1, label: "test" });
+  expect(queries.details(1, "test").queryKey).toEqual(["details", 1, "test"]);
+  expectTypeOf(queries.details(1, "test")).toMatchTypeOf<{ queryFn: () => Promise<{ id: number, label: string }>, queryKey: ["details", number, string] }>()
+});
+
+test("should handle object nesting", async () => {
+  const queries = getQueryKeys({
+    account: {
+      agreements: {
+        queryFn: () => Promise.resolve("agreements"),
+      },
+      avilability: {
+        all: {
+          queryFn: () => Promise.resolve("all"),
+        },
+        paginated: (params: string, filters: number) => ({
+          queryFn: () => Promise.resolve(params),
+          queryKey: [params, filters],
+        }),
+      },
+      info: {
+        queryFn: () => Promise.resolve("info"),
+      },
+    }
+  });
+
+  expect(queries.account.avilability.paginated("test", 1).queryKey).toStrictEqual(["account", "avilability", "paginated", "test", 1]);
+  expect((await queries.account.avilability.paginated("test", 1).queryFn())).toEqual("test");
+
+  expectTypeOf(queries.account.info.queryFn).toBeFunction()
+  expectTypeOf(queries.account.info).toMatchTypeOf<{ queryFn: () => Promise<string>, queryKey: ["account", "info"] }>()
+});
+
+test("should handle very deep nesting", async () => {
+  const queries = getQueryKeys({
+    linodes: {
+      paginated: (params: string, filters: number) => ({
+        queryFn: () => Promise.resolve(params),
+        queryKey: [params, filters],
+      }),
+      all: {
+        queryFn: () => Promise.resolve("all")
+      },
+      linode: {
+        details: (id: number) => ({
+          queryFn: () => Promise.resolve(id),
+          queryKey: [id],
+        }),
+        volumes: (id: number) => ({
+          queryFn: () => Promise.resolve(id),
+          queryKey: [id],
+        }),
+      }
+    }
+  });
+
+  expect(queries.linodes.paginated("test", 1).queryKey).toStrictEqual(["linodes", "paginated", "test", 1]);
+  expect(queries.linodes.linode.details(1).queryKey).toStrictEqual(["linodes", "linode", "details", 1]);
+  expect(queries.linodes.linode.volumes(1).queryKey).toStrictEqual(["linodes", "linode", "volumes", 1]);
+  expect((await queries.linodes.linode.volumes(1).queryFn())).toEqual(1);
+});
+
+test("should handle very deep nesting", async () => {
+  const queries = getQueryKeys({
+    linodes: {
+      paginated: (params: string, filters: number) => ({
+        queryFn: () => Promise.resolve(params),
+        queryKey: [params, filters],
+      }),
+      all: {
+        queryFn: () => Promise.resolve("all")
+      },
+      linode: (id: number) => ({
+        details: {
+          queryFn: () => Promise.resolve(id),
+        },
+        volumes: {
+          queryFn: () => Promise.resolve(id),
+        },
+      }),
+    }
+  });
+
+  expect(queries.linodes.paginated("test", 1).queryKey).toStrictEqual(["linodes", "paginated", "test", 1]);
+  expect((await queries.linodes.paginated("test", 1).queryFn())).toStrictEqual("test");
+  expect(queries.linodes.linode(1).details.queryKey).toStrictEqual(["linodes", "linode", 1, "details"]);
+  expect(queries.linodes.linode(1).volumes.queryKey).toStrictEqual(["linodes", "linode", 1, "volumes"]);
+  expect((await queries.linodes.linode(1).volumes.queryFn())).toEqual(1);
+});
+
+
+test("should handle nesting function", async () => {
+  const queries = getQueryKeys({
+    linodes: {
+      linode: (id: number) => ({
+        details: {
+          queryFn: () => Promise.resolve(id),
+        },
+        volumes: (label: string) => ({
+          details: {
+            queryFn: () => Promise.resolve(id),
+          },
+          events: {
+            queryFn: () => Promise.resolve({ id, label }),
+            enabled: true,
+          },
+          notifications: (type: 'read' | 'unread') => ({
+            queryFn: () => Promise.resolve({ id, label, type }),
+            enabled: true,
+            queryKey: [type],
+          }),
+        }),
+      }),
+    }
+  });
+
+  expect(queries.linodes.linode(1).volumes("test").events.queryKey).toStrictEqual(["linodes", "linode", 1, "volumes", "test", "events"]);
+  expect(queries.linodes.linode(1).volumes("test").queryKey).toStrictEqual(["linodes", "linode", 1, "volumes", "test"]);
+  expect(queries.linodes.linode(1).volumes("test").events.enabled).toStrictEqual(true);
+  expect((await queries.linodes.linode(1).volumes("test").events.queryFn())).toStrictEqual({ id: 1, label: "test" });
+
+  // Check 3 functions deep
+  expect(queries.linodes.linode(1).volumes("test").notifications('read').queryKey).toStrictEqual(["linodes", "linode", 1, "volumes", "test", "notifications", 'read']);
+  expect((await queries.linodes.linode(1).volumes("test").notifications('unread').queryFn())).toStrictEqual({ id: 1, label: "test", type: 'unread' });
+});
+
+test("should handle function params", async () => {
+  const queries = getQueryKeys({
+    linode: (id: string) => ({
+      queryFn: () => Promise.resolve(id),
+    }),
+  });
+
+  expect((await queries.linode("test").queryFn())).toBe("test");
+});
+
+test("should be mergeable", async () => {
+  const linodes = getQueryKeys({
+    linodes: {
+      linode: (id: number) => ({
+        details: {
+          queryFn: () => Promise.resolve(id),
+        },
+        volumes: (label: string) => ({
+          details: {
+            queryFn: () => Promise.resolve(id),
+          },
+          events: {
+            queryFn: () => Promise.resolve(id),
+          },
+        }),
+      }),
+    }
+  });
+
+  const account = getQueryKeys({
+    account: {
+      agreements: {
+        queryFn: () => Promise.resolve("agreements"),
+      },
+      avilability: {
+        all: {
+          queryFn: () => Promise.resolve("all"),
+        },
+        paginated: (params: string, filters: number) => ({
+          queryFn: () => Promise.resolve(params),
+          queryKey: [params, filters],
+        }),
+      },
+      info: {
+        queryFn: () => Promise.resolve("info"),
+      },
+    }
+  });
+
+  const queries = { ...account, ...linodes };
+
+  expect(queries.linodes.linode(1).volumes("test").events.queryKey).toStrictEqual(["linodes", "linode", 1, "volumes", "test", "events"]);
+  expect(queries.account.avilability.all.queryKey).toStrictEqual(["account", "avilability", "all"]);
+});
+
+test("can passthrough options", async () => {
+  const queries = getQueryKeys({
+    linode: (id: string) => ({
+      queryFn: () => Promise.resolve(id),
+      enabled: true
+    }),
+    volumes: {
+      queryFn: () => Promise.resolve(1),
+      onSuccess: () => true
+    }
+  });
+
+  expect(queries.linode("test").enabled).toBe(true);
+  expect(queries.volumes.onSuccess()).toBe(true);
+});

--- a/packages/manager/src/utilities/queryKeys.ts
+++ b/packages/manager/src/utilities/queryKeys.ts
@@ -1,0 +1,79 @@
+type QueryKeys<T, P extends unknown[] = []> = {
+  queryKey: [...P];
+} & (T extends (...args: any[]) => {
+  queryFn: (...args: any[]) => any;
+}
+  ? (...args: Parameters<T>) => Omit<ReturnType<T>, "queryFn" | "queryKey"> & {
+    queryFn: () => ReturnType<ReturnType<T>["queryFn"]>;
+    queryKey: [...P, ...Parameters<T>];
+  }
+  : T extends (...args: any[]) => any
+  ? (...args: Parameters<T>) => { queryKey: [...P, ...Parameters<T>] } & {
+    [K in keyof ReturnType<T>]: QueryKeys<
+      ReturnType<T>[K],
+      [...P, ...Parameters<T>, K]
+    >;
+  }
+  : T extends
+  | {
+    queryFn: (...args: any[]) => any;
+    queryKey: any[];
+  }
+  | {
+    queryFn: (...args: any[]) => any;
+  }
+  ? T
+  : { [K in keyof T]: QueryKeys<T[K], [...P, K]> });
+
+type QueryDef = { queryFn: (...args: any[]) => any; queryKey?: unknown[] };
+
+type FactoryDef = {
+  [key: string]:
+  | QueryDef
+  | ((...params: any) => QueryDef | FactoryDef)
+  | FactoryDef;
+};
+
+export function getQueryKeys<T extends FactoryDef>(
+  input: T,
+  path: string[] = [],
+): QueryKeys<T> {
+  const result = { queryKey: path };
+
+  for (const key in input) {
+    const newPath = [...path, key];
+
+    if (typeof input[key] === "function" && key === "queryFn") {
+      // @ts-expect-error todo
+      return { ...input, queryFn: input[key], queryKey: path };
+    }
+
+    // @ts-expect-error todo
+    if (typeof input[key] === "function" && !input[key]()["queryFn"]) {
+      // @ts-expect-error todo
+      result[key] = (...args) =>
+        // @ts-expect-error todo
+        getQueryKeys(input[key](...args), [...path, key, ...args]);
+    } else if (typeof input[key] === "function") {
+      // Handle functions (query functions or paginated functions)
+      // @ts-expect-error todo
+      const fn = (...args) => ({
+        // @ts-expect-error todo
+        ...input[key](...args),
+        // @ts-expect-error todo
+        queryFn: input[key](...args)["queryFn"],
+        queryKey: [...newPath, ...args],
+      });
+      fn.queryKey = newPath;
+      // @ts-expect-error todo
+      result[key] = fn;
+    } else if (typeof input[key] === "object") {
+      // Recursively convert nested structures
+      // @ts-expect-error todo
+      result[key] = getQueryKeys(input[key], newPath);
+    }
+  }
+
+  // @ts-expect-error todo
+  return result;
+}

--- a/packages/manager/src/utilities/queryKeys.ts
+++ b/packages/manager/src/utilities/queryKeys.ts
@@ -1,27 +1,33 @@
 type QueryKeys<T, P extends unknown[] = []> = {
   queryKey: [...P];
-} & (T extends (...args: any[]) => {
+} & (T extends (
+  ...args: any[]
+) => {
   queryFn: (...args: any[]) => any;
 }
-  ? (...args: Parameters<T>) => Omit<ReturnType<T>, "queryFn" | "queryKey"> & {
-    queryFn: () => ReturnType<ReturnType<T>["queryFn"]>;
-    queryKey: [...P, ...Parameters<T>];
-  }
+  ? (
+      ...args: Parameters<T>
+    ) => Omit<ReturnType<T>, 'queryFn' | 'queryKey'> & {
+      queryFn: () => ReturnType<ReturnType<T>['queryFn']>;
+      queryKey: [...P, ...Parameters<T>];
+    }
   : T extends (...args: any[]) => any
-  ? (...args: Parameters<T>) => { queryKey: [...P, ...Parameters<T>] } & {
-    [K in keyof ReturnType<T>]: QueryKeys<
-      ReturnType<T>[K],
-      [...P, ...Parameters<T>, K]
-    >;
-  }
+  ? (
+      ...args: Parameters<T>
+    ) => { queryKey: [...P, ...Parameters<T>] } & {
+      [K in keyof ReturnType<T>]: QueryKeys<
+        ReturnType<T>[K],
+        [...P, ...Parameters<T>, K]
+      >;
+    }
   : T extends
-  | {
-    queryFn: (...args: any[]) => any;
-    queryKey: any[];
-  }
-  | {
-    queryFn: (...args: any[]) => any;
-  }
+      | {
+          queryFn: (...args: any[]) => any;
+          queryKey: any[];
+        }
+      | {
+          queryFn: (...args: any[]) => any;
+        }
   ? T
   : { [K in keyof T]: QueryKeys<T[K], [...P, K]> });
 
@@ -29,45 +35,45 @@ type QueryDef = { queryFn: (...args: any[]) => any; queryKey?: unknown[] };
 
 type FactoryDef = {
   [key: string]:
-  | QueryDef
-  | ((...params: any) => QueryDef | FactoryDef)
-  | FactoryDef;
+    | QueryDef
+    | ((...params: unknown[]) => QueryDef | FactoryDef)
+    | FactoryDef;
 };
 
 export function getQueryKeys<T extends FactoryDef>(
   input: T,
-  path: string[] = [],
+  path: string[] = []
 ): QueryKeys<T> {
   const result = { queryKey: path };
 
   for (const key in input) {
     const newPath = [...path, key];
 
-    if (typeof input[key] === "function" && key === "queryFn") {
+    if (typeof input[key] === 'function' && key === 'queryFn') {
       // @ts-expect-error todo
       return { ...input, queryFn: input[key], queryKey: path };
     }
 
     // @ts-expect-error todo
-    if (typeof input[key] === "function" && !input[key]()["queryFn"]) {
+    if (typeof input[key] === 'function' && !input[key]()['queryFn']) {
       // @ts-expect-error todo
       result[key] = (...args) =>
         // @ts-expect-error todo
         getQueryKeys(input[key](...args), [...path, key, ...args]);
-    } else if (typeof input[key] === "function") {
-      // Handle functions (query functions or paginated functions)
+    } else if (typeof input[key] === 'function') {
       // @ts-expect-error todo
-      const fn = (...args) => ({
+      const fn = (...args) => {
         // @ts-expect-error todo
-        ...input[key](...args),
-        // @ts-expect-error todo
-        queryFn: input[key](...args)["queryFn"],
-        queryKey: [...newPath, ...args],
-      });
+        return getQueryKeys(input[key](...args), [
+          ...newPath,
+          // @ts-expect-error todo
+          ...input[key](...args)?.['queryKey'] ?? [...args],
+        ]);
+      }
       fn.queryKey = newPath;
       // @ts-expect-error todo
       result[key] = fn;
-    } else if (typeof input[key] === "object") {
+    } else if (typeof input[key] === 'object') {
       // Recursively convert nested structures
       // @ts-expect-error todo
       result[key] = getQueryKeys(input[key], newPath);


### PR DESCRIPTION
## Description 📝
- Introduces our custom query key factory 🏭
- Switches all profile related queries to use the new factory 🎉

## Preview 📷
![Screenshot 2024-02-20 at 12 04 08 PM](https://github.com/linode/manager/assets/115251059/09590224-ad41-4071-9524-3a63c3a6d8be)

## How to test 🧪

- Verify the result of `getQueryKeys` is type-safe
- Check the diff for any mistakes
- Verify all automated testing passes
- Use the React Query dev tools to check out the new query key structure and check for any unexpected queries

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support