### PR TITLE
test: [M3-7820] - Suppress Cypress "MODULE_LEVEL_DIRECTIVE" and "SOURCEMAP_ERROR" warnings

### DIFF
--- a/packages/manager/.changeset/pr-10239-tests-1709145080838.md
+++ b/packages/manager/.changeset/pr-10239-tests-1709145080838.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Suppress Rollup warnings during Cypress tests ([#10239](https://github.com/linode/manager/pull/10239))

--- a/packages/manager/cypress/vite.config.ts
+++ b/packages/manager/cypress/vite.config.ts
@@ -1,3 +1,5 @@
+import react from '@vitejs/plugin-react-swc';
+import svgr from 'vite-plugin-svgr';
 import { defineConfig } from 'vite';
 import { URL } from 'url';
 
@@ -5,6 +7,30 @@ import { URL } from 'url';
 const DIRNAME = new URL('.', import.meta.url).pathname;
 
 export default defineConfig({
+  plugins: [react(), svgr({ exportAsDefault: true })],
+  build: {
+    rollupOptions: {
+      // Suppress "SOURCEMAP_ERROR" warnings.
+      // This is necessary because MUI contains React SSR "use client" module-level
+      // directive, and Rollup does not support module-level directives.
+      // `vite-plugin-react` and `vite-plugin-react-swc` both silence this warning,
+      // but the inability to handle module-level directives also causes Sourcemap
+      // output errors. The warnings for this are not suppressed by Vite plugins,
+      // so we need to suppress them ourselves.
+      //
+      // See also:
+      // - https://github.com/vitejs/vite-plugin-react/blob/7f53c63/packages/plugin-react/src/index.ts#L303
+      // - https://github.com/vitejs/vite-plugin-react-swc/blob/53ecc44/src/index.ts#L262
+      // - https://github.com/rollup/rollup/issues/4699#issuecomment-1299770973
+      // - https://github.com/vitejs/vite/issues/15012#issuecomment-1815854072
+      onwarn(warning, defaultHandler) {
+        if (warning.code === 'SOURCEMAP_ERROR') {
+          return;
+        }
+        defaultHandler(warning);
+      },
+    },
+  },
   resolve: {
     alias: {
       '@src': `${DIRNAME}/../src`,


### PR DESCRIPTION
## Description 📝
Recent improvements to Cloud Manager's dev tools introduced various `MODULE_LEVEL_DIRECTIVE` and `SOURCEMAP_ERROR` console warnings when Cypress builds each spec file via Vite.

The cause of these warnings is relatively well-understood[1] and the underlying issue(s) are harmless and irrelevant from a Cloud Manager development perspective. This PR addresses the issue by using the `@vitejs/react-plugin-swc` plugin to suppress the `MODULE_LEVEL_DIRECTIVE` warning, and by manually supressing the related `SOURCEMAP_ERROR` warnings.

(1) MUI contains [`'use client'` module-level directives](https://react.dev/reference/react/use-client), which are intended to allow library developers to denote client-side and server-side code. Meanwhile, Rollup (and therefore Vite) [does not support module-level directives](https://github.com/rollup/rollup/issues/4699#issuecomment-1299770973), hence the warning. 

## Changes  🔄
- Use `@vitejs/plugin-react-swc` in Cypress Vite config to suppress `MODULE_LEVEL_DIRECTIVE` warnings
- Manually suppress `SOURCEMAP_ERROR` Rollup warnings in Cypress Vite config

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img width="1765" alt="Screenshot 2024-02-28 at 1 27 58 PM" src="https://github.com/linode/manager/assets/97627410/382770e9-bfc3-4e4a-b5fc-59fd59768701"> | <img width="975" alt="Screenshot 2024-02-28 at 1 25 48 PM" src="https://github.com/linode/manager/assets/97627410/00e2e4bf-42fa-48d9-b619-045fe8021b2e">
 |

## How to test 🧪
We can rely on the automated tests for this. We just want to confirm that the tests continue to pass and that all of the relevant console warnings have been suppressed.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
