### PR TITLE
refactor: [M3-7960] - Update Notistack to `3.0.1`

### DIFF
--- a/packages/manager/.changeset/pr-10357-tech-stories-1712339827520.md
+++ b/packages/manager/.changeset/pr-10357-tech-stories-1712339827520.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Update Notistack to 3.0.1 ([#10357](https://github.com/linode/manager/pull/10357))

--- a/packages/manager/cypress/support/ui/toast.ts
+++ b/packages/manager/cypress/support/ui/toast.ts
@@ -24,7 +24,11 @@ export const toast = {
     message: string,
     options?: ToastFindOptions | undefined
   ): void => {
-    cy.contains('[data-qa-toast]', message, options).should('be.visible');
+    cy.contains(
+      '[aria-describedby="notistack-snackbar"]',
+      message,
+      options
+    ).should('be.visible');
   },
 
   /**
@@ -42,6 +46,10 @@ export const toast = {
     message: string,
     options?: ToastFindOptions | undefined
   ): Cypress.Chainable => {
-    return cy.contains('[data-qa-toast]', message, options);
+    return cy.contains(
+      '[aria-describedby="notistack-snackbar"]',
+      message,
+      options
+    );
   },
 };

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -48,7 +48,7 @@
     "luxon": "3.4.4",
     "markdown-it": "^12.3.2",
     "md5": "^2.2.1",
-    "notistack": "^2.0.5",
+    "notistack": "^3.0.1",
     "patch-package": "^7.0.0",
     "qrcode.react": "^0.8.0",
     "ramda": "~0.25.0",

--- a/packages/manager/src/components/Snackbar/Snackbar.tsx
+++ b/packages/manager/src/components/Snackbar/Snackbar.tsx
@@ -1,17 +1,31 @@
-import { Theme } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import { SnackbarProvider, SnackbarProviderProps } from 'notistack';
+import { MaterialDesignContent } from 'notistack';
 import * as React from 'react';
 import { makeStyles } from 'tss-react/mui';
 
 import { CloseSnackbar } from './CloseSnackbar';
 
+import type { Theme } from '@mui/material/styles';
+
+const StyledMaterialDesignContent = styled(MaterialDesignContent)(
+  ({ theme }: { theme: Theme }) => ({
+    '&.notistack-MuiContent-error': {
+      borderLeft: `6px solid ${theme.palette.error.dark}`,
+    },
+    '&.notistack-MuiContent-info': {
+      borderLeft: `6px solid ${theme.palette.primary.main}`,
+    },
+    '&.notistack-MuiContent-success': {
+      borderLeft: `6px solid ${theme.palette.success.main}`, // corrected to palette.success
+    },
+    '&.notistack-MuiContent-warning': {
+      borderLeft: `6px solid ${theme.palette.warning.dark}`,
+    },
+  })
+);
+
 const useStyles = makeStyles()((theme: Theme) => ({
-  error: {
-    borderLeft: `6px solid ${theme.palette.error.dark}`,
-  },
-  info: {
-    borderLeft: `6px solid ${theme.palette.primary.main}`,
-  },
   root: {
     '& div': {
       backgroundColor: `${theme.bg.white} !important`,
@@ -31,12 +45,6 @@ const useStyles = makeStyles()((theme: Theme) => ({
         paddingLeft: 0,
       },
     },
-  },
-  success: {
-    borderLeft: `6px solid ${theme.color.green}`,
-  },
-  warning: {
-    borderLeft: `6px solid ${theme.palette.warning.dark}`,
   },
 }));
 
@@ -59,6 +67,12 @@ export const Snackbar = (props: SnackbarProviderProps) => {
     <SnackbarProvider
       ref={notistackRef}
       {...rest}
+      Components={{
+        error: StyledMaterialDesignContent,
+        info: StyledMaterialDesignContent,
+        success: StyledMaterialDesignContent,
+        warning: StyledMaterialDesignContent,
+      }}
       action={(key) => (
         <CloseSnackbar
           onClick={onClickDismiss(key)}
@@ -67,10 +81,6 @@ export const Snackbar = (props: SnackbarProviderProps) => {
       )}
       classes={{
         root: classes.root,
-        variantError: classes.error,
-        variantInfo: classes.info,
-        variantSuccess: classes.success,
-        variantWarning: classes.warning,
       }}
     >
       {children}

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -8,7 +8,7 @@ import { APIError } from '@linode/api-v4/lib/types';
 import { vpcsValidateIP } from '@linode/validation';
 import { CreateLinodeSchema } from '@linode/validation/lib/linodes.schema';
 import Grid from '@mui/material/Unstable_Grid2';
-import { WithSnackbarProps, withSnackbar } from 'notistack';
+import { enqueueSnackbar } from 'notistack';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
@@ -63,11 +63,11 @@ import {
 } from 'src/utilities/analytics';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { ExtendedType, extendType } from 'src/utilities/extendType';
+import { isEURegion } from 'src/utilities/formatRegion';
 import {
   getGDPRDetails,
   getSelectedRegionGroup,
 } from 'src/utilities/formatRegion';
-import { isEURegion } from 'src/utilities/formatRegion';
 import { ExtendedIP } from 'src/utilities/ipUtils';
 import { UNKNOWN_PRICE } from 'src/utilities/pricing/constants';
 import { getLinodeRegionPrice } from 'src/utilities/pricing/linodes';
@@ -127,8 +127,7 @@ interface State {
   vpcIPv4AddressOfLinode?: string;
 }
 
-type CombinedProps = WithSnackbarProps &
-  CreateType &
+type CombinedProps = CreateType &
   WithImagesProps &
   WithTypesProps &
   WithLinodesProps &
@@ -896,12 +895,9 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
         );
 
         /** show toast */
-        this.props.enqueueSnackbar(
-          `Your Linode ${response.label} is being created.`,
-          {
-            variant: 'success',
-          }
-        );
+        enqueueSnackbar(`Your Linode ${response.label} is being created.`, {
+          variant: 'success',
+        });
 
         /** reset the Events polling */
         this.props.checkForNewEvents();
@@ -977,7 +973,6 @@ export default recompose<CombinedProps, {}>(
   withRegions,
   withTypes,
   connected,
-  withSnackbar,
   withFeatureFlags,
   withProfile,
   withAgreements,

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.tsx
@@ -16,6 +16,7 @@ import {
   useAllPlacementGroupsQuery,
   useAssignLinodesToPlacementGroup,
 } from 'src/queries/placementGroups';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
 import { LinodeSelect } from '../Linodes/LinodeSelect/LinodeSelect';
 import {
@@ -126,12 +127,12 @@ export const PlacementGroupsAssignLinodesDrawer = (
         variant: 'success',
       });
       handleDrawerClose();
-    } catch (error) {
-      setGeneralError(
-        error?.[0]?.reason
-          ? error[0].reason
-          : 'An error occurred while adding the Linode to the group'
+    } catch (errorResponse) {
+      const error = getErrorStringOrDefault(
+        errorResponse,
+        'An error occurred while adding the Linode to the group'
       );
+      setGeneralError(error);
       enqueueSnackbar(error, { variant: 'error' });
     }
   };

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.tsx
@@ -132,7 +132,7 @@ export const PlacementGroupsAssignLinodesDrawer = (
           ? error[0].reason
           : 'An error occurred while adding the Linode to the group'
       );
-      enqueueSnackbar(error[0]?.reason, { variant: 'error' });
+      enqueueSnackbar(error, { variant: 'error' });
     }
   };
 

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsLinodes/PlacementGroupsLinodesTable.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsLinodes/PlacementGroupsLinodesTable.tsx
@@ -72,7 +72,7 @@ export const PlacementGroupsLinodesTable = React.memo((props: Props) => {
                       handleClick={handleOrderChange}
                       label={orderStatusKey}
                     >
-                      Linode Status
+                      Status
                     </TableSortCell>
                     <TableCell />
                   </TableRow>

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsLinodes/PlacementGroupsLinodesTable.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsLinodes/PlacementGroupsLinodesTable.tsx
@@ -72,7 +72,7 @@ export const PlacementGroupsLinodesTable = React.memo((props: Props) => {
                       handleClick={handleOrderChange}
                       label={orderStatusKey}
                     >
-                      Status
+                      Linode Status
                     </TableSortCell>
                     <TableCell />
                   </TableRow>

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -13,7 +13,7 @@ import { APIError } from '@linode/api-v4/lib/types';
 import { Paper } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
 import { QueryClient } from '@tanstack/react-query';
-import { WithSnackbarProps, withSnackbar } from 'notistack';
+import { enqueueSnackbar } from 'notistack';
 import { compose, flatten, lensPath, omit, set } from 'ramda';
 import * as React from 'react';
 import { compose as recompose } from 'recompose';
@@ -89,10 +89,7 @@ interface State {
   userType: null | string;
 }
 
-type CombinedProps = Props &
-  WithSnackbarProps &
-  WithQueryClientProps &
-  WithFeatureFlagProps;
+type CombinedProps = Props & WithQueryClientProps & WithFeatureFlagProps;
 
 class UserPermissions extends React.Component<CombinedProps, State> {
   componentDidMount() {
@@ -308,7 +305,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           );
           // unconditionally sets this.state.loadingGrants to false
           this.getUserGrants();
-          this.props.enqueueSnackbar('User permissions successfully saved.', {
+          enqueueSnackbar('User permissions successfully saved.', {
             variant: 'success',
           });
         })
@@ -720,12 +717,9 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           const { tabs } = this.getTabInformation(grantsResponse);
           this.setState({ isSavingGlobal: false, tabs });
 
-          this.props.enqueueSnackbar(
-            'General user permissions successfully saved.',
-            {
-              variant: 'success',
-            }
-          );
+          enqueueSnackbar('General user permissions successfully saved.', {
+            variant: 'success',
+          });
 
           // Update the user's grants directly in the cache
           this.props.queryClient.setQueriesData<Grants>(
@@ -782,7 +776,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
         if (updateFns.length) {
           this.setState((compose as any)(...updateFns));
         }
-        this.props.enqueueSnackbar(
+        enqueueSnackbar(
           'Entity-specific user permissions successfully saved.',
           {
             variant: 'success',
@@ -833,7 +827,6 @@ class UserPermissions extends React.Component<CombinedProps, State> {
 }
 
 export default recompose<CombinedProps, Props>(
-  withSnackbar,
   withQueryClient,
   withFeatureFlags
 )(UserPermissions);

--- a/packages/manager/src/index.tsx
+++ b/packages/manager/src/index.tsx
@@ -63,10 +63,6 @@ const Main = () => {
                 <Route component={Logout} exact path="/logout" />
                 <Route component={CancelLanding} exact path="/cancel" />
                 <Snackbar
-                  SnackbarProps={{
-                    // @ts-expect-error used for testing 🥺
-                    'data-qa-toast': true,
-                  }}
                   anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
                   autoHideDuration={4000}
                   hideIconVariant={true}

--- a/packages/manager/src/index.tsx
+++ b/packages/manager/src/index.tsx
@@ -63,9 +63,12 @@ const Main = () => {
                 <Route component={Logout} exact path="/logout" />
                 <Route component={CancelLanding} exact path="/cancel" />
                 <Snackbar
+                  SnackbarProps={{
+                    // @ts-expect-error used for testing 🥺
+                    'data-qa-toast': true,
+                  }}
                   anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
                   autoHideDuration={4000}
-                  data-qa-toast
                   hideIconVariant={true}
                   maxSnack={3}
                 >

--- a/yarn.lock
+++ b/yarn.lock
@@ -7502,6 +7502,11 @@ globby@^11.0.1, globby@^11.0.2, globby@^11.0.3, globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+goober@^2.0.33:
+  version "2.1.14"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.14.tgz#4a5c94fc34dc086a8e6035360ae1800005135acd"
+  integrity sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -9777,13 +9782,13 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-notistack@^2.0.5:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/notistack/-/notistack-2.0.8.tgz#78cdf34c64e311bf1d1d71c2123396bcdea5e95b"
-  integrity sha512-/IY14wkFp5qjPgKNvAdfL5Jp6q90+MjgKTPh4c81r/lW70KeuX6b9pE/4f8L4FG31cNudbN9siiFS5ql1aSLRw==
+notistack@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/notistack/-/notistack-3.0.1.tgz#daf59888ab7e2c30a1fa8f71f9cba2978773236e"
+  integrity sha512-ntVZXXgSQH5WYfyU+3HfcXuKaapzAJ8fBLQ/G618rn3yvSzEbnOB8ZSOwhX+dAORy/lw+GC2N061JA0+gYWTVA==
   dependencies:
     clsx "^1.1.0"
-    hoist-non-react-statics "^3.3.0"
+    goober "^2.0.33"
 
 npm-run-all@^4.1.5:
   version "4.1.5"


### PR DESCRIPTION
## Description 📝
Update Notistack to 3.0.1 - pretty light refactor for a major update. This will bring us up to date with the lib and prevent some console errors we saw surface recently between React/Router & Notistack. ex:

![Screenshot 2024-04-03 at 16 05 00](https://github.com/linode/manager/assets/130582365/1e7edc14-d395-43fb-a7dc-8d126391a525)

Every time we'd have a snackbar pop up ⬆️ 

see [Migration Notes](https://notistack.com/migration) for more info

## Changes  🔄
- Update Notistack to `3.0.1`
- Update Styling with new API in Snackbar.tsx
- Update Class Components instances

## Target release date 🗓️
Please specify a release date to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷
ℹ️ There should be no functional or visual regressions as a result of this PR (1/1 refactor)

## How to test 🧪

### Verification steps
- pull code, run `yarn && yarn up`
- test application overall for potential regression

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support


