### PR TITLE
fix: [M3-8193] - Check account access for disabling add tags button

### DIFF
--- a/packages/manager/.changeset/pr-10583-fixed-1718375225734.md
+++ b/packages/manager/.changeset/pr-10583-fixed-1718375225734.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Users must be an unrestricted User in order to add or modify tags on Linodes ([#10583](https://github.com/linode/manager/pull/10583))

--- a/packages/manager/src/components/TagCell/TagCell.test.tsx
+++ b/packages/manager/src/components/TagCell/TagCell.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { TagCell } from './TagCell';
+
+describe('TagCell Component', () => {
+  const tags = ['tag1', 'tag2'];
+  const updateTags = vi.fn(() => Promise.resolve());
+
+  describe('Disabled States', () => {
+    it('does not allow adding a new tag when disabled', async () => {
+      const { getByTestId } = renderWithTheme(
+        <TagCell disabled tags={tags} updateTags={updateTags} />
+      );
+      const disabledButton = getByTestId('Button');
+      expect(disabledButton).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('should display the tooltip if disabled and tooltipText is true', async () => {
+      const { getByTestId } = renderWithTheme(
+        <TagCell disabled tags={tags} updateTags={updateTags} />
+      );
+      const disabledButton = getByTestId('Button');
+      expect(disabledButton).toBeInTheDocument();
+
+      fireEvent.mouseOver(disabledButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText(
+          'You must be an unrestricted User in order to add or modify tags on Linodes.'
+        )
+      ).toBeVisible();
+    });
+  });
+});

--- a/packages/manager/src/components/TagCell/TagCell.tsx
+++ b/packages/manager/src/components/TagCell/TagCell.tsx
@@ -1,7 +1,6 @@
 import MoreHoriz from '@mui/icons-material/MoreHoriz';
 import { styled } from '@mui/material/styles';
 import Grid from '@mui/material/Unstable_Grid2';
-import { SxProps } from '@mui/system';
 import * as React from 'react';
 
 import { IconButton } from 'src/components/IconButton';
@@ -12,6 +11,8 @@ import { omittedProps } from 'src/utilities/omittedProps';
 import { StyledPlusIcon, StyledTagButton } from '../Button/StyledTagButton';
 import { CircleProgress } from '../CircleProgress';
 import { AddTag } from './AddTag';
+
+import type { SxProps } from '@mui/system';
 
 export interface TagCellProps {
   /**
@@ -83,6 +84,11 @@ export const TagCell = (props: TagCellProps) => {
 
   const AddButton = (props: { panel?: boolean }) => (
     <StyledTagButton
+      tooltipText={`${
+        disabled
+          ? 'You must be an unrestricted User in order to add or modify tags on Linodes.'
+          : ''
+      }`}
       buttonType="outlined"
       disabled={disabled}
       endIcon={<StyledPlusIcon disabled={disabled} />}

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailFooter.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailFooter.tsx
@@ -4,6 +4,7 @@ import { useSnackbar } from 'notistack';
 import * as React from 'react';
 
 import { TagCell } from 'src/components/TagCell/TagCell';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 import { useLinodeUpdateMutation } from 'src/queries/linodes/linodes';
 import { useProfile } from 'src/queries/profile/profile';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
@@ -16,8 +17,8 @@ import {
   sxLastListItem,
   sxListItemFirstChild,
 } from './LinodeEntityDetail.styles';
-import { LinodeHandlers } from './LinodesLanding/LinodesLanding';
 
+import type { LinodeHandlers } from './LinodesLanding/LinodesLanding';
 import type { Linode } from '@linode/api-v4/lib/linodes/types';
 import type { TypographyProps } from 'src/components/Typography';
 
@@ -58,6 +59,11 @@ export const LinodeEntityDetailFooter = React.memo((props: FooterProps) => {
     linodeTags,
     openTagDrawer,
   } = props;
+
+  const isReadOnlyAccountAccess = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'account_access',
+    permittedGrantLevel: 'read_write',
+  });
 
   const { mutateAsync: updateLinode } = useLinodeUpdateMutation(linodeId);
 
@@ -157,7 +163,7 @@ export const LinodeEntityDetailFooter = React.memo((props: FooterProps) => {
           sx={{
             width: '100%',
           }}
-          disabled={isLinodesGrantReadOnly}
+          disabled={isLinodesGrantReadOnly || isReadOnlyAccountAccess}
           listAllTags={openTagDrawer}
           tags={linodeTags}
           updateTags={updateTags}


### PR DESCRIPTION
## Description 📝
Attempting to add a tag to the Linode would give the `"" already added` error, even if no text is entered or no tag has been applied. This is because a User must be an unrestricted User in order to add or modify tags on Linodes. This is actually explicitly mentioned in [the API docs](https://techdocs.akamai.com/linode-api/reference/put-linode-instance)

## Changes  🔄
- Added account access grant check
- Added disabled tooltip text
- Added unit test

## Target release date 🗓️
Next release

## Preview 📷
| Before  | After   |
| ------- | ------- |
| <img width="452" alt="Screenshot 2024-06-14 at 10 23 05 AM" src="https://github.com/linode/manager/assets/125309814/75d2c4e2-4091-4310-9c81-f453e23c6d1a"> | <img width="255" alt="Screenshot 2024-06-14 at 9 40 15 AM" src="https://github.com/linode/manager/assets/125309814/203fd06c-900e-4195-a727-cee7e8732480"> |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Have a restricted user account with R/W access to a Linode, but Billing Access set to `none`.

### Reproduction steps
(How to reproduce the issue, if applicable)
- Go to the linodes detail page and try adding a tag
- Observe the issue in the `before` screenshot

### Verification steps
(How to verify changes)
- Checkout branch and follow same reproduction steps
- Observe button is now disabled with tooltip text

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
