### PR TITLE
change: [M3-6541] - eslint: consistent-type-imports

### DIFF
--- a/packages/manager/.changeset/pr-10540-added-1717433580405.md
+++ b/packages/manager/.changeset/pr-10540-added-1717433580405.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+New `consistent-type-imports` es-lint warning ([#10540](https://github.com/linode/manager/pull/10540))

--- a/packages/manager/.changeset/pr-10540-tech-stories-1717433580405.md
+++ b/packages/manager/.changeset/pr-10540-tech-stories-1717433580405.md
@@ -1,5 +1,5 @@
 ---
-"@linode/manager": Added
+"@linode/manager": Tech Stories
 ---
 
 New `consistent-type-imports` es-lint warning ([#10540](https://github.com/linode/manager/pull/10540))

--- a/packages/manager/.eslintrc.cjs
+++ b/packages/manager/.eslintrc.cjs
@@ -115,6 +115,7 @@ module.exports = {
   rules: {
     '@linode/cloud-manager/no-custom-fontWeight': 'error',
     '@typescript-eslint/camelcase': 'off',
+    "@typescript-eslint/consistent-type-imports": "warn",
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/interface-name-prefix': 'off',


### PR DESCRIPTION
## Description 📝
Tiny PR to start enforcing `consistent-type-imports` through the codebase (`import type` for type file)

https://typescript-eslint.io/rules/consistent-type-imports

This will remain a warning it does not affect the developer experience negatively other than suggesting to make that change when creating or editing a file. It will also make it easier/quicker to fix those via shortcuts when encountered.

## Changes  🔄
- Add `consistent-type-imports` warning to our `es-lint` rules

## Preview 📷
**Include a screenshot or screen recording of the change**

![Screenshot 2024-06-03 at 12 39 07](https://github.com/linode/manager/assets/130582365/346ad69f-b71a-407b-a904-c813bdac1daf)

## How to test 🧪

### Verification steps
- Pull locally and open random file to see the new lint warning

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
