### PR TITLE
upcoming: [M3-7901] - Update navigation items for Placement Groups

### DIFF
--- a/packages/manager/.changeset/pr-10340-upcoming-features-1712145875071.md
+++ b/packages/manager/.changeset/pr-10340-upcoming-features-1712145875071.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update navigation and add new menu items for Placement Groups  ([#10340](https://github.com/linode/manager/pull/10340))

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -201,14 +201,6 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
           icon: <Linode />,
         },
         {
-          betaChipClassName: 'beta-chip-placement-groups',
-          display: 'Placement Groups',
-          hide: !flags.placementGroups?.enabled,
-          href: '/placement-groups',
-          icon: <PlacementGroups />,
-          isBeta: flags.placementGroups?.beta,
-        },
-        {
           display: 'Volumes',
           href: '/volumes',
           icon: <Volume />,
@@ -249,6 +241,14 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
           display: 'Images',
           href: '/images',
           icon: <Image />,
+        },
+        {
+          betaChipClassName: 'beta-chip-placement-groups',
+          display: 'Placement Groups',
+          hide: !flags.placementGroups?.enabled,
+          href: '/placement-groups',
+          icon: <PlacementGroups />,
+          isBeta: flags.placementGroups?.beta,
         },
       ],
       [

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -114,6 +114,7 @@ export const AddNewMenu = () => {
     {
       description: 'Control the physical placement of your Linodes',
       entity: 'Placement Groups',
+      hide: !flags.placementGroups?.enabled,
       icon: PlacementGroupsIcon,
       link: '/placement-groups/create',
     },

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -112,7 +112,7 @@ export const AddNewMenu = () => {
       link: '/firewalls/create',
     },
     {
-      description: 'Control the physical placement of your Linodes',
+      description: "Control your Linodes' physical placement",
       entity: 'Placement Groups',
       hide: !flags.placementGroups?.enabled,
       icon: PlacementGroupsIcon,

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -21,6 +21,7 @@ import LinodeIcon from 'src/assets/icons/entityIcons/linode.svg';
 import LoadBalancerIcon from 'src/assets/icons/entityIcons/loadbalancer.svg';
 import NodebalancerIcon from 'src/assets/icons/entityIcons/nodebalancer.svg';
 import OneClickIcon from 'src/assets/icons/entityIcons/oneclick.svg';
+import PlacementGroupsIcon from 'src/assets/icons/entityIcons/placement-groups.svg';
 import VolumeIcon from 'src/assets/icons/entityIcons/volume.svg';
 import VPCIcon from 'src/assets/icons/entityIcons/vpc.svg';
 import { Button } from 'src/components/Button/Button';
@@ -109,6 +110,12 @@ export const AddNewMenu = () => {
       entity: 'Firewall',
       icon: FirewallIcon,
       link: '/firewalls/create',
+    },
+    {
+      description: 'Control the physical placement of your Linodes',
+      entity: 'Placement Groups',
+      icon: PlacementGroupsIcon,
+      link: '/placement-groups/create',
     },
     {
       description: 'Manage your DNS records',


### PR DESCRIPTION
## Description 📝
This PR mainly just updates the UI for the `PrimaryNav` and `TopMenu` components.

## Changes  🔄
- Move `Placement Groups` below `Images`
- Add `Placement Groups` to the `Create` menu on the `TopMenu` component.

## Target release date 🗓️
04/15/2024

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![b1](https://github.com/linode/manager/assets/119514965/4786f0cb-b832-4a61-a9d8-6a024ea01c8d) | ![a1](https://github.com/linode/manager/assets/119514965/efc1ebf4-7dc4-4edf-86bd-1b0d3d8e0c13) |
| ![b2](https://github.com/linode/manager/assets/119514965/abe27866-d43d-4126-8adf-a02152fa0fca) | ![a2](https://github.com/linode/manager/assets/119514965/ce389833-1349-4a5d-8e48-90603544cc69) |

## How to test 🧪
### Prerequisites
- Have the `Placement Group` feature flag turned on.

### Verification steps
- Verify the UI to reflect the changes described in the `Description`.
- Verify the interactions of the UI updates behave as expected.

## As an Author I have considered 🤔
*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
