### PR TITLE
upcoming: [M3-7842] - Update Assign Linode Drawer and improve query skipping

### DIFF
--- a/packages/manager/.changeset/pr-10263-upcoming-features-1709749179406.md
+++ b/packages/manager/.changeset/pr-10263-upcoming-features-1709749179406.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update Assign Linode Drawer and improve query skipping ([#10263](https://github.com/linode/manager/pull/10263))

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.test.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.test.tsx
@@ -57,7 +57,7 @@ describe('PlacementGroupsAssignLinodesDrawer', () => {
       error: [{ reason: 'Not found' }],
     });
 
-    const { getByText } = renderWithTheme(
+    const { container } = renderWithTheme(
       <PlacementGroupsAssignLinodesDrawer
         onClose={vi.fn()}
         open={true}
@@ -65,11 +65,7 @@ describe('PlacementGroupsAssignLinodesDrawer', () => {
       />
     );
 
-    expect(
-      getByText(
-        'There was a problem retrieving your placement group. Please try again'
-      )
-    ).toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement;
   });
 
   it('should render the drawer components', () => {

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.test.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.test.tsx
@@ -131,12 +131,7 @@ describe('PlacementGroupsAssignLinodesDrawer', () => {
       })
     );
 
-    const {
-      getByPlaceholderText,
-      getByRole,
-      getByTestId,
-      getByText,
-    } = renderWithTheme(
+    const { getByPlaceholderText, getByRole, getByText } = renderWithTheme(
       <PlacementGroupsAssignLinodesDrawer
         selectedPlacementGroup={placementGroupFactory.build({
           affinity_type: 'anti_affinity',
@@ -148,33 +143,23 @@ describe('PlacementGroupsAssignLinodesDrawer', () => {
       />
     );
 
-    const linodesSelect = getByPlaceholderText('Select a Linode');
-    const addLinodeButton = getByRole('button', { name: 'Add Linode' });
-    const removableLinodesList = getByTestId('pg-linode-removable-list');
+    const linodesSelect = getByPlaceholderText(
+      'Select Linode or type to search'
+    );
+    const assignLinodeButton = getByRole('button', { name: 'Assign Linode' });
 
     expect(linodesSelect).toBeInTheDocument();
-    expect(addLinodeButton).toHaveAttribute('aria-disabled', 'true');
-    expect(removableLinodesList).toHaveTextContent(
-      'No Linodes have been assigned.'
-    );
+    expect(assignLinodeButton).toHaveAttribute('aria-disabled', 'true');
 
     fireEvent.focus(linodesSelect);
     fireEvent.change(linodesSelect, { target: { value: 'Linode-11' } });
     const optionElement = getByText('Linode-11');
     fireEvent.click(optionElement);
 
-    expect(addLinodeButton).not.toHaveAttribute('aria-disabled', 'true');
+    expect(assignLinodeButton).not.toHaveAttribute('aria-disabled', 'true');
 
-    fireEvent.click(getByRole('button', { name: 'Add Linode' }));
+    fireEvent.click(getByRole('button', { name: 'Assign Linode' }));
 
-    expect(addLinodeButton).toHaveAttribute('aria-disabled', 'true');
-    expect(removableLinodesList).toHaveTextContent('Linode-11');
-
-    const removeButton = getByRole('button', { name: 'remove Linode-11' });
-    fireEvent.click(removeButton);
-
-    expect(removableLinodesList).toHaveTextContent(
-      'No Linodes have been assigned.'
-    );
+    expect(assignLinodeButton).toHaveAttribute('aria-disabled', 'true');
   });
 });

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.test.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.test.tsx
@@ -65,7 +65,7 @@ describe('PlacementGroupsAssignLinodesDrawer', () => {
       />
     );
 
-    expect(container).toBeEmptyDOMElement;
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('should render the drawer components', () => {

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.tsx
@@ -6,7 +6,6 @@ import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Box } from 'src/components/Box';
 import { Divider } from 'src/components/Divider';
 import { Drawer } from 'src/components/Drawer';
-import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
 import { Stack } from 'src/components/Stack';
@@ -80,22 +79,23 @@ export const PlacementGroupsAssignLinodesDrawer = (
     allPlacementGroups
   );
 
+  const getLinodeSelectOptions = (): Linode[] => {
+    // We filter out Linodes that are already assigned to a Placement Group
+    return (
+      allLinodesInRegion?.filter((linode) => {
+        return !linodesFromAllPlacementGroups.includes(linode.id);
+      }) ?? []
+    );
+  };
+
   if (
     !allLinodesInRegion ||
     !selectedPlacementGroup ||
     linodesError ||
     allPlacementGroupsError
   ) {
-    return (
-      <ErrorState errorText="There was a problem retrieving your placement group. Please try again" />
-    );
+    return null;
   }
-
-  const getLinodeSelectOptions = (): Linode[] => {
-    return allLinodesInRegion.filter((linode) => {
-      return !linodesFromAllPlacementGroups.includes(linode.id);
-    });
-  };
 
   const { affinity_type, label } = selectedPlacementGroup;
   const linodeSelectLabel = region
@@ -115,6 +115,8 @@ export const PlacementGroupsAssignLinodesDrawer = (
       return;
     }
 
+    // Since we allow only one Linode to be assigned to a Placement Group,
+    // We're using a tuple with the selected Linode ID
     const payload: AssignLinodesToPlacementGroupPayload = {
       linodes: [selectedLinode.id],
     };

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.tsx
@@ -1,5 +1,4 @@
 import { AFFINITY_TYPES } from '@linode/api-v4';
-import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
@@ -130,62 +129,60 @@ export const PlacementGroupsAssignLinodesDrawer = (
 
   return (
     <Drawer onClose={handleDrawerClose} open={open} title={drawerTitle}>
-      <Grid>
-        {generalError ? <Notice text={generalError} variant="error" /> : null}
-        <Typography my={4}>
-          <strong>Affinity Enforcement: </strong>
-          {getAffinityEnforcement(selectedPlacementGroup.is_strict)}
-        </Typography>
-        <Divider sx={{ mb: 4 }} />
-        <form onSubmit={handleAssignLinode}>
-          <Stack spacing={1}>
-            {hasReachedCapacity && open && (
-              <Notice
-                text="This Placement Group has the maximum number of Linodes allowed"
-                variant="error"
-              />
-            )}
-            <Typography>
-              A Linode can only be assigned to a single Placement Group.
-            </Typography>
-
-            <Typography>
-              If you need to create a new Linode, go to{' '}
-              <Link to="/linodes/create">Create Linode</Link> and return to this
-              page to assign it to this Placement Group.
-            </Typography>
-            <Box sx={{ alignItems: 'flex-end', display: 'flex' }}>
-              <LinodeSelect
-                onSelectionChange={(value) => {
-                  setSelectedLinode(value);
-                }}
-                disabled={hasReachedCapacity}
-                label={linodeSelectLabel}
-                options={getLinodeSelectOptions()}
-                placeholder="Select Linode or type to search"
-                sx={{ flexGrow: 1 }}
-                value={selectedLinode?.id ?? null}
-              />
-              <TooltipIcon
-                placement="right"
-                status="help"
-                sxTooltipIcon={{ position: 'relative', top: 4 }}
-                text="Only displaying Linodes that aren’t assigned to a Placement Group"
-              />
-            </Box>
-
-            <ActionsPanel
-              primaryButtonProps={{
-                'data-testid': 'submit',
-                disabled: !selectedLinode || hasReachedCapacity,
-                label: 'Assign Linode',
-                type: 'submit',
-              }}
-              sx={{ pt: 2 }}
+      {generalError ? <Notice text={generalError} variant="error" /> : null}
+      <Typography my={4}>
+        <strong>Affinity Enforcement: </strong>
+        {getAffinityEnforcement(selectedPlacementGroup.is_strict)}
+      </Typography>
+      <Divider sx={{ mb: 4 }} />
+      <form onSubmit={handleAssignLinode}>
+        <Stack spacing={1}>
+          {hasReachedCapacity && open && (
+            <Notice
+              text="This Placement Group has the maximum number of Linodes allowed"
+              variant="error"
             />
-          </Stack>
-        </form>
-      </Grid>
+          )}
+          <Typography>
+            A Linode can only be assigned to a single Placement Group.
+          </Typography>
+
+          <Typography>
+            If you need to create a new Linode, go to{' '}
+            <Link to="/linodes/create">Create Linode</Link> and return to this
+            page to assign it to this Placement Group.
+          </Typography>
+          <Box sx={{ alignItems: 'flex-end', display: 'flex' }}>
+            <LinodeSelect
+              onSelectionChange={(value) => {
+                setSelectedLinode(value);
+              }}
+              disabled={hasReachedCapacity}
+              label={linodeSelectLabel}
+              options={getLinodeSelectOptions()}
+              placeholder="Select Linode or type to search"
+              sx={{ flexGrow: 1 }}
+              value={selectedLinode?.id ?? null}
+            />
+            <TooltipIcon
+              placement="right"
+              status="help"
+              sxTooltipIcon={{ position: 'relative', top: 4 }}
+              text="Only displaying Linodes that aren’t assigned to a Placement Group"
+            />
+          </Box>
+
+          <ActionsPanel
+            primaryButtonProps={{
+              'data-testid': 'submit',
+              disabled: !selectedLinode || hasReachedCapacity,
+              label: 'Assign Linode',
+              type: 'submit',
+            }}
+            sx={{ pt: 2 }}
+          />
+        </Stack>
+      </form>
     </Drawer>
   );
 };

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.tsx
@@ -37,13 +37,8 @@ export const PlacementGroupsAssignLinodesDrawer = (
   const { data: allLinodesInRegion, error: linodesError } = useAllLinodesQuery(
     {},
     {
-      '+or': [
-        {
-          region: selectedPlacementGroup?.region,
-        },
-      ],
-    },
-    open
+      region: selectedPlacementGroup?.region,
+    }
   );
   const {
     data: allPlacementGroups,

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.tsx
@@ -3,30 +3,32 @@ import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
+import { Box } from 'src/components/Box';
+import { Divider } from 'src/components/Divider';
 import { Drawer } from 'src/components/Drawer';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
-import { FormLabel } from 'src/components/FormLabel';
 import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
-import { RemovableSelectionsList } from 'src/components/RemovableSelectionsList/RemovableSelectionsList';
 import { Stack } from 'src/components/Stack';
+import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
 import { usePlacementGroupData } from 'src/hooks/usePlacementGroupsData';
 import { useAllLinodesQuery } from 'src/queries/linodes/linodes';
 import {
   useAssignLinodesToPlacementGroup,
-  useUnassignLinodesFromPlacementGroup,
   useUnpaginatedPlacementGroupsQuery,
 } from 'src/queries/placementGroups';
 
 import { LinodeSelect } from '../Linodes/LinodeSelect/LinodeSelect';
-import { getLinodesFromAllPlacementGroups } from './utils';
+import {
+  getAffinityEnforcement,
+  getLinodesFromAllPlacementGroups,
+} from './utils';
 
 import type { PlacementGroupsAssignLinodesDrawerProps } from './types';
 import type {
   AssignLinodesToPlacementGroupPayload,
   Linode,
-  UnassignLinodesFromPlacementGroupPayload,
 } from '@linode/api-v4';
 
 export const PlacementGroupsAssignLinodesDrawer = (
@@ -41,40 +43,38 @@ export const PlacementGroupsAssignLinodesDrawer = (
           region: selectedPlacementGroup?.region,
         },
       ],
-    }
+    },
+    open
   );
   const {
     data: allPlacementGroups,
     error: allPlacementGroupsError,
   } = useUnpaginatedPlacementGroupsQuery();
 
+  // We display a notice and disable inputs in case the user reaches this drawer somehow
+  // (not supposed to happen as the "Assign Linode to Placement Group" button should be disabled
   const { hasReachedCapacity, region } = usePlacementGroupData({
     placementGroup: selectedPlacementGroup,
   });
-
   const { mutateAsync: assignLinodes } = useAssignLinodesToPlacementGroup(
-    selectedPlacementGroup?.id ?? -1
-  );
-  const { mutateAsync: unassignLinodes } = useUnassignLinodesFromPlacementGroup(
     selectedPlacementGroup?.id ?? -1
   );
   const [selectedLinode, setSelectedLinode] = React.useState<Linode | null>(
     null
   );
-  const [localLinodesSelection, setLocalLinodesSelection] = React.useState<
-    Linode[]
-  >([]);
   const [generalError, setGeneralError] = React.useState<string | undefined>(
     undefined
   );
 
-  React.useEffect(() => {
-    if (open) {
-      setSelectedLinode(null);
-      setLocalLinodesSelection([]);
-      setGeneralError(undefined);
-    }
-  }, [open]);
+  const handleResetForm = () => {
+    setSelectedLinode(null);
+    setGeneralError(undefined);
+  };
+
+  const handleDrawerClose = () => {
+    onClose();
+    handleResetForm();
+  };
 
   const linodesFromAllPlacementGroups = getLinodesFromAllPlacementGroups(
     allPlacementGroups
@@ -92,18 +92,9 @@ export const PlacementGroupsAssignLinodesDrawer = (
   }
 
   const getLinodeSelectOptions = (): Linode[] => {
-    return (
-      allLinodesInRegion.filter((linode) => {
-        const isNotAlreadyAssigned = !linodesFromAllPlacementGroups.includes(
-          linode.id
-        );
-        const isNotAssignedInDrawer = !localLinodesSelection.find(
-          (l) => l.id === linode.id
-        );
-
-        return isNotAlreadyAssigned && isNotAssignedInDrawer;
-      }) ?? []
-    );
+    return allLinodesInRegion.filter((linode) => {
+      return !linodesFromAllPlacementGroups.includes(linode.id);
+    });
   };
 
   const { affinity_type, label } = selectedPlacementGroup;
@@ -113,22 +104,8 @@ export const PlacementGroupsAssignLinodesDrawer = (
 
   const drawerTitle =
     label && affinity_type
-      ? `Add Linodes to Placement Group ${label} (${AFFINITY_TYPES[affinity_type]})`
-      : 'Add Linodes to Placement Group';
-
-  const removableSelectionsListLabel = (
-    <>
-      <FormLabel htmlFor="pg-linode-removable-list">
-        {label && affinity_type
-          ? `Linodes Assigned to Placement Group ${label}
-        (${AFFINITY_TYPES[affinity_type]})`
-          : 'Linodes Assigned to Placement Group'}
-      </FormLabel>
-      <Typography component="span" display="block" fontSize="0.8rem">
-        Maximum Number of Linodes for this group: {region?.maximum_vms_per_pg}
-      </Typography>
-    </>
-  );
+      ? `Assign Linodes to Placement Group ${label} (${AFFINITY_TYPES[affinity_type]})`
+      : 'Assign Linodes to Placement Group';
 
   const handleAssignLinode = async (e: React.SyntheticEvent<HTMLElement>) => {
     e.preventDefault();
@@ -138,104 +115,74 @@ export const PlacementGroupsAssignLinodesDrawer = (
       return;
     }
 
-    setLocalLinodesSelection([...localLinodesSelection, selectedLinode]);
-
     const payload: AssignLinodesToPlacementGroupPayload = {
       linodes: [selectedLinode.id],
     };
 
     try {
       await assignLinodes(payload);
+      handleDrawerClose();
     } catch (error) {
       setGeneralError(
         error?.[0]?.reason
           ? error[0].reason
-          : 'An error occurred while adding the Linode to the group'
-      );
-    }
-  };
-
-  const handleUnassignLinode = async (linode: Linode) => {
-    setLocalLinodesSelection(
-      localLinodesSelection.filter((l) => l.id !== linode.id)
-    );
-
-    const payload: UnassignLinodesFromPlacementGroupPayload = {
-      linodes: [linode.id],
-    };
-
-    try {
-      await unassignLinodes(payload);
-    } catch (error) {
-      setGeneralError(
-        error
-          ? error?.[0]?.reason
-          : 'An error occurred while removing the Linode from the group'
+          : 'An error occurred while assigning the Linode to the group'
       );
     }
   };
 
   return (
-    <Drawer onClose={onClose} open={open} title={drawerTitle}>
+    <Drawer onClose={handleDrawerClose} open={open} title={drawerTitle}>
       <Grid>
         {generalError ? <Notice text={generalError} variant="error" /> : null}
+        <Typography my={4}>
+          <strong>Affinity Enforcement: </strong>
+          {getAffinityEnforcement(selectedPlacementGroup.is_strict)}
+        </Typography>
+        <Divider sx={{ mb: 4 }} />
         <form onSubmit={handleAssignLinode}>
           <Stack spacing={1}>
+            {hasReachedCapacity && open && (
+              <Notice
+                text="This Placement Group has the maximum number of Linodes allowed"
+                variant="error"
+              />
+            )}
             <Typography>
               A Linode can only be assigned to a single Placement Group.
             </Typography>
 
             <Typography>
-              If you need to add a new Linode, go to{' '}
+              If you need to create a new Linode, go to{' '}
               <Link to="/linodes/create">Create Linode</Link> and return to this
               page to assign it to this Placement Group.
             </Typography>
-            <LinodeSelect
-              onSelectionChange={(value) => {
-                setSelectedLinode(value);
-              }}
-              disabled={hasReachedCapacity}
-              helperText="Only displaying Linodes that aren’t assigned to a Placement Group"
-              label={linodeSelectLabel}
-              options={getLinodeSelectOptions()}
-              value={selectedLinode?.id ?? null}
-            />
+            <Box sx={{ alignItems: 'flex-end', display: 'flex' }}>
+              <LinodeSelect
+                onSelectionChange={(value) => {
+                  setSelectedLinode(value);
+                }}
+                disabled={hasReachedCapacity}
+                label={linodeSelectLabel}
+                options={getLinodeSelectOptions()}
+                placeholder="Select Linode or type to search"
+                sx={{ flexGrow: 1 }}
+                value={selectedLinode?.id ?? null}
+              />
+              <TooltipIcon
+                placement="right"
+                status="help"
+                sxTooltipIcon={{ position: 'relative', top: 4 }}
+                text="Only displaying Linodes that aren’t assigned to a Placement Group"
+              />
+            </Box>
 
             <ActionsPanel
               primaryButtonProps={{
                 'data-testid': 'submit',
                 disabled: !selectedLinode || hasReachedCapacity,
-                label: 'Add Linode',
+                label: 'Assign Linode',
                 type: 'submit',
-              }}
-              sx={{ pt: 2 }}
-            />
-            {hasReachedCapacity && (
-              <Notice
-                text="This Placement Group has the maximum number of Linodes allowed"
-                variant="warning"
-              />
-            )}
-            <RemovableSelectionsList
-              LabelComponent={({ selection }) => {
-                return (
-                  <Typography component="span">{selection.label}</Typography>
-                );
-              }}
-              onRemove={(data: Linode) => {
-                handleUnassignLinode(data);
-              }}
-              headerText={removableSelectionsListLabel}
-              id="pg-linode-removable-list"
-              noDataText={'No Linodes have been assigned.'}
-              selectionData={localLinodesSelection}
-              sx={{ pt: 2 }}
-            />
-            <ActionsPanel
-              primaryButtonProps={{
-                buttonType: 'outlined',
-                label: 'Done',
-                onClick: onClose,
               }}
               sx={{ pt: 2 }}
             />

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -29,7 +29,10 @@ interface Props {
 export const PlacementGroupsDeleteModal = (props: Props) => {
   const { onClose, open } = props;
   const { id } = useParams<{ id: string }>();
-  const { data: selectedPlacementGroup } = usePlacementGroupQuery(+id);
+  const { data: selectedPlacementGroup } = usePlacementGroupQuery(
+    +id,
+    Boolean(id)
+  );
   const {
     assignedLinodes,
     isLoading: placementGroupDataLoading,

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsLinodes/PlacementGroupsLinodes.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsLinodes/PlacementGroupsLinodes.tsx
@@ -12,12 +12,12 @@ import { Stack } from 'src/components/Stack';
 import { Typography } from 'src/components/Typography';
 import { usePlacementGroupData } from 'src/hooks/usePlacementGroupsData';
 
-import { PlacementGroupsAssignLinodesDrawer } from '../../PlacementGroupsAssignLinodesDrawer';
-import { PlacementGroupsUnassignModal } from '../../PlacementGroupsUnassignModal';
 import {
   MAX_NUMBER_OF_LINODES_IN_PLACEMENT_GROUP_MESSAGE,
   PLACEMENT_GROUP_LINODES_ERROR_MESSAGE,
 } from '../../constants';
+import { PlacementGroupsAssignLinodesDrawer } from '../../PlacementGroupsAssignLinodesDrawer';
+import { PlacementGroupsUnassignModal } from '../../PlacementGroupsUnassignModal';
 import { PlacementGroupsLinodesTable } from './PlacementGroupsLinodesTable';
 
 import type { Linode, PlacementGroup } from '@linode/api-v4';
@@ -102,12 +102,11 @@ export const PlacementGroupsLinodes = (props: Props) => {
         <Grid>
           <Button
             buttonType="primary"
-            data-testid="add-linode-to-placement-group-button"
             disabled={hasReachedCapacity}
             onClick={handleOpenAssignLinodesDrawer}
             tooltipText={MAX_NUMBER_OF_LINODES_IN_PLACEMENT_GROUP_MESSAGE}
           >
-            Add Linode to Placement Group
+            Assign Linode to Placement Group
           </Button>
         </Grid>
       </Grid>

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
@@ -1,7 +1,7 @@
 import { AFFINITY_TYPES } from '@linode/api-v4';
 import { useTheme } from '@mui/material';
-import Grid from '@mui/material/Unstable_Grid2';
 import { styled } from '@mui/material/styles';
+import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 
 import { Box } from 'src/components/Box';

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
@@ -1,7 +1,7 @@
 import { AFFINITY_TYPES } from '@linode/api-v4';
 import { useTheme } from '@mui/material';
-import { styled } from '@mui/material/styles';
 import Grid from '@mui/material/Unstable_Grid2';
+import { styled } from '@mui/material/styles';
 import * as React from 'react';
 
 import { Box } from 'src/components/Box';

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsEditDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsEditDrawer.tsx
@@ -30,7 +30,10 @@ export const PlacementGroupsEditDrawer = (
 ) => {
   const { onClose, onPlacementGroupEdit, open } = props;
   const { id } = useParams<{ id: string }>();
-  const { data: selectedPlacementGroup } = usePlacementGroupQuery(+id);
+  const { data: selectedPlacementGroup } = usePlacementGroupQuery(
+    +id,
+    Boolean(id)
+  );
   const { region } = usePlacementGroupData({
     placementGroup: selectedPlacementGroup,
   });

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsUnassignModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsUnassignModal.tsx
@@ -26,7 +26,10 @@ export const PlacementGroupsUnassignModal = (props: Props) => {
     isLoading,
     mutateAsync: unassignLinodes,
   } = useUnassignLinodesFromPlacementGroup(+placementGroupId ?? -1);
-  const { data: selectedLinode } = useLinodeQuery(+linodeId ?? -1);
+  const { data: selectedLinode } = useLinodeQuery(
+    +linodeId ?? -1,
+    Boolean(linodeId)
+  );
 
   const payload: UnassignLinodesFromPlacementGroupPayload = {
     linodes: [+linodeId ?? -1],

--- a/packages/manager/src/features/PlacementGroups/constants.ts
+++ b/packages/manager/src/features/PlacementGroups/constants.ts
@@ -4,7 +4,7 @@ export const PLACEMENT_GROUP_LABEL = 'Placement Groups';
 export const MAX_NUMBER_OF_PLACEMENT_GROUPS = 5;
 
 export const MAX_NUMBER_OF_LINODES_IN_PLACEMENT_GROUP_MESSAGE =
-  "You've reached the maximum number of Linodes in a Placement Group. Please remove a Linode from this Placement Group before adding another.";
+  "You've reached the maximum number of Linodes in a Placement Group. Please remove a Linode from this Placement Group before assigning another.";
 
 export const PLACEMENT_GROUP_LINODES_ERROR_MESSAGE =
   'There was an error loading Linodes for this Placement Group.';

--- a/packages/manager/src/hooks/usePlacementGroupsData.ts
+++ b/packages/manager/src/hooks/usePlacementGroupsData.ts
@@ -31,9 +31,7 @@ export const usePlacementGroupData = ({
   const { data: linodes, error, isLoading } = useAllLinodesQuery(
     {},
     {
-      '+or': placementGroup?.linodes.map(({ linode }) => ({
-        linode,
-      })),
+      '+or': placementGroup?.linodes.filter(({ linode }) => linode),
     }
   );
   const { data: regions } = useRegionsQuery();

--- a/packages/manager/src/hooks/usePlacementGroupsData.ts
+++ b/packages/manager/src/hooks/usePlacementGroupsData.ts
@@ -31,7 +31,9 @@ export const usePlacementGroupData = ({
   const { data: linodes, error, isLoading } = useAllLinodesQuery(
     {},
     {
-      '+or': placementGroup?.linodes.filter(({ linode }) => linode),
+      '+or': placementGroup?.linodes.map((linodeItem) => ({
+        id: linodeItem.linode,
+      })),
     }
   );
   const { data: regions } = useRegionsQuery();

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -745,7 +745,7 @@ export const handlers = [
       if (orFilters) {
         const filteredLinodes = linodes.filter((linode) => {
           const filteredById = orFilters.some(
-            (filter: { linode: number }) => filter.linode === linode.id
+            (filter: { id: number }) => filter.id === linode.id
           );
           const filteredByRegion = orFilters.some(
             (filter: { region: string }) => filter.region === linode.region


### PR DESCRIPTION
## Description 📝
Pretty simple PR to update the assign linode drawer. Due to some recent UX changes, the decision was made to assign one linode at a time in the drawer and remove the current experience with the unassign selectable list inside the drawer.

## Changes  🔄
- Simplify Assign Linode Drawer logic and adjust tests
- Rename "edit" to "assign" through the feature
- Improve query skipping where relevant


## Preview 📷
![localhost_3000_placement-groups_1_linodes_assign](https://github.com/linode/manager/assets/130582365/96fdd0f6-0615-4720-a453-34e610da0767)

## How to test 🧪

### Prerequisites
- Turn on both the "Placement Groups" feature flag and MSW

### Verification steps
- Navigate to http://localhost:3000/placement-groups/1/linodes/assign
- Click on "Assign Linode to Placement Group"
- Confirm Drawer appearance and behavior

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
