### PR TITLE
upcoming: [M3-8320] - Add Image distributed compatibility notice to Linode Create

### DIFF
--- a/packages/manager/.changeset/pr-10636-upcoming-features-1719935270528.md
+++ b/packages/manager/.changeset/pr-10636-upcoming-features-1719935270528.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add Image distributed compatibility notice to Linode Create ([#10636](https://github.com/linode/manager/pull/10636))

--- a/packages/manager/src/components/ImageSelect/ImageOption.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageOption.tsx
@@ -74,7 +74,7 @@ export const ImageOption = (props: ImageOptionProps) => {
       </Stack>
       <Stack alignItems="center" direction="row" spacing={1}>
         {data.isDistributedCompatible && (
-          <Tooltip title="This image is compatible with distributed regions.">
+          <Tooltip title="This image is compatible with distributed compute regions.">
             <div style={{ display: 'flex' }}>
               <DistributedRegionIcon height="24px" width="24px" />
             </div>

--- a/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
@@ -5,7 +5,6 @@ import { imageFactory } from 'src/factories';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { ImageSelect, imagesToGroupedItems } from './ImageSelect';
-import { Image } from '@linode/api-v4';
 
 describe('imagesToGroupedItems', () => {
   it('should filter deprecated images when end of life is past beyond 6 months ', () => {

--- a/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
@@ -98,7 +98,7 @@ describe('imagesToGroupedItems', () => {
 });
 
 describe('ImageSelect', () => {
-  it('renders a "Indicates compatibility with distributed compute regions." notice if the user has atleast one image with the distributed capability', async () => {
+  it('renders a "Indicates compatibility with distributed compute regions." notice if the user has at least one image with the distributed capability', async () => {
     const images = [
       imageFactory.build({ capabilities: [] }),
       imageFactory.build({ capabilities: ['distributed-images'] }),
@@ -109,7 +109,7 @@ describe('ImageSelect', () => {
       <ImageSelect
         handleSelectImage={vi.fn()}
         images={images}
-        title={'Images'}
+        title="Images"
         variant="private"
       />
     );

--- a/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
@@ -1,8 +1,11 @@
 import { DateTime } from 'luxon';
+import React from 'react';
 
 import { imageFactory } from 'src/factories';
+import { renderWithTheme } from 'src/utilities/testHelpers';
 
-import { imagesToGroupedItems } from './ImageSelect';
+import { ImageSelect, imagesToGroupedItems } from './ImageSelect';
+import { Image } from '@linode/api-v4';
 
 describe('imagesToGroupedItems', () => {
   it('should filter deprecated images when end of life is past beyond 6 months ', () => {
@@ -92,5 +95,28 @@ describe('imagesToGroupedItems', () => {
       },
     ];
     expect(imagesToGroupedItems(images)).toStrictEqual(expected);
+  });
+});
+
+describe('ImageSelect', () => {
+  it('renders a "Indicates compatibility with distributed compute regions." notice if the user has atleast one image with the distributed capability', async () => {
+    const images = [
+      imageFactory.build({ capabilities: [] }),
+      imageFactory.build({ capabilities: ['distributed-images'] }),
+      imageFactory.build({ capabilities: [] }),
+    ];
+
+    const { getByText } = renderWithTheme(
+      <ImageSelect
+        handleSelectImage={vi.fn()}
+        images={images}
+        title={'Images'}
+        variant="private"
+      />
+    );
+
+    expect(
+      getByText('Indicates compatibility with distributed compute regions.')
+    ).toBeVisible();
   });
 });

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -155,6 +155,7 @@ export const ImageSelect = React.memo((props: ImageSelectProps) => {
   const {
     classNames,
     disabled,
+    error: errorText,
     handleSelectImage,
     images,
     selectedImageID,
@@ -231,7 +232,7 @@ export const ImageSelect = React.memo((props: ImageSelectProps) => {
           className={classNames}
           components={{ Option: ImageOption, SingleValue: _SingleValue }}
           disabled={disabled}
-          errorText={imageError}
+          errorText={errorText ?? imageError}
           isLoading={_loading}
           label="Images"
           onChange={onChange}

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -1,13 +1,11 @@
-import { Image } from '@linode/api-v4/lib/images';
-import Grid from '@mui/material/Unstable_Grid2';
 import produce from 'immer';
 import { DateTime } from 'luxon';
 import { equals, groupBy } from 'ramda';
 import * as React from 'react';
 
-import Select, { GroupType, Item } from 'src/components/EnhancedSelect';
+import DistributedRegionIcon from 'src/assets/icons/entityIcons/distributed-region.svg';
+import Select from 'src/components/EnhancedSelect';
 import { _SingleValue } from 'src/components/EnhancedSelect/components/SingleValue';
-import { BaseSelectProps } from 'src/components/EnhancedSelect/Select';
 import { ImageOption } from 'src/components/ImageSelect/ImageOption';
 import { Paper } from 'src/components/Paper';
 import { Typography } from 'src/components/Typography';
@@ -17,7 +15,13 @@ import { arePropsEqual } from 'src/utilities/arePropsEqual';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getSelectedOptionFromGroupedOptions } from 'src/utilities/getSelectedOptionFromGroupedOptions';
 
+import { Box } from '../Box';
 import { distroIcons } from '../DistributionIcon';
+import { Stack } from '../Stack';
+
+import type { Image } from '@linode/api-v4/lib/images';
+import type { GroupType, Item } from 'src/components/EnhancedSelect';
+import type { BaseSelectProps } from 'src/components/EnhancedSelect/Select';
 
 export type Variant = 'all' | 'private' | 'public';
 
@@ -156,7 +160,6 @@ export const ImageSelect = React.memo((props: ImageSelectProps) => {
     selectedImageID,
     title,
     variant,
-    ...reactSelectProps
   } = props;
 
   // Check for loading status and request errors in React Query
@@ -203,31 +206,47 @@ export const ImageSelect = React.memo((props: ImageSelectProps) => {
     return handleSelectImage(selection.value, selectedImage);
   };
 
+  const showDistributedCapabilityNotice =
+    variant === 'private' &&
+    filteredImages.some((image) =>
+      image.capabilities.includes('distributed-images')
+    );
+
   return (
     <Paper data-qa-select-image-panel>
       <Typography data-qa-tp={title} variant="h2">
         {title}
       </Typography>
-      <Grid container>
-        <Grid xs={12}>
-          <Select
-            value={getSelectedOptionFromGroupedOptions(
-              selectedImageID || '',
-              options
-            )}
-            components={{ Option: ImageOption, SingleValue: _SingleValue }}
-            disabled={disabled}
-            errorText={imageError}
-            isLoading={_loading}
-            label="Images"
-            onChange={onChange}
-            options={options}
-            placeholder="Choose an image"
-            {...reactSelectProps}
-            className={classNames}
-          />
-        </Grid>
-      </Grid>
+      <Box alignItems="flex-end" display="flex" flexWrap="wrap" gap={2}>
+        <Select
+          styles={{
+            container(base) {
+              return { ...base, width: '416px' };
+            },
+          }}
+          value={getSelectedOptionFromGroupedOptions(
+            selectedImageID || '',
+            options
+          )}
+          className={classNames}
+          components={{ Option: ImageOption, SingleValue: _SingleValue }}
+          disabled={disabled}
+          errorText={imageError}
+          isLoading={_loading}
+          label="Images"
+          onChange={onChange}
+          options={options}
+          placeholder="Choose an image"
+        />
+        {showDistributedCapabilityNotice && (
+          <Stack alignItems="center" direction="row" pb={0.8} spacing={1}>
+            <DistributedRegionIcon height="21px" width="24px" />
+            <Typography>
+              Indicates compatibility with distributed compute regions.
+            </Typography>
+          </Stack>
+        )}
+      </Box>
     </Paper>
   );
 }, isMemo);

--- a/packages/manager/src/components/ImageSelectv2/ImageOptionv2.test.tsx
+++ b/packages/manager/src/components/ImageSelectv2/ImageOptionv2.test.tsx
@@ -44,7 +44,9 @@ describe('ImageOptionv2', () => {
     );
 
     expect(
-      getByLabelText('This image is compatible with distributed regions.')
+      getByLabelText(
+        'This image is compatible with distributed compute regions.'
+      )
     ).toBeVisible();
   });
 });

--- a/packages/manager/src/components/ImageSelectv2/ImageOptionv2.tsx
+++ b/packages/manager/src/components/ImageSelectv2/ImageOptionv2.tsx
@@ -40,7 +40,7 @@ export const ImageOptionv2 = ({ image, isSelected, listItemProps }: Props) => {
       </Stack>
       <Stack alignItems="center" direction="row" spacing={1}>
         {image.capabilities.includes('distributed-images') && (
-          <Tooltip title="This image is compatible with distributed regions.">
+          <Tooltip title="This image is compatible with distributed compute regions.">
             <div style={{ display: 'flex' }}>
               <DistributedRegionIcon height="24px" width="24px" />
             </div>

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Images.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Images.test.tsx
@@ -3,6 +3,9 @@ import React from 'react';
 import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
 
 import { Images } from './Images';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
+import { imageFactory } from 'src/factories';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
 
 describe('Images', () => {
   it('renders a header', () => {
@@ -26,5 +29,28 @@ describe('Images', () => {
 
     expect(getByLabelText('Images')).toBeVisible();
     expect(getByPlaceholderText('Choose an image')).toBeVisible();
+  });
+
+  it('renders a "Indicates compatibility with distributed compute regions." notice if the user has atleast one image with the distributed capability', async () => {
+    server.use(
+      http.get('*/v4/images', () => {
+        const images = [
+          imageFactory.build({ capabilities: [] }),
+          imageFactory.build({ capabilities: ['distributed-images'] }),
+          imageFactory.build({ capabilities: [] }),
+        ];
+        return HttpResponse.json(makeResourcePage(images));
+      })
+    );
+
+    const { findByText } = renderWithThemeAndHookFormContext({
+      component: <Images />,
+    });
+
+    expect(
+      await findByText(
+        'Indicates compatibility with distributed compute regions.'
+      )
+    ).toBeVisible();
   });
 });

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Images.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Images.test.tsx
@@ -31,7 +31,7 @@ describe('Images', () => {
     expect(getByPlaceholderText('Choose an image')).toBeVisible();
   });
 
-  it('renders a "Indicates compatibility with distributed compute regions." notice if the user has atleast one image with the distributed capability', async () => {
+  it('renders a "Indicates compatibility with distributed compute regions." notice if the user has at least one image with the distributed capability', async () => {
     server.use(
       http.get('*/v4/images', () => {
         const images = [

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Images.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Images.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import { useController, useFormContext, useWatch } from 'react-hook-form';
 
+import DistributedRegionIcon from 'src/assets/icons/entityIcons/distributed-region.svg';
+import { Box } from 'src/components/Box';
 import { ImageSelectv2 } from 'src/components/ImageSelectv2/ImageSelectv2';
+import { getAPIFilterForImageSelect } from 'src/components/ImageSelectv2/utilities';
 import { Paper } from 'src/components/Paper';
+import { Stack } from 'src/components/Stack';
 import { Typography } from 'src/components/Typography';
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
+import { useAllImagesQuery } from 'src/queries/images';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 
 import type { LinodeCreateFormValues } from '../utilities';
@@ -32,6 +37,7 @@ export const Images = () => {
 
     // Non-"distributed compatible" Images must only be deployed to core sites.
     // Clear the region field if the currently selected region is a distributed site and the Image is only core compatible.
+    // @todo: delete this logic when all Images are "distributed compatible"
     if (
       image &&
       !image.capabilities.includes('distributed-images') &&
@@ -41,17 +47,38 @@ export const Images = () => {
     }
   };
 
+  const { data: images } = useAllImagesQuery(
+    {},
+    getAPIFilterForImageSelect('private')
+  );
+
+  // @todo: delete this logic when all Images are "distributed compatible"
+  const showDistributedCapabilityNotice = images?.some((image) =>
+    image.capabilities.includes('distributed-images')
+  );
+
   return (
     <Paper>
       <Typography variant="h2">Choose an Image</Typography>
-      <ImageSelectv2
-        disabled={isCreateLinodeRestricted}
-        errorText={fieldState.error?.message}
-        onBlur={field.onBlur}
-        onChange={onChange}
-        value={field.value}
-        variant="private"
-      />
+      <Box alignItems="flex-end" display="flex" flexWrap="wrap" gap={2}>
+        <ImageSelectv2
+          disabled={isCreateLinodeRestricted}
+          errorText={fieldState.error?.message}
+          onBlur={field.onBlur}
+          onChange={onChange}
+          sx={{ width: '416px' }}
+          value={field.value}
+          variant="private"
+        />
+        {showDistributedCapabilityNotice && (
+          <Stack alignItems="center" direction="row" pb={0.8} spacing={1}>
+            <DistributedRegionIcon height="21px" width="24px" />
+            <Typography>
+              Indicates compatibility with distributed compute regions.
+            </Typography>
+          </Stack>
+        )}
+      </Box>
     </Paper>
   );
 };


### PR DESCRIPTION
## Description 📝

- Adds a notice saying `Indicates compatibility with distributed compute regions.` beside the Image Select on the Linode Create flow for customers that have Images with the `distributed-images` capability 🌐 
- Add to both Linode Create v1 and v2 ➕ 
-  Added unit test for both flows 🧪 

## Preview 📷

![Screenshot 2024-07-02 at 11 38 34 AM](https://github.com/linode/manager/assets/115251059/f28181b0-7ff5-4be0-b37e-75cfa8158960)

## How to test 🧪

### Prerequisites
- Turn on the MSW

### Verification steps

> [!important]
> Please test using Linode Create v1 and v2

- Verify you see `Indicates compatibility with distributed compute regions.` if the customer has >= 1 image with the `distributed-images` capability 🌐 
- Verify this only shows on the `Images` tab of the Linode Create flow 👀 
- Verify styles, alignment, and spacing look good 🎨  

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support