### PR TITLE
test: Improve stability of StackScript pagination test

### DIFF
--- a/packages/manager/.changeset/pr-10574-tests-1718222529272.md
+++ b/packages/manager/.changeset/pr-10574-tests-1718222529272.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Improve stability of StackScripts pagination test ([#10574](https://github.com/linode/manager/pull/10574))

--- a/packages/manager/cypress/e2e/core/stackscripts/smoke-community-stackscrips.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/smoke-community-stackscrips.spec.ts
@@ -12,8 +12,10 @@ import { chooseRegion } from 'support/util/regions';
 import { cleanUp } from 'support/util/cleanup';
 import { interceptCreateLinode } from 'support/intercepts/linodes';
 import { getProfile } from '@linode/api-v4';
-import { Profile, StackScript } from '@linode/api-v4';
+import { Profile } from '@linode/api-v4';
 import { formatDate } from '@src/utilities/formatDate';
+
+import type { StackScript } from '@linode/api-v4';
 
 const mockStackScripts: StackScript[] = [
   stackScriptFactory.build({
@@ -188,30 +190,34 @@ describe('Community Stackscripts integration tests', () => {
     cy.visitWithLogin('/stackscripts/community');
     cy.wait('@getStackScripts');
 
+    // Confirm that empty state is not shown.
     cy.get('[data-qa-stackscript-empty-msg="true"]').should('not.exist');
     cy.findByText('Automate deployment scripts').should('not.exist');
 
-    cy.get('tr').then((value) => {
-      const rowCount = Cypress.$(value).length - 1; // Remove the table title row
-
-      interceptGetStackScripts().as('getStackScripts1');
-      cy.scrollTo(0, 500);
-      cy.wait('@getStackScripts1');
-
-      cy.get('tr').its('length').should('be.gt', rowCount);
-
-      cy.get('tr').then((value) => {
-        const rowCount = Cypress.$(value).length - 1;
-
-        interceptGetStackScripts().as('getStackScripts2');
-        cy.get('tr')
-          .eq(rowCount)
-          .scrollIntoView({ offset: { top: 150, left: 0 } });
-        cy.wait('@getStackScripts2');
-
-        cy.get('tr').its('length').should('be.gt', rowCount);
-      });
-    });
+    // Confirm that scrolling to the bottom of the StackScripts list causes
+    // pagination to occur automatically. Perform this check 3 times.
+    for (let i = 0; i < 3; i += 1) {
+      cy.findByLabelText('List of StackScripts')
+        .should('be.visible')
+        .within(() => {
+          // Scroll to the bottom of the StackScripts list, confirm Cloud fetches StackScripts,
+          // then confirm that list updates with the new StackScripts shown.
+          cy.get('tr').last().scrollIntoView();
+          cy.wait('@getStackScripts').then((xhr) => {
+            const stackScripts = xhr.response?.body['data'] as
+              | StackScript[]
+              | undefined;
+            if (!stackScripts) {
+              throw new Error(
+                'Unexpected response received when fetching StackScripts'
+              );
+            }
+            cy.contains(
+              `${stackScripts[0].username} / ${stackScripts[0].label}`
+            ).should('be.visible');
+          });
+        });
+    }
   });
 
   /*


### PR DESCRIPTION
## Description 📝
The StackScript pagination test has recently started failing. It's failing because Cypress is not scrolling down far enough in the page to trigger pagination, although I'm not sure specifically what changed to cause this to happen.

I've cleaned up the test a bit and specifically changed it so that it will always scroll to the last item in the StackScripts list to trigger pagination.

## How to test 🧪
We can rely on CI, or we can run it locally. I ran it on repeat 20 times (skipping the rest of the tests in the spec) and it passed each time:

```bash
repeat 5 yarn cy:run -s "cypress/e2e/core/stackscripts/smoke-community-stackscrips.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

