### PR TITLE
fix: [M3-7718] - Stale assigned Firewall data displaying on Linode and NodeBalancer details pages

### DIFF
--- a/packages/manager/.changeset/pr-10534-fixed-1717169773875.md
+++ b/packages/manager/.changeset/pr-10534-fixed-1717169773875.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Stale assigned Firewall data displaying on Linode and NodeBalancer details pages ([#10534](https://github.com/linode/manager/pull/10534))

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/RemoveDeviceDialog.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/RemoveDeviceDialog.tsx
@@ -1,15 +1,15 @@
 import { FirewallDevice } from '@linode/api-v4';
+import { useQueryClient } from '@tanstack/react-query';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
-import { useQueryClient } from '@tanstack/react-query';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
 import { Typography } from 'src/components/Typography';
-import { queryKey as firewallQueryKey } from 'src/queries/firewalls';
 import { useRemoveFirewallDeviceMutation } from 'src/queries/firewalls';
+import { queryKey as firewallQueryKey } from 'src/queries/firewalls';
 import { queryKey as linodesQueryKey } from 'src/queries/linodes/linodes';
-import { queryKey as nodeBalancerQueryKey } from 'src/queries/nodebalancers';
+import { queryKey as nodebalancersQueryKey } from 'src/queries/nodebalancers';
 
 export interface Props {
   device: FirewallDevice | undefined;
@@ -48,12 +48,12 @@ export const RemoveDeviceDialog = React.memo((props: Props) => {
       enqueueSnackbar(error[0].reason, { variant: 'error' });
     }
 
-    const querykey =
-      deviceType === 'linode' ? linodesQueryKey : nodeBalancerQueryKey;
+    const queryKey =
+      deviceType === 'linode' ? linodesQueryKey : nodebalancersQueryKey;
 
     // Since the linode was removed as a device, invalidate the linode-specific firewall query
     queryClient.invalidateQueries([
-      querykey,
+      queryKey,
       deviceType,
       device?.entity.id,
       'firewalls',

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
@@ -13,7 +13,7 @@ import {
   useUpdateFirewallRulesMutation,
 } from 'src/queries/firewalls';
 import { queryKey as linodesQueryKey } from 'src/queries/linodes/linodes';
-import { queryKey as nodebalancerQueryKey } from 'src/queries/nodebalancers';
+import { queryKey as nodebalancersQueryKey } from 'src/queries/nodebalancers';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 import { FirewallRuleDrawer } from './FirewallRuleDrawer';
@@ -207,7 +207,7 @@ export const FirewallRulesLanding = React.memo((props: Props) => {
           queryClient.invalidateQueries([
             device.entity.type === 'linode'
               ? linodesQueryKey
-              : nodebalancerQueryKey,
+              : nodebalancersQueryKey,
             device.entity.type,
             device.entity.id,
             'firewalls',

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
@@ -1,4 +1,5 @@
 import { styled } from '@mui/material/styles';
+import { useQueryClient } from '@tanstack/react-query';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
 
@@ -7,11 +8,15 @@ import { ConfirmationDialog } from 'src/components/ConfirmationDialog/Confirmati
 import { Notice } from 'src/components/Notice/Notice';
 import { Prompt } from 'src/components/Prompt/Prompt';
 import { Typography } from 'src/components/Typography';
-import { useUpdateFirewallRulesMutation } from 'src/queries/firewalls';
+import {
+  useAllFirewallDevicesQuery,
+  useUpdateFirewallRulesMutation,
+} from 'src/queries/firewalls';
+import { queryKey as linodesQueryKey } from 'src/queries/linodes/linodes';
+import { queryKey as nodebalancerQueryKey } from 'src/queries/nodebalancers';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 import { FirewallRuleDrawer } from './FirewallRuleDrawer';
-import { FirewallRuleTable } from './FirewallRuleTable';
 import {
   hasModified as _hasModified,
   curriedFirewallRuleEditorReducer,
@@ -20,6 +25,7 @@ import {
   prepareRules,
   stripExtendedFields,
 } from './firewallRuleEditor';
+import { FirewallRuleTable } from './FirewallRuleTable';
 import { parseFirewallRuleError } from './shared';
 
 import type { FirewallRuleDrawerMode } from './FirewallRuleDrawer.types';
@@ -51,6 +57,8 @@ export const FirewallRulesLanding = React.memo((props: Props) => {
   const { mutateAsync: updateFirewallRules } = useUpdateFirewallRulesMutation(
     firewallID
   );
+  const { data: devices } = useAllFirewallDevicesQuery(firewallID);
+  const queryClient = useQueryClient();
 
   const { enqueueSnackbar } = useSnackbar();
 
@@ -193,6 +201,19 @@ export const FirewallRulesLanding = React.memo((props: Props) => {
     updateFirewallRules(finalRules)
       .then((_rules) => {
         setSubmitting(false);
+        // Invalidate Firewalls assigned to NodeBalancers and Linodes.
+        // eslint-disable-next-line no-unused-expressions
+        devices?.forEach((device) =>
+          queryClient.invalidateQueries([
+            device.entity.type === 'linode'
+              ? linodesQueryKey
+              : nodebalancerQueryKey,
+            device.entity.type,
+            device.entity.id,
+            'firewalls',
+          ])
+        );
+
         // Reset editor state.
         inboundDispatch({ rules: _rules.inbound ?? [], type: 'RESET' });
         outboundDispatch({ rules: _rules.outbound ?? [], type: 'RESET' });

--- a/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
@@ -33,7 +33,7 @@ import {
   useCreateFirewall,
 } from 'src/queries/firewalls';
 import { queryKey as linodesQueryKey } from 'src/queries/linodes/linodes';
-import { queryKey as nodebalancerQueryKey } from 'src/queries/nodebalancers';
+import { queryKey as nodebalancersQueryKey } from 'src/queries/nodebalancers';
 import { useGrants } from 'src/queries/profile';
 import { sendLinodeCreateFormStepEvent } from 'src/utilities/analytics/formEventAnalytics';
 import { getErrorMap } from 'src/utilities/errorUtils';
@@ -153,7 +153,7 @@ export const CreateFirewallDrawer = React.memo(
             if (payload.devices?.nodebalancers) {
               payload.devices.nodebalancers.forEach((nodebalancerId) => {
                 queryClient.invalidateQueries([
-                  nodebalancerQueryKey,
+                  nodebalancersQueryKey,
                   'nodebalancer',
                   nodebalancerId,
                   'firewalls',

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallDialog.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallDialog.tsx
@@ -66,17 +66,19 @@ export const FirewallDialog = React.memo((props: Props) => {
 
   const onSubmit = async () => {
     await requestMap[mode]();
+    // Invalidate Firewalls assigned to NodeBalancers and Linodes when Firewall is enabled, disabled, or deleted.
+    // eslint-disable-next-line no-unused-expressions
+    devices?.forEach((device) => {
+      const deviceType = device.entity.type;
+      queryClient.invalidateQueries([
+        deviceType === 'linode' ? linodesQueryKey : nodebalancerQueryKey,
+        deviceType,
+        device.entity.id,
+        'firewalls',
+      ]);
+    });
     if (mode === 'delete') {
-      devices?.forEach((device) => {
-        const deviceType = device.entity.type;
-        queryClient.invalidateQueries([
-          deviceType === 'linode' ? linodesQueryKey : nodebalancerQueryKey,
-          deviceType,
-          device.entity.id,
-          'firewalls',
-        ]);
-        queryClient.invalidateQueries([firewallQueryKey]);
-      });
+      queryClient.invalidateQueries([firewallQueryKey]);
     }
     enqueueSnackbar(`Firewall ${label} successfully ${mode}d`, {
       variant: 'success',

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallDialog.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallDialog.tsx
@@ -8,7 +8,7 @@ import { useDeleteFirewall, useMutateFirewall } from 'src/queries/firewalls';
 import { queryKey as firewallQueryKey } from 'src/queries/firewalls';
 import { useAllFirewallDevicesQuery } from 'src/queries/firewalls';
 import { queryKey as linodesQueryKey } from 'src/queries/linodes/linodes';
-import { queryKey as nodebalancerQueryKey } from 'src/queries/nodebalancers';
+import { queryKey as nodebalancersQueryKey } from 'src/queries/nodebalancers';
 import { capitalize } from 'src/utilities/capitalize';
 
 export type Mode = 'delete' | 'disable' | 'enable';
@@ -71,7 +71,7 @@ export const FirewallDialog = React.memo((props: Props) => {
     devices?.forEach((device) => {
       const deviceType = device.entity.type;
       queryClient.invalidateQueries([
-        deviceType === 'linode' ? linodesQueryKey : nodebalancerQueryKey,
+        deviceType === 'linode' ? linodesQueryKey : nodebalancersQueryKey,
         deviceType,
         device.entity.id,
         'firewalls',


### PR DESCRIPTION
## Description 📝
`useAllFirewallDevicesQuery` was not always being invalidated when modifying a Firewall.

As a result, without refreshing the page, adding/deleting rules or enabling/disabling a Firewall with assigned device(s) will not show the Firewall's most accurate status or rules on the NodeBalancer Details > Settings  or Linode Details > Network tab if the query for that Firewall has already been cached because the page was previously visited.

## Changes  🔄
- Added query invalidation on submission of the Firewall Dialog for enabling and disabling a Firewall.
- Added query invalidation on submission of updated Firewall rules.
- Cleaned up naming of query keys for consistency (capitalization; made query key plural for `nodebalancers`).

## Target release date 🗓️
6/10

## Preview 📷
| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/114685994/d78b20fc-3cfd-4b1e-a103-84ebedcdf381" /> | <video src="https://github.com/linode/manager/assets/114685994/ab8fffb5-1f40-4a85-bd1e-f28cd2977bc2" /> |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Have/create a device (Linode and/or NodeBalancer) on your account.

### Reproduction steps
(How to reproduce the issue, if applicable)
1. Go to https://cloud.linode.com/firewalls and create a new Firewall.
2. Attach your device to that Firewall.
3. Click on the label of the device to navigate to the Details page.
4. Go to the Linode Details > Network tab or NodeBalancer Details > Settings tab. Observe under the Firewalls section that the Firewall from step 2 is listed and there are "No rules" and it is Enabled.
5. Click on the Firewall label to navigate to the Firewall's details page and add a new inbound or outbound rule. (Can be a preset rule; it's fastest.) Save the changes. 
6. Switch the Firewall's Status from Enabled to Disabled via the Firewall landing page.
7. Navigate back to the device with the Firewall, either via nav bar or via the Firewall details page > device tab.
8. Go back to the Network or Settings tab where the Firewalls table is shown for that device.
9. Observe the bug: the Firewall listed in the table will not have the newly added rule and its status will not have updated.
10. Refresh the page.
111. Observe the rule now shows up. (e.g. "1 inbound rule" or "1 outbound rule") and the status has changed.

### Verification steps
(How to verify changes)
- Check out this PR.
- Repeat the steps above to modify the Firewall's rules and status. 
- Confirm that no page refresh is needed to see the device's accurate Firewall data due to RQ correctly invalidating as expected when the Firewall is modified, and then refetching once the user navigates to the Firewalls table on the Linode Network tab or NodeBalancer Settings tab.


## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
