### PR TITLE
upcoming: [M3-7925] - Linode Create Refactor - Add Firewall - Part 5

### DIFF
--- a/packages/manager/.changeset/pr-10315-upcoming-features-1711410039390.md
+++ b/packages/manager/.changeset/pr-10315-upcoming-features-1711410039390.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Linode Create Refactor - Add Firewall - Part 5  ([#10315](https://github.com/linode/manager/pull/10315))

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Firewall.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Firewall.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { firewallFactory } from 'src/factories';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
+
+import { Firewall } from './Firewall';
+
+import type { CreateLinodeRequest } from '@linode/api-v4';
+
+describe('Linode Create v2 Firewall', () => {
+  it('should render a header', () => {
+    const { getByText } = renderWithThemeAndHookFormContext({
+      component: <Firewall />,
+    });
+
+    const heading = getByText('Firewall');
+
+    expect(heading).toBeVisible();
+    expect(heading.tagName).toBe('H2');
+  });
+
+  it('should render a Firewall select', () => {
+    const { getByLabelText } = renderWithThemeAndHookFormContext({
+      component: <Firewall />,
+    });
+
+    const firewallSelect = getByLabelText('Assign Firewall');
+
+    expect(firewallSelect).toBeVisible();
+    expect(firewallSelect).toBeEnabled();
+  });
+
+  it('should render a "Create Firewall" button', () => {
+    const { getByText } = renderWithThemeAndHookFormContext({
+      component: <Firewall />,
+    });
+
+    const createFirewallButton = getByText('Create Firewall');
+
+    expect(createFirewallButton).toBeVisible();
+    expect(createFirewallButton).toBeEnabled();
+  });
+
+  it('should populate the select based on form data and the firewall API response', async () => {
+    const firewall = firewallFactory.build();
+
+    server.use(
+      http.get('*/v4/firewalls', () => {
+        return HttpResponse.json(makeResourcePage([firewall]));
+      })
+    );
+
+    const {
+      findByDisplayValue,
+    } = renderWithThemeAndHookFormContext<CreateLinodeRequest>({
+      component: <Firewall />,
+      useFormOptions: { defaultValues: { firewall_id: firewall.id } },
+    });
+
+    await findByDisplayValue(firewall.label);
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Firewall.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Firewall.tsx
@@ -1,0 +1,62 @@
+import { CreateLinodeRequest } from '@linode/api-v4';
+import React, { useState } from 'react';
+import { useController } from 'react-hook-form';
+
+import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
+import { Box } from 'src/components/Box';
+import { Link } from 'src/components/Link';
+import { LinkButton } from 'src/components/LinkButton';
+import { Paper } from 'src/components/Paper';
+import { Stack } from 'src/components/Stack';
+import { Typography } from 'src/components/Typography';
+import { FIREWALL_GET_STARTED_LINK } from 'src/constants';
+import { CreateFirewallDrawer } from 'src/features/Firewalls/FirewallLanding/CreateFirewallDrawer';
+import { useAllFirewallsQuery } from 'src/queries/firewalls';
+
+export const Firewall = () => {
+  const { field, fieldState } = useController<
+    CreateLinodeRequest,
+    'firewall_id'
+  >({ name: 'firewall_id' });
+
+  const { data: firewalls } = useAllFirewallsQuery();
+
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  const selectedFirewall =
+    firewalls?.find((firewall) => firewall.id === field.value) ?? null;
+
+  return (
+    <Paper>
+      <Stack spacing={2}>
+        <Typography variant="h2">Firewall</Typography>
+        <Typography>
+          Assign an existing Firewall to this Linode to control inbound and
+          outbound network traffic.{' '}
+          <Link to={FIREWALL_GET_STARTED_LINK}>Learn more</Link>.
+        </Typography>
+        <Stack spacing={1.5}>
+          <Autocomplete
+            errorText={fieldState.error?.message}
+            label="Assign Firewall"
+            noMarginTop
+            onChange={(e, firewall) => field.onChange(firewall?.id ?? null)}
+            options={firewalls ?? []}
+            value={selectedFirewall}
+          />
+          <Box>
+            <LinkButton onClick={() => setIsDrawerOpen(true)}>
+              Create Firewall
+            </LinkButton>
+          </Box>
+        </Stack>
+      </Stack>
+      <CreateFirewallDrawer
+        createFlow="linode"
+        onClose={() => setIsDrawerOpen(false)}
+        onFirewallCreated={(firewall) => field.onChange(firewall.id)}
+        open={isDrawerOpen}
+      />
+    </Paper>
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
@@ -14,6 +14,7 @@ import { useCreateLinodeMutation } from 'src/queries/linodes/linodes';
 import { Access } from './Access';
 import { Details } from './Details/Details';
 import { Error } from './Error';
+import { Firewall } from './Firewall';
 import { Plan } from './Plan';
 import { Region } from './Region';
 import { Summary } from './Summary';
@@ -23,7 +24,6 @@ import { getTabIndex, tabs, useLinodeCreateQueryParams } from './utilities';
 
 import type { CreateLinodeRequest } from '@linode/api-v4';
 import type { SubmitHandler } from 'react-hook-form';
-import { Firewall } from './Firewall';
 
 export const LinodeCreatev2 = () => {
   const methods = useForm<CreateLinodeRequest>();

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
@@ -23,6 +23,7 @@ import { getTabIndex, tabs, useLinodeCreateQueryParams } from './utilities';
 
 import type { CreateLinodeRequest } from '@linode/api-v4';
 import type { SubmitHandler } from 'react-hook-form';
+import { Firewall } from './Firewall';
 
 export const LinodeCreatev2 = () => {
   const methods = useForm<CreateLinodeRequest>();
@@ -90,6 +91,7 @@ export const LinodeCreatev2 = () => {
           <Plan />
           <Details />
           <Access />
+          <Firewall />
           <Summary />
         </Stack>
       </form>


### PR DESCRIPTION
## Description 📝

- Adds the ability to attach a Firewall to a Linode in the new Linode Create Flow 🔥

## Preview 📷
![Screenshot 2024-03-25 at 7 33 58 PM](https://github.com/linode/manager/assets/115251059/ebb31214-bbc7-4355-8f34-5358fe3dc673)

## How to test 🧪

### Prerequisites
- Turn on the `Linode Create v2` feature flag using the local dev tools

### Verification steps
- Test creating a Linode with a firewall attached
- Verify you can create a Firewall from the Linode Create Flow
- Verify functionality is the same as the existing create flow

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support