### PR TITLE
test: [M3-6226] - Clean up cy.intercept calls in notification and events

### DIFF
--- a/packages/manager/.changeset/pr-10472-tests-1715794017061.md
+++ b/packages/manager/.changeset/pr-10472-tests-1715794017061.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Clean up cy.intercept calls in notification and events ([#10472](https://github.com/linode/manager/pull/10472))

--- a/packages/manager/cypress/e2e/core/notificationsAndEvents/events.spec.ts
+++ b/packages/manager/cypress/e2e/core/notificationsAndEvents/events.spec.ts
@@ -1,9 +1,9 @@
 import { Event, EventAction } from '@linode/api-v4';
 import { eventFactory } from '@src/factories/events';
-import { makeResourcePage } from '@src/mocks/serverHandlers';
+
 import { RecPartial } from 'factory.ts';
 import { containsClick, getClick } from 'support/helpers';
-import { apiMatcher } from 'support/util/intercepts';
+import { mockGetEvents } from 'support/intercepts/events';
 
 const eventActions: RecPartial<EventAction>[] = [
   'backups_cancel',
@@ -108,9 +108,7 @@ const events: Event[] = eventActions.map((action) => {
 
 describe('verify notification types and icons', () => {
   it(`notifications`, () => {
-    cy.intercept(apiMatcher('account/events*'), (req) => {
-      req.reply(makeResourcePage(events));
-    }).as('mockEvents');
+    mockGetEvents(events).as('mockEvents');
     cy.visitWithLogin('/linodes');
     cy.wait('@mockEvents').then(() => {
       getClick('button[aria-label="Notifications"]');

--- a/packages/manager/cypress/e2e/core/notificationsAndEvents/events.spec.ts
+++ b/packages/manager/cypress/e2e/core/notificationsAndEvents/events.spec.ts
@@ -1,6 +1,5 @@
 import { Event, EventAction } from '@linode/api-v4';
 import { eventFactory } from '@src/factories/events';
-
 import { RecPartial } from 'factory.ts';
 import { containsClick, getClick } from 'support/helpers';
 import { mockGetEvents } from 'support/intercepts/events';

--- a/packages/manager/cypress/e2e/core/notificationsAndEvents/notifications.spec.ts
+++ b/packages/manager/cypress/e2e/core/notificationsAndEvents/notifications.spec.ts
@@ -1,8 +1,7 @@
 import { Notification } from '@linode/api-v4';
 import { notificationFactory } from '@src/factories/notification';
-import { makeResourcePage } from '@src/mocks/serverHandlers';
 import { getClick } from 'support/helpers';
-import { apiMatcher } from 'support/util/intercepts';
+import { mockGetNotifications } from 'support/intercepts/events';
 
 const notifications: Notification[] = [
   notificationFactory.build({
@@ -21,11 +20,7 @@ const notifications: Notification[] = [
 
 describe('verify notification types and icons', () => {
   it(`notifications`, () => {
-    cy.intercept('GET', apiMatcher('account/notifications*'), (req) => {
-      req.reply((res) => {
-        res.send(makeResourcePage(notifications));
-      });
-    }).as('mockNotifications');
+    mockGetNotifications(notifications).as('mockNotifications');
     cy.visitWithLogin('/linodes');
     cy.wait('@mockNotifications');
     getClick('button[aria-label="Notifications"]');


### PR DESCRIPTION
## Description 📝
Clean up cy.intercept calls in notification and events

## Changes  🔄
List any change relevant to the reviewer.

Replace calls to cy.intercept with intercept utils in events.ts

## How to test 🧪
We can rely on CI to confirm that this test has not been broken by these changes, but to run the test locally you can use this command:
```
yarn cy:run -s "cypress/e2e/core/notificationsAndEvents/*"
```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support