### PR TITLE
fix: [M3-7909] - Hide the Child Account Access table header for parent users without `child_account_access` grant

### DIFF
--- a/packages/manager/.changeset/pr-10305-upcoming-features-1711059101461.md
+++ b/packages/manager/.changeset/pr-10305-upcoming-features-1711059101461.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Hide the Child Account Access table header for parent users without the enabled grant ([#10305](https://github.com/linode/manager/pull/10305))

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -23,6 +23,7 @@ import { UsersLandingTableBody } from './UsersLandingTableBody';
 import { UsersLandingTableHead } from './UsersLandingTableHead';
 
 import type { Filter } from '@linode/api-v4';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 
 export const UsersLanding = () => {
   const theme = useTheme();
@@ -69,8 +70,14 @@ export const UsersLanding = () => {
     filters: { user_type: 'proxy' },
   });
 
+  const isChildAccountAccessRestricted = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'child_account_access',
+  });
+
   const showChildAccountAccessCol = Boolean(
-    flags.parentChildAccountAccess && profile?.user_type === 'parent'
+    flags.parentChildAccountAccess &&
+      profile?.user_type === 'parent' &&
+      !isChildAccountAccessRestricted
   );
 
   // Parent/Child accounts include additional "child account access" column.


### PR DESCRIPTION
## Description 📝
We should make a UI change to only display the Child Account Access column for users with the `child_account_access` grant enabled.

This is a place where we missed the grant check for a restricted parent. Since this is a restricted user they won’t ever see anything more than that column header without Full Account Access, so this is minor. But, to maintain consistency, a restricted parent user without the child account access grant should not see any UI features related to Parent/Child. 

## Changes  🔄
- Adds a grant check for `child_account_access` to determine whether to display the Child Account Access column header

## Target release date 🗓️
4/1/24

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Current](https://github.com/linode/manager/assets/114685994/d0849d71-55c2-4ae4-9e1b-b4d1071ff35e) | ![NoGrant](https://github.com/linode/manager/assets/114685994/cc8314d5-d3a0-4251-a161-fbd373fbdbeb) ![WithGrant](https://github.com/linode/manager/assets/114685994/b85f3dba-bcb5-425f-a5bd-d20fdbc502d4) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Use the shared Cloud Manager parent and restricted parent test accounts. 
- The `restricted-parent-cloud-manager` should have `child_account_access` disabled initially.

### Reproduction steps
(How to reproduce the issue, if applicable)
- Log into dev with the restricted parent account credentials. 
- Go to https://cloud.dev.linode.com/account/users.
- Observe that although the table displays no data for a restricted user, you can still see the "Child Account Access" column in the table header.

### Verification steps
(How to verify changes)
- Check out this PR, `yarn dev`, and switch to the *dev* environment. 
- Ensure Parent/Child feature flag is on and mocks are off.
By logging into the various user accounts, confirm:
- The Child Account Access column is NOT visible in the Users table for restricted parent users with the global child_account_access set to false.
- The Child Account Access column is visible in the Users table for restricted parent users with the global child_account_access set to true. (To change this, log into the unrestricted parent account, go to http://localhost:3000/account/users/restricted-parent-cloud-manager/permissions, and toggle `Enable child account access`.)
- We will update test coverage in #10240 to test this case.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

