### PR TITLE
fix: [M3-8112] - Reset errors in PlacementGroupDeleteModal

### DIFF
--- a/packages/manager/.changeset/pr-10486-upcoming-features-1716217159383.md
+++ b/packages/manager/.changeset/pr-10486-upcoming-features-1716217159383.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Reset errors in PlacementGroupDeleteModal ([#10486](https://github.com/linode/manager/pull/10486))

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDeleteModal.tsx
@@ -45,10 +45,12 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
     error: deletePlacementError,
     isLoading: deletePlacementLoading,
     mutateAsync: deletePlacementGroup,
+    reset: resetDeletePlacementGroup,
   } = useDeletePlacementGroup(selectedPlacementGroup?.id ?? -1);
   const {
     error: unassignLinodeError,
     mutateAsync: unassignLinodes,
+    reset: resetUnassignLinodes,
   } = useUnassignLinodesFromPlacementGroup(selectedPlacementGroup?.id ?? -1);
   const [assignedLinodes, setAssignedLinodes] = React.useState<
     Linode[] | undefined
@@ -85,6 +87,12 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
         variant: 'success',
       }
     );
+    handleClose();
+  };
+
+  const handleClose = () => {
+    resetDeletePlacementGroup();
+    resetUnassignLinodes();
     onClose();
   };
 
@@ -108,7 +116,7 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
             width: 500,
           },
         }}
-        onClose={onClose}
+        onClose={handleClose}
         open={open}
         title="Delete Placement Group"
       >
@@ -130,7 +138,7 @@ export const PlacementGroupsDeleteModal = (props: Props) => {
       label="Placement Group"
       loading={deletePlacementLoading}
       onClick={onDelete}
-      onClose={onClose}
+      onClose={handleClose}
       open={open}
       title={`Delete Placement Group ${selectedPlacementGroup.label}`}
     >


### PR DESCRIPTION
## Description 📝
In the `PlacementGroupDeleteModal`, API error messages are persisting when encountering an error, closing the dialog and reopening it. This PR resets error messages on Close so the user the does see then when reopening the modal

## Changes  🔄
- Reset delete and unassign queries errors on modal close

## Preview 📷
![Screen Shot 2024-05-20 at 10 54 09](https://github.com/linode/manager/assets/130582365/f1ef07b0-644d-4b38-88d2-0cdda965ef8f)

## How to test 🧪

### Prerequisites
- ℹ️ test in ALPHA
- have at least one placement group created

### Verification steps
- Navigate to http://localhost:3000/placement-groups/delete/{your placement group ID}
- In your network tab, block network request for `DELETE | https://api.dev.linode.com/v4/placement/groups/`
- Click on the "Delete" button
- Confirm "An unexpected error occurred." error message in dialog
- Close dialog
- Reopen by clicking on "Delete" for the same PG in the table row
- Confirm error is no longer in the modal (was without the fix) 

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support


