### PR TITLE
hotfix: [M3-8182] - Remove leaveDelay from TooltipText

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2024-05-29] - v1.120.1
+
+
+### Fixed:
+
+- Tooltip not closing when unhovered ([#10523](https://github.com/linode/manager/pull/10523))
+
 ## [2024-05-28] - v1.120.0
 
 

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.120.0",
+  "version": "1.120.1",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/manager/src/components/TextTooltip/TextTooltip.test.tsx
+++ b/packages/manager/src/components/TextTooltip/TextTooltip.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { renderWithTheme } from 'src/utilities/testHelpers';
@@ -58,5 +58,26 @@ describe('TextTooltip', () => {
 
     expect(displayText).toHaveStyle('color: rgb(54, 131, 220)');
     expect(displayText).toHaveStyle('font-size: 18px');
+  });
+
+  it('the tooltip should disappear on mouseout', async () => {
+    const props = {
+      displayText: 'Hover me',
+      tooltipText: 'This is a tooltip',
+    };
+
+    const { findByRole, getByText, queryByRole } = renderWithTheme(
+      <TextTooltip {...props} />
+    );
+
+    fireEvent.mouseEnter(getByText(props.displayText));
+
+    const tooltip = await findByRole('tooltip');
+
+    expect(tooltip).toBeInTheDocument();
+
+    fireEvent.mouseLeave(getByText(props.displayText));
+
+    await waitFor(() => expect(queryByRole('tooltip')).not.toBeInTheDocument());
   });
 });

--- a/packages/manager/src/components/TextTooltip/TextTooltip.tsx
+++ b/packages/manager/src/components/TextTooltip/TextTooltip.tsx
@@ -66,7 +66,6 @@ export const TextTooltip = (props: TextTooltipProps) => {
           },
         },
       }}
-      leaveDelay={500000}
       data-qa-tooltip={dataQaTooltip}
       enterTouchDelay={0}
       placement={placement ? placement : 'bottom'}


### PR DESCRIPTION
## Description 📝
A bug/artifact [I introduced](https://github.com/linode/manager/pull/10473/files#diff-12683df425c3158844e1a0ae2f06f393deb4a8d757ffddda5ea966624c52730dR69) for testing purposes while writing an end to end test (mea culpa 😭).


![Screenshot 2024-05-29 at 10 54 08](https://github.com/linode/manager/assets/130582365/1ef291d9-7b75-4c35-893b-4bbdd44b328d)

## Changes  🔄
- Remove erroneous `leaveDelay` on `<TextTooltip />`
- Add unit

## Target release date 🗓️
5/29/2024

## How to test 🧪
Use PROD

### Reproduction steps
- Go to linode/create
- select a region
- Scroll down the the details panel
- Hover over Placement Groups "region"
- Notice tooltip won't go away

### Verification steps
- Go to linode/create
- select a region
- Scroll down the the details panel
- Hover over Placement Groups "region"
- Confirm tooltip goes away

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
