### PR TITLE
test: [M3-8106] - Clean up cy.intercept calls in smoke-delete-linode

### DIFF
--- a/packages/manager/.changeset/pr-10478-tests-1715876232371.md
+++ b/packages/manager/.changeset/pr-10478-tests-1715876232371.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Clean up cy.intercept calls in smoke-delete-linode ([#10478](https://github.com/linode/manager/pull/10478))

--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -247,6 +247,19 @@ export const mockDeleteLinodes = (
 };
 
 /**
+ * Intercepts DELETE request to delete linode.
+ *
+ * @param linodeId - ID of Linode for intercepted request.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptDeleteLinode = (
+  linodeId: number
+): Cypress.Chainable<null> => {
+  return cy.intercept('DELETE', apiMatcher(`linode/instances/${linodeId}`));
+};
+
+/**
  * Intercepts GET request to fetch Linode types and mocks the response.
  *
  * @param types - Linode types with which to mock response.


### PR DESCRIPTION
## Description 📝
Clean up cy.intercept calls in smoke-delete-linode

## Changes  🔄
List any change relevant to the reviewer.
- Replace calls to cy.intercept with intercept utils in linodes.ts and account.ts
- Adds interceptDeleteLinode() util

## How to test 🧪
We can rely on CI to confirm that this test has not been broken by these changes, but to run the test locally you can use this command:
```
yarn cy:run -s "cypress/e2e/core/linodes/smoke-delete-linode.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support