### PR TITLE
change: [M3-7964] - Update developer guide documentation for Adobe Analytics

### DIFF
--- a/docs/development-guide/13-coding-standards.md
+++ b/docs/development-guide/13-coding-standards.md
@@ -158,39 +158,3 @@ For this reason, extending types with interfaces/extends is suggested over creat
 ```
 
 Source: [TypeScript Wiki](https://github.com/microsoft/TypeScript/wiki/Performance#preferring-interfaces-over-intersections)
-
-## Adobe Analytics
-
-### Writing a Custom Event
-
-Custom events live (mostly) in `src/utilities/analytics.ts`. Try to write and export custom events in this file if possible, and import them in the component(s) where they are used.
-
-```tsx
-// Component.tsx {file(s) where the event is called, for quick reference}
-// OtherComponent.tsx
-
-sendDescriptiveNameEvent () => {
-      category: '{Descriptive/Page Name}',
-      action: '{interaction such as Click, Hover, Focus}:{input type such as button, link, toggle, checkbox, text field} e.g. Click:link',
-      label: '{string associated with the event; e.g event label} (optional)',
-      value: '{number associated with the event; e.g. size of a volume} (optional)',
-}
-```
-
-When adding a new custom event, coordinating with UX on the event's `category`, `action`, `label`, and `value` props values ensures consistency across our data.
-
-Avoid including pipes (`|`) as delimiters in any of the event properties. They are used in Adobe Analytics to separate fields.
-
-Avoid creating custom events that collect such as search queries, entity names, or other forms of user input. Custom events can still be fired on these actions with a generic `label` or no label at all.
-
-Examples
-
-- `sendMarketplaceSearchEvent` fires when selecting a category from the dropdown (`label` is predefined) and clicking the search field (a generic `label` is used).
-- `sendBucketCreateEvent` sends the region of the bucket, but does not send the bucket label.
-
-### Locally Testing Page Views & Custom Events and/or Troubleshooting
-
-1. Set the `REACT_APP_ADOBE_ANALYTICS_URL` environment variable in `.env`.
-2. Use the browser tools Network tab, filter requests by "adobe", and check that successful network requests have been made to load the launch script and its extensions.
-3. In the browser console, type `_satellite.setDebug(true)`.
-4. Refresh the page. You should see Adobe debug log output in the console. Each page view change or custom event that fires should be visible in the logs.

--- a/docs/tooling/analytics.md
+++ b/docs/tooling/analytics.md
@@ -1,0 +1,42 @@
+# Adobe Analytics
+
+Cloud Manager uses Adobe Analytics to capture page view and custom event statistics. To view analytics, Cloud Manager developers must follow internal processes to request access to Adobe Analytics dashboards.
+
+## Writing a Custom Event
+
+Custom events live (mostly) in `src/utilities/analytics.ts`. Try to write and export custom events in this file if possible, and import them in the component(s) where they are used.
+
+A custom event will take this shape:
+```tsx
+// Component.tsx {file(s) where the event is called, for quick reference}
+// OtherComponent.tsx
+
+sendDescriptiveNameEvent () => {
+      category: '{Descriptive/Page/Flow Name}',
+      action: '{interaction such as Click, Hover, Focus}:{input type such as button, link, toggle, checkbox, text field} e.g. Click:link',
+      label: '{string associated with the event; e.g event label} (optional)',
+      value: '{number associated with the event; e.g. size of a volume} (optional)',
+      data: '{stringified object of additional key-value pairs; e.g. "{isLinodePoweredOff: true}"} (optional)'
+}
+```
+
+When adding a new custom event, coordinate with UX on the event's `category`, `action`, `label`, and `value` variables to ensure consistency across our data.
+
+`data` is an additional variable we use to capture information associated with an event that cannot easily or clearly be represented via the other variables; for example, boolean key-value pair(s). To add an additional property to `data`, it should first be added as an optional property and typed in the `CustomAnalyticsData` interface.
+
+Avoid including pipes (`|`) as delimiters in any of the event properties. They are used in Adobe Analytics to separate fields.
+
+Avoid creating custom events that collect such as search queries, entity names, or other forms of user input. Custom events can still be fired on these actions with a generic `label` or no label at all.
+
+Examples
+
+- `sendMarketplaceSearchEvent` fires when selecting a category from the dropdown (`label` is predefined) and clicking the search field (a generic `label` is used).
+- `sendBucketCreateEvent` sends the region of the bucket, but does not send the bucket label.
+
+## Locally Testing Page Views & Custom Events and/or Troubleshooting
+
+1. Set the `REACT_APP_ADOBE_ANALYTICS_URL` environment variable in `.env`.
+2. Use the browser tools Network tab, filter requests by "adobe", and check that successful network requests have been made to load the launch script and its extensions.
+3. In the browser console, type `_satellite.setDebug(true)`.
+4. Refresh the page. You should see Adobe debug log output in the console. Each page view change or custom event that fires should be visible in the logs.
+5. When viewing dashboards in Adobe Analytics, it may take ~1 hour for analytics data to update. Once this happens, locally fired events will be visible in the dev dashboard.

--- a/packages/manager/.changeset/pr-10365-tech-stories-1712760397845.md
+++ b/packages/manager/.changeset/pr-10365-tech-stories-1712760397845.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Update documentation on Adobe Analytics to cover data property ([#10365](https://github.com/linode/manager/pull/10365))


### PR DESCRIPTION
## Description 📝
Based on cafe discussion, we want to be able to send a new variable to Adobe Analytics to capture more information about custom events. An example of this is a boolean like "isLinodePoweredOn": [true/false], which is not easily decipherable via our existing variables. See #10337.

After working with the Adobe Analytics backend team, we have added a new object variable, which we stringify before sending to Adobe Analytics, to allow us to capture more descriptive aspects of our custom events, as needed. (**Note**: the changes to the AA backend are testable Cloud + their dev environment right now, and were released to their prod environment on 4/10, ahead of our next release.)

**This PR handles only the documentation updates for the described changes above.**

## Changes  🔄
- Removes the Adobe Analytics section from the Coding Standards page. It never totally fit in there, anyway and adding it as its own page to the Tooling section will make it more discoverable.
- Updates the docs to include information about the new data property we can now pass in with our custom events. Makes a couple of other miscellaneous copy updates for clarity.

## Target release date 🗓️
4/15/24

## Preview 📷
![Screenshot 2024-04-10 at 7 26 44 AM](https://github.com/linode/manager/assets/114685994/b3306925-8e9a-4e73-b99d-fe7b17a7cfad)

## How to test 🧪

### Verification steps
(How to verify changes)
- Check out this PR and `yarn docs`, then go to http://localhost:5173/manager/tooling/analytics.html.
- Or just read the diff, check for typos or any confusing statements. 

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
