### PR TITLE
test: [M3-6225] - Clean up cy.intercept calls in nodebalancer

### DIFF
--- a/packages/manager/.changeset/pr-10467-tests-1715779598575.md
+++ b/packages/manager/.changeset/pr-10467-tests-1715779598575.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Clean up cy.intercept calls in nodebalancer ([#10467](https://github.com/linode/manager/pull/10467))

--- a/packages/manager/cypress/e2e/core/nodebalancers/smoke-create-nodebal.spec.ts
+++ b/packages/manager/cypress/e2e/core/nodebalancers/smoke-create-nodebal.spec.ts
@@ -7,7 +7,7 @@ import {
   getClick,
   getVisible,
 } from 'support/helpers';
-import { apiMatcher } from 'support/util/intercepts';
+
 import { randomLabel } from 'support/util/random';
 import { chooseRegion, getRegionById } from 'support/util/regions';
 import {
@@ -25,7 +25,7 @@ const deployNodeBalancer = () => {
 };
 
 import { nodeBalancerFactory } from 'src/factories';
-import { mockCreateNodeBalancers } from 'support/intercepts/nodebalancers';
+import { interceptCreateNodeBalancers } from 'support/intercepts/nodebalancers';
 
 const createNodeBalancerWithUI = (
   nodeBal: NodeBalancer,
@@ -94,7 +94,7 @@ describe('create NodeBalancer', () => {
         ipv4: linode.ipv4[1],
       });
       // catch request
-      mockCreateNodeBalancers([nodeBal]).as('createNodeBalancer');
+      interceptCreateNodeBalancers().as('createNodeBalancer');
 
       createNodeBalancerWithUI(nodeBal);
       cy.wait('@createNodeBalancer')
@@ -117,7 +117,7 @@ describe('create NodeBalancer', () => {
       });
 
       // catch request
-      mockCreateNodeBalancers([nodeBal]).as('createNodeBalancer');
+      interceptCreateNodeBalancers().as('createNodeBalancer');
 
       createNodeBalancerWithUI(nodeBal);
       fbtVisible(`Label can't contain special characters or spaces.`);
@@ -154,7 +154,7 @@ describe('create NodeBalancer', () => {
       });
 
       // catch request
-      mockCreateNodeBalancers([nodeBal]).as('createNodeBalancer');
+      interceptCreateNodeBalancers().as('createNodeBalancer');
 
       createNodeBalancerWithUI(nodeBal, true);
     });

--- a/packages/manager/cypress/e2e/core/nodebalancers/smoke-create-nodebal.spec.ts
+++ b/packages/manager/cypress/e2e/core/nodebalancers/smoke-create-nodebal.spec.ts
@@ -25,7 +25,7 @@ const deployNodeBalancer = () => {
 };
 
 import { nodeBalancerFactory } from 'src/factories';
-import { interceptCreateNodeBalancers } from 'support/intercepts/nodebalancers';
+import { interceptCreateNodeBalancer } from 'support/intercepts/nodebalancers';
 
 const createNodeBalancerWithUI = (
   nodeBal: NodeBalancer,
@@ -94,7 +94,7 @@ describe('create NodeBalancer', () => {
         ipv4: linode.ipv4[1],
       });
       // catch request
-      interceptCreateNodeBalancers().as('createNodeBalancer');
+      interceptCreateNodeBalancer().as('createNodeBalancer');
 
       createNodeBalancerWithUI(nodeBal);
       cy.wait('@createNodeBalancer')
@@ -117,7 +117,7 @@ describe('create NodeBalancer', () => {
       });
 
       // catch request
-      interceptCreateNodeBalancers().as('createNodeBalancer');
+      interceptCreateNodeBalancer().as('createNodeBalancer');
 
       createNodeBalancerWithUI(nodeBal);
       fbtVisible(`Label can't contain special characters or spaces.`);
@@ -154,7 +154,7 @@ describe('create NodeBalancer', () => {
       });
 
       // catch request
-      interceptCreateNodeBalancers().as('createNodeBalancer');
+      interceptCreateNodeBalancer().as('createNodeBalancer');
 
       createNodeBalancerWithUI(nodeBal, true);
     });

--- a/packages/manager/cypress/e2e/core/nodebalancers/smoke-create-nodebal.spec.ts
+++ b/packages/manager/cypress/e2e/core/nodebalancers/smoke-create-nodebal.spec.ts
@@ -25,6 +25,7 @@ const deployNodeBalancer = () => {
 };
 
 import { nodeBalancerFactory } from 'src/factories';
+import { mockCreateNodeBalancers } from 'support/intercepts/nodebalancers';
 
 const createNodeBalancerWithUI = (
   nodeBal: NodeBalancer,
@@ -93,9 +94,8 @@ describe('create NodeBalancer', () => {
         ipv4: linode.ipv4[1],
       });
       // catch request
-      cy.intercept('POST', apiMatcher('nodebalancers')).as(
-        'createNodeBalancer'
-      );
+      mockCreateNodeBalancers([nodeBal]).as('createNodeBalancer');
+
       createNodeBalancerWithUI(nodeBal);
       cy.wait('@createNodeBalancer')
         .its('response.statusCode')
@@ -110,15 +110,15 @@ describe('create NodeBalancer', () => {
   it('displays API errors for NodeBalancer Create form fields', () => {
     const region = chooseRegion();
     createLinode({ region: region.id }).then((linode) => {
-      // catch request
-      cy.intercept('POST', apiMatcher('nodebalancers')).as(
-        'createNodeBalancer'
-      );
       const nodeBal = nodeBalancerFactory.build({
         label: `${randomLabel()}-^`,
         ipv4: linode.ipv4[1],
         region: region.id,
       });
+
+      // catch request
+      mockCreateNodeBalancers([nodeBal]).as('createNodeBalancer');
+
       createNodeBalancerWithUI(nodeBal);
       fbtVisible(`Label can't contain special characters or spaces.`);
       getVisible('[id="nodebalancer-label"]')
@@ -154,9 +154,7 @@ describe('create NodeBalancer', () => {
       });
 
       // catch request
-      cy.intercept('POST', apiMatcher('nodebalancers')).as(
-        'createNodeBalancer'
-      );
+      mockCreateNodeBalancers([nodeBal]).as('createNodeBalancer');
 
       createNodeBalancerWithUI(nodeBal, true);
     });

--- a/packages/manager/cypress/support/intercepts/nodebalancers.ts
+++ b/packages/manager/cypress/support/intercepts/nodebalancers.ts
@@ -27,8 +27,6 @@ export const mockGetNodeBalancers = (
 /**
  * Intercepts POST request to intercept nodeBalancer data.
  *
- * @param
- *
  * @returns Cypress chainable.
  */
 export const interceptCreateNodeBalancers = (): Cypress.Chainable<null> => {

--- a/packages/manager/cypress/support/intercepts/nodebalancers.ts
+++ b/packages/manager/cypress/support/intercepts/nodebalancers.ts
@@ -25,18 +25,12 @@ export const mockGetNodeBalancers = (
 };
 
 /**
- * Intercepts POST request to mock nodeBalancer data.
+ * Intercepts POST request to intercept nodeBalancer data.
  *
- * @param nodeBalancers - an array of mock nodeBalancer objects
+ * @param
  *
  * @returns Cypress chainable.
  */
-export const mockCreateNodeBalancers = (
-  nodeBalancers: NodeBalancer[]
-): Cypress.Chainable<null> => {
-  return cy.intercept(
-    'POST',
-    apiMatcher('nodebalancers'),
-    paginateResponse(nodeBalancers)
-  );
+export const interceptCreateNodeBalancers = (): Cypress.Chainable<null> => {
+  return cy.intercept('POST', apiMatcher('nodebalancers'));
 };

--- a/packages/manager/cypress/support/intercepts/nodebalancers.ts
+++ b/packages/manager/cypress/support/intercepts/nodebalancers.ts
@@ -23,3 +23,20 @@ export const mockGetNodeBalancers = (
     paginateResponse(nodeBalancers)
   );
 };
+
+/**
+ * Intercepts POST request to mock nodeBalancer data.
+ *
+ * @param nodeBalancers - an array of mock nodeBalancer objects
+ *
+ * @returns Cypress chainable.
+ */
+export const mockCreateNodeBalancers = (
+  nodeBalancers: NodeBalancer[]
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher('nodebalancers'),
+    paginateResponse(nodeBalancers)
+  );
+};

--- a/packages/manager/cypress/support/intercepts/nodebalancers.ts
+++ b/packages/manager/cypress/support/intercepts/nodebalancers.ts
@@ -29,6 +29,6 @@ export const mockGetNodeBalancers = (
  *
  * @returns Cypress chainable.
  */
-export const interceptCreateNodeBalancers = (): Cypress.Chainable<null> => {
+export const interceptCreateNodeBalancer = (): Cypress.Chainable<null> => {
   return cy.intercept('POST', apiMatcher('nodebalancers'));
 };


### PR DESCRIPTION
## Description 📝
Clean up cy.intercept calls in nodebalancer

## Changes  🔄
List any change relevant to the reviewer.

- Replace calls to cy.intercept with intercept utils in nodebalancers.ts.
- Adds interceptCreateNodeBalancers() util

## How to test 🧪
We can rely on CI to confirm that this test has not been broken by these changes, but to run the test locally you can use this command:
`yarn cy:run -s "cypress/e2e/core/nodebalancers/smoke-create-nodebal.spec.ts"`

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support