### PR TITLE
fix: [M3-7953] - Reset SSH key form on cancel and close

### DIFF
--- a/packages/manager/.changeset/pr-10344-fixed-1712089845550.md
+++ b/packages/manager/.changeset/pr-10344-fixed-1712089845550.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Reset SSH key form state on cancel ([#10344](https://github.com/linode/manager/pull/10344))

--- a/packages/manager/src/features/Profile/SSHKeys/CreateSSHKeyDrawer.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/CreateSSHKeyDrawer.tsx
@@ -34,10 +34,14 @@ export const CreateSSHKeyDrawer = React.memo(({ onClose, open }: Props) => {
     async onSubmit(values) {
       await createSSHKey(values);
       enqueueSnackbar('Successfully created SSH key.', { variant: 'success' });
-      formik.resetForm();
-      onClose();
+      handleClose();
     },
   });
+
+  const handleClose = () => {
+    formik.resetForm();
+    onClose();
+  };
 
   const hasErrorFor = getAPIErrorFor(
     {
@@ -61,7 +65,7 @@ export const CreateSSHKeyDrawer = React.memo(({ onClose, open }: Props) => {
   );
 
   return (
-    <Drawer onClose={onClose} open={open} title="Add SSH Key">
+    <Drawer onClose={handleClose} open={open} title="Add SSH Key">
       {generalError && <Notice text={generalError} variant="error" />}
       <form onSubmit={formik.handleSubmit}>
         <TextField
@@ -89,7 +93,7 @@ export const CreateSSHKeyDrawer = React.memo(({ onClose, open }: Props) => {
             loading: isLoading,
             type: 'submit',
           }}
-          secondaryButtonProps={{ label: 'Cancel', onClick: onClose }}
+          secondaryButtonProps={{ label: 'Cancel', onClick: handleClose }}
         />
       </form>
     </Drawer>


### PR DESCRIPTION
## Description 📝
Fixes a small issue where the "Add an SSH Key" form doesn't reset when clicking the drawer's close or cancel buttons.

## Changes  🔄
- Resets formik state when clicking the drawer's close and cancel buttons

## How to test 🧪
- Confirm form resets as expected via Profile page at `/profile/keys`
- Confirm form resets as expected via Linode create flow
- Confirm SSH keys can still be added via Profile page at `/profile/keys`
- Confirm SSH keys can still be added via Linode create flow
