### PR TITLE
fix: [M3-7952] - Unable to update label of OBJ limited access key

### DIFF
--- a/packages/manager/.changeset/pr-10362-fixed-1712610411475.md
+++ b/packages/manager/.changeset/pr-10362-fixed-1712610411475.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Unable to update label of OBJ limited access key ([#10362](https://github.com/linode/manager/pull/10362))

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -4,6 +4,7 @@ import {
   ObjectStorageKey,
   ObjectStorageKeyRequest,
   Scope,
+  UpdateObjectStorageKeyRequest,
 } from '@linode/api-v4/lib/object-storage';
 import { createObjectStorageKeysSchema } from '@linode/validation/lib/objectStorageKeys.schema';
 import { Formik, FormikProps } from 'formik';
@@ -38,7 +39,7 @@ export interface AccessKeyDrawerProps {
   objectStorageKey?: ObjectStorageKey;
   onClose: () => void;
   onSubmit: (
-    values: ObjectStorageKeyRequest,
+    values: ObjectStorageKeyRequest | UpdateObjectStorageKeyRequest,
     formikProps: FormikProps<ObjectStorageKeyRequest>
   ) => void;
   open: boolean;
@@ -162,16 +163,29 @@ export const AccessKeyDrawer = (props: AccessKeyDrawerProps) => {
     // don't include any bucket_access information in the payload.
 
     // If any/all values are 'none', don't include them in the response.
-    const access = values.bucket_access ?? [];
-    const payload = limitedAccessChecked
-      ? {
-          ...values,
-          bucket_access: access.filter(
-            (thisAccess) => thisAccess.permissions !== 'none'
-          ),
-        }
-      : { ...values, bucket_access: null };
+    let payload = {};
+    if (
+      mode === 'creating' &&
+      'bucket_access' in values &&
+      values.bucket_access !== null &&
+      limitedAccessChecked
+    ) {
+      const access = values?.bucket_access ?? [];
+      payload = {
+        ...values,
+        bucket_access: access.filter(
+          (thisAccess) => thisAccess.permissions !== 'none'
+        ),
+      };
+    } else {
+      payload = { ...values, bucket_access: null };
+    }
 
+    if (mode === 'editing') {
+      payload = {
+        label: values.label,
+      };
+    }
     return onSubmit(payload, formikProps);
   };
 

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -166,8 +166,7 @@ export const AccessKeyDrawer = (props: AccessKeyDrawerProps) => {
     let payload = {};
     if (
       mode === 'creating' &&
-      'bucket_access' in values &&
-      values.bucket_access !== null &&
+      values?.bucket_access !== null &&
       limitedAccessChecked
     ) {
       const access = values?.bucket_access ?? [];

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.tsx
@@ -1,6 +1,7 @@
 import {
   ObjectStorageKey,
   ObjectStorageKeyRequest,
+  UpdateObjectStorageKeyRequest,
   createObjectStorageKeys,
   revokeObjectStorageKey,
   updateObjectStorageKey,
@@ -30,8 +31,8 @@ import { AccessKeyDrawer } from './AccessKeyDrawer';
 import { AccessKeyTable } from './AccessKeyTable/AccessKeyTable';
 import { OMC_AccessKeyDrawer } from './OMC_AccessKeyDrawer';
 import { RevokeAccessKeyDialog } from './RevokeAccessKeyDialog';
-import ViewPermissionsDrawer from './ViewPermissionsDrawer';
 import { MODE, OpenAccessDrawer } from './types';
+import ViewPermissionsDrawer from './ViewPermissionsDrawer';
 
 interface Props {
   accessDrawerOpen: boolean;
@@ -155,12 +156,12 @@ export const AccessKeyLanding = (props: Props) => {
   };
 
   const handleEditKey = (
-    values: ObjectStorageKeyRequest,
+    values: UpdateObjectStorageKeyRequest,
     {
       setErrors,
       setStatus,
       setSubmitting,
-    }: FormikHelpers<ObjectStorageKeyRequest>
+    }: FormikHelpers<UpdateObjectStorageKeyRequest>
   ) => {
     // This shouldn't happen, but just in case.
     if (!keyToEdit) {
@@ -178,7 +179,10 @@ export const AccessKeyLanding = (props: Props) => {
 
     setSubmitting(true);
 
-    updateObjectStorageKey(keyToEdit.id, values)
+    updateObjectStorageKey(
+      keyToEdit.id,
+      isObjMultiClusterEnabled ? values : { label: values.label }
+    )
       .then((_) => {
         setSubmitting(false);
 


### PR DESCRIPTION
## Description 📝
This PR fixes the issue of unable to update label of OBJ limited access key.
## Changes  🔄
List any change relevant to the reviewer.
- Updated relevant type `UpdateObjectStorageKeyRequest` for `handleEditKey` 
- Update payload includes only `lablel` 

## How to test 🧪

### Reproduction steps
(How to reproduce the issue, if applicable)
- Checkout develop. 
- Create Object Storage access key with limited access.
- Click "Edit Label".
- Change label and click Save Changes.

### Verification steps
(How to verify changes) 
- Checkout this PR branch.
- Turn off OBJ feature flag and MSW 
- Create Object Storage access key with limited access.
- Click "Edit Label".
- Change label and click Save Changes. 
- Should be able to update label.
- Verify payload.
-  Turn on OBJ feature flag and MSW 
- Create / update Access key and verify the payload.
- Make sure there is no regression around creating and updating Access keys. 

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

