### PR TITLE
test: Resolve OBJ create and delete E2E test flake

### DIFF
--- a/packages/manager/.changeset/pr-10245-tests-1709311899662.md
+++ b/packages/manager/.changeset/pr-10245-tests-1709311899662.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Resolve OBJ Bucket create/delete E2E test flake ([#10245](https://github.com/linode/manager/pull/10245))

--- a/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
@@ -137,7 +137,9 @@ describe('object storage end-to-end tests', () => {
       cy.findByLabelText('Content is loading').should('not.exist');
     });
 
-    ui.button.findByTitle('Create Bucket').should('be.visible').click();
+    ui.entityHeader.find().within(() => {
+      ui.button.findByTitle('Create Bucket').should('be.visible').click();
+    });
 
     ui.drawer
       .findByTitle('Create Bucket')

--- a/packages/manager/cypress/e2e/core/objectStorage/object-storage.smoke.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/object-storage.smoke.spec.ts
@@ -26,11 +26,6 @@ import { ui } from 'support/ui';
 import { regionFactory } from 'src/factories';
 
 describe('object storage smoke tests', () => {
-
-  it('will fail', () => {
-    throw new Error('This is a forced failure!');
-  })
-
   /*
    * - Tests Object Storage bucket creation flow when OBJ Multicluster is enabled.
    * - Confirms that expected regions are displayed in drop-down.

--- a/packages/manager/cypress/e2e/core/objectStorage/object-storage.smoke.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/object-storage.smoke.spec.ts
@@ -26,6 +26,11 @@ import { ui } from 'support/ui';
 import { regionFactory } from 'src/factories';
 
 describe('object storage smoke tests', () => {
+
+  it('will fail', () => {
+    throw new Error('This is a forced failure!');
+  })
+
   /*
    * - Tests Object Storage bucket creation flow when OBJ Multicluster is enabled.
    * - Confirms that expected regions are displayed in drop-down.

--- a/packages/manager/cypress/support/intercepts/account.ts
+++ b/packages/manager/cypress/support/intercepts/account.ts
@@ -610,3 +610,12 @@ export const mockGetAccountLogins = (
     paginateResponse(accountLogins)
   );
 };
+
+/**
+ * Intercepts GET request to fetch the account network utilization data.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptGetNetworkUtilization = (): Cypress.Chainable<null> => {
+  return cy.intercept('GET', apiMatcher('account/transfer'));
+};


### PR DESCRIPTION
## Description 📝
This resolves the test failures that we've recently been seeing in `object-storage.e2e.spec.ts`. There are a couple issues at play that contribute to these failures:

- After a Bucket has been created, the landing page re-renders (presumably in response to some API request resolving), causing occasional failures when the re-render occurs after Cypress has located some element (e.g. the "Delete" table row button) but before it has interacted with it. (I think this is irrelevant from a user experience point of view)
- Less frequently, the test fails due to an issue with the Buckets landing page where the page fails to display a newly created Bucket if the Bucket was created before the initial requests to fetch Buckets have all completed (see M3-7833)

This PR only seeks to resolve test failures related to these behaviors, and it does so by waiting for all related API requests to resolve before attempting to create a Bucket. Because Cloud makes an indeterminate number of requests to fetch Buckets, the test waits for the loader to disappear instead of intercepting and waiting on the requests directly.

I was able to reproduce these failures easily on `develop`, and after making these changes I ran the test on repeat 50 times and all 50 runs passed.

## Changes  🔄
- Wait for loader to disappear and for network utilization data to be fetched before creating an OBJ bucket

## How to test 🧪
We can lean on CI for this, but you can use this command to run the tests locally:

```bash
yarn cy:run -s "cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts"
```

If you want to run them repeatedly, you can use this command if you're using `zsh` as your shell:

```bash
repeat 5 yarn cy:run -s "cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
