### PR TITLE
upcoming: [M3-7690] - Support PlacementGroups in CLI tool

### DIFF
--- a/packages/manager/.changeset/pr-10438-upcoming-features-1714732245367.md
+++ b/packages/manager/.changeset/pr-10438-upcoming-features-1714732245367.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add support for Placement Groups in Linode CLI tool ([#10438](https://github.com/linode/manager/pull/10438))

--- a/packages/manager/src/utilities/generate-cli.test.ts
+++ b/packages/manager/src/utilities/generate-cli.test.ts
@@ -25,6 +25,9 @@ const linodeData = {
   metadata: {
     user_data: 'cmVrbmpnYmloZXVma2xkbQpqZXZia2Y=',
   },
+  placement_group: {
+    id: 1234,
+  },
   stackscript_data: {
     gh_username: 'linode',
   },
@@ -43,6 +46,7 @@ const linodeDataForCLI = `
   --authorized_users Gritty \\
   --interfaces.ipam_address null --interfaces.ipv4.nat_1_1 \"any\" --interfaces.ipv4.vpc \"123\" --interfaces.label null --interfaces.primary true --interfaces.purpose \"vpc\" --interfaces.subnet_id 8296 \\
   --metadata.user_data="cmVrbmpnYmloZXVma2xkbQpqZXZia2Y=" \\
+  --placement_group.id 1234 \\
   --stackscript_data '{"gh_username": "linode"}' \\
   --stackscript_id 10079
 `.trim();

--- a/packages/manager/src/utilities/generate-cli.ts
+++ b/packages/manager/src/utilities/generate-cli.ts
@@ -3,6 +3,8 @@ import {
   UserData,
 } from '@linode/api-v4/lib/linodes/types';
 
+import type { PlacementGroup } from '@linode/api-v4';
+
 // Credit: https://github.com/xxorax/node-shell-escape
 function escapeStringForCLI(s: string): string {
   if (/[^A-Za-z0-9_\/:=-]/.test(s)) {
@@ -78,6 +80,7 @@ const dataEntriesReduce = (acc: string[], [key, value]: JSONFieldToArray) => {
   if (value === undefined || value === null) {
     return acc;
   }
+
   if (Array.isArray(value)) {
     if (value.length === 0) {
       return acc;
@@ -89,6 +92,12 @@ const dataEntriesReduce = (acc: string[], [key, value]: JSONFieldToArray) => {
   if (key === 'metadata') {
     const userData = value as UserData;
     acc.push(`  --${key}.user_data="${userData.user_data}"`);
+  } else if (key === 'placement_group') {
+    const placementGroup = value as PlacementGroup;
+    acc.push(`  --${key}.id ${placementGroup.id}`);
+    {
+      /* TODO VM_Placement: Add logic to include the `compliant_only` argument */
+    }
   } else if (typeof value === 'object') {
     const valueAsString = convertObjectToCLIArg(value);
     acc.push(`  --${key} ${valueAsString}`);
@@ -98,6 +107,7 @@ const dataEntriesReduce = (acc: string[], [key, value]: JSONFieldToArray) => {
   } else {
     acc.push(`  --${key} ${value}`);
   }
+
   return acc;
 };
 


### PR DESCRIPTION
## Description 📝
This PR allows Placement Group data to be passed in as arguments via the `Linode CLI`. 

## Changes  🔄
- The Placement Group object is flattened to obtain and pass the `id` value. In the end the relevant argument and value are passed as follows: `placement_group.id 1234`.


## Target release date 🗓️
05/13/2024

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-05-03 at 10 22 09 AM](https://github.com/linode/manager/assets/119514965/36aeab3e-a4d6-4abd-8a2d-454dea2f0239) | ![linode-cli-arg](https://github.com/linode/manager/assets/119514965/afbf418c-fb8f-4c1a-8bd5-74eaf50cdf2a) |

## How to test 🧪
### Prerequisites
(How to setup test environment)
- ...

### Verification steps
(How to verify changes)
- Verify that a new Linode instance can be created when passing a Placement Group id argument using the `linode-cli` tool.

## As an Author I have considered 🤔
*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
