### PR TITLE
fix: [M3-8124] - `RegionSelect` unexpected keyboard behavior

### DIFF
--- a/packages/manager/src/components/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.tsx
@@ -112,12 +112,6 @@ export const RegionSelect = React.memo((props: RegionSelectProps) => {
         onChange={(_, selectedOption: RegionSelectOption) => {
           handleRegionChange(selectedOption);
         }}
-        onKeyDown={(e) => {
-          if (e.key !== 'Tab') {
-            setSelectedRegion(null);
-            handleRegionChange(null);
-          }
-        }}
         renderOption={(props, option) => {
           return (
             <RegionOption


### PR DESCRIPTION
## Description 📝

Removes one-off `onKeyDown` logic from the `RegionSelect` to fixe unexpected keyboard behavior

### Expected Behavior ✅ 
- Pressing esc should close the popover (not clear the value)
- Pressing enter should not clear the value

### Actual Behavior ❌ 
- Pressing esc clears the value
- Pressing enter clears the value

Basically, any keypress clears the input

## How to test 🧪

- Go to the Linode Create flow (v1 or v2 is fine)
- Test the RegionSelect
- Verify the RegionSelect feels ergonomic and works as you'd expect

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support