### PR TITLE
test: [M3-8155,M3-8154] - Add tests for longview client rename and deletion

### DIFF
--- a/packages/manager/.changeset/pr-10644-tests-1720540166205.md
+++ b/packages/manager/.changeset/pr-10644-tests-1720540166205.md
@@ -2,4 +2,4 @@
 "@linode/manager": Tests
 ---
 
-Add tests for longview client rename and deletion ([#10644](https://github.com/linode/manager/pull/10644))
+Add tests for Longview client rename and deletion ([#10644](https://github.com/linode/manager/pull/10644))

--- a/packages/manager/.changeset/pr-10644-tests-1720540166205.md
+++ b/packages/manager/.changeset/pr-10644-tests-1720540166205.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add tests for longview client rename and deletion ([#10644](https://github.com/linode/manager/pull/10644))

--- a/packages/manager/cypress/e2e/core/longview/longview.spec.ts
+++ b/packages/manager/cypress/e2e/core/longview/longview.spec.ts
@@ -18,9 +18,12 @@ import {
   mockGetLongviewClients,
   mockFetchLongviewStatus,
   mockCreateLongviewClient,
+  mockDeleteLongviewClient,
+  mockUpdateLongviewClient,
 } from 'support/intercepts/longview';
 import { ui } from 'support/ui';
 import { cleanUp } from 'support/util/cleanup';
+import { randomLabel } from 'support/util/random';
 
 /**
  * Returns the command used to install Longview which is shown in Cloud's UI.
@@ -265,5 +268,166 @@ describe('longview', () => {
         cy.findByText('Network').should('be.visible');
         cy.findByText('Storage').should('be.visible');
       });
+  });
+
+  /*
+   * - Tests Longview installation end-to-end using mock API data.
+   * - Confirms that Cloud Manager UI can rename longview client.
+   */
+
+  it('can rename a Longview client on a Linode', () => {
+    const client: LongviewClient = longviewClientFactory.build({
+      api_key: '01AE82DD-6F99-44F6-95781512B64FFBC3',
+      apps: longviewAppsFactory.build(),
+      created: new Date().toISOString(),
+      id: 338283,
+      install_code: '748632FC-E92B-491F-A29D44019039017C',
+      label: randomLabel(),
+      updated: new Date().toISOString(),
+    });
+
+    const newClient: LongviewClient = longviewClientFactory.build({
+      api_key: '01AE82DD-6F99-44F6-95781512B64FFBC3',
+      apps: longviewAppsFactory.build(),
+      created: new Date().toISOString(),
+      id: 338283,
+      install_code: '748632FC-E92B-491F-A29D44019039017C',
+      label: randomLabel(),
+      updated: new Date().toISOString(),
+    });
+
+    mockGetLongviewClients([client]).as('getLongviewClients');
+    mockFetchLongviewStatus(client, 'lastUpdated', longviewLastUpdatedWaiting);
+    mockFetchLongviewStatus(client, 'getValues', longviewGetValuesWaiting);
+    mockFetchLongviewStatus(
+      client,
+      'getLatestValue',
+      longviewGetLatestValueWaiting
+    ).as('fetchLongview');
+
+    cy.visitWithLogin('/longview');
+    cy.wait('@getLongviewClients');
+
+    // Update mocks after initial Longview fetch to simulate client installation and data retrieval.
+    // The next time Cloud makes a request to the fetch endpoint, data will start being returned.
+    // 3 fetches is necessary because the Longview landing page fires 3 requests to the Longview fetch endpoint for each client.
+    // See https://github.com/linode/manager/pull/10579#discussion_r1647945160
+    cy.wait(['@fetchLongview', '@fetchLongview', '@fetchLongview']).then(() => {
+      mockFetchLongviewStatus(
+        client,
+        'lastUpdated',
+        longviewLastUpdatedInstalled
+      );
+      mockFetchLongviewStatus(client, 'getValues', longviewGetValuesInstalled);
+      mockFetchLongviewStatus(
+        client,
+        'getLatestValue',
+        longviewGetLatestValueInstalled
+      );
+    });
+
+    mockUpdateLongviewClient(newClient.id, newClient).as('updateLongview');
+
+    // Confirms that Cloud Manager UI can rename longview client.
+    cy.get(`[data-testid="editable-text"] > [data-testid="Button"]`)
+      .should('be.visible')
+      .click();
+
+    cy.get(`[data-qa-longview-client="${client.id}"]`).within(() => {
+      cy.get(`[data-testid="textfield-input"]`).clear().type(newClient.label);
+      cy.get(`[aria-label="Save new label"]`).should('be.visible').click();
+    });
+
+    cy.wait('@updateLongview');
+    cy.findAllByText(newClient.label).should('be.visible');
+  });
+
+  /*
+   * - Tests Longview installation end-to-end using mock API data.
+   * - Confirms that Cloud Manager UI can delete longview client.
+   */
+
+  it('can delete a Longview client on a Linode', () => {
+    const client: LongviewClient = longviewClientFactory.build({
+      api_key: '01AE82DD-6F99-44F6-95781512B64FFBC3',
+      apps: longviewAppsFactory.build(),
+      created: new Date().toISOString(),
+      id: 338283,
+      install_code: '748632FC-E92B-491F-A29D44019039017C',
+      label: 'longview-client-longview338283',
+      updated: new Date().toISOString(),
+    });
+    const deleteWarnMessage =
+      'Are you sure you want to delete this Longview Client?';
+
+    mockGetLongviewClients([client]).as('getLongviewClients');
+    mockFetchLongviewStatus(client, 'lastUpdated', longviewLastUpdatedWaiting);
+    mockFetchLongviewStatus(client, 'getValues', longviewGetValuesWaiting);
+    mockFetchLongviewStatus(
+      client,
+      'getLatestValue',
+      longviewGetLatestValueWaiting
+    ).as('fetchLongview');
+
+    cy.visitWithLogin('/longview');
+    cy.wait('@getLongviewClients');
+
+    // Update mocks after initial Longview fetch to simulate client installation and data retrieval.
+    // The next time Cloud makes a request to the fetch endpoint, data will start being returned.
+    // 3 fetches is necessary because the Longview landing page fires 3 requests to the Longview fetch endpoint for each client.
+    // See https://github.com/linode/manager/pull/10579#discussion_r1647945160
+    cy.wait(['@fetchLongview', '@fetchLongview', '@fetchLongview']).then(() => {
+      mockFetchLongviewStatus(
+        client,
+        'lastUpdated',
+        longviewLastUpdatedInstalled
+      );
+      mockFetchLongviewStatus(client, 'getValues', longviewGetValuesInstalled);
+      mockFetchLongviewStatus(
+        client,
+        'getLatestValue',
+        longviewGetLatestValueInstalled
+      );
+    });
+
+    mockDeleteLongviewClient(client.id).as('deleteLongview');
+
+    // Confirms that Cloud Manager UI has delete option.
+    cy.get(`[data-qa-longview-client="${client.id}"]`).within(() => {
+      ui.actionMenu
+        .findByTitle(`Action menu for Longview Client ${client.label}`)
+        .should('be.visible')
+        .click();
+    });
+    ui.actionMenuItem.findByTitle('Delete').should('be.visible').click();
+
+    // Confirms that Cloud Manager UI has delete warning message and can cancel deletion.
+    ui.dialog
+      .findByTitle(`Delete ${client.label}?`)
+      .should('be.visible')
+      .within(() => {
+        cy.findByText(deleteWarnMessage).should('be.visible');
+        ui.buttonGroup.findButtonByTitle('Cancel').should('be.visible').click();
+      });
+
+    // Confirms that Cloud Manager UI can delete a Longview Client.
+    cy.get(`[data-qa-longview-client="${client.id}"]`).within(() => {
+      ui.actionMenu
+        .findByTitle(`Action menu for Longview Client ${client.label}`)
+        .click();
+    });
+    ui.actionMenuItem.findByTitle('Delete').should('be.visible').click();
+
+    ui.dialog.findByTitle(`Delete ${client.label}?`).within(() => {
+      ui.buttonGroup
+        .findButtonByTitle('Delete')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+    });
+
+    // Confirm that Longview Client is deleted.
+    cy.wait('@deleteLongview');
+    cy.findByText(client.label).should('not.exist');
   });
 });

--- a/packages/manager/cypress/e2e/core/longview/longview.spec.ts
+++ b/packages/manager/cypress/e2e/core/longview/longview.spec.ts
@@ -276,24 +276,11 @@ describe('longview', () => {
    */
 
   it('can rename a Longview client on a Linode', () => {
-    const client: LongviewClient = longviewClientFactory.build({
-      api_key: '01AE82DD-6F99-44F6-95781512B64FFBC3',
-      apps: longviewAppsFactory.build(),
-      created: new Date().toISOString(),
-      id: 338283,
-      install_code: '748632FC-E92B-491F-A29D44019039017C',
-      label: randomLabel(),
-      updated: new Date().toISOString(),
-    });
+    const client: LongviewClient = longviewClientFactory.build();
 
     const newClient: LongviewClient = longviewClientFactory.build({
-      api_key: '01AE82DD-6F99-44F6-95781512B64FFBC3',
-      apps: longviewAppsFactory.build(),
-      created: new Date().toISOString(),
-      id: 338283,
-      install_code: '748632FC-E92B-491F-A29D44019039017C',
+      ...client,
       label: randomLabel(),
-      updated: new Date().toISOString(),
     });
 
     mockGetLongviewClients([client]).as('getLongviewClients');
@@ -348,15 +335,7 @@ describe('longview', () => {
    */
 
   it('can delete a Longview client on a Linode', () => {
-    const client: LongviewClient = longviewClientFactory.build({
-      api_key: '01AE82DD-6F99-44F6-95781512B64FFBC3',
-      apps: longviewAppsFactory.build(),
-      created: new Date().toISOString(),
-      id: 338283,
-      install_code: '748632FC-E92B-491F-A29D44019039017C',
-      label: 'longview-client-longview338283',
-      updated: new Date().toISOString(),
-    });
+    const client: LongviewClient = longviewClientFactory.build();
     const deleteWarnMessage =
       'Are you sure you want to delete this Longview Client?';
 

--- a/packages/manager/cypress/support/intercepts/longview.ts
+++ b/packages/manager/cypress/support/intercepts/longview.ts
@@ -92,3 +92,34 @@ export const mockCreateLongviewClient = (
     makeResponse(client)
   );
 };
+
+/**
+ * Mocks request to delete a Longview Client.
+ *
+ * @param clientID - ID of Longview Client for which to intercept delete request.
+ *
+ */
+export const mockDeleteLongviewClient = (
+  clientID: number
+): Cypress.Chainable<null> => {
+  return cy.intercept('DELETE', apiMatcher(`longview/clients/${clientID}`), {});
+};
+
+/**
+ * Intercepts PUT request to update Longview Client and mocks response.
+ *
+ * @param clientID - ID of Longview Client for which to intercept update request.
+ * @param newClient - new Longview Client object with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockUpdateLongviewClient = (
+  clientID: number,
+  newClient: LongviewClient
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'PUT',
+    apiMatcher(`longview/clients/${clientID}`),
+    makeResponse(newClient)
+  );
+};


### PR DESCRIPTION
## Description 📝
Add Cypress integration tests using mock API data to confirm the UI flow when a user renames or deletes a Longview client in Cloud Manager.

## Changes  🔄
- Add new tests in e2e longview.spec.ts
- Add new intercepts functions in longview.ts

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/longview/longview.spec.ts”
```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
