### PR TITLE
upcoming: [M3 -8049] - Last round of placement group copy updates

### DIFF
--- a/packages/api-v4/src/placement-groups/types.ts
+++ b/packages/api-v4/src/placement-groups/types.ts
@@ -6,7 +6,7 @@ export const AFFINITY_TYPES = {
 } as const;
 
 export type AffinityType = keyof typeof AFFINITY_TYPES;
-export type AffinityEnforcement = 'Strict' | 'Flexible';
+export type AffinityTypeEnforcement = 'Strict' | 'Flexible';
 
 export interface PlacementGroup {
   id: number;

--- a/packages/manager/.changeset/pr-10434-upcoming-features-1714746439358.md
+++ b/packages/manager/.changeset/pr-10434-upcoming-features-1714746439358.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Placement Groups final copy updates ([#10434](https://github.com/linode/manager/pull/10434))

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsAffinityEnforcementRadioGroup.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsAffinityEnforcementRadioGroup.tsx
@@ -17,7 +17,9 @@ interface Props {
   value: boolean;
 }
 
-export const PlacementGroupsAffinityEnforcementRadioGroup = (props: Props) => {
+export const PlacementGroupsAffinityTypeEnforcementRadioGroup = (
+  props: Props
+) => {
   const {
     disabledPlacementGroupCreateButton,
     handleChange,
@@ -27,18 +29,18 @@ export const PlacementGroupsAffinityEnforcementRadioGroup = (props: Props) => {
   return (
     <Box sx={{ pt: 2 }}>
       <Notice
-        text="Once you create a placement group, you cannot change its Affinity Enforcement setting."
+        text="Once you create a placement group, you cannot change its Affinity Type Enforcement setting."
         variant="warning"
       />
-      <FormLabel htmlFor="affinity-enforcement-radio-group">
-        Affinity Enforcement
+      <FormLabel htmlFor="affinity-type-enforcement-radio-group">
+        Affinity Type Enforcement
       </FormLabel>
       <RadioGroup
         onChange={(event) => {
           handleChange(event);
           setFieldValue('is_strict', event.target.value === 'true');
         }}
-        id="affinity-enforcement-radio-group"
+        id="affinity-type-enforcement-radio-group"
         name="is_strict"
         value={value}
       >

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsAffinityEnforcementRadioGroup.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsAffinityEnforcementRadioGroup.tsx
@@ -47,9 +47,9 @@ export const PlacementGroupsAffinityTypeEnforcementRadioGroup = (
         <FormControlLabel
           label={
             <Typography>
-              <strong>Strict.</strong> You cannot assign a Linode to your
-              placement group if it will violate the policy of your selected
-              Affinity Type (best practice).
+              <strong>Strict.</strong> You can’t assign Linodes if the preferred
+              container defined by your Affinity Type lacks capacity or is
+              unavailable (best practice).
             </Typography>
           }
           control={<Radio />}
@@ -59,9 +59,9 @@ export const PlacementGroupsAffinityTypeEnforcementRadioGroup = (
         <FormControlLabel
           label={
             <Typography>
-              <strong>Flexible.</strong> You can assign a Linode to your
-              placement group, even if it violates the policy of your selected
-              Affinity Type.
+              <strong>Flexible.</strong> You can assign Linodes, even if they’re
+              not in the preferred container defined by your Affinity Type, but
+              your placement group will be non-compliant.
             </Typography>
           }
           control={<Radio />}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsAffinityTypeSelect.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsAffinityTypeSelect.tsx
@@ -35,7 +35,7 @@ export const PlacementGroupsAffinityTypeSelect = (props: Props) => {
             title={
               isDisabledMenuItem ? (
                 <Typography>
-                  Only supporting Anti-affinity host placement groups for Beta.{' '}
+                  Currently, only Anti-affinity placement groups are supported.{' '}
                   <Link to={PLACEMENT_GROUPS_DOCS_LINK}>Learn more</Link>.
                 </Typography>
               ) : (
@@ -80,8 +80,6 @@ export const PlacementGroupsAffinityTypeSelect = (props: Props) => {
             performance. Linodes in a placement group that use Anti-affinity are
             in separate fault domains, but still in the same data center. Use
             this to support a high-availability model.
-            <br />
-            <Link to={PLACEMENT_GROUPS_DOCS_LINK}>Learn more.</Link>
           </Typography>
         ),
       }}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.tsx
@@ -181,7 +181,7 @@ export const PlacementGroupsAssignLinodesDrawer = (
               placement="right"
               status="help"
               sxTooltipIcon={{ position: 'relative', top: 4 }}
-              text="Only displaying Linodes that aren’t assigned to a Placement Group"
+              text="Only displaying Linodes that aren’t assigned to a Placement Group."
             />
           </Box>
           <ActionsPanel

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsCreateDrawer.test.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsCreateDrawer.test.tsx
@@ -39,7 +39,7 @@ describe('PlacementGroupsCreateDrawer', () => {
     expect(getByLabelText('Label')).toBeEnabled();
     expect(getByLabelText('Region')).toBeEnabled();
     expect(getByLabelText('Affinity Type')).toBeEnabled();
-    expect(getByText('Affinity Enforcement')).toBeInTheDocument();
+    expect(getByText('Affinity Type Enforcement')).toBeInTheDocument();
 
     const radioInputs = getAllByRole('radio');
     expect(radioInputs).toHaveLength(2);

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsCreateDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsCreateDrawer.tsx
@@ -24,7 +24,7 @@ import { getFormikErrorsFromAPIErrors } from 'src/utilities/formikErrorUtils';
 import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
 
 import { MAXIMUM_NUMBER_OF_PLACEMENT_GROUPS_IN_REGION } from './constants';
-import { PlacementGroupsAffinityEnforcementRadioGroup } from './PlacementGroupsAffinityEnforcementRadioGroup';
+import { PlacementGroupsAffinityTypeEnforcementRadioGroup } from './PlacementGroupsAffinityEnforcementRadioGroup';
 import { PlacementGroupsAffinityTypeSelect } from './PlacementGroupsAffinityTypeSelect';
 import {
   getMaxPGsPerCustomer,
@@ -222,7 +222,7 @@ export const PlacementGroupsCreateDrawer = (
             error={errors.affinity_type}
             setFieldValue={setFieldValue}
           />
-          <PlacementGroupsAffinityEnforcementRadioGroup
+          <PlacementGroupsAffinityTypeEnforcementRadioGroup
             disabledPlacementGroupCreateButton={
               disabledPlacementGroupCreateButton
             }

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsCreateDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsCreateDrawer.tsx
@@ -212,7 +212,7 @@ export const PlacementGroupsCreateDrawer = (
               helperText={values.region && pgRegionLimitHelperText}
               regions={regions ?? []}
               selectedId={selectedRegionId ?? values.region}
-              tooltipText="Only regions supporting Placement Groups are listed."
+              tooltipText="Only Linode data center regions that support placement groups are listed."
             />
           )}
           <PlacementGroupsAffinityTypeSelect

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsEditDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsEditDrawer.tsx
@@ -143,13 +143,13 @@ export const PlacementGroupsEditDrawer = (
               },
               {
                 description: AFFINITY_TYPES[placementGroup.affinity_type],
-                title: 'Affinity',
+                title: 'Affinity Type',
               },
               {
                 description: getAffinityTypeEnforcement(
                   placementGroup.is_strict
                 ),
-                title: 'Affinity Enforcement',
+                title: 'Affinity Type Enforcement',
               },
             ]}
             sx={{

--- a/packages/manager/src/features/PlacementGroups/utils.test.ts
+++ b/packages/manager/src/features/PlacementGroups/utils.test.ts
@@ -128,7 +128,7 @@ describe('getLinodesFromAllPlacementGroups', () => {
   });
 });
 
-describe('getAffinityEnforcement', () => {
+describe('getAffinityTypeEnforcement', () => {
   it('returns "Strict" if `is_strict` is true', () => {
     expect(getAffinityTypeEnforcement(true)).toBe('Strict');
   });

--- a/packages/manager/src/features/PlacementGroups/utils.ts
+++ b/packages/manager/src/features/PlacementGroups/utils.ts
@@ -4,7 +4,7 @@ import { useFlags } from 'src/hooks/useFlags';
 import { useAccount } from 'src/queries/account/account';
 
 import type {
-  AffinityEnforcement,
+  AffinityTypeEnforcement,
   CreatePlacementGroupPayload,
   Linode,
   PlacementGroup,
@@ -12,11 +12,11 @@ import type {
 } from '@linode/api-v4';
 
 /**
- * Helper to get the affinity enforcement readable string.
+ * Helper to get the affinity type enforcement readable string.
  */
 export const getAffinityTypeEnforcement = (
   is_strict: boolean
-): AffinityEnforcement => {
+): AffinityTypeEnforcement => {
   return is_strict ? 'Strict' : 'Flexible';
 };
 


### PR DESCRIPTION
## Description 📝
Part 2 (final) of Placement Group copy updates

## Changes  🔄
- Update copy in various places
- Update interface names to reflect copy changes
- Update relevant tests

## Target release date 🗓️
**5/13/2024**

## Preview 📷

## How to test 🧪

### Verification steps
- Confirm copy changes in code and UI (placement group features)
  - Placement Group Create Drawer
  - Placement Group Assign Linode Drawer
  - Placement Group Edit drawer

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support


