### PR TITLE
refactor: [M3-7770] - isFeatureEnabledV2 to check for feature flag AND account capability

### DIFF
--- a/packages/manager/.changeset/pr-10371-tech-stories-1713200214722.md
+++ b/packages/manager/.changeset/pr-10371-tech-stories-1713200214722.md
@@ -2,4 +2,4 @@
 "@linode/manager": Tech Stories
 ---
 
-isFeatureEnabledV2 to check for feature flag AND account capability ([#10371](https://github.com/linode/manager/pull/10371))
+Add isFeatureEnabledV2 to check for feature flag AND account capability ([#10371](https://github.com/linode/manager/pull/10371))

--- a/packages/manager/.changeset/pr-10371-tech-stories-1713200214722.md
+++ b/packages/manager/.changeset/pr-10371-tech-stories-1713200214722.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+isFeatureEnabledV2 to check for feature flag AND account capability ([#10371](https://github.com/linode/manager/pull/10371))

--- a/packages/manager/src/utilities/accountCapabilities.test.ts
+++ b/packages/manager/src/utilities/accountCapabilities.test.ts
@@ -1,4 +1,24 @@
-import { isFeatureEnabled } from './accountCapabilities';
+import { isFeatureEnabled, isFeatureEnabledV2 } from './accountCapabilities';
+
+describe('isFeatureEnabledV2', () => {
+  it('returns `false` when the flag is off and the item is not in account capabilities', () => {
+    expect(isFeatureEnabledV2('Object Storage', false, [])).toBe(false);
+  });
+
+  it('returns `false` when the flag is on, but the capability is not present', () => {
+    expect(isFeatureEnabledV2('Object Storage', true, [])).toBe(false);
+  });
+
+  it('returns `true` when the flag is on and the account capability is present', () => {
+    expect(isFeatureEnabledV2('Object Storage', true, ['Object Storage'])).toBe(
+      true
+    );
+  });
+
+  it('returns `false` when both the flag is on but the account capability is not present', () => {
+    expect(isFeatureEnabledV2('Object Storage', true, [])).toBe(false);
+  });
+});
 
 describe('isFeatureEnabled', () => {
   it('returns `false` when both the flag is off and the item is not in account capabilities', () => {

--- a/packages/manager/src/utilities/accountCapabilities.ts
+++ b/packages/manager/src/utilities/accountCapabilities.ts
@@ -3,12 +3,10 @@ import type { AccountCapability } from '@linode/api-v4';
 /**
  * Determines if a feature should be enabled.
  *
- * @returns true if the feature is returned from account.capabilities AND if it is explicitly enabled
+ * @returns true if the feature is returned from account.capabilities **AND** if it is explicitly enabled
  * by a feature flag
  *
- * If you need to launch a production feature, but have it be gated,
- * you would turn the flag *off* for that environment, but have the API return
- * the account capability.
+ * If the feature will never depend on account.capabilites, use Launch Darkly flags directly via the useFlags hook instead.
  */
 export const isFeatureEnabledV2 = (
   featureName: AccountCapability,
@@ -19,7 +17,7 @@ export const isFeatureEnabledV2 = (
 };
 
 /**
- * DEPRECATED USE isFeatureEnabledV2
+ * @deprecated Use isFeatureEnabledV2 instead
  *
  * Determines if a feature should be enabled.
  *

--- a/packages/manager/src/utilities/accountCapabilities.ts
+++ b/packages/manager/src/utilities/accountCapabilities.ts
@@ -3,11 +3,8 @@ import type { AccountCapability } from '@linode/api-v4';
 /**
  * Determines if a feature should be enabled.
  *
- * @returns true if the feature is returned from account.capabilities **or** if it is explicitly enabled
+ * @returns true if the feature is returned from account.capabilities AND if it is explicitly enabled
  * by a feature flag
- *
- * We use "or" instead of "and" here to allow us to enable features in "lower" environments
- * without needing the customer capability.
  *
  * If you need to launch a production feature, but have it be gated,
  * you would turn the flag *off* for that environment, but have the API return
@@ -18,5 +15,5 @@ export const isFeatureEnabled = (
   isFeatureFlagEnabled: boolean,
   capabilities: AccountCapability[]
 ) => {
-  return isFeatureFlagEnabled || capabilities.includes(featureName);
+  return isFeatureFlagEnabled && capabilities.includes(featureName);
 };

--- a/packages/manager/src/utilities/accountCapabilities.ts
+++ b/packages/manager/src/utilities/accountCapabilities.ts
@@ -10,10 +10,33 @@ import type { AccountCapability } from '@linode/api-v4';
  * you would turn the flag *off* for that environment, but have the API return
  * the account capability.
  */
-export const isFeatureEnabled = (
+export const isFeatureEnabledV2 = (
   featureName: AccountCapability,
   isFeatureFlagEnabled: boolean,
   capabilities: AccountCapability[]
 ) => {
   return isFeatureFlagEnabled && capabilities.includes(featureName);
+};
+
+/**
+ * DEPRECATED USE isFeatureEnabledV2
+ *
+ * Determines if a feature should be enabled.
+ *
+ * @returns true if the feature is returned from account.capabilities **or** if it is explicitly enabled
+ * by a feature flag
+ *
+ * We use "or" instead of "and" here to allow us to enable features in "lower" environments
+ * without needing the customer capability.
+ *
+ * If you need to launch a production feature, but have it be gated,
+ * you would turn the flag *off* for that environment, but have the API return
+ * the account capability.
+ */
+export const isFeatureEnabled = (
+  featureName: AccountCapability,
+  isFeatureFlagEnabled: boolean,
+  capabilities: AccountCapability[]
+) => {
+  return isFeatureFlagEnabled || capabilities.includes(featureName);
 };


### PR DESCRIPTION
## Description 📝
Deprecate `isFeatureEnabled` function and add new function `isFeatureEnabledV2` which uses AND logic instead of OR

## Preview 📷
|  | Capabilities On   | Capabilities Off |
| ------- | ------- | ------- |
| LD Feature Flag On | Show feature: YES | Show feature: NO |
| LD Feature Flag Off | Show feature: NO | Show feature: NO |

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support