### PR TITLE
fix: [M3-8162] - Inability to create access keys due to incorrectly running `/types` query

### DIFF
--- a/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
+++ b/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
@@ -1,4 +1,3 @@
-import { Region } from '@linode/api-v4';
 import { styled } from '@mui/material/styles';
 import * as React from 'react';
 
@@ -14,6 +13,8 @@ import {
 } from 'src/utilities/pricing/constants';
 import { getDCSpecificPriceByType } from 'src/utilities/pricing/dynamicPricing';
 
+import type { Region } from '@linode/api-v4';
+
 export const OBJ_STORAGE_STORAGE_AMT = '250 GB';
 export const OBJ_STORAGE_NETWORK_TRANSFER_AMT = '1 TB';
 export interface EnableObjectStorageProps {
@@ -23,13 +24,16 @@ export interface EnableObjectStorageProps {
   regionId?: Region['id'];
 }
 
+const defaultPrice = 5;
+
 export const EnableObjectStorageModal = React.memo(
   (props: EnableObjectStorageProps) => {
     const { handleSubmit, onClose, open, regionId } = props;
-
-    const { data: types, isError, isLoading } = useObjectStorageTypesQuery(
-      Boolean(regionId)
-    );
+    const {
+      data: types,
+      isError,
+      isInitialLoading,
+    } = useObjectStorageTypesQuery(Boolean(regionId));
 
     const isInvalidPrice = Boolean(regionId) && (!types || isError);
 
@@ -43,7 +47,7 @@ export const EnableObjectStorageModal = React.memo(
           regionId,
           type: objectStorageType,
         })
-      : objectStorageType?.price.monthly;
+      : defaultPrice;
 
     return (
       <ConfirmationDialog
@@ -53,13 +57,13 @@ export const EnableObjectStorageModal = React.memo(
               'data-testid': 'enable-obj',
               disabled: isInvalidPrice,
               label: 'Enable Object Storage',
-              loading: isLoading,
+              loading: isInitialLoading,
               onClick: () => {
                 onClose();
                 handleSubmit();
               },
               tooltipText:
-                !isLoading && isInvalidPrice
+                !isInitialLoading && isInvalidPrice
                   ? PRICES_RELOAD_ERROR_NOTICE_TEXT
                   : '',
             }}

--- a/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
+++ b/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
@@ -33,7 +33,7 @@ export const EnableObjectStorageModal = React.memo(
       data: types,
       isError,
       isInitialLoading,
-    } = useObjectStorageTypesQuery(Boolean(regionId));
+    } = useObjectStorageTypesQuery();
 
     const isInvalidPrice = Boolean(regionId) && (!types || isError);
 

--- a/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
+++ b/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
@@ -24,16 +24,10 @@ export interface EnableObjectStorageProps {
   regionId?: Region['id'];
 }
 
-const defaultPrice = 5;
-
 export const EnableObjectStorageModal = React.memo(
   (props: EnableObjectStorageProps) => {
     const { handleSubmit, onClose, open, regionId } = props;
-    const {
-      data: types,
-      isError,
-      isInitialLoading,
-    } = useObjectStorageTypesQuery();
+    const { data: types, isError, isLoading } = useObjectStorageTypesQuery();
 
     const isInvalidPrice = Boolean(regionId) && (!types || isError);
 
@@ -47,7 +41,7 @@ export const EnableObjectStorageModal = React.memo(
           regionId,
           type: objectStorageType,
         })
-      : defaultPrice;
+      : objectStorageType?.price.monthly;
 
     return (
       <ConfirmationDialog
@@ -57,13 +51,13 @@ export const EnableObjectStorageModal = React.memo(
               'data-testid': 'enable-obj',
               disabled: isInvalidPrice,
               label: 'Enable Object Storage',
-              loading: isInitialLoading,
+              loading: isLoading,
               onClick: () => {
                 onClose();
                 handleSubmit();
               },
               tooltipText:
-                !isInitialLoading && isInvalidPrice
+                !isLoading && isInvalidPrice
                   ? PRICES_RELOAD_ERROR_NOTICE_TEXT
                   : '',
             }}


### PR DESCRIPTION
## Description 📝
This PR fixes two bugs in the Access Key drawer caused by the transition to `object-storage/types` (#10468).

The two issues were that:
1. Since we were disabling the query conditionally, we needed to be using `isInitialLoading` rather than `isLoading` to avoid getting stuck in perpetual loading state
2. Even with the above change, we were still using a value from the query to determine the fallback pricing. If the query was disabled, then that value would be undefined, and we'd see the $--.-- (unknown pricing) for Access Keys. 

## Changes  🔄
- Remove the condition that disabled the query when `regionId` was not provided. This means that the query will always run, which we want to be the case so we can get pricing from the API even when there is no `regionId` (e.g. for Access Keys). If there *is* a regionId provided, we can calculate pricing through the DC pricing util (which will also be $5, but is dynamic in case base pricing by region changes in the future). 

## Target release date 🗓️
6/10

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/114685994/f91b3981-faeb-459e-87e7-c589ab5ae90a" /> | ![image](https://github.com/linode/manager/assets/114685994/5888de25-c4d4-4c85-ab05-e568bb8b9d9b) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- **Cancel Object Storage on your account.**

### Reproduction steps
- On dev, go to object-storage/access-keys (the Create Access key page), and attempt to create a key via the drawer.
- Observe that the Enable Object Storage Modal pops up and is stuck in loading state.

### Verification steps
(How to verify changes)
- On this branch, go to http://localhost:3000/object-storage/access-keys and attempt to create an access key via the drawer.
- Observe that the Enable Object Storage Modal pops up, has pricing filled in, and allows the user to Enable Object Storage and create an access key successfully.
- Confirm that with the obj_use_reagions_mode and regions_allowed tags on your account, you can still see the pricing and create an access key.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

