### PR TITLE
fix: `EditRouteDrawer.test.tsx` unit test flake

### DIFF
--- a/packages/manager/src/features/LoadBalancers/LoadBalancerCreate/LoadBalancerSummary/EditLoadBalancerConfigurations/EditRoutes/EditRouteDrawer.test.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerCreate/LoadBalancerSummary/EditLoadBalancerConfigurations/EditRoutes/EditRouteDrawer.test.tsx
@@ -70,7 +70,7 @@ describe('EditRouteDrawer', () => {
 
     expect(routeLabelFiled).toHaveDisplayValue('route-label');
 
-    userEvent.type(routeLabelFiled, 'rote-new-label');
+    await userEvent.type(routeLabelFiled, 'rote-new-label');
 
     await userEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
   });


### PR DESCRIPTION
## Description 📝

An attempt to fix the test flake we've been seeing with the `EditRouteDrawer.test.tsx` unit test 🔧 
I'm not positive this will fix the issue, but hopefully it does! 🤞 

## How to test 🧪

- Verify unit tests in Github Actions pass
- Verify the test passes reliably locally 

> [!note]
> You can use this command to run the test `n` number of times
>  ```sh
> repeat 10 yarn test src/features/LoadBalancers/LoadBalancerCreate/LoadBalancerSummary/EditLoadBalancerConfigurations/EditRoutes/EditRouteDrawer.test.tsx
> ```

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support