### PR TITLE
test: [M3-8132] - Add Cypress integration test for email bounce banners

### DIFF
--- a/packages/manager/cypress/e2e/core/account/email-bounce.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/email-bounce.spec.ts
@@ -9,6 +9,8 @@ import { getProfile } from 'support/api/account';
 import { ui } from 'support/ui';
 import { mockUpdateProfile } from 'support/intercepts/profile';
 import { randomString } from 'support/util/random';
+import { accountFactory } from 'src/factories/account';
+import { mockGetAccount, mockUpdateAccount } from 'support/intercepts/account';
 
 const notifications_billing_email_bounce: Notification[] = [
   notificationFactory.build({
@@ -86,11 +88,6 @@ describe('Email bounce banners', () => {
       cy.visitWithLogin('/account/users');
       cy.wait('@mockNotifications');
 
-      mockUpdateProfile({
-        ...profile.body,
-        email: userprofileEmail,
-      }).as('updateEmail');
-
       cy.contains(UserProfileEmailBounceBanner)
         .should('be.visible')
         .parent()
@@ -121,25 +118,29 @@ describe('Email bounce banners', () => {
             .click();
         });
 
-      cy.wait('@updateEmail');
       cy.findByText('Email updated successfully.').should('be.visible');
       // email bounce still exist ???
     });
   });
 
-  it.only('Billing email bounce is visible and can be confirmed by users', () => {
-    //how to get billing email???
-    const BillingEmail = 'azsh@akamai.com';
+  /*
+   *   Confirm that the billing email banner appears when the billing_email_bounce notification is present
+   *   Confirm that clicking "Yes, it's correct" causes a PUT request to be made to the API account endpoint containing the current billing email address
+   */
+  it('Billing email bounce is visible and can be confirmed by users', () => {
+    const accountData = accountFactory.build();
+    const billingemail = accountData.email;
 
-    const BillingEmailBounceBanner = `An email to your account’s email address couldn’t be delivered. Is ${BillingEmail} the correct address?`;
+    const BillingEmailBounceBanner = `An email to your account’s email address couldn’t be delivered. Is ${billingemail} the correct address?`;
 
     mockGetNotifications(notifications_billing_email_bounce).as(
       'mockNotifications'
     );
-    cy.visitWithLogin('/account/billing');
-    cy.wait('@mockNotifications');
+    // mock the user's account data and confirm that it is displayed correctly upon page load
+    mockGetAccount(accountData).as('getAccount');
 
-    //mockUpdateAccount(mockAccount).as('AccountBilling');
+    cy.visitWithLogin('/account/billing');
+    cy.wait(['@mockNotifications', '@getAccount']);
 
     cy.contains(BillingEmailBounceBanner)
       .should('be.visible')
@@ -155,14 +156,52 @@ describe('Email bounce banners', () => {
 
     ui.toast.assertMessage('Email confirmed');
 
-    //cy.wait('@AccountBilling');
     cy.contains(BillingEmailBounceBanner).should('not.exist');
     cy.findByText('Billing Contact')
       .should('be.visible')
       .parent()
       .parent()
       .within(() => {
-        cy.findByText(`${BillingEmail}`).should('be.visible');
+        cy.findByText(`${billingemail}`).should('be.visible');
       });
+  });
+
+  /*
+   *   Confirm that the billing email banner appears when the billing_email_bounce notification is present
+   *   Confirm that clicking "No, let's update it" redirects the user to {{/account} and that the contact info edit drawer is automatically opened
+   */
+  it.only('Billing email bounce is visible and can be updated by users', () => {
+    const accountData = accountFactory.build();
+    const billingemail = accountData.email;
+
+    const BillingEmailBounceBanner = `An email to your account’s email address couldn’t be delivered. Is ${billingemail} the correct address?`;
+
+    mockGetNotifications(notifications_billing_email_bounce).as(
+      'mockNotifications'
+    );
+
+    // mock the user's account data and confirm that it is displayed correctly upon page load
+    mockGetAccount(accountData).as('getAccount');
+
+    cy.visitWithLogin('/account/billing');
+    cy.wait(['@mockNotifications', '@getAccount']);
+
+    // mock the user's account data and confirm that it is displayed correctly upon page load
+    //mockUpdateAccount(accountFactory.build()).as('updateAccount');
+
+    cy.contains(BillingEmailBounceBanner)
+      .should('be.visible')
+      .parent()
+      .parent()
+      .within(() => {
+        ui.button
+          .findByTitle(updateButton)
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+    mockUpdateAccount(accountFactory.build()).as('updateAccount');
+
+    cy.wait('@updateAccount');
   });
 });

--- a/packages/manager/cypress/e2e/core/account/email-bounce.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/email-bounce.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * @file Integration tests for Cloud Manager email bounce banners.
+ */
+
+import { Notification } from '@linode/api-v4';
+import { notificationFactory } from '@src/factories/notification';
+import { mockGetNotifications } from 'support/intercepts/events';
+import { getProfile } from 'support/api/account';
+import { ui } from 'support/ui';
+import { mockUpdateProfile } from 'support/intercepts/profile';
+import { randomString } from 'support/util/random';
+
+const notifications_billing_email_bounce: Notification[] = [
+  notificationFactory.build({
+    type: 'billing_email_bounce',
+    severity: 'major',
+  }),
+];
+
+const notifications_user_email_bounce: Notification[] = [
+  notificationFactory.build({
+    type: 'user_email_bounce',
+    severity: 'major',
+  }),
+];
+
+const confirmButton = 'Yes it’s correct.';
+const updateButton = 'No, let’s update it.';
+
+describe('Email bounce banners', () => {
+  /*
+   * Confirm that the user profile email banner appears when the user_email_bounce notification is present
+   * Confirm that clicking "Yes, it's correct" causes a PUT request to be made to the API account endpoint containing the current user profile email address
+   */
+  it('User profile email bounce is visible and can be confirmed by users', () => {
+    getProfile().then((profile) => {
+      const userprofileEmail = profile.body.email;
+
+      const UserProfileEmailBounceBanner = `An email to your user profile’s email address couldn’t be delivered. Is ${userprofileEmail} the correct address?`;
+
+      mockGetNotifications(notifications_user_email_bounce).as(
+        'mockNotifications'
+      );
+      cy.visitWithLogin('/account/users');
+      cy.wait('@mockNotifications');
+
+      mockUpdateProfile({
+        ...profile.body,
+        email: userprofileEmail,
+      }).as('updateEmail');
+
+      cy.contains(UserProfileEmailBounceBanner)
+        .should('be.visible')
+        .parent()
+        .parent()
+        .within(() => {
+          ui.button
+            .findByTitle(confirmButton)
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      ui.toast.assertMessage('Email confirmed');
+      cy.contains(UserProfileEmailBounceBanner).should('not.exist');
+      cy.wait('@updateEmail');
+      cy.findByText(`${userprofileEmail}`).should('be.visible');
+    });
+  });
+
+  /*
+   * Confirm that the user profile email banner appears when the user_email_bounce notification is present
+   * Confirm that clicking "No, let's update it" redirects the user to {{/account} and that the contact info edit drawer is automatically opened
+   */
+  it('User profile email bounce is visible and can be updated by users', () => {
+    const newEmail = `${randomString(12)}@example.com`;
+
+    getProfile().then((profile) => {
+      const userprofileEmail = profile.body.email;
+
+      const UserProfileEmailBounceBanner = `An email to your user profile’s email address couldn’t be delivered. Is ${userprofileEmail} the correct address?`;
+
+      mockGetNotifications(notifications_user_email_bounce).as(
+        'mockNotifications'
+      );
+      cy.visitWithLogin('/account/users');
+      cy.wait('@mockNotifications');
+
+      mockUpdateProfile({
+        ...profile.body,
+        email: userprofileEmail,
+      }).as('updateEmail');
+
+      cy.contains(UserProfileEmailBounceBanner)
+        .should('be.visible')
+        .parent()
+        .parent()
+        .within(() => {
+          ui.button
+            .findByTitle(updateButton)
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      cy.get('[id="email"]')
+        .should('be.visible')
+        .should('have.value', userprofileEmail)
+        .clear()
+        .type(newEmail);
+
+      cy.get('[data-qa-textfield-label="Email"]')
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          ui.button
+            .findByTitle('Update Email')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      cy.wait('@updateEmail');
+      cy.findByText('Email updated successfully.').should('be.visible');
+      // email bounce still exist ???
+    });
+  });
+
+  it.only('Billing email bounce is visible and can be confirmed by users', () => {
+    //how to get billing email???
+    const BillingEmail = 'azsh@akamai.com';
+
+    const BillingEmailBounceBanner = `An email to your account’s email address couldn’t be delivered. Is ${BillingEmail} the correct address?`;
+
+    mockGetNotifications(notifications_billing_email_bounce).as(
+      'mockNotifications'
+    );
+    cy.visitWithLogin('/account/billing');
+    cy.wait('@mockNotifications');
+
+    //mockUpdateAccount(mockAccount).as('AccountBilling');
+
+    cy.contains(BillingEmailBounceBanner)
+      .should('be.visible')
+      .parent()
+      .parent()
+      .within(() => {
+        ui.button
+          .findByTitle(confirmButton)
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    ui.toast.assertMessage('Email confirmed');
+
+    //cy.wait('@AccountBilling');
+    cy.contains(BillingEmailBounceBanner).should('not.exist');
+    cy.findByText('Billing Contact')
+      .should('be.visible')
+      .parent()
+      .parent()
+      .within(() => {
+        cy.findByText(`${BillingEmail}`).should('be.visible');
+      });
+  });
+});

--- a/packages/manager/cypress/e2e/core/account/email-bounce.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/email-bounce.spec.ts
@@ -10,7 +10,7 @@ import { ui } from 'support/ui';
 import { mockUpdateProfile } from 'support/intercepts/profile';
 import { randomString } from 'support/util/random';
 import { accountFactory } from 'src/factories/account';
-import { mockGetAccount, mockUpdateAccount } from 'support/intercepts/account';
+import { mockGetAccount } from 'support/intercepts/account';
 
 const notifications_billing_email_bounce: Notification[] = [
   notificationFactory.build({
@@ -74,7 +74,8 @@ describe('Email bounce banners', () => {
    * Confirm that the user profile email banner appears when the user_email_bounce notification is present
    * Confirm that clicking "No, let's update it" redirects the user to {{/account} and that the contact info edit drawer is automatically opened
    */
-  it.only('User profile email bounce is visible and can be updated by users', () => {
+  // TODO unskip the test once https://jira.linode.com/browse/M3-8181 is fixed
+  it.skip('User profile email bounce is visible and can be updated by users', () => {
     const newEmail = `${randomString(12)}@example.com`;
 
     getProfile().then((profile) => {
@@ -119,8 +120,9 @@ describe('Email bounce banners', () => {
         });
 
       cy.findByText('Email updated successfully.').should('be.visible');
+
+      // https://jira.linode.com/browse/M3-8181
       cy.contains(UserProfileEmailBounceBanner).should('not.exist');
-      // email bounce still exist ???
     });
   });
 
@@ -171,7 +173,8 @@ describe('Email bounce banners', () => {
    *   Confirm that the billing email banner appears when the billing_email_bounce notification is present
    *   Confirm that clicking "No, let's update it" redirects the user to {{/account} and that the contact info edit drawer is automatically opened
    */
-  it('Billing email bounce is visible and can be updated by users', () => {
+  // TODO unskip the test once https://jira.linode.com/browse/M3-8181 is fixed
+  it.skip('Billing email bounce is visible and can be updated by users', () => {
     const accountData = accountFactory.build();
     const billingemail = accountData.email;
 
@@ -187,9 +190,6 @@ describe('Email bounce banners', () => {
     cy.visitWithLogin('/account/billing');
     cy.wait(['@mockNotifications', '@getAccount']);
 
-    // mock the user's account data and confirm that it is displayed correctly upon page load
-    //mockUpdateAccount(accountFactory.build()).as('updateAccount');
-
     cy.contains(BillingEmailBounceBanner)
       .should('be.visible')
       .parent()
@@ -201,8 +201,8 @@ describe('Email bounce banners', () => {
           .should('be.enabled')
           .click();
       });
-    mockUpdateAccount(accountFactory.build()).as('updateAccount');
 
-    cy.wait('@updateAccount');
+    //https://jira.linode.com/browse/M3-8181
+    cy.contains(BillingEmailBounceBanner).should('not.exist');
   });
 });

--- a/packages/manager/cypress/e2e/core/account/email-bounce.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/email-bounce.spec.ts
@@ -74,7 +74,7 @@ describe('Email bounce banners', () => {
    * Confirm that the user profile email banner appears when the user_email_bounce notification is present
    * Confirm that clicking "No, let's update it" redirects the user to {{/account} and that the contact info edit drawer is automatically opened
    */
-  it('User profile email bounce is visible and can be updated by users', () => {
+  it.only('User profile email bounce is visible and can be updated by users', () => {
     const newEmail = `${randomString(12)}@example.com`;
 
     getProfile().then((profile) => {
@@ -119,6 +119,7 @@ describe('Email bounce banners', () => {
         });
 
       cy.findByText('Email updated successfully.').should('be.visible');
+      cy.contains(UserProfileEmailBounceBanner).should('not.exist');
       // email bounce still exist ???
     });
   });
@@ -170,7 +171,7 @@ describe('Email bounce banners', () => {
    *   Confirm that the billing email banner appears when the billing_email_bounce notification is present
    *   Confirm that clicking "No, let's update it" redirects the user to {{/account} and that the contact info edit drawer is automatically opened
    */
-  it.only('Billing email bounce is visible and can be updated by users', () => {
+  it('Billing email bounce is visible and can be updated by users', () => {
     const accountData = accountFactory.build();
     const billingemail = accountData.email;
 


### PR DESCRIPTION
## Description 📝
Add a Cypress integration test to confirm that the email bounce notification banner appears when Akamai is unable to email a user at their specified address. There are two cases where this might happen: upon failure to send an email to the billing email address, and upon failure to send an email to the user profile email address.

## Changes  🔄
- Add test for the use case that user profile email bounce is visible and can be confirmed by users
- Add test for the use case that billing email bounce is visible and can be confirmed by users
- Add test for the use case that user profile email bounce is visible and can be updated by users
- Add test for the use case that billing email bounce is visible and can be updated by users
- Skip tests regarding update button due to https://jira.linode.com/browse/M3-8181

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/account/email-bounce.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
