### PR TITLE
change: [UIE-7563] - Delete tooltip displaying for current plan in Databases

### DIFF
--- a/packages/manager/.changeset/pr-10364-changed-1712674027336.md
+++ b/packages/manager/.changeset/pr-10364-changed-1712674027336.md
@@ -1,0 +1,5 @@
+---
+'@linode/manager': Changed
+---
+
+Delete tooltip for current plan in Database Cluster ([#10364](https://github.com/linode/manager/pull/10364))

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.tsx
@@ -8,18 +8,19 @@ import {
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
+
 import { Box } from 'src/components/Box';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { Notice } from 'src/components/Notice/Notice';
 import { Paper } from 'src/components/Paper';
+import { TypeToConfirmDialog } from 'src/components/TypeToConfirmDialog/TypeToConfirmDialog';
 import { Typography } from 'src/components/Typography';
-import { typeLabelDetails } from 'src/features/Linodes/presentation';
 import { PlanSelectionType } from 'src/features/components/PlansPanel/types';
+import { typeLabelDetails } from 'src/features/Linodes/presentation';
 import { useDatabaseTypesQuery } from 'src/queries/databases';
 import { useDatabaseMutation } from 'src/queries/databases';
 import { formatStorageUnits } from 'src/utilities/formatStorageUnits';
-import { TypeToConfirmDialog } from 'src/components/TypeToConfirmDialog/TypeToConfirmDialog';
 
 import {
   StyledGrid,
@@ -203,9 +204,7 @@ export const DatabaseResize = ({ database }: Props) => {
   const currentPlan = displayTypes?.find((type) => type.id === database.type);
 
   const disabledPlans = displayTypes?.filter(
-    (type) =>
-      type.disk < (currentPlan ? currentPlan.disk : 0) ||
-      (currentPlan?.class === 'dedicated' && type.disk === currentPlan?.disk)
+    (type) => type.disk < (currentPlan ? currentPlan.disk : 0)
   );
   if (typesLoading) {
     return <CircleProgress />;

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -58,16 +58,14 @@ const getDisabledClass = (
 
 const getToolTip = ({
   disabledToolTip,
-  isSamePlan,
   planIsDisabled,
   sizeTooSmall,
 }: {
   disabledToolTip?: string;
-  isSamePlan: boolean;
   planIsDisabled?: boolean;
   sizeTooSmall: boolean;
 }) => {
-  if (planIsDisabled && !isSamePlan) {
+  if (planIsDisabled) {
     return disabledToolTip;
   }
   if (sizeTooSmall) {
@@ -110,9 +108,8 @@ export const PlanSelection = (props: PlanSelectionProps) => {
   const planTooSmall = diskSize > type.disk;
   const isSamePlan = type.heading === currentPlanHeading;
   const tooltip = getToolTip({
-    disabledToolTip: disabledToolTip,
-    isSamePlan: isSamePlan,
-    planIsDisabled: planIsDisabled,
+    disabledToolTip,
+    planIsDisabled,
     sizeTooSmall: planTooSmall,
   });
   const isGPU = type.class === 'gpu';
@@ -150,15 +147,15 @@ export const PlanSelection = (props: PlanSelectionProps) => {
       {/* Displays Table Row for larger screens */}
       <Hidden lgDown={isCreate} mdDown={!isCreate}>
         <StyledDisabledTableRow
-          aria-disabled={rowAriaDisabled}
-          disabled={rowAriaDisabled}
           onClick={() =>
             !isSamePlan && !isDisabled && !isDisabledClass && !planTooSmall
               ? onSelect(type.id)
               : undefined
           }
+          aria-disabled={rowAriaDisabled}
           aria-label={rowAriaLabel}
           data-qa-plan-row={type.formattedLabel}
+          disabled={rowAriaDisabled}
           key={type.id}
         >
           <StyledRadioCell>

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -57,15 +57,17 @@ const getDisabledClass = (
 };
 
 const getToolTip = ({
-  sizeTooSmall,
-  planIsDisabled,
   disabledToolTip,
+  isSamePlan,
+  planIsDisabled,
+  sizeTooSmall,
 }: {
-  sizeTooSmall: boolean;
-  planIsDisabled?: boolean;
   disabledToolTip?: string;
+  isSamePlan: boolean;
+  planIsDisabled?: boolean;
+  sizeTooSmall: boolean;
 }) => {
-  if (planIsDisabled) {
+  if (planIsDisabled && !isSamePlan) {
     return disabledToolTip;
   }
   if (sizeTooSmall) {
@@ -79,8 +81,8 @@ export const PlanSelection = (props: PlanSelectionProps) => {
     currentPlanHeading,
     disabled,
     disabledClasses,
-    hideDisabledHelpIcons,
     disabledToolTip,
+    hideDisabledHelpIcons,
     idx,
     isCreate,
     isLimitedAvailabilityPlan,
@@ -106,12 +108,13 @@ export const PlanSelection = (props: PlanSelectionProps) => {
 
   const diskSize = selectedDiskSize ? selectedDiskSize : 0;
   const planTooSmall = diskSize > type.disk;
-  const tooltip = getToolTip({
-    sizeTooSmall: planTooSmall,
-    planIsDisabled: planIsDisabled,
-    disabledToolTip: disabledToolTip,
-  });
   const isSamePlan = type.heading === currentPlanHeading;
+  const tooltip = getToolTip({
+    disabledToolTip: disabledToolTip,
+    isSamePlan: isSamePlan,
+    planIsDisabled: planIsDisabled,
+    sizeTooSmall: planTooSmall,
+  });
   const isGPU = type.class === 'gpu';
   const isDisabledClass = getDisabledClass(type.class, disabledClasses ?? []);
   const shouldShowTransfer = showTransfer && type.transfer;


### PR DESCRIPTION
## Description 📝
Delete "Resizing to smaller plans is not supported" tooltip for current plan in Dedicated tab.

## Changes  🔄
Delete "Resizing to smaller plans is not supported" tooltip for current plan in Dedicated tab. 

## Target release date 🗓️
Release date 04/15/24

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img src="https://github.com/linode/manager/assets/157619599/d593b77a-3887-480c-aa60-0bf8cf58529e" width="400" /> | <img src="https://github.com/linode/manager/assets/157619599/be2e4fe4-4d50-4362-8fcf-dd87537adcd4" width="400" />|

## How to test 🧪

### Verification steps
(How to verify changes)

- Navigate to Databases
- Choose a Database cluster with Dedicated plan
- Navigate to Resize tab
- In the table of plans, the current plan does not have a tooltip.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

