### PR TITLE
upcoming: [M3-7903] - Placement Groups: Edit Drawer & Delete Modal UI Updates

### DIFF
--- a/packages/manager/.changeset/pr-10312-upcoming-features-1711384895230.md
+++ b/packages/manager/.changeset/pr-10312-upcoming-features-1711384895230.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Placement Groups: Edit Drawer & Delete Modal UI Updates ([#10312](https://github.com/linode/manager/pull/10312))

--- a/packages/manager/.changeset/pr-10312-upcoming-features-1711384895230.md
+++ b/packages/manager/.changeset/pr-10312-upcoming-features-1711384895230.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-Placement Groups: Edit Drawer & Delete Modal UI Updates ([#10312](https://github.com/linode/manager/pull/10312))
+Update Placement Groups UI for Edit Drawer & Delete Modal ([#10312](https://github.com/linode/manager/pull/10312))

--- a/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -34,6 +34,7 @@ export interface ConfirmationDialogProps extends DialogProps {
   actions?: ((props: any) => JSX.Element) | JSX.Element;
   error?: JSX.Element | string;
   onClose: () => void;
+  onExited?: () => void;
   title: string;
 }
 
@@ -49,11 +50,23 @@ export interface ConfirmationDialogProps extends DialogProps {
 export const ConfirmationDialog = (props: ConfirmationDialogProps) => {
   const { classes } = useStyles();
 
-  const { actions, children, error, onClose, title, ...dialogProps } = props;
+  const {
+    actions,
+    children,
+    error,
+    onClose,
+    onExited,
+    title,
+    ...dialogProps
+  } = props;
 
   return (
     <Dialog
       {...dialogProps}
+      TransitionProps={{
+        ...dialogProps.TransitionProps,
+        onExited,
+      }}
       onClose={(_, reason) => {
         if (reason !== 'backdropClick') {
           onClose();

--- a/packages/manager/src/components/Drawer.tsx
+++ b/packages/manager/src/components/Drawer.tsx
@@ -111,7 +111,6 @@ export const Drawer = (props: Props) => {
       aria-labelledby={titleID}
       data-qa-drawer
       data-testid="drawer"
-      // onTransitionEnd={onExited}
       onTransitionExited={onExited}
       role="dialog"
     >

--- a/packages/manager/src/components/Drawer.tsx
+++ b/packages/manager/src/components/Drawer.tsx
@@ -11,6 +11,10 @@ import { convertForAria } from 'src/utilities/stringUtils';
 
 interface Props extends DrawerProps {
   /**
+   * Callback fired when the drawer closing animation has completed.
+   */
+  onExited?: () => void;
+  /**
    * Title that appears at the top of the drawer
    */
   title: string;
@@ -85,7 +89,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
 export const Drawer = (props: Props) => {
   const { classes, cx } = useStyles();
 
-  const { children, onClose, title, wide, ...rest } = props;
+  const { children, onClose, onExited, title, wide, ...rest } = props;
 
   const titleID = convertForAria(title);
 
@@ -107,6 +111,8 @@ export const Drawer = (props: Props) => {
       aria-labelledby={titleID}
       data-qa-drawer
       data-testid="drawer"
+      // onTransitionEnd={onExited}
+      onTransitionExited={onExited}
       role="dialog"
     >
       <Grid

--- a/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
+++ b/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
@@ -17,8 +17,8 @@ interface EntityInfo {
     | 'cancellation'
     | 'deletion'
     | 'detachment'
-    | 'restoration'
-    | 'resizing';
+    | 'resizing'
+    | 'restoration';
   name?: string | undefined;
   primaryBtnText: string;
   subType?: 'CloseAccount' | 'Cluster' | 'ObjectStorage';
@@ -70,6 +70,10 @@ interface TypeToConfirmDialogProps {
    */
   onClick: () => void;
   /**
+   * Optional callback to be executed when the closing animation has completed
+   */
+  onExited?: (() => void) & (() => void);
+  /**
    * The open/closed state of the dialog
    */
   open: boolean;
@@ -91,6 +95,7 @@ export const TypeToConfirmDialog = (props: CombinedProps) => {
     loading,
     onClick,
     onClose,
+    onExited,
     open,
     textFieldStyle,
     title,
@@ -139,6 +144,7 @@ export const TypeToConfirmDialog = (props: CombinedProps) => {
       actions={actions}
       error={errors ? errors[0].reason : undefined}
       onClose={onClose}
+      onExited={onExited}
       open={open}
       title={title}
     >

--- a/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
+++ b/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
@@ -72,7 +72,7 @@ interface TypeToConfirmDialogProps {
   /**
    * Optional callback to be executed when the closing animation has completed
    */
-  onExited?: (() => void) & (() => void);
+  onExited?: () => void;
   /**
    * The open/closed state of the dialog
    */

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.test.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.test.tsx
@@ -143,9 +143,7 @@ describe('PlacementGroupsDeleteModal', () => {
       );
     });
 
-    const { getByRole, getByTestId, getByText } = renderResult!;
-
-    expect(getByText('No Linodes assigned to this Placement Group.'));
+    const { getByRole, getByTestId } = renderResult!;
 
     const textField = getByTestId('textfield-input');
     const deleteButton = getByRole('button', { name: 'Delete' });

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.test.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.test.tsx
@@ -19,7 +19,6 @@ const queryMocks = vi.hoisted(() => ({
     reset: vi.fn(),
   }),
   useParams: vi.fn().mockReturnValue({}),
-  usePlacementGroupQuery: vi.fn().mockReturnValue({}),
   useRegionsQuery: vi.fn().mockReturnValue({}),
 }));
 
@@ -44,7 +43,6 @@ vi.mock('src/queries/placementGroups', async () => {
   return {
     ...actual,
     useDeletePlacementGroup: queryMocks.useDeletePlacementGroup,
-    usePlacementGroupQuery: queryMocks.usePlacementGroupQuery,
   };
 });
 
@@ -85,25 +83,25 @@ describe('PlacementGroupsDeleteModal', () => {
   });
 
   it('should render the right form elements', async () => {
-    queryMocks.usePlacementGroupQuery.mockReturnValue({
-      data: placementGroupFactory.build({
-        affinity_type: 'anti_affinity:local',
-        id: 1,
-        label: 'PG-to-delete',
-        members: [
-          {
-            is_compliant: true,
-            linode_id: 1,
-          },
-        ],
-        region: 'us-east',
-      }),
-    });
-
     let renderResult: RenderResult;
     await act(async () => {
       renderResult = renderWithTheme(
-        <PlacementGroupsDeleteModal disableUnassignButton={false} {...props} />
+        <PlacementGroupsDeleteModal
+          {...props}
+          selectedPlacementGroup={placementGroupFactory.build({
+            affinity_type: 'anti_affinity:local',
+            id: 1,
+            label: 'PG-to-delete',
+            members: [
+              {
+                is_compliant: true,
+                linode_id: 1,
+              },
+            ],
+            region: 'us-east',
+          })}
+          disableUnassignButton={false}
+        />
       );
     });
 
@@ -129,19 +127,19 @@ describe('PlacementGroupsDeleteModal', () => {
   });
 
   it("should be enabled when there's no assigned linodes", async () => {
-    queryMocks.usePlacementGroupQuery.mockReturnValue({
-      data: placementGroupFactory.build({
-        affinity_type: 'anti_affinity:local',
-        id: 1,
-        label: 'PG-to-delete',
-        members: [],
-      }),
-    });
-
     let renderResult: RenderResult;
     await act(async () => {
       renderResult = renderWithTheme(
-        <PlacementGroupsDeleteModal disableUnassignButton={false} {...props} />
+        <PlacementGroupsDeleteModal
+          {...props}
+          selectedPlacementGroup={placementGroupFactory.build({
+            affinity_type: 'anti_affinity:local',
+            id: 1,
+            label: 'PG-to-delete',
+            members: [],
+          })}
+          disableUnassignButton={false}
+        />
       );
     });
 

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -123,7 +123,7 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
         }}
         onClose={onClose}
         open={open}
-        title="Placement Group Not Found"
+        title="Delete Placement Group"
       >
         {isFetching ? <CircleProgress /> : <NotFound />}
       </ConfirmationDialog>

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -24,6 +24,7 @@ import type {
 interface Props {
   disableUnassignButton: boolean;
   onClose: () => void;
+  onExited?: () => void;
   open: boolean;
   selectedPlacementGroup: PlacementGroup | undefined;
 }
@@ -32,6 +33,7 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
   const {
     disableUnassignButton,
     onClose,
+    onExited,
     open,
     selectedPlacementGroup,
   } = props;
@@ -114,6 +116,7 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
       loading={placementGroupDataLoading || deletePlacementLoading}
       onClick={onDelete}
       onClose={onClose}
+      onExited={onExited}
       open={open}
       title={`Delete ${placementGroupLabel}`}
     >

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -115,7 +115,7 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
           '& .MuiDialog-paper': {
             '& > .MuiDialogContent-root > div': {
               maxHeight: 300,
-              padding: 0,
+              padding: 4,
             },
             maxHeight: 500,
             width: 500,

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -1,7 +1,6 @@
 import { AFFINITY_TYPES } from '@linode/api-v4';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
-import { useParams } from 'react-router-dom';
 
 import { Button } from 'src/components/Button/Button';
 import { List } from 'src/components/List';
@@ -13,12 +12,12 @@ import { Typography } from 'src/components/Typography';
 import { usePlacementGroupData } from 'src/hooks/usePlacementGroupsData';
 import {
   useDeletePlacementGroup,
-  usePlacementGroupQuery,
   useUnassignLinodesFromPlacementGroup,
 } from 'src/queries/placementGroups';
 
 import type {
   Linode,
+  PlacementGroup,
   UnassignLinodesFromPlacementGroupPayload,
 } from '@linode/api-v4';
 
@@ -26,15 +25,16 @@ interface Props {
   disableUnassignButton: boolean;
   onClose: () => void;
   open: boolean;
+  selectedPlacementGroup: PlacementGroup | undefined;
 }
 
 export const PlacementGroupsDeleteModal = (props: Props) => {
-  const { disableUnassignButton, onClose, open } = props;
-  const { id } = useParams<{ id: string }>();
-  const { data: selectedPlacementGroup } = usePlacementGroupQuery(
-    +id,
-    Boolean(id)
-  );
+  const {
+    disableUnassignButton,
+    onClose,
+    open,
+    selectedPlacementGroup,
+  } = props;
   const {
     assignedLinodes,
     isLoading: placementGroupDataLoading,

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -3,8 +3,10 @@ import { useSnackbar } from 'notistack';
 import * as React from 'react';
 
 import { Button } from 'src/components/Button/Button';
+import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
 import { List } from 'src/components/List';
 import { ListItem } from 'src/components/ListItem';
+import { NotFound } from 'src/components/NotFound';
 import { Notice } from 'src/components/Notice/Notice';
 import { RemovableSelectionsList } from 'src/components/RemovableSelectionsList/RemovableSelectionsList';
 import { TypeToConfirmDialog } from 'src/components/TypeToConfirmDialog/TypeToConfirmDialog';
@@ -97,6 +99,28 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
 
   const isDisabled = !selectedPlacementGroup || assignedLinodesCount > 0;
 
+  if (!selectedPlacementGroup) {
+    return (
+      <ConfirmationDialog
+        sx={{
+          '& .MuiDialog-paper': {
+            '& > .MuiDialogContent-root > div': {
+              padding: 0,
+              maxHeight: 300,
+            },
+            maxHeight: 500,
+            width: 500,
+          },
+        }}
+        onClose={onClose}
+        open={open}
+        title="Placement Group Not Found"
+      >
+        <NotFound />
+      </ConfirmationDialog>
+    );
+  }
+
   return (
     <TypeToConfirmDialog
       entity={{
@@ -105,11 +129,6 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
         primaryBtnText: 'Delete',
         type: 'Placement Group',
       }}
-      errors={
-        !selectedPlacementGroup
-          ? [{ reason: 'Placement Group not found.' }]
-          : undefined
-      }
       disableTypeToConfirmInput={isDisabled}
       disableTypeToConfirmSubmit={isDisabled}
       label="Placement Group"
@@ -128,53 +147,62 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
         />
       )}
 
-      <Notice spacingTop={8} variant="warning">
-        <Typography>
-          <strong>Warning:</strong>
-        </Typography>
-        <List
-          sx={(theme) => ({
-            '& > li': {
-              display: 'list-item',
-              fontSize: '0.875rem',
-              pb: 0,
-              pl: 0,
-            },
-            listStyle: 'disc',
-            ml: theme.spacing(2),
-            mt: theme.spacing(),
-          })}
-        >
-          <ListItem>
-            Deleting a placement group is permanent and cannot be undone.
-          </ListItem>
-          <ListItem>
-            You need to unassign all Linodes before deleting a placement group.
-          </ListItem>
-        </List>
-      </Notice>
-      <RemovableSelectionsList
-        RemoveButton={() => (
-          <Button
-            sx={(theme) => ({
-              fontFamily: theme.font.normal,
-              fontSize: '0.875rem',
-            })}
-            disabled={disableUnassignButton}
-            loading={unassignLinodeLoading}
-            variant="text"
-          >
-            Unassign
-          </Button>
-        )}
-        headerText={`Linodes assigned to ${placementGroupLabel}`}
-        id="assigned-linodes"
-        maxWidth={540}
-        noDataText="No Linodes assigned to this Placement Group."
-        onRemove={handleUnassignLinode}
-        selectionData={assignedLinodes ?? []}
-        sx={{ mb: 3, mt: 1 }}
-      />
+      {assignedLinodesCount > 0 ? (
+        <>
+          <Notice spacingTop={8} variant="warning">
+            <Typography>
+              <strong>Warning:</strong>
+            </Typography>
+            <List
+              sx={(theme) => ({
+                '& > li': {
+                  display: 'list-item',
+                  fontSize: '0.875rem',
+                  pb: 0,
+                  pl: 0,
+                },
+                listStyle: 'disc',
+                ml: theme.spacing(2),
+                mt: theme.spacing(),
+              })}
+            >
+              <ListItem>
+                Deleting a placement group is permanent and cannot be undone.
+              </ListItem>
+              <ListItem>
+                You need to unassign all Linodes before deleting a placement
+                group.
+              </ListItem>
+            </List>
+          </Notice>
+          <RemovableSelectionsList
+            RemoveButton={() => (
+              <Button
+                sx={(theme) => ({
+                  fontFamily: theme.font.normal,
+                  fontSize: '0.875rem',
+                })}
+                disabled={disableUnassignButton}
+                loading={unassignLinodeLoading}
+                variant="text"
+              >
+                Unassign
+              </Button>
+            )}
+            headerText={`Linodes assigned to ${placementGroupLabel}`}
+            id="assigned-linodes"
+            maxWidth={540}
+            noDataText="No Linodes assigned to this Placement Group."
+            onRemove={handleUnassignLinode}
+            selectionData={assignedLinodes ?? []}
+            sx={{ mb: 3, mt: 1 }}
+          />
+        </>
+      ) : (
+        <Notice spacingTop={8} variant="warning">
+          Deleting a placement group is permanent and cannot be undone.
+        </Notice>
+      )}
     </TypeToConfirmDialog>
   );
 };

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsEditDrawer.test.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsEditDrawer.test.tsx
@@ -12,7 +12,6 @@ const queryMocks = vi.hoisted(() => ({
     reset: vi.fn(),
   }),
   useParams: vi.fn().mockReturnValue({}),
-  usePlacementGroupQuery: vi.fn().mockReturnValue({}),
   useRegionsQuery: vi.fn().mockReturnValue({}),
 }));
 
@@ -37,7 +36,6 @@ vi.mock('src/queries/placementGroups', async () => {
   return {
     ...actual,
     useMutatePlacementGroup: queryMocks.useMutatePlacementGroup,
-    usePlacementGroupQuery: queryMocks.usePlacementGroupQuery,
   };
 });
 
@@ -47,17 +45,15 @@ describe('PlacementGroupsCreateDrawer', () => {
     queryMocks.useRegionsQuery.mockReturnValue({
       data: regionFactory.buildList(1, { id: 'us-east', label: 'Newark, NJ' }),
     });
-    queryMocks.usePlacementGroupQuery.mockReturnValue({
-      data: placementGroupFactory.build({
-        affinity_type: 'anti_affinity:local',
-        id: 1,
-        label: 'PG-to-edit',
-        region: 'us-east',
-      }),
-    });
 
     const { getByLabelText, getByRole, getByText } = renderWithTheme(
       <PlacementGroupsEditDrawer
+        selectedPlacementGroup={placementGroupFactory.build({
+          affinity_type: 'anti_affinity:local',
+          id: 1,
+          label: 'PG-to-edit',
+          region: 'us-east',
+        })}
         disableEditButton={false}
         onClose={vi.fn()}
         onPlacementGroupEdit={vi.fn()}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsEditDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsEditDrawer.tsx
@@ -121,7 +121,7 @@ export const PlacementGroupsEditDrawer = (
           ? `Edit Placement Group ${placementGroup.label} (${
               AFFINITY_TYPES[placementGroup.affinity_type]
             })`
-          : 'Placement Group Not Found'
+          : 'Edit Placement Group'
       }
       onClose={handleDrawerClose}
       onExited={onExited}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsEditDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsEditDrawer.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Divider } from 'src/components/Divider';
 import { Drawer } from 'src/components/Drawer';
+import { NotFound } from 'src/components/NotFound';
 import { Notice } from 'src/components/Notice/Notice';
 import { Stack } from 'src/components/Stack';
 import { TextField } from 'src/components/TextField';
@@ -109,57 +110,62 @@ export const PlacementGroupsEditDrawer = (
           ? `Edit Placement Group ${selectedPlacementGroup.label} (${
               AFFINITY_TYPES[selectedPlacementGroup.affinity_type]
             })`
-          : 'Edit Placement Group'
+          : 'Placement Group Not Found'
       }
       onClose={handleDrawerClose}
       onExited={onExited}
       open={open}
     >
       {generalError && <Notice text={generalError} variant="error" />}
-      <Typography mb={1} mt={4}>
-        <strong>Region: </strong>
-        {region ? `${region.label} (${region.id})` : 'Unknown'}
-      </Typography>
-      {selectedPlacementGroup && (
-        <Typography mb={4}>
-          <strong>Affinity Enforcement: </strong>
-          {getAffinityEnforcement(selectedPlacementGroup.is_strict)}
-        </Typography>
-      )}
-      <Divider />
-      <form onSubmit={handleSubmit}>
-        <Stack spacing={1}>
-          <TextField
-            inputProps={{
-              autoFocus: true,
-            }}
-            aria-label="Label for the Placement Group"
-            disabled={disableEditButton || false}
-            errorText={errors.label}
-            label="Label"
-            name="label"
-            onBlur={handleBlur}
-            onChange={handleChange}
-            value={values.label}
-          />
+      {selectedPlacementGroup ? (
+        <>
+          <Typography mb={1} mt={4}>
+            <strong>Region: </strong>
+            {region ? `${region.label} (${region.id})` : 'Unknown'}
+          </Typography>
 
-          <ActionsPanel
-            primaryButtonProps={{
-              'data-testid': 'submit',
-              disabled: disableEditButton,
-              label: 'Edit',
-              loading: isSubmitting,
-              type: 'submit',
-            }}
-            secondaryButtonProps={{
-              'data-testid': 'cancel',
-              label: 'Cancel',
-              onClick: onClose,
-            }}
-            sx={{ pt: 4 }}
-          />
-        </Stack>
-      </form>
+          <Typography mb={4}>
+            <strong>Affinity Enforcement: </strong>
+            {getAffinityEnforcement(selectedPlacementGroup.is_strict)}
+          </Typography>
+          <Divider />
+          <form onSubmit={handleSubmit}>
+            <Stack spacing={1}>
+              <TextField
+                inputProps={{
+                  autoFocus: true,
+                }}
+                aria-label="Label for the Placement Group"
+                disabled={!selectedPlacementGroup || disableEditButton || false}
+                errorText={errors.label}
+                label="Label"
+                name="label"
+                onBlur={handleBlur}
+                onChange={handleChange}
+                value={values.label}
+              />
+
+              <ActionsPanel
+                primaryButtonProps={{
+                  'data-testid': 'submit',
+                  disabled: !selectedPlacementGroup || disableEditButton,
+                  label: 'Edit',
+                  loading: isSubmitting,
+                  type: 'submit',
+                }}
+                secondaryButtonProps={{
+                  'data-testid': 'cancel',
+                  label: 'Cancel',
+                  onClick: onClose,
+                }}
+                sx={{ pt: 4 }}
+              />
+            </Stack>
+          </form>
+        </>
+      ) : (
+        <NotFound />
+      )}
     </Drawer>
   );
 };

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsEditDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsEditDrawer.tsx
@@ -101,15 +101,15 @@ export const PlacementGroupsEditDrawer = (
 
   const generalError = error?.find((e) => !e.field)?.reason;
 
-  if (!selectedPlacementGroup) {
-    return null;
-  }
-
   return (
     <Drawer
-      title={`Edit Placement Group ${selectedPlacementGroup.label} (${
-        AFFINITY_TYPES[selectedPlacementGroup.affinity_type]
-      })`}
+      title={
+        selectedPlacementGroup
+          ? `Edit Placement Group ${selectedPlacementGroup.label} (${
+              AFFINITY_TYPES[selectedPlacementGroup.affinity_type]
+            })`
+          : 'Edit Placement Group'
+      }
       onClose={handleDrawerClose}
       open={open}
     >
@@ -118,10 +118,12 @@ export const PlacementGroupsEditDrawer = (
         <strong>Region: </strong>
         {region ? `${region.label} (${region.id})` : 'Unknown'}
       </Typography>
-      <Typography mb={4}>
-        <strong>Affinity Enforcement: </strong>
-        {getAffinityEnforcement(selectedPlacementGroup.is_strict)}
-      </Typography>
+      {selectedPlacementGroup && (
+        <Typography mb={4}>
+          <strong>Affinity Enforcement: </strong>
+          {getAffinityEnforcement(selectedPlacementGroup.is_strict)}
+        </Typography>
+      )}
       <Divider />
       <form onSubmit={handleSubmit}>
         <Stack spacing={1}>

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsEditDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsEditDrawer.tsx
@@ -3,7 +3,6 @@ import { updatePlacementGroupSchema } from '@linode/validation';
 import { useFormik } from 'formik';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
-import { useParams } from 'react-router-dom';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Divider } from 'src/components/Divider';
@@ -14,7 +13,6 @@ import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
 import { useFormValidateOnChange } from 'src/hooks/useFormValidateOnChange';
 import { usePlacementGroupData } from 'src/hooks/usePlacementGroupsData';
-import { usePlacementGroupQuery } from 'src/queries/placementGroups';
 import { useMutatePlacementGroup } from 'src/queries/placementGroups';
 import { getFormikErrorsFromAPIErrors } from 'src/utilities/formikErrorUtils';
 import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
@@ -28,12 +26,13 @@ import type { FormikHelpers } from 'formik';
 export const PlacementGroupsEditDrawer = (
   props: PlacementGroupsEditDrawerProps
 ) => {
-  const { disableEditButton, onClose, onPlacementGroupEdit, open } = props;
-  const { id } = useParams<{ id: string }>();
-  const { data: selectedPlacementGroup } = usePlacementGroupQuery(
-    +id,
-    Boolean(id)
-  );
+  const {
+    disableEditButton,
+    onClose,
+    onPlacementGroupEdit,
+    open,
+    selectedPlacementGroup,
+  } = props;
   const { region } = usePlacementGroupData({
     placementGroup: selectedPlacementGroup,
   });

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsEditDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsEditDrawer.tsx
@@ -29,6 +29,7 @@ export const PlacementGroupsEditDrawer = (
   const {
     disableEditButton,
     onClose,
+    onExited,
     onPlacementGroupEdit,
     open,
     selectedPlacementGroup,
@@ -111,6 +112,7 @@ export const PlacementGroupsEditDrawer = (
           : 'Edit Placement Group'
       }
       onClose={handleDrawerClose}
+      onExited={onExited}
       open={open}
     >
       {generalError && <Notice text={generalError} variant="error" />}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLanding.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLanding.tsx
@@ -37,6 +37,9 @@ export const PlacementGroupsLanding = React.memo(() => {
   const history = useHistory();
   const pagination = usePagination(1, preferenceKey);
   const [query, setQuery] = React.useState<string>('');
+  const [selectedPlacementGroup, setSelectedPlacementGroup] = React.useState<
+    PlacementGroup | undefined
+  >(undefined);
   const { handleOrderChange, order, orderBy } = useOrder(
     {
       order: 'asc',
@@ -73,6 +76,7 @@ export const PlacementGroupsLanding = React.memo(() => {
   };
 
   const handleEditPlacementGroup = (placementGroup: PlacementGroup) => {
+    setSelectedPlacementGroup(placementGroup);
     history.replace(`/placement-groups/edit/${placementGroup.id}`);
   };
 
@@ -82,6 +86,7 @@ export const PlacementGroupsLanding = React.memo(() => {
 
   const onClosePlacementGroupDrawer = () => {
     history.replace('/placement-groups');
+    setSelectedPlacementGroup(undefined);
   };
 
   const isPlacementGroupCreateDrawerOpen = location.pathname.endsWith('create');
@@ -219,6 +224,7 @@ export const PlacementGroupsLanding = React.memo(() => {
         disableEditButton={isLinodeReadOnly}
         onClose={onClosePlacementGroupDrawer}
         open={isPlacementGroupEditDrawerOpen}
+        selectedPlacementGroup={selectedPlacementGroup}
       />
       <PlacementGroupsDeleteModal
         disableUnassignButton={isLinodeReadOnly}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLanding.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLanding.tsx
@@ -81,6 +81,7 @@ export const PlacementGroupsLanding = React.memo(() => {
   };
 
   const handleDeletePlacementGroup = (placementGroup: PlacementGroup) => {
+    setSelectedPlacementGroup(placementGroup);
     history.replace(`/placement-groups/delete/${placementGroup.id}`);
   };
 
@@ -230,6 +231,7 @@ export const PlacementGroupsLanding = React.memo(() => {
         disableUnassignButton={isLinodeReadOnly}
         onClose={onClosePlacementGroupDrawer}
         open={isPlacementGroupDeleteModalOpen}
+        selectedPlacementGroup={selectedPlacementGroup}
       />
     </>
   );

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLanding.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLanding.tsx
@@ -87,6 +87,9 @@ export const PlacementGroupsLanding = React.memo(() => {
 
   const onClosePlacementGroupDrawer = () => {
     history.replace('/placement-groups');
+  };
+
+  const onExited = () => {
     setSelectedPlacementGroup(undefined);
   };
 
@@ -224,12 +227,14 @@ export const PlacementGroupsLanding = React.memo(() => {
       <PlacementGroupsEditDrawer
         disableEditButton={isLinodeReadOnly}
         onClose={onClosePlacementGroupDrawer}
+        onExited={onExited}
         open={isPlacementGroupEditDrawerOpen}
         selectedPlacementGroup={selectedPlacementGroup}
       />
       <PlacementGroupsDeleteModal
         disableUnassignButton={isLinodeReadOnly}
         onClose={onClosePlacementGroupDrawer}
+        onExited={onExited}
         open={isPlacementGroupDeleteModalOpen}
         selectedPlacementGroup={selectedPlacementGroup}
       />

--- a/packages/manager/src/features/PlacementGroups/types.ts
+++ b/packages/manager/src/features/PlacementGroups/types.ts
@@ -17,6 +17,7 @@ export interface PlacementGroupsCreateDrawerProps {
 export interface PlacementGroupsEditDrawerProps {
   disableEditButton: boolean;
   onClose: PlacementGroupsDrawerPropsBase['onClose'];
+  onExited?: () => void;
   onPlacementGroupEdit?: (placementGroup: PlacementGroup) => void;
   open: PlacementGroupsDrawerPropsBase['open'];
   selectedPlacementGroup: PlacementGroup | undefined;

--- a/packages/manager/src/features/PlacementGroups/types.ts
+++ b/packages/manager/src/features/PlacementGroups/types.ts
@@ -19,7 +19,8 @@ export interface PlacementGroupsEditDrawerProps {
   onClose: PlacementGroupsDrawerPropsBase['onClose'];
   onPlacementGroupEdit?: (placementGroup: PlacementGroup) => void;
   open: PlacementGroupsDrawerPropsBase['open'];
-}
+  selectedPlacementGroup: PlacementGroup | undefined;
+};
 
 export interface PlacementGroupsAssignLinodesDrawerProps {
   onClose: PlacementGroupsDrawerPropsBase['onClose'];


### PR DESCRIPTION
## Description 📝
This PR brings UI improvements to both the PG Edit Drawer & Delete Modal. Now that the feature is in ALPHA, it is easier to implement the right patterns (loading, error handling) to both these flows.

## Changes  🔄
- Add new `onExited` optional prop to Dialog and Drawer in order to reset state/data when closing animation completes (see https://github.com/linode/manager/pull/10287 and cafe item for reference)
- **Delete Modal**: 
  - Notice: remove second bullet point notice (turn it into regular notice (no bullet) when no linode is attached) & remove linode list, only keep type to confirm when no linode is attached
  - Improve error and loading patterns
- Edit Drawer
  - Improve error and loading patterns

## Preview 📷

| Delete Modal  | Edit Drawer   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/130582365/f84fcd8f-e84f-4caf-b4aa-458431cb9190" /> | <video src="https://github.com/linode/manager/assets/130582365/cb9989d5-e97c-45b8-a660-1e557d1d4c3d" /> |

## How to test 🧪

### Prerequisites
- ⚠️⚠️ have the dev admin placement-group customer tag ⚠️⚠️
- Switch to the dev API
- Have the "Placement Group" feature flag on
- Have MSW off

### Verification steps
- Navigate to http://localhost:3000/placement-groups

**Delete Modal**
- Click on "Delete" and confirm modal behavior
- While Dialog open, reload page and confirm behavior
- While Dialog open, Change URL to a non existing ID, reload page and confirm behavior

**Edit Drawer**
- Click on "Edit" and confirm Drawer behavior
- While Drawer open, reload page and confirm behavior
- While Drawer open, Change URL to a non existing ID, reload page and confirm behavior

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
