### PR TITLE
upcoming: [M3-7924] - Linode Create Refactor - VPC - Part 10

### DIFF
--- a/packages/manager/.changeset/pr-10354-upcoming-features-1712327982879.md
+++ b/packages/manager/.changeset/pr-10354-upcoming-features-1712327982879.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Linode Create Refactor - VPC - Part 10 ([#10354](https://github.com/linode/manager/pull/10354))

--- a/packages/manager/src/components/VLANSelect.tsx
+++ b/packages/manager/src/components/VLANSelect.tsx
@@ -62,7 +62,7 @@ export const VLANSelect = (props: Props) => {
 
   const vlans = data?.pages.flatMap((page) => page.data) ?? [];
 
-  const newVlanPlacehodler = {
+  const newVlanPlaceholder = {
     cidr_block: '',
     created: '',
     id: 0,
@@ -74,7 +74,7 @@ export const VLANSelect = (props: Props) => {
   const hasVLANWithExactLabel = vlans.some((vlan) => vlan.label === inputValue);
 
   if (!isFetching && inputValue && !hasVLANWithExactLabel) {
-    vlans.push(newVlanPlacehodler);
+    vlans.push(newVlanPlaceholder);
   }
 
   const selectedVLAN = vlans?.find((option) => option.label === value) ?? null;
@@ -94,7 +94,7 @@ export const VLANSelect = (props: Props) => {
         },
       }}
       getOptionLabel={(option) =>
-        option === newVlanPlacehodler ? `Create "${inputValue}"` : option.label
+        option === newVlanPlaceholder ? `Create "${inputValue}"` : option.label
       }
       isOptionEqualToValue={(option1, options2) =>
         option1.label === options2.label
@@ -103,7 +103,7 @@ export const VLANSelect = (props: Props) => {
         if (onChange) {
           onChange(value?.label ?? null);
         }
-        if (value !== newVlanPlacehodler) {
+        if (value !== newVlanPlaceholder) {
           setInputValue('');
         }
       }}

--- a/packages/manager/src/components/VPCSelect.test.tsx
+++ b/packages/manager/src/components/VPCSelect.test.tsx
@@ -1,0 +1,37 @@
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { vpcFactory } from 'src/factories';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { VPCSelect } from './VPCSelect';
+
+describe('VPCSelect', () => {
+  it('should render a label', () => {
+    const { getByLabelText } = renderWithTheme(<VPCSelect value={undefined} />);
+
+    expect(getByLabelText('VPC')).toBeVisible();
+  });
+
+  it('should render VPCs returned by the API', async () => {
+    const vpcs = vpcFactory.buildList(5);
+
+    server.use(
+      http.get('*/v4beta/vpcs', () => {
+        return HttpResponse.json(makeResourcePage(vpcs));
+      })
+    );
+
+    const { getByPlaceholderText, getByText } = renderWithTheme(
+      <VPCSelect value={null} />
+    );
+
+    await userEvent.click(getByPlaceholderText('Select an option'));
+
+    for (const vpc of vpcs) {
+      expect(getByText(vpc.label)).toBeVisible();
+    }
+  });
+});

--- a/packages/manager/src/components/VPCSelect.tsx
+++ b/packages/manager/src/components/VPCSelect.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { useVPCsQuery } from 'src/queries/vpcs';
+
+import { Autocomplete } from './Autocomplete/Autocomplete';
+
+import type { EnhancedAutocompleteProps } from './Autocomplete/Autocomplete';
+import type { Filter, VPC } from '@linode/api-v4';
+
+interface Props extends Partial<Omit<EnhancedAutocompleteProps<VPC>, 'value'>> {
+  /**
+   * An optional API filter to filter the VPC options
+   */
+  filter?: Filter;
+  /**
+   * The ID of the selected VPC
+   */
+  value: null | number | undefined;
+}
+
+export const VPCSelect = (props: Props) => {
+  const { filter, value, ...rest } = props;
+
+  const { data, isFetching } = useVPCsQuery({}, filter ?? {});
+
+  const selectedVPC = data?.data.find((vpc) => vpc.id === value) ?? null;
+
+  return (
+    <Autocomplete
+      label="VPC"
+      loading={isFetching}
+      options={data?.data ?? []}
+      value={selectedVPC}
+      {...rest}
+    />
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Summary.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Summary.tsx
@@ -32,6 +32,7 @@ export const Summary = () => {
     privateIPEnabled,
     placementGroupId,
     vlanLabel,
+    vpcId,
   ] = useWatch({
     control,
     name: [
@@ -44,6 +45,7 @@ export const Summary = () => {
       'private_ip',
       'placement_group.id',
       'interfaces.1.label',
+      'interfaces.2.vpc_id',
     ],
   });
 
@@ -107,6 +109,12 @@ export const Summary = () => {
     },
     {
       item: {
+        title: 'VPC Assigned',
+      },
+      show: Boolean(vpcId),
+    },
+    {
+      item: {
         title: 'Firewall Assigned',
       },
       show: Boolean(firewallId),
@@ -132,8 +140,8 @@ export const Summary = () => {
                 />
               )
             }
-            flexWrap="wrap"
             direction={isSmallScreen ? 'column' : 'row'}
+            flexWrap="wrap"
             gap={1.5}
           >
             {summaryItemsToShow.map(({ item }) => (

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Summary.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Summary.tsx
@@ -45,7 +45,7 @@ export const Summary = () => {
       'private_ip',
       'placement_group.id',
       'interfaces.1.label',
-      'interfaces.2.vpc_id',
+      'interfaces.0.vpc_id',
     ],
   });
 

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC.tsx
@@ -1,0 +1,263 @@
+import CloseIcon from '@mui/icons-material/Close';
+import React, { useState } from 'react';
+import {
+  Controller,
+  useFieldArray,
+  useFormContext,
+  useWatch,
+} from 'react-hook-form';
+
+import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
+import { Box } from 'src/components/Box';
+import { Checkbox } from 'src/components/Checkbox';
+import { Divider } from 'src/components/Divider';
+import { FormControlLabel } from 'src/components/FormControlLabel';
+import { IconButton } from 'src/components/IconButton';
+import { Link } from 'src/components/Link';
+import { LinkButton } from 'src/components/LinkButton';
+import { Notice } from 'src/components/Notice/Notice';
+import { Paper } from 'src/components/Paper';
+import { Stack } from 'src/components/Stack';
+import { TextField } from 'src/components/TextField';
+import { TooltipIcon } from 'src/components/TooltipIcon';
+import { Typography } from 'src/components/Typography';
+import { VPCSelect } from 'src/components/VPCSelect';
+import { VPC_AUTO_ASSIGN_IPV4_TOOLTIP } from 'src/features/VPCs/constants';
+import { useVPCQuery } from 'src/queries/vpcs';
+
+import { VPCCreateDrawer } from '../LinodesCreate/VPCCreateDrawer';
+
+import type { CreateLinodeRequest } from '@linode/api-v4';
+
+export const VPC = () => {
+  const [isCreateDrawerOpen, setIsCreateDrawerOpen] = useState(false);
+
+  const {
+    control,
+    formState,
+    setValue,
+  } = useFormContext<CreateLinodeRequest>();
+
+  const [
+    regionId,
+    selectedVPCId,
+    selectedSubnetId,
+    linodeVPCIPAddress,
+  ] = useWatch({
+    control,
+    name: [
+      'region',
+      'interfaces.2.vpc_id',
+      'interfaces.2.subnet_id',
+      'interfaces.2.ipv4.vpc',
+    ],
+  });
+
+  const { data: selectedVPC } = useVPCQuery(
+    selectedVPCId ?? -1,
+    Boolean(selectedVPCId)
+  );
+
+  return (
+    <Paper>
+      <Stack spacing={2}>
+        <Typography variant="h2">VPC</Typography>
+        <Typography>
+          Assign this Linode to an existing VPC.{' '}
+          <Link to="https://www.linode.com/docs/products/networking/vpc/guides/assign-services/">
+            Learn more.
+          </Link>
+        </Typography>
+        <Stack spacing={1.5}>
+          <Controller
+            render={({ field, fieldState }) => (
+              <VPCSelect
+                errorText={fieldState.error?.message}
+                filter={{ region: regionId }}
+                label="Assign VPC"
+                noMarginTop
+                onChange={(e, vpc) => field.onChange(vpc?.id ?? null)}
+                placeholder="None"
+                value={field.value ?? null}
+              />
+            )}
+            control={control}
+            name="interfaces.2.vpc_id"
+          />
+          <Box>
+            <LinkButton onClick={() => setIsCreateDrawerOpen(true)}>
+              Create VPC
+            </LinkButton>
+          </Box>
+          {selectedVPCId && (
+            <>
+              <Controller
+                render={({ field, fieldState }) => (
+                  <Autocomplete
+                    getOptionLabel={(subnet) =>
+                      `${subnet.label} (${subnet.ipv4})`
+                    }
+                    value={
+                      selectedVPC?.subnets.find(
+                        (subnet) => subnet.id === field.value
+                      ) ?? null
+                    }
+                    errorText={fieldState.error?.message}
+                    label="Subnet"
+                    noMarginTop
+                    onChange={(e, subnet) => field.onChange(subnet?.id ?? null)}
+                    options={selectedVPC?.subnets ?? []}
+                    placeholder="Select Subnet"
+                  />
+                )}
+                control={control}
+                name="interfaces.2.subnet_id"
+              />
+              {selectedSubnetId && (
+                <>
+                  <Controller
+                    render={({ field }) => (
+                      <FormControlLabel
+                        checked={
+                          field.value === null || field.value === undefined
+                        }
+                        label={
+                          <Stack alignItems="center" direction="row">
+                            <Typography>
+                              Auto-assign a VPC IPv4 address for this Linode in
+                              the VPC
+                            </Typography>
+                            <TooltipIcon
+                              status="help"
+                              text={VPC_AUTO_ASSIGN_IPV4_TOOLTIP}
+                            />
+                          </Stack>
+                        }
+                        onChange={(e, checked) =>
+                          field.onChange(checked ? null : '')
+                        }
+                        control={<Checkbox sx={{ ml: -1 }} />}
+                      />
+                    )}
+                    control={control}
+                    name="interfaces.2.ipv4.vpc"
+                  />
+                  {linodeVPCIPAddress !== null &&
+                    linodeVPCIPAddress !== undefined && (
+                      <Controller
+                        render={({ field, fieldState }) => (
+                          <TextField
+                            errorText={fieldState.error?.message}
+                            label="VPC IPv4"
+                            noMarginTop
+                            onChange={field.onChange}
+                            required
+                            value={field.value}
+                          />
+                        )}
+                        control={control}
+                        name="interfaces.2.ipv4.vpc"
+                      />
+                    )}
+                  <Controller
+                    render={({ field }) => (
+                      <FormControlLabel
+                        label={
+                          <Stack alignItems="center" direction="row">
+                            <Typography>
+                              Assign a public IPv4 address for this Linode
+                            </Typography>
+                            <TooltipIcon
+                              text={
+                                'Access the internet through the public IPv4 address using static 1:1 NAT.'
+                              }
+                              status="help"
+                            />
+                          </Stack>
+                        }
+                        onChange={(e, checked) =>
+                          field.onChange(checked ? 'any' : null)
+                        }
+                        checked={field.value === 'any'}
+                        control={<Checkbox sx={{ ml: -1 }} />}
+                        sx={{ mt: 0 }}
+                      />
+                    )}
+                    control={control}
+                    name="interfaces.2.ipv4.nat_1_1"
+                  />
+                  <Divider />
+                  <Typography variant="h3">
+                    Assign additional IPv4 ranges
+                  </Typography>
+                  {formState.errors.interfaces?.[1]?.ip_ranges?.message && (
+                    <Notice
+                      text={formState.errors.interfaces[1]?.ip_ranges?.message}
+                      variant="error"
+                    />
+                  )}
+                  <Typography>
+                    Assign additional IPv4 address ranges that the VPC can use
+                    to reach services running on this Linode.{' '}
+                    <Link to="https://www.linode.com/docs/products/networking/vpc/guides/assign-services/">
+                      Learn more
+                    </Link>
+                    .
+                  </Typography>
+                  <VPCRanges />
+                </>
+              )}
+            </>
+          )}
+        </Stack>
+      </Stack>
+      <VPCCreateDrawer
+        handleSelectVPC={(vpcId) => setValue('interfaces.1.vpc_id', vpcId)}
+        onClose={() => setIsCreateDrawerOpen(false)}
+        open={isCreateDrawerOpen}
+      />
+    </Paper>
+  );
+};
+
+const VPCRanges = () => {
+  const { control } = useFormContext<CreateLinodeRequest>();
+
+  const { append, fields, remove } = useFieldArray({
+    control,
+    name: 'interfaces.2.ip_ranges',
+  });
+
+  return (
+    <Stack spacing={1}>
+      <Stack>
+        {fields.map((field, index) => (
+          <Stack alignItems="center" direction="row" key={field.id}>
+            <Controller
+              render={({ field }) => (
+                <TextField
+                  hideLabel
+                  label={`IP Range ${index}`}
+                  onChange={field.onChange}
+                  placeholder="10.0.0.0/24"
+                  value={field.value}
+                />
+              )}
+              control={control}
+              name={`interfaces.2.ip_ranges.${index}`}
+            />
+            <IconButton
+              aria-label={`Remove IP Range ${index}`}
+              onClick={() => remove(index)}
+            >
+              <CloseIcon />
+            </IconButton>
+          </Stack>
+        ))}
+      </Stack>
+      <Box>
+        <LinkButton onClick={() => append('')}>Add IPv4 Range</LinkButton>
+      </Box>
+    </Stack>
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC.tsx
@@ -215,6 +215,7 @@ export const VPC = () => {
         handleSelectVPC={(vpcId) => setValue('interfaces.1.vpc_id', vpcId)}
         onClose={() => setIsCreateDrawerOpen(false)}
         open={isCreateDrawerOpen}
+        selectedRegion={regionId}
       />
     </Paper>
   );

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.test.tsx
@@ -58,7 +58,7 @@ describe('VPC', () => {
       component: <VPC />,
       useFormOptions: {
         defaultValues: {
-          interfaces: [{}, {}, { vpc_id: 4 }],
+          interfaces: [{ vpc_id: 4 }, {}, {}],
           region: 'fake-region',
         },
       },
@@ -75,7 +75,7 @@ describe('VPC', () => {
       component: <VPC />,
       useFormOptions: {
         defaultValues: {
-          interfaces: [{}, {}, { subnet_id: 5, vpc_id: 4 }],
+          interfaces: [{ subnet_id: 5, vpc_id: 4 }, {}, {}],
           region: 'fake-region',
         },
       },
@@ -102,9 +102,9 @@ describe('VPC', () => {
       useFormOptions: {
         defaultValues: {
           interfaces: [
-            {},
-            {},
             { ipv4: { vpc: undefined }, subnet_id: 5, vpc_id: 4 },
+            {},
+            {},
           ],
           region: 'fake-region',
         },
@@ -125,7 +125,7 @@ describe('VPC', () => {
       component: <VPC />,
       useFormOptions: {
         defaultValues: {
-          interfaces: [{}, {}, { ipv4: { vpc: '' }, subnet_id: 5, vpc_id: 4 }],
+          interfaces: [{ ipv4: { vpc: '' }, subnet_id: 5, vpc_id: 4 }, {}, {}],
           region: 'fake-region',
         },
       },

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.test.tsx
@@ -93,4 +93,50 @@ describe('VPC', () => {
 
     expect(getByText('Assign additional IPv4 ranges')).toBeInTheDocument();
   });
+
+  it('should check the VPC IPv4 if a "ipv4.vpc" is null/undefined', async () => {
+    const {
+      getByLabelText,
+    } = renderWithThemeAndHookFormContext<CreateLinodeRequest>({
+      component: <VPC />,
+      useFormOptions: {
+        defaultValues: {
+          interfaces: [
+            {},
+            {},
+            { ipv4: { vpc: undefined }, subnet_id: 5, vpc_id: 4 },
+          ],
+          region: 'fake-region',
+        },
+      },
+    });
+
+    expect(
+      getByLabelText(
+        'Auto-assign a VPC IPv4 address for this Linode in the VPC'
+      )
+    ).toBeChecked();
+  });
+
+  it('should uncheck the VPC IPv4 if a "ipv4.vpc" is a string value and show the VPC IP TextField', async () => {
+    const {
+      getByLabelText,
+    } = renderWithThemeAndHookFormContext<CreateLinodeRequest>({
+      component: <VPC />,
+      useFormOptions: {
+        defaultValues: {
+          interfaces: [{}, {}, { ipv4: { vpc: '' }, subnet_id: 5, vpc_id: 4 }],
+          region: 'fake-region',
+        },
+      },
+    });
+
+    expect(
+      getByLabelText(
+        'Auto-assign a VPC IPv4 address for this Linode in the VPC'
+      )
+    ).not.toBeChecked();
+
+    expect(getByLabelText('VPC IPv4 (required)')).toBeVisible();
+  });
 });

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+
+import { regionFactory } from 'src/factories';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
+
+import { VPC } from './VPC';
+
+import type { CreateLinodeRequest } from '@linode/api-v4';
+
+describe('VPC', () => {
+  it('renders a heading', () => {
+    const { getByText } = renderWithThemeAndHookFormContext({
+      component: <VPC />,
+    });
+
+    const heading = getByText('VPC');
+
+    expect(heading).toBeVisible();
+    expect(heading.tagName).toBe('H2');
+  });
+
+  it('disables the VPC select if no region is selected', () => {
+    const { getByLabelText } = renderWithThemeAndHookFormContext({
+      component: <VPC />,
+    });
+
+    const vpcSelect = getByLabelText('Assign VPC');
+
+    expect(vpcSelect).toBeVisible();
+    expect(vpcSelect).toBeDisabled();
+  });
+
+  it('renders a warning if the selected region does not support VPC', async () => {
+    const region = regionFactory.build({ capabilities: [] });
+
+    server.use(
+      http.get('*/v4/regions', () => {
+        return HttpResponse.json(makeResourcePage([region]));
+      })
+    );
+
+    const {
+      findByText,
+    } = renderWithThemeAndHookFormContext<CreateLinodeRequest>({
+      component: <VPC />,
+      useFormOptions: { defaultValues: { region: region.id } },
+    });
+
+    await findByText('VPC is not available in the selected region.');
+  });
+
+  it('renders a subnet select if a VPC is selected', async () => {
+    const {
+      getByLabelText,
+    } = renderWithThemeAndHookFormContext<CreateLinodeRequest>({
+      component: <VPC />,
+      useFormOptions: {
+        defaultValues: {
+          interfaces: [{}, {}, { vpc_id: 4 }],
+          region: 'fake-region',
+        },
+      },
+    });
+
+    expect(getByLabelText('Subnet')).toBeVisible();
+  });
+
+  it('renders VPC IPv4, NAT checkboxes, and IP Ranges inputs when a subnet is selected', async () => {
+    const {
+      getByLabelText,
+      getByText,
+    } = renderWithThemeAndHookFormContext<CreateLinodeRequest>({
+      component: <VPC />,
+      useFormOptions: {
+        defaultValues: {
+          interfaces: [{}, {}, { subnet_id: 5, vpc_id: 4 }],
+          region: 'fake-region',
+        },
+      },
+    });
+
+    expect(
+      getByLabelText(
+        'Auto-assign a VPC IPv4 address for this Linode in the VPC'
+      )
+    ).toBeInTheDocument();
+
+    expect(
+      getByLabelText('Assign a public IPv4 address for this Linode')
+    ).toBeInTheDocument();
+
+    expect(getByText('Assign additional IPv4 ranges')).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
@@ -46,9 +46,9 @@ export const VPC = () => {
     control,
     name: [
       'region',
-      'interfaces.2.vpc_id',
-      'interfaces.2.subnet_id',
-      'interfaces.2.ipv4.vpc',
+      'interfaces.0.vpc_id',
+      'interfaces.0.subnet_id',
+      'interfaces.0.ipv4.vpc',
     ],
   });
 
@@ -91,7 +91,7 @@ export const VPC = () => {
               />
             )}
             control={control}
-            name="interfaces.2.vpc_id"
+            name="interfaces.0.vpc_id"
           />
           {regionId && !regionSupportsVPCs && (
             <Typography>
@@ -127,7 +127,7 @@ export const VPC = () => {
                   />
                 )}
                 control={control}
-                name="interfaces.2.subnet_id"
+                name="interfaces.0.subnet_id"
               />
               {selectedSubnetId && (
                 <>
@@ -156,7 +156,7 @@ export const VPC = () => {
                       />
                     )}
                     control={control}
-                    name="interfaces.2.ipv4.vpc"
+                    name="interfaces.0.ipv4.vpc"
                   />
                   {linodeVPCIPAddress !== null &&
                     linodeVPCIPAddress !== undefined && (
@@ -172,7 +172,7 @@ export const VPC = () => {
                           />
                         )}
                         control={control}
-                        name="interfaces.2.ipv4.vpc"
+                        name="interfaces.0.ipv4.vpc"
                       />
                     )}
                   <Controller
@@ -200,7 +200,7 @@ export const VPC = () => {
                       />
                     )}
                     control={control}
-                    name="interfaces.2.ipv4.nat_1_1"
+                    name="interfaces.0.ipv4.nat_1_1"
                   />
                   <Divider />
                   <Typography variant="h3">
@@ -228,7 +228,7 @@ export const VPC = () => {
         </Stack>
       </Stack>
       <VPCCreateDrawer
-        handleSelectVPC={(vpcId) => setValue('interfaces.1.vpc_id', vpcId)}
+        handleSelectVPC={(vpcId) => setValue('interfaces.0.vpc_id', vpcId)}
         onClose={() => setIsCreateDrawerOpen(false)}
         open={isCreateDrawerOpen}
         selectedRegion={regionId}

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
@@ -139,57 +139,57 @@ export const VPC = () => {
               />
               {selectedSubnetId && (
                 <>
-                  <Box pl={1.5}>
+                  <Stack>
                     <Controller
                       render={({ field }) => (
-                        <FormControlLabel
-                          checked={
-                            field.value === null || field.value === undefined
-                          }
-                          label={
-                            <Stack alignItems="center" direction="row">
-                              <Typography>
-                                Auto-assign a VPC IPv4 address for this Linode
-                                in the VPC
-                              </Typography>
-                              <TooltipIcon
-                                status="help"
-                                text={VPC_AUTO_ASSIGN_IPV4_TOOLTIP}
-                              />
-                            </Stack>
-                          }
-                          onChange={(e, checked) =>
-                            // If "Auto-assign" is checked, set the VPC IP to null
-                            // so that it gets auto-assigned. Otherwise, set it to
-                            // an empty string so that the TextField renders and a
-                            // user can enter one.
-                            field.onChange(checked ? null : '')
-                          }
-                          control={<Checkbox sx={{ ml: -1 }} />}
-                        />
+                        <Box>
+                          <FormControlLabel
+                            checked={
+                              field.value === null || field.value === undefined
+                            }
+                            label={
+                              <Stack alignItems="center" direction="row">
+                                <Typography>
+                                  Auto-assign a VPC IPv4 address for this Linode
+                                  in the VPC
+                                </Typography>
+                                <TooltipIcon
+                                  status="help"
+                                  text={VPC_AUTO_ASSIGN_IPV4_TOOLTIP}
+                                />
+                              </Stack>
+                            }
+                            onChange={(e, checked) =>
+                              // If "Auto-assign" is checked, set the VPC IP to null
+                              // so that it gets auto-assigned. Otherwise, set it to
+                              // an empty string so that the TextField renders and a
+                              // user can enter one.
+                              field.onChange(checked ? null : '')
+                            }
+                            control={<Checkbox sx={{ ml: 0.5 }} />}
+                          />
+                        </Box>
                       )}
                       control={control}
                       name="interfaces.0.ipv4.vpc"
                     />
-                  </Box>
-                  {linodeVPCIPAddress !== null &&
-                    linodeVPCIPAddress !== undefined && (
-                      <Controller
-                        render={({ field, fieldState }) => (
-                          <TextField
-                            errorText={fieldState.error?.message}
-                            label="VPC IPv4"
-                            noMarginTop
-                            onChange={field.onChange}
-                            required
-                            value={field.value}
-                          />
-                        )}
-                        control={control}
-                        name="interfaces.0.ipv4.vpc"
-                      />
-                    )}
-                  <Box pl={1.5}>
+                    {linodeVPCIPAddress !== null &&
+                      linodeVPCIPAddress !== undefined && (
+                        <Controller
+                          render={({ field, fieldState }) => (
+                            <TextField
+                              errorText={fieldState.error?.message}
+                              label="VPC IPv4"
+                              onChange={field.onChange}
+                              required
+                              sx={{ my: 2 }}
+                              value={field.value}
+                            />
+                          )}
+                          control={control}
+                          name="interfaces.0.ipv4.vpc"
+                        />
+                      )}
                     <Controller
                       render={({ field }) => (
                         <FormControlLabel
@@ -210,14 +210,14 @@ export const VPC = () => {
                             field.onChange(checked ? 'any' : null)
                           }
                           checked={field.value === 'any'}
-                          control={<Checkbox sx={{ ml: -1 }} />}
+                          control={<Checkbox sx={{ ml: 0.5 }} />}
                           sx={{ mt: 0 }}
                         />
                       )}
                       control={control}
                       name="interfaces.0.ipv4.nat_1_1"
                     />
-                  </Box>
+                  </Stack>
                   <Divider />
                   <Typography fontFamily={(theme) => theme.font.bold}>
                     Assign additional IPv4 ranges

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
@@ -77,6 +77,11 @@ export const VPC = () => {
           <Controller
             render={({ field, fieldState }) => (
               <VPCSelect
+                helperText={
+                  regionId && !regionSupportsVPCs
+                    ? 'VPC is not available in the selected region.'
+                    : undefined
+                }
                 textFieldProps={{
                   tooltipText: REGION_CAVEAT_HELPER_TEXT,
                 }}
@@ -93,11 +98,6 @@ export const VPC = () => {
             control={control}
             name="interfaces.0.vpc_id"
           />
-          {regionId && !regionSupportsVPCs && (
-            <Typography>
-              VPC is not available in the selected region.
-            </Typography>
-          )}
           {regionId && regionSupportsVPCs && (
             <Box>
               <LinkButton onClick={() => setIsCreateDrawerOpen(true)}>
@@ -150,6 +150,10 @@ export const VPC = () => {
                           </Stack>
                         }
                         onChange={(e, checked) =>
+                          // If "Auto-assign" is checked, set the VPC IP to null
+                          // so that it gets auto-assigned. Otherwise, set it to
+                          // an empty string so that the TextField renders and a
+                          // user can enter one.
                           field.onChange(checked ? null : '')
                         }
                         control={<Checkbox sx={{ ml: -1 }} />}

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
@@ -63,8 +63,8 @@ export const VPC = () => {
     Boolean(selectedVPCId)
   );
 
-  // This is here only to determine which copy should show...
-  const { data } = useVPCsQuery({}, {});
+  // This is here only to determine which copy to show...
+  const { data } = useVPCsQuery({}, { region: regionId }, regionSupportsVPCs);
 
   const copy =
     data?.results === 0

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
@@ -17,7 +17,7 @@ import { Typography } from 'src/components/Typography';
 import { VPCSelect } from 'src/components/VPCSelect';
 import { VPC_AUTO_ASSIGN_IPV4_TOOLTIP } from 'src/features/VPCs/constants';
 import { useRegionsQuery } from 'src/queries/regions/regions';
-import { useVPCQuery } from 'src/queries/vpcs';
+import { useVPCQuery, useVPCsQuery } from 'src/queries/vpcs';
 import { doesRegionSupportFeature } from 'src/utilities/doesRegionSupportFeature';
 
 import { REGION_CAVEAT_HELPER_TEXT } from '../../LinodesCreate/constants';
@@ -63,12 +63,20 @@ export const VPC = () => {
     Boolean(selectedVPCId)
   );
 
+  // This is here only to determine which copy should show...
+  const { data } = useVPCsQuery({}, {});
+
+  const copy =
+    data?.results === 0
+      ? 'Allow Linode to communicate in an isolated environment.'
+      : 'Assign this Linode to an existing VPC.';
+
   return (
     <Paper>
       <Stack spacing={2}>
         <Typography variant="h2">VPC</Typography>
         <Typography>
-          Assign this Linode to an existing VPC.{' '}
+          {copy}{' '}
           <Link to="https://www.linode.com/docs/products/networking/vpc/guides/assign-services/">
             Learn more.
           </Link>

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
@@ -131,37 +131,39 @@ export const VPC = () => {
               />
               {selectedSubnetId && (
                 <>
-                  <Controller
-                    render={({ field }) => (
-                      <FormControlLabel
-                        checked={
-                          field.value === null || field.value === undefined
-                        }
-                        label={
-                          <Stack alignItems="center" direction="row">
-                            <Typography>
-                              Auto-assign a VPC IPv4 address for this Linode in
-                              the VPC
-                            </Typography>
-                            <TooltipIcon
-                              status="help"
-                              text={VPC_AUTO_ASSIGN_IPV4_TOOLTIP}
-                            />
-                          </Stack>
-                        }
-                        onChange={(e, checked) =>
-                          // If "Auto-assign" is checked, set the VPC IP to null
-                          // so that it gets auto-assigned. Otherwise, set it to
-                          // an empty string so that the TextField renders and a
-                          // user can enter one.
-                          field.onChange(checked ? null : '')
-                        }
-                        control={<Checkbox sx={{ ml: -1 }} />}
-                      />
-                    )}
-                    control={control}
-                    name="interfaces.0.ipv4.vpc"
-                  />
+                  <Box pl={1.5}>
+                    <Controller
+                      render={({ field }) => (
+                        <FormControlLabel
+                          checked={
+                            field.value === null || field.value === undefined
+                          }
+                          label={
+                            <Stack alignItems="center" direction="row">
+                              <Typography>
+                                Auto-assign a VPC IPv4 address for this Linode
+                                in the VPC
+                              </Typography>
+                              <TooltipIcon
+                                status="help"
+                                text={VPC_AUTO_ASSIGN_IPV4_TOOLTIP}
+                              />
+                            </Stack>
+                          }
+                          onChange={(e, checked) =>
+                            // If "Auto-assign" is checked, set the VPC IP to null
+                            // so that it gets auto-assigned. Otherwise, set it to
+                            // an empty string so that the TextField renders and a
+                            // user can enter one.
+                            field.onChange(checked ? null : '')
+                          }
+                          control={<Checkbox sx={{ ml: -1 }} />}
+                        />
+                      )}
+                      control={control}
+                      name="interfaces.0.ipv4.vpc"
+                    />
+                  </Box>
                   {linodeVPCIPAddress !== null &&
                     linodeVPCIPAddress !== undefined && (
                       <Controller
@@ -179,33 +181,35 @@ export const VPC = () => {
                         name="interfaces.0.ipv4.vpc"
                       />
                     )}
-                  <Controller
-                    render={({ field }) => (
-                      <FormControlLabel
-                        label={
-                          <Stack alignItems="center" direction="row">
-                            <Typography>
-                              Assign a public IPv4 address for this Linode
-                            </Typography>
-                            <TooltipIcon
-                              text={
-                                'Access the internet through the public IPv4 address using static 1:1 NAT.'
-                              }
-                              status="help"
-                            />
-                          </Stack>
-                        }
-                        onChange={(e, checked) =>
-                          field.onChange(checked ? 'any' : null)
-                        }
-                        checked={field.value === 'any'}
-                        control={<Checkbox sx={{ ml: -1 }} />}
-                        sx={{ mt: 0 }}
-                      />
-                    )}
-                    control={control}
-                    name="interfaces.0.ipv4.nat_1_1"
-                  />
+                  <Box pl={1.5}>
+                    <Controller
+                      render={({ field }) => (
+                        <FormControlLabel
+                          label={
+                            <Stack alignItems="center" direction="row">
+                              <Typography>
+                                Assign a public IPv4 address for this Linode
+                              </Typography>
+                              <TooltipIcon
+                                text={
+                                  'Access the internet through the public IPv4 address using static 1:1 NAT.'
+                                }
+                                status="help"
+                              />
+                            </Stack>
+                          }
+                          onChange={(e, checked) =>
+                            field.onChange(checked ? 'any' : null)
+                          }
+                          checked={field.value === 'any'}
+                          control={<Checkbox sx={{ ml: -1 }} />}
+                          sx={{ mt: 0 }}
+                        />
+                      )}
+                      control={control}
+                      name="interfaces.0.ipv4.nat_1_1"
+                    />
+                  </Box>
                   <Divider />
                   <Typography variant="h3">
                     Assign additional IPv4 ranges

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
@@ -16,6 +16,7 @@ import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
 import { VPCSelect } from 'src/components/VPCSelect';
 import { VPC_AUTO_ASSIGN_IPV4_TOOLTIP } from 'src/features/VPCs/constants';
+import { inputMaxWidth } from 'src/foundations/themes/light';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { useVPCQuery, useVPCsQuery } from 'src/queries/vpcs';
 import { doesRegionSupportFeature } from 'src/utilities/doesRegionSupportFeature';
@@ -91,6 +92,9 @@ export const VPC = () => {
                     : undefined
                 }
                 textFieldProps={{
+                  sx: (theme) => ({
+                    [theme.breakpoints.up('sm')]: { minWidth: inputMaxWidth },
+                  }),
                   tooltipText: REGION_CAVEAT_HELPER_TEXT,
                 }}
                 disabled={!regionSupportsVPCs}

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
@@ -211,7 +211,7 @@ export const VPC = () => {
                     />
                   </Box>
                   <Divider />
-                  <Typography variant="h3">
+                  <Typography fontFamily={(theme) => theme.font.bold}>
                     Assign additional IPv4 ranges
                   </Typography>
                   {formState.errors.interfaces?.[1]?.ip_ranges?.message && (

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPCRanges.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPCRanges.test.tsx
@@ -1,0 +1,82 @@
+import { userEvent } from '@testing-library/user-event';
+import React from 'react';
+
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
+
+import { VPCRanges } from './VPCRanges';
+
+describe('VPCRanges', () => {
+  it('renders IP ranges from form data', () => {
+    const {
+      getByDisplayValue,
+      getByLabelText,
+    } = renderWithThemeAndHookFormContext({
+      component: <VPCRanges />,
+      useFormOptions: {
+        defaultValues: {
+          interfaces: [
+            {},
+            {},
+            { ip_ranges: ['192.168.1.1/24'], subnet_id: 5, vpc_id: 4 },
+          ],
+          region: 'fake-region',
+        },
+      },
+    });
+
+    expect(getByDisplayValue('192.168.1.1/24')).toBeVisible();
+    expect(getByLabelText('Remove IP Range 0')).toBeVisible();
+  });
+
+  it('can add an IP range', async () => {
+    const {
+      getByPlaceholderText,
+      getByText,
+    } = renderWithThemeAndHookFormContext({
+      component: <VPCRanges />,
+      useFormOptions: {
+        defaultValues: {
+          interfaces: [{}, {}, { ip_ranges: [], subnet_id: 5, vpc_id: 4 }],
+          region: 'fake-region',
+        },
+      },
+    });
+
+    const addButton = getByText('Add IPv4 Range');
+
+    expect(addButton).toBeVisible();
+    expect(addButton).toBeEnabled();
+
+    await userEvent.click(addButton);
+
+    expect(getByPlaceholderText('10.0.0.0/24')).toBeVisible();
+  });
+
+  it('can remove an IP range', async () => {
+    const {
+      getByLabelText,
+      queryByDisplayValue,
+    } = renderWithThemeAndHookFormContext({
+      component: <VPCRanges />,
+      useFormOptions: {
+        defaultValues: {
+          interfaces: [
+            {},
+            {},
+            { ip_ranges: ['192.168.1.1/24'], subnet_id: 5, vpc_id: 4 },
+          ],
+          region: 'fake-region',
+        },
+      },
+    });
+
+    const removeButton = getByLabelText('Remove IP Range 0');
+
+    expect(removeButton).toBeVisible();
+    expect(removeButton).toBeEnabled();
+
+    await userEvent.click(removeButton);
+
+    expect(queryByDisplayValue('192.168.1.1/24')).toBeNull();
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPCRanges.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPCRanges.test.tsx
@@ -15,9 +15,9 @@ describe('VPCRanges', () => {
       useFormOptions: {
         defaultValues: {
           interfaces: [
-            {},
-            {},
             { ip_ranges: ['192.168.1.1/24'], subnet_id: 5, vpc_id: 4 },
+            {},
+            {},
           ],
           region: 'fake-region',
         },
@@ -36,7 +36,7 @@ describe('VPCRanges', () => {
       component: <VPCRanges />,
       useFormOptions: {
         defaultValues: {
-          interfaces: [{}, {}, { ip_ranges: [], subnet_id: 5, vpc_id: 4 }],
+          interfaces: [{ ip_ranges: [], subnet_id: 5, vpc_id: 4 }, {}, {}],
           region: 'fake-region',
         },
       },
@@ -61,9 +61,9 @@ describe('VPCRanges', () => {
       useFormOptions: {
         defaultValues: {
           interfaces: [
-            {},
-            {},
             { ip_ranges: ['192.168.1.1/24'], subnet_id: 5, vpc_id: 4 },
+            {},
+            {},
           ],
           region: 'fake-region',
         },

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPCRanges.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPCRanges.tsx
@@ -20,38 +20,36 @@ export const VPCRanges = () => {
 
   return (
     <Stack spacing={1}>
-      <Stack>
-        {fields.map((field, index) => (
-          <Stack
-            alignItems="flex-start"
-            direction="row"
-            key={field.id}
-            spacing={0.5}
+      {fields.map((field, index) => (
+        <Stack
+          alignItems="flex-start"
+          direction="row"
+          key={field.id}
+          spacing={0.5}
+        >
+          <Controller
+            render={({ field, fieldState }) => (
+              <TextField
+                errorText={fieldState.error?.message}
+                hideLabel
+                label={`IP Range ${index}`}
+                onChange={field.onChange}
+                placeholder="10.0.0.0/24"
+                value={field.value}
+              />
+            )}
+            control={control}
+            name={`interfaces.0.ip_ranges.${index}`}
+          />
+          <IconButton
+            aria-label={`Remove IP Range ${index}`}
+            onClick={() => remove(index)}
+            sx={{ padding: 0.75 }}
           >
-            <Controller
-              render={({ field, fieldState }) => (
-                <TextField
-                  errorText={fieldState.error?.message}
-                  hideLabel
-                  label={`IP Range ${index}`}
-                  onChange={field.onChange}
-                  placeholder="10.0.0.0/24"
-                  value={field.value}
-                />
-              )}
-              control={control}
-              name={`interfaces.0.ip_ranges.${index}`}
-            />
-            <IconButton
-              aria-label={`Remove IP Range ${index}`}
-              onClick={() => remove(index)}
-              sx={{ padding: 0.75 }}
-            >
-              <CloseIcon />
-            </IconButton>
-          </Stack>
-        ))}
-      </Stack>
+            <CloseIcon />
+          </IconButton>
+        </Stack>
+      ))}
       <Box>
         <LinkButton onClick={() => append('')}>Add IPv4 Range</LinkButton>
       </Box>

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPCRanges.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPCRanges.tsx
@@ -1,0 +1,53 @@
+import CloseIcon from '@mui/icons-material/Close';
+import React from 'react';
+import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
+
+import { Box } from 'src/components/Box';
+import { IconButton } from 'src/components/IconButton';
+import { LinkButton } from 'src/components/LinkButton';
+import { Stack } from 'src/components/Stack';
+import { TextField } from 'src/components/TextField';
+
+import type { CreateLinodeRequest } from '@linode/api-v4';
+
+export const VPCRanges = () => {
+  const { control } = useFormContext<CreateLinodeRequest>();
+
+  const { append, fields, remove } = useFieldArray({
+    control,
+    name: 'interfaces.2.ip_ranges',
+  });
+
+  return (
+    <Stack spacing={1}>
+      <Stack>
+        {fields.map((field, index) => (
+          <Stack alignItems="center" direction="row" key={field.id}>
+            <Controller
+              render={({ field }) => (
+                <TextField
+                  hideLabel
+                  label={`IP Range ${index}`}
+                  onChange={field.onChange}
+                  placeholder="10.0.0.0/24"
+                  value={field.value}
+                />
+              )}
+              control={control}
+              name={`interfaces.2.ip_ranges.${index}`}
+            />
+            <IconButton
+              aria-label={`Remove IP Range ${index}`}
+              onClick={() => remove(index)}
+            >
+              <CloseIcon />
+            </IconButton>
+          </Stack>
+        ))}
+      </Stack>
+      <Box>
+        <LinkButton onClick={() => append('')}>Add IPv4 Range</LinkButton>
+      </Box>
+    </Stack>
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPCRanges.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPCRanges.tsx
@@ -22,7 +22,12 @@ export const VPCRanges = () => {
     <Stack spacing={1}>
       <Stack>
         {fields.map((field, index) => (
-          <Stack alignItems="center" direction="row" key={field.id}>
+          <Stack
+            alignItems="flex-start"
+            direction="row"
+            key={field.id}
+            spacing={0.5}
+          >
             <Controller
               render={({ field, fieldState }) => (
                 <TextField
@@ -40,6 +45,7 @@ export const VPCRanges = () => {
             <IconButton
               aria-label={`Remove IP Range ${index}`}
               onClick={() => remove(index)}
+              sx={{ padding: 0.75 }}
             >
               <CloseIcon />
             </IconButton>

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPCRanges.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPCRanges.tsx
@@ -15,7 +15,7 @@ export const VPCRanges = () => {
 
   const { append, fields, remove } = useFieldArray({
     control,
-    name: 'interfaces.2.ip_ranges',
+    name: 'interfaces.0.ip_ranges',
   });
 
   return (
@@ -24,8 +24,9 @@ export const VPCRanges = () => {
         {fields.map((field, index) => (
           <Stack alignItems="center" direction="row" key={field.id}>
             <Controller
-              render={({ field }) => (
+              render={({ field, fieldState }) => (
                 <TextField
+                  errorText={fieldState.error?.message}
                   hideLabel
                   label={`IP Range ${index}`}
                   onChange={field.onChange}
@@ -34,7 +35,7 @@ export const VPCRanges = () => {
                 />
               )}
               control={control}
-              name={`interfaces.2.ip_ranges.${index}`}
+              name={`interfaces.0.ip_ranges.${index}`}
             />
             <IconButton
               aria-label={`Remove IP Range ${index}`}

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
@@ -31,6 +31,7 @@ import {
   useLinodeCreateQueryParams,
 } from './utilities';
 import { VLAN } from './VLAN';
+import { VPC } from './VPC';
 
 import type { CreateLinodeRequest } from '@linode/api-v4';
 import type { SubmitHandler } from 'react-hook-form';
@@ -102,6 +103,7 @@ export const LinodeCreatev2 = () => {
           <Plan />
           <Details />
           <Access />
+          <VPC />
           <Firewall />
           <VLAN />
           <UserData />

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
@@ -31,7 +31,7 @@ import {
   useLinodeCreateQueryParams,
 } from './utilities';
 import { VLAN } from './VLAN';
-import { VPC } from './VPC';
+import { VPC } from './VPC/VPC';
 
 import type { CreateLinodeRequest } from '@linode/api-v4';
 import type { SubmitHandler } from 'react-hook-form';

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useHistory } from 'react-router-dom';
 
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { LandingHeader } from 'src/components/LandingHeader';
 import { Stack } from 'src/components/Stack';
 import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
@@ -66,6 +67,7 @@ export const LinodeCreatev2 = () => {
 
   return (
     <FormProvider {...methods}>
+      <DocumentTitleSegment segment="Create a Linode" />
       <LandingHeader
         docsLabel="Getting Started"
         docsLink="https://www.linode.com/docs/guides/platform/get-started/"

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.test.tsx
@@ -40,40 +40,252 @@ describe('getLinodeCreatePayload', () => {
 });
 
 describe('getInterfacesPayload', () => {
-  it('should remove a VLAN from the payload if the label is empty', () => {
+  it('should return undefined when there is no vpc or vlan', () => {
     expect(
-      getInterfacesPayload([
-        {
-          ipam_address: '',
-          label: '',
-          purpose: 'vlan',
-        },
-      ])
-    ).toStrictEqual([]);
-  });
-
-  it('should remove a VPC from the payload if the id is not set', () => {
-    expect(
-      getInterfacesPayload([
-        {
-          ipam_address: '',
-          label: '',
-          purpose: 'vpc',
-          vpc_id: null,
-        },
-      ])
-    ).toStrictEqual([]);
-  });
-
-  it('should return undefined if there is only a public interface', () => {
-    expect(
-      getInterfacesPayload([
-        {
-          ipam_address: '',
-          label: '',
-          purpose: 'public',
-        },
-      ])
+      getInterfacesPayload(
+        [
+          {
+            ipam_address: '',
+            label: '',
+            purpose: 'vpc',
+          },
+          {
+            ipam_address: '',
+            label: '',
+            purpose: 'vlan',
+          },
+          {
+            ipam_address: '',
+            label: '',
+            purpose: 'public',
+          },
+        ],
+        false
+      )
     ).toStrictEqual(undefined);
+  });
+
+  it('should return a public interface and a VLAN interface when a VLAN is selected', () => {
+    expect(
+      getInterfacesPayload(
+        [
+          {
+            ipam_address: '',
+            label: '',
+            purpose: 'vpc',
+          },
+          {
+            ipam_address: '',
+            label: 'my-vlan',
+            purpose: 'vlan',
+          },
+          {
+            ipam_address: '',
+            label: '',
+            purpose: 'public',
+          },
+        ],
+        false
+      )
+    ).toStrictEqual([
+      {
+        ipam_address: '',
+        label: '',
+        purpose: 'public',
+      },
+      {
+        ipam_address: '',
+        label: 'my-vlan',
+        purpose: 'vlan',
+      },
+    ]);
+  });
+
+  it('should return a public interface and a VLAN interface when a VLAN is selected with a private IP', () => {
+    expect(
+      getInterfacesPayload(
+        [
+          {
+            ipam_address: '',
+            label: '',
+            purpose: 'vpc',
+          },
+          {
+            ipam_address: '',
+            label: 'my-vlan',
+            purpose: 'vlan',
+          },
+          {
+            ipam_address: '',
+            label: '',
+            purpose: 'public',
+          },
+        ],
+        true
+      )
+    ).toStrictEqual([
+      {
+        ipam_address: '',
+        label: '',
+        purpose: 'public',
+      },
+      {
+        ipam_address: '',
+        label: 'my-vlan',
+        purpose: 'vlan',
+      },
+    ]);
+  });
+
+  it('should return a VPC interface if only a VPC is selected', () => {
+    expect(
+      getInterfacesPayload(
+        [
+          {
+            ipam_address: '',
+            label: '',
+            purpose: 'vpc',
+            vpc_id: 5,
+          },
+          {
+            ipam_address: '',
+            label: '',
+            purpose: 'vlan',
+          },
+          {
+            ipam_address: '',
+            label: '',
+            purpose: 'public',
+          },
+        ],
+        false
+      )
+    ).toStrictEqual([
+      {
+        ipam_address: '',
+        label: '',
+        purpose: 'vpc',
+        vpc_id: 5,
+      },
+    ]);
+  });
+
+  it('should return a VPC interface and a public interface if a VPC is selected and Private IP is enabled', () => {
+    expect(
+      getInterfacesPayload(
+        [
+          {
+            ipam_address: '',
+            label: '',
+            purpose: 'vpc',
+            vpc_id: 5,
+          },
+          {
+            ipam_address: '',
+            label: '',
+            purpose: 'vlan',
+          },
+          {
+            ipam_address: '',
+            label: '',
+            purpose: 'public',
+          },
+        ],
+        true
+      )
+    ).toStrictEqual([
+      {
+        ipam_address: '',
+        label: '',
+        purpose: 'vpc',
+        vpc_id: 5,
+      },
+      {
+        ipam_address: '',
+        label: '',
+        purpose: 'public',
+      },
+    ]);
+  });
+
+  it('should return a VPC interface and a VLAN interface when both are specified (no private IP)', () => {
+    expect(
+      getInterfacesPayload(
+        [
+          {
+            ipam_address: '',
+            label: '',
+            purpose: 'vpc',
+            vpc_id: 5,
+          },
+          {
+            ipam_address: '',
+            label: 'my-vlan',
+            purpose: 'vlan',
+          },
+          {
+            ipam_address: '',
+            label: '',
+            purpose: 'public',
+          },
+        ],
+        false
+      )
+    ).toStrictEqual([
+      {
+        ipam_address: '',
+        label: '',
+        purpose: 'vpc',
+        vpc_id: 5,
+      },
+      {
+        ipam_address: '',
+        label: 'my-vlan',
+        purpose: 'vlan',
+      },
+    ]);
+  });
+
+  it('should return a VPC, VLAN, and Public interface if a VPC is selcted, a VLAN is selected, and Private IP is enabled', () => {
+    expect(
+      getInterfacesPayload(
+        [
+          {
+            ipam_address: '',
+            label: '',
+            purpose: 'vpc',
+            vpc_id: 5,
+          },
+          {
+            ipam_address: '',
+            label: 'my-vlan',
+            purpose: 'vlan',
+          },
+          {
+            ipam_address: '',
+            label: '',
+            purpose: 'public',
+          },
+        ],
+        true
+      )
+    ).toStrictEqual([
+      {
+        ipam_address: '',
+        label: '',
+        purpose: 'vpc',
+        vpc_id: 5,
+      },
+      {
+        ipam_address: '',
+        label: 'my-vlan',
+        purpose: 'vlan',
+      },
+      {
+        ipam_address: '',
+        label: '',
+        purpose: 'public',
+      },
+    ]);
   });
 });

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
@@ -133,6 +133,9 @@ export const getInterfacesPayload = (
     return [vpcInterface];
   }
 
+  // If no special case is met, don't send `interfaces` in the Linode
+  // create payload. This will cause the API to deault to giving the Linode
+  // public communication.
   return undefined;
 };
 

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
@@ -91,9 +91,9 @@ export const getLinodeCreatePayload = (
 };
 
 /**
- * Performans transformation and ordering on the Linode Create "interfaces" form data.
+ * Transforms and orders the Linode Create "interfaces" form data.
  *
- * We need this so we can put interfaces in the correct order and omit unused iterfaces.
+ * We need this so we can put interfaces in the correct order and omit unused interfaces.
  *
  * @param interfaces raw interfaces from the Linode create flow form
  * @returns a transformed interfaces array in the correct order and with the expected values for the API

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
@@ -134,7 +134,7 @@ export const getInterfacesPayload = (
   }
 
   // If no special case is met, don't send `interfaces` in the Linode
-  // create payload. This will cause the API to deault to giving the Linode
+  // create payload. This will cause the API to default to giving the Linode
   // public communication.
   return undefined;
 };

--- a/packages/manager/src/hooks/useCreateVPC.ts
+++ b/packages/manager/src/hooks/useCreateVPC.ts
@@ -181,6 +181,7 @@ export const useCreateVPC = (inputs: UseCreateVPCInputs) => {
   };
 
   const formik = useFormik({
+    enableReinitialize: true,
     initialValues: {
       description: '',
       label: '',

--- a/packages/manager/src/queries/vpcs.ts
+++ b/packages/manager/src/queries/vpcs.ts
@@ -28,11 +28,16 @@ export const vpcQueryKey = 'vpcs';
 export const subnetQueryKey = 'subnets';
 
 // VPC queries
-export const useVPCsQuery = (params: Params, filter: Filter) => {
+export const useVPCsQuery = (
+  params: Params,
+  filter: Filter,
+  enabled = true
+) => {
   return useQuery<ResourcePage<VPC>, APIError[]>(
     [vpcQueryKey, 'paginated', params, filter],
     () => getVPCs(params, filter),
     {
+      enabled,
       keepPreviousData: true,
     }
   );

--- a/packages/validation/.changeset/pr-10354-changed-1712605368375.md
+++ b/packages/validation/.changeset/pr-10354-changed-1712605368375.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Changed
+---
+
+Improved VPC `ip_ranges` validation in `LinodeInterfaceSchema` ([#10354](https://github.com/linode/manager/pull/10354))

--- a/packages/validation/src/linodes.schema.ts
+++ b/packages/validation/src/linodes.schema.ts
@@ -195,7 +195,15 @@ export const LinodeInterfaceSchema = object().shape({
     .of(string())
     .when('purpose', {
       is: 'vpc',
-      then: array().of(string().test(validateIP)).notRequired(),
+      then: array()
+        .of(
+          string().test(
+            'valid-ip-range',
+            'Must be a valid IPv4 range, e.g. 192.0.2.0/24.',
+            validateIP
+          )
+        )
+        .notRequired(),
       otherwise: array().test({
         name: testnameDisallowedBasedOnPurpose('VPC'),
         message: testmessageDisallowedBasedOnPurpose('vpc', 'ip_ranges'),


### PR DESCRIPTION
## Description 📝

- Adds a VPC section to the new Linode Create flow ✨

## Changes  🔄
- Builds **new** VPC panel that uses react hook from tooling 🔧
- Adds a VPC Select
- Adds `Create a Linode` to the document title to match the existing flow
- Improves error handling for VPC IP ranges

## Preview 📷

![Screenshot 2024-04-04 at 8 00 07 PM](https://github.com/linode/manager/assets/115251059/515032eb-928a-438b-b120-14634f69c750)

## How to test 🧪

### Prerequisites
- Turn on the `Linode Create v2` feature flag 🎏 

### Verification steps
- Test the new VPC selction 🧪 
- Compare functionality to the existing Linode Create flow 🔍 
- Test error handling in the VPC section ❌ 

## As an Author I have considered 🤔

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support