### PR TITLE
change: [M3-8322] - Add Design Update Global Notification Banner

### DIFF
--- a/packages/manager/.changeset/pr-10640-added-1720026539138.md
+++ b/packages/manager/.changeset/pr-10640-added-1720026539138.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Design update dismissible banner ([#10640](https://github.com/linode/manager/pull/10640))

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -66,13 +66,20 @@ interface AclpFlag {
 interface gpuV2 {
   planDivider: boolean;
 }
+
 type OneClickApp = Record<string, string>;
+
+interface DesignUpdatesBannerFlag extends BaseFeatureFlag {
+  key: string;
+  link: string;
+}
 
 export interface Flags {
   aclb: boolean;
   aclbFullCreateFlow: boolean;
   aclp: AclpFlag;
   apiMaintenance: APIMaintenance;
+  cloudManagerDesignUpdatesBanner: DesignUpdatesBannerFlag;
   databaseBeta: boolean;
   databaseResize: boolean;
   databases: boolean;

--- a/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
+++ b/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
@@ -17,7 +17,7 @@ import { ComplianceUpdateModal } from './ComplianceUpdateModal';
 import { EmailBounceNotificationSection } from './EmailBounce';
 import { RegionStatusBanner } from './RegionStatusBanner';
 import { TaxCollectionBanner } from './TaxCollectionBanner';
-import { TokensUpdateBanner } from './TokensUpdateBanner';
+import { DesignUpdateBanner } from './TokensUpdateBanner';
 import { VerificationDetailsBanner } from './VerificationDetailsBanner';
 
 export const GlobalNotifications = () => {
@@ -53,7 +53,7 @@ export const GlobalNotifications = () => {
 
   return (
     <>
-      <TokensUpdateBanner />
+      <DesignUpdateBanner />
       <EmailBounceNotificationSection />
       <RegionStatusBanner />
       <AbuseTicketBanner />

--- a/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
+++ b/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
@@ -17,7 +17,9 @@ import { ComplianceUpdateModal } from './ComplianceUpdateModal';
 import { EmailBounceNotificationSection } from './EmailBounce';
 import { RegionStatusBanner } from './RegionStatusBanner';
 import { TaxCollectionBanner } from './TaxCollectionBanner';
+import { TokensUpdateBanner } from './TokensUpdateBanner';
 import { VerificationDetailsBanner } from './VerificationDetailsBanner';
+
 export const GlobalNotifications = () => {
   const flags = useFlags();
   const { data: profile } = useProfile();
@@ -51,6 +53,7 @@ export const GlobalNotifications = () => {
 
   return (
     <>
+      <TokensUpdateBanner />
       <EmailBounceNotificationSection />
       <RegionStatusBanner />
       <AbuseTicketBanner />

--- a/packages/manager/src/features/GlobalNotifications/TokensUpdateBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/TokensUpdateBanner.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+import { Box } from 'src/components/Box';
+import { DismissibleBanner } from 'src/components/DismissibleBanner/DismissibleBanner';
+import { Link } from 'src/components/Link';
+import { Typography } from 'src/components/Typography';
+
+export const TokensUpdateBanner = () => {
+  return (
+    <DismissibleBanner important preferenceKey="tokens-update" variant="info">
+      <Box
+        alignItems="center"
+        display="flex"
+        flexDirection="row"
+        justifyContent="space-between"
+      >
+        <Typography>
+          We are improving the Cloud Manager experience for our users.{' '}
+          <Link to="">Read more</Link> about recent updates.
+        </Typography>
+      </Box>
+    </DismissibleBanner>
+  );
+};

--- a/packages/manager/src/features/GlobalNotifications/TokensUpdateBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/TokensUpdateBanner.tsx
@@ -1,24 +1,39 @@
 import * as React from 'react';
 
-import { Box } from 'src/components/Box';
 import { DismissibleBanner } from 'src/components/DismissibleBanner/DismissibleBanner';
 import { Link } from 'src/components/Link';
 import { Typography } from 'src/components/Typography';
+import { useFlags } from 'src/hooks/useFlags';
 
-export const TokensUpdateBanner = () => {
+export const DesignUpdateBanner = () => {
+  const flags = useFlags();
+  const designUpdateFlag = flags.cloudManagerDesignUpdatesBanner;
+
+  if (!designUpdateFlag || !designUpdateFlag.enabled) {
+    return null;
+  }
+  const { key, link } = designUpdateFlag;
+
+  /**
+   * This banner is a reusable banner for future Cloud Manager design updates.
+   * Since this banner is dismissible, we want to be able to dynamically change the key,
+   * so we can show it again as needed to users who have dismissed it in the past in the case of a new series of UI updates.
+   *
+   * Flag shape is as follows:
+   *
+   *  {
+   *    "enabled": boolean,
+   *    "key": "some-key",
+   *    "link": "link to docs"
+   *  }
+   *
+   */
   return (
-    <DismissibleBanner important preferenceKey="tokens-update" variant="info">
-      <Box
-        alignItems="center"
-        display="flex"
-        flexDirection="row"
-        justifyContent="space-between"
-      >
-        <Typography>
-          We are improving the Cloud Manager experience for our users.{' '}
-          <Link to="">Read more</Link> about recent updates.
-        </Typography>
-      </Box>
+    <DismissibleBanner preferenceKey={key} variant="info">
+      <Typography variant="body2">
+        We are improving the Cloud Manager experience for our users.{' '}
+        <Link to={link}>Read more</Link> about recent updates.
+      </Typography>
     </DismissibleBanner>
   );
 };


### PR DESCRIPTION
## Description 📝
This PR adds a new dismissible banner for the upcoming design/token updates.

The banner needs to be a little dynamic, featuring the two following variations:

```
{
  "enabled": true,
  "key": "design-tokens-7-9-2024",
  "link": "https://www.linode.com/docs/guides/an-overview-of-the-cloud-manager"
}
```

```
{
  "enabled": false,
  "key": "design-tokens-7-9-2024",
  "link": "https://www.linode.com/docs/guides/an-overview-of-the-cloud-manager"
}
```

The key is meant to give us the ability to re-introduce the banner for future updates (since it is generic) when people have dismissed it already. 

## Changes  🔄
- Create new feature flag
- Implement banner

## Target release date 🗓️
**7/8 2024**

## Preview 📷
![Screenshot 2024-07-03 at 12 39 28](https://github.com/linode/manager/assets/130582365/536ff36d-f927-40a9-81a9-e86a60833f8b)

## How to test 🧪
The flag is currently only enabled in `development`

### Verification steps
- Verify `Cloud Manager Design Updates Banner` configuration in LD
- Pull code locally and confirm banner + linkage + dismissible state 

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support


