### PR TITLE
feat: [M3-8018] – "Disk Encryption" section component

### DIFF
--- a/packages/manager/.changeset/pr-10439-upcoming-features-1715011188623.md
+++ b/packages/manager/.changeset/pr-10439-upcoming-features-1715011188623.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add DiskEncryption component ([#10439](https://github.com/linode/manager/pull/10439))

--- a/packages/manager/src/components/AccessPanel/AccessPanel.tsx
+++ b/packages/manager/src/components/AccessPanel/AccessPanel.tsx
@@ -5,6 +5,11 @@ import { makeStyles } from 'tss-react/mui';
 import { Paper } from 'src/components/Paper';
 import { SuspenseLoader } from 'src/components/SuspenseLoader';
 
+import {
+  DISK_ENCRYPTION_GENERAL_DESCRIPTION,
+  DISK_ENCRYPTION_UNAVAILABLE_IN_REGION_COPY,
+} from '../DiskEncryption/constants';
+import { DiskEncryption } from '../DiskEncryption/DiskEncryption';
 import { Divider } from '../Divider';
 import UserSSHKeyPanel from './UserSSHKeyPanel';
 
@@ -110,6 +115,14 @@ export const AccessPanel = (props: Props) => {
           />
         </>
       ) : null}
+      <>
+        <Divider spacingBottom={20} spacingTop={24} />
+        <DiskEncryption
+          descriptionCopy={DISK_ENCRYPTION_GENERAL_DESCRIPTION}
+          disabled={true}
+          disabledReason={DISK_ENCRYPTION_UNAVAILABLE_IN_REGION_COPY}
+        />
+      </>
     </Paper>
   );
 };

--- a/packages/manager/src/components/AccessPanel/AccessPanel.tsx
+++ b/packages/manager/src/components/AccessPanel/AccessPanel.tsx
@@ -5,11 +5,6 @@ import { makeStyles } from 'tss-react/mui';
 import { Paper } from 'src/components/Paper';
 import { SuspenseLoader } from 'src/components/SuspenseLoader';
 
-import {
-  DISK_ENCRYPTION_GENERAL_DESCRIPTION,
-  DISK_ENCRYPTION_UNAVAILABLE_IN_REGION_COPY,
-} from '../DiskEncryption/constants';
-import { DiskEncryption } from '../DiskEncryption/DiskEncryption';
 import { Divider } from '../Divider';
 import UserSSHKeyPanel from './UserSSHKeyPanel';
 
@@ -115,14 +110,6 @@ export const AccessPanel = (props: Props) => {
           />
         </>
       ) : null}
-      <>
-        <Divider spacingBottom={20} spacingTop={24} />
-        <DiskEncryption
-          descriptionCopy={DISK_ENCRYPTION_GENERAL_DESCRIPTION}
-          disabled={true}
-          disabledReason={DISK_ENCRYPTION_UNAVAILABLE_IN_REGION_COPY}
-        />
-      </>
     </Paper>
   );
 };

--- a/packages/manager/src/components/DiskEncryption/DiskEncryption.test.tsx
+++ b/packages/manager/src/components/DiskEncryption/DiskEncryption.test.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import {
+  DiskEncryption,
+  checkboxTestId,
+  descriptionTestId,
+  headerTestId,
+} from './DiskEncryption';
+
+describe('DiskEncryption', () => {
+  it('should render a header', () => {
+    const { getByTestId } = renderWithTheme(
+      <DiskEncryption descriptionCopy="Description for unit test" />
+    );
+
+    const heading = getByTestId(headerTestId);
+
+    expect(heading).toBeVisible();
+    expect(heading.tagName).toBe('H3');
+  });
+
+  it('should render a description', () => {
+    const { getByTestId } = renderWithTheme(
+      <DiskEncryption descriptionCopy="Description for unit test" />
+    );
+
+    const description = getByTestId(descriptionTestId);
+
+    expect(description).toBeVisible();
+  });
+
+  it('should render a checkbox', () => {
+    const { getByTestId } = renderWithTheme(
+      <DiskEncryption descriptionCopy="Description for unit test" />
+    );
+
+    const checkbox = getByTestId(checkboxTestId);
+
+    expect(checkbox).toBeVisible();
+  });
+});

--- a/packages/manager/src/components/DiskEncryption/DiskEncryption.tsx
+++ b/packages/manager/src/components/DiskEncryption/DiskEncryption.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+import { Box } from 'src/components/Box';
+import { Checkbox } from 'src/components/Checkbox';
+import { Typography } from 'src/components/Typography';
+
+export interface DiskEncryptionProps {
+  descriptionCopy: JSX.Element | string;
+  disabled?: boolean;
+  disabledReason?: string;
+  // encryptionStatus
+  // toggleEncryption
+}
+
+export const headerTestId = 'disk-encryption-header';
+export const descriptionTestId = 'disk-encryption-description';
+export const checkboxTestId = 'encrypt-disk-checkbox';
+
+export const DiskEncryption = (props: DiskEncryptionProps) => {
+  const { descriptionCopy, disabled, disabledReason } = props;
+
+  const [checked, setChecked] = React.useState<boolean>(false); // @TODO LDE: temporary placeholder until toggleEncryption logic is in place
+
+  return (
+    <>
+      <Typography data-testid={headerTestId} variant="h3">
+        Disk Encryption
+      </Typography>
+      <Typography
+        data-testid={descriptionTestId}
+        sx={(theme) => ({ padding: `${theme.spacing()} 0` })}
+      >
+        {descriptionCopy}
+      </Typography>
+      <Box
+        sx={{
+          marginLeft: '4px',
+        }}
+        alignItems="center"
+        display="flex"
+        flexDirection="row"
+      >
+        <Checkbox
+          checked={checked} // @TODO LDE: in Create flows, this will be defaulted to be checked. Otherwise, we will rely on the current encryption status for the initial value
+          data-testid={checkboxTestId}
+          disabled={disabled}
+          onChange={() => setChecked(!checked)} // @TODO LDE: toggleEncryption will be used here
+          text="Encrypt Disk"
+          toolTipText={disabled ? disabledReason : ''}
+        />
+      </Box>
+    </>
+  );
+};

--- a/packages/manager/src/components/DiskEncryption/constants.tsx
+++ b/packages/manager/src/components/DiskEncryption/constants.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { Link } from 'src/components/Link';
+
+// @TODO LDE: Update "Learn more" link
+export const DISK_ENCRYPTION_GENERAL_DESCRIPTION = (
+  <>
+    Secure this Linode using data at rest encryption. Data center systems take
+    care of encrypting and decrypting for you. After the Linode is created, use
+    Rebuild to enable or disable this feature. <Link to="">Learn more</Link>.
+  </>
+);
+
+export const DISK_ENCRYPTION_DESCRIPTION_NODE_POOL_REBUILD_CAVEAT =
+  'Encrypt Linode data at rest to improve security. The disk encryption setting for Linodes added to a node pool will not be changed after rebuild.';
+
+export const DISK_ENCRYPTION_UNAVAILABLE_IN_REGION_COPY =
+  'Disk encryption is not available in the selected region.';


### PR DESCRIPTION
## Description 📝
This PR adds a new `DiskEncryption` component that will be used (with some coming modifications) in the Linode Create, Linode Rebuild, and LKE Create flows.

## Target release date 🗓️
5/13/24

## Preview 📷
| Enabled  | Disabled   |
| ------- | ------- |
| ![Screenshot 2024-05-06 at 11 54 50 AM](https://github.com/linode/manager/assets/114682940/04a41438-d3e1-4a1b-8668-90cfcc669247) | ![Screenshot 2024-05-06 at 10 27 12 AM](https://github.com/linode/manager/assets/114682940/651de78d-97e8-450e-aa33-22929f900c9f) |

## How to test 🧪
### Verification steps
Temporary code that will be removed prior to merging was added to `AccessPanel.tsx` so you can see the "Disk Encryption" section in the Linode Create flow or in the Linode Rebuild dialog. You may set L122 in `AccessPanel.tsx` to `false` to see the enabled state.

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support