### PR TITLE
test: [M3-7557] - remove console logs from e2e tests

### DIFF
--- a/packages/manager/.changeset/pr-10506-tests-1716399579811.md
+++ b/packages/manager/.changeset/pr-10506-tests-1716399579811.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+remove console logs from e2e tests ([#10506](https://github.com/linode/manager/pull/10506))

--- a/packages/manager/cypress/e2e/core/images/create-linode-from-image.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/create-linode-from-image.spec.ts
@@ -53,8 +53,6 @@ const createLinodeWithImageMock = (url: string, preselectedImage: boolean) => {
 
   cy.wait('@mockLinodeRequest');
 
-  console.log('mockLinode', mockLinode);
-
   fbtVisible(mockLinode.label);
   fbtVisible(region.label);
   fbtVisible(`${mockLinode.id}`);

--- a/packages/manager/cypress/e2e/core/longview/longview.spec.ts
+++ b/packages/manager/cypress/e2e/core/longview/longview.spec.ts
@@ -4,6 +4,7 @@ import { longviewResponseFactory, longviewClientFactory } from 'src/factories';
 import { LongviewResponse } from 'src/features/Longview/request.types';
 import { authenticate } from 'support/api/authentication';
 import {
+  longviewInstallTimeout,
   longviewStatusTimeout,
   longviewEmptyStateMessage,
   longviewAddClientButtonText,
@@ -32,6 +33,31 @@ const linodeCreateTimeout = 90000;
  */
 const getInstallCommand = (installCode: string): string => {
   return `curl -s https://lv.linode.com/${installCode} | sudo bash`;
+};
+
+/**
+ * Installs Longview on a Linode.
+ *
+ * @param linodeIp - IP of Linode on which to install Longview.
+ * @param linodePass - Root password of Linode on which to install Longview.
+ * @param installCommand - Longview installation command.
+ *
+ * @returns Cypress chainable.
+ */
+const installLongview = (
+  linodeIp: string,
+  linodePass: string,
+  installCommand: string
+) => {
+  return cy.exec('./cypress/support/scripts/longview/install-longview.sh', {
+    failOnNonZeroExit: true,
+    timeout: longviewInstallTimeout,
+    env: {
+      LINODEIP: linodeIp,
+      LINODEPASSWORD: linodePass,
+      CURLCOMMAND: installCommand,
+    },
+  });
 };
 
 /**
@@ -109,6 +135,7 @@ describe('longview', () => {
       label: 'Creating Linode and Longview Client...',
       timeout: linodeCreateTimeout,
     }).then(([linode, client]: [Linode, LongviewClient]) => {
+      const linodeIp = linode.ipv4[0];
       const installCommand = getInstallCommand(client.install_code);
 
       interceptGetLongviewClients().as('getLongviewClients');
@@ -126,6 +153,9 @@ describe('longview', () => {
           cy.contains(installCommand).should('be.visible');
           cy.findByText('Waiting for data...');
         });
+
+      // Install Longview on Linode by SSHing into machine and executing cURL command.
+      installLongview(linodeIp, linodePassword, installCommand);
 
       // Wait for Longview to begin serving data and confirm that Cloud Manager
       // UI updates accordingly.


### PR DESCRIPTION
## Description 📝
Some of our Cypress tests have stray calls to console.log and similar functions (console.info, console.error, etc.), and these should be removed.

## Changes  🔄
Remove console.log functions in the spec files (cypress/e2e/*/)

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/longview/longview.spec.ts,cypress/e2e/core/images/create-linode-from-image.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
