### PR TITLE
upcoming: [M3-8218] - Obj fix for crashing accesskey page when relevant customer tags are not added.

### DIFF
--- a/packages/manager/.changeset/pr-10555-upcoming-features-1717778847157.md
+++ b/packages/manager/.changeset/pr-10555-upcoming-features-1717778847157.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Obj fix for crashing accesskey page when relevant customer tags are not added ([#10555](https://github.com/linode/manager/pull/10555))

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/HostNameTableCell.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/HostNameTableCell.tsx
@@ -28,7 +28,7 @@ export const HostNameTableCell = ({
 
   const { regions } = storageKeyData;
 
-  if (!regionsLookup || !regionsData || regions.length === 0) {
+  if (!regionsLookup || !regionsData || !regions || regions.length === 0) {
     return <TableCell>None</TableCell>;
   }
 

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/OMC_AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/OMC_AccessKeyDrawer.tsx
@@ -184,7 +184,6 @@ export const OMC_AccessKeyDrawer = (props: AccessKeyDrawerProps) => {
             ),
           }
         : { ...values, bucket_access: null };
-      debugger;
       const updatePayload = generateUpdatePayload(values, initialValues);
 
       if (mode !== 'creating') {

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/OMC_AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/OMC_AccessKeyDrawer.tsx
@@ -156,8 +156,8 @@ export const OMC_AccessKeyDrawer = (props: AccessKeyDrawerProps) => {
     !createMode && objectStorageKey ? objectStorageKey.label : '';
 
   const initialRegions =
-    !createMode && objectStorageKey
-      ? objectStorageKey.regions?.map((region) => region.id)
+    !createMode && objectStorageKey?.regions
+      ? objectStorageKey.regions.map((region) => region.id)
       : [];
 
   const initialValues: FormState = {
@@ -184,7 +184,7 @@ export const OMC_AccessKeyDrawer = (props: AccessKeyDrawerProps) => {
             ),
           }
         : { ...values, bucket_access: null };
-
+      debugger;
       const updatePayload = generateUpdatePayload(values, initialValues);
 
       if (mode !== 'creating') {
@@ -203,7 +203,7 @@ export const OMC_AccessKeyDrawer = (props: AccessKeyDrawerProps) => {
   const isSaveDisabled =
     isRestrictedUser ||
     (mode !== 'creating' &&
-      objectStorageKey &&
+      objectStorageKey?.regions &&
       !hasLabelOrRegionsChanged(formik.values, objectStorageKey)) ||
     (mode === 'creating' &&
       limitedAccessChecked &&


### PR DESCRIPTION
## Description 📝
This PR prevents causing potential defect of crashing the Access key landing page when flag is on but no tags are assigned to the customer.  

## Target release date 🗓️
6/10

## How to test 🧪

### Reproduction steps
(How to reproduce the issue, if applicable)
- Checkout to develop
- Turn the OBJ flan on. use the account that doesn't have obj regions tag.
- Verify the Accesskey landing page.

### Verification steps
(How to verify changes)
- Checkout to develop
- Turn the OBJ flan on. use the account that doesn't have obj regions tag.
- Verify Accesskey landing page.
- Verify Edit/ Permission / Revoke actions for the key.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

