### PR TITLE
test: Fix test flake for Images landing page test

### DIFF
--- a/packages/manager/.changeset/pr-10267-tests-1709834235631.md
+++ b/packages/manager/.changeset/pr-10267-tests-1709834235631.md
@@ -2,4 +2,4 @@
 "@linode/manager": Tests
 ---
 
-Fix URL redirect test flake for Images empty state landing page test ([#10267](https://github.com/linode/manager/pull/10267))
+Fix URL redirect flake for Images empty state landing page test ([#10267](https://github.com/linode/manager/pull/10267))

--- a/packages/manager/.changeset/pr-10267-tests-1709834235631.md
+++ b/packages/manager/.changeset/pr-10267-tests-1709834235631.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix URL redirect test flake for Images empty state landing page test ([#10267](https://github.com/linode/manager/pull/10267))

--- a/packages/manager/cypress/e2e/core/images/images-empty-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/images-empty-landing-page.spec.ts
@@ -44,6 +44,6 @@ describe('Images empty landing page', () => {
       .should('be.enabled')
       .click();
 
-    cy.url().should('endWith', '/images/create');
+    cy.url().should('endWith', '/images/create/disk');
   });
 });


### PR DESCRIPTION
## Description 📝
This is a tiny fix for a test flake issue in `images-empty-landing-page.spec.ts`. Clicking "Create Image" directs to `images/create` which quickly redirects to `images/create/disk`. Most of the time Cypress is able to assert that the URL did end with `images/create`, but because it redirects so quickly the assertion occasionally fails.

This fixes the issue by checking for `images/create/disk` instead. I'm mostly interested in fixing this for the performance benefit; it doesn't seem like this has ever led to an actual test failure, but does cause flake pretty often.

## How to test 🧪

We can lean on CI, or

```bash
yarn cy:run -s "cypress/e2e/core/images/images-empty-landing-page.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
