### PR TITLE
test: [M3-7465] - Add Cypress test coverage for Firewall renaming

### DIFF
--- a/packages/manager/.changeset/pr-10384-tests-1713976558483.md
+++ b/packages/manager/.changeset/pr-10384-tests-1713976558483.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add Cypress test coverage for Firewall renaming ([#10384](https://github.com/linode/manager/pull/10384))

--- a/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
@@ -437,21 +437,24 @@ describe('update firewall', () => {
 
       cy.visitWithLogin(`/firewalls/${firewall.id}`);
 
-      cy.get(`[aria-label="Edit ${firewall.label}"]`).click();
+      cy.findByLabelText(`Edit ${firewall.label}`).click();
       cy.get(`[id="edit-${firewall.label}-label"]`)
         .click()
         .clear()
         .type(`${newFirewallLabel}{enter}`);
 
-      cy.reload();
+      // Confirm Firewall label updates in breadcrumbs.
+      ui.entityHeader.find().within(() => {
+        cy.findByText(newFirewallLabel).should('be.visible');
+        cy.findByText('firewalls').click();
+      });
 
-      // Confirm firewall label is updated on details page.
+      // Confirm firewall label is updated on landing page without refresh.
       cy.findByText(newFirewallLabel).should('be.visible');
 
-      cy.visitWithLogin('/firewalls');
-
-      // Confirm firewall label is updated on landing page.
-      cy.findByText(newFirewallLabel).closest('tr').should('be.visible');
+      // Confirm firewall label is updated on landing page after refresh.
+      cy.reload();
+      cy.findByText(newFirewallLabel).should('be.visible');
     });
   });
 });

--- a/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
@@ -396,4 +396,62 @@ describe('update firewall', () => {
         });
     });
   });
+
+  /*
+   * - Confirms that firewall's label can be updated on landing page'.
+   */
+  it("updates a firewall's label", () => {
+    const region = chooseRegion();
+
+    const linodeRequest = createLinodeRequestFactory.build({
+      label: randomLabel(),
+      region: region.id,
+      root_pass: randomString(16),
+    });
+
+    const firewallRequest = firewallFactory.build({
+      label: randomLabel(),
+      rules: {
+        inbound: [],
+        outbound: [],
+      },
+    });
+
+    const newFirewallLabel = randomLabel();
+
+    cy.defer(
+      createLinodeAndFirewall(linodeRequest, firewallRequest),
+      'creating Linode and firewall'
+    ).then(([_linode, firewall]) => {
+      cy.visitWithLogin('/firewalls');
+
+      // Confirm that firewall is listed on landing page with expected configuration.
+      cy.findByText(firewall.label)
+        .closest('tr')
+        .within(() => {
+          cy.findByText(firewall.label).should('be.visible');
+          cy.findByText('Enabled').should('be.visible');
+          cy.findByText('No rules').should('be.visible');
+          cy.findByText('None assigned').should('be.visible');
+        });
+
+      cy.visitWithLogin(`/firewalls/${firewall.id}`);
+
+      cy.get(`[aria-label="Edit ${firewall.label}"]`).click();
+      cy.get(`[id="edit-${firewall.label}-label"]`)
+        .click()
+        .clear()
+        .type(`${newFirewallLabel}{enter}`);
+
+      cy.reload();
+
+      // Confirm firewall label is updated on details page.
+      cy.findByText(newFirewallLabel).should('be.visible');
+
+      cy.visitWithLogin('/firewalls');
+
+      // Confirm firewall label is updated on landing page.
+      cy.findByText(newFirewallLabel).closest('tr').should('be.visible');
+    });
+  });
 });

--- a/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
@@ -398,7 +398,7 @@ describe('update firewall', () => {
   });
 
   /*
-   * - Confirms that firewall's label can be updated on landing page'.
+   * - Confirms that firewall's label can be updated on landing page.
    */
   it("updates a firewall's label", () => {
     const region = chooseRegion();


### PR DESCRIPTION
## Description 📝
Add regression tests to rename firewall label on landing page.

## Major Changes 🔄
- Check user can update a Firewall's label from the Firewall details page
- Check label shown on details page updates to reflect change

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/firewalls/update-firewall.spec.ts"
```