### PR TITLE
test: Fix Firewall update test flake by using less specific selectors

### DIFF
--- a/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
@@ -218,10 +218,10 @@ describe('update firewall', () => {
       addFirewallRules(inboundRule, 'inbound');
 
       // Confirm that the inbound rules are listed on edit page with expected configuration
-      cy.get('[data-rbd-droppable-context-id="0"]')
+      cy.findByText(inboundRule.label!)
         .should('be.visible')
+        .closest('li')
         .within(() => {
-          cy.findByText(inboundRule.label!).should('be.visible');
           cy.findByText(inboundRule.protocol).should('be.visible');
           cy.findByText(inboundRule.ports!).should('be.visible');
           cy.findByText(getRuleActionLabel(inboundRule.action)).should(
@@ -233,10 +233,11 @@ describe('update firewall', () => {
       addFirewallRules(outboundRule, 'outbound');
 
       // Confirm that the outbound rules are listed on edit page with expected configuration
-      cy.get('[data-rbd-droppable-context-id="1"]')
+      cy.get('[data-rbd-droppable-context-id="1"]');
+      cy.findByText(outboundRule.label!)
         .should('be.visible')
+        .closest('li')
         .within(() => {
-          cy.findByText(outboundRule.label!).should('be.visible');
           cy.findByText(outboundRule.protocol).should('be.visible');
           cy.findByText(outboundRule.ports!).should('be.visible');
           cy.findByText(getRuleActionLabel(outboundRule.action)).should(


### PR DESCRIPTION
## Description 📝
Fixes an occasional test failure in `update-firewall.spec.ts` by using a less specific selector to find the inbound/outbound rules in the list.

## Changes  🔄
- Find inboud and outbound rules by looking for a `<li />` element

## How to test 🧪

```bash
yarn cy:run -s "cypress/e2e/core/firewalls/update-firewall.spec.ts"
```
(Repeat as needed to gain confidence that flake is resolved)

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
