### PR TITLE
refactor: [M3-7382] - Use `object-storage/types` endpoint for pricing data 

### DIFF
--- a/packages/api-v4/.changeset/pr-10468-added-1716219170108.md
+++ b/packages/api-v4/.changeset/pr-10468-added-1716219170108.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Added
+---
+
+New endpoint for `object-storage/types` ([#10468](https://github.com/linode/manager/pull/10468))

--- a/packages/api-v4/src/object-storage/index.ts
+++ b/packages/api-v4/src/object-storage/index.ts
@@ -9,3 +9,5 @@ export * from './objects';
 export * from './objectStorageKeys';
 
 export * from './types';
+
+export * from './prices';

--- a/packages/api-v4/src/object-storage/prices.ts
+++ b/packages/api-v4/src/object-storage/prices.ts
@@ -2,7 +2,6 @@ import { Params, PriceType, ResourcePage } from 'src/types';
 import { API_ROOT } from '../constants';
 import Request, { setMethod, setParams, setURL } from '../request';
 
-// TODO: decide the best place to put this.
 /**
  * getObjectStorageTypes
  *

--- a/packages/api-v4/src/object-storage/prices.ts
+++ b/packages/api-v4/src/object-storage/prices.ts
@@ -1,0 +1,17 @@
+import { Params, PriceType, ResourcePage } from 'src/types';
+import { API_ROOT } from '../constants';
+import Request, { setMethod, setParams, setURL } from '../request';
+
+// TODO: decide the best place to put this.
+/**
+ * getObjectStorageTypes
+ *
+ * Return a paginated list of available Object Storage types; used for pricing.
+ * This endpoint does not require authentication.
+ */
+export const getObjectStorageTypes = (params?: Params) =>
+  Request<ResourcePage<PriceType>>(
+    setURL(`${API_ROOT}/object-storage/types`),
+    setMethod('GET'),
+    setParams(params)
+  );

--- a/packages/manager/.changeset/pr-10468-changed-1716219242980.md
+++ b/packages/manager/.changeset/pr-10468-changed-1716219242980.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Use dynamic pricing with `object-storage/types` endpoint ([#10468](https://github.com/linode/manager/pull/10468))

--- a/packages/manager/cypress/e2e/core/objectStorage/enable-object-storage.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/enable-object-storage.spec.ts
@@ -36,16 +36,6 @@ import { makeFeatureFlagData } from 'support/util/feature-flags';
 // Various messages, notes, and warnings that may be shown when enabling Object Storage
 // under different circumstances.
 const objNotes = {
-  // When enabling OBJ using a region with a regular pricing structure, when OBJ DC-specific pricing is disabled.
-  regularPricing: /Linode Object Storage costs a flat rate of \$5\/month, and includes 250 GB of storage and 1 TB of outbound data transfer. Beyond that, it.*s \$0.02 per GB per month./,
-
-  // When enabling OBJ using a region with special pricing during the free beta period (OBJ DC-specific pricing is disabled).
-  dcSpecificBetaPricing: /Object Storage for .* is currently in beta\. During the beta period, Object Storage in these regions is free\. After the beta period, customers will be notified before charges for this service begin./,
-
-  // When enabling OBJ without having selected a region, when OBJ DC-specific pricing is disabled.
-  dcPricingGenericExplanation:
-    'Pricing for monthly rate and overage costs will depend on the data center you select for deployment.',
-
   // When enabling OBJ, in both the Access Key flow and Create Bucket flow, when OBJ DC-specific pricing is enabled.
   objDCPricing:
     'Object Storage costs a flat rate of $5/month, and includes 250 GB of storage. When you enable Object Storage, 1 TB of outbound data transfer will be added to your global network transfer pool.',

--- a/packages/manager/src/factories/types.ts
+++ b/packages/manager/src/factories/types.ts
@@ -173,28 +173,29 @@ export const volumeTypeFactory = Factory.Sync.makeFactory<PriceType>({
   transfer: 0,
 });
 
-export const objectStorageTypeFactory = Factory.Sync.makeFactory<PriceType[]>([
-  {
-    id: 'objectstorage',
-    label: 'Object Storage',
-    price: {
+export const objectStorageTypeFactory = Factory.Sync.makeFactory<PriceType>({
+  id: 'objectstorage',
+  label: 'Object Storage',
+  price: {
+    hourly: 0.0075,
+    monthly: 5.0,
+  },
+  region_prices: [
+    {
       hourly: 0.0075,
+      id: 'id-cgk',
       monthly: 5.0,
     },
-    region_prices: [
-      {
-        hourly: 0.0075,
-        id: 'id-cgk',
-        monthly: 5.0,
-      },
-      {
-        hourly: 0.0075,
-        id: 'br-gru',
-        monthly: 5.0,
-      },
-    ],
-    transfer: 1000,
-  },
+    {
+      hourly: 0.0075,
+      id: 'br-gru',
+      monthly: 5.0,
+    },
+  ],
+  transfer: 1000,
+});
+
+export const objectStorageTypeOverageFactory = Factory.Sync.makeFactory<PriceType>(
   {
     id: 'objectstorage-overage',
     label: 'Object Storage Overage',
@@ -215,5 +216,5 @@ export const objectStorageTypeFactory = Factory.Sync.makeFactory<PriceType[]>([
       },
     ],
     transfer: 0,
-  },
-]);
+  }
+);

--- a/packages/manager/src/factories/types.ts
+++ b/packages/manager/src/factories/types.ts
@@ -172,3 +172,48 @@ export const volumeTypeFactory = Factory.Sync.makeFactory<PriceType>({
   ],
   transfer: 0,
 });
+
+export const objectStorageTypeFactory = Factory.Sync.makeFactory<PriceType[]>([
+  {
+    id: 'objectstorage',
+    label: 'Object Storage',
+    price: {
+      hourly: 0.0075,
+      monthly: 5.0,
+    },
+    region_prices: [
+      {
+        hourly: 0.0075,
+        id: 'id-cgk',
+        monthly: 5.0,
+      },
+      {
+        hourly: 0.0075,
+        id: 'br-gru',
+        monthly: 5.0,
+      },
+    ],
+    transfer: 1000,
+  },
+  {
+    id: 'objectstorage-overage',
+    label: 'Object Storage Overage',
+    price: {
+      hourly: 0.02,
+      monthly: null,
+    },
+    region_prices: [
+      {
+        hourly: 0.024,
+        id: 'id-cgk',
+        monthly: null,
+      },
+      {
+        hourly: 0.028,
+        id: 'br-gru',
+        monthly: null,
+      },
+    ],
+    transfer: 0,
+  },
+]);

--- a/packages/manager/src/factories/types.ts
+++ b/packages/manager/src/factories/types.ts
@@ -195,7 +195,7 @@ export const objectStorageTypeFactory = Factory.Sync.makeFactory<PriceType>({
   transfer: 1000,
 });
 
-export const objectStorageTypeOverageFactory = Factory.Sync.makeFactory<PriceType>(
+export const objectStorageOverageTypeFactory = Factory.Sync.makeFactory<PriceType>(
   {
     id: 'objectstorage-overage',
     label: 'Object Storage Overage',

--- a/packages/manager/src/features/Account/EnableObjectStorage.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.tsx
@@ -2,8 +2,8 @@ import { AccountSettings } from '@linode/api-v4/lib/account';
 import { cancelObjectStorage } from '@linode/api-v4/lib/object-storage';
 import { APIError } from '@linode/api-v4/lib/types';
 import Grid from '@mui/material/Unstable_Grid2';
-import * as React from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import * as React from 'react';
 
 import { Accordion } from 'src/components/Accordion';
 import { Button } from 'src/components/Button/Button';

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.tsx
@@ -27,11 +27,11 @@ import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 import { sendCreateBucketEvent } from 'src/utilities/analytics';
 import { getErrorMap } from 'src/utilities/errorUtils';
 import { getGDPRDetails } from 'src/utilities/formatRegion';
+import { PRICES_RELOAD_ERROR_NOTICE_TEXT } from 'src/utilities/pricing/constants';
 
 import { EnableObjectStorageModal } from '../EnableObjectStorageModal';
 import ClusterSelect from './ClusterSelect';
 import { OveragePricing } from './OveragePricing';
-import { PRICES_RELOAD_ERROR_NOTICE_TEXT } from 'src/utilities/pricing/constants';
 
 interface Props {
   isOpen: boolean;
@@ -80,7 +80,7 @@ export const CreateBucketDrawer = (props: Props) => {
     data: types,
     isError: isErrorTypes,
     isLoading: isLoadingTypes,
-  } = useObjectStorageTypesQuery();
+  } = useObjectStorageTypesQuery(isOpen);
 
   const isInvalidPrice = !types || isErrorTypes;
 

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.tsx
@@ -19,6 +19,7 @@ import {
   useCreateBucketMutation,
   useObjectStorageBuckets,
   useObjectStorageClusters,
+  useObjectStorageTypesQuery,
 } from 'src/queries/objectStorage';
 import { useProfile } from 'src/queries/profile';
 import { useRegionsQuery } from 'src/queries/regions/regions';
@@ -30,6 +31,7 @@ import { getGDPRDetails } from 'src/utilities/formatRegion';
 import { EnableObjectStorageModal } from '../EnableObjectStorageModal';
 import ClusterSelect from './ClusterSelect';
 import { OveragePricing } from './OveragePricing';
+import { PRICES_RELOAD_ERROR_NOTICE_TEXT } from 'src/utilities/pricing/constants';
 
 interface Props {
   isOpen: boolean;
@@ -73,6 +75,14 @@ export const CreateBucketDrawer = (props: Props) => {
       ? regionsSupportingObjectStorage
       : undefined,
   });
+
+  const {
+    data: types,
+    isError: isErrorTypes,
+    isLoading: isLoadingTypes,
+  } = useObjectStorageTypesQuery();
+
+  const isInvalidPrice = !types || isErrorTypes;
 
   const {
     error,
@@ -199,9 +209,15 @@ export const CreateBucketDrawer = (props: Props) => {
             'data-testid': 'create-bucket-button',
             disabled:
               !formik.values.cluster ||
-              (showGDPRCheckbox && !hasSignedAgreement),
+              (showGDPRCheckbox && !hasSignedAgreement) ||
+              isErrorTypes,
             label: 'Create Bucket',
-            loading: isLoading,
+            loading:
+              isLoading || Boolean(clusterRegion?.[0]?.id && isLoadingTypes),
+            tooltipText:
+              !isLoadingTypes && isInvalidPrice
+                ? PRICES_RELOAD_ERROR_NOTICE_TEXT
+                : '',
             type: 'submit',
           }}
           secondaryButtonProps={{ label: 'Cancel', onClick: onClose }}

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.test.tsx
@@ -1,7 +1,10 @@
 import { fireEvent } from '@testing-library/react';
 import React from 'react';
 
-import { objectStorageTypeFactory } from 'src/factories';
+import {
+  objectStorageTypeFactory,
+  objectStorageTypeOverageFactory,
+} from 'src/factories';
 import { OBJ_STORAGE_PRICE } from 'src/utilities/pricing/constants';
 import { objectStoragePriceIncreaseMap } from 'src/utilities/pricing/dynamicPricing';
 import { renderWithTheme } from 'src/utilities/testHelpers';
@@ -12,15 +15,35 @@ import {
   OveragePricing,
 } from './OveragePricing';
 
-const mockObjectStorageTypes = objectStorageTypeFactory.build();
-const storageOveragePriceType = mockObjectStorageTypes[1];
+const mockObjectStorageTypes = [
+  objectStorageTypeFactory.build(),
+  objectStorageTypeOverageFactory.build(),
+];
+
+const queryMocks = vi.hoisted(() => ({
+  useObjectStorageTypesQuery: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('src/queries/objectStorage', async () => {
+  const actual = await vi.importActual('src/queries/objectStorage');
+  return {
+    ...actual,
+    useObjectStorageTypesQuery: queryMocks.useObjectStorageTypesQuery,
+  };
+});
 
 describe('OveragePricing', async () => {
-  it.skip('Renders base overage pricing for a region without price increases', () => {
+  beforeAll(() => {
+    queryMocks.useObjectStorageTypesQuery.mockReturnValue({
+      data: mockObjectStorageTypes,
+    });
+  });
+
+  it('Renders base overage pricing for a region without price increases', () => {
     const { getByText } = renderWithTheme(
       <OveragePricing regionId="us-east" />
     );
-    getByText(`$${storageOveragePriceType.price.hourly} per GB`, {
+    getByText(`$${mockObjectStorageTypes[1].price.hourly?.toFixed(3)} per GB`, {
       exact: false,
     });
     getByText(`$${OBJ_STORAGE_PRICE.transfer_overage} per GB`, {
@@ -28,14 +51,11 @@ describe('OveragePricing', async () => {
     });
   });
 
-  it.skip('Renders DC-specific overage pricing for a region with price increases', () => {
+  it('Renders DC-specific overage pricing for a region with price increases', () => {
     const { getByText } = renderWithTheme(<OveragePricing regionId="br-gru" />);
-    getByText(
-      `$${storageOveragePriceType?.region_prices?.['br-gru']?.hourly} per GB`,
-      {
-        exact: false,
-      }
-    );
+    getByText(`$${mockObjectStorageTypes[1].region_prices[1].hourly} per GB`, {
+      exact: false,
+    });
     getByText(
       `$${objectStoragePriceIncreaseMap['br-gru'].transfer_overage} per GB`,
       { exact: false }
@@ -66,5 +86,41 @@ describe('OveragePricing', async () => {
 
     expect(tooltip).toBeInTheDocument();
     expect(getByText(GLOBAL_TRANSFER_POOL_TOOLTIP_TEXT)).toBeVisible();
+  });
+
+  it('Renders a loading state while prices are loading', () => {
+    queryMocks.useObjectStorageTypesQuery.mockReturnValue({
+      isLoading: true,
+    });
+
+    const { getByRole } = renderWithTheme(
+      <OveragePricing regionId="us-east" />
+    );
+
+    expect(getByRole('progressbar')).toBeVisible();
+  });
+
+  it('Renders placeholder unknown pricing when there is an error', async () => {
+    queryMocks.useObjectStorageTypesQuery.mockReturnValue({
+      isError: true,
+    });
+
+    const { getAllByText } = renderWithTheme(
+      <OveragePricing regionId="us-east" />
+    );
+
+    expect(getAllByText('$--.-- per GB')).toHaveLength(1);
+  });
+
+  it('Renders placeholder unknown pricing when prices are undefined', async () => {
+    queryMocks.useObjectStorageTypesQuery.mockReturnValue({
+      data: undefined,
+    });
+
+    const { getAllByText } = renderWithTheme(
+      <OveragePricing regionId="us-east" />
+    );
+
+    expect(getAllByText('$--.-- per GB')).toHaveLength(1);
   });
 });

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.test.tsx
@@ -2,10 +2,13 @@ import { fireEvent } from '@testing-library/react';
 import React from 'react';
 
 import {
+  objectStorageOverageTypeFactory,
   objectStorageTypeFactory,
-  objectStorageTypeOverageFactory,
 } from 'src/factories';
-import { OBJ_STORAGE_PRICE } from 'src/utilities/pricing/constants';
+import {
+  OBJ_STORAGE_PRICE,
+  UNKNOWN_PRICE,
+} from 'src/utilities/pricing/constants';
 import { objectStoragePriceIncreaseMap } from 'src/utilities/pricing/dynamicPricing';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
@@ -17,7 +20,7 @@ import {
 
 const mockObjectStorageTypes = [
   objectStorageTypeFactory.build(),
-  objectStorageTypeOverageFactory.build(),
+  objectStorageOverageTypeFactory.build(),
 ];
 
 const queryMocks = vi.hoisted(() => ({
@@ -109,7 +112,7 @@ describe('OveragePricing', async () => {
       <OveragePricing regionId="us-east" />
     );
 
-    expect(getAllByText('$--.-- per GB')).toHaveLength(1);
+    expect(getAllByText(`$${UNKNOWN_PRICE} per GB`)).toHaveLength(1);
   });
 
   it('Renders placeholder unknown pricing when prices are undefined', async () => {
@@ -121,6 +124,6 @@ describe('OveragePricing', async () => {
       <OveragePricing regionId="us-east" />
     );
 
-    expect(getAllByText('$--.-- per GB')).toHaveLength(1);
+    expect(getAllByText(`$${UNKNOWN_PRICE} per GB`)).toHaveLength(1);
   });
 });

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent } from '@testing-library/react';
 import React from 'react';
 
+import { objectStorageTypeFactory } from 'src/factories';
 import { OBJ_STORAGE_PRICE } from 'src/utilities/pricing/constants';
 import { objectStoragePriceIncreaseMap } from 'src/utilities/pricing/dynamicPricing';
 import { renderWithTheme } from 'src/utilities/testHelpers';
@@ -11,22 +12,29 @@ import {
   OveragePricing,
 } from './OveragePricing';
 
-describe('OveragePricing', () => {
-  it('Renders base overage pricing for a region without price increases', () => {
+const mockObjectStorageTypes = objectStorageTypeFactory.build();
+const storageOveragePriceType = mockObjectStorageTypes[1];
+
+describe('OveragePricing', async () => {
+  it.skip('Renders base overage pricing for a region without price increases', () => {
     const { getByText } = renderWithTheme(
       <OveragePricing regionId="us-east" />
     );
-    getByText(`$${OBJ_STORAGE_PRICE.storage_overage} per GB`, { exact: false });
+    getByText(`$${storageOveragePriceType.price.hourly} per GB`, {
+      exact: false,
+    });
     getByText(`$${OBJ_STORAGE_PRICE.transfer_overage} per GB`, {
       exact: false,
     });
   });
 
-  it('Renders DC-specific overage pricing for a region with price increases', () => {
+  it.skip('Renders DC-specific overage pricing for a region with price increases', () => {
     const { getByText } = renderWithTheme(<OveragePricing regionId="br-gru" />);
     getByText(
-      `$${objectStoragePriceIncreaseMap['br-gru'].storage_overage} per GB`,
-      { exact: false }
+      `$${storageOveragePriceType?.region_prices?.['br-gru']?.hourly} per GB`,
+      {
+        exact: false,
+      }
     );
     getByText(
       `$${objectStoragePriceIncreaseMap['br-gru'].transfer_overage} per GB`,

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.test.tsx
@@ -103,7 +103,7 @@ describe('OveragePricing', async () => {
     expect(getByRole('progressbar')).toBeVisible();
   });
 
-  it('Renders placeholder unknown pricing when there is an error', async () => {
+  it('Renders placeholder unknown pricing when there is an error', () => {
     queryMocks.useObjectStorageTypesQuery.mockReturnValue({
       isError: true,
     });
@@ -115,7 +115,7 @@ describe('OveragePricing', async () => {
     expect(getAllByText(`$${UNKNOWN_PRICE} per GB`)).toHaveLength(1);
   });
 
-  it('Renders placeholder unknown pricing when prices are undefined', async () => {
+  it('Renders placeholder unknown pricing when prices are undefined', () => {
     queryMocks.useObjectStorageTypesQuery.mockReturnValue({
       data: undefined,
     });

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.test.tsx
@@ -46,7 +46,7 @@ describe('OveragePricing', async () => {
     const { getByText } = renderWithTheme(
       <OveragePricing regionId="us-east" />
     );
-    getByText(`$${mockObjectStorageTypes[1].price.hourly?.toFixed(3)} per GB`, {
+    getByText(`$${mockObjectStorageTypes[1].price.hourly?.toFixed(2)} per GB`, {
       exact: false,
     });
     getByText(`$${OBJ_STORAGE_PRICE.transfer_overage} per GB`, {

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.tsx
@@ -29,7 +29,9 @@ export const OveragePricing = (props: Props) => {
 
   const { data: types, isError, isLoading } = useObjectStorageTypesQuery();
 
-  const overageType = types?.find((type) => type.id.includes('overage'));
+  const overageType = types?.find(
+    (type) => type.id === 'objectstorage-overage'
+  );
 
   const storageOveragePrice = getDCSpecificPriceByType({
     decimalPrecision: 3,
@@ -42,23 +44,22 @@ export const OveragePricing = (props: Props) => {
     regionId
   );
 
-  return (
+  return isLoading ? (
+    <CircularProgress size={16} sx={{ marginTop: 2 }} />
+  ) : (
     <>
-      {isLoading ? (
-        <CircularProgress size={16} sx={{ marginTop: 2 }} />
-      ) : (
-        <StyledTypography>
-          For this region, additional storage costs{' '}
-          <strong>
-            $
-            {storageOveragePrice && !isError
-              ? storageOveragePrice
-              : UNKNOWN_PRICE}{' '}
-            per GB
-          </strong>
-          .
-        </StyledTypography>
-      )}
+      <StyledTypography>
+        For this region, additional storage costs{' '}
+        <strong>
+          $
+          {storageOveragePrice && !isError
+            ? storageOveragePrice
+            : UNKNOWN_PRICE}{' '}
+          per GB
+        </strong>
+        .
+      </StyledTypography>
+
       <StyledTypography>
         Outbound transfer will cost{' '}
         <strong>
@@ -66,11 +67,6 @@ export const OveragePricing = (props: Props) => {
           {isDcSpecificPricingRegion
             ? objectStoragePriceIncreaseMap[regionId].transfer_overage
             : OBJ_STORAGE_PRICE.transfer_overage}{' '}
-          {/* {getDCSpecificPriceByType({
-            regionId,
-            timePeriod: 'hourly',
-            type: overageType,
-          })}{' '} */}
           per GB
         </strong>{' '}
         if it exceeds{' '}

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.tsx
@@ -2,10 +2,14 @@ import { Region } from '@linode/api-v4';
 import { styled } from '@mui/material/styles';
 import React from 'react';
 
+import { CircularProgress } from 'src/components/CircularProgress';
 import { TextTooltip } from 'src/components/TextTooltip';
 import { Typography } from 'src/components/Typography';
 import { useObjectStorageTypesQuery } from 'src/queries/objectStorage';
-import { OBJ_STORAGE_PRICE } from 'src/utilities/pricing/constants';
+import {
+  OBJ_STORAGE_PRICE,
+  UNKNOWN_PRICE,
+} from 'src/utilities/pricing/constants';
 import {
   getDCSpecificPriceByType,
   objectStoragePriceIncreaseMap,
@@ -23,9 +27,15 @@ export const GLOBAL_TRANSFER_POOL_TOOLTIP_TEXT =
 export const OveragePricing = (props: Props) => {
   const { regionId } = props;
 
-  const { data: types /*, isError, isLoading*/ } = useObjectStorageTypesQuery();
+  const { data: types, isError, isLoading } = useObjectStorageTypesQuery();
 
   const overageType = types?.find((type) => type.id.includes('overage'));
+
+  const storageOveragePrice = getDCSpecificPriceByType({
+    interval: 'hourly',
+    regionId,
+    type: overageType,
+  });
 
   const isDcSpecificPricingRegion = objectStoragePriceIncreaseMap.hasOwnProperty(
     regionId
@@ -33,22 +43,21 @@ export const OveragePricing = (props: Props) => {
 
   return (
     <>
-      <StyledTypography>
-        For this region, additional storage costs{' '}
-        <strong>
-          $
-          {/* {isDcSpecificPricingRegion
-            ? objectStoragePriceIncreaseMap[regionId].storage_overage
-            : OBJ_STORAGE_PRICE.storage_overage}{' '} */}
-          {getDCSpecificPriceByType({
-            regionId,
-            timePeriod: 'hourly',
-            type: overageType,
-          })}{' '}
-          per GB
-        </strong>
-        .
-      </StyledTypography>
+      {isLoading ? (
+        <CircularProgress size={16} sx={{ marginTop: 2 }} />
+      ) : (
+        <StyledTypography>
+          For this region, additional storage costs{' '}
+          <strong>
+            $
+            {storageOveragePrice && !isError
+              ? storageOveragePrice
+              : UNKNOWN_PRICE}{' '}
+            per GB
+          </strong>
+          .
+        </StyledTypography>
+      )}
       <StyledTypography>
         Outbound transfer will cost{' '}
         <strong>

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.tsx
@@ -53,7 +53,7 @@ export const OveragePricing = (props: Props) => {
         <strong>
           $
           {storageOveragePrice && !isError
-            ? storageOveragePrice
+            ? parseFloat(storageOveragePrice)
             : UNKNOWN_PRICE}{' '}
           per GB
         </strong>

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.tsx
@@ -32,6 +32,7 @@ export const OveragePricing = (props: Props) => {
   const overageType = types?.find((type) => type.id.includes('overage'));
 
   const storageOveragePrice = getDCSpecificPriceByType({
+    decimalPrecision: 3,
     interval: 'hourly',
     regionId,
     type: overageType,

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OveragePricing.tsx
@@ -4,8 +4,12 @@ import React from 'react';
 
 import { TextTooltip } from 'src/components/TextTooltip';
 import { Typography } from 'src/components/Typography';
+import { useObjectStorageTypesQuery } from 'src/queries/objectStorage';
 import { OBJ_STORAGE_PRICE } from 'src/utilities/pricing/constants';
-import { objectStoragePriceIncreaseMap } from 'src/utilities/pricing/dynamicPricing';
+import {
+  getDCSpecificPriceByType,
+  objectStoragePriceIncreaseMap,
+} from 'src/utilities/pricing/dynamicPricing';
 
 interface Props {
   regionId: Region['id'];
@@ -18,6 +22,11 @@ export const GLOBAL_TRANSFER_POOL_TOOLTIP_TEXT =
 
 export const OveragePricing = (props: Props) => {
   const { regionId } = props;
+
+  const { data: types /*, isError, isLoading*/ } = useObjectStorageTypesQuery();
+
+  const overageType = types?.find((type) => type.id.includes('overage'));
+
   const isDcSpecificPricingRegion = objectStoragePriceIncreaseMap.hasOwnProperty(
     regionId
   );
@@ -28,9 +37,14 @@ export const OveragePricing = (props: Props) => {
         For this region, additional storage costs{' '}
         <strong>
           $
-          {isDcSpecificPricingRegion
+          {/* {isDcSpecificPricingRegion
             ? objectStoragePriceIncreaseMap[regionId].storage_overage
-            : OBJ_STORAGE_PRICE.storage_overage}{' '}
+            : OBJ_STORAGE_PRICE.storage_overage}{' '} */}
+          {getDCSpecificPriceByType({
+            regionId,
+            timePeriod: 'hourly',
+            type: overageType,
+          })}{' '}
           per GB
         </strong>
         .
@@ -42,6 +56,11 @@ export const OveragePricing = (props: Props) => {
           {isDcSpecificPricingRegion
             ? objectStoragePriceIncreaseMap[regionId].transfer_overage
             : OBJ_STORAGE_PRICE.transfer_overage}{' '}
+          {/* {getDCSpecificPriceByType({
+            regionId,
+            timePeriod: 'hourly',
+            type: overageType,
+          })}{' '} */}
           per GB
         </strong>{' '}
         if it exceeds{' '}

--- a/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render } from '@testing-library/react';
 import * as React from 'react';
 
+import { objectStorageTypeFactory } from 'src/factories';
 import { OBJ_STORAGE_PRICE } from 'src/utilities/pricing/constants';
 import { wrapWithTheme } from 'src/utilities/testHelpers';
 
@@ -23,7 +24,26 @@ const props: EnableObjectStorageProps = {
   open: true,
 };
 
+const queryMocks = vi.hoisted(() => ({
+  useObjectStorageTypes: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('src/queries/objectStorage', async () => {
+  const actual = await vi.importActual('src/queries/objectStorage');
+  return {
+    ...actual,
+    useObjectStorageTypesQuery: queryMocks.useObjectStorageTypes,
+  };
+});
+
 describe('EnableObjectStorageModal', () => {
+  beforeEach(() => {
+    const mockObjectStorageTypes = objectStorageTypeFactory.build();
+    queryMocks.useObjectStorageTypes.mockReturnValue({
+      data: mockObjectStorageTypes,
+    });
+  });
+
   it('includes a header', () => {
     const { getAllByText } = render(
       wrapWithTheme(<EnableObjectStorageModal {...props} />)

--- a/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
+++ b/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
@@ -27,9 +27,11 @@ export const EnableObjectStorageModal = React.memo(
   (props: EnableObjectStorageProps) => {
     const { handleSubmit, onClose, open, regionId } = props;
 
-    const { data: types, isError, isLoading } = useObjectStorageTypesQuery();
+    const { data: types, isError, isLoading } = useObjectStorageTypesQuery(
+      Boolean(regionId)
+    );
 
-    const isInvalidPrice = !types || isError;
+    const isInvalidPrice = Boolean(regionId) && (!types || isError);
 
     const objectStorageType = types?.find(
       (type) => type.id === 'objectstorage'

--- a/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
+++ b/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
@@ -37,10 +37,11 @@ export const EnableObjectStorageModal = React.memo(
 
     const price = regionId
       ? getDCSpecificPriceByType({
+          decimalPrecision: 0,
           regionId,
           type: objectStorageType,
         })
-      : objectStorageType?.price.monthly?.toFixed(2);
+      : objectStorageType?.price.monthly;
 
     return (
       <ConfirmationDialog

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -76,6 +76,8 @@ import {
   objectStorageBucketFactory,
   objectStorageClusterFactory,
   objectStorageKeyFactory,
+  objectStorageTypeFactory,
+  objectStorageTypeOverageFactory,
   paymentFactory,
   paymentMethodFactory,
   placementGroupFactory,
@@ -918,6 +920,17 @@ export const handlers = [
       nodeBalancerConfigNodeFactory.build({ status: 'unknown' }),
     ];
     return HttpResponse.json(makeResourcePage(configs));
+  }),
+  http.get('*/v4/nodebalancers/types', () => {
+    const nodeBalancerTypes = nodeBalancerTypeFactory.buildList(1);
+    return HttpResponse.json(makeResourcePage(nodeBalancerTypes));
+  }),
+  http.get('*/v4/object-storage/types', () => {
+    const objectStorageTypes = [
+      objectStorageTypeFactory.build(),
+      objectStorageTypeOverageFactory.build(),
+    ];
+    return HttpResponse.json(makeResourcePage(objectStorageTypes));
   }),
   http.get('*object-storage/buckets/*/*/access', async () => {
     await sleep(2000);

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -77,7 +77,7 @@ import {
   objectStorageClusterFactory,
   objectStorageKeyFactory,
   objectStorageTypeFactory,
-  objectStorageTypeOverageFactory,
+  objectStorageOverageTypeFactory,
   paymentFactory,
   paymentMethodFactory,
   placementGroupFactory,
@@ -928,7 +928,7 @@ export const handlers = [
   http.get('*/v4/object-storage/types', () => {
     const objectStorageTypes = [
       objectStorageTypeFactory.build(),
-      objectStorageTypeOverageFactory.build(),
+      objectStorageOverageTypeFactory.build(),
     ];
     return HttpResponse.json(makeResourcePage(objectStorageTypes));
   }),

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -921,10 +921,6 @@ export const handlers = [
     ];
     return HttpResponse.json(makeResourcePage(configs));
   }),
-  http.get('*/v4/nodebalancers/types', () => {
-    const nodeBalancerTypes = nodeBalancerTypeFactory.buildList(1);
-    return HttpResponse.json(makeResourcePage(nodeBalancerTypes));
-  }),
   http.get('*/v4/object-storage/types', () => {
     const objectStorageTypes = [
       objectStorageTypeFactory.build(),

--- a/packages/manager/src/queries/objectStorage.ts
+++ b/packages/manager/src/queries/objectStorage.ts
@@ -418,11 +418,12 @@ const getAllObjectStorageTypes = () =>
     (data) => data.data
   );
 
-export const useObjectStorageTypesQuery = () =>
+export const useObjectStorageTypesQuery = (enabled = true) =>
   useQuery<PriceType[], APIError[]>(
     [`${queryKey}-types`],
     getAllObjectStorageTypes,
     {
       ...queryPresets.oneTimeFetch,
+      enabled,
     }
   );

--- a/packages/manager/src/queries/objectStorage.ts
+++ b/packages/manager/src/queries/objectStorage.ts
@@ -20,11 +20,17 @@ import {
   getClusters,
   getObjectList,
   getObjectStorageKeys,
+  getObjectStorageTypes,
   getObjectURL,
   getSSLCert,
   uploadSSLCert,
 } from '@linode/api-v4';
-import { APIError, Params, ResourcePage } from '@linode/api-v4/lib/types';
+import {
+  APIError,
+  Params,
+  PriceType,
+  ResourcePage,
+} from '@linode/api-v4/lib/types';
 import {
   QueryClient,
   useInfiniteQuery,
@@ -406,3 +412,17 @@ export const useBucketSSLDeleteMutation = (cluster: string, bucket: string) => {
     },
   });
 };
+
+const getAllObjectStorageTypes = () =>
+  getAll<PriceType>((params) => getObjectStorageTypes(params))().then(
+    (data) => data.data
+  );
+
+export const useObjectStorageTypesQuery = () =>
+  useQuery<PriceType[], APIError[]>(
+    [`${queryKey}-types`],
+    getAllObjectStorageTypes,
+    {
+      ...queryPresets.oneTimeFetch,
+    }
+  );

--- a/packages/manager/src/queries/objectStorage.ts
+++ b/packages/manager/src/queries/objectStorage.ts
@@ -419,11 +419,9 @@ const getAllObjectStorageTypes = () =>
   );
 
 export const useObjectStorageTypesQuery = (enabled = true) =>
-  useQuery<PriceType[], APIError[]>(
-    [`${queryKey}-types`],
-    getAllObjectStorageTypes,
-    {
-      ...queryPresets.oneTimeFetch,
-      enabled,
-    }
-  );
+  useQuery<PriceType[], APIError[]>({
+    queryFn: getAllObjectStorageTypes,
+    queryKey: [queryKey, 'types'],
+    ...queryPresets.oneTimeFetch,
+    enabled,
+  });

--- a/packages/manager/src/utilities/pricing/dynamicPricing.test.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.test.ts
@@ -75,9 +75,10 @@ describe('getDCSpecificPricingByType', () => {
     ).toBe('14.00');
   });
 
-  it('calculates dynamic pricing for a region without an increase on an hourly interval', () => {
+  it('calculates dynamic pricing for a region without an increase on an hourly interval to the specified decimal', () => {
     expect(
       getDCSpecificPriceByType({
+        decimalPrecision: 3,
         interval: 'hourly',
         regionId: 'us-east',
         type: mockNodeBalancerType,
@@ -85,9 +86,10 @@ describe('getDCSpecificPricingByType', () => {
     ).toBe('0.015');
   });
 
-  it('calculates dynamic pricing for a region with an increase on an hourly interval', () => {
+  it('calculates dynamic pricing for a region with an increase on an hourly interval to the specified decimal', () => {
     expect(
       getDCSpecificPriceByType({
+        decimalPrecision: 3,
         interval: 'hourly',
         regionId: 'id-cgk',
         type: mockNodeBalancerType,

--- a/packages/manager/src/utilities/pricing/dynamicPricing.test.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.test.ts
@@ -75,6 +75,26 @@ describe('getDCSpecificPricingByType', () => {
     ).toBe('14.00');
   });
 
+  it('calculates dynamic pricing for a region without an increase on an hourly interval', () => {
+    expect(
+      getDCSpecificPriceByType({
+        interval: 'hourly',
+        regionId: 'us-east',
+        type: mockNodeBalancerType,
+      })
+    ).toBe('0.015');
+  });
+
+  it('calculates dynamic pricing for a region with an increase on an hourly interval', () => {
+    expect(
+      getDCSpecificPriceByType({
+        interval: 'hourly',
+        regionId: 'id-cgk',
+        type: mockNodeBalancerType,
+      })
+    ).toBe('0.018');
+  });
+
   it('calculates dynamic pricing for a volume based on size', () => {
     expect(
       getDCSpecificPriceByType({

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -2,6 +2,7 @@ import { UNKNOWN_PRICE } from './constants';
 
 import type { PriceType, Region, RegionPriceObject } from '@linode/api-v4';
 
+type TimePeriod = 'hourly' | 'monthly';
 export interface RegionPrice extends RegionPriceObject {
   id: string;
 }
@@ -31,6 +32,10 @@ export interface DataCenterPricingByTypeOptions {
    * @example 20 (GB) for a volume
    */
   size?: number;
+  /**
+   * The time period for which to find pricing data for (hourly or monthly).
+   */
+  timePeriod?: TimePeriod;
   /**
    * The type data from a product's /types endpoint.
    */
@@ -96,6 +101,7 @@ export const getDCSpecificPrice = ({
 export const getDCSpecificPriceByType = ({
   regionId,
   size,
+  timePeriod = 'monthly',
   type,
 }: DataCenterPricingByTypeOptions): string | undefined => {
   if (!regionId || !type) {
@@ -106,7 +112,7 @@ export const getDCSpecificPriceByType = ({
   const price =
     type.region_prices.find((region_price: RegionPrice) => {
       return region_price.id === regionId;
-    })?.monthly ?? type.price.monthly;
+    })?.[timePeriod] ?? type.price?.[timePeriod];
 
   // If pricing is determined by size of the entity
   if (size && price) {

--- a/packages/manager/src/utilities/pricing/dynamicPricing.ts
+++ b/packages/manager/src/utilities/pricing/dynamicPricing.ts
@@ -22,6 +22,11 @@ export interface DataCenterPricingOptions {
 
 export interface DataCenterPricingByTypeOptions {
   /**
+   * The number of decimal places to return for the price.
+   *  @default 2
+   */
+  decimalPrecision?: number;
+  /**
    * The time period for which to find pricing data for (hourly or monthly).
    *  @default monthly
    */
@@ -99,6 +104,7 @@ export const getDCSpecificPrice = ({
  * @returns a data center specific price or undefined if this cannot be calculated
  */
 export const getDCSpecificPriceByType = ({
+  decimalPrecision = 2,
   interval = 'monthly',
   regionId,
   size,
@@ -115,10 +121,10 @@ export const getDCSpecificPriceByType = ({
 
   // If pricing is determined by size of the entity
   if (size && price) {
-    return (size * price).toFixed(2);
+    return (size * price).toFixed(decimalPrecision);
   }
 
-  return price?.toFixed(interval === 'hourly' ? 3 : 2) ?? undefined;
+  return price?.toFixed(decimalPrecision) ?? undefined;
 };
 
 export const renderMonthlyPriceToCorrectDecimalPlace = (


### PR DESCRIPTION
## Description 📝
API is now returning pricing data through the `/object-storage/types` endpoint. 

In this PR, prices can be dynamically displayed for base region pricing and DC-specific region pricing, using the prices returned in the new endpoint, for Object Storage.

> [!NOTE]  
> Outbound transfer overages will be done in a follow-up PR, since pricing for network transfer overages is the same across Cloud Manager and not currently being returned by the API. They are creating a new endpoint for this.

## Changes  🔄
- Created the necessary api-v4 endpoint, query, and interface to use the object-storage/types endpoint.
- Modified `getDCSpecificPriceByType` to optionally accept interval (hourly or monthly) and decimal precision params and updated util unit test accordingly.
- Created the necessary factories and endpoint in the MSW to support a mocked response to the API endpoint.
- Added UX for error handling in the unlikely event that pricing cannot be calculated: disable primary action button and display tooltip error. 
- Added loading state for prices.
- Updated unit tests.

## Target release date 🗓️
5/28/24

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-05-17 at 12 50 05 AM](https://github.com/linode/manager/assets/114685994/6bdbf681-4673-435e-b0ec-42ea8054d2b9) ![Screenshot 2024-05-17 at 12 50 23 AM](https://github.com/linode/manager/assets/114685994/4e431b16-ee31-4aeb-a947-0789bbb15cb6) ![Screenshot 2024-05-17 at 12 50 33 AM](https://github.com/linode/manager/assets/114685994/c0e5263c-9022-4843-88c5-9fa8e9594c53) | ![Screenshot 2024-05-20 at 8 08 52 AM](https://github.com/linode/manager/assets/114685994/0938106c-b6af-47b3-bc3f-36f1feaf7cc7) ![Screenshot 2024-05-17 at 12 47 38 AM](https://github.com/linode/manager/assets/114685994/0eb5f0fd-a8d4-4d35-8ba3-059d4603f37d) ![Screenshot 2024-05-17 at 12 47 49 AM](https://github.com/linode/manager/assets/114685994/b445d5a8-868d-4e1f-a0de-e4eb10c4016a) |
| N/A | <video src="https://github.com/linode/manager/assets/114685994/c2551927-a383-4fda-a8b7-afa4cc026501"/>|
| ![Screenshot 2024-05-17 at 12 50 46 AM](https://github.com/linode/manager/assets/114685994/d9fa5437-dfd1-4977-bd86-206588c3a48f) | ![Screenshot 2024-05-17 at 12 46 48 AM](https://github.com/linode/manager/assets/114685994/77f6fd78-ae68-43dd-86c2-b3df6b862afc) |
| ![Screenshot 2024-05-17 at 12 51 03 AM](https://github.com/linode/manager/assets/114685994/ed1b47a6-7d22-4ce3-928d-f2750d1f831d) | ![Screenshot 2024-05-17 at 12 47 10 AM](https://github.com/linode/manager/assets/114685994/8b7172c1-a951-4af6-8ddb-71c39c12dce8) |


## How to test 🧪

### Prerequisites
(How to setup test environment)
- Check out this PR and `yarn up`.
- Go to http://localhost:3000/account/settings and Cancel Object Storage if it is enabled on your account.

### Verification steps
(How to verify changes)
- Go to http://localhost:3000/object-storage/buckets/create.
- Select a region without DC specific pricing (e.g. `us-east`).
- Open the network tab and filter on `/types`. Confirm the "additional storage overage" pricing is consistent with the overage pricing returned by the API endpoint AND that price is consistent with prod.
- Repeat the same process for Sao Paulo (`br-gru`) and Jakarta (`id-cgk`).
- Fill out the necessary fields, click Create Bucket, and confirm the Enable Object Storage modal pops up with no regressions. *Cancel out of the modal - don't enable OBJ.*
- Use the Network tools to slow and block network requests - confirm that loading and error behavior is handled gracefully in the Create Bucket drawer if prices can't be retrieved from the `object-storage/types` endpoint.
- Go to http://localhost:3000/object-storage/access-keys.
- Fill out the necessary fields, click Create Access Key, and confirm the Enable Object Storage modal pops up with no regressions. *Cancel out of the modal - don't enable OBJ.*
- Ensure object storage e2e tests pass.
- Ensure updated unit tests pass:
```
yarn test OveragePricing dynamicPricing EnableObjectStorageModal
```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

