### PR TITLE
poc: [M3-7799] - Improve Docs Site Sidebar

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,6 +1,6 @@
 import { getSidebar } from "./plugins/sidebar";
 
-export default async () => ({
+export default {
   title: "Cloud Manager Docs",
   description: "Akamai Cloud Manger Documentation",
   srcDir: "./",
@@ -15,10 +15,10 @@ export default async () => ({
     search: {
       provider: "local",
     },
-    sidebar: await getSidebar(),
+    sidebar: getSidebar(),
     socialLinks: [
       { icon: "github", link: "https://github.com/linode/manager" },
     ],
   },
   head: [["link", { rel: "icon", href: "/manager/favicon.ico" }]],
-});
+};

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,9 +1,11 @@
-import { getSidebar } from "./plugins/sidebar";
+import { generateSidebar } from "./plugins/sidebar";
+
+const DOCS_SRC_DIR = new URL('./../', import.meta.url).pathname;
 
 export default {
   title: "Cloud Manager Docs",
   description: "Akamai Cloud Manger Documentation",
-  srcDir: "./",
+  srcDir: DOCS_SRC_DIR,
   base: "/manager/",
   themeConfig: {
     logo: "/akamai-wave.svg",
@@ -15,7 +17,7 @@ export default {
     search: {
       provider: "local",
     },
-    sidebar: getSidebar(),
+    sidebar: generateSidebar(DOCS_SRC_DIR),
     socialLinks: [
       { icon: "github", link: "https://github.com/linode/manager" },
     ],

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,6 +1,6 @@
-import { guides } from "./plugins/sidebar";
+import { getSidebar } from "./plugins/sidebar";
 
-export default {
+export default async () => ({
   title: "Cloud Manager Docs",
   description: "Akamai Cloud Manger Documentation",
   srcDir: "./",
@@ -15,15 +15,10 @@ export default {
     search: {
       provider: "local",
     },
-    sidebar: [
-      {
-        text: "Development Guide",
-        items: guides,
-      },
-    ],
+    sidebar: await getSidebar(),
     socialLinks: [
       { icon: "github", link: "https://github.com/linode/manager" },
     ],
   },
   head: [["link", { rel: "icon", href: "/manager/favicon.ico" }]],
-};
+});

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,6 +1,6 @@
 import { generateSidebar } from "./plugins/sidebar";
 
-const DOCS_SRC_DIR = new URL('./../', import.meta.url).pathname;
+export const DOCS_SRC_DIR = new URL("./../", import.meta.url).pathname;
 
 export default {
   title: "Cloud Manager Docs",

--- a/docs/.vitepress/plugins/sidebar.ts
+++ b/docs/.vitepress/plugins/sidebar.ts
@@ -1,12 +1,12 @@
 import { readdir } from "fs/promises";
 import { join, resolve } from "path";
 
-type Item = { text: string; link: string }
+type LinkItem = { text: string; link: string }
 
-type Sidebar = {
+type SidebarItem = {
   text: string;
-  items: Sidebar[] | Item[]
-} | Item;
+  items: SidebarItem[] | LinkItem[]
+} | LinkItem;
 
 const DOCS_PATH = resolve(__dirname + '/../../');
 
@@ -21,8 +21,10 @@ function isPathIgnored(path: string) {
   return false;
 }
 
-const walk = async (dir: string, sidebar: Sidebar[] = []) => {
+const walk = async (dir: string) => {
   const files = await readdir(dir, { withFileTypes: true });
+
+  const sidebar: SidebarItem[] = [];
 
   for (const file of files) {
     const filepath = join(dir, file.name);
@@ -32,17 +34,16 @@ const walk = async (dir: string, sidebar: Sidebar[] = []) => {
     }
 
     if (file.isDirectory()) {
-      const items = await walk(filepath, sidebar)
-      sidebar.push({ text: file.name, items });
+      sidebar.push({ text: file.name, items: await walk(filepath) });
     } else {
-      sidebar = [...sidebar, { text: file.name, link: filepath.split(DOCS_PATH)[1] }];
+      sidebar.push({ text: file.name, link: filepath });
     }
   }
 
   return sidebar;
 }
 
-export async function getSidebar(): Promise<Sidebar[]> {
+export async function getSidebar(): Promise<SidebarItem[]> {
   const files = await walk(DOCS_PATH)
   console.log(files)
   return files;

--- a/docs/.vitepress/plugins/sidebar.ts
+++ b/docs/.vitepress/plugins/sidebar.ts
@@ -1,10 +1,11 @@
-import { readdir } from "fs/promises";
+import { readdirSync } from "fs";
 import { join, resolve } from "path";
 
 type LinkItem = { text: string; link: string }
 
 type SidebarItem = {
   text: string;
+  collapsed?: boolean;
   items: SidebarItem[] | LinkItem[]
 } | LinkItem;
 
@@ -21,8 +22,8 @@ function isPathIgnored(path: string) {
   return false;
 }
 
-const walk = async (dir: string) => {
-  const files = await readdir(dir, { withFileTypes: true });
+const walk = (dir: string) => {
+  const files = readdirSync(dir, { withFileTypes: true });
 
   const sidebar: SidebarItem[] = [];
 
@@ -34,7 +35,7 @@ const walk = async (dir: string) => {
     }
 
     if (file.isDirectory()) {
-      sidebar.push({ text: file.name, items: await walk(filepath) });
+      sidebar.push({ text: file.name, collapsed: false, items: walk(filepath) });
     } else {
       sidebar.push({ text: file.name, link: filepath.split(DOCS_PATH)[1] });
     }
@@ -43,8 +44,8 @@ const walk = async (dir: string) => {
   return sidebar;
 }
 
-export async function getSidebar(): Promise<SidebarItem[]> {
-  const files = await walk(DOCS_PATH)
+export function getSidebar() {
+  const files = walk(DOCS_PATH)
   console.log(files)
   return files;
 }

--- a/docs/.vitepress/plugins/sidebar.ts
+++ b/docs/.vitepress/plugins/sidebar.ts
@@ -41,6 +41,9 @@ function capitalize(s: string) {
   );
 }
 
+/**
+ * Given a file name, this function returns a formatted title.
+ */
 function formatSidebarItemText(fileName: string) {
   // removes -, _, and .md from files names to generate the title
   for (const [from, to] of replacements) {
@@ -53,6 +56,9 @@ function formatSidebarItemText(fileName: string) {
   return fileName;
 }
 
+/**
+ * Generates a VitePress sidebar by recursively traversing the given directory.
+ */
 export function generateSidebar(dir: string) {
   const files = readdirSync(dir, { withFileTypes: true });
 

--- a/docs/.vitepress/plugins/sidebar.ts
+++ b/docs/.vitepress/plugins/sidebar.ts
@@ -1,5 +1,6 @@
 import { readdirSync } from "fs";
-import { join, resolve } from "path";
+import { join } from "path";
+import { DOCS_SRC_DIR } from "../config";
 
 type LinkItem = { text: string; link: string };
 
@@ -10,8 +11,6 @@ type SidebarItem =
       items: SidebarItem[] | LinkItem[];
     }
   | LinkItem;
-
-const DOCS_PATH = resolve(__dirname + "/../../");
 
 const exclude = [
   "cache",
@@ -75,7 +74,7 @@ export function generateSidebar(dir: string) {
     } else {
       sidebar.push({
         text: formatSidebarItemText(file.name),
-        link: filepath.split(DOCS_PATH)[1],
+        link: filepath.split(DOCS_SRC_DIR)[1],
       });
     }
   }

--- a/docs/.vitepress/plugins/sidebar.ts
+++ b/docs/.vitepress/plugins/sidebar.ts
@@ -11,7 +11,13 @@ type SidebarItem = {
 
 const DOCS_PATH = resolve(__dirname + '/../../');
 
-const exclude = ["cache", "public", "PULL_REQUEST_TEMPLATE.md", ".vitepress"];
+const exclude = ["cache", "public", "PULL_REQUEST_TEMPLATE.md", ".vitepress", "index.md"];
+
+const replacements = [
+  ['-', ' '],
+  ['_', ' '],
+  ['.md', ''],
+];
 
 function isPathIgnored(path: string) {
   for (const item of exclude) {
@@ -22,7 +28,14 @@ function isPathIgnored(path: string) {
   return false;
 }
 
-const walk = (dir: string) => {
+function formatSidebarItemText(fileName: string) {
+  for (const [from, to] of replacements) {
+    fileName = fileName.replaceAll(from, to);
+  }
+  return fileName;
+}
+
+export function generateSidebar(dir: string) {
   const files = readdirSync(dir, { withFileTypes: true });
 
   const sidebar: SidebarItem[] = [];
@@ -35,17 +48,11 @@ const walk = (dir: string) => {
     }
 
     if (file.isDirectory()) {
-      sidebar.push({ text: file.name, collapsed: false, items: walk(filepath) });
+      sidebar.push({ text: formatSidebarItemText(file.name), collapsed: false, items: generateSidebar(filepath) });
     } else {
-      sidebar.push({ text: file.name, link: filepath.split(DOCS_PATH)[1] });
+      sidebar.push({ text: formatSidebarItemText(file.name), link: filepath.split(DOCS_PATH)[1] });
     }
   }
 
   return sidebar;
-}
-
-export function getSidebar() {
-  const files = walk(DOCS_PATH)
-  console.log(files)
-  return files;
 }

--- a/docs/.vitepress/plugins/sidebar.ts
+++ b/docs/.vitepress/plugins/sidebar.ts
@@ -1,22 +1,30 @@
 import { readdirSync } from "fs";
 import { join, resolve } from "path";
 
-type LinkItem = { text: string; link: string }
+type LinkItem = { text: string; link: string };
 
-type SidebarItem = {
-  text: string;
-  collapsed?: boolean;
-  items: SidebarItem[] | LinkItem[]
-} | LinkItem;
+type SidebarItem =
+  | {
+      text: string;
+      collapsed?: boolean;
+      items: SidebarItem[] | LinkItem[];
+    }
+  | LinkItem;
 
-const DOCS_PATH = resolve(__dirname + '/../../');
+const DOCS_PATH = resolve(__dirname + "/../../");
 
-const exclude = ["cache", "public", "PULL_REQUEST_TEMPLATE.md", ".vitepress", "index.md"];
+const exclude = [
+  "cache",
+  "public",
+  "PULL_REQUEST_TEMPLATE.md",
+  ".vitepress",
+  "index.md",
+];
 
 const replacements = [
-  ['-', ' '],
-  ['_', ' '],
-  ['.md', ''],
+  ["-", " "],
+  ["_", " "],
+  [".md", ""],
 ];
 
 function isPathIgnored(path: string) {
@@ -28,10 +36,21 @@ function isPathIgnored(path: string) {
   return false;
 }
 
+function capitalize(s: string) {
+  return (
+    s.substring(0, 1).toUpperCase() + s.substring(1, s.length).toLowerCase()
+  );
+}
+
 function formatSidebarItemText(fileName: string) {
+  // removes -, _, and .md from files names to generate the title
   for (const [from, to] of replacements) {
     fileName = fileName.replaceAll(from, to);
   }
+  // Removes any number prefix. This allows us to order things by putting numbers in file names.
+  fileName = fileName.replace(/^[0-9]*/, "");
+  // Capitalizes each word in the file name
+  fileName = fileName.split(" ").map(capitalize).join(" ");
   return fileName;
 }
 
@@ -48,9 +67,16 @@ export function generateSidebar(dir: string) {
     }
 
     if (file.isDirectory()) {
-      sidebar.push({ text: formatSidebarItemText(file.name), collapsed: false, items: generateSidebar(filepath) });
+      sidebar.push({
+        text: formatSidebarItemText(file.name),
+        collapsed: false,
+        items: generateSidebar(filepath),
+      });
     } else {
-      sidebar.push({ text: formatSidebarItemText(file.name), link: filepath.split(DOCS_PATH)[1] });
+      sidebar.push({
+        text: formatSidebarItemText(file.name),
+        link: filepath.split(DOCS_PATH)[1],
+      });
     }
   }
 

--- a/docs/.vitepress/plugins/sidebar.ts
+++ b/docs/.vitepress/plugins/sidebar.ts
@@ -36,7 +36,7 @@ const walk = async (dir: string) => {
     if (file.isDirectory()) {
       sidebar.push({ text: file.name, items: await walk(filepath) });
     } else {
-      sidebar.push({ text: file.name, link: filepath });
+      sidebar.push({ text: file.name, link: filepath.split(DOCS_PATH)[1] });
     }
   }
 

--- a/docs/.vitepress/tsconfig.json
+++ b/docs/.vitepress/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "module": "ESNext",
+  }
+}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "coverage": "yarn workspace linode-manager coverage",
     "coverage:summary": "yarn workspace linode-manager coverage:summary",
     "junit:summary": "ts-node scripts/junit-summary/index.ts",
-    "docs": "bunx vitepress@1.0.0-rc.35 dev docs"
+    "docs": "bunx vitepress@1.0.0-rc.44 dev docs"
   },
   "resolutions": {
     "@babel/traverse": "^7.23.3",

--- a/packages/manager/.changeset/pr-10214-tech-stories-1708552464325.md
+++ b/packages/manager/.changeset/pr-10214-tech-stories-1708552464325.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Generate docs site sidebar based on folder structure ([#10214](https://github.com/linode/manager/pull/10214))

--- a/packages/manager/tsconfig.json
+++ b/packages/manager/tsconfig.json
@@ -3,7 +3,7 @@
     /* Language and Environment */
     "jsx": "react",
     "lib": ["dom", "es2020"],
-    "target": "es5",
+    "target": "es2021",
 
     /* Modules */
     "baseUrl": ".",

--- a/packages/manager/tsconfig.json
+++ b/packages/manager/tsconfig.json
@@ -3,7 +3,7 @@
     /* Language and Environment */
     "jsx": "react",
     "lib": ["dom", "es2020"],
-    "target": "es2021",
+    "target": "es5",
 
     /* Modules */
     "baseUrl": ".",
@@ -45,5 +45,5 @@
   "include": [
     "src",
     "package.json"
-  ] 
+  ]
 }


### PR DESCRIPTION
## Description 📝

- Updates the docs site sidebar to be generated based on file names and folder structure of the `docs/` folder 🗂️
- I think this will be nice because it will enable anyone to add documentation without needing to modify any Vitepress configuration 🔧
- Updates Vitepress to latest 🆕

## Preview 📷


| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-02-21 at 3 46 12 PM](https://github.com/linode/manager/assets/115251059/df3feb8f-1d89-4969-b141-e6b801109f8a) | ![Screenshot 2024-02-21 at 4 45 18 PM](https://github.com/linode/manager/assets/115251059/a00d7f36-d174-4245-9f89-c80cd63f3784)  |

## How to test 🧪

- Check out this PR
- Create a test markdown file at `docs/development-guide/example/testing.md` with some markdown in it
- Run `yarn docs`
- Go to `http://localhost:5173/manager/`
- Observe that the new docs page was added to the sidebar with correct nesting 📂

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support