### PR TITLE
refactor: [M3-8299] - Fix Notification Toast in Dark Mode

### DIFF
--- a/packages/manager/.changeset/pr-10637-upcoming-features-1719936723714.md
+++ b/packages/manager/.changeset/pr-10637-upcoming-features-1719936723714.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Fix Notification Toast in Dark Mode ([#10637](https://github.com/linode/manager/pull/10637))

--- a/packages/manager/src/components/Snackbar/Snackbar.tsx
+++ b/packages/manager/src/components/Snackbar/Snackbar.tsx
@@ -12,30 +12,33 @@ import type { SnackbarProviderProps } from 'notistack';
 const StyledMaterialDesignContent = styled(MaterialDesignContent)(
   ({ theme }: { theme: Theme }) => ({
     '&.notistack-MuiContent-error': {
-      backgroundColor: theme.palette.error.light,
-      borderLeft: `6px solid ${theme.palette.error.dark}`,
+      backgroundColor: theme.notificationToast.error.backgroundColor,
+      borderLeft: theme.notificationToast.error.borderLeft,
     },
     '&.notistack-MuiContent-info': {
-      backgroundColor: theme.palette.info.light,
-      borderLeft: `6px solid ${theme.palette.primary.main}`,
+      backgroundColor: theme.notificationToast.info.backgroundColor,
+      borderLeft: theme.notificationToast.info.borderLeft,
     },
     '&.notistack-MuiContent-success': {
-      backgroundColor: theme.palette.success.light,
-      borderLeft: `6px solid ${theme.palette.success.dark}`,
+      backgroundColor: theme.notificationToast.success.backgroundColor,
+      borderLeft: theme.notificationToast.success.borderLeft,
     },
     '&.notistack-MuiContent-warning': {
-      backgroundColor: theme.palette.warning.light,
-      borderLeft: `6px solid ${theme.palette.warning.dark}`,
+      backgroundColor: theme.notificationToast.warning.backgroundColor,
+      borderLeft: theme.notificationToast.warning.borderLeft,
     },
   })
 );
 
 const useStyles = makeStyles()((theme: Theme) => ({
   root: {
-    '& div': {
-      backgroundColor: `transparent`,
-      color: theme.palette.text.primary,
+    '& .notistack-MuiContent': {
+      color: theme.notificationToast.default.color,
       fontSize: '0.875rem',
+    },
+    '& .notistack-MuiContent-default': {
+      backgroundColor: theme.notificationToast.default.backgroundColor,
+      borderLeft: theme.notificationToast.default.borderLeft,
     },
     [theme.breakpoints.down('md')]: {
       '& .SnackbarItem-contentRoot': {

--- a/packages/manager/src/foundations/themes/dark.ts
+++ b/packages/manager/src/foundations/themes/dark.ts
@@ -5,6 +5,7 @@ import {
   Color,
   Dropdown,
   Interaction,
+  NotificationToast,
   Select,
   TextField,
 } from '@linode/design-language-system/themes/dark';
@@ -93,6 +94,30 @@ export const customDarkModeOptions = {
     tableHeader: Color.Neutrals[60],
     tableStatic: Color.Neutrals[20],
     textAccessTable: Color.Neutrals[50],
+  },
+} as const;
+
+export const notificationToast = {
+  default: {
+    backgroundColor: NotificationToast.Informative.Background,
+    borderLeft: `6px solid ${NotificationToast.Informative.Border}`,
+    color: NotificationToast.Text,
+  },
+  error: {
+    backgroundColor: NotificationToast.Error.Background,
+    borderLeft: `6px solid ${NotificationToast.Error.Border}`,
+  },
+  info: {
+    backgroundColor: NotificationToast.Informative.Background,
+    borderLeft: `6px solid ${NotificationToast.Informative.Border}`,
+  },
+  success: {
+    backgroundColor: NotificationToast.Success.Background,
+    borderLeft: `6px solid ${NotificationToast.Success.Border}`,
+  },
+  warning: {
+    backgroundColor: NotificationToast.Warning.Background,
+    borderLeft: `6px solid ${NotificationToast.Warning.Border}`,
   },
 } as const;
 
@@ -826,6 +851,7 @@ export const darkTheme: ThemeOptions = {
     },
   },
   name: 'dark',
+  notificationToast,
   palette: {
     background: {
       default: customDarkModeOptions.bg.app,

--- a/packages/manager/src/foundations/themes/index.ts
+++ b/packages/manager/src/foundations/themes/index.ts
@@ -1,18 +1,23 @@
 import { createTheme } from '@mui/material/styles';
 
-import { latoWeb } from 'src/foundations/fonts';
 // Themes & Brands
 import { darkTheme } from 'src/foundations/themes/dark';
-// Types & Interfaces
-import { customDarkModeOptions } from 'src/foundations/themes/dark';
 import { lightTheme } from 'src/foundations/themes/light';
-import {
+import { deepMerge } from 'src/utilities/deepMerge';
+
+import type { latoWeb } from 'src/foundations/fonts';
+// Types & Interfaces
+import type {
+  customDarkModeOptions,
+  notificationToast as notificationToastDark,
+} from 'src/foundations/themes/dark';
+import type {
   bg,
   borderColors,
   color,
+  notificationToast,
   textColors,
 } from 'src/foundations/themes/light';
-import { deepMerge } from 'src/utilities/deepMerge';
 
 export type ThemeName = 'dark' | 'light';
 
@@ -38,8 +43,14 @@ type TextColors = MergeTypes<LightModeTextColors, DarkModeTextColors>;
 
 type LightModeBorderColors = typeof borderColors;
 type DarkModeBorderColors = typeof customDarkModeOptions.borderColors;
-
 type BorderColors = MergeTypes<LightModeBorderColors, DarkModeBorderColors>;
+
+type LightNotificationToast = typeof notificationToast;
+type DarkNotificationToast = typeof notificationToastDark;
+type NotificationToast = MergeTypes<
+  LightNotificationToast,
+  DarkNotificationToast
+>;
 
 /**
  * Augmenting the Theme and ThemeOptions.
@@ -60,6 +71,7 @@ declare module '@mui/material/styles/createTheme' {
     graphs: any;
     inputStyles: any;
     name: ThemeName;
+    notificationToast: NotificationToast;
     textColors: TextColors;
     visually: any;
   }
@@ -77,6 +89,7 @@ declare module '@mui/material/styles/createTheme' {
     graphs?: any;
     inputStyles?: any;
     name: ThemeName;
+    notificationToast?: NotificationToast;
     textColors?: DarkModeTextColors | LightModeTextColors;
     visually?: any;
   }

--- a/packages/manager/src/foundations/themes/light.ts
+++ b/packages/manager/src/foundations/themes/light.ts
@@ -5,6 +5,7 @@ import {
   Color,
   Dropdown,
   Interaction,
+  NotificationToast,
   Select,
 } from '@linode/design-language-system';
 
@@ -98,6 +99,30 @@ export const borderColors = {
   borderTypography: Color.Neutrals[30],
   divider: Color.Neutrals[30],
   dividerDark: Color.Neutrals[80],
+} as const;
+
+export const notificationToast = {
+  default: {
+    backgroundColor: NotificationToast.Informative.Background,
+    borderLeft: `6px solid ${NotificationToast.Informative.Border}`,
+    color: NotificationToast.Text,
+  },
+  error: {
+    backgroundColor: NotificationToast.Error.Background,
+    borderLeft: `6px solid ${NotificationToast.Error.Border}`,
+  },
+  info: {
+    backgroundColor: NotificationToast.Informative.Background,
+    borderLeft: `6px solid ${NotificationToast.Informative.Border}`,
+  },
+  success: {
+    backgroundColor: NotificationToast.Success.Background,
+    borderLeft: `6px solid ${NotificationToast.Success.Border}`,
+  },
+  warning: {
+    backgroundColor: NotificationToast.Warning.Background,
+    borderLeft: `6px solid ${NotificationToast.Warning.Border}`,
+  },
 } as const;
 
 const iconCircleAnimation = {
@@ -1547,6 +1572,7 @@ export const lightTheme: ThemeOptions = {
     },
   },
   name: 'light', // @todo remove this because we leverage pallete.mode now
+  notificationToast,
   palette: {
     background: {
       default: bg.app,


### PR DESCRIPTION
## Description 📝
Toast notifications are not properly styled for Cloud Manager's dark theme, resulting in white text on an almost white background.

## Changes  🔄
- Since we're using 3rd party `Notistack`, I created a new style in our theme. Note: This will get cleaned up with the refactoring post launch.
- Now using `NotificationToast` tokens
- CDS does not have a default, so info colors are used for that

## Target release date 🗓️
7/8

## Preview 📷
**Include a screenshot or screen recording of the change**

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-06-27 at 1 31 26 PM](https://github.com/linode/manager/assets/125309814/176fdbcc-08f6-44f4-a448-b5c176e85278) | <video src="https://github.com/linode/manager/assets/125309814/adf2d641-b356-405f-825a-2ca95c06c0dc" /> |

| Light Spec | Dark Spec  |
| ------- | ------- |
|<img width="448" alt="Screenshot 2024-07-02 at 12 13 44 PM" src="https://github.com/linode/manager/assets/125309814/fe5b93c2-2267-46f5-bc6b-a760d4676ccb">|<img width="440" alt="Screenshot 2024-07-02 at 12 13 54 PM" src="https://github.com/linode/manager/assets/125309814/7274b32f-2637-453b-ab3f-fbda833ef304">|

## How to test 🧪

### Prerequisites
- Checkout branch or preview link

### Reproduction steps
- Go to storybook or find a toast in our app

### Verification steps
- Observe the toast looks good in both light/dark mode