### PR TITLE
fix: [M3-7605] - Wrong status indicator when provisioning a LKE

### DIFF
--- a/packages/manager/.changeset/pr-10320-fixed-1711553963315.md
+++ b/packages/manager/.changeset/pr-10320-fixed-1711553963315.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Wrong status indicator when provisioning a LKE ([#10320](https://github.com/linode/manager/pull/10320))

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -2,16 +2,16 @@ import {
   AutoscaleSettings,
   PoolNodeResponse,
 } from '@linode/api-v4/lib/kubernetes';
-import Grid from '@mui/material/Unstable_Grid2';
 import { Theme } from '@mui/material/styles';
-import { makeStyles } from 'tss-react/mui';
+import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
+import { makeStyles } from 'tss-react/mui';
 
 import { Button } from 'src/components/Button/Button';
 import { Tooltip } from 'src/components/Tooltip';
 import { Typography } from 'src/components/Typography';
 
-import NodeTable from './NodeTable';
+import { NodeTable } from './NodeTable';
 
 interface Props {
   autoscaler: AutoscaleSettings;

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeRow.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeRow.tsx
@@ -1,0 +1,128 @@
+import { APIError } from '@linode/api-v4/lib/types';
+import Grid from '@mui/material/Unstable_Grid2';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+
+import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
+import { StatusIcon } from 'src/components/StatusIcon/StatusIcon';
+import { TableCell } from 'src/components/TableCell';
+import { Typography } from 'src/components/Typography';
+import { transitionText } from 'src/features/Linodes/transitions';
+import { useInProgressEvents } from 'src/queries/events/events';
+
+import NodeActionMenu from './NodeActionMenu';
+import { StyledCopyTooltip, StyledTableRow } from './NodeTable.styles';
+
+export interface NodeRow {
+  instanceId?: number;
+  instanceStatus?: string;
+  ip?: string;
+  label?: string;
+  nodeId: string;
+  nodeStatus: string;
+}
+
+interface NodeRowProps extends NodeRow {
+  linodeError?: APIError[];
+  openRecycleNodeDialog: (nodeID: string, linodeLabel: string) => void;
+  typeLabel: string;
+}
+
+export const NodeRow = React.memo((props: NodeRowProps) => {
+  const {
+    instanceId,
+    instanceStatus,
+    ip,
+    label,
+    linodeError,
+    nodeId,
+    nodeStatus,
+    openRecycleNodeDialog,
+    typeLabel,
+  } = props;
+
+  const { data: events } = useInProgressEvents();
+
+  const recentEvent = events?.find(
+    (event) =>
+      event.entity?.id === instanceId && event.entity?.type === 'linode'
+  );
+
+  const linodeLink = instanceId ? `/linodes/${instanceId}` : undefined;
+
+  const nodeReadyAndInstanceRunning =
+    nodeStatus === 'ready' && instanceStatus === 'running';
+
+  const iconStatus =
+    nodeStatus === 'not_ready'
+      ? 'other'
+      : nodeReadyAndInstanceRunning
+      ? 'active'
+      : 'inactive';
+
+  const displayLabel = label ?? typeLabel;
+
+  const displayStatus =
+    nodeStatus === 'not_ready'
+      ? 'Provisioning'
+      : transitionText(instanceStatus ?? '', instanceId ?? -1, recentEvent);
+
+  const displayIP = ip ?? '';
+
+  return (
+    <StyledTableRow ariaLabel={label} data-qa-node-row={nodeId}>
+      <TableCell>
+        <Grid alignItems="center" container wrap="nowrap">
+          <Grid>
+            <Typography>
+              {linodeLink ? (
+                <Link to={linodeLink}>{displayLabel}</Link>
+              ) : (
+                displayLabel
+              )}
+            </Typography>
+          </Grid>
+        </Grid>
+      </TableCell>
+      <TableCell statusCell={!linodeError}>
+        {linodeError ? (
+          <Typography
+            sx={(theme) => ({
+              color: theme.color.red,
+            })}
+          >
+            Error retrieving status
+          </Typography>
+        ) : (
+          <>
+            <StatusIcon status={iconStatus} />
+            {displayStatus}
+          </>
+        )}
+      </TableCell>
+      <TableCell>
+        {linodeError ? (
+          <Typography
+            sx={(theme) => ({
+              color: theme.color.red,
+            })}
+          >
+            Error retrieving IP
+          </Typography>
+        ) : displayIP.length > 0 ? (
+          <>
+            <CopyTooltip copyableText text={displayIP} />
+            <StyledCopyTooltip text={displayIP} />
+          </>
+        ) : null}
+      </TableCell>
+      <TableCell>
+        <NodeActionMenu
+          instanceLabel={label}
+          nodeId={nodeId}
+          openRecycleNodeDialog={openRecycleNodeDialog}
+        />
+      </TableCell>
+    </StyledTableRow>
+  );
+});

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.styles.ts
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.styles.ts
@@ -1,0 +1,34 @@
+import { styled } from '@mui/material/styles';
+
+import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
+import { TableRow } from 'src/components/TableRow';
+
+export const StyledTableRow = styled(TableRow, {
+  label: 'TableRow',
+})(({ theme }) => ({
+  '& svg': {
+    height: `12px`,
+    opacity: 0,
+    width: `12px`,
+  },
+  '&:hover': {
+    backgroundColor: theme.bg.lightBlue1,
+  },
+  [`&:hover > svg, & :focus > svg`]: {
+    opacity: 1,
+  },
+  marginLeft: 4,
+  top: 1,
+}));
+
+export const StyledCopyTooltip = styled(CopyTooltip, {
+  label: 'CopyTooltip',
+})(() => ({
+  '& svg': {
+    height: `12px`,
+    opacity: 0,
+    width: `12px`,
+  },
+  marginLeft: 4,
+  top: 1,
+}));

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.styles.ts
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.styles.ts
@@ -1,6 +1,7 @@
 import { styled } from '@mui/material/styles';
 
 import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
+import { Table } from 'src/components/Table';
 import { TableRow } from 'src/components/TableRow';
 
 export const StyledTableRow = styled(TableRow, {
@@ -14,11 +15,18 @@ export const StyledTableRow = styled(TableRow, {
   '&:hover': {
     backgroundColor: theme.bg.lightBlue1,
   },
-  [`&:hover > svg, & :focus > svg`]: {
+  [`&:hover .copy-tooltip > svg, & .copy-tooltip:focus > svg`]: {
     opacity: 1,
   },
   marginLeft: 4,
   top: 1,
+}));
+
+export const StyledTable = styled(Table, {
+  label: 'Table',
+})(({ theme }) => ({
+  borderLeft: `1px solid ${theme.borderColors.borderTable}`,
+  borderRight: `1px solid ${theme.borderColors.borderTable}`,
 }));
 
 export const StyledCopyTooltip = styled(CopyTooltip, {

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -1,10 +1,10 @@
 import { PoolNodeResponse } from '@linode/api-v4/lib/kubernetes';
 import { APIError } from '@linode/api-v4/lib/types';
-import Grid from '@mui/material/Unstable_Grid2';
 import { Theme } from '@mui/material/styles';
-import { makeStyles } from 'tss-react/mui';
+import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import { makeStyles } from 'tss-react/mui';
 
 import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
 import OrderBy from 'src/components/OrderBy';
@@ -230,9 +230,16 @@ export const NodeRow: React.FC<NodeRowProps> = React.memo((props) => {
 
   const nodeReadyAndInstanceRunning =
     nodeStatus === 'ready' && instanceStatus === 'running';
-  const iconStatus = nodeReadyAndInstanceRunning ? 'active' : 'inactive';
+
+  const iconStatus =
+    nodeStatus === 'not_ready'
+      ? 'other'
+      : nodeReadyAndInstanceRunning
+      ? 'active'
+      : 'inactive';
 
   const displayLabel = label ?? typeLabel;
+
   const displayStatus =
     nodeStatus === 'not_ready'
       ? 'Provisioning'

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -1,12 +1,9 @@
 import { PoolNodeResponse } from '@linode/api-v4/lib/kubernetes';
-import { Theme } from '@mui/material/styles';
 import * as React from 'react';
-import { makeStyles } from 'tss-react/mui';
 
 import OrderBy from 'src/components/OrderBy';
 import Paginate from 'src/components/Paginate';
 import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFooter';
-import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
 import { TableCell } from 'src/components/TableCell';
 import { TableContentWrapper } from 'src/components/TableContentWrapper/TableContentWrapper';
@@ -19,53 +16,10 @@ import { useAllLinodesQuery } from 'src/queries/linodes/linodes';
 import { LinodeWithMaintenance } from 'src/utilities/linodes';
 
 import { NodeRow as _NodeRow } from './NodeRow';
+import { StyledTable } from './NodeTable.styles';
 
 import type { NodeRow } from './NodeRow';
 
-const useStyles = makeStyles<void, 'copy'>()(
-  (theme: Theme, _params, classes) => ({
-    copy: {
-      '& svg': {
-        height: `12px`,
-        opacity: 0,
-        width: `12px`,
-      },
-      marginLeft: 4,
-      top: 1,
-    },
-    error: {
-      color: theme.color.red,
-    },
-    ipCell: {
-      ...theme.applyTableHeaderStyles,
-      width: '35%',
-    },
-    labelCell: {
-      ...theme.applyTableHeaderStyles,
-      width: '35%',
-    },
-    row: {
-      '&:hover': {
-        backgroundColor: theme.bg.lightBlue1,
-      },
-      [`&:hover .${classes.copy} > svg, & .${classes.copy}:focus > svg`]: {
-        opacity: 1,
-      },
-    },
-    statusCell: {
-      ...theme.applyTableHeaderStyles,
-      width: '15%',
-    },
-    table: {
-      borderLeft: `1px solid ${theme.borderColors.borderTable}`,
-      borderRight: `1px solid ${theme.borderColors.borderTable}`,
-    },
-  })
-);
-
-// =============================================================================
-// NodeTable
-// =============================================================================
 export interface Props {
   nodes: PoolNodeResponse[];
   openRecycleNodeDialog: (nodeID: string, linodeLabel: string) => void;
@@ -73,10 +27,8 @@ export interface Props {
   typeLabel: string;
 }
 
-export const NodeTable = (props: Props) => {
+export const NodeTable = React.memo((props: Props) => {
   const { nodes, openRecycleNodeDialog, poolId, typeLabel } = props;
-
-  const { classes } = useStyles();
 
   const { data: linodes, error, isLoading } = useAllLinodesQuery();
 
@@ -95,15 +47,15 @@ export const NodeTable = (props: Props) => {
             pageSize,
           }) => (
             <>
-              <Table
-                aria-label="List of Your Cluster Nodes"
-                className={classes.table}
-              >
+              <StyledTable aria-label="List of Your Cluster Nodes">
                 <TableHead>
                   <TableRow>
                     <TableSortCell
+                      sx={(theme) => ({
+                        ...theme.applyTableHeaderStyles,
+                        width: '35%',
+                      })}
                       active={orderBy === 'label'}
-                      className={classes.labelCell}
                       direction={order}
                       handleClick={handleOrderChange}
                       label={'label'}
@@ -111,8 +63,11 @@ export const NodeTable = (props: Props) => {
                       Linode
                     </TableSortCell>
                     <TableSortCell
+                      sx={(theme) => ({
+                        ...theme.applyTableHeaderStyles,
+                        width: '35%',
+                      })}
                       active={orderBy === 'instanceStatus'}
-                      className={classes.statusCell}
                       direction={order}
                       handleClick={handleOrderChange}
                       label={'instanceStatus'}
@@ -120,8 +75,11 @@ export const NodeTable = (props: Props) => {
                       Status
                     </TableSortCell>
                     <TableSortCell
+                      sx={(theme) => ({
+                        ...theme.applyTableHeaderStyles,
+                        width: '15%',
+                      })}
                       active={orderBy === 'ip'}
-                      className={classes.ipCell}
                       direction={order}
                       handleClick={handleOrderChange}
                       label={'ip'}
@@ -162,7 +120,7 @@ export const NodeTable = (props: Props) => {
                     </TableCell>
                   </TableRow>
                 </TableFooter>
-              </Table>
+              </StyledTable>
               <PaginationFooter
                 count={count}
                 eventCategory="Node Table"
@@ -177,13 +135,7 @@ export const NodeTable = (props: Props) => {
       )}
     </OrderBy>
   );
-};
-
-export default React.memo(NodeTable);
-
-// =============================================================================
-// Utilities
-// =============================================================================
+});
 
 /**
  * Transforms an LKE Pool Node to a NodeRow.


### PR DESCRIPTION
## Description 📝
Fix the status icon indicator when a Kubernetes Linode is provisioning from grey to pulsing orange. I also went ahead and did some styling/file cleanup.

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-03-27 at 10 38 24 AM](https://github.com/linode/manager/assets/115299789/e7c9142f-49b4-4c7d-841d-f553c2c9a6ad) | <video src="https://github.com/linode/manager/assets/115299789/591ae82c-45d2-453f-818b-2719f06dc2d5" /> |

## How to test 🧪
### Reproduction steps
(How to reproduce the issue, if applicable)
- On develop or prod, create a new Kubernetes cluster and observe the grey provisioning Linode icon status in the details page

### Verification steps
(How to verify changes)
- Create a new Kubernetes cluster and observe the pulsing orange provisioning Linode icon status in the details page
- Ensure there are no visual regressions from the code clean up

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support