### PR TITLE
fix: React Query `updateInPaginatedStore` helper function not working as expected

### DIFF
--- a/packages/manager/src/queries/base.ts
+++ b/packages/manager/src/queries/base.ts
@@ -244,16 +244,16 @@ export const updateInPaginatedStore = <T extends { id: number | string }>(
         return oldData;
       }
 
-      const updatedDATA = [...oldData.data];
+      const updatedPaginatedData = [...oldData.data];
 
-      updatedDATA[toUpdateIndex] = {
+      updatedPaginatedData[toUpdateIndex] = {
         ...oldData.data[toUpdateIndex],
         ...newData,
       };
 
       return {
         ...oldData,
-        data: updatedDATA,
+        data: updatedPaginatedData,
       };
     }
   );

--- a/packages/manager/src/queries/base.ts
+++ b/packages/manager/src/queries/base.ts
@@ -244,12 +244,17 @@ export const updateInPaginatedStore = <T extends { id: number | string }>(
         return oldData;
       }
 
-      oldData.data[toUpdateIndex] = {
+      const updatedDATA = [...oldData.data];
+
+      updatedDATA[toUpdateIndex] = {
         ...oldData.data[toUpdateIndex],
         ...newData,
       };
 
-      return oldData;
+      return {
+        ...oldData,
+        data: updatedDATA,
+      };
     }
   );
 };


### PR DESCRIPTION
## Description 📝

With React Query, it is reccomneded that you update the cache in an "immutable" way. 

Essentially, we were updating the cache, but the changes were not getting propagated and rendered because updating an existing value within the same array. The fix in this case to just copy the array before committing to the cache. 

See https://tanstack.com/query/v4/docs/framework/react/guides/updates-from-mutation-responses#immutability

> [!note]
> This PR fixes Cypress test failures in `machine-image-upload.spec.ts`

## How to test 🧪

- Run `yarn cy:debug` and watch the `uploads machine image, mock finish event` test. After `@getImage`, we should see the changes render immediately and the test should pass.

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support