### PR TITLE
upcoming: [M3-8282] - Prevent Linode Create v2 from toggling mid-creation

### DIFF
--- a/packages/manager/.changeset/pr-10611-upcoming-features-1719332278758.md
+++ b/packages/manager/.changeset/pr-10611-upcoming-features-1719332278758.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Prevent Linode Create v2 from toggling mid-creation ([#10611](https://github.com/linode/manager/pull/10611))

--- a/packages/manager/src/features/Linodes/index.tsx
+++ b/packages/manager/src/features/Linodes/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useState } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
 import { SuspenseLoader } from 'src/components/SuspenseLoader';
@@ -25,13 +25,16 @@ const LinodesCreatev2 = React.lazy(() =>
 
 const LinodesRoutes = () => {
   const flags = useFlags();
+
+  // Hold this feature flag in state so that the user's Linode creation
+  // isn't interupted when the flag is toggled.
+  const [isLinodeCreateV2Enabled] = useState(flags.linodeCreateRefactor);
+
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <Switch>
         <Route
-          component={
-            flags.linodeCreateRefactor ? LinodesCreatev2 : LinodesCreate
-          }
+          component={isLinodeCreateV2Enabled ? LinodesCreatev2 : LinodesCreate}
           path="/linodes/create"
         />
         <Route component={LinodesDetail} path="/linodes/:linodeId" />


### PR DESCRIPTION
## Description 📝

- Prevent Linode Create v2 from toggling mid-creation
  - We are doing this so that if we need to toggle the flag, the user's form progress to be lost. That could be frustrating to a user 😠 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/115251059/546cb772-b4a8-41f9-a1c9-6c2780de08f2" /> | <video src="https://github.com/linode/manager/assets/115251059/2463eab5-9559-490f-8982-f04f0cbc09ab" /> |
| Notice how the form resets when the flag is toggled because the create flows changed | Notice how the create flow does not change when the flag is toggled | 

## How to test 🧪

- By toggling the flag with local dev tools, verify the form does not reset when the flag is toggled

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support