### PR TITLE
test: Update Object Storage tests to mock account `capabilities` as needed

### DIFF
--- a/packages/manager/.changeset/pr-10602-tests-1718985699307.md
+++ b/packages/manager/.changeset/pr-10602-tests-1718985699307.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Update Object Storage tests to mock account capabilities as needed for multi cluster ([#10602](https://github.com/linode/manager/pull/10602))

--- a/packages/manager/cypress/e2e/core/objectStorage/access-key.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/access-key.e2e.spec.ts
@@ -17,6 +17,8 @@ import { makeFeatureFlagData } from 'support/util/feature-flags';
 import { randomLabel } from 'support/util/random';
 import { ui } from 'support/ui';
 import { cleanUp } from 'support/util/cleanup';
+import { mockGetAccount } from 'support/intercepts/account';
+import { accountFactory } from 'src/factories';
 
 authenticate();
 describe('object storage access key end-to-end tests', () => {
@@ -37,6 +39,7 @@ describe('object storage access key end-to-end tests', () => {
     interceptGetAccessKeys().as('getKeys');
     interceptCreateAccessKey().as('createKey');
 
+    mockGetAccount(accountFactory.build({ capabilities: [] }));
     mockAppendFeatureFlags({
       objMultiCluster: makeFeatureFlagData(false),
     });
@@ -131,6 +134,7 @@ describe('object storage access key end-to-end tests', () => {
     ).then(() => {
       const keyLabel = randomLabel();
 
+      mockGetAccount(accountFactory.build({ capabilities: [] }));
       mockAppendFeatureFlags({
         objMultiCluster: makeFeatureFlagData(false),
       });

--- a/packages/manager/cypress/e2e/core/objectStorage/access-keys.smoke.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/access-keys.smoke.spec.ts
@@ -25,10 +25,11 @@ import {
   randomString,
 } from 'support/util/random';
 import { ui } from 'support/ui';
-import { regionFactory } from 'src/factories';
+import { accountFactory, regionFactory } from 'src/factories';
 import { mockGetRegions } from 'support/intercepts/regions';
 import { buildArray } from 'support/util/arrays';
 import { Scope } from '@linode/api-v4';
+import { mockGetAccount } from 'support/intercepts/account';
 
 describe('object storage access keys smoke tests', () => {
   /*
@@ -44,6 +45,7 @@ describe('object storage access keys smoke tests', () => {
       secret_key: randomString(39),
     });
 
+    mockGetAccount(accountFactory.build({ capabilities: [] }));
     mockAppendFeatureFlags({
       objMultiCluster: makeFeatureFlagData(false),
     });
@@ -115,6 +117,7 @@ describe('object storage access keys smoke tests', () => {
       secret_key: randomString(39),
     });
 
+    mockGetAccount(accountFactory.build({ capabilities: [] }));
     mockAppendFeatureFlags({
       objMultiCluster: makeFeatureFlagData(false),
     });
@@ -164,6 +167,11 @@ describe('object storage access keys smoke tests', () => {
     const mockRegions = [...mockRegionsObj, ...mockRegionsNoObj];
 
     beforeEach(() => {
+      mockGetAccount(
+        accountFactory.build({
+          capabilities: ['Object Storage Access Key Regions'],
+        })
+      );
       mockAppendFeatureFlags({
         objMultiCluster: makeFeatureFlagData(true),
       });

--- a/packages/manager/cypress/e2e/core/objectStorage/enable-object-storage.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/enable-object-storage.spec.ts
@@ -14,8 +14,12 @@ import {
   profileFactory,
   regionFactory,
   objectStorageKeyFactory,
+  accountFactory,
 } from '@src/factories';
-import { mockGetAccountSettings } from 'support/intercepts/account';
+import {
+  mockGetAccount,
+  mockGetAccountSettings,
+} from 'support/intercepts/account';
 import {
   mockCancelObjectStorage,
   mockCreateAccessKey,
@@ -56,6 +60,7 @@ describe('Object Storage enrollment', () => {
    * - Confirms that consistent pricing information is shown for all regions in the enable modal.
    */
   it('can enroll in Object Storage', () => {
+    mockGetAccount(accountFactory.build({ capabilities: [] }));
     mockAppendFeatureFlags({
       objMultiCluster: makeFeatureFlagData(false),
     });

--- a/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
@@ -4,9 +4,12 @@
 
 import 'cypress-file-upload';
 import { createBucket } from '@linode/api-v4/lib/object-storage';
-import { objectStorageBucketFactory } from 'src/factories';
+import { accountFactory, objectStorageBucketFactory } from 'src/factories';
 import { authenticate } from 'support/api/authentication';
-import { interceptGetNetworkUtilization } from 'support/intercepts/account';
+import {
+  interceptGetNetworkUtilization,
+  mockGetAccount,
+} from 'support/intercepts/account';
 import {
   interceptCreateBucket,
   interceptDeleteBucket,
@@ -132,6 +135,7 @@ describe('object storage end-to-end tests', () => {
     interceptDeleteBucket(bucketLabel, bucketCluster).as('deleteBucket');
     interceptGetNetworkUtilization().as('getNetworkUtilization');
 
+    mockGetAccount(accountFactory.build({ capabilities: [] }));
     mockAppendFeatureFlags({
       objMultiCluster: makeFeatureFlagData(false),
     }).as('getFeatureFlags');

--- a/packages/manager/cypress/e2e/core/objectStorage/object-storage.smoke.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/object-storage.smoke.spec.ts
@@ -23,7 +23,8 @@ import {
 import { makeFeatureFlagData } from 'support/util/feature-flags';
 import { randomLabel, randomString } from 'support/util/random';
 import { ui } from 'support/ui';
-import { regionFactory } from 'src/factories';
+import { accountFactory, regionFactory } from 'src/factories';
+import { mockGetAccount } from 'support/intercepts/account';
 
 describe('object storage smoke tests', () => {
   /*
@@ -56,6 +57,11 @@ describe('object storage smoke tests', () => {
       objects: 0,
     });
 
+    mockGetAccount(
+      accountFactory.build({
+        capabilities: ['Object Storage Access Key Regions'],
+      })
+    );
     mockAppendFeatureFlags({
       objMultiCluster: makeFeatureFlagData(true),
     }).as('getFeatureFlags');
@@ -160,6 +166,7 @@ describe('object storage smoke tests', () => {
       hostname: bucketHostname,
     });
 
+    mockGetAccount(accountFactory.build({ capabilities: [] }));
     mockAppendFeatureFlags({
       objMultiCluster: makeFeatureFlagData(false),
     }).as('getFeatureFlags');
@@ -286,7 +293,7 @@ describe('object storage smoke tests', () => {
    * - Mocks existing buckets.
    * - Deletes mocked bucket, confirms that landing page reflects deletion.
    */
-  it('can delete object storage bucket - smoke', () => {
+  it('can delete object storage bucket - smoke - Multi Cluster Disabled', () => {
     const bucketLabel = randomLabel();
     const bucketCluster = 'us-southeast-1';
     const bucketMock = objectStorageBucketFactory.build({
@@ -296,8 +303,68 @@ describe('object storage smoke tests', () => {
       objects: 0,
     });
 
+    mockGetAccount(accountFactory.build({ capabilities: [] }));
+    mockAppendFeatureFlags({
+      objMultiCluster: makeFeatureFlagData(false),
+    });
+    mockGetFeatureFlagClientstream();
+
     mockGetBuckets([bucketMock]).as('getBuckets');
     mockDeleteBucket(bucketLabel, bucketCluster).as('deleteBucket');
+
+    cy.visitWithLogin('/object-storage');
+    cy.wait('@getBuckets');
+
+    cy.findByText(bucketLabel)
+      .should('be.visible')
+      .closest('tr')
+      .within(() => {
+        cy.findByText('Delete').should('be.visible').click();
+      });
+
+    ui.dialog
+      .findByTitle(`Delete Bucket ${bucketLabel}`)
+      .should('be.visible')
+      .within(() => {
+        cy.findByLabelText('Bucket Name').click().type(bucketLabel);
+        ui.buttonGroup
+          .findButtonByTitle('Delete')
+          .should('be.enabled')
+          .should('be.visible')
+          .click();
+      });
+
+    cy.wait('@deleteBucket');
+    cy.findByText('S3-compatible storage solution').should('be.visible');
+  });
+
+  /*
+   * - Tests core object storage bucket deletion flow using mocked API responses.
+   * - Mocks existing buckets.
+   * - Deletes mocked bucket, confirms that landing page reflects deletion.
+   */
+  it('can delete object storage bucket - smoke - Multi Cluster Enabled', () => {
+    const bucketLabel = randomLabel();
+    const bucketCluster = 'us-southeast-1';
+    const bucketMock = objectStorageBucketFactory.build({
+      label: bucketLabel,
+      cluster: bucketCluster,
+      hostname: `${bucketLabel}.${bucketCluster}.linodeobjects.com`,
+      objects: 0,
+    });
+
+    mockGetAccount(
+      accountFactory.build({
+        capabilities: ['Object Storage Access Key Regions'],
+      })
+    );
+    mockAppendFeatureFlags({
+      objMultiCluster: makeFeatureFlagData(true),
+    });
+    mockGetFeatureFlagClientstream();
+
+    mockGetBuckets([bucketMock]).as('getBuckets');
+    mockDeleteBucket(bucketLabel, bucketMock.region!).as('deleteBucket');
 
     cy.visitWithLogin('/object-storage');
     cy.wait('@getBuckets');


### PR DESCRIPTION
## Description 📝

- Updates Object Storage Cypress tests to mock account `capabilities` as needed 👤 
  - We need to mock capabilities because the API recently turned on the `Object Storage Access Key Regions` capability and many of our tests were written under the assumption that `Object Storage Access Key Regions` was not returned in `capabilities`

## How to test 🧪

- Verify Cypress tests pass ✅ 

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support