### PR TITLE
fix: [M3-7269] - Display parent/proxy username in user menu and toast if no company name is available

### DIFF
--- a/packages/api-v4/.changeset/pr-10248-changed-1709325648578.md
+++ b/packages/api-v4/.changeset/pr-10248-changed-1709325648578.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Changed
+---
+
+Allow `company` to be `null`  ([#10248](https://github.com/linode/manager/pull/10248))

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -51,7 +51,7 @@ export interface Account {
   billing_source: BillingSource;
   city: string;
   phone: string;
-  company: string;
+  company: string | null;
   active_promotions: ActivePromotion[];
   capabilities: AccountCapability[];
   euuid: string;

--- a/packages/manager/.changeset/pr-10248-upcoming-features-1709325591286.md
+++ b/packages/manager/.changeset/pr-10248-upcoming-features-1709325591286.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Display parent/proxy username in user menu and toast if no company name is available ([#10248](https://github.com/linode/manager/pull/10248))

--- a/packages/manager/cypress/e2e/core/billing/billing-contact.spec.ts
+++ b/packages/manager/cypress/e2e/core/billing/billing-contact.spec.ts
@@ -58,7 +58,7 @@ const newAccountData = accountFactory.build({
 
 const checkAccountContactDisplay = (accountInfo: Account) => {
   cy.findByText('Billing Contact').should('be.visible');
-  cy.findByText(accountInfo['company']).should('be.visible');
+  cy.findByText(accountInfo['company'] as string).should('be.visible');
   cy.get('[data-qa-contact-name]').should('be.visible');
   cy.findByText(accountInfo['first_name'], { exact: false });
   cy.findByText(accountInfo['last_name'], { exact: false });
@@ -103,7 +103,7 @@ describe('Billing Contact', () => {
           .should('be.visible')
           .click()
           .clear()
-          .type(newAccountData['company']);
+          .type(newAccountData['company'] as string);
         cy.findByLabelText('Address')
           .should('be.visible')
           .click()

--- a/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
+++ b/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
@@ -62,8 +62,11 @@ const assertAuthLocalStorage = (
   assertLocalStorageValue('authentication/scopes', scopes);
 };
 
+const PARENT_COMPANY_NAME = 'Parent Company';
+const CHILD_COMPANY_NAME = 'Child Company';
+
 const mockParentAccount = accountFactory.build({
-  company: 'Parent Company',
+  company: PARENT_COMPANY_NAME,
 });
 
 const mockParentProfile = profileFactory.build({
@@ -77,7 +80,7 @@ const mockParentUser = accountUserFactory.build({
 });
 
 const mockChildAccount = accountFactory.build({
-  company: 'Child Company',
+  company: CHILD_COMPANY_NAME,
 });
 
 const mockChildAccountToken = appTokenFactory.build({
@@ -151,7 +154,7 @@ describe('Parent/Child account switching', () => {
         .findByTitle('Switch Account')
         .should('be.visible')
         .within(() => {
-          cy.findByText(mockChildAccount.company).should('be.visible').click();
+          cy.findByText(CHILD_COMPANY_NAME).should('be.visible').click();
         });
 
       cy.wait('@switchAccount');
@@ -165,10 +168,7 @@ describe('Parent/Child account switching', () => {
       );
 
       // Confirm expected username and company are shown in user menu button.
-      assertUserMenuButton(
-        mockParentProfile.username,
-        mockChildAccount.company
-      );
+      assertUserMenuButton(mockParentProfile.username, CHILD_COMPANY_NAME);
     });
 
     /*
@@ -189,7 +189,7 @@ describe('Parent/Child account switching', () => {
       // menu button, then click the button.
       assertUserMenuButton(
         mockParentProfile.username,
-        mockParentAccount.company
+        PARENT_COMPANY_NAME
       ).click();
 
       // Click "Switch Account" button in user menu.
@@ -228,7 +228,7 @@ describe('Parent/Child account switching', () => {
         .findByTitle('Switch Account')
         .should('be.visible')
         .within(() => {
-          cy.findByText(mockChildAccount.company).should('be.visible').click();
+          cy.findByText(CHILD_COMPANY_NAME).should('be.visible').click();
         });
 
       cy.wait('@switchAccount');
@@ -242,10 +242,7 @@ describe('Parent/Child account switching', () => {
       );
 
       // Confirm expected username and company are shown in user menu button.
-      assertUserMenuButton(
-        mockParentProfile.username,
-        mockChildAccount.company
-      );
+      assertUserMenuButton(mockParentProfile.username, CHILD_COMPANY_NAME);
     });
   });
 
@@ -292,7 +289,7 @@ describe('Parent/Child account switching', () => {
           // Click child company and mock an error.
           // Confirm that Cloud Manager displays the error message in the drawer.
           mockCreateChildAccountTokenError(mockChildAccount, mockErrorMessage);
-          cy.findByText(mockChildAccount.company).click();
+          cy.findByText(CHILD_COMPANY_NAME).click();
           cy.findByText(mockErrorMessage).should('be.visible');
         });
     });

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
@@ -22,7 +22,7 @@ interface Props {
   address1: string;
   address2: string;
   city: string;
-  company: string;
+  company: null | string;
   country: string;
   email: string;
   firstName: string;

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.test.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.test.tsx
@@ -197,4 +197,64 @@ describe('UserMenu', () => {
     expect(within(userMenuPopover).getByText('Child Company')).toBeVisible();
     expect(within(userMenuPopover).getByText('Switch Account')).toBeVisible();
   });
+
+  it('shows the proxy username for a proxy user if no child company name is set', async () => {
+    server.use(
+      rest.get('*/account', (req, res, ctx) => {
+        return res(ctx.json(accountFactory.build({ company: null })));
+      }),
+      rest.get('*/profile', (req, res, ctx) => {
+        return res(
+          ctx.json(
+            profileFactory.build({
+              user_type: 'proxy',
+              username: 'ParentCompany_a1b2c3d4e5',
+            })
+          )
+        );
+      })
+    );
+
+    const { findByLabelText, findByTestId } = renderWithTheme(<UserMenu />, {
+      flags: { parentChildAccountAccess: true },
+    });
+
+    const userMenuButton = await findByLabelText('Profile & Account');
+    fireEvent.click(userMenuButton);
+
+    const userMenuPopover = await findByTestId('user-menu-popover');
+
+    expect(
+      within(userMenuPopover).getByText('ParentCompany_a1b2c3d4e5')
+    ).toBeVisible();
+  });
+
+  it('shows the parent username for a parent user if their company name is not set', async () => {
+    server.use(
+      rest.get('*/account', (req, res, ctx) => {
+        return res(ctx.json(accountFactory.build({ company: null })));
+      }),
+      rest.get('*/profile', (req, res, ctx) => {
+        return res(
+          ctx.json(
+            profileFactory.build({
+              user_type: 'parent',
+              username: 'parent-username',
+            })
+          )
+        );
+      })
+    );
+
+    const { findByLabelText, findByTestId } = renderWithTheme(<UserMenu />, {
+      flags: { parentChildAccountAccess: true },
+    });
+
+    const userMenuButton = await findByLabelText('Profile & Account');
+    fireEvent.click(userMenuButton);
+
+    const userMenuPopover = await findByTestId('user-menu-popover');
+
+    expect(within(userMenuPopover).getByText('parent-username')).toBeVisible();
+  });
 });

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -295,10 +295,7 @@ export const UserMenu = React.memo(() => {
           <Box>
             <Heading>My Profile</Heading>
             <Divider color="#9ea4ae" />
-            <Grid
-              columnGap={isProxyUser && !companyName ? 1 : undefined}
-              container
-            >
+            <Grid columnGap={userName.length >= 29 ? 1 : undefined} container>
               <Grid
                 container
                 direction="column"


### PR DESCRIPTION
## Description 📝
We learned on the backend that `company` may be `null` for some users, even if they payByAkamai. (Though awaiting final confirmation that this won't change going forward and can be retroactively applied to parent/child accounts when the relationship made on the backend.) Assuming company can still be `null`,  we won't always be able to display the company under the helper text "You are currently logged in as:" in the user menu dropdown for parent and proxy users.

This PR falls back on username in those cases, so we are no longer rendering an empty string in the UserMenu dropdown and success toast.

**UPDATE (3/4)**: Marked as Do Not Merge and Requires Changes because:

- Product wants us to fall back on email rather than username (pending final confirmation)
   - We'd need to ensure parent email cannot be updated to null
- The child account list in the Switch Account Drawer uses company name; we would also need to replace with email

## Changes  🔄
- For a proxy user, we fall back on proxy username rather than parent username + child company if we can’t display the child company name.
- For a parent user, we fall back on parent username if we can’t display the parent company name.
- Updates test coverage in `UserMenu.test.tsx` to reflect this. 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-03-01 at 11 35 24 AM](https://github.com/linode/manager/assets/114685994/70eb4557-048a-400d-982d-094d0010d4db) | ![Screenshot 2024-03-01 at 11 30 15 AM](https://github.com/linode/manager/assets/114685994/f706d371-dae8-4503-8ef1-e90e3a01dadd) |
| ![Screenshot 2024-03-01 at 7 05 36 AM](https://github.com/linode/manager/assets/114685994/0630aa49-5a06-4e84-be18-95166c069c23) | ![Screenshot 2024-03-01 at 11 30 30 AM](https://github.com/linode/manager/assets/114685994/31afb484-ad76-4e82-a598-6aaae6adc5ab) |


## How to test 🧪

### Prerequisites
- This can be tested with mocks more easily than in the dev environment because you'd need to ask me for provisioned parent/child account access, then log into alpha admin and delete a child account's company name, and make one manual code edit due to an API bug with `child_account_access` (the grant isn't being returned correctly) to eliminate the final `!isChildAccountAccessRestricted` check from `const canSwitchBetweenParentOrProxyAccount` if you want the Switch Account button to show up.

### Reproduction steps
- Look at the diff and notice how this code before was defaulting to `company` being an empty string if the conditional was false, and then displaying that empty string in the user menu and tooltip.

### Verification steps
- Check out this PR and `yarn up`.
- Ensure the parent/child feature flag is on.
With mocks:
- Edit the account endpoint [here](https://github.com/linode/manager/blob/develop/packages/manager/src/mocks/serverHandlers.ts#L1201) in serverHandlers.ts to return a `null` company name.  Confirm your `user_type` is [`parent`](https://github.com/linode/manager/blob/develop/packages/manager/src/mocks/serverHandlers.ts#L558).
- Open the user menu and confirm the username is visible. Click the Switch Account button and switch into a proxy account by selecting a child.
- Edit the profile endpoint in serverHandlers.ts to have a `user_type` of [`proxy`](https://github.com/linode/manager/blob/develop/packages/manager/src/mocks/serverHandlers.ts#L558).
- Confirm the success toast includes the username.
- Open the user menu and confirm the username is visible.
- (Note that it will be the same username ("mock-user") since mocks will use the same profile endpoint.)

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
