### PR TITLE
fix: `README.md` Logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h3 align="center">
-  <img src="https://github.com/linode/manager/blob/develop/packages/manager/src/assets/logo/akamai-logo.svg" width="200" />
+  <img src="https://github.com/linode/manager/blob/develop/packages/manager/src/assets/logo/akamai-logo-color.svg" width="200" />
   <br />
   <br />
   Akamai Connected Cloud Manager


### PR DESCRIPTION
## Description 📝

Update the `README.md` to use the correct logo

For context, the Logo became white in https://github.com/linode/manager/pull/10137 so we need to update the `README.md` to pull the color logo