### PR TITLE
change: [M3-7684] - Keep Create Volumes Page Error Notification Position Consistent

### DIFF
--- a/packages/manager/.changeset/pr-10632-changed-1719914806428.md
+++ b/packages/manager/.changeset/pr-10632-changed-1719914806428.md
@@ -2,4 +2,4 @@
 "@linode/manager": Changed
 ---
 
-Position of error notif has been moved from inside the box to outside & used getRestrictedResourceText utility for the Notice ([#10632](https://github.com/linode/manager/pull/10632))
+Use `getRestrictedResourceText` utility and move restrictions Notice to top of Volume Create ([#10632](https://github.com/linode/manager/pull/10632))

--- a/packages/manager/.changeset/pr-10632-changed-1719914806428.md
+++ b/packages/manager/.changeset/pr-10632-changed-1719914806428.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Position of error notif has been moved from inside the box to outside & used getRestrictedResourceText utility for the Notice ([#10632](https://github.com/linode/manager/pull/10632))

--- a/packages/manager/src/features/Volumes/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate.tsx
@@ -19,6 +19,7 @@ import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
 import { MAX_VOLUME_SIZE } from 'src/constants';
 import { EUAgreementCheckbox } from 'src/features/Account/Agreements/EUAgreementCheckbox';
+import { getRestrictedResourceText } from 'src/features/Account/utils';
 import { LinodeSelect } from 'src/features/Linodes/LinodeSelect/LinodeSelect';
 import {
   reportAgreementSigningError,
@@ -254,6 +255,18 @@ export const VolumeCreate = () => {
         }}
         title="Create"
       />
+      {error && <Notice spacingTop={8} text={error} variant="error" />}
+      {doesNotHavePermission && (
+        <Notice
+          text={getRestrictedResourceText({
+            action: 'create',
+            resourceType: 'Volumes',
+          })}
+          important
+          spacingTop={16}
+          variant="error"
+        />
+      )}
       <form onSubmit={handleSubmit}>
         <Box display="flex" flexDirection="column">
           <Paper>
@@ -268,24 +281,6 @@ export const VolumeCreate = () => {
                 Select a region to see cost per GB.
               </span>
             </Typography>
-            {error && (
-              <Notice
-                spacingBottom={0}
-                spacingTop={12}
-                text={error}
-                variant="error"
-              />
-            )}
-            {doesNotHavePermission && (
-              <Notice
-                text={
-                  "You don't have permissions to create a new Volume. Please contact an account administrator for details."
-                }
-                important
-                spacingBottom={0}
-                variant="error"
-              />
-            )}
             <TextField
               tooltipText="Use only ASCII letters, numbers,
                   underscores, and dashes."

--- a/packages/manager/src/features/Volumes/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate.tsx
@@ -255,7 +255,6 @@ export const VolumeCreate = () => {
         }}
         title="Create"
       />
-      {error && <Notice spacingTop={8} text={error} variant="error" />}
       {doesNotHavePermission && (
         <Notice
           text={getRestrictedResourceText({
@@ -281,6 +280,14 @@ export const VolumeCreate = () => {
                 Select a region to see cost per GB.
               </span>
             </Typography>
+            {error && (
+              <Notice
+                spacingBottom={0}
+                spacingTop={12}
+                text={'Hello there'}
+                variant="error"
+              />
+            )}
             <TextField
               tooltipText="Use only ASCII letters, numbers,
                   underscores, and dashes."

--- a/packages/manager/src/features/Volumes/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate.tsx
@@ -284,7 +284,7 @@ export const VolumeCreate = () => {
               <Notice
                 spacingBottom={0}
                 spacingTop={12}
-                text={'Hello there'}
+                text={error}
                 variant="error"
               />
             )}


### PR DESCRIPTION
## Description 📝

Keeping the Create Volumes Page error notification position consistent with other tabs like NodeBalancers.

## Changes  🔄

- For restricted users: 
    - The position of error notification has been moved from inside the box to outside, which is now consistent with other tabs like NodeBalancers.
    - Used `getRestrictedResourceText` utility to show a Notice / error notification message.

## Target release date 🗓️
July 8th, 2024

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-07-01 at 11 21 53 PM](https://github.com/linode/manager/assets/172569094/3d806e80-7c76-43b7-9fec-5cf3e7de1299) | ![Screenshot 2024-07-01 at 11 48 30 PM](https://github.com/linode/manager/assets/172569094/ddbb868e-77b8-4fe9-94b7-12ebeaec9dad) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Log in with a restricted user account (read-only access) and go to the Create Volumes Page via volumes/create route directly from you browser.


### Reproduction steps
 -  Observe as restricted user, error notification shows out of the box (not inside as before) and you cannot create Volumes.

### Verification steps
- As a restricted user, compare Create Volumes Page (route: volumes/create) with Create NodeBalancers Page (route: nodebalancers/create) to ensure consistency.   

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support