### PR TITLE
upcoming: [M3-7980] - Update PlacementGroups linodes tooltip and SelectPlacementGroup option label

### DIFF
--- a/packages/manager/.changeset/pr-10408-upcoming-features-1714066606151.md
+++ b/packages/manager/.changeset/pr-10408-upcoming-features-1714066606151.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update Placement GroupTable Row linodes tooltip and SelectPlacementGroup option label ([#10408](https://github.com/linode/manager/pull/10408))

--- a/packages/manager/.changeset/pr-10408-upcoming-features-1714066606151.md
+++ b/packages/manager/.changeset/pr-10408-upcoming-features-1714066606151.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-Update Placement GroupTable Row linodes tooltip and SelectPlacementGroup option label ([#10408](https://github.com/linode/manager/pull/10408))
+Update Placement Group Table Row linodes tooltip and SelectPlacementGroup option label ([#10408](https://github.com/linode/manager/pull/10408))

--- a/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupSelectOption.tsx
+++ b/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupSelectOption.tsx
@@ -15,7 +15,7 @@ import type { ListItemComponentsPropsOverrides } from '@mui/material/ListItem';
 
 interface PlacementGroupSelectOptionProps {
   disabled?: boolean;
-  label: string;
+  label: JSX.Element;
   props: React.HTMLAttributes<HTMLLIElement>;
   selected?: boolean;
   value: PlacementGroup;

--- a/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupSelectOption.tsx
+++ b/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupSelectOption.tsx
@@ -1,8 +1,9 @@
-import { PlacementGroup } from '@linode/api-v4';
+import { AFFINITY_TYPES, PlacementGroup } from '@linode/api-v4';
 import { visuallyHidden } from '@mui/utils';
 import React from 'react';
 
 import { Box } from 'src/components/Box';
+import { Stack } from 'src/components/Stack';
 import { Tooltip } from 'src/components/Tooltip';
 import { PLACEMENT_GROUP_HAS_NO_CAPACITY } from 'src/features/PlacementGroups/constants';
 
@@ -15,7 +16,7 @@ import type { ListItemComponentsPropsOverrides } from '@mui/material/ListItem';
 
 interface PlacementGroupSelectOptionProps {
   disabled?: boolean;
-  label: JSX.Element;
+  label: string;
   props: React.HTMLAttributes<HTMLLIElement>;
   selected?: boolean;
   value: PlacementGroup;
@@ -63,7 +64,18 @@ export const PlacementGroupSelectOption = ({
         aria-disabled={undefined}
       >
         <Box alignItems="center" display="flex" flexGrow={1}>
-          {label}
+          <Stack alignItems="center" direction="row" flexGrow={1} gap={2}>
+            <Stack>{label}</Stack>
+            <Stack flexGrow={1} />
+            <Stack
+              sx={{
+                position: 'relative',
+                right: selected ? 14 : 34,
+              }}
+            >
+              ({AFFINITY_TYPES[value.affinity_type]})
+            </Stack>
+          </Stack>
           {disabled && (
             <Box
               sx={visuallyHidden}

--- a/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.test.tsx
+++ b/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.test.tsx
@@ -102,10 +102,10 @@ describe('PlacementGroupSelect', () => {
 
     fireEvent.focus(select);
     fireEvent.change(select, {
-      target: { value: 'my-placement-group (Affinity)' },
+      target: { value: 'my-placement-group' },
     });
 
-    const selectedRegionOption = getByText('my-placement-group (Affinity)');
+    const selectedRegionOption = getByText('my-placement-group');
     fireEvent.click(selectedRegionOption);
 
     expect(

--- a/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
+++ b/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
@@ -4,6 +4,7 @@ import { SxProps } from '@mui/system';
 import * as React from 'react';
 
 import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
+import { Stack } from 'src/components/Stack';
 import { TextFieldProps } from 'src/components/TextField';
 import { hasPlacementGroupReachedCapacity } from 'src/features/PlacementGroups/utils';
 import { useAllPlacementGroupsQuery } from 'src/queries/placementGroups';
@@ -71,8 +72,27 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
     return null;
   }
 
-  const formatLabel = (placementGroup: PlacementGroup) =>
-    `${placementGroup.label} (${AFFINITY_TYPES[placementGroup.affinity_type]})`;
+  const optionLabel = (placementGroup: PlacementGroup, selected?: boolean) => (
+    <Stack
+      alignItems="center"
+      direction="row"
+      flex={1}
+      position="relative"
+      width="100%"
+    >
+      <Stack component="span">{placementGroup.label}</Stack>{' '}
+      <Stack
+        sx={{
+          position: 'absolute',
+          right: selected ? 14 : 34,
+          whiteSpace: 'nowrap',
+        }}
+        component="span"
+      >
+        ({AFFINITY_TYPES[placementGroup.affinity_type]})
+      </Stack>
+    </Stack>
+  );
 
   const placementGroupsOptions: PlacementGroup[] = placementGroups.filter(
     (placementGroup) => placementGroup.region === selectedRegion?.id
@@ -96,7 +116,7 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
           <PlacementGroupSelectOption
             disabled={isDisabledPlacementGroup(option, selectedRegion)}
             key={option.id}
-            label={formatLabel(option)}
+            label={optionLabel(option, selected)}
             props={props}
             selected={selected}
             value={option}
@@ -109,7 +129,7 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
       disableClearable={!clearable}
       disabled={Boolean(!selectedRegion?.id) || disabled}
       errorText={errorText}
-      getOptionLabel={formatLabel}
+      getOptionLabel={(placementGroup: PlacementGroup) => placementGroup.label}
       id={id}
       label={label}
       loading={isLoading || loading}

--- a/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
+++ b/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
@@ -1,10 +1,7 @@
-import { AFFINITY_TYPES } from '@linode/api-v4';
 import { APIError } from '@linode/api-v4/lib/types';
-import { SxProps } from '@mui/system';
 import * as React from 'react';
 
 import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
-import { Stack } from 'src/components/Stack';
 import { TextFieldProps } from 'src/components/TextField';
 import { hasPlacementGroupReachedCapacity } from 'src/features/PlacementGroups/utils';
 import { useAllPlacementGroupsQuery } from 'src/queries/placementGroups';
@@ -12,6 +9,7 @@ import { useAllPlacementGroupsQuery } from 'src/queries/placementGroups';
 import { PlacementGroupSelectOption } from './PlacementGroupSelectOption';
 
 import type { PlacementGroup, Region } from '@linode/api-v4';
+import type { SxProps } from '@mui/system';
 
 export interface PlacementGroupsSelectProps {
   clearable?: boolean;
@@ -72,28 +70,6 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
     return null;
   }
 
-  const optionLabel = (placementGroup: PlacementGroup, selected?: boolean) => (
-    <Stack
-      alignItems="center"
-      direction="row"
-      flex={1}
-      position="relative"
-      width="100%"
-    >
-      <Stack component="span">{placementGroup.label}</Stack>{' '}
-      <Stack
-        sx={{
-          position: 'absolute',
-          right: selected ? 14 : 34,
-          whiteSpace: 'nowrap',
-        }}
-        component="span"
-      >
-        ({AFFINITY_TYPES[placementGroup.affinity_type]})
-      </Stack>
-    </Stack>
-  );
-
   const placementGroupsOptions: PlacementGroup[] = placementGroups.filter(
     (placementGroup) => placementGroup.region === selectedRegion?.id
   );
@@ -116,7 +92,7 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
           <PlacementGroupSelectOption
             disabled={isDisabledPlacementGroup(option, selectedRegion)}
             key={option.id}
-            label={optionLabel(option, selected)}
+            label={option.label}
             props={props}
             selected={selected}
             value={option}

--- a/packages/manager/src/components/TextTooltip/TextTooltip.tsx
+++ b/packages/manager/src/components/TextTooltip/TextTooltip.tsx
@@ -9,6 +9,10 @@ import type { TooltipProps } from '@mui/material/Tooltip';
 import type { TypographyProps } from 'src/components/Typography';
 
 export interface TextTooltipProps {
+  /**
+   * Props to pass to the Popper component
+   */
+  PopperProps?: TooltipProps['PopperProps'];
   /** The text to hover on to display the tooltip */
   displayText: string;
   /** If true, the tooltip will not have a min-width of 375px
@@ -36,6 +40,7 @@ export interface TextTooltipProps {
  */
 export const TextTooltip = (props: TextTooltipProps) => {
   const {
+    PopperProps,
     displayText,
     minWidth,
     placement,
@@ -47,7 +52,9 @@ export const TextTooltip = (props: TextTooltipProps) => {
   return (
     <StyledRootTooltip
       PopperProps={{
+        ...PopperProps,
         sx: {
+          ...PopperProps?.sx,
           '& > div': {
             minWidth: minWidth ? minWidth : 375,
           },

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
@@ -123,12 +123,16 @@ export const PlacementGroupsDetailPanel = (props: Props) => {
             mb: 1,
             width: '100%',
           }}
+          textFieldProps={{
+            tooltipClasses: 'poo',
+            tooltipPosition: 'right',
+            tooltipText: PLACEMENT_GROUP_SELECT_TOOLTIP_COPY,
+          }}
           disabled={isPlacementGroupSelectDisabled}
           label={placementGroupSelectLabel}
           noOptionsMessage="There are no Placement Groups in this region."
           selectedPlacementGroup={selectedPlacementGroup}
           selectedRegion={selectedRegion}
-          textFieldProps={{ tooltipText: PLACEMENT_GROUP_SELECT_TOOLTIP_COPY }}
         />
         {selectedRegion && hasRegionPlacementGroupCapability && (
           <Button
@@ -142,6 +146,9 @@ export const PlacementGroupsDetailPanel = (props: Props) => {
               mt: -0.75,
               p: 0,
             })}
+            sxEndIcon={{
+              color: theme.color.grey4,
+            }}
             onClick={() => setIsCreatePlacementGroupDrawerOpen(true)}
             tooltipText="This region has reached its Placement Group capacity."
             variant="text"

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
@@ -124,7 +124,6 @@ export const PlacementGroupsDetailPanel = (props: Props) => {
             width: '100%',
           }}
           textFieldProps={{
-            tooltipClasses: 'poo',
             tooltipPosition: 'right',
             tooltipText: PLACEMENT_GROUP_SELECT_TOOLTIP_COPY,
           }}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsRow.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsRow.tsx
@@ -85,20 +85,25 @@ export const PlacementGroupsRow = React.memo(
             '0'
           ) : (
             <TextTooltip
+              PopperProps={{
+                sx: {
+                  '& .MuiTooltip-tooltip': {
+                    transform: 'translateX(-16px) !important',
+                  },
+                },
+              }}
               tooltipText={
                 <List>
                   {assignedLinodes?.map((linode, idx) => (
-                    <ListItem
-                      key={`pg-linode-${idx}`}
-                      sx={{ paddingBottom: 0.5, paddingTop: 0.5 }}
-                    >
-                      {linode.label}
+                    <ListItem key={`pg-linode-${idx}`} sx={{ p: 0.5 }}>
+                      <Link to={`linodes/${linode.id}`}>{linode.label}</Link>
                     </ListItem>
                   ))}
                 </List>
               }
               displayText={`${assignedLinodes?.length ?? 0}`}
               minWidth={250}
+              placement="bottom-start"
             />
           )}
           &nbsp; of{' '}


### PR DESCRIPTION
## Description 📝
Small PR to bring a couple UI updates to the Placement Groups

## Changes  🔄
List any change relevant to the reviewer.
- Change PlacementGroupSelect option label to have the affinity type floating right and remove affinity type from selected option
- Improve PG table row linodes tooltip (linking, placement)

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-04-25 at 13 24 59](https://github.com/linode/manager/assets/130582365/aa8015fd-a24b-472f-8bbc-66d704fed75d) | ![Screenshot 2024-04-25 at 13 25 34](https://github.com/linode/manager/assets/130582365/4bd411b7-af5d-42f1-a283-a5a655b4632f) |
|  ![Screenshot 2024-04-25 at 13 28 03](https://github.com/linode/manager/assets/130582365/8f19a529-cecb-47ac-b3a3-c1ba0f4812d4) | ![Screenshot 2024-04-25 at 13 27 47](https://github.com/linode/manager/assets/130582365/5d2a1c7b-9d57-4ce4-8f58-fe6251b948bb) |

## How to test 🧪

### Verification steps
ℹ️ Perform these verifications in Alpha
- Verify the PlacementGroupSelect change in the linode create flow (select Newark region)
- Verify the tooltip changes at http://localhost:3000/placement-groups (make sure to have a PG and a Linode assigned to it)

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support


