### PR TITLE
test: [M3-7991] - Integration Test: Linode Create with Placement Group 

### DIFF
--- a/packages/manager/.changeset/pr-10473-tests-1715795923381.md
+++ b/packages/manager/.changeset/pr-10473-tests-1715795923381.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Integration Test: Linode Create with Placement Group ([#10473](https://github.com/linode/manager/pull/10473))

--- a/packages/manager/.changeset/pr-10473-tests-1715795923381.md
+++ b/packages/manager/.changeset/pr-10473-tests-1715795923381.md
@@ -2,4 +2,4 @@
 "@linode/manager": Tests
 ---
 
-Integration Test: Linode Create with Placement Group ([#10473](https://github.com/linode/manager/pull/10473))
+Add Integration Test for Linode Create with Placement Group ([#10473](https://github.com/linode/manager/pull/10473))

--- a/packages/manager/cypress/e2e/core/placementGroups/create-linode-with-placement-groups.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/create-linode-with-placement-groups.spec.ts
@@ -1,0 +1,205 @@
+import {
+  mockAppendFeatureFlags,
+  mockGetFeatureFlagClientstream,
+} from 'support/intercepts/feature-flags';
+import { authenticate } from 'support/api/authentication';
+import { makeFeatureFlagData } from 'support/util/feature-flags';
+import { mockGetAccount } from 'support/intercepts/account';
+import {
+  accountFactory,
+  linodeFactory,
+  placementGroupFactory,
+} from 'src/factories';
+import { regionFactory } from 'src/factories';
+import { ui } from 'support/ui/';
+import { cleanUp } from 'support/util/cleanup';
+import { mockCreateLinode } from 'support/intercepts/linodes';
+import { mockGetRegions } from 'support/intercepts/regions';
+import {
+  mockCreatePlacementGroup,
+  mockGetPlacementGroups,
+} from 'support/intercepts/placement-groups';
+import { randomString } from 'support/util/random';
+
+import type { Region } from '@linode/api-v4';
+import type { Flags } from 'src/featureFlags';
+
+const mockAccount = accountFactory.build();
+const mockRegions: Region[] = [
+  regionFactory.build({
+    capabilities: ['Linodes', 'Placement Group'],
+    id: 'us-east',
+    label: 'Newark, NJ',
+    country: 'us',
+  }),
+  regionFactory.build({
+    capabilities: ['Linodes'],
+    id: 'us-central',
+    label: 'Dallas, TX',
+    country: 'us',
+  }),
+];
+
+authenticate();
+describe('Linode create flow with Placement Group', () => {
+  beforeEach(() => {
+    cleanUp('linodes');
+    mockGetAccount(mockAccount);
+    mockGetRegions(mockRegions).as('getRegions');
+    // TODO Remove feature flag mocks when `placementGroups` flag is retired.
+    mockAppendFeatureFlags({
+      placementGroups: makeFeatureFlagData<Flags['placementGroups']>({
+        beta: true,
+        enabled: true,
+      }),
+    });
+    mockGetFeatureFlagClientstream();
+  });
+
+  /*
+   * - Confirms Placement Group create UI flow using mock API data.
+   * - Confirms that outgoing Placement Group create request contains expected data.
+   * - Confirms that Cloud automatically updates to list new Placement Group on landing page.
+   */
+  it('can create a linode with a newly created Placement Group', () => {
+    cy.visitWithLogin('/linodes/create');
+
+    cy.findByText(
+      'Select a Region for your Linode to see existing placement groups.'
+    ).should('be.visible');
+
+    // Region without capability
+    // Choose region
+    ui.regionSelect.find().click();
+    ui.regionSelect.findItemByRegionLabel(mockRegions[1].label).click();
+
+    // Choose plan
+    cy.findByText('Shared CPU').click();
+    cy.get('[id="g6-nanode-1"]').click();
+
+    cy.findByText('Placement Groups in Dallas, TX (us-central)').should(
+      'be.visible'
+    );
+    cy.get('[data-testid="placement-groups-no-capability-notice"]').should(
+      'be.visible'
+    );
+    ui.tooltip
+      .findByText('Regions that support placement groups')
+      .should('be.visible')
+      .click();
+    cy.get('[data-testid="supported-pg-region-us-east"]').should('be.visible');
+
+    // Region with capability
+    // Choose region
+    ui.regionSelect.find().click();
+    ui.regionSelect.findItemByRegionLabel(mockRegions[0].label).click();
+
+    // Choose plan
+    cy.findByText('Shared CPU').click();
+    cy.get('[id="g6-nanode-1"]').click();
+
+    // Choose Placement Group
+    // No Placement Group available
+    cy.findByText('Placement Groups in Newark, NJ (us-east)').should(
+      'be.visible'
+    );
+    // Open the select
+    cy.get('[data-testid="placement-groups-select"] input').click();
+    cy.findByText('There are no placement groups in this region.').click();
+    // Close the select
+    cy.get('[data-testid="placement-groups-select"] input').click();
+
+    // Create a Placement Group
+    ui.button
+      .findByTitle('Create Placement Group')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    const mockPlacementGroup = placementGroupFactory.build({
+      label: 'pg-1-us-east',
+      region: mockRegions[0].id,
+      affinity_type: 'anti_affinity:local',
+      is_strict: true,
+      is_compliant: true,
+    });
+
+    const affinityTypeMessage =
+      'Once you create a placement group, you cannot change its Affinity Type Enforcement setting.';
+
+    mockGetPlacementGroups([mockPlacementGroup]).as('getPlacementGroups');
+    mockCreatePlacementGroup(mockPlacementGroup).as('createPlacementGroup');
+
+    ui.drawer
+      .findByTitle('Create Placement Group')
+      .should('be.visible')
+      .within(() => {
+        // Confirm that the drawer contains the expected default information.
+        // - A selection region
+        // - An Affinity Type Enforcement message
+        // - a disabled "Create Placement Group" button.
+        cy.findByText('Newark, NJ (us-east)').should('be.visible');
+        cy.findByText(affinityTypeMessage).should('be.visible');
+        ui.buttonGroup
+          .findButtonByTitle('Create Placement Group')
+          .should('be.disabled');
+
+        // Enter label and submit form.
+        cy.findByLabelText('Label').type(mockPlacementGroup.label);
+
+        ui.buttonGroup
+          .findButtonByTitle('Create Placement Group')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    // Wait for outgoing API request and confirm that payload contains expected data.
+    cy.wait('@createPlacementGroup').then((xhr) => {
+      const requestPayload = xhr.request?.body;
+      expect(requestPayload['affinity_type']).to.equal('anti_affinity:local');
+      expect(requestPayload['is_strict']).to.equal(true);
+      expect(requestPayload['label']).to.equal(mockPlacementGroup.label);
+      expect(requestPayload['region']).to.equal(mockRegions[0].id);
+    });
+
+    // Confirm that the drawer closes and a success message is displayed.
+    ui.toast.assertMessage(
+      `Placement Group ${mockPlacementGroup.label} successfully created.`
+    );
+
+    // Select the newly created Placement Group.
+    cy.wait('@getPlacementGroups');
+    cy.get('[data-testid="placement-groups-select"] input').should(
+      'have.value',
+      mockPlacementGroup.label
+    );
+
+    const linodeLabel = 'linode-with-placement-group';
+    const mockLinode = linodeFactory.build({
+      label: linodeLabel,
+      region: mockRegions[0].id,
+      placement_group: {
+        id: mockPlacementGroup.id,
+      },
+    });
+
+    // Type in a label, password and submit the form.
+    mockCreateLinode(mockLinode).as('createLinode');
+    cy.get('#linode-label').clear().type('linode-with-placement-group');
+    cy.get('#root-password').type(randomString(32));
+
+    cy.get('[data-qa-deploy-linode]').click();
+
+    // Wait for outgoing API request and confirm that payload contains expected data.
+    cy.wait('@createLinode').then((xhr) => {
+      const requestPayload = xhr.request?.body;
+
+      expect(requestPayload['region']).to.equal(mockRegions[0].id);
+      expect(requestPayload['label']).to.equal(linodeLabel);
+      expect(requestPayload['placement_group'].id).to.equal(
+        mockPlacementGroup.id
+      );
+    });
+  });
+});

--- a/packages/manager/cypress/e2e/core/placementGroups/create-linode-with-placement-groups.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/create-linode-with-placement-groups.spec.ts
@@ -184,6 +184,11 @@ describe('Linode create flow with Placement Group', () => {
       },
     });
 
+    // Confirm the Placement group assignment is accounted for in the summary.
+    cy.get('[data-qa-summary="true"]').within(() => {
+      cy.findByText('Assigned to Placement Group').should('be.visible');
+    });
+
     // Type in a label, password and submit the form.
     mockCreateLinode(mockLinode).as('createLinode');
     cy.get('#linode-label').clear().type('linode-with-placement-group');

--- a/packages/manager/cypress/e2e/core/placementGroups/create-linode-with-placement-groups.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/create-linode-with-placement-groups.spec.ts
@@ -2,7 +2,6 @@ import {
   mockAppendFeatureFlags,
   mockGetFeatureFlagClientstream,
 } from 'support/intercepts/feature-flags';
-import { authenticate } from 'support/api/authentication';
 import { makeFeatureFlagData } from 'support/util/feature-flags';
 import { mockGetAccount } from 'support/intercepts/account';
 import {
@@ -12,7 +11,6 @@ import {
 } from 'src/factories';
 import { regionFactory } from 'src/factories';
 import { ui } from 'support/ui/';
-import { cleanUp } from 'support/util/cleanup';
 import { mockCreateLinode } from 'support/intercepts/linodes';
 import { mockGetRegions } from 'support/intercepts/regions';
 import {
@@ -41,10 +39,8 @@ const mockRegions: Region[] = [
   }),
 ];
 
-authenticate();
 describe('Linode create flow with Placement Group', () => {
   beforeEach(() => {
-    cleanUp('linodes');
     mockGetAccount(mockAccount);
     mockGetRegions(mockRegions).as('getRegions');
     // TODO Remove feature flag mocks when `placementGroups` flag is retired.

--- a/packages/manager/cypress/e2e/core/placementGroups/create-linode-with-placement-groups.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/create-linode-with-placement-groups.spec.ts
@@ -20,6 +20,7 @@ import {
   mockGetPlacementGroups,
 } from 'support/intercepts/placement-groups';
 import { randomString } from 'support/util/random';
+import { CANNOT_CHANGE_AFFINITY_TYPE_ENFORCEMENT_MESSAGE } from 'src/features/PlacementGroups/constants';
 
 import type { Region } from '@linode/api-v4';
 import type { Flags } from 'src/featureFlags';
@@ -124,9 +125,6 @@ describe('Linode create flow with Placement Group', () => {
       is_compliant: true,
     });
 
-    const affinityTypeMessage =
-      'Once you create a placement group, you cannot change its Affinity Type Enforcement setting.';
-
     mockGetPlacementGroups([mockPlacementGroup]).as('getPlacementGroups');
     mockCreatePlacementGroup(mockPlacementGroup).as('createPlacementGroup');
 
@@ -139,7 +137,9 @@ describe('Linode create flow with Placement Group', () => {
         // - An Affinity Type Enforcement message
         // - a disabled "Create Placement Group" button.
         cy.findByText('Newark, NJ (us-east)').should('be.visible');
-        cy.findByText(affinityTypeMessage).should('be.visible');
+        cy.findByText(CANNOT_CHANGE_AFFINITY_TYPE_ENFORCEMENT_MESSAGE).should(
+          'be.visible'
+        );
         ui.buttonGroup
           .findButtonByTitle('Create Placement Group')
           .should('be.disabled');

--- a/packages/manager/cypress/e2e/core/placementGroups/create-linode-with-placement-groups.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/create-linode-with-placement-groups.spec.ts
@@ -49,6 +49,9 @@ describe('Linode create flow with Placement Group', () => {
         beta: true,
         enabled: true,
       }),
+      linodeCreateRefactor: makeFeatureFlagData<Flags['linodeCreateRefactor']>(
+        false
+      ),
     });
     mockGetFeatureFlagClientstream();
   });

--- a/packages/manager/cypress/e2e/core/placementGroups/create-placement-groups.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/create-placement-groups.spec.ts
@@ -17,6 +17,8 @@ import {
 import { randomLabel, randomNumber } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
 
+import { CANNOT_CHANGE_AFFINITY_TYPE_ENFORCEMENT_MESSAGE } from 'src/features/PlacementGroups/constants';
+
 const mockAccount = accountFactory.build();
 
 describe('Placement Group create flow', () => {
@@ -69,8 +71,6 @@ describe('Placement Group create flow', () => {
     });
 
     const placementGroupLimitMessage = `Maximum placement groups in region: ${mockPlacementGroupRegion.placement_group_limits.maximum_pgs_per_customer}`;
-    const affinityTypeMessage =
-      'Once you create a placement group, you cannot change its Affinity Type Enforcement setting.';
 
     mockGetRegions(mockRegions);
     mockGetPlacementGroups([]).as('getPlacementGroups');
@@ -103,7 +103,9 @@ describe('Placement Group create flow', () => {
           .type(`${mockPlacementGroupRegion.label}{enter}`);
 
         cy.findByText(placementGroupLimitMessage).should('be.visible');
-        cy.findByText(affinityTypeMessage).should('be.visible');
+        cy.findByText(CANNOT_CHANGE_AFFINITY_TYPE_ENFORCEMENT_MESSAGE).should(
+          'be.visible'
+        );
 
         ui.buttonGroup
           .findButtonByTitle('Create Placement Group')

--- a/packages/manager/src/components/TextTooltip/TextTooltip.tsx
+++ b/packages/manager/src/components/TextTooltip/TextTooltip.tsx
@@ -13,6 +13,11 @@ export interface TextTooltipProps {
    * Props to pass to the Popper component
    */
   PopperProps?: TooltipProps['PopperProps'];
+  /**
+   * The data-qa-tooltip attribute for the tooltip.
+   * Defaults to the tooltip title, but will be undefined if the title is a JSX element.
+   */
+  dataQaTooltip?: string;
   /** The text to hover on to display the tooltip */
   displayText: string;
   /** If true, the tooltip will not have a min-width of 375px
@@ -41,6 +46,7 @@ export interface TextTooltipProps {
 export const TextTooltip = (props: TextTooltipProps) => {
   const {
     PopperProps,
+    dataQaTooltip,
     displayText,
     minWidth,
     placement,
@@ -60,6 +66,8 @@ export const TextTooltip = (props: TextTooltipProps) => {
           },
         },
       }}
+      leaveDelay={500000}
+      data-qa-tooltip={dataQaTooltip}
       enterTouchDelay={0}
       placement={placement ? placement : 'bottom'}
       title={tooltipText}

--- a/packages/manager/src/components/Tooltip.tsx
+++ b/packages/manager/src/components/Tooltip.tsx
@@ -7,7 +7,12 @@ import type { TooltipProps } from '@mui/material/Tooltip';
  * Tooltips display informative text when users hover over, focus on, or tap an element.
  */
 export const Tooltip = (props: TooltipProps) => {
-  return <_Tooltip data-qa-tooltip={props.title} {...props} />;
+  // Avoiding displaying [object Object] in the data-qa-tooltip attribute when the title is an JSX element.
+  // Can be overridden by passing data-qa-tooltip directly to the Tooltip component.
+  const dataQaTooltip: string | undefined =
+    typeof props.title === 'string' ? props.title : undefined;
+
+  return <_Tooltip data-qa-tooltip={dataQaTooltip} {...props} />;
 };
 export { tooltipClasses };
 export type { TooltipProps };

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsAffinityEnforcementRadioGroup.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsAffinityEnforcementRadioGroup.tsx
@@ -8,6 +8,8 @@ import { Radio } from 'src/components/Radio/Radio';
 import { RadioGroup } from 'src/components/RadioGroup';
 import { Typography } from 'src/components/Typography';
 
+import { CANNOT_CHANGE_AFFINITY_TYPE_ENFORCEMENT_MESSAGE } from './constants';
+
 import type { FormikHelpers } from 'formik';
 
 interface Props {
@@ -29,7 +31,7 @@ export const PlacementGroupsAffinityTypeEnforcementRadioGroup = (
   return (
     <Box sx={{ pt: 2 }}>
       <Notice
-        text="Once you create a placement group, you cannot change its Affinity Type Enforcement setting."
+        text={CANNOT_CHANGE_AFFINITY_TYPE_ENFORCEMENT_MESSAGE}
         variant="warning"
       />
       <FormLabel htmlFor="affinity-type-enforcement-radio-group">

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
@@ -106,7 +106,10 @@ export const PlacementGroupsDetailPanel = (props: Props) => {
                 allRegionsWithPlacementGroupCapability?.length ? (
                   <StyledDetailPanelFormattedRegionList>
                     {allRegionsWithPlacementGroupCapability?.map((region) => (
-                      <ListItem key={region.id}>
+                      <ListItem
+                        data-testid={`supported-pg-region-${region.id}`}
+                        key={region.id}
+                      >
                         {region.label} ({region.id})
                       </ListItem>
                     ))}
@@ -115,6 +118,7 @@ export const PlacementGroupsDetailPanel = (props: Props) => {
                   NO_REGIONS_SUPPORT_PLACEMENT_GROUPS_MESSAGE
                 )
               }
+              dataQaTooltip="Regions that support placement groups"
               displayText="regions"
               minWidth={225}
             />{' '}

--- a/packages/manager/src/features/PlacementGroups/constants.ts
+++ b/packages/manager/src/features/PlacementGroups/constants.ts
@@ -25,6 +25,9 @@ export const NO_PLACEMENT_GROUPS_IN_SELECTED_REGION_MESSAGE =
 export const NO_REGIONS_SUPPORT_PLACEMENT_GROUPS_MESSAGE =
   'No regions currently support Placement Groups.';
 
+export const CANNOT_CHANGE_AFFINITY_TYPE_ENFORCEMENT_MESSAGE =
+  'Once you create a placement group, you cannot change its Affinity Type Enforcement setting.';
+
 // Links
 export const PLACEMENT_GROUPS_DOCS_LINK =
   'https://www.linode.com/docs/products/compute/compute-instances/guides/placement-groups/';


### PR DESCRIPTION
## Description 📝
PR to add an integration test to the Placement Group feature within Linode Create flow

The test covers the following:
- "Placement Group" Region capability including related notices
- Placement Group creation within the Linode Create flow
- Linode Creation with a placement group

## Changes  🔄
- New `create-linode-with-placement-groups.spec.ts` test
- Add needed `data-test-id`
- Fix small issue with tooltip  `data-test-id` containing JSX element as a child (was showing as "Object Object")

## How to test 🧪

### Verification steps
- Confirm appropriate steps for the test
- run `yarn cy:run -s "cypress/e2e/core/placementGroups/create-linode-with-placement-groups.spec.ts"`

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
