### PR TITLE
refactor: [M3-8045] - remove aria-label from TableRow

### DIFF
--- a/packages/manager/.changeset/pr-10485-tech-stories-1716214544667.md
+++ b/packages/manager/.changeset/pr-10485-tech-stories-1716214544667.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Remove aria-label from TableRow ([#10485](https://github.com/linode/manager/pull/10485))

--- a/packages/manager/cypress/e2e/core/account/users-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/users-landing-page.spec.ts
@@ -114,7 +114,7 @@ describe('Users landing page', () => {
     // Confirm that "Child account access" column is present
     cy.findByText('Child Account Access').should('be.visible');
     mockUsers.forEach((user) => {
-      cy.get(`[aria-label="User ${user.username}"]`)
+      cy.get(`[data-qa-table-row="${user.username}"]`)
         .should('be.visible')
         .within(() => {
           if (

--- a/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
@@ -237,7 +237,7 @@ describe('object storage end-to-end tests', () => {
       cy.wait('@uploadObject');
       cy.reload();
 
-      cy.findByLabelText(bucketFiles[0].name).should('be.visible');
+      cy.findByText(bucketFiles[0].name).should('be.visible');
       ui.button.findByTitle('Delete').should('be.visible').click();
 
       ui.dialog

--- a/packages/manager/cypress/e2e/core/stackscripts/delete-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/delete-stackscripts.spec.ts
@@ -23,7 +23,7 @@ describe('Delete stackscripts', () => {
     cy.wait('@getStackScripts');
 
     // Do nothing when cancelling
-    cy.get(`[aria-label="${stackScripts[0].label}"]`)
+    cy.get(`[data-qa-table-row="${stackScripts[0].label}"]`)
       .closest('tr')
       .within(() => {
         ui.actionMenu
@@ -47,7 +47,7 @@ describe('Delete stackscripts', () => {
       });
 
     // The StackScript is deleted successfully.
-    cy.get(`[aria-label="${stackScripts[0].label}"]`)
+    cy.get(`[data-qa-table-row="${stackScripts[0].label}"]`)
       .closest('tr')
       .within(() => {
         ui.actionMenu
@@ -73,7 +73,7 @@ describe('Delete stackscripts', () => {
     cy.findByText(stackScripts[0].label).should('not.exist');
 
     // The "Automate Deployment with StackScripts!" welcome page appears when no StackScript exists.
-    cy.get(`[aria-label="${stackScripts[1].label}"]`)
+    cy.get(`[data-qa-table-row="${stackScripts[1].label}"]`)
       .closest('tr')
       .within(() => {
         ui.actionMenu

--- a/packages/manager/cypress/e2e/core/stackscripts/smoke-stackscripts-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/smoke-stackscripts-landing-page.spec.ts
@@ -36,7 +36,7 @@ describe('Display stackscripts', () => {
     cy.wait('@getStackScripts');
 
     stackScripts.forEach((stackScript) => {
-      cy.get(`[aria-label="${stackScript.label}"]`)
+      cy.get(`[data-qa-table-row="${stackScript.label}"]`)
         .closest('tr')
         .within(() => {
           cy.findByText(stackScript.deployments_total).should('be.visible');

--- a/packages/manager/cypress/e2e/core/stackscripts/update-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/update-stackscripts.spec.ts
@@ -95,14 +95,12 @@ describe('Update stackscripts', () => {
     cy.visitWithLogin('/stackscripts/account');
     cy.wait('@getStackScripts');
 
-    cy.get(`[aria-label="${stackScripts[0].label}"]`)
-      .closest('tr')
-      .within(() => {
-        ui.actionMenu
-          .findByTitle(`Action menu for StackScript ${stackScripts[0].label}`)
-          .should('be.visible')
-          .click();
-      });
+    cy.get(`[data-qa-table-row="${stackScripts[0].label}"]`).within(() => {
+      ui.actionMenu
+        .findByTitle(`Action menu for StackScript ${stackScripts[0].label}`)
+        .should('be.visible')
+        .click();
+    });
     mockGetStackScript(stackScripts[0].id, stackScripts[0]).as(
       'getStackScript'
     );
@@ -205,14 +203,12 @@ describe('Update stackscripts', () => {
     cy.wait('@getStackScripts');
 
     // Do nothing when cancelling
-    cy.get(`[aria-label="${stackScripts[0].label}"]`)
-      .closest('tr')
-      .within(() => {
-        ui.actionMenu
-          .findByTitle(`Action menu for StackScript ${stackScripts[0].label}`)
-          .should('be.visible')
-          .click();
-      });
+    cy.get(`[data-qa-table-row="${stackScripts[0].label}"]`).within(() => {
+      ui.actionMenu
+        .findByTitle(`Action menu for StackScript ${stackScripts[0].label}`)
+        .should('be.visible')
+        .click();
+    });
     ui.actionMenuItem
       .findByTitle('Make StackScript Public')
       .should('be.visible')
@@ -234,14 +230,12 @@ describe('Update stackscripts', () => {
       });
 
     // The status of the StackScript will become public
-    cy.get(`[aria-label="${stackScripts[0].label}"]`)
-      .closest('tr')
-      .within(() => {
-        ui.actionMenu
-          .findByTitle(`Action menu for StackScript ${stackScripts[0].label}`)
-          .should('be.visible')
-          .click();
-      });
+    cy.get(`[data-qa-table-row="${stackScripts[0].label}"]`).within(() => {
+      ui.actionMenu
+        .findByTitle(`Action menu for StackScript ${stackScripts[0].label}`)
+        .should('be.visible')
+        .click();
+    });
     ui.actionMenuItem
       .findByTitle('Make StackScript Public')
       .should('be.visible')

--- a/packages/manager/cypress/e2e/core/vpc/vpc-linodes-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/vpc/vpc-linodes-update.spec.ts
@@ -192,8 +192,8 @@ describe('VPC assign/unassign flows', () => {
           .click();
       });
 
-    cy.get('[aria-label="View Details"]')
-      .closest('tbody')
+    cy.get('[data-qa-table-row="vpc-subnets"]')
+      .siblings('tbody')
       .within(() => {
         // after assigning Linode(s) to a VPC, VPC page increases number in 'Linodes' column
         cy.findByText('1').should('be.visible');

--- a/packages/manager/cypress/e2e/core/vpc/vpc-linodes-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/vpc/vpc-linodes-update.spec.ts
@@ -192,7 +192,7 @@ describe('VPC assign/unassign flows', () => {
           .click();
       });
 
-    cy.get('[data-qa-table-row="vpc-subnets"]')
+    cy.get('[data-qa-table-row="collapsible-table-headers-row"]')
       .siblings('tbody')
       .within(() => {
         // after assigning Linode(s) to a VPC, VPC page increases number in 'Linodes' column

--- a/packages/manager/src/components/CollapsibleTable/CollapsibleTable.tsx
+++ b/packages/manager/src/components/CollapsibleTable/CollapsibleTable.tsx
@@ -27,7 +27,9 @@ export const CollapsibleTable = (props: Props) => {
   return (
     <TableContainer component={Paper}>
       <Table aria-label="collapsible table">
-        <TableHead data-qa-table-row="vpc-subnets">{TableRowHead}</TableHead>
+        <TableHead data-qa-table-row="collapsible-table-headers-row">
+          {TableRowHead}
+        </TableHead>
         <TableBody>
           {TableItems.length === 0 && TableRowEmpty}
           {TableItems.map((item) => {

--- a/packages/manager/src/components/CollapsibleTable/CollapsibleTable.tsx
+++ b/packages/manager/src/components/CollapsibleTable/CollapsibleTable.tsx
@@ -27,7 +27,7 @@ export const CollapsibleTable = (props: Props) => {
   return (
     <TableContainer component={Paper}>
       <Table aria-label="collapsible table">
-        <TableHead>{TableRowHead}</TableHead>
+        <TableHead data-qa-table-row="vpc-subnets">{TableRowHead}</TableHead>
         <TableBody>
           {TableItems.length === 0 && TableRowEmpty}
           {TableItems.map((item) => {

--- a/packages/manager/src/components/TableRow/TableRow.tsx
+++ b/packages/manager/src/components/TableRow/TableRow.tsx
@@ -6,7 +6,6 @@ import { Hidden } from 'src/components/Hidden';
 import { StyledTableDataCell, StyledTableRow } from './TableRow.styles';
 
 export interface TableRowProps extends _TableRowProps {
-  ariaLabel?: string;
   className?: string;
   disabled?: boolean;
   domRef?: any;
@@ -18,15 +17,10 @@ export interface TableRowProps extends _TableRowProps {
 }
 
 export const TableRow = React.memo((props: TableRowProps) => {
-  const { ariaLabel, domRef, selected, ...rest } = props;
+  const { domRef, selected, ...rest } = props;
 
   return (
-    <StyledTableRow
-      aria-label={ariaLabel ?? `View Details`}
-      ref={domRef}
-      selected={selected}
-      {...rest}
-    >
+    <StyledTableRow ref={domRef} selected={selected} {...rest}>
       {props.children}
       {selected && (
         <Hidden lgDown>

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
@@ -26,7 +26,7 @@ export const databaseEngineMap: Record<Engine, string> = {
 };
 
 interface Props {
-  database: DatabaseInstance | Database;
+  database: Database | DatabaseInstance;
   events?: Event[];
 }
 
@@ -62,16 +62,12 @@ export const DatabaseRow = ({ database, events }: Props) => {
     );
 
   return (
-    <TableRow
-      ariaLabel={`Database ${label}`}
-      data-qa-database-cluster-id={id}
-      key={`database-row-${id}`}
-    >
+    <TableRow data-qa-database-cluster-id={id} key={`database-row-${id}`}>
       <TableCell>
         <Link to={`/databases/${engine}/${id}`}>{label}</Link>
       </TableCell>
       <TableCell statusCell>
-        <DatabaseStatusDisplay events={events} database={database} />
+        <DatabaseStatusDisplay database={database} events={events} />
       </TableCell>
       <Hidden smDown>
         <TableCell>{configuration}</TableCell>

--- a/packages/manager/src/features/Domains/DomainTableRow.tsx
+++ b/packages/manager/src/features/Domains/DomainTableRow.tsx
@@ -21,11 +21,7 @@ export const DomainTableRow = React.memo((props: DomainTableRowProps) => {
   const { domain, onClone, onDisableOrEnable, onEdit, onRemove } = props;
 
   return (
-    <TableRow
-      ariaLabel={`Domain ${domain.domain}`}
-      data-qa-domain-cell={domain.domain}
-      key={domain.id}
-    >
+    <TableRow data-qa-domain-cell={domain.domain} key={domain.id}>
       <TableCell data-qa-domain-label>
         <StyledDiv>
           {domain.type !== 'slave' ? (

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -68,11 +68,7 @@ export const Row = (props: RowProps) => {
   }
 
   return (
-    <TableRow
-      ariaLabel={`Event ${message}`}
-      data-qa-event-row
-      data-test-id={action}
-    >
+    <TableRow data-qa-event-row data-test-id={action}>
       <Hidden smDown>
         <TableCell data-qa-event-icon-cell>
           <StyledGravatar username={username ?? ''} />

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceRow.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceRow.tsx
@@ -14,10 +14,7 @@ export const FirewallDeviceRow = React.memo(
     const { deviceEntityID, deviceID, deviceLabel, deviceType } = props;
 
     return (
-      <TableRow
-        ariaLabel={`Device ${deviceLabel}`}
-        data-testid={`firewall-device-row-${deviceID}`}
-      >
+      <TableRow data-testid={`firewall-device-row-${deviceID}`}>
         <TableCell>
           <Link
             tabIndex={0}

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
@@ -22,10 +22,7 @@ export const FirewallRow = React.memo((props: FirewallRowProps) => {
   const count = getCountOfRules(rules);
 
   return (
-    <TableRow
-      ariaLabel={`Firewall ${label}`}
-      data-testid={`firewall-row-${id}`}
-    >
+    <TableRow data-testid={`firewall-row-${id}`}>
       <TableCell>
         <Link tabIndex={0} to={`/firewalls/${id}`}>
           {label}

--- a/packages/manager/src/features/Kubernetes/ClusterList/KubernetesClusterRow.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/KubernetesClusterRow.tsx
@@ -1,8 +1,8 @@
 import { KubeNodePoolResponse, KubernetesCluster } from '@linode/api-v4';
 import Grid from '@mui/material/Unstable_Grid2';
-import { makeStyles } from 'tss-react/mui';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import { makeStyles } from 'tss-react/mui';
 
 import { Chip } from 'src/components/Chip';
 import { DateTimeDisplay } from 'src/components/DateTimeDisplay';
@@ -83,7 +83,6 @@ export const KubernetesClusterRow = (props: Props) => {
 
   return (
     <TableRow
-      ariaLabel={`Cluster ${cluster.label}`}
       className={classes.clusterRow}
       data-qa-cluster-cell={cluster.id}
       data-testid={'cluster-row'}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeRow.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeRow.tsx
@@ -70,7 +70,7 @@ export const NodeRow = React.memo((props: NodeRowProps) => {
   const displayIP = ip ?? '';
 
   return (
-    <StyledTableRow ariaLabel={label} data-qa-node-row={nodeId}>
+    <StyledTableRow data-qa-node-row={nodeId}>
       <TableCell>
         <Grid alignItems="center" container wrap="nowrap">
           <Grid>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeFirewalls/LinodeFirewallsRow.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeFirewalls/LinodeFirewallsRow.tsx
@@ -37,11 +37,7 @@ export const LinodeFirewallsRow = (props: LinodeFirewallsRowProps) => {
   const count = getCountOfRules(rules);
 
   return (
-    <TableRow
-      ariaLabel={`Firewall ${label}`}
-      data-qa-linode-firewall-row
-      key={`firewall-${firewallID}`}
-    >
+    <TableRow data-qa-linode-firewall-row key={`firewall-${firewallID}`}>
       <TableCell data-qa-firewall-label>
         <Link tabIndex={0} to={`/firewalls/${firewallID}`}>
           {label}

--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -93,7 +93,6 @@ export const LinodeRow = (props: Props) => {
 
   return (
     <TableRow
-      ariaLabel={label}
       data-qa-linode={label}
       data-qa-loading
       key={id}

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerLanding/LoadBalancerRow.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerLanding/LoadBalancerRow.tsx
@@ -25,10 +25,7 @@ export const LoadBalancerRow = ({ handlers, loadBalancer }: Props) => {
   const { hostname, id, label, regions } = loadBalancer;
 
   return (
-    <TableRow
-      ariaLabel={`Load Balancer ${label}`}
-      key={`loadbalancer-row-${id}`}
-    >
+    <TableRow key={`loadbalancer-row-${id}`}>
       <TableCell>
         <Link to={`/loadbalancers/${id}`}>{label}</Link>
       </TableCell>

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ConnectionRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ConnectionRow.tsx
@@ -12,7 +12,7 @@ export const ConnectionRow = (props: Props) => {
   const { connection } = props;
 
   return (
-    <TableRow ariaLabel={connection.name} data-testid="longview-connection-row">
+    <TableRow data-testid="longview-connection-row">
       <TableCell data-qa-active-connection-name parentColumn="Name">
         {connection.name}
       </TableCell>

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/LongviewServiceRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/LongviewServiceRow.tsx
@@ -12,7 +12,7 @@ export const LongviewServiceRow = (props: Props) => {
   const { service } = props;
 
   return (
-    <TableRow ariaLabel={service.name} data-testid="longview-service-row">
+    <TableRow data-testid="longview-service-row">
       <TableCell data-qa-service-process parentColumn="Process">
         {service.name}
       </TableCell>

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesTable.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesTable.tsx
@@ -13,8 +13,8 @@ import { TableSortCell } from 'src/components/TableSortCell';
 import { formatCPU } from 'src/features/Longview/shared/formatters';
 import { useWindowDimensions } from 'src/hooks/useWindowDimensions';
 import { readableBytes } from 'src/utilities/unitConversions';
-import { StyledDiv, StyledTable } from './ProcessesTable.styles';
 
+import { StyledDiv, StyledTable } from './ProcessesTable.styles';
 import { Process } from './types';
 
 export interface ProcessesTableProps {
@@ -176,7 +176,6 @@ export const ProcessesTableRow = React.memo((props: ProcessTableRowProps) => {
       onKeyUp={(e: any) =>
         e.key === 'Enter' && setSelectedProcess({ name, user })
       }
-      ariaLabel={`${name} for ${user}`}
       data-testid="longview-service-row"
       forceIndex
       onClick={() => setSelectedProcess({ name, user })}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/TopProcesses.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/TopProcesses.tsx
@@ -151,7 +151,7 @@ export const TopProcessRow = React.memo((props: TopProcessRowProps) => {
   const memInBytes = mem * 1024;
 
   return (
-    <TableRow ariaLabel={name} data-testid="longview-top-process-row">
+    <TableRow data-testid="longview-top-process-row">
       <TableCell data-qa-top-process-process parentColumn="Process">
         {name}
       </TableCell>

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
@@ -24,6 +24,7 @@ import { UseAPIRequest } from 'src/hooks/useAPIRequest';
 import { useAccountSettings } from 'src/queries/account/settings';
 import { useGrants, useProfile } from 'src/queries/profile';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+
 import {
   StyledChip,
   StyledClientCell,
@@ -228,15 +229,15 @@ export const LongviewPlans = (props: LongviewPlansProps) => {
                 </TableBody>
               </StyledTable>
               <Button
+                sx={{
+                  marginBottom: theme.spacing(3),
+                  marginTop: theme.spacing(3),
+                }}
                 buttonType="primary"
                 data-testid="submit-button"
                 disabled={isButtonDisabled}
                 loading={updateLoading}
                 onClick={onSubmit}
-                sx={{
-                  marginBottom: theme.spacing(3),
-                  marginTop: theme.spacing(3),
-                }}
               >
                 Change Plan
               </Button>
@@ -355,25 +356,24 @@ export const LongviewSubscriptionRow = React.memo(
 
     return (
       <StyledTableRow
-        ariaLabel={plan}
-        disabled={disabled}
         data-testid={`lv-sub-table-row-${id}`}
+        disabled={disabled}
         key={id}
         onClick={handleClick}
       >
         <TableCell data-testid={`plan-cell-${id}`}>
           <StyledDiv>
             <Radio
-              checked={isSelected}
-              data-testid={`lv-sub-radio-${id}`}
-              disabled={disabled}
-              id={id}
-              onChange={onRadioSelect}
               sx={{
                 marginLeft: `-${theme.spacing(0.5)}`,
                 marginRight: theme.spacing(2),
                 padding: '2px',
               }}
+              checked={isSelected}
+              data-testid={`lv-sub-radio-${id}`}
+              disabled={disabled}
+              id={id}
+              onChange={onRadioSelect}
               value={id}
             />
             {plan}

--- a/packages/manager/src/features/Longview/LongviewPackageRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewPackageRow.tsx
@@ -16,7 +16,7 @@ export const LongviewPackageRow = (props: Props) => {
   const theme = useTheme();
 
   return (
-    <TableRow ariaLabel={lvPackage.name}>
+    <TableRow>
       <TableCell parentColumn={'Package'}>{lvPackage.name}</TableCell>
       <TableCell parentColumn="Installed Version / Latest Version">
         <div>{lvPackage.current}</div>

--- a/packages/manager/src/features/Managed/Contacts/ContactsRow.tsx
+++ b/packages/manager/src/features/Managed/Contacts/ContactsRow.tsx
@@ -17,7 +17,7 @@ export const ContactsRow = (props: ContactsRowProps) => {
   const { contact, openDialog, openDrawer } = props;
 
   return (
-    <TableRow ariaLabel={`Contact ${contact.id}`} key={contact.id}>
+    <TableRow key={contact.id}>
       <TableCell>{contact.name}</TableCell>
       <Hidden mdDown>
         <TableCell>{contact.group}</TableCell>

--- a/packages/manager/src/features/Managed/Credentials/CredentialRow.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialRow.tsx
@@ -19,7 +19,6 @@ export const CredentialRow = (props: CredentialRowProps) => {
 
   return (
     <StyledTableRow
-      ariaLabel={`Credential ${credential.label}`}
       data-qa-credential-cell={credential.id}
       data-testid={'credential-row'}
       key={credential.id}

--- a/packages/manager/src/features/Managed/Monitors/MonitorRow.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorRow.tsx
@@ -9,6 +9,7 @@ import { Typography } from 'src/components/Typography';
 import { ExtendedIssue } from 'src/queries/managed/types';
 
 import ActionMenu from './MonitorActionMenu';
+import { statusIconMap, statusTextMap } from './monitorMaps';
 import {
   StyledGrid,
   StyledLink,
@@ -16,7 +17,6 @@ import {
   StyledTableRow,
   StyledTypography,
 } from './MonitorRow.styles';
-import { statusIconMap, statusTextMap } from './monitorMaps';
 
 interface MonitorRowProps {
   issues: ExtendedIssue[];
@@ -45,7 +45,6 @@ export const MonitorRow = (props: MonitorRowProps) => {
 
   return (
     <StyledTableRow
-      ariaLabel={`Monitor ${monitor.label}`}
       data-qa-monitor-cell={monitor.id}
       data-testid={'monitor-row'}
       key={monitor.id}

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
@@ -19,7 +19,6 @@ export const SSHAccessRow = (props: SSHAccessRowProps) => {
 
   return (
     <TableRow
-      ariaLabel={linodeSetting.label}
       data-qa-monitor-cell={linodeSetting.id}
       data-testid={'linode-row'}
       key={linodeSetting.id}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerFirewallsRow.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerFirewallsRow.tsx
@@ -39,11 +39,7 @@ export const NodeBalancerFirewallsRow = (props: Props) => {
   const count = getCountOfRules(rules);
 
   return (
-    <TableRow
-      ariaLabel={`Firewall ${label}`}
-      data-qa-linode-firewall-row
-      key={`firewall-${firewallID}`}
-    >
+    <TableRow data-qa-linode-firewall-row key={`firewall-${firewallID}`}>
       <TableCell data-qa-firewall-label>
         <Link tabIndex={0} to={`/firewalls/${firewallID}`}>
           {label}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerTableRow.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerTableRow.tsx
@@ -30,7 +30,7 @@ export const NodeBalancerTableRow = (props: Props) => {
     0;
 
   return (
-    <TableRow ariaLabel={label} key={id}>
+    <TableRow key={id}>
       <TableCell>
         <Link tabIndex={0} to={`/nodebalancers/${id}`}>
           {label}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
@@ -1,5 +1,5 @@
-import Grid from '@mui/material/Unstable_Grid2';
 import { styled } from '@mui/material/styles';
+import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 
@@ -21,7 +21,7 @@ export const FolderTableRow = (props: Props) => {
   const { displayName, folderName, handleClickDelete } = props;
 
   return (
-    <TableRow ariaLabel={`Folder ${displayName}`} key={folderName} {...props}>
+    <TableRow key={folderName} {...props}>
       <TableCell parentColumn="Object">
         <Grid alignItems="center" container spacing={2} wrap="nowrap">
           <StyledIconWrapper>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
@@ -36,7 +36,7 @@ export const ObjectTableRow = (props: Props) => {
   } = props;
 
   return (
-    <TableRow ariaLabel={displayName}>
+    <TableRow>
       <TableCell>
         <Grid alignItems="center" container spacing={2} wrap="nowrap">
           <Grid className="py0">

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
@@ -63,7 +63,7 @@ export const BucketTableRow = (props: BucketTableRowProps) => {
   const regionsLookup = regions && getRegionsByRegionId(regions);
 
   return (
-    <StyledBucketRow ariaLabel={label} data-qa-bucket-cell={label} key={label}>
+    <StyledBucketRow data-qa-bucket-cell={label} key={label}>
       <TableCell>
         <Grid alignItems="center" container spacing={2} wrap="nowrap">
           <Grid>

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsLinodes/PlacementGroupsLinodesTableRow.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetail/PlacementGroupsLinodes/PlacementGroupsLinodesTableRow.tsx
@@ -28,10 +28,7 @@ export const PlacementGroupsLinodesTableRow = React.memo((props: Props) => {
   });
 
   return (
-    <TableRow
-      ariaLabel={`Linode ${label}`}
-      data-testid={`placement-group-linode-${linode.id}`}
-    >
+    <TableRow data-testid={`placement-group-linode-${linode.id}`}>
       <TableCell>
         <Link to={`/linodes/${linode.id}`}>{label}</Link>
       </TableCell>

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsRow.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsRow.tsx
@@ -55,10 +55,7 @@ export const PlacementGroupsRow = React.memo(
     ];
 
     return (
-      <TableRow
-        ariaLabel={`Placement Group ${label}`}
-        data-testid={`placement-group-${id}`}
-      >
+      <TableRow data-testid={`placement-group-${id}`}>
         <TableCell>
           <Link
             data-testid={`link-to-placement-group-${id}`}

--- a/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
@@ -37,8 +37,8 @@ import {
 import { CreateAPITokenDrawer } from './CreateAPITokenDrawer';
 import { EditAPITokenDrawer } from './EditAPITokenDrawer';
 import { RevokeTokenDialog } from './RevokeTokenDialog';
-import { ViewAPITokenDrawer } from './ViewAPITokenDrawer';
 import { isWayInTheFuture } from './utils';
+import { ViewAPITokenDrawer } from './ViewAPITokenDrawer';
 
 export type APITokenType = 'OAuth Client Token' | 'Personal Access Token';
 
@@ -146,11 +146,7 @@ export const APITokenTable = (props: Props) => {
 
   const renderRows = (tokens: Token[]) => {
     return tokens.map((token: Token) => (
-      <TableRow
-        ariaLabel={token.label}
-        data-qa-table-row={token.label}
-        key={token.id}
-      >
+      <TableRow data-qa-table-row={token.label} key={token.id}>
         <TableCell data-qa-token-label>{token.label}</TableCell>
         <TableCell>
           <Typography data-qa-token-created variant="body1">

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TrustedDevices.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TrustedDevices.tsx
@@ -86,7 +86,7 @@ const TrustedDevices = () => {
 
     return data?.data.map((device) => {
       return (
-        <TableRow ariaLabel={`Device ${device.id}`} key={device.id}>
+        <TableRow key={device.id}>
           <TableCell>{device.user_agent}</TableCell>
           <TableCell>{device.last_remote_addr}</TableCell>
           <TableCell>

--- a/packages/manager/src/features/Profile/OAuthClients/OAuthClients.tsx
+++ b/packages/manager/src/features/Profile/OAuthClients/OAuthClients.tsx
@@ -90,7 +90,7 @@ const OAuthClients = () => {
     }
 
     return data?.data.map(({ id, label, public: isPublic, redirect_uri }) => (
-      <TableRow ariaLabel={label} key={id}>
+      <TableRow key={id}>
         <TableCell>{label}</TableCell>
         <Hidden smDown>
           <TableCell>{isPublic ? 'Public' : 'Private'}</TableCell>

--- a/packages/manager/src/features/Search/ResultRow.tsx
+++ b/packages/manager/src/features/Search/ResultRow.tsx
@@ -24,7 +24,7 @@ export const ResultRow = (props: ResultRowProps) => {
   const { result } = props;
 
   return (
-    <StyledTableRow ariaLabel={result.label} data-qa-result-row={result.label}>
+    <StyledTableRow data-qa-result-row={result.label}>
       <StyledLabelTableCell>
         <StyledLink title={result.label} to={result.data.path}>
           {result.label}

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/StackScriptSelectionRow.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/StackScriptSelectionRow.tsx
@@ -93,7 +93,7 @@ export class StackScriptSelectionRow extends React.Component<
     };
 
     return (
-      <TableRow ariaLabel={label} data-qa-table-row={label}>
+      <TableRow data-qa-table-row={label}>
         <TableCell>
           <Radio
             checked={!disabled && checked}

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
@@ -78,7 +78,7 @@ export const StackScriptRow = (props: Props) => {
   };
 
   return (
-    <StyledTableRow ariaLabel={label} data-qa-table-row={label}>
+    <StyledTableRow data-qa-table-row={label}>
       <StyledTitleTableCell data-qa-stackscript-title>
         {renderLabel()}
       </StyledTitleTableCell>

--- a/packages/manager/src/features/Support/SupportTickets/TicketRow.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/TicketRow.tsx
@@ -45,7 +45,6 @@ export const TicketRow = ({ ticket }: Props) => {
 
   return (
     <TableRow
-      ariaLabel={`Ticket subject ${ticketSummary}`}
       data-qa-support-ticket={ticket.id}
       data-testid="ticket-row"
       key={`ticket-${ticket.id}`}

--- a/packages/manager/src/features/Users/UserRow.tsx
+++ b/packages/manager/src/features/Users/UserRow.tsx
@@ -36,7 +36,7 @@ export const UserRow = ({ onDelete, user }: Props) => {
     flags.parentChildAccountAccess && profile?.user_type === 'parent';
 
   return (
-    <TableRow ariaLabel={`User ${user.username}`} key={user.username}>
+    <TableRow key={user.username}>
       <TableCell>
         <Stack alignItems="center" direction="row" spacing={1.5}>
           <GravatarByEmail email={user.email} />

--- a/packages/manager/src/features/Users/UserRow.tsx
+++ b/packages/manager/src/features/Users/UserRow.tsx
@@ -36,7 +36,7 @@ export const UserRow = ({ onDelete, user }: Props) => {
     flags.parentChildAccountAccess && profile?.user_type === 'parent';
 
   return (
-    <TableRow key={user.username}>
+    <TableRow data-qa-table-row={user.username} key={user.username}>
       <TableCell>
         <Stack alignItems="center" direction="row" spacing={1.5}>
           <GravatarByEmail email={user.email} />

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
@@ -1,8 +1,8 @@
 import { APIError, Firewall, Linode } from '@linode/api-v4';
 import { Config, Interface } from '@linode/api-v4/lib/linodes/types';
 import ErrorOutline from '@mui/icons-material/ErrorOutline';
-import * as React from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import * as React from 'react';
 
 import { Box } from 'src/components/Box';
 import { CircleProgress } from 'src/components/CircleProgress';

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCRow.tsx
@@ -37,11 +37,7 @@ export const VPCRow = ({ handleDeleteVPC, handleEditVPC, vpc }: Props) => {
   ];
 
   return (
-    <TableRow
-      ariaLabel={`VPC ${label}`}
-      data-qa-vpc-id={id}
-      key={`vpc-row-${id}`}
-    >
+    <TableRow data-qa-vpc-id={id} key={`vpc-row-${id}`}>
       <TableCell>
         <Link to={`/vpcs/${id}`}>{label}</Link>
       </TableCell>


### PR DESCRIPTION
## Description 📝
While aria-label can be used on any element that can have an accessible name, in practice however, it is supported only on interactive elements, [widgets](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles#2._widget_roles), [landmarks](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles#3._landmark_roles), images, and iframes.

While aria-label can be used on any element that has an accessible name, it's best supported for interactive elements, widgets, landmarks, images, and iframes. In general, it shouldn't be used on static content. Using aria-label on non-interactive elements **can cause a confusing user experience or the label may not be announced by assistive technology.** For example, Microsoft's screen reader, JAWS, ignores aria-label on all static content except for content with “an interactive role, img role, or nav, main, search roles”. 

also: https://stackoverflow.com/questions/72568204/what-can-aria-label-be-used-on

In the case of our table rows, having an aria label dos not really make sense:
- Our tables already have accessible elements, which is encouraged albeit not being technically interactive 
> `aria-label`, `aria-labelledby` and `aria-describedby` work well on `table`, `th` and `td` elements with a few exceptions for NVDA, VoiceOver on iOS, and Talkback discussed in next section. 
see this [link](https://www.w3.org/TR/using-aria/#practical-support-aria-label-aria-labelledby-and-aria-describedby)
- all we were doing (which this PR removes) is taking the label in the first column and use it as an aria label on the row. The table context provides enough accessibility with the table header and its content.

## Changes  🔄
- Remove `ariaLabel` on `<TableRow />`
- Update components passing the prop

## Preview 📷
No visual changes should be expected as part of this PR

## How to test 🧪

### Verification steps
- There isn't much to verify here, except that our tests pass and the tag was properly removed from the rows affected by this PR

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [x] ♿  Providing accessibility support
