### PR TITLE
upcoming: [M3-8028]: Linode Create Refactor - User Defined Fields

### DIFF
--- a/packages/manager/.changeset/pr-10395-upcoming-features-1713819325776.md
+++ b/packages/manager/.changeset/pr-10395-upcoming-features-1713819325776.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Linode Create Refactor - Add User Defined Fields ([#10395](https://github.com/linode/manager/pull/10395))

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/StackScriptSelection.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/StackScriptSelection.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
+
+import { StackScriptSelection } from './StackScriptSelection';
+
+describe('StackScriptSelection', () => {
+  it('should select tab based on query params', () => {
+    const { getByText } = renderWithThemeAndHookFormContext({
+      component: <StackScriptSelection />,
+      options: {
+        MemoryRouter: {
+          initialEntries: [
+            '/linodes/create?type=StackScripts&subtype=Community',
+          ],
+        },
+      },
+    });
+
+    const communityTabButton = getByText('Community StackScripts');
+
+    expect(communityTabButton).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/StackScriptSelection.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/StackScriptSelection.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { Notice } from 'src/components/Notice/Notice';
+import { Paper } from 'src/components/Paper';
+import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
+import { Tab } from 'src/components/Tabs/Tab';
+import { TabList } from 'src/components/Tabs/TabList';
+import { TabPanels } from 'src/components/Tabs/TabPanels';
+import { Tabs } from 'src/components/Tabs/Tabs';
+import { Typography } from 'src/components/Typography';
+
+import { useLinodeCreateQueryParams } from '../../utilities';
+import { StackScriptSelectionList } from './StackScriptSelectionList';
+import { getStackScriptTabIndex, tabs } from './utilities';
+
+import type { CreateLinodeRequest } from '@linode/api-v4';
+
+export const StackScriptSelection = () => {
+  const { params, updateParams } = useLinodeCreateQueryParams();
+  const { formState, reset } = useFormContext<CreateLinodeRequest>();
+
+  const onTabChange = (index: number) => {
+    // Update the "subtype" query param. (This switches between "Community" and "Account" tabs).
+    updateParams({ stackScriptID: undefined, subtype: tabs[index] });
+    // Reset the selected image, the selected StackScript, and the StackScript data when changing tabs.
+    reset((prev) => ({
+      ...prev,
+      image: null,
+      stackscript_data: null,
+      stackscript_id: null,
+    }));
+  };
+  return (
+    <Paper>
+      <Typography variant="h2">Create From:</Typography>
+      {formState.errors.stackscript_id && (
+        <Notice
+          spacingBottom={0}
+          spacingTop={8}
+          text={formState.errors.stackscript_id.message}
+          variant="error"
+        />
+      )}
+      <Tabs
+        index={getStackScriptTabIndex(params.subtype)}
+        onChange={onTabChange}
+      >
+        <TabList>
+          <Tab>Account StackScripts</Tab>
+          <Tab>Community StackScripts</Tab>
+        </TabList>
+        <TabPanels>
+          <SafeTabPanel index={0}>
+            <StackScriptSelectionList type="Account" />
+          </SafeTabPanel>
+          <SafeTabPanel index={1}>
+            <StackScriptSelectionList type="Community" />
+          </SafeTabPanel>
+        </TabPanels>
+      </Tabs>
+    </Paper>
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/StackScriptSelectionList.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/StackScriptSelectionList.tsx
@@ -29,6 +29,7 @@ import {
 
 import type { StackScriptTabType } from './utilities';
 import type { CreateLinodeRequest } from '@linode/api-v4';
+import { getDefaultUDFData } from './UserDefinedFields/utilities';
 
 interface Props {
   type: StackScriptTabType;
@@ -98,7 +99,6 @@ export const StackScriptSelectionList = ({ type }: Props) => {
                 disabled
                 isSelected={field.value === stackscript.id}
                 onOpenDetails={() => setSelectedStackScriptId(stackscript.id)}
-                onSelect={() => field.onChange(stackscript.id)}
                 stackscript={stackscript}
               />
             )}
@@ -140,6 +140,10 @@ export const StackScriptSelectionList = ({ type }: Props) => {
             <StackScriptSelectionRow
               onSelect={() => {
                 setValue('image', null);
+                setValue(
+                  'stackscript_data',
+                  getDefaultUDFData(stackscript.user_defined_fields)
+                );
                 field.onChange(stackscript.id);
               }}
               isSelected={field.value === stackscript.id}

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/StackScriptSelectionRow.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/StackScriptSelectionRow.tsx
@@ -15,7 +15,7 @@ interface Props {
   disabled?: boolean;
   isSelected: boolean;
   onOpenDetails: () => void;
-  onSelect: () => void;
+  onSelect?: () => void;
   stackscript: StackScript;
 }
 

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/StackScripts.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/StackScripts.tsx
@@ -1,69 +1,16 @@
 import React from 'react';
-import { useFormContext } from 'react-hook-form';
 
-import { Notice } from 'src/components/Notice/Notice';
-import { Paper } from 'src/components/Paper';
 import { Stack } from 'src/components/Stack';
-import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
-import { Tab } from 'src/components/Tabs/Tab';
-import { TabList } from 'src/components/Tabs/TabList';
-import { TabPanels } from 'src/components/Tabs/TabPanels';
-import { Tabs } from 'src/components/Tabs/Tabs';
-import { Typography } from 'src/components/Typography';
 
-import { useLinodeCreateQueryParams } from '../../utilities';
 import { StackScriptImages } from './StackScriptImages';
-import { StackScriptSelectionList } from './StackScriptSelectionList';
-import { getStackScriptTabIndex, tabs } from './utilities';
-
-import type { CreateLinodeRequest } from '@linode/api-v4';
+import { StackScriptSelection } from './StackScriptSelection';
+import { UserDefinedFields } from './UserDefinedFields/UserDefinedFields';
 
 export const StackScripts = () => {
-  const { params, updateParams } = useLinodeCreateQueryParams();
-  const { formState, reset } = useFormContext<CreateLinodeRequest>();
-
-  const onTabChange = (index: number) => {
-    // Update the "subtype" query param. (This switches between "Community" and "Account" tabs).
-    updateParams({ stackScriptID: undefined, subtype: tabs[index] });
-    // Reset the selected image, the selected StackScript, and the StackScript data when changing tabs.
-    reset((prev) => ({
-      ...prev,
-      image: null,
-      stackscript_data: null,
-      stackscript_id: null,
-    }));
-  };
-
   return (
     <Stack spacing={3}>
-      <Paper>
-        <Typography variant="h2">Create From:</Typography>
-        {formState.errors.stackscript_id && (
-          <Notice
-            spacingBottom={0}
-            spacingTop={8}
-            text={formState.errors.stackscript_id.message}
-            variant="error"
-          />
-        )}
-        <Tabs
-          index={getStackScriptTabIndex(params.subtype)}
-          onChange={onTabChange}
-        >
-          <TabList>
-            <Tab>Account StackScripts</Tab>
-            <Tab>Community StackScripts</Tab>
-          </TabList>
-          <TabPanels>
-            <SafeTabPanel index={0}>
-              <StackScriptSelectionList type="Account" />
-            </SafeTabPanel>
-            <SafeTabPanel index={1}>
-              <StackScriptSelectionList type="Community" />
-            </SafeTabPanel>
-          </TabPanels>
-        </Tabs>
-      </Paper>
+      <StackScriptSelection />
+      <UserDefinedFields />
       <StackScriptImages />
     </Stack>
   );

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFieldInput.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFieldInput.test.tsx
@@ -1,0 +1,113 @@
+import { UserDefinedField } from '@linode/api-v4';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
+
+import { UserDefinedFieldInput } from './UserDefinedFieldInput';
+
+describe('UserDefinedFieldInput', () => {
+  it('should render a TextField for a required UDF', () => {
+    const udf: UserDefinedField = {
+      label: 'Username',
+      name: 'username',
+    };
+
+    const { getByLabelText } = renderWithThemeAndHookFormContext({
+      component: <UserDefinedFieldInput userDefinedField={udf} />,
+    });
+
+    expect(getByLabelText('Username (required)')).toBeVisible();
+  });
+
+  it('should render a TextField for an optional UDF', () => {
+    const udf: UserDefinedField = {
+      default: 'admin',
+      label: 'Username',
+      name: 'username',
+    };
+
+    const { getByLabelText } = renderWithThemeAndHookFormContext({
+      component: <UserDefinedFieldInput userDefinedField={udf} />,
+    });
+
+    expect(getByLabelText('Username')).toBeVisible();
+  });
+
+  it('should render helper text', () => {
+    const udf: UserDefinedField = {
+      example: 'This is a username',
+      label: 'Username',
+      name: 'username',
+    };
+
+    const { getByText } = renderWithThemeAndHookFormContext({
+      component: <UserDefinedFieldInput userDefinedField={udf} />,
+    });
+
+    expect(getByText('This is a username')).toBeVisible();
+  });
+
+  it('should render a radio when oneOf is defined with 4 or less items', () => {
+    const udf: UserDefinedField = {
+      label: 'Protocol',
+      name: 'protocol',
+      oneof: 'tcp,http,imap,ftp',
+    };
+
+    const { getByLabelText } = renderWithThemeAndHookFormContext({
+      component: <UserDefinedFieldInput userDefinedField={udf} />,
+    });
+
+    expect(getByLabelText('tcp')).toHaveRole('radio');
+    expect(getByLabelText('http')).toHaveRole('radio');
+    expect(getByLabelText('imap')).toHaveRole('radio');
+    expect(getByLabelText('ftp')).toHaveRole('radio');
+  });
+
+  it('should render a select when oneOf is defined with > 4 items', async () => {
+    const udf: UserDefinedField = {
+      default: 'tcp',
+      label: 'Protocol',
+      name: 'protocol',
+      oneof: 'tcp,http,imap,ftp,telnet',
+    };
+
+    const { getByLabelText, getByText } = renderWithThemeAndHookFormContext({
+      component: <UserDefinedFieldInput userDefinedField={udf} />,
+    });
+
+    const select = getByLabelText('Protocol');
+
+    await userEvent.click(select);
+
+    expect(getByText('tcp')).toBeVisible();
+    expect(getByText('http')).toBeVisible();
+    expect(getByText('imap')).toBeVisible();
+    expect(getByText('ftp')).toBeVisible();
+    expect(getByText('telnet')).toBeVisible();
+  });
+
+  it('should render a multi-select when manyOf is defined', async () => {
+    const udf: UserDefinedField = {
+      default: 'tcp',
+      label: 'Protocol',
+      manyof: 'tcp,http,imap,ftp,telnet',
+      name: 'protocol',
+    };
+
+    const { getByLabelText, getByText } = renderWithThemeAndHookFormContext({
+      component: <UserDefinedFieldInput userDefinedField={udf} />,
+    });
+
+    const select = getByLabelText('Protocol');
+
+    await userEvent.click(select);
+
+    expect(getByText('tcp')).toBeVisible();
+    expect(getByText('http')).toBeVisible();
+    expect(getByText('imap')).toBeVisible();
+    expect(getByText('ftp')).toBeVisible();
+    expect(getByText('telnet')).toBeVisible();
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFieldInput.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFieldInput.tsx
@@ -66,9 +66,9 @@ export const UserDefinedFieldInput = ({ userDefinedField }: Props) => {
         label={userDefinedField.label}
         multiple
         noMarginTop
-        onChange={(e, options) => field.onChange(options.join(',')) }
+        onChange={(e, options) => field.onChange(options.join(','))}
         options={options}
-        value={field.value.split(',') ?? null}
+        value={field.value?.split(',') ?? []}
       />
     );
   }

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFieldInput.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFieldInput.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { useController } from 'react-hook-form';
+
+import { Divider } from 'src/components/Divider';
+import { Link } from 'src/components/Link';
+import PasswordInput from 'src/components/PasswordInput/PasswordInput';
+import { Stack } from 'src/components/Stack';
+import { TextField } from 'src/components/TextField';
+import { Typography } from 'src/components/Typography';
+
+import {
+  isHeader,
+  isMultiSelect,
+  isOneSelect,
+  isPasswordField,
+} from './utilities';
+
+import type { CreateLinodeRequest, UserDefinedField } from '@linode/api-v4';
+
+interface Props {
+  userDefinedField: UserDefinedField;
+}
+
+export const UserDefinedFieldInput = ({ userDefinedField }: Props) => {
+  const isRequired = !userDefinedField.default;
+
+  const { field } = useController<CreateLinodeRequest, 'stackscript_data'>({
+    name: 'stackscript_data',
+  });
+
+  const onChange = (key: string, value: string) => {
+    field.onChange({
+      ...field.value,
+      [key]: value,
+    });
+  };
+
+  if (isHeader(userDefinedField)) {
+    return (
+      <Stack>
+        <Divider />
+        <Typography variant="h3">{userDefinedField.label}</Typography>
+      </Stack>
+    );
+  }
+
+  // if (isMultiSelect(userDefinedField)) {
+  //   return (
+  //     <UserDefinedMultiSelect
+  //       error={error}
+  //       field={field}
+  //       isOptional={isOptional}
+  //       key={field.name}
+  //       updateFor={[field.label, udf_data[field.name], error]}
+  //       updateFormState={handleChange}
+  //       value={udf_data[field.name] || ''}
+  //     />
+  //   );
+  // }
+
+  // if (isOneSelect(field)) {
+  //   return (
+  //     <Grid key={field.name} lg={5} xs={12}>
+  //       <UserDefinedSelect
+  //         error={error}
+  //         field={field}
+  //         isOptional={isOptional}
+  //         key={field.name}
+  //         updateFormState={handleChange}
+  //         value={udf_data[field.name] || ''}
+  //       />{' '}
+  //     </Grid>
+  //   );
+  // }
+
+  if (isPasswordField(userDefinedField.name)) {
+    const isTokenPassword = userDefinedField.name === 'token_password';
+    return (
+      <PasswordInput
+        placeholder={
+          isTokenPassword ? 'Enter your token' : userDefinedField.example
+        }
+        tooltipText={
+          isTokenPassword ? (
+            <>
+              {' '}
+              To create an API token, go to{' '}
+              <Link to="/profile/tokens">your profile.</Link>
+            </>
+          ) : undefined
+        }
+        // errorText={error}
+        label={userDefinedField.label}
+        onChange={(e) => onChange(userDefinedField.name, e.target.value)}
+        required={isRequired}
+        tooltipInteractive={isTokenPassword}
+        value={field.value[userDefinedField.name] || ''}
+      />
+    );
+  }
+
+  return (
+    <TextField
+      // errorText={error}
+      label={userDefinedField.label}
+      onChange={(e) => onChange(userDefinedField.name, e.target.value)}
+      placeholder={userDefinedField.example}
+      required={isRequired}
+      value={field.value[userDefinedField.name] || ''}
+    />
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFieldInput.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFieldInput.tsx
@@ -1,14 +1,21 @@
 import React from 'react';
 import { useController } from 'react-hook-form';
 
+import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
 import { Divider } from 'src/components/Divider';
+import { FormControl } from 'src/components/FormControl';
+import { FormControlLabel } from 'src/components/FormControlLabel';
+import { FormLabel } from 'src/components/FormLabel';
 import { Link } from 'src/components/Link';
 import PasswordInput from 'src/components/PasswordInput/PasswordInput';
+import { Radio } from 'src/components/Radio/Radio';
+import { RadioGroup } from 'src/components/RadioGroup';
 import { Stack } from 'src/components/Stack';
 import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
 
 import {
+  getIsUDFRequired,
   isHeader,
   isMultiSelect,
   isOneSelect,
@@ -22,7 +29,7 @@ interface Props {
 }
 
 export const UserDefinedFieldInput = ({ userDefinedField }: Props) => {
-  const isRequired = !userDefinedField.default;
+  const isRequired = getIsUDFRequired(userDefinedField);
 
   const { field } = useController<CreateLinodeRequest, 'stackscript_data'>({
     name: 'stackscript_data',
@@ -44,42 +51,73 @@ export const UserDefinedFieldInput = ({ userDefinedField }: Props) => {
     );
   }
 
-  // if (isMultiSelect(userDefinedField)) {
-  //   return (
-  //     <UserDefinedMultiSelect
-  //       error={error}
-  //       field={field}
-  //       isOptional={isOptional}
-  //       key={field.name}
-  //       updateFor={[field.label, udf_data[field.name], error]}
-  //       updateFormState={handleChange}
-  //       value={udf_data[field.name] || ''}
-  //     />
-  //   );
-  // }
+  if (isMultiSelect(userDefinedField)) {
+    return (
+      <Autocomplete
+        onChange={(e, options) =>
+          onChange(userDefinedField.name, options.join(','))
+        }
+        textFieldProps={{
+          required: isRequired,
+        }}
+        // errorText={error}
+        label={userDefinedField.label}
+        multiple
+        noMarginTop
+        options={userDefinedField.manyof!.split(',') ?? []}
+        value={field.value[userDefinedField.name] ?? null}
+      />
+    );
+  }
 
-  // if (isOneSelect(field)) {
-  //   return (
-  //     <Grid key={field.name} lg={5} xs={12}>
-  //       <UserDefinedSelect
-  //         error={error}
-  //         field={field}
-  //         isOptional={isOptional}
-  //         key={field.name}
-  //         updateFormState={handleChange}
-  //         value={udf_data[field.name] || ''}
-  //       />{' '}
-  //     </Grid>
-  //   );
-  // }
+  if (isOneSelect(userDefinedField)) {
+    const options = userDefinedField
+      .oneof!.split(',')
+      .map((option) => ({ label: option }));
+
+    if (options.length > 4) {
+      return (
+        <Autocomplete
+          onChange={(_, option) =>
+            onChange(userDefinedField.name, option?.label ?? '')
+          }
+          value={options.find(
+            (option) => option.label === field.value[userDefinedField.name]
+          )}
+          disableClearable={isRequired}
+          label={userDefinedField.label}
+          options={options}
+        />
+      );
+    }
+
+    return (
+      <FormControl>
+        <FormLabel id={`${userDefinedField.name}-radio-group`} sx={{ mb: 0 }}>
+          {userDefinedField.label}
+        </FormLabel>
+        <RadioGroup
+          aria-labelledby={`${userDefinedField.name}-radio-group`}
+          sx={{ mb: '0 !important' }}
+        >
+          {options.map((option) => (
+            <FormControlLabel
+              checked={option.label === field.value[userDefinedField.name]}
+              control={<Radio />}
+              key={option.label}
+              label={option.label}
+              onChange={(e) => onChange(userDefinedField.name, option.label)}
+            />
+          ))}
+        </RadioGroup>
+      </FormControl>
+    );
+  }
 
   if (isPasswordField(userDefinedField.name)) {
     const isTokenPassword = userDefinedField.name === 'token_password';
     return (
       <PasswordInput
-        placeholder={
-          isTokenPassword ? 'Enter your token' : userDefinedField.example
-        }
         tooltipText={
           isTokenPassword ? (
             <>
@@ -91,7 +129,9 @@ export const UserDefinedFieldInput = ({ userDefinedField }: Props) => {
         }
         // errorText={error}
         label={userDefinedField.label}
+        noMarginTop
         onChange={(e) => onChange(userDefinedField.name, e.target.value)}
+        placeholder={isTokenPassword ? 'Enter your token' : 'Enter a password.'}
         required={isRequired}
         tooltipInteractive={isTokenPassword}
         value={field.value[userDefinedField.name] || ''}
@@ -101,10 +141,11 @@ export const UserDefinedFieldInput = ({ userDefinedField }: Props) => {
 
   return (
     <TextField
-      // errorText={error}
+      helperText={userDefinedField.example}
       label={userDefinedField.label}
+      // errorText={error}
+      noMarginTop
       onChange={(e) => onChange(userDefinedField.name, e.target.value)}
-      placeholder={userDefinedField.example}
       required={isRequired}
       value={field.value[userDefinedField.name] || ''}
     />

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFieldInput.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFieldInput.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useController } from 'react-hook-form';
+import { useController, useFormContext } from 'react-hook-form';
 
 import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
 import { Divider } from 'src/components/Divider';
@@ -31,9 +31,12 @@ interface Props {
 export const UserDefinedFieldInput = ({ userDefinedField }: Props) => {
   const isRequired = getIsUDFRequired(userDefinedField);
 
+  const { formState } = useFormContext<CreateLinodeRequest>();
   const { field } = useController<CreateLinodeRequest, 'stackscript_data'>({
     name: 'stackscript_data',
   });
+
+  const error = formState.errors?.[userDefinedField.name]?.message;
 
   const udfs = field.value;
 
@@ -66,7 +69,7 @@ export const UserDefinedFieldInput = ({ userDefinedField }: Props) => {
         textFieldProps={{
           required: isRequired,
         }}
-        // errorText={error}
+        errorText={error}
         label={userDefinedField.label}
         multiple
         noMarginTop
@@ -136,7 +139,7 @@ export const UserDefinedFieldInput = ({ userDefinedField }: Props) => {
             </>
           ) : undefined
         }
-        // errorText={error}
+        errorText={error}
         label={userDefinedField.label}
         noMarginTop
         onChange={(e) => onChange(userDefinedField.name, e.target.value)}
@@ -152,7 +155,7 @@ export const UserDefinedFieldInput = ({ userDefinedField }: Props) => {
     <TextField
       helperText={userDefinedField.example}
       label={userDefinedField.label}
-      // errorText={error}
+      errorText={error}
       noMarginTop
       onChange={(e) => onChange(userDefinedField.name, e.target.value)}
       required={isRequired}

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFields.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFields.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import { stackScriptFactory } from 'src/factories';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
+
+import { UserDefinedFields } from './UserDefinedFields';
+
+import type { CreateLinodeRequest } from '@linode/api-v4';
+
+describe('UserDefinedFields', () => {
+  it('should render UDFs for the selected StackScript', async () => {
+    const stackscript = stackScriptFactory.build({
+      user_defined_fields: [
+        {
+          label: 'Server Username',
+          name: 'username',
+        },
+        {
+          label: 'Server Password',
+          name: 'password',
+        },
+        {
+          label: 'Protocol',
+          name: 'protocol',
+          oneof: 'tcp',
+        },
+        {
+          label: 'User Type',
+          manyof: 'admin,mod,normal',
+          name: 'user_type',
+        },
+        {
+          default: 'password123',
+          label: 'Admin Password',
+          name: 'admin_password',
+        },
+      ],
+    });
+
+    server.use(
+      http.get('*/linode/stackscripts/:id', () => {
+        return HttpResponse.json(stackscript);
+      })
+    );
+
+    const {
+      findByLabelText,
+    } = renderWithThemeAndHookFormContext<CreateLinodeRequest>({
+      component: <UserDefinedFields />,
+      useFormOptions: {
+        defaultValues: { stackscript_id: stackscript.id },
+      },
+    });
+
+    for (const udf of stackscript.user_defined_fields) {
+      // eslint-disable-next-line no-await-in-loop
+      await findByLabelText(udf.label, { exact: false });
+    }
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFields.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFields.tsx
@@ -1,0 +1,61 @@
+import { CreateLinodeRequest } from '@linode/api-v4';
+import React from 'react';
+import { useWatch } from 'react-hook-form';
+
+import { Paper } from 'src/components/Paper';
+import { ShowMoreExpansion } from 'src/components/ShowMoreExpansion';
+import { Stack } from 'src/components/Stack';
+import { Typography } from 'src/components/Typography';
+import { useStackScriptQuery } from 'src/queries/stackscripts';
+
+import { UserDefinedFieldInput } from './UserDefinedFieldInput';
+import { separateUDFsByRequiredStatus } from './utilities';
+
+export const UserDefinedFields = () => {
+  const stackscriptId = useWatch<CreateLinodeRequest, 'stackscript_id'>({
+    name: 'stackscript_id',
+  });
+
+  const hasStackscriptSelected =
+    stackscriptId !== null && stackscriptId !== undefined;
+
+  const { data: stackscript } = useStackScriptQuery(
+    stackscriptId ?? -1,
+    hasStackscriptSelected
+  );
+
+  const userDefinedFields = stackscript?.user_defined_fields;
+
+  const [requiredUDFs, optionalUDFs] = separateUDFsByRequiredStatus(
+    userDefinedFields
+  );
+
+  if (!stackscript || userDefinedFields?.length === 0) {
+    return null;
+  }
+
+  return (
+    <Paper>
+      <Typography variant="h2">{stackscript.label} Setup</Typography>
+      {requiredUDFs.map((field) => (
+        <UserDefinedFieldInput key={field.name} userDefinedField={field} />
+      ))}
+      {optionalUDFs.length !== 0 && (
+        <ShowMoreExpansion defaultExpanded name="Advanced Options">
+          <Stack spacing={1}>
+            <Typography>
+              These fields are additional configuration options and are not
+              required for creation.
+            </Typography>
+            {optionalUDFs.map((field) => (
+              <UserDefinedFieldInput
+                key={field.name}
+                userDefinedField={field}
+              />
+            ))}
+          </Stack>
+        </ShowMoreExpansion>
+      )}
+    </Paper>
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFields.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFields.tsx
@@ -1,8 +1,9 @@
 import { CreateLinodeRequest } from '@linode/api-v4';
 import React from 'react';
-import { useWatch } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 
 import { Box } from 'src/components/Box';
+import { Notice } from 'src/components/Notice/Notice';
 import { Paper } from 'src/components/Paper';
 import { ShowMoreExpansion } from 'src/components/ShowMoreExpansion';
 import { Stack } from 'src/components/Stack';
@@ -16,6 +17,8 @@ export const UserDefinedFields = () => {
   const stackscriptId = useWatch<CreateLinodeRequest, 'stackscript_id'>({
     name: 'stackscript_id',
   });
+
+  const { formState } = useFormContext<CreateLinodeRequest>();
 
   const hasStackscriptSelected =
     stackscriptId !== null && stackscriptId !== undefined;
@@ -39,6 +42,12 @@ export const UserDefinedFields = () => {
     <Paper>
       <Stack spacing={2}>
         <Typography variant="h2">{stackscript.label} Setup</Typography>
+        {formState.errors.stackscript_data && (
+          <Notice
+            text={formState.errors.stackscript_data.message as string}
+            variant="error"
+          />
+        )}
         <Stack spacing={2}>
           {requiredUDFs.map((field) => (
             <UserDefinedFieldInput key={field.name} userDefinedField={field} />

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFields.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFields.tsx
@@ -1,8 +1,8 @@
 import { CreateLinodeRequest } from '@linode/api-v4';
 import React from 'react';
 import { useWatch } from 'react-hook-form';
-import { Box } from 'src/components/Box';
 
+import { Box } from 'src/components/Box';
 import { Paper } from 'src/components/Paper';
 import { ShowMoreExpansion } from 'src/components/ShowMoreExpansion';
 import { Stack } from 'src/components/Stack';

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFields.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFields.tsx
@@ -1,6 +1,7 @@
 import { CreateLinodeRequest } from '@linode/api-v4';
 import React from 'react';
 import { useWatch } from 'react-hook-form';
+import { Box } from 'src/components/Box';
 
 import { Paper } from 'src/components/Paper';
 import { ShowMoreExpansion } from 'src/components/ShowMoreExpansion';
@@ -36,26 +37,34 @@ export const UserDefinedFields = () => {
 
   return (
     <Paper>
-      <Typography variant="h2">{stackscript.label} Setup</Typography>
-      {requiredUDFs.map((field) => (
-        <UserDefinedFieldInput key={field.name} userDefinedField={field} />
-      ))}
-      {optionalUDFs.length !== 0 && (
-        <ShowMoreExpansion defaultExpanded name="Advanced Options">
-          <Stack spacing={1}>
-            <Typography>
-              These fields are additional configuration options and are not
-              required for creation.
-            </Typography>
-            {optionalUDFs.map((field) => (
-              <UserDefinedFieldInput
-                key={field.name}
-                userDefinedField={field}
-              />
-            ))}
-          </Stack>
-        </ShowMoreExpansion>
-      )}
+      <Stack spacing={2}>
+        <Typography variant="h2">{stackscript.label} Setup</Typography>
+        <Stack spacing={2}>
+          {requiredUDFs.map((field) => (
+            <UserDefinedFieldInput key={field.name} userDefinedField={field} />
+          ))}
+        </Stack>
+        <Box>
+          {optionalUDFs.length !== 0 && (
+            <ShowMoreExpansion defaultExpanded name="Advanced Options">
+              <Stack spacing={1}>
+                <Typography py={1}>
+                  These fields are additional configuration options and are not
+                  required for creation.
+                </Typography>
+                <Stack spacing={2}>
+                  {optionalUDFs.map((field) => (
+                    <UserDefinedFieldInput
+                      key={field.name}
+                      userDefinedField={field}
+                    />
+                  ))}
+                </Stack>
+              </Stack>
+            </ShowMoreExpansion>
+          )}
+        </Box>
+      </Stack>
     </Paper>
   );
 };

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities.test.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities.test.ts
@@ -1,0 +1,25 @@
+import { separateUDFsByRequiredStatus } from './utilities';
+
+import type { UserDefinedField } from '@linode/api-v4';
+
+describe('separateUDFsByRequiredStatus', () => {
+  it('should seperate udfs by required', () => {
+    const requiredUserDefinedField: UserDefinedField = {
+      label: 'Server Username',
+      name: 'username',
+    };
+
+    const optionalUserDefinedField: UserDefinedField = {
+      default: 'password',
+      label: 'Server Password',
+      name: 'password',
+    };
+
+    expect(
+      separateUDFsByRequiredStatus([
+        optionalUserDefinedField,
+        requiredUserDefinedField,
+      ])
+    ).toStrictEqual([[requiredUserDefinedField], [optionalUserDefinedField]]);
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities.test.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities.test.ts
@@ -1,4 +1,11 @@
-import { separateUDFsByRequiredStatus } from './utilities';
+import {
+  getDefaultUDFData,
+  getIsUDFHeader,
+  getIsUDFMultiSelect,
+  getIsUDFPasswordField,
+  getIsUDFSingleSelect,
+  separateUDFsByRequiredStatus,
+} from './utilities';
 
 import type { UserDefinedField } from '@linode/api-v4';
 
@@ -21,5 +28,129 @@ describe('separateUDFsByRequiredStatus', () => {
         requiredUserDefinedField,
       ])
     ).toStrictEqual([[requiredUserDefinedField], [optionalUserDefinedField]]);
+  });
+});
+
+describe('getDefaultUDFData', () => {
+  it('should return key-value pairs for values with defaults', () => {
+    const udfs: UserDefinedField[] = [
+      {
+        default: 'admin',
+        label: 'Server Username',
+        name: 'username',
+      },
+      {
+        label: 'Server Password',
+        name: 'password',
+      },
+    ];
+
+    expect(getDefaultUDFData(udfs)).toStrictEqual({
+      username: 'admin',
+    });
+  });
+});
+
+describe('getIsUDFHeader', () => {
+  it('should return true if UDF has header with value yes', () => {
+    const udf: UserDefinedField = {
+      header: 'yes',
+      label: 'Server Username',
+      name: 'username',
+    };
+
+    expect(getIsUDFHeader(udf)).toBe(true);
+  });
+
+  it('should return false if UDF has header with value no', () => {
+    const udf: UserDefinedField = {
+      header: 'no',
+      label: 'Server Username',
+      name: 'username',
+    };
+
+    expect(getIsUDFHeader(udf)).toBe(false);
+  });
+
+  it('should return false if UDF has no header value', () => {
+    const udf: UserDefinedField = {
+      label: 'Server Username',
+      name: 'username',
+    };
+
+    expect(getIsUDFHeader(udf)).toBe(false);
+  });
+});
+
+describe('getIsUDFMultiSelect', () => {
+  it('should return true if UDF has a manyof value', () => {
+    const udf: UserDefinedField = {
+      label: 'Server Username',
+      manyof: 'php,js,go',
+      name: 'username',
+    };
+
+    expect(getIsUDFMultiSelect(udf)).toBe(true);
+  });
+
+  it('should return false if UDF has no manyof value', () => {
+    const udf: UserDefinedField = {
+      label: 'Server Username',
+      name: 'username',
+    };
+
+    expect(getIsUDFMultiSelect(udf)).toBe(false);
+  });
+});
+
+describe('getIsUDFSingleSelect', () => {
+  it('should return true if UDF has a oneOf value', () => {
+    const udf: UserDefinedField = {
+      label: 'Server Username',
+      name: 'username',
+      oneof: 'php,js,go',
+    };
+
+    expect(getIsUDFSingleSelect(udf)).toBe(true);
+  });
+
+  it('should return false if UDF has no oneOf value', () => {
+    const udf: UserDefinedField = {
+      label: 'Server Username',
+      manyof: 'omg',
+      name: 'username',
+    };
+
+    expect(getIsUDFSingleSelect(udf)).toBe(false);
+  });
+});
+
+describe('getIsUDFPasswordField', () => {
+  it('should return true if UDF has password in the name (any capitalization)', () => {
+    const udf: UserDefinedField = {
+      label: 'Server Username',
+      name: 'PasSwOrd',
+    };
+
+    expect(getIsUDFPasswordField(udf)).toBe(true);
+  });
+
+  it('should return true if UDF has password in the name', () => {
+    const udf: UserDefinedField = {
+      label: 'Server Username',
+      name: 'password',
+    };
+
+    expect(getIsUDFPasswordField(udf)).toBe(true);
+  });
+
+  it('should return false if UDF does not have password in the name', () => {
+    const udf: UserDefinedField = {
+      label: 'Server Username',
+      manyof: 'omg',
+      name: 'username',
+    };
+
+    expect(getIsUDFPasswordField(udf)).toBe(false);
   });
 });

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities.ts
@@ -3,7 +3,7 @@ import type { UserDefinedField } from '@linode/api-v4';
 /**
  * Used to separate required UDFs from non-required ones
  *
- * @return nested array [[...requiredUDFs], [...nonRequiredUDFs]]
+ * @returns nested array [[...requiredUDFs], [...nonRequiredUDFs]]
  */
 export const separateUDFsByRequiredStatus = (udfs: UserDefinedField[] = []) => {
   return udfs.reduce(

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities.ts
@@ -9,9 +9,9 @@ export const separateUDFsByRequiredStatus = (udfs: UserDefinedField[] = []) => {
   return udfs.reduce(
     (accum, udf) => {
       if (getIsUDFOptional(udf)) {
-        return [[...accum[0]], [...accum[1], udf]];
+        return [accum[0], [...accum[1], udf]];
       } else {
-        return [[...accum[0], udf], [...accum[1]]];
+        return [[...accum[0], udf], accum[1]];
       }
     },
     [[], []]

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities.ts
@@ -18,11 +18,22 @@ export const separateUDFsByRequiredStatus = (udfs: UserDefinedField[] = []) => {
   );
 };
 
+/**
+ * @returns true if a User Defined Field should be considered optional
+ */
 export const getIsUDFOptional = (udf: UserDefinedField) =>
   udf.hasOwnProperty('default') && !udf.hasOwnProperty('required');
 
-export const getIsUDFRequired = (udf: UserDefinedField) => !getIsUDFOptional(udf);
+/**
+ * @returns true if a User Defined Field should be considered required
+ */
+export const getIsUDFRequired = (udf: UserDefinedField) =>
+  !getIsUDFOptional(udf);
 
+/**
+ * Given an array of User Defined Fields, this returns an object of
+ * key-value pairs based on the default values.
+ */
 export const getDefaultUDFData = (
   userDefinedFields: UserDefinedField[]
 ): Record<string, string> =>
@@ -33,18 +44,30 @@ export const getDefaultUDFData = (
     return accum;
   }, {});
 
-export const isPasswordField = (udfName: string) => {
-  return udfName.toLowerCase().includes('password');
+/**
+ * @returns true if a user defined field should be treated as a password
+ */
+export const getIsUDFPasswordField = (udf: UserDefinedField) => {
+  return udf.name.toLowerCase().includes('password');
 };
 
-export const isOneSelect = (udf: UserDefinedField) => {
-  return !!udf.oneof; // if we have a oneof prop, it's a radio button
+/**
+ * @returns true if a user defined field should be treated as a single select
+ */
+export const getIsUDFSingleSelect = (udf: UserDefinedField) => {
+  return !!udf.oneof;
 };
 
-export const isMultiSelect = (udf: UserDefinedField) => {
-  return !!udf.manyof; // if we have a manyof prop, it's a checkbox
+/**
+ * @returns true if a user defined field should be treated as a multi-select
+ */
+export const getIsUDFMultiSelect = (udf: UserDefinedField) => {
+  return !!udf.manyof;
 };
 
-export const isHeader = (udf: UserDefinedField) => {
+/**
+ * @returns true if a user defined field should be treated as a header
+ */
+export const getIsUDFHeader = (udf: UserDefinedField) => {
   return udf.header?.toLowerCase() === 'yes';
 };

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities.ts
@@ -7,22 +7,21 @@ import type { UserDefinedField } from '@linode/api-v4';
  */
 export const separateUDFsByRequiredStatus = (udfs: UserDefinedField[] = []) => {
   return udfs.reduce(
-    (accum, eachUDF) => {
-      /**
-       * if the "default" key exists, it's optional
-       */
-      if (
-        eachUDF.hasOwnProperty('default') &&
-        !eachUDF.hasOwnProperty('required')
-      ) {
-        return [[...accum[0]], [...accum[1], eachUDF]];
+    (accum, udf) => {
+      if (getIsUDFOptional(udf)) {
+        return [[...accum[0]], [...accum[1], udf]];
       } else {
-        return [[...accum[0], eachUDF], [...accum[1]]];
+        return [[...accum[0], udf], [...accum[1]]];
       }
     },
     [[], []]
   );
 };
+
+export const getIsUDFOptional = (udf: UserDefinedField) =>
+  udf.hasOwnProperty('default') && !udf.hasOwnProperty('required');
+
+export const getIsUDFRequired = (udf: UserDefinedField) => !getIsUDFOptional(udf);
 
 export const getDefaultUDFData = (
   userDefinedFields: UserDefinedField[]

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities.ts
@@ -22,7 +22,7 @@ export const separateUDFsByRequiredStatus = (udfs: UserDefinedField[] = []) => {
  * @returns true if a User Defined Field should be considered required
  */
 export const getIsUDFRequired = (udf: UserDefinedField) =>
-  !udf.hasOwnProperty('default') && udf.hasOwnProperty('required');
+  !udf.hasOwnProperty('default') || udf.hasOwnProperty('required');
 
 /**
  * Given an array of User Defined Fields, this returns an object of

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities.ts
@@ -1,0 +1,51 @@
+import type { UserDefinedField } from '@linode/api-v4';
+
+/**
+ * Used to separate required UDFs from non-required ones
+ *
+ * @return nested array [[...requiredUDFs], [...nonRequiredUDFs]]
+ */
+export const separateUDFsByRequiredStatus = (udfs: UserDefinedField[] = []) => {
+  return udfs.reduce(
+    (accum, eachUDF) => {
+      /**
+       * if the "default" key exists, it's optional
+       */
+      if (
+        eachUDF.hasOwnProperty('default') &&
+        !eachUDF.hasOwnProperty('required')
+      ) {
+        return [[...accum[0]], [...accum[1], eachUDF]];
+      } else {
+        return [[...accum[0], eachUDF], [...accum[1]]];
+      }
+    },
+    [[], []]
+  );
+};
+
+export const getDefaultUDFData = (
+  userDefinedFields: UserDefinedField[]
+): Record<string, string> =>
+  userDefinedFields.reduce((accum, eachField) => {
+    if (eachField.default) {
+      accum[eachField.name] = eachField.default;
+    }
+    return accum;
+  }, {});
+
+export const isPasswordField = (udfName: string) => {
+  return udfName.toLowerCase().includes('password');
+};
+
+export const isOneSelect = (udf: UserDefinedField) => {
+  return !!udf.oneof; // if we have a oneof prop, it's a radio button
+};
+
+export const isMultiSelect = (udf: UserDefinedField) => {
+  return !!udf.manyof; // if we have a manyof prop, it's a checkbox
+};
+
+export const isHeader = (udf: UserDefinedField) => {
+  return udf.header?.toLowerCase() === 'yes';
+};

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities.ts
@@ -8,10 +8,10 @@ import type { UserDefinedField } from '@linode/api-v4';
 export const separateUDFsByRequiredStatus = (udfs: UserDefinedField[] = []) => {
   return udfs.reduce(
     (accum, udf) => {
-      if (getIsUDFOptional(udf)) {
-        return [accum[0], [...accum[1], udf]];
-      } else {
+      if (getIsUDFRequired(udf)) {
         return [[...accum[0], udf], accum[1]];
+      } else {
+        return [accum[0], [...accum[1], udf]];
       }
     },
     [[], []]
@@ -19,16 +19,10 @@ export const separateUDFsByRequiredStatus = (udfs: UserDefinedField[] = []) => {
 };
 
 /**
- * @returns true if a User Defined Field should be considered optional
- */
-export const getIsUDFOptional = (udf: UserDefinedField) =>
-  udf.hasOwnProperty('default') && !udf.hasOwnProperty('required');
-
-/**
  * @returns true if a User Defined Field should be considered required
  */
 export const getIsUDFRequired = (udf: UserDefinedField) =>
-  !getIsUDFOptional(udf);
+  !udf.hasOwnProperty('default') && udf.hasOwnProperty('required');
 
 /**
  * Given an array of User Defined Fields, this returns an object of

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.test.tsx
@@ -37,6 +37,17 @@ describe('getLinodeCreatePayload', () => {
       metadata: { user_data: base64UserData },
     });
   });
+
+  it('should remove placement_group from the payload if no id exists', () => {
+    const values = createLinodeRequestFactory.build({
+      placement_group: {},
+    });
+
+    expect(getLinodeCreatePayload(values)).toEqual({
+      ...values,
+      placement_group: undefined,
+    });
+  });
 });
 
 describe('getInterfacesPayload', () => {

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
@@ -1,4 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
+import { getStackScript } from '@linode/api-v4';
 import { CreateLinodeSchema } from '@linode/validation';
 import { useHistory } from 'react-router-dom';
 
@@ -8,7 +9,7 @@ import { utoa } from '../LinodesCreate/utilities';
 
 import type { LinodeCreateType } from '../LinodesCreate/types';
 import type { StackScriptTabType } from './Tabs/StackScripts/utilities';
-import { CreateLinodeRequest, getStackScript, InterfacePayload } from '@linode/api-v4';
+import type { CreateLinodeRequest, InterfacePayload } from '@linode/api-v4';
 import type { Resolver } from 'react-hook-form';
 
 /**

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
@@ -116,6 +116,10 @@ export const getLinodeCreatePayload = (
     values.metadata = undefined;
   }
 
+  if (values.placement_group?.id === undefined) {
+    values.placement_group = undefined;
+  }
+
   values.interfaces = getInterfacesPayload(
     values.interfaces,
     Boolean(values.private_ip)

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
@@ -8,7 +8,7 @@ import { utoa } from '../LinodesCreate/utilities';
 
 import type { LinodeCreateType } from '../LinodesCreate/types';
 import type { StackScriptTabType } from './Tabs/StackScripts/utilities';
-import type { CreateLinodeRequest, InterfacePayload } from '@linode/api-v4';
+import { CreateLinodeRequest, getStackScript, InterfacePayload } from '@linode/api-v4';
 import type { Resolver } from 'react-hook-form';
 
 /**
@@ -204,6 +204,10 @@ export const defaultValues = async (): Promise<CreateLinodeRequest> => {
     ? Number(queryParams.stackScriptID)
     : undefined;
 
+  const stackscript = stackScriptID
+    ? await getStackScript(stackScriptID)
+    : null;
+
   const imageID = queryParams.imageID;
 
   return {
@@ -214,6 +218,7 @@ export const defaultValues = async (): Promise<CreateLinodeRequest> => {
       defaultPublicInterface,
     ],
     region: '',
+    stackscript_data: stackscript?.user_defined_fields,
     stackscript_id: stackScriptID,
     type: '',
   };

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -10,7 +10,7 @@ import { Notice } from 'src/components/Notice/Notice';
 import { RenderGuard } from 'src/components/RenderGuard';
 import { ShowMoreExpansion } from 'src/components/ShowMoreExpansion';
 import { Typography } from 'src/components/Typography';
-import { isHeader, isMultiSelect, isOneSelect, isPasswordField, separateUDFsByRequiredStatus } from 'src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities';
+import { getIsUDFHeader, getIsUDFMultiSelect, getIsUDFSingleSelect, getIsUDFPasswordField, separateUDFsByRequiredStatus } from 'src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities';
 
 import { AppInfo } from '../../Linodes/LinodesCreate/AppInfo';
 import UserDefinedMultiSelect from './FieldTypes/UserDefinedMultiSelect';
@@ -39,7 +39,7 @@ const renderField = (
   // if the 'default' key is returned from the API, the field is optional
   const isOptional = field.hasOwnProperty('default');
 
-  if (isHeader(field)) {
+  if (getIsUDFHeader(field)) {
     return (
       <Grid key={field.name} lg={5} style={{ marginTop: 24 }} xs={12}>
         <Divider />
@@ -48,7 +48,7 @@ const renderField = (
     );
   }
 
-  if (isMultiSelect(field)) {
+  if (getIsUDFMultiSelect(field)) {
     return (
       <Grid key={field.name} lg={5} xs={12}>
         <UserDefinedMultiSelect
@@ -63,7 +63,7 @@ const renderField = (
       </Grid>
     );
   }
-  if (isOneSelect(field)) {
+  if (getIsUDFSingleSelect(field)) {
     return (
       <Grid key={field.name} lg={5} xs={12}>
         <UserDefinedSelect
@@ -77,7 +77,7 @@ const renderField = (
       </Grid>
     );
   }
-  if (isPasswordField(field.name)) {
+  if (getIsUDFPasswordField(field)) {
     const isTokenPassword = field.name === 'token_password';
     return (
       <Grid key={field.name} lg={5} xs={12}>

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -10,6 +10,7 @@ import { Notice } from 'src/components/Notice/Notice';
 import { RenderGuard } from 'src/components/RenderGuard';
 import { ShowMoreExpansion } from 'src/components/ShowMoreExpansion';
 import { Typography } from 'src/components/Typography';
+import { isHeader, isMultiSelect, isOneSelect, isPasswordField, separateUDFsByRequiredStatus } from 'src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/utilities';
 
 import { AppInfo } from '../../Linodes/LinodesCreate/AppInfo';
 import UserDefinedMultiSelect from './FieldTypes/UserDefinedMultiSelect';
@@ -236,46 +237,6 @@ const getError = (field: UserDefinedField, errors?: APIError[]) => {
   }
   const error = errors.find((thisError) => thisError.field === field.name);
   return error ? error.reason.replace('the UDF', '') : undefined;
-};
-
-const isPasswordField = (udfName: string) => {
-  return udfName.toLowerCase().includes('password');
-};
-
-const isOneSelect = (udf: UserDefinedField) => {
-  return !!udf.oneof; // if we have a oneof prop, it's a radio button
-};
-
-const isMultiSelect = (udf: UserDefinedField) => {
-  return !!udf.manyof; // if we have a manyof prop, it's a checkbox
-};
-
-const isHeader = (udf: UserDefinedField) => {
-  return udf.header?.toLowerCase() === 'yes';
-};
-
-/**
- * Used to separate required UDFs from non-required ones
- *
- * @return nested array [[...requiredUDFs], [...nonRequiredUDFs]]
- */
-const separateUDFsByRequiredStatus = (udfs: UserDefinedField[] = []) => {
-  return udfs.reduce(
-    (accum, eachUDF) => {
-      /**
-       * if the "default" key exists, it's optional
-       */
-      if (
-        eachUDF.hasOwnProperty('default') &&
-        !eachUDF.hasOwnProperty('required')
-      ) {
-        return [[...accum[0]], [...accum[1], eachUDF]];
-      } else {
-        return [[...accum[0], eachUDF], [...accum[1]]];
-      }
-    },
-    [[], []]
-  );
 };
 
 export default RenderGuard(UserDefinedFieldsPanel);


### PR DESCRIPTION
## Description 📝

Adds initial User Defined Field support to the Linode Create flow when deploying from a StackScript

## Changes  🔄
- Extracts out some until functions from the existing create flow and unit tests them (no changes in logic, only naming changes) 🧪 
- Adds initial User Defined Field support to the new Linode Create flow

## Preview 📷

![Screenshot 2024-04-22 at 3 02 13 PM](https://github.com/linode/manager/assets/115251059/01a1f955-db8d-4d3c-8b14-3d6e2ddd9e5c)


## How to test 🧪

### Prerequisites
- Check out this PR or use an internal preview link
- Enable the `Linode Create v2` feature flag

### Verification steps
- Select various community StackScripts and check the functionality of the user defined fields section
- Compare behavior to production

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support