### PR TITLE
test: Improve disk encryption banner test in CI

### DIFF
--- a/packages/manager/cypress/e2e/core/kubernetes/lke-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-landing-page.spec.ts
@@ -32,13 +32,17 @@ describe('LKE landing page', () => {
       capabilities: ['Linodes', 'Disk Encryption'],
     });
 
+    const mockCluster = kubernetesClusterFactory.build();
+
     mockGetAccount(mockAccount).as('getAccount');
+    mockGetClusters([mockCluster]).as('getClusters');
 
     // Intercept request
     cy.visitWithLogin('/kubernetes/clusters');
-    cy.wait('@getAccount');
+    cy.wait(['@getClusters', '@getAccount']);
 
-    // Check if banner is visible
+    // Wait for page to load before confirming that banner is not present.
+    cy.findByText(mockCluster.label).should('be.visible');
     cy.findByText('Disk encryption is now standard on Linodes.').should(
       'not.exist'
     );
@@ -55,12 +59,14 @@ describe('LKE landing page', () => {
     const mockAccount = accountFactory.build({
       capabilities: ['Linodes', 'Disk Encryption'],
     });
+    const mockClusters = kubernetesClusterFactory.buildList(3);
 
     mockGetAccount(mockAccount).as('getAccount');
+    mockGetClusters(mockClusters).as('getClusters');
 
     // Intercept request
     cy.visitWithLogin('/kubernetes/clusters');
-    cy.wait('@getAccount');
+    cy.wait(['@getClusters', '@getAccount']);
 
     // Check if banner is visible
     cy.contains('Disk encryption is now standard on Linodes.').should(


### PR DESCRIPTION
## Description 📝
This tweaks our new LKE disk encryption banner tests to be more resilient to differences between our development accounts and our CI test accounts. Specifically, our CI test accounts often don't have LKE clusters, so I added mocks so that the tests continue to pass when this is the case.

I don't think a changelog entry is necessary here since these tests have not been included in a release yet.

## Changes  🔄
- Mock clusters for both LKE landing page disk encryption banner tests

## How to test 🧪
We can rely on the automated tests for this since they're currently failing consistently, but you can also run the test locally if you want to check it out:

```bash
yarn cy:run -s "cypress/e2e/core/kubernetes/lke-landing-page.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
