### PR TITLE
test: Fix Cypress failure by accounting for OBJ Multicluster in upload test

### DIFF
--- a/packages/manager/.changeset/pr-10609-tests-1719255666019.md
+++ b/packages/manager/.changeset/pr-10609-tests-1719255666019.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix OBJ test failure caused by visiting hardcoded and out-of-date URL ([#10609](https://github.com/linode/manager/pull/10609))


### PR DESCRIPTION
## Description 📝
This fixes the failure in `cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts` that's currently present in `develop`. The test is failing because it navigates directly to the bucket, and the URL we're using for that is out-of-date (`/object-storage/buckets/:cluster` instead of `/object-storage/buckets/:region`). As a result, Cloud Manager eventually fails to retrieve a desired object's URL, causing the URL not to be rendered in the object details drawer which triggers a failure.

Our OBJ tests are in a messy state since some of the tests target multicluster and others don't, and this PR probably worsens the situation. I'll follow up by writing some tickets to organize these tests and add coverage where it's lacking.

## Changes  🔄
- Resolve failure by navigating to `/object-storage/buckets/:region/:bucket` instead of `/object-storage/buckets/:cluster/:bucket`

## How to test 🧪
We can rely on CI since this is intended to fix a failure that's already occurring in CI. You can also run the test locally with this command:

```bash
yarn cy:run -s "cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
