### PR TITLE
fix: [M3-7961] - Disable usePersonAccessTokensQuery in token revocation hook based on `user_type`

### DIFF
--- a/packages/manager/.changeset/pr-10358-fixed-1712607995201.md
+++ b/packages/manager/.changeset/pr-10358-fixed-1712607995201.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Unnecessary requests to /tokens endpoint for some user types ([#10358](https://github.com/linode/manager/pull/10358))

--- a/packages/manager/.changeset/pr-10358-fixed-1712607995201.md
+++ b/packages/manager/.changeset/pr-10358-fixed-1712607995201.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Unnecessary requests to /tokens endpoint for some user types ([#10358](https://github.com/linode/manager/pull/10358))
+`usePersonAccessTokensQuery` running without option to be disabled ([#10358](https://github.com/linode/manager/pull/10358))

--- a/packages/manager/src/hooks/usePendingRevocationToken.ts
+++ b/packages/manager/src/hooks/usePendingRevocationToken.ts
@@ -6,8 +6,6 @@ import { useCurrentToken } from 'src/hooks/useAuthentication';
 import { useProfile } from 'src/queries/profile';
 import { usePersonalAccessTokensQuery } from 'src/queries/tokens';
 
-import { useRestrictedGlobalGrantCheck } from './useRestrictedGlobalGrantCheck';
-
 /**
  * Custom hook to manage the ID of a personal access token pending revocation.
  *
@@ -28,14 +26,8 @@ export const usePendingRevocationToken = () => {
   const { data: profile } = useProfile();
   const currentTokenWithBearer = useCurrentToken() ?? '';
 
-  // Only run query on proxy and parent accounts with child_account_access.
-  const isChildAccountAccessRestricted = useRestrictedGlobalGrantCheck({
-    globalGrantType: 'child_account_access',
-  });
-  const isQueryEnabled = Boolean(
-    (profile?.user_type === 'parent' && !isChildAccountAccessRestricted) ||
-      profile?.user_type === 'proxy'
-  );
+  // Only run query on proxy accounts.
+  const isQueryEnabled = Boolean(profile?.user_type === 'proxy');
 
   const { data: personalAccessTokens } = usePersonalAccessTokensQuery(
     {},

--- a/packages/manager/src/queries/tokens.ts
+++ b/packages/manager/src/queries/tokens.ts
@@ -26,9 +26,11 @@ export const useAppTokensQuery = (params?: Params, filter?: Filter) => {
 
 export const usePersonalAccessTokensQuery = (
   params?: Params,
-  filter?: Filter
+  filter?: Filter,
+  enabled = true
 ) => {
   return useQuery<ResourcePage<Token>, APIError[]>({
+    enabled,
     keepPreviousData: true,
     ...profileQueries.personalAccessTokens(params, filter),
   });


### PR DESCRIPTION
## Description 📝
Disable unnecessary runs of the usePersonalAccessTokensQuery, which was running for all accounts - regardless of `user_type` - from the UserMenu. This query is used within the `usePendingRevocationToken` hook, which allows us to revoke PATs for proxy accounts when account switching occurs (see #10313). 

## Changes  🔄
- Updates `usePersonalAccessTokensQuery` to allow it to be enabled/disabled.

## Target release date 🗓️
4/15/24

## How to test 🧪

### Reproduction steps
(How to reproduce the issue, if applicable)
- Log into https://cloud.linode.com as a regular user and observe that there is an API call to `/tokens` made when Cloud is loaded, since the user menu will load on any page. The UI doesn't need access to tokens for this user at this point, so the call is unnecessary.

### Verification steps
(How to verify changes)
- Check out this branch and, as the same user, log into http://localhost:3000 and observe that there is NOT an API call made to `/tokens` when Cloud is loaded, since the user is not of `proxy` `user_type`.
- Then log into a parent user (using our shared parent account credentials - ask if you don't know where to find these) and switch into to a proxy account via the user menu > Switch Account button. Confirm there is an API call to `/tokens`. Confirm that #10313 works as expected.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
