### PR TITLE
fix: [M3-8269] - Accessibility: Add tabindex to TextTooltip

### DIFF
--- a/packages/manager/.changeset/pr-10590-fixed-1718722141069.md
+++ b/packages/manager/.changeset/pr-10590-fixed-1718722141069.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Accessibility: Add tabindex to TextTooltip ([#10590](https://github.com/linode/manager/pull/10590))

--- a/packages/manager/src/components/TextTooltip/TextTooltip.tsx
+++ b/packages/manager/src/components/TextTooltip/TextTooltip.tsx
@@ -69,6 +69,7 @@ export const TextTooltip = (props: TextTooltipProps) => {
       data-qa-tooltip={dataQaTooltip}
       enterTouchDelay={0}
       placement={placement ? placement : 'bottom'}
+      tabIndex={0}
       title={tooltipText}
     >
       <Typography component="span" sx={sxTypography} variant={variant}>


### PR DESCRIPTION
## Description 📝
Small PR to add a missing `TabIndex` to the `TextTooltip` so that we can properly trigger the tooltip while navigation tabbing.

## Changes  🔄
- Add a missing `TabIndex` to the `TextTooltip`

## Preview 📷
![Screenshot 2024-06-18 at 10 32 43](https://github.com/linode/manager/assets/130582365/30ff815b-6355-42bf-b5b5-1f158c562692)

## How to test 🧪

### Verification steps
- One example where this can be tested is the Linode Create flow in the Plan Selection GPU tab, as shown in screenshot

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [x] ♿  Providing accessibility support