### PR TITLE
change: [M3-6856] - Update Account Closure Dialog Wording

### DIFF
--- a/packages/manager/.changeset/pr-10406-changed-1714060751957.md
+++ b/packages/manager/.changeset/pr-10406-changed-1714060751957.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Update Account Closure Dialog Wording ([#10406](https://github.com/linode/manager/pull/10406))

--- a/packages/manager/cypress/e2e/core/account/account-cancellation.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/account-cancellation.spec.ts
@@ -79,7 +79,9 @@ describe('Account cancellation', () => {
       });
 
     ui.dialog
-      .findByTitle('Are you sure you want to close your Linode account?')
+      .findByTitle(
+        'Are you sure you want to close your cloud computing services account?'
+      )
       .should('be.visible')
       .within(() => {
         cy.findByText(cancellationDataLossWarning, { exact: false }).should(
@@ -179,7 +181,9 @@ describe('Account cancellation', () => {
 
     // Fill out cancellation dialog and attempt submission.
     ui.dialog
-      .findByTitle('Are you sure you want to close your Linode account?')
+      .findByTitle(
+        'Are you sure you want to close your cloud computing services account?'
+      )
       .should('be.visible')
       .within(() => {
         cy.findByLabelText(
@@ -353,7 +357,9 @@ describe('Parent/Child account cancellation', () => {
       });
 
     ui.dialog
-      .findByTitle('Are you sure you want to close your Linode account?')
+      .findByTitle(
+        'Are you sure you want to close your cloud computing services account?'
+      )
       .should('be.visible')
       .within(() => {
         cy.findByText(cancellationDataLossWarning, { exact: false }).should(

--- a/packages/manager/src/features/Account/CloseAccountDialog.tsx
+++ b/packages/manager/src/features/Account/CloseAccountDialog.tsx
@@ -94,7 +94,7 @@ const CloseAccountDialog = ({ closeDialog, open }: Props) => {
       onClose={closeDialog}
       open={open}
       textFieldStyle={{ maxWidth: '415px' }}
-      title="Are you sure you want to close your Linode account?"
+      title="Are you sure you want to close your cloud computing services account?"
     >
       {errors ? (
         <Notice text={errors ? errors[0].reason : ''} variant="error" />


### PR DESCRIPTION
## Description 📝
Update Account Closure Dialog Wording

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/119517080/2fce6c13-585d-4845-92bc-a525aa0010e0)| ![image](https://github.com/linode/manager/assets/119517080/db0dd617-b8de-4b08-bccf-d6fd98be6a81)|


### Verification steps
(How to verify changes)
- Navigate to http://localhost:3000/account/settings
- Verify Account Closure Dialog title.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

