### PR TITLE
upcoming: [M3-7939] - Refactor for Auto-Token Refresh Prep

### DIFF
--- a/packages/manager/.changeset/pr-10323-upcoming-features-1711570823407.md
+++ b/packages/manager/.changeset/pr-10323-upcoming-features-1711570823407.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Refactored code for enhanced reusability, paving the way for smoother automatic token refresh and an improved user experience. ([#10323](https://github.com/linode/manager/pull/10323))

--- a/packages/manager/.changeset/pr-10323-upcoming-features-1711570823407.md
+++ b/packages/manager/.changeset/pr-10323-upcoming-features-1711570823407.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-Refactored code for enhanced reusability, paving the way for smoother automatic token refresh and an improved user experience. ([#10323](https://github.com/linode/manager/pull/10323))
+Refactor account switching utils for reusability and automatic token refreshing ([#10323](https://github.com/linode/manager/pull/10323))

--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -221,10 +221,10 @@ const AccountLanding = () => {
         </React.Suspense>
       </Tabs>
       <SwitchAccountDrawer
-        isProxyUser={isProxyUser}
         onClose={() => setIsDrawerOpen(false)}
         open={isDrawerOpen}
         proxyToken={pendingRevocationToken}
+        userType={profile?.user_type}
       />
     </React.Fragment>
   );

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.test.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.test.tsx
@@ -2,16 +2,15 @@ import { fireEvent } from '@testing-library/react';
 import * as React from 'react';
 
 import { profileFactory } from 'src/factories/profile';
-import { http, HttpResponse, server } from 'src/mocks/testServer';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { SwitchAccountDrawer } from './SwitchAccountDrawer';
 
 const props = {
-  isProxyUser: false,
   onClose: vi.fn(),
   open: true,
-  username: 'mock-user',
+  userType: undefined,
 };
 
 describe('SwitchAccountDrawer', () => {
@@ -38,7 +37,7 @@ describe('SwitchAccountDrawer', () => {
     );
 
     const { findByLabelText, getByText } = renderWithTheme(
-      <SwitchAccountDrawer {...props} isProxyUser />
+      <SwitchAccountDrawer {...props} userType="proxy" />
     );
 
     expect(

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
@@ -1,4 +1,3 @@
-import { createChildAccountPersonalAccessToken } from '@linode/api-v4';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 
@@ -9,7 +8,6 @@ import { Typography } from 'src/components/Typography';
 import { PARENT_USER_SESSION_EXPIRED } from 'src/features/Account/constants';
 import {
   isParentTokenValid,
-  setTokenInLocalStorage,
   updateCurrentTokenBasedOnUserType,
 } from 'src/features/Account/utils';
 import { useCurrentToken } from 'src/hooks/useAuthentication';
@@ -18,21 +16,25 @@ import { sendSwitchToParentAccountEvent } from 'src/utilities/analytics';
 import { getStorage, setStorage } from 'src/utilities/storage';
 
 import { ChildAccountList } from './SwitchAccounts/ChildAccountList';
+import {
+  updateParentTokenInLocalStorage,
+  updateProxyTokenInLocalStorage,
+} from './SwitchAccounts/utils';
 
-import type { Token } from '@linode/api-v4';
-import type { APIError, ChildAccountPayload, UserType } from '@linode/api-v4';
+import type { APIError, Token, UserType } from '@linode/api-v4';
 import type { State as AuthState } from 'src/store/authentication';
 
 interface Props {
-  isProxyUser: boolean;
   onClose: () => void;
   open: boolean;
   proxyToken?: Token;
+  userType: UserType | undefined;
 }
 
 export const SwitchAccountDrawer = (props: Props) => {
-  const { isProxyUser, onClose, open, proxyToken } = props;
+  const { onClose, open, proxyToken, userType } = props;
   const proxyTokenLabel = proxyToken?.label;
+  const isProxyUser = userType === 'proxy';
 
   const [isParentTokenError, setIsParentTokenError] = React.useState<
     APIError[]
@@ -50,10 +52,6 @@ export const SwitchAccountDrawer = (props: Props) => {
   const currentParentTokenWithBearer =
     getStorage('authentication/parent_token/token') ?? '';
 
-  const handleClose = React.useCallback(() => {
-    onClose();
-  }, [onClose]);
-
   const handleProxyTokenRevocation = React.useCallback(async () => {
     try {
       await revokeToken();
@@ -67,63 +65,6 @@ export const SwitchAccountDrawer = (props: Props) => {
     }
   }, [enqueueSnackbar, proxyTokenLabel, revokeToken]);
 
-  const handleSwitchAccount = async ({
-    currentTokenWithBearer,
-    euuid,
-    event,
-    handleClose,
-    isProxyUser,
-  }: {
-    currentTokenWithBearer?: AuthState['token'];
-    euuid: string;
-    event: React.MouseEvent<HTMLElement>;
-    handleClose: (e: React.SyntheticEvent<HTMLElement>) => void;
-    isProxyUser: boolean;
-  }) => {
-    if (isProxyUser) {
-      await handleProxyTokenRevocation();
-    }
-    handleSwitchToChildAccount({
-      currentTokenWithBearer,
-      euuid,
-      event,
-      handleClose,
-      isProxyUser,
-    });
-  };
-
-  /**
-   * Headers are required for proxy users when obtaining a proxy token.
-   * For 'proxy' userType, use the stored parent token in the request.
-   */
-  const getProxyToken = React.useCallback(
-    async ({
-      euuid,
-      token,
-      userType,
-    }: {
-      euuid: ChildAccountPayload['euuid'];
-      token: string;
-      userType: Omit<UserType, 'child'>;
-    }) => {
-      try {
-        return await createChildAccountPersonalAccessToken({
-          euuid,
-          headers:
-            userType === 'proxy'
-              ? {
-                  Authorization: token,
-                }
-              : undefined,
-        });
-      } catch (error) {
-        setIsProxyTokenError(error as APIError[]);
-        throw error;
-      }
-    },
-    []
-  );
-
   const refreshPage = React.useCallback(() => {
     location.reload();
   }, []);
@@ -133,60 +74,45 @@ export const SwitchAccountDrawer = (props: Props) => {
       currentTokenWithBearer,
       euuid,
       event,
-      handleClose,
-      isProxyUser,
+      onClose,
+      userType,
     }: {
       currentTokenWithBearer?: AuthState['token'];
       euuid: string;
       event: React.MouseEvent<HTMLElement>;
-      handleClose: (e: React.SyntheticEvent<HTMLElement>) => void;
-      isProxyUser: boolean;
+      onClose: (e: React.SyntheticEvent<HTMLElement>) => void;
+      userType: UserType | undefined;
     }) => {
+      const isProxyUser = userType === 'proxy';
+
+      // Only if we're a proxy user do we need to revoke the proxy token.
+      if (isProxyUser) {
+        await handleProxyTokenRevocation();
+      }
+
+      // Before switching to a child account, update the parent token in local storage.
+      if (!isProxyUser) {
+        updateParentTokenInLocalStorage({
+          currentTokenWithBearer,
+        });
+      }
+
       try {
-        // We don't need to worry about this if we're a proxy user.
-        if (!isProxyUser) {
-          const parentToken: Token = {
-            created: getStorage('authentication/created'),
-            expiry: getStorage('authentication/expire'),
-            id: getStorage('authentication/id'),
-            label: getStorage('authentication/label'),
-            scopes: getStorage('authentication/scopes'),
-            token: currentTokenWithBearer ?? '',
-          };
-
-          setTokenInLocalStorage({
-            prefix: 'authentication/parent_token',
-            token: parentToken,
-          });
-        }
-
-        const proxyToken = await getProxyToken({
+        await updateProxyTokenInLocalStorage({
           euuid,
           token: isProxyUser
             ? getStorage('authentication/parent_token/token')
             : currentTokenWithBearer,
           userType: isProxyUser ? 'proxy' : 'parent',
         });
-
-        setTokenInLocalStorage({
-          prefix: 'authentication/proxy_token',
-          token: {
-            ...proxyToken,
-            token: `Bearer ${proxyToken.token}`,
-          },
-        });
-
-        updateCurrentTokenBasedOnUserType({
-          userType: 'proxy',
-        });
-
-        handleClose(event);
-        refreshPage();
       } catch (error) {
-        setIsProxyTokenError(error as APIError[]);
+        setIsProxyTokenError(error);
       }
+
+      onClose(event);
+      refreshPage();
     },
-    [getProxyToken, refreshPage]
+    [handleProxyTokenRevocation, refreshPage]
   );
 
   const handleSwitchToParentAccount = React.useCallback(async () => {
@@ -209,12 +135,12 @@ export const SwitchAccountDrawer = (props: Props) => {
     // Reset flag for proxy user to display success toast once.
     setStorage('proxy_user', 'false');
 
-    handleClose();
+    onClose();
     refreshPage();
-  }, [handleClose, handleProxyTokenRevocation, refreshPage]);
+  }, [onClose, handleProxyTokenRevocation, refreshPage]);
 
   return (
-    <Drawer onClose={handleClose} open={open} title="Switch Account">
+    <Drawer onClose={onClose} open={open} title="Switch Account">
       {isProxyTokenError.length > 0 && (
         <Notice text={isProxyTokenError[0].reason} variant="error" />
       )}
@@ -247,9 +173,9 @@ export const SwitchAccountDrawer = (props: Props) => {
         currentTokenWithBearer={
           isProxyUser ? currentParentTokenWithBearer : currentTokenWithBearer
         }
-        isProxyUser={isProxyUser}
-        onClose={handleClose}
-        onSwitchAccount={handleSwitchAccount}
+        onClose={onClose}
+        onSwitchAccount={handleSwitchToChildAccount}
+        userType={userType}
       />
     </Drawer>
   );

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
@@ -85,16 +85,12 @@ export const SwitchAccountDrawer = (props: Props) => {
     }) => {
       const isProxyUser = userType === 'proxy';
 
-      // Only if we're a proxy user do we need to revoke the proxy token.
       if (isProxyUser) {
+        // Revoke proxy token before switching accounts.
         await handleProxyTokenRevocation();
-      }
-
-      // Before switching to a child account, update the parent token in local storage.
-      if (!isProxyUser) {
-        updateParentTokenInLocalStorage({
-          currentTokenWithBearer,
-        });
+      } else {
+        // Before switching to a child account, update the parent token in local storage.
+        updateParentTokenInLocalStorage({ currentTokenWithBearer });
       }
 
       try {

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
@@ -103,6 +103,7 @@ export const SwitchAccountDrawer = (props: Props) => {
         });
       } catch (error) {
         setIsProxyTokenError(error);
+        throw error;
       }
 
       onClose(event);

--- a/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.test.tsx
+++ b/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.test.tsx
@@ -9,9 +9,9 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 
 const props = {
   currentTokenWithBearer: 'Bearer 123',
-  isProxyUser: false,
   onClose: vi.fn(),
   onSwitchAccount: vi.fn(),
+  userType: undefined,
 };
 
 it('should display a list of child accounts', async () => {

--- a/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
+++ b/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
@@ -11,25 +11,27 @@ import { Stack } from 'src/components/Stack';
 import { Typography } from 'src/components/Typography';
 import { useChildAccountsInfiniteQuery } from 'src/queries/account/account';
 
+import type { UserType } from '@linode/api-v4';
+
 interface ChildAccountListProps {
   currentTokenWithBearer: string;
-  isProxyUser: boolean;
   onClose: () => void;
   onSwitchAccount: (props: {
     currentTokenWithBearer: string;
     euuid: string;
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>;
-    handleClose: () => void;
-    isProxyUser: boolean;
+    onClose: () => void;
+    userType: UserType | undefined;
   }) => void;
+  userType: UserType | undefined;
 }
 
 export const ChildAccountList = React.memo(
   ({
     currentTokenWithBearer,
-    isProxyUser,
     onClose,
     onSwitchAccount,
+    userType,
   }: ChildAccountListProps) => {
     const {
       data,
@@ -40,11 +42,12 @@ export const ChildAccountList = React.memo(
       isLoading,
       refetch: refetchChildAccounts,
     } = useChildAccountsInfiniteQuery({
-      headers: isProxyUser
-        ? {
-            Authorization: currentTokenWithBearer,
-          }
-        : undefined,
+      headers:
+        userType === 'proxy'
+          ? {
+              Authorization: currentTokenWithBearer,
+            }
+          : undefined,
     });
     const childAccounts = data?.pages.flatMap((page) => page.data);
 
@@ -92,8 +95,8 @@ export const ChildAccountList = React.memo(
               currentTokenWithBearer,
               euuid,
               event,
-              handleClose: onClose,
-              isProxyUser,
+              onClose,
+              userType,
             })
           }
           sx={(theme) => ({

--- a/packages/manager/src/features/Account/SwitchAccounts/utils.ts
+++ b/packages/manager/src/features/Account/SwitchAccounts/utils.ts
@@ -1,0 +1,89 @@
+import { createChildAccountPersonalAccessToken } from '@linode/api-v4';
+
+import {
+  setTokenInLocalStorage,
+  updateCurrentTokenBasedOnUserType,
+} from 'src/features/Account/utils';
+import { getStorage } from 'src/utilities/storage';
+
+import type { Token, UserType } from '@linode/api-v4';
+import type { State as AuthState } from 'src/store/authentication';
+
+export interface ProxyTokenCreationParams {
+  /**
+   * The euuid of the child account for which the token is being created.
+   */
+  euuid: string;
+  /**
+   * The parent token used to create the proxy token (includes 'Bearer' prefix).
+   */
+  token: string;
+  /**
+   * The userType of the child account.
+   */
+  userType: Omit<UserType, 'child' | 'default'>;
+}
+
+/**
+ * Headers are required for proxy users when obtaining a proxy token.
+ * For 'proxy' userType, use the stored parent token in the request.
+ */
+export const getProxyToken = async ({
+  euuid,
+  token,
+  userType,
+}: ProxyTokenCreationParams) => {
+  return await createChildAccountPersonalAccessToken({
+    euuid,
+    headers:
+      userType === 'proxy'
+        ? {
+            Authorization: token,
+          }
+        : undefined,
+  });
+};
+
+export const updateParentTokenInLocalStorage = ({
+  currentTokenWithBearer,
+}: {
+  currentTokenWithBearer?: AuthState['token'];
+}) => {
+  const parentToken: Token = {
+    created: getStorage('authentication/created'),
+    expiry: getStorage('authentication/expire'),
+    id: getStorage('authentication/id'),
+    label: getStorage('authentication/label'),
+    scopes: getStorage('authentication/scopes'),
+    token: currentTokenWithBearer ?? '',
+  };
+
+  setTokenInLocalStorage({
+    prefix: 'authentication/parent_token',
+    token: parentToken,
+  });
+};
+
+export const updateProxyTokenInLocalStorage = async ({
+  euuid,
+  token,
+  userType,
+}: ProxyTokenCreationParams) => {
+  const proxyToken = await getProxyToken({
+    euuid,
+    token,
+    userType,
+  });
+
+  setTokenInLocalStorage({
+    prefix: 'authentication/proxy_token',
+    token: {
+      ...proxyToken,
+      token: `Bearer ${proxyToken.token}`,
+    },
+  });
+
+  updateCurrentTokenBasedOnUserType({
+    userType: 'proxy',
+  });
+};

--- a/packages/manager/src/features/Account/SwitchAccounts/utils.ts
+++ b/packages/manager/src/features/Account/SwitchAccounts/utils.ts
@@ -24,26 +24,6 @@ export interface ProxyTokenCreationParams {
   userType: Omit<UserType, 'child' | 'default'>;
 }
 
-/**
- * Headers are required for proxy users when obtaining a proxy token.
- * For 'proxy' userType, use the stored parent token in the request.
- */
-export const getProxyToken = async ({
-  euuid,
-  token,
-  userType,
-}: ProxyTokenCreationParams) => {
-  return await createChildAccountPersonalAccessToken({
-    euuid,
-    headers:
-      userType === 'proxy'
-        ? {
-            Authorization: token,
-          }
-        : undefined,
-  });
-};
-
 export const updateParentTokenInLocalStorage = ({
   currentTokenWithBearer,
 }: {
@@ -64,15 +44,23 @@ export const updateParentTokenInLocalStorage = ({
   });
 };
 
+/**
+ * Headers are required for proxy users when obtaining a proxy token.
+ * For 'proxy' userType, use the stored parent token in the request.
+ */
 export const updateProxyTokenInLocalStorage = async ({
   euuid,
   token,
   userType,
 }: ProxyTokenCreationParams) => {
-  const proxyToken = await getProxyToken({
+  const proxyToken = await createChildAccountPersonalAccessToken({
     euuid,
-    token,
-    userType,
+    headers:
+      userType === 'proxy'
+        ? {
+            Authorization: token,
+          }
+        : undefined,
   });
 
   setTokenInLocalStorage({

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -345,10 +345,10 @@ export const UserMenu = React.memo(() => {
         </Stack>
       </Popover>
       <SwitchAccountDrawer
-        isProxyUser={isProxyUser}
         onClose={() => setIsDrawerOpen(false)}
         open={isDrawerOpen}
         proxyToken={pendingRevocationToken}
+        userType={profile?.user_type}
       />
     </>
   );


### PR DESCRIPTION
## Description 📝
To set the stage for automatic token refresh features, we need to tweak our code to make it more reusable. This effort is a step towards that goal, aiming to make our token management smoother and improve overall user experience.

## Changes  🔄
- Moved the functions that handle proxy token creation and storage management into a utils file. This move streamlines our code and makes these key functionalities easier to access and use across the board.

>[!note]
In a follow-up PR, I'll tidy up by moving all the account switching stuff – files, utils, and components – into the `/Account/SwitchAccount/` directory.

## Target release date 🗓️
4/15

## Preview 📷
No visual changes

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Log into Parent account using developer credentials

### Verification steps
- Ensure you can switch accounts back and forth between parent/proxy
- Ensure that proxy PATs are still being revoked every time you switch from within a proxy account. see: https://github.com/linode/manager/pull/10313

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support