### PR TITLE
feat: [M3-7684] - Disable Create Volume button with tooltiptext on Landing Page for restricted users

### DIFF
--- a/packages/manager/.changeset/pr-10627-added-1719905623432.md
+++ b/packages/manager/.changeset/pr-10627-added-1719905623432.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Disabled Create Volume Button on the Landing Page for Restricted Users ([#10627](https://github.com/linode/manager/pull/10627))

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -18,8 +18,10 @@ import { TableRow } from 'src/components/TableRow';
 import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
 import { TableSortCell } from 'src/components/TableSortCell';
 import { TextField } from 'src/components/TextField';
+import { getRestrictedResourceText } from 'src/features/Account/utils';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 import { useVolumesQuery } from 'src/queries/volumes/volumes';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
@@ -43,6 +45,9 @@ export const VolumesLanding = () => {
   const history = useHistory();
   const location = useLocation<{ volume: Volume | undefined }>();
   const pagination = usePagination(1, preferenceKey);
+  const isRestricted = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'add_volumes',
+  });
   const queryParams = new URLSearchParams(location.search);
   const volumeLabelFromParam = queryParams.get(searchQueryKey) ?? '';
 
@@ -161,6 +166,14 @@ export const VolumesLanding = () => {
           pathname: location.pathname,
           removeCrumbX: 1,
         }}
+        buttonDataAttrs={{
+          tooltipText: getRestrictedResourceText({
+            action: 'create',
+            isSingular: false,
+            resourceType: 'Volumes',
+          }),
+        }}
+        disabledCreateButton={isRestricted}
         docsLink="https://www.linode.com/docs/platform/block-storage/how-to-use-block-storage-with-your-linode/"
         entity="Volume"
         onButtonClick={() => history.push('/volumes/create')}


### PR DESCRIPTION
## Description 📝

To prevent unauthorized access to specific flows and provide clearer guidance, we aim to restrict entry to users without the required permissions.

Here, we are restricting users from creating new Volume when they do not have access or have read only access.

## Changes  🔄

- For restricted users: 
    - Disabled Create Volume Button on the Landing Page

## Target release date 🗓️
July 8th, 2024

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-07-01 at 8 30 45 PM](https://github.com/linode/manager/assets/172569094/94f048b4-a188-4c97-a15c-e090ed91deff) | ![Screenshot 2024-07-01 at 8 36 41 PM](https://github.com/linode/manager/assets/172569094/4b1a388a-bb68-4fb0-a845-891261f5ca4a) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Log into two accounts side by side:
     - An unrestricted admin user account: full access
     - A restricted user account (use Incognito for this)
           - Start with `Read Only` for everything


### Reproduction steps
- Landing:
   -  Observe as restricted user, notice shows and you cannot create Volumes

### Verification steps
- After changes, observe tooltips are tailored to the action.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support