### PR TITLE
upcoming: [M3-7972] - Invalidate PG queries on Linode create/delete

### DIFF
--- a/packages/manager/.changeset/pr-10366-upcoming-features-1712781737734.md
+++ b/packages/manager/.changeset/pr-10366-upcoming-features-1712781737734.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Invalidate Placement Group queries on Linode create & delete mutations ([#10366](https://github.com/linode/manager/pull/10366))

--- a/packages/manager/src/queries/linodes/linodes.ts
+++ b/packages/manager/src/queries/linodes/linodes.ts
@@ -36,6 +36,7 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 
+import { placementGroupQueries } from 'src/queries/placementGroups';
 import { manuallySetVPCConfigInterfacesToActive } from 'src/utilities/configs';
 
 import { accountQueries } from '../account/queries';
@@ -138,12 +139,30 @@ export const useLinodeLishTokenQuery = (id: number) => {
 
 export const useDeleteLinodeMutation = (id: number) => {
   const queryClient = useQueryClient();
+  const linode = queryClient.getQueryData<Linode>([
+    queryKey,
+    'linode',
+    id,
+    'details',
+  ]);
+  const placementGroupId = linode?.placement_group?.id;
+
   return useMutation<{}, APIError[]>(() => deleteLinode(id), {
     onSuccess() {
       queryClient.removeQueries([queryKey, 'linode', id]);
       queryClient.invalidateQueries([queryKey, 'paginated']);
       queryClient.invalidateQueries([queryKey, 'all']);
       queryClient.invalidateQueries([queryKey, 'infinite']);
+
+      // If the linode is assigned to a placement group,
+      // we need to invalidate the placement group queries
+      if (placementGroupId) {
+        queryClient.invalidateQueries(
+          placementGroupQueries.placementGroup(placementGroupId).queryKey
+        );
+        queryClient.invalidateQueries(placementGroupQueries.all.queryKey);
+        queryClient.invalidateQueries(placementGroupQueries.paginated._def);
+      }
     },
   });
 };
@@ -166,6 +185,17 @@ export const useCreateLinodeMutation = () => {
         // If a Linode is created with a VLAN, invalidate vlans because
         // they are derived from Linode configs.
         queryClient.invalidateQueries(vlanQueries._def);
+      }
+
+      // If the Linode is assigned to a placement group on creation,
+      // we need to invalidate the placement group queries
+      if (variables.placement_group?.id) {
+        queryClient.invalidateQueries(
+          placementGroupQueries.placementGroup(variables.placement_group.id)
+            .queryKey
+        );
+        queryClient.invalidateQueries(placementGroupQueries.all.queryKey);
+        queryClient.invalidateQueries(placementGroupQueries.paginated._def);
       }
     },
   });


### PR DESCRIPTION
## Description 📝
Now that the `POST` & `DELETE` `linode/instances` Alpha endpoint have been updated to work with placement groups, we need to invalidate the related PG if:
- on POST (create linode) we assign a placement group
- on DELETE (delete linode) we delete a linode assigned to a placement group

## Changes  🔄
- Invalidate PG queries on Linode create & delete mutations

## Preview 📷
| Create Linode (and assign to PG)  | Delete Linode (and unassign from PG) |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/130582365/0d2e2f0b-d1c6-4a13-8e34-ecb9f73c98fc" /> |  <video src="https://github.com/linode/manager/assets/130582365/0935c560-a7c0-487c-bb60-9b2ac5094125" /> |

## How to test 🧪

### Prerequisites
- Using alpha environment and having the "Placement Group" feature flag enabled, either:
  - use your account (need the `placement-group` customer tag
  - use the `pg-user-1` (see creds in 1Password vault)
- Have at least one Placement Group created 

### Verification steps
- See the video above:
  - Create a linode and assign to a PG: confirm UI updates accordingly in the placement group section
  - Delete a linode that has a linode assigned: confirm UI updates accordingly in the placement group section

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
