### PR TITLE
fix: [M3-7804] - LinodeVolumeCreateForm crash (for real this time)

### DIFF
--- a/packages/manager/.changeset/pr-10225-fixed-1708720961774.md
+++ b/packages/manager/.changeset/pr-10225-fixed-1708720961774.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Linode storage Volume Create Drawer crash ([#10225](https://github.com/linode/manager/pull/10225))

--- a/packages/manager/.changeset/pr-10235-fixed-1709135736984.md
+++ b/packages/manager/.changeset/pr-10235-fixed-1709135736984.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+LinodeVolumeCreateForm crash ([#10235](https://github.com/linode/manager/pull/10235))

--- a/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
@@ -36,14 +36,12 @@ export const ConfigSelect = React.memo((props: Props) => {
     return { label: config.label, value: config.id };
   });
 
-  React.useEffect(() => {
-    if (configList?.length === 1) {
-      const newValue = configList[0].value;
-      if (value !== newValue) {
-        onChange(configList[0].value);
-      }
+  if (configList?.length === 1) {
+    const newValue = configList[0].value;
+    if (value !== newValue) {
+      onChange(newValue);
     }
-  }, [configList, onChange, value]);
+  }
 
   if (linodeId === null) {
     return null;

--- a/packages/manager/src/features/Volumes/VolumeDrawer/LinodeVolumeCreateForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/LinodeVolumeCreateForm.tsx
@@ -10,7 +10,6 @@ import { TagsInput } from 'src/components/TagsInput/TagsInput';
 import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
 import { MAX_VOLUME_SIZE } from 'src/constants';
-import { useFormValidateOnChange } from 'src/hooks/useFormValidateOnChange';
 import { useEventsPollingActions } from 'src/queries/events/events';
 import { useGrants, useProfile } from 'src/queries/profile';
 import { useCreateVolumeMutation } from 'src/queries/volumes';
@@ -57,10 +56,6 @@ export const LinodeVolumeCreateForm = (props: Props) => {
   const { data: profile } = useProfile();
   const { data: grants } = useGrants();
   const { mutateAsync: createVolume } = useCreateVolumeMutation();
-  const {
-    hasFormBeenSubmitted,
-    setHasFormBeenSubmitted,
-  } = useFormValidateOnChange();
 
   const { checkForNewEvents } = useEventsPollingActions();
 
@@ -95,7 +90,6 @@ export const LinodeVolumeCreateForm = (props: Props) => {
           size: maybeCastToNumber(size),
           tags,
         });
-        setHasFormBeenSubmitted(false);
         checkForNewEvents();
         enqueueSnackbar(`Volume scheduled for creation.`, {
           variant: 'success',
@@ -105,7 +99,6 @@ export const LinodeVolumeCreateForm = (props: Props) => {
         // Analytics Event
         sendCreateVolumeEvent(`Size: ${size}GB`, origin);
       } catch (error) {
-        setHasFormBeenSubmitted(true);
         handleFieldErrors(setErrors, error);
         handleGeneralErrors(
           setStatus,
@@ -114,8 +107,6 @@ export const LinodeVolumeCreateForm = (props: Props) => {
         );
       }
     },
-    validateOnBlur: false,
-    validateOnChange: hasFormBeenSubmitted,
     validationSchema: CreateVolumeSchema,
   });
 
@@ -214,7 +205,6 @@ export const LinodeVolumeCreateForm = (props: Props) => {
           disabled,
           label: 'Create Volume',
           loading: isSubmitting,
-          onClick: () => setHasFormBeenSubmitted(true),
           type: 'submit',
         }}
         secondaryButtonProps={{

--- a/packages/manager/src/features/Volumes/VolumeDrawer/LinodeVolumeCreateForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/LinodeVolumeCreateForm.tsx
@@ -167,6 +167,7 @@ export const LinodeVolumeCreateForm = (props: Props) => {
       <ConfigSelect
         disabled={disabled}
         error={touched.config_id ? errors.config_id : undefined}
+        key={linode.id}
         linodeId={linode.id}
         name="configId"
         onBlur={handleBlur}


### PR DESCRIPTION
## Description 📝
This PR fixes a bad bug crashing the application when attempting to create a volume from the linode detail (storage tab).

follow up to https://github.com/linode/manager/pull/10225 which did not fix it completely

The `useEffect` in question was attempting to select a default value for the config select component and set the value for the field, creating an infinite loop with the label validation of the formik form (expecting a non-falsy value).

It is a bit a of weird bug, which did not surface before the react 18 update and the way useEffect was optimized. I can't say I fully understand the clash between our `formik` initial values, `setFieldValue` and our validation patterns. The fix here is to avoid the useEffect all together

Due to another interesting fact, the e2e test was not breaking as a result, perhaps due to the click methods timing differences between a user click and a `CY.click()`.

## Changes  🔄
- revert https://github.com/linode/manager/pull/10225
- Remove useEffect

## Preview 📷
![cloud linode com_linodes_50934298_storage](https://github.com/linode/manager/assets/130582365/f8574439-53c9-447b-a798-7735cc73e4eb)

## How to test 🧪

### Reproduction steps
- Navigate to http://localhost:3000/linodes/{linode id}/storage
- Click on "Create Volume"
- Congratulations! your browser has crashed, close and reopen

### Verification steps
- Navigate to http://localhost:3000/linodes/{linode id}/storage
- Ensure only one config is present on the instance
- Click on "Create Volume"
- Notice the config selected in the config select
- Create the volume, confirm payload and succession
- Add a new config to the linode instance
- Click on "Create Volume"
- Notice the config select does not have a default value
- Select a config
- Create the volume, confirm payload and succession

**Also**
- Verify that the [volume create](http://localhost:3000/volumes/create) form is working properly with this update

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support


