### PR TITLE
chore: Update `axios` to resolve `follow-redirects` CVE-2024-28849 

### DIFF
--- a/packages/api-v4/.changeset/pr-10291-tech-stories-1710770920874.md
+++ b/packages/api-v4/.changeset/pr-10291-tech-stories-1710770920874.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Tech Stories
+---
+
+Update `axios` to resolve `follow-redirects` CVE-2024-28849 ([#10291](https://github.com/linode/manager/pull/10291))

--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -41,7 +41,7 @@
   "unpkg": "./lib/index.global.js",
   "dependencies": {
     "@linode/validation": "*",
-    "axios": "~1.6.5",
+    "axios": "~1.6.8",
     "ipaddr.js": "^2.0.0",
     "yup": "^0.32.9"
   },

--- a/packages/manager/.changeset/pr-10291-tech-stories-1710770854595.md
+++ b/packages/manager/.changeset/pr-10291-tech-stories-1710770854595.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Update `axios` to resolve `follow-redirects` CVE-2024-28849 ([#10291](https://github.com/linode/manager/pull/10291))

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -27,7 +27,7 @@
     "@tanstack/react-query": "4.36.1",
     "@tanstack/react-query-devtools": "4.36.1",
     "algoliasearch": "^4.14.3",
-    "axios": "~1.6.5",
+    "axios": "~1.6.8",
     "braintree-web": "^3.92.2",
     "chart.js": "~2.9.4",
     "copy-to-clipboard": "^3.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4969,12 +4969,12 @@ axios-mock-adapter@^1.22.0:
     fast-deep-equal "^3.1.3"
     is-buffer "^2.0.5"
 
-axios@~1.6.5:
-  version "1.6.7"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.7.tgz#7b48c2e27c96f9c68a2f8f31e2ab19f59b06b0a7"
-  integrity sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==
+axios@~1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.8.tgz#66d294951f5d988a00e87a0ffb955316a619ea66"
+  integrity sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==
   dependencies:
-    follow-redirects "^1.15.4"
+    follow-redirects "^1.15.6"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
@@ -7592,10 +7592,10 @@ flow-parser@0.*:
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.228.0.tgz#0b801507c8cf44257338596b49bd0904caea2026"
   integrity sha512-xPWkzCO07AnS8X+fQFpWm+tJ+C7aeaiVzJ+rSepbkCXUvUJ6l6squEl63axoMcixyH4wLjmypOzq/+zTD0O93w==
 
-follow-redirects@^1.15.4:
-  version "1.15.5"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
-  integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
+follow-redirects@^1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
 font-logos@^0.18.0:
   version "0.18.0"


### PR DESCRIPTION
## Description 📝

- Bumps our `axios` version so that `follow-redirects` gets bumped for CVE-2024-28849
- Resolves https://github.com/linode/manager/pull/10290

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-03-18 at 10 02 55 AM](https://github.com/linode/manager/assets/115251059/5f645d71-e5a9-4b89-8867-5504f2dfbe48) | ![Screenshot 2024-03-18 at 10 01 55 AM](https://github.com/linode/manager/assets/115251059/fa1abfaa-4762-457c-b57c-1476eef04729) |


## How to test 🧪

- Checkout this PR
- Run `yarn` for good measure (installs dependencies)
- Run `yarn why follow-redirects` and verify we are on `follow-redirects` >= 1.15.6

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support