### PR TITLE
fix: Update latest kernel version to fix `linode-config.spec.ts`

### DIFF
--- a/packages/manager/.changeset/pr-10391-tests-1713534776248.md
+++ b/packages/manager/.changeset/pr-10391-tests-1713534776248.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Update latest kernel version to fix `linode-config.spec.ts` ([#10391](https://github.com/linode/manager/pull/10391))

--- a/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
@@ -110,7 +110,7 @@ describe('Linode Config', () => {
       cy.findByLabelText('List of Configurations').within(() => {
         cy.get('tr').should('have.length', 2);
         containsVisible(
-          `${linode.id}-test-config – Latest 64 bit (6.2.9-x86_64-linode160)`
+          `${linode.id}-test-config – Latest 64 bit (6.7.9-x86_64-linode163)`
         );
         containsVisible('eth0 – Public Internet');
       });
@@ -467,7 +467,7 @@ describe('Linode Config', () => {
         cy.findByLabelText('List of Configurations').within(() => {
           cy.get('tr').should('have.length', 2);
           containsVisible(
-            `sharable-configuration – Latest 64 bit (6.2.9-x86_64-linode160)`
+            `sharable-configuration – Latest 64 bit (6.7.9-x86_64-linode163)`
           );
           containsVisible('eth0 – Public Internet');
         });


### PR DESCRIPTION
## Description 📝

- Updates the latest kernel to fix the `linode-config.spec.ts` failures ❌ 

## How to test 🧪

- Verify `linode-config.spec.ts` passes in Jenkins ✅ 
- Verify `linode-config.spec.ts` passes locally (_optional_) ✅ 
```
yarn cy:run -s "cypress/e2e/core/linodes/linode-config.spec.ts"
```

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support