### PR TITLE
fix: [M3-7826-v2] - Fix email displaying in top menu for all users without a company name

### DIFF
--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.test.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.test.tsx
@@ -121,29 +121,16 @@ describe('UserMenu', () => {
     expect(queryByText('Test Company')).not.toBeInTheDocument();
   });
 
-  it("shows the restricted user's username and no email in the TopMenu for a regular user", async () => {
-    // Mock a forbidden request to the /account endpoint, which happens if Billing (Account) Access is None.
+  it("shows the user's username and no email in the TopMenu for a regular user without a company name", async () => {
     server.use(
-      rest.get('*/account/users/*/grants', (req, res, ctx) => {
-        return res(
-          ctx.json(
-            grantsFactory.build({
-              global: {
-                account_access: null,
-              },
-            })
-          )
-        );
-      }),
       rest.get('*/account', (req, res, ctx) => {
-        return res(ctx.status(403));
+        return res(ctx.json(accountFactory.build({ company: undefined })));
       }),
       rest.get('*/profile', (req, res, ctx) => {
         return res(
           ctx.json(
             profileFactory.build({
               email: 'user@email.com',
-              restricted: true,
               user_type: 'default',
               username: 'regular-user',
             })

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.test.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.test.tsx
@@ -121,33 +121,6 @@ describe('UserMenu', () => {
     expect(queryByText('Test Company')).not.toBeInTheDocument();
   });
 
-  it("shows the user's username and no email in the TopMenu for a regular user without a company name", async () => {
-    server.use(
-      rest.get('*/account', (req, res, ctx) => {
-        return res(ctx.json(accountFactory.build({ company: undefined })));
-      }),
-      rest.get('*/profile', (req, res, ctx) => {
-        return res(
-          ctx.json(
-            profileFactory.build({
-              email: 'user@email.com',
-              user_type: 'default',
-              username: 'regular-user',
-            })
-          )
-        );
-      })
-    );
-
-    const { findByText, queryByText } = renderWithTheme(<UserMenu />, {
-      flags: { parentChildAccountAccess: true },
-    });
-
-    expect(await findByText('regular-user')).toBeInTheDocument();
-    // Should not be displayed for regular restricted users, only restricted parents.
-    expect(queryByText('user@email.com')).not.toBeInTheDocument();
-  });
-
   it('shows the parent company name and Switch Account button in the dropdown menu for a parent user', async () => {
     server.use(
       rest.get('*/account', (req, res, ctx) => {

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.test.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.test.tsx
@@ -17,7 +17,7 @@ describe('UserMenu', () => {
     expect(getByRole('button')).toBeInTheDocument();
   });
 
-  it("shows a parent user's username and company name for a parent user", async () => {
+  it("shows a parent user's username and company name in the TopMenu for a parent user", async () => {
     server.use(
       rest.get('*/account', (req, res, ctx) => {
         return res(
@@ -44,7 +44,7 @@ describe('UserMenu', () => {
     expect(await findByText('Parent Company')).toBeInTheDocument();
   });
 
-  it("shows the parent user's username and child company name for a proxy user", async () => {
+  it("shows the parent user's username and child company name in the TopMenu for a proxy user", async () => {
     server.use(
       rest.get('*/account', (req, res, ctx) => {
         return res(
@@ -71,7 +71,7 @@ describe('UserMenu', () => {
     expect(await findByText('Child Company')).toBeInTheDocument();
   });
 
-  it("shows the child user's username and company name for a child user", async () => {
+  it("shows the child user's username and company name in the TopMenu for a child user", async () => {
     server.use(
       rest.get('*/account', (req, res, ctx) => {
         return res(
@@ -95,7 +95,7 @@ describe('UserMenu', () => {
     expect(await findByText('Child Company')).toBeInTheDocument();
   });
 
-  it("shows the user's username and no company name for a regular user", async () => {
+  it("shows the user's username and no company name in the TopMenu for a regular user", async () => {
     server.use(
       rest.get('*/account', (req, res, ctx) => {
         return res(ctx.json(accountFactory.build({ company: 'Test Company' })));
@@ -117,7 +117,48 @@ describe('UserMenu', () => {
     });
 
     expect(await findByText('regular-user')).toBeInTheDocument();
+    // Should not be displayed for regular users, only parent/child/proxy users.
     expect(queryByText('Test Company')).not.toBeInTheDocument();
+  });
+
+  it("shows the restricted user's username and no email in the TopMenu for a regular user", async () => {
+    // Mock a forbidden request to the /account endpoint, which happens if Billing (Account) Access is None.
+    server.use(
+      rest.get('*/account/users/*/grants', (req, res, ctx) => {
+        return res(
+          ctx.json(
+            grantsFactory.build({
+              global: {
+                account_access: null,
+              },
+            })
+          )
+        );
+      }),
+      rest.get('*/account', (req, res, ctx) => {
+        return res(ctx.status(403));
+      }),
+      rest.get('*/profile', (req, res, ctx) => {
+        return res(
+          ctx.json(
+            profileFactory.build({
+              email: 'user@email.com',
+              restricted: true,
+              user_type: 'default',
+              username: 'regular-user',
+            })
+          )
+        );
+      })
+    );
+
+    const { findByText, queryByText } = renderWithTheme(<UserMenu />, {
+      flags: { parentChildAccountAccess: true },
+    });
+
+    expect(await findByText('regular-user')).toBeInTheDocument();
+    // Should not be displayed for regular restricted users, only restricted parents.
+    expect(queryByText('user@email.com')).not.toBeInTheDocument();
   });
 
   it('shows the parent company name and Switch Account button in the dropdown menu for a parent user', async () => {
@@ -145,7 +186,7 @@ describe('UserMenu', () => {
     expect(within(userMenuPopover).getByText('Switch Account')).toBeVisible();
   });
 
-  it('hides Switch Account button for parent accounts lacking child_account_access', async () => {
+  it('hides Switch Account button in the dropdown menu for parent accounts lacking child_account_access', async () => {
     server.use(
       rest.get('*/account/users/*/grants', (req, res, ctx) => {
         return res(
@@ -198,7 +239,7 @@ describe('UserMenu', () => {
     expect(within(userMenuPopover).getByText('Switch Account')).toBeVisible();
   });
 
-  it('shows the parent email for a parent user if their company name is not set', async () => {
+  it('shows the parent email for a parent user in the top menu and dropdown menu if their company name is unavailable', async () => {
     // Mock a forbidden request to the /account endpoint, which happens if Billing (Account) Access is None.
     server.use(
       rest.get('*/account/users/*/grants', (req, res, ctx) => {

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -27,6 +27,8 @@ import { useGrants, useProfile } from 'src/queries/profile';
 import { sendSwitchAccountEvent } from 'src/utilities/analytics';
 import { getStorage } from 'src/utilities/storage';
 
+import { getCompanyNameOrEmail } from './utils';
+
 interface MenuLink {
   display: string;
   hide?: boolean;
@@ -81,15 +83,11 @@ export const UserMenu = React.memo(() => {
   const open = Boolean(anchorEl);
   const id = open ? 'user-menu-popover' : undefined;
 
-  // For parent users lacking `account_access`: without a company name to identify an account, fall back on the email.
-  const companyNameOrEmail =
-    hasParentChildAccountAccess &&
-    profile?.user_type !== 'default' &&
-    account?.company
-      ? account.company
-      : isParentUser && profile?.email
-      ? profile.email
-      : undefined;
+  const companyNameOrEmail = getCompanyNameOrEmail({
+    company: account?.company,
+    isParentChildFeatureEnabled: hasParentChildAccountAccess,
+    profile,
+  });
 
   const { isParentTokenExpired } = useParentTokenManagement({ isProxyUser });
 

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -81,14 +81,15 @@ export const UserMenu = React.memo(() => {
   const open = Boolean(anchorEl);
   const id = open ? 'user-menu-popover' : undefined;
 
-  // If there is no company name to identify an account, fall back on the email.
-  // Covers an edge case in which a restricted parent user without `account_access` cannot access the account company.
+  // For parent users lacking `account_access`: without a company name to identify an account, fall back on the email.
   const companyNameOrEmail =
     hasParentChildAccountAccess &&
     profile?.user_type !== 'default' &&
     account?.company
       ? account.company
-      : profile?.email;
+      : isParentUser && profile?.email
+      ? profile.email
+      : undefined;
 
   const { isParentTokenExpired } = useParentTokenManagement({ isProxyUser });
 

--- a/packages/manager/src/features/TopMenu/UserMenu/utils.test.ts
+++ b/packages/manager/src/features/TopMenu/UserMenu/utils.test.ts
@@ -1,0 +1,62 @@
+import { UserType } from '@linode/api-v4';
+
+import { profileFactory } from 'src/factories';
+
+import { getCompanyNameOrEmail } from './utils';
+
+const MOCK_COMPANY_NAME = 'Test Company, LLC';
+
+describe('getCompanyNameOrEmail', () => {
+  it('returns the company name for a parent/child/proxy user who has one', async () => {
+    const newUserTypes = ['parent', 'child', 'proxy'];
+
+    newUserTypes.forEach((newUserType: UserType) => {
+      const actual = getCompanyNameOrEmail({
+        company: MOCK_COMPANY_NAME,
+        isParentChildFeatureEnabled: true,
+        profile: profileFactory.build({ user_type: newUserType }),
+      });
+      const expected = MOCK_COMPANY_NAME;
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  it('returns email of a parent user who does not have (access to) a company name', async () => {
+    const parentEmail = 'parent@email.com';
+
+    const actual = getCompanyNameOrEmail({
+      company: undefined,
+      isParentChildFeatureEnabled: true,
+      profile: profileFactory.build({
+        email: parentEmail,
+        user_type: 'parent',
+      }),
+    });
+    const expected = parentEmail;
+    expect(actual).toEqual(expected);
+  });
+
+  it('returns undefined for the company/email of a regular (default) user', async () => {
+    const actual = getCompanyNameOrEmail({
+      company: MOCK_COMPANY_NAME,
+      isParentChildFeatureEnabled: true,
+      profile: profileFactory.build({ user_type: 'default' }),
+    });
+    const expected = undefined;
+    expect(actual).toEqual(expected);
+  });
+
+  it('returns undefined for the company/email of all users when the parent/child feature is not enabled', async () => {
+    const allUserTypes = ['parent', 'child', 'proxy', 'default'];
+
+    allUserTypes.forEach((userType: UserType) => {
+      const actual = getCompanyNameOrEmail({
+        company: MOCK_COMPANY_NAME,
+        isParentChildFeatureEnabled: false,
+        profile: profileFactory.build({ user_type: userType }),
+      });
+      const expected = undefined;
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/packages/manager/src/features/TopMenu/UserMenu/utils.test.ts
+++ b/packages/manager/src/features/TopMenu/UserMenu/utils.test.ts
@@ -36,6 +36,21 @@ describe('getCompanyNameOrEmail', () => {
     expect(actual).toEqual(expected);
   });
 
+  it("returns undefined for a child user who does not have (access to) a company name, since we don't need to display it", async () => {
+    const childEmail = 'child@email.com';
+
+    const actual = getCompanyNameOrEmail({
+      company: undefined,
+      isParentChildFeatureEnabled: true,
+      profile: profileFactory.build({
+        email: childEmail,
+        user_type: 'child',
+      }),
+    });
+    const expected = undefined;
+    expect(actual).toEqual(expected);
+  });
+
   it('returns undefined for the company/email of a regular (default) user', async () => {
     const actual = getCompanyNameOrEmail({
       company: MOCK_COMPANY_NAME,

--- a/packages/manager/src/features/TopMenu/UserMenu/utils.ts
+++ b/packages/manager/src/features/TopMenu/UserMenu/utils.ts
@@ -1,0 +1,33 @@
+import { Profile } from '@linode/api-v4';
+
+export interface CompanyNameOrEmailOptions {
+  company: string | undefined;
+  isParentChildFeatureEnabled: boolean;
+  profile: Profile | undefined;
+}
+
+/**
+ * This util will determine a string displayed in the top and user menus that indicates the parent/child account that the user is viewing.
+ *
+ * @returns company name for parent/child/proxy users when available, email in the case of the restricted parent, or undefined for regular users
+ */
+export const getCompanyNameOrEmail = ({
+  company,
+  isParentChildFeatureEnabled,
+  profile,
+}: CompanyNameOrEmailOptions) => {
+  const isParentChildOrProxyUser = profile?.user_type !== 'default';
+  const isParentUser = profile?.user_type === 'parent';
+
+  // Return early if we do not need the company name or email.
+  if (!isParentChildFeatureEnabled || !profile || !isParentChildOrProxyUser) {
+    return undefined;
+  }
+
+  // For parent users lacking `account_access`: without a company name to identify an account, fall back on the email.
+  // In all other parent/child/proxy cases, company will be available, as it is a required field.
+  if (isParentUser && !company) {
+    return profile.email;
+  }
+  return company;
+};

--- a/packages/manager/src/features/TopMenu/UserMenu/utils.ts
+++ b/packages/manager/src/features/TopMenu/UserMenu/utils.ts
@@ -25,9 +25,11 @@ export const getCompanyNameOrEmail = ({
   }
 
   // For parent users lacking `account_access`: without a company name to identify an account, fall back on the email.
-  // In all other parent/child/proxy cases, company will be available, as it is a required field.
+  // We do not need to do this for child users lacking `account_access` because we do not need to display the email.
   if (isParentUser && !company) {
     return profile.email;
   }
+
+  // In all other parent/child/proxy cases, company will be available, as it is a required field.
   return company;
 };


### PR DESCRIPTION
## Description 📝
In #10248, I didn't test the regular user experience thoroughly enough, because the conditional logic was defaulting to the profile email of the user if no company name was set, even if the user was not a parent/child/proxy account. We don't want this. 

We **should** see the following:
- For a regular (default) user, there should be no changes to the top menu and user menu (i.e. it should display username only). 
- For parent/child/proxy users, the top menu should display username and company names. 
- For parent/proxy users, the user menu dropdown should display the company name.
- For **restricted parent users who do not have `account_access` set to at least `read_only`**, the top menu should display username and email (in place of company).
For **restricted parent users who do not have `account_access` set to at least `read_only`**, the dropdown menu should display email (in place of company).

## Changes  🔄
- Fixed the conditional logic to check if the user is a parent user and is missing an account company in order to resort to email, otherwise defaults to undefined.
- Added the other piece of unit test coverage that was missing for this edge-case, confirming a regular user does not see their email in the top menu or dropdown user menu.

## Target release date 🗓️
3/18

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-03-12 at 8 53 37 AM](https://github.com/linode/manager/assets/114685994/47465139-adf0-4cbd-987e-e731ae3f9f8f) | ![Screenshot 2024-03-12 at 8 52 57 AM](https://github.com/linode/manager/assets/114685994/76f0c27f-b6d5-48a6-8ac1-b2e7551c3879) |


## How to test 🧪

### Prerequisites
(How to setup test environment)
- You can use the MSW to toggle the different user types, or you can use real parent/child/proxy and default user accounts (ask me). 

### Reproduction steps
(How to reproduce the issue, if applicable)
- Check out develop.
- Observe for your regular user account, the top menu now includes your email if you don't have a company name associated with your account.

### Verification steps
(How to verify changes)
- Check out this branch. 
- With mocks off: confirm that the top menu and user menu dropdown include *only* your username (no email). There should be no change from prod.
- With mocks on: update the `user_type` to `parent`, `proxy`, `child`, and `default` in the [MSW](https://github.com/linode/manager/blob/develop/packages/manager/src/mocks/serverHandlers.ts#L558). For a restricted parent user, you'd want to mock a 403 on the [account](https://github.com/linode/manager/blob/develop/packages/manager/src/mocks/serverHandlers.ts#L1203) endpoint.
```
      rest.get('*/account', (req, res, ctx) => {
        return res(ctx.status(403));
      }),
```
- For each user_type, confirm that the top menu and user menu match the description outlined in the PR description. 

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset - Note: this was a bug fix to a bug fix, and did not ever make it into a release so I left the changeset off. 
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

