### PR TITLE
fix: [M3-7811] - Fix Users & Grants query filtering on user_type

### DIFF
--- a/packages/manager/.changeset/pr-10230-upcoming-features-1708982538087.md
+++ b/packages/manager/.changeset/pr-10230-upcoming-features-1708982538087.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Fix Users & Grants filtering error based on `user_type` ([#10230](https://github.com/linode/manager/pull/10230))

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -33,14 +33,16 @@ export const UsersLanding = () => {
   const pagination = usePagination(1, 'account-users');
   const order = useOrder();
 
+  const isRestrictedUser = profile?.restricted;
+  const isChildUser = Boolean(
+    flags.parentChildAccountAccess && profile?.user_type === 'child'
+  );
+
   const usersFilter: Filter = {
     ['+order']: order.order,
     ['+order_by']: order.orderBy,
+    ['user_type']: isChildUser ? 'child' : undefined,
   };
-
-  if (flags.parentChildAccountAccess) {
-    usersFilter['user_type'] = { '+neq': 'proxy' };
-  }
 
   const { data: users, error, isLoading, refetch } = useAccountUsers({
     filters: usersFilter,
@@ -58,8 +60,6 @@ export const UsersLanding = () => {
     enabled: flags.parentChildAccountAccess,
     filters: { user_type: 'proxy' },
   });
-
-  const isRestrictedUser = profile?.restricted;
 
   const showProxyUserTable =
     flags.parentChildAccountAccess &&

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -97,7 +97,7 @@ export const UsersLanding = () => {
             <UsersLandingTableBody
               error={proxyUserError}
               isLoading={isLoadingProxyUser}
-              numCols={numCols}
+              numCols={4}
               onDelete={handleDelete}
               users={proxyUser?.data}
             />

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -33,15 +33,14 @@ export const UsersLanding = () => {
   const pagination = usePagination(1, 'account-users');
   const order = useOrder();
 
-  const isRestrictedUser = profile?.restricted;
-  const isChildUser = Boolean(
-    flags.parentChildAccountAccess && profile?.user_type === 'child'
-  );
+  const showProxyUserTable =
+    flags.parentChildAccountAccess &&
+    (profile?.user_type === 'child' || profile?.user_type === 'proxy');
 
   const usersFilter: Filter = {
     ['+order']: order.order,
     ['+order_by']: order.orderBy,
-    ['user_type']: isChildUser ? 'child' : undefined,
+    ['user_type']: showProxyUserTable ? 'child' : undefined,
   };
 
   const { data: users, error, isLoading, refetch } = useAccountUsers({
@@ -61,9 +60,7 @@ export const UsersLanding = () => {
     filters: { user_type: 'proxy' },
   });
 
-  const showProxyUserTable =
-    flags.parentChildAccountAccess &&
-    (profile?.user_type === 'child' || profile?.user_type === 'proxy');
+  const isRestrictedUser = profile?.restricted;
 
   const showChildAccountAccessCol = Boolean(
     flags.parentChildAccountAccess && profile?.user_type === 'parent'


### PR DESCRIPTION
## Description 📝
The filter we're applying to child accounts needs to be scoped to child users. Currently, with the parent/child flag on, all users are seeing an error.

From API: "Because this is a computed filter, the API only supports filtering on a single user_type (and no other complex filtering logic), which in this case would be `child`."

## Changes  🔄
- Updated the filters on the `useAccountUsers` that populates the table of non-proxy users to only filter on `child` users when logged into a child  or proxy user account. API doesn't support complex filtering logic on this field.
- Fixed an issue where the `numCols` was dynamic for the users in the Business Partner table, and it should not have been. (We don't display the Child Account Access column there, as we do in the other table.)

> [!NOTE]  
> Test coverage for this flow will be completed in M3-7500.

## Target release date 🗓️
3/5/2024

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-02-26 at 12 51 00 PM](https://github.com/linode/manager/assets/114685994/3fae060d-c150-4cc9-8bec-6a569796c548) | Child user: ![Screenshot 2024-02-26 at 12 41 56 PM](https://github.com/linode/manager/assets/114685994/645bdc79-b326-4dab-9170-dd13992430af) Proxy user: ![Screenshot 2024-02-26 at 1 26 33 PM](https://github.com/linode/manager/assets/114685994/02ede27e-b83c-48ac-9bba-c3af9b508c86) Parent user: ![Screenshot 2024-02-26 at 12 47 21 PM](https://github.com/linode/manager/assets/114685994/daad151c-71fc-4e5e-a1e8-a75017cad18c) Regular user: ![Screenshot 2024-02-26 at 12 51 17 PM](https://github.com/linode/manager/assets/114685994/6cbe18af-1fc8-4304-afb3-52f1f5ae51fb) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Ensure Parent/Child feature flag is on in dev tools.

### Reproduction steps
(How to reproduce the issue, if applicable)
- Using our dev site, visit the Users & Grants page.
- Observe that after attempting to load, the Users table fails to populate and displays the above filtering error. 

### Verification steps
(How to verify changes)
- Note: You *can* use the MSW to test these changes locally, but it's a little weird for `parent` and `default` users unless you comment out the proxy user being returned from the */users endpoint. Proxy users will only exist on `child` accounts, so it's never the case that we'd be returning a proxy user for users of `parent` or `default` type. 
- Go to serverHandlers.ts and modify the [`*/profile` `user_type`](https://github.com/linode/manager/blob/develop/packages/manager/src/mocks/serverHandlers.ts#L558) to `child`. Confirm that both tables load with the expected data (proxy user in the first table, child user(s) in the second).
- Modify the `user_type` to `proxy`. Confirm the same behavior as above.
- If you want to test `parent` or `child` with real API data, contact me if you want me to share my parent/child test account details or follow the provisioning instructions to create your own.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

