### PR TITLE
fix: Linode Create v2 - UDFs

### DIFF
--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFieldInput.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFieldInput.tsx
@@ -35,7 +35,7 @@ export const UserDefinedFieldInput = ({ userDefinedField }: Props) => {
 
   const { field } = useController<CreateLinodeRequest>({
     control,
-    name: `stackscript_data.${userDefinedField.name}` as const,
+    name: `stackscript_data.${userDefinedField.name}`,
   });
 
   const error = formState.errors?.[userDefinedField.name]?.message?.replace(
@@ -84,9 +84,7 @@ export const UserDefinedFieldInput = ({ userDefinedField }: Props) => {
       .oneof!.split(',')
       .map((option) => ({ label: option }));
 
-    const value = options.find((option) => option.label === field.value) ?? {
-      label: userDefinedField.default ?? '',
-    };
+    const value = options.find((option) => option.label === field.value);
 
     if (options.length > 4) {
       return (

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFieldInput.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFieldInput.tsx
@@ -35,7 +35,7 @@ export const UserDefinedFieldInput = ({ userDefinedField }: Props) => {
 
   const { field } = useController<CreateLinodeRequest>({
     control,
-    name: `stackscript_data.${userDefinedField.name}`,
+    name: `stackscript_data.${userDefinedField.name}` as const,
   });
 
   const error = formState.errors?.[userDefinedField.name]?.message?.replace(
@@ -57,8 +57,15 @@ export const UserDefinedFieldInput = ({ userDefinedField }: Props) => {
       .manyof!.split(',')
       .map((option) => ({ label: option }));
 
+    const value = options.filter((option) =>
+      field.value?.split(',').includes(option.label)
+    );
+
     return (
       <Autocomplete
+        onChange={(e, options) => {
+          field.onChange(options.map((option) => option.label).join(','));
+        }}
         textFieldProps={{
           required: isRequired,
         }}
@@ -66,9 +73,8 @@ export const UserDefinedFieldInput = ({ userDefinedField }: Props) => {
         label={userDefinedField.label}
         multiple
         noMarginTop
-        onChange={(e, options) => field.onChange(options.join(','))}
         options={options}
-        value={field.value?.split(',') ?? []}
+        value={value}
       />
     );
   }
@@ -78,6 +84,10 @@ export const UserDefinedFieldInput = ({ userDefinedField }: Props) => {
       .oneof!.split(',')
       .map((option) => ({ label: option }));
 
+    const value = options.find((option) => option.label === field.value) ?? {
+      label: userDefinedField.default ?? '',
+    };
+
     if (options.length > 4) {
       return (
         <Autocomplete
@@ -86,9 +96,9 @@ export const UserDefinedFieldInput = ({ userDefinedField }: Props) => {
           }}
           disableClearable
           label={userDefinedField.label}
-          onChange={(_, option) => field.onChange(option.label)}
+          onChange={(_, option) => field.onChange(option?.label ?? '')}
           options={options}
-          value={options.find((option) => option.label === field.value)}
+          value={value}
         />
       );
     }

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFieldInput.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/StackScripts/UserDefinedFields/UserDefinedFieldInput.tsx
@@ -74,6 +74,8 @@ export const UserDefinedFieldInput = ({ userDefinedField }: Props) => {
         multiple
         noMarginTop
         options={options}
+        // If options are selected, hide the placeholder
+        placeholder={value.length > 0 ? ' ' : undefined}
         value={value}
       />
     );


### PR DESCRIPTION
## Description 📝

Fixes bugs and console errors with Linode Create v2 User Defined Fields 🐛 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/115251059/e0cc6c9a-fda5-49f6-a3cc-d8e58835c6e4" /> | <video src="https://github.com/linode/manager/assets/115251059/98ce6dd1-6311-43d8-83c0-da7da70a2ae2" />  |

## How to test 🧪

### Prerequisites
- Enable the Linode Create v2 flag

### Verification steps
- Test UFDs for various StackScripts or marketplace apps
  - To test a multi-select you can use the `lillq / Apache, MySQL, Ruby Setup` on the community tab

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support