### PR TITLE
fix: [M3-7967] - Returning proper scope when selecting all perms

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2024-04-05] - v1.116.1
+## [2024-04-08] - v1.116.1
 
 ### Fixed:
 
 - Search indefinitely loading on large accounts ([#10351](https://github.com/linode/manager/pull/10351))
+- Returning proper scope when selecting all perms ([#10359](https://github.com/linode/manager/pull/10359))
 
 ## [2024-04-01] - v1.116.0
 

--- a/packages/manager/src/features/Profile/APITokens/ViewAPITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/ViewAPITokenDrawer.tsx
@@ -16,11 +16,7 @@ import {
   StyledPermissionsCell,
   StyledPermsTable,
 } from './APITokenDrawer.styles';
-import {
-  basePermNameMap as _basePermNameMap,
-  filterPermsNameMap,
-  scopeStringToPermTuples,
-} from './utils';
+import { basePermNameMap, scopeStringToPermTuples } from './utils';
 
 interface Props {
   onClose: () => void;
@@ -39,39 +35,13 @@ export const ViewAPITokenDrawer = (props: Props) => {
     globalGrantType: 'child_account_access',
   });
 
-  const hasParentChildAccountAccess = Boolean(flags.parentChildAccountAccess);
-
-  // @TODO: Parent/Child - once in GA, remove _basePermNameMap logic and references.
-  // Just use the basePermNameMap import directly w/o any manipulation.
-  const basePermNameMap = filterPermsNameMap(_basePermNameMap, [
-    {
-      name: 'child_account',
-      shouldBeIncluded: hasParentChildAccountAccess,
-    },
-  ]);
-
   const allPermissions = scopeStringToPermTuples(token?.scopes ?? '');
 
-  /**
-   * A parent user with child_account_access can issue a PAT with child_account scope.
-   * If access is later revoked, we'll still display this scope for existing PATs, but not for new ones.
-   * */
-  const hideChildAccountAccessScope = allPermissions.some(
-    (scope) =>
-      scope[0] === 'child_account' &&
-      scope[1] === 0 &&
-      isChildAccountAccessRestricted
-  );
-
-  // Filter permissions for all users except parent user accounts.
-  const showFilteredPermissions =
-    !flags.parentChildAccountAccess ||
+  // Visually hide the "Child Account Access" permission even though it's still part of the base perms.
+  const hideChildAccountAccessScope =
     profile?.user_type !== 'parent' ||
-    hideChildAccountAccessScope;
-
-  const filteredPermissions = allPermissions.filter(
-    (scopeTup) => basePermNameMap[scopeTup[0]] !== 'Child Account Access'
-  );
+    isChildAccountAccessRestricted ||
+    !flags.parentChildAccountAccess;
 
   return (
     <Drawer onClose={onClose} open={open} title={token?.label ?? 'Token'}>
@@ -95,56 +65,58 @@ export const ViewAPITokenDrawer = (props: Props) => {
           </TableRow>
         </TableHead>
         <TableBody>
-          {(showFilteredPermissions ? filteredPermissions : allPermissions).map(
-            (scopeTup) => {
-              if (!basePermNameMap[scopeTup[0]]) {
-                return null;
-              }
-              return (
-                <TableRow
-                  data-qa-row={basePermNameMap[scopeTup[0]]}
-                  key={scopeTup[0]}
-                >
-                  <StyledAccessCell padding="checkbox" parentColumn="Access">
-                    {basePermNameMap[scopeTup[0]]}
-                  </StyledAccessCell>
-                  <StyledPermissionsCell padding="checkbox" parentColumn="None">
-                    <AccessCell
-                      active={scopeTup[1] === 0}
-                      disabled={false}
-                      onChange={() => null}
-                      scope="0"
-                      scopeDisplay={scopeTup[0]}
-                      viewOnly={true}
-                    />
-                  </StyledPermissionsCell>
-                  <StyledPermissionsCell
-                    padding="checkbox"
-                    parentColumn="Read Only"
-                  >
-                    <AccessCell
-                      active={scopeTup[1] === 1}
-                      disabled={false}
-                      onChange={() => null}
-                      scope="1"
-                      scopeDisplay={scopeTup[0]}
-                      viewOnly={true}
-                    />
-                  </StyledPermissionsCell>
-                  <TableCell padding="checkbox" parentColumn="Read/Write">
-                    <AccessCell
-                      active={scopeTup[1] === 2}
-                      disabled={false}
-                      onChange={() => null}
-                      scope="2"
-                      scopeDisplay={scopeTup[0]}
-                      viewOnly={true}
-                    />
-                  </TableCell>
-                </TableRow>
-              );
+          {allPermissions.map((scopeTup) => {
+            if (
+              !basePermNameMap[scopeTup[0]] ||
+              (hideChildAccountAccessScope &&
+                basePermNameMap[scopeTup[0]] === 'Child Account Access')
+            ) {
+              return null;
             }
-          )}
+            return (
+              <TableRow
+                data-qa-row={basePermNameMap[scopeTup[0]]}
+                key={scopeTup[0]}
+              >
+                <StyledAccessCell padding="checkbox" parentColumn="Access">
+                  {basePermNameMap[scopeTup[0]]}
+                </StyledAccessCell>
+                <StyledPermissionsCell padding="checkbox" parentColumn="None">
+                  <AccessCell
+                    active={scopeTup[1] === 0}
+                    disabled={false}
+                    onChange={() => null}
+                    scope="0"
+                    scopeDisplay={scopeTup[0]}
+                    viewOnly={true}
+                  />
+                </StyledPermissionsCell>
+                <StyledPermissionsCell
+                  padding="checkbox"
+                  parentColumn="Read Only"
+                >
+                  <AccessCell
+                    active={scopeTup[1] === 1}
+                    disabled={false}
+                    onChange={() => null}
+                    scope="1"
+                    scopeDisplay={scopeTup[0]}
+                    viewOnly={true}
+                  />
+                </StyledPermissionsCell>
+                <TableCell padding="checkbox" parentColumn="Read/Write">
+                  <AccessCell
+                    active={scopeTup[1] === 2}
+                    disabled={false}
+                    onChange={() => null}
+                    scope="2"
+                    scopeDisplay={scopeTup[0]}
+                    viewOnly={true}
+                  />
+                </TableCell>
+              </TableRow>
+            );
+          })}
         </TableBody>
       </StyledPermsTable>
     </Drawer>


### PR DESCRIPTION
## Description 📝
The Cloud Manager isn't working right when making tokens that should have access to everything. Even when you choose 'all' for the token's access level, it's mistakenly giving limited access (even though the scopes are all included). Also, when making tokens using the API and setting access to * (which should mean everything), it should reply with * to show that. But, it's listing out each access area one by one instead of just using *, which is not what's supposed to happen.

## Changes  🔄
- No longer need to filter out `child account access` since API is in prod
- We're still only visually showing the "child account access" perm for accounts that have access to it from a user experience point of view (even though the perm will be part of the token). This is ok since features are still blocked from a grants perspective.

## Target release date 🗓️
4/8-9/2024 (Hotfix)

## Preview 📷
Before:
```
{
  "id": 123,
  "scopes": "account:read_write child_account:read_write databases:read_write domains:read_write events:read_write firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write vpc:read_write volumes: read_write",
  "created": "2024-04-08T13:26:24",
  "label": "all-scopes-but-not-star",
  "token": "abcd",
  "expiry": "2024-10-08T00:00:00"
}
```
After:
```
{
  "id": 123,
  "scopes": "*",
  "created": "2024-04-08T13:26:24",
  "label": "this-has-star-indicating-all-scopes",
  "token": "abcd",
  "expiry": "2024-10-08T00:00:00"
}
```

## How to test 🧪

### Prerequisites
- Log into normal development account
- Log into Parent account using developer credentials
  - Test as Parent User - Unrestricted Access
  - Test as Parent User - Restricted Access with no child account access grant

### Reproduction steps
- Currently, selected "All" for any new PAT in any account will generate an enumerated scope list, not `scopes: "*"`

### Verification steps
- In a normal development account (non-parent/child), create a PAT with all scopes, and observe response has `scopes: "*"`
   - Further, observe that `child account access` is NOT visible
- In a parent user account (unrestricted access), create a PAT with all scopes, and observe response has `scopes: "*"`
   - Further, observe that `child account access` is visible. 
- In a parent user account (restricted access with no child account access grant), create a PAT with all scopes, and observe response has `scopes: "*"`
   - Further, observe that `child account access` is NOT visible. 

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support