### PR TITLE
fix: [M3-8164] - regions length check

### DIFF
--- a/packages/manager/.changeset/pr-10519-upcoming-features-1716918242639.md
+++ b/packages/manager/.changeset/pr-10519-upcoming-features-1716918242639.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+fix regions length check in HostNameTableCell ([#10519](https://github.com/linode/manager/pull/10519))

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/HostNameTableCell.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/HostNameTableCell.tsx
@@ -28,7 +28,7 @@ export const HostNameTableCell = ({
 
   const { regions } = storageKeyData;
 
-  if (!regionsLookup || !regionsData || !regions) {
+  if (!regionsLookup || !regionsData || !regions.length) {
     return <TableCell />;
   }
 

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/HostNameTableCell.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/HostNameTableCell.tsx
@@ -28,8 +28,8 @@ export const HostNameTableCell = ({
 
   const { regions } = storageKeyData;
 
-  if (!regionsLookup || !regionsData || !regions.length) {
-    return <TableCell />;
+  if (!regionsLookup || !regionsData || regions.length === 0) {
+    return <TableCell>None</TableCell>;
   }
 
   return (


### PR DESCRIPTION
## Description 📝
This PR checks the length of regions before reading its data while rending Table cell in Access Key table.

## Target release date 🗓️
6/7

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Use dev env and dev account with appropriate account tags.(reach me if you need help on account tags).

### Reproduction steps
(How to reproduce the issue, if applicable)
- Navigate to http://localhost:3000/object-storage/access-keys
- Verify Access Key landing page renders.

### Verification steps
(How to verify changes)
- Navigate to http://localhost:3000/object-storage/access-keys
- Verify Access Key landing page renders.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

