### PR TITLE
fix: `machine-image-upload.spec.ts` e2e test flake

### DIFF
--- a/packages/manager/.changeset/pr-10370-tests-1712857880206.md
+++ b/packages/manager/.changeset/pr-10370-tests-1712857880206.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix `machine-image-upload.spec.ts` e2e test flake  ([#10370](https://github.com/linode/manager/pull/10370))

--- a/packages/manager/cypress/e2e/core/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/machine-image-upload.spec.ts
@@ -8,7 +8,6 @@ import { authenticate } from 'support/api/authentication';
 import { fbtVisible, getClick } from 'support/helpers';
 import {
   mockDeleteImage,
-  mockGetAllImages,
   mockGetCustomImages,
   mockUpdateImage,
 } from 'support/intercepts/images';
@@ -249,7 +248,7 @@ describe('machine image', () => {
     cy.wait('@imageUpload').then((xhr) => {
       const imageId = xhr.response?.body.image.id;
       assertProcessing(label, imageId);
-      mockGetAllImages([
+      mockGetCustomImages([
         imageFactory.build({ label, id: imageId, status: 'available' }),
       ]).as('getImages');
       eventIntercept(label, imageId, status);


### PR DESCRIPTION
## Description 📝

- I'm hoping this fixes the constant failures we're getting on the Github Actions cypress tests 

## What is happening ❓ 

- We were returning the **same** API response for different Image endpoint filters. This is causing the same image to show up in two tables. It should only show in one. 

## The Fix 🔧 
-  This PR just updates the mock to respect the API filtering so that. the image only shows once on the page

## How to test 🧪

- Verify e2e test passes in Jenkins
- Verify e2e test passes locally

We will hope and pray it passes in Github Actions 🙏 😅 

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support