### PR TITLE
test: [M3-7330] - Attempt to fix hanging unit tests

### DIFF
--- a/packages/manager/.changeset/pr-10591-tests-1718746383365.md
+++ b/packages/manager/.changeset/pr-10591-tests-1718746383365.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix hanging unit tests ([#10591](https://github.com/linode/manager/pull/10591))

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -92,7 +92,7 @@
     "build": "vite build",
     "build:analyze": "bunx vite-bundle-visualizer",
     "precommit": "lint-staged && yarn typecheck",
-    "test": "vitest run",
+    "test": "vitest run --reporter=hanging-process",
     "test:debug": "node --inspect-brk scripts/test.js --runInBand",
     "storybook": "storybook dev -p 6006",
     "storybook-static": "storybook build -c .storybook -o .out",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -92,7 +92,7 @@
     "build": "vite build",
     "build:analyze": "bunx vite-bundle-visualizer",
     "precommit": "lint-staged && yarn typecheck",
-    "test": "vitest run --reporter=hanging-process",
+    "test": "vitest run",
     "test:debug": "node --inspect-brk scripts/test.js --runInBand",
     "storybook": "storybook dev -p 6006",
     "storybook-static": "storybook build -c .storybook -o .out",

--- a/packages/manager/src/features/Events/utils.test.tsx
+++ b/packages/manager/src/features/Events/utils.test.tsx
@@ -8,6 +8,7 @@ import {
 } from './utils';
 
 import type { Event } from '@linode/api-v4';
+import { DateTime } from 'luxon';
 
 describe('getEventMessage', () => {
   const mockEvent1: Event = eventFactory.build({
@@ -126,6 +127,10 @@ describe('formatProgressEvent', () => {
   });
 
   it('returns the correct format for a finished Event', () => {
+    const currentDateMock = DateTime.fromISO(mockEvent1.created).plus({
+      seconds: 1,
+    });
+    vi.setSystemTime(currentDateMock.toJSDate());
     const { progressEventDisplay, showProgress } = formatProgressEvent(
       mockEvent1
     );
@@ -135,6 +140,10 @@ describe('formatProgressEvent', () => {
   });
 
   it('returns the correct format for a "started" event without time remaining info', () => {
+    const currentDateMock = DateTime.fromISO(mockEvent2.created).plus({
+      seconds: 1,
+    });
+    vi.setSystemTime(currentDateMock.toJSDate());
     const { progressEventDisplay, showProgress } = formatProgressEvent(
       mockEvent2
     );

--- a/packages/manager/src/hooks/useOrder.test.tsx
+++ b/packages/manager/src/hooks/useOrder.test.tsx
@@ -1,6 +1,4 @@
-import { QueryClient } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
-
 import { HttpResponse, http, server } from 'src/mocks/testServer';
 import { queryClientFactory } from 'src/queries/base';
 import { usePreferences } from 'src/queries/profile/preferences';
@@ -77,8 +75,7 @@ describe('useOrder hook', () => {
   });
 
   it('use preferences are used when there are no query params', async () => {
-    const queryClient = new QueryClient();
-
+    const queryClient = queryClientFactory();
     server.use(
       http.get('*/profile/preferences', () => {
         return HttpResponse.json({

--- a/packages/manager/src/index.tsx
+++ b/packages/manager/src/index.tsx
@@ -21,7 +21,7 @@ import './index.css';
 import { LinodeThemeWrapper } from './LinodeThemeWrapper';
 import { queryClientFactory } from './queries/base';
 
-const queryClient = queryClientFactory();
+const queryClient = queryClientFactory('longLived');
 const store = storeFactory();
 
 setupInterceptors(store);

--- a/packages/manager/src/queries/base.ts
+++ b/packages/manager/src/queries/base.ts
@@ -31,9 +31,22 @@ export const queryPresets = {
   },
 };
 
-export const queryClientFactory = () => {
+/**
+ * Creates and returns a new TanStack Query query client instance.
+ *
+ * Allows the query client behavior to be configured by specifying a preset. The
+ * 'longLived' preset is most suitable for production use, while 'oneTimeFetch' is
+ * preferred for tests.
+ *
+ * @param preset - Optional query preset for client. Either 'longLived' or 'oneTimeFetch'.
+ *
+ * @returns New `QueryClient` instance.
+ */
+export const queryClientFactory = (
+  preset: 'longLived' | 'oneTimeFetch' = 'oneTimeFetch'
+) => {
   return new QueryClient({
-    defaultOptions: { queries: queryPresets.longLived },
+    defaultOptions: { queries: queryPresets[preset] },
   });
 };
 

--- a/packages/manager/vite.config.ts
+++ b/packages/manager/vite.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
         'src/**/*.utils.{js,jsx,ts,tsx}',
       ],
     },
+    pool: 'forks',
     environment: 'jsdom',
     globals: true,
     setupFiles: './src/testSetup.ts',


### PR DESCRIPTION
## Description 📝
This attempts to fix the hanging tests we've been dealing with recently in CI. This has been an issue when running the tests locally for a long time, but we recently began seeing the issue in CI as well (possibly related to the recent Vitest version upgrade).

The fix, if it works, involves modifying our React Query client factory to use our `oneTimeFetch` preset by default. Specifically, our `oneTimeFetch` preset sets the RQ cache time to `Infinity` per [React Query's recommendation](https://tanstack.com/query/v4/docs/framework/react/guides/testing#set-cachetime-to-infinity-with-jest) for testing. The query client that is used by the app will continue to use the `longLived` preset, but tests (existing and future) will get a `oneTimeFetch` query client unless another preset is specified.

If this passes in CI, we'll re-run it a few times just in case we're getting false positives. There is also a possibility that this PR will help fix the issue without resolving it entirely.

## Changes  🔄
- Set Vitest `pool` option to `forks` from its default of `threads` (this change in particular seems to be what fixed the issue)
- `queryClientFactory` now accepts an optional `preset` param that defaults to `oneTimeFetch`, which is preferable for our tests
- The query client created for the app explicitly requests a client with the `longLived` preset which should ensure that the app's behavior stays the same
- Unrelated stability improvements to `features/Events/utils.test.tsx` to fix an issue where slow running tests (e.g. when running locally) would fail due to relative date comparison

## Preview 📷
| Before |
| ------- |
| ![Screenshot 2024-06-18 at 10 24 26 AM](https://github.com/linode/manager/assets/97627410/da1d0e49-218b-4364-822a-7d7ce07e7018) |

| After |
| ------- |
| ![Screenshot 2024-06-18 at 11 24 19 AM](https://github.com/linode/manager/assets/97627410/10ebf0bc-8902-4722-8cff-11e82619edc2) |
**Note**: the tests always fail on my machine due to performance issues; the fact that there are failures in the screenshot above can be disregarded assuming CI passes as expected |

## How to test 🧪
- Observe CI results
- Run `yarn test` locally and confirm tests run/pass as expected
- Run `yarn test --reporter=hanging-process` and confirm that no handles are reported when the process exits (no other console output will be rendered during the run)

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
