### PR TITLE
fix: [M3-7867] -Ensure IP / Mask for firewall rules drawer correctly populates

### DIFF
--- a/packages/manager/.changeset/pr-10279-fixed-1710360079232.md
+++ b/packages/manager/.changeset/pr-10279-fixed-1710360079232.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Ensure IP / Mask for firewall rules drawer correctly populates ([#10279](https://github.com/linode/manager/pull/10279))

--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
@@ -105,7 +105,8 @@ export const MultipleIPInput = React.memo((props: Props) => {
     e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
     idx: number
   ) => {
-    if (!onBlur) {
+    if (!onBlur || e.target.value === '') {
+      // If onBlur is not provided or the input value is an empty string, exit the function early
       return;
     }
 

--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
@@ -106,7 +106,6 @@ export const MultipleIPInput = React.memo((props: Props) => {
     idx: number
   ) => {
     if (!onBlur || e.target.value === '') {
-      // If onBlur is not provided or the input value is an empty string, exit the function early
       return;
     }
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleForm.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleForm.tsx
@@ -293,7 +293,6 @@ export const FirewallRuleForm = React.memo((props: FirewallRuleFormProps) => {
       {values.addresses === 'ip/netmask' && (
         <StyledMultipleIPInput
           aria-label="IP / Netmask for Firewall rule"
-          inputProps={{ autoFocus: true }}
           ips={ips}
           onBlur={handleIPBlur}
           onChange={handleIPChange}


### PR DESCRIPTION
## Description 📝
There was an issue where on first page load where the `IP / Netmask` input fields weren't populating properly when you first open the firewall rules drawer.

## Changes  🔄
- Remove the autoFocus which we don't need. We could technically keep this, but just seemed odd that we wanted to focus those fields apart from all the other relevant fields.
- Root issue was we're overriding our IPs when an input is blurred. I added a check to ensure the value is not empty before we attempt to call onBlur and set our state

## Target release date 🗓️
3/18

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/125309814/bd1cb6f7-44a6-49cd-a317-274c5bac00d3" /> | <video src="https://github.com/linode/manager/assets/125309814/25ecd4c3-3d09-4fc2-9626-153565918479" /> |

Initial / Secondary Render
<img width="198" alt="Screenshot 2024-03-13 at 3 08 27 PM" src="https://github.com/linode/manager/assets/125309814/81347fd3-a1eb-46d7-be7b-16ea75bf8d09">


## How to test 🧪

### Prerequisites
- Create an inbound firewall rule with two IP/Netmasks

### Reproduction steps
- Reload the page
- Open firewall rules drawer
- Observer bug

### Verification steps
- Checkout branch
- Reload page
- Open firewall rules drawer
- Observe fix

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support