### PR TITLE
test: [M3-7797] - Add Cypress tests for Account billing drawers

### DIFF
--- a/packages/manager/.changeset/pr-10349-tests-1712253815522.md
+++ b/packages/manager/.changeset/pr-10349-tests-1712253815522.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add Cypress tests for Account billing drawers ([#10349](https://github.com/linode/manager/pull/10349))


### PR DESCRIPTION
## Description 📝
Add new tests to check the Account billing drawers.

## Major Changes 🔄
- Add new cypress tests to tests `Make a Payment`, `Update Billing Contact Information`, and `Add Payment Method` access will be disabled for restricted users or child user accounts

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/billing/restricted-user-billing.spec.ts"
```