### PR TITLE
change: [M3-7815] - Change ACLB Beta Regions

### DIFF
--- a/packages/manager/.changeset/pr-10232-changed-1709130492234.md
+++ b/packages/manager/.changeset/pr-10232-changed-1709130492234.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+ACLB beta region `Washington, DC` to `Miami, FL` ([#10232](https://github.com/linode/manager/pull/10232))

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerRegions.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerRegions.tsx
@@ -7,7 +7,7 @@ import { Typography } from 'src/components/Typography';
 import type { Country } from '@linode/api-v4';
 
 export const regions = [
-  { country: 'us', id: 'us-iad', label: 'Washington, DC' },
+  { country: 'us', id: 'us-mia', label: 'Miami, FL' },
   { country: 'us', id: 'us-lax', label: 'Los Angeles, CA' },
   { country: 'fr', id: 'fr-par', label: 'Paris, FR' },
   { country: 'jp', id: 'jp-osa', label: 'Osaka, JP' },


### PR DESCRIPTION
## Description 📝

- Switches IAD out for Miami 🇺🇸 
  - We are doing this for region availability reasons for the Beta period

## Target release date 🗓️

3/4/2024

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-02-27 at 1 06 18 PM](https://github.com/linode/manager/assets/115251059/c1bc7479-a4c4-42ee-9f50-ddd39c8d28b0) | ![Screenshot 2024-02-27 at 1 06 14 PM](https://github.com/linode/manager/assets/115251059/87468ca8-8983-4221-a180-53260527105f) |

## How to test 🧪

- Turn on the MSW
- Browse ACLB and verify that any place regions are displayed, you see `Miami, FL` and **not** `Washington, DC`

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support