### PR TITLE
feat: [M3-8104] - Add options for default policies when creating a Firewall

### DIFF
--- a/packages/manager/.changeset/pr-10474-added-1715961690900.md
+++ b/packages/manager/.changeset/pr-10474-added-1715961690900.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Add options for default policies when creating a Firewall ([#10474](https://github.com/linode/manager/pull/10474))

--- a/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.test.tsx
@@ -35,11 +35,13 @@ describe('Create Firewall Drawer', () => {
     );
     expect(withinInboundPolicy.getByText('Accept')).toBeVisible();
     expect(withinInboundPolicy.getByText('Drop')).toBeVisible();
+    expect(withinInboundPolicy.getByLabelText('Drop')).toBeChecked();
 
     const withinOutboundPolicy = within(
-      screen.getByTestId('default-inbound-policy')
+      screen.getByTestId('default-outbound-policy')
     );
     expect(withinOutboundPolicy.getByText('Accept')).toBeVisible();
+    expect(withinOutboundPolicy.getByLabelText('Accept')).toBeChecked();
     expect(withinOutboundPolicy.getByText('Drop')).toBeVisible();
   });
 

--- a/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.test.tsx
@@ -28,6 +28,21 @@ describe('Create Firewall Drawer', () => {
     expect(title).toBeVisible();
   });
 
+  it('should render radio buttons for default inbound/outbound policies', () => {
+    renderWithTheme(<CreateFirewallDrawer {...props} />);
+    const withinInboundPolicy = within(
+      screen.getByTestId('default-inbound-policy')
+    );
+    expect(withinInboundPolicy.getByText('Accept')).toBeVisible();
+    expect(withinInboundPolicy.getByText('Drop')).toBeVisible();
+
+    const withinOutboundPolicy = within(
+      screen.getByTestId('default-inbound-policy')
+    );
+    expect(withinOutboundPolicy.getByText('Accept')).toBeVisible();
+    expect(withinOutboundPolicy.getByText('Drop')).toBeVisible();
+  });
+
   it('should validate the form on submit', async () => {
     renderWithTheme(<CreateFirewallDrawer {...props} />);
     await userEvent.type(screen.getByLabelText('Label (required)'), 'a');

--- a/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
@@ -308,7 +308,7 @@ export const CreateFirewallDrawer = React.memo(
             value={values.label}
           />
 
-          <Typography style={{ marginTop: 16 }}>
+          <Typography style={{ marginTop: 24 }}>
             <strong>Default Inbound Policy</strong>
           </Typography>
           <RadioGroup

--- a/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
@@ -312,9 +312,8 @@ export const CreateFirewallDrawer = React.memo(
             <strong>Default Inbound Policy</strong>
           </Typography>
           <RadioGroup
-            aria-label="action"
+            aria-label="default inbound policy "
             data-testid="default-inbound-policy"
-            name="action"
             onChange={handleInboundPolicyChange}
             row
             value={values.rules.inbound_policy}
@@ -331,9 +330,8 @@ export const CreateFirewallDrawer = React.memo(
             <strong>Default Outbound Policy</strong>
           </Typography>
           <RadioGroup
-            aria-label="action"
+            aria-label="default outbound policy"
             data-testid="default-outbound-policy"
-            name="action"
             onChange={handleOutboundPolicyChange}
             row
             value={values.rules.outbound_policy}

--- a/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
@@ -16,17 +16,22 @@ import { useLocation } from 'react-router-dom';
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Box } from 'src/components/Box';
 import { Drawer } from 'src/components/Drawer';
+import { FormControlLabel } from 'src/components/FormControlLabel';
 import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
+import { Radio } from 'src/components/Radio/Radio';
+import { RadioGroup } from 'src/components/RadioGroup';
 import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
 import { FIREWALL_LIMITS_CONSIDERATIONS_LINK } from 'src/constants';
 import { LinodeSelect } from 'src/features/Linodes/LinodeSelect/LinodeSelect';
 import { NodeBalancerSelect } from 'src/features/NodeBalancers/NodeBalancerSelect';
 import { useAccountManagement } from 'src/hooks/useAccountManagement';
-import { queryKey as firewallQueryKey } from 'src/queries/firewalls';
-import { useAllFirewallsQuery } from 'src/queries/firewalls';
-import { useCreateFirewall } from 'src/queries/firewalls';
+import {
+  queryKey as firewallQueryKey,
+  useAllFirewallsQuery,
+  useCreateFirewall,
+} from 'src/queries/firewalls';
 import { queryKey as linodesQueryKey } from 'src/queries/linodes/linodes';
 import { queryKey as nodebalancerQueryKey } from 'src/queries/nodebalancers';
 import { useGrants } from 'src/queries/profile';
@@ -64,7 +69,7 @@ const initialValues: CreateFirewallPayload = {
   },
   label: '',
   rules: {
-    inbound_policy: 'ACCEPT',
+    inbound_policy: 'DROP',
     outbound_policy: 'ACCEPT',
   },
 };
@@ -188,6 +193,20 @@ export const CreateFirewallDrawer = React.memo(
       }
     }, [open, resetForm]);
 
+    const handleInboundPolicyChange = React.useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>, value: 'ACCEPT' | 'DROP') => {
+        setFieldValue('rules.inbound_policy', value);
+      },
+      [setFieldValue]
+    );
+
+    const handleOutboundPolicyChange = React.useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>, value: 'ACCEPT' | 'DROP') => {
+        setFieldValue('rules.outbound_policy', value);
+      },
+      [setFieldValue]
+    );
+
     const userCannotAddFirewall =
       _isRestrictedUser && !_hasGrant('add_firewalls');
 
@@ -288,6 +307,45 @@ export const CreateFirewallDrawer = React.memo(
             required
             value={values.label}
           />
+
+          <Typography style={{ marginTop: 16 }}>
+            <strong>Default Inbound Policy</strong>
+          </Typography>
+          <RadioGroup
+            aria-label="action"
+            data-testid="default-inbound-policy"
+            name="action"
+            onChange={handleInboundPolicyChange}
+            row
+            value={values.rules.inbound_policy}
+          >
+            <FormControlLabel
+              control={<Radio />}
+              label="Accept"
+              value="ACCEPT"
+            />
+            <FormControlLabel control={<Radio />} label="Drop" value="DROP" />
+          </RadioGroup>
+
+          <Typography style={{ marginTop: 16 }}>
+            <strong>Default Outbound Policy</strong>
+          </Typography>
+          <RadioGroup
+            aria-label="action"
+            data-testid="default-outbound-policy"
+            name="action"
+            onChange={handleOutboundPolicyChange}
+            row
+            value={values.rules.outbound_policy}
+          >
+            <FormControlLabel
+              control={<Radio />}
+              label="Accept"
+              value="ACCEPT"
+            />
+            <FormControlLabel control={<Radio />} label="Drop" value="DROP" />
+          </RadioGroup>
+
           <Box>
             <Typography
               sx={(theme) => ({


### PR DESCRIPTION
## Description 📝
This adds "Default Inbound Policy" and "Default Outbound Policy" to the Create Firewall Drawer.

The default inbound policy is now "Drop", which is a change from what Firewalls implicitly default to in Production today. Note: Cloud Manager currently specifies this default, not the API.

## Changes  🔄
- Add "Default Inbound Policy" and "Default Outbound Policy" to the Create Firewall Drawer.

## Target release date 🗓️
May 27, 2024

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-05-15 at 3 14 07 PM](https://github.com/linode/manager/assets/114753608/1f392e08-1b9d-4137-87e9-c5ffeee7599c) | ![Screenshot 2024-05-15 at 3 12 30 PM](https://github.com/linode/manager/assets/114753608/0a406d7c-33eb-4b4e-8910-7cd33fbe37aa) |

## How to test 🧪
- Run the updated unit tests: `yarn test CreateFirewallDrawer`
- Open the Create Firewall Drawer and observe the two additional radio buttons.
- Create Firewalls with varying default policy combinations and ensure the Firewall is created appropriately.

## As an Author I have considered 🤔

*Check all that apply*

- [X] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support