### PR TITLE
fix: [M3-7646]  CONTRIBUTING commit type list markup

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -28,14 +28,15 @@ Feel free to open an issue to report a bug or request a feature.
 
 6. Open a pull request against `develop` and make sure the title follows the same format as the commit message.
 7. If needed, create a changeset to populate our changelog
-    -  If you don't have the Github CLI installed or need to update it (you need GH CLI 2.21.0 or greater),
+    - If you don't have the Github CLI installed or need to update it (you need GH CLI 2.21.0 or greater),
         - install it via `brew`: https://cli.github.com/manual/installation or upgrade with `brew upgrade gh`
         - Once installed, run `gh repo set-default` and pick `linode/manager` (only > 2.21.0)
         - You can also just create the changeset manually, in this case make sure to use the proper formatting for it.
     - Run `yarn changeset`from the root, choose the package to create a changeset for, and provide a description for the change.
     You can either have it committed automatically or do it manually if you need to edit it.
-    - A changeset is optional, it merely depends if it falls in one of the following categories:
+    - A changeset is optional, but should be included if the PR falls in one of the following categories:<br>
     `Added`, `Fixed`, `Changed`, `Removed`, `Tech Stories`, `Tests`, `Upcoming Features`
+      - Select the changeset category that matches the commit type in your PR title. (Where this isn't a 1:1 match: generally, a `feat` commit type falls under an `Added` change and `refactor` falls under `Tech Stories`.)
 
 Two reviews from members of the Cloud Manager team are required before merge. After approval, all pull requests are squash merged.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -17,12 +17,12 @@ Feel free to open an issue to report a bug or request a feature.
 5. Commit message format standard: `<commit type>: [JIRA-ticket-number] - <description>`
 
     **Commit Types:**
-    `feat`: New feature for the user (not a part of the code, or ci, ...).
-    `fix`: Bugfix for the user (not a fix to build something, ...).
-    `change`: Modifying an existing visual UI instance. Such as a component or a feature.
-    `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
-    `test`: New tests or changes to existing tests. Does not change the production code.
-    `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.
+    - `feat`: New feature for the user (not a part of the code, or ci, ...).
+    - `fix`: Bugfix for the user (not a fix to build something, ...).
+    - `change`: Modifying an existing visual UI instance. Such as a component or a feature.
+    - `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
+    - `test`: New tests or changes to existing tests. Does not change the production code.
+    - `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.
 
     **Example:** `feat: [M3-1234] - Allow user to view their login history`
 

--- a/packages/manager/.changeset/pr-10587-fixed-1718643059797.md
+++ b/packages/manager/.changeset/pr-10587-fixed-1718643059797.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+CONTRIBUTING doc page commit type list markup ([#10587](https://github.com/linode/manager/pull/10587))


### PR DESCRIPTION
## Description 📝
Follow up to https://github.com/linode/manager/pull/10582
Small fix to fix the display of the commit types list in out CONTRIBUTING doc page.

## Changes  🔄
- fix markup

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Linode Manager Contributing](https://github.com/linode/manager/assets/130582365/af98ea43-570e-4b3a-a69f-c373c11940b4) | ![Contributing html screenshot](https://github.com/linode/manager/assets/130582365/6f31e728-4b76-4014-9020-0f05748c9896) |

## How to test 🧪

### Verification steps
- Pull code locally, run `yarn docs` and navigate to http://localhost:5173/manager/CONTRIBUTING.html

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
