### PR TITLE
feat: [M3-7883] - Add search and alphabetical sorting to Switch Account drawer

### DIFF
--- a/packages/manager/.changeset/pr-10515-added-1716569243109.md
+++ b/packages/manager/.changeset/pr-10515-added-1716569243109.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Alphabetical account sorting and search capabilities to Switch Account drawer ([#10515](https://github.com/linode/manager/pull/10515))

--- a/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
+++ b/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
@@ -311,7 +311,7 @@ describe('Parent/Child account switching', () => {
     /*
      * - Confirms search functionality in the account switching drawer.
      */
-    it.only('can search child accounts', () => {
+    it('can search child accounts', () => {
       mockGetProfile(mockParentProfile);
       mockGetAccount(mockParentAccount);
       mockGetChildAccounts([mockChildAccount, mockAlternateChildAccount]);
@@ -349,8 +349,8 @@ describe('Parent/Child account switching', () => {
           cy.findByText(mockAlternateChildAccount.company).should('be.visible');
 
           // Confirm no results message.
-          cy.findByPlaceholderText('Search').click().type('Fake Name');
           mockGetChildAccounts([]).as('getEmptySearchResults');
+          cy.findByPlaceholderText('Search').click().type('Fake Name');
           cy.wait('@getEmptySearchResults');
 
           cy.contains(mockChildAccount.company).should('not.exist');
@@ -359,14 +359,13 @@ describe('Parent/Child account switching', () => {
           ).should('be.visible');
 
           // Confirm filtering by company name displays only one search result.
+          mockGetChildAccounts([mockChildAccount]).as('getSearchResults');
           cy.findByPlaceholderText('Search')
             .click()
             .clear()
             .type(mockChildAccount.company);
-          mockGetChildAccounts([mockChildAccount]).as('getSearchResults');
           cy.wait('@getSearchResults');
 
-          // TODO: Debug - search result isn't reliable. Sometimes shows the no results notice instead of the account.
           cy.findByText(mockChildAccount.company).should('be.visible');
           cy.contains(mockAlternateChildAccount.company).should('not.exist');
           cy.contains(

--- a/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
+++ b/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
@@ -230,6 +230,68 @@ describe('Parent/Child account switching', () => {
     });
 
     /*
+     * - Confirms search functionality in the account switching drawer.
+     */
+    it('can search child accounts', () => {
+      mockGetProfile(mockParentProfile);
+      mockGetAccount(mockParentAccount);
+      mockGetChildAccounts([mockChildAccount, mockAlternateChildAccount]);
+      mockGetUser(mockParentUser);
+
+      cy.visitWithLogin('/');
+      cy.trackPageVisit().as('pageVisit');
+
+      // Confirm that Parent account username and company name are shown in user
+      // menu button, then click the button.
+      assertUserMenuButton(
+        mockParentProfile.username,
+        mockParentAccount.company
+      ).click();
+
+      // Click "Switch Account" button in user menu.
+      ui.userMenu
+        .find()
+        .should('be.visible')
+        .within(() => {
+          ui.button
+            .findByTitle('Switch Account')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      // Confirm search functionality.
+      ui.drawer
+        .findByTitle('Switch Account')
+        .should('be.visible')
+        .within(() => {
+          // Confirm all child accounts are displayed when drawer loads.
+          cy.findByText(mockChildAccount.company).should('be.visible');
+          cy.findByText(mockAlternateChildAccount.company).should('be.visible');
+
+          // Confirm no results message.
+          cy.findByPlaceholderText('Search').click().type('Fake Name');
+          mockGetChildAccounts([]).as('getEmptySearchResults');
+          cy.wait('@getEmptySearchResults');
+          cy.contains(mockChildAccount.company).should('not.exist');
+          cy.findByText(
+            'There are no indirect customer accounts that match this query.'
+          ).should('be.visible');
+
+          // Confirm filtering by company name displays only one search result.
+          cy.findByPlaceholderText('Search')
+            .click()
+            .clear()
+            .type(mockChildAccount.company);
+          mockGetChildAccounts([mockChildAccount]).as('getSearchResults');
+          cy.wait('@getSearchResults');
+
+          cy.findByText(mockChildAccount.company).should('be.visible');
+          cy.contains(mockAlternateChildAccount.company).should('not.exist');
+        });
+    });
+
+    /*
      * - Confirms that Parent account user can switch to Child account using the user menu.
      * - Confirms that Parent account information is initially displayed in user menu button.
      * - Confirms that Child account information is displayed in user menu button after switch.

--- a/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
+++ b/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
@@ -355,7 +355,7 @@ describe('Parent/Child account switching', () => {
 
           cy.contains(mockChildAccount.company).should('not.exist');
           cy.findByText(
-            'There are no indirect customer accounts that match this query.'
+            'There are no child accounts that match this query.'
           ).should('be.visible');
 
           // Confirm filtering by company name displays only one search result.
@@ -369,7 +369,7 @@ describe('Parent/Child account switching', () => {
           cy.findByText(mockChildAccount.company).should('be.visible');
           cy.contains(mockAlternateChildAccount.company).should('not.exist');
           cy.contains(
-            'There are no indirect customer accounts that match this query.'
+            'There are no child accounts that match this query.'
           ).should('not.exist');
         });
     });
@@ -444,9 +444,7 @@ describe('Parent/Child account switching', () => {
         .findByTitle('Switch Account')
         .should('be.visible')
         .within(() => {
-          cy.findByText('There are no indirect customer accounts.').should(
-            'be.visible'
-          );
+          cy.findByText('There are no child accounts.').should('be.visible');
           cy.findByText('switch back to your account')
             .should('be.visible')
             .click();

--- a/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
+++ b/packages/manager/cypress/e2e/core/parentChild/account-switching.spec.ts
@@ -230,68 +230,6 @@ describe('Parent/Child account switching', () => {
     });
 
     /*
-     * - Confirms search functionality in the account switching drawer.
-     */
-    it('can search child accounts', () => {
-      mockGetProfile(mockParentProfile);
-      mockGetAccount(mockParentAccount);
-      mockGetChildAccounts([mockChildAccount, mockAlternateChildAccount]);
-      mockGetUser(mockParentUser);
-
-      cy.visitWithLogin('/');
-      cy.trackPageVisit().as('pageVisit');
-
-      // Confirm that Parent account username and company name are shown in user
-      // menu button, then click the button.
-      assertUserMenuButton(
-        mockParentProfile.username,
-        mockParentAccount.company
-      ).click();
-
-      // Click "Switch Account" button in user menu.
-      ui.userMenu
-        .find()
-        .should('be.visible')
-        .within(() => {
-          ui.button
-            .findByTitle('Switch Account')
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-        });
-
-      // Confirm search functionality.
-      ui.drawer
-        .findByTitle('Switch Account')
-        .should('be.visible')
-        .within(() => {
-          // Confirm all child accounts are displayed when drawer loads.
-          cy.findByText(mockChildAccount.company).should('be.visible');
-          cy.findByText(mockAlternateChildAccount.company).should('be.visible');
-
-          // Confirm no results message.
-          cy.findByPlaceholderText('Search').click().type('Fake Name');
-          mockGetChildAccounts([]).as('getEmptySearchResults');
-          cy.wait('@getEmptySearchResults');
-          cy.contains(mockChildAccount.company).should('not.exist');
-          cy.findByText(
-            'There are no indirect customer accounts that match this query.'
-          ).should('be.visible');
-
-          // Confirm filtering by company name displays only one search result.
-          cy.findByPlaceholderText('Search')
-            .click()
-            .clear()
-            .type(mockChildAccount.company);
-          mockGetChildAccounts([mockChildAccount]).as('getSearchResults');
-          cy.wait('@getSearchResults');
-
-          cy.findByText(mockChildAccount.company).should('be.visible');
-          cy.contains(mockAlternateChildAccount.company).should('not.exist');
-        });
-    });
-
-    /*
      * - Confirms that Parent account user can switch to Child account using the user menu.
      * - Confirms that Parent account information is initially displayed in user menu button.
      * - Confirms that Child account information is displayed in user menu button after switch.
@@ -368,6 +306,73 @@ describe('Parent/Child account switching', () => {
         mockParentProfile.username,
         mockChildAccount.company
       );
+    });
+
+    /*
+     * - Confirms search functionality in the account switching drawer.
+     */
+    it.only('can search child accounts', () => {
+      mockGetProfile(mockParentProfile);
+      mockGetAccount(mockParentAccount);
+      mockGetChildAccounts([mockChildAccount, mockAlternateChildAccount]);
+      mockGetUser(mockParentUser);
+
+      cy.visitWithLogin('/');
+      cy.trackPageVisit().as('pageVisit');
+
+      // Confirm that Parent account username and company name are shown in user
+      // menu button, then click the button.
+      assertUserMenuButton(
+        mockParentProfile.username,
+        mockParentAccount.company
+      ).click();
+
+      // Click "Switch Account" button in user menu.
+      ui.userMenu
+        .find()
+        .should('be.visible')
+        .within(() => {
+          ui.button
+            .findByTitle('Switch Account')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      // Confirm search functionality.
+      ui.drawer
+        .findByTitle('Switch Account')
+        .should('be.visible')
+        .within(() => {
+          // Confirm all child accounts are displayed when drawer loads.
+          cy.findByText(mockChildAccount.company).should('be.visible');
+          cy.findByText(mockAlternateChildAccount.company).should('be.visible');
+
+          // Confirm no results message.
+          cy.findByPlaceholderText('Search').click().type('Fake Name');
+          mockGetChildAccounts([]).as('getEmptySearchResults');
+          cy.wait('@getEmptySearchResults');
+
+          cy.contains(mockChildAccount.company).should('not.exist');
+          cy.findByText(
+            'There are no indirect customer accounts that match this query.'
+          ).should('be.visible');
+
+          // Confirm filtering by company name displays only one search result.
+          cy.findByPlaceholderText('Search')
+            .click()
+            .clear()
+            .type(mockChildAccount.company);
+          mockGetChildAccounts([mockChildAccount]).as('getSearchResults');
+          cy.wait('@getSearchResults');
+
+          // TODO: Debug - search result isn't reliable. Sometimes shows the no results notice instead of the account.
+          cy.findByText(mockChildAccount.company).should('be.visible');
+          cy.contains(mockAlternateChildAccount.company).should('not.exist');
+          cy.contains(
+            'There are no indirect customer accounts that match this query.'
+          ).should('not.exist');
+        });
     });
   });
 

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.test.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.test.tsx
@@ -29,6 +29,12 @@ describe('SwitchAccountDrawer', () => {
     ).toBeInTheDocument();
   });
 
+  it('should have a search bar', () => {
+    const { getByText } = renderWithTheme(<SwitchAccountDrawer {...props} />);
+
+    expect(getByText('Search')).toBeVisible();
+  });
+
   it('should include a link to switch back to the parent account if the active user is a proxy user', async () => {
     server.use(
       http.get('*/profile', () => {

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
@@ -40,14 +40,6 @@ export const SwitchAccountDrawer = (props: Props) => {
   >([]);
   const [query, setQuery] = React.useState<string>('');
 
-  const filter = {
-    ['+order']: 'asc',
-    ['+order_by']: 'company',
-  };
-  if (query) {
-    filter['company'] = { '+contains': query };
-  }
-
   const isProxyUser = userType === 'proxy';
   const currentParentTokenWithBearer =
     getStorage('authentication/parent_token/token') ?? '';
@@ -165,10 +157,11 @@ export const SwitchAccountDrawer = (props: Props) => {
         .
       </Typography>
       <DebouncedSearchTextField
+        clearable
         debounceTime={250}
         hideLabel
         label="Search"
-        onSearch={(query) => setQuery(query)}
+        onSearch={setQuery}
         placeholder="Search"
         sx={{ marginBottom: 3 }}
         value={query}
@@ -177,10 +170,10 @@ export const SwitchAccountDrawer = (props: Props) => {
         currentTokenWithBearer={
           isProxyUser ? currentParentTokenWithBearer : currentTokenWithBearer
         }
-        filter={filter}
         isLoading={isSubmitting}
         onClose={onClose}
         onSwitchAccount={handleSwitchToChildAccount}
+        searchQuery={query}
         userType={userType}
       />
     </Drawer>

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { StyledLinkButton } from 'src/components/Button/StyledLinkButton';
+import { DebouncedSearchTextField } from 'src/components/DebouncedSearchTextField';
 import { Drawer } from 'src/components/Drawer';
 import { Notice } from 'src/components/Notice/Notice';
 import { Typography } from 'src/components/Typography';
@@ -37,6 +38,11 @@ export const SwitchAccountDrawer = (props: Props) => {
   const [isParentTokenError, setIsParentTokenError] = React.useState<
     APIError[]
   >([]);
+  const filter = {};
+  const [query, setQuery] = React.useState<string>('');
+  if (query) {
+    filter['company'] = { '+contains': query };
+  }
 
   const isProxyUser = userType === 'proxy';
   const currentParentTokenWithBearer =
@@ -154,10 +160,20 @@ export const SwitchAccountDrawer = (props: Props) => {
         )}
         .
       </Typography>
+      <DebouncedSearchTextField
+        debounceTime={250}
+        hideLabel
+        label="Search"
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search"
+        sx={{ marginBottom: 2 }}
+        value={query}
+      />
       <ChildAccountList
         currentTokenWithBearer={
           isProxyUser ? currentParentTokenWithBearer : currentTokenWithBearer
         }
+        filter={filter}
         isLoading={isSubmitting}
         onClose={onClose}
         onSwitchAccount={handleSwitchToChildAccount}

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
@@ -164,16 +164,16 @@ export const SwitchAccountDrawer = (props: Props) => {
         debounceTime={250}
         hideLabel
         label="Search"
-        onChange={(e) => setQuery(e.target.value)}
+        onSearch={(query) => setQuery(query)}
         placeholder="Search"
-        sx={{ marginBottom: 2 }}
+        sx={{ marginBottom: 3 }}
         value={query}
       />
       <ChildAccountList
         currentTokenWithBearer={
           isProxyUser ? currentParentTokenWithBearer : currentTokenWithBearer
         }
-        filter={filter}
+        filter={Object.keys(filter).length > 0 ? filter : undefined}
         isLoading={isSubmitting}
         onClose={onClose}
         onSwitchAccount={handleSwitchToChildAccount}

--- a/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
+++ b/packages/manager/src/features/Account/SwitchAccountDrawer.tsx
@@ -38,8 +38,12 @@ export const SwitchAccountDrawer = (props: Props) => {
   const [isParentTokenError, setIsParentTokenError] = React.useState<
     APIError[]
   >([]);
-  const filter = {};
   const [query, setQuery] = React.useState<string>('');
+
+  const filter = {
+    ['+order']: 'asc',
+    ['+order_by']: 'company',
+  };
   if (query) {
     filter['company'] = { '+contains': query };
   }
@@ -173,7 +177,7 @@ export const SwitchAccountDrawer = (props: Props) => {
         currentTokenWithBearer={
           isProxyUser ? currentParentTokenWithBearer : currentTokenWithBearer
         }
-        filter={Object.keys(filter).length > 0 ? filter : undefined}
+        filter={filter}
         isLoading={isSubmitting}
         onClose={onClose}
         onSwitchAccount={handleSwitchToChildAccount}

--- a/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.test.tsx
+++ b/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.test.tsx
@@ -9,22 +9,18 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 
 const props = {
   currentTokenWithBearer: 'Bearer 123',
+  filter: {},
   onClose: vi.fn(),
   onSwitchAccount: vi.fn(),
   userType: undefined,
 };
 
-beforeAll(() => {
-  server.use(
-    http.get('*/profile', () => {
-      return HttpResponse.json(profileFactory.build({ user_type: 'parent' }));
-    })
-  );
-});
-
 it('should display a list of child accounts', async () => {
   const { findByTestId } = renderWithTheme(<ChildAccountList {...props} />);
   server.use(
+    http.get('*/profile', () => {
+      return HttpResponse.json(profileFactory.build({ user_type: 'parent' }));
+    }),
     http.get('*/account/child-accounts', () => {
       return HttpResponse.json(
         makeResourcePage(accountFactory.buildList(5, { company: 'Child Co.' }))
@@ -36,47 +32,7 @@ it('should display a list of child accounts', async () => {
   });
 
   const childAccounts = await findByTestId('child-account-list');
-
-  // Confirm that all child accounts are listed.
   expect(
     within(childAccounts).getAllByText('Child Co.', { exact: false })
   ).toHaveLength(5);
-});
-
-it('should display the list of child accounts in alphabetical order', async () => {
-  const mockChildAccounts = [
-    accountFactory.build({ company: 'Z Child Co.' }),
-    accountFactory.build({ company: '42 Child Co.' }),
-    accountFactory.build({ company: 'Z Child Co. 2' }),
-    accountFactory.build({ company: 'A Child Co.' }),
-  ];
-  const mockAlphabeticalCompanyNames = [
-    '42 Child Co.',
-    'A Child Co.',
-    'Z Child Co.',
-    'Z Child Co. 2',
-  ];
-
-  server.use(
-    http.get('*/account/child-accounts', () => {
-      return HttpResponse.json(makeResourcePage(mockChildAccounts));
-    })
-  );
-
-  const { findByTestId, getAllByRole } = renderWithTheme(
-    <ChildAccountList {...props} />
-  );
-
-  await waitFor(async () => {
-    expect(await findByTestId('child-account-list')).not.toBeNull();
-  });
-
-  const childAccounts = await findByTestId('child-account-list');
-  const childAccountCompanyNames = getAllByRole('button').map(
-    (account) => account.textContent
-  );
-
-  expect(childAccounts).toBeInTheDocument();
-  // Confirm that child accounts are listed in alphabetical order by company name.
-  expect(childAccountCompanyNames).toEqual(mockAlphabeticalCompanyNames);
 });

--- a/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.test.tsx
+++ b/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.test.tsx
@@ -14,27 +14,69 @@ const props = {
   userType: undefined,
 };
 
-it('should display a list of child accounts', async () => {
+beforeAll(() => {
   server.use(
     http.get('*/profile', () => {
       return HttpResponse.json(profileFactory.build({ user_type: 'parent' }));
-    }),
+    })
+  );
+});
+
+it('should display a list of child accounts', async () => {
+  const { findByTestId } = renderWithTheme(<ChildAccountList {...props} />);
+  server.use(
     http.get('*/account/child-accounts', () => {
       return HttpResponse.json(
         makeResourcePage(accountFactory.buildList(5, { company: 'Child Co.' }))
       );
     })
   );
-
-  const { findByTestId } = renderWithTheme(<ChildAccountList {...props} />);
-
   await waitFor(async () => {
     expect(await findByTestId('child-account-list')).not.toBeNull();
   });
 
   const childAccounts = await findByTestId('child-account-list');
 
+  // Confirm that all child accounts are listed.
   expect(
     within(childAccounts).getAllByText('Child Co.', { exact: false })
   ).toHaveLength(5);
+});
+
+it('should display the list of child accounts in alphabetical order', async () => {
+  const mockChildAccounts = [
+    accountFactory.build({ company: 'Z Child Co.' }),
+    accountFactory.build({ company: '42 Child Co.' }),
+    accountFactory.build({ company: 'Z Child Co. 2' }),
+    accountFactory.build({ company: 'A Child Co.' }),
+  ];
+  const mockAlphabeticalCompanyNames = [
+    '42 Child Co.',
+    'A Child Co.',
+    'Z Child Co.',
+    'Z Child Co. 2',
+  ];
+
+  server.use(
+    http.get('*/account/child-accounts', () => {
+      return HttpResponse.json(makeResourcePage(mockChildAccounts));
+    })
+  );
+
+  const { findByTestId, getAllByRole } = renderWithTheme(
+    <ChildAccountList {...props} />
+  );
+
+  await waitFor(async () => {
+    expect(await findByTestId('child-account-list')).not.toBeNull();
+  });
+
+  const childAccounts = await findByTestId('child-account-list');
+  const childAccountCompanyNames = getAllByRole('button').map(
+    (account) => account.textContent
+  );
+
+  expect(childAccounts).toBeInTheDocument();
+  // Confirm that child accounts are listed in alphabetical order by company name.
+  expect(childAccountCompanyNames).toEqual(mockAlphabeticalCompanyNames);
 });

--- a/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.test.tsx
+++ b/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.test.tsx
@@ -9,9 +9,9 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 
 const props = {
   currentTokenWithBearer: 'Bearer 123',
-  filter: {},
   onClose: vi.fn(),
   onSwitchAccount: vi.fn(),
+  searchQuery: '',
   userType: undefined,
 };
 

--- a/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.test.tsx
+++ b/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.test.tsx
@@ -16,7 +16,6 @@ const props = {
 };
 
 it('should display a list of child accounts', async () => {
-  const { findByTestId } = renderWithTheme(<ChildAccountList {...props} />);
   server.use(
     http.get('*/profile', () => {
       return HttpResponse.json(profileFactory.build({ user_type: 'parent' }));
@@ -27,11 +26,15 @@ it('should display a list of child accounts', async () => {
       );
     })
   );
+
+  const { findByTestId } = renderWithTheme(<ChildAccountList {...props} />);
+
   await waitFor(async () => {
     expect(await findByTestId('child-account-list')).not.toBeNull();
   });
 
   const childAccounts = await findByTestId('child-account-list');
+
   expect(
     within(childAccounts).getAllByText('Child Co.', { exact: false })
   ).toHaveLength(5);

--- a/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
+++ b/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
@@ -58,7 +58,9 @@ export const ChildAccountList = React.memo(
             }
           : undefined,
     });
-    const childAccounts = data?.pages.flatMap((page) => page.data);
+    const childAccounts = data?.pages
+      .flatMap((page) => page.data)
+      .sort((a, b) => a.company.localeCompare(b.company));
 
     if (isInitialLoading) {
       return (

--- a/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
+++ b/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
@@ -50,7 +50,7 @@ export const ChildAccountList = React.memo(
       isInitialLoading,
       refetch: refetchChildAccounts,
     } = useChildAccountsInfiniteQuery({
-      filter: filter ?? undefined,
+      filter,
       headers:
         userType === 'proxy'
           ? {
@@ -74,8 +74,8 @@ export const ChildAccountList = React.memo(
     if (childAccounts?.length === 0) {
       return (
         <Notice variant="info">
-          There are no indirect customer accounts{' '}
-          {filter !== undefined ? 'that match this query' : undefined}.
+          There are no indirect customer accounts
+          {filter ? ' that match this query' : undefined}.
         </Notice>
       );
     }

--- a/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
+++ b/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
@@ -58,6 +58,7 @@ export const ChildAccountList = React.memo(
             }
           : undefined,
     });
+    // Sort the list of child accounts alphabetically.
     const childAccounts = data?.pages
       .flatMap((page) => page.data)
       .sort((a, b) => a.company.localeCompare(b.company));

--- a/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
+++ b/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
@@ -80,7 +80,7 @@ export const ChildAccountList = React.memo(
     if (childAccounts?.length === 0) {
       return (
         <Notice variant="info">
-          There are no indirect customer accounts
+          There are no child accounts
           {filter ? ' that match this query' : undefined}.
         </Notice>
       );

--- a/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
+++ b/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
@@ -11,10 +11,11 @@ import { Stack } from 'src/components/Stack';
 import { Typography } from 'src/components/Typography';
 import { useChildAccountsInfiniteQuery } from 'src/queries/account/account';
 
-import type { UserType } from '@linode/api-v4';
+import type { Filter, UserType } from '@linode/api-v4';
 
 interface ChildAccountListProps {
   currentTokenWithBearer: string;
+  filter?: Filter;
   isLoading?: boolean;
   onClose: () => void;
   onSwitchAccount: (props: {
@@ -30,6 +31,7 @@ interface ChildAccountListProps {
 export const ChildAccountList = React.memo(
   ({
     currentTokenWithBearer,
+    filter,
     isLoading,
     onClose,
     onSwitchAccount,
@@ -48,6 +50,7 @@ export const ChildAccountList = React.memo(
       isInitialLoading,
       refetch: refetchChildAccounts,
     } = useChildAccountsInfiniteQuery({
+      filter: filter ?? undefined,
       headers:
         userType === 'proxy'
           ? {
@@ -67,7 +70,10 @@ export const ChildAccountList = React.memo(
 
     if (childAccounts?.length === 0) {
       return (
-        <Notice variant="info">There are no indirect customer accounts.</Notice>
+        <Notice variant="info">
+          There are no indirect customer accounts{' '}
+          {filter !== undefined ? 'that match this query' : undefined}.
+        </Notice>
       );
     }
 

--- a/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
+++ b/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
@@ -15,7 +15,7 @@ import type { Filter, UserType } from '@linode/api-v4';
 
 interface ChildAccountListProps {
   currentTokenWithBearer: string;
-  filter?: Filter;
+  filter: Filter;
   isLoading?: boolean;
   onClose: () => void;
   onSwitchAccount: (props: {
@@ -60,9 +60,7 @@ export const ChildAccountList = React.memo(
           : undefined,
     });
     // Sort the list of child accounts alphabetically.
-    const childAccounts = data?.pages
-      .flatMap((page) => page.data)
-      .sort((a, b) => a.company.localeCompare(b.company));
+    const childAccounts = data?.pages.flatMap((page) => page.data);
 
     if (
       isInitialLoading ||

--- a/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
+++ b/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
@@ -15,7 +15,6 @@ import type { Filter, UserType } from '@linode/api-v4';
 
 interface ChildAccountListProps {
   currentTokenWithBearer: string;
-  filter: Filter;
   isLoading?: boolean;
   onClose: () => void;
   onSwitchAccount: (props: {
@@ -25,18 +24,27 @@ interface ChildAccountListProps {
     onClose: () => void;
     userType: UserType | undefined;
   }) => void;
+  searchQuery: string;
   userType: UserType | undefined;
 }
 
 export const ChildAccountList = React.memo(
   ({
     currentTokenWithBearer,
-    filter,
     isLoading,
     onClose,
     onSwitchAccount,
+    searchQuery,
     userType,
   }: ChildAccountListProps) => {
+    const filter: Filter = {
+      ['+order']: 'asc',
+      ['+order_by']: 'company',
+    };
+    if (searchQuery) {
+      filter['company'] = { '+contains': searchQuery };
+    }
+
     const [
       isSwitchingChildAccounts,
       setIsSwitchingChildAccounts,
@@ -59,7 +67,6 @@ export const ChildAccountList = React.memo(
             }
           : undefined,
     });
-    // Sort the list of child accounts alphabetically.
     const childAccounts = data?.pages.flatMap((page) => page.data);
 
     if (

--- a/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
+++ b/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
@@ -79,7 +79,10 @@ export const ChildAccountList = React.memo(
       return (
         <Notice variant="info">
           There are no child accounts
-          {filter ? ' that match this query' : undefined}.
+          {filter.hasOwnProperty('company')
+            ? ' that match this query'
+            : undefined}
+          .
         </Notice>
       );
     }

--- a/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
+++ b/packages/manager/src/features/Account/SwitchAccounts/ChildAccountList.tsx
@@ -48,6 +48,7 @@ export const ChildAccountList = React.memo(
       isError,
       isFetchingNextPage,
       isInitialLoading,
+      isRefetching,
       refetch: refetchChildAccounts,
     } = useChildAccountsInfiniteQuery({
       filter,
@@ -63,7 +64,12 @@ export const ChildAccountList = React.memo(
       .flatMap((page) => page.data)
       .sort((a, b) => a.company.localeCompare(b.company));
 
-    if (isInitialLoading) {
+    if (
+      isInitialLoading ||
+      isLoading ||
+      isSwitchingChildAccounts ||
+      isRefetching
+    ) {
       return (
         <Box display="flex" justifyContent="center">
           <CircleProgress mini size={70} />
@@ -128,11 +134,6 @@ export const ChildAccountList = React.memo(
 
     return (
       <Stack alignItems={'flex-start'} data-testid="child-account-list">
-        {(isSwitchingChildAccounts || isLoading) && (
-          <Box display="flex" justifyContent="center" width={'100%'}>
-            <CircleProgress mini size={70} />
-          </Box>
-        )}
         {!isSwitchingChildAccounts && !isLoading && renderChildAccounts}
         {hasNextPage && <Waypoint onEnter={() => fetchNextPage()} />}
         {isFetchingNextPage && <CircleProgress mini />}

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1354,7 +1354,7 @@ export const handlers = [
     const url = new URL(request.url);
     const page = Number(url.searchParams.get('page') || 1);
     const pageSize = Number(url.searchParams.get('page_size') || 25);
-    const childAccounts = [...accountFactory.buildList(100)];
+    const childAccounts = accountFactory.buildList(100);
     return HttpResponse.json({
       data: childAccounts.slice(
         (page - 1) * pageSize,

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1354,7 +1354,12 @@ export const handlers = [
     const url = new URL(request.url);
     const page = Number(url.searchParams.get('page') || 1);
     const pageSize = Number(url.searchParams.get('page_size') || 25);
-    const childAccounts = accountFactory.buildList(100);
+    const childAccounts = [
+      accountFactory.build({ company: 'z-company-2' }),
+      accountFactory.build({ company: 'z-company' }),
+      accountFactory.build({ company: 'b-company' }),
+      ...accountFactory.buildList(50),
+    ];
     return HttpResponse.json({
       data: childAccounts.slice(
         (page - 1) * pageSize,

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -76,8 +76,8 @@ import {
   objectStorageBucketFactory,
   objectStorageClusterFactory,
   objectStorageKeyFactory,
-  objectStorageTypeFactory,
   objectStorageOverageTypeFactory,
+  objectStorageTypeFactory,
   paymentFactory,
   paymentMethodFactory,
   placementGroupFactory,
@@ -1354,11 +1354,7 @@ export const handlers = [
     const url = new URL(request.url);
     const page = Number(url.searchParams.get('page') || 1);
     const pageSize = Number(url.searchParams.get('page_size') || 25);
-    const childAccounts = [
-      accountFactory.build({ company: 'z-company-2' }),
-      accountFactory.build({ company: 'z-company' }),
-      ...accountFactory.buildList(100),
-    ];
+    const childAccounts = [...accountFactory.buildList(100)];
     return HttpResponse.json({
       data: childAccounts.slice(
         (page - 1) * pageSize,

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1357,8 +1357,7 @@ export const handlers = [
     const childAccounts = [
       accountFactory.build({ company: 'z-company-2' }),
       accountFactory.build({ company: 'z-company' }),
-      accountFactory.build({ company: 'b-company' }),
-      ...accountFactory.buildList(50),
+      ...accountFactory.buildList(100),
     ];
     return HttpResponse.json({
       data: childAccounts.slice(


### PR DESCRIPTION
## Description 📝
This PR brings two improvements to the Switch Account drawer, allowing users with hundreds of child accounts to more easily navigate that list:
1. Search capabilities on the company name
2. Alphabetization of the list of company names

We are already incrementally fetching the list using an infinite query, but the existing UI still requires scrolling and visually searching, which can be a burden on the user.

## Changes  🔄
- Sorted the list of child accounts alphabetically.
- Added a search bar and functionality to filter the child account list based on company name.
- Updated the info notice to show more accurate terminology and slightly more specific helper text if there are no results.
- Added unit test and Cypress test coverage.

## Target release date 🗓️
06/10

## Preview 📷

https://github.com/linode/manager/assets/114685994/525d3e2a-e7d9-48b0-960c-4b33872ff38f

| Dev (Cloud Manager Parent Test Account) | This Branch |
| --- | --- |
| ![Screenshot 2024-05-24 at 12 15 32 PM](https://github.com/linode/manager/assets/114685994/8d75c39f-acf1-427e-b910-baf6241cfdb2) | ![Screenshot 2024-05-24 at 12 16 47 PM](https://github.com/linode/manager/assets/114685994/5cfbecb4-bb2f-4f08-bcc2-dcca454b4ebb) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Log into our Cloud Manager parent user test dev account to test these changes.

### Verification steps
(How to verify changes)
- Confirm the x-filter in the network request is correct and all child accounts are displayed in alphabetical order.
- Search for a company that is in the list and confirm the child accounts list updates to only show relevant results.
- Search for a company name that is not in the list and confirm a message displays to inform the user there are no results.
- Confirm loading and error states for `/child-accounts` request.
- Confirm tests pass:
```
yarn test ChildAccountList SwitchAccountDrawer
```
```
yarn cy:run -s "cypress/e2e/core/parentChild/account-switching.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
