### PR TITLE
fix: [M3-7977] - Surface interface error in Linode Config dialog 

### DIFF
--- a/packages/manager/.changeset/pr-10429-fixed-1716930064091.md
+++ b/packages/manager/.changeset/pr-10429-fixed-1716930064091.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Surface interface error in Linode Config dialog ([#10429](https://github.com/linode/manager/pull/10429))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 
 import { Divider } from 'src/components/Divider';
 import Select from 'src/components/EnhancedSelect/Select';
+import { Notice } from 'src/components/Notice/Notice';
 import { Stack } from 'src/components/Stack';
 import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
@@ -384,25 +385,30 @@ export const InterfaceSelect = (props: InterfaceSelectProps) => {
   return (
     <Grid container>
       {fromAddonsPanel ? null : (
-        <Grid xs={isSmallBp ? 12 : 6}>
-          <Select
-            options={
-              // Do not display "None" as an option for eth0 (must be Public Internet, VLAN, or VPC).
-              slotNumber > 0
-                ? purposeOptions
-                : purposeOptions.filter(
-                    (thisPurposeOption) => thisPurposeOption.value !== 'none'
-                  )
-            }
-            value={purposeOptions.find(
-              (thisOption) => thisOption.value === purpose
+        <Grid>
+          <Grid xs={isSmallBp ? 12 : 6}>
+            {errors.primaryError && (
+              <Notice text={errors.primaryError} variant="error" />
             )}
-            disabled={readOnly}
-            isClearable={false}
-            label={`eth${slotNumber}`}
-            onChange={handlePurposeChange}
-          />
-          {unavailableInRegionHelperTextJSX}
+            <Select
+              options={
+                // Do not display "None" as an option for eth0 (must be Public Internet, VLAN, or VPC).
+                slotNumber > 0
+                  ? purposeOptions
+                  : purposeOptions.filter(
+                      (thisPurposeOption) => thisPurposeOption.value !== 'none'
+                    )
+              }
+              value={purposeOptions.find(
+                (thisOption) => thisOption.value === purpose
+              )}
+              disabled={readOnly}
+              isClearable={false}
+              label={`eth${slotNumber}`}
+              onChange={handlePurposeChange}
+            />
+            {unavailableInRegionHelperTextJSX}
+          </Grid>
         </Grid>
       )}
       {purpose === 'vlan' &&

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
@@ -385,30 +385,28 @@ export const InterfaceSelect = (props: InterfaceSelectProps) => {
   return (
     <Grid container>
       {fromAddonsPanel ? null : (
-        <Grid>
-          <Grid xs={isSmallBp ? 12 : 6}>
-            {errors.primaryError && (
-              <Notice text={errors.primaryError} variant="error" />
+        <Grid xs={isSmallBp ? 12 : 6}>
+          {errors.primaryError && (
+            <Notice text={errors.primaryError} variant="error" />
+          )}
+          <Select
+            options={
+              // Do not display "None" as an option for eth0 (must be Public Internet, VLAN, or VPC).
+              slotNumber > 0
+                ? purposeOptions
+                : purposeOptions.filter(
+                    (thisPurposeOption) => thisPurposeOption.value !== 'none'
+                  )
+            }
+            value={purposeOptions.find(
+              (thisOption) => thisOption.value === purpose
             )}
-            <Select
-              options={
-                // Do not display "None" as an option for eth0 (must be Public Internet, VLAN, or VPC).
-                slotNumber > 0
-                  ? purposeOptions
-                  : purposeOptions.filter(
-                      (thisPurposeOption) => thisPurposeOption.value !== 'none'
-                    )
-              }
-              value={purposeOptions.find(
-                (thisOption) => thisOption.value === purpose
-              )}
-              disabled={readOnly}
-              isClearable={false}
-              label={`eth${slotNumber}`}
-              onChange={handlePurposeChange}
-            />
-            {unavailableInRegionHelperTextJSX}
-          </Grid>
+            disabled={readOnly}
+            isClearable={false}
+            label={`eth${slotNumber}`}
+            onChange={handlePurposeChange}
+          />
+          {unavailableInRegionHelperTextJSX}
         </Grid>
       )}
       {purpose === 'vlan' &&

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
@@ -385,29 +385,33 @@ export const InterfaceSelect = (props: InterfaceSelectProps) => {
   return (
     <Grid container>
       {fromAddonsPanel ? null : (
-        <Grid xs={isSmallBp ? 12 : 6}>
-          {errors.primaryError && (
-            <Notice text={errors.primaryError} variant="error" />
-          )}
-          <Select
-            options={
-              // Do not display "None" as an option for eth0 (must be Public Internet, VLAN, or VPC).
-              slotNumber > 0
-                ? purposeOptions
-                : purposeOptions.filter(
-                    (thisPurposeOption) => thisPurposeOption.value !== 'none'
-                  )
-            }
-            value={purposeOptions.find(
-              (thisOption) => thisOption.value === purpose
+        <>
+          <Grid width={'100%'}>
+            {errors.primaryError && (
+              <Notice text={errors.primaryError} variant="error" />
             )}
-            disabled={readOnly}
-            isClearable={false}
-            label={`eth${slotNumber}`}
-            onChange={handlePurposeChange}
-          />
-          {unavailableInRegionHelperTextJSX}
-        </Grid>
+          </Grid>
+          <Grid xs={isSmallBp ? 12 : 6}>
+            <Select
+              options={
+                // Do not display "None" as an option for eth0 (must be Public Internet, VLAN, or VPC).
+                slotNumber > 0
+                  ? purposeOptions
+                  : purposeOptions.filter(
+                      (thisPurposeOption) => thisPurposeOption.value !== 'none'
+                    )
+              }
+              value={purposeOptions.find(
+                (thisOption) => thisOption.value === purpose
+              )}
+              disabled={readOnly}
+              isClearable={false}
+              label={`eth${slotNumber}`}
+              onChange={handlePurposeChange}
+            />
+            {unavailableInRegionHelperTextJSX}
+          </Grid>
+        </>
       )}
       {purpose === 'vlan' &&
         regionHasVLANs !== false &&


### PR DESCRIPTION
## Description 📝
There were a couple of problems in the Add/Edit Configuration dialog:

- Interface select errors were not always being surfaced.
- ~**This was fixed in PR #10459:** General errors were not reliably being focused by `scrollErrorIntoView` because the scrolling can happen before the general error is updated in form state (via `formik.setStatus`), and therefore there is no notice to scroll to in the DOM, since `generalError` being defined is a condition for rendering the notice.~

> [!NOTE] 
> This PR's scope is small. There is more going on with the Linode Config Dialog because it's too large of a component handling both Create and Edit state and should be refactored. This is resulting in:
> -  A bug related to form state for the `interfaces` array causing it to sometimes display incorrect form values for  interfaces in Create (or Edit) mode, depending on the actions the user has taken, e.g. previously opening the Edit (or Create).
> - An issue permitting the user to Edit an existing config and add a VLAN in eth0, because `primary` (interface) is set to `false`. Instead of seeing the same error as in the Add Config dialog detailed beflow, the request submits successfully but the interfaces no longer have a primary interface. 
> Creating a follow up ticket with subtasks to refactor this component and address its issues: M3-8165.

## Changes  🔄
- Surfaced a previously unsurfaced API error on config interfaces by adding an error notice in the Networking section of the Config dialog. 

## Target release date 🗓️
6/10

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-05-28 at 11 33 16 AM](https://github.com/linode/manager/assets/114685994/a0f8818e-b0de-4ea2-894a-aa8a890e4865) | ![Screenshot 2024-05-28 at 11 31 48 AM](https://github.com/linode/manager/assets/114685994/52ea998e-8ee3-48fe-955e-bafbf5f93933) |

## How to test 🧪

### Reproduction steps
(How to reproduce the issue, if applicable)
 - Test the following in production:

**Error**: assigning a VLAN to eth0 is not a valid configuration, but does not surface an error
**Repro**:
1. Add a Config.
2. Primary interface should be eth0.
3. Set eth0 to VLAN and give it an IP a name and optionally IP address.
4. Set eth1 to None.
5. Set eth2 to None. 
6. Click Add Configuration.
7. Observe nothing happens. 
8. Open the browser tools and note the failed 400 POST request with the error:
```
{reason: "Field is not allowed for this interface type", field: "interfaces[0].primary"}
```

### Verification steps
(How to verify changes)
- Check out this branch and repeat the above steps to trigger errors.
- Confirm that for each error, it is scrolled into view.
- Confirm that assigning a VLAN to eth0 does show a surfaced error. 

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support