### PR TITLE
feat: [M3-8006] – Support `disk_encryption` in mocks

### DIFF
--- a/packages/manager/.changeset/pr-10418-upcoming-features-1714423037799.md
+++ b/packages/manager/.changeset/pr-10418-upcoming-features-1714423037799.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add disk_encryption to several factories for mocked data ([#10418](https://github.com/linode/manager/pull/10418))

--- a/packages/manager/src/factories/disk.ts
+++ b/packages/manager/src/factories/disk.ts
@@ -3,6 +3,7 @@ import * as Factory from 'factory.ts';
 
 export const linodeDiskFactory = Factory.Sync.makeFactory<Disk>({
   created: '2018-01-01',
+  disk_encryption: 'enabled',
   filesystem: 'raw',
   id: Factory.each((id) => id),
   label: Factory.each((id) => `disk-${id}`),

--- a/packages/manager/src/factories/kubernetesCluster.ts
+++ b/packages/manager/src/factories/kubernetesCluster.ts
@@ -22,6 +22,7 @@ export const nodePoolFactory = Factory.Sync.makeFactory<KubeNodePoolResponse>({
     min: 1,
   },
   count: 3,
+  disk_encryption: 'enabled',
   id: Factory.each((id) => id),
   nodes: kubeLinodeFactory.buildList(3),
   type: 'g6-standard-1',

--- a/packages/manager/src/factories/linodes.ts
+++ b/packages/manager/src/factories/linodes.ts
@@ -255,6 +255,7 @@ export const linodeFactory = Factory.Sync.makeFactory<Linode>({
   alerts: linodeAlertsFactory.build(),
   backups: linodeBackupsFactory.build(),
   created: '2020-01-01',
+  disk_encryption: 'enabled',
   group: '',
   hypervisor: 'kvm',
   id: Factory.each((i) => i),


### PR DESCRIPTION
## Description 📝
Add `disk_encryption` to `linodeDiskFactory`, `linodeFactory`, and `nodePoolFactory`

## Target release date 🗓️
5/13/24

## How to test 🧪
### Verification steps
This can be verified with the RQ Dev Tool -- with the MSW on, when going to the Linodes landing page, Linode Details page, and the Kubernetes landing page, you should be able to click into the relevant queries and observe `disk_encryption` is present.

<details>
<summary>Screenshots</summary>

![Screenshot 2024-04-29 at 4 31 13 PM](https://github.com/linode/manager/assets/114682940/2f5d01cf-9d1c-44cd-aa51-299eacc6212b)

![Screenshot 2024-04-29 at 4 31 30 PM](https://github.com/linode/manager/assets/114682940/4d37ff03-b18e-490b-a0c6-8c71246832c0)

![Screenshot 2024-04-29 at 4 32 19 PM](https://github.com/linode/manager/assets/114682940/353ca2a9-e24c-450c-ab6d-5ae5d6fc3196)
</details>

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support