### PR TITLE
change: [M3-8153] - Rename to Choose an OS in Linode Create flow

### DIFF
--- a/packages/manager/.changeset/pr-10554-changed-1718122854647.md
+++ b/packages/manager/.changeset/pr-10554-changed-1718122854647.md
@@ -2,4 +2,4 @@
 "@linode/manager": Changed
 ---
 
-Rename to Choose an OS in Linode Create flow ([#10554](https://github.com/linode/manager/pull/10554))
+Rename to 'Choose a Distribution' to 'Choose an OS' in Linode Create flow ([#10554](https://github.com/linode/manager/pull/10554))

--- a/packages/manager/.changeset/pr-10554-changed-1718122854647.md
+++ b/packages/manager/.changeset/pr-10554-changed-1718122854647.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Rename to Choose an OS in Linode Create flow ([#10554](https://github.com/linode/manager/pull/10554))

--- a/packages/manager/cypress/support/ui/constants.ts
+++ b/packages/manager/cypress/support/ui/constants.ts
@@ -41,8 +41,7 @@ export interface Page {
 // List of Routes and validator of the route
 export const pages: Page[] = [
   {
-    assertIsLoaded: () =>
-      cy.findByText('Choose a Distribution').should('be.visible'),
+    assertIsLoaded: () => cy.findByText('Choose an OS').should('be.visible'),
     goWithUI: [
       {
         go: () => {

--- a/packages/manager/cypress/support/ui/pages/linode-create-page.ts
+++ b/packages/manager/cypress/support/ui/pages/linode-create-page.ts
@@ -9,32 +9,12 @@ import { ui } from 'support/ui';
  */
 export const linodeCreatePage = {
   /**
-   * Sets the Linode's label.
-   *
-   * @param linodeLabel - Linode label to set.
-   */
-  setLabel: (linodeLabel: string) => {
-    cy.findByLabelText('Linode Label').type(`{selectall}{del}${linodeLabel}`);
-  },
-
-  /**
-   * Sets the Linode's root password.
-   *
-   * @param linodePassword - Root password to set.
-   */
-  setRootPassword: (linodePassword: string) => {
-    cy.findByLabelText('Root Password').as('rootPasswordField').click();
-
-    cy.get('@rootPasswordField').type(linodePassword, { log: false });
-  },
-
-  /**
    * Selects the Image with the given name.
    *
    * @param imageName - Name of Image to select.
    */
   selectImage: (imageName: string) => {
-    cy.findByText('Choose a Distribution')
+    cy.findByText('Choose an OS')
       .closest('[data-qa-paper]')
       .within(() => {
         ui.autocomplete.find().click();
@@ -44,15 +24,6 @@ export const linodeCreatePage = {
           .should('be.visible')
           .click();
       });
-  },
-
-  /**
-   * Select the Region with the given ID.
-   *
-   * @param regionId - ID of Region to select.
-   */
-  selectRegionById: (regionId: string) => {
-    ui.regionSelect.find().click().type(`${regionId}{enter}`);
   },
 
   /**
@@ -90,5 +61,34 @@ export const linodeCreatePage = {
 
       cy.get('@selectionCard').click();
     });
+  },
+
+  /**
+   * Select the Region with the given ID.
+   *
+   * @param regionId - ID of Region to select.
+   */
+  selectRegionById: (regionId: string) => {
+    ui.regionSelect.find().click().type(`${regionId}{enter}`);
+  },
+
+  /**
+   * Sets the Linode's label.
+   *
+   * @param linodeLabel - Linode label to set.
+   */
+  setLabel: (linodeLabel: string) => {
+    cy.findByLabelText('Linode Label').type(`{selectall}{del}${linodeLabel}`);
+  },
+
+  /**
+   * Sets the Linode's root password.
+   *
+   * @param linodePassword - Root password to set.
+   */
+  setRootPassword: (linodePassword: string) => {
+    cy.findByLabelText('Root Password').as('rootPasswordField').click();
+
+    cy.get('@rootPasswordField').type(linodePassword, { log: false });
   },
 };

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Distributions.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Distributions.test.tsx
@@ -10,7 +10,7 @@ describe('Distributions', () => {
       component: <Distributions />,
     });
 
-    const header = getByText('Choose a Distribution');
+    const header = getByText('Choose an OS');
 
     expect(header).toBeVisible();
     expect(header.tagName).toBe('H2');

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Distributions.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Distributions.tsx
@@ -19,7 +19,7 @@ export const Distributions = () => {
 
   return (
     <Paper>
-      <Typography variant="h2">Choose a Distribution</Typography>
+      <Typography variant="h2">Choose an OS</Typography>
       <ImageSelectv2
         disabled={isCreateLinodeRestricted}
         errorText={fieldState.error?.message}

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
@@ -543,7 +543,7 @@ export class LinodeCreate extends React.PureComponent<
                   <FromImageContent
                     accountBackupsEnabled={accountBackupsEnabled}
                     error={hasErrorFor.image}
-                    imagePanelTitle="Choose a Distribution"
+                    imagePanelTitle="Choose an OS"
                     imagesData={imagesData!}
                     regionsData={regionsData!}
                     typesData={typesData!}


### PR DESCRIPTION
## Description 📝
Rename `Choose a Distribution` to `Choose an OS` in the Linode Create flow. The tab will stay as Distribution for now.

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![distro](https://github.com/linode/manager/assets/115299789/1073ca09-5a4c-4366-88bc-79871e3b4973) | ![os](https://github.com/linode/manager/assets/115299789/75ce3eeb-cf60-4118-8e94-1f76b26b3f64) |

## How to test 🧪
### Verification steps
(How to verify changes)
- Go to `/linodes/create?type=Distributions`

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support