### PR TITLE
change: [M3-8323] - Remove Region Helper Text

### DIFF
--- a/packages/manager/.changeset/pr-10642-removed-1720016794302.md
+++ b/packages/manager/.changeset/pr-10642-removed-1720016794302.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Removed
+---
+
+Region helper text on the Image Upload page ([#10642](https://github.com/linode/manager/pull/10642))

--- a/packages/manager/src/features/Images/ImagesCreate/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/ImageUpload.tsx
@@ -258,7 +258,6 @@ export const ImageUpload = () => {
                   currentCapability={undefined}
                   disableClearable
                   errorText={fieldState.error?.message}
-                  helperText="For fastest initial upload, select the region that is geographically closest to you. Once uploaded, you will be able to deploy the image to other regions."
                   label="Region"
                   onChange={(e, region) => field.onChange(region.id)}
                   regionFilter="core" // Images service will not be supported for Gecko Beta

--- a/packages/manager/src/features/Images/ImagesCreate/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/ImageUpload.tsx
@@ -251,7 +251,6 @@ export const ImageUpload = () => {
                     isImageCreateRestricted || form.formState.isSubmitting
                   }
                   textFieldProps={{
-                    helperTextPosition: 'top',
                     inputRef: field.ref,
                     onBlur: field.onBlur,
                   }}


### PR DESCRIPTION
## Description 📝

Removes inaccurate helper text on the Image Upload page 🗑️ based on Image Service product and UX feedback

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-07-03 at 10 24 31 AM](https://github.com/linode/manager/assets/115251059/f0b056fb-f8d8-436f-87f1-13f721bac1ef) | ![Screenshot 2024-07-03 at 10 24 09 AM](https://github.com/linode/manager/assets/115251059/40f69872-a91b-4ca6-9c15-8188f56c4e51) |

## How to test 🧪

- Go to `http://localhost:3000/images/create/upload` and verify the helper text above the `Region` field is gone

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support