### PR TITLE
test: [M3-8105] - Clean up cy.intercept calls in resize-linode

### DIFF
--- a/packages/manager/.changeset/pr-10476-tests-1715869194947.md
+++ b/packages/manager/.changeset/pr-10476-tests-1715869194947.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Clean up cy.intercept calls in resize-linode ([#10476](https://github.com/linode/manager/pull/10476))

--- a/packages/manager/cypress/e2e/core/linodes/resize-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/resize-linode.spec.ts
@@ -5,6 +5,7 @@ import { ui } from 'support/ui';
 import { cleanUp } from 'support/util/cleanup';
 import { authenticate } from 'support/api/authentication';
 import { mockGetFeatureFlagClientstream } from 'support/intercepts/feature-flags';
+import { interceptLinodeResize } from 'support/intercepts/linodes';
 
 authenticate();
 describe('resize linode', () => {
@@ -16,10 +17,7 @@ describe('resize linode', () => {
     mockGetFeatureFlagClientstream().as('getClientStream');
 
     createLinode().then((linode) => {
-      cy.intercept(
-        'POST',
-        apiMatcher(`linode/instances/${linode.id}/resize`)
-      ).as('linodeResize');
+      interceptLinodeResize(linode.id).as('linodeResize');
       cy.visitWithLogin(`/linodes/${linode.id}?resize=true`);
       cy.findByText('Shared CPU').click({ scrollBehavior: false });
       containsVisible('Linode 8 GB');
@@ -80,10 +78,7 @@ describe('resize linode', () => {
 
       containsVisible('OFFLINE');
 
-      cy.intercept(
-        'POST',
-        apiMatcher(`linode/instances/${linode.id}/resize`)
-      ).as('linodeResize');
+      mockGetFeatureFlagClientstream().as('linodeResize');
       cy.visitWithLogin(`/linodes/${linode.id}?resize=true`);
       cy.findByText('Shared CPU').click({ scrollBehavior: false });
       containsVisible('Linode 8 GB');
@@ -113,10 +108,7 @@ describe('resize linode', () => {
 
       // Error flow when attempting to resize a linode to a smaller size without
       // resizing the disk to the requested size first.
-      cy.intercept(
-        'POST',
-        apiMatcher(`linode/instances/${linode.id}/resize`)
-      ).as('linodeResize');
+      mockGetFeatureFlagClientstream().as('linodeResize');
       cy.visitWithLogin(`/linodes/${linode.id}?resize=true`);
       cy.findByText('Shared CPU').click({ scrollBehavior: false });
       containsVisible('Linode 2 GB');
@@ -175,10 +167,7 @@ describe('resize linode', () => {
       // Wait until the disk resize is done.
       ui.toast.assertMessage(`Disk ${diskName} successfully resized.`);
 
-      cy.intercept(
-        'POST',
-        apiMatcher(`linode/instances/${linode.id}/resize`)
-      ).as('linodeResize');
+      mockGetFeatureFlagClientstream().as('linodeResize');
       cy.visitWithLogin(`/linodes/${linode.id}?resize=true`);
       cy.findByText('Shared CPU').click({ scrollBehavior: false });
       containsVisible('Linode 2 GB');

--- a/packages/manager/cypress/e2e/core/linodes/resize-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/resize-linode.spec.ts
@@ -1,6 +1,5 @@
 import { createLinode } from 'support/api/linodes';
 import { containsVisible, fbtVisible, getClick } from 'support/helpers';
-import { apiMatcher } from 'support/util/intercepts';
 import { ui } from 'support/ui';
 import { cleanUp } from 'support/util/cleanup';
 import { authenticate } from 'support/api/authentication';
@@ -37,10 +36,7 @@ describe('resize linode', () => {
   it('resizes a linode by increasing size: cold migration', () => {
     mockGetFeatureFlagClientstream().as('getClientStream');
     createLinode().then((linode) => {
-      cy.intercept(
-        'POST',
-        apiMatcher(`linode/instances/${linode.id}/resize`)
-      ).as('linodeResize');
+      interceptLinodeResize(linode.id).as('linodeResize');
       cy.visitWithLogin(`/linodes/${linode.id}?resize=true`);
       cy.findByText('Shared CPU').click({ scrollBehavior: false });
       containsVisible('Linode 8 GB');
@@ -78,7 +74,7 @@ describe('resize linode', () => {
 
       containsVisible('OFFLINE');
 
-      mockGetFeatureFlagClientstream().as('linodeResize');
+      interceptLinodeResize(linode.id).as('linodeResize');
       cy.visitWithLogin(`/linodes/${linode.id}?resize=true`);
       cy.findByText('Shared CPU').click({ scrollBehavior: false });
       containsVisible('Linode 8 GB');
@@ -108,7 +104,7 @@ describe('resize linode', () => {
 
       // Error flow when attempting to resize a linode to a smaller size without
       // resizing the disk to the requested size first.
-      mockGetFeatureFlagClientstream().as('linodeResize');
+      interceptLinodeResize(linode.id).as('linodeResize');
       cy.visitWithLogin(`/linodes/${linode.id}?resize=true`);
       cy.findByText('Shared CPU').click({ scrollBehavior: false });
       containsVisible('Linode 2 GB');
@@ -167,7 +163,7 @@ describe('resize linode', () => {
       // Wait until the disk resize is done.
       ui.toast.assertMessage(`Disk ${diskName} successfully resized.`);
 
-      mockGetFeatureFlagClientstream().as('linodeResize');
+      interceptLinodeResize(linode.id).as('linodeResize');
       cy.visitWithLogin(`/linodes/${linode.id}?resize=true`);
       cy.findByText('Shared CPU').click({ scrollBehavior: false });
       containsVisible('Linode 2 GB');

--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -410,3 +410,18 @@ export const mockGetLinodeKernel = (
     makeResponse(mockKernel)
   );
 };
+
+/* Intercepts POST request to get a Linode Resize.
+ *
+ * @param linodeId - ID of Linode to fetch.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptLinodeResize = (
+  linodeId: number
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`linode/instances/${linodeId}/resize`)
+  );
+};


### PR DESCRIPTION
## Description 📝
Clean up cy.intercept calls in resize-linode

## Changes  🔄
List any change relevant to the reviewer.

- Replace calls to cy.intercept with intercept utils in linodes.ts.
- Adds interceptLinodeResize() util

## How to test 🧪
We can rely on CI to confirm that this test has not been broken by these changes, but to run the test locally you can use this command:
```
yarn cy:run -s "cypress/e2e/core/linodes/resize-linode.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
