### PR TITLE
fix: TopMenu related console errors

### DIFF
--- a/packages/manager/src/components/Link.tsx
+++ b/packages/manager/src/components/Link.tsx
@@ -69,78 +69,82 @@ export interface LinkProps extends _LinkProps {
  * - External links provide by default "noopener noreferrer" attributes to prevent security vulnerabilities.
  * - ExternalLink component provides by default "aria-label" attributes to improve accessibility.
  */
-export const Link = (props: LinkProps) => {
-  const {
-    accessibleAriaLabel,
-    children,
-    className,
-    external,
-    forceCopyColor,
-    hideIcon,
-    onClick,
-    to,
-  } = props;
-  const { classes, cx } = useStyles();
-  const sanitizedUrl = () => sanitizeUrl(to);
-  const shouldOpenInNewTab = opensInNewTab(sanitizedUrl());
-  const childrenAsAriaLabel = flattenChildrenIntoAriaLabel(children);
-  const externalNotice = '- link opens in a new tab';
-  const ariaLabel = accessibleAriaLabel
-    ? `${accessibleAriaLabel} ${shouldOpenInNewTab ? externalNotice : ''}`
-    : `${childrenAsAriaLabel} ${shouldOpenInNewTab ? externalNotice : ''}`;
+export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
+  (props, ref) => {
+    const {
+      accessibleAriaLabel,
+      children,
+      className,
+      external,
+      forceCopyColor,
+      hideIcon,
+      onClick,
+      to,
+    } = props;
+    const { classes, cx } = useStyles();
+    const sanitizedUrl = () => sanitizeUrl(to);
+    const shouldOpenInNewTab = opensInNewTab(sanitizedUrl());
+    const childrenAsAriaLabel = flattenChildrenIntoAriaLabel(children);
+    const externalNotice = '- link opens in a new tab';
+    const ariaLabel = accessibleAriaLabel
+      ? `${accessibleAriaLabel} ${shouldOpenInNewTab ? externalNotice : ''}`
+      : `${childrenAsAriaLabel} ${shouldOpenInNewTab ? externalNotice : ''}`;
 
-  if (childrenContainsNoText(children) && !accessibleAriaLabel) {
-    // eslint-disable-next-line no-console
-    console.error(
-      'Link component must have text content to be accessible to screen readers. Please provide an accessibleAriaLabel prop or text content.'
+    if (childrenContainsNoText(children) && !accessibleAriaLabel) {
+      // eslint-disable-next-line no-console
+      console.error(
+        'Link component must have text content to be accessible to screen readers. Please provide an accessibleAriaLabel prop or text content.'
+      );
+    }
+
+    const routerLinkProps = omit(props, [
+      'accessibleAriaLabel',
+      'external',
+      'forceCopyColor',
+    ]);
+
+    return shouldOpenInNewTab ? (
+      <a
+        className={cx(
+          classes.root,
+          {
+            [classes.forceCopyColor]: forceCopyColor,
+          },
+          className
+        )}
+        aria-label={ariaLabel}
+        data-testid={external ? 'external-site-link' : 'external-link'}
+        href={sanitizedUrl()}
+        onClick={onClick}
+        ref={ref}
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        {children}
+        {external && !hideIcon && (
+          <span
+            className={cx(classes.iconContainer, {
+              [classes.forceCopyColor]: forceCopyColor,
+            })}
+          >
+            <ExternalLinkIcon />
+          </span>
+        )}
+      </a>
+    ) : (
+      <RouterLink
+        aria-label={ariaLabel}
+        data-testid="internal-link"
+        {...routerLinkProps}
+        className={cx(
+          classes.root,
+          {
+            [classes.forceCopyColor]: forceCopyColor,
+          },
+          className
+        )}
+        ref={ref}
+      />
     );
   }
-
-  const routerLinkProps = omit(props, [
-    'accessibleAriaLabel',
-    'external',
-    'forceCopyColor',
-  ]);
-
-  return shouldOpenInNewTab ? (
-    <a
-      className={cx(
-        classes.root,
-        {
-          [classes.forceCopyColor]: forceCopyColor,
-        },
-        className
-      )}
-      aria-label={ariaLabel}
-      data-testid={external ? 'external-site-link' : 'external-link'}
-      href={sanitizedUrl()}
-      onClick={onClick}
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      {children}
-      {external && !hideIcon && (
-        <span
-          className={cx(classes.iconContainer, {
-            [classes.forceCopyColor]: forceCopyColor,
-          })}
-        >
-          <ExternalLinkIcon />
-        </span>
-      )}
-    </a>
-  ) : (
-    <RouterLink
-      aria-label={ariaLabel}
-      data-testid="internal-link"
-      {...routerLinkProps}
-      className={cx(
-        classes.root,
-        {
-          [classes.forceCopyColor]: forceCopyColor,
-        },
-        className
-      )}
-    />
-  );
-};
+);

--- a/packages/manager/src/features/TopMenu/Help.tsx
+++ b/packages/manager/src/features/TopMenu/Help.tsx
@@ -10,7 +10,7 @@ export const Help = () => {
   return (
     <TopMenuTooltip title="Help & Support">
       <IconButton
-        aria-label="Help & Support"
+        accessibleAriaLabel="Help & Support"
         component={Link}
         sx={topMenuIconButtonSx}
         to="/support"


### PR DESCRIPTION
## Description 📝

- Fixes a few console errors caused by https://github.com/linode/manager/pull/10383 Sorry!! 🤦 
- Allows our `Link` component to accept a ref (had to do this to fix Tooltip ref error)

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-04-23 at 10 54 24 AM](https://github.com/linode/manager/assets/115251059/864192f0-e875-452c-8ef4-8b7c30fb08a4) | ![Screenshot 2024-04-23 at 10 54 16 AM](https://github.com/linode/manager/assets/115251059/7bb73a12-6f4b-4ac7-8d7c-35dc0bd7d4f1) |

## How to test 🧪

- Check out this PR
- Verify you don't see any console errors related to the Top Menu 
- Verify the top menu buttons for Help and Community...
  - Have working tooltips 💡 
  - Have `aria-label`s 📖 
  - Look good and consistent 🎨 

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support