### PR TITLE
fix: [M3-8042] - Firewall landing device request with -1 ID

### DIFF
--- a/packages/manager/.changeset/pr-10509-fixed-1716415172498.md
+++ b/packages/manager/.changeset/pr-10509-fixed-1716415172498.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Firewall landing device request with -1 ID ([#10509](https://github.com/linode/manager/pull/10509))

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallDialog.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallDialog.tsx
@@ -1,11 +1,11 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
-import { useQueryClient } from '@tanstack/react-query';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
-import { queryKey as firewallQueryKey } from 'src/queries/firewalls';
 import { useDeleteFirewall, useMutateFirewall } from 'src/queries/firewalls';
+import { queryKey as firewallQueryKey } from 'src/queries/firewalls';
 import { useAllFirewallDevicesQuery } from 'src/queries/firewalls';
 import { queryKey as linodesQueryKey } from 'src/queries/linodes/linodes';
 import { queryKey as nodebalancerQueryKey } from 'src/queries/nodebalancers';
@@ -17,7 +17,7 @@ interface Props {
   mode: Mode;
   onClose: () => void;
   open: boolean;
-  selectedFirewallId?: number;
+  selectedFirewallId: number;
   selectedFirewallLabel: string;
 }
 
@@ -33,20 +33,18 @@ export const FirewallDialog = React.memo((props: Props) => {
     selectedFirewallLabel: label,
   } = props;
 
-  const { data: devices } = useAllFirewallDevicesQuery(
-    selectedFirewallId ?? -1
-  );
+  const { data: devices } = useAllFirewallDevicesQuery(selectedFirewallId);
 
   const {
     error: updateError,
     isLoading: isUpdating,
     mutateAsync: updateFirewall,
-  } = useMutateFirewall(selectedFirewallId ?? -1);
+  } = useMutateFirewall(selectedFirewallId);
   const {
     error: deleteError,
     isLoading: isDeleting,
     mutateAsync: deleteFirewall,
-  } = useDeleteFirewall(selectedFirewallId ?? -1);
+  } = useDeleteFirewall(selectedFirewallId);
 
   const requestMap = {
     delete: () => deleteFirewall(),

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
@@ -175,13 +175,15 @@ const FirewallLanding = () => {
         onClose={onCloseCreateDrawer}
         open={isCreateFirewallDrawerOpen}
       />
-      <FirewallDialog
-        mode={dialogMode}
-        onClose={() => setIsModalOpen(false)}
-        open={isModalOpen}
-        selectedFirewallId={selectedFirewallId}
-        selectedFirewallLabel={selectedFirewall?.label ?? ''}
-      />
+      {selectedFirewallId && (
+        <FirewallDialog
+          mode={dialogMode}
+          onClose={() => setIsModalOpen(false)}
+          open={isModalOpen}
+          selectedFirewallId={selectedFirewallId}
+          selectedFirewallLabel={selectedFirewall?.label ?? ''}
+        />
+      )}
     </React.Fragment>
   );
 };


### PR DESCRIPTION
## Description 📝
Fix bug where we were trying to fetch devices with an invalid Firewall id

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/115299789/d8f56067-552a-4422-8f8d-7217cd34b0cd) | ![image](https://github.com/linode/manager/assets/115299789/63201a5a-b79a-4a68-ad73-22a4060fd9ea) |

## How to test 🧪
### Reproduction steps
(How to reproduce the issue, if applicable)
- Go to the Firewalls landing page `/firewalls` and observe the devices network request. Notice failed device requests with a -1 firewall id

### Verification steps
(How to verify changes)
- Go to the Firewalls landing page `/firewalls` and observe the devices network request. Notice no more failed device requests

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support