### PR TITLE
fix: Delete testing error introduced by mistake

### DIFF
--- a/packages/manager/src/features/Images/ImagesDrawer.tsx
+++ b/packages/manager/src/features/Images/ImagesDrawer.tsx
@@ -93,7 +93,6 @@ export const ImagesDrawer = (props: CombinedProps) => {
         }
 
         updateImage({ description: safeDescription, imageId, label, tags })
-          .then(() => Promise.reject([{ reason: 'Unable to edit Image' }]))
           .then(onClose)
           .catch((errorResponse: APIError[]) => {
             setErrors(


### PR DESCRIPTION
## Description 📝
In #10466 I accidentally committed a `Promise.reject` that was intended to test error handling in `ImagesDrawer`.

## Changes  🔄
- Delete testing error

## How to test 🧪

Verify images can be edited without generating the test error.