### PR TITLE
test: [M3-8050] - Fix OBJ E2E tests following API release

### DIFF
--- a/packages/manager/.changeset/pr-10417-tests-1714418018265.md
+++ b/packages/manager/.changeset/pr-10417-tests-1714418018265.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix failing OBJ E2E tests following API release ([#10417](https://github.com/linode/manager/pull/10417))

--- a/packages/manager/cypress/e2e/core/objectStorage/access-key.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/access-key.e2e.spec.ts
@@ -120,6 +120,8 @@ describe('object storage access key end-to-end tests', () => {
     const bucketRequest = objectStorageBucketFactory.build({
       label: bucketLabel,
       cluster: bucketCluster,
+      // Default factory sets `cluster` and `region`, but API does not accept `region` yet.
+      region: undefined,
     });
 
     // Create a bucket before creating access key.

--- a/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
@@ -53,7 +53,14 @@ const getNonEmptyBucketMessage = (bucketLabel: string) => {
  * @returns Promise that resolves to created Bucket.
  */
 const setUpBucket = (label: string, cluster: string) => {
-  return createBucket(objectStorageBucketFactory.build({ label, cluster }));
+  return createBucket(
+    objectStorageBucketFactory.build({
+      label,
+      cluster,
+      // Default factory sets `region`, but API does not accept it yet.
+      region: undefined,
+    })
+  );
 };
 
 /**


### PR DESCRIPTION
## Description 📝
This fixes a couple OBJ E2E tests that are failing following the latest API release. The failures are caused by the API responding with a `400` when we pass the `region` property in OBJ requests; previously this property was ignored, but now the API handles the property by rejecting it when a certain API-side config flag is not set.

Our OBJ factories include values for both the `region` and `cluster` properties, so this fixes the issue by manually setting `region` to `undefined` in the impacted tests.

## How to test 🧪
We can rely on CI for this; in its current state, these two tests fail 100% of the time, so it should be pretty easy to determine whether or not this PR resolves the problem.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
