### PR TITLE
 test: [M3-7954] - Cypress integration test to add SSH key via Profile page

### DIFF
--- a/packages/manager/.changeset/pr-10477-tests-1717448262964.md
+++ b/packages/manager/.changeset/pr-10477-tests-1717448262964.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Cypress integration test to add SSH key via Profile page ([#10477](https://github.com/linode/manager/pull/10477))

--- a/packages/manager/cypress/e2e/core/account/ssh-keys.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/ssh-keys.spec.ts
@@ -1,0 +1,177 @@
+import { sshKeyFactory } from 'src/factories';
+import { authenticate } from 'support/api/authentication';
+import {
+  mockCreateSSHKey,
+  mockCreateSSHKeyError,
+  mockGetSSHKeys,
+} from 'support/intercepts/profile';
+import { ui } from 'support/ui';
+import { randomLabel, randomString } from 'support/util/random';
+
+authenticate();
+describe('SSH keys', () => {
+  /*
+   * - Vaildates SSH key creation flow using mock data.
+   * - Confirms that the drawer opens when clicking.
+   * - Confirms that a form validation error appears when the label or public key is not present.
+   * - Confirms UI flow when user enters incorrect public key.
+   * - Confirms UI flow when user clicks "Cancel".
+   * - Confirms UI flow when user creates a new SSH key.
+   */
+  it('adds an SSH key via Profile page as expected', () => {
+    const randomKey = randomString(400, {
+      uppercase: true,
+      lowercase: true,
+      numbers: true,
+      spaces: false,
+      symbols: false,
+    });
+    const mockSSHKey = sshKeyFactory.build({
+      label: randomLabel(),
+      ssh_key: `ssh-rsa e2etestkey${randomKey} e2etest@linode`,
+    });
+
+    mockGetSSHKeys([]).as('getSSHKeys');
+
+    // Navigate to SSH key landing page, click the "Add an SSH Key" button.
+    cy.visitWithLogin('/profile/keys');
+    cy.wait('@getSSHKeys');
+
+    // When a user clicks "Add an SSH Key" button on SSH key landing page (/profile/keys), the "Add an SSH Key" drawer opens
+    ui.button
+      .findByTitle('Add an SSH Key')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+    ui.drawer
+      .findByTitle('Add SSH Key')
+      .should('be.visible')
+      .within(() => {
+        // When a user tries to create an SSH key without a label, a form validation error appears
+        ui.button
+          .findByTitle('Add Key')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+        cy.findByText('Label is required.');
+
+        // When a user tries to create an SSH key without the SSH Public Key, a form validation error
+        cy.get('[id="label"]').clear().type(mockSSHKey.label);
+        ui.button
+          .findByTitle('Add Key')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+        cy.findAllByText(
+          'SSH Key key-type must be ssh-dss, ssh-rsa, ecdsa-sha2-nistp, ssh-ed25519, or sk-ecdsa-sha2-nistp256.'
+        ).should('be.visible');
+
+        // An alert displays when the format of SSH key is incorrect
+        cy.get('[id="ssh-public-key"]').clear().type('WrongFormatSshKey');
+        ui.button
+          .findByTitle('Add Key')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+        cy.findAllByText(
+          'SSH Key key-type must be ssh-dss, ssh-rsa, ecdsa-sha2-nistp, ssh-ed25519, or sk-ecdsa-sha2-nistp256.'
+        ).should('be.visible');
+
+        cy.get('[id="ssh-public-key"]').clear().type(mockSSHKey.ssh_key);
+        ui.button
+          .findByTitle('Cancel')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+    // No new key is added when cancelling.
+    cy.findAllByText(mockSSHKey.label).should('not.exist');
+
+    mockGetSSHKeys([mockSSHKey]).as('getSSHKeys');
+    mockCreateSSHKey(mockSSHKey).as('createSSHKey');
+
+    ui.button
+      .findByTitle('Add an SSH Key')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+    ui.drawer
+      .findByTitle('Add SSH Key')
+      .should('be.visible')
+      .within(() => {
+        // When a user clicks "Cancel" or the drawer's close button, and then clicks "Add an SSH Key" again, the content they previously entered into the form is erased
+        cy.get('[id="label"]').should('be.empty');
+        cy.get('[id="ssh-public-key"]').should('be.empty');
+
+        // Create a new ssh key
+        cy.get('[id="label"]').clear().type(mockSSHKey.label);
+        cy.get('[id="ssh-public-key"]').clear().type(mockSSHKey.ssh_key);
+        ui.button
+          .findByTitle('Add Key')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    cy.wait('@getSSHKeys');
+
+    // When a user creates an SSH key, a toast notification appears that says "Successfully created SSH key."
+    ui.toast.assertMessage('Successfully created SSH key.');
+
+    // When a user creates an SSH key, the list of SSH keys for each user updates to show the new key for the signed in user
+    cy.findAllByText(mockSSHKey.label).should('be.visible');
+  });
+
+  /*
+   * - Vaildates SSH key creation error flow using mock data.
+   * - Confirms that a useful error message is displayed on the form when receiving an API response error.
+   */
+  it('shows an error message when fail to add an SSH key', () => {
+    const errorMessage = 'failed to add an SSH key.';
+    const sshKeyLabel = randomLabel();
+    const randomKey = randomString(400, {
+      uppercase: true,
+      lowercase: true,
+      numbers: true,
+      spaces: false,
+      symbols: false,
+    });
+    const sshPublicKey = `ssh-rsa e2etestkey${randomKey} e2etest@linode`;
+
+    mockCreateSSHKeyError(errorMessage).as('createSSHKeyError');
+    mockGetSSHKeys([]).as('getSSHKeys');
+
+    // Navigate to SSH key landing page, click the "Add an SSH Key" button.
+    cy.visitWithLogin('/profile/keys');
+    cy.wait('@getSSHKeys');
+
+    // When a user clicks "Add an SSH Key" button on SSH key landing page (/profile/keys), the "Add an SSH Key" drawer opens
+    ui.button
+      .findByTitle('Add an SSH Key')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+    ui.drawer
+      .findByTitle('Add SSH Key')
+      .should('be.visible')
+      .within(() => {
+        // When a user clicks "Cancel" or the drawer's close button, and then clicks "Add an SSH Key" again, the content they previously entered into the form is erased
+        cy.get('[id="label"]').should('be.empty');
+        cy.get('[id="ssh-public-key"]').should('be.empty');
+
+        // Create a new ssh key
+        cy.get('[id="label"]').clear().type(sshKeyLabel);
+        cy.get('[id="ssh-public-key"]').clear().type(sshPublicKey);
+        ui.button
+          .findByTitle('Add Key')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    cy.wait('@createSSHKeyError');
+
+    // When the API responds with an error (e.g. a 400 response), the API response error message is displayed on the form
+    cy.findByText(errorMessage);
+  });
+});

--- a/packages/manager/cypress/e2e/core/account/ssh-keys.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/ssh-keys.spec.ts
@@ -1,5 +1,4 @@
 import { sshKeyFactory } from 'src/factories';
-import { authenticate } from 'support/api/authentication';
 import {
   mockCreateSSHKey,
   mockCreateSSHKeyError,
@@ -7,8 +6,8 @@ import {
 } from 'support/intercepts/profile';
 import { ui } from 'support/ui';
 import { randomLabel, randomString } from 'support/util/random';
+import { sshFormatErrorMessage } from 'support/constants/account';
 
-authenticate();
 describe('SSH keys', () => {
   /*
    * - Vaildates SSH key creation flow using mock data.
@@ -55,16 +54,14 @@ describe('SSH keys', () => {
           .click();
         cy.findByText('Label is required.');
 
-        // When a user tries to create an SSH key without the SSH Public Key, a form validation error
+        // When a user tries to create an SSH key without the SSH Public Key, a form validation error appears
         cy.get('[id="label"]').clear().type(mockSSHKey.label);
         ui.button
           .findByTitle('Add Key')
           .should('be.visible')
           .should('be.enabled')
           .click();
-        cy.findAllByText(
-          'SSH Key key-type must be ssh-dss, ssh-rsa, ecdsa-sha2-nistp, ssh-ed25519, or sk-ecdsa-sha2-nistp256.'
-        ).should('be.visible');
+        cy.findAllByText(sshFormatErrorMessage).should('be.visible');
 
         // An alert displays when the format of SSH key is incorrect
         cy.get('[id="ssh-public-key"]').clear().type('WrongFormatSshKey');
@@ -73,9 +70,7 @@ describe('SSH keys', () => {
           .should('be.visible')
           .should('be.enabled')
           .click();
-        cy.findAllByText(
-          'SSH Key key-type must be ssh-dss, ssh-rsa, ecdsa-sha2-nistp, ssh-ed25519, or sk-ecdsa-sha2-nistp256.'
-        ).should('be.visible');
+        cy.findAllByText(sshFormatErrorMessage).should('be.visible');
 
         cy.get('[id="ssh-public-key"]').clear().type(mockSSHKey.ssh_key);
         ui.button

--- a/packages/manager/cypress/support/constants/account.ts
+++ b/packages/manager/cypress/support/constants/account.ts
@@ -12,3 +12,9 @@ may not be able be restored.';
 export const cancellationPaymentErrorMessage =
   'We were unable to charge your credit card for services rendered. \
 We cannot cancel this account until the balance has been paid.';
+
+/**
+ * Error message that appears when typing an error SSH key.
+ */
+export const sshFormatErrorMessage =
+  'SSH Key key-type must be ssh-dss, ssh-rsa, ecdsa-sha2-nistp, ssh-ed25519, or sk-ecdsa-sha2-nistp256.';

--- a/packages/manager/cypress/support/intercepts/profile.ts
+++ b/packages/manager/cypress/support/intercepts/profile.ts
@@ -13,9 +13,9 @@ import type {
   Profile,
   SecurityQuestionsData,
   SecurityQuestionsPayload,
-  SSHKey,
   Token,
   UserPreferences,
+  SSHKey,
 } from '@linode/api-v4';
 
 /**
@@ -421,16 +421,40 @@ export const mockGetSSHKey = (sshKey: SSHKey): Cypress.Chainable<null> => {
 };
 
 /**
- * Intercepts POST request to create an SSH key and mocks the response.
+ * Intercepts POST request to create an SSH key.
  *
- * @param sshKey - SSH key object with which to mock response.
+ * @returns Cypress chainable.
+ */
+export const interceptCreateSSHKey = (): Cypress.Chainable<null> => {
+  return cy.intercept('POST', apiMatcher(`profile/sshkeys*`));
+};
+
+/**
+ * Intercepts POST request to create an SSH key and mocks response.
+ *
+ * @param sshKey - An SSH key with which to create.
  *
  * @returns Cypress chainable.
  */
 export const mockCreateSSHKey = (sshKey: SSHKey): Cypress.Chainable<null> => {
+  return cy.intercept('POST', apiMatcher(`profile/sshkeys`), sshKey);
+};
+
+/**
+ * Intercepts POST request to create an SSH key and mocks an API error response.
+ *
+ * @param errorMessage - Error message to include in mock error response.
+ * @param status - HTTP status for mock error response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockCreateSSHKeyError = (
+  errorMessage: string,
+  status: number = 400
+): Cypress.Chainable<null> => {
   return cy.intercept(
     'POST',
-    apiMatcher('/profile/sshkeys'),
-    makeResponse(sshKey)
+    apiMatcher('profile/sshkeys'),
+    makeErrorResponse(errorMessage, status)
   );
 };


### PR DESCRIPTION
## Description 📝
Add integration test to add SSH key via Profile page.

## Major Changes 🔄
- Check users can add SSH key through Profile page

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/account/ssh-keys.spec.ts"
```