### PR TITLE
change: Remove semver bump in `generate-changelogs.mjs`

### DIFF
--- a/scripts/changelog/generate-changelogs.mjs
+++ b/scripts/changelog/generate-changelogs.mjs
@@ -70,17 +70,6 @@ try {
             default: today,
           },
         ]);
-        const { semverBump } = await inquirer.prompt([
-          {
-            type: "list",
-            prefix: `📦 Semver bump for ${chalk.red(
-              `@linode/${linodePackage}`
-            )}`,
-            name: "semverBump",
-            message: "\nChoose the type of version bump:",
-            choices: ["patch", "minor", "major"],
-          },
-        ]);
 
         try {
           files.forEach((file) => {
@@ -113,8 +102,7 @@ try {
           });
         }
 
-        const newSemver = incrementSemver(currentSemver, semverBump);
-        const changelogContent = initiateChangelogEntry(releaseDate, newSemver);
+        const changelogContent = initiateChangelogEntry(releaseDate, currentSemver);
         // Generate the final changelog content
         populateChangelogEntry(changesetEntries, changelogContent);
 

--- a/scripts/changelog/generate-changelogs.mjs
+++ b/scripts/changelog/generate-changelogs.mjs
@@ -59,7 +59,7 @@ try {
             )}`,
             name: "releaseDate",
             message:
-              "\nEnter the release date (YYYY-MM-DD, press enter to select today's date:",
+              "\nEnter the release date (YYYY-MM-DD), press enter to select today's date:",
             validate: (input) => {
               if (!input.match(/^\d{4}-\d{2}-\d{2}$/)) {
                 return "Please enter a valid date in the format YYYY-MM-DD.";
@@ -156,7 +156,7 @@ try {
         }
 
         // Delete the changeset files for each package
-        deleteChangesets(linodePackage);
+        await deleteChangesets(linodePackage);
       }
     } catch (error) {
       logger.error({

--- a/scripts/changelog/utils/initiateChangelogEntry.mjs
+++ b/scripts/changelog/utils/initiateChangelogEntry.mjs
@@ -1,13 +1,13 @@
 /**
  * Generates the changelog content with the provided release date and version.
  * @param {string} releaseDate - The release date in YYYY-MM-DD format.
- * @param {string} newVersion - The new version.
+ * @param {string} semver - The release version.
  * @returns {string[]} The array of lines for the initial changelog content (date & semver).
  */
-export const initiateChangelogEntry = (releaseDate, newSemver) => {
+export const initiateChangelogEntry = (releaseDate, semver) => {
   const changelogContent = [];
 
-  changelogContent.push(`## [${releaseDate}] - v${newSemver}\n`);
+  changelogContent.push(`## [${releaseDate}] - v${semver}\n`);
 
   return changelogContent;
 };


### PR DESCRIPTION
## Description 📝
Based on a cafe discussion, remove the semver bump in `generate-changelogs.mjs` since those are handled in a different step in the release process.

## How to test 🧪
* Run `yarn generate-changelogs`
* Verify changelogs are generated as before, except without a version bump