### PR TITLE
upcoming: [M3-8051] - Set PlacementGroupSelect clearOnBlur

### DIFF
--- a/packages/manager/.changeset/pr-10427-fixed-1714532198771.md
+++ b/packages/manager/.changeset/pr-10427-fixed-1714532198771.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Set PlacementGroupSelect clearOnBlur to true ([#10427](https://github.com/linode/manager/pull/10427))

--- a/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
+++ b/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
@@ -12,6 +12,7 @@ import type { PlacementGroup, Region } from '@linode/api-v4';
 import type { SxProps } from '@mui/system';
 
 export interface PlacementGroupsSelectProps {
+  clearOnBlur?: boolean;
   clearable?: boolean;
   defaultValue?: PlacementGroup;
   disabled?: boolean;
@@ -30,6 +31,7 @@ export interface PlacementGroupsSelectProps {
 
 export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
   const {
+    clearOnBlur,
     clearable = true,
     defaultValue,
     disabled,
@@ -99,7 +101,7 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
           />
         );
       }}
-      clearOnBlur={false}
+      clearOnBlur={clearOnBlur}
       data-testid="placement-groups-select"
       defaultValue={defaultValue}
       disableClearable={!clearable}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
@@ -127,6 +127,7 @@ export const PlacementGroupsDetailPanel = (props: Props) => {
             tooltipPosition: 'right',
             tooltipText: PLACEMENT_GROUP_SELECT_TOOLTIP_COPY,
           }}
+          clearOnBlur={true}
           disabled={isPlacementGroupSelectDisabled}
           label={placementGroupSelectLabel}
           noOptionsMessage="There are no Placement Groups in this region."


### PR DESCRIPTION
## Description 📝
Small fix to make sure the PlacementGroupSelect gets its selected option cleared when no value is selected. In the Linode create flow, we clear the value when the `selectedRegionId` is updated. While the value is cleared and everything works as expected, an artifact of not clearing the input results in the selected option still showing in the select instead of the desired "None" placeholder.

from [mui.com](https://mui.com/material-ui/api/autocomplete/)

`clearOnBlur`
> If true, the input's text is cleared on blur if no value is selected. Set it to true if you want to help the user enter a new value. Set it to false if you want to help the user resume their search.

## Changes  🔄
- Set `PlacementGroupSelect` `clearOnBlur` to `true`

## Target release date 🗓️
**5/13/2024**

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/130582365/e84242fe-2476-45fb-9b07-bdc5055856eb" /> | <video src="https://github.com/linode/manager/assets/130582365/5046b61a-e6f2-4709-a007-2ec0e0d26c95" /> |

## How to test 🧪

### Verification steps
See videos above. Using **ALPHA**
- Navigate to http://localhost:3000/linodes/create
- Select Newark, NJ for the region
- Select a PG
- Select a different region
- Confirm the option is reset to the placeholder as opposed to the previously selected option

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
