### PR TITLE
fix: [UIE-7491] - Hide DBaaS resize tab behind feature flag

### DIFF
--- a/packages/manager/.changeset/pr-10324-fixed-1711637470278.md
+++ b/packages/manager/.changeset/pr-10324-fixed-1711637470278.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Hide DBaaS resize tab behind feature flag ([#10324](https://github.com/linode/manager/pull/10324))

--- a/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
@@ -79,14 +79,17 @@ export const DatabaseDetail = () => {
       title: 'Backups',
     },
     {
-      routeName: `/databases/${engine}/${id}/resize`,
-      title: 'Resize',
-    },
-    {
       routeName: `/databases/${engine}/${id}/settings`,
       title: 'Settings',
     },
   ];
+
+  if (flags.databaseResize) {
+    tabs.splice(2, 0, {
+      routeName: `/databases/${engine}/${id}/resize`,
+      title: 'Resize',
+    });
+  }
 
   const getTabIndex = () => {
     const tabChoice = tabs.findIndex((tab) =>
@@ -163,7 +166,7 @@ export const DatabaseDetail = () => {
               <DatabaseResize database={database} />
             </SafeTabPanel>
           ) : null}
-          <SafeTabPanel index={3}>
+          <SafeTabPanel index={flags.databaseResize ? 3 : 2}>
             <DatabaseSettings database={database} />
           </SafeTabPanel>
         </TabPanels>


### PR DESCRIPTION
## Description 📝
Fix issues with the Resize tab and Settings tab when the "databaseResize" feature flag is turned off in the alpha.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img src="https://github.com/linode/manager/assets/157619599/abd47813-a4b6-4961-8dde-d1ffe6a11d46" width="400" /> | <img src="https://github.com/linode/manager/assets/157619599/cc4bdfd4-963f-4526-93dc-04aef6ae5b98" width="400" />

| Before  | After   |
| ------- | ------- |
|<img src="https://github.com/linode/manager/assets/157619599/ef232596-20b3-4350-a200-0f887e75a396" width="400" />  | <img src="https://github.com/linode/manager/assets/157619599/0b9e4371-389c-4370-93b5-c37fe8cb1ba3" width="400" />

## How to test 🧪
Open application, navigate to /databases, select the database cluster. If feature flag is turned on go to the Resize tab. If feature flag is turned off, the Resize tab is not visible.

