### PR TITLE
upcoming: [M3-7723] - Placement Group feature flag as object

### DIFF
--- a/docs/development-guide/11-feature-flags.md
+++ b/docs/development-guide/11-feature-flags.md
@@ -20,6 +20,13 @@ We often need to control more than one setting for a given feature. For instance
 }
 ```
 
+Feature flags variations should also be labelled as clearly as possible to avoid confusion for a potential third party managing the flag you created.
+For instance, for the example above, the variations could be labelled:
+
+- Variation 1: Feature ON, Beta ON
+- Variation 2: Feature ON, Beta OFF
+- Variation 3: Everything OFF
+
 ## Creating a feature flag
 
 Feature flags are created in the LaunchDarkly dashboard. Give your flag a name (like "Images Pricing Banner") and key (like "imagesPricingBanner") and select the flag type (boolean, etc). Configure the desired variations and targeting options.

--- a/docs/development-guide/11-feature-flags.md
+++ b/docs/development-guide/11-feature-flags.md
@@ -11,6 +11,15 @@ Feature flags are served by [LaunchDarkly](https://launchdarkly.com/). On app lo
 
 Feature flag values themselves can be booleans (most common), strings, numbers, or JSON (also common).
 
+We often need to control more than one setting for a given feature. For instance, a feature might have a boolean flag to enable/disable it, and a secondary flag to control its "beta" status. In LaunchDarkly, if using a JSON object and still wanting to control the on/off status of a feature, **all variations must contain an `enabled` key**. ex:
+
+```json
+{
+  "enabled": true,
+  "beta": true
+}
+```
+
 ## Creating a feature flag
 
 Feature flags are created in the LaunchDarkly dashboard. Give your flag a name (like "Images Pricing Banner") and key (like "imagesPricingBanner") and select the flag type (boolean, etc). Configure the desired variations and targeting options.

--- a/packages/manager/.changeset/pr-10256-upcoming-features-1709671609446.md
+++ b/packages/manager/.changeset/pr-10256-upcoming-features-1709671609446.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Change Placement Group Feature Flag to return a JSON object ([#10256](https://github.com/linode/manager/pull/10256))

--- a/packages/manager/src/components/DetailsPanel/DetailsPanel.tsx
+++ b/packages/manager/src/components/DetailsPanel/DetailsPanel.tsx
@@ -33,7 +33,7 @@ interface DetailsPanelProps {
 export const DetailsPanel = (props: DetailsPanelProps) => {
   const theme = useTheme();
   const flags = useFlags();
-  const showPlacementGroups = Boolean(flags.vmPlacement);
+  const showPlacementGroups = Boolean(flags.placementGroups?.enabled);
   const {
     error,
     labelFieldProps,

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -180,10 +180,10 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
         {
           betaChipClassName: 'beta-chip-placement-groups',
           display: 'Placement Groups',
-          hide: !flags.vmPlacement,
+          hide: !flags.placementGroups?.enabled,
           href: '/placement-groups',
           icon: <PlacementGroups />,
-          isBeta: true,
+          isBeta: flags.placementGroups?.beta,
         },
         {
           display: 'Volumes',
@@ -301,7 +301,7 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
       allowMarketplacePrefetch,
       flags.databaseBeta,
       isACLBEnabled,
-      flags.vmPlacement,
+      flags.placementGroups,
       showVPCs,
     ]
   );

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -11,6 +11,12 @@ import { setMockFeatureFlags } from 'src/store/mockFeatureFlags';
 import { getStorage, setStorage } from 'src/utilities/storage';
 const MOCK_FEATURE_FLAGS_STORAGE_KEY = 'devTools/mock-feature-flags';
 
+/**
+ * Our flags can be either a boolean or an JSON object
+ * In the case of JSON Objects, the `enabled` key will be used to control flag.
+ * It is required to have the `enabled` key if using a JSON object for on/off Featured flags.
+ * This requirement is both documented here and in our Docs since we don't have a way to enforce types from Launch Darkly objects. .
+ */
 const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'aclb', label: 'ACLB' },
   { flag: 'aclbFullCreateFlow', label: 'ACLB Full Create Flow' },
@@ -22,7 +28,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'firewallNodebalancer', label: 'Firewall NodeBalancer' },
   { flag: 'recharts', label: 'Recharts' },
   { flag: 'objMultiCluster', label: 'OBJ Multi-Cluster' },
-  { flag: 'vmPlacement', label: 'Placement Groups' },
+  { flag: 'placementGroups', label: 'Placement Groups' },
 ];
 
 export const FeatureFlagTool = withFeatureFlagProvider(() => {
@@ -41,12 +47,17 @@ export const FeatureFlagTool = withFeatureFlagProvider(() => {
     e: React.ChangeEvent<HTMLInputElement>,
     flag: keyof FlagSet
   ) => {
-    dispatch(setMockFeatureFlags({ [flag]: e.target.checked }));
-    const updatedFlags = JSON.stringify({
+    const currentFlag = flags[flag];
+    const updatedValue =
+      typeof currentFlag === 'boolean'
+        ? e.target.checked
+        : { ...currentFlag, enabled: e.target.checked }; // If current flag is an object, update 'enabled' key
+    const updatedFlags = {
       ...getStorage(MOCK_FEATURE_FLAGS_STORAGE_KEY),
-      [flag]: e.target.checked,
-    });
-    setStorage(MOCK_FEATURE_FLAGS_STORAGE_KEY, updatedFlags);
+      [flag]: updatedValue,
+    };
+    dispatch(setMockFeatureFlags(updatedFlags));
+    setStorage(MOCK_FEATURE_FLAGS_STORAGE_KEY, JSON.stringify(updatedFlags));
   };
 
   /**
@@ -65,6 +76,11 @@ export const FeatureFlagTool = withFeatureFlagProvider(() => {
       <Grid xs={12}>
         <div style={{ display: 'flex', flexDirection: 'column' }}>
           {options.map((thisOption) => {
+            const flagValue = flags[thisOption.flag];
+            const isChecked =
+              typeof flagValue === 'object' && 'enabled' in flagValue
+                ? Boolean(flagValue.enabled)
+                : Boolean(flagValue);
             return (
               <div
                 style={{
@@ -77,7 +93,7 @@ export const FeatureFlagTool = withFeatureFlagProvider(() => {
               >
                 <span>{thisOption.label} </span>
                 <input
-                  checked={Boolean(flags[thisOption.flag])}
+                  checked={isChecked}
                   onChange={(e) => handleCheck(e, thisOption.flag)}
                   type="checkbox"
                 />

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -101,7 +101,7 @@ export const FeatureFlagTool = withFeatureFlagProvider(() => {
             );
           })}
           <button onClick={resetFlags} style={{ marginTop: 8 }}>
-            Reset default flags
+            Reset to LD default flags
           </button>
         </div>
       </Grid>

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -12,10 +12,10 @@ import { getStorage, setStorage } from 'src/utilities/storage';
 const MOCK_FEATURE_FLAGS_STORAGE_KEY = 'devTools/mock-feature-flags';
 
 /**
- * Our flags can be either a boolean or an JSON object
+ * Our flags can be either a boolean or a JSON object
  * In the case of JSON Objects, the `enabled` key will be used to control flag.
- * It is required to have the `enabled` key if using a JSON object for on/off Featured flags.
- * This requirement is both documented here and in our Docs since we don't have a way to enforce types from Launch Darkly objects. .
+ * It is required to have the `enabled` key if using a JSON object for on/off featured flags.
+ * This requirement is both documented here and in our Docs since we don't have a way to enforce types from Launch Darkly objects.
  */
 const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'aclb', label: 'ACLB' },

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -37,6 +37,11 @@ interface TaxCollectionBanner {
   regions?: TaxCollectionRegion[];
 }
 
+interface PlacementGroupsFlag {
+  beta: boolean;
+  enabled: boolean;
+}
+
 type OneClickApp = Record<string, string>;
 
 export interface Flags {
@@ -57,6 +62,7 @@ export interface Flags {
   oneClickApps: OneClickApp;
   oneClickAppsDocsOverride: Record<string, Doc[]>;
   parentChildAccountAccess: boolean;
+  placementGroups: PlacementGroupsFlag;
   productInformationBanners: ProductInformationBannerFlag[];
   promos: boolean;
   promotionalOffers: PromotionalOffer[];
@@ -68,7 +74,6 @@ export interface Flags {
   taxCollectionBanner: TaxCollectionBanner;
   taxes: Taxes;
   tpaProviders: Provider[];
-  vmPlacement: boolean;
   vpc: boolean;
 }
 

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
@@ -40,18 +40,18 @@ import { RegionsProps } from 'src/containers/regions.container';
 import { WithTypesProps } from 'src/containers/types.container';
 import { WithLinodesProps } from 'src/containers/withLinodes.container';
 import { EUAgreementCheckbox } from 'src/features/Account/Agreements/EUAgreementCheckbox';
+import { PlansPanel } from 'src/features/components/PlansPanel/PlansPanel';
+import { regionSupportsMetadata } from 'src/features/Linodes/LinodesCreate/utilities';
 import {
   getMonthlyAndHourlyNodePricing,
   utoa,
 } from 'src/features/Linodes/LinodesCreate/utilities';
-import { regionSupportsMetadata } from 'src/features/Linodes/LinodesCreate/utilities';
 import { SMTPRestrictionText } from 'src/features/Linodes/SMTPRestrictionText';
 import { hasPlacementGroupReachedCapacity } from 'src/features/PlacementGroups/utils';
 import {
   getCommunityStackscripts,
   getMineAndAccountStackScripts,
 } from 'src/features/StackScripts/stackScriptUtils';
-import { PlansPanel } from 'src/features/components/PlansPanel/PlansPanel';
 import {
   CreateTypes,
   handleChangeCreateType,
@@ -88,7 +88,6 @@ import { FromImageContent } from './TabbedContent/FromImageContent';
 import { FromLinodeContent } from './TabbedContent/FromLinodeContent';
 import { FromStackScriptContent } from './TabbedContent/FromStackScriptContent';
 import { renderBackupsDisplaySection } from './TabbedContent/utils';
-import { VPCPanel } from './VPCPanel';
 import {
   AllFormStateAndHandlers,
   AppsData,
@@ -101,6 +100,7 @@ import {
   WithDisplayData,
   WithTypesRegionsAndImages,
 } from './types';
+import { VPCPanel } from './VPCPanel';
 
 import type { Tab } from 'src/components/Tabs/TabLinkList';
 import type { LinodeCreateType } from 'src/features/Linodes/LinodesCreate/types';
@@ -853,7 +853,7 @@ export class LinodeCreate extends React.PureComponent<
         this.props.firewallId !== -1 ? this.props.firewallId : undefined,
       image: this.props.selectedImageID,
       label: this.props.label,
-      placement_group: this.props.flags.vmPlacement
+      placement_group: this.props.flags.placementGroups?.enabled
         ? placement_group_payload
         : undefined,
       private_ip: this.props.privateIPEnabled,

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
@@ -32,7 +32,10 @@ export const PlacementGroupsDetail = () => {
     data: placementGroup,
     error: placementGroupError,
     isLoading,
-  } = usePlacementGroupQuery(placementGroupId, Boolean(flags.vmPlacement));
+  } = usePlacementGroupQuery(
+    placementGroupId,
+    Boolean(flags.placementGroups?.enabled)
+  );
 
   const {
     error: updatePlacementGroupError,


### PR DESCRIPTION
## Description 📝
This PR introduces JSON payload for the Placement Group feature.

## Changes  🔄
- Add new flag in Launch Darkly with JSON payload variations (will delete old one once this is merged to production)
- Apply to flag to codebase
- Modify Flag Dev Tools to handle JSON object (with `enabled` key)
- Update Feature Flag documentation

## Preview 📷
![Screenshot 2024-03-04 at 12 39 24](https://github.com/linode/manager/assets/130582365/7422d7ab-b6d1-4fff-8ac0-998b27061dbf)

## How to test 🧪

### Verification steps
- Pull code locally
- Open Cloud Manager Dev Tools and click on the "Reset to LD default flags" button.
- Confirm the toggling of the Placement Groups feature flag and other flags (no regression)

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support


