### PR TITLE
test: Mock profile to fix GHA test failure

### DIFF
--- a/packages/manager/.changeset/pr-10585-tests-1718380830458.md
+++ b/packages/manager/.changeset/pr-10585-tests-1718380830458.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Mock profile request to improve security questions test stability ([#10585](https://github.com/linode/manager/pull/10585))

--- a/packages/manager/cypress/e2e/core/account/security-questions.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/security-questions.spec.ts
@@ -2,8 +2,10 @@
  * @file Integration tests for account security questions.
  */
 
+import { profileFactory } from 'src/factories/profile';
 import { securityQuestionsFactory } from 'src/factories/profile';
 import {
+  mockGetProfile,
   mockGetSecurityQuestions,
   mockUpdateSecurityQuestions,
 } from 'support/intercepts/profile';
@@ -117,6 +119,10 @@ describe('Account security questions', () => {
     const securityQuestions = securityQuestionsFactory.build();
     const securityQuestionAnswers = ['Answer 1', 'Answer 2', 'Answer 3'];
 
+    const mockProfile = profileFactory.build({
+      two_factor_auth: false,
+    });
+
     const securityQuestionsPayload = {
       security_questions: [
         { question_id: 1, response: securityQuestionAnswers[0] },
@@ -128,6 +134,7 @@ describe('Account security questions', () => {
     const tfaSecurityQuestionsWarning =
       'To use two-factor authentication you must set up your security questions listed below.';
 
+    mockGetProfile(mockProfile);
     mockGetSecurityQuestions(securityQuestions).as('getSecurityQuestions');
     mockUpdateSecurityQuestions(securityQuestionsPayload).as(
       'setSecurityQuestions'


### PR DESCRIPTION
## Description 📝
This mocks the profile request in the security questions test so that TFA is disabled in the API response. This is necessary to fix a test failure in our GHA runs (and soon our Jenkins runs), but is probably good to have mocked anyway just so the test runs consistently.

## Target release date 🗓️
Please specify a release date to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## How to test 🧪
- Confirm that test continues to pass in CI
- Confirm that test passes when running using a test account that has TFA enabled

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
