### PR TITLE
change: [M3-8159] - Modify limited availability banner display logic

### DIFF
--- a/packages/manager/.changeset/pr-10536-changed-1717183226858.md
+++ b/packages/manager/.changeset/pr-10536-changed-1717183226858.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Modify limited availability banner display logic ([#10536](https://github.com/linode/manager/pull/10536))

--- a/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
@@ -44,6 +44,11 @@ const mockDedicatedLinodeTypes = [
     label: 'dedicated-3',
     class: 'dedicated',
   }),
+  linodeTypeFactory.build({
+    id: 'dedicated-4',
+    label: 'dedicated-4',
+    class: 'dedicated',
+  }),
 ];
 
 const mockSharedLinodeTypes = [
@@ -99,7 +104,17 @@ const mockRegionAvailability = [
     region: 'us-east',
   }),
   regionAvailabilityFactory.build({
+    plan: 'dedicated-4',
+    available: false,
+    region: 'us-east',
+  }),
+  regionAvailabilityFactory.build({
     plan: 'highmem-1',
+    available: false,
+    region: 'us-east',
+  }),
+  regionAvailabilityFactory.build({
+    plan: 'shared-3',
     available: false,
     region: 'us-east',
   }),
@@ -110,7 +125,7 @@ const k8PlansPanel = '[data-qa-tp="Add Node Pools"]';
 const planSelectionTable = 'List of Linode Plans';
 
 const notices = {
-  limitedAvailability: '[data-testid="disabled-plan-tooltip"]',
+  limitedAvailability: '[data-testid="limited-availability-banner"]',
   unavailable: '[data-testid="notice-error"]',
 };
 
@@ -136,15 +151,15 @@ describe('displays linode plans panel based on availability', () => {
     // Dedicated CPU tab
     // Should be selected/open by default
     // Should have the limited availability notice
-    // Should contain 4 plans (5 rows including the header row)
-    // Should have 2 plans disabled
-    // Should have tooltips for the disabled plans (not more than half disabled plans in the panel)
+    // Should contain 5 plans (6 rows including the header row)
+    // Should have 3 plans disabled
+    // Should not have tooltips for the disabled plans (more than half disabled plans in the panel)
     cy.get(linodePlansPanel).within(() => {
       cy.findAllByRole('alert').should('have.length', 1);
       cy.get(notices.limitedAvailability).should('be.visible');
 
       cy.findByRole('table', { name: planSelectionTable }).within(() => {
-        cy.findAllByRole('row').should('have.length', 5);
+        cy.findAllByRole('row').should('have.length', 6);
         cy.get('[id="dedicated-1"]').should('be.enabled');
         cy.get('[id="dedicated-2"]').should('be.enabled');
         cy.get(
@@ -152,15 +167,15 @@ describe('displays linode plans panel based on availability', () => {
         );
         cy.get('[id="dedicated-3"]').should('be.disabled');
         cy.get('[id="g6-dedicated-64"]').should('be.disabled');
-        cy.findAllByTestId('disabled-plan-tooltip').should('have.length', 2);
+        cy.findAllByTestId('disabled-plan-tooltip').should('have.length', 0);
       });
     });
 
     // Shared CPU tab
     // Should have no notices
     // Should contain 3 plans (4 rows including the header row)
-    // Should have 0 disabled plan
-    // Should have no tooltip for the disabled plan
+    // Should have 1 disabled plan
+    // Should have one tooltip for the disabled plan
     cy.findByText('Shared CPU').click();
     cy.get(linodePlansPanel).within(() => {
       cy.findAllByRole('alert').should('have.length', 0);
@@ -169,8 +184,8 @@ describe('displays linode plans panel based on availability', () => {
         cy.findAllByRole('row').should('have.length', 4);
         cy.get('[id="shared-1"]').should('be.enabled');
         cy.get('[id="shared-2"]').should('be.enabled');
-        cy.get('[id="shared-3"]').should('be.enabled');
-        cy.findAllByTestId('disabled-plan-tooltip').should('have.length', 0);
+        cy.get('[id="shared-3"]').should('be.disabled');
+        cy.findAllByTestId('disabled-plan-tooltip').should('have.length', 1);
       });
     });
 
@@ -178,7 +193,7 @@ describe('displays linode plans panel based on availability', () => {
     // Should have the limited availability notice
     // Should contain 1 plan (2 rows including the header row)
     // Should have one disabled plan
-    // Should have tooltip for the disabled plan (more than half disabled plans in the panel, but only one plan)
+    // Should have no tooltip for the disabled plan (more than half disabled plans in the panel)
     cy.findByText('High Memory').click();
     cy.get(linodePlansPanel).within(() => {
       cy.findAllByRole('alert').should('have.length', 1);
@@ -187,7 +202,7 @@ describe('displays linode plans panel based on availability', () => {
       cy.findByRole('table', { name: planSelectionTable }).within(() => {
         cy.findAllByRole('row').should('have.length', 2);
         cy.get('[id="highmem-1"]').should('be.disabled');
-        cy.findAllByTestId('disabled-plan-tooltip').should('have.length', 1);
+        cy.findAllByTestId('disabled-plan-tooltip').should('have.length', 0);
       });
     });
 
@@ -232,9 +247,9 @@ describe('displays kubernetes plans panel based on availability', () => {
     // Dedicated CPU tab
     // Should be selected/open by default
     // Should have the limited availability notice
-    // Should contain 4 plans (5 rows including the header row)
-    // Should have 2 plans disabled
-    // Should have tooltips for the disabled plans (not more than half disabled plans in the panel)
+    // Should contain 5 plans (6 rows including the header row)
+    // Should have 3 plans disabled
+    // Should have no tooltips for the disabled plans (more than half disabled plans in the panel)
     // All inputs for a row should be enabled if row is enabled (only testing one row in suite)
     // All inputs for a disabled row should be disabled (only testing one row in suite)
     cy.get(k8PlansPanel).within(() => {
@@ -242,7 +257,7 @@ describe('displays kubernetes plans panel based on availability', () => {
       cy.get(notices.limitedAvailability).should('be.visible');
 
       cy.findByRole('table', { name: planSelectionTable }).within(() => {
-        cy.findAllByRole('row').should('have.length', 5);
+        cy.findAllByRole('row').should('have.length', 6);
         cy.get('[data-qa-plan-row="dedicated-1"]').should(
           'not.have.attr',
           'disabled'
@@ -270,14 +285,14 @@ describe('displays kubernetes plans panel based on availability', () => {
             )
             .should('be.disabled');
         });
-        cy.findAllByTestId('disabled-plan-tooltip').should('have.length', 2);
+        cy.findAllByTestId('disabled-plan-tooltip').should('have.length', 0);
       });
     });
 
     // Shared CPU tab
     // Should have no notices
     // Should contain 3 plans (4 rows including the header row)
-    // Should have 1 disabled plan
+    // Should have 2 disabled plans
     // Should have tooltip for the disabled plan (not more than half disabled plans in the panel)
     cy.findByText('Shared CPU').click();
     cy.get(k8PlansPanel).within(() => {
@@ -293,11 +308,8 @@ describe('displays kubernetes plans panel based on availability', () => {
           'not.have.attr',
           'disabled'
         );
-        cy.get('[data-qa-plan-row="shared-3"]').should(
-          'not.have.attr',
-          'disabled'
-        );
-        cy.findAllByTestId('disabled-plan-tooltip').should('have.length', 0);
+        cy.get('[data-qa-plan-row="shared-3"]').should('have.attr', 'disabled');
+        cy.findAllByTestId('disabled-plan-tooltip').should('have.length', 1);
       });
     });
 
@@ -305,7 +317,7 @@ describe('displays kubernetes plans panel based on availability', () => {
     // Should have the limited availability notice
     // Should contain 1 plan (2 rows including the header row)
     // Should have one disabled plan
-    // Should have tooltip for the disabled plan (more than half disabled plans in the panel, but only one plan)
+    // Should have no tooltip for the disabled plan (more than half disabled plans in the panel)
     cy.findByText('High Memory').click();
     cy.get(k8PlansPanel).within(() => {
       cy.findAllByRole('alert').should('have.length', 1);
@@ -317,7 +329,7 @@ describe('displays kubernetes plans panel based on availability', () => {
           'have.attr',
           'disabled'
         );
-        cy.findAllByTestId('disabled-plan-tooltip').should('have.length', 1);
+        cy.findAllByTestId('disabled-plan-tooltip').should('have.length', 0);
       });
     });
 

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
@@ -76,7 +76,6 @@ export const KubernetesPlansPanel = (props: Props) => {
     const plansMap: PlanSelectionType[] = plans[plan];
     const {
       allDisabledPlans,
-      hasDisabledPlans,
       hasMajorityOfPlansDisabled,
       plansForThisLinodeTypeClass,
     } = extractPlansInformation({
@@ -94,7 +93,7 @@ export const KubernetesPlansPanel = (props: Props) => {
               isSelectedRegionEligibleForPlan={isSelectedRegionEligibleForPlan(
                 plan
               )}
-              hasDisabledPlans={hasDisabledPlans}
+              hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
               hasSelectedRegion={hasSelectedRegion}
               planType={plan}
               regionsData={regionsData}

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.test.tsx
@@ -11,7 +11,7 @@ import {
 import type { PlanInformationProps } from './PlanInformation';
 
 const mockProps: PlanInformationProps = {
-  hasDisabledPlans: false,
+  hasMajorityOfPlansDisabled: false,
   hasSelectedRegion: true,
   isSelectedRegionEligibleForPlan: false,
   planType: 'standard',
@@ -38,7 +38,7 @@ describe('PlanInformation', () => {
     renderWithTheme(
       <PlanInformation
         {...mockProps}
-        hasDisabledPlans={true}
+        hasMajorityOfPlansDisabled={true}
         isSelectedRegionEligibleForPlan={true}
         planType="dedicated"
       />

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
@@ -31,7 +31,6 @@ export interface PlanInformationProps {
 }
 
 export const PlanInformation = (props: PlanInformationProps) => {
-  const theme = useTheme();
   const {
     disabledClasses,
     hasMajorityOfPlansDisabled,
@@ -72,111 +71,72 @@ export const PlanInformation = (props: PlanInformationProps) => {
       ) : null}
       {hasSelectedRegion &&
         isSelectedRegionEligibleForPlan &&
-        !hideLimitedAvailabilityBanner && (
-          <LimitedAvailabilityNotice
-            hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
-            planType={planType}
-          />
+        !hideLimitedAvailabilityBanner &&
+        hasMajorityOfPlansDisabled && (
+          <Notice
+            sx={(theme: Theme) => ({
+              marginBottom: theme.spacing(3),
+              marginLeft: 0,
+              marginTop: 0,
+              padding: `${theme.spacing(0.5)} ${theme.spacing(2)}`,
+            })}
+            dataTestId={limitedAvailabilityBannerTestId}
+            variant="warning"
+          >
+            <StyledNoticeTypography>
+              These plans have limited deployment availability.
+            </StyledNoticeTypography>
+          </Notice>
         )}
-      <Typography
-        data-qa-prodedi
-        sx={{ marginBottom: theme.spacing(3), marginTop: theme.spacing(1) }}
-      >
-        {planTabInfoContent[planType]?.typography}
-      </Typography>
+      <ClassDescriptionCopy planType={planType} />
     </>
   );
 };
 
 export const limitedAvailabilityBannerTestId = 'limited-availability-banner';
 
-interface LimitedAvailabilityNoticeProps {
-  hasMajorityOfPlansDisabled: boolean;
+interface ClassDescriptionCopyProps {
   planType: 'shared' | LinodeTypeClass;
 }
 
-export const LimitedAvailabilityNotice = (
-  props: LimitedAvailabilityNoticeProps
-) => {
-  const { hasMajorityOfPlansDisabled, planType } = props;
+export const ClassDescriptionCopy = (props: ClassDescriptionCopyProps) => {
+  const { planType } = props;
+  const theme = useTheme();
+  let planTypeLabel: null | string;
+  let docLink: null | string;
 
   switch (planType) {
     case 'dedicated':
-      return (
-        <LimitedAvailabilityNoticeCopy
-          docsLink={DEDICATED_COMPUTE_INSTANCES_LINK}
-          hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
-          planTypeLabel="Dedicated CPU"
-        />
-      );
-
+      planTypeLabel = 'Dedicated CPU';
+      docLink = DEDICATED_COMPUTE_INSTANCES_LINK;
+      break;
     case 'shared':
-      return (
-        <LimitedAvailabilityNoticeCopy
-          docsLink={SHARED_COMPUTE_INSTANCES_LINK}
-          hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
-          planTypeLabel="Shared CPU"
-        />
-      );
-
+      planTypeLabel = 'Shared CPU';
+      docLink = SHARED_COMPUTE_INSTANCES_LINK;
+      break;
     case 'highmem':
-      return (
-        <LimitedAvailabilityNoticeCopy
-          docsLink={HIGH_MEMORY_COMPUTE_INSTANCES_LINK}
-          hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
-          planTypeLabel="High Memory"
-        />
-      );
-
+      planTypeLabel = 'High Memory';
+      docLink = HIGH_MEMORY_COMPUTE_INSTANCES_LINK;
+      break;
     case 'premium':
-      return (
-        <LimitedAvailabilityNoticeCopy
-          docsLink={PREMIUM_COMPUTE_INSTANCES_LINK}
-          hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
-          planTypeLabel="Premium CPU"
-        />
-      );
-
+      planTypeLabel = 'Premium CPU';
+      docLink = PREMIUM_COMPUTE_INSTANCES_LINK;
+      break;
     case 'gpu':
-      return (
-        <LimitedAvailabilityNoticeCopy
-          docsLink={GPU_COMPUTE_INSTANCES_LINK}
-          hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
-          planTypeLabel="GPU"
-        />
-      );
-
+      planTypeLabel = 'GPU';
+      docLink = GPU_COMPUTE_INSTANCES_LINK;
+      break;
     default:
-      return null;
+      planTypeLabel = null;
+      docLink = null;
   }
-};
 
-interface LimitedAvailabilityNoticeCopyProps {
-  docsLink: string;
-  hasMajorityOfPlansDisabled: boolean;
-  planTypeLabel: string;
-}
-
-export const LimitedAvailabilityNoticeCopy = (
-  props: LimitedAvailabilityNoticeCopyProps
-) => {
-  const { docsLink, hasMajorityOfPlansDisabled, planTypeLabel } = props;
-
-  return hasMajorityOfPlansDisabled ? (
-    <Notice
-      sx={(theme: Theme) => ({
-        marginBottom: theme.spacing(3),
-        marginLeft: 0,
-        marginTop: 0,
-        padding: `${theme.spacing(0.5)} ${theme.spacing(2)}`,
-      })}
-      dataTestId={limitedAvailabilityBannerTestId}
-      variant="warning"
+  return planTypeLabel && docLink ? (
+    <Typography
+      sx={{ marginBottom: theme.spacing(3), marginTop: theme.spacing(1) }}
     >
-      <StyledNoticeTypography>
-        These plans have limited deployment availability.{' '}
-        <Link to={docsLink}>Learn more</Link> about our {planTypeLabel} plans.
-      </StyledNoticeTypography>
-    </Notice>
+      {planTabInfoContent[planType]?.typography}{' '}
+      <Link to={docLink}>Learn more</Link> about our {planTypeLabel} plans.
+    </Typography>
   ) : null;
 };

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
@@ -22,7 +22,7 @@ import type { Region } from '@linode/api-v4';
 
 export interface PlanInformationProps {
   disabledClasses?: LinodeTypeClass[];
-  hasDisabledPlans: boolean;
+  hasMajorityOfPlansDisabled: boolean;
   hasSelectedRegion: boolean;
   hideLimitedAvailabilityBanner?: boolean;
   isSelectedRegionEligibleForPlan: boolean;
@@ -34,7 +34,7 @@ export const PlanInformation = (props: PlanInformationProps) => {
   const theme = useTheme();
   const {
     disabledClasses,
-    hasDisabledPlans,
+    hasMajorityOfPlansDisabled,
     hasSelectedRegion,
     hideLimitedAvailabilityBanner,
     isSelectedRegionEligibleForPlan,
@@ -74,7 +74,7 @@ export const PlanInformation = (props: PlanInformationProps) => {
         isSelectedRegionEligibleForPlan &&
         !hideLimitedAvailabilityBanner && (
           <LimitedAvailabilityNotice
-            hasDisabledPlans={hasDisabledPlans}
+            hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
             planType={planType}
           />
         )}
@@ -91,21 +91,21 @@ export const PlanInformation = (props: PlanInformationProps) => {
 export const limitedAvailabilityBannerTestId = 'limited-availability-banner';
 
 interface LimitedAvailabilityNoticeProps {
-  hasDisabledPlans: boolean;
+  hasMajorityOfPlansDisabled: boolean;
   planType: 'shared' | LinodeTypeClass;
 }
 
 export const LimitedAvailabilityNotice = (
   props: LimitedAvailabilityNoticeProps
 ) => {
-  const { hasDisabledPlans, planType } = props;
+  const { hasMajorityOfPlansDisabled, planType } = props;
 
   switch (planType) {
     case 'dedicated':
       return (
         <LimitedAvailabilityNoticeCopy
           docsLink={DEDICATED_COMPUTE_INSTANCES_LINK}
-          hasDisabledPlans={hasDisabledPlans}
+          hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
           planTypeLabel="Dedicated CPU"
         />
       );
@@ -114,7 +114,7 @@ export const LimitedAvailabilityNotice = (
       return (
         <LimitedAvailabilityNoticeCopy
           docsLink={SHARED_COMPUTE_INSTANCES_LINK}
-          hasDisabledPlans={hasDisabledPlans}
+          hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
           planTypeLabel="Shared CPU"
         />
       );
@@ -123,7 +123,7 @@ export const LimitedAvailabilityNotice = (
       return (
         <LimitedAvailabilityNoticeCopy
           docsLink={HIGH_MEMORY_COMPUTE_INSTANCES_LINK}
-          hasDisabledPlans={hasDisabledPlans}
+          hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
           planTypeLabel="High Memory"
         />
       );
@@ -132,7 +132,7 @@ export const LimitedAvailabilityNotice = (
       return (
         <LimitedAvailabilityNoticeCopy
           docsLink={PREMIUM_COMPUTE_INSTANCES_LINK}
-          hasDisabledPlans={hasDisabledPlans}
+          hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
           planTypeLabel="Premium CPU"
         />
       );
@@ -141,7 +141,7 @@ export const LimitedAvailabilityNotice = (
       return (
         <LimitedAvailabilityNoticeCopy
           docsLink={GPU_COMPUTE_INSTANCES_LINK}
-          hasDisabledPlans={hasDisabledPlans}
+          hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
           planTypeLabel="GPU"
         />
       );
@@ -153,16 +153,16 @@ export const LimitedAvailabilityNotice = (
 
 interface LimitedAvailabilityNoticeCopyProps {
   docsLink: string;
-  hasDisabledPlans: boolean;
+  hasMajorityOfPlansDisabled: boolean;
   planTypeLabel: string;
 }
 
 export const LimitedAvailabilityNoticeCopy = (
   props: LimitedAvailabilityNoticeCopyProps
 ) => {
-  const { docsLink, hasDisabledPlans, planTypeLabel } = props;
+  const { docsLink, hasMajorityOfPlansDisabled, planTypeLabel } = props;
 
-  return hasDisabledPlans ? (
+  return hasMajorityOfPlansDisabled ? (
     <Notice
       sx={(theme: Theme) => ({
         marginBottom: theme.spacing(3),

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -119,7 +119,6 @@ export const PlansPanel = (props: PlansPanelProps) => {
     const plansMap: PlanSelectionType[] = plans[plan];
     const {
       allDisabledPlans,
-      hasDisabledPlans,
       hasMajorityOfPlansDisabled,
       plansForThisLinodeTypeClass,
     } = extractPlansInformation({
@@ -144,7 +143,7 @@ export const PlansPanel = (props: PlansPanelProps) => {
                 plan
               )}
               disabledClasses={disabledClasses}
-              hasDisabledPlans={hasDisabledPlans}
+              hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
               hasSelectedRegion={hasSelectedRegion}
               planType={plan}
               regionsData={regionsData || []}

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -145,7 +145,9 @@ export const PlansPanel = (props: PlansPanelProps) => {
           <>
             <PlanInformation
               hideLimitedAvailabilityBanner={
-                showDistributedRegionPlanTable || !flags.disableLargestGbPlans
+                showDistributedRegionPlanTable ||
+                !flags.disableLargestGbPlans ||
+                plan === 'metal' // Bare Metal plans handle their own limited availability banner since they are an special case
               }
               isSelectedRegionEligibleForPlan={isSelectedRegionEligibleForPlan(
                 plan

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -53,8 +53,8 @@ export interface PlansPanelProps {
  * It is used in the Linode create, Kubernetes and Database create flows.
  * It contains ample logic to determine which plans are available based on the selected region availability and display related visual indicators:
  * - If the region is not supported, show an error notice and disable all plans.
- * - If more than half plans are disabled, show the limited availability banner and hide the limited availability tooltip
- * - If less than half plans are disabled, hide the limited availability banner and show the limited availability tooltip
+ * - If more than half the plans are disabled, show the limited availability banner and hide the limited availability tooltip
+ * - If less than half the plans are disabled, hide the limited availability banner and show the limited availability tooltip
  */
 export const PlansPanel = (props: PlansPanelProps) => {
   const {

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -48,6 +48,14 @@ export interface PlansPanelProps {
   types: PlanSelectionType[];
 }
 
+/**
+ * PlansPanel is a tabbed panel that displays a list of plans for a Linode.
+ * It is used in the Linode create, Kubernetes and Database create flows.
+ * It contains ample logic to determine which plans are available based on the selected region availability and display related visual indicators:
+ * - If the region is not supported, show an error notice and disable all plans.
+ * - If more than half plans are disabled, show the limited availability banner and hide the limited availability tooltip
+ * - If less than half plans are disabled, hide the limited availability banner and show the limited availability tooltip
+ */
 export const PlansPanel = (props: PlansPanelProps) => {
   const {
     className,

--- a/packages/manager/src/features/components/PlansPanel/utils.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.ts
@@ -331,7 +331,6 @@ export const extractPlansInformation = ({
   }, []);
   const hasDisabledPlans = allDisabledPlans.length > 0;
   const hasMajorityOfPlansDisabled =
-    plans.length !== 1 &&
     allDisabledPlans.length > plansForThisLinodeTypeClass.length / 2;
 
   return {


### PR DESCRIPTION
## Description 📝
This PR modifies the display logic of the limited availability banner in the Selection Plan. This is the result of product wanted to limit the display of the banner, especially as it relates to the 512Gb plan since the banner would always display for any class with a 512 plan.

The solution was to only display the banner if more than half of the plans are disabled. Since that logic already existed for the disabled tooltip, I leveraged this util to apply it to the notice.

As a result, the logic is as follow:
- If more than half plans are disabled, show the limited availability banner and hide the limited availability tooltip
- If less than half plans are disabled, hide the limited availability banner and show the limited availability tooltip

Additionally, it was decided to include the "learn more" link in the Class description copy and remove it from the banner so it is always available for the user now that the banner won't display often.

## Changes  🔄
- Update limited availability banner display logic
- Remove the "Learn More" copy from the limited availability banner
- Update the Class copy to feature the "Learn More" copy
- Update selection plan e2e suite

## Target release date 🗓️
**6/10/2024**

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Create a Linode _ Akamai Cloud Manager · 3 14pm · 05-31](https://github.com/linode/manager/assets/130582365/a4c40033-85a4-43ea-9d19-60fb1cc35a44) | ![Create · 3 04pm · 05-31](https://github.com/linode/manager/assets/130582365/af8a41f2-19f7-4cbe-8d67-659e0efe69de) |
| ![Create a Linode _ Akamai Cloud Manager · 3 14pm · 05-31 (1)](https://github.com/linode/manager/assets/130582365/698c5460-ed7f-4681-946d-89ee5a60eeab) | ![Create](https://github.com/linode/manager/assets/130582365/0c869753-a4e1-4e61-bc0e-f5e41331971d) |

## How to test 🧪

### Verification steps
- Confirm updated display and no regression of selection plans (with different regions) in
  - Linode Create flows
  - Kubernetes Create flow
  - Database create flow

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
