### PR TITLE
test: [M3-8122] - Disable access to internet for Linodes created during Cypress tests

### DIFF
--- a/packages/manager/.changeset/pr-10633-tests-1719934397905.md
+++ b/packages/manager/.changeset/pr-10633-tests-1719934397905.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Improve security of Linodes created during tests ([#10633](https://github.com/linode/manager/pull/10633))

--- a/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
@@ -33,8 +33,8 @@ const getLinodeCloneUrl = (linode: Linode): string => {
   return `/linodes/create?linodeID=${linode.id}${regionQuery}&type=Clone+Linode${typeQuery}`;
 };
 
-/* Timeout after 3 minutes while waiting for clone. */
-const CLONE_TIMEOUT = 180_000;
+/* Timeout after 4 minutes while waiting for clone. */
+const CLONE_TIMEOUT = 240_000;
 
 authenticate();
 describe('clone linode', () => {
@@ -47,7 +47,7 @@ describe('clone linode', () => {
    * - Confirms that Linode can be cloned successfully.
    */
   it('can clone a Linode from Linode details page', () => {
-    const linodeRegion = chooseRegion();
+    const linodeRegion = chooseRegion({ capabilities: ['Vlans'] });
     const linodePayload = createLinodeRequestFactory.build({
       label: randomLabel(),
       region: linodeRegion.id,
@@ -64,8 +64,6 @@ describe('clone linode', () => {
     cy.defer(() =>
       createTestLinode(linodePayload, { securityMethod: 'vlan_no_internet' })
     ).then((linode: Linode) => {
-      const linodeRegion = getRegionById(linodePayload.region!);
-
       interceptCloneLinode(linode.id).as('cloneLinode');
       cy.visitWithLogin(`/linodes/${linode.id}`);
 

--- a/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
@@ -69,7 +69,7 @@ describe('Create Linode', () => {
          */
         it(`creates a ${planConfig.planType} Linode`, () => {
           const linodeRegion = chooseRegion({
-            capabilities: ['Linodes', 'Premium Plans'],
+            capabilities: ['Linodes', 'Premium Plans', 'Vlans'],
           });
           const linodeLabel = randomLabel();
 

--- a/packages/manager/cypress/e2e/core/linodes/legacy-create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/legacy-create-linode.spec.ts
@@ -12,7 +12,6 @@ import {
   getVisible,
 } from 'support/helpers';
 import { ui } from 'support/ui';
-import { apiMatcher } from 'support/util/intercepts';
 import { randomString, randomLabel, randomNumber } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
 import { getRegionById } from 'support/util/regions';
@@ -39,6 +38,7 @@ import {
 import { mockGetVLANs } from 'support/intercepts/vlans';
 import { mockGetLinodeConfigs } from 'support/intercepts/configs';
 import {
+  interceptCreateLinode,
   mockCreateLinode,
   mockGetLinodeType,
   mockGetLinodeTypes,
@@ -155,10 +155,14 @@ describe('create linode', () => {
     // intercept request
     cy.visitWithLogin('/linodes/create');
     cy.get('[data-qa-deploy-linode]');
-    cy.intercept('POST', apiMatcher('linode/instances')).as('linodeCreated');
+    interceptCreateLinode().as('linodeCreated');
     cy.get('[data-qa-header="Create"]').should('have.text', 'Create');
     ui.regionSelect.find().click();
-    ui.regionSelect.findItemByRegionLabel(chooseRegion().label).click();
+    ui.regionSelect
+      .findItemByRegionLabel(
+        chooseRegion({ capabilities: ['Vlans', 'Linodes'] }).label
+      )
+      .click();
     fbtClick('Shared CPU');
     getClick('[id="g6-nanode-1"]');
     getClick('#linode-label').clear().type(linodeLabel);

--- a/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
+++ b/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
@@ -162,7 +162,7 @@ describe('OneClick Apps (OCA)', () => {
     const password = randomString(16);
     const image = 'linode/ubuntu22.04';
     const rootPassword = randomString(16);
-    const region = chooseRegion();
+    const region = chooseRegion({ capabilities: ['Vlans'] });
     const linodeLabel = randomLabel();
     const levelName = 'Get the enderman!';
 

--- a/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
@@ -169,7 +169,7 @@ describe('Create stackscripts', () => {
     const stackscriptImageTag = 'alpine3.19';
 
     const linodeLabel = randomLabel();
-    const linodeRegion = chooseRegion();
+    const linodeRegion = chooseRegion({ capabilities: ['Vlans'] });
 
     interceptCreateStackScript().as('createStackScript');
     interceptGetStackScripts().as('getStackScripts');
@@ -372,7 +372,10 @@ describe('Create stackscripts', () => {
         .click();
 
       interceptCreateLinode().as('createLinode');
-      fillOutLinodeForm(linodeLabel, chooseRegion().label);
+      fillOutLinodeForm(
+        linodeLabel,
+        chooseRegion({ capabilities: ['Vlans'] }).label
+      );
       ui.button
         .findByTitle('Create Linode')
         .should('be.visible')

--- a/packages/manager/cypress/e2e/core/stackscripts/smoke-community-stackscrips.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/smoke-community-stackscrips.spec.ts
@@ -260,7 +260,7 @@ describe('Community Stackscripts integration tests', () => {
     const fairPassword = 'Akamai123';
     const rootPassword = randomString(16);
     const image = 'AlmaLinux 9';
-    const region = chooseRegion();
+    const region = chooseRegion({ capabilities: ['Vlans'] });
     const linodeLabel = randomLabel();
 
     interceptGetStackScripts().as('getStackScripts');

--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -6,16 +6,25 @@ import { makeErrorResponse } from 'support/util/errors';
 import { apiMatcher } from 'support/util/intercepts';
 import { paginateResponse } from 'support/util/paginate';
 import { makeResponse } from 'support/util/response';
+import { linodeVlanNoInternetConfig } from 'support/util/linodes';
 
 import type { Disk, Kernel, Linode, LinodeType, Volume } from '@linode/api-v4';
 
 /**
  * Intercepts POST request to create a Linode.
  *
+ * The outgoing request payload is modified to create a Linode without access
+ * to the internet.
+ *
  * @returns Cypress chainable.
  */
 export const interceptCreateLinode = (): Cypress.Chainable<null> => {
-  return cy.intercept('POST', apiMatcher('linode/instances'));
+  return cy.intercept('POST', apiMatcher('linode/instances'), (req) => {
+    req.body = {
+      ...req.body,
+      interfaces: linodeVlanNoInternetConfig,
+    };
+  });
 };
 
 /**

--- a/packages/manager/cypress/support/util/linodes.ts
+++ b/packages/manager/cypress/support/util/linodes.ts
@@ -7,8 +7,25 @@ import { chooseRegion } from 'support/util/regions';
 import { depaginate } from './paginate';
 import { pageSize } from 'support/constants/api';
 
-import type { Config, CreateLinodeRequest, Linode } from '@linode/api-v4';
+import type {
+  Config,
+  CreateLinodeRequest,
+  InterfacePayload,
+  Linode,
+} from '@linode/api-v4';
 import { findOrCreateDependencyFirewall } from 'support/api/firewalls';
+
+/**
+ * Linode create interface to configure a Linode with no public internet access.
+ */
+export const linodeVlanNoInternetConfig: InterfacePayload[] = [
+  {
+    purpose: 'vlan',
+    primary: false,
+    label: randomLabel(),
+    ipam_address: null,
+  },
+];
 
 /**
  * Methods used to secure test Linodes.
@@ -77,14 +94,7 @@ export const createTestLinode = async (
 
       case 'vlan_no_internet':
         return {
-          interfaces: [
-            {
-              purpose: 'vlan',
-              primary: false,
-              label: randomLabel(),
-              ipam_address: null,
-            },
-          ],
+          interfaces: linodeVlanNoInternetConfig,
         };
 
       case 'powered_off':


### PR DESCRIPTION
## Description 📝
This modifies our Cypress tests so that any Linodes created during the course of a test are created with no access to the internet. It does this by modifying the `interceptCreateLinode` util to mutate the outgoing request.

Note that this applies only to Linodes that are created via Cloud Manager during the tests -- Linodes created directly by Cypress via our JS SDK already have extra measures taken to secure them (see #10538).

## Changes  🔄
- Mutate outgoing Linode create requests to place Linodes behind VLAN and, more importantly, without access to the internet
- Increase clone test timeout

## How to test 🧪
1. Confirm that tests continue to pass (we can do this via CI)
2. Confirm that created Linodes are not connected to the internet
  - There are a couple ways to do this, but this is the easiest:
    1. Run a Linode create test, then sign into Cloud and find the Linode that was created
    2. Observe the IP address of the created Linode
    3. Run `ping <IP address>` and confirm that you cannot connect
    4. Run `ssh root@<IP address>` and confirm that you cannot connect
  - To be extra thorough, you can confirm that the Linode itself can't connect to the internet
    1. Run a Linode create test via `yarn cy:debug` with the Chrome dev tools open
    2. In the network tab, observe the outgoing Linode create request and make note of the root password
    3. Sign into Cloud, find the Linode that was created, and launch Glish/Weblish
    4. Sign into the root account using the root password you observed in step 2
    5. From the Linode, run `ping 1.1.1.1` and confirm that there is no internet connectivity

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
