### PR TITLE
fix: [M3-8067] - Remove duplicate speedtest helper text in Create Cluster form

### DIFF
--- a/packages/manager/.changeset/pr-10490-fixed-1716227619276.md
+++ b/packages/manager/.changeset/pr-10490-fixed-1716227619276.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Duplicate speedtest helper text in Create Cluster form ([#10490](https://github.com/linode/manager/pull/10490))

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -232,7 +232,6 @@ export const CreateCluster = () => {
                 regions={regionsData}
                 selectedId={selectedId}
               />
-              <RegionHelperText sx={{ marginTop: 1 }} />
             </Stack>
             <StyledDocsLinkContainer>
               <DocsLink


### PR DESCRIPTION
## Description 📝
We ended up with two speedtext helper texts displaying on the LKE Create Cluster form. I'm not entirely sure why this happened, but I think it was a combination of deciding where to place the helper text in this form once the pricing link was added *and* changes to RegionSelect and/or Autocomplete that made the helper text show up where it should be, when it wasn't originally due to some bug.

## Changes  🔄
- Removed one of the helper texts. 

## Target release date 🗓️
05/28

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-05-20 at 10 55 29 AM](https://github.com/linode/manager/assets/114685994/ebf99bc0-7159-4df9-bafa-aa6ee25be607) ![Screenshot 2024-05-20 at 10 55 15 AM](https://github.com/linode/manager/assets/114685994/a16f6718-f1cc-4944-8774-38ddb656fdd4) | ![Screenshot 2024-05-20 at 10 54 40 AM](https://github.com/linode/manager/assets/114685994/f6cd5769-f4ac-4583-b488-e43774bcb6a5) ![Screenshot 2024-05-20 at 10 54 54 AM](https://github.com/linode/manager/assets/114685994/642c1bea-03fd-47b4-85b5-3479f52138cc) |


## How to test 🧪

### Reproduction steps
(How to reproduce the issue, if applicable)
- Go to https://cloud.linode.com/kubernetes/create.
- Observe that under the Region selection, you can see helper text about the speedtest both above and below the select field. 

### Verification steps
(How to verify changes)
- Go to http://localhost:3000/kubernetes/create. 
- Observe that under the Region section, you can only see helper text about the speed test above the select field. 

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

