### PR TITLE
fix: [M3-8264] - Conditional invocation of useEventInfiniteQuery hook

### DIFF
--- a/packages/manager/.changeset/pr-10584-fixed-1718376872460.md
+++ b/packages/manager/.changeset/pr-10584-fixed-1718376872460.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Potential runtime issue with conditional hook ([#10584](https://github.com/linode/manager/pull/10584))

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useEventNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useEventNotifications.tsx
@@ -24,10 +24,12 @@ const defaultUnwantedEvents: EventAction[] = [
 ];
 
 export const useEventNotifications = (
-  givenEvents?: Event[]
+  providedEvents?: Event[]
 ): NotificationItem[] => {
   const { events: fetchedEvents } = useEventsInfiniteQuery();
-  const relevantEvents = removeBlocklistedEvents(givenEvents ?? fetchedEvents);
+  const relevantEvents = removeBlocklistedEvents(
+    providedEvents ?? fetchedEvents
+  );
   const { isTaxIdEnabled } = useIsTaxIdEnabled();
   const notificationContext = React.useContext(_notificationContext);
 

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useEventNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useEventNotifications.tsx
@@ -23,13 +23,9 @@ const defaultUnwantedEvents: EventAction[] = [
   'volume_update',
 ];
 
-export const useEventNotifications = (
-  providedEvents?: Event[]
-): NotificationItem[] => {
+export const useEventNotifications = (): NotificationItem[] => {
   const { events: fetchedEvents } = useEventsInfiniteQuery();
-  const relevantEvents = removeBlocklistedEvents(
-    providedEvents ?? fetchedEvents
-  );
+  const relevantEvents = removeBlocklistedEvents(fetchedEvents);
   const { isTaxIdEnabled } = useIsTaxIdEnabled();
   const notificationContext = React.useContext(_notificationContext);
 

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useEventNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useEventNotifications.tsx
@@ -23,40 +23,44 @@ const defaultUnwantedEvents: EventAction[] = [
   'volume_update',
 ];
 
-export const useEventNotifications = (givenEvents?: Event[]) => {
-  const events = removeBlocklistedEvents(
-    givenEvents ?? useEventsInfiniteQuery().events
-  );
+export const useEventNotifications = (
+  givenEvents?: Event[]
+): NotificationItem[] => {
+  const { events: fetchedEvents } = useEventsInfiniteQuery();
+  const relevantEvents = removeBlocklistedEvents(givenEvents ?? fetchedEvents);
   const { isTaxIdEnabled } = useIsTaxIdEnabled();
   const notificationContext = React.useContext(_notificationContext);
 
   // TODO: TaxId - This entire function can be removed when we cleanup tax id feature flags
-  const unwantedEvents = React.useMemo(() => {
-    const events = [...defaultUnwantedEvents];
+  const unwantedEventTypes = React.useMemo(() => {
+    const eventTypes = [...defaultUnwantedEvents];
     if (!isTaxIdEnabled) {
-      events.push('tax_id_invalid');
+      eventTypes.push('tax_id_invalid');
     }
-    return events;
+    return eventTypes;
   }, [isTaxIdEnabled]);
 
-  const _events = events.filter(
-    (thisEvent) => !unwantedEvents.includes(thisEvent.action)
+  const filteredEvents = relevantEvents.filter(
+    (event) => !unwantedEventTypes.includes(event.action)
   );
 
-  const [inProgress, completed] = partition<Event>(isInProgressEvent, _events);
+  const [inProgressEvents, completedEvents] = partition<Event>(
+    isInProgressEvent,
+    filteredEvents
+  );
 
-  const allEvents = [
-    ...inProgress.map((thisEvent) =>
-      formatProgressEventForDisplay(thisEvent, notificationContext.closeMenu)
+  const allNotificationItems = [
+    ...inProgressEvents.map((event) =>
+      formatProgressEventForDisplay(event, notificationContext.closeMenu)
     ),
-    ...completed.map((thisEvent) =>
-      formatEventForDisplay(thisEvent, notificationContext.closeMenu)
+    ...completedEvents.map((event) =>
+      formatEventForDisplay(event, notificationContext.closeMenu)
     ),
   ];
 
-  return allEvents.filter((thisAction) =>
-    Boolean(thisAction.body)
-  ) as NotificationItem[];
+  return allNotificationItems.filter((notification) =>
+    Boolean(notification.body)
+  );
 };
 
 const formatEventForDisplay = (


### PR DESCRIPTION
## Description 📝
We have a conditional hook in our code that could cause a runtime crash. We don’t pass any givenEvents anywhere in the app, so I guess we’ve just never had a problem with it

## Changes  🔄
List any change relevant to the reviewer.
- Renamed some variables for clarity
- Added a return type to avoid type casting

## Target release date 🗓️
Next release

## Preview 📷
No visual changes

## How to test 🧪
- Run linter and ensure it passes
- Check events and ensure there's no changes (there shouldn't be)
- For fun, you can pass in `providedEvents` and see app crash.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support