### PR TITLE
test: Prevent Cypress failures when `cy.visit` hits non-200 response

### DIFF
--- a/packages/manager/cypress/support/setup/login-command.ts
+++ b/packages/manager/cypress/support/setup/login-command.ts
@@ -75,6 +75,7 @@ Cypress.Commands.add(
           );
         }
       },
+      failOnStatusCode: false,
     };
 
     if (resolvedLinodeOptions.preferenceOverrides) {


### PR DESCRIPTION
## Description 📝
This fixes an issue where Cypress tests will immediately fail upon calling `cy.visitWithLogin(...)` when the desired URL responds with a bad HTTP status.

This may be relevant for some server configurations that are not set up to properly route requests for single page apps. See M3-8227 for an explanation as to why this is relevant for us.

## Changes  🔄
- Don't throw an error when `cy.visit` URL responds with non-200 status

## How to test 🧪

We want to make sure that the tests continue passing as-is (CI can accomplish this), and that the tests can run against URLs that respond with bad statuses. M3-8227 explains which URLs this may apply to.

```bash
CYPRESS_BASE_URL='<your URL here>' yarn cy:run
```
(Once you observe a test pass, you can stop running Cypress; we just need to confirm that the tests do not immediately fail, which is what would happen against `develop` currently)

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
