### PR TITLE
feat: [M3-7684] - Disable Volume Action Menu Buttons for Restricted Users

### DIFF
--- a/packages/manager/.changeset/pr-10641-added-1720011097638.md
+++ b/packages/manager/.changeset/pr-10641-added-1720011097638.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Disable Volume Action Menu buttons for restricted users ([#10641](https://github.com/linode/manager/pull/10641))

--- a/packages/manager/src/features/Account/utils.ts
+++ b/packages/manager/src/features/Account/utils.ts
@@ -6,9 +6,11 @@ import type { GlobalGrantTypes, GrantLevel } from '@linode/api-v4';
 import type { GrantTypeMap } from 'src/features/Account/types';
 
 export type ActionType =
+  | 'attach'
   | 'clone'
   | 'create'
   | 'delete'
+  | 'detach'
   | 'edit'
   | 'migrate'
   | 'modify'

--- a/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
+++ b/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
@@ -130,8 +130,10 @@ export const VolumesActionMenu = (props: Props) => {
           return (
             <InlineMenuAction
               actionText={action.title}
+              disabled={action.disabled}
               key={action.title}
               onClick={action.onClick}
+              tooltip={action.tooltip}
             />
           );
         })}

--- a/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
+++ b/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
@@ -6,6 +6,8 @@ import * as React from 'react';
 
 import { Action, ActionMenu } from 'src/components/ActionMenu/ActionMenu';
 import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
+import { getRestrictedResourceText } from 'src/features/Account/utils';
+import { useIsResourceRestricted } from 'src/hooks/useIsResourceRestricted';
 
 export interface ActionHandlers {
   handleAttach: () => void;
@@ -32,42 +34,88 @@ export const VolumesActionMenu = (props: Props) => {
   const theme = useTheme<Theme>();
   const matchesSmDown = useMediaQuery(theme.breakpoints.down('md'));
 
+  const isVolumeReadOnly = useIsResourceRestricted({
+    grantLevel: 'read_only',
+    grantType: 'volume',
+    id: volume.id,
+  });
+
   const actions: Action[] = [
     {
       onClick: handlers.handleDetails,
       title: 'Show Config',
     },
     {
+      disabled: isVolumeReadOnly,
       onClick: handlers.handleEdit,
       title: 'Edit',
+      tooltip: isVolumeReadOnly
+        ? getRestrictedResourceText({
+            action: 'edit',
+            isSingular: true,
+            resourceType: 'Volumes',
+          })
+        : undefined,
     },
     {
+      disabled: isVolumeReadOnly,
       onClick: handlers.handleResize,
       title: 'Resize',
+      tooltip: isVolumeReadOnly
+        ? getRestrictedResourceText({
+            action: 'resize',
+            isSingular: true,
+            resourceType: 'Volumes',
+          })
+        : undefined,
     },
     {
+      disabled: isVolumeReadOnly,
       onClick: handlers.handleClone,
       title: 'Clone',
+      tooltip: isVolumeReadOnly
+        ? getRestrictedResourceText({
+            action: 'clone',
+            isSingular: true,
+            resourceType: 'Volumes',
+          })
+        : undefined,
     },
   ];
 
   if (!attached && isVolumesLanding) {
     actions.push({
+      disabled: isVolumeReadOnly,
       onClick: handlers.handleAttach,
       title: 'Attach',
+      tooltip: isVolumeReadOnly
+        ? "You don't have permissions to attach this Volume. \
+        Please contact your account administrator to request the necessary permissions."
+        : undefined,
     });
   } else {
     actions.push({
+      disabled: isVolumeReadOnly,
       onClick: handlers.handleDetach,
       title: 'Detach',
+      tooltip: isVolumeReadOnly
+        ? "You don't have permissions to detach this Volume. \
+        Please contact your account administrator to request the necessary permissions."
+        : undefined,
     });
   }
 
   actions.push({
-    disabled: attached,
+    disabled: isVolumeReadOnly || attached,
     onClick: handlers.handleDelete,
     title: 'Delete',
-    tooltip: attached
+    tooltip: isVolumeReadOnly
+      ? getRestrictedResourceText({
+          action: 'delete',
+          isSingular: true,
+          resourceType: 'Volumes',
+        })
+      : attached
       ? 'Your volume must be detached before it can be deleted.'
       : undefined,
   });

--- a/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
+++ b/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
@@ -89,8 +89,11 @@ export const VolumesActionMenu = (props: Props) => {
       onClick: handlers.handleAttach,
       title: 'Attach',
       tooltip: isVolumeReadOnly
-        ? "You don't have permissions to attach this Volume. \
-        Please contact your account administrator to request the necessary permissions."
+        ? getRestrictedResourceText({
+            action: 'attach',
+            isSingular: true,
+            resourceType: 'Volumes',
+          })
         : undefined,
     });
   } else {
@@ -99,8 +102,11 @@ export const VolumesActionMenu = (props: Props) => {
       onClick: handlers.handleDetach,
       title: 'Detach',
       tooltip: isVolumeReadOnly
-        ? "You don't have permissions to detach this Volume. \
-        Please contact your account administrator to request the necessary permissions."
+        ? getRestrictedResourceText({
+            action: 'detach',
+            isSingular: true,
+            resourceType: 'Volumes',
+          })
         : undefined,
     });
   }


### PR DESCRIPTION
## Description 📝

To prevent unauthorized access to specific flows and provide clearer guidance, we aim to restrict entry to users without the required permissions.

Here, we are disabling Volume Action Menu buttons when they do not have access or have read-only access.

## Changes  🔄

- For restricted users: 
    - Disabled Volume Action Menu buttons (edit, resize, clone, detach, delete)
    - Disabled delete action menu will show a restricted user tooltip notice due to `read-only` access.  Otherwise, it will show a restricted action notice if a Linode is attached.

## Target release date 🗓️
July 8th, 2024

## Preview 📷

Before_readonly_user_unattached_linode
![Before_readonly_user_unattached_linode](https://github.com/linode/manager/assets/172569094/ac20347f-eec4-4e35-86a8-0529e9687ad2)


https://github.com/linode/manager/assets/172569094/22258cdc-1952-4e89-8194-22476ba888de



https://github.com/linode/manager/assets/172569094/96e8d42f-4550-42f9-8eba-653303ee2a80



https://github.com/linode/manager/assets/172569094/d50062ce-c89c-4015-959c-937e70374c8a


--- 
Note: `Read-Write` user access is same Before and After (Delete tooltip will show a restricted action notice if a Linode is attached)


https://github.com/linode/manager/assets/172569094/a3b4eeeb-4ef9-468e-851a-8315a1dc5a3a

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Log into two accounts side by side:
     - An unrestricted admin user account: full access
     - A restricted user account (use Incognito for this)
           - Start with `Read Only` for everything

### Reproduction steps
-  Observe as restricted user:
       - Action Menu buttons will be disabled and will display their own corresponding tooltiptext notice message.

### Verification steps
- After the changes, observe that the action menu buttons and the tooltips are tailored to the action.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support