### PR TITLE
upcoming: [M3-7993] - PlacementGroups Select optimizations & cleanup

### DIFF
--- a/packages/manager/.changeset/pr-10455-upcoming-features-1715611895814.md
+++ b/packages/manager/.changeset/pr-10455-upcoming-features-1715611895814.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+PlacementGroups Select optimizations & cleanup ([#10455](https://github.com/linode/manager/pull/10455))

--- a/packages/manager/src/components/DetailsPanel/DetailsPanel.test.tsx
+++ b/packages/manager/src/components/DetailsPanel/DetailsPanel.test.tsx
@@ -26,6 +26,7 @@ describe('Tags list', () => {
           value: ['tag1', 'tag2'].map((tag) => ({ label: tag, value: tag })),
         }}
         handlePlacementGroupChange={handlePlacementGroupChange}
+        selectedPlacementGroupId={null}
       />
     );
 
@@ -53,6 +54,7 @@ describe('Tags list', () => {
           })),
         }}
         handlePlacementGroupChange={handlePlacementGroupChange}
+        selectedPlacementGroupId={null}
       />
     );
 
@@ -69,6 +71,7 @@ describe('Tags list', () => {
           value: '',
         }}
         handlePlacementGroupChange={handlePlacementGroupChange}
+        selectedPlacementGroupId={null}
       />
     );
     expect(queryByLabelText(TAG_LABEL)).not.toBeInTheDocument();

--- a/packages/manager/src/components/DetailsPanel/DetailsPanel.tsx
+++ b/packages/manager/src/components/DetailsPanel/DetailsPanel.tsx
@@ -13,9 +13,9 @@ import type { PlacementGroup } from '@linode/api-v4';
 
 interface DetailsPanelProps {
   error?: string;
-  handlePlacementGroupChange: (selected: PlacementGroup) => void;
+  handlePlacementGroupChange: (selected: PlacementGroup | null) => void;
   labelFieldProps?: TextFieldProps;
-  selectedPlacementGroupId?: number;
+  selectedPlacementGroupId: null | number;
   selectedRegionId?: string;
   tagsInputProps?: TagsInputProps;
 }

--- a/packages/manager/src/components/DetailsPanel/DetailsPanel.tsx
+++ b/packages/manager/src/components/DetailsPanel/DetailsPanel.tsx
@@ -15,6 +15,7 @@ interface DetailsPanelProps {
   error?: string;
   handlePlacementGroupChange: (selected: PlacementGroup) => void;
   labelFieldProps?: TextFieldProps;
+  selectedPlacementGroupId?: number;
   selectedRegionId?: string;
   tagsInputProps?: TagsInputProps;
 }
@@ -24,6 +25,7 @@ export const DetailsPanel = (props: DetailsPanelProps) => {
     error,
     handlePlacementGroupChange,
     labelFieldProps,
+    selectedPlacementGroupId,
     selectedRegionId,
     tagsInputProps,
   } = props;
@@ -62,6 +64,7 @@ export const DetailsPanel = (props: DetailsPanelProps) => {
       {isPlacementGroupsEnabled && (
         <PlacementGroupsDetailPanel
           handlePlacementGroupChange={handlePlacementGroupChange}
+          selectedPlacementGroupId={selectedPlacementGroupId}
           selectedRegionId={selectedRegionId}
         />
       )}

--- a/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.test.tsx
+++ b/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.test.tsx
@@ -10,12 +10,11 @@ import { PlacementGroupsSelect } from './PlacementGroupsSelect';
 import type { PlacementGroupsSelectProps } from './PlacementGroupsSelect';
 
 const props: PlacementGroupsSelectProps = {
-  errorText: '',
   handlePlacementGroupChange: vi.fn(),
   id: '',
   label: 'Placement Groups in Atlanta, GA (us-southeast)',
   noOptionsMessage: '',
-  selectedPlacementGroup: null,
+  selectedPlacementGroupId: undefined,
   selectedRegion: regionFactory.build({ id: 'us-southeast' }),
 };
 

--- a/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.test.tsx
+++ b/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.test.tsx
@@ -14,7 +14,7 @@ const props: PlacementGroupsSelectProps = {
   id: '',
   label: 'Placement Groups in Atlanta, GA (us-southeast)',
   noOptionsMessage: '',
-  selectedPlacementGroupId: undefined,
+  selectedPlacementGroupId: null,
   selectedRegion: regionFactory.build({ id: 'us-southeast' }),
 };
 

--- a/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.test.tsx
+++ b/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.test.tsx
@@ -11,7 +11,6 @@ import type { PlacementGroupsSelectProps } from './PlacementGroupsSelect';
 
 const props: PlacementGroupsSelectProps = {
   handlePlacementGroupChange: vi.fn(),
-  id: '',
   label: 'Placement Groups in Atlanta, GA (us-southeast)',
   noOptionsMessage: '',
   selectedPlacementGroupId: null,

--- a/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
+++ b/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
@@ -12,7 +12,6 @@ import type { PlacementGroup, Region } from '@linode/api-v4';
 import type { SxProps } from '@mui/system';
 
 export interface PlacementGroupsSelectProps {
-  clearable?: boolean;
   defaultValue?: PlacementGroup;
   disabled?: boolean;
   handlePlacementGroupChange: (selected: PlacementGroup) => void;
@@ -20,7 +19,6 @@ export interface PlacementGroupsSelectProps {
   label: string;
   loading?: boolean;
   noOptionsMessage?: string;
-  onBlur?: (e: React.FocusEvent) => void;
   selectedPlacementGroupId: number | undefined;
   /**
    * We want the full region object here so we can check if the selected Placement Group is at capacity.
@@ -32,14 +30,12 @@ export interface PlacementGroupsSelectProps {
 
 export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
   const {
-    clearable = true,
     defaultValue,
     disabled,
     handlePlacementGroupChange,
     id,
     label,
     noOptionsMessage,
-    onBlur,
     selectedPlacementGroupId,
     selectedRegion,
     sx,
@@ -106,14 +102,12 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
       clearOnBlur={true}
       data-testid="placement-groups-select"
       defaultValue={defaultValue}
-      disableClearable={!clearable}
       disabled={Boolean(!selectedRegion?.id) || disabled}
       errorText={error?.[0]?.reason}
       getOptionLabel={(placementGroup: PlacementGroup) => placementGroup.label}
       id={id}
       label={label}
       loading={isFetching}
-      onBlur={onBlur}
       options={placementGroupsOptions ?? []}
       placeholder="None"
       sx={sx}

--- a/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
+++ b/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
@@ -14,12 +14,12 @@ import type { SxProps } from '@mui/system';
 export interface PlacementGroupsSelectProps {
   defaultValue?: PlacementGroup;
   disabled?: boolean;
-  handlePlacementGroupChange: (selected: PlacementGroup) => void;
+  handlePlacementGroupChange: (selected: PlacementGroup | null) => void;
   id?: string;
   label: string;
   loading?: boolean;
   noOptionsMessage?: string;
-  selectedPlacementGroupId: number | undefined;
+  selectedPlacementGroupId: null | number;
   /**
    * We want the full region object here so we can check if the selected Placement Group is at capacity.
    */
@@ -84,8 +84,8 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
       noOptionsText={
         noOptionsMessage ?? getDefaultNoOptionsMessage(error, isLoading)
       }
-      onChange={(_, selectedOption: PlacementGroup) => {
-        handlePlacementGroupChange(selectedOption);
+      onChange={(_, selectedOption) => {
+        handlePlacementGroupChange(selectedOption ?? null);
       }}
       renderOption={(props, option, { selected }) => {
         return (

--- a/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
+++ b/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
@@ -90,14 +90,8 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
     });
   };
 
-  const placementGroupsOptions:
-    | PlacementGroup[]
-    | undefined = placementGroups?.filter(
-    (placementGroup) => placementGroup.region === selectedRegion?.id
-  );
-
   const selection =
-    placementGroupsOptions?.find(
+    placementGroups?.find(
       (placementGroup) => placementGroup.id === selectedPlacementGroupId
     ) ?? null;
 
@@ -128,7 +122,7 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
       getOptionLabel={(placementGroup: PlacementGroup) => placementGroup.label}
       label={label}
       loading={isFetching}
-      options={placementGroupsOptions ?? []}
+      options={placementGroups ?? []}
       placeholder="None"
       sx={sx}
       value={selection}

--- a/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
+++ b/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
@@ -12,7 +12,6 @@ import type { PlacementGroup, Region } from '@linode/api-v4';
 import type { SxProps } from '@mui/system';
 
 export interface PlacementGroupsSelectProps {
-  clearOnBlur?: boolean;
   clearable?: boolean;
   defaultValue?: PlacementGroup;
   disabled?: boolean;
@@ -23,21 +22,22 @@ export interface PlacementGroupsSelectProps {
   noOptionsMessage?: string;
   onBlur?: (e: React.FocusEvent) => void;
   selectedPlacementGroupId: number | undefined;
-  selectedRegion?: Region;
+  /**
+   * We want the full region object here so we can check if the selected Placement Group is at capacity.
+   */
+  selectedRegion: Region | undefined;
   sx?: SxProps;
   textFieldProps?: Partial<TextFieldProps>;
 }
 
 export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
   const {
-    clearOnBlur,
     clearable = true,
     defaultValue,
     disabled,
     handlePlacementGroupChange,
     id,
     label,
-    loading,
     noOptionsMessage,
     onBlur,
     selectedPlacementGroupId,
@@ -49,8 +49,14 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
   const {
     data: placementGroups,
     error,
+    isFetching,
     isLoading,
-  } = useAllPlacementGroupsQuery(Boolean(selectedRegion?.id));
+  } = useAllPlacementGroupsQuery({
+    enabled: Boolean(selectedRegion?.id),
+    filter: {
+      region: selectedRegion?.id,
+    },
+  });
 
   const isDisabledPlacementGroup = (
     selectedPlacementGroup: PlacementGroup,
@@ -97,7 +103,7 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
           />
         );
       }}
-      clearOnBlur={clearOnBlur}
+      clearOnBlur={true}
       data-testid="placement-groups-select"
       defaultValue={defaultValue}
       disableClearable={!clearable}
@@ -106,7 +112,7 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
       getOptionLabel={(placementGroup: PlacementGroup) => placementGroup.label}
       id={id}
       label={label}
-      loading={isLoading || loading}
+      loading={isFetching}
       onBlur={onBlur}
       options={placementGroupsOptions ?? []}
       placeholder="None"

--- a/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
+++ b/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
@@ -16,14 +16,13 @@ export interface PlacementGroupsSelectProps {
   clearable?: boolean;
   defaultValue?: PlacementGroup;
   disabled?: boolean;
-  errorText?: string;
   handlePlacementGroupChange: (selected: PlacementGroup) => void;
   id?: string;
   label: string;
   loading?: boolean;
   noOptionsMessage?: string;
   onBlur?: (e: React.FocusEvent) => void;
-  selectedPlacementGroup: PlacementGroup | null;
+  selectedPlacementGroupId: number | undefined;
   selectedRegion?: Region;
   sx?: SxProps;
   textFieldProps?: Partial<TextFieldProps>;
@@ -35,14 +34,13 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
     clearable = true,
     defaultValue,
     disabled,
-    errorText,
     handlePlacementGroupChange,
     id,
     label,
     loading,
     noOptionsMessage,
     onBlur,
-    selectedPlacementGroup,
+    selectedPlacementGroupId,
     selectedRegion,
     sx,
     ...textFieldProps
@@ -68,17 +66,15 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
     });
   };
 
-  if (!placementGroups) {
-    return null;
-  }
-
-  const placementGroupsOptions: PlacementGroup[] = placementGroups.filter(
+  const placementGroupsOptions:
+    | PlacementGroup[]
+    | undefined = placementGroups?.filter(
     (placementGroup) => placementGroup.region === selectedRegion?.id
   );
 
   const selection =
-    placementGroupsOptions.find(
-      (placementGroup) => placementGroup.id === selectedPlacementGroup?.id
+    placementGroupsOptions?.find(
+      (placementGroup) => placementGroup.id === selectedPlacementGroupId
     ) ?? null;
 
   return (
@@ -106,7 +102,7 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
       defaultValue={defaultValue}
       disableClearable={!clearable}
       disabled={Boolean(!selectedRegion?.id) || disabled}
-      errorText={errorText}
+      errorText={error?.[0]?.reason}
       getOptionLabel={(placementGroup: PlacementGroup) => placementGroup.label}
       id={id}
       label={label}

--- a/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
+++ b/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
@@ -12,28 +12,49 @@ import type { PlacementGroup, Region } from '@linode/api-v4';
 import type { SxProps } from '@mui/system';
 
 export interface PlacementGroupsSelectProps {
-  defaultValue?: PlacementGroup;
+  /**
+   * If true, the component will be disabled.
+   */
   disabled?: boolean;
+  /**
+   * A callback to execute when the selected Placement Group changes.
+   * The selection is handled by a parent component.
+   */
   handlePlacementGroupChange: (selected: PlacementGroup | null) => void;
-  id?: string;
+  /**
+   * The label for the TextField component.
+   */
   label: string;
+  /**
+   * If true, the component will display a loading spinner. (usually when fetching data)
+   */
   loading?: boolean;
+  /**
+   * The message to display when there are no options available.
+   */
   noOptionsMessage?: string;
+  /**
+   * The ID of the selected Placement Group.
+   */
   selectedPlacementGroupId: null | number;
   /**
-   * We want the full region object here so we can check if the selected Placement Group is at capacity.
+   * We want to pass the full region object here so we can check if the selected Placement Group is at capacity.
    */
   selectedRegion: Region | undefined;
+  /**
+   * Any additional styles to apply to the root element.
+   */
   sx?: SxProps;
+  /**
+   * Any additional props to pass to the TextField component.
+   */
   textFieldProps?: Partial<TextFieldProps>;
 }
 
 export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
   const {
-    defaultValue,
     disabled,
     handlePlacementGroupChange,
-    id,
     label,
     noOptionsMessage,
     selectedPlacementGroupId,
@@ -49,6 +70,7 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
     isLoading,
   } = useAllPlacementGroupsQuery({
     enabled: Boolean(selectedRegion?.id),
+    // Placement Group selection is always dependent on a selected region.
     filter: {
       region: selectedRegion?.id,
     },
@@ -101,11 +123,9 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
       }}
       clearOnBlur={true}
       data-testid="placement-groups-select"
-      defaultValue={defaultValue}
       disabled={Boolean(!selectedRegion?.id) || disabled}
       errorText={error?.[0]?.reason}
       getOptionLabel={(placementGroup: PlacementGroup) => placementGroup.label}
-      id={id}
       label={label}
       loading={isFetching}
       options={placementGroupsOptions ?? []}

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Details/PlacementGroupPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Details/PlacementGroupPanel.tsx
@@ -15,7 +15,7 @@ export const PlacementGroupPanel = () => {
   return (
     <PlacementGroupsDetailPanel
       handlePlacementGroupChange={(placementGroup) =>
-        field.onChange(placementGroup.id)
+        field.onChange(placementGroup?.id)
       }
       selectedPlacementGroupId={field.value}
       selectedRegionId={regionId}

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Details/PlacementGroupPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Details/PlacementGroupPanel.tsx
@@ -17,6 +17,7 @@ export const PlacementGroupPanel = () => {
       handlePlacementGroupChange={(placementGroup) =>
         field.onChange(placementGroup.id)
       }
+      selectedPlacementGroupId={field.value}
       selectedRegionId={regionId}
     />
   );

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Details/PlacementGroupPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Details/PlacementGroupPanel.tsx
@@ -17,7 +17,7 @@ export const PlacementGroupPanel = () => {
       handlePlacementGroupChange={(placementGroup) =>
         field.onChange(placementGroup?.id)
       }
-      selectedPlacementGroupId={field.value}
+      selectedPlacementGroupId={field.value ?? null}
       selectedRegionId={regionId}
     />
   );

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
@@ -664,6 +664,7 @@ export class LinodeCreate extends React.PureComponent<
             data-qa-details-panel
             error={hasErrorFor.placement_group}
             handlePlacementGroupChange={handlePlacementGroupChange}
+            selectedPlacementGroupId={this.props.placementGroupSelection?.id}
             selectedRegionId={selectedRegionID}
           />
           {/* Hide for backups and clone */}

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
@@ -116,7 +116,7 @@ export interface LinodeCreateProps {
   handleAgreementChange: () => void;
   handleFirewallChange: (firewallId: number) => void;
   handleIPv4RangesForVPC: (ranges: ExtendedIP[]) => void;
-  handlePlacementGroupChange: (placementGroup: PlacementGroup) => void;
+  handlePlacementGroupChange: (placementGroup: PlacementGroup | null) => void;
   handleShowApiAwarenessModal: () => void;
   handleSubmitForm: HandleSubmit;
   handleSubnetChange: (subnetId: number) => void;
@@ -656,6 +656,9 @@ export class LinodeCreate extends React.PureComponent<
               onChange: (e) => updateLabel(e.target.value),
               value: label || '',
             }}
+            selectedPlacementGroupId={
+              this.props.placementGroupSelection?.id ?? null
+            }
             tagsInputProps={
               this.props.createType !== 'fromLinode'
                 ? tagsInputProps
@@ -664,7 +667,6 @@ export class LinodeCreate extends React.PureComponent<
             data-qa-details-panel
             error={hasErrorFor.placement_group}
             handlePlacementGroupChange={handlePlacementGroupChange}
-            selectedPlacementGroupId={this.props.placementGroupSelection?.id}
             selectedRegionId={selectedRegionID}
           />
           {/* Hide for backups and clone */}

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -292,6 +292,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
             imageDisplayInfo={this.getImageInfo()}
             ipamAddress={this.state.vlanIPAMAddress}
             label={this.generateLabel()}
+            placementGroupSelection={this.state.placementGroupSelection}
             regionDisplayInfo={this.getRegionInfo()}
             regionsData={regionsData}
             resetCreationState={this.clearCreationState}

--- a/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
@@ -209,7 +209,7 @@ export const ConfigureForm = React.memo((props: Props) => {
               key={selectedRegion}
               label={placementGroupSelectLabel}
               noOptionsMessage="There are no Placement Groups in this region."
-              selectedPlacementGroupId={selectedPlacementGroup?.id}
+              selectedPlacementGroupId={selectedPlacementGroup?.id ?? null}
               selectedRegion={newRegion}
             />
           )}

--- a/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
@@ -8,7 +8,7 @@ import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
 import { sxEdgeIcon } from 'src/components/RegionSelect/RegionSelect.styles';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
-import { NO_PLACEMENT_GROUPS_In_SELECTED_REGION_MESSAGE } from 'src/features/PlacementGroups/constants';
+import { NO_PLACEMENT_GROUPS_IN_SELECTED_REGION_MESSAGE } from 'src/features/PlacementGroups/constants';
 import { useIsPlacementGroupsEnabled } from 'src/features/PlacementGroups/utils';
 import { useFlags } from 'src/hooks/useFlags';
 import { useRegionsQuery } from 'src/queries/regions/regions';
@@ -209,7 +209,7 @@ export const ConfigureForm = React.memo((props: Props) => {
               disabled={isPlacementGroupSelectDisabled}
               key={selectedRegion}
               label={placementGroupSelectLabel}
-              noOptionsMessage={NO_PLACEMENT_GROUPS_In_SELECTED_REGION_MESSAGE}
+              noOptionsMessage={NO_PLACEMENT_GROUPS_IN_SELECTED_REGION_MESSAGE}
               selectedPlacementGroupId={selectedPlacementGroup?.id ?? null}
               selectedRegion={newRegion}
             />

--- a/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
@@ -8,6 +8,7 @@ import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
 import { sxEdgeIcon } from 'src/components/RegionSelect/RegionSelect.styles';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
+import { NO_PLACEMENT_GROUPS_In_SELECTED_REGION_MESSAGE } from 'src/features/PlacementGroups/constants';
 import { useIsPlacementGroupsEnabled } from 'src/features/PlacementGroups/utils';
 import { useFlags } from 'src/hooks/useFlags';
 import { useRegionsQuery } from 'src/queries/regions/regions';
@@ -208,7 +209,7 @@ export const ConfigureForm = React.memo((props: Props) => {
               disabled={isPlacementGroupSelectDisabled}
               key={selectedRegion}
               label={placementGroupSelectLabel}
-              noOptionsMessage="There are no Placement Groups in this region."
+              noOptionsMessage={NO_PLACEMENT_GROUPS_In_SELECTED_REGION_MESSAGE}
               selectedPlacementGroupId={selectedPlacementGroup?.id ?? null}
               selectedRegion={newRegion}
             />

--- a/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.tsx
@@ -209,7 +209,7 @@ export const ConfigureForm = React.memo((props: Props) => {
               key={selectedRegion}
               label={placementGroupSelectLabel}
               noOptionsMessage="There are no Placement Groups in this region."
-              selectedPlacementGroup={selectedPlacementGroup}
+              selectedPlacementGroupId={selectedPlacementGroup?.id}
               selectedRegion={newRegion}
             />
           )}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsAssignLinodesDrawer.tsx
@@ -44,7 +44,7 @@ export const PlacementGroupsAssignLinodesDrawer = (
   const {
     data: allPlacementGroups,
     error: allPlacementGroupsError,
-  } = useAllPlacementGroupsQuery();
+  } = useAllPlacementGroupsQuery({});
   const { enqueueSnackbar } = useSnackbar();
 
   // We display a notice and disable inputs in case the user reaches this drawer somehow

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsCreateDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsCreateDrawer.tsx
@@ -46,7 +46,12 @@ export const PlacementGroupsCreateDrawer = (
     selectedRegionId,
   } = props;
   const { data: regions } = useRegionsQuery();
-  const { data: allPlacementGroups } = useAllPlacementGroupsQuery();
+  const { data: allPlacementGroupsInRegion } = useAllPlacementGroupsQuery({
+    enabled: Boolean(selectedRegionId),
+    filter: {
+      region: selectedRegionId,
+    },
+  });
   const { error, mutateAsync } = useCreatePlacementGroup();
   const { enqueueSnackbar } = useSnackbar();
   const {
@@ -183,7 +188,7 @@ export const PlacementGroupsCreateDrawer = (
               handleDisabledRegion={(region) => {
                 const isRegionAtCapacity = hasRegionReachedPlacementGroupCapacity(
                   {
-                    allPlacementGroups,
+                    allPlacementGroups: allPlacementGroupsInRegion,
                     region,
                   }
                 );

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.test.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.test.tsx
@@ -7,6 +7,7 @@ import { PlacementGroupsDetailPanel } from './PlacementGroupsDetailPanel';
 
 const defaultProps = {
   handlePlacementGroupChange: vi.fn(),
+  selectedPlacementGroupId: null,
 };
 
 const queryMocks = vi.hoisted(() => ({

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
@@ -20,8 +20,8 @@ import { StyledDetailPanelFormattedRegionList } from './PlacementGroups.styles';
 import type { PlacementGroup } from '@linode/api-v4';
 
 interface Props {
-  handlePlacementGroupChange: (selected: PlacementGroup) => void;
-  selectedPlacementGroupId?: number;
+  handlePlacementGroupChange: (selected: PlacementGroup | null) => void;
+  selectedPlacementGroupId: null | number;
   selectedRegionId?: string;
 }
 

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
@@ -8,6 +8,7 @@ import { Notice } from 'src/components/Notice/Notice';
 import { PlacementGroupsSelect } from 'src/components/PlacementGroupsSelect/PlacementGroupsSelect';
 import { TextTooltip } from 'src/components/TextTooltip';
 import { Typography } from 'src/components/Typography';
+import { NO_PLACEMENT_GROUPS_In_SELECTED_REGION_MESSAGE } from 'src/features/PlacementGroups/constants';
 import { PlacementGroupsCreateDrawer } from 'src/features/PlacementGroups/PlacementGroupsCreateDrawer';
 import { hasRegionReachedPlacementGroupCapacity } from 'src/features/PlacementGroups/utils';
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
@@ -127,7 +128,7 @@ export const PlacementGroupsDetailPanel = (props: Props) => {
           disabled={isPlacementGroupSelectDisabled}
           handlePlacementGroupChange={handlePlacementGroupChange}
           label={placementGroupSelectLabel}
-          noOptionsMessage="There are no Placement Groups in this region."
+          noOptionsMessage={NO_PLACEMENT_GROUPS_In_SELECTED_REGION_MESSAGE}
           selectedPlacementGroupId={selectedPlacementGroupId}
           selectedRegion={selectedRegion}
         />

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
@@ -8,7 +8,7 @@ import { Notice } from 'src/components/Notice/Notice';
 import { PlacementGroupsSelect } from 'src/components/PlacementGroupsSelect/PlacementGroupsSelect';
 import { TextTooltip } from 'src/components/TextTooltip';
 import { Typography } from 'src/components/Typography';
-import { NO_PLACEMENT_GROUPS_In_SELECTED_REGION_MESSAGE } from 'src/features/PlacementGroups/constants';
+import { NO_PLACEMENT_GROUPS_IN_SELECTED_REGION_MESSAGE } from 'src/features/PlacementGroups/constants';
 import { PlacementGroupsCreateDrawer } from 'src/features/PlacementGroups/PlacementGroupsCreateDrawer';
 import { hasRegionReachedPlacementGroupCapacity } from 'src/features/PlacementGroups/utils';
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
@@ -128,7 +128,7 @@ export const PlacementGroupsDetailPanel = (props: Props) => {
           disabled={isPlacementGroupSelectDisabled}
           handlePlacementGroupChange={handlePlacementGroupChange}
           label={placementGroupSelectLabel}
-          noOptionsMessage={NO_PLACEMENT_GROUPS_In_SELECTED_REGION_MESSAGE}
+          noOptionsMessage={NO_PLACEMENT_GROUPS_IN_SELECTED_REGION_MESSAGE}
           selectedPlacementGroupId={selectedPlacementGroupId}
           selectedRegion={selectedRegion}
         />

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
@@ -15,7 +15,10 @@ import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGran
 import { useAllPlacementGroupsQuery } from 'src/queries/placementGroups';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 
-import { PLACEMENT_GROUP_SELECT_TOOLTIP_COPY } from './constants';
+import {
+  NO_REGIONS_SUPPORT_PLACEMENT_GROUPS_MESSAGE,
+  PLACEMENT_GROUP_SELECT_TOOLTIP_COPY,
+} from './constants';
 import { StyledDetailPanelFormattedRegionList } from './PlacementGroups.styles';
 
 import type { PlacementGroup } from '@linode/api-v4';
@@ -109,7 +112,7 @@ export const PlacementGroupsDetailPanel = (props: Props) => {
                     ))}
                   </StyledDetailPanelFormattedRegionList>
                 ) : (
-                  'No regions currently support Placement Groups.'
+                  NO_REGIONS_SUPPORT_PLACEMENT_GROUPS_MESSAGE
                 )
               }
               displayText="regions"

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
@@ -21,12 +21,17 @@ import type { PlacementGroup } from '@linode/api-v4';
 
 interface Props {
   handlePlacementGroupChange: (selected: PlacementGroup) => void;
+  selectedPlacementGroupId?: number;
   selectedRegionId?: string;
 }
 
 export const PlacementGroupsDetailPanel = (props: Props) => {
   const theme = useTheme();
-  const { handlePlacementGroupChange, selectedRegionId } = props;
+  const {
+    handlePlacementGroupChange,
+    selectedPlacementGroupId,
+    selectedRegionId,
+  } = props;
   const { data: allPlacementGroups } = useAllPlacementGroupsQuery();
   const { data: regions } = useRegionsQuery();
 
@@ -34,11 +39,6 @@ export const PlacementGroupsDetailPanel = (props: Props) => {
     isCreatePlacementGroupDrawerOpen,
     setIsCreatePlacementGroupDrawerOpen,
   ] = React.useState(false);
-
-  const [
-    selectedPlacementGroup,
-    setSelectedPlacementGroup,
-  ] = React.useState<PlacementGroup | null>(null);
 
   const selectedRegion = regions?.find(
     (thisRegion) => thisRegion.id === selectedRegionId
@@ -52,13 +52,8 @@ export const PlacementGroupsDetailPanel = (props: Props) => {
     globalGrantType: 'add_linodes',
   });
 
-  const handlePlacementGroupSelection = (placementGroup: PlacementGroup) => {
-    setSelectedPlacementGroup(placementGroup);
-    handlePlacementGroupChange(placementGroup);
-  };
-
   const handlePlacementGroupCreated = (placementGroup: PlacementGroup) => {
-    handlePlacementGroupSelection(placementGroup);
+    handlePlacementGroupChange(placementGroup);
   };
 
   const allRegionsWithPlacementGroupCapability = regions?.filter((region) =>
@@ -116,9 +111,6 @@ export const PlacementGroupsDetailPanel = (props: Props) => {
       )}
       <Box>
         <PlacementGroupsSelect
-          handlePlacementGroupChange={(placementGroup) => {
-            handlePlacementGroupSelection(placementGroup);
-          }}
           sx={{
             mb: 1,
             width: '100%',
@@ -129,9 +121,10 @@ export const PlacementGroupsDetailPanel = (props: Props) => {
           }}
           clearOnBlur={true}
           disabled={isPlacementGroupSelectDisabled}
+          handlePlacementGroupChange={handlePlacementGroupChange}
           label={placementGroupSelectLabel}
           noOptionsMessage="There are no Placement Groups in this region."
-          selectedPlacementGroup={selectedPlacementGroup}
+          selectedPlacementGroupId={selectedPlacementGroupId}
           selectedRegion={selectedRegion}
         />
         {selectedRegion && hasRegionPlacementGroupCapability && (

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
@@ -100,13 +100,17 @@ export const PlacementGroupsDetailPanel = (props: Props) => {
                 fontFamily: theme.font.bold,
               }}
               tooltipText={
-                <StyledDetailPanelFormattedRegionList>
-                  {allRegionsWithPlacementGroupCapability?.map((region) => (
-                    <ListItem key={region.id}>
-                      {region.label} ({region.id})
-                    </ListItem>
-                  ))}
-                </StyledDetailPanelFormattedRegionList>
+                allRegionsWithPlacementGroupCapability?.length ? (
+                  <StyledDetailPanelFormattedRegionList>
+                    {allRegionsWithPlacementGroupCapability?.map((region) => (
+                      <ListItem key={region.id}>
+                        {region.label} ({region.id})
+                      </ListItem>
+                    ))}
+                  </StyledDetailPanelFormattedRegionList>
+                ) : (
+                  'No regions currently support Placement Groups.'
+                )
               }
               displayText="regions"
               minWidth={225}

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
@@ -32,7 +32,12 @@ export const PlacementGroupsDetailPanel = (props: Props) => {
     selectedPlacementGroupId,
     selectedRegionId,
   } = props;
-  const { data: allPlacementGroups } = useAllPlacementGroupsQuery();
+  const { data: allPlacementGroupsInRegion } = useAllPlacementGroupsQuery({
+    enabled: Boolean(selectedRegionId),
+    filter: {
+      region: selectedRegionId,
+    },
+  });
   const { data: regions } = useRegionsQuery();
 
   const [
@@ -119,7 +124,6 @@ export const PlacementGroupsDetailPanel = (props: Props) => {
             tooltipPosition: 'right',
             tooltipText: PLACEMENT_GROUP_SELECT_TOOLTIP_COPY,
           }}
-          clearOnBlur={true}
           disabled={isPlacementGroupSelectDisabled}
           handlePlacementGroupChange={handlePlacementGroupChange}
           label={placementGroupSelectLabel}
@@ -130,7 +134,7 @@ export const PlacementGroupsDetailPanel = (props: Props) => {
         {selectedRegion && hasRegionPlacementGroupCapability && (
           <Button
             disabled={hasRegionReachedPlacementGroupCapacity({
-              allPlacementGroups,
+              allPlacementGroups: allPlacementGroupsInRegion,
               region: selectedRegion,
             })}
             sx={(theme) => ({

--- a/packages/manager/src/features/PlacementGroups/constants.ts
+++ b/packages/manager/src/features/PlacementGroups/constants.ts
@@ -22,6 +22,9 @@ export const MAXIMUM_NUMBER_OF_PLACEMENT_GROUPS_IN_REGION =
 export const NO_PLACEMENT_GROUPS_IN_SELECTED_REGION_MESSAGE =
   'There are no placement groups in this region.';
 
+export const NO_REGIONS_SUPPORT_PLACEMENT_GROUPS_MESSAGE =
+  'No regions currently support Placement Groups.';
+
 // Links
 export const PLACEMENT_GROUPS_DOCS_LINK =
   'https://www.linode.com/docs/products/compute/compute-instances/guides/placement-groups/';

--- a/packages/manager/src/features/PlacementGroups/constants.ts
+++ b/packages/manager/src/features/PlacementGroups/constants.ts
@@ -19,7 +19,7 @@ export const PLACEMENT_GROUP_HAS_NO_CAPACITY =
 export const MAXIMUM_NUMBER_OF_PLACEMENT_GROUPS_IN_REGION =
   'Maximum placement groups in region:';
 
-export const NO_PLACEMENT_GROUPS_In_SELECTED_REGION_MESSAGE =
+export const NO_PLACEMENT_GROUPS_IN_SELECTED_REGION_MESSAGE =
   'There are no placement groups in this region.';
 
 // Links

--- a/packages/manager/src/features/PlacementGroups/constants.ts
+++ b/packages/manager/src/features/PlacementGroups/constants.ts
@@ -19,6 +19,9 @@ export const PLACEMENT_GROUP_HAS_NO_CAPACITY =
 export const MAXIMUM_NUMBER_OF_PLACEMENT_GROUPS_IN_REGION =
   'Maximum placement groups in region:';
 
+export const NO_PLACEMENT_GROUPS_In_SELECTED_REGION_MESSAGE =
+  'There are no placement groups in this region.';
+
 // Links
 export const PLACEMENT_GROUPS_DOCS_LINK =
   'https://www.linode.com/docs/products/compute/compute-instances/guides/placement-groups/';

--- a/packages/manager/src/queries/linodes/linodes.ts
+++ b/packages/manager/src/queries/linodes/linodes.ts
@@ -161,7 +161,7 @@ export const useDeleteLinodeMutation = (id: number) => {
         queryClient.invalidateQueries(
           placementGroupQueries.placementGroup(placementGroupId).queryKey
         );
-        queryClient.invalidateQueries(placementGroupQueries.all.queryKey);
+        queryClient.invalidateQueries(placementGroupQueries.all._def);
         queryClient.invalidateQueries(placementGroupQueries.paginated._def);
       }
     },
@@ -195,7 +195,7 @@ export const useCreateLinodeMutation = () => {
           placementGroupQueries.placementGroup(variables.placement_group.id)
             .queryKey
         );
-        queryClient.invalidateQueries(placementGroupQueries.all.queryKey);
+        queryClient.invalidateQueries(placementGroupQueries.all._def);
         queryClient.invalidateQueries(placementGroupQueries.paginated._def);
       }
     },
@@ -323,7 +323,7 @@ export const useLinodeMigrateMutation = (id: number) => {
             placementGroupQueries.placementGroup(data.placement_group.id)
               .queryKey
           );
-          queryClient.invalidateQueries(placementGroupQueries.all.queryKey);
+          queryClient.invalidateQueries(placementGroupQueries.all._def);
           queryClient.invalidateQueries(placementGroupQueries.paginated._def);
         }
       },


### PR DESCRIPTION
## Description 📝
This PR addresses small tech debt left by iterations on the PlacementGroupSelect component and related utils.

## Changes  🔄
- `PlacementGroupSelect` now filters PGs via query instead of client-side
- Cleanup `PlacementGroupSelect` props and remove what's unused
- Remove duplicate state management in `PlacementGroupDetailPanel`
- Use `selectedPlacementGroupId` rather than the whole PG object for prop drilling
- Allow `useAllPlacementGroupsQuery` query to take a filter
- Small capitalization copy change for the `PlacementGroupSelect`  `noOptionsMessage`

## Preview 📷
There should be no visual change as a result of this PR

## How to test 🧪
ℹ️ Test in ALPHA

### Verification steps
- Confirm behavior of PG select in Linode Create Flow (both v1 and v2)
  - Make sure PGs are properly filtered by region
  - Make sure flows work and PG is selected in the final payload
  - Make sure we can create & select a new PG in the the v1 and v2 linode create flows
- Confirm behavior of PG select in Linode Migration Flow

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
