### PR TITLE
fix: Large Account Search loading

### DIFF
--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -92,7 +92,7 @@ const SearchBar = (props: SearchProps) => {
   // know if the account is large or not
   const shouldMakeRequests =
     searchActive && isLargeAccount !== undefined && !isLargeAccount;
-
+console.log(searchActive, isLargeAccount, shouldMakeRequests)
   // Data fetching
   const { data: objectStorageClusters } = useObjectStorageClusters(
     shouldMakeRequests
@@ -105,7 +105,7 @@ const SearchBar = (props: SearchProps) => {
   const { data: clusters } = useAllKubernetesClustersQuery(shouldMakeRequests);
   const { data: volumes } = useAllVolumesQuery({}, {}, shouldMakeRequests);
   const { data: nodebalancers } = useAllNodeBalancersQuery(shouldMakeRequests);
-  const { data: _privateImages, isLoading: imagesLoading } = useAllImagesQuery(
+  const { data: _privateImages, isFetching: imagesLoading } = useAllImagesQuery(
     {},
     { is_public: false }, // We want to display private images (i.e., not Debian, Ubuntu, etc. distros)
     shouldMakeRequests
@@ -115,7 +115,7 @@ const SearchBar = (props: SearchProps) => {
     { is_public: true },
     searchActive
   );
-  const { data: linodes, isLoading: linodesLoading } = useAllLinodesQuery(
+  const { data: linodes, isFetching: linodesLoading } = useAllLinodesQuery(
     {},
     {},
     shouldMakeRequests
@@ -287,6 +287,11 @@ const SearchBar = (props: SearchProps) => {
     return true;
   };
 
+  console.log('large acc', isLargeAccount)
+  console.log('apiSearchLoading', apiSearchLoading)
+  console.log('linodesLoading', linodesLoading)
+  console.log('imagesLoading', imagesLoading)
+  console.log(Boolean(apiError) && apiError !== 'Unauthorized')
   const finalOptions = createFinalOptions(
     isLargeAccount ? apiResults : combinedResults,
     searchText,


### PR DESCRIPTION
## Description 📝
Fix search loading spinner hang for large accounts

## Changes  🔄
- Update `isLoading` to `isFetching`

## How to test 🧪
- Test on small/large accounts

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support