### PR TITLE
change: [M3-7922] - Clear ACLB configuration certificates if `http` or `tcp` protocol is selected

### DIFF
--- a/packages/manager/.changeset/pr-10311-changed-1711378782884.md
+++ b/packages/manager/.changeset/pr-10311-changed-1711378782884.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Clear ACLB configuration certificates if `http` or `tcp` protocol is selected ([#10311](https://github.com/linode/manager/pull/10311))

--- a/packages/manager/cypress/e2e/core/loadBalancers/load-balancer-configurations.spec.ts
+++ b/packages/manager/cypress/e2e/core/loadBalancers/load-balancer-configurations.spec.ts
@@ -456,6 +456,7 @@ describe('Akamai Cloud Load Balancer configurations page', () => {
       const routes = routeFactory.buildList(3);
       const configuration = configurationFactory.build({
         protocol: 'http',
+        certificates: [],
         routes: routes.map((route) => ({ id: route.id, label: route.label })),
       });
       const loadbalancer = loadbalancerFactory.build({

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ConfigurationForm.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ConfigurationForm.tsx
@@ -157,22 +157,28 @@ export const ConfigurationForm = (props: CreateProps | EditProps) => {
 
   const handleProtocolChange = (protocol: Protocol) => {
     let certificates = [...formik.values.certificates];
+    let port = formik.values.port;
 
     if (protocol !== 'https') {
+      // Clear the certificates array if the selected protocol is not HTTPS.
+      // The API will error if you try to pass certificates for HTTP or TCP.
       certificates = [];
     }
 
-    let port = formik.values.port;
+    if (!hasChangedPort) {
+      // If the user has not manually changed the port, and they select HTTP,
+      // set the port to 80 for them.
+      if (protocol === 'http') {
+        port = 80;
+      }
 
-    if (!hasChangedPort && protocol === 'http') {
-      port = 80;
+      // If the user has not manually changed the port, and they select HTTPS,
+      // set the port to 443 for them.
+      if (protocol === 'https') {
+        port = 443;
+      }
     }
 
-    if (!hasChangedPort && protocol === 'https') {
-      port = 443;
-    }
-
-    // Update the protocol and port at the same time if the port is unchanged.
     formik.setFormikState((prev) => ({
       ...prev,
       values: {

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ConfigurationForm.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/Configurations/ConfigurationForm.tsx
@@ -156,19 +156,20 @@ export const ConfigurationForm = (props: CreateProps | EditProps) => {
   };
 
   const handleProtocolChange = (protocol: Protocol) => {
-    // If the user has changed the port manually, just update the protocol and NOT the port.
-    if (hasChangedPort) {
-      return formik.setFieldValue('protocol', protocol);
+    let certificates = [...formik.values.certificates];
+
+    if (protocol !== 'https') {
+      certificates = [];
     }
 
-    let newPort = formik.values.port;
+    let port = formik.values.port;
 
-    if (protocol === 'http') {
-      newPort = 80;
+    if (!hasChangedPort && protocol === 'http') {
+      port = 80;
     }
 
-    if (protocol === 'https') {
-      newPort = 443;
+    if (!hasChangedPort && protocol === 'https') {
+      port = 443;
     }
 
     // Update the protocol and port at the same time if the port is unchanged.
@@ -176,7 +177,8 @@ export const ConfigurationForm = (props: CreateProps | EditProps) => {
       ...prev,
       values: {
         ...prev.values,
-        port: newPort,
+        certificates,
+        port,
         protocol,
       },
     }));

--- a/packages/validation/.changeset/pr-10311-changed-1711379618292.md
+++ b/packages/validation/.changeset/pr-10311-changed-1711379618292.md
@@ -2,4 +2,4 @@
 "@linode/validation": Changed
 ---
 
-Enforce that the `certificates` array is empty for `http` and `tcp` configutions ([#10311](https://github.com/linode/manager/pull/10311))
+Enforce that the `certificates` array is empty for `http` and `tcp` configurations ([#10311](https://github.com/linode/manager/pull/10311))

--- a/packages/validation/.changeset/pr-10311-changed-1711379618292.md
+++ b/packages/validation/.changeset/pr-10311-changed-1711379618292.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Changed
+---
+
+Enforce that the `certificates` array is empty for `http` and `tcp` configutions ([#10311](https://github.com/linode/manager/pull/10311))

--- a/packages/validation/src/loadbalancers.schema.ts
+++ b/packages/validation/src/loadbalancers.schema.ts
@@ -180,7 +180,7 @@ export const UpdateConfigurationSchema = object({
         .of(CertificateEntrySchema)
         .min(1, 'Certificates must not be empty for HTTPS configurations.')
         .required(),
-    otherwise: (o) => o.notRequired(),
+    otherwise: (o) => o.max(0).notRequired(),
   }),
   route_ids: array().of(number()),
 });
@@ -202,7 +202,7 @@ export const CreateConfigurationSchema = object({
         .of(CertificateEntrySchema)
         .min(1, 'Certificates must not be empty for HTTPS configurations.')
         .required(),
-    otherwise: (o) => o.notRequired(),
+    otherwise: (o) => o.max(0).notRequired(),
   }),
   route_ids: array().of(number()),
 });


### PR DESCRIPTION
## Description 📝

Updates the ACLB configuration to prevent users from running into an API error.

New API validation was added that will throw if you try to send `certificates` with a `http` or `tcp` configuration. We now need to make sure we don't send certificates if the user selects `http` or `tcp` for their configuration

## How to test 🧪

### Prerequisites
- Login to `dev-test-aglb`
- Go to http://localhost:3000/loadbalancers/38/configurations/17


### Reproduction steps
- Without this PR checked out, you will observe that you can't change an HTTPS configuration to a HTTP or TCP. You would get an error saying `Certificate table must be empty with configuration protocol "http"`

![Screenshot 2024-03-25 at 10 55 44 AM](https://github.com/linode/manager/assets/115251059/c0361adc-9c81-4ad9-be34-33863aac104c)

### Verification steps
- Test creating/updating a configuration
  - Test with various different **certificate** / **protocol** combinations
  - Ensure the form works as expected

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support