### PR TITLE
test: Resolve Linode/Firewall E2E flake by using alternative security method

### DIFF
--- a/packages/manager/.changeset/pr-10581-tests-1718308219716.md
+++ b/packages/manager/.changeset/pr-10581-tests-1718308219716.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix Linode/Firewall related E2E test flake ([#10581](https://github.com/linode/manager/pull/10581))

--- a/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
@@ -33,6 +33,9 @@ const getLinodeCloneUrl = (linode: Linode): string => {
   return `/linodes/create?linodeID=${linode.id}${regionQuery}&type=Clone+Linode${typeQuery}`;
 };
 
+/* Timeout after 3 seconds while waiting for clone. */
+const CLONE_TIMEOUT = 180_000;
+
 authenticate();
 describe('clone linode', () => {
   before(() => {
@@ -48,15 +51,19 @@ describe('clone linode', () => {
     const linodePayload = createLinodeRequestFactory.build({
       label: randomLabel(),
       region: linodeRegion.id,
-      // Specifying no image allows the Linode to provision and clone faster.
-      image: undefined,
       booted: false,
       type: 'g6-nanode-1',
     });
 
     const newLinodeLabel = `${linodePayload.label}-clone`;
 
-    cy.defer(() => createTestLinode(linodePayload)).then((linode: Linode) => {
+    // Use `vlan_no_internet` security method.
+    // This works around an issue where the Linode API responds with a 400
+    // when attempting to interact with it shortly after booting up when the
+    // Linode is attached to a Cloud Firewall.
+    cy.defer(() =>
+      createTestLinode(linodePayload, { securityMethod: 'vlan_no_internet' })
+    ).then((linode: Linode) => {
       const linodeRegion = getRegionById(linodePayload.region!);
 
       interceptCloneLinode(linode.id).as('cloneLinode');
@@ -101,7 +108,8 @@ describe('clone linode', () => {
 
       ui.toast.assertMessage(`Your Linode ${newLinodeLabel} is being created.`);
       ui.toast.assertMessage(
-        `Linode ${linode.label} successfully cloned to ${newLinodeLabel}.`
+        `Linode ${linode.label} successfully cloned to ${newLinodeLabel}.`,
+        { timeout: CLONE_TIMEOUT }
       );
     });
   });

--- a/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
@@ -33,7 +33,7 @@ const getLinodeCloneUrl = (linode: Linode): string => {
   return `/linodes/create?linodeID=${linode.id}${regionQuery}&type=Clone+Linode${typeQuery}`;
 };
 
-/* Timeout after 3 seconds while waiting for clone. */
+/* Timeout after 3 minutes while waiting for clone. */
 const CLONE_TIMEOUT = 180_000;
 
 authenticate();

--- a/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
@@ -291,10 +291,20 @@ describe('Linode Config management', () => {
      */
     it('Clones a config', () => {
       // Create clone source and destination Linodes.
+      // Use `vlan_no_internet` security method.
+      // This works around an issue where the Linode API responds with a 400
+      // when attempting to interact with it shortly after booting up when the
+      // Linode is attached to a Cloud Firewall.
       const createCloneTestLinodes = async () => {
         return Promise.all([
-          createTestLinode({ booted: true }, { waitForBoot: true }),
-          createTestLinode({ booted: true }),
+          createTestLinode(
+            { booted: true },
+            { securityMethod: 'vlan_no_internet', waitForBoot: true }
+          ),
+          createTestLinode(
+            { booted: true },
+            { securityMethod: 'vlan_no_internet' }
+          ),
         ]);
       };
 

--- a/packages/manager/cypress/e2e/core/linodes/rescue-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/rescue-linode.spec.ts
@@ -43,44 +43,50 @@ describe('Rescue Linodes', () => {
       region: chooseRegion().id,
     });
 
-    cy.defer(() => createTestLinode(linodePayload), 'creating Linode').then(
-      (linode: Linode) => {
-        interceptGetLinodeDetails(linode.id).as('getLinode');
-        interceptRebootLinodeIntoRescueMode(linode.id).as(
-          'rebootLinodeRescueMode'
-        );
+    // Use `vlan_no_internet` security method.
+    // This works around an issue where the Linode API responds with a 400
+    // when attempting to interact with it shortly after booting up when the
+    // Linode is attached to a Cloud Firewall.
+    cy.defer(
+      () =>
+        createTestLinode(linodePayload, { securityMethod: 'vlan_no_internet' }),
+      'creating Linode'
+    ).then((linode: Linode) => {
+      interceptGetLinodeDetails(linode.id).as('getLinode');
+      interceptRebootLinodeIntoRescueMode(linode.id).as(
+        'rebootLinodeRescueMode'
+      );
 
-        const rescueUrl = `/linodes/${linode.id}`;
-        cy.visitWithLogin(rescueUrl);
-        cy.wait('@getLinode');
+      const rescueUrl = `/linodes/${linode.id}`;
+      cy.visitWithLogin(rescueUrl);
+      cy.wait('@getLinode');
 
-        // Wait for Linode to boot.
-        cy.findByText('RUNNING').should('be.visible');
+      // Wait for Linode to boot.
+      cy.findByText('RUNNING').should('be.visible');
 
-        // Open rescue dialog using action menu..
-        ui.actionMenu
-          .findByTitle(`Action menu for Linode ${linode.label}`)
-          .should('be.visible')
-          .click();
+      // Open rescue dialog using action menu..
+      ui.actionMenu
+        .findByTitle(`Action menu for Linode ${linode.label}`)
+        .should('be.visible')
+        .click();
 
-        ui.actionMenuItem.findByTitle('Rescue').should('be.visible').click();
+      ui.actionMenuItem.findByTitle('Rescue').should('be.visible').click();
 
-        ui.dialog
-          .findByTitle(`Rescue Linode ${linode.label}`)
-          .should('be.visible')
-          .within(() => {
-            rebootInRescueMode();
-          });
+      ui.dialog
+        .findByTitle(`Rescue Linode ${linode.label}`)
+        .should('be.visible')
+        .within(() => {
+          rebootInRescueMode();
+        });
 
-        // Check intercepted response and make sure UI responded correctly.
-        cy.wait('@rebootLinodeRescueMode')
-          .its('response.statusCode')
-          .should('eq', 200);
+      // Check intercepted response and make sure UI responded correctly.
+      cy.wait('@rebootLinodeRescueMode')
+        .its('response.statusCode')
+        .should('eq', 200);
 
-        ui.toast.assertMessage('Linode rescue started.');
-        cy.findByText('REBOOTING').should('be.visible');
-      }
-    );
+      ui.toast.assertMessage('Linode rescue started.');
+      cy.findByText('REBOOTING').should('be.visible');
+    });
   });
 
   /*

--- a/packages/manager/cypress/e2e/core/linodes/resize-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/resize-linode.spec.ts
@@ -15,7 +15,13 @@ describe('resize linode', () => {
   it('resizes a linode by increasing size: warm migration', () => {
     mockGetFeatureFlagClientstream().as('getClientStream');
 
-    cy.defer(() => createTestLinode({ booted: true })).then((linode) => {
+    // Use `vlan_no_internet` security method.
+    // This works around an issue where the Linode API responds with a 400
+    // when attempting to interact with it shortly after booting up when the
+    // Linode is attached to a Cloud Firewall.
+    cy.defer(() =>
+      createTestLinode({ booted: true }, { securityMethod: 'vlan_no_internet' })
+    ).then((linode) => {
       interceptLinodeResize(linode.id).as('linodeResize');
       cy.visitWithLogin(`/linodes/${linode.id}?resize=true`);
       cy.findByText('Shared CPU').click({ scrollBehavior: false });
@@ -35,7 +41,13 @@ describe('resize linode', () => {
 
   it('resizes a linode by increasing size: cold migration', () => {
     mockGetFeatureFlagClientstream().as('getClientStream');
-    cy.defer(() => createTestLinode({ booted: true })).then((linode) => {
+    // Use `vlan_no_internet` security method.
+    // This works around an issue where the Linode API responds with a 400
+    // when attempting to interact with it shortly after booting up when the
+    // Linode is attached to a Cloud Firewall.
+    cy.defer(() =>
+      createTestLinode({ booted: true }, { securityMethod: 'vlan_no_internet' })
+    ).then((linode) => {
       interceptLinodeResize(linode.id).as('linodeResize');
       cy.visitWithLogin(`/linodes/${linode.id}?resize=true`);
       cy.findByText('Shared CPU').click({ scrollBehavior: false });
@@ -56,7 +68,13 @@ describe('resize linode', () => {
 
   it('resizes a linode by increasing size when offline: cold migration', () => {
     mockGetFeatureFlagClientstream().as('getClientStream');
-    cy.defer(() => createTestLinode({ booted: true })).then((linode) => {
+    // Use `vlan_no_internet` security method.
+    // This works around an issue where the Linode API responds with a 400
+    // when attempting to interact with it shortly after booting up when the
+    // Linode is attached to a Cloud Firewall.
+    cy.defer(() =>
+      createTestLinode({ booted: true }, { securityMethod: 'vlan_no_internet' })
+    ).then((linode) => {
       cy.visitWithLogin(`/linodes/${linode.id}`);
 
       // Turn off the linode to resize the disk
@@ -97,9 +115,16 @@ describe('resize linode', () => {
     });
   });
 
-  it.only('resizes a linode by decreasing size', () => {
+  it('resizes a linode by decreasing size', () => {
+    // Use `vlan_no_internet` security method.
+    // This works around an issue where the Linode API responds with a 400
+    // when attempting to interact with it shortly after booting up when the
+    // Linode is attached to a Cloud Firewall.
     cy.defer(() =>
-      createTestLinode({ booted: true, type: 'g6-standard-2' })
+      createTestLinode(
+        { booted: true, type: 'g6-standard-2' },
+        { securityMethod: 'vlan_no_internet' }
+      )
     ).then((linode) => {
       const diskName = 'Debian 11 Disk';
       const size = '50000'; // 50 GB


### PR DESCRIPTION
## Description 📝
Since merging #10538, a few of our tests have become especially flaky. This appears to be caused by an API issue where the API responds with `400` `Linode busy` when performing some actions on Linodes that are attached to Firewalls. This happens most often when attempting to interact with a Linode that has just finished booting.

See also #10580, which makes this issue more reproducible for troubleshooting/exploration purposes.

## Changes  🔄
- Avoid attaching Firewalls to Linodes in impacted tests, disabling internet access instead
- Increase clone test timeout (disabling internet access requires the Linode to have an image, which causes the clone operation to be slower)

## How to test 🧪
We can rely on CI for this. Ideally all of the identified tests will pass without any flake.

To run the tests locally, use this command:

```bash
yarn cy:run -s "cypress/e2e/core/linodes/rescue-linode.spec.ts,cypress/e2e/core/linodes/resize-linode.spec.ts,cypress/e2e/core/linodes/linode-config.spec.ts,cypress/e2e/core/linodes/switch-linode-state.spec.ts,cypress/e2e/core/linodes/clone-linode.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
