### PR TITLE
upcoming: [M3-7431] - Add placement group to checkout summary

### DIFF
--- a/packages/manager/.changeset/pr-10304-upcoming-features-1711050408019.md
+++ b/packages/manager/.changeset/pr-10304-upcoming-features-1711050408019.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add placement group item to checkout summary ([#10304](https://github.com/linode/manager/pull/10304))

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
@@ -421,6 +421,12 @@ export class LinodeCreate extends React.PureComponent<
       });
     }
 
+    if (this.props.placementGroupSelection) {
+      displaySections.push({
+        title: 'Assigned to Placement Group',
+      });
+    }
+
     if (
       this.props.selectedVPCId !== undefined &&
       this.props.selectedVPCId !== -1


### PR DESCRIPTION
## Description 📝
Very simple PR to add a placement group display section to the checkout summary: "Assigned to Placement Group"

## Changes  🔄
- Add placement group display section to the checkout summary

## Preview 📷
![Screenshot 2024-03-21 at 15 38 07](https://github.com/linode/manager/assets/130582365/65367639-e956-4050-a0ed-f09ee07dabd3)

## How to test 🧪

### Prerequisites
- Have both the "Placement Group" feature flag and MSW enabled

### Verification steps
- Go to http://localhost:3000/linodes/create
- Select the "Newark, NJ" region
- Scroll to the Details panel
- Select a placement group in the drop down
- Confirm the "Assigned to Placement Group" item in the checkout summary at the bottom of the page

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
