### PR TITLE
refactor: [M3-7895] – Remove VPC feature flag

### DIFF
--- a/packages/manager/.changeset/pr-10306-tech-stories-1711123927073.md
+++ b/packages/manager/.changeset/pr-10306-tech-stories-1711123927073.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Removed VPC feature flag ([#10306](https://github.com/linode/manager/pull/10306))

--- a/packages/manager/.changeset/pr-10306-tech-stories-1711123927073.md
+++ b/packages/manager/.changeset/pr-10306-tech-stories-1711123927073.md
@@ -2,4 +2,4 @@
 "@linode/manager": Tech Stories
 ---
 
-Removed VPC feature flag ([#10306](https://github.com/linode/manager/pull/10306))
+Remove VPC feature flag ([#10306](https://github.com/linode/manager/pull/10306))

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -25,7 +25,6 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'gecko', label: 'Gecko' },
   { flag: 'parentChildAccountAccess', label: 'Parent/Child Account' },
   { flag: 'selfServeBetas', label: 'Self Serve Betas' },
-  { flag: 'vpc', label: 'VPC' },
   { flag: 'firewallNodebalancer', label: 'Firewall NodeBalancer' },
   { flag: 'recharts', label: 'Recharts' },
   { flag: 'objMultiCluster', label: 'OBJ Multi-Cluster' },

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -76,7 +76,6 @@ export interface Flags {
   taxCollectionBanner: TaxCollectionBanner;
   taxes: Taxes;
   tpaProviders: Provider[];
-  vpc: boolean;
 }
 
 type PromotionalOfferFeature =

--- a/packages/manager/src/features/Linodes/LinodeEntityDetail.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetail.test.tsx
@@ -10,7 +10,7 @@ import {
   vpcFactory,
 } from 'src/factories';
 import { makeResourcePage } from 'src/mocks/serverHandlers';
-import { http, HttpResponse, server } from 'src/mocks/testServer';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
 import { queryClientFactory } from 'src/queries/base';
 import { mockMatchMedia, renderWithTheme } from 'src/utilities/testHelpers';
 
@@ -34,47 +34,6 @@ describe('Linode Entity Detail', () => {
 
   const vpcSectionTestId = 'vpc-section-title';
   const assignedVPCLabelTestId = 'assigned-vpc-label';
-
-  it('should not display a VPC section if the feature flag is off and the account capabilities do not include VPC', async () => {
-    const account = accountFactory.build({
-      capabilities: accountCapabilitiesWithoutVPC,
-    });
-
-    const subnet = subnetFactory.build({
-      id: 2,
-      linodes: [subnetAssignedLinodeDataFactory.build({ id: 5 })],
-    });
-
-    const vpc = vpcFactory.build({
-      subnets: [subnet],
-    });
-
-    server.use(
-      http.get('*/account', () => {
-        return HttpResponse.json(account);
-      }),
-
-      http.get('*/vpcs', () => {
-        return HttpResponse.json(makeResourcePage([vpc]));
-      })
-    );
-
-    const { queryByTestId } = renderWithTheme(
-      <LinodeEntityDetail
-        handlers={handlers}
-        id={5}
-        linode={linode}
-        openTagDrawer={vi.fn()}
-      />,
-      {
-        flags: { vpc: false },
-      }
-    );
-
-    await waitFor(() => {
-      expect(queryByTestId(vpcSectionTestId)).not.toBeInTheDocument();
-    });
-  });
 
   it('should not display the VPC section if the linode is not assigned to a VPC', async () => {
     const account = accountFactory.build({
@@ -141,7 +100,6 @@ describe('Linode Entity Detail', () => {
         openTagDrawer={vi.fn()}
       />,
       {
-        flags: { vpc: true },
         queryClient,
       }
     );

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.test.tsx
@@ -1,21 +1,13 @@
-import { waitFor } from '@testing-library/react';
-import * as React from 'react';
-
-import { LinodeConfigInterfaceFactory, configFactory } from 'src/factories';
-import { accountFactory } from 'src/factories/account';
+import { LinodeConfigInterfaceFactory } from 'src/factories';
 import {
   LINODE_UNREACHABLE_HELPER_TEXT,
   NATTED_PUBLIC_IP_HELPER_TEXT,
   NOT_NATTED_HELPER_TEXT,
 } from 'src/features/VPCs/constants';
-import { http, HttpResponse, server } from 'src/mocks/testServer';
 import { queryClientFactory } from 'src/queries/base';
-import { mockMatchMedia, renderWithTheme } from 'src/utilities/testHelpers';
+import { mockMatchMedia } from 'src/utilities/testHelpers';
 
-import {
-  LinodeConfigDialog,
-  unrecommendedConfigNoticeSelector,
-} from './LinodeConfigDialog';
+import { unrecommendedConfigNoticeSelector } from './LinodeConfigDialog';
 import { MemoryLimit, padList } from './LinodeConfigDialog';
 
 const queryClient = queryClientFactory();
@@ -24,8 +16,6 @@ beforeAll(() => mockMatchMedia());
 afterEach(() => {
   queryClient.clear();
 });
-
-const primaryInterfaceDropdownTestId = 'primary-interface-dropdown';
 
 describe('LinodeConfigDialog', () => {
   describe('padInterface helper method', () => {
@@ -39,41 +29,6 @@ describe('LinodeConfigDialog', () => {
 
     it('should return a list longer than the limit unchanged', () => {
       expect(padList([1, 2, 3, 4, 5], 0, 2)).toEqual([1, 2, 3, 4, 5]);
-    });
-  });
-
-  describe('Primary Interface (Default Route) dropdown', () => {
-    it('should not display if the VPC feature flag is off and the account capabilities do not include VPC', async () => {
-      const account = accountFactory.build({
-        capabilities: [],
-      });
-
-      const config = configFactory.build();
-
-      server.use(
-        http.get('*/account', () => {
-          return HttpResponse.json(account);
-        })
-      );
-
-      const { queryByTestId } = renderWithTheme(
-        <LinodeConfigDialog
-          config={config}
-          isReadOnly={false}
-          linodeId={1}
-          onClose={vi.fn()}
-          open={true}
-        />,
-        {
-          flags: { vpc: false },
-        }
-      );
-
-      await waitFor(() => {
-        expect(
-          queryByTestId(primaryInterfaceDropdownTestId)
-        ).not.toBeInTheDocument();
-      });
     });
   });
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/InterfaceSelect.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/InterfaceSelect.test.tsx
@@ -1,11 +1,11 @@
+import { InterfacePurpose } from '@linode/api-v4';
 import { waitFor } from '@testing-library/react';
 import * as React from 'react';
 
-import { InterfacePurpose } from '@linode/api-v4';
-import { InterfaceSelect } from './InterfaceSelect';
-
 import { queryClientFactory } from 'src/queries/base';
 import { mockMatchMedia, renderWithTheme } from 'src/utilities/testHelpers';
+
+import { InterfaceSelect } from './InterfaceSelect';
 
 const queryClient = queryClientFactory();
 
@@ -18,15 +18,15 @@ const unavailableInRegionTextTestId = 'unavailable-in-region-text';
 
 describe('InterfaceSelect', () => {
   const props = {
+    errors: {},
     fromAddonsPanel: false,
     handleChange: vi.fn(),
     ipamAddress: null,
     label: null,
     readOnly: false,
     region: 'us-east',
-    slotNumber: 0,
     regionHasVLANs: true,
-    errors: {},
+    slotNumber: 0,
   };
 
   it('should display helper text regarding VPCs not being available in the region in the Linode Add/Edit Config dialog if applicable', async () => {
@@ -36,9 +36,7 @@ describe('InterfaceSelect', () => {
       regionHasVPCs: false,
     };
 
-    const { queryByTestId } = renderWithTheme(<InterfaceSelect {..._props} />, {
-      flags: { vpc: true },
-    });
+    const { queryByTestId } = renderWithTheme(<InterfaceSelect {..._props} />);
 
     await waitFor(() => {
       expect(queryByTestId(unavailableInRegionTextTestId)).toBeInTheDocument();
@@ -52,9 +50,7 @@ describe('InterfaceSelect', () => {
       regionHasVLANs: false,
     };
 
-    const { queryByTestId } = renderWithTheme(<InterfaceSelect {..._props} />, {
-      flags: { vpc: false },
-    });
+    const { queryByTestId } = renderWithTheme(<InterfaceSelect {..._props} />);
 
     await waitFor(() => {
       expect(queryByTestId(unavailableInRegionTextTestId)).toBeInTheDocument();


### PR DESCRIPTION
## Description 📝
Following up on #10299, this PR removes the VPC feature flag from `featureFlags.ts`, removes it from our feature flag DevTool, and cleans up a few unit tests accordingly.

After the next release, the LD flag will be archived.

## Target release date 🗓️
04/01/2024

## How to test 🧪
### Verification steps
- `InterfaceSelect.test.tsx`, `LinodeConfigDialog.test.tsx`, `LinodeEntityDetail.test.tsx` should pass
- VPC should no longer be an option in our feature flag DevTool

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support