### PR TITLE
upcoming: [M3-8031] – Add Disk Encryption info banner to Kubernetes landing page

### DIFF
--- a/packages/manager/.changeset/pr-10546-tests-1717604850412.md
+++ b/packages/manager/.changeset/pr-10546-tests-1717604850412.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add assertions regarding Disk Encryption info banner to lke-landing-page.spec.ts ([#10546](https://github.com/linode/manager/pull/10546))

--- a/packages/manager/.changeset/pr-10546-upcoming-features-1717603180090.md
+++ b/packages/manager/.changeset/pr-10546-upcoming-features-1717603180090.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add Disk Encryption info banner to Kubernetes landing page ([#10546](https://github.com/linode/manager/pull/10546))

--- a/packages/manager/src/components/DiskEncryption/constants.tsx
+++ b/packages/manager/src/components/DiskEncryption/constants.tsx
@@ -11,20 +11,33 @@ export const DISK_ENCRYPTION_GENERAL_DESCRIPTION = (
   </>
 );
 
-export const DISK_ENCRYPTION_DESCRIPTION_NODE_POOL_REBUILD_CAVEAT =
-  'Encrypt Linode data at rest to improve security. The disk encryption setting for Linodes added to a node pool will not be changed after rebuild.';
+// @TODO LDE: Update "Learn more" link
+export const DISK_ENCRYPTION_UPDATE_PROTECT_CLUSTERS_COPY = (
+  <>
+    Disk encryption is now standard on Linodes. <Link to="">Learn how</Link> to
+    update and protect your clusters.
+  </>
+);
+
+export const DISK_ENCRYPTION_UPDATE_PROTECT_CLUSTERS_BANNER_KEY =
+  'disk-encryption-update-protect-clusters-banner';
 
 export const DISK_ENCRYPTION_UNAVAILABLE_IN_REGION_COPY =
   'Disk encryption is not available in the selected region.';
 
-export const DISK_ENCRYPTION_BACKUPS_CAVEAT_COPY =
-  'Virtual Machine Backups are not encrypted.';
-
+// Guidance
 export const DISK_ENCRYPTION_NODE_POOL_GUIDANCE_COPY =
   'To enable disk encryption, delete the node pool and create a new node pool. New node pools are always encrypted.';
 
 export const UNENCRYPTED_STANDARD_LINODE_GUIDANCE_COPY =
   'Rebuild this Linode to enable or disable disk encryption.';
+
+// Caveats
+export const DISK_ENCRYPTION_DESCRIPTION_NODE_POOL_REBUILD_CAVEAT =
+  'Encrypt Linode data at rest to improve security. The disk encryption setting for Linodes added to a node pool will not be changed after rebuild.';
+
+export const DISK_ENCRYPTION_BACKUPS_CAVEAT_COPY =
+  'Virtual Machine Backups are not encrypted.';
 
 export const DISK_ENCRYPTION_IMAGES_CAVEAT_COPY =
   'Virtual Machine Images are not encrypted.';

--- a/packages/manager/src/components/DiskEncryption/constants.tsx
+++ b/packages/manager/src/components/DiskEncryption/constants.tsx
@@ -11,11 +11,16 @@ export const DISK_ENCRYPTION_GENERAL_DESCRIPTION = (
   </>
 );
 
-// @TODO LDE: Update "Learn more" link
+const DISK_ENCRYPTION_UPDATE_PROTECT_CLUSTERS_DOCS_LINK =
+  'https://www.linode.com/docs/products/compute/compute-instances/guides/local-disk-encryption/';
+
 export const DISK_ENCRYPTION_UPDATE_PROTECT_CLUSTERS_COPY = (
   <>
-    Disk encryption is now standard on Linodes. <Link to="">Learn how</Link> to
-    update and protect your clusters.
+    Disk encryption is now standard on Linodes.{' '}
+    <Link to={DISK_ENCRYPTION_UPDATE_PROTECT_CLUSTERS_DOCS_LINK}>
+      Learn how
+    </Link>{' '}
+    to update and protect your clusters.
   </>
 );
 

--- a/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
@@ -160,13 +160,6 @@ export const KubernetesLanding = () => {
   return (
     <>
       <DocumentTitleSegment segment="Kubernetes Clusters" />
-      <LandingHeader
-        docsLink="https://www.linode.com/docs/kubernetes/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/"
-        entity="Cluster"
-        onButtonClick={() => push('/kubernetes/create')}
-        removeCrumbX={1}
-        title="Kubernetes"
-      />
       {isDiskEncryptionFeatureEnabled && (
         <DismissibleBanner
           preferenceKey={DISK_ENCRYPTION_UPDATE_PROTECT_CLUSTERS_BANNER_KEY}
@@ -178,6 +171,13 @@ export const KubernetesLanding = () => {
           </Typography>
         </DismissibleBanner>
       )}
+      <LandingHeader
+        docsLink="https://www.linode.com/docs/kubernetes/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/"
+        entity="Cluster"
+        onButtonClick={() => push('/kubernetes/create')}
+        removeCrumbX={1}
+        title="Kubernetes"
+      />
       <Table aria-label="List of Your Kubernetes Clusters">
         <TableHead>
           <TableRow>

--- a/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
@@ -3,6 +3,12 @@ import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { CircleProgress } from 'src/components/CircleProgress';
+import {
+  DISK_ENCRYPTION_UPDATE_PROTECT_CLUSTERS_BANNER_KEY,
+  DISK_ENCRYPTION_UPDATE_PROTECT_CLUSTERS_COPY,
+} from 'src/components/DiskEncryption/constants';
+import { useIsDiskEncryptionFeatureEnabled } from 'src/components/DiskEncryption/utils';
+import { DismissibleBanner } from 'src/components/DismissibleBanner/DismissibleBanner';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { Hidden } from 'src/components/Hidden';
@@ -15,6 +21,7 @@ import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
 import { TableSortCell } from 'src/components/TableSortCell';
 import { TransferDisplay } from 'src/components/TransferDisplay/TransferDisplay';
+import { Typography } from 'src/components/Typography';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
 import { useKubernetesClustersQuery } from 'src/queries/kubernetes';
@@ -92,6 +99,10 @@ export const KubernetesLanding = () => {
     filter
   );
 
+  const {
+    isDiskEncryptionFeatureEnabled,
+  } = useIsDiskEncryptionFeatureEnabled();
+
   const openUpgradeDialog = (
     clusterID: number,
     clusterLabel: string,
@@ -156,6 +167,17 @@ export const KubernetesLanding = () => {
         removeCrumbX={1}
         title="Kubernetes"
       />
+      {isDiskEncryptionFeatureEnabled && (
+        <DismissibleBanner
+          preferenceKey={DISK_ENCRYPTION_UPDATE_PROTECT_CLUSTERS_BANNER_KEY}
+          sx={{ margin: '1rem 0 1rem 0' }}
+          variant="info"
+        >
+          <Typography>
+            {DISK_ENCRYPTION_UPDATE_PROTECT_CLUSTERS_COPY}
+          </Typography>
+        </DismissibleBanner>
+      )}
       <Table aria-label="List of Your Kubernetes Clusters">
         <TableHead>
           <TableRow>


### PR DESCRIPTION
## Description 📝
Add a dismissible banner regarding disk encryption to the Kubernetes landing page.

Initially I mentioned in the ticket to consider using `ProductInformationBanner` for this, but that's not well-suited to this case because this banner needs to be feature flagged.

## Changes  🔄
- Organize `DiskEncryption/constants.ts` file better
- Add dismissible Disk Encryption info banner to Kubernetes landing page

## Target release date 🗓️
6/24

## Preview 📷
![Screenshot 2024-06-11 at 4 40 58 PM](https://github.com/linode/manager/assets/114682940/e3c7b369-dcaf-41d2-8529-0af8988e90e1)

## How to test 🧪

### Prerequisites
1. Have the `linode_disk_encryption` tag on your account
2. Point at the alpha/dev environment
3. Have the Linode Disk Encryption (LDE) flag in our dev tool toggled on

### Verification steps
Without the tag and/or with the LDE flag in our dev tool toggled off, you should not see any LDE-related things in the UI. Otherwise,

- Navigate to the Kubernetes landing page
- Confirm: you see a dismissible banner that reads, "Disk encryption is now standard on Linodes. Learn how to update and protect your clusters."
- Confirm: the banner doesn't appear when you toggle the flag off or remove the tag
- Confirm: the banner doesn't reappear when you dismiss it

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support