### PR TITLE
fix: [M3-7717] - Fix leading whitespace in list of Linode and Nodebalancer links for Firewall Services

### DIFF
--- a/packages/manager/.changeset/pr-10527-fixed-1717019227934.md
+++ b/packages/manager/.changeset/pr-10527-fixed-1717019227934.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Leading whitespace in list of Firewall Services ([#10527](https://github.com/linode/manager/pull/10527))

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
@@ -105,21 +105,19 @@ export const getDeviceLinks = (data: FirewallDevice[]): JSX.Element => {
   return (
     <>
       {firstThree.map((thisDevice, idx) => (
-        <Link
-          className="link secondaryLink"
-          data-testid="firewall-row-link"
-          key={thisDevice.id}
-          to={`/${thisDevice.entity.type}s/${thisDevice.entity.id}`}
-        >
-          {idx > 0 && `, `}
-          {thisDevice.entity.label}
-        </Link>
+        <>
+          {idx > 0 && ', '}
+          <Link
+            className="link secondaryLink"
+            data-testid="firewall-row-link"
+            key={thisDevice.id}
+            to={`/${thisDevice.entity.type}s/${thisDevice.entity.id}`}
+          >
+            {thisDevice.entity.label}
+          </Link>
+        </>
       ))}
-      {data.length > 3 && (
-        <span>
-          {`, `}plus {data.length - 3} more.
-        </span>
-      )}
+      {data.length > 3 && <span>, plus {data.length - 3} more.</span>}
     </>
   );
 };


### PR DESCRIPTION
## Description 📝
Tiny PR to close out a ticket I made many months ago that was sitting in the backlog.

On the Firewalls landing page, linked linodes and NBs in the Services column list have some extra leading white space included in the link.

## Changes  🔄
- Moved the comma and spacing out of the Link component.
- Very minor string clean up.

## Target release date 🗓️
6/10

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-05-29 at 1 52 30 PM](https://github.com/linode/manager/assets/114685994/c06f2c01-68cf-40ca-8e59-1d618a5fc4fa)| ![Screenshot 2024-05-29 at 1 52 03 PM](https://github.com/linode/manager/assets/114685994/1885ea2f-7d60-4af7-8777-ff04ca93c265) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Have a combination of at least 4 linodes or nodebalancers on your account, or create them.

### Reproduction steps
(How to reproduce the issue, if applicable)
1. Go to https://cloud.linode.com/firewalls.
2. Have an existing firewall or create one.
3. Attach at least 2 nodebalancers/linodes/any combination thereof to the firewall.
4. Hover over the second or greater link in the list and observe the leading whitespace included in the link.

### Verification steps
(How to verify changes)
1. Check out this branch and go to http://localhost:3000.
2. Have an existing firewall or create one.
3. Attach at least 2 nodebalancers/linodes/any combination thereof to the firewall.
4. Hover over the second or greater link in the list and observe the leading whitespace is not included in the link, nor are commas.
5. Confirm no regressions when adding/removing >3 devices.

 ## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support