### PR TITLE
fix: [M3-7592] - Fix misalignment of Cluster Summary at small desktop screen sizes

### DIFF
--- a/packages/manager/.changeset/pr-10531-fixed-1717084620266.md
+++ b/packages/manager/.changeset/pr-10531-fixed-1717084620266.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Misalignment of Cluster Summary section at some screen sizes ([#10531](https://github.com/linode/manager/pull/10531))

--- a/packages/manager/src/components/CheckoutBar/styles.ts
+++ b/packages/manager/src/components/CheckoutBar/styles.ts
@@ -16,6 +16,9 @@ const StyledRoot = styled('div')(() => {
   return {
     minHeight: '24px',
     minWidth: '24px',
+    [theme.breakpoints.between('md', 1280)]: {
+      padding: theme.spacing(2),
+    },
     [theme.breakpoints.down('md')]: {
       background: theme.color.white,
       bottom: '0 !important' as '0',

--- a/packages/manager/src/components/CheckoutBar/styles.ts
+++ b/packages/manager/src/components/CheckoutBar/styles.ts
@@ -16,10 +16,7 @@ const StyledRoot = styled('div')(() => {
   return {
     minHeight: '24px',
     minWidth: '24px',
-    [theme.breakpoints.between('md', 1280)]: {
-      padding: theme.spacing(2),
-    },
-    [theme.breakpoints.down('md')]: {
+    [theme.breakpoints.down(1280)]: {
       background: theme.color.white,
       bottom: '0 !important' as '0',
       left: '0 !important' as '0',


### PR DESCRIPTION
## Description 📝
The Cluster Summary section needs some padding on the left-hand side at breakpoints between 1280px and tablet view (960px).

## Changes  🔄
- Changed the breakpoint from `md` to 1280, which is when the checkout bar is no longer visually a sidebar. This happens before we hit the tablet breakpoint. 

## Target release date 🗓️
6/10

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-05-29 at 4 09 59 PM](https://github.com/linode/manager/assets/114685994/9b7aeba6-82ec-4c4e-ae92-ff0e8cd1a908) | <video src="https://github.com/linode/manager/assets/114685994/a7d8ed04-b8e8-4ed8-b0c8-f91e932309e8" /> |

## How to test 🧪

### Reproduction steps
(How to reproduce the issue, if applicable)
- Use the dev tools to set screen size < 1280 and >= 960
- Go to https://cloud.linode.com/kubernetes/create
- Observe the Cluster Summary section is too close to the edge of the paper and doesn't align with the rest of the form

### Verification steps
(How to verify changes)
- With your screen at the same size, go to https://localhost:3000/kubernetes/create
- Confirm the Cluster Summary section is left and right aligned with the other form sections on the page in when resizing from desktop to tablet view
- Confirm there aren't any unintended styling regressions

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
