### PR TITLE
upcoming: [M3-7835] - Adjust user table column count

### DIFF
--- a/packages/manager/.changeset/pr-10252-upcoming-features-1709581147040.md
+++ b/packages/manager/.changeset/pr-10252-upcoming-features-1709581147040.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Adjust user table column count for parent/child ([#10252](https://github.com/linode/manager/pull/10252))

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -1,3 +1,5 @@
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import * as React from 'react';
 
 import AddNewLink from 'src/components/AddNewLink';
@@ -22,6 +24,7 @@ import { UsersLandingTableHead } from './UsersLandingTableHead';
 import type { Filter } from '@linode/api-v4';
 
 export const UsersLanding = () => {
+  const theme = useTheme();
   const [isCreateDrawerOpen, setIsCreateDrawerOpen] = React.useState<boolean>(
     false
   );
@@ -29,6 +32,8 @@ export const UsersLanding = () => {
   const [selectedUsername, setSelectedUsername] = React.useState('');
   const flags = useFlags();
   const { data: profile } = useProfile();
+  const matchesSmDown = useMediaQuery(theme.breakpoints.down('sm'));
+  const matchesLgUp = useMediaQuery(theme.breakpoints.up('lg'));
 
   const pagination = usePagination(1, 'account-users');
   const order = useOrder();
@@ -56,7 +61,7 @@ export const UsersLanding = () => {
     error: proxyUserError,
     isLoading: isLoadingProxyUser,
   } = useAccountUsers({
-    enabled: flags.parentChildAccountAccess,
+    enabled: flags.parentChildAccountAccess && !profile?.restricted,
     filters: { user_type: 'proxy' },
   });
 
@@ -66,7 +71,15 @@ export const UsersLanding = () => {
     flags.parentChildAccountAccess && profile?.user_type === 'parent'
   );
 
-  const numCols = showChildAccountAccessCol ? 6 : 5;
+  const numCols = matchesLgUp
+    ? showChildAccountAccessCol
+      ? 6
+      : 5
+    : matchesSmDown
+    ? 3
+    : 4;
+
+  const proxyNumCols = matchesLgUp ? 4 : numCols;
 
   const handleDelete = (username: string) => {
     setIsDeleteDialogOpen(true);
@@ -97,7 +110,7 @@ export const UsersLanding = () => {
             <UsersLandingTableBody
               error={proxyUserError}
               isLoading={isLoadingProxyUser}
-              numCols={4}
+              numCols={proxyNumCols}
               onDelete={handleDelete}
               users={proxyUser?.data}
             />

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -56,16 +56,16 @@ export const UsersLanding = () => {
     },
   });
 
+  const isRestrictedUser = profile?.restricted;
+
   const {
     data: proxyUser,
     error: proxyUserError,
     isLoading: isLoadingProxyUser,
   } = useAccountUsers({
-    enabled: flags.parentChildAccountAccess && !profile?.restricted,
+    enabled: flags.parentChildAccountAccess && !isRestrictedUser,
     filters: { user_type: 'proxy' },
   });
-
-  const isRestrictedUser = profile?.restricted;
 
   const showChildAccountAccessCol = Boolean(
     flags.parentChildAccountAccess && profile?.user_type === 'parent'

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -63,7 +63,8 @@ export const UsersLanding = () => {
     error: proxyUserError,
     isLoading: isLoadingProxyUser,
   } = useAccountUsers({
-    enabled: flags.parentChildAccountAccess && !isRestrictedUser,
+    enabled:
+      flags.parentChildAccountAccess && showProxyUserTable && !isRestrictedUser,
     filters: { user_type: 'proxy' },
   });
 

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -72,6 +72,7 @@ export const UsersLanding = () => {
     flags.parentChildAccountAccess && profile?.user_type === 'parent'
   );
 
+  // Parent/Child accounts include additional "child account access" column.
   const numCols = matchesLgUp
     ? showChildAccountAccessCol
       ? 6
@@ -80,6 +81,7 @@ export const UsersLanding = () => {
     ? 3
     : 4;
 
+  // "last login" column omitted for proxy table.
   const proxyNumCols = matchesLgUp ? 4 : numCols;
 
   const handleDelete = (username: string) => {

--- a/packages/manager/src/features/Users/UsersLandingProxyTableHead.tsx
+++ b/packages/manager/src/features/Users/UsersLandingProxyTableHead.tsx
@@ -14,7 +14,11 @@ interface Props {
 
 export const UsersLandingProxyTableHead = ({ order }: Props) => {
   return (
-    <TableHead>
+    <TableHead
+      sx={{
+        whiteSpace: 'nowrap',
+      }}
+    >
       <TableRow>
         <TableSortCell
           active={order.orderBy === 'username'}

--- a/packages/manager/src/features/Users/UsersLandingTableBody.tsx
+++ b/packages/manager/src/features/Users/UsersLandingTableBody.tsx
@@ -19,13 +19,7 @@ export const UsersLandingTableBody = (props: Props) => {
   const { error, isLoading, numCols, onDelete, users } = props;
 
   if (isLoading) {
-    return (
-      <TableRowLoading
-        columns={numCols}
-        responsive={{ 1: { smDown: true }, 3: { lgDown: true } }}
-        rows={1}
-      />
-    );
+    return <TableRowLoading columns={numCols} rows={1} />;
   }
 
   if (error) {

--- a/packages/manager/src/features/Users/UsersLandingTableHead.tsx
+++ b/packages/manager/src/features/Users/UsersLandingTableHead.tsx
@@ -24,7 +24,11 @@ export const UsersLandingTableHead = ({
   showChildAccountAccessCol,
 }: Props) => {
   return (
-    <TableHead>
+    <TableHead
+      sx={{
+        whiteSpace: 'nowrap',
+      }}
+    >
       <TableRow>
         <TableSortCell
           active={order.orderBy === 'username'}


### PR DESCRIPTION
## Description 📝
Navigating through different breakpoints in the application, I notice that the loading state columns are misaligned. This inconsistency is particularly noticeable for normal users, parent users with additional "child account access" column, and proxy users where the "last login" column is removed. To enhance the user experience and ensure clarity in data presentation, we need to account for these variations in column arrangement and loading state across breakpoints.

In addition, if the proxy user doesn't have full access - we should disable the query to fetch the proxy user in the table instead of returning "Unauthorized".

## Changes  🔄
- Adjusting column count based on the three conditions described.
- Adding `whiteSpace: 'nowrap'` to prevent excessive collapsing as we scale down breakpoints. It's not perfect, but it's much better.

## Target release date 🗓️
3/18

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![unauthorized](https://github.com/linode/manager/assets/125309814/71f99f7e-d016-4191-9346-3f55ea0e7aa2)![z-01](https://github.com/linode/manager/assets/125309814/14609172-607c-4925-b182-a9cd67ba6105)![z-02](https://github.com/linode/manager/assets/125309814/3513c394-0ed4-4b9d-b94e-7b5616a13b8b)![z-03](https://github.com/linode/manager/assets/125309814/9ce5ff50-39a3-4220-a056-36938521e3aa) | <video src="https://github.com/linode/manager/assets/125309814/e948d9bd-04e2-46da-93bb-f340458d90e1" /><video src="https://github.com/linode/manager/assets/125309814/ef7eda21-39d4-400a-b50e-23efa3cf9c5e" /> |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Run branch locally
- Turn on MSW and Parent/Child feature flag using dev tools
- Change [this line](https://github.com/linode/manager/blob/develop/packages/manager/src/mocks/serverHandlers.ts#L556) to `proxy || parent || child`
- Change this line to `true`: https://github.com/linode/manager/blob/develop/packages/manager/src/features/Users/UsersLandingTableBody.tsx#L21

### Reproduction steps
(How to reproduce the issue, if applicable)
- Go to http://localhost:3000/account/users and change breakpoints to see issue.

### Verification steps
(How to verify changes)
- On branch, observe that the columns and headers all match and align regardless of breakpoint

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
