### PR TITLE
upcoming: [M3-7814, M3-7819] - Fix Account Switching

### DIFF
--- a/packages/manager/.changeset/pr-10234-upcoming-features-1709068609413.md
+++ b/packages/manager/.changeset/pr-10234-upcoming-features-1709068609413.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Fix Account Switching ([#10234](https://github.com/linode/manager/pull/10234))

--- a/packages/manager/.changeset/pr-10234-upcoming-features-1709068764309.md
+++ b/packages/manager/.changeset/pr-10234-upcoming-features-1709068764309.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Fix to ensure ChildAccountList receives proper account token ([#10234](https://github.com/linode/manager/pull/10234))

--- a/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
+++ b/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
@@ -57,7 +57,7 @@ const assertAuthLocalStorage = (
   expiry: string,
   scopes: string
 ) => {
-  assertLocalStorageValue('authentication/token', token);
+  assertLocalStorageValue('authentication/token', `Bearer ${token}`);
   assertLocalStorageValue('authentication/expire', expiry);
   assertLocalStorageValue('authentication/scopes', scopes);
 };
@@ -126,6 +126,23 @@ describe('Parent/Child account switching', () => {
         .should('be.enabled')
         .click();
 
+      // Prepare up mocks in advance of the account switch. As soon as the child account is clicked,
+      // Cloud will replace its stored token with the token provided by the API and then reload.
+      // From that point forward, we will not have a valid test account token stored in local storage,
+      // so all non-intercepted API requests will respond with a 401 status code and we will get booted to login.
+      // We'll mitigate this by broadly mocking ALL API-v4 requests, then applying more specific mocks to the
+      // individual requests as needed.
+      mockAllApiRequests();
+      mockGetLinodes([]);
+      mockGetRegions([]);
+      mockGetEvents([]);
+      mockGetNotifications([]);
+      mockGetAccount(mockChildAccount);
+      mockGetProfile(mockParentProfile);
+      mockGetUser(mockParentUser);
+
+      // Mock the account switch itself -- we have to do this after the mocks above
+      // to ensure that it is applied.
       mockCreateChildAccountToken(mockChildAccount, mockChildAccountToken).as(
         'switchAccount'
       );
@@ -146,24 +163,6 @@ describe('Parent/Child account switching', () => {
         mockChildAccountToken.expiry!,
         mockChildAccountToken.scopes
       );
-
-      // From this point forward, we will not have a valid test account token stored in local storage,
-      // so all non-intercepted API requests will respond with a 401 status code and we will get booted to login.
-      // We'll mitigate this by broadly mocking ALL API-v4 requests, then applying more specific mocks to the
-      // individual requests as needed.
-      mockAllApiRequests();
-      mockGetLinodes([]);
-      mockGetRegions([]);
-      mockGetEvents([]);
-      mockGetNotifications([]);
-
-      mockGetAccount(mockChildAccount);
-      mockGetProfile(mockParentProfile);
-      mockGetUser(mockParentUser);
-
-      // TODO Remove the call to `cy.reload()` once Cloud Manager automatically updates itself upon account switching.
-      // TODO Add assertions for toast upon account switch. This might involve improving mocks for events/notifications.
-      cy.reload();
 
       // Confirm expected username and company are shown in user menu button.
       assertUserMenuButton(
@@ -205,6 +204,21 @@ describe('Parent/Child account switching', () => {
             .click();
         });
 
+      // Prepare up mocks in advance of the account switch. As soon as the child account is clicked,
+      // Cloud will replace its stored token with the token provided by the API and then reload.
+      // From that point forward, we will not have a valid test account token stored in local storage,
+      // so all non-intercepted API requests will respond with a 401 status code and we will get booted to login.
+      // We'll mitigate this by broadly mocking ALL API-v4 requests, then applying more specific mocks to the
+      // individual requests as needed.
+      mockAllApiRequests();
+      mockGetLinodes([]);
+      mockGetRegions([]);
+      mockGetEvents([]);
+      mockGetNotifications([]);
+      mockGetAccount(mockChildAccount);
+      mockGetProfile(mockParentProfile);
+      mockGetUser(mockParentUser);
+
       // Click mock company name in "Switch Account" drawer.
       mockCreateChildAccountToken(mockChildAccount, mockChildAccountToken).as(
         'switchAccount'
@@ -226,23 +240,6 @@ describe('Parent/Child account switching', () => {
         mockChildAccountToken.expiry!,
         mockChildAccountToken.scopes
       );
-
-      // From this point forward, we will not have a valid test account token stored in local storage,
-      // so all non-intercepted API requests will respond with a 401 status code and we will get booted to login.
-      // We'll mitigate this by broadly mocking ALL API-v4 requests, then applying more specific mocks to the
-      // individual requests as needed.
-      mockAllApiRequests();
-      mockGetLinodes([]);
-      mockGetRegions([]);
-      mockGetEvents([]);
-      mockGetNotifications([]);
-      mockGetAccount(mockChildAccount);
-      mockGetProfile(mockParentProfile);
-      mockGetUser(mockParentUser);
-
-      // TODO Remove the call to `cy.reload()` once Cloud Manager automatically updates itself upon account switching.
-      // TODO Add assertions for toast upon account switch. This might involve improving mocks for events/notifications.
-      cy.reload();
 
       // Confirm expected username and company are shown in user menu button.
       assertUserMenuButton(

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
@@ -38,7 +38,7 @@ export const SwitchAccountDrawer = (props: Props) => {
   );
 
   const currentTokenWithBearer = useCurrentToken() ?? '';
-  const currentParentToken =
+  const currentParentTokenWithBearer =
     getStorage('authentication/parent_token/token') ?? '';
 
   const handleClose = React.useCallback(() => {

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
@@ -191,7 +191,7 @@ export const SwitchAccountDrawer = (props: Props) => {
       </Typography>
       <ChildAccountList
         currentTokenWithBearer={
-          isProxyUser ? currentParentToken : currentTokenWithBearer
+          isProxyUser ? currentParentTokenWithBearer : currentTokenWithBearer
         }
         isProxyUser={isProxyUser}
         onClose={handleClose}

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
@@ -1,6 +1,5 @@
 import { createChildAccountPersonalAccessToken } from '@linode/api-v4';
 import React from 'react';
-import { useHistory } from 'react-router-dom';
 
 import { StyledLinkButton } from 'src/components/Button/StyledLinkButton';
 import { Drawer } from 'src/components/Drawer';
@@ -18,6 +17,7 @@ import { getStorage } from 'src/utilities/storage';
 
 import { ChildAccountList } from './SwitchAccounts/ChildAccountList';
 
+import type { Token } from '@linode/api-v4';
 import type { APIError, ChildAccountPayload, UserType } from '@linode/api-v4';
 import type { State as AuthState } from 'src/store/authentication';
 
@@ -38,7 +38,8 @@ export const SwitchAccountDrawer = (props: Props) => {
   );
 
   const currentTokenWithBearer = useCurrentToken() ?? '';
-  const history = useHistory();
+  const currentParentToken =
+    getStorage('authentication/parent_token/token') ?? '';
 
   const handleClose = React.useCallback(() => {
     onClose();
@@ -76,11 +77,9 @@ export const SwitchAccountDrawer = (props: Props) => {
     []
   );
 
-  // Navigate to the current location, triggering a re-render without a full page reload.
   const refreshPage = React.useCallback(() => {
-    // TODO: Parent/Child: We need to test this against the real API.
-    history.push(history.location.pathname);
-  }, [history]);
+    location.reload();
+  }, []);
 
   const handleSwitchToChildAccount = React.useCallback(
     async ({
@@ -97,17 +96,13 @@ export const SwitchAccountDrawer = (props: Props) => {
       isProxyUser: boolean;
     }) => {
       try {
-        // TODO: Parent/Child: FOR MSW ONLY, REMOVE WHEN API IS READY
-        // ================================================================
-        // throw new Error(
-        //   `Account switching failed. Try again.`
-        // );
-        // ================================================================
-
         // We don't need to worry about this if we're a proxy user.
         if (!isProxyUser) {
-          const parentToken = {
+          const parentToken: Token = {
+            created: getStorage('authentication/created'),
             expiry: getStorage('authentication/expire'),
+            id: getStorage('authentication/id'),
+            label: getStorage('authentication/label'),
             scopes: getStorage('authentication/scopes'),
             token: currentTokenWithBearer ?? '',
           };
@@ -128,7 +123,10 @@ export const SwitchAccountDrawer = (props: Props) => {
 
         setTokenInLocalStorage({
           prefix: 'authentication/proxy_token',
-          token: proxyToken,
+          token: {
+            ...proxyToken,
+            token: `Bearer ${proxyToken.token}`,
+          },
         });
 
         updateCurrentTokenBasedOnUserType({
@@ -139,16 +137,6 @@ export const SwitchAccountDrawer = (props: Props) => {
         refreshPage();
       } catch (error) {
         setIsProxyTokenError(error as APIError[]);
-
-        // TODO: Parent/Child: FOR MSW ONLY, REMOVE WHEN API IS READY
-        // ================================================================
-        // setIsProxyTokenError([
-        //   {
-        //     field: 'token',
-        //     reason: error.message,
-        //   },
-        // ]);
-        // ================================================================
       }
     },
     [getProxyToken, refreshPage]
@@ -168,7 +156,8 @@ export const SwitchAccountDrawer = (props: Props) => {
 
     updateCurrentTokenBasedOnUserType({ userType: 'parent' });
     handleClose();
-  }, [handleClose, isProxyUser]);
+    refreshPage();
+  }, [handleClose, refreshPage]);
 
   return (
     <Drawer onClose={handleClose} open={open} title="Switch Account">
@@ -201,7 +190,9 @@ export const SwitchAccountDrawer = (props: Props) => {
         .
       </Typography>
       <ChildAccountList
-        currentTokenWithBearer={currentTokenWithBearer}
+        currentTokenWithBearer={
+          isProxyUser ? currentParentToken : currentTokenWithBearer
+        }
         isProxyUser={isProxyUser}
         onClose={handleClose}
         onSwitchAccount={handleSwitchToChildAccount}


### PR DESCRIPTION
## Description 📝
There were a few issues with proxy tokens and loading child users for proxy accounts.

## Changes  🔄
- The prefix `Bearer` was missing from the proxy token sending us back to login upon switching.
- We were always passing the current token to `ChildAccountList` which prevented us from fetching child accounts while in a proxy account. This token needs to be the parent token when logged in as a proxy.

## Target release date 🗓️
03/04/2024

## Preview 📷

https://github.com/linode/manager/assets/125309814/527048e9-531f-4979-8a0b-a726ba5569ef


## How to test 🧪

### Prerequisites
(How to setup test environment)
- You need to create parent & child accounts (see me if you want to)

### Verification steps
- Log into dev using parent account creds
- Open user menu and click "Switch Accounts"
- Observe children load
- Select any child accounts and observe page refresh 
- You should now be in proxy account
- Open user menu and click "Switch Accounts"
- Observe children load
- Click "switch back to your account" and observe you should now be back in the parent account.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support