### PR TITLE
upcoming: [M3-7816-v2] - Adjust logic for when to show Switch Account button

### DIFF
--- a/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
+++ b/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
@@ -306,7 +306,7 @@ describe('Parent/Child account switching', () => {
 
       cy.visitWithLogin('/account/billing');
 
-      cy.get('[data-testid="switch-account-button"]').should('be.visible');
+      cy.findByTestId('switch-account-button').should('be.visible');
     });
   });
 

--- a/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
+++ b/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
@@ -267,7 +267,7 @@ describe('Parent/Child account switching', () => {
      * - Confirms that the "Switch Account" button is rendered.
      */
     describe('Enabled', () => {
-      it('renders "Switch Account" button for restricted users on billing page', () => {
+      it('renders "Switch Account" button for restricted users on Billing page', () => {
         mockGetProfile({ ...mockParentProfile, restricted: true });
         mockGetUser(mockParentUser);
         mockGetProfileGrants(childAccountAccessGrantEnabled);
@@ -303,7 +303,7 @@ describe('Parent/Child account switching', () => {
      * - Confirms that the "Switch Account" button is not rendered.
      */
     describe('Disabled', () => {
-      it('does not render "Switch Account" button for restricted users on billing page', () => {
+      it('does not render "Switch Account" button for restricted users on Billing page', () => {
         mockGetProfile({ ...mockParentProfile, restricted: true });
         mockGetUser(mockParentUser);
         mockGetProfileGrants(childAccountAccessGrantDisabled);

--- a/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
+++ b/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
@@ -258,7 +258,7 @@ describe('Parent/Child account switching', () => {
      * - Smoke test to confirm that restricted parent users without the child_account_access grant cannot switch accounts.
      * - Confirms that the "Switch Account" button is not rendered.
      */
-    it('does not display the "Switch Account" button for parent account users without child_account_access grant', () => {
+    it('does not display the "Switch Account" button for restricted parent account users without child_account_access grant', () => {
       const mockProfile = profileFactory.build({
         restricted: true,
         user_type: 'parent',
@@ -285,7 +285,7 @@ describe('Parent/Child account switching', () => {
      * - Smoke test to confirm that restricted parent users with the child_account_access grant can switch accounts.
      * - Confirms that the "Switch Account" button is rendered.
      */
-    it('displays the "Switch Account" button for parent account users with child_account_access grant', () => {
+    it('displays the "Switch Account" button for restricted parent account users with child_account_access grant', () => {
       const mockProfile = profileFactory.build({
         restricted: true,
         user_type: 'parent',

--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -144,8 +144,7 @@ const AccountLanding = () => {
   const isBillingTabSelected = location.pathname.match(/billing/);
   const canSwitchBetweenParentOrProxyAccount =
     flags.parentChildAccountAccess &&
-    (isParentUser || isProxyUser) &&
-    !isChildAccountAccessRestricted;
+    ((!isChildAccountAccessRestricted && isParentUser) || isProxyUser);
 
   const landingHeaderProps: LandingHeaderProps = {
     breadcrumbProps: {

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -76,9 +76,8 @@ export const UserMenu = React.memo(() => {
     globalGrantType: 'child_account_access',
   });
   const canSwitchBetweenParentOrProxyAccount =
-    hasParentChildAccountAccess &&
-    (isParentUser || isProxyUser) &&
-    !isChildAccountAccessRestricted;
+    flags.parentChildAccountAccess &&
+    ((!isChildAccountAccessRestricted && isParentUser) || isProxyUser);
   const open = Boolean(anchorEl);
   const id = open ? 'user-menu-popover' : undefined;
   const companyName =


### PR DESCRIPTION
## Description 📝
We had to adjust the logic for `isChildAccountAccessRestricted` to parent users only since this is where the grant can be toggled. This was being applied to the proxy user inadvertently preventing the proxy from switching to accounts.

## Changes  🔄
- Added E2E test for this use-case

## Target release date 🗓️
3/18

## Screenshots
![Screenshot 2024-03-07 at 2 32 50 PM](https://github.com/linode/manager/assets/125309814/194d8354-431d-4018-bf3f-2933f35f261b)

## How to test 🧪
See testing instructions: https://github.com/linode/manager/pull/10237