### PR TITLE
feat: [M3-7888] - Revoke proxy PAT when switching accounts

### DIFF
--- a/packages/manager/.changeset/pr-10313-upcoming-features-1711398916591.md
+++ b/packages/manager/.changeset/pr-10313-upcoming-features-1711398916591.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Revoke proxy PAT when switching accounts ([#10313](https://github.com/linode/manager/pull/10313))

--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -58,7 +58,7 @@ const AccountLanding = () => {
   const sessionContext = React.useContext(switchAccountSessionContext);
   const {
     getPendingRevocationToken,
-    pendingRevocationTokenId,
+    pendingRevocationToken,
   } = usePendingRevocationToken();
 
   const isAkamaiAccount = account?.billing_source === 'akamai';
@@ -224,7 +224,7 @@ const AccountLanding = () => {
         isProxyUser={isProxyUser}
         onClose={() => setIsDrawerOpen(false)}
         open={isDrawerOpen}
-        proxyTokenId={pendingRevocationTokenId}
+        proxyToken={pendingRevocationToken}
       />
     </React.Fragment>
   );

--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -15,6 +15,7 @@ import { switchAccountSessionContext } from 'src/context/switchAccountSessionCon
 import { useParentTokenManagement } from 'src/features/Account/SwitchAccounts/useParentTokenManagement';
 import { getRestrictedResourceText } from 'src/features/Account/utils';
 import { useFlags } from 'src/hooks/useFlags';
+import { usePendingRevocationToken } from 'src/hooks/usePendingRevocationToken';
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 import { useAccount } from 'src/queries/account';
 import { useProfile } from 'src/queries/profile';
@@ -55,6 +56,10 @@ const AccountLanding = () => {
   const flags = useFlags();
   const [isDrawerOpen, setIsDrawerOpen] = React.useState<boolean>(false);
   const sessionContext = React.useContext(switchAccountSessionContext);
+  const {
+    getPendingRevocationToken,
+    pendingRevocationTokenId,
+  } = usePendingRevocationToken();
 
   const isAkamaiAccount = account?.billing_source === 'akamai';
   const isProxyUser = profile?.user_type === 'proxy';
@@ -111,6 +116,10 @@ const AccountLanding = () => {
       return sessionContext.updateState({
         isOpen: true,
       });
+    }
+
+    if (isProxyUser) {
+      getPendingRevocationToken();
     }
 
     setIsDrawerOpen(true);
@@ -215,6 +224,7 @@ const AccountLanding = () => {
         isProxyUser={isProxyUser}
         onClose={() => setIsDrawerOpen(false)}
         open={isDrawerOpen}
+        proxyTokenId={pendingRevocationTokenId}
       />
     </React.Fragment>
   );

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
@@ -27,11 +27,12 @@ interface Props {
   isProxyUser: boolean;
   onClose: () => void;
   open: boolean;
-  proxyTokenId?: number;
+  proxyToken?: Token;
 }
 
 export const SwitchAccountDrawer = (props: Props) => {
-  const { isProxyUser, onClose, open, proxyTokenId } = props;
+  const { isProxyUser, onClose, open, proxyToken } = props;
+  const proxyTokenLabel = proxyToken?.label;
 
   const [isParentTokenError, setIsParentTokenError] = React.useState<
     APIError[]
@@ -41,7 +42,7 @@ export const SwitchAccountDrawer = (props: Props) => {
   );
 
   const { mutateAsync: revokeToken } = useRevokePersonalAccessTokenMutation(
-    proxyTokenId ?? -1
+    proxyToken?.id ?? -1
   );
   const { enqueueSnackbar } = useSnackbar();
   const currentTokenWithBearer = useCurrentToken() ?? '';
@@ -56,15 +57,15 @@ export const SwitchAccountDrawer = (props: Props) => {
   const handleProxyTokenRevocation = React.useCallback(async () => {
     try {
       await revokeToken();
-      enqueueSnackbar(`Successfully revoked ${proxyTokenId}.`, {
+      enqueueSnackbar(`Successfully revoked ${proxyTokenLabel}.`, {
         variant: 'success',
       });
     } catch (error) {
-      enqueueSnackbar('Failed to revoke token.', {
+      enqueueSnackbar(`Failed to revoke ${proxyTokenLabel}.`, {
         variant: 'error',
       });
     }
-  }, [enqueueSnackbar, proxyTokenId, revokeToken]);
+  }, [enqueueSnackbar, proxyTokenLabel, revokeToken]);
 
   const handleSwitchAccount = async ({
     currentTokenWithBearer,

--- a/packages/manager/src/features/Account/utils.ts
+++ b/packages/manager/src/features/Account/utils.ts
@@ -135,3 +135,19 @@ export const updateCurrentTokenBasedOnUserType = ({
     setStorage('authentication/expire', userExpiry);
   }
 };
+
+/**
+ * Finds a personal access token stored locally for revocation,
+ * typically used when switching between accounts. Searching local storage
+ * for the token is necessary because the token is not persisted in state.
+ */
+export async function getPersonalAccessTokenForRevocation(
+  tokens: Token[],
+  currentTokenWithBearer: string
+): Promise<Token | undefined> {
+  return tokens.find(
+    (token) =>
+      token.token &&
+      currentTokenWithBearer.replace('Bearer ', '').startsWith(token.token)
+  );
+}

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -61,7 +61,7 @@ export const UserMenu = React.memo(() => {
   const [isDrawerOpen, setIsDrawerOpen] = React.useState<boolean>(false);
   const {
     getPendingRevocationToken,
-    pendingRevocationTokenId,
+    pendingRevocationToken,
   } = usePendingRevocationToken();
 
   const { data: account } = useAccount();
@@ -348,7 +348,7 @@ export const UserMenu = React.memo(() => {
         isProxyUser={isProxyUser}
         onClose={() => setIsDrawerOpen(false)}
         open={isDrawerOpen}
-        proxyTokenId={pendingRevocationTokenId}
+        proxyToken={pendingRevocationToken}
       />
     </>
   );

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -22,6 +22,7 @@ import { SwitchAccountButton } from 'src/features/Account/SwitchAccountButton';
 import { SwitchAccountDrawer } from 'src/features/Account/SwitchAccountDrawer';
 import { useParentTokenManagement } from 'src/features/Account/SwitchAccounts/useParentTokenManagement';
 import { useFlags } from 'src/hooks/useFlags';
+import { usePendingRevocationToken } from 'src/hooks/usePendingRevocationToken';
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 import { useAccount } from 'src/queries/account';
 import { useGrants, useProfile } from 'src/queries/profile';
@@ -29,7 +30,6 @@ import { sendSwitchAccountEvent } from 'src/utilities/analytics';
 import { getStorage, setStorage } from 'src/utilities/storage';
 
 import { getCompanyNameOrEmail } from './utils';
-
 interface MenuLink {
   display: string;
   hide?: boolean;
@@ -59,6 +59,10 @@ export const UserMenu = React.memo(() => {
     null
   );
   const [isDrawerOpen, setIsDrawerOpen] = React.useState<boolean>(false);
+  const {
+    getPendingRevocationToken,
+    pendingRevocationTokenId,
+  } = usePendingRevocationToken();
 
   const { data: account } = useAccount();
   const { data: profile } = useProfile();
@@ -201,6 +205,10 @@ export const UserMenu = React.memo(() => {
       });
     }
 
+    if (isProxyUser) {
+      getPendingRevocationToken();
+    }
+
     setIsDrawerOpen(true);
   };
 
@@ -340,6 +348,7 @@ export const UserMenu = React.memo(() => {
         isProxyUser={isProxyUser}
         onClose={() => setIsDrawerOpen(false)}
         open={isDrawerOpen}
+        proxyTokenId={pendingRevocationTokenId}
       />
     </>
   );

--- a/packages/manager/src/hooks/usePendingRevocationToken.test.ts
+++ b/packages/manager/src/hooks/usePendingRevocationToken.test.ts
@@ -52,13 +52,13 @@ vi.mock('src/hooks/useAuthentication', async () => {
 });
 
 describe('usePendingRevocationToken', () => {
-  it('should set pendingRevocationTokenId when personal access tokens are available', async () => {
+  it('should set pendingRevocationToken id when personal access tokens are available', async () => {
     const { result } = renderHook(() => usePendingRevocationToken(), {
       wrapper: (ui) => wrapWithTheme(ui, { queryClient }),
     });
 
     await waitFor(() => {
-      expect(result.current.pendingRevocationTokenId).toBeUndefined();
+      expect(result.current.pendingRevocationToken?.id).toBeUndefined();
     });
 
     await act(async () => {
@@ -66,11 +66,11 @@ describe('usePendingRevocationToken', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.pendingRevocationTokenId).toEqual(123);
+      expect(result.current.pendingRevocationToken?.id).toEqual(123);
     });
   });
 
-  it('should not set pendingRevocationTokenId when no matching tokens are available', async () => {
+  it('should not set pendingRevocationToken?.id when no matching tokens are available', async () => {
     // Adjust the mock to return a token that doesn't match
     queryMocks.useCurrentToken.mockReturnValue('Bearer nonMatchingToken');
 
@@ -84,7 +84,7 @@ describe('usePendingRevocationToken', () => {
 
     // Now expecting undefined because there should be no match
     await waitFor(() => {
-      expect(result.current.pendingRevocationTokenId).toBeUndefined();
+      expect(result.current.pendingRevocationToken?.id).toBeUndefined();
     });
   });
 });

--- a/packages/manager/src/hooks/usePendingRevocationToken.test.ts
+++ b/packages/manager/src/hooks/usePendingRevocationToken.test.ts
@@ -1,0 +1,90 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { queryClientFactory } from 'src/queries/base';
+import { wrapWithTheme } from 'src/utilities/testHelpers';
+
+import { usePendingRevocationToken } from './usePendingRevocationToken'; // Adjust path as needed
+import { Token } from '@linode/api-v4';
+
+const queryClient = queryClientFactory();
+
+const queryMocks = vi.hoisted(() => ({
+  getPersonalAccessTokenForRevocation: vi.fn(
+    (tokens, currentTokenWithBearer) => {
+      const tokenValue = currentTokenWithBearer.replace('Bearer ', '');
+      const foundToken = tokens.find(
+        (token: Token) => token.token === tokenValue
+      );
+      return Promise.resolve(foundToken);
+    }
+  ),
+  useCurrentToken: vi.fn(() => 'Bearer 232345245345'),
+  usePersonalAccessTokensQuery: vi.fn().mockReturnValue({
+    data: {
+      data: [{ id: 123, token: '232345245345' }],
+    },
+  }),
+}));
+
+vi.mock('src/queries/tokens', async () => {
+  const actual = await vi.importActual('src/queries/tokens');
+  return {
+    ...actual,
+    usePersonalAccessTokensQuery: queryMocks.usePersonalAccessTokensQuery,
+  };
+});
+
+vi.mock('src/features/Account/utils', async () => {
+  const actual = await vi.importActual('src/features/Account/utils');
+  return {
+    ...actual,
+    getPersonalAccessTokenForRevocation:
+      queryMocks.getPersonalAccessTokenForRevocation,
+  };
+});
+
+vi.mock('src/hooks/useAuthentication', async () => {
+  const actual = await vi.importActual('src/hooks/useAuthentication');
+  return {
+    ...actual,
+    useCurrentToken: queryMocks.useCurrentToken,
+  };
+});
+
+describe('usePendingRevocationToken', () => {
+  it('should set pendingRevocationTokenId when personal access tokens are available', async () => {
+    const { result } = renderHook(() => usePendingRevocationToken(), {
+      wrapper: (ui) => wrapWithTheme(ui, { queryClient }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.pendingRevocationTokenId).toBeUndefined();
+    });
+
+    await act(async () => {
+      await result.current.getPendingRevocationToken();
+    });
+
+    await waitFor(() => {
+      expect(result.current.pendingRevocationTokenId).toEqual(123);
+    });
+  });
+
+  it('should not set pendingRevocationTokenId when no matching tokens are available', async () => {
+    // Adjust the mock to return a token that doesn't match
+    queryMocks.useCurrentToken.mockReturnValue('Bearer nonMatchingToken');
+
+    const { result } = renderHook(() => usePendingRevocationToken(), {
+      wrapper: (ui) => wrapWithTheme(ui, { queryClient }),
+    });
+
+    await act(async () => {
+      await result.current.getPendingRevocationToken();
+    });
+
+    // Now expecting undefined because there should be no match
+    await waitFor(() => {
+      expect(result.current.pendingRevocationTokenId).toBeUndefined();
+    });
+  });
+});

--- a/packages/manager/src/hooks/usePendingRevocationToken.ts
+++ b/packages/manager/src/hooks/usePendingRevocationToken.ts
@@ -1,3 +1,4 @@
+import { Token } from '@linode/api-v4';
 import React from 'react';
 
 import { getPersonalAccessTokenForRevocation } from 'src/features/Account/utils';
@@ -18,10 +19,9 @@ import { usePersonalAccessTokensQuery } from 'src/queries/tokens';
  * - `pendingRevocationTokenId`: The ID of the token currently marked for pending revocation, or `undefined` if none.
  */
 export const usePendingRevocationToken = () => {
-  const [
-    pendingRevocationTokenId,
-    setPendingRevocationTokenId,
-  ] = React.useState<number | undefined>(undefined);
+  const [pendingRevocationToken, setPendingRevocationToken] = React.useState<
+    Token | undefined
+  >(undefined);
   const currentTokenWithBearer = useCurrentToken() ?? '';
   const { data: personalAccessTokens } = usePersonalAccessTokensQuery();
 
@@ -35,11 +35,11 @@ export const usePendingRevocationToken = () => {
       currentTokenWithBearer
     );
 
-    setPendingRevocationTokenId(token?.id);
+    setPendingRevocationToken(token);
   };
 
   return {
     getPendingRevocationToken,
-    pendingRevocationTokenId,
+    pendingRevocationToken,
   };
 };

--- a/packages/manager/src/hooks/usePendingRevocationToken.ts
+++ b/packages/manager/src/hooks/usePendingRevocationToken.ts
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { getPersonalAccessTokenForRevocation } from 'src/features/Account/utils';
+import { useCurrentToken } from 'src/hooks/useAuthentication';
+import { usePersonalAccessTokensQuery } from 'src/queries/tokens';
+
+/**
+ * Custom hook to manage the ID of a personal access token pending revocation.
+ *
+ * This hook provides functionality to determine which personal access token
+ * should be considered for revocation based on the current authentication state
+ * and the list of personal access tokens associated with the account. It utilizes
+ * the current bearer token to identify the corresponding personal access token
+ * and sets its ID for potential revocation actions.
+ *
+ * @returns {object} An object containing:
+ * - `getPendingRevocationToken`: A function to fetch and set the pending revocation token ID based on current conditions.
+ * - `pendingRevocationTokenId`: The ID of the token currently marked for pending revocation, or `undefined` if none.
+ */
+export const usePendingRevocationToken = () => {
+  const [
+    pendingRevocationTokenId,
+    setPendingRevocationTokenId,
+  ] = React.useState<number | undefined>(undefined);
+  const currentTokenWithBearer = useCurrentToken() ?? '';
+  const { data: personalAccessTokens } = usePersonalAccessTokensQuery();
+
+  const getPendingRevocationToken = async () => {
+    if (!personalAccessTokens?.data) {
+      return;
+    }
+
+    const token = await getPersonalAccessTokenForRevocation(
+      personalAccessTokens?.data,
+      currentTokenWithBearer
+    );
+
+    setPendingRevocationTokenId(token?.id);
+  };
+
+  return {
+    getPendingRevocationToken,
+    pendingRevocationTokenId,
+  };
+};


### PR DESCRIPTION
## Description 📝
As a user who frequently switches between accounts, I notice that proxy tokens (PATs) accumulate when switching into the same account repeatedly. To mitigate this, we want to ensure that we automatically revoke proxy tokens whenever a user switches accounts.

## Changes  🔄
- New `usePendingRevocationToken` hook with accompanying unit test.
    - Needed to consolidate code required for both `UserMenu` and `AccountLanding` 
- Added `getPersonalAccessTokenForRevocation` to compare the token we have in local storage to what we have stored in our database from the API endpoint.

## Target release date 🗓️
4/1

## Preview 📷
| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/125309814/d0453e41-86cf-40ab-a73b-dc983ef249e3" /> | <video src="https://github.com/linode/manager/assets/125309814/17d5418b-4cf3-4382-8047-f7a160ff9511" /> |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Log into Parent account using developer credentials

### Reproduction steps
- Switch into proxy account and go to PAT page
- Keep switching into proxy and observe multiple PATs accumulating

### Verification steps
- Follow same reproduction steps and observe that this issue is fixed.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support