### PR TITLE
refactor: [M3-6708] – Implement new React 18 hooks

### DIFF
--- a/docs/development-guide/13-coding-standards.md
+++ b/docs/development-guide/13-coding-standards.md
@@ -17,7 +17,26 @@ If you are using VSCode it is highly recommended to use the ESlint extension. Th
 
 [Several new hooks were introduced with the release of React 18](https://react.dev/blog/2022/03/29/react-v18#new-hooks).
 
-It should be noted that the `useId()` hook is particularly useful for generating unique IDs for accessibility attributes. Per the [docs](https://react.dev/reference/react/useId#usage), the hook should not be used for generating keys in a list.
+It should be noted that the `useId()` hook is particularly useful for generating unique IDs for accessibility attributes. For this use case, `useId()` is preferred over hardcoding the ID because components may be rendered more than once on a page, but IDs must be unique.
+
+As an example from `DisplayLinodes.tsx`, early in the file we invoke the hook: `const displayViewDescriptionId = React.useId()`
+
+And make use of the unique ID by passing it as the value for a component's `aria-describedby` attribute in the `return` value:
+
+```
+  <StyledToggleButton
+  aria-describedby={displayViewDescriptionId}
+  aria-label="Toggle display"
+  disableRipple
+  isActive={true}
+  onClick={toggleLinodeView}
+  size="large"
+>
+  <GridView />
+</StyledToggleButton>
+```
+
+Per the [docs](https://react.dev/reference/react/useId#usage), the hook should not be used for generating keys in a list.
 
 ## Event Handler Naming Convention
 

--- a/docs/development-guide/13-coding-standards.md
+++ b/docs/development-guide/13-coding-standards.md
@@ -15,9 +15,9 @@ If you are using VSCode it is highly recommended to use the ESlint extension. Th
 
 ## React
 
-- When conditionally rendering JSX, use ternaries instead of `&&`.
-  - Example: `condition ? <Component /> : null` instead of `condition && <Component />`
-  - This is to avoid hard-to-catch bugs ([read more](https://kentcdodds.com/blog/use-ternaries-rather-than-and-and-in-jsx)).
+[Several new hooks were introduced with the release of React 18](https://react.dev/blog/2022/03/29/react-v18#new-hooks).
+
+It should be noted that the `useId()` hook is particularly useful for generating unique IDs for accessibility attributes. Per the [docs](https://react.dev/reference/react/useId#usage), the hook should not be used for generating keys in a list.
 
 ## Event Handler Naming Convention
 

--- a/packages/manager/.changeset/pr-10261-tech-stories-1709842863706.md
+++ b/packages/manager/.changeset/pr-10261-tech-stories-1709842863706.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Implement new useId() hook in several components ([#10261](https://github.com/linode/manager/pull/10261))

--- a/packages/manager/src/components/GroupByTagToggle.tsx
+++ b/packages/manager/src/components/GroupByTagToggle.tsx
@@ -13,9 +13,11 @@ interface GroupByTagToggleProps {
 export const GroupByTagToggle = React.memo((props: GroupByTagToggleProps) => {
   const { isGroupedByTag, isLargeAccount, toggleGroupByTag } = props;
 
+  const groupByDescriptionId = React.useId();
+
   return (
     <>
-      <div className="visually-hidden" id="groupByDescription">
+      <div className="visually-hidden" id={groupByDescriptionId}>
         {isGroupedByTag
           ? 'group by tag is currently enabled'
           : 'group by tag is currently disabled'}
@@ -25,7 +27,7 @@ export const GroupByTagToggle = React.memo((props: GroupByTagToggleProps) => {
         title={`${isGroupedByTag ? 'Ungroup' : 'Group'} by tag`}
       >
         <StyledToggleButton
-          aria-describedby={'groupByDescription'}
+          aria-describedby={groupByDescriptionId}
           aria-label={`Toggle group by tag`}
           disableRipple
           // See https://github.com/linode/manager/pull/6653 for more details

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
@@ -242,6 +242,8 @@ export const LinodeConfigDialog = (props: Props) => {
 
   const { enqueueSnackbar } = useSnackbar();
 
+  const virtModeCaptionId = React.useId();
+
   const {
     data: kernels,
     error: kernelsError,
@@ -721,7 +723,7 @@ export const LinodeConfigDialog = (props: Props) => {
               <Typography variant="h3">Virtual Machine</Typography>
               <FormControl>
                 <FormLabel
-                  aria-describedby="virtModeCaption"
+                  aria-describedby={virtModeCaptionId}
                   disabled={isReadOnly}
                   htmlFor="virt_mode"
                 >
@@ -745,7 +747,7 @@ export const LinodeConfigDialog = (props: Props) => {
                     label="Full virtualization"
                     value="fullvirt"
                   />
-                  <FormHelperText id="virtModeCaption">
+                  <FormHelperText id={virtModeCaptionId}>
                     Controls if devices inside your virtual machine are
                     paravirtualized or fully virtualized. Paravirt is what you
                     want, unless you&rsquo;re doing weird things.

--- a/packages/manager/src/features/Linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -71,6 +71,9 @@ export const DisplayGroupedLinodes = (props: CombinedProps) => {
     ...rest
   } = props;
 
+  const displayViewDescriptionId = React.useId();
+  const groupByDescriptionId = React.useId();
+
   const dataLength = data.length;
 
   const orderedGroupedLinodes = compose(sortGroups, groupByTags)(data);
@@ -96,12 +99,12 @@ export const DisplayGroupedLinodes = (props: CombinedProps) => {
       <>
         <Grid className={'px0'} xs={12}>
           <StyledControlHeader isGroupedByTag={linodesAreGrouped}>
-            <div className="visually-hidden" id="displayViewDescription">
+            <div className="visually-hidden" id={displayViewDescriptionId}>
               Currently in {linodeViewPreference} view
             </div>
             <Tooltip placement="top" title="List view">
               <StyledToggleButton
-                aria-describedby={'displayViewDescription'}
+                aria-describedby={displayViewDescriptionId}
                 aria-label="Toggle display"
                 disableRipple
                 isActive={linodesAreGrouped}
@@ -112,14 +115,14 @@ export const DisplayGroupedLinodes = (props: CombinedProps) => {
               </StyledToggleButton>
             </Tooltip>
 
-            <div className="visually-hidden" id="groupByDescription">
+            <div className="visually-hidden" id={groupByDescriptionId}>
               {linodesAreGrouped
                 ? 'group by tag is currently enabled'
                 : 'group by tag is currently disabled'}
             </div>
             <Tooltip placement="top-end" title="Ungroup by tag">
               <StyledToggleButton
-                aria-describedby={'groupByDescription'}
+                aria-describedby={groupByDescriptionId}
                 aria-label={`Toggle group by tag`}
                 disableRipple
                 isActive={linodesAreGrouped}

--- a/packages/manager/src/features/Linodes/LinodesLanding/DisplayLinodes.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/DisplayLinodes.tsx
@@ -69,6 +69,9 @@ export const DisplayLinodes = React.memo((props: CombinedProps) => {
     ...rest
   } = props;
 
+  const displayViewDescriptionId = React.useId();
+  const groupByDescriptionId = React.useId();
+
   const { infinitePageSize, setInfinitePageSize } = useInfinitePageSize();
   const numberOfLinodesWithMaintenance = React.useMemo(() => {
     return data.reduce((acc, thisLinode) => {
@@ -143,13 +146,13 @@ export const DisplayLinodes = React.memo((props: CombinedProps) => {
                   <StyledControlHeader isGroupedByTag={linodesAreGrouped}>
                     <div
                       className="visually-hidden"
-                      id="displayViewDescription"
+                      id={displayViewDescriptionId}
                     >
                       Currently in {linodeViewPreference} view
                     </div>
                     <Tooltip placement="top" title="List view">
                       <StyledToggleButton
-                        aria-describedby={'displayViewDescription'}
+                        aria-describedby={displayViewDescriptionId}
                         aria-label="Toggle display"
                         disableRipple
                         isActive={true}
@@ -160,14 +163,14 @@ export const DisplayLinodes = React.memo((props: CombinedProps) => {
                       </StyledToggleButton>
                     </Tooltip>
 
-                    <div className="visually-hidden" id="groupByDescription">
+                    <div className="visually-hidden" id={groupByDescriptionId}>
                       {linodesAreGrouped
                         ? 'group by tag is currently enabled'
                         : 'group by tag is currently disabled'}
                     </div>
                     <Tooltip placement="top-end" title="Group by tag">
                       <StyledToggleButton
-                        aria-describedby={'groupByDescription'}
+                        aria-describedby={groupByDescriptionId}
                         aria-label={`Toggle group by tag`}
                         disableRipple
                         isActive={linodesAreGrouped}

--- a/packages/manager/src/features/Linodes/LinodesLanding/SortableTableHead.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/SortableTableHead.tsx
@@ -42,6 +42,8 @@ export const SortableTableHead = <T extends unknown>(
     toggleLinodeView,
   } = props;
 
+  const displayViewDescriptionId = React.useId();
+
   const isActive = (label: string) =>
     label.toLowerCase() === orderBy.toLowerCase();
 
@@ -167,12 +169,12 @@ export const SortableTableHead = <T extends unknown>(
               justifyContent: 'flex-end',
             }}
           >
-            <div className="visually-hidden" id="displayViewDescription">
+            <div className="visually-hidden" id={displayViewDescriptionId}>
               Currently in {linodeViewPreference} view
             </div>
             <Tooltip placement="top" title="Summary view">
               <StyledToggleButton
-                aria-describedby={'displayViewDescription'}
+                aria-describedby={displayViewDescriptionId}
                 aria-label="Toggle display"
                 disableRipple
                 isActive={linodeViewPreference === 'grid'}


### PR DESCRIPTION
## Description 📝
With our recent upgrade to React 18, we can begin making use of new hooks that were introduced with that version. This PR implements `useId()` in a few files.

- **useId**
  - One potential use case we discussed early on was using this hook for generating unique IDs for React list items, but the [docs](https://react.dev/reference/react/useId#usage) explicitly state this should not be done. Of the scenarios outlined in the "Usage" section of the docs, the most relevant one for us is generating unique IDs for accessibility attributes.
- **useTransition**
  - Our use of React Query and reliance on the loading state it provides makes `useTransition` mostly superfluous to us.
- **useDeferredValue** 
  - May have some applicability, but it cannot be used as a 1:1 replacement everywhere we do debouncing. For example, we often debounce to limit API requests.
- **useInsertionEffect** 
  - Seems it can be a replacement for `componentDidMount` and `componentWillUnmount`, so it may have some applicability when converting class components to function components.

## Changes  🔄
- Update Coding Standards doc
- Implement `useId()` in `GroupByTagToggle.tsx`, `LinodeConfigDialog.tsx`, `DisplayGroupedLinodes.tsx`, `DisplayLinodes.tsx`, and `SortableTableHead.tsx`

## How to test 🧪
### Verification steps
With VoiceOver on, ensure there have been no regressions/changes compared to prod for the following:

1. Linode Config Dialog -- Virt Mode section
2. Linode landing page -- Summary/List view button, Group by Tag button

Alternatively or in addition to the above, you can verify by looking at the HTML and confirming that the `id` and `aria-describedby` attributes on the related elements match up:

![Screenshot 2024-03-07 at 3 31 58 PM](https://github.com/linode/manager/assets/114682940/f38ed59c-3b0f-4c0f-bced-b3ffa3117626)

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support