### PR TITLE
refactor: [M3-8130] - Query Key Factory for Databases

### DIFF
--- a/packages/api-v4/.changeset/pr-10503-added-1716386367795.md
+++ b/packages/api-v4/.changeset/pr-10503-added-1716386367795.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Added
+---
+
+`members` to `DatabaseInstance` and `Database` types ([#10503](https://github.com/linode/manager/pull/10503))

--- a/packages/api-v4/.changeset/pr-10503-changed-1716386563929.md
+++ b/packages/api-v4/.changeset/pr-10503-changed-1716386563929.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Changed
+---
+
+Update return type of `updateDatabase` to be `Database` ([#10503](https://github.com/linode/manager/pull/10503))

--- a/packages/api-v4/src/databases/databases.ts
+++ b/packages/api-v4/src/databases/databases.ts
@@ -22,7 +22,6 @@ import {
   Engine,
   SSLFields,
   UpdateDatabasePayload,
-  UpdateDatabaseResponse,
 } from './types';
 
 /**
@@ -153,7 +152,7 @@ export const updateDatabase = (
   databaseID: number,
   data: UpdateDatabasePayload
 ) =>
-  Request<UpdateDatabaseResponse>(
+  Request<Database>(
     setURL(
       `${API_ROOT}/databases/${encodeURIComponent(
         engine

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -61,6 +61,8 @@ export interface SSLFields {
   ca_certificate: string;
 }
 
+type MemberType = 'primary' | 'failover';
+
 // DatabaseInstance is the interface for the shape of data returned by the /databases/instances endpoint.
 export interface DatabaseInstance {
   id: number;
@@ -75,6 +77,10 @@ export interface DatabaseInstance {
   created: string;
   instance_uri: string;
   hosts: DatabaseHosts;
+  /**
+   * A key/value object where the key is an IP address and the value is a member type.
+   */
+  members: Record<string, MemberType>;
 }
 
 export type ClusterSize = 1 | 3;
@@ -139,6 +145,10 @@ export interface BaseDatabase {
    * It may not be defined.
    */
   used_disk_size_gb?: number;
+  /**
+   * A key/value object where the key is an IP address and the value is a member type.
+   */
+  members: Record<string, MemberType>;
 }
 
 export interface MySQLDatabase extends BaseDatabase {
@@ -182,4 +192,3 @@ export interface UpdateDatabasePayload {
   updates?: UpdatesSchedule;
   type?: string;
 }
-

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -183,7 +183,3 @@ export interface UpdateDatabasePayload {
   type?: string;
 }
 
-export interface UpdateDatabaseResponse {
-  label: string;
-  allow_list: string[];
-}

--- a/packages/manager/.changeset/pr-10503-tech-stories-1716386590480.md
+++ b/packages/manager/.changeset/pr-10503-tech-stories-1716386590480.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Query Key Factory for Databases ([#10503](https://github.com/linode/manager/pull/10503))

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -150,6 +150,9 @@ export const databaseInstanceFactory = Factory.Sync.makeFactory<DatabaseInstance
     id: Factory.each((i) => i),
     instance_uri: '',
     label: Factory.each((i) => `database-${i}`),
+    members: {
+      '2.2.2.2': 'primary',
+    },
     region: 'us-east',
     status: Factory.each(() => pickRandom(possibleStatuses)),
     type: databaseTypeFactory.build().id,
@@ -176,6 +179,9 @@ export const databaseFactory = Factory.Sync.makeFactory<Database>({
   },
   id: Factory.each((i) => i),
   label: Factory.each((i) => `database-${i}`),
+  members: {
+    '2.2.2.2': 'primary',
+  },
   port: 3306,
   region: 'us-east',
   ssl_connection: false,

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -50,7 +50,7 @@ import {
   useCreateDatabaseMutation,
   useDatabaseEnginesQuery,
   useDatabaseTypesQuery,
-} from 'src/queries/databases';
+} from 'src/queries/databases/databases';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { formatStorageUnits } from 'src/utilities/formatStorageUnits';
 import { handleAPIErrors } from 'src/utilities/formikErrorUtils';

--- a/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
@@ -14,7 +14,7 @@ import { TableBody } from 'src/components/TableBody';
 import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
 import { Typography } from 'src/components/Typography';
-import { useDatabaseMutation } from 'src/queries/databases';
+import { useDatabaseMutation } from 'src/queries/databases/databases';
 import { ExtendedIP, stringToExtendedIP } from 'src/utilities/ipUtils';
 
 import AddAccessControlDrawer from './AddAccessControlDrawer';

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -17,7 +17,7 @@ import { useOrder } from 'src/hooks/useOrder';
 import {
   useDatabaseBackupsQuery,
   useDatabaseQuery,
-} from 'src/queries/databases';
+} from 'src/queries/databases/databases';
 
 import RestoreFromBackupDialog from './RestoreFromBackupDialog';
 import { BackupTableRow } from './DatabaseBackupTableRow';

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/RestoreFromBackupDialog.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/RestoreFromBackupDialog.tsx
@@ -7,7 +7,7 @@ import { DialogProps } from 'src/components/Dialog/Dialog';
 import { Notice } from 'src/components/Notice/Notice';
 import { TypeToConfirmDialog } from 'src/components/TypeToConfirmDialog/TypeToConfirmDialog';
 import { Typography } from 'src/components/Typography';
-import { useRestoreFromBackupMutation } from 'src/queries/databases';
+import { useRestoreFromBackupMutation } from 'src/queries/databases/databases';
 import { useProfile } from 'src/queries/profile';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { formatDate } from 'src/utilities/formatDate';

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.tsx
@@ -18,8 +18,8 @@ import { TypeToConfirmDialog } from 'src/components/TypeToConfirmDialog/TypeToCo
 import { Typography } from 'src/components/Typography';
 import { PlanSelectionType } from 'src/features/components/PlansPanel/types';
 import { typeLabelDetails } from 'src/features/Linodes/presentation';
-import { useDatabaseTypesQuery } from 'src/queries/databases';
-import { useDatabaseMutation } from 'src/queries/databases';
+import { useDatabaseTypesQuery } from 'src/queries/databases/databases';
+import { useDatabaseMutation } from 'src/queries/databases/databases';
 import { formatStorageUnits } from 'src/utilities/formatStorageUnits';
 
 import {

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResizeCurrentConfiguration.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResizeCurrentConfiguration.tsx
@@ -11,7 +11,7 @@ import { Box } from 'src/components/Box';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { TooltipIcon } from 'src/components/TooltipIcon';
-import { useDatabaseTypesQuery } from 'src/queries/databases';
+import { useDatabaseTypesQuery } from 'src/queries/databases/databases';
 import { useInProgressEvents } from 'src/queries/events/events';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { formatStorageUnits } from 'src/utilities/formatStorageUnits';

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsDeleteClusterDialog.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsDeleteClusterDialog.tsx
@@ -6,7 +6,7 @@ import { useHistory } from 'react-router-dom';
 import { Notice } from 'src/components/Notice/Notice';
 import { TypeToConfirmDialog } from 'src/components/TypeToConfirmDialog/TypeToConfirmDialog';
 import { Typography } from 'src/components/Typography';
-import { useDeleteDatabaseMutation } from 'src/queries/databases';
+import { useDeleteDatabaseMutation } from 'src/queries/databases/databases';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 interface Props {

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsResetPasswordDialog.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsResetPasswordDialog.tsx
@@ -5,7 +5,7 @@ import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
 import { Notice } from 'src/components/Notice/Notice';
 import { Typography } from 'src/components/Typography';
-import { useDatabaseCredentialsMutation } from 'src/queries/databases';
+import { useDatabaseCredentialsMutation } from 'src/queries/databases/databases';
 
 interface Props {
   databaseEngine: Engine;

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/MaintenanceWindow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/MaintenanceWindow.tsx
@@ -17,7 +17,7 @@ import { Typography } from 'src/components/Typography';
 import { FormControl } from 'src/components/FormControl';
 import { FormControlLabel } from 'src/components/FormControlLabel';
 import { RadioGroup } from 'src/components/RadioGroup';
-import { useDatabaseMutation } from 'src/queries/databases';
+import { useDatabaseMutation } from 'src/queries/databases/databases';
 
 // import { updateDatabaseSchema } from '@linode/validation/src/databases.schema';
 

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.tsx
@@ -11,7 +11,7 @@ import { makeStyles } from 'tss-react/mui';
 import { Box } from 'src/components/Box';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
-import { useDatabaseTypesQuery } from 'src/queries/databases';
+import { useDatabaseTypesQuery } from 'src/queries/databases/databases';
 import { useInProgressEvents } from 'src/queries/events/events';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { formatStorageUnits } from 'src/utilities/formatStorageUnits';

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -14,7 +14,7 @@ import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
 import { DB_ROOT_USERNAME } from 'src/constants';
-import { useDatabaseCredentialsQuery } from 'src/queries/databases';
+import { useDatabaseCredentialsQuery } from 'src/queries/databases/databases';
 import { downloadFile } from 'src/utilities/downloadFile';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 

--- a/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
@@ -17,7 +17,7 @@ import {
   useDatabaseMutation,
   useDatabaseQuery,
   useDatabaseTypesQuery,
-} from 'src/queries/databases';
+} from 'src/queries/databases/databases';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 const DatabaseSummary = React.lazy(() => import('./DatabaseSummary'));

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -15,7 +15,7 @@ import { TableRow } from 'src/components/TableRow';
 import { TableSortCell } from 'src/components/TableSortCell';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
-import { useDatabasesQuery } from 'src/queries/databases';
+import { useDatabasesQuery } from 'src/queries/databases/databases';
 import { useInProgressEvents } from 'src/queries/events/events';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { DatabaseEmptyState } from './DatabaseEmptyState';

--- a/packages/manager/src/features/Databases/utilities.ts
+++ b/packages/manager/src/features/Databases/utilities.ts
@@ -1,5 +1,5 @@
 import { useAccount } from 'src/queries/account/account';
-import { useDatabaseEnginesQuery } from 'src/queries/databases';
+import { useDatabaseEnginesQuery } from 'src/queries/databases/databases';
 
 /**
  * A hook to determine if Databases should be visible to the user.

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDialog.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDialog.tsx
@@ -21,7 +21,7 @@ import { EntityForTicketDetails } from 'src/components/SupportLink/SupportLink';
 import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
 import { useAccount } from 'src/queries/account/account';
-import { useAllDatabasesQuery } from 'src/queries/databases';
+import { useAllDatabasesQuery } from 'src/queries/databases/databases';
 import { useAllDomainsQuery } from 'src/queries/domains';
 import { useAllFirewallsQuery } from 'src/queries/firewalls';
 import { useAllKubernetesClustersQuery } from 'src/queries/kubernetes';

--- a/packages/manager/src/hooks/useEventHandlers.ts
+++ b/packages/manager/src/hooks/useEventHandlers.ts
@@ -1,7 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 
 import { oauthClientsEventHandler } from 'src/queries/account/oauth';
-import { databaseEventsHandler } from 'src/queries/databases';
+import { databaseEventsHandler } from 'src/queries/databases/events';
 import { domainEventsHandler } from 'src/queries/domains';
 import { firewallEventsHandler } from 'src/queries/firewalls';
 import { imageEventsHandler } from 'src/queries/images';

--- a/packages/manager/src/queries/databases/databases.ts
+++ b/packages/manager/src/queries/databases/databases.ts
@@ -51,11 +51,7 @@ export const databaseQueries = createQueryKeys('databases', {
     queryFn: () => getEngineDatabase(engine, id),
     queryKey: [engine, id],
   }),
-  engines: {
-    queryFn: getAllDatabaseEngines,
-    queryKey: null,
-  },
-  lists: {
+  databases: {
     contextQueries: {
       all: {
         queryFn: getAllDatabases,
@@ -66,6 +62,10 @@ export const databaseQueries = createQueryKeys('databases', {
         queryKey: [params, filter],
       }),
     },
+    queryKey: null,
+  },
+  engines: {
+    queryFn: getAllDatabaseEngines,
     queryKey: null,
   },
   types: {
@@ -86,7 +86,7 @@ export const useDatabaseQuery = (engine: Engine, id: number) =>
 
 export const useDatabasesQuery = (params: Params, filter: Filter) =>
   useQuery<ResourcePage<DatabaseInstance>, APIError[]>({
-    ...databaseQueries.lists._ctx.paginated(params, filter),
+    ...databaseQueries.databases._ctx.paginated(params, filter),
     keepPreviousData: true,
     // @TODO Consider removing polling
     refetchInterval: 20000,
@@ -94,7 +94,7 @@ export const useDatabasesQuery = (params: Params, filter: Filter) =>
 
 export const useAllDatabasesQuery = (enabled: boolean = true) =>
   useQuery<DatabaseInstance[], APIError[]>({
-    ...databaseQueries.lists._ctx.all,
+    ...databaseQueries.databases._ctx.all,
     enabled,
   });
 
@@ -104,7 +104,7 @@ export const useDatabaseMutation = (engine: Engine, id: number) => {
     mutationFn: (data) => updateDatabase(engine, id, data),
     onSuccess(database) {
       queryClient.invalidateQueries({
-        queryKey: databaseQueries.lists.queryKey,
+        queryKey: databaseQueries.databases.queryKey,
       });
       queryClient.setQueryData<Database>(
         databaseQueries.database(engine, id).queryKey,
@@ -121,7 +121,7 @@ export const useCreateDatabaseMutation = () => {
       createDatabase(data.engine?.split('/')[0] as Engine, data),
     onSuccess(database) {
       queryClient.invalidateQueries({
-        queryKey: databaseQueries.lists.queryKey,
+        queryKey: databaseQueries.databases.queryKey,
       });
       queryClient.setQueryData<Database>(
         databaseQueries.database(database.engine, database.id).queryKey,
@@ -139,7 +139,7 @@ export const useDeleteDatabaseMutation = (engine: Engine, id: number) => {
     mutationFn: () => deleteDatabase(engine, id),
     onSuccess() {
       queryClient.invalidateQueries({
-        queryKey: databaseQueries.lists.queryKey,
+        queryKey: databaseQueries.databases.queryKey,
       });
       queryClient.removeQueries({
         queryKey: databaseQueries.database(engine, id).queryKey,
@@ -200,7 +200,7 @@ export const useRestoreFromBackupMutation = (
     mutationFn: () => restoreWithBackup(engine, databaseId, backupId),
     onSuccess() {
       queryClient.invalidateQueries({
-        queryKey: databaseQueries.lists.queryKey,
+        queryKey: databaseQueries.databases.queryKey,
       });
       queryClient.invalidateQueries({
         queryKey: databaseQueries.database(engine, databaseId).queryKey,

--- a/packages/manager/src/queries/databases/events.ts
+++ b/packages/manager/src/queries/databases/events.ts
@@ -1,0 +1,42 @@
+import { getEngineFromDatabaseEntityURL } from 'src/utilities/getEventsActionLink';
+
+import { databaseQueries } from './databases';
+
+import type { Engine } from '@linode/api-v4';
+import type { EventHandlerData } from 'src/hooks/useEventHandlers';
+
+export const databaseEventsHandler = ({
+  event,
+  queryClient,
+}: EventHandlerData) => {
+  if (['failed', 'finished', 'notification'].includes(event.status)) {
+    queryClient.invalidateQueries({ queryKey: databaseQueries.lists.queryKey });
+
+    /**
+     * This is what a Database event entity looks like:
+     *
+     * "entity": {
+     *   "label": "my-db-staging",
+     *   "id": 2959,
+     *   "type": "database",
+     *   "url": "/v4/databases/postgresql/instances/2959"
+     * },
+     */
+    if (event.entity) {
+      const engine = getEngineFromDatabaseEntityURL(event.entity.url);
+
+      if (!engine) {
+        // eslint-disable-next-line no-console
+        return console.warn(
+          'Unable to get DBaaS engine from entity URL in event',
+          event.id
+        );
+      }
+
+      queryClient.invalidateQueries({
+        queryKey: databaseQueries.database(engine as Engine, event.entity.id)
+          .queryKey,
+      });
+    }
+  }
+};

--- a/packages/manager/src/queries/databases/events.ts
+++ b/packages/manager/src/queries/databases/events.ts
@@ -10,7 +10,9 @@ export const databaseEventsHandler = ({
   queryClient,
 }: EventHandlerData) => {
   if (['failed', 'finished', 'notification'].includes(event.status)) {
-    queryClient.invalidateQueries({ queryKey: databaseQueries.lists.queryKey });
+    queryClient.invalidateQueries({
+      queryKey: databaseQueries.databases.queryKey,
+    });
 
     /**
      * This is what a Database event entity looks like:

--- a/packages/manager/src/queries/databases/requests.ts
+++ b/packages/manager/src/queries/databases/requests.ts
@@ -1,0 +1,23 @@
+import {
+  getDatabaseEngines,
+  getDatabaseTypes,
+  getDatabases,
+} from '@linode/api-v4';
+import { DatabaseEngine, DatabaseInstance, DatabaseType } from '@linode/api-v4';
+
+import { getAll } from 'src/utilities/getAll';
+
+export const getAllDatabases = () =>
+  getAll<DatabaseInstance>((params) => getDatabases(params))().then(
+    (data) => data.data
+  );
+
+export const getAllDatabaseEngines = () =>
+  getAll<DatabaseEngine>((params) => getDatabaseEngines(params))().then(
+    (data) => data.data
+  );
+
+export const getAllDatabaseTypes = () =>
+  getAll<DatabaseType>((params) => getDatabaseTypes(params))().then(
+    (data) => data.data
+  );

--- a/packages/manager/src/utilities/getEventsActionLink.test.ts
+++ b/packages/manager/src/utilities/getEventsActionLink.test.ts
@@ -1,0 +1,9 @@
+import { getEngineFromDatabaseEntityURL } from './getEventsActionLink';
+
+describe('getEngineFromDatabaseEntityURL', () => {
+  it('should return an engine from a URL returned by apiv4', () => {
+    expect(
+      getEngineFromDatabaseEntityURL('/v4/databases/postgresql/instances/2959')
+    ).toBe('postgresql');
+  });
+});


### PR DESCRIPTION
## Description 📝

Updates React Query layer of Databases to adapt our latest patterns

## Changes  🔄
- Updates Database queries to use a query key factory 🏭 
- Updates Database queries and mutations to use the "single object notation" (see [here](https://tanstack.com/query/v5/docs/framework/react/guides/migrating-to-v5#supports-a-single-signature-one-object)) in efforts to make updating from v4 to v5 easier 📦 
- Updates some Database responses and types to match what the API actually returns 💡 

## Preview 📷

> [!note]
> No UI changes

## How to test 🧪

- Checkout this PR locally and/or test with the internal preview link 🔗 
- Test Database functionality in general 👀 
  - Verify general cache updates happen as expected. For example, renaming a database should propagate to all screens
- Verify all Database automated testing passes ✅ 

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support