### PR TITLE
test: [M3-7769] - Add Placement Groups Navigation Integration Tests

### DIFF
--- a/packages/manager/.changeset/pr-10552-tests-1717702940797.md
+++ b/packages/manager/.changeset/pr-10552-tests-1717702940797.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add Placement Group navigation integration tests ([#10552](https://github.com/linode/manager/pull/10552))

--- a/packages/manager/cypress/e2e/core/placementGroups/placement-groups-navigation.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/placement-groups-navigation.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * @file Integration tests for Placement Groups navigation.
+ */
+
+import {
+  mockAppendFeatureFlags,
+  mockGetFeatureFlagClientstream,
+} from 'support/intercepts/feature-flags';
+import { makeFeatureFlagData } from 'support/util/feature-flags';
+import { ui } from 'support/ui';
+import type { Flags } from 'src/featureFlags';
+
+describe('Placement Groups navigation', () => {
+  /*
+   * - Confirms that Placement Groups navigation item is shown when feature flag is enabled.
+   * - Confirms that clicking Placement Groups navigation item directs user to Placement Groups landing page.
+   */
+  it('can navigate to Placement Groups landing page', () => {
+    mockAppendFeatureFlags({
+      placementGroups: makeFeatureFlagData<Flags['placementGroups']>({
+        beta: true,
+        enabled: true,
+      }),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+
+    cy.visitWithLogin('/linodes');
+    cy.wait(['@getFeatureFlags', '@getClientStream']);
+
+    ui.nav.findItemByTitle('Placement Groups').should('be.visible').click();
+
+    cy.url().should('endWith', '/placement-groups');
+  });
+
+  /*
+   * - Confirms that Placement Groups navigation item is not shown when feature flag is disabled.
+   */
+  it('does not show Placement Groups navigation item when feature is disabled', () => {
+    mockAppendFeatureFlags({
+      placementGroups: makeFeatureFlagData<Flags['placementGroups']>({
+        beta: true,
+        enabled: false,
+      }),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+
+    cy.visitWithLogin('/linodes');
+    cy.wait(['@getFeatureFlags', '@getClientStream']);
+
+    ui.nav.find().within(() => {
+      cy.findByText('Placement Groups').should('not.exist');
+    });
+  });
+
+  /*
+   * - Confirms that manual navigation to Placement Groups landing page with feature is disabled displays Not Found to user.
+   */
+  it('displays Not Found when manually navigating to /placement-groups with feature flag disabled', () => {
+    mockAppendFeatureFlags({
+      placementGroups: makeFeatureFlagData<Flags['placementGroups']>({
+        beta: true,
+        enabled: false,
+      }),
+    }).as('getFeatureFlags');
+    mockGetFeatureFlagClientstream().as('getClientStream');
+
+    cy.visitWithLogin('/placement-groups');
+    cy.wait(['@getFeatureFlags', '@getClientStream']);
+
+    cy.findByText('Not Found').should('be.visible');
+  });
+});

--- a/packages/manager/cypress/e2e/core/placementGroups/placement-groups-navigation.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/placement-groups-navigation.spec.ts
@@ -7,10 +7,20 @@ import {
   mockGetFeatureFlagClientstream,
 } from 'support/intercepts/feature-flags';
 import { makeFeatureFlagData } from 'support/util/feature-flags';
+import { mockGetAccount } from 'support/intercepts/account';
+import { accountFactory } from 'src/factories';
 import { ui } from 'support/ui';
+
 import type { Flags } from 'src/featureFlags';
 
+const mockAccount = accountFactory.build();
+
 describe('Placement Groups navigation', () => {
+  // Mock User Account to include Placement Group capability
+  beforeEach(() => {
+    mockGetAccount(mockAccount).as('getAccount');
+  });
+
   /*
    * - Confirms that Placement Groups navigation item is shown when feature flag is enabled.
    * - Confirms that clicking Placement Groups navigation item directs user to Placement Groups landing page.


### PR DESCRIPTION
## Description 📝
This PR adds integration tests for the Placement Groups navigation with the feature flag on and off.

## Changes  🔄
- Tests for displaying and hiding the `Placement Groups` item in the sidebar navigation.
- Tests for manual navigation to `/placement-groups` when feature flag is disabled.
- No visual changes.

## How to test 🧪
### Verification steps
- Run the tests by running 
  - `yarn cy:debug` and selecting the `placement-groups-navigation.spect.ts` test.
  - Or run `yarn cy:run -s "cypress/e2e/core/placementGroups/placement-groups-navigation.spect.ts"` from the terminal.


## As an Author I have considered 🤔
*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

