### PR TITLE
test: [M3-7320] - De-Parameterize Cypress Domain Record Create Tests

### DIFF
--- a/packages/manager/.changeset/pr-10615-tests-1719412831217.md
+++ b/packages/manager/.changeset/pr-10615-tests-1719412831217.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+De-Parameterize Cypress Domain Record Create Tests ([#10615](https://github.com/linode/manager/pull/10615))

--- a/packages/manager/cypress/e2e/core/domains/smoke-create-domain-records.spec.ts
+++ b/packages/manager/cypress/e2e/core/domains/smoke-create-domain-records.spec.ts
@@ -1,40 +1,33 @@
-/* eslint-disable sonarjs/no-duplicate-string */
 import { authenticate } from 'support/api/authentication';
 import { createDomain } from 'support/api/domains';
-import { fbtClick, getClick } from 'support/helpers';
 import { interceptCreateDomainRecord } from 'support/intercepts/domains';
-import { cleanUp } from 'support/util/cleanup';
 import { createDomainRecords } from 'support/constants/domains';
 
 authenticate();
-describe('Creates Domains record with Form', () => {
-  before(() => {
-    cleanUp('domains');
-  });
 
-  createDomainRecords().forEach((rec) => {
-    return it(rec.name, () => {
-      createDomain().then((domain) => {
-        // intercept create api record request
-        interceptCreateDomainRecord().as('apiCreateRecord');
-        const url = `/domains/${domain.id}`;
-        cy.visitWithLogin(url);
-        cy.url().should('contain', url);
-        fbtClick(rec.name);
+describe('Creates Domains records with Form', () => {
+  it('Adds domain records to a newly created Domain', () => {
+    createDomain().then((domain) => {
+      // intercept create api record request
+      interceptCreateDomainRecord().as('apiCreateRecord');
+      const url = `/domains/${domain.id}`;
+      cy.visitWithLogin(url);
+      cy.url().should('contain', url);
+    });
+
+    createDomainRecords().forEach((rec) => {
+      cy.findByText(rec.name).click();
+      rec.fields.forEach((f) => {
+        cy.get(f.name).type(f.value);
+      });
+      cy.findByText('Save').click();
+      cy.wait('@apiCreateRecord').its('response.statusCode').should('eq', 200);
+      cy.get(`[aria-label="${rec.tableAriaLabel}"]`).within((_table) => {
         rec.fields.forEach((f) => {
-          getClick(f.name).type(f.value);
-        });
-        fbtClick('Save');
-        cy.wait('@apiCreateRecord')
-          .its('response.statusCode')
-          .should('eq', 200);
-        cy.get(`[aria-label="${rec.tableAriaLabel}"]`).within((_table) => {
-          rec.fields.forEach((f) => {
-            if (f.skipCheck) {
-              return;
-            }
-            cy.findByText(f.value, { exact: !f.approximate });
-          });
+          if (f.skipCheck) {
+            return;
+          }
+          cy.findByText(f.value, { exact: !f.approximate });
         });
       });
     });

--- a/packages/manager/cypress/e2e/core/domains/smoke-create-domain-records.spec.ts
+++ b/packages/manager/cypress/e2e/core/domains/smoke-create-domain-records.spec.ts
@@ -17,17 +17,17 @@ describe('Creates Domains records with Form', () => {
 
     createDomainRecords().forEach((rec) => {
       cy.findByText(rec.name).click();
-      rec.fields.forEach((f) => {
-        cy.get(f.name).type(f.value);
+      rec.fields.forEach((field) => {
+        cy.get(field.name).type(field.value);
       });
       cy.findByText('Save').click();
       cy.wait('@apiCreateRecord').its('response.statusCode').should('eq', 200);
       cy.get(`[aria-label="${rec.tableAriaLabel}"]`).within((_table) => {
-        rec.fields.forEach((f) => {
-          if (f.skipCheck) {
+        rec.fields.forEach((field) => {
+          if (field.skipCheck) {
             return;
           }
-          cy.findByText(f.value, { exact: !f.approximate });
+          cy.findByText(field.value, { exact: !field.approximate });
         });
       });
     });

--- a/packages/manager/cypress/support/api/domains.ts
+++ b/packages/manager/cypress/support/api/domains.ts
@@ -1,16 +1,14 @@
-import {
-  Domain,
-  deleteDomain,
-  getDomains,
-  CreateDomainPayload,
-} from '@linode/api-v4';
-import { createDomainPayloadFactory } from 'src/factories';
+import { deleteDomain, getDomains } from '@linode/api-v4';
 import { isTestLabel } from 'support/api/common';
 import { oauthToken, pageSize } from 'support/constants/api';
 import { depaginate } from 'support/util/paginate';
 import { randomDomainName } from 'support/util/random';
 
+import { createDomainPayloadFactory } from 'src/factories';
+
 import { apiCheckErrors } from './common';
+
+import type { CreateDomainPayload, Domain } from '@linode/api-v4';
 
 /**
  * Deletes all domains which are prefixed with the test entity prefix.

--- a/packages/manager/cypress/support/constants/domains.ts
+++ b/packages/manager/cypress/support/constants/domains.ts
@@ -18,7 +18,7 @@ export const createDomainRecords = () => [
       {
         name: '[data-qa-target="IP Address"]',
         skipCheck: false,
-        value: `${randomIp()}`,
+        value: randomIp(),
       },
     ],
     name: 'Add an A/AAAA Record',

--- a/packages/manager/cypress/support/constants/domains.ts
+++ b/packages/manager/cypress/support/constants/domains.ts
@@ -1,90 +1,91 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 import {
-  randomLabel,
-  randomIp,
-  randomString,
   randomDomainName,
+  randomIp,
+  randomLabel,
+  randomString,
 } from 'support/util/random';
 
 // Array of domain records for which to test creation.
 export const createDomainRecords = () => [
   {
-    name: 'Add an A/AAAA Record',
-    tableAriaLabel: 'List of Domains A/AAAA Record',
     fields: [
       {
         name: '[data-qa-target="Hostname"]',
-        value: randomLabel(),
         skipCheck: false,
+        value: randomLabel(),
       },
       {
         name: '[data-qa-target="IP Address"]',
-        value: `${randomIp()}`,
         skipCheck: false,
+        value: `${randomIp()}`,
       },
     ],
+    name: 'Add an A/AAAA Record',
+    tableAriaLabel: 'List of Domains A/AAAA Record',
   },
   {
-    name: 'Add a CNAME Record',
-    tableAriaLabel: 'List of Domains CNAME Record',
     fields: [
       {
         name: '[data-qa-target="Hostname"]',
-        value: randomLabel(),
         skipCheck: false,
+        value: randomLabel(),
       },
       {
         name: '[data-qa-target="Alias to"]',
-        value: `${randomLabel()}.net`,
         skipCheck: false,
+        value: `${randomLabel()}.net`,
       },
     ],
+    name: 'Add a CNAME Record',
+    tableAriaLabel: 'List of Domains CNAME Record',
   },
   {
-    name: 'Add a TXT Record',
-    tableAriaLabel: 'List of Domains TXT Record',
     fields: [
       {
         name: '[data-qa-target="Hostname"]',
-        value: randomLabel(),
         skipCheck: false,
+        value: randomLabel(),
       },
       {
         name: '[data-qa-target="Value"]',
-        value: `${randomLabel()}=${randomString()}`,
         skipCheck: false,
+        value: `${randomLabel()}=${randomString()}`,
       },
     ],
+    name: 'Add a TXT Record',
+    tableAriaLabel: 'List of Domains TXT Record',
   },
   {
-    name: 'Add an SRV Record',
-    tableAriaLabel: 'List of Domains SRV Record',
     fields: [
       {
         name: '[data-qa-target="Service"]',
-        value: randomLabel(),
         skipCheck: true,
+        value: randomLabel(),
       },
       {
+        approximate: true,
         name: '[data-qa-target="Target"]',
         value: randomLabel(),
-        approximate: true,
       },
     ],
+    name: 'Add an SRV Record',
+    tableAriaLabel: 'List of Domains SRV Record',
   },
   {
-    name: 'Add a CAA Record',
-    tableAriaLabel: 'List of Domains CAA Record',
     fields: [
       {
         name: '[data-qa-target="Name"]',
-        value: randomLabel(),
         skipCheck: false,
+        value: randomLabel(),
       },
       {
         name: '[data-qa-target="Value"]',
-        value: randomDomainName(),
         skipCheck: false,
+        value: randomDomainName(),
       },
     ],
+    name: 'Add a CAA Record',
+    tableAriaLabel: 'List of Domains CAA Record',
   },
 ];


### PR DESCRIPTION
## Description 📝
The domain record tests in `smoke-create-domain-records.spec.ts` are parameterized against an array containing 5 items (each item representing a domain record type that can be created). This PR combines the tests into a single test which attempts to create each type of record as a result. By reducing the number of tests from 5 to 1, it results in a more performant solution (cuts test run time in half).

## Changes  🔄
List any change relevant to the reviewer.
- Combines the assertions from each record type creation in a single assertion.

## Target release date 🗓️
2024/07/08

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![before-change](https://github.com/linode/manager/assets/119514965/8b47919d-7c7b-4cbc-9927-124f2b736382) | ![after-change](https://github.com/linode/manager/assets/119514965/dcb34410-7244-4019-9aab-a119067db4b5) |

## How to test 🧪
### Verification steps
- Checkout this branch and run the verify the test passes with the performance improvements as described above.
- Execute either of the following commands:
  - `yarn cy:debug` then run the `smoke-create-domain-records.spec.ts` test in the browser.
  - `yarn cy:run -s "cypress/e2e/core/domains/smoke-create-domain-records.spec.ts"`

## As an Author I have considered 🤔
*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
