### PR TITLE
change: [M3-7856] - Update ACLB Match Condition Tooltips and Placeholders

### DIFF
--- a/packages/manager/.changeset/pr-10271-changed-1710174159065.md
+++ b/packages/manager/.changeset/pr-10271-changed-1710174159065.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Update ACLB Match Condition Tooltips and Placeholders ([#10271](https://github.com/linode/manager/pull/10271))

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/constants.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/constants.tsx
@@ -28,7 +28,7 @@ export const ROUTE_COPY = {
         'For TCP load balancers, a rule consists of service targets and the percentage of incoming requests that should be directed to each target. Add as many service targets as required, but the percentages for all targets must total 100%.',
     },
     MatchValue: {
-      header: 'The format for http header is: X-name:value.',
+      header: 'The format for http header is: X-name=value.',
       method: 'The request methods include: DELETE, GET, HEAD, POST, and PUT.',
       path_prefix:
         'The format of the path rule is: /pathname1/pathame2. The initial slash is required, but the trailing slash is not.',
@@ -39,8 +39,7 @@ export const ROUTE_COPY = {
           <Code>/path/.*[.]jpg</Code>. Initial slash is required.
         </>
       ),
-      query:
-        'The format for query string is: ?name=value. The query string name must be preceded by a question mark (?).',
+      query: 'The format for query string is: name=value.',
     },
     Stickiness: {
       Cookie:

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/utils.ts
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Routes/utils.ts
@@ -24,11 +24,11 @@ export const matchValuePlaceholder: Record<
   CustomerFacingMatchFieldOption,
   string
 > = {
-  header: 'x-my-header:this',
+  header: 'x-my-header=this',
   method: 'POST',
   path_prefix: '/my-path',
   path_regex: '/path/.*[.](jpg)',
-  query: '?my-query-param=this',
+  query: 'my-query-param=this',
 };
 
 export const matchTypeOptions = Object.keys(matchFieldMap).map(


### PR DESCRIPTION
## Description 📝

We were not recommending  valid values to the user. This PR updates our placeholders and tooltips to use the correct format of `key=value`

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-03-11 at 12 03 00 PM](https://github.com/linode/manager/assets/115251059/3487eb34-8208-439b-9597-32fba4d31a18) | ![Screenshot 2024-03-11 at 12 02 35 PM](https://github.com/linode/manager/assets/115251059/a9cc3ea0-234f-4fe8-aab3-d068d7d277a0) |

## How to test 🧪

### Prerequisites
- Use the MSW, `dev-test-aglb`, or `prod-test-065`

### How to verify
- Go the an existing ACLB
- Go to the **routes tab**
- **Create a route** if none exits
- On a route, open the **add rule drawer**
- In this drawer, verify the tooltip and placeholder text uses **`key=value`** format for **header** and **query string** matches

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support