### PR TITLE
test: Fix Placement Group delete tests following wording improvement

### DIFF
--- a/packages/manager/cypress/e2e/core/placementGroups/delete-placement-groups.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/delete-placement-groups.spec.ts
@@ -110,7 +110,9 @@ describe('Placement Group deletion', () => {
 
     // Confirm that UI updates to reflect deleted Placement Group.
     cy.wait(['@deletePlacementGroup', '@getPlacementGroups']);
-    ui.toast.assertMessage('Placement Group successfully deleted.');
+    ui.toast.assertMessage(
+      `Placement Group ${mockPlacementGroup.label} successfully deleted.`
+    );
     cy.findByText(emptyStateMessage).should('be.visible');
   });
 
@@ -245,7 +247,9 @@ describe('Placement Group deletion', () => {
       });
 
     cy.wait(['@deletePlacementGroup', '@getPlacementGroups']);
-    ui.toast.assertMessage('Placement Group successfully deleted.');
+    ui.toast.assertMessage(
+      `Placement Group ${mockPlacementGroup.label} successfully deleted.`
+    );
 
     // Confirm that deleted Placement Group has been removed from list and that
     // other Placement Group remains.


### PR DESCRIPTION
## Description 📝
Quick fix for the VMPG delete failures -- the wording on the toast notification was improved, but on a branch that didn't have these tests, so the tests began failing when they were merged.

(Don't think a changeset is even necessary here since these tests haven't been released yet -- any other thoughts?)

## How to test 🧪
CI's good enough here.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
