### PR TITLE
upcoming: [M3-7868] - Gecko Beta Demo feedback

### DIFF
--- a/packages/manager/.changeset/pr-10284-upcoming-features-1710432233464.md
+++ b/packages/manager/.changeset/pr-10284-upcoming-features-1710432233464.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Gecko Beta Demo feedback ([#10284](https://github.com/linode/manager/pull/10284))

--- a/packages/manager/src/features/Images/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImageUpload.tsx
@@ -1,9 +1,9 @@
 import { APIError } from '@linode/api-v4/lib/types';
 import { Theme } from '@mui/material/styles';
-import { makeStyles } from 'tss-react/mui';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import { makeStyles } from 'tss-react/mui';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Checkbox } from 'src/components/Checkbox';
@@ -275,6 +275,7 @@ export const ImageUpload: React.FC<Props> = (props) => {
             errorText={errorMap.region}
             handleSelection={setRegion}
             label="Region"
+            regionFilter="core" // Images service will not be supported for Gecko Beta
             regions={regions}
             required
             selectedId={region}

--- a/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.tsx
@@ -196,7 +196,7 @@ export const AddonsPanel = React.memo((props: AddonsPanelProps) => {
         </Typography>
         {isEdgeRegionSelected && (
           <Notice
-            text="Backups and Private IP are currently not available for Edge regions"
+            text="Backups and Private IP are currently not available for Edge regions."
             variant="warning"
           />
         )}

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
@@ -182,7 +182,7 @@ export const AddIPDrawer = (props: Props) => {
           {linodeIsInEdgeRegion && (
             <Notice
               sx={{ fontSize: 15 }}
-              text="Private IP is currently not available for Edge regions"
+              text="Private IP is currently not available for Edge regions."
               variant="warning"
             />
           )}

--- a/packages/manager/src/features/Linodes/MigrateLinode/CautionNotice.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/CautionNotice.tsx
@@ -20,6 +20,15 @@ interface Props {
 }
 
 export const CautionNotice = React.memo((props: Props) => {
+  const {
+    edgeRegionWarning,
+    error,
+    hasConfirmed,
+    linodeId,
+    metadataWarning,
+    migrationTimeInMins,
+    setConfirmed,
+  } = props;
   const theme = useTheme();
 
   // This is not great, but lets us get all of the volumes for a Linode while keeping
@@ -27,12 +36,12 @@ export const CautionNotice = React.memo((props: Props) => {
   // because the event handler automatically updates stored paginated data.
   // We can safely do this because linodes can't have more than 64 volumes.
   const { data: volumesData } = useLinodeVolumesQuery(
-    props.linodeId ?? -1,
+    linodeId ?? -1,
     {
       page_size: API_MAX_PAGE_SIZE,
     },
     {},
-    props.linodeId !== undefined
+    linodeId !== undefined
   );
 
   const amountOfAttachedVolumes = volumesData?.results ?? 0;
@@ -90,21 +99,21 @@ export const CautionNotice = React.memo((props: Props) => {
         <li>
           When this migration begins, we estimate it will take approximately{' '}
           {DateTime.local()
-            .plus({ minutes: props.migrationTimeInMins })
+            .plus({ minutes: migrationTimeInMins })
             .toRelative()
             ?.replace('in', '')}{' '}
           to complete.
         </li>
-        {props.metadataWarning ? <li>{props.metadataWarning}</li> : null}
-        {props.edgeRegionWarning ? <li>{props.edgeRegionWarning}</li> : null}
+        {metadataWarning && <li>{metadataWarning}</li>}
+        {edgeRegionWarning && <li>{edgeRegionWarning}</li>}
       </ul>
-      {props.error && <Notice text={props.error} variant="error" />}
+      {error && <Notice text={error} variant="error" />}
       <Checkbox
         sx={{
           marginLeft: theme.spacing(2),
         }}
-        checked={props.hasConfirmed}
-        onChange={() => props.setConfirmed(!props.hasConfirmed)}
+        checked={hasConfirmed}
+        onChange={() => setConfirmed(!hasConfirmed)}
         text="Accept"
       />
     </StyledRootDiv>

--- a/packages/manager/src/features/Linodes/MigrateLinode/CautionNotice.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/CautionNotice.tsx
@@ -10,6 +10,7 @@ import { API_MAX_PAGE_SIZE } from 'src/constants';
 import { useLinodeVolumesQuery } from 'src/queries/volumes';
 
 interface Props {
+  edgeRegionWarning?: string;
   error?: string;
   hasConfirmed: boolean;
   linodeId: number | undefined;
@@ -95,6 +96,7 @@ export const CautionNotice = React.memo((props: Props) => {
           to complete.
         </li>
         {props.metadataWarning ? <li>{props.metadataWarning}</li> : null}
+        {props.edgeRegionWarning ? <li>{props.edgeRegionWarning}</li> : null}
       </ul>
       {props.error && <Notice text={props.error} variant="error" />}
       <Checkbox

--- a/packages/manager/src/features/Linodes/MigrateLinode/MigrateLinode.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/MigrateLinode.tsx
@@ -7,6 +7,7 @@ import { Box } from 'src/components/Box';
 import { Button } from 'src/components/Button/Button';
 import { Dialog } from 'src/components/Dialog/Dialog';
 import { Notice } from 'src/components/Notice/Notice';
+import { getIsEdgeRegion } from 'src/components/RegionSelect/RegionSelect.utils';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
 import { MBpsInterDC } from 'src/constants';
@@ -144,6 +145,16 @@ export const MigrateLinode = React.memo((props: Props) => {
       : undefined;
   }, [flags.metadata, linode, regionsData, selectedRegion]);
 
+  const linodeIsInEdgeRegion = getIsEdgeRegion(
+    regionsData ?? [],
+    linode?.region ?? ''
+  );
+
+  const edgeRegionWarning =
+    flags.gecko && linodeIsInEdgeRegion
+      ? 'Edge sites may only be migrated to other Edge sites.'
+      : undefined;
+
   if (!linode) {
     return null;
   }
@@ -224,6 +235,7 @@ export const MigrateLinode = React.memo((props: Props) => {
         notifications={notifications}
       /> */}
       <CautionNotice
+        edgeRegionWarning={edgeRegionWarning}
         hasConfirmed={hasConfirmed}
         linodeId={linodeId}
         metadataWarning={metadataMigrateWarning}

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -207,7 +207,7 @@ export const PlanSelection = (props: PlanSelectionProps) => {
             {type.vcpus}
           </TableCell>
           <TableCell center data-qa-storage noWrap>
-            {type.disk === 0 ? 'N/A' : convertMegabytesTo(type.disk, true)}
+            {convertMegabytesTo(type.disk, true)}
           </TableCell>
           {shouldShowTransfer && type.transfer ? (
             <TableCell center data-qa-transfer>

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -133,7 +133,7 @@ export const PlansPanel = (props: Props) => {
             />
             {showEdgePlanTable && (
               <Notice
-                text="Edge region pricing is temporarily $0 during the beta period, after which standard pricing will begin."
+                text="Edge region pricing is temporarily $0 during the beta period, after which billing will begin."
                 variant="warning"
               />
             )}

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -91,7 +91,6 @@ export const PlansPanel = (props: Props) => {
       delete plan.transfer;
       return {
         ...plan,
-        disk: 0,
         price: {
           hourly: 0,
           monthly: 0,


### PR DESCRIPTION
## Description 📝
Address feedback from the Gecko Beta Demo/Review meeting

## Changes  🔄
- Warning notice updates
  - Add period to end of sentences
  - Replace "standard pricing" warning text from the edge plan table to "billing"
  - Add warning text to the caution notice for edge migrations
- Storage table column should display as normal (should not be N/A) for edge plans
- Filter edge regions from Image Upload

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/115299789/82cd337f-7ab2-4786-aca6-f306e912fcee) | ![image](https://github.com/linode/manager/assets/115299789/2557692f-096c-451e-a8bb-ac4deb202a65) |
| ![image](https://github.com/linode/manager/assets/115299789/e01663de-1abd-4c3a-9419-3b9be6f1b25c) | ![image](https://github.com/linode/manager/assets/115299789/bf3451a9-a339-42c1-99d6-41178bb6fd04) |
| ![image](https://github.com/linode/manager/assets/115299789/4589729d-5c60-4710-b6ab-5d17ac698da9) | ![image](https://github.com/linode/manager/assets/115299789/78b4bc07-4758-4064-bf01-f5db6fafdff7) |

## How to test 🧪

### Prerequisites
- Ensure your account has the correct customer tag (reach out for more info)

### Verification steps
- Go to `/linodes/create` and select an Edge region
  - The edge plan table warning notice should say "billing" instead of "standard pricing"
  - The Storage column should display the storage amount instead of N/A
- On the Linode landings table, open the action menu for a Linode located in an edge region and click on "Migrate"
  - There should be a warning bullet about edge migrations in the Caution notice
- Go to `/images/create/upload` and open the region select dropdown
  - There should be no edge regions displayed

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support