### PR TITLE
change: [M3-7847] - Add Akamai's Japanese QI System ID to Japanese Invoices.

### DIFF
--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -5,6 +5,7 @@ import type { NoticeVariant } from 'src/components/Notice/Notice';
 // These flags should correspond with active features flags in LD
 
 export interface TaxDetail {
+  qi_registration?: string;
   tax_id: string;
   tax_name: string;
 }

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -97,12 +97,16 @@ const addLeftHeader = (
     addLine('Tax ID(s):');
     doc.setFont(baseFont, 'normal');
 
-    // M3-7847 Add Akamai's Japanese QI System ID to Japanese Invoices.
+    /**
+     * M3-7847 Add Akamai's Japanese QI System ID to Japanese Invoices.
+     * Since LD automatically serves Tax data based on the user's
+     * we can check on qi_registration field to render QI Registration.
+     * */
+
     if (countryTax) {
-      const line =
-        country === 'JP' && countryTax.qi_registration
-          ? `QI Registration # ${countryTax.qi_registration}`
-          : `${countryTax.tax_name}: ${countryTax.tax_id}`;
+      const line = countryTax.qi_registration
+        ? `QI Registration # ${countryTax.qi_registration}`
+        : `${countryTax.tax_name}: ${countryTax.tax_id}`;
       addLine(line);
     }
     if (provincialTax) {

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -97,8 +97,13 @@ const addLeftHeader = (
     addLine('Tax ID(s):');
     doc.setFont(baseFont, 'normal');
 
+    // M3-7847 Add Akamai's Japanese QI System ID to Japanese Invoices.
     if (countryTax) {
-      addLine(`${countryTax.tax_name}: ${countryTax.tax_id}`);
+      const line =
+        country === 'JP'
+          ? `QI Registration # ${countryTax.qi_registration}`
+          : `${countryTax.tax_name}: ${countryTax.tax_id}`;
+      addLine(line);
     }
     if (provincialTax) {
       addLine(`${provincialTax.tax_name}: ${provincialTax.tax_id}`);
@@ -199,7 +204,7 @@ interface PrintInvoiceOptions {
 export const printInvoice = async (
   options: PrintInvoiceOptions
 ): Promise<PdfResult> => {
-  const { account, invoice, items, taxes, timezone, regions } = options;
+  const { account, invoice, items, regions, taxes, timezone } = options;
 
   try {
     const itemsPerPage = 12;

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -97,16 +97,16 @@ const addLeftHeader = (
     addLine('Tax ID(s):');
     doc.setFont(baseFont, 'normal');
 
+    if (countryTax) {
+      addLine(`${countryTax.tax_name}: ${countryTax.tax_id}`);
+    }
     /**
      * M3-7847 Add Akamai's Japanese QI System ID to Japanese Invoices.
      * Since LD automatically serves Tax data based on the user's
      * we can check on qi_registration field to render QI Registration.
      * */
-
-    if (countryTax) {
-      const line = countryTax.qi_registration
-        ? `QI Registration # ${countryTax.qi_registration}`
-        : `${countryTax.tax_name}: ${countryTax.tax_id}`;
+    if (countryTax && countryTax.qi_registration) {
+      const line = `QI Registration # ${countryTax.qi_registration}`;
       addLine(line);
     }
     if (provincialTax) {

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -100,7 +100,7 @@ const addLeftHeader = (
     // M3-7847 Add Akamai's Japanese QI System ID to Japanese Invoices.
     if (countryTax) {
       const line =
-        country === 'JP'
+        country === 'JP' && countryTax.qi_registration
           ? `QI Registration # ${countryTax.qi_registration}`
           : `${countryTax.tax_name}: ${countryTax.tax_id}`;
       addLine(line);


### PR DESCRIPTION
## Description 📝
Add Akamai's Japanese QI System ID to Japanese Invoices.

## Changes  🔄
List any change relevant to the reviewer.
- Conditionally render Japanese QI System ID in pdfGenerator function.
- Add's new field to the taxes object in LD (Note this filed is not yet added. Will be added once it is merged into Prod.)
Example: 
```
 {
  "country_tax": {
    "tax_id": "******",
    "tax_name": "Japan JCT",
    **"qi_registration": "**********"**
  },
  "provincial_tax_ids": {}
}
```

## Preview 📷
![image](https://github.com/linode/manager/assets/119517080/9d51960d-8b3c-49d9-9a7c-af4e787e872a)


## How to test 🧪

### Prerequisites
(How to setup test environment)
- Turn on MSW
- Change account country to "JP" in MSW


### Verification steps
(How to verify changes)
- Navigate to http://localhost:3000/account/billing
- Click on Download invoice and verify the IQ registration appears under Tax Id's (top left side in invoice).
- Validate the changes reflect AC in the ticket. 

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

