### PR TITLE
change: [M3-7813] - Allow the disabling of the TypeToConfirm input

### DIFF
--- a/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.test.tsx
+++ b/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.test.tsx
@@ -65,7 +65,7 @@ describe('TypeToConfirmDialog Component', () => {
     expect(submitButton).toBeEnabled();
   });
 
-  it('should disabled the Type To Confirm input field given the prop', () => {
+  it('should disabled the Type To Confirm input field given the `disableTypeToConfirmInput` prop', () => {
     const { getByTestId } = renderWithTheme(
       <TypeToConfirmDialog
         entity={{
@@ -89,5 +89,36 @@ describe('TypeToConfirmDialog Component', () => {
 
     const input = getByTestId('textfield-input');
     expect(input).toBeDisabled();
+  });
+
+  it('should disabled the Type To Confirm input field given the prop', () => {
+    const { getByTestId } = renderWithTheme(
+      <TypeToConfirmDialog
+        entity={{
+          action: 'deletion',
+          name: 'test',
+          primaryBtnText: 'Delete',
+          type: 'Linode',
+        }}
+        disableTypeToConfirmSubmit
+        label={'Linode Label'}
+        loading={false}
+        open={true}
+        title="Delete Linode test?"
+        {...props}
+      >
+        <Typography style={{ fontSize: '0.875rem' }}>
+          <strong>Warning:</strong> {warningText}
+        </Typography>
+      </TypeToConfirmDialog>
+    );
+
+    const input = getByTestId('textfield-input');
+    fireEvent.change(input, { target: { value: 'test' } });
+
+    const submitButton = getByTestId('confirm');
+    // Should still be disabled cause we overrode the disabled state with the prop
+
+    expect(submitButton).toBeDisabled();
   });
 });

--- a/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.test.tsx
+++ b/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/react';
 import * as React from 'react';
 
 import { Typography } from 'src/components/Typography';
@@ -32,5 +33,62 @@ describe('TypeToConfirmDialog Component', () => {
       </TypeToConfirmDialog>
     );
     getByText(warningText);
+  });
+
+  it('should have its button disabled by default', () => {
+    const { getByTestId } = renderWithTheme(
+      <TypeToConfirmDialog
+        entity={{
+          action: 'deletion',
+          name: 'test',
+          primaryBtnText: 'Delete',
+          type: 'Linode',
+        }}
+        label={'Linode Label'}
+        loading={false}
+        open={true}
+        title="Delete Linode test?"
+        {...props}
+      >
+        <Typography style={{ fontSize: '0.875rem' }}>
+          <strong>Warning:</strong> {warningText}
+        </Typography>
+      </TypeToConfirmDialog>
+    );
+
+    const submitButton = getByTestId('confirm');
+    expect(submitButton).toBeDisabled();
+
+    const input = getByTestId('textfield-input');
+    fireEvent.change(input, { target: { value: 'test' } });
+
+    expect(submitButton).toBeEnabled();
+  });
+
+  it('should disabled the Type To Confirm input field given the prop', () => {
+    const { getByTestId } = renderWithTheme(
+      <TypeToConfirmDialog
+        entity={{
+          action: 'deletion',
+          name: 'test',
+          primaryBtnText: 'Delete',
+          type: 'Linode',
+        }}
+        disableTypeToConfirmInput
+        label={'Linode Label'}
+        loading={false}
+        open={true}
+        title="Delete Linode test?"
+        {...props}
+        disabled
+      >
+        <Typography style={{ fontSize: '0.875rem' }}>
+          <strong>Warning:</strong> {warningText}
+        </Typography>
+      </TypeToConfirmDialog>
+    );
+
+    const input = getByTestId('textfield-input');
+    expect(input).toBeDisabled();
   });
 });

--- a/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.test.tsx
+++ b/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.test.tsx
@@ -80,7 +80,6 @@ describe('TypeToConfirmDialog Component', () => {
         open={true}
         title="Delete Linode test?"
         {...props}
-        disabled
       >
         <Typography style={{ fontSize: '0.875rem' }}>
           <strong>Warning:</strong> {warningText}

--- a/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
+++ b/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
@@ -33,6 +33,7 @@ interface EntityInfo {
 
 interface TypeToConfirmDialogProps {
   children?: React.ReactNode;
+  disableTypeToConfirmInput?: boolean;
   entity: EntityInfo;
   errors?: APIError[] | null | undefined;
   label: string;
@@ -48,6 +49,7 @@ type CombinedProps = TypeToConfirmDialogProps &
 export const TypeToConfirmDialog = (props: CombinedProps) => {
   const {
     children,
+    disableTypeToConfirmInput,
     entity,
     errors,
     inputProps,
@@ -64,8 +66,9 @@ export const TypeToConfirmDialog = (props: CombinedProps) => {
   const [confirmText, setConfirmText] = React.useState('');
 
   const { data: preferences } = usePreferences();
-  const disabled =
+  const isPrimaryButtonDisabled =
     preferences?.type_to_confirm !== false && confirmText !== entity.name;
+  const isTypeToConfirmInputDisabled = disableTypeToConfirmInput;
 
   React.useEffect(() => {
     if (open) {
@@ -82,7 +85,7 @@ export const TypeToConfirmDialog = (props: CombinedProps) => {
     <ActionsPanel
       primaryButtonProps={{
         'data-testid': 'confirm',
-        disabled,
+        disabled: isPrimaryButtonDisabled,
         label: entity.primaryBtnText,
         loading,
         onClick,
@@ -120,6 +123,7 @@ export const TypeToConfirmDialog = (props: CombinedProps) => {
           setConfirmText(input);
         }}
         data-testid={'dialog-confirm-text-input'}
+        disabled={isTypeToConfirmInputDisabled}
         expand
         hideInstructions={entity.subType === 'CloseAccount'}
         inputProps={inputProps}

--- a/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
+++ b/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
@@ -32,13 +32,37 @@ interface EntityInfo {
 }
 
 interface TypeToConfirmDialogProps {
+  /**
+   * Chidlren are rendered above the TypeToConfirm input
+   */
   children?: React.ReactNode;
+  /**
+   * Props to be allow disabling the input
+   */
   disableTypeToConfirmInput?: boolean;
+  /**
+   * The entity being confirmed
+   */
   entity: EntityInfo;
+  /**
+   * Error to be displayed in the dialog
+   */
   errors?: APIError[] | null | undefined;
+  /*
+   * The label for the dialog
+   */
   label: string;
+  /**
+   * The loading state of dialog
+   */
   loading: boolean;
+  /**
+   * The click handler for the primary button
+   */
   onClick: () => void;
+  /**
+   * The open/closed state of the dialog
+   */
   open: boolean;
 }
 

--- a/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
+++ b/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
@@ -41,6 +41,10 @@ interface TypeToConfirmDialogProps {
    */
   disableTypeToConfirmInput?: boolean;
   /**
+   * Props to be allow disabling the submit button
+   */
+  disableTypeToConfirmSubmit?: boolean;
+  /**
    * The entity being confirmed
    */
   entity: EntityInfo;
@@ -68,12 +72,13 @@ interface TypeToConfirmDialogProps {
 
 type CombinedProps = TypeToConfirmDialogProps &
   ConfirmationDialogProps &
-  Partial<TypeToConfirmProps>;
+  Partial<Omit<TypeToConfirmProps, 'disabled'>>;
 
 export const TypeToConfirmDialog = (props: CombinedProps) => {
   const {
     children,
     disableTypeToConfirmInput,
+    disableTypeToConfirmSubmit,
     entity,
     errors,
     inputProps,
@@ -91,7 +96,8 @@ export const TypeToConfirmDialog = (props: CombinedProps) => {
 
   const { data: preferences } = usePreferences();
   const isPrimaryButtonDisabled =
-    preferences?.type_to_confirm !== false && confirmText !== entity.name;
+    (preferences?.type_to_confirm !== false && confirmText !== entity.name) ||
+    disableTypeToConfirmSubmit;
   const isTypeToConfirmInputDisabled = disableTypeToConfirmInput;
 
   React.useEffect(() => {

--- a/packages/manager/src/features/Account/CloseAccountDialog.tsx
+++ b/packages/manager/src/features/Account/CloseAccountDialog.tsx
@@ -29,8 +29,6 @@ const CloseAccountDialog = ({ closeDialog, open }: Props) => {
   );
   const [errors, setErrors] = React.useState<APIError[] | undefined>(undefined);
   const [comments, setComments] = React.useState<string>('');
-  const [inputtedUsername, setUsername] = React.useState<string>('');
-  const [canSubmit, setCanSubmit] = React.useState<boolean>(false);
   const { classes } = useStyles();
   const history = useHistory();
   const { data: profile } = useProfile();
@@ -42,22 +40,8 @@ const CloseAccountDialog = ({ closeDialog, open }: Props) => {
        * intentionally not resetting comments
        */
       setErrors(undefined);
-      setUsername('');
-      setCanSubmit(false);
     }
   }, [open]);
-
-  /**
-   * enable the submit button if the user entered their
-   * username correctly
-   */
-  React.useEffect(() => {
-    if (inputtedUsername === profile?.username) {
-      setCanSubmit(true);
-    } else {
-      setCanSubmit(false);
-    }
-  }, [inputtedUsername, profile]);
 
   const inputRef = React.useCallback(
     (node: any) => {
@@ -103,7 +87,6 @@ const CloseAccountDialog = ({ closeDialog, open }: Props) => {
         subType: 'CloseAccount',
         type: 'AccountSetting',
       }}
-      disabled={!canSubmit}
       inputRef={inputRef}
       label={`Please enter your Username (${profile.username}) to confirm.`}
       loading={isClosingAccount}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/DeleteKubernetesClusterDialog.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/DeleteKubernetesClusterDialog.test.tsx
@@ -42,13 +42,13 @@ describe('Kubernetes deletion dialog', () => {
     );
     const button = getByTestId('confirm');
 
-    expect(button).toHaveAttribute('aria-disabled', 'true');
+    expect(button).toBeDisabled;
 
     await findByTestId('textfield-input');
 
     const input = getByTestId('textfield-input');
     fireEvent.change(input, { target: { value: 'this-cluster' } });
 
-    expect(button).toHaveAttribute('aria-disabled', 'false');
+    expect(button).toBeEnabled();
   });
 });

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -93,10 +93,7 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
           ? [{ reason: 'Placement Group not found.' }]
           : undefined
       }
-      inputProps={{
-        disabled: isDisabled,
-      }}
-      disableTypeToConfirmInput
+      disableTypeToConfirmInput={isDisabled}
       disabled={isDisabled}
       label="Placement Group"
       loading={placementGroupDataLoading || deletePlacementLoading}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -94,7 +94,6 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
           : undefined
       }
       disableTypeToConfirmInput={isDisabled}
-      disabled={isDisabled}
       label="Placement Group"
       loading={placementGroupDataLoading || deletePlacementLoading}
       onClick={onDelete}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -96,6 +96,7 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
       inputProps={{
         disabled: isDisabled,
       }}
+      disableTypeToConfirmInput
       disabled={isDisabled}
       label="Placement Group"
       loading={placementGroupDataLoading || deletePlacementLoading}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -94,6 +94,7 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
           : undefined
       }
       disableTypeToConfirmInput={isDisabled}
+      disableTypeToConfirmSubmit={isDisabled}
       label="Placement Group"
       loading={placementGroupDataLoading || deletePlacementLoading}
       onClick={onDelete}


### PR DESCRIPTION
## Description 📝
We currently don't have the possibility of disabling the TypeToConfirm input (only its submit button).

In the case of a TypeToConfirm Modal where an action needs to be taken before being abled to delete the entity, we want to be able to disable the input in order for the user to not fill and then to realize they still can't delete it.

This is the case for the `PlacementGroupDeleteModal` for which we need to delete all attached Linodes in order to delete the PlacementGroup

## Changes  🔄
- Add new `disableTypeToConfirmInput` prop to allow disabling the input 
- Improve naming conventions
- Improve test coverage


## Preview 📷
**Include a screenshot or screen recording of the change**

![localhost_3000_placement-groups_delete_1](https://github.com/linode/manager/assets/130582365/c274407f-7b8b-476e-ab65-fff80679ee81)


## How to test 🧪

### Prerequisites
- Have both the "Placement Group" feature flag and MSW turned on

### Verification steps
- Navigate to http://localhost:3000/placement-groups/delete/1
- Confirm TypeToConfirm input is disabled
- Modify [PG factory](https://github.com/linode/manager/blob/develop/packages/manager/src/factories/placementGroups.ts#L16) to have an empty `linodes` array
- Confirm TypeToConfirm input is enabled

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

---
## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**
- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

---
