### PR TITLE
test: [M3-7784] - Cypress integration tests for Placement Group update label flow

### DIFF
--- a/packages/manager/.changeset/pr-10529-tests-1717072137790.md
+++ b/packages/manager/.changeset/pr-10529-tests-1717072137790.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Cypress integration tests for PG update label flow ([#10529](https://github.com/linode/manager/pull/10529))

--- a/packages/manager/cypress/e2e/core/placementGroups/update-placement-group-label.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/update-placement-group-label.spec.ts
@@ -15,13 +15,11 @@ import {
 } from 'support/intercepts/placement-groups';
 import { accountFactory, placementGroupFactory } from 'src/factories';
 import { mockGetAccount } from 'support/intercepts/account';
-import { authenticate } from 'support/api/authentication';
 import type { Flags } from 'src/featureFlags';
 import { chooseRegion } from 'support/util/regions';
 import { ui } from 'support/ui';
 
 const mockAccount = accountFactory.build();
-authenticate();
 
 describe('Placement Group update label flow', () => {
   // Mock the VM Placement Groups feature flag to be enabled for each test in this block.
@@ -33,7 +31,7 @@ describe('Placement Group update label flow', () => {
       }),
     });
     mockGetFeatureFlagClientstream();
-    mockGetAccount(mockAccount).as('getAccount');
+    mockGetAccount(mockAccount);
   });
 
   /**
@@ -110,7 +108,7 @@ describe('Placement Group update label flow', () => {
    * - A new value can be entered into the label field.
    * - Confirms an error notice is shown upon failure to label update.
    */
-  it("update to a Placement Group's label fails", () => {
+  it("update to a Placement Group's label fails with error message", () => {
     const mockPlacementGroupCompliantRegion = chooseRegion();
 
     const mockPlacementGroup = placementGroupFactory.build({

--- a/packages/manager/cypress/support/intercepts/placement-groups.ts
+++ b/packages/manager/cypress/support/intercepts/placement-groups.ts
@@ -1,8 +1,12 @@
+import { makeErrorResponse } from 'support/util/errors';
 import { apiMatcher } from 'support/util/intercepts';
 import { paginateResponse } from 'support/util/paginate';
-import type { PlacementGroup } from '@linode/api-v4';
 import { makeResponse } from 'support/util/response';
-import { makeErrorResponse } from 'support/util/errors';
+
+import type {
+  PlacementGroup,
+  UpdatePlacementGroupPayload,
+} from '@linode/api-v4';
 
 /**
  * Intercepts GET request to fetch Placement Groups and mocks response.
@@ -171,6 +175,48 @@ export const mockDeletePlacementGroupError = (
 ): Cypress.Chainable<null> => {
   return cy.intercept(
     'DELETE',
+    apiMatcher(`placement/groups/${placementGroupId}`),
+    makeErrorResponse(errorMessage, errorCode)
+  );
+};
+
+/**
+ * Intercepts PUT request to update Placement Group label and mocks response.
+ *
+ * @param placementGroupId - ID of Placement Group for which to intercept update label request.
+ * @param placementGroupData - Placement Group object with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockUpdatePlacementGroupLabel = (
+  placementGroupId: number,
+  placementGroupData: UpdatePlacementGroupPayload
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'PUT',
+    apiMatcher(`placement/groups/${placementGroupId}`),
+    makeResponse(placementGroupData)
+  );
+};
+
+/**
+ * Intercepts PUT request to update Placement Group label and mocks HTTP error response.
+ *
+ * By default, a 500 response is mocked.
+ *
+ * @param placementGroupId - ID of Placement Group for which to intercept update label request.
+ * @param errorMessage - Optional error message with which to mock response.
+ * @param errorCode - Optional error code with which to mock response. Default is `500`.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockUpdatePlacementGroupLabelError = (
+  placementGroupId: number,
+  errorMessage: string = 'An error has occurred',
+  errorCode: number = 500
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'PUT',
     apiMatcher(`placement/groups/${placementGroupId}`),
     makeErrorResponse(errorMessage, errorCode)
   );

--- a/packages/manager/cypress/support/intercepts/placement-groups.ts
+++ b/packages/manager/cypress/support/intercepts/placement-groups.ts
@@ -3,10 +3,7 @@ import { apiMatcher } from 'support/util/intercepts';
 import { paginateResponse } from 'support/util/paginate';
 import { makeResponse } from 'support/util/response';
 
-import type {
-  PlacementGroup,
-  UpdatePlacementGroupPayload,
-} from '@linode/api-v4';
+import type { PlacementGroup } from '@linode/api-v4';
 
 /**
  * Intercepts GET request to fetch Placement Groups and mocks response.
@@ -188,9 +185,9 @@ export const mockDeletePlacementGroupError = (
  *
  * @returns Cypress chainable.
  */
-export const mockUpdatePlacementGroupLabel = (
+export const mockUpdatePlacementGroup = (
   placementGroupId: number,
-  placementGroupData: UpdatePlacementGroupPayload
+  placementGroupData: string
 ): Cypress.Chainable<null> => {
   return cy.intercept(
     'PUT',
@@ -210,7 +207,7 @@ export const mockUpdatePlacementGroupLabel = (
  *
  * @returns Cypress chainable.
  */
-export const mockUpdatePlacementGroupLabelError = (
+export const mockUpdatePlacementGroupError = (
   placementGroupId: number,
   errorMessage: string = 'An error has occurred',
   errorCode: number = 500


### PR DESCRIPTION
## Description 📝
This adds Cypress integration tests for the Placement Group update label flow via Placement Group's landing page.

## Changes  🔄
List any change relevant to the reviewer.
- Two new mocking functions for the label update flow: `mockUpdatePlacementGroupLabel()` and `mockUpdatePlacementGroupLabelError()`

## Target release date 🗓️
06/10/2024

## How to test 🧪
### Prerequisites
- Check this branch out and run 
```
yarn cy:run -s "cypress/e2e/core/placementGroups/update-placement-group-label.spec.ts"
```
- Or you can run the tests in `debug` mode by running `yarn cy:debug`.


### Verification steps
(How to verify changes)
- Verify that all tests are passing.
- Validate that the flows and assertions covered by these changes are adequate.

## As an Author I have considered 🤔
*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
