### PR TITLE
upcoming: [M3-7928] - Linode Create Refactor - Summary - Part 8

### DIFF
--- a/packages/manager/.changeset/pr-10334-upcoming-features-1711997020117.md
+++ b/packages/manager/.changeset/pr-10334-upcoming-features-1711997020117.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Linode Create Refactor - Summary - Part 8 ([#10334](https://github.com/linode/manager/pull/10334))

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Actions.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Actions.tsx
@@ -1,0 +1,28 @@
+import { CreateLinodeRequest } from '@linode/api-v4';
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { Box } from 'src/components/Box';
+import { Button } from 'src/components/Button/Button';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
+
+export const Actions = () => {
+  const { formState } = useFormContext<CreateLinodeRequest>();
+
+  const isLinodeCreateRestricted = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'add_linodes',
+  });
+
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+      <Button
+        buttonType="primary"
+        disabled={isLinodeCreateRestricted}
+        loading={formState.isSubmitting}
+        type="submit"
+      >
+        Create Linode
+      </Button>
+    </Box>
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Summary.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Summary.test.tsx
@@ -21,22 +21,32 @@ describe('Linode Create v2 Summary', () => {
     expect(heading.tagName).toBe('H2');
   });
 
-  it('should render "Backups" if backups are enabled', async () => {
-    const { findByText } = renderWithThemeAndHookFormContext({
-      component: <Summary />,
-      useFormOptions: { defaultValues: { backups_enabled: true } },
-    });
-
-    await findByText('Backups');
-  });
-
   it('should render "Private IP" if private ip is enabled', async () => {
-    const { findByText } = renderWithThemeAndHookFormContext({
+    const { getByText } = renderWithThemeAndHookFormContext({
       component: <Summary />,
       useFormOptions: { defaultValues: { private_ip: true } },
     });
 
-    await findByText('Private IP');
+    expect(getByText('Private IP')).toBeVisible();
+  });
+
+  it('should render "Backups" if backups are enabled and a type is selected', async () => {
+    const type = typeFactory.build();
+
+    server.use(
+      http.get('*/v4/linode/types/*', () => {
+        return HttpResponse.json(type);
+      })
+    );
+
+    const { findByText } = renderWithThemeAndHookFormContext({
+      component: <Summary />,
+      useFormOptions: {
+        defaultValues: { backups_enabled: true, type: type.id },
+      },
+    });
+
+    await findByText('Backups');
   });
 
   it('should render an image label if an image is selected', async () => {

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Summary.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Summary.test.tsx
@@ -1,0 +1,190 @@
+import React from 'react';
+
+import { imageFactory, regionFactory, typeFactory } from 'src/factories';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
+
+import { Summary } from './Summary';
+
+describe('Linode Create v2 Summary', () => {
+  it('should render a heading based on the Linode label', async () => {
+    const label = 'my-linode-1';
+    const { findByText } = renderWithThemeAndHookFormContext({
+      component: <Summary />,
+      useFormOptions: { defaultValues: { label } },
+    });
+
+    const heading = await findByText(`Summary ${label}`);
+
+    expect(heading).toBeVisible();
+    expect(heading.tagName).toBe('H2');
+  });
+
+  it('should render "Backups" if backups are enabled', async () => {
+    const { findByText } = renderWithThemeAndHookFormContext({
+      component: <Summary />,
+      useFormOptions: { defaultValues: { backups_enabled: true } },
+    });
+
+    await findByText('Backups');
+  });
+
+  it('should render "Private IP" if private ip is enabled', async () => {
+    const { findByText } = renderWithThemeAndHookFormContext({
+      component: <Summary />,
+      useFormOptions: { defaultValues: { private_ip: true } },
+    });
+
+    await findByText('Private IP');
+  });
+
+  it('should render an image label if an image is selected', async () => {
+    const image = imageFactory.build();
+
+    server.use(
+      http.get('*/v4/images/*', () => {
+        return HttpResponse.json(image);
+      })
+    );
+
+    const { findByText } = renderWithThemeAndHookFormContext({
+      component: <Summary />,
+      useFormOptions: { defaultValues: { image: image.id } },
+    });
+
+    await findByText(image.label);
+  });
+
+  it('should render a region label if a region is selected', async () => {
+    const region = regionFactory.build();
+
+    server.use(
+      http.get('*/v4/regions', () => {
+        return HttpResponse.json(makeResourcePage([region]));
+      })
+    );
+
+    const { findByText } = renderWithThemeAndHookFormContext({
+      component: <Summary />,
+      useFormOptions: { defaultValues: { region: region.id } },
+    });
+
+    await findByText(region.label);
+  });
+
+  it('should render a plan (type) label if a type is selected', async () => {
+    const type = typeFactory.build();
+
+    server.use(
+      http.get('*/v4/linode/types/*', () => {
+        return HttpResponse.json(type);
+      })
+    );
+
+    const { findByText } = renderWithThemeAndHookFormContext({
+      component: <Summary />,
+      useFormOptions: { defaultValues: { type: type.id } },
+    });
+
+    await findByText(type.label);
+  });
+
+  it('should a monthly price if a region and plan are selected', async () => {
+    const type = typeFactory.build({ price: { monthly: 5 } });
+
+    server.use(
+      http.get('*/v4/linode/types/*', () => {
+        return HttpResponse.json(type);
+      })
+    );
+
+    const { findByText } = renderWithThemeAndHookFormContext({
+      component: <Summary />,
+      useFormOptions: { defaultValues: { region: 'us-east', type: type.id } },
+    });
+
+    await findByText('$5/month');
+  });
+
+  it('should render a DC specific price if the selected region has price overrides', async () => {
+    const regionId = 'id-cgk';
+
+    const type = typeFactory.build({
+      price: { monthly: 5 },
+      region_prices: [{ id: regionId, monthly: 7 }],
+    });
+
+    server.use(
+      http.get('*/v4/linode/types/*', () => {
+        return HttpResponse.json(type);
+      })
+    );
+
+    const { findByText } = renderWithThemeAndHookFormContext({
+      component: <Summary />,
+      useFormOptions: { defaultValues: { region: regionId, type: type.id } },
+    });
+
+    await findByText('$7/month');
+  });
+
+  it('should render a backups price if backups are enabled, a type is selected, and a region is selected', async () => {
+    const type = typeFactory.build({
+      addons: {
+        backups: { price: { monthly: 2 } },
+      },
+    });
+
+    server.use(
+      http.get('*/v4/linode/types/*', () => {
+        return HttpResponse.json(type);
+      })
+    );
+
+    const { findByText } = renderWithThemeAndHookFormContext({
+      component: <Summary />,
+      useFormOptions: {
+        defaultValues: {
+          backups_enabled: true,
+          region: 'us-east',
+          type: type.id,
+        },
+      },
+    });
+
+    await findByText('$2/month');
+  });
+
+  it('should render a DC specific backups price if the region has overrides ', async () => {
+    const regionId = 'id-cgk';
+
+    const type = typeFactory.build({
+      addons: {
+        backups: {
+          price: { monthly: 2 },
+          region_prices: [{ id: regionId, monthly: 4.2 }],
+        },
+      },
+    });
+
+    server.use(
+      http.get('*/v4/linode/types/*', () => {
+        return HttpResponse.json(type);
+      })
+    );
+
+    const { findByText } = renderWithThemeAndHookFormContext({
+      component: <Summary />,
+      useFormOptions: {
+        defaultValues: {
+          backups_enabled: true,
+          region: regionId,
+          type: type.id,
+        },
+      },
+    });
+
+    await findByText('$4.20/month');
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Summary.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Summary.tsx
@@ -81,7 +81,7 @@ export const Summary = () => {
         details: `$${backupsPrice}/month`,
         title: 'Backups',
       },
-      show: backupsEnabled,
+      show: backupsEnabled && Boolean(type),
     },
     {
       item: {

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Summary.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Summary.tsx
@@ -30,6 +30,7 @@ export const Summary = () => {
     typeId,
     backupsEnabled,
     privateIPEnabled,
+    placementGroupId,
   ] = useWatch({
     control,
     name: [
@@ -40,6 +41,7 @@ export const Summary = () => {
       'type',
       'backups_enabled',
       'private_ip',
+      'placement_group.id',
     ],
   });
 
@@ -94,6 +96,12 @@ export const Summary = () => {
         title: 'Firewall Assigned',
       },
       show: Boolean(firewallId),
+    },
+    {
+      item: {
+        title: 'Assigned to Placement Group',
+      },
+      show: Boolean(placementGroupId),
     },
   ];
 

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Summary.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Summary.tsx
@@ -124,6 +124,7 @@ export const Summary = () => {
                 />
               )
             }
+            flexWrap="wrap"
             direction={isSmallScreen ? 'column' : 'row'}
             gap={1.5}
           >

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Summary.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Summary.tsx
@@ -1,28 +1,94 @@
-import { CreateLinodeRequest } from '@linode/api-v4';
 import React from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 
-import { Box } from 'src/components/Box';
-import { Button } from 'src/components/Button/Button';
-import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
+import { Divider } from 'src/components/Divider';
+import { Paper } from 'src/components/Paper';
+import { Stack } from 'src/components/Stack';
+import { Typography } from 'src/components/Typography';
+import { useImageQuery } from 'src/queries/images';
+import { useRegionsQuery } from 'src/queries/regions/regions';
+import { useTypeQuery } from 'src/queries/types';
+
+import type { CreateLinodeRequest } from '@linode/api-v4';
 
 export const Summary = () => {
-  const { formState } = useFormContext<CreateLinodeRequest>();
+  const { control } = useFormContext<CreateLinodeRequest>();
 
-  const isLinodeCreateRestricted = useRestrictedGlobalGrantCheck({
-    globalGrantType: 'add_linodes',
+  const [label, regionId, imageId, firewallId, typeId] = useWatch({
+    control,
+    name: ['label', 'region', 'image', 'firewall_id', 'type'],
   });
 
+  const { data: regions } = useRegionsQuery();
+  const { data: type } = useTypeQuery(typeId ?? '', Boolean(typeId));
+  const { data: image } = useImageQuery(imageId ?? '', Boolean(imageId));
+
+  const region = regions?.find((r) => r.id === regionId);
+
+  const summaryItems = [
+    {
+      item: {
+        title: image?.label,
+      },
+      show: Boolean(image),
+    },
+    {
+      item: {
+        title: region?.label,
+      },
+      show: Boolean(region),
+    },
+    {
+      item: {
+        details: `$${type?.price.monthly}/month`,
+        title: type?.label,
+      },
+      show: Boolean(region),
+    },
+    {
+      item: {
+        title: 'Firewall Assigned',
+      },
+      show: Boolean(firewallId),
+    },
+  ];
+
+  const summaryItemsToShow = summaryItems.filter((item) => item.show);
+
   return (
-    <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-      <Button
-        buttonType="primary"
-        disabled={isLinodeCreateRestricted}
-        loading={formState.isSubmitting}
-        type="submit"
-      >
-        Create Linode
-      </Button>
-    </Box>
+    <Paper>
+      <Stack spacing={2}>
+        <Typography variant="h2">Summary {label}</Typography>
+        {summaryItemsToShow.length === 0 ? (
+          <Typography>Please configure your Linode.</Typography>
+        ) : (
+          <Stack
+            divider={
+              <Divider
+                flexItem
+                orientation="vertical"
+                sx={{ borderWidth: 1, margin: 0 }}
+              />
+            }
+            direction={{ sm: 'row', xs: 'column' }}
+            gap={1.5}
+          >
+            {summaryItems.map(({ item }) => (
+              <Stack
+                alignItems="center"
+                direction="row"
+                key={item.title}
+                spacing={1}
+              >
+                <Typography fontFamily={(theme) => theme.font.bold}>
+                  {item.title}
+                </Typography>
+                {item.details && <Typography>{item.details}</Typography>}
+              </Stack>
+            ))}
+          </Stack>
+        )}
+      </Stack>
+    </Paper>
   );
 };

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
@@ -12,6 +12,7 @@ import { Tabs } from 'src/components/Tabs/Tabs';
 import { useCreateLinodeMutation } from 'src/queries/linodes/linodes';
 
 import { Access } from './Access';
+import { Actions } from './Actions';
 import { Addons } from './Addons/Addons';
 import { Details } from './Details/Details';
 import { Error } from './Error';
@@ -95,6 +96,7 @@ export const LinodeCreatev2 = () => {
           <Firewall />
           <Addons />
           <Summary />
+          <Actions />
         </Stack>
       </form>
     </FormProvider>


### PR DESCRIPTION
## Description 📝

- Adds the _Summary_ section to the new Linode Create flow 📄 

## Preview 📷

![Screenshot 2024-03-29 at 4 35 50 PM](https://github.com/linode/manager/assets/115251059/a79c2c57-c3ca-4b00-82ce-2ab465f22591)

## How to test 🧪

### Prerequisites
- Check out this PR
- Using local dev tools, turn on the `Linode Create v2` flag 🎏 

### Verification steps
- Test the summary section on the new Linode Create flow
- Verify it correctly summarizes what options you have selected
- Verify it behaves the same as the current Linode Create flow (compare to production)
- Check on smaller screen sizes 📱 

## As an Author I have considered 🤔

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support