### PR TITLE
test: [M3-7771] - Add Placement Group populated landing page test

### DIFF
--- a/packages/manager/.changeset/pr-10446-tests-1715197487403.md
+++ b/packages/manager/.changeset/pr-10446-tests-1715197487403.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add Placement Group populated landing page UI tests ([#10446](https://github.com/linode/manager/pull/10446))

--- a/packages/manager/cypress/e2e/core/placementGroups/placement-groups-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/placement-groups-landing-page.spec.ts
@@ -5,10 +5,17 @@ import {
 import { makeFeatureFlagData } from 'support/util/feature-flags';
 import { mockGetPlacementGroups } from 'support/intercepts/placement-groups';
 import { ui } from 'support/ui';
-import { accountFactory } from 'src/factories';
+import {
+  accountFactory,
+  linodeFactory,
+  placementGroupFactory,
+} from 'src/factories';
+import { mockGetAccount } from 'support/intercepts/account';
+import { randomLabel, randomNumber } from 'support/util/random';
+import { chooseRegion } from 'support/util/regions';
+import { mockGetLinodes } from 'support/intercepts/linodes';
 
 import type { Flags } from 'src/featureFlags';
-import { mockGetAccount } from 'support/intercepts/account';
 
 const mockAccount = accountFactory.build();
 
@@ -46,4 +53,92 @@ describe('VM Placement landing page', () => {
 
     ui.drawer.findByTitle('Create Placement Group').should('be.visible');
   });
+
+  /**
+   * - Confirms landing page populated state is shown when there are Placement Groups.
+   * - Confirms that each Placement Group is listed on the landing page.
+   * - Confirms that clicking a Placement Group's label navigates to its details page.
+   */
+  it('lists Placement Groups when user has Placement Groups', () => {
+    const mockPlacementGroupCompliantRegion = chooseRegion();
+    const mockPlacementGroupNoncompliantRegion = chooseRegion();
+
+    const mockPlacementGroupLinode = linodeFactory.build({
+      label: randomLabel(),
+      id: randomNumber(),
+      region: mockPlacementGroupNoncompliantRegion.id,
+    });
+
+    const mockPlacementGroupCompliant = placementGroupFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: mockPlacementGroupCompliantRegion.id,
+      affinity_type: 'anti_affinity:local',
+      is_compliant: true,
+      is_strict: false,
+      members: [],
+    });
+
+    const mockPlacementGroupNoncompliant = placementGroupFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: mockPlacementGroupNoncompliantRegion.id,
+      affinity_type: 'affinity:local',
+      is_compliant: false,
+      is_strict: true,
+      members: [
+        { linode_id: mockPlacementGroupLinode.id, is_compliant: false },
+      ],
+    });
+
+    const mockPlacementGroups = [
+      mockPlacementGroupCompliant,
+      mockPlacementGroupNoncompliant,
+    ];
+
+    mockGetPlacementGroups(mockPlacementGroups).as('getPlacementGroups');
+    mockGetLinodes([mockPlacementGroupLinode]);
+
+    cy.visitWithLogin('/placement-groups');
+    cy.wait('@getPlacementGroups');
+
+    // Confirm that compliant Placement Group is listed with expected info.
+    cy.findByText(mockPlacementGroupCompliant.label)
+      .should('be.visible')
+      .closest('tr')
+      .within(() => {
+        cy.findByText('Anti-affinity').should('be.visible');
+        cy.findByText('Flexible').should('be.visible');
+        cy.findByText('0 of 5').should('be.visible');
+        cy.findByText(mockPlacementGroupCompliantRegion.label).should(
+          'be.visible'
+        );
+        cy.findByText('Non-compliant').should('not.exist');
+      });
+
+    // Confirm that non-compliant Placement Group is listed with expected info.
+    cy.findByText(mockPlacementGroupNoncompliant.label)
+      .should('be.visible')
+      .closest('tr')
+      .within(() => {
+        cy.findByText('Affinity').should('be.visible');
+        cy.findByText('Strict').should('be.visible');
+        cy.contains('1 of 5').should('be.visible');
+        cy.findByText(mockPlacementGroupNoncompliantRegion.label).should(
+          'be.visible'
+        );
+        cy.findByText('Non-compliant').should('be.visible');
+      });
+
+    cy.findByText(mockPlacementGroupCompliant.label).click();
+    cy.url().should(
+      'endWith',
+      `/placement-groups/${mockPlacementGroupCompliant.id}`
+    );
+  });
+
+  /**
+   * - Confirms that Cloud responds to compliance events and updates status on landing page.
+   */
+  it.skip('updates Placement Group compliance status on event');
 });

--- a/packages/manager/cypress/support/intercepts/placement-groups.ts
+++ b/packages/manager/cypress/support/intercepts/placement-groups.ts
@@ -22,6 +22,23 @@ export const mockGetPlacementGroups = (
 };
 
 /**
+ * Intercepts GET request to fetch a Placement Group and mocks response.
+ *
+ * @param placementGroup - Placement Group to intercept and mock.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetPlacementGroup = (
+  placementGroup: PlacementGroup
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher(`placement/groups/${placementGroup.id}`),
+    makeResponse(placementGroup)
+  );
+};
+
+/**
  * Intercepts DELETE request to delete Placement Group and mocks response.
  *
  * @param placementGroupId - ID of Placement Group for which to intercept delete request.


### PR DESCRIPTION
## Description 📝
Adds a test to confirm the populated state of the Placement Group landing page. Specifically, confirms that each Placement Group is listed as expected and that non-compliance indicator is present when necessary (and absent otherwise).

## Changes  🔄
- Adds Placement Group populated landing page test
- Adds a mock util that will be necessary but didn't actually get used

## How to test 🧪

```bash
yarn cy:run -s "cypress/e2e/core/placementGroups/placement-groups-landing-page.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
