### PR TITLE
change: [M3-7873] - Use Chip for notification badge

### DIFF
--- a/packages/manager/.changeset/pr-10333-changed-1711728610850.md
+++ b/packages/manager/.changeset/pr-10333-changed-1711728610850.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Use Chip for notification badge ([#10333](https://github.com/linode/manager/pull/10333))

--- a/packages/manager/src/features/TopMenu/NotificationMenu/NotificationMenu.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationMenu/NotificationMenu.tsx
@@ -5,6 +5,7 @@ import { useDispatch } from 'react-redux';
 
 import Bell from 'src/assets/icons/notification.svg';
 import { Button } from 'src/components/Button/Button';
+import { Chip } from 'src/components/Chip';
 import { ClickAwayListener } from 'src/components/ClickAwayListener';
 import { WrapperMenuItem } from 'src/components/MenuItem/MenuItem';
 import { MenuList } from 'src/components/MenuList';
@@ -36,19 +37,18 @@ const NotificationIconWrapper = styled(StyledTopMenuIconWrapper, {
   color: props.isMenuOpen ? '#606469' : '#c9c7c7',
 }));
 
-const NotificationIconBadge = styled('div')(({ theme }) => ({
-  alignItems: 'center',
-  backgroundColor: theme.color.green,
-  borderRadius: '50%',
-  color: 'white',
-  display: 'flex',
+const StyledChip = styled(Chip)(() => ({
+  '& .MuiChip-label': {
+    paddingLeft: 2,
+    paddingRight: 2,
+  },
   fontSize: '0.72rem',
   height: '1rem',
   justifyContent: 'center',
   left: 20,
+  padding: 0,
   position: 'absolute',
-  top: 2,
-  width: '1rem',
+  top: 1,
 }));
 
 export const NotificationMenu = () => {
@@ -135,7 +135,12 @@ export const NotificationMenu = () => {
           <NotificationIconWrapper isMenuOpen={notificationContext.menuOpen}>
             <Bell />
             {numNotifications > 0 ? (
-              <NotificationIconBadge>{numNotifications}</NotificationIconBadge>
+              <StyledChip
+                color="success"
+                component="span"
+                label={numNotifications}
+                size="small"
+              />
             ) : null}
           </NotificationIconWrapper>
         </Button>


### PR DESCRIPTION
## Description 📝
When the Notification count is past 100, the numbers become difficult to read because their edges appear outside the colored dot. I decided to use the chip component to better display the Notification count.

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/115299789/5216c7a7-265e-4ab0-90e2-df76b98e6c79) | ![image](https://github.com/linode/manager/assets/115299789/ab487188-1028-41ac-bc21-2344c0cbd9f6) |

## How to test 🧪

### Verification steps
(How to verify changes)
- Update the label to a 3 digit number on line 141 of `NotificationMenu.tsx`
- Confirm the notification badge display in the top right corner

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support