### PR TITLE
test: [M3-8088] - Fix One-Click App test failure by using Ubuntu 22.04 image

### DIFF
--- a/packages/manager/.changeset/pr-10447-fixed-1715190382947.md
+++ b/packages/manager/.changeset/pr-10447-fixed-1715190382947.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fix One-Click App test by using Ubuntu 22.04 image ([#10447](https://github.com/linode/manager/pull/10447))

--- a/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
+++ b/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
@@ -131,7 +131,7 @@ describe('OneClick Apps (OCA)', () => {
       description: 'Minecraft OCA',
       ordinal: 10,
       logo_url: 'assets/Minecraft.svg',
-      images: ['linode/debian11', 'linode/ubuntu20.04'],
+      images: ['linode/debian11', 'linode/ubuntu22.04'],
       deployments_total: 18854,
       deployments_active: 412,
       is_public: true,
@@ -161,7 +161,7 @@ describe('OneClick Apps (OCA)', () => {
 
     const firstName = randomLabel();
     const password = randomString(16);
-    const image = 'linode/ubuntu20.04';
+    const image = 'linode/ubuntu22.04';
     const rootPassword = randomString(16);
     const region = chooseRegion();
     const linodeLabel = randomLabel();


### PR DESCRIPTION
## Description 📝
Fixes a test failure in `one-click-apps.spec.ts` stemming from a backend update made to the Minecraft app earlier today. The backend change made the app compatible only with Ubuntu 22.04, and this test attempts to deploy using Ubuntu 20.04, leading to the failure.

This is a really quick fix to get the test passing again, but wrote up M3-8089 to revisit this test and eliminate the risk of this type of issue happening again.

## Changes  🔄
- Fixes failure by replacing Ubuntu 20.04 with Ubuntu 22.04

## How to test 🧪
We can rely on CI for this one.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
