### PR TITLE
fix: Object Storage Object URLs

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2024-06-21] - v1.121.2
+
+### Fixed:
+
+- Object Storage showing incorrect object URLs ([#10603](https://github.com/linode/manager/pull/10603))
+
 ## [2024-06-11] - v1.121.1
 
 ### Fixed:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.121.1",
+  "version": "1.121.2",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -440,7 +440,7 @@ export const BucketDetail = () => {
         url={
           selectedObject
             ? generateObjectUrl(
-                (bucket?.cluster ?? '') as ObjectStorageClusterID,
+                bucket?.cluster ?? '',
                 bucketName,
                 selectedObject.name
               ).absolute

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -62,6 +62,10 @@ interface MatchParams {
 }
 
 export const BucketDetail = () => {
+  /**
+   * @note If `Object Storage Access Key Regions` is enabled, clusterId will actually contain
+   * the bucket's region id
+   */
   const match = useRouteMatch<MatchParams>(
     '/object-storage/buckets/:clusterId/:bucketName'
   );
@@ -76,6 +80,11 @@ export const BucketDetail = () => {
   const { data: clusters } = useObjectStorageClusters();
   const { data: buckets } = useObjectStorageBuckets({ clusters });
 
+  /**
+   * We need to fetch all buckets and find the bucket
+   * because we need to know the clusterId of the bucket.
+   * (If `Object Storage Access Key Regions` is enabled, we don't have the clusterId readily available)
+   */
   const bucket = buckets?.buckets.find(
     (b) => b.region === clusterId && b.label === bucketName
   );

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -29,6 +29,8 @@ import {
   queryKey,
   updateBucket,
   useObjectBucketDetailsInfiniteQuery,
+  useObjectStorageBuckets,
+  useObjectStorageClusters,
 } from 'src/queries/objectStorage';
 import { sendDownloadObjectEvent } from 'src/utilities/analytics/customEventAnalytics';
 import { getQueryParamFromQueryString } from 'src/utilities/queryParams';
@@ -70,6 +72,14 @@ export const BucketDetail = () => {
   const clusterId = match?.params.clusterId || '';
   const prefix = getQueryParamFromQueryString(location.search, 'prefix');
   const queryClient = useQueryClient();
+
+  const { data: clusters } = useObjectStorageClusters();
+  const { data: buckets } = useObjectStorageBuckets({ clusters });
+
+  const bucket = buckets?.buckets.find(
+    (b) => b.region === clusterId && b.label === bucketName
+  );
+
   const {
     data,
     error,
@@ -429,8 +439,11 @@ export const BucketDetail = () => {
       <ObjectDetailsDrawer
         url={
           selectedObject
-            ? generateObjectUrl(clusterId, bucketName, selectedObject.name)
-                .absolute
+            ? generateObjectUrl(
+                (bucket?.cluster ?? '') as ObjectStorageClusterID,
+                bucketName,
+                selectedObject.name
+              ).absolute
             : undefined
         }
         bucketName={bucketName}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -91,11 +91,16 @@ export const BucketDetail = () => {
   );
 
   const { data: regions } = useRegionsQuery();
+
+  const regionsSupportingObjectStorage = regions?.filter((region) =>
+    region.capabilities.includes('Object Storage')
+  );
+
   const { data: clusters } = useObjectStorageClusters();
   const { data: buckets } = useObjectStorageBuckets({
     clusters,
     isObjMultiClusterEnabled,
-    regions,
+    regions: regionsSupportingObjectStorage,
   });
 
   const bucket = buckets?.buckets.find((bucket) => {

--- a/packages/manager/src/features/ObjectStorage/utilities.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.ts
@@ -1,7 +1,6 @@
 import { AccountSettings } from '@linode/api-v4/lib/account';
 import {
   ACLType,
-  ObjectStorageClusterID,
   ObjectStorageObject,
 } from '@linode/api-v4/lib/object-storage';
 import { FormikProps } from 'formik';
@@ -10,7 +9,7 @@ import { Item } from 'src/components/EnhancedSelect/Select';
 import { OBJECT_STORAGE_DELIMITER, OBJECT_STORAGE_ROOT } from 'src/constants';
 
 export const generateObjectUrl = (
-  clusterId: ObjectStorageClusterID,
+  clusterId: string,
   bucketName: string,
   objectName: string
 ) => {

--- a/packages/manager/src/features/ObjectStorage/utilities.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.ts
@@ -6,18 +6,10 @@ import {
 import { FormikProps } from 'formik';
 
 import { Item } from 'src/components/EnhancedSelect/Select';
-import { OBJECT_STORAGE_DELIMITER, OBJECT_STORAGE_ROOT } from 'src/constants';
+import { OBJECT_STORAGE_DELIMITER } from 'src/constants';
 
-export const generateObjectUrl = (
-  clusterId: string,
-  bucketName: string,
-  objectName: string
-) => {
-  const path = `${bucketName}.${clusterId}.${OBJECT_STORAGE_ROOT}/${objectName}`;
-  return {
-    absolute: 'https://' + path,
-    path,
-  };
+export const generateObjectUrl = (hostname: string, objectName: string) => {
+  return `https://${hostname}/${objectName}`;
 };
 
 // Objects ending with a / and having a size of 0 are often used to represent

--- a/packages/manager/src/utilities/accountCapabilities.ts
+++ b/packages/manager/src/utilities/accountCapabilities.ts
@@ -36,5 +36,5 @@ export const isFeatureEnabled = (
   isFeatureFlagEnabled: boolean,
   capabilities: AccountCapability[]
 ) => {
-  return isFeatureFlagEnabled && capabilities.includes(featureName);
+  return isFeatureFlagEnabled || capabilities.includes(featureName);
 };

--- a/packages/manager/src/utilities/accountCapabilities.ts
+++ b/packages/manager/src/utilities/accountCapabilities.ts
@@ -36,5 +36,5 @@ export const isFeatureEnabled = (
   isFeatureFlagEnabled: boolean,
   capabilities: AccountCapability[]
 ) => {
-  return isFeatureFlagEnabled || capabilities.includes(featureName);
+  return isFeatureFlagEnabled && capabilities.includes(featureName);
 };


### PR DESCRIPTION
## Description 📝

- Fixes incorrect Object Storage URLs given to users by Cloud Manager when Multi-Cluster is **enabled**

## The Issue 🐛 

- Cloud Manager was putting the **region id** in the URL instead of the expected **cluster id**

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/115251059/c1fdacfb-4541-4e7d-9d3a-a2e3c65153ed" /> | <video src="https://github.com/linode/manager/assets/115251059/fa880759-5d2e-46cc-a422-12836caeb4ff" /> |

## How to test 🧪

- Make sure you have an Object Storage bucket on your account
- Using an existing object (or upload a new object), open that object's details drawer
- Verify the link in that details drawer brings you to the object 🔗 

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support