### PR TITLE
upcoming: [M3-7927] - Linode Create Refactor - Part 6 - Add-ons

### DIFF
--- a/packages/api-v4/.changeset/pr-10319-changed-1711487054721.md
+++ b/packages/api-v4/.changeset/pr-10319-changed-1711487054721.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Changed
+---
+
+Added jsdoc style comments to `CreateLinodeRequest` based on API documentation ([#10319](https://github.com/linode/manager/pull/10319))

--- a/packages/api-v4/.changeset/pr-10319-changed-1711487087221.md
+++ b/packages/api-v4/.changeset/pr-10319-changed-1711487087221.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Changed
+---
+
+Allows `firewall_id` to be `null` in `CreateLinodeRequest` ([#10319](https://github.com/linode/manager/pull/10319))

--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -350,24 +350,104 @@ export interface CreateLinodePlacementGroupPayload {
 }
 
 export interface CreateLinodeRequest {
+  /**
+   * The Linode Type of the Linode you are creating.
+   */
   type: string;
+  /**
+   * The Region where the Linode will be located.
+   */
   region: string;
+  /**
+   * A StackScript ID that will cause the referenced StackScript to be run during deployment of this Linode.
+   *
+   * This field cannot be used when deploying from a Backup or a Private Image.
+   */
   stackscript_id?: number;
+  /**
+   * A Backup ID from another Linode’s available backups.
+   *
+   * Your User must have read_write access to that Linode,
+   * the Backup must have a status of successful,
+   * and the Linode must be deployed to the same region as the Backup.
+   *
+   * This field and the image field are mutually exclusive.
+   */
   backup_id?: number;
+  /**
+   * When deploying from an Image, this field is optional, otherwise it is ignored.
+   * This is used to set the swap disk size for the newly-created Linode.
+   * @default 512
+   */
   swap_size?: number;
+  /**
+   * An Image ID to deploy the Linode Disk from.
+   */
   image?: string | null;
+  /**
+   * This sets the root user’s password on a newly-created Linode Disk when deploying from an Image.
+   */
   root_pass?: string;
+  /**
+   * A list of public SSH keys that will be automatically appended to the root user’s
+   * `~/.ssh/authorized_keys`file when deploying from an Image.
+   */
   authorized_keys?: string[];
+  /**
+   * If this field is set to true, the created Linode will automatically be enrolled in the Linode Backup service.
+   * This will incur an additional charge. The cost for the Backup service is dependent on the Type of Linode deployed.
+   *
+   * This option is always treated as true if the account-wide backups_enabled setting is true.
+   *
+   * @default false
+   */
   backups_enabled?: boolean;
+  /**
+   * This field is required only if the StackScript being deployed requires input data from the User for successful completion
+   */
   stackscript_data?: any;
+  /**
+   * If it is deployed from an Image or a Backup and you wish it to remain offline after deployment, set this to false.
+   * @default true if the Linode is created with an Image or from a Backup.
+   */
   booted?: boolean;
+  /**
+   * The Linode’s label is for display purposes only.
+   * If no label is provided for a Linode, a default will be assigned.
+   */
   label?: string;
+  /**
+   * An array of tags applied to this object.
+   *
+   * Tags are for organizational purposes only.
+   */
   tags?: string[];
+  /**
+   * If true, the created Linode will have private networking enabled and assigned a private IPv4 address.
+   * @default false
+   */
   private_ip?: boolean;
+  /**
+   * A list of usernames. If the usernames have associated SSH keys,
+   * the keys will be appended to the root users `~/.ssh/authorized_keys`
+   * file automatically when deploying from an Image.
+   */
   authorized_users?: string[];
+  /**
+   * An array of Network Interfaces to add to this Linode’s Configuration Profile.
+   */
   interfaces?: InterfacePayload[];
+  /**
+   * An object containing user-defined data relevant to the creation of Linodes.
+   */
   metadata?: UserData;
-  firewall_id?: number;
+  /**
+   * The `id` of the Firewall to attach this Linode to upon creation.
+   */
+  firewall_id?: number | null;
+  /**
+   * An object that assigns this the Linode to a placment group upon creation.
+   */
   placement_group?: CreateLinodePlacementGroupPayload;
 }
 

--- a/packages/manager/.changeset/pr-10319-upcoming-features-1711487110394.md
+++ b/packages/manager/.changeset/pr-10319-upcoming-features-1711487110394.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Linode Create Refactor - Part 6 - Add-ons ([#10319](https://github.com/linode/manager/pull/10319))

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Addons.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Addons.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { regionFactory } from 'src/factories';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
+
+import { Addons } from './Addons';
+
+describe('Linode Create v2 Addons', () => {
+  it('should render a root password input', () => {
+    const { getByText } = renderWithThemeAndHookFormContext({
+      component: <Addons />,
+    });
+
+    const heading = getByText('Add-ons');
+
+    expect(heading).toBeVisible();
+    expect(heading.tagName).toBe('H2');
+  });
+
+  it('renders a warning if an edge region is selected', async () => {
+    const region = regionFactory.build({ site_type: 'edge' });
+
+    server.use(
+      http.get('*/v4/regions', () => {
+        return HttpResponse.json(makeResourcePage([region]));
+      })
+    );
+
+    const { findByText } = renderWithThemeAndHookFormContext({
+      component: <Addons />,
+      useFormOptions: { defaultValues: { region: region.id } },
+    });
+
+    await findByText(
+      'Backups and Private IP are currently not available for Edge regions.'
+    );
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Addons.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Addons.test.tsx
@@ -8,7 +8,7 @@ import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
 import { Addons } from './Addons';
 
 describe('Linode Create v2 Addons', () => {
-  it('should render a root password input', () => {
+  it('should render an "Add-ons" heading', () => {
     const { getByText } = renderWithThemeAndHookFormContext({
       component: <Addons />,
     });

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Addons.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Addons.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useWatch } from 'react-hook-form';
 
 import { Divider } from 'src/components/Divider';
@@ -18,7 +18,10 @@ export const Addons = () => {
 
   const { data: regions } = useRegionsQuery();
 
-  const selectedRegion = regions?.find((r) => r.id === regionId);
+  const selectedRegion = useMemo(
+    () => regions?.find((r) => r.id === regionId),
+    [regions, regionId]
+  );
 
   const isEdgeRegionSelected = selectedRegion?.site_type === 'edge';
 

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Addons.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Addons.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { useWatch } from 'react-hook-form';
+
+import { Divider } from 'src/components/Divider';
+import { Notice } from 'src/components/Notice/Notice';
+import { Paper } from 'src/components/Paper';
+import { Stack } from 'src/components/Stack';
+import { Typography } from 'src/components/Typography';
+import { useRegionsQuery } from 'src/queries/regions/regions';
+
+import { Backups } from './Backups';
+import { PrivateIP } from './PrivateIP';
+
+import type { CreateLinodeRequest } from '@linode/api-v4';
+
+export const Addons = () => {
+  const regionId = useWatch<CreateLinodeRequest, 'region'>({ name: 'region' });
+
+  const { data: regions } = useRegionsQuery();
+
+  const selectedRegion = regions?.find((r) => r.id === regionId);
+
+  const isEdgeRegionSelected = selectedRegion?.site_type === 'edge';
+
+  return (
+    <Paper>
+      <Stack spacing={2}>
+        <Typography variant="h2">Add-ons</Typography>
+        {isEdgeRegionSelected && (
+          <Notice
+            text="Backups and Private IP are currently not available for Edge regions."
+            variant="warning"
+          />
+        )}
+        <Stack divider={<Divider />} spacing={2}>
+          <Backups />
+          <PrivateIP />
+        </Stack>
+      </Stack>
+    </Paper>
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Backups.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Backups.test.tsx
@@ -27,7 +27,7 @@ describe('Linode Create V2 Backups Addon', () => {
     expect(checkbox).not.toBeChecked();
   });
 
-  it('should get its value from the from context', () => {
+  it('should get its value from the form context', () => {
     const {
       getByRole,
     } = renderWithThemeAndHookFormContext<CreateLinodeRequest>({

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Backups.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Backups.test.tsx
@@ -1,7 +1,12 @@
 import { waitFor } from '@testing-library/react';
 import React from 'react';
 
-import { accountSettingsFactory, regionFactory } from 'src/factories';
+import {
+  accountSettingsFactory,
+  profileFactory,
+  regionFactory,
+} from 'src/factories';
+import { grantsFactory } from 'src/factories/grants';
 import { makeResourcePage } from 'src/mocks/serverHandlers';
 import { HttpResponse, http, server } from 'src/mocks/testServer';
 import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
@@ -73,6 +78,31 @@ describe('Linode Create V2 Backups Addon', () => {
     } = renderWithThemeAndHookFormContext<CreateLinodeRequest>({
       component: <Backups />,
       useFormOptions: { defaultValues: { region: region.id } },
+    });
+
+    const checkbox = getByRole('checkbox');
+
+    await waitFor(() => {
+      expect(checkbox).toBeDisabled();
+    });
+  });
+
+  it('should be disabled if the user does not have permission to create a linode', async () => {
+    server.use(
+      http.get('*/v4/profile', () => {
+        return HttpResponse.json(profileFactory.build({ restricted: true }));
+      }),
+      http.get('*/v4/profile/grants', () => {
+        return HttpResponse.json(
+          grantsFactory.build({ global: { add_linodes: false } })
+        );
+      })
+    );
+
+    const {
+      getByRole,
+    } = renderWithThemeAndHookFormContext<CreateLinodeRequest>({
+      component: <Backups />,
     });
 
     const checkbox = getByRole('checkbox');

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Backups.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Backups.test.tsx
@@ -1,0 +1,84 @@
+import { waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { accountSettingsFactory, regionFactory } from 'src/factories';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
+
+import { Backups } from './Backups';
+
+import type { CreateLinodeRequest } from '@linode/api-v4';
+
+describe('Linode Create V2 Backups Addon', () => {
+  it('should render a label and checkbox', () => {
+    const { getByLabelText } = renderWithThemeAndHookFormContext({
+      component: <Backups />,
+    });
+
+    const checkbox = getByLabelText('Backups', { exact: false });
+
+    expect(checkbox).toBeEnabled();
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('should get its value from the from context', () => {
+    const {
+      getByRole,
+    } = renderWithThemeAndHookFormContext<CreateLinodeRequest>({
+      component: <Backups />,
+      useFormOptions: { defaultValues: { backups_enabled: true } },
+    });
+
+    const checkbox = getByRole('checkbox');
+
+    expect(checkbox).toBeEnabled();
+    expect(checkbox).toBeChecked();
+  });
+
+  it('should render special copy, be checked, and be disabled if account backups are enabled', async () => {
+    server.use(
+      http.get('*/v4/account/settings', () => {
+        return HttpResponse.json(
+          accountSettingsFactory.build({ backups_enabled: true })
+        );
+      })
+    );
+
+    const { findByText, getByRole } = renderWithThemeAndHookFormContext({
+      component: <Backups />,
+    });
+
+    const checkbox = getByRole('checkbox');
+
+    await findByText('You have enabled automatic backups for your account.', {
+      exact: false,
+    });
+
+    expect(checkbox).toBeDisabled();
+    expect(checkbox).toBeChecked();
+  });
+
+  it('should be disabled if an edge region is selected', async () => {
+    const region = regionFactory.build({ site_type: 'edge' });
+
+    server.use(
+      http.get('*/v4/regions', () => {
+        return HttpResponse.json(makeResourcePage([region]));
+      })
+    );
+
+    const {
+      getByRole,
+    } = renderWithThemeAndHookFormContext<CreateLinodeRequest>({
+      component: <Backups />,
+      useFormOptions: { defaultValues: { region: region.id } },
+    });
+
+    const checkbox = getByRole('checkbox');
+
+    await waitFor(() => {
+      expect(checkbox).toBeDisabled();
+    });
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Backups.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Backups.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { useController, useWatch } from 'react-hook-form';
+
+import { Checkbox } from 'src/components/Checkbox';
+import { Currency } from 'src/components/Currency';
+import { FormControlLabel } from 'src/components/FormControlLabel';
+import { Link } from 'src/components/Link';
+import { Stack } from 'src/components/Stack';
+import { Typography } from 'src/components/Typography';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
+import { useAccountSettings } from 'src/queries/account/settings';
+import { useRegionsQuery } from 'src/queries/regions/regions';
+import { useTypeQuery } from 'src/queries/types';
+import { getMonthlyBackupsPrice } from 'src/utilities/pricing/backups';
+
+import { getBackupsEnabledValue } from './utilities';
+
+import type { CreateLinodeRequest } from '@linode/api-v4';
+
+export const Backups = () => {
+  const { field } = useController<CreateLinodeRequest, 'backups_enabled'>({
+    name: 'backups_enabled',
+  });
+
+  const isLinodeCreateRestricted = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'add_linodes',
+  });
+
+  const regionId = useWatch<CreateLinodeRequest, 'region'>({ name: 'region' });
+  const typeId = useWatch<CreateLinodeRequest, 'type'>({ name: 'type' });
+
+  const { data: type } = useTypeQuery(typeId, Boolean(typeId));
+  const { data: regions } = useRegionsQuery();
+  const { data: accountSettings } = useAccountSettings();
+
+  const backupsMonthlyPrice = getMonthlyBackupsPrice({
+    region: regionId,
+    type,
+  });
+
+  const selectedRegion = regions?.find((r) => r.id === regionId);
+
+  const isAccountBackupsEnabled = accountSettings?.backups_enabled ?? false;
+
+  const isEdgeRegionSelected = selectedRegion?.site_type === 'edge';
+
+  return (
+    <FormControlLabel
+      checked={getBackupsEnabledValue({
+        accountBackupsEnabled: isAccountBackupsEnabled,
+        isEdgeRegion: isEdgeRegionSelected,
+        value: field.value,
+      })}
+      disabled={
+        isEdgeRegionSelected ||
+        isLinodeCreateRestricted ||
+        isAccountBackupsEnabled
+      }
+      label={
+        <Stack sx={{ pl: 2 }}>
+          <Stack alignItems="center" direction="row" spacing={2}>
+            <Typography variant="h3">Backups</Typography>
+            {backupsMonthlyPrice && (
+              <Typography>
+                <Currency quantity={backupsMonthlyPrice} /> per month
+              </Typography>
+            )}
+          </Stack>
+          <Typography>
+            {isAccountBackupsEnabled ? (
+              <React.Fragment>
+                You have enabled automatic backups for your account. This Linode
+                will automatically have backups enabled. To change this setting,{' '}
+                <Link to={'/account/settings'}>click here.</Link>
+              </React.Fragment>
+            ) : (
+              <React.Fragment>
+                Three backup slots are executed and rotated automatically: a
+                daily backup, a 2-7 day old backup, and an 8-14 day old backup.
+                Plans are priced according to the Linode plan selected above.
+              </React.Fragment>
+            )}
+          </Typography>
+        </Stack>
+      }
+      control={<Checkbox />}
+      onChange={field.onChange}
+    />
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Backups.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Backups.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useController, useWatch } from 'react-hook-form';
 
 import { Checkbox } from 'src/components/Checkbox';
@@ -38,7 +38,10 @@ export const Backups = () => {
     type,
   });
 
-  const selectedRegion = regions?.find((r) => r.id === regionId);
+  const selectedRegion = useMemo(
+    () => regions?.find((r) => r.id === regionId),
+    [regions, regionId]
+  );
 
   const isAccountBackupsEnabled = accountSettings?.backups_enabled ?? false;
 

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/PrivateIP.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/PrivateIP.test.tsx
@@ -23,7 +23,7 @@ describe('Linode Create V2 Private IP Add-on', () => {
     expect(checkbox).not.toBeChecked();
   });
 
-  it('should get its value from the from context', () => {
+  it('should get its value from the form context', () => {
     const {
       getByRole,
     } = renderWithThemeAndHookFormContext<CreateLinodeRequest>({

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/PrivateIP.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/PrivateIP.test.tsx
@@ -1,7 +1,8 @@
 import { waitFor } from '@testing-library/react';
 import React from 'react';
 
-import { regionFactory } from 'src/factories';
+import { profileFactory, regionFactory } from 'src/factories';
+import { grantsFactory } from 'src/factories/grants';
 import { makeResourcePage } from 'src/mocks/serverHandlers';
 import { HttpResponse, http, server } from 'src/mocks/testServer';
 import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
@@ -50,6 +51,31 @@ describe('Linode Create V2 Private IP Add-on', () => {
     } = renderWithThemeAndHookFormContext<CreateLinodeRequest>({
       component: <PrivateIP />,
       useFormOptions: { defaultValues: { region: region.id } },
+    });
+
+    const checkbox = getByRole('checkbox');
+
+    await waitFor(() => {
+      expect(checkbox).toBeDisabled();
+    });
+  });
+
+  it('should be disabled if the user does not have permission to create a linode', async () => {
+    server.use(
+      http.get('*/v4/profile', () => {
+        return HttpResponse.json(profileFactory.build({ restricted: true }));
+      }),
+      http.get('*/v4/profile/grants', () => {
+        return HttpResponse.json(
+          grantsFactory.build({ global: { add_linodes: false } })
+        );
+      })
+    );
+
+    const {
+      getByRole,
+    } = renderWithThemeAndHookFormContext<CreateLinodeRequest>({
+      component: <PrivateIP />,
     });
 
     const checkbox = getByRole('checkbox');

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/PrivateIP.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/PrivateIP.test.tsx
@@ -1,0 +1,61 @@
+import { waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { regionFactory } from 'src/factories';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
+
+import { PrivateIP } from './PrivateIP';
+
+import type { CreateLinodeRequest } from '@linode/api-v4';
+
+describe('Linode Create V2 Private IP Add-on', () => {
+  it('should render a label and checkbox', () => {
+    const { getByLabelText } = renderWithThemeAndHookFormContext({
+      component: <PrivateIP />,
+    });
+
+    const checkbox = getByLabelText('Private IP', { exact: false });
+
+    expect(checkbox).toBeEnabled();
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('should get its value from the from context', () => {
+    const {
+      getByRole,
+    } = renderWithThemeAndHookFormContext<CreateLinodeRequest>({
+      component: <PrivateIP />,
+      useFormOptions: { defaultValues: { private_ip: true } },
+    });
+
+    const checkbox = getByRole('checkbox');
+
+    expect(checkbox).toBeEnabled();
+    expect(checkbox).toBeChecked();
+  });
+
+  it('should be disabled if an edge region is selected', async () => {
+    const region = regionFactory.build({ site_type: 'edge' });
+
+    server.use(
+      http.get('*/v4/regions', () => {
+        return HttpResponse.json(makeResourcePage([region]));
+      })
+    );
+
+    const {
+      getByRole,
+    } = renderWithThemeAndHookFormContext<CreateLinodeRequest>({
+      component: <PrivateIP />,
+      useFormOptions: { defaultValues: { region: region.id } },
+    });
+
+    const checkbox = getByRole('checkbox');
+
+    await waitFor(() => {
+      expect(checkbox).toBeDisabled();
+    });
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/PrivateIP.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/PrivateIP.tsx
@@ -1,5 +1,4 @@
-import type { CreateLinodeRequest } from '@linode/api-v4';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useController, useWatch } from 'react-hook-form';
 
 import { Checkbox } from 'src/components/Checkbox';
@@ -8,6 +7,8 @@ import { Stack } from 'src/components/Stack';
 import { Typography } from 'src/components/Typography';
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 import { useRegionsQuery } from 'src/queries/regions/regions';
+
+import type { CreateLinodeRequest } from '@linode/api-v4';
 
 export const PrivateIP = () => {
   const { field } = useController<CreateLinodeRequest, 'private_ip'>({
@@ -22,7 +23,10 @@ export const PrivateIP = () => {
 
   const regionId = useWatch<CreateLinodeRequest, 'region'>({ name: 'region' });
 
-  const selectedRegion = regions?.find((r) => r.id === regionId);
+  const selectedRegion = useMemo(
+    () => regions?.find((r) => r.id === regionId),
+    [regions, regionId]
+  );
 
   const isEdgeRegionSelected = selectedRegion?.site_type === 'edge';
 

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/PrivateIP.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/PrivateIP.tsx
@@ -1,0 +1,46 @@
+import { CreateLinodeRequest } from '@linode/api-v4';
+import React from 'react';
+import { useController, useWatch } from 'react-hook-form';
+
+import { Checkbox } from 'src/components/Checkbox';
+import { FormControlLabel } from 'src/components/FormControlLabel';
+import { Stack } from 'src/components/Stack';
+import { Typography } from 'src/components/Typography';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
+import { useRegionsQuery } from 'src/queries/regions/regions';
+
+export const PrivateIP = () => {
+  const { field } = useController<CreateLinodeRequest, 'private_ip'>({
+    name: 'private_ip',
+  });
+
+  const { data: regions } = useRegionsQuery();
+
+  const isLinodeCreateRestricted = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'add_linodes',
+  });
+
+  const regionId = useWatch<CreateLinodeRequest, 'region'>({ name: 'region' });
+
+  const selectedRegion = regions?.find((r) => r.id === regionId);
+
+  const isEdgeRegionSelected = selectedRegion?.site_type === 'edge';
+
+  return (
+    <FormControlLabel
+      label={
+        <Stack sx={{ pl: 2 }}>
+          <Typography variant="h3">Private IP</Typography>
+          <Typography>
+            Use Private IP for a backend node to a NodeBalancer. Use VPC instead
+            for private communication between your Linodes.
+          </Typography>
+        </Stack>
+      }
+      checked={field.value ?? false}
+      control={<Checkbox />}
+      disabled={isEdgeRegionSelected || isLinodeCreateRestricted}
+      onChange={field.onChange}
+    />
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/PrivateIP.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/PrivateIP.tsx
@@ -1,4 +1,4 @@
-import { CreateLinodeRequest } from '@linode/api-v4';
+import type { CreateLinodeRequest } from '@linode/api-v4';
 import React from 'react';
 import { useController, useWatch } from 'react-hook-form';
 

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/utilities.test.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/utilities.test.ts
@@ -1,0 +1,88 @@
+import { getBackupsEnabledValue } from './utilities';
+
+describe('getBackupsEnabledValue', () => {
+  it('should always return true if account backups are enabled', () => {
+    expect(
+      getBackupsEnabledValue({
+        accountBackupsEnabled: true,
+        isEdgeRegion: false,
+        value: false,
+      })
+    ).toBe(true);
+    expect(
+      getBackupsEnabledValue({
+        accountBackupsEnabled: true,
+        isEdgeRegion: false,
+        value: true,
+      })
+    ).toBe(true);
+    expect(
+      getBackupsEnabledValue({
+        accountBackupsEnabled: true,
+        isEdgeRegion: false,
+        value: undefined,
+      })
+    ).toBe(true);
+  });
+
+  it('should return the form value if account backups are not enabled', () => {
+    expect(
+      getBackupsEnabledValue({
+        accountBackupsEnabled: false,
+        isEdgeRegion: false,
+        value: true,
+      })
+    ).toBe(true);
+    expect(
+      getBackupsEnabledValue({
+        accountBackupsEnabled: false,
+        isEdgeRegion: false,
+        value: false,
+      })
+    ).toBe(false);
+  });
+
+  it('should default to false if the form data is undefined', () => {
+    expect(
+      getBackupsEnabledValue({
+        accountBackupsEnabled: false,
+        isEdgeRegion: false,
+        value: undefined,
+      })
+    ).toBe(false);
+  });
+
+  it('should ignore `accountBackupsEnabled` if it is undefined', () => {
+    expect(
+      getBackupsEnabledValue({
+        accountBackupsEnabled: undefined,
+        isEdgeRegion: false,
+        value: false,
+      })
+    ).toBe(false);
+    expect(
+      getBackupsEnabledValue({
+        accountBackupsEnabled: undefined,
+        isEdgeRegion: false,
+        value: true,
+      })
+    ).toBe(true);
+  });
+
+  it('should always return false if an edge region is selected becuase edge regions do not support backups', () => {
+    expect(
+      getBackupsEnabledValue({
+        accountBackupsEnabled: undefined,
+        isEdgeRegion: true,
+        value: true,
+      })
+    ).toBe(false);
+    expect(
+      getBackupsEnabledValue({
+        accountBackupsEnabled: undefined,
+        isEdgeRegion: true,
+        value: false,
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/utilities.ts
@@ -1,0 +1,21 @@
+interface BackupsEnabledOptions {
+  accountBackupsEnabled: boolean | undefined;
+  isEdgeRegion: boolean;
+  value: boolean | undefined;
+}
+
+export const getBackupsEnabledValue = (options: BackupsEnabledOptions) => {
+  if (options.isEdgeRegion) {
+    return false;
+  }
+
+  if (options.accountBackupsEnabled) {
+    return true;
+  }
+
+  if (options.value === undefined) {
+    return false;
+  }
+
+  return options.value;
+};

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Details/Details.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Details/Details.tsx
@@ -7,6 +7,7 @@ import { TagsInput } from 'src/components/TagsInput/TagsInput';
 import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
 import { useFlags } from 'src/hooks/useFlags';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 
 import { PlacementGroupPanel } from './PlacementGroupPanel';
 
@@ -16,12 +17,17 @@ export const Details = () => {
 
   const showPlacementGroups = Boolean(flags.placementGroups?.enabled);
 
+  const isCreateLinodeRestricted = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'add_linodes',
+  });
+
   return (
     <Paper>
       <Typography variant="h2">Details</Typography>
       <Controller
         render={({ field, fieldState }) => (
           <TextField
+            disabled={isCreateLinodeRestricted}
             errorText={fieldState.error?.message}
             label="Linode Label"
             onChange={field.onChange}
@@ -37,6 +43,7 @@ export const Details = () => {
             value={
               field.value?.map((tag) => ({ label: tag, value: tag })) ?? []
             }
+            disabled={isCreateLinodeRestricted}
             onChange={(item) => field.onChange(item.map((i) => i.value))}
             tagError={fieldState.error?.message}
           />

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Summary.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Summary.tsx
@@ -4,14 +4,20 @@ import { useFormContext } from 'react-hook-form';
 
 import { Box } from 'src/components/Box';
 import { Button } from 'src/components/Button/Button';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 
 export const Summary = () => {
   const { formState } = useFormContext<CreateLinodeRequest>();
+
+  const isLinodeCreateRestricted = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'add_linodes',
+  });
 
   return (
     <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
       <Button
         buttonType="primary"
+        disabled={isLinodeCreateRestricted}
         loading={formState.isSubmitting}
         type="submit"
       >

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Distributions.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Distributions.tsx
@@ -4,6 +4,7 @@ import { useController } from 'react-hook-form';
 import { ImageSelectv2 } from 'src/components/ImageSelectv2/ImageSelectv2';
 import { Paper } from 'src/components/Paper';
 import { Typography } from 'src/components/Typography';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 
 import type { CreateLinodeRequest } from '@linode/api-v4';
 
@@ -12,10 +13,15 @@ export const Distributions = () => {
     name: 'image',
   });
 
+  const isCreateLinodeRestricted = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'add_linodes',
+  });
+
   return (
     <Paper>
       <Typography variant="h2">Choose a Distribution</Typography>
       <ImageSelectv2
+        disabled={isCreateLinodeRestricted}
         errorText={fieldState.error?.message}
         onChange={(_, image) => field.onChange(image?.id ?? null)}
         value={field.value}

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Images.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Images.tsx
@@ -4,6 +4,7 @@ import { useController } from 'react-hook-form';
 import { ImageSelectv2 } from 'src/components/ImageSelectv2/ImageSelectv2';
 import { Paper } from 'src/components/Paper';
 import { Typography } from 'src/components/Typography';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 
 import type { CreateLinodeRequest } from '@linode/api-v4';
 
@@ -12,10 +13,15 @@ export const Images = () => {
     name: 'image',
   });
 
+  const isCreateLinodeRestricted = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'add_linodes',
+  });
+
   return (
     <Paper>
       <Typography variant="h2">Choose an Image</Typography>
       <ImageSelectv2
+        disabled={isCreateLinodeRestricted}
         errorText={fieldState.error?.message}
         onChange={(_, image) => field.onChange(image?.id ?? null)}
         value={field.value}

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
@@ -12,6 +12,7 @@ import { Tabs } from 'src/components/Tabs/Tabs';
 import { useCreateLinodeMutation } from 'src/queries/linodes/linodes';
 
 import { Access } from './Access';
+import { Addons } from './Addons/Addons';
 import { Details } from './Details/Details';
 import { Error } from './Error';
 import { Firewall } from './Firewall';
@@ -92,6 +93,7 @@ export const LinodeCreatev2 = () => {
           <Details />
           <Access />
           <Firewall />
+          <Addons />
           <Summary />
         </Stack>
       </form>

--- a/packages/validation/.changeset/pr-10319-changed-1711487139814.md
+++ b/packages/validation/.changeset/pr-10319-changed-1711487139814.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Changed
+---
+
+Allows `firewall_id` to be `null` in `CreateLinodeSchema` ([#10319](https://github.com/linode/manager/pull/10319))

--- a/packages/validation/src/linodes.schema.ts
+++ b/packages/validation/src/linodes.schema.ts
@@ -297,7 +297,7 @@ export const CreateLinodeSchema = object({
   }),
   interfaces: LinodeInterfacesSchema,
   metadata: MetadataSchema,
-  firewall_id: number().notRequired(),
+  firewall_id: number().nullable().notRequired(),
   placement_group: PlacementGroupPayloadSchema,
 });
 


### PR DESCRIPTION
## Description 📝

Adds the "Add-ons" section to the new Linode Create Flow 🎉 

## Changes  🔄
- Adds the "Add-ons" section to the new Linode Create flow
  - The ability to add a private IP 🔌  
  - The ability to enable backups 💾 
- Adds jsdoc style comments to the Linode Create type in api-v4 📝 (copy paste from API spec)
- Allows `firewall_id` to be null in the Linode Create type because the API allows it ✅ 

## Preview 📷

![Screenshot 2024-03-26 at 4 58 24 PM](https://github.com/linode/manager/assets/115251059/49d9087b-f460-4510-9143-a7fa841e7764)

## How to test 🧪

### Prerequisites
- Turn on the new Linode Create Flow feature flag using your local dev tools 🎏  (you can use the preview link or checkout this PR)

### Verification steps
- Go to the Linode Create Flow
- Test general create flow functionality
- Test both the `Private IP` checkbox and the `Backups` checkbox ☑️ 
- Check my code for anything unreadable or questionable 📖 
- Verify unit tests are sufficient 🧪 

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
