### PR TITLE
fix: [OCA: 1382] correct docs urls

### DIFF
--- a/packages/manager/src/features/OneClickApps/oneClickAppsv2.ts
+++ b/packages/manager/src/features/OneClickApps/oneClickAppsv2.ts
@@ -2472,7 +2472,7 @@ export const oneClickApps: Record<number, OCA> = {
     related_guides: [
       {
         href:
-          'https://www.linode.com/docs/products/tools/marketplace/guides/couchbase/',
+          'https://www.linode.com/docs/products/tools/marketplace/guides/couchbase-cluster/',
         title:
           'Deploy a Couchbase Enterprise Server cluster through the Linode Marketplace',
       },
@@ -2495,7 +2495,7 @@ export const oneClickApps: Record<number, OCA> = {
     related_guides: [
       {
         href:
-          'https://www.linode.com/docs/products/tools/marketplace/guides/apache-kafka/',
+          'https://www.linode.com/docs/products/tools/marketplace/guides/apache-kafka-cluster/',
         title: 'Deploy an Apache Kafka cluster through the Linode Marketplace',
       },
     ],


### PR DESCRIPTION
## Description 📝
patches invalid urls for oca documentation

## Changes  🔄
List any change relevant to the reviewer.
- oneClickAppsvs2.ts ln# 2475 correct to "couchbase-cluster"
- oneClickAppsvs2.ts ln# 2498 correct to "apache-kafka-cluster"
