### PR TITLE
test: Fix CI support ticket test failure by mocking clusters

### DIFF
--- a/packages/manager/cypress/e2e/core/helpAndSupport/open-support-ticket.spec.ts
+++ b/packages/manager/cypress/e2e/core/helpAndSupport/open-support-ticket.spec.ts
@@ -46,6 +46,7 @@ import { authenticate } from 'support/api/authentication';
 import { MAGIC_DATE_THAT_EMAIL_RESTRICTIONS_WERE_IMPLEMENTED } from 'src/constants';
 import { mockGetLinodes } from 'support/intercepts/linodes';
 import { mockGetDomains } from 'support/intercepts/domains';
+import { mockGetClusters } from 'support/intercepts/lke';
 
 describe('help & support', () => {
   after(() => {
@@ -342,7 +343,7 @@ describe('help & support', () => {
 
   it('can create a support ticket with an entity', () => {
     const mockLinodes = linodeFactory.buildList(2);
-    const mockDomains = domainFactory.buildList(1);
+    const mockDomain = domainFactory.build();
 
     const mockTicket = supportTicketFactory.build({
       id: randomNumber(),
@@ -352,11 +353,12 @@ describe('help & support', () => {
     });
 
     mockCreateSupportTicket(mockTicket).as('createTicket');
+    mockGetClusters([]);
     mockGetSupportTickets([]);
     mockGetSupportTicket(mockTicket);
     mockGetSupportTicketReplies(mockTicket.id, []);
     mockGetLinodes(mockLinodes);
-    mockGetDomains(mockDomains);
+    mockGetDomains([mockDomain]);
 
     cy.visitWithLogin('/support/tickets');
 
@@ -418,7 +420,7 @@ describe('help & support', () => {
         cy.get('[data-qa-ticket-entity-id]')
           .should('be.visible')
           .click()
-          .type('domain-0{downarrow}{enter}');
+          .type(`${mockDomain.domain}{downarrow}{enter}`);
 
         ui.button
           .findByTitle('Open Ticket')


### PR DESCRIPTION
## Description 📝
This fixes a failure in one of our new Help & Support tests that's occurring in CI -- the test checks the support ticket form's validation error behavior and asserts the presence of a note stating that no LKE entities exist. This assertion fails on test accounts that do have clusters, so this PR mocks the cluster request to ensure the form behaves as expected.

## Changes  🔄
- Mock empty LKE clusters array so that expected validation message always appears
- Remove hardcoded domain label to make test more resilient to factory changes and Factory.ts sequence tracking

## How to test 🧪
It's probably best to test this one manually since we can't guarantee whether a CI account will (or will not) have LKE clusters.

1. Create an LKE cluster on your account
2. Run the test via `yarn cy:run -s "cypress/e2e/core/helpAndSupport/open-support-ticket.spec.ts"`, confirm all tests pass
3. Delete the LKE cluster, rerun the tests, confirm they still pass

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
  - No changeset needed since this test hasn't been released yet
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
