### PR TITLE
refactor: [M3-7944] - Linode Create Refactor v2 - User Data - Part 7

### DIFF
--- a/packages/manager/src/features/Linodes/LinodeCreatev2/UserData/UserData.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/UserData/UserData.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent } from '@testing-library/react';
+import * as React from 'react';
+
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
+
+import { UserData } from './UserData';
+
+describe('Linode Create v2 UserData', () => {
+  it('should display a warning message if the user data is not in an accepted format', () => {
+    const inputValue = '#test-string';
+    const { getByLabelText, getByText } = renderWithThemeAndHookFormContext({
+      component: <UserData />,
+    });
+
+    const input = getByLabelText('User Data');
+    fireEvent.change(input, { target: { value: inputValue } });
+    fireEvent.blur(input); // triggers format check
+
+    expect(
+      getByText('The user data may be formatted incorrectly.')
+    ).toBeInTheDocument();
+  });
+
+  it('should display a warning in the header for cloning', () => {
+    const { getByText } = renderWithThemeAndHookFormContext({
+      component: <UserData />,
+      options: {
+        MemoryRouter: {
+          initialEntries: [{ pathname: '/linodes/create?type=Clone+Linode' }],
+        },
+      },
+    });
+
+    expect(
+      getByText(
+        'Existing user data is not cloned. You may add new user data now.'
+      )
+    ).toBeVisible();
+  });
+
+  it('should display a warning in the header for creating from a Linode backup', () => {
+    const { getByText } = renderWithThemeAndHookFormContext({
+      component: <UserData />,
+      options: {
+        MemoryRouter: {
+          initialEntries: [{ pathname: '/linodes/create?type=Backups' }],
+        },
+      },
+    });
+
+    expect(
+      getByText(
+        'Existing user data is not accessible when creating a Linode from a backup. You may add new user data now.'
+      )
+    ).toBeVisible();
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/UserData/UserData.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/UserData/UserData.test.tsx
@@ -1,57 +1,63 @@
 import { fireEvent } from '@testing-library/react';
 import * as React from 'react';
 
+import { imageFactory, regionFactory } from 'src/factories';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
 import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
 
 import { UserData } from './UserData';
 
 describe('Linode Create v2 UserData', () => {
-  it('should display a warning message if the user data is not in an accepted format', () => {
-    const inputValue = '#test-string';
-    const { getByLabelText, getByText } = renderWithThemeAndHookFormContext({
+  it('should render if the selected image supports cloud-init and the region supports metadata', async () => {
+    const image = imageFactory.build({ capabilities: ['cloud-init'] });
+    const region = regionFactory.build({ capabilities: ['Metadata'] });
+
+    server.use(
+      http.get('*/v4/images/*', () => {
+        return HttpResponse.json(image);
+      }),
+      http.get('*/v4/regions', () => {
+        return HttpResponse.json(makeResourcePage([region]));
+      })
+    );
+
+    const { findByText } = renderWithThemeAndHookFormContext({
       component: <UserData />,
+      useFormOptions: { defaultValues: { image: image.id, region: region.id } },
     });
 
-    const input = getByLabelText('User Data');
+    const userDataHeading = await findByText('Add User Data');
+
+    expect(userDataHeading).toBeVisible();
+    expect(userDataHeading.tagName).toBe('H2');
+  });
+
+  it('should display a warning message if the user data is not in an accepted format', async () => {
+    const image = imageFactory.build({ capabilities: ['cloud-init'] });
+    const region = regionFactory.build({ capabilities: ['Metadata'] });
+
+    server.use(
+      http.get('*/v4/images/*', () => {
+        return HttpResponse.json(image);
+      }),
+      http.get('*/v4/regions', () => {
+        return HttpResponse.json(makeResourcePage([region]));
+      })
+    );
+
+    const inputValue = '#test-string';
+    const { findByLabelText, getByText } = renderWithThemeAndHookFormContext({
+      component: <UserData />,
+      useFormOptions: { defaultValues: { image: image.id, region: region.id } },
+    });
+
+    const input = await findByLabelText('User Data');
     fireEvent.change(input, { target: { value: inputValue } });
     fireEvent.blur(input); // triggers format check
 
     expect(
       getByText('The user data may be formatted incorrectly.')
     ).toBeInTheDocument();
-  });
-
-  it('should display a warning in the header for cloning', () => {
-    const { getByText } = renderWithThemeAndHookFormContext({
-      component: <UserData />,
-      options: {
-        MemoryRouter: {
-          initialEntries: [{ pathname: '/linodes/create?type=Clone+Linode' }],
-        },
-      },
-    });
-
-    expect(
-      getByText(
-        'Existing user data is not cloned. You may add new user data now.'
-      )
-    ).toBeVisible();
-  });
-
-  it('should display a warning in the header for creating from a Linode backup', () => {
-    const { getByText } = renderWithThemeAndHookFormContext({
-      component: <UserData />,
-      options: {
-        MemoryRouter: {
-          initialEntries: [{ pathname: '/linodes/create?type=Backups' }],
-        },
-      },
-    });
-
-    expect(
-      getByText(
-        'Existing user data is not accessible when creating a Linode from a backup. You may add new user data now.'
-      )
-    ).toBeVisible();
   });
 });

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/UserData/UserData.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/UserData/UserData.tsx
@@ -1,0 +1,113 @@
+import React, { useMemo } from 'react';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
+
+import { Accordion } from 'src/components/Accordion';
+import { Link } from 'src/components/Link';
+import { Notice } from 'src/components/Notice/Notice';
+import { TextField } from 'src/components/TextField';
+import { Typography } from 'src/components/Typography';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
+import { useImageQuery } from 'src/queries/images';
+import { useRegionsQuery } from 'src/queries/regions/regions';
+
+import { atou, utoa } from '../../LinodesCreate/utilities';
+import { UserDataHeading } from './UserDataHeading';
+
+import type { CreateLinodeRequest } from '@linode/api-v4';
+
+export const UserData = () => {
+  const { control } = useFormContext<CreateLinodeRequest>();
+
+  const regionId = useWatch({ control, name: 'region' });
+  const imageId = useWatch({ control, name: 'image' });
+
+  const [formatWarning, setFormatWarning] = React.useState(false);
+
+  const { data: regions } = useRegionsQuery();
+  const { data: image } = useImageQuery(imageId ?? '', Boolean(imageId));
+
+  const checkFormat = ({
+    hasInputValueChanged,
+    userData,
+  }: {
+    hasInputValueChanged: boolean;
+    userData: string;
+  }) => {
+    const userDataLower = userData.toLowerCase();
+    const validPrefixes = ['#cloud-config', 'content-type: text/', '#!/bin/'];
+    const isUserDataValid = validPrefixes.some((prefix) =>
+      userDataLower.startsWith(prefix)
+    );
+    if (userData.length > 0 && !isUserDataValid && !hasInputValueChanged) {
+      setFormatWarning(true);
+    } else {
+      setFormatWarning(false);
+    }
+  };
+
+  const region = useMemo(() => regions?.find((r) => r.id === regionId), [
+    regions,
+    regionId,
+  ]);
+
+  const isLinodeCreateRestricted = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'add_linodes',
+  });
+
+  if (!region?.capabilities.includes('Metadata')) {
+    return null;
+  }
+
+  if (!image?.capabilities.includes('cloud-init')) {
+    return null;
+  }
+
+  return (
+    <Accordion heading={<UserDataHeading />} sx={{ m: '0 !important', p: 1 }}>
+      <Typography>
+        User data is a feature of the Metadata service that enables you to
+        perform system configuration tasks (such as adding users and installing
+        software) by providing custom instructions or scripts to cloud-init. Any
+        user data should be added at this step and cannot be modified after the
+        the Linode has been created.{' '}
+        <Link to="https://www.linode.com/docs/products/compute/compute-instances/guides/metadata/">
+          Learn more.
+        </Link>
+      </Typography>
+      {formatWarning && (
+        <Notice spacingBottom={16} spacingTop={16} variant="warning">
+          The user data may be formatted incorrectly.
+        </Notice>
+      )}
+      <Controller
+        render={({ field, fieldState }) => (
+          <TextField
+            onBlur={(e) =>
+              checkFormat({
+                hasInputValueChanged: false,
+                userData: e.target.value,
+              })
+            }
+            onChange={(e) => {
+              checkFormat({
+                hasInputValueChanged: true,
+                userData: e.target.value,
+              });
+              field.onChange(utoa(e.target.value));
+            }}
+            disabled={isLinodeCreateRestricted}
+            errorText={fieldState.error?.message}
+            expand
+            label="User Data"
+            labelTooltipText="Compatible formats include cloud-config data and executable scripts."
+            multiline
+            rows={1}
+            value={atou(field.value ?? '')}
+          />
+        )}
+        control={control}
+        name="metadata.user_data"
+      />
+    </Accordion>
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/UserData/UserDataHeading.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/UserData/UserDataHeading.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { UserDataHeading } from './UserDataHeading';
+
+describe('UserDataHeading', () => {
+  it('should display a warning in the header for cloning', () => {
+    const { getByText } = renderWithTheme(<UserDataHeading />, {
+      MemoryRouter: {
+        initialEntries: ['/linodes/create?type=Clone+Linode'],
+      },
+    });
+
+    expect(
+      getByText(
+        'Existing user data is not cloned. You may add new user data now.'
+      )
+    ).toBeVisible();
+  });
+
+  it('should display a warning in the header for creating from a Linode backup', () => {
+    const { getByText } = renderWithTheme(<UserDataHeading />, {
+      MemoryRouter: {
+        initialEntries: ['/linodes/create?type=Backups'],
+      },
+    });
+
+    expect(
+      getByText(
+        'Existing user data is not accessible when creating a Linode from a backup. You may add new user data now.'
+      )
+    ).toBeVisible();
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/UserData/UserDataHeading.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/UserData/UserDataHeading.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+import { Link } from 'src/components/Link';
+import { Notice } from 'src/components/Notice/Notice';
+import { Stack } from 'src/components/Stack';
+import { TooltipIcon } from 'src/components/TooltipIcon';
+import { Typography } from 'src/components/Typography';
+
+import { useLinodeCreateQueryParams } from '../utilities';
+
+import type { LinodeCreateType } from '../../LinodesCreate/types';
+
+export const UserDataHeading = () => {
+  const { params } = useLinodeCreateQueryParams();
+
+  const warningMessageMap: Record<LinodeCreateType, null | string> = {
+    Backups:
+      'Existing user data is not accessible when creating a Linode from a backup. You may add new user data now.',
+    'Clone Linode':
+      'Existing user data is not cloned. You may add new user data now.',
+    Distributions: null,
+    Images: null,
+    'One-Click': null,
+    StackScripts: null,
+  };
+
+  const warningMessage = params.type ? warningMessageMap[params.type] : null;
+
+  return (
+    <Stack>
+      <Stack direction="row" spacing={1}>
+        <Typography variant="h2">Add User Data</Typography>
+        <TooltipIcon
+          text={
+            <>
+              User data allows you to provide additional custom data to
+              cloud-init to further configure your system.{' '}
+              <Link to="https://www.linode.com/docs/products/compute/compute-instances/guides/metadata/">
+                Learn more.
+              </Link>
+            </>
+          }
+          interactive
+          status="help"
+          sxTooltipIcon={{ p: 0 }}
+        />
+      </Stack>
+      {warningMessage && (
+        <Notice spacingBottom={16} spacingTop={16} variant="warning">
+          {warningMessage}
+        </Notice>
+      )}
+    </Stack>
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
@@ -21,6 +21,7 @@ import { Region } from './Region';
 import { Summary } from './Summary';
 import { Distributions } from './Tabs/Distributions';
 import { Images } from './Tabs/Images';
+import { UserData } from './UserData/UserData';
 import { getTabIndex, tabs, useLinodeCreateQueryParams } from './utilities';
 
 import type { CreateLinodeRequest } from '@linode/api-v4';
@@ -93,6 +94,7 @@ export const LinodeCreatev2 = () => {
           <Details />
           <Access />
           <Firewall />
+          <UserData />
           <Addons />
           <Summary />
         </Stack>

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
@@ -7,7 +7,7 @@ import type { LinodeCreateType } from '../LinodesCreate/types';
 /**
  * This interface is used to type the query params on the Linode Create flow.
  */
-interface LinodeCreateQueryParams {
+export interface LinodeCreateQueryParams {
   type: LinodeCreateType | undefined;
 }
 

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
@@ -7,7 +7,7 @@ import type { LinodeCreateType } from '../LinodesCreate/types';
 /**
  * This interface is used to type the query params on the Linode Create flow.
  */
-export interface LinodeCreateQueryParams {
+interface LinodeCreateQueryParams {
   type: LinodeCreateType | undefined;
 }
 

--- a/packages/manager/src/features/Linodes/LinodesCreate/utilities.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/utilities.tsx
@@ -27,6 +27,13 @@ export const utoa = (data: string) => {
   }
 };
 
+/**
+ * ASCII to Unicode (decode Base64 to original data)
+ */
+export function atou(b64: string) {
+  return decodeURIComponent(escape(atob(b64)));
+}
+
 export const regionSupportsMetadata = (
   regionsData: Region[],
   region: string


### PR DESCRIPTION
## Description 📝

Adds User Data section to the new Linode Create page 👤📑 🎉 

> [!note]
> The User Data section will only show up if  you select an Image that is cloud-init capable and a region that supports Metadata. I don't necessarily agree with this UX, but this matches the existing behavior.

## Preview 📷

![Screenshot 2024-03-29 at 11 38 08 AM](https://github.com/linode/manager/assets/115251059/31b6d2bd-56f2-48a4-b98f-4bdb0450bd09)

## How to test 🧪

- Turn on the `Linode Create v2` feature flag using load dev tools
- Verify you see the Metadata section if you select a `cloud-init` capable image and a Region that supports metadata
- Verify you can specify metadata 
 - Observe that the base64 encoded user data is in the payload

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support