### PR TITLE
upcoming: [M3-7671] - Add Resources Section to Placement Groups Landing in Empty State

### DIFF
--- a/packages/manager/.changeset/pr-10411-upcoming-features-1714138447215.md
+++ b/packages/manager/.changeset/pr-10411-upcoming-features-1714138447215.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add content to the ResourcesSection of the PG landing page in empty state ([#10411](https://github.com/linode/manager/pull/10411))

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsAffinityTypeSelect.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsAffinityTypeSelect.tsx
@@ -6,6 +6,7 @@ import { ListItem } from 'src/components/ListItem';
 import { Tooltip } from 'src/components/Tooltip';
 import { Typography } from 'src/components/Typography';
 
+import { PLACEMENT_GROUPS_DOCS_LINK } from './constants';
 import { affinityTypeOptions } from './utils';
 
 import type { FormikHelpers } from 'formik';
@@ -35,7 +36,7 @@ export const PlacementGroupsAffinityTypeSelect = (props: Props) => {
               isDisabledMenuItem ? (
                 <Typography>
                   Only supporting Anti-affinity host placement groups for Beta.{' '}
-                  <Link to="TODO VM_Placement: update link">Learn more</Link>.
+                  <Link to={PLACEMENT_GROUPS_DOCS_LINK}>Learn more</Link>.
                 </Typography>
               ) : (
                 ''
@@ -80,8 +81,7 @@ export const PlacementGroupsAffinityTypeSelect = (props: Props) => {
             in separate fault domains, but still in the same data center. Use
             this to support a high-availability model.
             <br />
-            {/* TODO VM_Placement: Add link path or determine if removal desired */}
-            <Link to="TODO VM_Placement: update link">Learn more.</Link>
+            <Link to={PLACEMENT_GROUPS_DOCS_LINK}>Learn more.</Link>
           </Typography>
         ),
       }}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsDetail.tsx
@@ -18,6 +18,7 @@ import {
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
+import { PLACEMENT_GROUPS_DOCS_LINK } from '../constants';
 import { PlacementGroupsLinodes } from './PlacementGroupsLinodes/PlacementGroupsLinodes';
 import { PlacementGroupsSummary } from './PlacementGroupsSummary/PlacementGroupsSummary';
 
@@ -109,7 +110,7 @@ export const PlacementGroupsDetail = () => {
         }}
         disabledBreadcrumbEditButton={isLinodeReadOnly}
         docsLabel="Docs"
-        docsLink="TODO VM_Placement: add doc link"
+        docsLink={PLACEMENT_GROUPS_DOCS_LINK}
         title="Placement Group Detail"
       />
       {isLinodeReadOnly && (

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsSummary/PlacementGroupsSummary.tsx
@@ -10,7 +10,10 @@ import { Notice } from 'src/components/Notice/Notice';
 import { Paper } from 'src/components/Paper';
 import { Typography } from 'src/components/Typography';
 
-import { PLACEMENT_GROUP_TOOLTIP_TEXT } from '../../constants';
+import {
+  PLACEMENT_GROUP_TOOLTIP_TEXT,
+  PLACEMENT_GROUPS_DOCS_LINK,
+} from '../../constants';
 import { getAffinityTypeEnforcement } from '../../utils';
 
 import type { PlacementGroup, Region } from '@linode/api-v4';
@@ -31,11 +34,10 @@ export const PlacementGroupsSummary = (props: Props) => {
         <Notice spacingBottom={20} spacingTop={24} variant="warning">
           <Typography fontFamily={theme.font.bold}>
             {`Placement Group ${placementGroup.label} is non-compliant. We are working to resolve compliance issues so that you can continue assigning Linodes to this Placement Group. `}
-            {/* TODO VM_Placement: Get link location */}
             <Link
               className="secondaryLink"
               data-testid="pg-non-compliant-notice-link"
-              to={'#'}
+              to={PLACEMENT_GROUPS_DOCS_LINK}
             >
               Learn more
             </Link>

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLanding.test.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLanding.test.tsx
@@ -93,4 +93,17 @@ describe('PlacementGroupsLanding', () => {
       )
     ).toBeInTheDocument();
   });
+
+  it('should render placement group Getting Started Guides on landing page with empty state', () => {
+    queryMocks.usePlacementGroupsQuery.mockReturnValue({
+      data: {
+        data: [],
+        results: 0,
+      },
+    });
+
+    const { getByText } = renderWithTheme(<PlacementGroupsLanding />);
+
+    expect(getByText('Getting Started Guides')).toBeInTheDocument();
+  });
 });

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLanding.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLanding.tsx
@@ -1,8 +1,8 @@
 import CloseIcon from '@mui/icons-material/Close';
 import { useMediaQuery, useTheme } from '@mui/material';
 import * as React from 'react';
-import { useParams } from 'react-router-dom';
 import { useHistory } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import { CircleProgress } from 'src/components/CircleProgress';
 import { DebouncedSearchTextField } from 'src/components/DebouncedSearchTextField';
@@ -28,6 +28,7 @@ import { usePlacementGroupsQuery } from 'src/queries/placementGroups';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
+import { PLACEMENT_GROUPS_DOCS_LINK } from '../constants';
 import { PlacementGroupsCreateDrawer } from '../PlacementGroupsCreateDrawer';
 import { PlacementGroupsDeleteModal } from '../PlacementGroupsDeleteModal';
 import { PlacementGroupsEditDrawer } from '../PlacementGroupsEditDrawer';
@@ -170,7 +171,7 @@ export const PlacementGroupsLanding = React.memo(() => {
         }}
         breadcrumbProps={{ pathname: '/placement-groups' }}
         disabledCreateButton={isLinodeReadOnly}
-        docsLink={'TODO VM_Placement: add doc link'}
+        docsLink={PLACEMENT_GROUPS_DOCS_LINK}
         entity="Placement Group"
         onButtonClick={handleCreatePlacementGroup}
         title="Placement Groups"

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLandingEmptyStateData.ts
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLandingEmptyStateData.ts
@@ -1,4 +1,7 @@
-import { PLACEMENT_GROUP_LABEL } from 'src/features/PlacementGroups/constants';
+import {
+  PLACEMENT_GROUP_LABEL,
+  PLACEMENT_GROUPS_DOCS_LINK,
+} from 'src/features/PlacementGroups/constants';
 
 import type {
   ResourcesHeaders,
@@ -17,8 +20,7 @@ export const gettingStartedGuides: ResourcesLinkSection = {
   links: [
     {
       text: 'Overview of Placement Groups',
-      to:
-        'https://www.linode.com/docs/products/compute/compute-instances/guides/placement-groups/',
+      to: PLACEMENT_GROUPS_DOCS_LINK,
     },
   ],
   moreInfo: {

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLandingEmptyStateData.ts
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLandingEmptyStateData.ts
@@ -16,15 +16,16 @@ export const headers: ResourcesHeaders = {
 export const gettingStartedGuides: ResourcesLinkSection = {
   links: [
     {
-      text: '',
-      to: '',
+      text: 'Overview of Placement Groups',
+      to:
+        'https://www.linode.com/docs/products/compute/compute-instances/guides/placement-groups/',
     },
   ],
   moreInfo: {
-    text: '',
-    to: '',
+    text: 'Check out all our Docs',
+    to: 'https://www.linode.com/docs/',
   },
-  title: '',
+  title: 'Getting Started Guides',
 };
 
 export const linkAnalyticsEvent: ResourcesLinks['linkAnalyticsEvent'] = {

--- a/packages/manager/src/features/PlacementGroups/constants.ts
+++ b/packages/manager/src/features/PlacementGroups/constants.ts
@@ -15,3 +15,7 @@ You may want to group Linodes closer together to help improve performance, or fu
 
 export const PLACEMENT_GROUP_HAS_NO_CAPACITY =
   'This placement group has reached the maximum Linode capacity.';
+
+// Links
+export const PLACEMENT_GROUPS_DOCS_LINK =
+  'https://www.linode.com/docs/products/compute/compute-instances/guides/placement-groups/';


### PR DESCRIPTION
## Description 📝
This PR adds content to the `ResourcesSection` component of the Placement Groups landing page with an empty state.

## Changes  🔄
- Links to the Placement Groups docs and the Linode docs.

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![aaaa](https://github.com/linode/manager/assets/119514965/a51da6c5-34a7-4cb7-af24-24de45f558dd) | ![bbbb](https://github.com/linode/manager/assets/119514965/cf035454-30f7-4d57-ace7-5f5271445058) |

## How to test 🧪
### Prerequisites
(How to setup test environment)
- Using the Cloud Manager developer tools, turn on the `Placement Groups` feature flag.

### Verification steps
(How to verify changes)
- Verify that the `ResourcesSection` component is rendered in the Placement Groups landing page with an empty state.
- Verify that both links open in new tabs.
- Verify that all tests are passing.

## As an Author I have considered 🤔
*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
