### PR TITLE
fix: [M3-7962] - Large Account Search Loading State

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2024-04-05] - v1.116.1
+
+### Fixed:
+
+- Search indefinitely loading on large accounts ([#10351](https://github.com/linode/manager/pull/10351))
+
 ## [2024-04-01] - v1.116.0
 
 ### Changed:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.116.0",
+  "version": "1.116.1",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/manager/src/features/Search/SearchLanding.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.tsx
@@ -237,15 +237,16 @@ export const SearchLanding = (props: SearchLandingProps) => {
 
   const resultsEmpty = equals(finalResults, emptyResults);
 
-  const loading =
-    areLinodesLoading ||
-    areBucketsLoading ||
-    areClustersLoading ||
-    areDomainsLoading ||
-    areVolumesLoading ||
-    areKubernetesClustersLoading ||
-    areImagesLoading ||
-    areNodeBalancersLoading;
+  const loading = isLargeAccount
+    ? apiSearchLoading
+    : areLinodesLoading ||
+      areBucketsLoading ||
+      areClustersLoading ||
+      areDomainsLoading ||
+      areVolumesLoading ||
+      areKubernetesClustersLoading ||
+      areImagesLoading ||
+      areNodeBalancersLoading;
 
   const errorMessage = getErrorMessage();
 

--- a/packages/manager/src/features/Search/SearchLanding.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.tsx
@@ -69,59 +69,64 @@ export const SearchLanding = (props: SearchLandingProps) => {
 
   const isLargeAccount = useIsLargeAccount();
 
+  // We only want to fetch all entities if we know they
+  // are not a large account. We do this rather than `!isLargeAccount`
+  // because we don't want to fetch all entities if isLargeAccount is loading (undefined).
+  const shouldFetchAllEntities = isLargeAccount === false;
+
   const {
     data: objectStorageClusters,
     error: objectStorageClustersError,
     isLoading: areClustersLoading,
-  } = useObjectStorageClusters(!isLargeAccount);
+  } = useObjectStorageClusters(shouldFetchAllEntities);
 
   const {
     data: objectStorageBuckets,
     error: bucketsError,
     isLoading: areBucketsLoading,
-  } = useObjectStorageBuckets(objectStorageClusters, !isLargeAccount);
+  } = useObjectStorageBuckets(objectStorageClusters, shouldFetchAllEntities);
 
   const {
     data: domains,
     error: domainsError,
     isLoading: areDomainsLoading,
-  } = useAllDomainsQuery(!isLargeAccount);
+  } = useAllDomainsQuery(shouldFetchAllEntities);
 
   const {
     data: kubernetesClusters,
     error: kubernetesClustersError,
     isLoading: areKubernetesClustersLoading,
-  } = useAllKubernetesClustersQuery(!isLargeAccount);
+  } = useAllKubernetesClustersQuery(shouldFetchAllEntities);
 
   const {
     data: nodebalancers,
     error: nodebalancersError,
     isLoading: areNodeBalancersLoading,
-  } = useAllNodeBalancersQuery(!isLargeAccount);
+  } = useAllNodeBalancersQuery(shouldFetchAllEntities);
 
   const {
     data: volumes,
     error: volumesError,
     isLoading: areVolumesLoading,
-  } = useAllVolumesQuery({}, {}, !isLargeAccount);
+  } = useAllVolumesQuery({}, {}, shouldFetchAllEntities);
 
   const {
     data: _privateImages,
     error: imagesError,
     isLoading: areImagesLoading,
-  } = useAllImagesQuery({}, { is_public: false }, !isLargeAccount); // We want to display private images (i.e., not Debian, Ubuntu, etc. distros)
+  } = useAllImagesQuery({}, { is_public: false }, shouldFetchAllEntities); // We want to display private images (i.e., not Debian, Ubuntu, etc. distros)
 
   const { data: publicImages } = useAllImagesQuery(
     {},
     { is_public: true },
-    !isLargeAccount
+    shouldFetchAllEntities
   );
 
   const {
     data: linodes,
     error: linodesError,
     isLoading: areLinodesLoading,
-  } = useAllLinodesQuery({}, {}, !isLargeAccount);
+  } = useAllLinodesQuery({}, {}, shouldFetchAllEntities);
 
   const { data: regions } = useRegionsQuery();
 

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -290,7 +290,7 @@ const SearchBar = (props: SearchProps) => {
   const finalOptions = createFinalOptions(
     isLargeAccount ? apiResults : combinedResults,
     searchText,
-    apiSearchLoading || linodesLoading || imagesLoading,
+    isLargeAccount ? apiSearchLoading : linodesLoading || imagesLoading,
     // Ignore "Unauthorized" errors, since these will always happen on LKE
     // endpoints for restricted users. It's not really an "error" in this case.
     // We still want these users to be able to use the search feature.


### PR DESCRIPTION
## Description 📝

- Fixes search for large accounts

## The Bug 🐛 

- React Query queries with `enabled: false` now mark `isLoading` as `true`. It use to be `isLoading` `false` when a query was disabled.
- "Why does everything work if you hard refresh on the search landing page"
  - We enabled queries when `!isLargeAccount` in `SearchLanding.tsx`. The queries will be enabled for a split second while we load `isLargeAccount ` because `!undefined` is `true`

## Target release date 🗓️
Please specify a release date to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## How to test 🧪

- Test search on both small and large accounts

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support