### PR TITLE
change: [M3-7996] - DC Get Well - PlanSelection availability updates and consolidation

### DIFF
--- a/packages/manager/.changeset/pr-10387-changed-1713887237963.md
+++ b/packages/manager/.changeset/pr-10387-changed-1713887237963.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+PlanSelection availability updates and consolidation ([#10387](https://github.com/linode/manager/pull/10387))

--- a/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
@@ -80,6 +80,10 @@ describe('create linode', () => {
 
   /*
    * Region select test.
+   *
+   * TODO: Cypress
+   * Move this to cypress component testing once the setup is complete - see https://github.com/linode/manager/pull/10134
+   *
    * - Confirms that region select dropdown is visible and interactive.
    * - Confirms that region select dropdown is populated with expected regions.
    * - Confirms that region select dropdown is sorted alphabetically by region, with North America first.

--- a/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
@@ -1,0 +1,174 @@
+import { fbtClick } from 'support/helpers';
+import { ui } from 'support/ui';
+import {
+  regionFactory,
+  regionAvailabilityFactory,
+  linodeTypeFactory,
+} from '@src/factories';
+import { authenticate } from 'support/api/authentication';
+import { cleanUp } from 'support/util/cleanup';
+import {
+  mockGetRegions,
+  mockGetRegionAvailability,
+} from 'support/intercepts/regions';
+import { mockGetLinodeTypes } from 'support/intercepts/linodes';
+
+const mockRegions = [
+  regionFactory.build({
+    capabilities: ['Linodes'],
+    id: 'us-east',
+    label: 'Newark, NJ',
+  }),
+];
+
+const mockDedicatedLinodeTypes = [
+  linodeTypeFactory.build({
+    id: 'dedicated-1',
+    class: 'dedicated',
+  }),
+  linodeTypeFactory.build({
+    id: 'dedicated-2',
+    class: 'dedicated',
+  }),
+  linodeTypeFactory.build({
+    id: 'dedicated-3',
+    class: 'dedicated',
+  }),
+];
+
+const mockSharedLinodeTypes = [
+  linodeTypeFactory.build({
+    id: 'shared-1',
+    class: 'standard',
+  }),
+  linodeTypeFactory.build({
+    id: 'shared-2',
+    class: 'standard',
+  }),
+  linodeTypeFactory.build({
+    id: 'shared-3',
+    class: 'standard',
+  }),
+];
+
+const mockHighMemoryLinodeTypes = [
+  linodeTypeFactory.build({
+    id: 'highmem-1',
+    class: 'highmem',
+  }),
+];
+
+const mockGPUType = [
+  linodeTypeFactory.build({
+    id: 'gpu-1',
+    class: 'gpu',
+  }),
+];
+
+const mockLinodeTypes = [
+  ...mockDedicatedLinodeTypes,
+  ...mockHighMemoryLinodeTypes,
+  ...mockSharedLinodeTypes,
+  ...mockGPUType,
+];
+
+const mockRegionAvailability = [
+  regionAvailabilityFactory.build({
+    plan: 'dedicated-3',
+    available: false,
+    region: 'us-east',
+  }),
+  regionAvailabilityFactory.build({
+    plan: 'highmem-1',
+    available: false,
+    region: 'us-east',
+  }),
+  regionAvailabilityFactory.build({
+    plan: 'shared-3',
+    available: false,
+    region: 'us-east',
+  }),
+];
+
+authenticate();
+describe('displays plan selection status based on availability', () => {
+  before(() => {
+    cleanUp('linodes');
+    mockGetRegions(mockRegions).as('getRegions');
+    mockGetLinodeTypes(mockLinodeTypes).as('getLinodeTypes');
+    mockGetRegionAvailability(mockRegions[0].id, mockRegionAvailability).as(
+      'getRegionAvailability'
+    );
+  });
+
+  it('displays the proper plans based on the region and types', () => {
+    cy.visitWithLogin('/linodes/create');
+    cy.wait(['@getRegions', '@getLinodeTypes']);
+
+    ui.regionSelect.find().click();
+    ui.regionSelect.findItemByRegionLabel(mockRegions[0].label).click();
+
+    cy.wait(['@getRegionAvailability']);
+
+    // Dedicated CPU tab
+    // Should be selected/open by default
+    // Should contains 4 plans (5 rows including the header row)
+    // Should have 2 plans disabled
+    // Should have tooltips for the disabled plans (not more than half disabled plans in the panel)
+    cy.findByRole('table', { name: 'List of Linode Plans' }).within(() => {
+      cy.findAllByRole('row').should('have.length', 5);
+      cy.get('[id="dedicated-1"]').should('be.enabled');
+      cy.get('[id="dedicated-2"]').should('be.enabled');
+      cy.get('[id="dedicated-3"]').should('be.disabled');
+      cy.get('[id="g6-dedicated-64"]').should('be.disabled');
+      cy.findAllByTestId('limited-availability').should('have.length', 2);
+    });
+
+    // Shared CPU tab
+    // Should contains 3 plans (4 rows including the header row)
+    // Should have 1 disabled plan
+    // Should have tooltip for the disabled plan (not more than half disabled plans in the panel)
+    fbtClick('Shared CPU');
+    cy.findByRole('table', { name: 'List of Linode Plans' }).within(() => {
+      cy.findAllByRole('row').should('have.length', 4);
+      cy.get('[id="shared-1"]').should('be.enabled');
+      cy.get('[id="shared-2"]').should('be.enabled');
+      cy.get('[id="shared-3"]').should('be.disabled');
+      cy.findAllByTestId('limited-availability').should('have.length', 1);
+    });
+
+    // High Memory tab
+    // Should contains 1 plan (2 rows including the header row)
+    // Should have one disabled plan
+    // Should have tooltip for the disabled plan (more than half disabled plans in the panel, but only one plan)
+    fbtClick('High Memory');
+    cy.findByRole('table', { name: 'List of Linode Plans' }).within(() => {
+      cy.findAllByRole('row').should('have.length', 2);
+      cy.get('[id="highmem-1"]').should('be.disabled');
+      cy.findAllByTestId('limited-availability').should('have.length', 1);
+    });
+
+    // GPU tab
+    // Should contains 1 plan (2 rows including the header row)
+    // Should have its panel disabled
+    // Should not have tooltip for the disabled plan (not needed on disabled panels)
+    fbtClick('GPU');
+    cy.findByRole('table', { name: 'List of Linode Plans' }).within(() => {
+      cy.findAllByRole('row').should('have.length', 2);
+      cy.get('[id="gpu-1"]').should('be.disabled');
+      cy.findAllByTestId('limited-availability').should('have.length', 0);
+    });
+
+    // Premium CPU
+    // Only present since we manually inject the 512 plan for it
+    // Should contains 1 plan (2 rows including the header row)
+    // Should have its panel disabled
+    // Should not have tooltip for the disabled plan (not needed on disabled panels)
+    fbtClick('Premium CPU');
+    cy.findByRole('table', { name: 'List of Linode Plans' }).within(() => {
+      cy.findAllByRole('row').should('have.length', 2);
+      cy.get('[id="g7-premium-64"]').should('be.disabled');
+      cy.findAllByTestId('limited-availability').should('have.length', 0);
+    });
+  });
+});

--- a/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
@@ -1,3 +1,5 @@
+// TODO: Cypress
+// Move this to cypress component testing once the setup is complete - see https://github.com/linode/manager/pull/10134
 import { fbtClick } from 'support/helpers';
 import { ui } from 'support/ui';
 import {

--- a/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
@@ -125,7 +125,7 @@ describe('displays linode plans panel based on availability', () => {
     // Dedicated CPU tab
     // Should be selected/open by default
     // Should have the limited availability notice
-    // Should contains 4 plans (5 rows including the header row)
+    // Should contain 4 plans (5 rows including the header row)
     // Should have 2 plans disabled
     // Should have tooltips for the disabled plans (not more than half disabled plans in the panel)
     cy.get(linodePlansPanel).within(() => {
@@ -144,7 +144,7 @@ describe('displays linode plans panel based on availability', () => {
 
     // Shared CPU tab
     // Should have no notices
-    // Should contains 3 plans (4 rows including the header row)
+    // Should contain 3 plans (4 rows including the header row)
     // Should have 0 disabled plan
     // Should have no tooltip for the disabled plan
     fbtClick('Shared CPU');
@@ -162,7 +162,7 @@ describe('displays linode plans panel based on availability', () => {
 
     // High Memory tab
     // Should have the limited availability notice
-    // Should contains 1 plan (2 rows including the header row)
+    // Should contain 1 plan (2 rows including the header row)
     // Should have one disabled plan
     // Should have tooltip for the disabled plan (more than half disabled plans in the panel, but only one plan)
     fbtClick('High Memory');
@@ -179,7 +179,7 @@ describe('displays linode plans panel based on availability', () => {
 
     // GPU tab
     // Should have the unavailable notice
-    // Should contains 1 plan (2 rows including the header row)
+    // Should contain 1 plan (2 rows including the header row)
     // Should have its panel disabled
     // Should not have tooltip for the disabled plan (not needed on disabled panels)
     fbtClick('GPU');
@@ -197,7 +197,7 @@ describe('displays linode plans panel based on availability', () => {
     // Premium CPU
     // Should have the unavailable notice
     // Only present since we manually inject the 512 plan for it
-    // Should contains 1 plan (2 rows including the header row)
+    // Should contain 1 plan (2 rows including the header row)
     // Should have its whole panel disabled
     // Should not have tooltip for the disabled plan (not needed on disabled panels)
     fbtClick('Premium CPU');
@@ -235,7 +235,7 @@ describe('displays kubernetes plans panel based on availability', () => {
     // Dedicated CPU tab
     // Should be selected/open by default
     // Should have the limited availability notice
-    // Should contains 4 plans (5 rows including the header row)
+    // Should contain 4 plans (5 rows including the header row)
     // Should have 2 plans disabled
     // Should have tooltips for the disabled plans (not more than half disabled plans in the panel)
     // All inputs for a row should be enabled if row is enabled (only testing one row in suite)
@@ -273,7 +273,7 @@ describe('displays kubernetes plans panel based on availability', () => {
 
     // Shared CPU tab
     // Should have no notices
-    // Should contains 3 plans (4 rows including the header row)
+    // Should contain 3 plans (4 rows including the header row)
     // Should have 1 disabled plan
     // Should have tooltip for the disabled plan (not more than half disabled plans in the panel)
     fbtClick('Shared CPU');
@@ -300,7 +300,7 @@ describe('displays kubernetes plans panel based on availability', () => {
 
     // High Memory tab
     // Should have the limited availability notice
-    // Should contains 1 plan (2 rows including the header row)
+    // Should contain 1 plan (2 rows including the header row)
     // Should have one disabled plan
     // Should have tooltip for the disabled plan (more than half disabled plans in the panel, but only one plan)
     fbtClick('High Memory');
@@ -321,7 +321,7 @@ describe('displays kubernetes plans panel based on availability', () => {
     // Premium CPU
     // Should have the unavailable notice
     // Only present since we manually inject the 512 plan for it
-    // Should contains 1 plan (2 rows including the header row)
+    // Should contain 1 plan (2 rows including the header row)
     // Should have its whole panel disabled
     // Should not have tooltip for the disabled plan (not needed on disabled panels)
     fbtClick('Premium CPU');

--- a/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
@@ -6,7 +6,6 @@ import {
   linodeTypeFactory,
 } from '@src/factories';
 import { authenticate } from 'support/api/authentication';
-import { cleanUp } from 'support/util/cleanup';
 import {
   mockGetRegions,
   mockGetRegionAvailability,
@@ -15,7 +14,7 @@ import { mockGetLinodeTypes } from 'support/intercepts/linodes';
 
 const mockRegions = [
   regionFactory.build({
-    capabilities: ['Linodes'],
+    capabilities: ['Linodes', 'Kubernetes'],
     id: 'us-east',
     label: 'Newark, NJ',
   }),
@@ -24,14 +23,17 @@ const mockRegions = [
 const mockDedicatedLinodeTypes = [
   linodeTypeFactory.build({
     id: 'dedicated-1',
+    label: 'dedicated-1',
     class: 'dedicated',
   }),
   linodeTypeFactory.build({
     id: 'dedicated-2',
+    label: 'dedicated-2',
     class: 'dedicated',
   }),
   linodeTypeFactory.build({
     id: 'dedicated-3',
+    label: 'dedicated-3',
     class: 'dedicated',
   }),
 ];
@@ -39,14 +41,17 @@ const mockDedicatedLinodeTypes = [
 const mockSharedLinodeTypes = [
   linodeTypeFactory.build({
     id: 'shared-1',
+    label: 'shared-1',
     class: 'standard',
   }),
   linodeTypeFactory.build({
     id: 'shared-2',
+    label: 'shared-2',
     class: 'standard',
   }),
   linodeTypeFactory.build({
     id: 'shared-3',
+    label: 'shared-3',
     class: 'standard',
   }),
 ];
@@ -54,6 +59,7 @@ const mockSharedLinodeTypes = [
 const mockHighMemoryLinodeTypes = [
   linodeTypeFactory.build({
     id: 'highmem-1',
+    label: 'highmem-1',
     class: 'highmem',
   }),
 ];
@@ -61,6 +67,7 @@ const mockHighMemoryLinodeTypes = [
 const mockGPUType = [
   linodeTypeFactory.build({
     id: 'gpu-1',
+    label: 'gpu-1',
     class: 'gpu',
   }),
 ];
@@ -83,17 +90,20 @@ const mockRegionAvailability = [
     available: false,
     region: 'us-east',
   }),
-  regionAvailabilityFactory.build({
-    plan: 'shared-3',
-    available: false,
-    region: 'us-east',
-  }),
 ];
 
+const linodePlansPanel = '[data-qa-tp="Linode Plan"]';
+const k8PlansPanel = '[data-qa-tp="Add Node Pools"]';
+const planSelectionTable = 'List of Linode Plans';
+
+const notices = {
+  limitedAvailability: '[data-testid="limited-availability"]',
+  unavailable: '[data-testid="notice-error"]',
+};
+
 authenticate();
-describe('displays plan selection status based on availability', () => {
+describe('displays linode plans panel based on availability', () => {
   before(() => {
-    cleanUp('linodes');
     mockGetRegions(mockRegions).as('getRegions');
     mockGetLinodeTypes(mockLinodeTypes).as('getLinodeTypes');
     mockGetRegionAvailability(mockRegions[0].id, mockRegionAvailability).as(
@@ -112,63 +122,219 @@ describe('displays plan selection status based on availability', () => {
 
     // Dedicated CPU tab
     // Should be selected/open by default
+    // Should have the limited availability notice
     // Should contains 4 plans (5 rows including the header row)
     // Should have 2 plans disabled
     // Should have tooltips for the disabled plans (not more than half disabled plans in the panel)
-    cy.findByRole('table', { name: 'List of Linode Plans' }).within(() => {
-      cy.findAllByRole('row').should('have.length', 5);
-      cy.get('[id="dedicated-1"]').should('be.enabled');
-      cy.get('[id="dedicated-2"]').should('be.enabled');
-      cy.get('[id="dedicated-3"]').should('be.disabled');
-      cy.get('[id="g6-dedicated-64"]').should('be.disabled');
-      cy.findAllByTestId('limited-availability').should('have.length', 2);
+    cy.get(linodePlansPanel).within(() => {
+      cy.findAllByRole('alert').should('have.length', 1);
+      cy.get(notices.limitedAvailability).should('be.visible');
+
+      cy.findByRole('table', { name: planSelectionTable }).within(() => {
+        cy.findAllByRole('row').should('have.length', 5);
+        cy.get('[id="dedicated-1"]').should('be.enabled');
+        cy.get('[id="dedicated-2"]').should('be.enabled');
+        cy.get('[id="dedicated-3"]').should('be.disabled');
+        cy.get('[id="g6-dedicated-64"]').should('be.disabled');
+        cy.findAllByTestId('limited-availability').should('have.length', 2);
+      });
     });
 
     // Shared CPU tab
+    // Should have no notices
     // Should contains 3 plans (4 rows including the header row)
-    // Should have 1 disabled plan
-    // Should have tooltip for the disabled plan (not more than half disabled plans in the panel)
+    // Should have 0 disabled plan
+    // Should have no tooltip for the disabled plan
     fbtClick('Shared CPU');
-    cy.findByRole('table', { name: 'List of Linode Plans' }).within(() => {
-      cy.findAllByRole('row').should('have.length', 4);
-      cy.get('[id="shared-1"]').should('be.enabled');
-      cy.get('[id="shared-2"]').should('be.enabled');
-      cy.get('[id="shared-3"]').should('be.disabled');
-      cy.findAllByTestId('limited-availability').should('have.length', 1);
+    cy.get(linodePlansPanel).within(() => {
+      cy.findAllByRole('alert').should('have.length', 0);
+
+      cy.findByRole('table', { name: planSelectionTable }).within(() => {
+        cy.findAllByRole('row').should('have.length', 4);
+        cy.get('[id="shared-1"]').should('be.enabled');
+        cy.get('[id="shared-2"]').should('be.enabled');
+        cy.get('[id="shared-3"]').should('be.enabled');
+        cy.findAllByTestId('limited-availability').should('have.length', 0);
+      });
     });
 
     // High Memory tab
+    // Should have the limited availability notice
     // Should contains 1 plan (2 rows including the header row)
     // Should have one disabled plan
     // Should have tooltip for the disabled plan (more than half disabled plans in the panel, but only one plan)
     fbtClick('High Memory');
-    cy.findByRole('table', { name: 'List of Linode Plans' }).within(() => {
-      cy.findAllByRole('row').should('have.length', 2);
-      cy.get('[id="highmem-1"]').should('be.disabled');
-      cy.findAllByTestId('limited-availability').should('have.length', 1);
+    cy.get(linodePlansPanel).within(() => {
+      cy.findAllByRole('alert').should('have.length', 1);
+      cy.get(notices.limitedAvailability).should('be.visible');
+
+      cy.findByRole('table', { name: planSelectionTable }).within(() => {
+        cy.findAllByRole('row').should('have.length', 2);
+        cy.get('[id="highmem-1"]').should('be.disabled');
+        cy.findAllByTestId('limited-availability').should('have.length', 1);
+      });
     });
 
     // GPU tab
+    // Should have the unavailable notice
     // Should contains 1 plan (2 rows including the header row)
     // Should have its panel disabled
     // Should not have tooltip for the disabled plan (not needed on disabled panels)
     fbtClick('GPU');
-    cy.findByRole('table', { name: 'List of Linode Plans' }).within(() => {
-      cy.findAllByRole('row').should('have.length', 2);
-      cy.get('[id="gpu-1"]').should('be.disabled');
-      cy.findAllByTestId('limited-availability').should('have.length', 0);
+    cy.get(linodePlansPanel).within(() => {
+      cy.findAllByRole('alert').should('have.length', 1);
+      cy.get(notices.unavailable).should('be.visible');
+
+      cy.findByRole('table', { name: planSelectionTable }).within(() => {
+        cy.findAllByRole('row').should('have.length', 2);
+        cy.get('[id="gpu-1"]').should('be.disabled');
+        cy.findAllByTestId('limited-availability').should('have.length', 0);
+      });
     });
 
     // Premium CPU
+    // Should have the unavailable notice
     // Only present since we manually inject the 512 plan for it
     // Should contains 1 plan (2 rows including the header row)
-    // Should have its panel disabled
+    // Should have its whole panel disabled
     // Should not have tooltip for the disabled plan (not needed on disabled panels)
     fbtClick('Premium CPU');
-    cy.findByRole('table', { name: 'List of Linode Plans' }).within(() => {
-      cy.findAllByRole('row').should('have.length', 2);
-      cy.get('[id="g7-premium-64"]').should('be.disabled');
-      cy.findAllByTestId('limited-availability').should('have.length', 0);
+    cy.get(linodePlansPanel).within(() => {
+      cy.findAllByRole('alert').should('have.length', 1);
+      cy.get(notices.unavailable).should('be.visible');
+
+      cy.findByRole('table', { name: planSelectionTable }).within(() => {
+        cy.findAllByRole('row').should('have.length', 2);
+        cy.get('[id="g7-premium-64"]').should('be.disabled');
+        cy.findAllByTestId('limited-availability').should('have.length', 0);
+      });
+    });
+  });
+});
+
+describe('displays kubernetes plans panel based on availability', () => {
+  before(() => {
+    mockGetRegions(mockRegions).as('getRegions');
+    mockGetLinodeTypes(mockLinodeTypes).as('getLinodeTypes');
+    mockGetRegionAvailability(mockRegions[0].id, mockRegionAvailability).as(
+      'getRegionAvailability'
+    );
+  });
+
+  it('displays the proper plans based on the region and types', () => {
+    cy.visitWithLogin('/kubernetes/create');
+    cy.wait(['@getRegions', '@getLinodeTypes']);
+
+    ui.regionSelect.find().click();
+    ui.regionSelect.findItemByRegionLabel(mockRegions[0].label).click();
+
+    cy.wait(['@getRegionAvailability']);
+
+    // Dedicated CPU tab
+    // Should be selected/open by default
+    // Should have the limited availability notice
+    // Should contains 4 plans (5 rows including the header row)
+    // Should have 2 plans disabled
+    // Should have tooltips for the disabled plans (not more than half disabled plans in the panel)
+    // All inputs for a row should be enabled if row is enabled (only testing one row in suite)
+    // All inputs for a disabled row should be disabled (only testing one row in suite)
+    cy.get(k8PlansPanel).within(() => {
+      cy.findAllByRole('alert').should('have.length', 1);
+      cy.get(notices.limitedAvailability).should('be.visible');
+
+      cy.findByRole('table', { name: planSelectionTable }).within(() => {
+        cy.findAllByRole('row').should('have.length', 5);
+        cy.get('[data-qa-plan-row="dedicated-1"]').should(
+          'not.have.attr',
+          'disabled'
+        );
+        cy.get('[data-qa-plan-row="dedicated-2"]').should(
+          'not.have.attr',
+          'disabled'
+        );
+        cy.get('[data-qa-plan-row="dedicated-3"]').should(
+          'have.attr',
+          'disabled'
+        );
+        cy.get('[data-qa-plan-row="Dedicated 512 GB"]').should(
+          'have.attr',
+          'disabled'
+        );
+        cy.get('[data-qa-plan-row="dedicated-3"]').within(() => {
+          cy.get('[data-testid="decrement-button"]').should('be.disabled');
+          cy.get('[data-testid="increment-button"]').should('be.disabled');
+          cy.findByRole('button', { name: 'Add' }).should('be.disabled');
+        });
+        cy.findAllByTestId('limited-availability').should('have.length', 2);
+      });
+    });
+
+    // Shared CPU tab
+    // Should have no notices
+    // Should contains 3 plans (4 rows including the header row)
+    // Should have 1 disabled plan
+    // Should have tooltip for the disabled plan (not more than half disabled plans in the panel)
+    fbtClick('Shared CPU');
+    cy.get(k8PlansPanel).within(() => {
+      cy.findAllByRole('alert').should('have.length', 0);
+
+      cy.findByRole('table', { name: planSelectionTable }).within(() => {
+        cy.findAllByRole('row').should('have.length', 4);
+        cy.get('[data-qa-plan-row="shared-1"]').should(
+          'not.have.attr',
+          'disabled'
+        );
+        cy.get('[data-qa-plan-row="shared-2"]').should(
+          'not.have.attr',
+          'disabled'
+        );
+        cy.get('[data-qa-plan-row="shared-3"]').should(
+          'not.have.attr',
+          'disabled'
+        );
+        cy.findAllByTestId('limited-availability').should('have.length', 0);
+      });
+    });
+
+    // High Memory tab
+    // Should have the limited availability notice
+    // Should contains 1 plan (2 rows including the header row)
+    // Should have one disabled plan
+    // Should have tooltip for the disabled plan (more than half disabled plans in the panel, but only one plan)
+    fbtClick('High Memory');
+    cy.get(k8PlansPanel).within(() => {
+      cy.findAllByRole('alert').should('have.length', 1);
+      cy.get(notices.limitedAvailability).should('be.visible');
+
+      cy.findByRole('table', { name: planSelectionTable }).within(() => {
+        cy.findAllByRole('row').should('have.length', 2);
+        cy.get('[data-qa-plan-row="highmem-1"]').should(
+          'have.attr',
+          'disabled'
+        );
+        cy.findAllByTestId('limited-availability').should('have.length', 1);
+      });
+    });
+
+    // Premium CPU
+    // Should have the unavailable notice
+    // Only present since we manually inject the 512 plan for it
+    // Should contains 1 plan (2 rows including the header row)
+    // Should have its whole panel disabled
+    // Should not have tooltip for the disabled plan (not needed on disabled panels)
+    fbtClick('Premium CPU');
+    cy.get(k8PlansPanel).within(() => {
+      cy.findAllByRole('alert').should('have.length', 1);
+      cy.get(notices.unavailable).should('be.visible');
+
+      cy.findByRole('table', { name: planSelectionTable }).within(() => {
+        cy.findAllByRole('row').should('have.length', 2);
+        cy.get('[data-qa-plan-row="Premium 512 GB"]').should(
+          'have.attr',
+          'disabled'
+        );
+        cy.findAllByTestId('limited-availability').should('have.length', 0);
+      });
     });
   });
 });

--- a/packages/manager/cypress/support/intercepts/regions.ts
+++ b/packages/manager/cypress/support/intercepts/regions.ts
@@ -2,7 +2,7 @@
  * @file Cypress intercept and mock utilities for Linode regions.
  */
 
-import { Region } from '@linode/api-v4';
+import { Region, RegionAvailability } from '@linode/api-v4';
 import { apiMatcher } from 'support/util/intercepts';
 import { paginateResponse } from 'support/util/paginate';
 
@@ -15,4 +15,20 @@ import { paginateResponse } from 'support/util/paginate';
  */
 export const mockGetRegions = (regions: Region[]): Cypress.Chainable<null> => {
   return cy.intercept('GET', apiMatcher('regions*'), paginateResponse(regions));
+};
+
+/**
+ * Intercepts GET request to fetch regions availability and mocks response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetRegionAvailability = (
+  regionId: Region['id'],
+  regionAvailability: RegionAvailability[]
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher(`regions/${regionId}/availability`),
+    regionAvailability
+  );
 };

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.tsx
@@ -1,7 +1,5 @@
 import { CONTINENT_CODE_TO_CONTINENT } from '@linode/api-v4';
-import * as React from 'react';
 
-import { Link } from 'src/components/Link';
 import {
   getRegionCountryGroup,
   getSelectedRegion,
@@ -62,15 +60,9 @@ export const getRegionOptions = ({
       const disabledProps = isRegionUnavailable(region)
         ? {
             disabled: true,
-            reason: (
-              <>
-                There may be limited capacity in this region.{' '}
-                <Link to="https://www.linode.com/global-infrastructure/availability">
-                  Learn more
-                </Link>
-                .
-              </>
-            ),
+            reason:
+              'This region is currently unavailable. For help, open a support ticket.',
+            tooltipWidth: 250,
           }
         : handleDisabledRegion?.(region)?.disabled
         ? handleDisabledRegion(region)

--- a/packages/manager/src/components/TableRow/TableRow.styles.ts
+++ b/packages/manager/src/components/TableRow/TableRow.styles.ts
@@ -1,5 +1,5 @@
-import { default as _TableRow } from '@mui/material/TableRow';
 import { styled } from '@mui/material/styles';
+import { default as _TableRow } from '@mui/material/TableRow';
 
 import { omittedProps } from 'src/utilities/omittedProps';
 
@@ -63,14 +63,10 @@ export const StyledTableRow = styled(_TableRow, {
     backgroundColor: theme.bg.lightBlue1,
   }),
   ...(props.disabled && {
-    '& td': {
+    '& td:not(.hasTooltip *), & td:has(.hasTooltip):not(.MuiRadio-root)': {
       color:
-        theme.palette.mode === 'dark'
-          ? theme.color.grey6
-          : theme.color.disabledText,
+        theme.palette.mode === 'dark' ? theme.color.grey6 : theme.color.grey1,
     },
-    backgroundColor:
-      theme.palette.mode === 'dark' ? '#32363c' : 'rgba(247, 247, 247, 0.25)',
   }),
 }));
 

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.test.tsx
@@ -26,11 +26,11 @@ const props: KubernetesPlanContainerProps = {
   allDisabledPlans: [],
   getTypeCount: vi.fn(),
   hasMajorityOfPlansDisabled: false,
-  isWholePanelDisabled: false,
   onSelect: vi.fn(),
   plans,
   selectedRegionId: undefined,
   updatePlanCount: vi.fn(),
+  wholePanelIsDisabled: false,
 };
 
 beforeAll(() => mockMatchMedia());

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.test.tsx
@@ -23,7 +23,10 @@ const plans: TypeWithAvailability[] = [
 ];
 
 const props: KubernetesPlanContainerProps = {
+  allDisabledPlans: [],
   getTypeCount: vi.fn(),
+  hasMajorityOfPlansDisabled: false,
+  isWholePanelDisabled: false,
   onSelect: vi.fn(),
   plans,
   selectedRegionId: undefined,

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
@@ -29,13 +29,13 @@ export interface KubernetesPlanContainerProps {
   allDisabledPlans: string[];
   getTypeCount: (planId: string) => number;
   hasMajorityOfPlansDisabled: boolean;
-  isWholePanelDisabled: boolean;
   onAdd?: (key: string, value: number) => void;
   onSelect: (key: string) => void;
   plans: TypeWithAvailability[];
   selectedId?: string;
   selectedRegionId?: string;
   updatePlanCount: (planId: string, newCount: number) => void;
+  wholePanelIsDisabled: boolean;
 }
 
 export const KubernetesPlanContainer = (
@@ -45,13 +45,13 @@ export const KubernetesPlanContainer = (
     allDisabledPlans,
     getTypeCount,
     hasMajorityOfPlansDisabled,
-    isWholePanelDisabled,
     onAdd,
     onSelect,
     plans,
     selectedId,
     selectedRegionId,
     updatePlanCount,
+    wholePanelIsDisabled,
   } = props;
 
   const shouldDisplayNoRegionSelectedMessage = !selectedRegionId;
@@ -65,21 +65,21 @@ export const KubernetesPlanContainer = (
           getTypeCount={getTypeCount}
           hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
           idx={id}
-          isPlanDisabled={isPlanDisabled}
-          isWholePanelDisabled={isWholePanelDisabled}
           key={id}
           onAdd={onAdd}
           onSelect={onSelect}
+          planIsDisabled={isPlanDisabled}
           selectedId={selectedId}
           selectedRegionId={selectedRegionId}
           type={plan}
           updatePlanCount={updatePlanCount}
+          wholePanelIsDisabled={wholePanelIsDisabled}
         />
       );
     });
   }, [
     allDisabledPlans,
-    isWholePanelDisabled,
+    wholePanelIsDisabled,
     hasMajorityOfPlansDisabled,
     getTypeCount,
     onAdd,

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
@@ -26,8 +26,10 @@ const tableCells = [
 ];
 
 export interface KubernetesPlanContainerProps {
-  disabled?: boolean;
+  allDisabledPlans: string[];
   getTypeCount: (planId: string) => number;
+  hasMajorityOfPlansDisabled: boolean;
+  isWholePanelDisabled: boolean;
   onAdd?: (key: string, value: number) => void;
   onSelect: (key: string) => void;
   plans: TypeWithAvailability[];
@@ -40,8 +42,10 @@ export const KubernetesPlanContainer = (
   props: KubernetesPlanContainerProps
 ) => {
   const {
-    disabled,
+    allDisabledPlans,
     getTypeCount,
+    hasMajorityOfPlansDisabled,
+    isWholePanelDisabled,
     onAdd,
     onSelect,
     plans,
@@ -54,14 +58,15 @@ export const KubernetesPlanContainer = (
 
   const renderPlanSelection = React.useCallback(() => {
     return plans.map((plan, id) => {
+      const isPlanDisabled = allDisabledPlans.includes(plan.id);
+
       return (
         <KubernetesPlanSelection
-          isLimitedAvailabilityPlan={
-            disabled ? false : plan.isLimitedAvailabilityPlan
-          } // No need for tooltip due to all plans being unavailable in region
-          disabled={disabled}
           getTypeCount={getTypeCount}
+          hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
           idx={id}
+          isPlanDisabled={isPlanDisabled}
+          isWholePanelDisabled={isWholePanelDisabled}
           key={id}
           onAdd={onAdd}
           onSelect={onSelect}
@@ -73,7 +78,9 @@ export const KubernetesPlanContainer = (
       );
     });
   }, [
-    disabled,
+    allDisabledPlans,
+    isWholePanelDisabled,
+    hasMajorityOfPlansDisabled,
     getTypeCount,
     onAdd,
     onSelect,

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
@@ -25,8 +25,13 @@ const tableCells = [
   { cellName: 'Quantity', center: false, noWrap: false, testId: 'quantity' },
 ];
 
+type AllDisabledPlans = TypeWithAvailability & {
+  isDisabled512GbPlan: boolean;
+  isLimitedAvailabilityPlan: boolean;
+};
+
 export interface KubernetesPlanContainerProps {
-  allDisabledPlans: string[];
+  allDisabledPlans: AllDisabledPlans[];
   getTypeCount: (planId: string) => number;
   hasMajorityOfPlansDisabled: boolean;
   onAdd?: (key: string, value: number) => void;
@@ -58,10 +63,21 @@ export const KubernetesPlanContainer = (
 
   const renderPlanSelection = React.useCallback(() => {
     return plans.map((plan, id) => {
-      const isPlanDisabled = allDisabledPlans.includes(plan.id);
+      const isPlanDisabled = allDisabledPlans.some(
+        (disabledPlan) => disabledPlan.id === plan.id
+      );
+      const currentDisabledPlan = allDisabledPlans.find(
+        (disabledPlan) => disabledPlan.id === plan.id
+      );
+      const currentDisabledPlanStatus = currentDisabledPlan && {
+        isDisabled512GbPlan: currentDisabledPlan.isDisabled512GbPlan,
+        isLimitedAvailabilityPlan:
+          currentDisabledPlan.isLimitedAvailabilityPlan,
+      };
 
       return (
         <KubernetesPlanSelection
+          disabledStatus={currentDisabledPlanStatus}
           getTypeCount={getTypeCount}
           hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
           idx={id}

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
@@ -35,13 +35,13 @@ const props: KubernetesPlanSelectionProps = {
   getTypeCount: vi.fn(),
   hasMajorityOfPlansDisabled: false,
   idx: 0,
-  isPlanDisabled: false,
-  isWholePanelDisabled: false,
   onAdd: vi.fn(),
   onSelect: vi.fn(),
+  planIsDisabled: false,
   selectedRegionId: 'us-east',
   type: typeWithAvailability,
   updatePlanCount: vi.fn(),
+  wholePanelIsDisabled: false,
 };
 
 describe('KubernetesPlanSelection (table, desktop view)', () => {
@@ -130,7 +130,7 @@ describe('KubernetesPlanSelection (table, desktop view)', () => {
       wrapWithTableBody(
         <KubernetesPlanSelection
           {...props}
-          isPlanDisabled={true}
+          planIsDisabled={true}
           type={bigPlanType}
         />
       )

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
@@ -33,8 +33,10 @@ const typeWithAvailability: TypeWithAvailability = {
 
 const props: KubernetesPlanSelectionProps = {
   getTypeCount: vi.fn(),
+  hasMajorityOfPlansDisabled: false,
   idx: 0,
-  isLimitedAvailabilityPlan: false,
+  isPlanDisabled: false,
+  isWholePanelDisabled: false,
   onAdd: vi.fn(),
   onSelect: vi.fn(),
   selectedRegionId: 'us-east',
@@ -126,11 +128,7 @@ describe('KubernetesPlanSelection (table, desktop view)', () => {
 
     const { getByRole, getByTestId, getByText } = renderWithTheme(
       wrapWithTableBody(
-        <KubernetesPlanSelection
-          {...props}
-          isLimitedAvailabilityPlan={true}
-          type={bigPlanType}
-        />,
+        <KubernetesPlanSelection {...props} type={bigPlanType} />,
         { flags: { disableLargestGbPlans: true } }
       )
     );
@@ -185,11 +183,7 @@ describe('KubernetesPlanSelection (cards, mobile view)', () => {
 
   it('shows limited availability messaging', async () => {
     const { getByRole, getByTestId, getByText } = renderWithTheme(
-      <KubernetesPlanSelection
-        {...props}
-        isLimitedAvailabilityPlan={true}
-        selectedRegionId={'us-east'}
-      />
+      <KubernetesPlanSelection {...props} selectedRegionId={'us-east'} />
     );
 
     const selectionCard = getByTestId('selection-card');
@@ -212,11 +206,7 @@ describe('KubernetesPlanSelection (cards, mobile view)', () => {
     };
 
     const { getByTestId } = renderWithTheme(
-      <KubernetesPlanSelection
-        {...props}
-        isLimitedAvailabilityPlan={false}
-        type={bigPlanType}
-      />,
+      <KubernetesPlanSelection {...props} type={bigPlanType} />,
       { flags: { disableLargestGbPlans: true } }
     );
 

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
@@ -128,8 +128,11 @@ describe('KubernetesPlanSelection (table, desktop view)', () => {
 
     const { getByRole, getByTestId, getByText } = renderWithTheme(
       wrapWithTableBody(
-        <KubernetesPlanSelection {...props} type={bigPlanType} />,
-        { flags: { disableLargestGbPlans: true } }
+        <KubernetesPlanSelection
+          {...props}
+          isPlanDisabled={true}
+          type={bigPlanType}
+        />
       )
     );
 
@@ -179,38 +182,5 @@ describe('KubernetesPlanSelection (cards, mobile view)', () => {
     expect(
       getByText(`${regionHourlyPrice}/hr`, { exact: false })
     ).toBeInTheDocument();
-  });
-
-  it('shows limited availability messaging', async () => {
-    const { getByRole, getByTestId, getByText } = renderWithTheme(
-      <KubernetesPlanSelection {...props} selectedRegionId={'us-east'} />
-    );
-
-    const selectionCard = getByTestId('selection-card');
-    fireEvent.mouseOver(selectionCard);
-
-    await waitFor(() => {
-      expect(getByRole('tooltip')).toBeInTheDocument();
-    });
-
-    expect(getByText(LIMITED_AVAILABILITY_TEXT)).toBeVisible();
-  });
-
-  it('is disabled for 512 GB plans', () => {
-    const bigPlanType: TypeWithAvailability = {
-      ...extendedTypeFactory.build({
-        heading: 'Dedicated 512 GB',
-        label: 'Dedicated 512GB',
-      }),
-      isLimitedAvailabilityPlan: false,
-    };
-
-    const { getByTestId } = renderWithTheme(
-      <KubernetesPlanSelection {...props} type={bigPlanType} />,
-      { flags: { disableLargestGbPlans: true } }
-    );
-
-    const selectionCard = getByTestId('selection-card');
-    expect(selectionCard).toBeDisabled();
   });
 });

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.test.tsx
@@ -32,6 +32,10 @@ const typeWithAvailability: TypeWithAvailability = {
 };
 
 const props: KubernetesPlanSelectionProps = {
+  disabledStatus: {
+    isDisabled512GbPlan: false,
+    isLimitedAvailabilityPlan: false,
+  },
   getTypeCount: vi.fn(),
   hasMajorityOfPlansDisabled: false,
   idx: 0,
@@ -130,6 +134,10 @@ describe('KubernetesPlanSelection (table, desktop view)', () => {
       wrapWithTableBody(
         <KubernetesPlanSelection
           {...props}
+          disabledStatus={{
+            isDisabled512GbPlan: true,
+            isLimitedAvailabilityPlan: false,
+          }}
           planIsDisabled={true}
           type={bigPlanType}
         />

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
@@ -30,14 +30,14 @@ export interface KubernetesPlanSelectionProps {
   getTypeCount: (planId: string) => number;
   hasMajorityOfPlansDisabled: boolean;
   idx: number;
-  isPlanDisabled: boolean;
-  isWholePanelDisabled: boolean;
   onAdd?: (key: string, value: number) => void;
   onSelect: (key: string) => void;
+  planIsDisabled: boolean;
   selectedId?: string;
   selectedRegionId?: Region['id'];
   type: TypeWithAvailability;
   updatePlanCount: (planId: string, newCount: number) => void;
+  wholePanelIsDisabled: boolean;
 }
 
 export const KubernetesPlanSelection = (
@@ -47,17 +47,17 @@ export const KubernetesPlanSelection = (
     getTypeCount,
     hasMajorityOfPlansDisabled,
     idx,
-    isPlanDisabled,
-    isWholePanelDisabled,
     onAdd,
     onSelect,
+    planIsDisabled,
     selectedId,
     selectedRegionId,
     type,
     updatePlanCount,
+    wholePanelIsDisabled,
   } = props;
 
-  const isDisabled = isPlanDisabled || isWholePanelDisabled;
+  const isDisabled = planIsDisabled || wholePanelIsDisabled;
   const count = getTypeCount(type.id);
   const price: PriceObject | undefined = getLinodeRegionPrice(
     type,
@@ -106,7 +106,7 @@ export const KubernetesPlanSelection = (
             <Box alignItems="center">
               {type.heading} &nbsp;
               {isDisabled &&
-                !isWholePanelDisabled &&
+                !wholePanelIsDisabled &&
                 !hasMajorityOfPlansDisabled && (
                   <Tooltip
                     PopperProps={{

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
@@ -13,9 +13,9 @@ import { Hidden } from 'src/components/Hidden';
 import { IconButton } from 'src/components/IconButton';
 import { SelectionCard } from 'src/components/SelectionCard/SelectionCard';
 import { TableCell } from 'src/components/TableCell';
+import { TableRow } from 'src/components/TableRow';
 import { Tooltip } from 'src/components/Tooltip';
 import { LIMITED_AVAILABILITY_TEXT } from 'src/features/components/PlansPanel/constants';
-import { StyledDisabledTableRow } from 'src/features/components/PlansPanel/PlansPanel.styles';
 import { useFlags } from 'src/hooks/useFlags';
 import {
   PRICE_ERROR_TOOLTIP_TEXT,
@@ -108,7 +108,7 @@ export const KubernetesPlanSelection = (
     <React.Fragment key={`tabbed-panel-${idx}`}>
       {/* Displays Table Row for larger screens */}
       <Hidden mdDown>
-        <StyledDisabledTableRow
+        <TableRow
           data-qa-plan-row={type.formattedLabel}
           disabled={isDisabled}
           key={type.id}
@@ -118,6 +118,13 @@ export const KubernetesPlanSelection = (
               {type.heading} &nbsp;
               {(isLimitedAvailabilityPlan || disabled512GbPlan) && (
                 <Tooltip
+                  PopperProps={{
+                    sx: {
+                      '& .MuiTooltip-tooltip': {
+                        minWidth: 225,
+                      },
+                    },
+                  }}
                   sx={{
                     alignItems: 'center',
                   }}
@@ -192,7 +199,7 @@ export const KubernetesPlanSelection = (
               )}
             </StyledInputOuter>
           </TableCell>
-        </StyledDisabledTableRow>
+        </TableRow>
       </Hidden>
       {/* Displays SelectionCard for small screens */}
       <Hidden mdUp>

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
@@ -105,33 +105,35 @@ export const KubernetesPlanSelection = (
           <TableCell data-qa-plan-name>
             <Box alignItems="center">
               {type.heading} &nbsp;
-              {isDisabled && !hasMajorityOfPlansDisabled && (
-                <Tooltip
-                  PopperProps={{
-                    sx: {
-                      '& .MuiTooltip-tooltip': {
-                        minWidth: 225,
+              {isDisabled &&
+                !isWholePanelDisabled &&
+                !hasMajorityOfPlansDisabled && (
+                  <Tooltip
+                    PopperProps={{
+                      sx: {
+                        '& .MuiTooltip-tooltip': {
+                          minWidth: 225,
+                        },
                       },
-                    },
-                  }}
-                  sx={{
-                    alignItems: 'center',
-                  }}
-                  data-qa-tooltip={LIMITED_AVAILABILITY_TEXT}
-                  data-testid="limited-availability"
-                  placement="right-start"
-                  title={LIMITED_AVAILABILITY_TEXT}
-                >
-                  <IconButton disableRipple size="small">
-                    <HelpOutline
-                      sx={{
-                        height: 16,
-                        width: 16,
-                      }}
-                    />
-                  </IconButton>
-                </Tooltip>
-              )}
+                    }}
+                    sx={{
+                      alignItems: 'center',
+                    }}
+                    data-qa-tooltip={LIMITED_AVAILABILITY_TEXT}
+                    data-testid="limited-availability"
+                    placement="right-start"
+                    title={LIMITED_AVAILABILITY_TEXT}
+                  >
+                    <IconButton disableRipple size="small">
+                      <HelpOutline
+                        sx={{
+                          height: 16,
+                          width: 16,
+                        }}
+                      />
+                    </IconButton>
+                  </Tooltip>
+                )}
             </Box>
           </TableCell>
           <TableCell

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
@@ -27,6 +27,12 @@ import { convertMegabytesTo } from 'src/utilities/unitConversions';
 import type { TypeWithAvailability } from 'src/features/components/PlansPanel/types';
 
 export interface KubernetesPlanSelectionProps {
+  disabledStatus:
+    | {
+        isDisabled512GbPlan: boolean;
+        isLimitedAvailabilityPlan: boolean;
+      }
+    | undefined;
   getTypeCount: (planId: string) => number;
   hasMajorityOfPlansDisabled: boolean;
   idx: number;
@@ -44,6 +50,7 @@ export const KubernetesPlanSelection = (
   props: KubernetesPlanSelectionProps
 ) => {
   const {
+    disabledStatus,
     getTypeCount,
     hasMajorityOfPlansDisabled,
     idx,
@@ -107,7 +114,9 @@ export const KubernetesPlanSelection = (
               {type.heading} &nbsp;
               {isDisabled &&
                 !wholePanelIsDisabled &&
-                !hasMajorityOfPlansDisabled && (
+                !hasMajorityOfPlansDisabled &&
+                (Boolean(disabledStatus?.isDisabled512GbPlan) ||
+                  Boolean(disabledStatus?.isLimitedAvailabilityPlan)) && (
                   <Tooltip
                     PopperProps={{
                       sx: {
@@ -127,8 +136,10 @@ export const KubernetesPlanSelection = (
                     <IconButton disableRipple size="small">
                       <HelpOutline
                         sx={{
-                          height: 16,
-                          width: 16,
+                          height: 18,
+                          position: 'relative',
+                          top: -2,
+                          width: 18,
                         }}
                       />
                     </IconButton>

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
@@ -4,9 +4,8 @@ import { TabbedPanel } from 'src/components/TabbedPanel/TabbedPanel';
 import { PlanInformation } from 'src/features/components/PlansPanel/PlanInformation';
 import {
   determineInitialPlanCategoryTab,
-  getIsLimitedAvailability,
+  extractPlansInformation,
   getPlanSelectionsByPlanType,
-  isMajorityLimitedAvailabilityPlans,
   planTabInfoContent,
   replaceOrAppendPlaceholder512GbPlans,
 } from 'src/features/components/PlansPanel/utils';
@@ -18,16 +17,12 @@ import { KubernetesPlanContainer } from './KubernetesPlanContainer';
 
 import type { CreateNodePoolData, Region } from '@linode/api-v4';
 import type { LinodeTypeClass } from '@linode/api-v4/lib/linodes/types';
-import type {
-  PlanSelectionType,
-  TypeWithAvailability,
-} from 'src/features/components/PlansPanel/types';
+import type { PlanSelectionType } from 'src/features/components/PlansPanel/types';
 
 interface Props {
   addPool?: (pool?: CreateNodePoolData) => void;
   copy?: string;
   currentPlanHeading?: string;
-  disabled?: boolean;
   error?: string;
   getTypeCount: (planId: string) => number;
   hasSelectedRegion: boolean;
@@ -49,7 +44,6 @@ export const KubernetesPlansPanel = (props: Props) => {
   const {
     copy,
     currentPlanHeading,
-    disabled,
     error,
     getTypeCount,
     hasSelectedRegion,
@@ -79,23 +73,19 @@ export const KubernetesPlansPanel = (props: Props) => {
   );
 
   const tabs = Object.keys(plans).map((plan: LinodeTypeClass) => {
-    const _plansForThisLinodeTypeClass: PlanSelectionType[] = plans[plan];
-    const plansForThisLinodeTypeClass: TypeWithAvailability[] = _plansForThisLinodeTypeClass.map(
-      (plan) => {
-        return {
-          ...plan,
-          isLimitedAvailabilityPlan: getIsLimitedAvailability({
-            plan,
-            regionAvailabilities,
-            selectedRegionId,
-          }),
-        };
-      }
-    );
-
-    const mostClassPlansAreLimitedAvailability = isMajorityLimitedAvailabilityPlans(
-      plansForThisLinodeTypeClass
-    );
+    const plansMap: PlanSelectionType[] = plans[plan];
+    const {
+      allDisabledPlans,
+      hasDisabledPlans,
+      hasMajorityOfPlansDisabled,
+      plansForThisLinodeTypeClass,
+    } = extractPlansInformation({
+      disableLargestGbPlans: flags.disableLargestGbPlans,
+      disabledPlanTypes: [],
+      plans: plansMap,
+      regionAvailabilities,
+      selectedRegionId,
+    });
 
     return {
       render: () => {
@@ -105,19 +95,19 @@ export const KubernetesPlansPanel = (props: Props) => {
               isSelectedRegionEligibleForPlan={isSelectedRegionEligibleForPlan(
                 plan
               )}
-              mostClassPlansAreLimitedAvailability={
-                mostClassPlansAreLimitedAvailability
-              }
+              hasDisabledPlans={hasDisabledPlans}
               hasSelectedRegion={hasSelectedRegion}
               planType={plan}
               regionsData={regionsData}
             />
             <KubernetesPlanContainer
-              disabled={disabled || isPlanPanelDisabled(plan)}
+              allDisabledPlans={allDisabledPlans}
               getTypeCount={getTypeCount}
+              hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
+              isWholePanelDisabled={isPlanPanelDisabled(plan)}
               onAdd={onAdd}
               onSelect={onSelect}
-              plans={plans[plan]}
+              plans={plansForThisLinodeTypeClass}
               selectedId={selectedId}
               selectedRegionId={selectedRegionId}
               updatePlanCount={updatePlanCount}

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
@@ -104,13 +104,13 @@ export const KubernetesPlansPanel = (props: Props) => {
               allDisabledPlans={allDisabledPlans}
               getTypeCount={getTypeCount}
               hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
-              isWholePanelDisabled={isPlanPanelDisabled(plan)}
               onAdd={onAdd}
               onSelect={onSelect}
               plans={plansForThisLinodeTypeClass}
               selectedId={selectedId}
               selectedRegionId={selectedRegionId}
               updatePlanCount={updatePlanCount}
+              wholePanelIsDisabled={isPlanPanelDisabled(plan)}
             />
           </>
         );

--- a/packages/manager/src/features/components/PlansPanel/PlanContainer.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanContainer.test.tsx
@@ -27,6 +27,8 @@ describe('PlanContainer', () => {
   it('shows the no region selected message when no region is selected', () => {
     const { getByText } = renderWithTheme(
       <PlanContainer
+        allDisabledPlans={[]}
+        hasMajorityOfPlansDisabled={false}
         onSelect={() => {}}
         plans={mockPlans}
         selectedRegionId={undefined}

--- a/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
@@ -38,9 +38,9 @@ export interface Props {
   currentPlanHeading?: string;
   disabled?: boolean;
   disabledClasses?: LinodeTypeClass[];
-  hideDisabledHelpIcons?: boolean;
   disabledPlanTypes?: PlanSelectionType[];
   disabledPlanTypesToolTipText?: string;
+  hideDisabledHelpIcons?: boolean;
   isCreate?: boolean;
   linodeID?: number | undefined;
   onSelect: (key: string) => void;
@@ -56,9 +56,9 @@ export const PlanContainer = (props: Props) => {
     currentPlanHeading,
     disabled,
     disabledClasses,
-    hideDisabledHelpIcons,
     disabledPlanTypes,
     disabledPlanTypesToolTipText,
+    hideDisabledHelpIcons,
     isCreate,
     linodeID,
     onSelect,
@@ -94,14 +94,16 @@ export const PlanContainer = (props: Props) => {
         undefined;
       return (
         <PlanSelection
+          disabled={
+            disabled || planIsDisabled || plan.isLimitedAvailabilityPlan
+          }
           isLimitedAvailabilityPlan={
             disabled ? false : plan.isLimitedAvailabilityPlan
           } // No need for tooltip due to all plans being unavailable in region
           currentPlanHeading={currentPlanHeading}
-          disabled={disabled || planIsDisabled}
           disabledClasses={disabledClasses}
-          hideDisabledHelpIcons={hideDisabledHelpIcons}
           disabledToolTip={disabledPlanTypesToolTipText}
+          hideDisabledHelpIcons={hideDisabledHelpIcons}
           idx={id}
           isCreate={isCreate}
           key={id}
@@ -117,6 +119,8 @@ export const PlanContainer = (props: Props) => {
       );
     });
   }, [
+    disabledPlanTypes,
+    disabledPlanTypesToolTipText,
     plans,
     selectedRegionId,
     disabled,

--- a/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
@@ -101,16 +101,16 @@ export const PlanContainer = (props: Props) => {
           disabledToolTip={disabledPlanTypesToolTipText}
           idx={id}
           isCreate={isCreate}
-          isPlanDisabled={isPlanDisabled}
-          isWholePanelDisabled={isWholePanelDisabled}
           key={id}
           linodeID={linodeID}
           onSelect={onSelect}
+          planIsDisabled={isPlanDisabled}
           selectedDiskSize={selectedDiskSize}
           selectedId={selectedId}
           selectedRegionId={selectedRegionId}
           showTransfer={showTransfer}
           type={plan}
+          wholePanelIsDisabled={isWholePanelDisabled}
         />
       );
     });

--- a/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
@@ -34,8 +34,13 @@ const tableCells = [
   },
 ];
 
+type AllDisabledPlans = TypeWithAvailability & {
+  isDisabled512GbPlan: boolean;
+  isLimitedAvailabilityPlan: boolean;
+};
+
 export interface Props {
-  allDisabledPlans: string[];
+  allDisabledPlans: AllDisabledPlans[];
   currentPlanHeading?: string;
   disabled?: boolean;
   disabledClasses?: LinodeTypeClass[];
@@ -89,7 +94,17 @@ export const PlanContainer = (props: Props) => {
 
   const renderPlanSelection = React.useCallback(() => {
     return plans.map((plan, id) => {
-      const isPlanDisabled = allDisabledPlans.includes(plan.id);
+      const isPlanDisabled = allDisabledPlans.some(
+        (disabledPlan) => disabledPlan.id === plan.id
+      );
+      const currentDisabledPlan = allDisabledPlans.find(
+        (disabledPlan) => disabledPlan.id === plan.id
+      );
+      const currentDisabledPlanStatus = currentDisabledPlan && {
+        isDisabled512GbPlan: currentDisabledPlan.isDisabled512GbPlan,
+        isLimitedAvailabilityPlan:
+          currentDisabledPlan.isLimitedAvailabilityPlan,
+      };
 
       return (
         <PlanSelection
@@ -98,6 +113,7 @@ export const PlanContainer = (props: Props) => {
           }
           currentPlanHeading={currentPlanHeading}
           disabledClasses={disabledClasses}
+          disabledStatus={currentDisabledPlanStatus}
           disabledToolTip={disabledPlanTypesToolTipText}
           idx={id}
           isCreate={isCreate}

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.test.tsx
@@ -49,36 +49,4 @@ describe('PlanInformation', () => {
     );
     expect(limitedAvailabilityBanner).toBeInTheDocument();
   });
-
-  it('should inform the user about Premium plans having limited availability when appropriate', () => {
-    renderWithTheme(
-      <PlanInformation
-        {...mockProps}
-        hasDisabledPlans={true}
-        isSelectedRegionEligibleForPlan={true}
-        planType="premium"
-      />
-    );
-
-    const limitedAvailabilityBanner = screen.getByTestId(
-      limitedAvailabilityBannerTestId
-    );
-    expect(limitedAvailabilityBanner).toBeInTheDocument();
-  });
-
-  it('should inform the user about GPU plans having limited availability when appropriate', () => {
-    renderWithTheme(
-      <PlanInformation
-        {...mockProps}
-        hasDisabledPlans={true}
-        isSelectedRegionEligibleForPlan={true}
-        planType="gpu"
-      />
-    );
-
-    const limitedAvailabilityBanner = screen.getByTestId(
-      limitedAvailabilityBannerTestId
-    );
-    expect(limitedAvailabilityBanner).toBeInTheDocument();
-  });
 });

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.test.tsx
@@ -11,6 +11,7 @@ import {
 import type { PlanInformationProps } from './PlanInformation';
 
 const mockProps: PlanInformationProps = {
+  hasDisabledPlans: false,
   hasSelectedRegion: true,
   isSelectedRegionEligibleForPlan: false,
   planType: 'standard',

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.test.tsx
@@ -38,6 +38,7 @@ describe('PlanInformation', () => {
     renderWithTheme(
       <PlanInformation
         {...mockProps}
+        hasDisabledPlans={true}
         isSelectedRegionEligibleForPlan={true}
         planType="dedicated"
       />
@@ -53,6 +54,7 @@ describe('PlanInformation', () => {
     renderWithTheme(
       <PlanInformation
         {...mockProps}
+        hasDisabledPlans={true}
         isSelectedRegionEligibleForPlan={true}
         planType="premium"
       />
@@ -68,6 +70,7 @@ describe('PlanInformation', () => {
     renderWithTheme(
       <PlanInformation
         {...mockProps}
+        hasDisabledPlans={true}
         isSelectedRegionEligibleForPlan={true}
         planType="gpu"
       />

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
@@ -2,8 +2,8 @@ import { LinodeTypeClass } from '@linode/api-v4/lib/linodes';
 import { Theme, useTheme } from '@mui/material/styles';
 import * as React from 'react';
 
-import { DismissibleBanner } from 'src/components/DismissibleBanner/DismissibleBanner';
 import { Link } from 'src/components/Link';
+import { Notice } from 'src/components/Notice/Notice';
 import { Typography } from 'src/components/Typography';
 import { StyledNoticeTypography } from 'src/features/Linodes/LinodesCreate/PlansAvailabilityNotice.styles';
 
@@ -11,7 +11,6 @@ import { PlansAvailabilityNotice } from '../../Linodes/LinodesCreate/PlansAvaila
 import {
   DEDICATED_COMPUTE_INSTANCES_LINK,
   GPU_COMPUTE_INSTANCES_LINK,
-  LIMITED_AVAILABILITY_DISMISSIBLEBANNER_KEY,
   PREMIUM_COMPUTE_INSTANCES_LINK,
 } from './constants';
 import { MetalNotice } from './MetalNotice';
@@ -143,7 +142,7 @@ export const LimitedAvailabilityNoticeCopy = (
 ) => {
   const { docsLink, hasDisabledPlans, planTypeLabel } = props;
   return (
-    <DismissibleBanner
+    <Notice
       sx={(theme: Theme) => ({
         marginBottom: theme.spacing(3),
         marginLeft: 0,
@@ -151,7 +150,6 @@ export const LimitedAvailabilityNoticeCopy = (
         padding: `${theme.spacing(0.5)} ${theme.spacing(2)}`,
       })}
       dataTestId={limitedAvailabilityBannerTestId}
-      preferenceKey={LIMITED_AVAILABILITY_DISMISSIBLEBANNER_KEY}
       variant="warning"
     >
       {hasDisabledPlans ? (
@@ -164,6 +162,6 @@ export const LimitedAvailabilityNoticeCopy = (
           <Link to={docsLink}>Learn more</Link> about plans and availability.
         </StyledNoticeTypography>
       )}
-    </DismissibleBanner>
+    </Notice>
   );
 };

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
@@ -91,7 +91,8 @@ export const limitedAvailabilityBannerTestId =
 
 export const determineLimitedAvailabilityNoticeCopy = (
   mostClassPlansAreLimitedAvailability: boolean,
-  docsLink: string
+  docsLink: string,
+  planTypeLabel: string
 ) => {
   return (
     <DismissibleBanner
@@ -108,7 +109,7 @@ export const determineLimitedAvailabilityNoticeCopy = (
       {mostClassPlansAreLimitedAvailability ? (
         <StyledNoticeTypography>
           These plans have limited deployment availability.{' '}
-          <Link to={docsLink}>Learn more</Link>.
+          <Link to={docsLink}>Learn more</Link> about our {planTypeLabel} plans.
         </StyledNoticeTypography>
       ) : (
         <StyledNoticeTypography>
@@ -127,19 +128,22 @@ export const generateLimitedAvailabilityJsx = (
     case 'dedicated':
       return determineLimitedAvailabilityNoticeCopy(
         mostClassPlansAreLimitedAvailability,
-        DEDICATED_COMPUTE_INSTANCES_LINK
+        DEDICATED_COMPUTE_INSTANCES_LINK,
+        'Dedicated CPU'
       );
 
     case 'premium':
       return determineLimitedAvailabilityNoticeCopy(
         mostClassPlansAreLimitedAvailability,
-        PREMIUM_COMPUTE_INSTANCES_LINK
+        PREMIUM_COMPUTE_INSTANCES_LINK,
+        'Premium CPU'
       );
 
     case 'gpu':
       return determineLimitedAvailabilityNoticeCopy(
         mostClassPlansAreLimitedAvailability,
-        GPU_COMPUTE_INSTANCES_LINK
+        GPU_COMPUTE_INSTANCES_LINK,
+        'GPU'
       );
 
     default:

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
@@ -21,10 +21,10 @@ import type { Region } from '@linode/api-v4';
 
 export interface PlanInformationProps {
   disabledClasses?: LinodeTypeClass[];
+  hasDisabledPlans: boolean;
   hasSelectedRegion: boolean;
   hideLimitedAvailabilityBanner?: boolean;
   isSelectedRegionEligibleForPlan: boolean;
-  mostClassPlansAreLimitedAvailability?: boolean;
   planType: LinodeTypeClass;
   regionsData?: Region[];
 }
@@ -33,10 +33,10 @@ export const PlanInformation = (props: PlanInformationProps) => {
   const theme = useTheme();
   const {
     disabledClasses,
+    hasDisabledPlans,
     hasSelectedRegion,
     hideLimitedAvailabilityBanner,
     isSelectedRegionEligibleForPlan,
-    mostClassPlansAreLimitedAvailability,
     planType,
     regionsData,
   } = props;
@@ -71,10 +71,11 @@ export const PlanInformation = (props: PlanInformationProps) => {
       ) : null}
       {hasSelectedRegion &&
         isSelectedRegionEligibleForPlan &&
-        !hideLimitedAvailabilityBanner &&
-        generateLimitedAvailabilityJsx(
-          planType,
-          Boolean(mostClassPlansAreLimitedAvailability)
+        !hideLimitedAvailabilityBanner && (
+          <LimitedAvailabilityNotice
+            hasDisabledPlans={hasDisabledPlans}
+            planType={planType}
+          />
         )}
       <Typography
         data-qa-prodedi
@@ -89,11 +90,58 @@ export const PlanInformation = (props: PlanInformationProps) => {
 export const limitedAvailabilityBannerTestId =
   'limited-availability-dismissible-banner';
 
-export const determineLimitedAvailabilityNoticeCopy = (
-  mostClassPlansAreLimitedAvailability: boolean,
-  docsLink: string,
-  planTypeLabel: string
+interface LimitedAvailabilityNoticeProps {
+  hasDisabledPlans: boolean;
+  planType: LinodeTypeClass;
+}
+
+export const LimitedAvailabilityNotice = (
+  props: LimitedAvailabilityNoticeProps
 ) => {
+  const { hasDisabledPlans, planType } = props;
+
+  switch (planType) {
+    case 'dedicated':
+      return (
+        <LimitedAvailabilityNoticeCopy
+          docsLink={DEDICATED_COMPUTE_INSTANCES_LINK}
+          hasDisabledPlans={hasDisabledPlans}
+          planTypeLabel="Dedicated CPU"
+        />
+      );
+
+    case 'premium':
+      return (
+        <LimitedAvailabilityNoticeCopy
+          docsLink={PREMIUM_COMPUTE_INSTANCES_LINK}
+          hasDisabledPlans={hasDisabledPlans}
+          planTypeLabel="Premium CPU"
+        />
+      );
+    case 'gpu':
+      return (
+        <LimitedAvailabilityNoticeCopy
+          docsLink={GPU_COMPUTE_INSTANCES_LINK}
+          hasDisabledPlans={hasDisabledPlans}
+          planTypeLabel="GPU"
+        />
+      );
+
+    default:
+      return null;
+  }
+};
+
+interface LimitedAvailabilityNoticeCopyProps {
+  docsLink: string;
+  hasDisabledPlans: boolean;
+  planTypeLabel: string;
+}
+
+export const LimitedAvailabilityNoticeCopy = (
+  props: LimitedAvailabilityNoticeCopyProps
+) => {
+  const { docsLink, hasDisabledPlans, planTypeLabel } = props;
   return (
     <DismissibleBanner
       sx={(theme: Theme) => ({
@@ -106,7 +154,7 @@ export const determineLimitedAvailabilityNoticeCopy = (
       preferenceKey={LIMITED_AVAILABILITY_DISMISSIBLEBANNER_KEY}
       variant="warning"
     >
-      {mostClassPlansAreLimitedAvailability ? (
+      {hasDisabledPlans ? (
         <StyledNoticeTypography>
           These plans have limited deployment availability.{' '}
           <Link to={docsLink}>Learn more</Link> about our {planTypeLabel} plans.
@@ -118,35 +166,4 @@ export const determineLimitedAvailabilityNoticeCopy = (
       )}
     </DismissibleBanner>
   );
-};
-
-export const generateLimitedAvailabilityJsx = (
-  planType: LinodeTypeClass,
-  mostClassPlansAreLimitedAvailability: boolean
-) => {
-  switch (planType) {
-    case 'dedicated':
-      return determineLimitedAvailabilityNoticeCopy(
-        mostClassPlansAreLimitedAvailability,
-        DEDICATED_COMPUTE_INSTANCES_LINK,
-        'Dedicated CPU'
-      );
-
-    case 'premium':
-      return determineLimitedAvailabilityNoticeCopy(
-        mostClassPlansAreLimitedAvailability,
-        PREMIUM_COMPUTE_INSTANCES_LINK,
-        'Premium CPU'
-      );
-
-    case 'gpu':
-      return determineLimitedAvailabilityNoticeCopy(
-        mostClassPlansAreLimitedAvailability,
-        GPU_COMPUTE_INSTANCES_LINK,
-        'GPU'
-      );
-
-    default:
-      return null;
-  }
 };

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
@@ -11,7 +11,9 @@ import { PlansAvailabilityNotice } from '../../Linodes/LinodesCreate/PlansAvaila
 import {
   DEDICATED_COMPUTE_INSTANCES_LINK,
   GPU_COMPUTE_INSTANCES_LINK,
+  HIGH_MEMORY_COMPUTE_INSTANCES_LINK,
   PREMIUM_COMPUTE_INSTANCES_LINK,
+  SHARED_COMPUTE_INSTANCES_LINK,
 } from './constants';
 import { MetalNotice } from './MetalNotice';
 import { planTabInfoContent } from './utils';
@@ -86,12 +88,11 @@ export const PlanInformation = (props: PlanInformationProps) => {
   );
 };
 
-export const limitedAvailabilityBannerTestId =
-  'limited-availability-dismissible-banner';
+export const limitedAvailabilityBannerTestId = 'limited-availability-banner';
 
 interface LimitedAvailabilityNoticeProps {
   hasDisabledPlans: boolean;
-  planType: LinodeTypeClass;
+  planType: 'shared' | LinodeTypeClass;
 }
 
 export const LimitedAvailabilityNotice = (
@@ -109,6 +110,24 @@ export const LimitedAvailabilityNotice = (
         />
       );
 
+    case 'shared':
+      return (
+        <LimitedAvailabilityNoticeCopy
+          docsLink={SHARED_COMPUTE_INSTANCES_LINK}
+          hasDisabledPlans={hasDisabledPlans}
+          planTypeLabel="Shared CPU"
+        />
+      );
+
+    case 'highmem':
+      return (
+        <LimitedAvailabilityNoticeCopy
+          docsLink={HIGH_MEMORY_COMPUTE_INSTANCES_LINK}
+          hasDisabledPlans={hasDisabledPlans}
+          planTypeLabel="High Memory"
+        />
+      );
+
     case 'premium':
       return (
         <LimitedAvailabilityNoticeCopy
@@ -117,6 +136,7 @@ export const LimitedAvailabilityNotice = (
           planTypeLabel="Premium CPU"
         />
       );
+
     case 'gpu':
       return (
         <LimitedAvailabilityNoticeCopy
@@ -141,7 +161,8 @@ export const LimitedAvailabilityNoticeCopy = (
   props: LimitedAvailabilityNoticeCopyProps
 ) => {
   const { docsLink, hasDisabledPlans, planTypeLabel } = props;
-  return (
+
+  return hasDisabledPlans ? (
     <Notice
       sx={(theme: Theme) => ({
         marginBottom: theme.spacing(3),
@@ -152,16 +173,10 @@ export const LimitedAvailabilityNoticeCopy = (
       dataTestId={limitedAvailabilityBannerTestId}
       variant="warning"
     >
-      {hasDisabledPlans ? (
-        <StyledNoticeTypography>
-          These plans have limited deployment availability.{' '}
-          <Link to={docsLink}>Learn more</Link> about our {planTypeLabel} plans.
-        </StyledNoticeTypography>
-      ) : (
-        <StyledNoticeTypography>
-          <Link to={docsLink}>Learn more</Link> about plans and availability.
-        </StyledNoticeTypography>
-      )}
+      <StyledNoticeTypography>
+        These plans have limited deployment availability.{' '}
+        <Link to={docsLink}>Learn more</Link> about our {planTypeLabel} plans.
+      </StyledNoticeTypography>
     </Notice>
-  );
+  ) : null;
 };

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
@@ -28,7 +28,6 @@ const mockPlan: PlanSelectionType = planSelectionTypeFactory.build({
 
 const defaultProps: PlanSelectionProps = {
   idx: 0,
-  isLimitedAvailabilityPlan: false,
   onSelect: () => vi.fn(),
   type: mockPlan,
 };
@@ -173,11 +172,7 @@ describe('PlanSelection (table, desktop)', () => {
 
     const { getByRole, getByTestId, getByText } = renderWithTheme(
       wrapWithTableBody(
-        <PlanSelection
-          {...defaultProps}
-          isLimitedAvailabilityPlan={true}
-          type={bigPlanType}
-        />,
+        <PlanSelection {...defaultProps} type={bigPlanType} />,
         { flags: { disableLargestGbPlans: true } }
       )
     );
@@ -276,11 +271,7 @@ describe('PlanSelection (card, mobile)', () => {
 
   it('verifies the presence of a help icon button accompanied by descriptive text for plans marked as "Limited Availability".', async () => {
     const { getByRole, getByTestId, getByText } = renderWithTheme(
-      <PlanSelection
-        {...defaultProps}
-        isLimitedAvailabilityPlan={true}
-        selectedRegionId={'us-east'}
-      />
+      <PlanSelection {...defaultProps} selectedRegionId={'us-east'} />
     );
 
     const selectionCard = getByTestId('selection-card');
@@ -300,11 +291,7 @@ describe('PlanSelection (card, mobile)', () => {
     });
 
     const { getByTestId } = renderWithTheme(
-      <PlanSelection
-        {...defaultProps}
-        isLimitedAvailabilityPlan={false}
-        type={bigPlanType}
-      />,
+      <PlanSelection {...defaultProps} type={bigPlanType} />,
       { flags: { disableLargestGbPlans: true } }
     );
 

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
@@ -174,7 +174,7 @@ describe('PlanSelection (table, desktop)', () => {
       wrapWithTableBody(
         <PlanSelection
           {...defaultProps}
-          isPlanDisabled={true}
+          planIsDisabled={true}
           type={bigPlanType}
         />
       )

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
@@ -172,8 +172,11 @@ describe('PlanSelection (table, desktop)', () => {
 
     const { getByRole, getByTestId, getByText } = renderWithTheme(
       wrapWithTableBody(
-        <PlanSelection {...defaultProps} type={bigPlanType} />,
-        { flags: { disableLargestGbPlans: true } }
+        <PlanSelection
+          {...defaultProps}
+          isPlanDisabled={true}
+          type={bigPlanType}
+        />
       )
     );
 
@@ -267,35 +270,5 @@ describe('PlanSelection (card, mobile)', () => {
     expect(
       container.querySelector('[data-qa-select-card-subheading="subheading-4"]')
     ).toHaveTextContent('40 Gbps In / 2 Gbps Out');
-  });
-
-  it('verifies the presence of a help icon button accompanied by descriptive text for plans marked as "Limited Availability".', async () => {
-    const { getByRole, getByTestId, getByText } = renderWithTheme(
-      <PlanSelection {...defaultProps} selectedRegionId={'us-east'} />
-    );
-
-    const selectionCard = getByTestId('selection-card');
-    fireEvent.mouseOver(selectionCard);
-
-    await waitFor(() => {
-      expect(getByRole('tooltip')).toBeInTheDocument();
-    });
-
-    expect(getByText(LIMITED_AVAILABILITY_TEXT)).toBeVisible();
-  });
-
-  it('is disabled for 512 GB plans', () => {
-    const bigPlanType = extendedTypeFactory.build({
-      heading: 'Dedicated 512 GB',
-      label: 'Dedicated 512GB',
-    });
-
-    const { getByTestId } = renderWithTheme(
-      <PlanSelection {...defaultProps} type={bigPlanType} />,
-      { flags: { disableLargestGbPlans: true } }
-    );
-
-    const selectionCard = getByTestId('selection-card');
-    expect(selectionCard).toBeDisabled();
   });
 });

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
@@ -27,6 +27,10 @@ const mockPlan: PlanSelectionType = planSelectionTypeFactory.build({
 });
 
 const defaultProps: PlanSelectionProps = {
+  disabledStatus: {
+    isDisabled512GbPlan: false,
+    isLimitedAvailabilityPlan: false,
+  },
   idx: 0,
   onSelect: () => vi.fn(),
   type: mockPlan,
@@ -174,6 +178,10 @@ describe('PlanSelection (table, desktop)', () => {
       wrapWithTableBody(
         <PlanSelection
           {...defaultProps}
+          disabledStatus={{
+            isDisabled512GbPlan: true,
+            isLimitedAvailabilityPlan: false,
+          }}
           planIsDisabled={true}
           type={bigPlanType}
         />

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -31,6 +31,12 @@ import type { LinodeTypeClass, PriceObject, Region } from '@linode/api-v4';
 export interface PlanSelectionProps {
   currentPlanHeading?: string;
   disabledClasses?: LinodeTypeClass[];
+  disabledStatus:
+    | {
+        isDisabled512GbPlan: boolean;
+        isLimitedAvailabilityPlan: boolean;
+      }
+    | undefined;
   disabledToolTip?: string;
   header?: string;
   hideDisabledHelpIcons?: boolean;
@@ -78,6 +84,7 @@ export const PlanSelection = (props: PlanSelectionProps) => {
   const {
     currentPlanHeading,
     disabledClasses,
+    disabledStatus,
     disabledToolTip,
     hideDisabledHelpIcons,
     idx,
@@ -182,33 +189,36 @@ export const PlanSelection = (props: PlanSelectionProps) => {
             data-qa-plan-name
           >
             {type.heading} &nbsp;
-            {rowIsDisabled && !hideDisabledHelpIcons && (
-              <Tooltip
-                PopperProps={{
-                  sx: {
-                    '& .MuiTooltip-tooltip': {
-                      width: 175,
+            {rowIsDisabled &&
+              !hideDisabledHelpIcons &&
+              (Boolean(disabledStatus?.isDisabled512GbPlan) ||
+                Boolean(disabledStatus?.isLimitedAvailabilityPlan)) && (
+                <Tooltip
+                  PopperProps={{
+                    sx: {
+                      '& .MuiTooltip-tooltip': {
+                        width: 175,
+                      },
                     },
-                  },
-                }}
-                sx={{
-                  top: -2,
-                }}
-                data-qa-tooltip={LIMITED_AVAILABILITY_TEXT}
-                data-testid="limited-availability"
-                placement="right-start"
-                title={LIMITED_AVAILABILITY_TEXT}
-              >
-                <IconButton disableRipple size="small">
-                  <HelpOutline
-                    sx={{
-                      height: 16,
-                      width: 16,
-                    }}
-                  />
-                </IconButton>
-              </Tooltip>
-            )}
+                  }}
+                  sx={{
+                    top: -2,
+                  }}
+                  data-qa-tooltip={LIMITED_AVAILABILITY_TEXT}
+                  data-testid="limited-availability"
+                  placement="right"
+                  title={LIMITED_AVAILABILITY_TEXT}
+                >
+                  <IconButton disableRipple size="small">
+                    <HelpOutline
+                      sx={{
+                        height: 18,
+                        width: 18,
+                      }}
+                    />
+                  </IconButton>
+                </Tooltip>
+              )}
             {(isSamePlan || type.id === selectedLinodePlanType) && (
               <StyledChip
                 aria-label="This is your current plan"
@@ -216,17 +226,26 @@ export const PlanSelection = (props: PlanSelectionProps) => {
                 label="Current Plan"
               />
             )}
-            {tooltip && (
-              <TooltipIcon
-                sxTooltipIcon={{
-                  paddingBottom: '0px !important',
-                  paddingTop: '0px !important',
-                }}
-                status="help"
-                text={tooltip}
-                tooltipPosition="right-end"
-              />
-            )}
+            {tooltip &&
+              !(
+                Boolean(disabledStatus?.isDisabled512GbPlan) ||
+                Boolean(disabledStatus?.isLimitedAvailabilityPlan)
+              ) && (
+                <TooltipIcon
+                  sxTooltipIcon={{
+                    paddingBottom: '0px !important',
+                    paddingTop: '0px !important',
+                    svg: {
+                      height: 18,
+                      width: 18,
+                    },
+                    top: -2,
+                  }}
+                  status="help"
+                  text={tooltip}
+                  tooltipPosition="right"
+                />
+              )}
           </TableCell>
           <TableCell
             data-qa-monthly

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -187,7 +187,7 @@ export const PlanSelection = (props: PlanSelectionProps) => {
                 PopperProps={{
                   sx: {
                     '& .MuiTooltip-tooltip': {
-                      minWidth: 225,
+                      width: 175,
                     },
                   },
                 }}

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -13,7 +13,6 @@ import { TableRow } from 'src/components/TableRow';
 import { Tooltip } from 'src/components/Tooltip';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { LINODE_NETWORK_IN } from 'src/constants';
-import { useFlags } from 'src/hooks/useFlags';
 import { useLinodeQuery } from 'src/queries/linodes/linodes';
 import {
   PRICE_ERROR_TOOLTIP_TEXT,
@@ -38,7 +37,6 @@ export interface PlanSelectionProps {
   hideDisabledHelpIcons?: boolean;
   idx: number;
   isCreate?: boolean;
-  isLimitedAvailabilityPlan: boolean;
   linodeID?: number | undefined;
   onSelect: (key: string) => void;
   planIsDisabled?: boolean;
@@ -85,7 +83,6 @@ export const PlanSelection = (props: PlanSelectionProps) => {
     hideDisabledHelpIcons,
     idx,
     isCreate,
-    isLimitedAvailabilityPlan,
     linodeID,
     onSelect,
     planIsDisabled,
@@ -95,14 +92,6 @@ export const PlanSelection = (props: PlanSelectionProps) => {
     showTransfer,
     type,
   } = props;
-
-  const flags = useFlags();
-
-  // Determine if the plan should be disabled solely due to being a 512GB plan
-  const disabled512GbPlan =
-    type.label.includes('512GB') &&
-    Boolean(flags.disableLargestGbPlans) &&
-    !disabled;
 
   const diskSize = selectedDiskSize ? selectedDiskSize : 0;
   const planTooSmall = diskSize > type.disk;
@@ -128,8 +117,8 @@ export const PlanSelection = (props: PlanSelectionProps) => {
     type && type.formattedLabel && isSamePlan
       ? `${type.formattedLabel} this is your current plan`
       : planTooSmall
-      ? `${type.formattedLabel} this plan is too small for resize`
-      : type.formattedLabel;
+        ? `${type.formattedLabel} this plan is too small for resize`
+        : type.formattedLabel;
 
   // DC Dynamic price logic - DB creation and DB resize flows are currently out of scope
   const isDatabaseFlow = location.pathname.includes('/databases');
@@ -141,13 +130,7 @@ export const PlanSelection = (props: PlanSelectionProps) => {
   )}/mo ($${price?.hourly ?? UNKNOWN_PRICE}/hr)`;
 
   const rowIsDisabled =
-    isSamePlan ||
-    planTooSmall ||
-    isDisabledClass ||
-    planIsDisabled ||
-    disabled ||
-    isLimitedAvailabilityPlan ||
-    disabled512GbPlan;
+    isSamePlan || planTooSmall || isDisabledClass || planIsDisabled || disabled;
 
   return (
     <React.Fragment key={`tabbed-panel-${idx}`}>

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -30,16 +30,16 @@ import type { LinodeTypeClass, PriceObject, Region } from '@linode/api-v4';
 
 export interface PlanSelectionProps {
   currentPlanHeading?: string;
-  disabled?: boolean;
   disabledClasses?: LinodeTypeClass[];
   disabledToolTip?: string;
   header?: string;
   hideDisabledHelpIcons?: boolean;
   idx: number;
   isCreate?: boolean;
+  isPlanDisabled?: boolean;
+  isWholePanelDisabled?: boolean;
   linodeID?: number | undefined;
   onSelect: (key: string) => void;
-  planIsDisabled?: boolean;
   selectedDiskSize?: number;
   selectedId?: string;
   selectedRegionId?: Region['id'];
@@ -77,15 +77,15 @@ const getToolTip = ({
 export const PlanSelection = (props: PlanSelectionProps) => {
   const {
     currentPlanHeading,
-    disabled,
     disabledClasses,
     disabledToolTip,
     hideDisabledHelpIcons,
     idx,
     isCreate,
+    isPlanDisabled,
+    isWholePanelDisabled,
     linodeID,
     onSelect,
-    planIsDisabled,
     selectedDiskSize,
     selectedId,
     selectedRegionId,
@@ -117,8 +117,8 @@ export const PlanSelection = (props: PlanSelectionProps) => {
     type && type.formattedLabel && isSamePlan
       ? `${type.formattedLabel} this is your current plan`
       : planTooSmall
-        ? `${type.formattedLabel} this plan is too small for resize`
-        : type.formattedLabel;
+      ? `${type.formattedLabel} this plan is too small for resize`
+      : type.formattedLabel;
 
   // DC Dynamic price logic - DB creation and DB resize flows are currently out of scope
   const isDatabaseFlow = location.pathname.includes('/databases');
@@ -130,7 +130,11 @@ export const PlanSelection = (props: PlanSelectionProps) => {
   )}/mo ($${price?.hourly ?? UNKNOWN_PRICE}/hr)`;
 
   const rowIsDisabled =
-    isSamePlan || planTooSmall || isDisabledClass || planIsDisabled || disabled;
+    isSamePlan ||
+    planTooSmall ||
+    isDisabledClass ||
+    isPlanDisabled ||
+    isWholePanelDisabled;
 
   return (
     <React.Fragment key={`tabbed-panel-${idx}`}>
@@ -150,14 +154,14 @@ export const PlanSelection = (props: PlanSelectionProps) => {
                 control={
                   <Radio
                     checked={
-                      !disabled &&
+                      !isWholePanelDisabled &&
                       !rowIsDisabled &&
                       !planTooSmall &&
                       type.id === String(selectedId)
                     }
                     disabled={
                       planTooSmall ||
-                      disabled ||
+                      isWholePanelDisabled ||
                       rowIsDisabled ||
                       isDisabledClass
                     }
@@ -273,7 +277,7 @@ export const PlanSelection = (props: PlanSelectionProps) => {
           disabled={
             planTooSmall ||
             isSamePlan ||
-            disabled ||
+            isWholePanelDisabled ||
             rowIsDisabled ||
             isDisabledClass
           }

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -36,15 +36,15 @@ export interface PlanSelectionProps {
   hideDisabledHelpIcons?: boolean;
   idx: number;
   isCreate?: boolean;
-  isPlanDisabled?: boolean;
-  isWholePanelDisabled?: boolean;
   linodeID?: number | undefined;
   onSelect: (key: string) => void;
+  planIsDisabled?: boolean;
   selectedDiskSize?: number;
   selectedId?: string;
   selectedRegionId?: Region['id'];
   showTransfer?: boolean;
   type: PlanSelectionType;
+  wholePanelIsDisabled?: boolean;
 }
 
 const getDisabledClass = (
@@ -82,15 +82,15 @@ export const PlanSelection = (props: PlanSelectionProps) => {
     hideDisabledHelpIcons,
     idx,
     isCreate,
-    isPlanDisabled,
-    isWholePanelDisabled,
     linodeID,
     onSelect,
+    planIsDisabled,
     selectedDiskSize,
     selectedId,
     selectedRegionId,
     showTransfer,
     type,
+    wholePanelIsDisabled,
   } = props;
 
   const diskSize = selectedDiskSize ? selectedDiskSize : 0;
@@ -133,8 +133,8 @@ export const PlanSelection = (props: PlanSelectionProps) => {
     isSamePlan ||
     planTooSmall ||
     isDisabledClass ||
-    isPlanDisabled ||
-    isWholePanelDisabled;
+    planIsDisabled ||
+    wholePanelIsDisabled;
 
   return (
     <React.Fragment key={`tabbed-panel-${idx}`}>
@@ -154,14 +154,14 @@ export const PlanSelection = (props: PlanSelectionProps) => {
                 control={
                   <Radio
                     checked={
-                      !isWholePanelDisabled &&
+                      !wholePanelIsDisabled &&
                       !rowIsDisabled &&
                       !planTooSmall &&
                       type.id === String(selectedId)
                     }
                     disabled={
                       planTooSmall ||
-                      isWholePanelDisabled ||
+                      wholePanelIsDisabled ||
                       rowIsDisabled ||
                       isDisabledClass
                     }
@@ -277,7 +277,7 @@ export const PlanSelection = (props: PlanSelectionProps) => {
           disabled={
             planTooSmall ||
             isSamePlan ||
-            isWholePanelDisabled ||
+            wholePanelIsDisabled ||
             rowIsDisabled ||
             isDisabledClass
           }

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.styles.ts
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.styles.ts
@@ -1,10 +1,6 @@
 import { styled } from '@mui/material/styles';
 
-import { TableRow, TableRowProps } from 'src/components/TableRow';
 import { Typography } from 'src/components/Typography';
-import { omittedProps } from 'src/utilities/omittedProps';
-
-type StyledDisabledTableRowProps = Pick<TableRowProps, 'disabled'>;
 
 export const StyledTypography = styled(Typography, {
   label: 'StyledTypography',
@@ -19,18 +15,4 @@ export const StyledTypography = styled(Typography, {
     fontFamily: '"LatoWebBold", sans-serif',
   },
   fontSize: '0.9em',
-}));
-
-export const StyledDisabledTableRow = styled(TableRow, {
-  label: 'StyledDisabledTableRow',
-  shouldForwardProp: omittedProps(['disabled']),
-})<StyledDisabledTableRowProps>(({ theme, ...props }) => ({
-  ...(props.disabled && {
-    backgroundColor: theme.bg.tableHeader,
-    cursor: 'not-allowed',
-    opacity: 0.5,
-  }),
-  '&:focus-within': {
-    backgroundColor: theme.bg.lightBlue1,
-  },
 }));

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.test.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+
+import { planSelectionTypeFactory } from 'src/factories';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { PlansPanel } from './PlansPanel';
+
+import type { PlansPanelProps } from './PlansPanel';
+
+const defaultProps: PlansPanelProps = {
+  onSelect: vi.fn(),
+  selectedRegionID: 'us-east',
+  types: [
+    {
+      ...planSelectionTypeFactory.build({
+        class: 'standard',
+      }),
+    },
+    {
+      ...planSelectionTypeFactory.build(),
+      class: 'nanode',
+    },
+    {
+      ...planSelectionTypeFactory.build(),
+      class: 'dedicated',
+    },
+    {
+      ...planSelectionTypeFactory.build(),
+      class: 'gpu',
+    },
+  ],
+};
+
+describe('plans panel', () => {
+  it('should render a tabbed panel based on plan selection types types', () => {
+    const { getByRole, getByText } = renderWithTheme(
+      <PlansPanel {...defaultProps} />
+    );
+
+    expect(getByText('Linode Plan')).toBeInTheDocument();
+    expect(getByRole('tab', { name: /dedicated cpu/i })).toBeInTheDocument();
+    expect(getByRole('tab', { name: /shared cpu/i })).toBeInTheDocument();
+    expect(getByRole('tab', { name: /gpu/i })).toBeInTheDocument();
+    expect(getByRole('tab', { name: /premium cpu/i })).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -56,6 +56,7 @@ export const PlansPanel = (props: Props) => {
     copy,
     currentPlanHeading,
     disabled,
+    disabledClasses,
     disabledPlanTypes,
     disabledPlanTypesToolTipText,
     docsLink,
@@ -65,6 +66,7 @@ export const PlansPanel = (props: Props) => {
     linodeID,
     onSelect,
     regionsData,
+    selectedDiskSize,
     selectedId,
     selectedRegionID,
     showTransfer,
@@ -117,8 +119,8 @@ export const PlansPanel = (props: Props) => {
   // @TODO Gecko: Get plan data from API when it's available instead of hardcoding
   const plans = showEdgePlanTable
     ? {
-      dedicated: getDedicatedEdgePlanType(),
-    }
+        dedicated: getDedicatedEdgePlanType(),
+      }
     : _plans;
 
   const {
@@ -145,6 +147,26 @@ export const PlansPanel = (props: Props) => {
       }
     );
 
+    const allDisabledPlans = plansForThisLinodeTypeClass.reduce((acc, plan) => {
+      // Determine if the plan should be disabled solely due to being a 512GB plan
+      const isDisabled512GbPlan =
+        plan.label.includes('512GB') && Boolean(flags.disableLargestGbPlans);
+      // && !isWholePanelDisabled;
+
+      if (
+        plan.isLimitedAvailabilityPlan ||
+        isDisabled512GbPlan ||
+        disabledPlanTypes?.some((disabledPlan) => disabledPlan.id === plan.id)
+      ) {
+        return [...acc, plan.id];
+      }
+
+      return acc;
+    }, []);
+    const hasDisabledPlans = allDisabledPlans.length > 0;
+    const hasMajorityOfPlansDisabled =
+      allDisabledPlans.length >= plansForThisLinodeTypeClass.length / 2;
+
     return {
       disabled: props.disabledTabs ? props.disabledTabs?.includes(plan) : false,
       render: () => {
@@ -157,8 +179,8 @@ export const PlansPanel = (props: Props) => {
               isSelectedRegionEligibleForPlan={isSelectedRegionEligibleForPlan(
                 plan
               )}
-              disabledClasses={props.disabledClasses}
-              hasDisabledPlans={false} // TODO GETWELL based on other TODO
+              disabledClasses={disabledClasses}
+              hasDisabledPlans={hasDisabledPlans}
               hasSelectedRegion={hasSelectedRegion}
               planType={plan}
               regionsData={regionsData || []}
@@ -170,17 +192,17 @@ export const PlansPanel = (props: Props) => {
               />
             )}
             <PlanContainer
+              allDisabledPlans={allDisabledPlans}
               currentPlanHeading={currentPlanHeading}
               disabled={disabled || isPlanPanelDisabled(plan)}
-              disabledClasses={props.disabledClasses}
-              disabledPlanTypes={disabledPlanTypes}
+              disabledClasses={disabledClasses}
               disabledPlanTypesToolTipText={disabledPlanTypesToolTipText}
-              hideDisabledHelpIcons={false} // TODO GETWELL: determined by callback from plan container if we have more than half of the plans disabledd
+              hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
               isCreate={isCreate}
               linodeID={linodeID}
               onSelect={onSelect}
               plans={plansForThisLinodeTypeClass}
-              selectedDiskSize={props.selectedDiskSize}
+              selectedDiskSize={selectedDiskSize}
               selectedId={selectedId}
               selectedRegionId={selectedRegionID}
               showTransfer={showTransfer}

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -25,7 +25,7 @@ import type { PlanSelectionType } from './types';
 import type { LinodeTypeClass, Region } from '@linode/api-v4';
 import type { LinodeCreateType } from 'src/features/Linodes/LinodesCreate/types';
 
-interface Props {
+export interface PlansPanelProps {
   className?: string;
   copy?: string;
   currentPlanHeading?: string;
@@ -50,7 +50,7 @@ interface Props {
   types: PlanSelectionType[];
 }
 
-export const PlansPanel = (props: Props) => {
+export const PlansPanel = (props: PlansPanelProps) => {
   const {
     className,
     copy,

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -17,7 +17,6 @@ import {
   determineInitialPlanCategoryTab,
   getIsLimitedAvailability,
   getPlanSelectionsByPlanType,
-  isMajorityLimitedAvailabilityPlans,
   planTabInfoContent,
   replaceOrAppendPlaceholder512GbPlans,
 } from './utils';
@@ -32,6 +31,8 @@ interface Props {
   currentPlanHeading?: string;
   disabled?: boolean;
   disabledClasses?: LinodeTypeClass[];
+  disabledPlanTypes?: PlanSelectionType[];
+  disabledPlanTypesToolTipText?: string;
   disabledTabs?: string[];
   docsLink?: JSX.Element;
   error?: string;
@@ -47,8 +48,6 @@ interface Props {
   tabDisabledMessage?: string;
   tabbedPanelInnerClass?: string;
   types: PlanSelectionType[];
-  disabledPlanTypes?: PlanSelectionType[];
-  disabledPlanTypesToolTipText?: string;
 }
 
 export const PlansPanel = (props: Props) => {
@@ -57,6 +56,8 @@ export const PlansPanel = (props: Props) => {
     copy,
     currentPlanHeading,
     disabled,
+    disabledPlanTypes,
+    disabledPlanTypesToolTipText,
     docsLink,
     error,
     header,
@@ -68,8 +69,6 @@ export const PlansPanel = (props: Props) => {
     selectedRegionID,
     showTransfer,
     types,
-    disabledPlanTypes,
-    disabledPlanTypesToolTipText,
   } = props;
 
   const flags = useFlags();
@@ -118,8 +117,8 @@ export const PlansPanel = (props: Props) => {
   // @TODO Gecko: Get plan data from API when it's available instead of hardcoding
   const plans = showEdgePlanTable
     ? {
-        dedicated: getDedicatedEdgePlanType(),
-      }
+      dedicated: getDedicatedEdgePlanType(),
+    }
     : _plans;
 
   const {
@@ -146,10 +145,6 @@ export const PlansPanel = (props: Props) => {
       }
     );
 
-    const mostClassPlansAreLimitedAvailability = isMajorityLimitedAvailabilityPlans(
-      plansForThisLinodeTypeClass
-    );
-
     return {
       disabled: props.disabledTabs ? props.disabledTabs?.includes(plan) : false,
       render: () => {
@@ -162,10 +157,8 @@ export const PlansPanel = (props: Props) => {
               isSelectedRegionEligibleForPlan={isSelectedRegionEligibleForPlan(
                 plan
               )}
-              mostClassPlansAreLimitedAvailability={
-                mostClassPlansAreLimitedAvailability
-              }
               disabledClasses={props.disabledClasses}
+              hasDisabledPlans={false} // TODO GETWELL based on other TODO
               hasSelectedRegion={hasSelectedRegion}
               planType={plan}
               regionsData={regionsData || []}
@@ -177,13 +170,12 @@ export const PlansPanel = (props: Props) => {
               />
             )}
             <PlanContainer
-              hideDisabledHelpIcons={
-                mostClassPlansAreLimitedAvailability &&
-                flags.disableLargestGbPlans
-              } // Making it conditional on the flag avoids scenario w/ flag off where all plans on a tab could be disabled with no explanation
               currentPlanHeading={currentPlanHeading}
               disabled={disabled || isPlanPanelDisabled(plan)}
               disabledClasses={props.disabledClasses}
+              disabledPlanTypes={disabledPlanTypes}
+              disabledPlanTypesToolTipText={disabledPlanTypesToolTipText}
+              hideDisabledHelpIcons={false} // TODO GETWELL: determined by callback from plan container if we have more than half of the plans disabledd
               isCreate={isCreate}
               linodeID={linodeID}
               onSelect={onSelect}
@@ -192,8 +184,6 @@ export const PlansPanel = (props: Props) => {
               selectedId={selectedId}
               selectedRegionId={selectedRegionID}
               showTransfer={showTransfer}
-              disabledPlanTypes={disabledPlanTypes}
-              disabledPlanTypesToolTipText={disabledPlanTypesToolTipText}
             />
           </>
         );

--- a/packages/manager/src/features/components/PlansPanel/constants.ts
+++ b/packages/manager/src/features/components/PlansPanel/constants.ts
@@ -5,8 +5,6 @@ export const LIMITED_AVAILABILITY_TEXT =
   'This plan has limited deployment availability.';
 export const LIMITED_AVAILABILITY_LINK =
   'https://www.linode.com/global-infrastructure/availability/';
-export const LIMITED_AVAILABILITY_DISMISSIBLEBANNER_KEY =
-  'plan-limited-availability-notice';
 
 export const DEDICATED_COMPUTE_INSTANCES_LINK =
   'https://www.linode.com/docs/products/compute/compute-instances/plans/dedicated-cpu/';

--- a/packages/manager/src/features/components/PlansPanel/constants.ts
+++ b/packages/manager/src/features/components/PlansPanel/constants.ts
@@ -8,6 +8,10 @@ export const LIMITED_AVAILABILITY_LINK =
 
 export const DEDICATED_COMPUTE_INSTANCES_LINK =
   'https://www.linode.com/docs/products/compute/compute-instances/plans/dedicated-cpu/';
+export const SHARED_COMPUTE_INSTANCES_LINK =
+  'https://www.linode.com/docs/products/compute/compute-instances/plans/shared-cpu/';
+export const HIGH_MEMORY_COMPUTE_INSTANCES_LINK =
+  'https://www.linode.com/docs/products/compute/compute-instances/plans/high-memory/';
 export const PREMIUM_COMPUTE_INSTANCES_LINK =
   'https://www.linode.com/docs/products/compute/compute-instances/plans/premium/';
 export const GPU_COMPUTE_INSTANCES_LINK =

--- a/packages/manager/src/features/components/PlansPanel/utils.test.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.test.ts
@@ -240,7 +240,15 @@ describe('extractPlansInformation', () => {
       selectedRegionId: 'us-east-1',
     });
 
-    expect(result).toHaveProperty('allDisabledPlans', ['g6-standard-1']);
+    expect(result).toHaveProperty('allDisabledPlans', [
+      {
+        ...g6Standard1,
+        ...{
+          isDisabled512GbPlan: false,
+          isLimitedAvailabilityPlan: false,
+        },
+      },
+    ]);
     expect(result).toHaveProperty('hasDisabledPlans', true);
     expect(result).toHaveProperty('hasMajorityOfPlansDisabled', false);
     expect(result).toHaveProperty('plansForThisLinodeTypeClass', [
@@ -269,8 +277,20 @@ describe('extractPlansInformation', () => {
     });
 
     expect(result).toHaveProperty('allDisabledPlans', [
-      'g6-standard-1',
-      'g6-nanode-1',
+      {
+        ...g6Standard1,
+        ...{
+          isDisabled512GbPlan: false,
+          isLimitedAvailabilityPlan: false,
+        },
+      },
+      {
+        ...g6Nanode1,
+        ...{
+          isDisabled512GbPlan: false,
+          isLimitedAvailabilityPlan: false,
+        },
+      },
     ]);
     expect(result).toHaveProperty('hasDisabledPlans', true);
     expect(result).toHaveProperty('hasMajorityOfPlansDisabled', true);

--- a/packages/manager/src/features/components/PlansPanel/utils.test.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.test.ts
@@ -3,6 +3,7 @@ import { planSelectionTypeFactory, typeFactory } from 'src/factories/types';
 
 import {
   determineInitialPlanCategoryTab,
+  extractPlansInformation,
   getIsLimitedAvailability,
   getPlanSelectionsByPlanType,
   planTypeOrder,
@@ -217,5 +218,95 @@ describe('getIsLimitedAvailability', () => {
     });
 
     expect(result).toBe(false);
+  });
+});
+
+describe('extractPlansInformation', () => {
+  const g6Standard1 = planSelectionTypeFactory.build({
+    id: 'g6-standard-1',
+  });
+  const g7Standard1 = planSelectionTypeFactory.build({
+    id: 'g7-standard-1',
+  });
+  const g6Nanode1 = planSelectionTypeFactory.build({
+    id: 'g6-nanode-1',
+  });
+  it('should return correct information when less than half of plans are disabled', () => {
+    const result = extractPlansInformation({
+      disableLargestGbPlans: false,
+      disabledPlanTypes: [g6Standard1],
+      plans: [g6Standard1, g7Standard1, g6Nanode1],
+      regionAvailabilities: [],
+      selectedRegionId: 'us-east-1',
+    });
+
+    expect(result).toHaveProperty('allDisabledPlans', ['g6-standard-1']);
+    expect(result).toHaveProperty('hasDisabledPlans', true);
+    expect(result).toHaveProperty('hasMajorityOfPlansDisabled', false);
+    expect(result).toHaveProperty('plansForThisLinodeTypeClass', [
+      {
+        ...g6Standard1,
+        isLimitedAvailabilityPlan: false,
+      },
+      {
+        ...g7Standard1,
+        isLimitedAvailabilityPlan: false,
+      },
+      {
+        ...g6Nanode1,
+        isLimitedAvailabilityPlan: false,
+      },
+    ]);
+  });
+
+  it('should return correct information when all plans are disabled', () => {
+    const result = extractPlansInformation({
+      disableLargestGbPlans: false,
+      disabledPlanTypes: [g6Standard1, g6Nanode1],
+      plans: [g6Standard1, g6Nanode1],
+      regionAvailabilities: [],
+      selectedRegionId: 'us-east-1',
+    });
+
+    expect(result).toHaveProperty('allDisabledPlans', [
+      'g6-standard-1',
+      'g6-nanode-1',
+    ]);
+    expect(result).toHaveProperty('hasDisabledPlans', true);
+    expect(result).toHaveProperty('hasMajorityOfPlansDisabled', true);
+    expect(result).toHaveProperty('plansForThisLinodeTypeClass', [
+      {
+        ...g6Standard1,
+        isLimitedAvailabilityPlan: false,
+      },
+      {
+        ...g6Nanode1,
+        isLimitedAvailabilityPlan: false,
+      },
+    ]);
+  });
+
+  it('should return correct information when no plans are disabled', () => {
+    const result = extractPlansInformation({
+      disableLargestGbPlans: false,
+      disabledPlanTypes: [],
+      plans: [g6Standard1, g6Nanode1],
+      regionAvailabilities: [],
+      selectedRegionId: 'us-east-1',
+    });
+
+    expect(result).toHaveProperty('allDisabledPlans', []);
+    expect(result).toHaveProperty('hasDisabledPlans', false);
+    expect(result).toHaveProperty('hasMajorityOfPlansDisabled', false);
+    expect(result).toHaveProperty('plansForThisLinodeTypeClass', [
+      {
+        ...g6Standard1,
+        isLimitedAvailabilityPlan: false,
+      },
+      {
+        ...g6Nanode1,
+        isLimitedAvailabilityPlan: false,
+      },
+    ]);
   });
 });

--- a/packages/manager/src/features/components/PlansPanel/utils.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.ts
@@ -298,7 +298,8 @@ export const extractPlansInformation = ({
   }, []);
   const hasDisabledPlans = allDisabledPlans.length > 0;
   const hasMajorityOfPlansDisabled =
-    allDisabledPlans.length >= plansForThisLinodeTypeClass.length / 2;
+    plans.length !== 1 &&
+    allDisabledPlans.length > plansForThisLinodeTypeClass.length / 2;
 
   return {
     allDisabledPlans,

--- a/packages/manager/src/features/components/PlansPanel/utils.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.ts
@@ -281,6 +281,11 @@ export const extractPlansInformation = ({
     // Determine if the plan should be disabled solely due to being a 512GB plan
     const isDisabled512GbPlan =
       plan.label.includes('512GB') && Boolean(disableLargestGbPlans);
+    const _plan = {
+      ...plan,
+      isDisabled512GbPlan,
+      isLimitedAvailabilityPlan: plan.isLimitedAvailabilityPlan,
+    };
 
     // Determine if the plan should be disabled due to
     // - having limited availability (API based)
@@ -291,7 +296,7 @@ export const extractPlansInformation = ({
       isDisabled512GbPlan ||
       disabledPlanTypes?.some((disabledPlan) => disabledPlan.id === plan.id)
     ) {
-      return [...acc, plan.id];
+      return [...acc, _plan];
     }
 
     return acc;

--- a/packages/manager/src/features/components/PlansPanel/utils.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.ts
@@ -250,7 +250,7 @@ interface ExtractPlansInformationProps {
  * Extracts plan information and determines if any plans are disabled.
  * Used for Linode and Kubernetes selection Plan tables and notices.
  *
- * @param disabledPlanTypes A list of disabled plan types. Optional.
+ * @param disabledPlanTypes A curated list of disabled plan types. Optional.
  * @param plans The plans for the Linode type class.
  * @param regionAvailabilities The region availabilities.
  * @param selectedRegionId The selected region ID.
@@ -282,6 +282,10 @@ export const extractPlansInformation = ({
     const isDisabled512GbPlan =
       plan.label.includes('512GB') && Boolean(disableLargestGbPlans);
 
+    // Determine if the plan should be disabled due to
+    // - having limited availability (API based)
+    // - being a 512GB plan (hard coded)
+    // - being "manually" disabled by the parent component
     if (
       plan.isLimitedAvailabilityPlan ||
       isDisabled512GbPlan ||


### PR DESCRIPTION
## Description 📝
This PR brings the latest changes to the PlanSelection panels on both the Linode and Kubernetes creation flows.
The diff is a bit larger than expected considering the need to refactor this portion of the code to allow for easier customization in the future. Both flows share very similar logic for rendering plan selection data, and identical logic for filtering unavailable and limited availability plans.

The logic implemented in this PR for the displaying of notices, disabled status and related tooltips is derived from the new requirements shown in the screenshots below:

| 1 | 2 | 3 | 4 | 5 |
| ------- | ------- | ------- | ------- | ------- |
| <img width="1440" alt="DC Get Well User Story #5_2@2x" src="https://github.com/linode/manager/assets/130582365/c499becc-3915-4258-8d56-e9b2bef3beb2"> | <img width="1440" alt="DC Get Well User Story #5_3_Premium@2x" src="https://github.com/linode/manager/assets/130582365/efff18d9-55e2-4ce0-b85e-82f6f38ed8a2"> | <img width="1440" alt="DC_Get_well_User_Story5 _lessthanhalf@2x" src="https://github.com/linode/manager/assets/130582365/99f78869-7940-44c7-8b59-41d5a5e0617b"> | <img width="1440" alt="DC_Get_well_User_Story5 G_morethanhalf@2x" src="https://github.com/linode/manager/assets/130582365/9d6d113a-e51f-4515-a429-9e6ea2223927"> | <img width="1440" alt="DC_Get_well_User_Story5 G_morethanhalf@2x" src="https://github.com/linode/manager/assets/130582365/7fddfdb6-7bb7-4a54-9baf-4d6bfce0b537"> |

## Changes  🔄
List any change relevant to the reviewer.
- Adjust RegionSelect tooltip copy
- Limited Availability banners are now non-dismissible
- Adjust table row disabled styles
  - make sure tooltip itself does not appear as disabled (lower opacity)
  - makes sure "greyed out" row treatment matches our disabled styles
- Update & Consolidate limited availability/unavailable logic for all plans panels (see the "How to test" section for breakdown) 
- Add new e2e for PlanSelection covering both the Linode and Kubernetes creation flows

## Target release date 🗓️
**04/29/2024**

## Preview 📷
![Screenshot 2024-04-23 at 10 53 20](https://github.com/linode/manager/assets/130582365/cf60a3f6-2f98-4c3e-a136-585ff83cdf91)

## How to test 🧪

### Prerequisites

### Verification steps
**RegionSelect tooltip update**
Best way i found to get a disabled RegionSelect item is on a newly created account (PROD)
- Verify tooltip copy
- Verify tooltip behavior

**Plan Selection** (both for Linode and Kubernetes flows)
rules:
- always show an "unavailable" banner (red) if the whole plan panel is disabled. ex:
  - Newark, NJ => Premium CPU
  - Dallas, TX => GPU
- always show a "limited availability" (yellow) notice if a plan panel has limited availability
  - Newark, NJ => Dedicated CPU (always have the 512Gb limited avail)
  - Newark, NJ => GPU
- always show a tooltip if <= half of plans have limited availability
  - Newark, NJ => Dedicated CPU
- never show a tooltip if more than half of plans have limited availability
  - Newark, NJ => GPU

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support


