### PR TITLE
test: [M3-7434]: Add a Cypress test for OBJ Multicluster Bucket create flow

### DIFF
--- a/packages/manager/.changeset/pr-10211-tests-1708466647763.md
+++ b/packages/manager/.changeset/pr-10211-tests-1708466647763.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add test for OBJ Multicluster bucket create flow ([#10211](https://github.com/linode/manager/pull/10211))

--- a/packages/manager/cypress/e2e/core/objectStorage/object-storage.smoke.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/object-storage.smoke.spec.ts
@@ -4,6 +4,7 @@
 
 import 'cypress-file-upload';
 import { objectStorageBucketFactory } from 'src/factories/objectStorage';
+import { mockGetRegions } from 'support/intercepts/regions';
 import {
   mockCreateBucket,
   mockDeleteBucket,
@@ -13,11 +14,137 @@ import {
   mockGetBucketObjects,
   mockUploadBucketObject,
   mockUploadBucketObjectS3,
+  mockCreateBucketError,
 } from 'support/intercepts/object-storage';
-import { randomLabel } from 'support/util/random';
+import {
+  mockAppendFeatureFlags,
+  mockGetFeatureFlagClientstream,
+} from 'support/intercepts/feature-flags';
+import { makeFeatureFlagData } from 'support/util/feature-flags';
+import { randomLabel, randomString } from 'support/util/random';
 import { ui } from 'support/ui';
+import { regionFactory } from 'src/factories';
 
 describe('object storage smoke tests', () => {
+  /*
+   * - Tests Object Storage bucket creation flow when OBJ Multicluster is enabled.
+   * - Confirms that expected regions are displayed in drop-down.
+   * - Confirms that region can be selected during create.
+   * - Confirms that API errors are handled gracefully by drawer.
+   * - Confirms that request payload contains desired Bucket region and not cluster.
+   * - Confirms that created Bucket is listed on the landing page.
+   */
+  it('can create object storage bucket with OBJ Multicluster', () => {
+    const mockErrorMessage = 'An unknown error has occurred.';
+
+    const mockRegionWithObj = regionFactory.build({
+      label: randomLabel(),
+      id: `${randomString(2)}-${randomString(3)}`,
+      capabilities: ['Object Storage'],
+    });
+
+    const mockRegionsWithoutObj = regionFactory.buildList(2, {
+      capabilities: [],
+    });
+
+    const mockRegions = [mockRegionWithObj, ...mockRegionsWithoutObj];
+
+    const mockBucket = objectStorageBucketFactory.build({
+      label: randomLabel(),
+      region: mockRegionWithObj.id,
+      cluster: undefined,
+      objects: 0,
+    });
+
+    mockAppendFeatureFlags({
+      objMultiCluster: makeFeatureFlagData(true),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+
+    mockGetRegions(mockRegions).as('getRegions');
+    mockGetBuckets([]).as('getBuckets');
+    mockCreateBucketError(mockErrorMessage).as('createBucket');
+
+    cy.visitWithLogin('/object-storage');
+    cy.wait(['@getRegions', '@getBuckets']);
+
+    ui.button
+      .findByTitle('Create Bucket')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    ui.drawer
+      .findByTitle('Create Bucket')
+      .should('be.visible')
+      .within(() => {
+        // Submit button is disabled when fields are empty.
+        ui.buttonGroup
+          .findButtonByTitle('Create Bucket')
+          .should('be.visible')
+          .should('be.disabled');
+
+        // Enter label.
+        cy.contains('Label').click().type(mockBucket.label);
+
+        cy.contains('Region').click().type(mockRegionWithObj.label);
+
+        ui.autocompletePopper
+          .find()
+          .should('be.visible')
+          .within(() => {
+            // Confirm that regions without 'Object Storage' capability are not listed.
+            mockRegionsWithoutObj.forEach((mockRegionWithoutObj) => {
+              cy.contains(mockRegionWithoutObj.id).should('not.exist');
+            });
+
+            // Confirm that region with 'Object Storage' capability is listed,
+            // then select it.
+            cy.findByText(
+              `${mockRegionWithObj.label} (${mockRegionWithObj.id})`
+            )
+              .should('be.visible')
+              .click();
+          });
+
+        // Close region select.
+        cy.contains('Region').click();
+
+        // On first attempt, mock an error response and confirm message is shown.
+        ui.buttonGroup
+          .findButtonByTitle('Create Bucket')
+          .should('be.visible')
+          .click();
+
+        cy.wait('@createBucket');
+        cy.findByText(mockErrorMessage).should('be.visible');
+
+        // Click submit again, mock a successful response.
+        mockCreateBucket(mockBucket).as('createBucket');
+        ui.buttonGroup
+          .findButtonByTitle('Create Bucket')
+          .should('be.visible')
+          .click();
+      });
+
+    // Confirm that Cloud includes the "region" property and omits the "cluster"
+    // property in its payload when creating a bucket.
+    cy.wait('@createBucket').then((xhr) => {
+      const body = xhr.request.body;
+      expect(body.cluster).to.be.undefined;
+      expect(body.region).to.eq(mockRegionWithObj.id);
+    });
+
+    cy.findByText(mockBucket.label)
+      .should('be.visible')
+      .closest('tr')
+      .within(() => {
+        // TODO Confirm that bucket region is shown in landing page.
+        cy.findByText(mockBucket.hostname).should('be.visible');
+        // cy.findByText(mockRegionWithObj.label).should('be.visible');
+      });
+  });
+
   /*
    * - Tests core object storage bucket create flow using mocked API responses.
    * - Creates bucket.
@@ -29,8 +156,20 @@ describe('object storage smoke tests', () => {
     const bucketCluster = 'us-southeast-1';
     const bucketHostname = `${bucketLabel}.${bucketCluster}.linodeobjects.com`;
 
+    const mockBucket = objectStorageBucketFactory.build({
+      label: bucketLabel,
+      cluster: bucketCluster,
+      hostname: bucketHostname,
+    });
+
+    mockAppendFeatureFlags({
+      objMultiCluster: makeFeatureFlagData(false),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+
     mockGetBuckets([]).as('getBuckets');
-    mockCreateBucket(bucketLabel, bucketCluster).as('createBucket');
+
+    mockCreateBucket(mockBucket).as('createBucket');
 
     cy.visitWithLogin('/object-storage');
     cy.wait('@getBuckets');

--- a/packages/manager/cypress/support/intercepts/object-storage.ts
+++ b/packages/manager/cypress/support/intercepts/object-storage.ts
@@ -7,13 +7,12 @@ import { apiMatcher } from 'support/util/intercepts';
 import { paginateResponse } from 'support/util/paginate';
 import { makeResponse } from 'support/util/response';
 
-import { objectStorageBucketFactory } from 'src/factories/objectStorage';
-
 import type {
   ObjectStorageBucket,
   ObjectStorageKey,
   ObjectStorageCluster,
 } from '@linode/api-v4';
+import { makeErrorResponse } from 'support/util/errors';
 
 /**
  * Intercepts GET requests to fetch buckets.
@@ -80,25 +79,38 @@ export const interceptCreateBucket = (): Cypress.Chainable<null> => {
 };
 
 /**
- * Intercepts POST request to create bucket and mocks response.
+ * Intercepts POST request to create a bucket and mocks response.
  *
- * @param label - Object storage bucket label.
- * @param cluster - Object storage bucket cluster.
+ * @param bucket - Bucket with which to mock response.
  *
  * @returns Cypress chainable.
  */
 export const mockCreateBucket = (
-  label: string,
-  cluster: string
+  bucket: ObjectStorageBucket
 ): Cypress.Chainable<null> => {
   return cy.intercept(
     'POST',
     apiMatcher('object-storage/buckets'),
-    objectStorageBucketFactory.build({
-      cluster,
-      hostname: `${label}.${cluster}.linodeobjects.com`,
-      label,
-    })
+    makeResponse(bucket)
+  );
+};
+
+/**
+ * Intercepts POST request to create a bucket and mocks an error response.
+ *
+ * @param errorMessage - Optional error message with which to mock response.
+ * @param statusCode - HTTP status code with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockCreateBucketError = (
+  errorMessage: string = 'An unknown error occurred.',
+  statusCode: number = 500
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher('object-storage/buckets'),
+    makeErrorResponse(errorMessage, statusCode)
   );
 };
 

--- a/packages/manager/cypress/support/ui/autocomplete.ts
+++ b/packages/manager/cypress/support/ui/autocomplete.ts
@@ -19,7 +19,14 @@ export const autocomplete = {
  */
 export const autocompletePopper = {
   /**
-   * Finds a autocomplete popper that has the given title.
+   * Finds an open autocomplete popper.
+   */
+  find: () => {
+    return cy.document().its('body').find('[data-qa-autocomplete-popper]');
+  },
+
+  /**
+   * Finds an item within an autocomplete popper that has the given title.
    */
   findByTitle: (
     title: string,


### PR DESCRIPTION
## Description 📝
Adds a Cypress test to cover the OBJ Bucket creation flow when OBJ Multicluster is enabled. Using mock API data, it confirms that a bucket can be created, that Cloud uses a region ID rather than a cluster ID in its payload, and that the landing page updates to reflect the new bucket.

## Changes  🔄
- Add a test for Bucket creation when OBJ Multicluster feature is enabled
- Update OBJ create mock util to be more consistent with other utils
- Add UI helper to find an autocomplete popper
- Add mock util for OBJ create error

## How to test 🧪
We can rely on CI for this, or `yarn cy:debug` and search for `object-storage.smoke.spec.ts`

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
