### PR TITLE
fix: [M3-7590, M3-7886] – Improve UX for Linode Resize dialog when linode data is being loaded or there is a form error

### DIFF
--- a/packages/manager/.changeset/pr-10618-fixed-1719521792524.md
+++ b/packages/manager/.changeset/pr-10618-fixed-1719521792524.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Linode Resize dialog UX when linode data is loading or there is an error ([#10618](https://github.com/linode/manager/pull/10618))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -27,7 +27,7 @@ import { usePreferences } from 'src/queries/profile/preferences';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { useAllTypes } from 'src/queries/types';
 import { extendType } from 'src/utilities/extendType';
-import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
+import { scrollErrorIntoViewV2 } from 'src/utilities/scrollErrorIntoViewV2';
 
 import { HostMaintenanceError } from '../HostMaintenanceError';
 import { LinodePermissionsError } from '../LinodePermissionsError';
@@ -79,6 +79,8 @@ export const LinodeResize = (props: Props) => {
 
   const [hasResizeError, setHasResizeError] = React.useState<boolean>(false);
 
+  const formRef = React.useRef<HTMLFormElement>(null);
+
   const {
     error: resizeError,
     isLoading,
@@ -127,6 +129,7 @@ export const LinodeResize = (props: Props) => {
       });
       onClose();
     },
+    validate: () => scrollErrorIntoViewV2(formRef),
   });
 
   React.useEffect(() => {
@@ -156,8 +159,6 @@ export const LinodeResize = (props: Props) => {
   React.useEffect(() => {
     if (resizeError) {
       setHasResizeError(true);
-      // Set to "block: end" since the sticky header would otherwise interfere.
-      scrollErrorIntoView(undefined, { block: 'end' });
     }
   }, [resizeError]);
 
@@ -197,7 +198,7 @@ export const LinodeResize = (props: Props) => {
       {isLinodeDataLoading ? (
         <CircleProgress />
       ) : (
-        <form onSubmit={formik.handleSubmit}>
+        <form onSubmit={formik.handleSubmit} ref={formRef}>
           {isLinodesGrantReadOnly && <LinodePermissionsError />}
           {hostMaintenance && <HostMaintenanceError />}
           {disksError && (

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -1,7 +1,3 @@
-import {
-  MigrationTypes,
-  ResizeLinodePayload,
-} from '@linode/api-v4/lib/linodes';
 import { useTheme } from '@mui/material/styles';
 import { useFormik } from 'formik';
 import { useSnackbar } from 'notistack';
@@ -10,6 +6,7 @@ import * as React from 'react';
 import { Box } from 'src/components/Box';
 import { Button } from 'src/components/Button/Button';
 import { Checkbox } from 'src/components/Checkbox';
+import { CircleProgress } from 'src/components/CircleProgress/CircleProgress';
 import { Dialog } from 'src/components/Dialog/Dialog';
 import { Divider } from 'src/components/Divider';
 import { Link } from 'src/components/Link';
@@ -41,6 +38,11 @@ import {
 } from './LinodeResize.utils';
 import { UnifiedMigrationPanel } from './LinodeResizeUnifiedMigrationPanel';
 
+import type {
+  MigrationTypes,
+  ResizeLinodePayload,
+} from '@linode/api-v4/lib/linodes';
+
 interface Props {
   linodeId?: number;
   linodeLabel?: string;
@@ -57,7 +59,7 @@ export const LinodeResize = (props: Props) => {
   const { linodeId, onClose, open } = props;
   const theme = useTheme();
 
-  const { data: linode } = useLinodeQuery(
+  const { data: linode, isLoading: isLinodeDataLoading } = useLinodeQuery(
     linodeId ?? -1,
     linodeId !== undefined && open
   );
@@ -190,148 +192,152 @@ export const LinodeResize = (props: Props) => {
       maxWidth="md"
       onClose={onClose}
       open={open}
-      title={`Resize Linode ${linode?.label}`}
+      title={`Resize Linode ${linode?.label ?? ''}`}
     >
-      <form onSubmit={formik.handleSubmit}>
-        {isLinodesGrantReadOnly && <LinodePermissionsError />}
-        {hostMaintenance && <HostMaintenanceError />}
-        {disksError && (
-          <Notice
-            text="There was an error loading your Linode&rsquo;s Disks."
-            variant="error"
-          />
-        )}
-        {hasResizeError && <Notice variant="error">{error}</Notice>}
-        <Typography data-qa-description>
-          If you&rsquo;re expecting a temporary burst of traffic to your
-          website, or if you&rsquo;re not using your Linode as much as you
-          thought, you can temporarily or permanently resize your Linode to a
-          different plan.{' '}
-          <Link to="https://www.linode.com/docs/platform/disk-images/resizing-a-linode/">
-            Learn more.
-          </Link>
-        </Typography>
+      {isLinodeDataLoading ? (
+        <CircleProgress />
+      ) : (
+        <form onSubmit={formik.handleSubmit}>
+          {isLinodesGrantReadOnly && <LinodePermissionsError />}
+          {hostMaintenance && <HostMaintenanceError />}
+          {disksError && (
+            <Notice
+              text="There was an error loading your Linode&rsquo;s Disks."
+              variant="error"
+            />
+          )}
+          {hasResizeError && <Notice variant="error">{error}</Notice>}
+          <Typography data-qa-description>
+            If you&rsquo;re expecting a temporary burst of traffic to your
+            website, or if you&rsquo;re not using your Linode as much as you
+            thought, you can temporarily or permanently resize your Linode to a
+            different plan.{' '}
+            <Link to="https://www.linode.com/docs/platform/disk-images/resizing-a-linode/">
+              Learn more.
+            </Link>
+          </Typography>
 
-        <Box
-          sx={{
-            '& > div': {
-              padding: 0,
-            },
-            marginBottom: theme.spacing(3),
-            marginTop: theme.spacing(5),
-          }}
-        >
-          <PlansPanel
-            currentPlanHeading={type ? extendType(type).heading : undefined} // lol, why make us pass the heading and not the plan id?
-            disabled={tableDisabled}
-            onSelect={(type) => formik.setFieldValue('type', type)}
-            regionsData={regionsData}
-            selectedId={formik.values.type}
-            selectedRegionID={linode?.region}
-            types={currentTypes.map(extendType)}
-          />
-        </Box>
-        <UnifiedMigrationPanel
-          formik={formik}
-          isLinodeOffline={isLinodeOffline}
-          migrationTypeOptions={migrationTypeOptions}
-        />
-        <Typography
-          sx={{ alignItems: 'center', display: 'flex', minHeight: '44px' }}
-          variant="h2"
-        >
-          Auto Resize Disk
-          {disksError ? (
-            <TooltipIcon
-              sxTooltipIcon={{
-                marginLeft: '-2px',
-              }}
-              status="help"
-              text={`There was an error loading your Linode&rsquo; disks.`}
-            />
-          ) : isSmaller ? (
-            <TooltipIcon
-              sxTooltipIcon={{
-                marginLeft: '-2px',
-              }}
-              status="help"
-              text={`Your disks cannot be automatically resized when moving to a smaller plan.`}
-            />
-          ) : !_shouldEnableAutoResizeDiskOption ? (
-            <TooltipIcon
-              sxTooltipIcon={{
-                marginLeft: '-2px',
-              }}
-              text={`Your ext disk can only be automatically resized if you have one ext
-                    disk or one ext disk and one swap disk on this Linode.`}
-              status="help"
-            />
-          ) : null}
-        </Typography>
-        <Checkbox
-          checked={
-            !_shouldEnableAutoResizeDiskOption || isSmaller
-              ? false
-              : formik.values.allow_auto_disk_resize
-          }
-          onChange={(value, checked) =>
-            formik.setFieldValue('allow_auto_disk_resize', checked)
-          }
-          text={
-            <Typography>
-              Would you like{' '}
-              {_shouldEnableAutoResizeDiskOption ? (
-                <strong>{diskToResize}</strong>
-              ) : (
-                'your disk'
-              )}{' '}
-              to be automatically scaled with this Linode&rsquo;s new size?{' '}
-              <br />
-              We recommend you keep this option enabled when available.
-            </Typography>
-          }
-          disabled={!_shouldEnableAutoResizeDiskOption || isSmaller}
-        />
-        <Divider
-          sx={{
-            marginTop: theme.spacing(2),
-          }}
-        />
-        <Box marginTop={2}>
-          <TypeToConfirm
-            confirmationText={
-              <span>
-                To confirm these changes, type the label of the Linode (
-                <strong>{linode?.label}</strong>) in the field below:
-              </span>
-            }
-            hideLabel
-            label="Linode Label"
-            onChange={setConfirmationText}
-            textFieldStyle={{ marginBottom: 16 }}
-            title="Confirm"
-            typographyStyle={{ marginBottom: 8 }}
-            value={confirmationText}
-            visible={preferences?.type_to_confirm}
-          />
-        </Box>
-        <Box display="flex" justifyContent="flex-end">
-          <Button
-            disabled={
-              !formik.values.type ||
-              linodeInTransition(linode?.status || '') ||
-              tableDisabled ||
-              submitButtonDisabled
-            }
-            buttonType="primary"
-            data-qa-resize
-            loading={isLoading}
-            type="submit"
+          <Box
+            sx={{
+              '& > div': {
+                padding: 0,
+              },
+              marginBottom: theme.spacing(3),
+              marginTop: theme.spacing(5),
+            }}
           >
-            Resize Linode
-          </Button>
-        </Box>
-      </form>
+            <PlansPanel
+              currentPlanHeading={type ? extendType(type).heading : undefined} // lol, why make us pass the heading and not the plan id?
+              disabled={tableDisabled}
+              onSelect={(type) => formik.setFieldValue('type', type)}
+              regionsData={regionsData}
+              selectedId={formik.values.type}
+              selectedRegionID={linode?.region}
+              types={currentTypes.map(extendType)}
+            />
+          </Box>
+          <UnifiedMigrationPanel
+            formik={formik}
+            isLinodeOffline={isLinodeOffline}
+            migrationTypeOptions={migrationTypeOptions}
+          />
+          <Typography
+            sx={{ alignItems: 'center', display: 'flex', minHeight: '44px' }}
+            variant="h2"
+          >
+            Auto Resize Disk
+            {disksError ? (
+              <TooltipIcon
+                sxTooltipIcon={{
+                  marginLeft: '-2px',
+                }}
+                status="help"
+                text={`There was an error loading your Linode&rsquo; disks.`}
+              />
+            ) : isSmaller ? (
+              <TooltipIcon
+                sxTooltipIcon={{
+                  marginLeft: '-2px',
+                }}
+                status="help"
+                text={`Your disks cannot be automatically resized when moving to a smaller plan.`}
+              />
+            ) : !_shouldEnableAutoResizeDiskOption ? (
+              <TooltipIcon
+                sxTooltipIcon={{
+                  marginLeft: '-2px',
+                }}
+                text={`Your ext disk can only be automatically resized if you have one ext
+                    disk or one ext disk and one swap disk on this Linode.`}
+                status="help"
+              />
+            ) : null}
+          </Typography>
+          <Checkbox
+            checked={
+              !_shouldEnableAutoResizeDiskOption || isSmaller
+                ? false
+                : formik.values.allow_auto_disk_resize
+            }
+            onChange={(value, checked) =>
+              formik.setFieldValue('allow_auto_disk_resize', checked)
+            }
+            text={
+              <Typography>
+                Would you like{' '}
+                {_shouldEnableAutoResizeDiskOption ? (
+                  <strong>{diskToResize}</strong>
+                ) : (
+                  'your disk'
+                )}{' '}
+                to be automatically scaled with this Linode&rsquo;s new size?{' '}
+                <br />
+                We recommend you keep this option enabled when available.
+              </Typography>
+            }
+            disabled={!_shouldEnableAutoResizeDiskOption || isSmaller}
+          />
+          <Divider
+            sx={{
+              marginTop: theme.spacing(2),
+            }}
+          />
+          <Box marginTop={2}>
+            <TypeToConfirm
+              confirmationText={
+                <span>
+                  To confirm these changes, type the label of the Linode (
+                  <strong>{linode?.label}</strong>) in the field below:
+                </span>
+              }
+              hideLabel
+              label="Linode Label"
+              onChange={setConfirmationText}
+              textFieldStyle={{ marginBottom: 16 }}
+              title="Confirm"
+              typographyStyle={{ marginBottom: 8 }}
+              value={confirmationText}
+              visible={preferences?.type_to_confirm}
+            />
+          </Box>
+          <Box display="flex" justifyContent="flex-end">
+            <Button
+              disabled={
+                !formik.values.type ||
+                linodeInTransition(linode?.status || '') ||
+                tableDisabled ||
+                submitButtonDisabled
+              }
+              buttonType="primary"
+              data-qa-resize
+              loading={isLoading}
+              type="submit"
+            >
+              Resize Linode
+            </Button>
+          </Box>
+        </form>
+      )}
     </Dialog>
   );
 };


### PR DESCRIPTION
## Description 📝
Improve the UX for the Linode Resize dialog.

## Changes  🔄
- Only display Linode Resize form if linode data has been loaded (if it is still loading, render a `<CircleProgress />`)
- Prevent dialog title from being `Resize Linode undefined` by rendering an empty string when `linode.label` is undefined as the linode data loads
- Implement `scrollErrorIntoViewV2()` to ensure errors are scrolled into view

## Target release date 🗓️
7/8/24

## Preview 📷
| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/114682940/2ac2565b-3e92-432f-968c-29ee653a01b4" /> | <video src="https://github.com/linode/manager/assets/114682940/95140031-c936-49cb-a712-5a1eaa82c97d" /> |

<details>
<summary>Error scrolls into view</summary>

https://github.com/linode/manager/assets/114682940/9ecc52bf-8773-49a3-ab04-a757d3a7bc87
</details>

## How to test 🧪
### Reproduction steps
From the Linodes landing page, open the Resize dialog for a linode. Observe: the dialog title briefly says "Resize Linode undefined" and the body of the dialog shifts once the linode data is loaded.

For the error, either block requests to `*resize*` or choose a larger linode that you can resize to a smaller plan. Try to submit the form and observe that the form does not scroll to the error at the top.

### Verification steps
- Confirm the "Resize Linode undefined" and dialog body shift issues are no longer happening
- Confirm we now scroll to errors

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support