### PR TITLE
test: [M3-7318] - Combine vpc details page subset create, edit, and delete tests

### DIFF
--- a/packages/manager/.changeset/pr-10612-tests-1719343415784.md
+++ b/packages/manager/.changeset/pr-10612-tests-1719343415784.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Combine VPC details page subnet create, edit, and delete Cypress tests ([#10612](https://github.com/linode/manager/pull/10612))

--- a/packages/manager/cypress/e2e/core/vpc/vpc-details-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/vpc/vpc-details-page.spec.ts
@@ -121,86 +121,17 @@ describe('VPC details page', () => {
   });
 
   /**
-   * - Confirms Subnets section and table is shown on the VPC details page
-   * - Confirms UI flow when deleting a subnet from a VPC's detail page
+   * - Confirms UI flow when creating a subnet on a VPC's detail page.
+   * - Confirms UI flow for editing a subnet.
+   * - Confirms Subnets section and table is shown on the VPC details page.
+   * - Confirms UI flow when deleting a subnet from a VPC's detail page.
    */
-  it('can delete a subnet from the VPC details page', () => {
+  it('can create, edit, and delete a subnet from the VPC details page', () => {
+    // create a subnet
     const mockSubnet = subnetFactory.build({
       id: randomNumber(),
       label: randomLabel(),
       linodes: [],
-    });
-    const mockVPC = vpcFactory.build({
-      id: randomNumber(),
-      label: randomLabel(),
-      subnets: [mockSubnet],
-    });
-
-    const mockVPCAfterSubnetDeletion = vpcFactory.build({
-      ...mockVPC,
-      subnets: [],
-    });
-
-    mockAppendFeatureFlags({
-      vpc: makeFeatureFlagData(true),
-    }).as('getFeatureFlags');
-
-    mockGetVPC(mockVPC).as('getVPC');
-    mockGetFeatureFlagClientstream().as('getClientStream');
-    mockGetSubnets(mockVPC.id, [mockSubnet]).as('getSubnets');
-    mockDeleteSubnet(mockVPC.id, mockSubnet.id).as('deleteSubnet');
-
-    cy.visitWithLogin(`/vpcs/${mockVPC.id}`);
-    cy.wait(['@getFeatureFlags', '@getClientStream', '@getVPC', '@getSubnets']);
-
-    // confirm that vpc and subnet details get displayed
-    cy.findByText(mockVPC.label).should('be.visible');
-    cy.findByText('Subnets (1)').should('be.visible');
-    cy.findByText(mockSubnet.label).should('be.visible');
-
-    // confirm that subnet can be deleted and that page reflects changes
-    ui.actionMenu
-      .findByTitle(`Action menu for Subnet ${mockSubnet.label}`)
-      .should('be.visible')
-      .click();
-    ui.actionMenuItem.findByTitle('Delete').should('be.visible').click();
-
-    mockGetVPC(mockVPCAfterSubnetDeletion).as('getVPC');
-    mockGetSubnets(mockVPC.id, []).as('getSubnets');
-
-    ui.dialog
-      .findByTitle(`Delete Subnet ${mockSubnet.label}`)
-      .should('be.visible')
-      .within(() => {
-        cy.findByLabelText('Subnet Label')
-          .should('be.visible')
-          .click()
-          .type(mockSubnet.label);
-
-        ui.button
-          .findByTitle('Delete')
-          .should('be.visible')
-          .should('be.enabled')
-          .click();
-      });
-
-    cy.wait(['@deleteSubnet', '@getVPC', '@getSubnets']);
-
-    // confirm that user should still be on VPC's detail page
-    // confirm there are no remaining subnets
-    cy.url().should('endWith', `/${mockVPC.id}`);
-    cy.findByText('Subnets (0)');
-    cy.findByText('No Subnets are assigned.');
-    cy.findByText(mockSubnet.label).should('not.exist');
-  });
-
-  /**
-   * - Confirms UI flow when creating a subnet on a VPC's detail page.
-   */
-  it('can create a subnet', () => {
-    const mockSubnet = subnetFactory.build({
-      id: randomNumber(),
-      label: randomLabel(),
     });
 
     const mockVPC = vpcFactory.build({
@@ -256,22 +187,8 @@ describe('VPC details page', () => {
     cy.findByText(mockVPC.label).should('be.visible');
     cy.findByText('Subnets (1)').should('be.visible');
     cy.findByText(mockSubnet.label).should('be.visible');
-  });
 
-  /**
-   * - Confirms UI flow for editing a subnet
-   */
-  it('can edit a subnet', () => {
-    const mockSubnet = subnetFactory.build({
-      id: randomNumber(),
-      label: randomLabel(),
-    });
-    const mockVPC = vpcFactory.build({
-      id: randomNumber(),
-      label: randomLabel(),
-      subnets: [mockSubnet],
-    });
-
+    // edit a subnet
     const mockEditedSubnet = subnetFactory.build({
       ...mockSubnet,
       label: randomLabel(),
@@ -281,22 +198,6 @@ describe('VPC details page', () => {
       ...mockVPC,
       subnets: [mockEditedSubnet],
     });
-
-    mockAppendFeatureFlags({
-      vpc: makeFeatureFlagData(true),
-    }).as('getFeatureFlags');
-
-    mockGetVPC(mockVPC).as('getVPC');
-    mockGetFeatureFlagClientstream().as('getClientStream');
-    mockGetSubnets(mockVPC.id, [mockSubnet]).as('getSubnets');
-
-    cy.visitWithLogin(`/vpcs/${mockVPC.id}`);
-    cy.wait(['@getFeatureFlags', '@getClientStream', '@getVPC', '@getSubnets']);
-
-    // confirm that vpc and subnet details get displayed
-    cy.findByText(mockVPC.label).should('be.visible');
-    cy.findByText('Subnets (1)').should('be.visible');
-    cy.findByText(mockSubnet.label).should('be.visible');
 
     // confirm that subnet can be edited and that page reflects changes
     mockEditSubnet(mockVPC.id, mockEditedSubnet.id, mockEditedSubnet).as(
@@ -336,5 +237,47 @@ describe('VPC details page', () => {
     cy.findByText(mockVPC.label).should('be.visible');
     cy.findByText('Subnets (1)').should('be.visible');
     cy.findByText(mockEditedSubnet.label).should('be.visible');
+
+    // delete a subnet
+    const mockVPCAfterSubnetDeletion = vpcFactory.build({
+      ...mockVPC,
+      subnets: [],
+    });
+    mockDeleteSubnet(mockVPC.id, mockEditedSubnet.id).as('deleteSubnet');
+
+    // confirm that subnet can be deleted and that page reflects changes
+    ui.actionMenu
+      .findByTitle(`Action menu for Subnet ${mockEditedSubnet.label}`)
+      .should('be.visible')
+      .click();
+    ui.actionMenuItem.findByTitle('Delete').should('be.visible').click();
+
+    mockGetVPC(mockVPCAfterSubnetDeletion).as('getVPC');
+    mockGetSubnets(mockVPC.id, []).as('getSubnets');
+
+    ui.dialog
+      .findByTitle(`Delete Subnet ${mockEditedSubnet.label}`)
+      .should('be.visible')
+      .within(() => {
+        cy.findByLabelText('Subnet Label')
+          .should('be.visible')
+          .click()
+          .type(mockEditedSubnet.label);
+
+        ui.button
+          .findByTitle('Delete')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    cy.wait(['@deleteSubnet', '@getVPC', '@getSubnets']);
+
+    // confirm that user should still be on VPC's detail page
+    // confirm there are no remaining subnets
+    cy.url().should('endWith', `/${mockVPC.id}`);
+    cy.findByText('Subnets (0)');
+    cy.findByText('No Subnets are assigned.');
+    cy.findByText(mockEditedSubnet.label).should('not.exist');
   });
 });


### PR DESCRIPTION
## Description 📝
Combine 3 tests into 1 to create a subnet, edit it and confirm the details page updates to reflect the change, and then delete the subnet and once again confirm that the page updates to reflect the removed subnet.

## Changes  🔄
- modified cypress/e2e/core/vpc/vpc-details-page.spec.ts

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/vpc/vpc-details-page.spec.ts”
```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
