### PR TITLE
upcoming: [M3-8066] - Debounce the Linode Create v2 `VLANSelect`

### DIFF
--- a/packages/manager/.changeset/pr-10628-upcoming-features-1719846490755.md
+++ b/packages/manager/.changeset/pr-10628-upcoming-features-1719846490755.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add debouncing to the Linode Create v2 `VLANSelect` ([#10628](https://github.com/linode/manager/pull/10628))

--- a/packages/manager/src/components/VLANSelect.tsx
+++ b/packages/manager/src/components/VLANSelect.tsx
@@ -60,7 +60,7 @@ export const VLANSelect = (props: Props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
-  const debouncedInputValue = useDebouncedValue(inputValue, 800);
+  const debouncedInputValue = useDebouncedValue(inputValue);
 
   const apiFilter = getVLANSelectFilter({
     defaultFilter: filter,

--- a/packages/manager/src/components/VLANSelect.tsx
+++ b/packages/manager/src/components/VLANSelect.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
+import { useDebouncedValue } from 'src/hooks/useDebouncedValue';
 import { useVLANsInfiniteQuery } from 'src/queries/vlans';
 
 import { Autocomplete } from './Autocomplete/Autocomplete';
@@ -59,9 +60,11 @@ export const VLANSelect = (props: Props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
+  const debouncedInputValue = useDebouncedValue(inputValue, 800);
+
   const apiFilter = getVLANSelectFilter({
     defaultFilter: filter,
-    inputValue,
+    inputValue: debouncedInputValue,
   });
 
   const {

--- a/packages/manager/src/hooks/useDebouncedValue.test.ts
+++ b/packages/manager/src/hooks/useDebouncedValue.test.ts
@@ -3,7 +3,7 @@ import { act, renderHook } from '@testing-library/react';
 import { useDebouncedValue } from './useDebouncedValue';
 
 describe('useDebouncedValue', () => {
-  it('debounced the provided value by the given time', () => {
+  it('debounces the provided value by the given delay', () => {
     vi.useFakeTimers();
 
     const { rerender, result } = renderHook(

--- a/packages/manager/src/hooks/useDebouncedValue.test.ts
+++ b/packages/manager/src/hooks/useDebouncedValue.test.ts
@@ -1,0 +1,32 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useDebouncedValue } from './useDebouncedValue';
+
+describe('useDebouncedValue', () => {
+  it('debounced the provided value by the given time', () => {
+    vi.useFakeTimers();
+
+    const { rerender, result } = renderHook(
+      ({ value }) => useDebouncedValue(value, 500),
+      { initialProps: { value: 'test' } }
+    );
+
+    expect(result.current).toBe('test');
+
+    rerender({ value: 'test-1' });
+
+    expect(result.current).toBe('test');
+
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(result.current).toBe('test');
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(result.current).toBe('test-1');
+  });
+});

--- a/packages/manager/src/hooks/useDebouncedValue.ts
+++ b/packages/manager/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+export const useDebouncedValue = <T>(value: T, delay: number) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};

--- a/packages/manager/src/hooks/useDebouncedValue.ts
+++ b/packages/manager/src/hooks/useDebouncedValue.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-export const useDebouncedValue = <T>(value: T, delay: number) => {
+export const useDebouncedValue = <T>(value: T, delay: number = 500) => {
   const [debouncedValue, setDebouncedValue] = useState(value);
 
   useEffect(() => {


### PR DESCRIPTION
## Description 📝

- Adds debouncing the `VLANSelect` created for and used on Linode Create v2 ⏲️ 
- Adds a new `useDebouncedValue` hook to make this easy
  - Let me know if you know of a better way 💡  

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/115251059/9bc3cab4-9c88-4980-8a66-d3dcc36b75a5" /> | <video src="https://github.com/linode/manager/assets/115251059/9b7c1a6e-fb92-41b7-b4fe-34e637c0e6b5" /> |

## How to test 🧪

### Prerequisites
- Turn on `Linode Create v2`

### Verification steps
- Verify that the API search performed by the `VLANSelect` is debounced and works as expected

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support