### PR TITLE
refactor: [M3-8097] - Retire recharts feature flag

### DIFF
--- a/packages/manager/.changeset/pr-10483-tech-stories-1715958313413.md
+++ b/packages/manager/.changeset/pr-10483-tech-stories-1715958313413.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Retire recharts feature flag ([#10483](https://github.com/linode/manager/pull/10483))

--- a/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
+++ b/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
@@ -1,3 +1,7 @@
+/**
+ * ONLY USED IN THE LINE GRAPH COMPONENT (Longview)
+ * Delete when LineGraph is sunsetted
+ */
 import { visuallyHidden } from '@mui/utils';
 import { DateTime } from 'luxon';
 import * as React from 'react';

--- a/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
+++ b/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
@@ -13,8 +13,6 @@ export interface GraphTabledDataProps {
   hiddenDatasets: number[];
 }
 
-// @todo recharts: delete this file when we decide recharts is stable (new version is AccessibleAreaChart)
-
 /**
  * This component is used to provide an accessible representation of the data
  * It does not care about styles, it only cares about presenting the data in bare HTML tables,

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -1,3 +1,7 @@
+/**
+ * ONLY USED IN LONGVIEW
+ * Delete when Lonview is sunsetted, along with AccessibleGraphData
+ */
 import { Theme, useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import {

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -27,7 +27,6 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'objMultiCluster', label: 'OBJ Multi-Cluster' },
   { flag: 'parentChildAccountAccess', label: 'Parent/Child Account' },
   { flag: 'placementGroups', label: 'Placement Groups' },
-  { flag: 'recharts', label: 'Recharts' },
   { flag: 'selfServeBetas', label: 'Self Serve Betas' },
   { flag: 'supportTicketSeverity', label: 'Support Ticket Severity' },
 ];

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -79,7 +79,6 @@ export interface Flags {
   productInformationBanners: ProductInformationBannerFlag[];
   promos: boolean;
   promotionalOffers: PromotionalOffer[];
-  recharts: boolean;
   referralBannerText: ReferralBannerText;
   selfServeBetas: boolean;
   soldOutChips: boolean;

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.tsx
@@ -12,14 +12,11 @@ import { LinodeNetworkTimeData, Point } from 'src/components/AreaChart/types';
 import { Box } from 'src/components/Box';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
-import { LineGraph } from 'src/components/LineGraph/LineGraph';
 import { Typography } from 'src/components/Typography';
 import {
   convertNetworkToUnit,
-  formatNetworkTooltip,
   generateNetworkUnits,
 } from 'src/features/Longview/shared/utilities';
-import { useFlags } from 'src/hooks/useFlags';
 import {
   STATS_NOT_READY_API_MESSAGE,
   STATS_NOT_READY_MESSAGE,
@@ -39,7 +36,6 @@ export const TransferHistory = React.memo((props: Props) => {
   const { linodeCreated, linodeID } = props;
 
   const theme = useTheme();
-  const flags = useFlags();
 
   // Needed to see the user's timezone.
   const { data: profile } = useProfile();
@@ -83,16 +79,6 @@ export const TransferHistory = React.memo((props: Props) => {
   const convertNetworkData = (value: number) => {
     return convertNetworkToUnit(value, unit);
   };
-
-  /**
-   * formatNetworkTooltip is a helper method from Longview, where
-   * data is expected in bytes. The method does the rounding, unit conversions, etc.
-   * that we want, but it first multiplies by 8 to convert to bits.
-   * APIv4 returns this data in bits to begin with,
-   * so we have to preemptively divide by 8 to counter the conversion inside the helper.
-   */
-  const formatTooltip = (valueInBytes: number) =>
-    formatNetworkTooltip(valueInBytes / 8);
 
   const maxMonthOffset = getOffsetFromDate(
     now,
@@ -155,64 +141,39 @@ export const TransferHistory = React.memo((props: Props) => {
       );
     }
 
-    // @TODO recharts: remove conditional code and delete old chart when we decide recharts is stable
-    if (flags?.recharts) {
-      const timeData = combinedData.reduce(
-        (acc: LinodeNetworkTimeData[], point: Point) => {
-          acc.push({
-            'Public Outbound Traffic': convertNetworkData
-              ? convertNetworkData(point[1])
-              : point[1],
-            timestamp: point[0],
-          });
-          return acc;
-        },
-        []
-      );
-
-      return (
-        <Box marginLeft={-5}>
-          <AreaChart
-            areas={[
-              {
-                color: '#1CB35C',
-                dataKey: 'Public Outbound Traffic',
-              },
-            ]}
-            xAxis={{
-              tickFormat: 'LLL dd',
-              tickGap: 15,
-            }}
-            ariaLabel={graphAriaLabel}
-            data={timeData}
-            height={190}
-            timezone={profile?.timezone ?? 'UTC'}
-            unit={` ${unit}/s`}
-          />
-        </Box>
-      );
-    }
+    const timeData = combinedData.reduce(
+      (acc: LinodeNetworkTimeData[], point: Point) => {
+        acc.push({
+          'Public Outbound Traffic': convertNetworkData
+            ? convertNetworkData(point[1])
+            : point[1],
+          timestamp: point[0],
+        });
+        return acc;
+      },
+      []
+    );
 
     return (
-      <LineGraph
-        data={[
-          {
-            backgroundColor: '#1CB35C',
-            borderColor: 'transparent',
-            data: combinedData,
-            label: 'Public Outbound Traffic',
-          },
-        ]}
-        accessibleDataTable={{ unit: 'Kb/s' }}
-        ariaLabel={graphAriaLabel}
-        chartHeight={190}
-        formatData={convertNetworkData}
-        formatTooltip={formatTooltip}
-        showToday={true}
-        tabIndex={-1}
-        timezone={profile?.timezone ?? 'UTC'}
-        unit={`/s`}
-      />
+      <Box marginLeft={-5}>
+        <AreaChart
+          areas={[
+            {
+              color: '#1CB35C',
+              dataKey: 'Public Outbound Traffic',
+            },
+          ]}
+          xAxis={{
+            tickFormat: 'LLL dd',
+            tickGap: 15,
+          }}
+          ariaLabel={graphAriaLabel}
+          data={timeData}
+          height={190}
+          timezone={profile?.timezone ?? 'UTC'}
+          unit={` ${unit}/s`}
+        />
+      </Box>
     );
   };
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -1,5 +1,5 @@
-import Grid from '@mui/material/Unstable_Grid2';
 import { styled, useTheme } from '@mui/material/styles';
+import Grid from '@mui/material/Unstable_Grid2';
 import { DateTime } from 'luxon';
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
@@ -15,7 +15,6 @@ import {
 import { Box } from 'src/components/Box';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
-import { LineGraph } from 'src/components/LineGraph/LineGraph';
 import { Paper } from 'src/components/Paper';
 import { Typography } from 'src/components/Typography';
 import { useFlags } from 'src/hooks/useFlags';
@@ -35,9 +34,9 @@ import {
   getMetrics,
 } from 'src/utilities/statMetrics';
 
+import { getDateOptions } from './helpers';
 import { NetworkGraphs } from './NetworkGraphs';
 import { StatsPanel } from './StatsPanel';
-import { getDateOptions } from './helpers';
 
 import type { ChartProps } from './NetworkGraphs';
 
@@ -130,72 +129,43 @@ const LinodeSummary: React.FC<Props> = (props) => {
     const data = stats?.data.cpu ?? [];
     const metrics = getMetrics(data);
 
-    // @TODO recharts: remove conditional code and delete old chart when we decide recharts is stable
-    if (flags.recharts) {
-      const timeData = data.reduce((acc: CPUTimeData[], point: Point) => {
-        acc.push({
-          'CPU %': point[1],
-          timestamp: point[0],
-        });
-        return acc;
-      }, []);
-
-      return (
-        <Box marginLeft={-4} marginTop={2}>
-          <AreaChart
-            areas={[
-              {
-                color: theme.graphs.cpu.percent,
-                dataKey: 'CPU %',
-              },
-            ]}
-            legendRows={[
-              {
-                data: metrics,
-                format: formatPercentage,
-                legendColor: 'blue',
-                legendTitle: 'CPU %',
-              },
-            ]}
-            xAxis={{
-              tickFormat: xAxisTickFormat,
-              tickGap: 60,
-            }}
-            ariaLabel="CPU Usage Graph"
-            data={timeData}
-            height={rechartsHeight}
-            showLegend
-            timezone={timezone}
-            unit={'%'}
-          />
-        </Box>
-      );
-    }
+    const timeData = data.reduce((acc: CPUTimeData[], point: Point) => {
+      acc.push({
+        'CPU %': point[1],
+        timestamp: point[0],
+      });
+      return acc;
+    }, []);
 
     return (
-      <LineGraph
-        data={[
-          {
-            backgroundColor: theme.graphs.cpu.percent,
-            borderColor: 'transparent',
-            data,
-            label: 'CPU %',
-          },
-        ]}
-        legendRows={[
-          {
-            data: metrics,
-            format: formatPercentage,
-            legendColor: 'blue',
-            legendTitle: 'CPU %',
-          },
-        ]}
-        accessibleDataTable={{ unit: '%' }}
-        ariaLabel="CPU Usage Graph"
-        chartHeight={chartHeight}
-        showToday={rangeSelection === '24'}
-        timezone={timezone}
-      />
+      <Box marginLeft={-4} marginTop={2}>
+        <AreaChart
+          areas={[
+            {
+              color: theme.graphs.cpu.percent,
+              dataKey: 'CPU %',
+            },
+          ]}
+          legendRows={[
+            {
+              data: metrics,
+              format: formatPercentage,
+              legendColor: 'blue',
+              legendTitle: 'CPU %',
+            },
+          ]}
+          xAxis={{
+            tickFormat: xAxisTickFormat,
+            tickGap: 60,
+          }}
+          ariaLabel="CPU Usage Graph"
+          data={timeData}
+          height={rechartsHeight}
+          showLegend
+          timezone={timezone}
+          unit={'%'}
+        />
+      </Box>
     );
   };
 
@@ -207,89 +177,53 @@ const LinodeSummary: React.FC<Props> = (props) => {
     const timeData: DiskIOTimeData[] = [];
 
     // @TODO recharts: remove conditional code and delete old chart when we decide recharts is stable
-    if (flags.recharts) {
-      for (let i = 0; i < data.io.length; i++) {
-        timeData.push({
-          'I/O Rate': data.io[i][1],
-          'Swap Rate': data.swap[i][1],
-          timestamp: data.io[i][0],
-        });
-      }
-
-      return (
-        <Box marginLeft={-4} marginTop={2}>
-          <AreaChart
-            areas={[
-              {
-                color: theme.graphs.diskIO.read,
-                dataKey: 'I/O Rate',
-              },
-              {
-                color: theme.graphs.diskIO.swap,
-                dataKey: 'Swap Rate',
-              },
-            ]}
-            legendRows={[
-              {
-                data: getMetrics(data.io),
-                format: formatNumber,
-                legendColor: 'yellow',
-                legendTitle: 'I/O Rate',
-              },
-              {
-                data: getMetrics(data.swap),
-                format: formatNumber,
-                legendColor: 'red',
-                legendTitle: 'Swap Rate',
-              },
-            ]}
-            xAxis={{
-              tickFormat: xAxisTickFormat,
-              tickGap: 60,
-            }}
-            ariaLabel="Disk I/O Graph"
-            data={timeData}
-            height={342}
-            showLegend
-            timezone={timezone}
-            unit={' blocks/s'}
-          />
-        </Box>
-      );
+    for (let i = 0; i < data.io.length; i++) {
+      timeData.push({
+        'I/O Rate': data.io[i][1],
+        'Swap Rate': data.swap[i][1],
+        timestamp: data.io[i][0],
+      });
     }
 
     return (
-      <LineGraph
-        data={[
-          {
-            backgroundColor: theme.graphs.diskIO.read,
-            borderColor: 'transparent',
-            data: data.io,
-            label: 'I/O Rate',
-          },
-          {
-            backgroundColor: theme.graphs.diskIO.swap,
-            borderColor: 'transparent',
-            data: data.swap,
-            label: 'Swap Rate',
-          },
-        ]}
-        legendRows={[
-          {
-            data: getMetrics(data.io),
-            format: formatNumber,
-          },
-          {
-            data: getMetrics(data.swap),
-            format: formatNumber,
-          },
-        ]}
-        accessibleDataTable={{ unit: 'blocks/s' }}
-        ariaLabel="Disk I/O Graph"
-        chartHeight={chartHeight}
-        showToday={rangeSelection === '24'}
-        timezone={timezone}
-      />
+      <Box marginLeft={-4} marginTop={2}>
+        <AreaChart
+          areas={[
+            {
+              color: theme.graphs.diskIO.read,
+              dataKey: 'I/O Rate',
+            },
+            {
+              color: theme.graphs.diskIO.swap,
+              dataKey: 'Swap Rate',
+            },
+          ]}
+          legendRows={[
+            {
+              data: getMetrics(data.io),
+              format: formatNumber,
+              legendColor: 'yellow',
+              legendTitle: 'I/O Rate',
+            },
+            {
+              data: getMetrics(data.swap),
+              format: formatNumber,
+              legendColor: 'red',
+              legendTitle: 'Swap Rate',
+            },
+          ]}
+          xAxis={{
+            tickFormat: xAxisTickFormat,
+            tickGap: 60,
+          }}
+          ariaLabel="Disk I/O Graph"
+          data={timeData}
+          height={342}
+          showLegend
+          timezone={timezone}
+          unit={' blocks/s'}
+        />
+      </Box>
     );
   };
 
@@ -377,14 +311,14 @@ const LinodeSummary: React.FC<Props> = (props) => {
           spacing={4}
           xs={12}
         >
-          <StyledGrid recharts={flags.recharts} xs={12}>
+          <StyledGrid xs={12}>
             <StatsPanel
               renderBody={renderCPUChart}
               title="CPU (%)"
               {...chartProps}
             />
           </StyledGrid>
-          <StyledGrid recharts={flags.recharts} xs={12}>
+          <StyledGrid xs={12}>
             <StatsPanel
               renderBody={renderDiskIOChart}
               title="Disk I/O (blocks/s)"
@@ -408,15 +342,14 @@ const StyledSelect = styled(Select, { label: 'StyledSelect' })({
 
 const StyledGrid = styled(Grid, {
   label: 'StyledGrid',
-  shouldForwardProp: (prop) => prop !== 'recharts',
-})<{ recharts?: boolean }>(({ recharts, theme }) => ({
+})(({ theme }) => ({
   '& h2': {
     fontSize: '1rem',
   },
   '&.MuiGrid-item': {
     padding: theme.spacing(2),
   },
-  backgroundColor: recharts ? theme.bg.white : theme.bg.offWhite,
+  backgroundColor: theme.bg.white,
   border: `solid 1px ${theme.borderColors.divider}`,
   marginBottom: theme.spacing(2),
   padding: theme.spacing(3),

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -17,7 +17,6 @@ import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { Paper } from 'src/components/Paper';
 import { Typography } from 'src/components/Typography';
-import { useFlags } from 'src/hooks/useFlags';
 import { useWindowDimensions } from 'src/hooks/useWindowDimensions';
 import {
   STATS_NOT_READY_API_MESSAGE,
@@ -55,7 +54,6 @@ const LinodeSummary: React.FC<Props> = (props) => {
   const { linodeId } = useParams<{ linodeId: string }>();
   const id = Number(linodeId);
   const theme = useTheme();
-  const flags = useFlags();
 
   const { data: profile } = useProfile();
   const timezone = profile?.timezone || DateTime.local().zoneName;

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -174,7 +174,6 @@ const LinodeSummary: React.FC<Props> = (props) => {
     };
     const timeData: DiskIOTimeData[] = [];
 
-    // @TODO recharts: remove conditional code and delete old chart when we decide recharts is stable
     for (let i = 0; i < data.io.length; i++) {
       timeData.push({
         'I/O Rate': data.io[i][1],

--- a/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedChartPanel.tsx
+++ b/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedChartPanel.tsx
@@ -7,23 +7,18 @@ import { AreaChart } from 'src/components/AreaChart/AreaChart';
 import { Box } from 'src/components/Box';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
-import { LineGraph } from 'src/components/LineGraph/LineGraph';
 import { TabbedPanel } from 'src/components/TabbedPanel/TabbedPanel';
 import { Typography } from 'src/components/Typography';
-import { FlagSet } from 'src/featureFlags';
 import {
   convertNetworkToUnit,
-  formatNetworkTooltip,
   generateNetworkUnits,
 } from 'src/features/Longview/shared/utilities';
-import { useFlags } from 'src/hooks/useFlags';
 import { useManagedStatsQuery } from 'src/queries/managed/managed';
 import { useProfile } from 'src/queries/profile';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getUserTimezone } from 'src/utilities/getUserTimezone';
 
 import {
-  StyledCanvasContainerDiv,
   StyledGraphControlsDiv,
   StyledRootDiv,
 } from './ManagedChartPanel.styles';
@@ -36,21 +31,13 @@ interface NetworkTransferProps {
   timestamp: number;
 }
 
-// @TODO recharts remove old format function
-const formatData = (value: DataSeries[]): [number, number][] =>
-  value.map((thisPoint) => [thisPoint.x, thisPoint.y]);
-
 const formatData2 = (value: DataSeries[], label: string) =>
   value.map((thisPoint) => ({ [label]: thisPoint.y, timestamp: thisPoint.x }));
-
-const _formatTooltip = (valueInBytes: number) =>
-  formatNetworkTooltip(valueInBytes / 8);
 
 const createTabs = (
   data: ManagedStatsData | undefined,
   timezone: string,
-  theme: Theme,
-  flags: FlagSet
+  theme: Theme
 ) => {
   const summaryCopy = (
     <Typography variant="body1">
@@ -76,15 +63,13 @@ const createTabs = (
   };
 
   const networkTransferData: NetworkTransferProps[] = [];
-  // @TODO recharts: remove conditional code and delete old chart when we decide recharts is stable
-  if (flags.recharts) {
-    for (let i = 0; i < data.net_in.length; i++) {
-      networkTransferData.push({
-        'Network Traffic In': convertNetworkData(data.net_in[i].y),
-        'Network Traffic Out': convertNetworkData(data.net_out[i].y),
-        timestamp: data.net_in[i].x,
-      });
-    }
+
+  for (let i = 0; i < data.net_in.length; i++) {
+    networkTransferData.push({
+      'Network Traffic In': convertNetworkData(data.net_in[i].y),
+      'Network Traffic Out': convertNetworkData(data.net_out[i].y),
+      timestamp: data.net_in[i].x,
+    });
   }
 
   // @TODO recharts: remove conditional code and delete old chart when we decide recharts is stable
@@ -94,45 +79,25 @@ const createTabs = (
         return (
           <StyledRootDiv>
             <div>{summaryCopy}</div>
-            {flags.recharts ? (
-              <Box marginLeft={-4} marginTop={3}>
-                <AreaChart
-                  areas={[
-                    {
-                      color: theme.graphs.cpu.percent,
-                      dataKey: 'CPU %',
-                    },
-                  ]}
-                  xAxis={{
-                    tickFormat: 'hh a',
-                    tickGap: 60,
-                  }}
-                  ariaLabel="CPU Usage Graph"
-                  data={formatData2(data.cpu, 'CPU %')}
-                  height={chartHeight}
-                  timezone={timezone}
-                  unit={'%'}
-                />
-              </Box>
-            ) : (
-              <StyledCanvasContainerDiv>
-                <LineGraph
-                  data={[
-                    {
-                      backgroundColor: theme.graphs.cpu.percent,
-                      borderColor: 'transparent',
-                      data: formatData(data.cpu),
-                      label: 'CPU %',
-                    },
-                  ]}
-                  accessibleDataTable={{ unit: '%' }}
-                  ariaLabel="CPU Usage Graph"
-                  chartHeight={chartHeight}
-                  showToday={true}
-                  timezone={timezone}
-                />
-              </StyledCanvasContainerDiv>
-            )}
+            <Box marginLeft={-4} marginTop={3}>
+              <AreaChart
+                areas={[
+                  {
+                    color: theme.graphs.cpu.percent,
+                    dataKey: 'CPU %',
+                  },
+                ]}
+                xAxis={{
+                  tickFormat: 'hh a',
+                  tickGap: 60,
+                }}
+                ariaLabel="CPU Usage Graph"
+                data={formatData2(data.cpu, 'CPU %')}
+                height={chartHeight}
+                timezone={timezone}
+                unit={'%'}
+              />
+            </Box>
           </StyledRootDiv>
         );
       },
@@ -143,60 +108,30 @@ const createTabs = (
         return (
           <StyledRootDiv>
             <div>{summaryCopy}</div>
-            {flags.recharts ? (
-              <Box marginLeft={-4} marginTop={3}>
-                <AreaChart
-                  areas={[
-                    {
-                      color: theme.graphs.darkGreen,
-                      dataKey: 'Network Traffic In',
-                    },
-                    {
-                      color: theme.graphs.lightGreen,
-                      dataKey: 'Network Traffic Out',
-                    },
-                  ]}
-                  xAxis={{
-                    tickFormat: 'hh a',
-                    tickGap: 60,
-                  }}
-                  ariaLabel="Network Transfer Graph"
-                  data={networkTransferData}
-                  height={chartHeight}
-                  showLegend
-                  timezone={timezone}
-                  unit={' Kb/s'}
-                />
-              </Box>
-            ) : (
-              <StyledCanvasContainerDiv>
-                <LineGraph
-                  data={[
-                    {
-                      backgroundColor: theme.graphs.darkGreen,
-                      borderColor: 'transparent',
-                      data: formatData(data.net_in),
-                      label: 'Network Traffic In',
-                    },
-                    {
-                      backgroundColor: theme.graphs.lightGreen,
-                      borderColor: 'transparent',
-                      data: formatData(data.net_out),
-                      label: 'Network Traffic Out',
-                    },
-                  ]}
-                  accessibleDataTable={{ unit: 'Kb/s"' }}
-                  ariaLabel="Network Transfer Graph"
-                  chartHeight={chartHeight}
-                  formatData={convertNetworkData}
-                  formatTooltip={_formatTooltip}
-                  nativeLegend
-                  showToday={true}
-                  timezone={timezone}
-                  unit="/s"
-                />
-              </StyledCanvasContainerDiv>
-            )}
+            <Box marginLeft={-4} marginTop={3}>
+              <AreaChart
+                areas={[
+                  {
+                    color: theme.graphs.darkGreen,
+                    dataKey: 'Network Traffic In',
+                  },
+                  {
+                    color: theme.graphs.lightGreen,
+                    dataKey: 'Network Traffic Out',
+                  },
+                ]}
+                xAxis={{
+                  tickFormat: 'hh a',
+                  tickGap: 60,
+                }}
+                ariaLabel="Network Transfer Graph"
+                data={networkTransferData}
+                height={chartHeight}
+                showLegend
+                timezone={timezone}
+                unit={' Kb/s'}
+              />
+            </Box>
           </StyledRootDiv>
         );
       },
@@ -207,45 +142,25 @@ const createTabs = (
         return (
           <StyledRootDiv>
             <div>{summaryCopy}</div>
-            {flags.recharts ? (
-              <Box marginLeft={-4} marginTop={3}>
-                <AreaChart
-                  areas={[
-                    {
-                      color: theme.graphs.yellow,
-                      dataKey: 'Disk I/O',
-                    },
-                  ]}
-                  xAxis={{
-                    tickFormat: 'hh a',
-                    tickGap: 60,
-                  }}
-                  ariaLabel="Disk I/O Graph"
-                  data={formatData2(data.disk, 'Disk I/O')}
-                  height={chartHeight}
-                  timezone={timezone}
-                  unit={' op/s'}
-                />
-              </Box>
-            ) : (
-              <StyledCanvasContainerDiv>
-                <LineGraph
-                  data={[
-                    {
-                      backgroundColor: theme.graphs.yellow,
-                      borderColor: 'transparent',
-                      data: formatData(data.disk),
-                      label: 'Disk I/O',
-                    },
-                  ]}
-                  accessibleDataTable={{ unit: 'op/s' }}
-                  ariaLabel="Disk I/O Graph"
-                  chartHeight={chartHeight}
-                  showToday={true}
-                  timezone={timezone}
-                />
-              </StyledCanvasContainerDiv>
-            )}
+            <Box marginLeft={-4} marginTop={3}>
+              <AreaChart
+                areas={[
+                  {
+                    color: theme.graphs.yellow,
+                    dataKey: 'Disk I/O',
+                  },
+                ]}
+                xAxis={{
+                  tickFormat: 'hh a',
+                  tickGap: 60,
+                }}
+                ariaLabel="Disk I/O Graph"
+                data={formatData2(data.disk, 'Disk I/O')}
+                height={chartHeight}
+                timezone={timezone}
+                unit={' op/s'}
+              />
+            </Box>
           </StyledRootDiv>
         );
       },
@@ -256,7 +171,6 @@ const createTabs = (
 
 export const ManagedChartPanel = () => {
   const theme = useTheme();
-  const flags = useFlags();
   const { data: profile } = useProfile();
   const timezone = getUserTimezone(profile?.timezone);
   const { data, error, isLoading } = useManagedStatsQuery();
@@ -286,7 +200,7 @@ export const ManagedChartPanel = () => {
     return null;
   }
 
-  const tabs = createTabs(data.data, timezone, theme, flags);
+  const tabs = createTabs(data.data, timezone, theme);
 
   const initialTab = 0;
 

--- a/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedChartPanel.tsx
+++ b/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedChartPanel.tsx
@@ -72,7 +72,6 @@ const createTabs = (
     });
   }
 
-  // @TODO recharts: remove conditional code and delete old chart when we decide recharts is stable
   return [
     {
       render: () => {

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -12,12 +12,9 @@ import {
 import { Box } from 'src/components/Box';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
-import { LineGraph } from 'src/components/LineGraph/LineGraph';
-import MetricsDisplay from 'src/components/LineGraph/MetricsDisplay';
 import { Paper } from 'src/components/Paper';
 import { Typography } from 'src/components/Typography';
 import { formatBitsPerSecond } from 'src/features/Longview/shared/utilities';
-import { useFlags } from 'src/hooks/useFlags';
 import {
   NODEBALANCER_STATS_NOT_READY_API_MESSAGE,
   useNodeBalancerQuery,
@@ -43,8 +40,6 @@ export const TablesPanel = () => {
     nodebalancer?.id ?? -1,
     nodebalancer?.created
   );
-
-  const flags = useFlags();
 
   const statsErrorString = error
     ? getAPIErrorOrDefault(error, 'Unable to load stats')[0].reason
@@ -89,82 +84,46 @@ export const TablesPanel = () => {
 
     const metrics = getMetrics(data);
 
-    // @TODO recharts: remove conditional code and delete old chart when we decide recharts is stable
-    if (flags.recharts) {
-      const timeData = data.reduce(
-        (acc: NodeBalancerConnectionsTimeData[], point: Point) => {
-          acc.push({
-            Connections: point[1],
-            timestamp: point[0],
-          });
-          return acc;
-        },
-        []
-      );
-
-      return (
-        <Box marginLeft={-3}>
-          <AreaChart
-            areas={[
-              {
-                color: theme.graphs.purple,
-                dataKey: 'Connections',
-              },
-            ]}
-            legendRows={[
-              {
-                data: metrics,
-                format: formatNumber,
-                legendColor: 'purple',
-                legendTitle: 'Connections',
-              },
-            ]}
-            xAxis={{
-              tickFormat: 'hh a',
-              tickGap: 60,
-            }}
-            ariaLabel="Connections Graph"
-            data={timeData}
-            height={412}
-            showLegend
-            timezone={timezone}
-            unit={' CXN/s'}
-          />
-        </Box>
-      );
-    }
+    const timeData = data.reduce(
+      (acc: NodeBalancerConnectionsTimeData[], point: Point) => {
+        acc.push({
+          Connections: point[1],
+          timestamp: point[0],
+        });
+        return acc;
+      },
+      []
+    );
 
     return (
-      <>
-        <StyledChart>
-          <LineGraph
-            data={[
-              {
-                backgroundColor: theme.graphs.purple,
-                borderColor: 'transparent',
-                data,
-                label: 'Connections',
-              },
-            ]}
-            accessibleDataTable={{ unit: 'CXN/s' }}
-            ariaLabel="Connections Graph"
-            showToday={true}
-            timezone={timezone}
-          />
-        </StyledChart>
-        <StyledBottomLegend>
-          <MetricsDisplay
-            rows={[
-              {
-                data: metrics,
-                format: formatNumber,
-                legendColor: 'purple',
-                legendTitle: 'Connections',
-              },
-            ]}
-          />
-        </StyledBottomLegend>
-      </>
+      <Box marginLeft={-3}>
+        <AreaChart
+          areas={[
+            {
+              color: theme.graphs.purple,
+              dataKey: 'Connections',
+            },
+          ]}
+          legendRows={[
+            {
+              data: metrics,
+              format: formatNumber,
+              legendColor: 'purple',
+              legendTitle: 'Connections',
+            },
+          ]}
+          xAxis={{
+            tickFormat: 'hh a',
+            tickGap: 60,
+          }}
+          ariaLabel="Connections Graph"
+          data={timeData}
+          height={412}
+          showLegend
+          timezone={timezone}
+          unit={' CXN/s'}
+        />
+      </Box>
     );
   };
 
@@ -174,7 +133,7 @@ export const TablesPanel = () => {
     const timeData = [];
 
     // @TODO recharts: remove conditional code and delete old chart when we decide recharts is stable
-    if (flags.recharts && trafficIn) {
+    if (trafficIn) {
       for (let i = 0; i < trafficIn.length; i++) {
         timeData.push({
           'Traffic In': trafficIn[i][1],
@@ -215,92 +174,45 @@ export const TablesPanel = () => {
       return <Loading />;
     }
 
-    if (flags.recharts) {
-      return (
-        <Box marginLeft={-3}>
-          <AreaChart
-            areas={[
-              {
-                color: theme.graphs.darkGreen,
-                dataKey: 'Traffic In',
-              },
-              {
-                color: theme.graphs.lightGreen,
-                dataKey: 'Traffic Out',
-              },
-            ]}
-            legendRows={[
-              {
-                data: getMetrics(trafficIn),
-                format: formatBitsPerSecond,
-                legendColor: 'darkGreen',
-                legendTitle: 'Traffic In',
-              },
-              {
-                data: getMetrics(trafficOut),
-                format: formatBitsPerSecond,
-                legendColor: 'lightGreen',
-                legendTitle: 'Traffic Out',
-              },
-            ]}
-            xAxis={{
-              tickFormat: 'hh a',
-              tickGap: 60,
-            }}
-            ariaLabel="Network Traffic Graph"
-            data={timeData}
-            height={412}
-            showLegend
-            timezone={timezone}
-            unit={' bits/s'}
-          />
-        </Box>
-      );
-    }
-
     return (
-      <React.Fragment>
-        <StyledChart>
-          <LineGraph
-            data={[
-              {
-                backgroundColor: theme.graphs.darkGreen,
-                borderColor: 'transparent',
-                data: trafficIn,
-                label: 'Traffic In',
-              },
-              {
-                backgroundColor: theme.graphs.lightGreen,
-                borderColor: 'transparent',
-                data: trafficOut,
-                label: 'Traffic Out',
-              },
-            ]}
-            accessibleDataTable={{ unit: 'bits/s' }}
-            ariaLabel="Traffic Graph"
-            showToday={true}
-            timezone={timezone}
-          />
-        </StyledChart>
-        <StyledBottomLegend>
-          <MetricsDisplay
-            rows={[
-              {
-                data: getMetrics(trafficIn),
-                format: formatBitsPerSecond,
-                legendColor: 'darkGreen',
-                legendTitle: 'Inbound',
-              },
-              {
-                data: getMetrics(trafficOut),
-                format: formatBitsPerSecond,
-                legendColor: 'lightGreen',
-                legendTitle: 'Outbound',
-              },
-            ]}
-          />
-        </StyledBottomLegend>
-      </React.Fragment>
+      <Box marginLeft={-3}>
+        <AreaChart
+          areas={[
+            {
+              color: theme.graphs.darkGreen,
+              dataKey: 'Traffic In',
+            },
+            {
+              color: theme.graphs.lightGreen,
+              dataKey: 'Traffic Out',
+            },
+          ]}
+          legendRows={[
+            {
+              data: getMetrics(trafficIn),
+              format: formatBitsPerSecond,
+              legendColor: 'darkGreen',
+              legendTitle: 'Traffic In',
+            },
+            {
+              data: getMetrics(trafficOut),
+              format: formatBitsPerSecond,
+              legendColor: 'lightGreen',
+              legendTitle: 'Traffic Out',
+            },
+          ]}
+          xAxis={{
+            tickFormat: 'hh a',
+            tickGap: 60,
+          }}
+          ariaLabel="Network Traffic Graph"
+          data={timeData}
+          height={412}
+          showLegend
+          timezone={timezone}
+          unit={' bits/s'}
+        />
+      </Box>
     );
   };
 
@@ -338,14 +250,6 @@ const StyledTitle = styled(Typography, {
   [theme.breakpoints.up('md')]: {
     margin: `${theme.spacing(2)} 0`,
   },
-}));
-
-const StyledChart = styled('div', {
-  label: 'StyledChart',
-})(({ theme }) => ({
-  paddingLeft: theme.spacing(1),
-  position: 'relative',
-  width: '100%',
 }));
 
 export const StyledBottomLegend = styled('div', {

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -132,7 +132,6 @@ export const TablesPanel = () => {
     const trafficOut = stats?.data.traffic.out ?? [];
     const timeData = [];
 
-    // @TODO recharts: remove conditional code and delete old chart when we decide recharts is stable
     if (trafficIn) {
       for (let i = 0; i < trafficIn.length; i++) {
         timeData.push({


### PR DESCRIPTION
## Description 📝
This PR gets rid of the recharts feature flag in order to remove heavy dependencies we're shipping to our users in the Linode detail flow.
- `charts.js`
- `moment,js` (which is a dpendency of the above)

It cleans up conditional rendering of the old charts since everything has been stable since the new charts have been released.

Only remaining components using charts.js:
- `GaugePercent` 
- `LineGraph`

which are both only for longview 🎉 

🥇 Thanks @hana-linode for the super clean handling of splitting the feature initially, was very easy to clean up

## Changes  🔄
- Remove flag and and old charts behind it

## Preview 📷
No visual change expected as part of this PR

## How to test 🧪

### Verification steps
- Confirm all charts are showing (recharts) in both the Linode detail/networking and managed UIs

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
