### PR TITLE
fix: [M3-8057] - Disable dedicated > shared DatabaseResize same plan size selection

### DIFF
--- a/packages/manager/.changeset/pr-10450-fixed-1715198221685.md
+++ b/packages/manager/.changeset/pr-10450-fixed-1715198221685.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Disable dedicated > shared DatabaseResize same plan size selection ([#10450](https://github.com/linode/manager/pull/10450))

--- a/packages/manager/src/factories/types.ts
+++ b/packages/manager/src/factories/types.ts
@@ -70,6 +70,7 @@ export const planSelectionTypeFactory = Factory.Sync.makeFactory<PlanWithAvailab
     planBelongsToDisabledClass: false,
     planHasLimitedAvailability: false,
     planIsDisabled512Gb: false,
+    planIsTooSmall: false,
     price: typeFactory.build().price,
     region_prices: typeFactory.build().region_prices,
     subHeadings: [
@@ -119,6 +120,7 @@ export const extendedTypeFactory = Factory.Sync.makeFactory<
   planBelongsToDisabledClass: false,
   planHasLimitedAvailability: false,
   planIsDisabled512Gb: false,
+  planIsTooSmall: false,
   price: typeFactory.build().price,
   region_prices: typeFactory.build().region_prices,
   subHeadings: ['$10/mo ($0.015/hr)', '8 CPU, 1024 GB Storage, 16 GB RAM'],

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.tsx
@@ -202,8 +202,12 @@ export const DatabaseResize = ({ database }: Props) => {
   }, [database.cluster_size, dbTypes, selectedEngine]);
 
   const currentPlan = displayTypes?.find((type) => type.id === database.type);
-
   const currentPlanDisk = currentPlan ? currentPlan.disk : 0;
+  const disabledPlans = displayTypes?.filter((type) =>
+    type.class === 'dedicated'
+      ? type.disk < currentPlanDisk
+      : type.disk <= currentPlanDisk
+  );
 
   if (typesLoading) {
     return <CircleProgress />;
@@ -222,11 +226,9 @@ export const DatabaseResize = ({ database }: Props) => {
       </Paper>
       <Paper sx={{ marginTop: 2 }}>
         <StyledPlansPanel
-          disableSmallerPlans={{
-            selectedDiskSize: currentPlanDisk,
-          }}
           currentPlanHeading={currentPlan?.heading}
           data-qa-select-plan
+          disabledSmallerPlans={disabledPlans}
           header="Choose a Plan"
           onSelect={(selected: string) => setPlanSelected(selected)}
           selectedId={planSelected}

--- a/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
@@ -40,7 +40,6 @@ export const PlanContainer = (props: PlanContainerProps) => {
     onSelect,
     planType,
     plans,
-    selectedDiskSize,
     selectedId,
     selectedRegionId,
     showLimits,
@@ -115,7 +114,6 @@ export const PlanContainer = (props: PlanContainerProps) => {
             linodeID={linodeID}
             onSelect={onSelect}
             plan={plan}
-            selectedDiskSize={selectedDiskSize}
             selectedId={selectedId}
             selectedRegionId={selectedRegionId}
             showNetwork={showNetwork}
@@ -132,7 +130,6 @@ export const PlanContainer = (props: PlanContainerProps) => {
       isCreate,
       linodeID,
       onSelect,
-      selectedDiskSize,
       selectedId,
       selectedRegionId,
       showTransfer,

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -35,7 +35,6 @@ export interface PlanSelectionProps {
   linodeID?: number | undefined;
   onSelect: (key: string) => void;
   plan: PlanWithAvailability;
-  selectedDiskSize?: number;
   selectedId?: string;
   selectedRegionId?: Region['id'];
   showNetwork?: boolean;
@@ -52,7 +51,6 @@ export const PlanSelection = (props: PlanSelectionProps) => {
     linodeID,
     onSelect,
     plan,
-    selectedDiskSize,
     selectedId,
     selectedRegionId,
     showNetwork,
@@ -63,10 +61,9 @@ export const PlanSelection = (props: PlanSelectionProps) => {
     planBelongsToDisabledClass,
     planHasLimitedAvailability,
     planIsDisabled512Gb,
+    planIsTooSmall,
   } = plan;
 
-  const diskSize = selectedDiskSize ? selectedDiskSize : 0;
-  const planIsTooSmall = diskSize > plan.disk;
   const isSamePlan = plan.heading === currentPlanHeading;
   const isGPU = plan.class === 'gpu';
 
@@ -134,11 +131,9 @@ export const PlanSelection = (props: PlanSelectionProps) => {
                     checked={
                       !wholePanelIsDisabled &&
                       !rowIsDisabled &&
-                      !planIsTooSmall &&
                       plan.id === String(selectedId)
                     }
                     disabled={
-                      planIsTooSmall ||
                       wholePanelIsDisabled ||
                       rowIsDisabled ||
                       planBelongsToDisabledClass
@@ -223,7 +218,6 @@ export const PlanSelection = (props: PlanSelectionProps) => {
       <Hidden lgUp={isCreate} mdUp={!isCreate}>
         <SelectionCard
           disabled={
-            planIsTooSmall ||
             isSamePlan ||
             wholePanelIsDisabled ||
             rowIsDisabled ||

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -29,11 +29,9 @@ export interface PlansPanelProps {
   className?: string;
   copy?: string;
   currentPlanHeading?: string;
-  disableSmallerPlans?: {
-    selectedDiskSize?: number;
-  };
   disabled?: boolean;
   disabledClasses?: LinodeTypeClass[];
+  disabledSmallerPlans?: PlanSelectionType[];
   disabledTabs?: string[];
   docsLink?: JSX.Element;
   error?: string;
@@ -55,9 +53,9 @@ export const PlansPanel = (props: PlansPanelProps) => {
     className,
     copy,
     currentPlanHeading,
-    disableSmallerPlans,
     disabled,
     disabledClasses,
+    disabledSmallerPlans,
     docsLink,
     error,
     header,
@@ -145,6 +143,7 @@ export const PlansPanel = (props: PlansPanelProps) => {
     } = extractPlansInformation({
       disableLargestGbPlansFlag: flags.disableLargestGbPlans,
       disabledClasses,
+      disabledSmallerPlans,
       plans: plansMap,
       regionAvailabilities,
       selectedRegionId: selectedRegionID,
@@ -183,7 +182,6 @@ export const PlansPanel = (props: PlansPanelProps) => {
               onSelect={onSelect}
               planType={plan}
               plans={plansForThisLinodeTypeClass}
-              selectedDiskSize={disableSmallerPlans?.selectedDiskSize}
               selectedId={selectedId}
               selectedRegionId={selectedRegionID}
               showLimits={showLimits}

--- a/packages/manager/src/features/components/PlansPanel/types.ts
+++ b/packages/manager/src/features/components/PlansPanel/types.ts
@@ -28,9 +28,9 @@ export interface PlanSelectionAvailabilityTypes {
   planBelongsToDisabledClass: boolean;
   planHasLimitedAvailability: boolean;
   planIsDisabled512Gb: boolean;
+  planIsTooSmall: boolean;
 }
 
 export interface DisabledTooltipReasons extends PlanSelectionAvailabilityTypes {
-  planIsTooSmall?: boolean;
   wholePanelIsDisabled?: boolean;
 }

--- a/packages/manager/src/features/components/PlansPanel/utils.test.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.test.ts
@@ -285,7 +285,8 @@ describe('extractPlansInformation', () => {
   it('should return correct information when all plans are disabled', () => {
     const result = extractPlansInformation({
       disableLargestGbPlansFlag: false,
-      plans: [g6Standard1, g6Nanode1],
+      disabledSmallerPlans: [g7Standard1],
+      plans: [g6Standard1, g6Nanode1, g7Standard1],
       regionAvailabilities: [
         regionAvailabilityFactory.build({
           available: false,
@@ -295,6 +296,11 @@ describe('extractPlansInformation', () => {
         regionAvailabilityFactory.build({
           available: false,
           plan: 'g6-nanode-1',
+          region: 'us-east',
+        }),
+        regionAvailabilityFactory.build({
+          available: true,
+          plan: 'g7-standard-1',
           region: 'us-east',
         }),
       ],
@@ -308,6 +314,7 @@ describe('extractPlansInformation', () => {
           planBelongsToDisabledClass: false,
           planHasLimitedAvailability: true,
           planIsDisabled512Gb: false,
+          planIsTooSmall: false,
         },
       },
       {
@@ -316,6 +323,16 @@ describe('extractPlansInformation', () => {
           planBelongsToDisabledClass: false,
           planHasLimitedAvailability: true,
           planIsDisabled512Gb: false,
+          planIsTooSmall: false,
+        },
+      },
+      {
+        ...g7Standard1,
+        ...{
+          planBelongsToDisabledClass: false,
+          planHasLimitedAvailability: false,
+          planIsDisabled512Gb: false,
+          planIsTooSmall: true,
         },
       },
     ]);
@@ -328,6 +345,7 @@ describe('extractPlansInformation', () => {
           planBelongsToDisabledClass: false,
           planHasLimitedAvailability: true,
           planIsDisabled512Gb: false,
+          planIsTooSmall: false,
         },
       },
       {
@@ -336,6 +354,16 @@ describe('extractPlansInformation', () => {
           planBelongsToDisabledClass: false,
           planHasLimitedAvailability: true,
           planIsDisabled512Gb: false,
+          planIsTooSmall: false,
+        },
+      },
+      {
+        ...g7Standard1,
+        ...{
+          planBelongsToDisabledClass: false,
+          planHasLimitedAvailability: false,
+          planIsDisabled512Gb: false,
+          planIsTooSmall: true,
         },
       },
     ]);
@@ -344,6 +372,7 @@ describe('extractPlansInformation', () => {
   it('should return correct information when no plans are disabled', () => {
     const result = extractPlansInformation({
       disableLargestGbPlansFlag: false,
+      disabledSmallerPlans: [],
       plans: [g6Standard1, g6Nanode1],
       regionAvailabilities: [
         regionAvailabilityFactory.build({
@@ -369,12 +398,14 @@ describe('extractPlansInformation', () => {
         planBelongsToDisabledClass: false,
         planHasLimitedAvailability: false,
         planIsDisabled512Gb: false,
+        planIsTooSmall: false,
       },
       {
         ...g6Nanode1,
         planBelongsToDisabledClass: false,
         planHasLimitedAvailability: false,
         planIsDisabled512Gb: false,
+        planIsTooSmall: false,
       },
     ]);
   });

--- a/packages/manager/src/features/components/PlansPanel/utils.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.ts
@@ -249,6 +249,7 @@ export const replaceOrAppendPlaceholder512GbPlans = (
 interface ExtractPlansInformationProps {
   disableLargestGbPlansFlag: Flags['disableLargestGbPlans'] | undefined;
   disabledClasses?: LinodeTypeClass[];
+  disabledSmallerPlans?: PlanSelectionType[];
   plans: PlanSelectionType[];
   regionAvailabilities: RegionAvailability[] | undefined;
   selectedRegionId: Region['id'] | undefined;
@@ -269,6 +270,7 @@ interface ExtractPlansInformationProps {
 export const extractPlansInformation = ({
   disableLargestGbPlansFlag,
   disabledClasses,
+  disabledSmallerPlans,
   plans,
   regionAvailabilities,
   selectedRegionId,
@@ -288,12 +290,18 @@ export const extractPlansInformation = ({
       const planBelongsToDisabledClass = Boolean(
         disabledClasses?.includes(plan.class)
       );
+      const planIsTooSmall = Boolean(
+        disabledSmallerPlans?.find(
+          (disabledPlan) => disabledPlan.id === plan.id
+        )
+      );
 
       return {
         ...plan,
         planBelongsToDisabledClass,
         planHasLimitedAvailability,
         planIsDisabled512Gb,
+        planIsTooSmall,
       };
     }
   );
@@ -303,6 +311,7 @@ export const extractPlansInformation = ({
       planBelongsToDisabledClass,
       planHasLimitedAvailability,
       planIsDisabled512Gb,
+      planIsTooSmall,
     } = plan;
 
     // Determine if the plan should be disabled due to
@@ -312,7 +321,8 @@ export const extractPlansInformation = ({
     if (
       planBelongsToDisabledClass ||
       planHasLimitedAvailability ||
-      planIsDisabled512Gb
+      planIsDisabled512Gb ||
+      planIsTooSmall
     ) {
       return [...acc, plan];
     }


### PR DESCRIPTION
## Description 📝
My previous [PR](https://github.com/linode/manager/pull/10407) (not yet released) introduced a regressions where the database resize plans disabled due to being smaller were not reflecting the original logic, due to a flaw in my understanding of the feature.

For plans of the **same size**:
expected: 
- resizing from dedicated to shared : **not allowed**
- resizing from shared to dedicated : **allowed**

The current bug in develop is the fact that resizing from dedicated to shared is allowed in Cloud Manager, but will result in an API error

## Changes  🔄
- Add smallerPlan filtering to the `extractPlansInformation` util and use original DatabaseResize smaller plan disabling logic
- Update tests

## Target release date 🗓️
**5/13/2024**

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screen Shot 2024-05-08 at 15 49 19](https://github.com/linode/manager/assets/130582365/10f78e3c-c702-4ff8-b9d8-54526d1626d5) | ![Screen Shot 2024-05-08 at 15 47 55](https://github.com/linode/manager/assets/130582365/63d73405-14b6-4405-85bf-36418bc7073e) |
| ![Screen Shot 2024-05-08 at 15 49 24](https://github.com/linode/manager/assets/130582365/b3d02a52-15d1-4217-b813-213aeb50af75) | ![Screen Shot 2024-05-08 at 15 48 45](https://github.com/linode/manager/assets/130582365/a11fc3d8-b5f6-42ae-bd05-4640af986896) |





## How to test 🧪

### Prerequisites
- go to http://localhost:3000/databases/create
- Create a `Dedicated 16 GB` db plan

### Reproduction steps
on **develop**
- http://localhost:3000/databases/mysql/{id}/resize
- click on the "Shared CPU" tab
- Notice that the "Linode 16 GB" is selectable (bug)

### Verification steps
on **this branch**
- http://localhost:3000/databases/mysql/{id}/resize
- click on the "Shared CPU" tab
- Notice that the "Linode 16 GB" is disabled

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
