### PR TITLE
fix: [M3-7508] - Follow up on tests to check Parent and Child 'Close Account' flows

### DIFF
--- a/packages/manager/.changeset/pr-10316-tests-1711480175744.md
+++ b/packages/manager/.changeset/pr-10316-tests-1711480175744.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add tests to check Parent and Child Close Account flows ([#10316](https://github.com/linode/manager/pull/10316))

--- a/packages/manager/.changeset/pr-10316-tests-1711480175744.md
+++ b/packages/manager/.changeset/pr-10316-tests-1711480175744.md
@@ -2,4 +2,4 @@
 "@linode/manager": Tests
 ---
 
-Add tests to check Parent and Child Close Account flows ([#10316](https://github.com/linode/manager/pull/10316))
+Add tests to check Parent and Child Close Account flows ([#10316](https://github.com/linode/manager/pull/10316), [#10296](https://github.com/linode/manager/pull/10296))

--- a/packages/manager/cypress/e2e/core/account/account-cancellation.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/account-cancellation.spec.ts
@@ -12,10 +12,12 @@ import {
 import {
   cancellationDataLossWarning,
   cancellationPaymentErrorMessage,
-  contactParentUserTooltipsMessage,
-  contactCustomerSupportTooltipsMessage,
-  removeChildAccountTooltipsMessage,
 } from 'support/constants/account';
+import {
+  CHILD_USER_CLOSE_ACCOUNT_TOOLTIP_TEXT,
+  PARENT_USER_CLOSE_ACCOUNT_TOOLTIP_TEXT,
+  PROXY_USER_CLOSE_ACCOUNT_TOOLTIP_TEXT,
+} from 'src/features/Account/constants';
 import { mockGetProfile } from 'support/intercepts/profile';
 import { ui } from 'support/ui';
 import {
@@ -230,7 +232,7 @@ describe('Parent/Child account cancellation', () => {
           .trigger('mouseover');
         // Click the button first, then confirm the tooltip is shown.
         ui.tooltip
-          .findByText(contactParentUserTooltipsMessage)
+          .findByText(CHILD_USER_CLOSE_ACCOUNT_TOOLTIP_TEXT)
           .should('be.visible');
       });
   });
@@ -264,7 +266,7 @@ describe('Parent/Child account cancellation', () => {
           .trigger('mouseover');
         // Click the button first, then confirm the tooltip is shown.
         ui.tooltip
-          .findByText(contactCustomerSupportTooltipsMessage)
+          .findByText(PROXY_USER_CLOSE_ACCOUNT_TOOLTIP_TEXT)
           .should('be.visible');
       });
   });
@@ -298,7 +300,7 @@ describe('Parent/Child account cancellation', () => {
           .trigger('mouseover');
         // Click the button first, then confirm the tooltip is shown.
         ui.tooltip
-          .findByText(removeChildAccountTooltipsMessage)
+          .findByText(PARENT_USER_CLOSE_ACCOUNT_TOOLTIP_TEXT)
           .should('be.visible');
       });
   });

--- a/packages/manager/cypress/e2e/core/account/account-cancellation.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/account-cancellation.spec.ts
@@ -9,6 +9,13 @@ import {
   mockCancelAccount,
   mockCancelAccountError,
 } from 'support/intercepts/account';
+import {
+  cancellationDataLossWarning,
+  cancellationPaymentErrorMessage,
+  contactParentUserTooltipsMessage,
+  contactCustomerSupportTooltipsMessage,
+  removeChildAccountTooltipsMessage,
+} from 'support/constants/account';
 import { mockGetProfile } from 'support/intercepts/profile';
 import { ui } from 'support/ui';
 import {
@@ -23,29 +30,6 @@ import {
   mockGetFeatureFlagClientstream,
 } from 'support/intercepts/feature-flags';
 import { makeFeatureFlagData } from 'support/util/feature-flags';
-
-// Data loss warning which is displayed in the account cancellation dialog.
-const cancellationDataLossWarning =
-  'Please note this is an extremely destructive action. Closing your account \
-means that all services Linodes, Volumes, DNS Records, etc will be lost and \
-may not be able be restored.';
-
-// Error message that appears when a payment failure occurs upon cancellation attempt.
-const cancellationPaymentErrorMessage =
-  'We were unable to charge your credit card for services rendered. \
-We cannot cancel this account until the balance has been paid.';
-
-// Tooltip message that appears when a child account tries to close the account.
-const contactParentUserTooltipsMessage =
-  'Contact your parent user to close your account.';
-
-// Tooltip message that appears when a child account tries to close the account.
-const contactCustomerSupportTooltipsMessage =
-  'Contact customer support to close this account.';
-
-// Tooltip message that appears when a parent account with one and more child accounts tries to close the account.
-const removeChildAccountTooltipsMessage =
-  'Remove child accounts before closing the account.';
 
 describe('Account cancellation', () => {
   /*
@@ -254,7 +238,7 @@ describe('Parent/Child account cancellation', () => {
   /**
    * Confirms that a proxy account cannot close the account
    */
-  it('disables a proxy account to close the account', () => {
+  it('disables "Close Account" button for proxy users', () => {
     const mockAccount = accountFactory.build();
     const mockProfile = profileFactory.build({
       username: 'proxy-user',
@@ -288,7 +272,7 @@ describe('Parent/Child account cancellation', () => {
   /**
    * Confirms that a parent account with one or more active child accounts cannot close the account
    */
-  it('disables a parent account with one or more active child accounts to close the account', () => {
+  it('disables "Close Account" button for parent users', () => {
     const mockAccount = accountFactory.build();
     const mockProfile = profileFactory.build({
       username: 'parent-user',
@@ -326,7 +310,7 @@ describe('Parent/Child account cancellation', () => {
     const mockAccount = accountFactory.build();
     const mockProfile = profileFactory.build({
       username: 'default-user',
-      restricted: true,
+      restricted: false,
       user_type: 'default',
     });
     const mockCancellationResponse: CancelAccount = {

--- a/packages/manager/cypress/support/constants/account.ts
+++ b/packages/manager/cypress/support/constants/account.ts
@@ -12,21 +12,3 @@ may not be able be restored.';
 export const cancellationPaymentErrorMessage =
   'We were unable to charge your credit card for services rendered. \
 We cannot cancel this account until the balance has been paid.';
-
-/**
- * Tooltip message that appears when a child user tries to close the account.
- */
-export const contactParentUserTooltipsMessage =
-  'Contact your parent user to close your account.';
-
-/**
- * Tooltip message that appears when a proxy user tries to close the account.
- */
-export const contactCustomerSupportTooltipsMessage =
-  'Contact customer support to close this account.';
-
-/**
- * Tooltip message that appears when a parent user with one and more child users tries to close the account.
- */
-export const removeChildAccountTooltipsMessage =
-  'Remove child accounts before closing the account.';

--- a/packages/manager/cypress/support/constants/account.ts
+++ b/packages/manager/cypress/support/constants/account.ts
@@ -1,0 +1,32 @@
+/**
+ * Data loss warning which is displayed in the account cancellation dialog.
+ */
+export const cancellationDataLossWarning =
+  'Please note this is an extremely destructive action. Closing your account \
+means that all services Linodes, Volumes, DNS Records, etc will be lost and \
+may not be able be restored.';
+
+/**
+ * Error message that appears when a payment failure occurs upon cancellation attempt.
+ */
+export const cancellationPaymentErrorMessage =
+  'We were unable to charge your credit card for services rendered. \
+We cannot cancel this account until the balance has been paid.';
+
+/**
+ * Tooltip message that appears when a child user tries to close the account.
+ */
+export const contactParentUserTooltipsMessage =
+  'Contact your parent user to close your account.';
+
+/**
+ * Tooltip message that appears when a proxy user tries to close the account.
+ */
+export const contactCustomerSupportTooltipsMessage =
+  'Contact customer support to close this account.';
+
+/**
+ * Tooltip message that appears when a parent user with one and more child users tries to close the account.
+ */
+export const removeChildAccountTooltipsMessage =
+  'Remove child accounts before closing the account.';


### PR DESCRIPTION
## Description 📝
Fix the PR comments in previous PR [Add tests to check Parent and Child Close Account flows](https://github.com/linode/manager/pull/10296).

