### PR TITLE
fix: [M3-7812] Textfield input disabled styles

### DIFF
--- a/packages/manager/.changeset/pr-10231-fixed-1708986686253.md
+++ b/packages/manager/.changeset/pr-10231-fixed-1708986686253.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Disabled styles for Textfield input ([#10231](https://github.com/linode/manager/pull/10231))

--- a/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
+++ b/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
@@ -120,7 +120,6 @@ export const TypeToConfirmDialog = (props: CombinedProps) => {
           setConfirmText(input);
         }}
         data-testid={'dialog-confirm-text-input'}
-        disabled={disabled}
         expand
         hideInstructions={entity.subType === 'CloseAccount'}
         inputProps={inputProps}

--- a/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
+++ b/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
@@ -48,6 +48,7 @@ type CombinedProps = TypeToConfirmDialogProps &
 export const TypeToConfirmDialog = (props: CombinedProps) => {
   const {
     children,
+    disabled: isTypeToConfirmFieldDisabled,
     entity,
     errors,
     inputProps,
@@ -64,7 +65,7 @@ export const TypeToConfirmDialog = (props: CombinedProps) => {
   const [confirmText, setConfirmText] = React.useState('');
 
   const { data: preferences } = usePreferences();
-  const disabled =
+  const isPrimaryButtonDisabled =
     preferences?.type_to_confirm !== false && confirmText !== entity.name;
 
   React.useEffect(() => {
@@ -82,7 +83,7 @@ export const TypeToConfirmDialog = (props: CombinedProps) => {
     <ActionsPanel
       primaryButtonProps={{
         'data-testid': 'confirm',
-        disabled,
+        disabled: isPrimaryButtonDisabled,
         label: entity.primaryBtnText,
         loading,
         onClick,
@@ -120,6 +121,7 @@ export const TypeToConfirmDialog = (props: CombinedProps) => {
           setConfirmText(input);
         }}
         data-testid={'dialog-confirm-text-input'}
+        disabled={isTypeToConfirmFieldDisabled}
         expand
         hideInstructions={entity.subType === 'CloseAccount'}
         inputProps={inputProps}

--- a/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
+++ b/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
@@ -48,7 +48,6 @@ type CombinedProps = TypeToConfirmDialogProps &
 export const TypeToConfirmDialog = (props: CombinedProps) => {
   const {
     children,
-    disabled: isTypeToConfirmFieldDisabled,
     entity,
     errors,
     inputProps,
@@ -65,7 +64,7 @@ export const TypeToConfirmDialog = (props: CombinedProps) => {
   const [confirmText, setConfirmText] = React.useState('');
 
   const { data: preferences } = usePreferences();
-  const isPrimaryButtonDisabled =
+  const disabled =
     preferences?.type_to_confirm !== false && confirmText !== entity.name;
 
   React.useEffect(() => {
@@ -83,7 +82,7 @@ export const TypeToConfirmDialog = (props: CombinedProps) => {
     <ActionsPanel
       primaryButtonProps={{
         'data-testid': 'confirm',
-        disabled: isPrimaryButtonDisabled,
+        disabled,
         label: entity.primaryBtnText,
         loading,
         onClick,
@@ -121,7 +120,6 @@ export const TypeToConfirmDialog = (props: CombinedProps) => {
           setConfirmText(input);
         }}
         data-testid={'dialog-confirm-text-input'}
-        disabled={isTypeToConfirmFieldDisabled}
         expand
         hideInstructions={entity.subType === 'CloseAccount'}
         inputProps={inputProps}

--- a/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
+++ b/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
@@ -120,6 +120,7 @@ export const TypeToConfirmDialog = (props: CombinedProps) => {
           setConfirmText(input);
         }}
         data-testid={'dialog-confirm-text-input'}
+        disabled={disabled}
         expand
         hideInstructions={entity.subType === 'CloseAccount'}
         inputProps={inputProps}

--- a/packages/manager/src/foundations/themes/light.ts
+++ b/packages/manager/src/foundations/themes/light.ts
@@ -743,9 +743,13 @@ export const lightTheme: ThemeOptions = {
             color: primaryColors.main,
             fontSize: 18,
           },
-          '&$disabled': {
+          '&.Mui-disabled': {
+            backgroundColor: '#f4f4f4',
             borderColor: '#ccc',
             color: 'rgba(0, 0, 0, 0.75)',
+            input: {
+              cursor: 'not-allowed',
+            },
             opacity: 0.5,
           },
           '&.Mui-error': {


### PR DESCRIPTION
## Description 📝
The disabled styles for the textfield input are currently broken, ending up having to impact on the styling when a field is disabled.

I picked the same bg color for disabled state as Radio/Checkboxes for consistency

## Changes  🔄
- Fix theme layer style declaration for Textfield disabled styles
- Add disabled cursor (**UX approved**)

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-02-27 at 08 20 00](https://github.com/linode/manager/assets/130582365/41709ded-a7ee-4029-ac5a-6712e33f0bec) | ![Screenshot 2024-02-27 at 08 20 00](https://github.com/linode/manager/assets/130582365/4e5991d1-f2c6-4035-889f-ac6acf080690) |


https://github.com/linode/manager/assets/130582365/ac78e971-ac88-4323-a7ef-dfbf321928ca


## How to test 🧪

### Verification steps
- Confirm the fix to the styles by all/either 
  - using storybook or, in context (esp white background)
  - manually change a field to be disabled within the CM UI


## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
