### PR TITLE
test: [M3-7319] - De-Parameterize Cypress Deep Link Smoke Tests

### DIFF
--- a/packages/manager/.changeset/pr-10622-tests-1719519067716.md
+++ b/packages/manager/.changeset/pr-10622-tests-1719519067716.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+De-Parameterize Cypress Deep Link Smoke Tests ([#10622](https://github.com/linode/manager/pull/10622))

--- a/packages/manager/cypress/e2e/core/general/smoke-deep-link.spec.ts
+++ b/packages/manager/cypress/e2e/core/general/smoke-deep-link.spec.ts
@@ -2,29 +2,19 @@ import { pages } from 'support/ui/constants';
 
 import type { Page } from 'support/ui/constants';
 
-describe('smoke - deep link', () => {
-  pages.forEach((page: Page) => {
-    describe(`Go to ${page.name}`, () => {
-      // check if we run only one test
-      if (!page.goWithUI) {
-        return;
-      }
+describe('smoke - deep links', () => {
+  beforeEach(() => {
+    cy.visitWithLogin('/null');
+  });
 
-      // Here we use login to /null here
-      // so this is independant from what is coded in constants and which path are skipped
-      beforeEach(() => {
-        cy.visitWithLogin('/null');
-      });
-
-      page.goWithUI.forEach((uiPath) => {
-        (page.first ? it.only : page.skip ? it.skip : it)(
-          `by ${uiPath.name}`,
-          () => {
-            expect(uiPath.name).not.to.be.empty;
-            uiPath.go();
-            cy.url().should('be.eq', `${Cypress.config('baseUrl')}${page.url}`);
-          }
-        );
+  it('Go to each route and validate deep links', () => {
+    pages.forEach((page: Page) => {
+      cy.log(`Go to ${page.name}`);
+      page.goWithUI?.forEach((uiPath) => {
+        cy.log(`by ${uiPath.name}`);
+        expect(uiPath.name).not.to.be.empty;
+        uiPath.go();
+        cy.url().should('be.eq', `${Cypress.config('baseUrl')}${page.url}`);
       });
     });
   });

--- a/packages/manager/cypress/support/ui/constants.ts
+++ b/packages/manager/cypress/support/ui/constants.ts
@@ -1,4 +1,3 @@
-import { containsClick, containsVisible, getVisible } from '../helpers';
 import { waitForAppLoad } from './common';
 
 export const loadAppNoLogin = (path: string) => waitForAppLoad(path, false);
@@ -31,10 +30,8 @@ interface GoWithUI {
 
 export interface Page {
   assertIsLoaded: () => void;
-  first?: boolean;
   goWithUI?: GoWithUI[];
   name: string;
-  skip?: boolean;
   url: string;
 }
 
@@ -117,10 +114,10 @@ export const pages: Page[] = [
         go: () => {
           const url = `${routes.profile}/auth`;
           loadAppNoLogin(url);
-          getVisible('[data-qa-header="My Profile"]');
-          containsVisible(
+          cy.get('[data-qa-header="My Profile"]').should('be.visible');
+          cy.contains(
             'How to Enable Third Party Authentication on Your User Account'
-          );
+          ).should('be.visible');
           waitDoubleRerender();
           cy.contains('Display').should('be.visible').click();
         },
@@ -149,7 +146,7 @@ export const pages: Page[] = [
           loadAppNoLogin(routes.profile);
           cy.findByText('Username').should('be.visible');
           waitDoubleRerender();
-          containsClick('Login & Authentication');
+          cy.contains('Login & Authentication').click();
         },
         name: 'Tab',
       },
@@ -182,7 +179,7 @@ export const pages: Page[] = [
           loadAppNoLogin(routes.profile);
           cy.findByText('Username');
           waitDoubleRerender();
-          containsClick('LISH Console Settings');
+          cy.contains('LISH Console Settings').click();
         },
         name: 'Tab',
       },
@@ -204,7 +201,7 @@ export const pages: Page[] = [
         name: 'Tab',
       },
     ],
-    name: 'Profile/API tokens',
+    name: 'Profile/API Tokens',
     url: `${routes.profile}/tokens`,
   },
   {
@@ -215,7 +212,7 @@ export const pages: Page[] = [
   },
   {
     assertIsLoaded: () => cy.findByText('Open New Ticket').should('be.visible'),
-    name: 'Support/tickets',
+    name: 'Support/Tickets',
     url: `${routes.supportTickets}`,
   },
   {
@@ -229,7 +226,7 @@ export const pages: Page[] = [
         name: 'Tab',
       },
     ],
-    name: 'Support/tickets/open',
+    name: 'Support/Tickets/Open',
     url: `${routes.supportTicketsOpen}`,
   },
   {
@@ -243,7 +240,7 @@ export const pages: Page[] = [
         name: 'Tab',
       },
     ],
-    name: 'Support/tickets/closed',
+    name: 'Support/Tickets/Closed',
     url: `${routes.supportTicketsClosed}`,
   },
   {
@@ -281,7 +278,7 @@ export const pages: Page[] = [
         name: 'Tab',
       },
     ],
-    name: 'account/Users',
+    name: 'Account/Users',
     url: `${routes.account}/users`,
   },
   {
@@ -298,7 +295,7 @@ export const pages: Page[] = [
         name: 'Tab',
       },
     ],
-    name: 'account/Settings',
+    name: 'Account/Settings',
     url: `${routes.account}/settings`,
   },
 ];


### PR DESCRIPTION
## Description 📝
The tests in the `deep-link-smoke.spect.ts` spec were originally parameterized against an array containing 19 items, and each test made one or two assertions. This PR de-parameterizes the tests and combines them into a single test that checks each deep link. In the end, it eliminates 18 tests and cuts down the test run time.

## Changes  🔄
List any change relevant to the reviewer.
- Replaced deprecated methods.
- Updated the `Page` interface by removing the `first` and `skip` properties.
- Removed the nested ternary assertion logic.

## Target release date 🗓️
2024/07/08

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![7319-before](https://github.com/linode/manager/assets/119514965/e692ed76-82e8-43c2-a8c1-462cf0dcb660) | ![7319-after](https://github.com/linode/manager/assets/119514965/5d839145-e307-4faf-a8d5-6b907dc09eb3) |

## How to test 🧪
### Verification steps
(How to verify changes)
- Checkout this branch and run the verify the test passes with the performance improvements as described above.
- Execute either of the following commands:
  - `yarn cy:debug` then run the `deep-link-smoke.spect.ts` test in the browser.
  - `yarn cy:run -s "cypress/e2e/core/general/deep-link-smoke.spect.ts"`

## As an Author I have considered 🤔
*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
