### PR TITLE
fix: [M3-8053] - Fix table component props forwarding

### DIFF
--- a/packages/manager/.changeset/pr-10424-fixed-1714505413640.md
+++ b/packages/manager/.changeset/pr-10424-fixed-1714505413640.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Table component props forwarding ([#10424](https://github.com/linode/manager/pull/10424))

--- a/packages/manager/src/components/Table/Table.tsx
+++ b/packages/manager/src/components/Table/Table.tsx
@@ -4,8 +4,6 @@ import {
 } from '@mui/material/Table';
 import * as React from 'react';
 
-import { omitProps } from 'src/utilities/omittedProps';
-
 import { StyledTableWrapper } from './Table.styles';
 
 export interface TableProps extends _TableProps {
@@ -79,17 +77,6 @@ export const Table = (props: TableProps) => {
     ...rest
   } = props;
 
-  const tableProps = omitProps({ ...props, ...rest }, [
-    'colCount',
-    'className',
-    'rowCount',
-    'noBorder',
-    'noOverflow',
-    'rowHoverState',
-    'spacingBottom',
-    'spacingTop',
-  ]);
-
   return (
     <StyledTableWrapper
       className={className}
@@ -101,7 +88,7 @@ export const Table = (props: TableProps) => {
     >
       <_Table
         className={tableClass}
-        {...tableProps}
+        {...rest}
         aria-colcount={colCount}
         aria-rowcount={rowCount}
         role="table"

--- a/packages/manager/src/components/Table/Table.tsx
+++ b/packages/manager/src/components/Table/Table.tsx
@@ -81,6 +81,7 @@ export const Table = (props: TableProps) => {
 
   const tableProps = omitProps({ ...props, ...rest }, [
     'colCount',
+    'className',
     'rowCount',
     'noBorder',
     'noOverflow',


### PR DESCRIPTION
## Description 📝
This previous [commit](https://github.com/linode/manager/commit/f9f33aa18ce9531123e73de65ea7781047243012#diff-dfeecf2f4fb1286e817742e67398c802505389acdc4c8f487c50b77e61b4a68eL81) introduced an issue with classes meant for the table wrapper being passed to the table component.

Previously, we were using `lodash` omit to remove props that were not even being passed, so it was useless. The good news is that my util is actually better typed than the `lodash` one so when i switched i was seeing typed errors trying to remove non-existing props. 

**The fix**: we only need to pass true table props to the actual Table component and keep the extra props for the wrapper.

## Changes  🔄
- prevent forwarding non table props to the `Table` component

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screen Shot 2024-04-30 at 15 19 12](https://github.com/linode/manager/assets/130582365/15fa7a10-5f41-4469-b835-504539d8c8be) | ![Screen Shot 2024-04-30 at 15 23 48](https://github.com/linode/manager/assets/130582365/5f0f674c-acac-4d72-8913-fb1ebd870077) |

## How to test 🧪

### Verification steps
- Only place where this regression was noticed is
  - http://localhost:3000/databases/mysql/{id} (need access controls)
- Verify no regression with tables and console warnings about invalid props

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
