### PR TITLE
upcoming: [M3-8025] - Placement Groups: Allow null for maximum_pgs_per_customer

### DIFF
--- a/packages/api-v4/.changeset/pr-10433-changed-1714662873531.md
+++ b/packages/api-v4/.changeset/pr-10433-changed-1714662873531.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Changed
+---
+
+Allow null for Placement Groups maximum_pgs_per_customer ([#10433](https://github.com/linode/manager/pull/10433))

--- a/packages/api-v4/src/regions/types.ts
+++ b/packages/api-v4/src/regions/types.ts
@@ -32,7 +32,7 @@ export interface Region {
   country: Country;
   capabilities: Capabilities[];
   placement_group_limits: {
-    maximum_pgs_per_customer: number;
+    maximum_pgs_per_customer: number | null; // This value can be unlimited for some customers, for which the API returns the `null` value.
     maximum_linodes_per_pg: number;
   };
   status: RegionStatus;

--- a/packages/manager/.changeset/pr-10433-changed-1714664264011.md
+++ b/packages/manager/.changeset/pr-10433-changed-1714664264011.md
@@ -2,4 +2,4 @@
 "@linode/manager": Changed
 ---
 
-Update maximum_pgs_per_customer UI ([#10433](https://github.com/linode/manager/pull/10433))
+Update Placement Groups maximum_pgs_per_customer UI ([#10433](https://github.com/linode/manager/pull/10433))

--- a/packages/manager/.changeset/pr-10433-changed-1714664264011.md
+++ b/packages/manager/.changeset/pr-10433-changed-1714664264011.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Update maximum_pgs_per_customer UI ([#10433](https://github.com/linode/manager/pull/10433))

--- a/packages/manager/src/__data__/regionsData.ts
+++ b/packages/manager/src/__data__/regionsData.ts
@@ -48,7 +48,7 @@ export const regions: Region[] = [
     label: 'Toronto, CA',
     placement_group_limits: {
       maximum_linodes_per_pg: 1,
-      maximum_pgs_per_customer: 5,
+      maximum_pgs_per_customer: null,
     },
     resolvers: {
       ipv4:

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsCreateDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsCreateDrawer.tsx
@@ -25,7 +25,10 @@ import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
 
 import { PlacementGroupsAffinityEnforcementRadioGroup } from './PlacementGroupsAffinityEnforcementRadioGroup';
 import { PlacementGroupsAffinityTypeSelect } from './PlacementGroupsAffinityTypeSelect';
-import { hasRegionReachedPlacementGroupCapacity } from './utils';
+import {
+  getMaxPGsPerCustomer,
+  hasRegionReachedPlacementGroupCapacity,
+} from './utils';
 
 import type { PlacementGroupsCreateDrawerProps } from './types';
 import type { CreatePlacementGroupPayload, Region } from '@linode/api-v4';
@@ -123,7 +126,9 @@ export const PlacementGroupsCreateDrawer = (
     [regions, values.region]
   );
 
-  const pgRegionLimitHelperText = `The maximum number of placement groups in this region is: ${selectedRegion?.placement_group_limits?.maximum_pgs_per_customer}`;
+  const pgRegionLimitHelperText = `The maximum number of placement groups in this region is: ${getMaxPGsPerCustomer(
+    selectedRegion
+  )}`;
 
   return (
     <Drawer
@@ -192,8 +197,7 @@ export const PlacementGroupsCreateDrawer = (
                       </Typography>
                       <Typography mt={2}>
                         The maximum number of placement groups in this region
-                        is:{' '}
-                        {region.placement_group_limits.maximum_pgs_per_customer}
+                        is: {getMaxPGsPerCustomer(region)}
                       </Typography>
                     </>
                   ),

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsCreateDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsCreateDrawer.tsx
@@ -23,6 +23,7 @@ import { useRegionsQuery } from 'src/queries/regions/regions';
 import { getFormikErrorsFromAPIErrors } from 'src/utilities/formikErrorUtils';
 import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
 
+import { MAXIMUM_NUMBER_OF_PLACEMENT_GROUPS_IN_REGION } from './constants';
 import { PlacementGroupsAffinityEnforcementRadioGroup } from './PlacementGroupsAffinityEnforcementRadioGroup';
 import { PlacementGroupsAffinityTypeSelect } from './PlacementGroupsAffinityTypeSelect';
 import {
@@ -126,7 +127,7 @@ export const PlacementGroupsCreateDrawer = (
     [regions, values.region]
   );
 
-  const pgRegionLimitHelperText = `The maximum number of placement groups in this region is: ${getMaxPGsPerCustomer(
+  const pgRegionLimitHelperText = `${MAXIMUM_NUMBER_OF_PLACEMENT_GROUPS_IN_REGION} ${getMaxPGsPerCustomer(
     selectedRegion
   )}`;
 
@@ -196,8 +197,8 @@ export const PlacementGroupsCreateDrawer = (
                         create in this region.
                       </Typography>
                       <Typography mt={2}>
-                        The maximum number of placement groups in this region
-                        is: {getMaxPGsPerCustomer(region)}
+                        {MAXIMUM_NUMBER_OF_PLACEMENT_GROUPS_IN_REGION}{' '}
+                        {getMaxPGsPerCustomer(region)}
                       </Typography>
                     </>
                   ),

--- a/packages/manager/src/features/PlacementGroups/constants.ts
+++ b/packages/manager/src/features/PlacementGroups/constants.ts
@@ -16,6 +16,9 @@ You may want to group Linodes closer together to help improve performance, or fu
 export const PLACEMENT_GROUP_HAS_NO_CAPACITY =
   'This placement group has reached the maximum Linode capacity.';
 
+export const MAXIMUM_NUMBER_OF_PLACEMENT_GROUPS_IN_REGION =
+  'Maximum placement groups in region:';
+
 // Links
 export const PLACEMENT_GROUPS_DOCS_LINK =
   'https://www.linode.com/docs/products/compute/compute-instances/guides/placement-groups/';

--- a/packages/manager/src/features/PlacementGroups/utils.test.ts
+++ b/packages/manager/src/features/PlacementGroups/utils.test.ts
@@ -10,6 +10,7 @@ import {
   affinityTypeOptions,
   getAffinityTypeEnforcement,
   getLinodesFromAllPlacementGroups,
+  getMaxPGsPerCustomer,
   getPlacementGroupLinodes,
   hasPlacementGroupReachedCapacity,
   hasRegionReachedPlacementGroupCapacity,
@@ -278,5 +279,31 @@ describe('useIsPlacementGroupsEnabled', () => {
     expect(result.current).toStrictEqual({
       isPlacementGroupsEnabled: false,
     });
+  });
+});
+
+describe('getMaxPGsPerCustomer', () => {
+  it('returns the maximum number of Placement Groups per region a customer is allowed to create', () => {
+    const region = regionFactory.build({
+      placement_group_limits: {
+        maximum_pgs_per_customer: 5,
+      },
+    });
+
+    expect(getMaxPGsPerCustomer(region)).toBe(5);
+  });
+
+  it('returns "unlimited" if the limit is `null`', () => {
+    const region = regionFactory.build({
+      placement_group_limits: {
+        maximum_pgs_per_customer: null,
+      },
+    });
+
+    expect(getMaxPGsPerCustomer(region)).toBe('unlimited');
+  });
+
+  it('returns undefined if the region is not provided', () => {
+    expect(getMaxPGsPerCustomer(undefined)).toBeUndefined();
   });
 });

--- a/packages/manager/src/features/PlacementGroups/utils.ts
+++ b/packages/manager/src/features/PlacementGroups/utils.ts
@@ -84,6 +84,10 @@ export const hasRegionReachedPlacementGroupCapacity = ({
     (pg) => pg.region === region.id
   );
 
+  if (maximum_pgs_per_customer === null) {
+    return false;
+  }
+
   return (
     placementGroupsInRegion.length >= maximum_pgs_per_customer ||
     maximum_pgs_per_customer === 0
@@ -147,4 +151,24 @@ export const useIsPlacementGroupsEnabled = (): {
   );
 
   return { isPlacementGroupsEnabled };
+};
+
+/**
+ * Helper to get the maximum number of Placement Groups per region a customer is allowed to create.
+ * When the limit is `null` (no limit), we show "unlimited" in the UI.
+ *
+ * @param region
+ * @returns {number | 'unlimited' | undefined} - The maximum number of Placement Groups per region a customer is allowed to create.
+ */
+export const getMaxPGsPerCustomer = (
+  region: Region | undefined
+): 'unlimited' | number | undefined => {
+  if (!region) {
+    return;
+  }
+
+  const maxPgsPerCustomer =
+    region.placement_group_limits.maximum_pgs_per_customer;
+
+  return maxPgsPerCustomer === null ? 'unlimited' : maxPgsPerCustomer;
 };


### PR DESCRIPTION
## Description 📝
`maximum_pgs_per_customer`: This value can be unlimited for some customers in some regions, for which the API returns the `null` value. The UI representation of this `null` value is the "unlimited" string

## Changes  🔄
- Allow `null` for `maximum_pgs_per_customer` in APIv4
- Add new util to return the proper limit in the UI

## Target release date 🗓️
**5/13/2024**

## Preview 📷
![Screen Shot 2024-05-03 at 10 14 14](https://github.com/linode/manager/assets/130582365/fc8020c3-3b80-4db0-a9a3-d3b9eb9ba97f)

## How to test 🧪

### Verification steps
ℹ️ have both the "Placement Group" feature flag and MSW on
- Navigate to http://localhost:3000/placement-groups/create
- Pick Toronto as the region
- Notice the helper text

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
