### PR TITLE
fix: [M3-8090] - OMC - Update scope.region type to reflect new API changes

### DIFF
--- a/packages/api-v4/.changeset/pr-10451-upcoming-features-1715221886743.md
+++ b/packages/api-v4/.changeset/pr-10451-upcoming-features-1715221886743.md
@@ -2,4 +2,4 @@
 "@linode/api-v4": Upcoming Features
 ---
 
-Update Object Storage Multicluster Scope.region type (required, nullable) ([#10451](https://github.com/linode/manager/pull/10451))
+Update Object Storage MultiCluster `Scope.region` type (required, nullable) ([#10451](https://github.com/linode/manager/pull/10451))

--- a/packages/api-v4/.changeset/pr-10451-upcoming-features-1715221886743.md
+++ b/packages/api-v4/.changeset/pr-10451-upcoming-features-1715221886743.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Upcoming Features
+---
+
+Update Object Storage Multicluster Scope.region type (required, nullable) ([#10451](https://github.com/linode/manager/pull/10451))

--- a/packages/api-v4/src/object-storage/types.ts
+++ b/packages/api-v4/src/object-storage/types.ts
@@ -19,13 +19,12 @@ export interface Scope {
   bucket_name: string;
   permissions: AccessType;
   cluster: string;
-  region?: string; // @TODO OBJ Multicluster: Remove optional indicator when API changes get released to prod
+  region: string | null;
 }
 
 export interface ScopeRequest extends Omit<Scope, 'cluster'> {
-  // @TODO OBJ Multicluster: Omit 'region' as well when API changes get released to prod
   cluster?: string;
-  region?: string;
+  region: string | null;
 }
 
 export interface ObjectStorageKeyRequest {

--- a/packages/manager/.changeset/pr-10451-upcoming-features-1715221976304.md
+++ b/packages/manager/.changeset/pr-10451-upcoming-features-1715221976304.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Make `Scope.region` nullable in POST object-storage/key payload ([#10451](https://github.com/linode/manager/pull/10451))

--- a/packages/manager/.changeset/pr-10451-upcoming-features-1715221976304.md
+++ b/packages/manager/.changeset/pr-10451-upcoming-features-1715221976304.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-Make `Scope.region` nullable in POST object-storage/key payload ([#10451](https://github.com/linode/manager/pull/10451))
+Make `Scope.region` nullable in POST `object-storage/key` payload ([#10451](https://github.com/linode/manager/pull/10451))

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -72,7 +72,7 @@ export const getDefaultScopes = (buckets: ObjectStorageBucket[]): Scope[] =>
       bucket_name: thisBucket.label,
       cluster: thisBucket.cluster,
       permissions: 'none' as AccessType,
-      region: thisBucket.region ?? '',
+      region: thisBucket.region ?? null,
     }))
     .sort(sortByCluster);
 

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessTable.tsx
@@ -51,8 +51,6 @@ interface TableProps {
 export const AccessTable = React.memo((props: TableProps) => {
   const { bucket_access, checked, mode, updateScopes } = props;
 
-  // console.log(bucket_access);
-
   if (!bucket_access) {
     return null;
   }

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessTable.tsx
@@ -51,6 +51,8 @@ interface TableProps {
 export const AccessTable = React.memo((props: TableProps) => {
   const { bucket_access, checked, mode, updateScopes } = props;
 
+  // console.log(bucket_access);
+
   if (!bucket_access) {
     return null;
   }

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/OMC_AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/OMC_AccessKeyDrawer.tsx
@@ -97,7 +97,7 @@ export const getDefaultScopes = (
       bucket_name: thisBucket.label,
       cluster: thisBucket.cluster,
       permissions: null,
-      region: thisBucket.region,
+      region: thisBucket.region ?? null,
     }))
     .sort(sortByRegion(regionLookup));
 


### PR DESCRIPTION
## Description 📝
In alpha, we're seeing  a payload error when POSTing to the object-storage/keys.

This is due to this [PR](https://bits.linode.com/LinodeAPI/apinext/pull/6248/files) having been merged to alpha and adding strictness to what is passed to the body of the endpoint in the absence of `regions_allowed` flag (Object MultiCluster)

The fact this was not caught is due to two reasons:

- passing a default empty [region](https://github.com/linode/manager/blob/develop/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx/#L75) as a string
- [weakening the type definition](https://github.com/linode/manager/blob/develop/packages/api-v4/src/object-storage/types.ts/#L22) during our development phase (which admittedly would have not  prevented the bug because of bullet point 1)

## Changes  🔄
- make `Scope.region` required and nullable
- reflect changes in front-end code

## Target release date 🗓️
**5/13/2024**

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/130582365/bb4450b8-4ac9-4f8d-9759-3eaa59a4d15d" /> | <video src="https://github.com/linode/manager/assets/130582365/ac648f42-0285-4370-9e37-801140f0c451" /> |

## How to test 🧪

### Prerequisites
- use ALPHA

### Reproduction steps
- navigate to http://localhost:3000/object-storage/access-keys
- click on "Create Access Key"
- select "limited access" for the radio
- submit drawer form
- notice submission error

### Verification steps (**verify in both ALPHA & PROD**)
- navigate to http://localhost:3000/object-storage/access-keys
- click on "Create Access Key"
- select "limited access" for the radio
- submit drawer form
- confirm no error

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
