### PR TITLE
[Do not merge] - Isolate flaky tests related to Linodes/Firewalls

### DIFF
--- a/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
@@ -242,11 +242,7 @@ describe('Linode Config management', () => {
      */
     it('Boots a config', () => {
       cy.defer(
-        () =>
-          createLinodeAndGetConfig(
-            { booted: true },
-            { waitForBoot: true, securityMethod: 'vlan_no_internet' }
-          ),
+        () => createLinodeAndGetConfig({ booted: true }, { waitForBoot: true }),
         'Creating and booting test Linode'
       ).then(([linode, config]: [Linode, Config]) => {
         const kernel = findKernelById(kernels, config.kernel);

--- a/packages/manager/cypress/e2e/core/linodes/resize-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/resize-linode.spec.ts
@@ -97,7 +97,7 @@ describe('resize linode', () => {
     });
   });
 
-  it.only('resizes a linode by decreasing size', () => {
+  it('resizes a linode by decreasing size', () => {
     cy.defer(() =>
       createTestLinode({ booted: true, type: 'g6-standard-2' })
     ).then((linode) => {

--- a/packages/manager/cypress/e2e/core/linodes/switch-linode-state.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/switch-linode-state.spec.ts
@@ -17,44 +17,40 @@ describe('switch linode state', () => {
    * - Does not wait for Linode to finish being shut down before succeeding.
    */
   it('powers off a linode from landing page', () => {
-    // Use `vlan_no_internet` security method.
-    // This works around an issue where the Linode API responds with a 400
-    // when attempting to reboot shortly after booting up when the Linode is
-    // attached to a Cloud Firewall.
-    cy.defer(() =>
-      createTestLinode({ booted: true }, { securityMethod: 'vlan_no_internet' })
-    ).then((linode: Linode) => {
-      cy.visitWithLogin('/linodes');
-      cy.get(`[data-qa-linode="${linode.label}"]`)
-        .should('be.visible')
-        .within(() => {
-          cy.contains('Running').should('be.visible');
-        });
+    cy.defer(() => createTestLinode({ booted: true })).then(
+      (linode: Linode) => {
+        cy.visitWithLogin('/linodes');
+        cy.get(`[data-qa-linode="${linode.label}"]`)
+          .should('be.visible')
+          .within(() => {
+            cy.contains('Running').should('be.visible');
+          });
 
-      ui.actionMenu
-        .findByTitle(`Action menu for Linode ${linode.label}`)
-        .should('be.visible')
-        .click();
+        ui.actionMenu
+          .findByTitle(`Action menu for Linode ${linode.label}`)
+          .should('be.visible')
+          .click();
 
-      ui.actionMenuItem.findByTitle('Power Off').should('be.visible').click();
+        ui.actionMenuItem.findByTitle('Power Off').should('be.visible').click();
 
-      ui.dialog
-        .findByTitle(`Power Off Linode ${linode.label}?`)
-        .should('be.visible')
-        .within(() => {
-          ui.button
-            .findByTitle('Power Off Linode')
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-        });
+        ui.dialog
+          .findByTitle(`Power Off Linode ${linode.label}?`)
+          .should('be.visible')
+          .within(() => {
+            ui.button
+              .findByTitle('Power Off Linode')
+              .should('be.visible')
+              .should('be.enabled')
+              .click();
+          });
 
-      cy.get(`[data-qa-linode="${linode.label}"]`)
-        .should('be.visible')
-        .within(() => {
-          cy.contains('Shutting Down').should('be.visible');
-        });
-    });
+        cy.get(`[data-qa-linode="${linode.label}"]`)
+          .should('be.visible')
+          .within(() => {
+            cy.contains('Shutting Down').should('be.visible');
+          });
+      }
+    );
   });
 
   /*
@@ -64,31 +60,27 @@ describe('switch linode state', () => {
    * - Waits for Linode to fully shut down before succeeding.
    */
   it('powers off a linode from details page', () => {
-    // Use `vlan_no_internet` security method.
-    // This works around an issue where the Linode API responds with a 400
-    // when attempting to reboot shortly after booting up when the Linode is
-    // attached to a Cloud Firewall.
-    cy.defer(() =>
-      createTestLinode({ booted: true }, { securityMethod: 'vlan_no_internet' })
-    ).then((linode: Linode) => {
-      cy.visitWithLogin(`/linodes/${linode.id}`);
-      cy.contains('RUNNING').should('be.visible');
-      cy.findByText(linode.label).should('be.visible');
+    cy.defer(() => createTestLinode({ booted: true })).then(
+      (linode: Linode) => {
+        cy.visitWithLogin(`/linodes/${linode.id}`);
+        cy.contains('RUNNING').should('be.visible');
+        cy.findByText(linode.label).should('be.visible');
 
-      cy.findByText('Power Off').should('be.visible').click();
-      ui.dialog
-        .findByTitle(`Power Off Linode ${linode.label}?`)
-        .should('be.visible')
-        .within(() => {
-          ui.button
-            .findByTitle('Power Off Linode')
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-        });
-      cy.contains('SHUTTING DOWN').should('be.visible');
-      cy.contains('OFFLINE', { timeout: 300000 }).should('be.visible');
-    });
+        cy.findByText('Power Off').should('be.visible').click();
+        ui.dialog
+          .findByTitle(`Power Off Linode ${linode.label}?`)
+          .should('be.visible')
+          .within(() => {
+            ui.button
+              .findByTitle('Power Off Linode')
+              .should('be.visible')
+              .should('be.enabled')
+              .click();
+          });
+        cy.contains('SHUTTING DOWN').should('be.visible');
+        cy.contains('OFFLINE', { timeout: 300000 }).should('be.visible');
+      }
+    );
   });
 
   /*
@@ -172,44 +164,40 @@ describe('switch linode state', () => {
    * - Does not wait for Linode to finish rebooting before succeeding.
    */
   it('reboots a linode from landing page', () => {
-    // Use `vlan_no_internet` security method.
-    // This works around an issue where the Linode API responds with a 400
-    // when attempting to reboot shortly after booting up when the Linode is
-    // attached to a Cloud Firewall.
-    cy.defer(() =>
-      createTestLinode({ booted: true }, { securityMethod: 'vlan_no_internet' })
-    ).then((linode: Linode) => {
-      cy.visitWithLogin('/linodes');
-      cy.get(`[data-qa-linode="${linode.label}"]`)
-        .should('be.visible')
-        .within(() => {
-          cy.contains('Running').should('be.visible');
-        });
+    cy.defer(() => createTestLinode({ booted: true })).then(
+      (linode: Linode) => {
+        cy.visitWithLogin('/linodes');
+        cy.get(`[data-qa-linode="${linode.label}"]`)
+          .should('be.visible')
+          .within(() => {
+            cy.contains('Running').should('be.visible');
+          });
 
-      ui.actionMenu
-        .findByTitle(`Action menu for Linode ${linode.label}`)
-        .should('be.visible')
-        .click();
+        ui.actionMenu
+          .findByTitle(`Action menu for Linode ${linode.label}`)
+          .should('be.visible')
+          .click();
 
-      ui.actionMenuItem.findByTitle('Reboot').should('be.visible').click();
+        ui.actionMenuItem.findByTitle('Reboot').should('be.visible').click();
 
-      ui.dialog
-        .findByTitle(`Reboot Linode ${linode.label}?`)
-        .should('be.visible')
-        .within(() => {
-          ui.button
-            .findByTitle('Reboot Linode')
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-        });
+        ui.dialog
+          .findByTitle(`Reboot Linode ${linode.label}?`)
+          .should('be.visible')
+          .within(() => {
+            ui.button
+              .findByTitle('Reboot Linode')
+              .should('be.visible')
+              .should('be.enabled')
+              .click();
+          });
 
-      cy.get(`[data-qa-linode="${linode.label}"]`)
-        .should('be.visible')
-        .within(() => {
-          cy.contains('Rebooting').should('be.visible');
-        });
-    });
+        cy.get(`[data-qa-linode="${linode.label}"]`)
+          .should('be.visible')
+          .within(() => {
+            cy.contains('Rebooting').should('be.visible');
+          });
+      }
+    );
   });
 
   /*
@@ -219,30 +207,26 @@ describe('switch linode state', () => {
    * - Waits for Linode to finish rebooting before succeeding.
    */
   it('reboots a linode from details page', () => {
-    // Use `vlan_no_internet` security method.
-    // This works around an issue where the Linode API responds with a 400
-    // when attempting to reboot shortly after booting up when the Linode is
-    // attached to a Cloud Firewall.
-    cy.defer(() =>
-      createTestLinode({ booted: true }, { securityMethod: 'vlan_no_internet' })
-    ).then((linode: Linode) => {
-      cy.visitWithLogin(`/linodes/${linode.id}`);
-      cy.contains('RUNNING').should('be.visible');
-      cy.findByText(linode.label).should('be.visible');
+    cy.defer(() => createTestLinode({ booted: true })).then(
+      (linode: Linode) => {
+        cy.visitWithLogin(`/linodes/${linode.id}`);
+        cy.contains('RUNNING').should('be.visible');
+        cy.findByText(linode.label).should('be.visible');
 
-      cy.findByText('Reboot').should('be.visible').click();
-      ui.dialog
-        .findByTitle(`Reboot Linode ${linode.label}?`)
-        .should('be.visible')
-        .within(() => {
-          ui.button
-            .findByTitle('Reboot Linode')
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-        });
-      cy.contains('REBOOTING').should('be.visible');
-      cy.contains('RUNNING', { timeout: 300000 }).should('be.visible');
-    });
+        cy.findByText('Reboot').should('be.visible').click();
+        ui.dialog
+          .findByTitle(`Reboot Linode ${linode.label}?`)
+          .should('be.visible')
+          .within(() => {
+            ui.button
+              .findByTitle('Reboot Linode')
+              .should('be.visible')
+              .should('be.enabled')
+              .click();
+          });
+        cy.contains('REBOOTING').should('be.visible');
+        cy.contains('RUNNING', { timeout: 300000 }).should('be.visible');
+      }
+    );
   });
 });

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -98,7 +98,7 @@
     "storybook-static": "storybook build -c .storybook -o .out",
     "build-storybook": "storybook build",
     "cy:run": "cypress run -b chrome -s \"cypress/e2e/core/linodes/rescue-linode.spec.ts,cypress/e2e/core/linodes/resize-linode.spec.ts,cypress/e2e/core/linodes/linode-config.spec.ts,cypress/e2e/core/linodes/switch-linode-state.spec.ts,cypress/e2e/core/linodes/clone-linode.spec.ts\"",
-    "cy:e2e": "cypress run --headless -b chrome",
+    "cy:e2e": "cypress run --headless -b chrome -s \"cypress/e2e/core/linodes/rescue-linode.spec.ts,cypress/e2e/core/linodes/resize-linode.spec.ts,cypress/e2e/core/linodes/linode-config.spec.ts,cypress/e2e/core/linodes/switch-linode-state.spec.ts,cypress/e2e/core/linodes/clone-linode.spec.ts\"",
     "cy:debug": "cypress open --e2e",
     "cy:rec-snap": "cypress run --headless -b chrome --env visualRegMode=record --spec ./cypress/integration/**/*visual*.spec.ts",
     "typecheck": "tsc --noEmit && tsc -p cypress --noEmit",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -97,7 +97,7 @@
     "storybook": "storybook dev -p 6006",
     "storybook-static": "storybook build -c .storybook -o .out",
     "build-storybook": "storybook build",
-    "cy:run": "cypress run -b chrome -s \"cypress/e2e/core/linodes/rescue-linode.spec.ts,cypress/e2e/core/linodes/resize-linode.spec.ts,cypress/e2e/core/linodes/linode-config.spec.ts,cypress/e2e/core/linodes/switch-linode-state.spec.ts\"",
+    "cy:run": "cypress run -b chrome -s \"cypress/e2e/core/linodes/rescue-linode.spec.ts,cypress/e2e/core/linodes/resize-linode.spec.ts,cypress/e2e/core/linodes/linode-config.spec.ts,cypress/e2e/core/linodes/switch-linode-state.spec.ts,cypress/e2e/core/linodes/clone-linode.spec.ts\"",
     "cy:e2e": "cypress run --headless -b chrome",
     "cy:debug": "cypress open --e2e",
     "cy:rec-snap": "cypress run --headless -b chrome --env visualRegMode=record --spec ./cypress/integration/**/*visual*.spec.ts",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -97,7 +97,7 @@
     "storybook": "storybook dev -p 6006",
     "storybook-static": "storybook build -c .storybook -o .out",
     "build-storybook": "storybook build",
-    "cy:run": "cypress run -b chrome",
+    "cy:run": "cypress run -b chrome -s \"cypress/e2e/core/linodes/rescue-linode.spec.ts,cypress/e2e/core/linodes/resize-linode.spec.ts,cypress/e2e/core/linodes/linode-config.spec.ts,cypress/e2e/core/linodes/switch-linode-state.spec.ts\"",
     "cy:e2e": "cypress run --headless -b chrome",
     "cy:debug": "cypress open --e2e",
     "cy:rec-snap": "cypress run --headless -b chrome --env visualRegMode=record --spec ./cypress/integration/**/*visual*.spec.ts",


### PR DESCRIPTION
## Description 📝
Adding Firewalls to our Linodes seems to have increased our test flakiness because the API is responding with 400s in situations where it's unexpected.

This PR is meant to isolate the affected tests for exploration/reproduction. It also modifies the `yarn cy:run` command to only run the affected tests.

(We do not want to merge this)