### PR TITLE
upcoming: [M3-7727] - Only support Edge to Edge Migrations

### DIFF
--- a/packages/manager/.changeset/pr-10238-upcoming-features-1709143092179.md
+++ b/packages/manager/.changeset/pr-10238-upcoming-features-1709143092179.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Only support Edge to Edge Migrations ([#10238](https://github.com/linode/manager/pull/10238))

--- a/packages/manager/src/__data__/regionsData.ts
+++ b/packages/manager/src/__data__/regionsData.ts
@@ -604,8 +604,24 @@ export const regions: Region[] = [
   {
     capabilities: ['Linodes'],
     country: 'us',
-    id: 'us-edgetest',
+    id: 'us-edge-1',
     label: 'Gecko Edge Test',
+    maximum_pgs_per_customer: 5,
+    maximum_vms_per_pg: 10,
+    resolvers: {
+      ipv4:
+        '139.162.130.5, 139.162.131.5, 139.162.132.5, 139.162.133.5, 139.162.134.5, 139.162.135.5, 139.162.136.5, 139.162.137.5, 139.162.138.5, 139.162.139.5',
+      ipv6:
+        '2a01:7e01::5, 2a01:7e01::9, 2a01:7e01::7, 2a01:7e01::c, 2a01:7e01::2, 2a01:7e01::4, 2a01:7e01::3, 2a01:7e01::6, 2a01:7e01::b, 2a01:7e01::8',
+    },
+    site_type: 'edge',
+    status: 'ok',
+  },
+  {
+    capabilities: ['Linodes'],
+    country: 'us',
+    id: 'us-edge-2',
+    label: 'Gecko Edge Test 2',
     maximum_pgs_per_customer: 5,
     maximum_vms_per_pg: 10,
     resolvers: {

--- a/packages/manager/src/components/RegionSelect/RegionSelect.test.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.test.tsx
@@ -68,7 +68,7 @@ describe('RegionSelect', () => {
   it('should render a Select component with edge region text', () => {
     const newProps = {
       ...props,
-      showGeckoHelperText: true,
+      showEdgeIconHelperText: true,
     };
     const { getByTestId } = renderWithTheme(<RegionSelect {...newProps} />);
     expect(getByTestId('region-select-edge-text')).toBeInTheDocument();
@@ -77,7 +77,7 @@ describe('RegionSelect', () => {
   it('should render a Select component with no edge region text', () => {
     const newProps = {
       ...props,
-      showGeckoHelperText: false,
+      showEdgeIconHelperText: false,
     };
     const { queryByTestId } = renderWithTheme(<RegionSelect {...newProps} />);
     expect(queryByTestId('region-select-edge-text')).not.toBeInTheDocument();

--- a/packages/manager/src/components/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.tsx
@@ -36,7 +36,6 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
     currentCapability,
     disabled,
     errorText,
-    geckoEnabled,
     handleSelection,
     helperText,
     isClearable,
@@ -44,7 +43,8 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
     regions,
     required,
     selectedId,
-    showGeckoHelperText,
+    showEdgeIcon,
+    showEdgeIconHelperText,
     width,
   } = props;
 
@@ -84,10 +84,10 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
       getRegionOptions({
         accountAvailabilityData: accountAvailability,
         currentCapability,
-        hideEdgeServers: !geckoEnabled,
+        hideEdgeServers: !showEdgeIcon,
         regions,
       }),
-    [accountAvailability, currentCapability, regions, geckoEnabled]
+    [accountAvailability, currentCapability, regions, showEdgeIcon]
   );
 
   return (
@@ -110,7 +110,7 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
           return (
             <RegionOption
               displayEdgeServerIcon={
-                geckoEnabled && option.site_type === 'edge'
+                showEdgeIcon && option.site_type === 'edge'
               }
               key={option.value}
               option={option}
@@ -125,7 +125,7 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
         })}
         textFieldProps={{
           InputProps: {
-            endAdornment: geckoEnabled &&
+            endAdornment: showEdgeIcon &&
               selectedRegion?.site_type === 'edge' && (
                 <TooltipIcon
                   icon={<EdgeServer />}
@@ -159,7 +159,7 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
         placeholder="Select a Region"
         value={selectedRegion}
       />
-      {showGeckoHelperText && ( // @TODO Gecko MVP: Add docs link
+      {showEdgeIconHelperText && ( // @TODO Gecko Beta: Add docs link
         <StyledEdgeBox>
           <EdgeServer />
           <Typography

--- a/packages/manager/src/components/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.tsx
@@ -38,12 +38,12 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
     errorText,
     handleSelection,
     helperText,
+    hideEdgeRegions,
     isClearable,
     label,
     regions,
     required,
     selectedId,
-    showEdgeIcon,
     showEdgeIconHelperText,
     width,
   } = props;
@@ -84,10 +84,10 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
       getRegionOptions({
         accountAvailabilityData: accountAvailability,
         currentCapability,
-        hideEdgeServers: !showEdgeIcon,
+        hideEdgeRegions,
         regions,
       }),
-    [accountAvailability, currentCapability, regions, showEdgeIcon]
+    [accountAvailability, currentCapability, regions, hideEdgeRegions]
   );
 
   return (
@@ -110,7 +110,7 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
           return (
             <RegionOption
               displayEdgeServerIcon={
-                showEdgeIcon && option.site_type === 'edge'
+                !hideEdgeRegions && option.site_type === 'edge'
               }
               key={option.value}
               option={option}
@@ -125,7 +125,7 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
         })}
         textFieldProps={{
           InputProps: {
-            endAdornment: showEdgeIcon &&
+            endAdornment: !hideEdgeRegions &&
               selectedRegion?.site_type === 'edge' && (
                 <TooltipIcon
                   icon={<EdgeServer />}

--- a/packages/manager/src/components/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.tsx
@@ -38,6 +38,7 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
     errorText,
     handleSelection,
     helperText,
+    hideCoreRegions,
     hideEdgeRegions,
     isClearable,
     label,
@@ -84,10 +85,17 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
       getRegionOptions({
         accountAvailabilityData: accountAvailability,
         currentCapability,
+        hideCoreRegions,
         hideEdgeRegions,
         regions,
       }),
-    [accountAvailability, currentCapability, regions, hideEdgeRegions]
+    [
+      accountAvailability,
+      currentCapability,
+      regions,
+      hideCoreRegions,
+      hideEdgeRegions,
+    ]
   );
 
   return (

--- a/packages/manager/src/components/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.tsx
@@ -38,10 +38,9 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
     errorText,
     handleSelection,
     helperText,
-    hideCoreRegions,
-    hideEdgeRegions,
     isClearable,
     label,
+    regionFilter,
     regions,
     required,
     selectedId,
@@ -85,17 +84,10 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
       getRegionOptions({
         accountAvailabilityData: accountAvailability,
         currentCapability,
-        hideCoreRegions,
-        hideEdgeRegions,
+        regionFilter,
         regions,
       }),
-    [
-      accountAvailability,
-      currentCapability,
-      regions,
-      hideCoreRegions,
-      hideEdgeRegions,
-    ]
+    [accountAvailability, currentCapability, regions, regionFilter]
   );
 
   return (
@@ -118,7 +110,7 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
           return (
             <RegionOption
               displayEdgeServerIcon={
-                !hideEdgeRegions && option.site_type === 'edge'
+                regionFilter !== 'core' && option.site_type === 'edge'
               }
               key={option.value}
               option={option}
@@ -133,7 +125,7 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
         })}
         textFieldProps={{
           InputProps: {
-            endAdornment: !hideEdgeRegions &&
+            endAdornment: regionFilter !== 'core' &&
               selectedRegion?.site_type === 'edge' && (
                 <TooltipIcon
                   icon={<EdgeServer />}

--- a/packages/manager/src/components/RegionSelect/RegionSelect.types.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.types.ts
@@ -35,10 +35,9 @@ export interface RegionSelectProps
   currentCapability: Capabilities | undefined;
   handleSelection: (id: string) => void;
   helperText?: string;
-  hideCoreRegions?: boolean;
-  hideEdgeRegions?: boolean;
   isClearable?: boolean;
   label?: string;
+  regionFilter?: RegionSite;
   regions: Region[];
   required?: boolean;
   selectedId: null | string;
@@ -73,8 +72,7 @@ export interface RegionOptionAvailability {
 }
 
 export interface GetRegionOptions extends RegionOptionAvailability {
-  hideCoreRegions?: boolean;
-  hideEdgeRegions?: boolean;
+  regionFilter?: RegionSite;
   regions: Region[];
 }
 

--- a/packages/manager/src/components/RegionSelect/RegionSelect.types.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.types.ts
@@ -35,6 +35,7 @@ export interface RegionSelectProps
   currentCapability: Capabilities | undefined;
   handleSelection: (id: string) => void;
   helperText?: string;
+  hideCoreRegions?: boolean;
   hideEdgeRegions?: boolean;
   isClearable?: boolean;
   label?: string;
@@ -72,6 +73,7 @@ export interface RegionOptionAvailability {
 }
 
 export interface GetRegionOptions extends RegionOptionAvailability {
+  hideCoreRegions?: boolean;
   hideEdgeRegions?: boolean;
   regions: Region[];
 }

--- a/packages/manager/src/components/RegionSelect/RegionSelect.types.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.types.ts
@@ -33,7 +33,6 @@ export interface RegionSelectProps
    * See `ImageUpload.tsx` for an example of a RegionSelect with an undefined `currentCapability` - there is no capability associated with Images yet.
    */
   currentCapability: Capabilities | undefined;
-  geckoEnabled?: boolean;
   handleSelection: (id: string) => void;
   helperText?: string;
   isClearable?: boolean;
@@ -41,7 +40,8 @@ export interface RegionSelectProps
   regions: Region[];
   required?: boolean;
   selectedId: null | string;
-  showGeckoHelperText?: boolean;
+  showEdgeIcon?: boolean;
+  showEdgeIconHelperText?: boolean;
   width?: number;
 }
 

--- a/packages/manager/src/components/RegionSelect/RegionSelect.types.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.types.ts
@@ -35,12 +35,12 @@ export interface RegionSelectProps
   currentCapability: Capabilities | undefined;
   handleSelection: (id: string) => void;
   helperText?: string;
+  hideEdgeRegions?: boolean;
   isClearable?: boolean;
   label?: string;
   regions: Region[];
   required?: boolean;
   selectedId: null | string;
-  showEdgeIcon?: boolean;
   showEdgeIconHelperText?: boolean;
   width?: number;
 }
@@ -72,7 +72,7 @@ export interface RegionOptionAvailability {
 }
 
 export interface GetRegionOptions extends RegionOptionAvailability {
-  hideEdgeServers?: boolean;
+  hideEdgeRegions?: boolean;
   regions: Region[];
 }
 

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.test.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.test.tsx
@@ -3,7 +3,6 @@ import { accountAvailabilityFactory, regionFactory } from 'src/factories';
 import {
   getRegionOptionAvailability,
   getRegionOptions,
-  getRegionsWithoutCurrentRegionAndCoreSites,
   getSelectedRegionById,
   getSelectedRegionsByIds,
 } from './RegionSelect.utils';
@@ -84,6 +83,23 @@ const expectedRegions: RegionSelectOption[] = [
   },
 ];
 
+const expectedEdgeRegions = [
+  {
+    data: { country: 'us', region: 'North America' },
+    label: 'Gecko Edge Test (us-edge-1)',
+    site_type: 'edge',
+    unavailable: false,
+    value: 'us-edge-1',
+  },
+  {
+    data: { country: 'us', region: 'North America' },
+    label: 'Gecko Edge Test 2 (us-edge-2)',
+    site_type: 'edge',
+    unavailable: false,
+    value: 'us-edge-2',
+  },
+];
+
 describe('getRegionOptions', () => {
   it('should return an empty array if no regions are provided', () => {
     const regions: Region[] = [];
@@ -139,20 +155,7 @@ describe('getRegionOptions', () => {
 
   it('should not filter out edge regions if hideEdgeRegions is false', () => {
     const expectedRegionsWithEdge = [
-      {
-        data: { country: 'us', region: 'North America' },
-        label: 'Gecko Edge Test (us-edge-1)',
-        site_type: 'edge',
-        unavailable: false,
-        value: 'us-edge-1',
-      },
-      {
-        data: { country: 'us', region: 'North America' },
-        label: 'Gecko Edge Test 2 (us-edge-2)',
-        site_type: 'edge',
-        unavailable: false,
-        value: 'us-edge-2',
-      },
+      ...expectedEdgeRegions,
       ...expectedRegions,
     ];
 
@@ -164,6 +167,28 @@ describe('getRegionOptions', () => {
     });
 
     expect(result).toEqual(expectedRegionsWithEdge);
+  });
+
+  it('should filter out core regions if hideCoreRegions is true', () => {
+    const result: RegionSelectOption[] = getRegionOptions({
+      accountAvailabilityData,
+      currentCapability: 'Linodes',
+      hideCoreRegions: true,
+      regions: regionsWithEdge,
+    });
+
+    expect(result).toEqual(expectedEdgeRegions);
+  });
+
+  it('should not filter out core regions if hideCoreRegions is false', () => {
+    const result: RegionSelectOption[] = getRegionOptions({
+      accountAvailabilityData,
+      currentCapability: 'Linodes',
+      hideCoreRegions: false,
+      regions,
+    });
+
+    expect(result).toEqual(expectedRegions);
   });
 });
 
@@ -294,29 +319,5 @@ describe('getSelectedRegionsByIds', () => {
     ];
 
     expect(result).toEqual(expected);
-  });
-});
-
-describe('getRegionsWithoutCurrentRegionAndCoreSites', () => {
-  it('should filter out current region and core regions, returning only edge regions', () => {
-    const result = getRegionsWithoutCurrentRegionAndCoreSites(
-      'us-edge-1',
-      regionsWithEdge
-    );
-    const expectedEdgeRegions = [
-      {
-        capabilities: ['Linodes'],
-        country: 'us',
-        id: 'us-edge-2',
-        label: 'Gecko Edge Test 2',
-        maximum_pgs_per_customer: 5,
-        maximum_vms_per_pg: 10,
-        resolvers: { ipv4: '1.1.1.1', ipv6: '2600:3c03::' },
-        site_type: 'edge',
-        status: 'ok',
-      },
-    ];
-
-    expect(result).toEqual(expectedEdgeRegions);
   });
 });

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.test.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.test.tsx
@@ -1,9 +1,9 @@
 import { accountAvailabilityFactory, regionFactory } from 'src/factories';
 
 import {
-  filterOutCurrentRegionAndCoreRegions,
   getRegionOptionAvailability,
   getRegionOptions,
+  getRegionsWithoutCurrentRegionAndCoreSites,
   getSelectedRegionById,
   getSelectedRegionsByIds,
 } from './RegionSelect.utils';
@@ -297,9 +297,9 @@ describe('getSelectedRegionsByIds', () => {
   });
 });
 
-describe('filterOutCurrentRegionAndCoreRegions', () => {
+describe('getRegionsWithoutCurrentRegionAndCoreSites', () => {
   it('should filter out current region and core regions, returning only edge regions', () => {
-    const result = filterOutCurrentRegionAndCoreRegions(
+    const result = getRegionsWithoutCurrentRegionAndCoreSites(
       'us-edge-1',
       regionsWithEdge
     );

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.test.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.test.tsx
@@ -1,6 +1,7 @@
 import { accountAvailabilityFactory, regionFactory } from 'src/factories';
 
 import {
+  filterOutCurrentRegionAndCoreRegions,
   getRegionOptionAvailability,
   getRegionOptions,
   getSelectedRegionById,
@@ -45,6 +46,13 @@ const regionsWithEdge = [
     country: 'us',
     id: 'us-edge-1',
     label: 'Gecko Edge Test',
+    site_type: 'edge',
+  }),
+  regionFactory.build({
+    capabilities: ['Linodes'],
+    country: 'us',
+    id: 'us-edge-2',
+    label: 'Gecko Edge Test 2',
     site_type: 'edge',
   }),
 ];
@@ -137,6 +145,13 @@ describe('getRegionOptions', () => {
         site_type: 'edge',
         unavailable: false,
         value: 'us-edge-1',
+      },
+      {
+        data: { country: 'us', region: 'North America' },
+        label: 'Gecko Edge Test 2 (us-edge-2)',
+        site_type: 'edge',
+        unavailable: false,
+        value: 'us-edge-2',
       },
       ...expectedRegions,
     ];
@@ -279,5 +294,29 @@ describe('getSelectedRegionsByIds', () => {
     ];
 
     expect(result).toEqual(expected);
+  });
+});
+
+describe('filterOutCurrentRegionAndCoreRegions', () => {
+  it('should filter out current region and core regions, returning only edge regions', () => {
+    const result = filterOutCurrentRegionAndCoreRegions(
+      'us-edge-1',
+      regionsWithEdge
+    );
+    const expectedEdgeRegions = [
+      {
+        capabilities: ['Linodes'],
+        country: 'us',
+        id: 'us-edge-2',
+        label: 'Gecko Edge Test 2',
+        maximum_pgs_per_customer: 5,
+        maximum_vms_per_pg: 10,
+        resolvers: { ipv4: '1.1.1.1', ipv6: '2600:3c03::' },
+        site_type: 'edge',
+        status: 'ok',
+      },
+    ];
+
+    expect(result).toEqual(expectedEdgeRegions);
   });
 });

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.test.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.test.tsx
@@ -126,18 +126,18 @@ describe('getRegionOptions', () => {
     expect(result).toEqual(expectedRegions);
   });
 
-  it('should filter out edge regions if hideEdgeServers is true', () => {
+  it('should filter out edge regions if hideEdgeRegions is true', () => {
     const result: RegionSelectOption[] = getRegionOptions({
       accountAvailabilityData,
       currentCapability: 'Linodes',
-      hideEdgeServers: true,
+      hideEdgeRegions: true,
       regions: regionsWithEdge,
     });
 
     expect(result).toEqual(expectedRegions);
   });
 
-  it('should not filter out edge regions if hideEdgeServers is false', () => {
+  it('should not filter out edge regions if hideEdgeRegions is false', () => {
     const expectedRegionsWithEdge = [
       {
         data: { country: 'us', region: 'North America' },
@@ -159,7 +159,7 @@ describe('getRegionOptions', () => {
     const result: RegionSelectOption[] = getRegionOptions({
       accountAvailabilityData,
       currentCapability: 'Linodes',
-      hideEdgeServers: false,
+      hideEdgeRegions: false,
       regions: regionsWithEdge,
     });
 

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.test.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.test.tsx
@@ -142,18 +142,29 @@ describe('getRegionOptions', () => {
     expect(result).toEqual(expectedRegions);
   });
 
-  it('should filter out edge regions if hideEdgeRegions is true', () => {
+  it('should filter out edge regions if regionFilter is core', () => {
     const result: RegionSelectOption[] = getRegionOptions({
       accountAvailabilityData,
       currentCapability: 'Linodes',
-      hideEdgeRegions: true,
+      regionFilter: 'core',
       regions: regionsWithEdge,
     });
 
     expect(result).toEqual(expectedRegions);
   });
 
-  it('should not filter out edge regions if hideEdgeRegions is false', () => {
+  it('should filter out core regions if regionFilter is edge', () => {
+    const result: RegionSelectOption[] = getRegionOptions({
+      accountAvailabilityData,
+      currentCapability: 'Linodes',
+      regionFilter: 'edge',
+      regions: regionsWithEdge,
+    });
+
+    expect(result).toEqual(expectedEdgeRegions);
+  });
+
+  it('should not filter out any regions if regionFilter is undefined', () => {
     const expectedRegionsWithEdge = [
       ...expectedEdgeRegions,
       ...expectedRegions,
@@ -162,33 +173,11 @@ describe('getRegionOptions', () => {
     const result: RegionSelectOption[] = getRegionOptions({
       accountAvailabilityData,
       currentCapability: 'Linodes',
-      hideEdgeRegions: false,
+      regionFilter: undefined,
       regions: regionsWithEdge,
     });
 
     expect(result).toEqual(expectedRegionsWithEdge);
-  });
-
-  it('should filter out core regions if hideCoreRegions is true', () => {
-    const result: RegionSelectOption[] = getRegionOptions({
-      accountAvailabilityData,
-      currentCapability: 'Linodes',
-      hideCoreRegions: true,
-      regions: regionsWithEdge,
-    });
-
-    expect(result).toEqual(expectedEdgeRegions);
-  });
-
-  it('should not filter out core regions if hideCoreRegions is false', () => {
-    const result: RegionSelectOption[] = getRegionOptions({
-      accountAvailabilityData,
-      currentCapability: 'Linodes',
-      hideCoreRegions: false,
-      regions,
-    });
-
-    expect(result).toEqual(expectedRegions);
   });
 });
 

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
@@ -1,6 +1,5 @@
 import { CONTINENT_CODE_TO_CONTINENT } from '@linode/api-v4';
 
-import { useFlags } from 'src/hooks/useFlags';
 import {
   getRegionCountryGroup,
   getSelectedRegion,
@@ -191,22 +190,22 @@ export const getSelectedRegionsByIds = ({
 /**
  * Util to determine whether a create type has support for edge regions.
  *
- * @returns a boolean indicating whether or not to enable gecko.
+ * @returns a boolean indicating whether or not the create type is edge supported.
  */
-export const useIsGeckoEnabled = (createType: LinodeCreateType) => {
-  const flags = useFlags();
-
+export const getIsLinodeCreateTypeEdgeSupported = (
+  createType: LinodeCreateType
+) => {
   const supportedEdgeTypes: SupportedEdgeTypes[] = [
     'Distributions',
     'StackScripts',
   ];
-  return Boolean(
-    flags.gecko &&
-      !supportedEdgeTypes.includes(createType as SupportedEdgeTypes)
+  return (
+    supportedEdgeTypes.includes(createType as SupportedEdgeTypes) ||
+    typeof createType === 'undefined' // /linodes/create route
   );
 };
 
-export const filterOutCurrentRegionAndCoreRegions = (
+export const getRegionsWithoutCurrentRegionAndCoreSites = (
   currentRegion: string,
   regions: Region[]
 ) => {

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
@@ -27,7 +27,7 @@ const NORTH_AMERICA = CONTINENT_CODE_TO_CONTINENT.NA;
 export const getRegionOptions = ({
   accountAvailabilityData,
   currentCapability,
-  hideEdgeServers = false,
+  hideEdgeRegions = false,
   regions,
 }: GetRegionOptions): RegionSelectOption[] => {
   const filteredRegionsByCapability = currentCapability
@@ -36,7 +36,7 @@ export const getRegionOptions = ({
       )
     : regions;
 
-  const filteredRegionsByCapabilityAndSiteType = hideEdgeServers
+  const filteredRegionsByCapabilityAndSiteType = hideEdgeRegions
     ? filteredRegionsByCapability.filter(
         (region) => region.site_type !== 'edge'
       )

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
@@ -221,9 +221,19 @@ export const isEdgeRegion = (regionsData: Region[], selectedRegion: string) => {
 };
 
 export const useIsEdgeRegion = (
-  regionsData: Region[],
-  selectedRegion: string
+  selectedRegion: string,
+  regionsData: Region[]
 ) => {
   const flags = useFlags();
   return Boolean(flags.gecko && isEdgeRegion(regionsData, selectedRegion));
+};
+
+export const filterOutCurrentRegionAndCoreRegions = (
+  currentRegion: string,
+  regions: Region[]
+) => {
+  return regions?.filter(
+    (eachRegion) =>
+      eachRegion.id !== currentRegion && eachRegion.site_type === 'edge'
+  );
 };

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
@@ -27,6 +27,7 @@ const NORTH_AMERICA = CONTINENT_CODE_TO_CONTINENT.NA;
 export const getRegionOptions = ({
   accountAvailabilityData,
   currentCapability,
+  hideCoreRegions = false,
   hideEdgeRegions = false,
   regions,
 }: GetRegionOptions): RegionSelectOption[] => {
@@ -39,6 +40,10 @@ export const getRegionOptions = ({
   const filteredRegionsByCapabilityAndSiteType = hideEdgeRegions
     ? filteredRegionsByCapability.filter(
         (region) => region.site_type !== 'edge'
+      )
+    : hideCoreRegions
+    ? filteredRegionsByCapability.filter(
+        (region) => region.site_type === 'edge'
       )
     : filteredRegionsByCapability;
 
@@ -202,15 +207,5 @@ export const getIsLinodeCreateTypeEdgeSupported = (
   return (
     supportedEdgeTypes.includes(createType as SupportedEdgeTypes) ||
     typeof createType === 'undefined' // /linodes/create route
-  );
-};
-
-export const getRegionsWithoutCurrentRegionAndCoreSites = (
-  currentRegion: string,
-  regions: Region[]
-) => {
-  return regions?.filter(
-    (eachRegion) =>
-      eachRegion.id !== currentRegion && eachRegion.site_type === 'edge'
   );
 };

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
@@ -206,28 +206,6 @@ export const useIsGeckoEnabled = (createType: LinodeCreateType) => {
   );
 };
 
-/**
- * Util to determine whether a selected region is an edge region.
- *
- * @returns a boolean indicating whether or not the selected region is an edge region.
- */
-export const isEdgeRegion = (regionsData: Region[], selectedRegion: string) => {
-  return (
-    regionsData.find(
-      (region) =>
-        region.id === selectedRegion || region.label === selectedRegion
-    )?.site_type === 'edge'
-  );
-};
-
-export const useIsEdgeRegion = (
-  selectedRegion: string,
-  regionsData: Region[]
-) => {
-  const flags = useFlags();
-  return Boolean(flags.gecko && isEdgeRegion(regionsData, selectedRegion));
-};
-
 export const filterOutCurrentRegionAndCoreRegions = (
   currentRegion: string,
   regions: Region[]

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
@@ -27,8 +27,7 @@ const NORTH_AMERICA = CONTINENT_CODE_TO_CONTINENT.NA;
 export const getRegionOptions = ({
   accountAvailabilityData,
   currentCapability,
-  hideCoreRegions = false,
-  hideEdgeRegions = false,
+  regionFilter,
   regions,
 }: GetRegionOptions): RegionSelectOption[] => {
   const filteredRegionsByCapability = currentCapability
@@ -37,13 +36,9 @@ export const getRegionOptions = ({
       )
     : regions;
 
-  const filteredRegionsByCapabilityAndSiteType = hideEdgeRegions
+  const filteredRegionsByCapabilityAndSiteType = regionFilter
     ? filteredRegionsByCapability.filter(
-        (region) => region.site_type !== 'edge'
-      )
-    : hideCoreRegions
-    ? filteredRegionsByCapability.filter(
-        (region) => region.site_type === 'edge'
+        (region) => region.site_type === regionFilter
       )
     : filteredRegionsByCapability;
 

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.ts
@@ -205,3 +205,25 @@ export const useIsGeckoEnabled = (createType: LinodeCreateType) => {
       !supportedEdgeTypes.includes(createType as SupportedEdgeTypes)
   );
 };
+
+/**
+ * Util to determine whether a selected region is an edge region.
+ *
+ * @returns a boolean indicating whether or not the selected region is an edge region.
+ */
+export const isEdgeRegion = (regionsData: Region[], selectedRegion: string) => {
+  return (
+    regionsData.find(
+      (region) =>
+        region.id === selectedRegion || region.label === selectedRegion
+    )?.site_type === 'edge'
+  );
+};
+
+export const useIsEdgeRegion = (
+  regionsData: Region[],
+  selectedRegion: string
+) => {
+  const flags = useFlags();
+  return Boolean(flags.gecko && isEdgeRegion(regionsData, selectedRegion));
+};

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -137,7 +137,7 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
         errorText={error}
         handleSelection={handleSelection}
         helperText={helperText}
-        hideEdgeRegions={hideEdgeRegions}
+        regionFilter={hideEdgeRegions ? 'core' : undefined}
         regions={regions}
         selectedId={selectedId || null}
         showEdgeIconHelperText={showEdgeIconHelperText}

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -77,12 +77,12 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
       type,
     });
 
-  const showEdgeIcon =
-    flags.gecko &&
-    getIsLinodeCreateTypeEdgeSupported(params.type as LinodeCreateType);
+  const hideEdgeRegions =
+    !flags.gecko ||
+    !getIsLinodeCreateTypeEdgeSupported(params.type as LinodeCreateType);
 
   const showEdgeIconHelperText = Boolean(
-    showEdgeIcon &&
+    !hideEdgeRegions &&
       currentCapability &&
       regions.find(
         (region) =>
@@ -137,9 +137,9 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
         errorText={error}
         handleSelection={handleSelection}
         helperText={helperText}
+        hideEdgeRegions={hideEdgeRegions}
         regions={regions}
         selectedId={selectedId || null}
-        showEdgeIcon={showEdgeIcon}
         showEdgeIconHelperText={showEdgeIconHelperText}
       />
       {showClonePriceWarning && (

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -6,10 +6,11 @@ import { useLocation } from 'react-router-dom';
 import { Notice } from 'src/components/Notice/Notice';
 import { Paper } from 'src/components/Paper';
 import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
-import { useIsGeckoEnabled } from 'src/components/RegionSelect/RegionSelect.utils';
+import { getIsLinodeCreateTypeEdgeSupported } from 'src/components/RegionSelect/RegionSelect.utils';
 import { RegionHelperText } from 'src/components/SelectRegionPanel/RegionHelperText';
 import { Typography } from 'src/components/Typography';
 import { CROSS_DATA_CENTER_CLONE_WARNING } from 'src/features/Linodes/LinodesCreate/constants';
+import { useFlags } from 'src/hooks/useFlags';
 import { useTypeQuery } from 'src/queries/types';
 import { sendLinodeCreateDocsEvent } from 'src/utilities/analytics';
 import {
@@ -51,6 +52,7 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
     selectedLinodeTypeId,
   } = props;
 
+  const flags = useFlags();
   const location = useLocation();
   const theme = useTheme();
   const params = getQueryParamsFromQueryString(location.search);
@@ -75,10 +77,12 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
       type,
     });
 
-  const geckoEnabled = useIsGeckoEnabled(params.type as LinodeCreateType);
+  const showEdgeIcon =
+    flags.gecko &&
+    getIsLinodeCreateTypeEdgeSupported(params.type as LinodeCreateType);
 
-  const showGeckoHelperText = Boolean(
-    geckoEnabled &&
+  const showEdgeIconHelperText = Boolean(
+    showEdgeIcon &&
       currentCapability &&
       regions.find(
         (region) =>
@@ -131,12 +135,12 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
         currentCapability={currentCapability}
         disabled={disabled}
         errorText={error}
-        geckoEnabled={geckoEnabled}
         handleSelection={handleSelection}
         helperText={helperText}
         regions={regions}
         selectedId={selectedId || null}
-        showGeckoHelperText={showGeckoHelperText}
+        showEdgeIcon={showEdgeIcon}
+        showEdgeIconHelperText={showEdgeIconHelperText}
       />
       {showClonePriceWarning && (
         <Notice

--- a/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
@@ -5,7 +5,10 @@ import { Flag } from 'src/components/Flag';
 import { Notice } from 'src/components/Notice/Notice';
 import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
 import { sxEdgeIcon } from 'src/components/RegionSelect/RegionSelect.styles';
-import { useIsEdgeRegion } from 'src/components/RegionSelect/RegionSelect.utils';
+import {
+  filterOutCurrentRegionAndCoreRegions,
+  useIsEdgeRegion,
+} from 'src/components/RegionSelect/RegionSelect.utils';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
 import { useRegionsQuery } from 'src/queries/regions';
@@ -102,15 +105,12 @@ export const ConfigureForm = React.memo((props: Props) => {
     [backupEnabled, currentLinodeType]
   );
 
-  const linodeIsInEdgeRegion = useIsEdgeRegion(regions ?? [], currentRegion);
+  const linodeIsInEdgeRegion = useIsEdgeRegion(currentRegion, regions ?? []);
 
   const filterRegions = () => {
     if (linodeIsInEdgeRegion) {
       // edge regions can only be migrated to other edge regions
-      return regions?.filter(
-        (eachRegion) =>
-          eachRegion.id !== currentRegion && eachRegion.site_type === 'edge'
-      );
+      return filterOutCurrentRegionAndCoreRegions(currentRegion, regions ?? []);
     }
     return regions?.filter((eachRegion) => eachRegion.id !== currentRegion);
   };

--- a/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react';
 
+import EdgeServer from 'src/assets/icons/entityIcons/edge-server.svg';
 import { Flag } from 'src/components/Flag';
 import { Notice } from 'src/components/Notice/Notice';
 import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
+import { sxEdgeIcon } from 'src/components/RegionSelect/RegionSelect.styles';
+import { useIsEdgeRegion } from 'src/components/RegionSelect/RegionSelect.utils';
+import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
 import { useRegionsQuery } from 'src/queries/regions';
 import { useTypeQuery } from 'src/queries/types';
@@ -98,6 +102,19 @@ export const ConfigureForm = React.memo((props: Props) => {
     [backupEnabled, currentLinodeType]
   );
 
+  const linodeIsInEdgeRegion = useIsEdgeRegion(regions ?? [], currentRegion);
+
+  const filterRegions = () => {
+    if (linodeIsInEdgeRegion) {
+      // edge regions can only be migrated to other edge regions
+      return regions?.filter(
+        (eachRegion) =>
+          eachRegion.id !== currentRegion && eachRegion.site_type === 'edge'
+      );
+    }
+    return regions?.filter((eachRegion) => eachRegion.id !== currentRegion);
+  };
+
   return (
     <StyledPaper>
       <Typography variant="h3">Configure Migration</Typography>
@@ -109,6 +126,14 @@ export const ConfigureForm = React.memo((props: Props) => {
             <Typography>{`${getRegionCountryGroup(currentActualRegion)}: ${
               currentActualRegion?.label ?? currentRegion
             }`}</Typography>
+            {linodeIsInEdgeRegion && (
+              <TooltipIcon
+                icon={<EdgeServer />}
+                status="other"
+                sxTooltipIcon={sxEdgeIcon}
+                text="This region is an Edge server."
+              />
+            )}
           </StyledDiv>
           {shouldDisplayPriceComparison && (
             <MigrationPricing
@@ -119,18 +144,15 @@ export const ConfigureForm = React.memo((props: Props) => {
 
         <StyledMigrationBox>
           <RegionSelect
-            regions={
-              regions?.filter(
-                (eachRegion) => eachRegion.id !== currentRegion
-              ) ?? []
-            }
             textFieldProps={{
               helperText,
             }}
             currentCapability="Linodes"
             errorText={errorText}
+            geckoEnabled={linodeIsInEdgeRegion}
             handleSelection={handleSelectRegion}
             label="New Region"
+            regions={filterRegions() ?? []}
             selectedId={selectedRegion}
           />
           {shouldDisplayPriceComparison && selectedRegion && (

--- a/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
@@ -5,12 +5,10 @@ import { Flag } from 'src/components/Flag';
 import { Notice } from 'src/components/Notice/Notice';
 import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
 import { sxEdgeIcon } from 'src/components/RegionSelect/RegionSelect.styles';
-import {
-  filterOutCurrentRegionAndCoreRegions,
-  useIsEdgeRegion,
-} from 'src/components/RegionSelect/RegionSelect.utils';
+import { filterOutCurrentRegionAndCoreRegions } from 'src/components/RegionSelect/RegionSelect.utils';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
+import { useFlags } from 'src/hooks/useFlags';
 import { useRegionsQuery } from 'src/queries/regions';
 import { useTypeQuery } from 'src/queries/types';
 import { getRegionCountryGroup } from 'src/utilities/formatRegion';
@@ -56,6 +54,7 @@ export const ConfigureForm = React.memo((props: Props) => {
     selectedRegion,
   } = props;
 
+  const flags = useFlags();
   const { data: regions } = useRegionsQuery();
   const { data: currentLinodeType } = useTypeQuery(
     linodeType || '',
@@ -105,7 +104,8 @@ export const ConfigureForm = React.memo((props: Props) => {
     [backupEnabled, currentLinodeType]
   );
 
-  const linodeIsInEdgeRegion = useIsEdgeRegion(currentRegion, regions ?? []);
+  const linodeIsInEdgeRegion =
+    flags.gecko && currentActualRegion?.site_type === 'edge';
 
   const filterRegions = () => {
     if (linodeIsInEdgeRegion) {

--- a/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
@@ -154,10 +154,10 @@ export const ConfigureForm = React.memo((props: Props) => {
             currentCapability="Linodes"
             errorText={errorText}
             handleSelection={handleSelectRegion}
+            hideEdgeRegions={!linodeIsInEdgeRegion}
             label="New Region"
             regions={filteredRegions ?? []}
             selectedId={selectedRegion}
-            showEdgeIcon={linodeIsInEdgeRegion}
           />
           {shouldDisplayPriceComparison && selectedRegion && (
             <MigrationPricing

--- a/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
@@ -145,9 +145,8 @@ export const ConfigureForm = React.memo((props: Props) => {
             currentCapability="Linodes"
             errorText={errorText}
             handleSelection={handleSelectRegion}
-            hideCoreRegions={flags.gecko && linodeIsInEdgeRegion}
-            hideEdgeRegions={flags.gecko && !linodeIsInEdgeRegion}
             label="New Region"
+            regionFilter={flags.gecko && linodeIsInEdgeRegion ? 'edge' : 'core'}
             selectedId={selectedRegion}
           />
           {shouldDisplayPriceComparison && selectedRegion && (

--- a/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
@@ -5,7 +5,7 @@ import { Flag } from 'src/components/Flag';
 import { Notice } from 'src/components/Notice/Notice';
 import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
 import { sxEdgeIcon } from 'src/components/RegionSelect/RegionSelect.styles';
-import { filterOutCurrentRegionAndCoreRegions } from 'src/components/RegionSelect/RegionSelect.utils';
+import { getRegionsWithoutCurrentRegionAndCoreSites } from 'src/components/RegionSelect/RegionSelect.utils';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
 import { useFlags } from 'src/hooks/useFlags';
@@ -104,16 +104,20 @@ export const ConfigureForm = React.memo((props: Props) => {
     [backupEnabled, currentLinodeType]
   );
 
-  const linodeIsInEdgeRegion =
-    flags.gecko && currentActualRegion?.site_type === 'edge';
+  const linodeIsInEdgeRegion = currentActualRegion?.site_type === 'edge';
 
-  const filterRegions = () => {
-    if (linodeIsInEdgeRegion) {
+  const getRegions = () => {
+    if (flags.gecko && linodeIsInEdgeRegion) {
       // edge regions can only be migrated to other edge regions
-      return filterOutCurrentRegionAndCoreRegions(currentRegion, regions ?? []);
+      return getRegionsWithoutCurrentRegionAndCoreSites(
+        currentRegion,
+        regions ?? []
+      );
     }
     return regions?.filter((eachRegion) => eachRegion.id !== currentRegion);
   };
+
+  const filteredRegions = getRegions();
 
   return (
     <StyledPaper>
@@ -149,11 +153,11 @@ export const ConfigureForm = React.memo((props: Props) => {
             }}
             currentCapability="Linodes"
             errorText={errorText}
-            geckoEnabled={linodeIsInEdgeRegion}
             handleSelection={handleSelectRegion}
             label="New Region"
-            regions={filterRegions() ?? []}
+            regions={filteredRegions ?? []}
             selectedId={selectedRegion}
+            showEdgeIcon={linodeIsInEdgeRegion}
           />
           {shouldDisplayPriceComparison && selectedRegion && (
             <MigrationPricing

--- a/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
@@ -5,7 +5,6 @@ import { Flag } from 'src/components/Flag';
 import { Notice } from 'src/components/Notice/Notice';
 import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
 import { sxEdgeIcon } from 'src/components/RegionSelect/RegionSelect.styles';
-import { getRegionsWithoutCurrentRegionAndCoreSites } from 'src/components/RegionSelect/RegionSelect.utils';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
 import { useFlags } from 'src/hooks/useFlags';
@@ -106,19 +105,6 @@ export const ConfigureForm = React.memo((props: Props) => {
 
   const linodeIsInEdgeRegion = currentActualRegion?.site_type === 'edge';
 
-  const getRegions = () => {
-    if (flags.gecko && linodeIsInEdgeRegion) {
-      // edge regions can only be migrated to other edge regions
-      return getRegionsWithoutCurrentRegionAndCoreSites(
-        currentRegion,
-        regions ?? []
-      );
-    }
-    return regions?.filter((eachRegion) => eachRegion.id !== currentRegion);
-  };
-
-  const filteredRegions = getRegions();
-
   return (
     <StyledPaper>
       <Typography variant="h3">Configure Migration</Typography>
@@ -148,15 +134,20 @@ export const ConfigureForm = React.memo((props: Props) => {
 
         <StyledMigrationBox>
           <RegionSelect
+            regions={
+              regions?.filter(
+                (eachRegion) => eachRegion.id !== currentRegion
+              ) ?? []
+            }
             textFieldProps={{
               helperText,
             }}
             currentCapability="Linodes"
             errorText={errorText}
             handleSelection={handleSelectRegion}
-            hideEdgeRegions={!linodeIsInEdgeRegion}
+            hideCoreRegions={flags.gecko && linodeIsInEdgeRegion}
+            hideEdgeRegions={flags.gecko && !linodeIsInEdgeRegion}
             label="New Region"
-            regions={filteredRegions ?? []}
             selectedId={selectedRegion}
           />
           {shouldDisplayPriceComparison && selectedRegion && (

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -766,8 +766,8 @@ export const handlers = [
         linodeFactory.build({
           backups: { enabled: false },
           id,
-          label: 'DC-Specific Pricing Linode',
-          region: 'id-cgk',
+          label: 'Gecko Edge Test',
+          region: 'us-edge-1',
         })
       )
     );


### PR DESCRIPTION
## Description 📝
We want to cultivate that edge instances are different from core instances. So, migrating a Linode instance from core to edge or from edge to core should not be possible. Only edge-to-edge migrations and core-to-core migrations should be possible.

## Changes  🔄
List any change relevant to the reviewer.
- Hide core regions if the current Linode is in an edge region
- Hide edge regions if the current Linode is in a core region

## Preview 📷
![image](https://github.com/linode/manager/assets/115299789/af054b7e-6396-45d7-a08a-de7d79f5ee22)

## How to test 🧪

### Verification steps
(How to verify changes)
- Turn on the MSW
- Open the Migrate Linode dialog via the Linodes landing table dropdown action or Linode details header dropdown action
- Observe the current region is an edge region and the New region input only contains edge regions
- Change line `770` in `serverHandlers.ts` to a core region like `us-east`
- Hard refresh the page and open the Migrate Linode dialog again
- Observe the current region is a core region and the New region input only contains core regions

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support