### PR TITLE
test: [M3-8102] - Fix StackScript test failure by using up-to-date images

### DIFF
--- a/packages/manager/.changeset/pr-10470-tests-1715719518601.md
+++ b/packages/manager/.changeset/pr-10470-tests-1715719518601.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix failing StackScript test following deprecation of Fedora 38 Image ([#10470](https://github.com/linode/manager/pull/10470))

--- a/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
@@ -163,8 +163,8 @@ describe('Create stackscripts', () => {
   it('creates a StackScript and deploys a Linode with it', () => {
     const stackscriptLabel = randomLabel();
     const stackscriptDesc = randomPhrase();
-    const stackscriptImage = 'Alpine 3.18';
-    const stackscriptImageTag = 'alpine3.18';
+    const stackscriptImage = 'Alpine 3.19';
+    const stackscriptImageTag = 'alpine3.19';
 
     const linodeLabel = randomLabel();
     const linodeRegion = chooseRegion();
@@ -294,13 +294,13 @@ describe('Create stackscripts', () => {
      */
     const imageSamples = [
       { label: 'AlmaLinux 9', sel: 'linode/almalinux9' },
-      { label: 'Alpine 3.18', sel: 'linode/alpine3.18' },
+      { label: 'Alpine 3.19', sel: 'linode/alpine3.19' },
       { label: 'Arch Linux', sel: 'linode/arch' },
       { label: 'CentOS Stream 9', sel: 'linode/centos-stream9' },
       { label: 'Debian 12', sel: 'linode/debian12' },
-      { label: 'Fedora 38', sel: 'linode/fedora38' },
+      { label: 'Fedora 40', sel: 'linode/fedora40' },
       { label: 'Rocky Linux 9', sel: 'linode/rocky9' },
-      { label: 'Ubuntu 23.10', sel: 'linode/ubuntu23.10' },
+      { label: 'Ubuntu 24.04 LTS', sel: 'linode/ubuntu24.04' },
     ];
 
     interceptCreateStackScript().as('createStackScript');


### PR DESCRIPTION
## Description 📝
Quick fix for the StackScript test that began failing today because Fedora 38 got marked as deprecated. Also opened M3-8098 to improve this test's resilience to backend Image changes.

## Changes  🔄
- Use up-to-date Images in StackScript test

## How to test 🧪
We can rely on CI for this, but to run the test locally you can use this command:

```bash
yarn cy:run -s "cypress/e2e/core/stackscripts/create-stackscripts.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

