### PR TITLE
upcoming: [M3-8062] - Replace PG feature flag restriction with `useIsPlacementGroupsEnabled`

### DIFF
--- a/packages/manager/.changeset/pr-10431-upcoming-features-1714656373835.md
+++ b/packages/manager/.changeset/pr-10431-upcoming-features-1714656373835.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Replace remaining feature flag implementation with useIsPlacementGroupsEnabled utility function ([#10431](https://github.com/linode/manager/pull/10431))

--- a/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
@@ -8,6 +8,7 @@ import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
 import { sxEdgeIcon } from 'src/components/RegionSelect/RegionSelect.styles';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
+import { useIsPlacementGroupsEnabled } from 'src/features/PlacementGroups/utils';
 import { useFlags } from 'src/hooks/useFlags';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { useTypeQuery } from 'src/queries/types';
@@ -57,7 +58,7 @@ export const ConfigureForm = React.memo((props: Props) => {
   } = props;
 
   const flags = useFlags();
-  const showPlacementGroups = Boolean(flags.placementGroups?.enabled);
+  const { isPlacementGroupsEnabled } = useIsPlacementGroupsEnabled();
   const { data: regions } = useRegionsQuery();
 
   const { data: currentLinodeType } = useTypeQuery(
@@ -194,7 +195,7 @@ export const ConfigureForm = React.memo((props: Props) => {
               {...panelPrice(selectedRegion, selectedRegionPrice, 'new')}
             />
           )}
-          {showPlacementGroups && (
+          {isPlacementGroupsEnabled && (
             <PlacementGroupsSelect
               handlePlacementGroupChange={(placementGroup) => {
                 handlePlacementGroupSelection(placementGroup);


### PR DESCRIPTION
## Description 📝
Replaces a remaining implementation of the feature flag restriction for Placement Groups feature with the recently created utility function `useIsPlacementGroupsEnabled()`.

## Changes  🔄
List any change relevant to the reviewer.
- Straight forward replacement of one function with another.
- No UI/UX changes.

## Preview 📷
| Feature Flag Off  |  Feature Flag On  |
| ------- | ------- |
| ![Screenshot 2024-05-02 at 6 06 47 AM](https://github.com/linode/manager/assets/119514965/e237183a-2fa9-4e35-8384-9793bbd79ae3) | ![Screenshot 2024-05-02 at 6 06 58 AM](https://github.com/linode/manager/assets/119514965/223b0cdc-243b-4706-82b5-199b4b4ce5af) |


## How to test 🧪
### Prerequisites
(How to setup test environment)
- Have the `placement-group` customer tag on the user account used for testing.
- Using the Cloud Manager Dev Tools:
  - Enable and Disable the `Placement Groups` feature flag to test functionality.


### Verification steps
(How to verify changes)
- Verify that the `PlacementGroup` feature is restricted to users who have the Placement Group capability in their account by toggling the `Placement Groups` feature flag in the Cloud Manger Developer Tools.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
