### PR TITLE
change: [M3-7646] - Link Cloud Manager README to new documentation pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ This repository is home to the Akamai Connected **[Cloud Manager](https://cloud.
 
 ## Developing Locally
 
-To get started running Cloud Manager locally, please see the [Getting Started_ guide](https://linode.github.io/manager/GETTING_STARTED.html).
+To get started running Cloud Manager locally, please see the [Getting Started guide](https://linode.github.io/manager/GETTING_STARTED.html).
 
 ## Contributing
 
-If you already have your development environment set up, please read the [contributing guidelines](https://linode.github.io/manager/CONTRIBUTING.html) to get help in creating your first Pull Request.
+If you already have your development environment set up, please read the [Contributing Guidelines](https://linode.github.io/manager/CONTRIBUTING.html) to get help in creating your first Pull Request.
 
 To report a bug or request a feature in Cloud Manager, please [open a GitHub Issue](https://github.com/linode/manager/issues/new). For general feedback, use [linode.com/feedback](https://www.linode.com/feedback/).
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ This repository is home to the Akamai Connected **[Cloud Manager](https://cloud.
 
 ## Developing Locally
 
-To get started running Cloud Manager locally, please see the [_Getting Started_ guide](docs/GETTING_STARTED.md).
+To get started running Cloud Manager locally, please see the [Getting Started_ guide](https://linode.github.io/manager/GETTING_STARTED.html).
 
 ## Contributing
 
-If you already have your development environment set up, please read the [contributing guidelines](docs/CONTRIBUTING.md) to get help in creating your first Pull Request.
+If you already have your development environment set up, please read the [contributing guidelines](https://linode.github.io/manager/CONTRIBUTING.html) to get help in creating your first Pull Request.
 
 To report a bug or request a feature in Cloud Manager, please [open a GitHub Issue](https://github.com/linode/manager/issues/new). For general feedback, use [linode.com/feedback](https://www.linode.com/feedback/).
 

--- a/packages/manager/.changeset/pr-10582-changed-1718310753730.md
+++ b/packages/manager/.changeset/pr-10582-changed-1718310753730.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Link Cloud Manager README to new documentation pages ([#10582](https://github.com/linode/manager/pull/10582))


### PR DESCRIPTION
## Description 📝
Tiny PR to link our README to the new docs

## Changes  🔄
- Update "Getting Started" and "Contributing" links to our new GH documentation pages

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
