### PR TITLE
change: [M3-7998] – "Limited Availability" --> "Limited Deployment Availability" phrasing change

### DIFF
--- a/packages/manager/.changeset/pr-10394-changed-1713812025608.md
+++ b/packages/manager/.changeset/pr-10394-changed-1713812025608.md
@@ -2,4 +2,4 @@
 "@linode/manager": Changed
 ---
 
-Shift verbiage from 'limited availability' to 'limited deployment availability' ([#10394](https://github.com/linode/manager/pull/10394))
+Shift wording from 'limited availability' to 'limited deployment availability' ([#10394](https://github.com/linode/manager/pull/10394))

--- a/packages/manager/.changeset/pr-10394-changed-1713812025608.md
+++ b/packages/manager/.changeset/pr-10394-changed-1713812025608.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Shift verbiage from 'limited availability' to 'limited deployment availability' ([#10394](https://github.com/linode/manager/pull/10394))

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelection.tsx
@@ -199,7 +199,7 @@ export const KubernetesPlanSelection = (
         <SelectionCard
           subheadings={[
             ...subHeadings,
-            isDisabled ? <Chip label="Limited Availability" /> : '',
+            isDisabled ? <Chip label="Limited Deployment Availability" /> : '',
           ]}
           checked={type.id === String(selectedId)}
           disabled={isDisabled}

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
@@ -107,7 +107,7 @@ export const determineLimitedAvailabilityNoticeCopy = (
     >
       {mostClassPlansAreLimitedAvailability ? (
         <StyledNoticeTypography>
-          These plans have limited availability.{' '}
+          These plans have limited deployment availability.{' '}
           <Link to={docsLink}>Learn more</Link>.
         </StyledNoticeTypography>
       ) : (

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -284,7 +284,7 @@ export const PlanSelection = (props: PlanSelectionProps) => {
           }
           subheadings={[
             ...type.subHeadings,
-            isDisabled ? <Chip label="Limited Availability" /> : '',
+            isDisabled ? <Chip label="Limited Deployment Availability" /> : '',
           ]}
           sxTooltip={{
             // There's no easy way to override the margin or transform due to inline styles and existing specificity rules.

--- a/packages/manager/src/features/components/PlansPanel/constants.ts
+++ b/packages/manager/src/features/components/PlansPanel/constants.ts
@@ -1,7 +1,8 @@
 import type { PlanSelectionType } from './types';
 import type { ExtendedType } from 'src/utilities/extendType';
 
-export const LIMITED_AVAILABILITY_TEXT = 'This plan has limited availability.';
+export const LIMITED_AVAILABILITY_TEXT =
+  'This plan has limited deployment availability.';
 export const LIMITED_AVAILABILITY_LINK =
   'https://www.linode.com/global-infrastructure/availability/';
 export const LIMITED_AVAILABILITY_DISMISSIBLEBANNER_KEY =


### PR DESCRIPTION
## Description 📝
Following up on https://github.com/linode/manager/pull/10228, shift from using "limited availability" verbiage to "limited **deployment** availability".

## Changes  🔄
- Tooltip for disabled plans: `This plan has limited availability.` --> `This plan has limited deployment availability.`
  - For these plans in tablet/mobile view, the chip should have also changed from `Limited Availability` --> `Limited Deployment Availability`
- Notice on plan panel when all plans are unavailable: `These plans have limited availability. Learn more.` --> `These plans have limited deployment availability. Learn more.`

## Target release date 🗓️
4/29/24

## Preview 📷
<details>
<summary>Screenshots</summary>

These screenshots are from the Linode Create flow, but the phrasing change should be observed in the corresponding flows for LKE and DBaaS as well.

![Screenshot 2024-04-22 at 2 35 44 PM](https://github.com/linode/manager/assets/114682940/1066c4ee-45a4-4f35-b647-ca3ed1536990)

![Screenshot 2024-04-22 at 2 36 01 PM](https://github.com/linode/manager/assets/114682940/bd033f6e-cff8-474b-93ae-92a4560f6e39)

![Screenshot 2024-04-22 at 2 36 25 PM](https://github.com/linode/manager/assets/114682940/3b2ce8f0-6161-418b-8f59-e27df69822bb)

![Screenshot 2024-04-22 at 2 36 58 PM](https://github.com/linode/manager/assets/114682940/a418c29d-64be-4047-8297-8679f963d12c)

![Screenshot 2024-04-22 at 2 38 40 PM](https://github.com/linode/manager/assets/114682940/a5c103d0-dd40-4611-93ae-dc01a0cc4920)

</details>

## How to test 🧪
### Verification steps
With the `Disable Largest GB Plans` flag toggled on in our dev tool:
- Confirm you see what is displayed in the screenshots in the previous section
- Confirm the updated language is seen (where applicable) in the LKE and DBaaS Create flows as well

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support