### PR TITLE
upcoming: [M3-7979] - Update Placement Group svg icon

### DIFF
--- a/packages/manager/.changeset/pr-10379-upcoming-features-1713259266637.md
+++ b/packages/manager/.changeset/pr-10379-upcoming-features-1713259266637.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update the Placement Groups svg icon ([#10379](https://github.com/linode/manager/pull/10379))

--- a/packages/manager/src/assets/icons/entityIcons/placement-groups.svg
+++ b/packages/manager/src/assets/icons/entityIcons/placement-groups.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M4.8 6.32L9.6 9.32V14.12L4.8 17.12L0 14.12V9.32L4.8 6.32Z" fill="#00B159"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M19.2 6.32L24 9.32V14.12L19.2 17.12L14.4 14.12V9.32L19.2 6.32Z" fill="#00B159"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M12 5C12.3976 5 12.72 5.32236 12.72 5.72L12.72 17.72C12.72 18.1176 12.3976 18.44 12 18.44C11.6024 18.44 11.28 18.1176 11.28 17.72V5.72C11.28 5.32236 11.6024 5 12 5Z" fill="#00B159"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M4.8 6.32L9.6 9.32V14.12L4.8 17.12L0 14.12V9.32L4.8 6.32Z" fill="currentColor"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M19.2 6.32L24 9.32V14.12L19.2 17.12L14.4 14.12V9.32L19.2 6.32Z" fill="currentColor"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M12 5C12.3976 5 12.72 5.32236 12.72 5.72L12.72 17.72C12.72 18.1176 12.3976 18.44 12 18.44C11.6024 18.44 11.28 18.1176 11.28 17.72V5.72C11.28 5.32236 11.6024 5 12 5Z" fill="currentColor"/>
 </svg>

--- a/packages/manager/src/assets/icons/entityIcons/placement-groups.svg
+++ b/packages/manager/src/assets/icons/entityIcons/placement-groups.svg
@@ -1,6 +1,5 @@
-
-<svg width="191" height="101" viewBox="0 0 191 101" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-  <path fill-rule="evenodd" clip-rule="evenodd" d="M89.1251 5.9424C89.1251 2.97058 92.2815 0.00309818 95.4379 -2.59723e-07C98.594 -0.00309846 101.75 2.97058 101.75 5.94248C101.75 39.849 101.75 25.9407 101.75 95.0589C101.75 98.3401 98.924 101 95.4379 101C91.9518 101 89.1257 98.3401 89.1257 95.0589C89.1257 25.9407 89.1248 54.7022 89.1251 5.9424Z" />
-  <path fill-rule="evenodd" clip-rule="evenodd" d="M38.625 6.3125L71.4257 25.25V63.125L38.625 82.0625L5.82429 63.125V25.25L38.625 6.3125Z" />
-  <path fill-rule="evenodd" clip-rule="evenodd" d="M152.25 6.3125L185.051 25.25V63.125L152.25 82.0625L119.449 63.125V25.25L152.25 6.3125Z" />
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4.8 6.32L9.6 9.32V14.12L4.8 17.12L0 14.12V9.32L4.8 6.32Z" fill="#00B159"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M19.2 6.32L24 9.32V14.12L19.2 17.12L14.4 14.12V9.32L19.2 6.32Z" fill="#00B159"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M12 5C12.3976 5 12.72 5.32236 12.72 5.72L12.72 17.72C12.72 18.1176 12.3976 18.44 12 18.44C11.6024 18.44 11.28 18.1176 11.28 17.72V5.72C11.28 5.32236 11.6024 5 12 5Z" fill="#00B159"/>
 </svg>


### PR DESCRIPTION
## Description 📝
Update the Placement Group icon/logo

## Changes  🔄
- The dimensions of the Placement Group svg icon are changed to 24 x 24.

## Target release date 🗓️
04/29/2024

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![icon-before](https://github.com/linode/manager/assets/119514965/42c45b60-4afc-4387-964a-f991d799bac2) | ![icon-after](https://github.com/linode/manager/assets/119514965/7e0f90ad-1a37-4cb8-8dd4-877a1c702b35) |
| ![beforee](https://github.com/linode/manager/assets/119514965/06586426-def0-4123-a3fd-423e38db41b6) | ![afterr](https://github.com/linode/manager/assets/119514965/4632fd12-dbac-42fe-aba9-f09cb533148f) |


## How to test 🧪

### Prerequisites
(How to setup test environment)
- Using the Cloud Manager developer tools switch over to the `Dev` environment and turn on the `Placement Groups` feature flag.

### Verification steps
(How to verify changes)
- Verify that the Placement Group icon is displayed without any visual regressions.
- Verify that the state (Ex. hover, click, etc) of the icon is denoted accordingly to the correct color in both Dark Mode and Light Mode.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
