### PR TITLE
fix: [M3-7059] - Stop resetting count and disabling Add button when adding node pool to Kubernetes cluster

### DIFF
--- a/packages/manager/.changeset/pr-10215-fixed-1708555044784.md
+++ b/packages/manager/.changeset/pr-10215-fixed-1708555044784.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Disabled Add button once a node pool is added to kubernetes cluster in Create flow ([#10215](https://github.com/linode/manager/pull/10215))

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -73,7 +73,6 @@ const Panel: React.FunctionComponent<NodePoolPanelProps> = (props) => {
       id: Math.random(),
       type: selectedPlanType,
     });
-    updatePlanCount(selectedPlanType, 0);
     setSelectedType(undefined);
   };
 


### PR DESCRIPTION
## Description 📝
🐛  On the cluster creation page, if you remove an added node pool from the cluster summary, that plan in the node pool does not become re-enabled.

Fix: This was happening because the number of node pools in the map was being reset to 0 when a node pool was added to a cluster. When the number input is 0, the add button is disabled. We should not reset the number of node pools to 0 once it has been added to the pool.

## Changes  🔄
List any change relevant to the reviewer.
- Removed the call to `updatePlanCount` in the handler for adding a node pool to a cluster. 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/114685994/3ffc5437-9855-4bfb-90c5-498c441fa67b"/> |<video src="https://github.com/linode/manager/assets/114685994/302f2862-4e75-4b03-8d12-81371ed6cdd4"/> |

## How to test 🧪

### Prerequisites

### Reproduction steps
(How to reproduce the issue, if applicable)
1. In prod, go to the [Create Cluster page](https://cloud.linode.com/kubernetes/create).
2. Click the Add button for a plan in the node pools table. That Add button is now disabled.
3. In the Cluster Summary section, click the X to remove that node pool. The Add button for that plan stays disabled.

### Verification steps
(How to verify changes)
1. Check out this PR and go to the [Create Cluster page](http://localhost:3000/kubernetes/create).
2. Click the Add button for a plan in the node pools table. That Add button remains enabled and the number input is not reset to 0; instead, it remains the same as whatever the user last input.
3. Verify the correct number of nodes and pricing shows up in the Cluster Summary, then remove the node pool from the cluster summary.
4. Confirm that the Add button remains enabled with the same number of nodes as whatever the user last input.
5. The behavior should be the same in mobile view with the selection cards.
6. Confirm kube e2es still pass.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
