### PR TITLE
fix: [M3-7992] - Fix CSS vendor prefix bug in Chrome

### DIFF
--- a/packages/manager/.changeset/pr-10380-fixed-1713263110419.md
+++ b/packages/manager/.changeset/pr-10380-fixed-1713263110419.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Chrome bug related to outdated CSS vendor prefixes ([#10380](https://github.com/linode/manager/pull/10380))

--- a/packages/manager/src/components/CopyableTextField/CopyableTextField.tsx
+++ b/packages/manager/src/components/CopyableTextField/CopyableTextField.tsx
@@ -42,7 +42,7 @@ const StyledTextField = styled(TextField)(({ theme }) => ({
   },
   '.removeDisabledStyles': {
     '& .MuiInput-input': {
-      '-webkit-text-fill-color': 'unset !important',
+      WebkitTextFillColor: 'unset !important',
       borderColor: theme.name === 'light' ? '#ccc' : '#222',
       color:
         theme.name === 'light'

--- a/packages/manager/src/foundations/themes/dark.ts
+++ b/packages/manager/src/foundations/themes/dark.ts
@@ -357,7 +357,7 @@ export const darkTheme: ThemeOptions = {
         focused: {},
         input: {
           '&.Mui-disabled': {
-            '-webkit-text-fill-color': 'unset !important',
+            WebkitTextFillColor: 'unset !important',
             borderColor: '#606469',
             color: '#ccc !important',
             opacity: 0.5,


### PR DESCRIPTION
## Description 📝
The `CopyableTextField` component and the `dark.ts` file contain outdated Material UI vendor specific CSS prefix properties. As a consequence, the console tab in Chrome dev tools is filled with a long console error message. This PR resolves that issue.

## Changes  🔄
List any change relevant to the reviewer.
- Updates the kebab-case styled css object property for text fill color.

## Target release date 🗓️
04/29/2024

## Preview 📷
### Before 
https://github.com/linode/manager/assets/119514965/dacc7a2b-7f70-4ad5-bb9a-616696a93ef2

### After
https://github.com/linode/manager/assets/119514965/9c2ee552-4cbb-4578-80f5-37372d61ecc2

## How to test 🧪
### Prerequisites
(How to setup test environment)
- Launch the Cloud Manager application from the Chrome web browser.
- Open the dev tools and click on the console tab. 

### Reproduction steps
(How to reproduce the issue, if applicable)
- Checkout the latest from `develop` and visit the Linode Create page and observe the console tab in the dev tools.
- Refresh the webpage and inspect the logs for an error message that reads the following: `Using kebab-case for css properties in objects is not supported. Did you mean WebkitTextFillColor?`
- Checkout this PR and repeat the previous two steps.
- The long error message should be gone while running this branch locally.

### Verification steps
(How to verify changes)
- Verify that the console log error messages related to the CSS object properties have been resolved.
- Verify that no regressions result from the change.

## As an Author I have considered 🤔
*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

