### PR TITLE
refactor: [M3-8128] - Query Key Factory for Support Tickets

### DIFF
--- a/packages/manager/.changeset/pr-10496-tech-stories-1716315886330.md
+++ b/packages/manager/.changeset/pr-10496-tech-stories-1716315886330.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Query Key Factory for Support Tickets ([#10496](https://github.com/linode/manager/pull/10496))

--- a/packages/manager/cypress/e2e/core/helpAndSupport/open-support-ticket.spec.ts
+++ b/packages/manager/cypress/e2e/core/helpAndSupport/open-support-ticket.spec.ts
@@ -75,7 +75,6 @@ describe('help & support', () => {
 
       // intercept create ticket request, stub response.
       mockCreateSupportTicket(mockTicketData).as('createTicket');
-      mockGetSupportTicket(mockTicketData).as('getTicket');
       mockGetSupportTicketReplies(ticketId, []).as('getReplies');
       mockAttachSupportTicketFile(ticketId).as('attachmentPost');
 
@@ -94,7 +93,6 @@ describe('help & support', () => {
       cy.wait('@createTicket').its('response.statusCode').should('eq', 200);
       cy.wait('@attachmentPost').its('response.statusCode').should('eq', 200);
       cy.wait('@getReplies').its('response.statusCode').should('eq', 200);
-      cy.wait('@getTicket').its('response.statusCode').should('eq', 200);
 
       containsVisible(`#${ticketId}: ${ticketLabel}`);
       containsVisible(ticketDescription);

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDialog.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDialog.tsx
@@ -1,8 +1,4 @@
-import {
-  TicketSeverity,
-  createSupportTicket,
-  uploadAttachment,
-} from '@linode/api-v4/lib/support';
+import { TicketSeverity, uploadAttachment } from '@linode/api-v4/lib/support';
 import { APIError } from '@linode/api-v4/lib/types';
 import { Theme } from '@mui/material/styles';
 import { update } from 'ramda';
@@ -27,6 +23,7 @@ import { useAllFirewallsQuery } from 'src/queries/firewalls';
 import { useAllKubernetesClustersQuery } from 'src/queries/kubernetes';
 import { useAllLinodesQuery } from 'src/queries/linodes/linodes';
 import { useAllNodeBalancersQuery } from 'src/queries/nodebalancers';
+import { useCreateSupportTicketMutation } from 'src/queries/support';
 import { useAllVolumesQuery } from 'src/queries/volumes/volumes';
 import {
   getAPIErrorOrDefault,
@@ -219,6 +216,8 @@ export const SupportTicketDialog = (props: SupportTicketDialogProps) => {
     publicInfo: '',
     useCase: '',
   });
+
+  const { mutateAsync: createSupportTicket } = useCreateSupportTicketMutation();
 
   const [files, setFiles] = React.useState<FileAttachment[]>([]);
 

--- a/packages/manager/src/queries/support.ts
+++ b/packages/manager/src/queries/support.ts
@@ -8,6 +8,7 @@ import {
   getTicketReplies,
   getTickets,
 } from '@linode/api-v4/lib/support';
+import { createQueryKeys } from '@lukemorales/query-key-factory';
 import {
   useInfiniteQuery,
   useMutation,
@@ -24,54 +25,98 @@ import type {
   ResourcePage,
 } from '@linode/api-v4/lib/types';
 
-const queryKey = `tickets`;
+const supportQueries = createQueryKeys('support', {
+  ticket: (id: number) => ({
+    contextQueries: {
+      replies: {
+        queryFn: ({ pageParam }) =>
+          getTicketReplies(id, { page: pageParam, page_size: 25 }),
+        queryKey: null,
+      },
+    },
+    queryFn: () => getTicket(id),
+    queryKey: [id],
+  }),
+  tickets: (params: Params, filter: Filter) => ({
+    queryFn: () => getTickets(params, filter),
+    queryKey: [params, filter],
+  }),
+});
 
 export const useSupportTicketsQuery = (params: Params, filter: Filter) =>
-  useQuery<ResourcePage<SupportTicket>, APIError[]>(
-    [queryKey, 'paginated', params, filter],
-    () => getTickets(params, filter),
-    { keepPreviousData: true }
-  );
+  useQuery<ResourcePage<SupportTicket>, APIError[]>({
+    ...supportQueries.tickets(params, filter),
+    keepPreviousData: true,
+  });
 
 export const useSupportTicketQuery = (id: number) =>
-  useQuery<SupportTicket, APIError[]>([queryKey, 'ticket', id], () =>
-    getTicket(id)
-  );
+  useQuery<SupportTicket, APIError[]>(supportQueries.ticket(id));
 
 export const useInfiniteSupportTicketRepliesQuery = (id: number) =>
-  useInfiniteQuery<ResourcePage<SupportReply>, APIError[]>(
-    [queryKey, 'ticket', id, 'replies'],
-    ({ pageParam }) => getTicketReplies(id, { page: pageParam, page_size: 25 }),
-    {
-      getNextPageParam: ({ page, pages }) => {
-        if (page === pages) {
-          return undefined;
-        }
-        return page + 1;
-      },
-    }
-  );
+  useInfiniteQuery<ResourcePage<SupportReply>, APIError[]>({
+    ...supportQueries.ticket(id)._ctx.replies,
+    getNextPageParam: ({ page, pages }) => {
+      if (page === pages) {
+        return undefined;
+      }
+      return page + 1;
+    },
+  });
 
 export const useSupportTicketReplyMutation = () => {
   const queryClient = useQueryClient();
-  return useMutation<SupportReply, APIError[], ReplyRequest>(createReply, {
-    onSuccess() {
-      queryClient.invalidateQueries([queryKey]);
+  return useMutation<SupportReply, APIError[], ReplyRequest>({
+    mutationFn: createReply,
+    onSuccess(data, variables) {
+      queryClient.invalidateQueries({
+        queryKey: supportQueries.tickets._def,
+      });
+      queryClient.invalidateQueries({
+        queryKey: supportQueries.ticket(variables.ticket_id).queryKey,
+      });
     },
   });
 };
 
 export const useSupportTicketCloseMutation = (id: number) => {
   const queryClient = useQueryClient();
-  return useMutation<{}, APIError[]>(() => closeSupportTicket(id), {
+  return useMutation<{}, APIError[]>({
+    mutationFn: () => closeSupportTicket(id),
     onSuccess() {
-      queryClient.invalidateQueries([queryKey]);
+      queryClient.invalidateQueries({
+        queryKey: supportQueries.tickets._def,
+      });
+      queryClient.invalidateQueries({
+        queryKey: supportQueries.ticket(id).queryKey,
+      });
     },
   });
 };
 
 export const supportTicketEventHandler = ({
+  event,
   queryClient,
 }: EventHandlerData) => {
-  queryClient.invalidateQueries([queryKey]);
+  /**
+   * Ticket events have entities that look like this:
+   *
+   * "entity": {
+   *   "label": "Great news! We're upgrading your Block Storage",
+   *   "id": 3674063,
+   *   "type": "ticket",
+   *   "url": "/v4/support/tickets/3674063"
+   * }
+   */
+
+  // Invalidate paginated support tickets
+  queryClient.invalidateQueries({
+    queryKey: supportQueries.tickets._def,
+  });
+
+  if (event.entity) {
+    // If there is an entity associated with the event, invalidate that ticket
+    queryClient.invalidateQueries({
+      queryKey: supportQueries.ticket(event.entity.id).queryKey,
+    });
+  }
 };

--- a/packages/manager/src/queries/support.ts
+++ b/packages/manager/src/queries/support.ts
@@ -7,6 +7,8 @@ import {
   getTicket,
   getTicketReplies,
   getTickets,
+  createSupportTicket,
+  TicketRequest,
 } from '@linode/api-v4/lib/support';
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 import {
@@ -51,6 +53,21 @@ export const useSupportTicketsQuery = (params: Params, filter: Filter) =>
 
 export const useSupportTicketQuery = (id: number) =>
   useQuery<SupportTicket, APIError[]>(supportQueries.ticket(id));
+
+export const useCreateSupportTicketMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<SupportTicket, APIError[], TicketRequest>({
+    mutationFn: createSupportTicket,
+    onSuccess(ticket) {
+      queryClient.invalidateQueries({ queryKey: supportQueries.tickets._def });
+      queryClient.setQueryData<SupportTicket>(
+        supportQueries.ticket(ticket.id).queryKey,
+        ticket
+      );
+    },
+  });
+};
 
 export const useInfiniteSupportTicketRepliesQuery = (id: number) =>
   useInfiniteQuery<ResourcePage<SupportReply>, APIError[]>({


### PR DESCRIPTION
## Description 📝

Updates Support Ticket Queries to use a query key factory and latest patterns

## Changes  🔄
- Uses query key factory for support ticket queries 🏭 
- Uses v5 compatible patterns to make upgrading easier in the future 📦  (see [here](https://tanstack.com/query/v5/docs/framework/react/guides/migrating-to-v5#supports-a-single-signature-one-object))
- Updates mutation handles to be a bit more optimized with the invalidations  🔁

## Preview 📷

> [!note]
> No UI changes

![Screenshot 2024-05-21 at 2 07 24 PM](https://github.com/linode/manager/assets/115251059/44383c1f-e1e7-4b51-9f1c-8e23d698ae10)

## How to test 🧪

> [!warning]
> I recommend testing this in dev so that our support team does not get test tickets coming in

- Test support tickets in general
- Test creating a Support Ticket
  - Verify cache updates as expected 
- Test adding a comment to a support ticket
  - Verify cache updates as expected

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support