### PR TITLE
fix: Cypress test creating an Image without a `cy-test` prefixed label

### DIFF
--- a/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
@@ -134,6 +134,7 @@ const createLinodeAndImage = async () => {
 
   const image = await createImage({
     disk_id: diskId,
+    label: randomLabel(),
   });
 
   await pollImageStatus(


### PR DESCRIPTION
## Description 📝

- I made a mistake in https://github.com/linode/manager/pull/10471 (specifically [here](https://github.com/linode/manager/pull/10471/files#diff-900b58e628d8181eeabb2f9ad13f1134a69af7ca3573aa1b38a8dd51e089b5faR135-R137))
- I removed the `randomLabel()` from the `createImage` call because at the time, it didn't occur to me that the image label mattered for the sake of the test. I was correct in that sense, but I failed to remember that cypress only cleans up entities that are prefixed with `cy-test` 🤦 . Our test accounts are filling up with Images that are not being cleaned up as a result 😣
- This PR adds back the `randomLabel()` so the image is created with a label that will be cleaned up

## How to test 🧪

- Verify the image created by `create-stackscripts.spec.ts` are prefixed with `cy-test`

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support