### PR TITLE
upcoming: [M3-8077] - Add Distribution Icon to Image Select v2

### DIFF
--- a/packages/manager/src/components/ImageSelectv2/ImageSelectv2.test.tsx
+++ b/packages/manager/src/components/ImageSelectv2/ImageSelectv2.test.tsx
@@ -83,4 +83,20 @@ describe('ImageSelectv2', () => {
 
     await findByDisplayValue(image.label);
   });
+
+  it('should render a distro icon for the selected Image', async () => {
+    const image = imageFactory.build();
+
+    server.use(
+      http.get('*/v4/images', () => {
+        return HttpResponse.json(makeResourcePage([image]));
+      })
+    );
+
+    const { findByTestId } = renderWithTheme(
+      <ImageSelectv2 value={image.id} />
+    );
+
+    await findByTestId('distro-icon');
+  });
 });

--- a/packages/manager/src/components/ImageSelectv2/ImageSelectv2.tsx
+++ b/packages/manager/src/components/ImageSelectv2/ImageSelectv2.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
 import { useAllImagesQuery } from 'src/queries/images';
 
+import { DistributionIcon } from '../DistributionIcon';
 import { ImageOptionv2 } from './ImageOptionv2';
 import {
   getAPIFilterForImageSelect,
@@ -77,6 +78,17 @@ export const ImageSelectv2 = (props: Props) => {
           listItemProps={props}
         />
       )}
+      textFieldProps={{
+        InputProps: {
+          startAdornment: value && (
+            <DistributionIcon
+              distribution={value.vendor}
+              fontSize="1.8em"
+              pr={1}
+            />
+          ),
+        },
+      }}
       clearOnBlur
       groupBy={(option) => option.vendor ?? 'My Images'}
       label="Images"

--- a/packages/manager/src/components/ImageSelectv2/ImageSelectv2.tsx
+++ b/packages/manager/src/components/ImageSelectv2/ImageSelectv2.tsx
@@ -83,7 +83,8 @@ export const ImageSelectv2 = (props: Props) => {
           startAdornment: value && (
             <DistributionIcon
               distribution={value.vendor}
-              fontSize="1.8em"
+              fontSize="24px"
+              height="24px"
               pl={1}
               pr={2}
             />

--- a/packages/manager/src/components/ImageSelectv2/ImageSelectv2.tsx
+++ b/packages/manager/src/components/ImageSelectv2/ImageSelectv2.tsx
@@ -84,7 +84,8 @@ export const ImageSelectv2 = (props: Props) => {
             <DistributionIcon
               distribution={value.vendor}
               fontSize="1.8em"
-              pr={1}
+              pl={1}
+              pr={2}
             />
           ),
         },


### PR DESCRIPTION
## Description 📝

- Adds the distribution icon to the new ImageSelect on the new Linode Create flow 🖼️ 
- Add unit test to ensure Icon renders

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-05-06 at 1 45 22 PM](https://github.com/linode/manager/assets/115251059/7c457538-39a1-48ce-b73d-9f722c4fcb57) |  ![Screenshot 2024-05-06 at 1 45 06 PM](https://github.com/linode/manager/assets/115251059/e29f7d67-3054-4b53-a5cb-a6504e8d2127) |

## How to test 🧪

### Prerequisites
- Turn on the `Linode Create v2` flag using local dev tool

### Verification steps
- Verify you see the distro icon of the selected distribution 👀 
- Compare styles to production make make sure they look very similar

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support