### PR TITLE
change: Link two VSCode extensions mentioned in our Coding Standards docs

### DIFF
--- a/docs/development-guide/13-coding-standards.md
+++ b/docs/development-guide/13-coding-standards.md
@@ -11,7 +11,7 @@ We use [ESLint](https://eslint.org/) to enforce coding and formatting standards.
 - **prettier** (code formatting)
 - **scanjs** (security)
 
-If you are using VSCode it is highly recommended to use the ESlint extension. The Prettier extension is also recommended, as it can be configured to format your code on save.
+If you are using VSCode it is **highly** recommended to use the [ESlint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint). The [Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) is also recommended, as it can be configured to format your code on save.
 
 ## React
 


### PR DESCRIPTION
## Description 📝
A tiny PR to update the Coding Standard sections of our Cloud Manager Docs to include links to two of our most important VSCode extensions. I found myself linking the extension, rather than our docs, in a PR review comment where linting needed to happen. We might as well include these links in our docs.

## Changes  🔄
- Adds links to the listed VS Code extensions
- Adds emphasis

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-07-03 at 12 14 58 PM](https://github.com/linode/manager/assets/114685994/a51b7a9c-c408-4675-a1ab-644168f1514d) | ![Screenshot 2024-07-03 at 12 05 46 PM](https://github.com/linode/manager/assets/114685994/0fcc6ea8-ccb3-4a91-b464-09009a28b8cf) |

## How to test 🧪

### Verification steps
(How to verify changes)
- Check out this PR, run `yarn docs` locally, go to the Coding Standards page, and confirm the above changes.
- Or just look at the diff.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset (I don't think this is significant enough to need a changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
