### PR TITLE
feat: [M3-7959] - Update gecko feature flag to object

### DIFF
--- a/packages/manager/.changeset/pr-10363-upcoming-features-1712613073120.md
+++ b/packages/manager/.changeset/pr-10363-upcoming-features-1712613073120.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update gecko feature flag to object ([#10363](https://github.com/linode/manager/pull/10363))

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -77,10 +77,16 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
       type,
     });
 
+  // Gecko Beta
   const hideEdgeRegions =
     !flags.gecko2?.enabled ||
     !flags.gecko2?.beta ||
     !getIsLinodeCreateTypeEdgeSupported(params.type as LinodeCreateType);
+
+  const isGeckoGA =
+    flags.gecko2?.enabled &&
+    flags.gecko2?.ga &&
+    getIsLinodeCreateTypeEdgeSupported(params.type as LinodeCreateType);
 
   const showEdgeIconHelperText = Boolean(
     !hideEdgeRegions &&
@@ -131,7 +137,7 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
           </Typography>
         </Notice>
       ) : null}
-      {flags.gecko2?.enabled && flags.gecko2?.ga && 'Gecko GA'}
+      {isGeckoGA && 'Gecko GA'}
       <RegionSelect
         currentCapability={currentCapability}
         disabled={disabled}

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -77,10 +77,9 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
       type,
     });
 
-  // Gecko Beta
   const hideEdgeRegions =
     !flags.gecko2?.enabled ||
-    !flags.gecko2?.beta ||
+    flags.gecko2?.ga ||
     !getIsLinodeCreateTypeEdgeSupported(params.type as LinodeCreateType);
 
   const isGeckoGA =

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -78,7 +78,8 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
     });
 
   const hideEdgeRegions =
-    !flags.gecko ||
+    !flags.gecko2?.enabled ||
+    !flags.gecko2?.beta ||
     !getIsLinodeCreateTypeEdgeSupported(params.type as LinodeCreateType);
 
   const showEdgeIconHelperText = Boolean(
@@ -130,6 +131,7 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
           </Typography>
         </Notice>
       ) : null}
+      {flags.gecko2?.enabled && flags.gecko2?.ga && 'Gecko GA'}
       <RegionSelect
         currentCapability={currentCapability}
         disabled={disabled}

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -22,7 +22,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'aclbFullCreateFlow', label: 'ACLB Full Create Flow' },
   { flag: 'disableLargestGbPlans', label: 'Disable Largest GB Plans' },
   { flag: 'linodeCloneUiChanges', label: 'Linode Clone UI Changes' },
-  { flag: 'gecko', label: 'Gecko' },
+  { flag: 'gecko2', label: 'Gecko' },
   { flag: 'parentChildAccountAccess', label: 'Parent/Child Account' },
   { flag: 'selfServeBetas', label: 'Self Serve Betas' },
   { flag: 'firewallNodebalancer', label: 'Firewall NodeBalancer' },

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -43,7 +43,6 @@ interface PlacementGroupsFlag {
 }
 
 interface GeckoFlag {
-  beta: boolean;
   enabled: boolean;
   ga: boolean;
 }
@@ -59,7 +58,7 @@ export interface Flags {
   databases: boolean;
   disableLargestGbPlans: boolean;
   firewallNodebalancer: boolean;
-  gecko: boolean;
+  gecko: boolean; // @TODO gecko: delete this after next release
   gecko2: GeckoFlag;
   ipv6Sharing: boolean;
   linodeCloneUiChanges: boolean;

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -42,6 +42,12 @@ interface PlacementGroupsFlag {
   enabled: boolean;
 }
 
+interface GeckoFlag {
+  beta: boolean;
+  enabled: boolean;
+  ga: boolean;
+}
+
 type OneClickApp = Record<string, string>;
 
 export interface Flags {
@@ -54,6 +60,7 @@ export interface Flags {
   disableLargestGbPlans: boolean;
   firewallNodebalancer: boolean;
   gecko: boolean;
+  gecko2: GeckoFlag;
   ipv6Sharing: boolean;
   linodeCloneUiChanges: boolean;
   linodeCreateRefactor: boolean;

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
@@ -474,7 +474,7 @@ export class LinodeCreate extends React.PureComponent<
       (imageIsCloudInitCompatible || linodeIsCloudInitCompatible);
 
     const isEdgeRegionSelected = Boolean(
-      flags.gecko &&
+      flags.gecko2?.enabled &&
         getIsEdgeRegion(regionsData, this.props.selectedRegionID ?? '')
     );
 

--- a/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -80,7 +80,7 @@ export const FromLinodeContent = (props: CombinedProps) => {
       (linode) => !getIsEdgeRegion(regionsData, linode.region) // Hide linodes that are in an edge region
     );
 
-  const filteredLinodes = flags.gecko
+  const filteredLinodes = flags.gecko2?.enabled
     ? filterEdgeLinodes(linodesData)
     : linodesData;
 

--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodesLanding.tsx
@@ -12,6 +12,10 @@ import { PreferenceToggle } from 'src/components/PreferenceToggle/PreferenceTogg
 import { ProductInformationBanner } from 'src/components/ProductInformationBanner/ProductInformationBanner';
 import { TransferDisplay } from 'src/components/TransferDisplay/TransferDisplay';
 import {
+  WithFeatureFlagProps,
+  withFeatureFlags,
+} from 'src/containers/flags.container';
+import {
   WithProfileProps,
   withProfile,
 } from 'src/containers/profile.container';
@@ -87,14 +91,15 @@ export interface LinodesLandingProps {
   someLinodesHaveScheduledMaintenance: boolean;
 }
 
-interface ListLinodesProps
-  extends LinodesLandingProps,
-    RouteProps,
-    WithProfileProps {}
+type CombinedProps = LinodesLandingProps &
+  RouteProps &
+  WithFeatureFlagProps &
+  WithProfileProps;
 
-class ListLinodes extends React.Component<ListLinodesProps, State> {
+class ListLinodes extends React.Component<CombinedProps, State> {
   render() {
     const {
+      flags,
       grants,
       linodesData,
       linodesInTransition,
@@ -161,6 +166,7 @@ class ListLinodes extends React.Component<ListLinodesProps, State> {
 
     return (
       <React.Fragment>
+        {flags.gecko2?.enabled && flags.gecko2?.ga && 'Gecko GA'}
         <LinodeResize
           linodeId={this.state.selectedLinodeID}
           onClose={this.closeDialogs}
@@ -447,9 +453,10 @@ const sendGroupByAnalytic = (value: boolean) => {
   sendGroupByTagEnabledEvent(eventCategory, value);
 };
 
-export const enhanced = compose<ListLinodesProps, LinodesLandingProps>(
+export const enhanced = compose<CombinedProps, LinodesLandingProps>(
   withRouter,
-  withProfile
+  withProfile,
+  withFeatureFlags
 );
 
 export default enhanced(ListLinodes);

--- a/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
@@ -134,6 +134,9 @@ export const ConfigureForm = React.memo((props: Props) => {
 
         <StyledMigrationBox>
           <RegionSelect
+            regionFilter={
+              flags.gecko2?.enabled && linodeIsInEdgeRegion ? 'edge' : 'core'
+            }
             regions={
               regions?.filter(
                 (eachRegion) => eachRegion.id !== currentRegion
@@ -146,7 +149,6 @@ export const ConfigureForm = React.memo((props: Props) => {
             errorText={errorText}
             handleSelection={handleSelectRegion}
             label="New Region"
-            regionFilter={flags.gecko && linodeIsInEdgeRegion ? 'edge' : 'core'}
             selectedId={selectedRegion}
           />
           {shouldDisplayPriceComparison && selectedRegion && (

--- a/packages/manager/src/features/Linodes/MigrateLinode/MigrateLinode.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/MigrateLinode.tsx
@@ -151,7 +151,7 @@ export const MigrateLinode = React.memo((props: Props) => {
   );
 
   const edgeRegionWarning =
-    flags.gecko && linodeIsInEdgeRegion
+    flags.gecko2?.enabled && linodeIsInEdgeRegion
       ? 'Edge sites may only be migrated to other Edge sites.'
       : undefined;
 

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -87,7 +87,7 @@ export const PlansPanel = (props: Props) => {
   );
 
   const hideEdgeRegions =
-    !flags.gecko ||
+    !flags.gecko2?.enabled ||
     !getIsLinodeCreateTypeEdgeSupported(params.type as LinodeCreateType);
 
   const showEdgePlanTable =


### PR DESCRIPTION
## Description 📝
Update the gecko feature flag from a boolean to an object so we can have more granular control for Beta/GA

## Changes  🔄
- Use `gecko2` object feature flag over `gecko` feature flag
- Add placeholder logic for GA for the Linode's landing page and region select

## Preview 📷
| Gecko Beta  | Gecko GA   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/115299789/5d18858c-6cf2-47f1-aaac-ed5b34633b3f) | ![Screenshot 2024-04-08 at 5 24 50 PM](https://github.com/linode/manager/assets/115299789/a52aea52-70c1-4f04-a9f2-ec0749eb3894) |
| ![Screenshot 2024-04-08 at 5 25 53 PM](https://github.com/linode/manager/assets/115299789/d1f26722-a792-429b-bf2e-c3a5d3dabef2) | ![image](https://github.com/linode/manager/assets/115299789/6114af77-7be0-4310-b6ac-d4c6208450e1) |

## How to test 🧪

### Prerequisites
- Ensure you have the gecko customer tag (reach out for more info)

### Verification steps
Note: You may need to click `reset to LD defaults flags` in dev tools after each variation switch to see the changes
- On LD development, test the gecko2 variations:
  - Feature ON, GA OFF
    - No GA Gecko text on the Linode's landing or region select in Linode Create
    - Gecko Beta features display as expected (See M3-7491 for feature overview)
  - Feature ON, GA ON
    - You should see GA Gecko text on the Linode's landing and region select in Linode Create
    - Gecko Beta features display as expected except for the above overwritten for GA
  - Everything OFF (you can just uncheck the Gecko feature flag in the dev tools)
    - You should see no Gecko features

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support