### PR TITLE
test: [M3-7844] - Add script to generate JSON payload for TOD test results

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "coverage": "yarn workspace linode-manager coverage",
     "coverage:summary": "yarn workspace linode-manager coverage:summary",
     "junit:summary": "ts-node scripts/junit-summary/index.ts",
+    "generate-tod": "ts-node scripts/tod-payload/index.ts",
     "docs": "bunx vitepress@1.0.0-rc.44 dev docs"
   },
   "resolutions": {

--- a/packages/manager/.changeset/pr-10422-tech-stories-1714510098465.md
+++ b/packages/manager/.changeset/pr-10422-tech-stories-1714510098465.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Add script to generate internal test results payload ([#10422](https://github.com/linode/manager/pull/10422))

--- a/scripts/tod-payload/index.ts
+++ b/scripts/tod-payload/index.ts
@@ -17,6 +17,7 @@ program
   .option('-v, --appVersion <str>', 'Application version')
   .option('-t, --appTeam <str>', 'Application team name')
   .option('-f, --fail', 'Treat payload as failure')
+  .option('-t, --tag <str>', 'Optional tag for run')
   .option('-o, --output <str>', 'Optional path to output TOD payload file')
 
   .action((junitPath: string) => {
@@ -47,6 +48,7 @@ const main = async (junitPath: string) => {
     semanticVersion: program.opts()['appVersion'],
     buildUrl: program.opts()['appBuildUrl'],
     pass: !program.opts()['fail'],
+    tag: !!program.opts()['tag'] ? program.opts()['tag'] : undefined,
     xunitResults: junitContents.map((junitContent) => {
       return btoa(junitContent);
     }),

--- a/scripts/tod-payload/index.ts
+++ b/scripts/tod-payload/index.ts
@@ -18,7 +18,6 @@ program
   .option('-t, --appTeam <str>', 'Application team name')
   .option('-f, --fail', 'Treat payload as failure')
   .option('-t, --tag <str>', 'Optional tag for run')
-  .option('-o, --output <str>', 'Optional path to output TOD payload file')
 
   .action((junitPath: string) => {
     return main(junitPath);
@@ -61,16 +60,6 @@ const main = async (junitPath: string) => {
       return btoa(junitContent);
     }),
   });
-
-  const outputPath = program.opts()['output'];
-  if (outputPath) {
-    try {
-      await fs.writeFile(outputPath, payload);
-    }
-    catch (e: unknown) {
-      console.warn(`Failed to output payload to ${outputPath}`);
-    }
-  }
 
   console.log(payload);
 };

--- a/scripts/tod-payload/index.ts
+++ b/scripts/tod-payload/index.ts
@@ -1,0 +1,52 @@
+import { program } from 'commander';
+// import { readFileSync } from 'fs';
+import * as fs from 'fs/promises';
+import { resolve } from 'path';
+
+
+program
+  .name('tod-payload')
+  .description('Output TOD test result payload')
+  .version('0.1.0')
+  .arguments('<junitPath>')
+  .option('-n, --appName <str>', 'Application name')
+  .option('-b, --appBuild <str>', 'Application build identifier')
+  .option('-u, --appBuildUrl <str>', 'Application build URL')
+  .option('-v, --appVersion <str>', 'Application version')
+  .option('-t, --appTeam <str>', 'Application team name')
+
+  .action((junitPath: string) => {
+    return main(junitPath);
+  });
+
+const main = async (junitPath: string) => {
+  const resolvedJunitPath = resolve(junitPath);
+
+  // Create an array of absolute file paths to JUnit XML report files.
+  const junitFiles = (await fs.readdir(resolvedJunitPath))
+    .filter((dirItem: string) => {
+      return dirItem.endsWith('.xml')
+    })
+    .map((dirItem: string) => {
+      return resolve(resolvedJunitPath, dirItem);
+    });
+
+  // Read all of the JUnit files.
+  const junitContents = await Promise.all(junitFiles.map((junitFile) => {
+    return fs.readFile(junitFile, 'utf8');
+  }));
+
+  console.log({
+    team: program.opts()['appTeam'],
+    name: program.opts()['appName'],
+    buildName: program.opts()['appBuild'],
+    semanticVersion: program.opts()['appVersion'],
+    buildUrl: program.opts()['appBuildUrl'],
+    pass: true,
+    xunitResults: junitContents.map((junitContent) => {
+      return btoa(junitContent);
+    }),
+  });
+};
+
+program.parse(process.argv);


### PR DESCRIPTION
## Description 📝
This adds another script in `scripts/` to generate a payload for our internal test result store, TOD. See M3-7843 for the Cloud/TOD epic which provides more context and outlines our plan to integrate Cloud with TOD.

The purpose of this script is to consume a JUnit XML file (or a bunch of JUnit XML files) and output a TOD-compatible JSON payload. This payload contains the JUnit data itself, along with various metadata describing the project and test run.

I opted to add the script here because it will need to be invoked from Jenkins and from GitHub Actions, and wanted to avoid having to implement the same script twice.

## Changes  🔄
- Add `yarn generate-tod` script

## How to test 🧪

### Pre-Requisites
You'll need at least one JUnit XML file to test with. The quickest way to generate one is to pass `--reporter=junit` when invoking `yarn test`, like this:

```bash
yarn --silent test features/Profile/APITokens/CreateAPITokenDrawer.test --reporter=junit >> junit.xml
```

Alternatively, you can generate JUnit files using Cypress:

```bash
CY_TEST_JUNIT_REPORT=1 yarn cy:run -s "cypress/e2e/core/account/account-cancellation.spec.ts"
```

The JUnit files will be output to `cypress/results`.

### Testing

Confirm that `yarn generate-tod` script works as expected. Run `yarn generate-tod --help` for a detailed breakdown of command syntax and optional parameters. Some scenarios to test:

- Generating a payload containing a single JUnit file by passing a path to the JUnit file
- Generating a payload containing multiple JUnit files by passing a path to a directory containing JUnit files
- Generating a payload containing extra metadata using `--appName`, `--appBuild`, `--appBuildUrl`, `--fail`, `--tag`, and related parameters

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

