### PR TITLE
feat: [M3-8005] – Add `disk_encryption` to types & validation schemas

### DIFF
--- a/packages/api-v4/.changeset/pr-10413-changed-1714154673845.md
+++ b/packages/api-v4/.changeset/pr-10413-changed-1714154673845.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Changed
+---
+
+Add disk_encryption to Linode, Disk, CreateLinodeRequest, RebuildRequest, and KubeNodePoolResponse interfaces ([#10413](https://github.com/linode/manager/pull/10413))

--- a/packages/api-v4/src/kubernetes/types.ts
+++ b/packages/api-v4/src/kubernetes/types.ts
@@ -1,3 +1,5 @@
+import type { EncryptionStatus } from 'src/linodes';
+
 export interface KubernetesCluster {
   created: string;
   updated: string;
@@ -16,6 +18,7 @@ export interface KubeNodePoolResponse {
   nodes: PoolNodeResponse[];
   type: string;
   autoscaler: AutoscaleSettings;
+  disk_encryption?: EncryptionStatus; // @TODO LDE: remove optionality once LDE is fully rolled out
 }
 
 export interface PoolNodeResponse {

--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -5,6 +5,8 @@ import type { PlacementGroupPayload } from '../placement-groups/types';
 
 export type Hypervisor = 'kvm' | 'zen';
 
+export type EncryptionStatus = 'enabled' | 'disabled';
+
 export interface LinodeSpecs {
   disk: number;
   memory: number;
@@ -18,6 +20,7 @@ export interface Linode {
   alerts: LinodeAlerts;
   backups: LinodeBackups;
   created: string;
+  disk_encryption?: EncryptionStatus; // @TODO LDE: Remove optionality once LDE is fully rolled out
   region: string;
   image: string | null;
   group: string;
@@ -267,6 +270,7 @@ export interface Disk {
   filesystem: Filesystem;
   created: string;
   updated: string;
+  disk_encryption?: EncryptionStatus; // @TODO LDE: remove optionality once LDE is fully rolled out
 }
 
 export type DiskStatus = 'ready' | 'not ready' | 'deleting';
@@ -446,9 +450,14 @@ export interface CreateLinodeRequest {
    */
   firewall_id?: number | null;
   /**
-   * An object that assigns this the Linode to a placment group upon creation.
+   * An object that assigns this the Linode to a placement group upon creation.
    */
   placement_group?: CreateLinodePlacementGroupPayload;
+  /**
+   * A property with a string literal type indicating whether the Linode is encrypted or unencrypted.
+   * @default 'enabled' (if the region supports LDE)
+   */
+  disk_encryption?: EncryptionStatus;
 }
 
 export interface MigrateLinodeRequest {
@@ -484,6 +493,7 @@ export interface RebuildRequest {
   stackscript_id?: number;
   stackscript_data?: any;
   booted?: boolean;
+  disk_encryption?: EncryptionStatus;
 }
 
 export interface LinodeDiskCreationData {

--- a/packages/validation/.changeset/pr-10413-changed-1714154797841.md
+++ b/packages/validation/.changeset/pr-10413-changed-1714154797841.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Changed
+---
+
+Include disk_encryption in CreateLinodeSchema and RebuildLinodeSchema ([#10413](https://github.com/linode/manager/pull/10413))

--- a/packages/validation/src/linodes.schema.ts
+++ b/packages/validation/src/linodes.schema.ts
@@ -274,6 +274,13 @@ const PlacementGroupPayloadSchema = object({
   id: number().notRequired().nullable(true),
 });
 
+const DiskEncryptionSchema = object({
+  disk_encryption: string()
+    .oneOf(['enabled', 'disabled'])
+    .nullable()
+    .notRequired(),
+});
+
 export const CreateLinodeSchema = object({
   type: string().ensure().required('Plan is required.'),
   region: string().ensure().required('Region is required.'),
@@ -309,6 +316,7 @@ export const CreateLinodeSchema = object({
   metadata: MetadataSchema,
   firewall_id: number().nullable().notRequired(),
   placement_group: PlacementGroupPayloadSchema,
+  disk_encryption: DiskEncryptionSchema,
 });
 
 const alerts = object({
@@ -389,6 +397,7 @@ export const RebuildLinodeSchema = object().shape({
   stackscript_data,
   booted: boolean().notRequired(),
   metadata: MetadataSchema,
+  disk_encryption: DiskEncryptionSchema,
 });
 
 export const RebuildLinodeFromStackScriptSchema = RebuildLinodeSchema.shape({


### PR DESCRIPTION
## Description 📝
Add `disk_encryption` to types & validation schemas as appropriate based on the API spec (see ticket for link)

## Changes  🔄
- `EncryptionStatus` type added; `disk_encryption` field added to `Linode`, `Disk`, `CreateLinodeRequest`, and `RebuildRequest` interfaces
- `disk_encryption` added to `CreateLinodeSchema` and `RebuildLinodeSchema`; it is nullable and optional, but if provided should have a value of either "enabled" or "disabled"

> [!NOTE]
> `@TODO LDE: remove optionality once LDE is fully rolled out` was added as a comment to a few new properties. These are instances where, when LDE is fully rolled out, `disk_encryption` will always be included on that object. I think marking them as optional at this point is fair because not doing so would be premature, and also likely confuse consumers of the JS Client.

## Target release date 🗓️
5/13/24

## How to test 🧪
### Verification steps
- Ensure that Create Linode and Rebuild Linode functionality have not been adversely impacted (should still go through as expected with no errors related to the the `disk_encryption` field)
- Confirm the changes align with the API spec

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support