### PR TITLE
fix: Distributed regions not displaying in the Linode Create flow

### DIFF
--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.tsx
@@ -134,6 +134,7 @@ export const isDistributedRegionSupported = (createType: LinodeCreateType) => {
     'Distributions',
     'StackScripts',
     'Images',
+    undefined, // /linodes/create route
   ];
   return supportedDistributedRegionTypes.includes(createType);
 };


### PR DESCRIPTION
## Description 📝
Looks like there was a change made to the `isDistributedRegionSupported` function which caused a regression in the distributed regions displaying in the Linode Create flow

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/115299789/9ca25b9f-6990-4afc-b674-3d3509c77cec) | ![image](https://github.com/linode/manager/assets/115299789/c1f2cca2-8f0b-442d-ba6e-eafc167acd97) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Ensure your account has the `new-dc-testing`, `edge_testing` and `edge_compute` customer tags

### Reproduction steps
(How to reproduce the issue, if applicable)
- Go to the remote dev environment and observe no Distributed regions in the Linode Create flow

### Verification steps
(How to verify changes)
- Either locally or in the preview link, go to the Linode Create flow. Distributed regions should be displaying again

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support