### PR TITLE
refactor: [M3-7433] - Query Key Factory for Images

### DIFF
--- a/packages/manager/src/components/Uploaders/ImageUploader/ImageUploader.tsx
+++ b/packages/manager/src/components/Uploaders/ImageUploader/ImageUploader.tsx
@@ -26,7 +26,7 @@ import {
 import { uploadImageFile } from 'src/features/Images/requests';
 import { Dispatch } from 'src/hooks/types';
 import { useCurrentToken } from 'src/hooks/useAuthentication';
-import { queryKey, useUploadImageQuery } from 'src/queries/images';
+import { imageQueries, useUploadImageMutation } from 'src/queries/images';
 import { redirectToLogin } from 'src/session';
 import { setPendingUpload } from 'src/store/pendingUpload';
 import { sendImageUploadEvent } from 'src/utilities/analytics';
@@ -86,7 +86,7 @@ export const ImageUploader = React.memo((props: ImageUploaderProps) => {
   const { enqueueSnackbar } = useSnackbar();
   const [uploadToURL, setUploadToURL] = React.useState<string>('');
   const queryClient = useQueryClient();
-  const { mutateAsync: uploadImage } = useUploadImageQuery({
+  const { mutateAsync: uploadImage } = useUploadImageMutation({
     cloud_init: isCloudInit ? isCloudInit : undefined,
     description: description ? description : undefined,
     label,
@@ -234,7 +234,8 @@ export const ImageUploader = React.memo((props: ImageUploaderProps) => {
             redirectToLogin('/images');
           }, 3000);
         } else {
-          queryClient.invalidateQueries([`${queryKey}-list`]);
+          queryClient.invalidateQueries(imageQueries.paginated._def);
+          queryClient.invalidateQueries(imageQueries.all._def);
           history.push('/images');
         }
       };

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -1,12 +1,12 @@
 import { Event, Image, ImageStatus } from '@linode/api-v4';
 import { APIError } from '@linode/api-v4/lib/types';
 import { Theme } from '@mui/material/styles';
-import { makeStyles } from 'tss-react/mui';
+import { useQueryClient } from '@tanstack/react-query';
 import produce from 'immer';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
-import { useQueryClient } from '@tanstack/react-query';
 import { useHistory } from 'react-router-dom';
+import { makeStyles } from 'tss-react/mui';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { CircleProgress } from 'src/components/CircleProgress';
@@ -29,17 +29,16 @@ import { Typography } from 'src/components/Typography';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
 import { listToItemsByID } from 'src/queries/base';
-import { useEventsInfiniteQuery } from 'src/queries/events/events';
-import {
-  queryKey,
-  removeImageFromCache,
-  useDeleteImageMutation,
-  useImagesQuery,
-} from 'src/queries/images';
 import {
   isEventImageUpload,
   isEventInProgressDiskImagize,
 } from 'src/queries/events/event.helpers';
+import { useEventsInfiniteQuery } from 'src/queries/events/events';
+import {
+  imageQueries,
+  useDeleteImageMutation,
+  useImagesQuery,
+} from 'src/queries/images';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
 import ImageRow, { ImageWithEvent } from './ImageRow';
@@ -105,12 +104,8 @@ export const ImagesLanding: React.FC<CombinedProps> = () => {
 
   const queryClient = useQueryClient();
 
-  // Pagination, order, and query hooks for manual/custom images
-  const paginationForManualImages = usePagination(
-    1,
-    `${queryKey}-manual`,
-    'manual'
-  );
+  const paginationForManualImages = usePagination(1, 'images-manual', 'manual');
+
   const {
     handleOrderChange: handleManualImagesOrderChange,
     order: manualImagesOrder,
@@ -120,7 +115,7 @@ export const ImagesLanding: React.FC<CombinedProps> = () => {
       order: 'asc',
       orderBy: 'label',
     },
-    `${queryKey}-manual-order`,
+    'images-manual-order',
     'manual'
   );
 
@@ -148,7 +143,7 @@ export const ImagesLanding: React.FC<CombinedProps> = () => {
   // Pagination, order, and query hooks for automatic/recovery images
   const paginationForAutomaticImages = usePagination(
     1,
-    `${queryKey}-automatic`,
+    'images-automatic',
     'automatic'
   );
   const {
@@ -160,7 +155,7 @@ export const ImagesLanding: React.FC<CombinedProps> = () => {
       order: 'asc',
       orderBy: 'label',
     },
-    `${queryKey}-automatic-order`,
+    'images-automatic-order',
     'automatic'
   );
 
@@ -284,7 +279,7 @@ export const ImagesLanding: React.FC<CombinedProps> = () => {
     imageLabel: string,
     imageDescription: string
   ) => {
-    removeImageFromCache(queryClient);
+    queryClient.invalidateQueries(imageQueries.paginated._def);
     history.push('/images/create/upload', {
       imageDescription,
       imageLabel,
@@ -292,7 +287,7 @@ export const ImagesLanding: React.FC<CombinedProps> = () => {
   };
 
   const onCancelFailedClick = () => {
-    removeImageFromCache(queryClient);
+    queryClient.invalidateQueries(imageQueries.paginated._def);
   };
 
   const openForEdit = (label: string, description: string, imageID: string) => {


### PR DESCRIPTION
## Description 📝

- Updates Image related queries to use the new _query key factory_ pattern 🏭 
- Updates images queries and mutations to use latest patterns 🎉 
- Improves images event handler (this should fix rate limiting issues I observed months ago in the e2e tests @jdamore-linode)

## How to test 🧪

- Test all image related features of Cloud Manager
  - Image Selection on Linode Create Flows
  - Images Landing
  - Image Upload
  - Image Creation 
- Verify the images landing page works as expected

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support