### PR TITLE
fix: [M3-7881] - Restore loading state to Users & Grants table

### DIFF
--- a/packages/manager/.changeset/pr-10303-fixed-1710976860713.md
+++ b/packages/manager/.changeset/pr-10303-fixed-1710976860713.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Loading state missing from Users & Grants table ([#10303](https://github.com/linode/manager/pull/10303))

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -49,6 +49,7 @@ export const UsersLanding = () => {
     ['user_type']: showProxyUserTable ? 'child' : undefined,
   };
 
+  // Since this query is disabled for restricted users, use isInitialLoading.
   const { data: users, error, isInitialLoading, refetch } = useAccountUsers({
     filters: usersFilter,
     params: {
@@ -59,10 +60,11 @@ export const UsersLanding = () => {
 
   const isRestrictedUser = profile?.restricted;
 
+  // Since this query is disabled for restricted users, use isInitialLoading.
   const {
     data: proxyUser,
     error: proxyUserError,
-    isLoading: isLoadingProxyUser,
+    isInitialLoading: isLoadingProxyUser,
   } = useAccountUsers({
     enabled:
       flags.parentChildAccountAccess && showProxyUserTable && !isRestrictedUser,

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -49,7 +49,7 @@ export const UsersLanding = () => {
     ['user_type']: showProxyUserTable ? 'child' : undefined,
   };
 
-  const { data: users, error, isLoading, refetch } = useAccountUsers({
+  const { data: users, error, isInitialLoading, refetch } = useAccountUsers({
     filters: usersFilter,
     params: {
       page: pagination.page,
@@ -162,7 +162,7 @@ export const UsersLanding = () => {
         <TableBody>
           <UsersLandingTableBody
             error={error}
-            isLoading={isLoading}
+            isLoading={isInitialLoading}
             numCols={numCols}
             onDelete={handleDelete}
             users={users?.data}

--- a/packages/manager/src/features/Users/UsersLandingTableBody.tsx
+++ b/packages/manager/src/features/Users/UsersLandingTableBody.tsx
@@ -18,10 +18,6 @@ interface Props {
 export const UsersLandingTableBody = (props: Props) => {
   const { error, isLoading, numCols, onDelete, users } = props;
 
-  if ((isLoading && !users) || (isLoading && users?.length === 0)) {
-    return <TableRowEmpty colSpan={numCols} />;
-  }
-
   if (isLoading) {
     return <TableRowLoading columns={numCols} rows={1} />;
   }
@@ -30,10 +26,13 @@ export const UsersLandingTableBody = (props: Props) => {
     return <TableRowError colSpan={numCols} message={error[0].reason} />;
   }
 
+  if (!users || users.length === 0) {
+    return <TableRowEmpty colSpan={numCols} />;
+  }
+
   return (
-    // eslint-disable-next-line react/jsx-no-useless-fragment
     <>
-      {users?.map((user) => (
+      {users.map((user) => (
         <UserRow key={user.username} onDelete={onDelete} user={user} />
       ))}
     </>


### PR DESCRIPTION
## Description 📝
Recently, we lost loading state on the Users table on the Users & Grants page. In the UI, this means we'd go directly from the empty state table ("No items to display.") to the full list of users, once the request returned the data. 

We attempted to throw in a bug fix for perpetually loading table state for a restricted user in #10233, and inadvertently broke the loading state for other users. This PR has the real fix for the original issue we were seeing, which stems from a [breaking change in TanStack Query v4](https://github.com/TanStack/query/issues/3584). TLDR: when a query is disabled, `isLoading` will perpetually return `true`. Since we disable the useAccountUsers query for a restricted user, that would be the case here (and therefore we got stuck in loading table state.)

## Changes  🔄
- Replace `isLoading` with `isInitialLoading` in the query to fetch users as per documentation [[1](https://tanstack.com/query/v4/docs/framework/react/guides/disabling-queries#isinitialloading), [2](https://github.com/TanStack/query/issues/3584#issuecomment-1782331608)]

## Target release date 🗓️
4/1/24

## Preview 📷

| Before - Initial Issue  | Before - Attempted Fix (Current Issue) | After - Unrestricted Users   | After - Restricted Users |
| ------- | ------- | ------- | ------ |
| <video src="https://github.com/linode/manager/assets/114685994/4f0a8ea3-2300-4e36-9a27-9b3cac470a02" /> | <video src="https://github.com/linode/manager/assets/114685994/873d0589-2454-4dde-ad41-b7352495be9b" /> | <video src="https://github.com/linode/manager/assets/114685994/0996cf7e-7b16-49cd-8a76-29b495f890b6" /> | <video src="https://github.com/linode/manager/assets/114685994/644a85ad-3c36-4db4-a3fe-7c498787bd50" />|

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Know where the team Parent/Child account login credentials are.

### Reproduction steps
(How to reproduce the issue, if applicable)
- In production, log in as an unrestricted user and go to https://cloud.linode.com/account/users.
- Observe that there is no loading state for the table.

### Verification steps
- On this branch, log in as unrestricted user and go to http://localhost:3000/account/users.
- Confirm that there is loading state for the table.
- Log into a parent account and switch to a proxy account. (Confirm that it is a *restricted* proxy account (you can check the proxy's `/profile` network request for this or log into the child account and confirm).)
- Since a restricted user does not have access to the `/account/users` endpoint, go to http://localhost:3000/account/users and confirm that empty state tables are displayed. Tables should not get stuck in loading state. 

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
