### PR TITLE
fix: [M3-7832] - Update root eslint parser to @typescript-eslint/parser 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
   root: true,
   ignorePatterns: ["**/node_modules/", "**/build/"],
-  parser: "@babel/eslint-parser",
+  parser: "@typescript-eslint/parser",
 };


### PR DESCRIPTION
## Description 📝
`@babel/eslint-parser`is no longer part of our devDependencies so this could throw errors in the IDE in some cases.

## Changes  🔄
List any change relevant to the reviewer.
- Update root eslint parser to @typescript-eslint/parser 
