### PR TITLE
refactor: [M3-8285] - Improve getQueryParamsFromQueryString type safety

### DIFF
--- a/packages/manager/.changeset/pr-10645-tech-stories-1720037366869.md
+++ b/packages/manager/.changeset/pr-10645-tech-stories-1720037366869.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Improve getQueryParamsFromQueryString type safety ([#10645](https://github.com/linode/manager/pull/10645))

--- a/packages/manager/src/components/OrderBy.tsx
+++ b/packages/manager/src/components/OrderBy.tsx
@@ -9,7 +9,6 @@ import {
   useMutatePreferences,
   usePreferences,
 } from 'src/queries/profile/preferences';
-import { ManagerPreferences } from 'src/types/ManagerPreferences';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 import {
   sortByArrayLength,
@@ -19,6 +18,7 @@ import {
 } from 'src/utilities/sort-by';
 
 import type { Order } from 'src/hooks/useOrder';
+import type { ManagerPreferences } from 'src/types/ManagerPreferences';
 
 export interface OrderByProps<T> extends State {
   data: T[];
@@ -165,7 +165,7 @@ export const OrderBy = <T,>(props: CombinedProps<T>) => {
   const initialValues = getInitialValuesFromUserPreferences(
     props.preferenceKey ?? '',
     preferences ?? {},
-    params as Record<string, string>,
+    params,
     props.orderBy,
     props.order
   );

--- a/packages/manager/src/components/SelectFirewallPanel/SelectFirewallPanel.tsx
+++ b/packages/manager/src/components/SelectFirewallPanel/SelectFirewallPanel.tsx
@@ -1,4 +1,3 @@
-import { Firewall, FirewallDeviceEntityType } from '@linode/api-v4';
 import { styled } from '@mui/material/styles';
 import * as React from 'react';
 import { useLocation } from 'react-router-dom';
@@ -15,7 +14,8 @@ import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 import { Autocomplete } from '../Autocomplete/Autocomplete';
 import { LinkButton } from '../LinkButton';
 
-import type { LinodeCreateType } from 'src/features/Linodes/LinodesCreate/types';
+import type { Firewall, FirewallDeviceEntityType } from '@linode/api-v4';
+import type { LinodeCreateQueryParams } from 'src/utilities/queryParams';
 
 interface Props {
   disabled?: boolean;
@@ -37,7 +37,9 @@ export const SelectFirewallPanel = (props: Props) => {
   const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
   const location = useLocation();
   const isFromLinodeCreate = location.pathname.includes('/linodes/create');
-  const queryParams = getQueryParamsFromQueryString(location.search);
+  const queryParams = getQueryParamsFromQueryString<LinodeCreateQueryParams>(
+    location.search
+  );
 
   const handleCreateFirewallClick = () => {
     setIsDrawerOpen(true);
@@ -45,7 +47,7 @@ export const SelectFirewallPanel = (props: Props) => {
       sendLinodeCreateFormStepEvent({
         action: 'click',
         category: 'button',
-        createType: (queryParams.type as LinodeCreateType) ?? 'Distributions',
+        createType: queryParams.type ?? 'Distributions',
         formStepName: 'Firewall Panel',
         label: 'Create Firewall',
         version: 'v1',
@@ -91,8 +93,7 @@ export const SelectFirewallPanel = (props: Props) => {
             sendLinodeCreateFormStepEvent({
               action: 'click',
               category: 'select',
-              createType:
-                (queryParams.type as LinodeCreateType) ?? 'Distributions',
+              createType: queryParams.type ?? 'Distributions',
               formStepName: 'Firewall Panel',
               label: 'Assign Firewall',
               version: 'v1',

--- a/packages/manager/src/components/SelectFirewallPanel/SelectFirewallPanel.tsx
+++ b/packages/manager/src/components/SelectFirewallPanel/SelectFirewallPanel.tsx
@@ -15,7 +15,7 @@ import { Autocomplete } from '../Autocomplete/Autocomplete';
 import { LinkButton } from '../LinkButton';
 
 import type { Firewall, FirewallDeviceEntityType } from '@linode/api-v4';
-import type { LinodeCreateQueryParams } from 'src/utilities/queryParams';
+import type { LinodeCreateQueryParams } from 'src/features/Linodes/types';
 
 interface Props {
   disabled?: boolean;

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -5,8 +5,8 @@ import { useLocation } from 'react-router-dom';
 import { Notice } from 'src/components/Notice/Notice';
 import { Paper } from 'src/components/Paper';
 import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
-import { useIsGeckoEnabled } from 'src/components/RegionSelect/RegionSelect.utils';
 import { isDistributedRegionSupported } from 'src/components/RegionSelect/RegionSelect.utils';
+import { useIsGeckoEnabled } from 'src/components/RegionSelect/RegionSelect.utils';
 import { TwoStepRegionSelect } from 'src/components/RegionSelect/TwoStepRegionSelect';
 import { RegionHelperText } from 'src/components/SelectRegionPanel/RegionHelperText';
 import { Typography } from 'src/components/Typography';
@@ -31,7 +31,7 @@ import { Link } from '../Link';
 
 import type { RegionSelectProps } from '../RegionSelect/RegionSelect.types';
 import type { Capabilities } from '@linode/api-v4/lib/regions';
-import type { LinodeCreateType } from 'src/features/Linodes/LinodesCreate/types';
+import type { LinodeCreateQueryParams } from 'src/utilities/queryParams';
 
 export interface SelectRegionPanelProps {
   RegionSelectProps?: Partial<RegionSelectProps<true>>;
@@ -66,7 +66,9 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
   const flags = useFlags();
   const location = useLocation();
   const theme = useTheme();
-  const params = getQueryParamsFromQueryString(location.search);
+  const params = getQueryParamsFromQueryString<LinodeCreateQueryParams>(
+    location.search
+  );
 
   const { isGeckoGAEnabled } = useIsGeckoEnabled();
 
@@ -99,8 +101,7 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
     });
 
   const hideDistributedRegions =
-    !flags.gecko2?.enabled ||
-    !isDistributedRegionSupported(params.type as LinodeCreateType);
+    !flags.gecko2?.enabled || !isDistributedRegionSupported(params.type);
 
   const showDistributedRegionIconHelperText = Boolean(
     !hideDistributedRegions &&
@@ -113,7 +114,7 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
   );
 
   const disabledRegions = getDisabledRegions({
-    linodeCreateTab: params.type as LinodeCreateType,
+    linodeCreateTab: params.type,
     regions: regions ?? [],
     selectedImage: image,
   });
@@ -151,7 +152,7 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
             sendLinodeCreateFormStepEvent({
               action: 'click',
               category: 'link',
-              createType: (params.type as LinodeCreateType) ?? 'Distributions',
+              createType: params.type ?? 'Distributions',
               label: DOCS_LINK_LABEL_DC_PRICING,
               version: 'v1',
             })
@@ -177,8 +178,7 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
           </Typography>
         </Notice>
       ) : null}
-      {isGeckoGAEnabled &&
-      isDistributedRegionSupported(params.type as LinodeCreateType) ? (
+      {isGeckoGAEnabled && isDistributedRegionSupported(params.type) ? (
         <TwoStepRegionSelect
           showDistributedRegionIconHelperText={
             showDistributedRegionIconHelperText

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -31,7 +31,7 @@ import { Link } from '../Link';
 
 import type { RegionSelectProps } from '../RegionSelect/RegionSelect.types';
 import type { Capabilities } from '@linode/api-v4/lib/regions';
-import type { LinodeCreateQueryParams } from 'src/utilities/queryParams';
+import type { LinodeCreateQueryParams } from 'src/features/Linodes/types';
 
 export interface SelectRegionPanelProps {
   RegionSelectProps?: Partial<RegionSelectProps<true>>;

--- a/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
@@ -42,7 +42,7 @@ import type {
   Linode,
   NodeBalancer,
 } from '@linode/api-v4';
-import type { LinodeCreateQueryParams } from 'src/utilities/queryParams';
+import type { LinodeCreateQueryParams } from 'src/features/Linodes/types';
 
 export const READ_ONLY_DEVICES_HIDDEN_MESSAGE =
   'Only services you have permission to modify are shown.';

--- a/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/CreateFirewallDrawer.tsx
@@ -42,7 +42,7 @@ import type {
   Linode,
   NodeBalancer,
 } from '@linode/api-v4';
-import type { LinodeCreateType } from 'src/features/Linodes/LinodesCreate/types';
+import type { LinodeCreateQueryParams } from 'src/utilities/queryParams';
 
 export const READ_ONLY_DEVICES_HIDDEN_MESSAGE =
   'Only services you have permission to modify are shown.';
@@ -80,7 +80,9 @@ export const CreateFirewallDrawer = React.memo(
 
     const location = useLocation();
     const isFromLinodeCreate = location.pathname.includes('/linodes/create');
-    const queryParams = getQueryParamsFromQueryString(location.search);
+    const queryParams = getQueryParamsFromQueryString<LinodeCreateQueryParams>(
+      location.search
+    );
 
     const {
       errors,
@@ -224,8 +226,7 @@ export const CreateFirewallDrawer = React.memo(
           sendLinodeCreateFormStepEvent({
             action: 'click',
             category: 'link',
-            createType:
-              (queryParams.type as LinodeCreateType) ?? 'Distributions',
+            createType: queryParams.type ?? 'Distributions',
             formStepName: 'Create Firewall Drawer',
             label: 'Learn more',
             version: 'v1',
@@ -379,8 +380,7 @@ export const CreateFirewallDrawer = React.memo(
                 sendLinodeCreateFormStepEvent({
                   action: 'click',
                   category: 'button',
-                  createType:
-                    (queryParams.type as LinodeCreateType) ?? 'Distributions',
+                  createType: queryParams.type ?? 'Distributions',
                   formStepName: 'Create Firewall Drawer',
                   label: 'Create Firewall',
                   version: 'v1',

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -33,12 +33,16 @@ import { useRegionsQuery } from 'src/queries/regions/regions';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 
 import type { CreateImagePayload } from '@linode/api-v4';
+import type { LinodeConfigAndDiskQueryParams } from 'src/utilities/queryParams';
 
 export const CreateImageTab = () => {
   const location = useLocation();
 
   const queryParams = React.useMemo(
-    () => getQueryParamsFromQueryString(location.search),
+    () =>
+      getQueryParamsFromQueryString<LinodeConfigAndDiskQueryParams>(
+        location.search
+      ),
     [location.search]
   );
 

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -33,7 +33,7 @@ import { useRegionsQuery } from 'src/queries/regions/regions';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 
 import type { CreateImagePayload } from '@linode/api-v4';
-import type { LinodeConfigAndDiskQueryParams } from 'src/utilities/queryParams';
+import type { LinodeConfigAndDiskQueryParams } from 'src/features/Linodes/types';
 
 export const CreateImageTab = () => {
   const location = useLocation();

--- a/packages/manager/src/features/Linodes/CloneLanding/CloneLanding.tsx
+++ b/packages/manager/src/features/Linodes/CloneLanding/CloneLanding.tsx
@@ -1,12 +1,6 @@
-import {
-  Disk,
-  Linode,
-  cloneLinode,
-  cloneLinodeDisk,
-} from '@linode/api-v4/lib/linodes';
-import { APIError } from '@linode/api-v4/lib/types';
-import Grid from '@mui/material/Unstable_Grid2';
+import { cloneLinode, cloneLinodeDisk } from '@linode/api-v4/lib/linodes';
 import { useTheme } from '@mui/material/styles';
+import Grid from '@mui/material/Unstable_Grid2';
 import { castDraft } from 'immer';
 import { intersection, pathOr } from 'ramda';
 import * as React from 'react';
@@ -45,6 +39,10 @@ import {
   curriedCloneLandingReducer,
   defaultState,
 } from './utilities';
+
+import type { Disk, Linode } from '@linode/api-v4/lib/linodes';
+import type { APIError } from '@linode/api-v4/lib/types';
+import type { LinodeConfigAndDiskQueryParams } from 'src/utilities/queryParams';
 
 const Configs = React.lazy(() => import('./Configs'));
 const Disks = React.lazy(() => import('./Disks'));
@@ -126,7 +124,10 @@ const CloneLanding = () => {
   // A config and/or disk can be selected via query param. Memoized
   // so it can be used as a dep in the useEffects that consume it.
   const queryParams = React.useMemo(
-    () => getQueryParamsFromQueryString(location.search),
+    () =>
+      getQueryParamsFromQueryString<LinodeConfigAndDiskQueryParams>(
+        location.search
+      ),
     [location.search]
   );
 

--- a/packages/manager/src/features/Linodes/CloneLanding/CloneLanding.tsx
+++ b/packages/manager/src/features/Linodes/CloneLanding/CloneLanding.tsx
@@ -42,7 +42,7 @@ import {
 
 import type { Disk, Linode } from '@linode/api-v4/lib/linodes';
 import type { APIError } from '@linode/api-v4/lib/types';
-import type { LinodeConfigAndDiskQueryParams } from 'src/utilities/queryParams';
+import type { LinodeConfigAndDiskQueryParams } from 'src/features/Linodes/types';
 
 const Configs = React.lazy(() => import('./Configs'));
 const Disks = React.lazy(() => import('./Disks'));

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
@@ -1,18 +1,9 @@
-import { PlacementGroup } from '@linode/api-v4';
-import {
-  CreateLinodePlacementGroupPayload,
-  EncryptionStatus,
-  InterfacePayload,
-  PriceObject,
-  restoreBackup,
-} from '@linode/api-v4/lib/linodes';
-import { Tag } from '@linode/api-v4/lib/tags/types';
+import { restoreBackup } from '@linode/api-v4/lib/linodes';
 import { CreateLinodeSchema } from '@linode/validation/lib/linodes.schema';
 import Grid from '@mui/material/Unstable_Grid2';
 import cloneDeep from 'lodash.clonedeep';
 import * as React from 'react';
-import { MapDispatchToProps, connect } from 'react-redux';
-import { RouteComponentProps } from 'react-router-dom';
+import { connect } from 'react-redux';
 import { v4 } from 'uuid';
 
 import { AccessPanel } from 'src/components/AccessPanel/AccessPanel';
@@ -33,28 +24,19 @@ import { TabPanels } from 'src/components/Tabs/TabPanels';
 import { Tabs } from 'src/components/Tabs/Tabs';
 import { Typography } from 'src/components/Typography';
 import { FIREWALL_GET_STARTED_LINK } from 'src/constants';
-import { WithAccountProps } from 'src/containers/account.container';
-import { WithFeatureFlagProps } from 'src/containers/flags.container';
-import { WithImagesProps as ImagesProps } from 'src/containers/images.container';
-import { RegionsProps } from 'src/containers/regions.container';
-import { WithTypesProps } from 'src/containers/types.container';
-import { WithLinodesProps } from 'src/containers/withLinodes.container';
 import { EUAgreementCheckbox } from 'src/features/Account/Agreements/EUAgreementCheckbox';
 import { PlansPanel } from 'src/features/components/PlansPanel/PlansPanel';
-import { regionSupportsMetadata } from 'src/features/Linodes/LinodesCreate/utilities';
 import {
   getMonthlyAndHourlyNodePricing,
   utoa,
 } from 'src/features/Linodes/LinodesCreate/utilities';
+import { regionSupportsMetadata } from 'src/features/Linodes/LinodesCreate/utilities';
 import { SMTPRestrictionText } from 'src/features/Linodes/SMTPRestrictionText';
 import {
   getCommunityStackscripts,
   getMineAndAccountStackScripts,
 } from 'src/features/StackScripts/stackScriptUtils';
-import {
-  CreateTypes,
-  handleChangeCreateType,
-} from 'src/store/linodeCreate/linodeCreate.actions';
+import { handleChangeCreateType } from 'src/store/linodeCreate/linodeCreate.actions';
 import { getInitialType } from 'src/store/linodeCreate/linodeCreate.reducer';
 import {
   sendApiAwarenessClickEvent,
@@ -69,7 +51,6 @@ import { doesRegionSupportFeature } from 'src/utilities/doesRegionSupportFeature
 import { getErrorMap } from 'src/utilities/errorUtils';
 import { extendType } from 'src/utilities/extendType';
 import { filterCurrentTypes } from 'src/utilities/filterCurrentLinodeTypes';
-import { ExtendedIP } from 'src/utilities/ipUtils';
 import { getMonthlyBackupsPrice } from 'src/utilities/pricing/backups';
 import { UNKNOWN_PRICE } from 'src/utilities/pricing/constants';
 import { renderMonthlyPriceToCorrectDecimalPlace } from 'src/utilities/pricing/dynamicPricing';
@@ -93,7 +74,9 @@ import { FromImageContent } from './TabbedContent/FromImageContent';
 import { FromLinodeContent } from './TabbedContent/FromLinodeContent';
 import { FromStackScriptContent } from './TabbedContent/FromStackScriptContent';
 import { renderBackupsDisplaySection } from './TabbedContent/utils';
-import {
+import { VPCPanel } from './VPCPanel';
+
+import type {
   AllFormStateAndHandlers,
   AppsData,
   HandleSubmit,
@@ -105,10 +88,27 @@ import {
   WithDisplayData,
   WithTypesRegionsAndImages,
 } from './types';
-import { VPCPanel } from './VPCPanel';
-
+import type { PlacementGroup } from '@linode/api-v4';
+import type {
+  CreateLinodePlacementGroupPayload,
+  EncryptionStatus,
+  InterfacePayload,
+  PriceObject,
+} from '@linode/api-v4/lib/linodes';
+import type { Tag } from '@linode/api-v4/lib/tags/types';
+import type { MapDispatchToProps } from 'react-redux';
+import type { RouteComponentProps } from 'react-router-dom';
 import type { Tab } from 'src/components/Tabs/TabLinkList';
+import type { WithAccountProps } from 'src/containers/account.container';
+import type { WithFeatureFlagProps } from 'src/containers/flags.container';
+import type { WithImagesProps as ImagesProps } from 'src/containers/images.container';
+import type { RegionsProps } from 'src/containers/regions.container';
+import type { WithTypesProps } from 'src/containers/types.container';
+import type { WithLinodesProps } from 'src/containers/withLinodes.container';
 import type { LinodeCreateType } from 'src/features/Linodes/LinodesCreate/types';
+import type { CreateTypes } from 'src/store/linodeCreate/linodeCreate.actions';
+import type { ExtendedIP } from 'src/utilities/ipUtils';
+import type { LinodeCreateQueryParams } from 'src/utilities/queryParams';
 
 export interface LinodeCreateProps {
   additionalIPv4RangesForVPC: ExtendedIP[];
@@ -212,11 +212,336 @@ export class LinodeCreate extends React.PureComponent<
   LinodeCreateComponentProps,
   State
 > {
+  createLinode = () => {
+    const payload = this.getPayload();
+    const { selectedTab } = this.state;
+    const selectedTabName = this.tabs[selectedTab].title as LinodeCreateType;
+
+    try {
+      CreateLinodeSchema.validateSync(payload, {
+        abortEarly: true,
+      });
+      this.setState({ hasError: false });
+    } catch (e) {
+      this.setState({ hasError: true }, () => {
+        scrollErrorIntoViewV2(this.createLinodeFormRef);
+      });
+    }
+    this.props.handleSubmitForm(payload, this.props.selectedLinodeID);
+    sendLinodeCreateFormSubmitEvent(
+      'Create Linode',
+      selectedTabName ?? 'Distributions',
+      'v1'
+    );
+  };
+
+  createLinodeFormRef = React.createRef<HTMLFormElement>();
+
+  filterTypes = () => {
+    const { createType, typesData } = this.props;
+    const { selectedTab } = this.state;
+    const currentTypes = filterCurrentTypes(typesData?.map(extendType));
+
+    return ['fromBackup', 'fromImage'].includes(createType) && selectedTab !== 0
+      ? currentTypes.filter((t) => t.class !== 'metal')
+      : currentTypes;
+  };
+
+  getPayload = () => {
+    const selectedRegion = this.props.selectedRegionID || '';
+
+    const regionSupportsVLANs = doesRegionSupportFeature(
+      selectedRegion,
+      this.props.regionsData,
+      'Vlans'
+    );
+
+    const regionSupportsVPCs = doesRegionSupportFeature(
+      this.props.selectedRegionID ?? '',
+      this.props.regionsData,
+      'VPCs'
+    );
+
+    const regionSupportsDiskEncryption = doesRegionSupportFeature(
+      this.props.selectedRegionID ?? '',
+      this.props.regionsData,
+      'Disk Encryption'
+    );
+
+    const hasDiskEncryptionAccountCapability = this.props.account.data?.capabilities?.includes(
+      'Disk Encryption'
+    );
+
+    const isDiskEncryptionFeatureEnabled =
+      this.props.flags.linodeDiskEncryption &&
+      hasDiskEncryptionAccountCapability;
+
+    const diskEncryptionPayload: EncryptionStatus = this.props
+      .diskEncryptionEnabled
+      ? 'enabled'
+      : 'disabled';
+
+    const placement_group_payload: CreateLinodePlacementGroupPayload = {
+      id: this.props.placementGroupSelection?.id ?? -1,
+    };
+
+    // eslint-disable-next-line sonarjs/no-unused-collection
+    const interfaces: InterfacePayload[] = [];
+
+    const payload = {
+      authorized_users: this.props.authorized_users,
+      backup_id: this.props.selectedBackupID,
+      backups_enabled: this.props.backupsEnabled,
+      booted: true,
+      disk_encryption:
+        isDiskEncryptionFeatureEnabled && regionSupportsDiskEncryption
+          ? diskEncryptionPayload
+          : undefined,
+      firewall_id:
+        this.props.firewallId !== -1 ? this.props.firewallId : undefined,
+      image: this.props.selectedImageID,
+      label: this.props.label,
+      placement_group:
+        placement_group_payload.id !== -1 ? placement_group_payload : undefined,
+      private_ip: this.props.privateIPEnabled,
+      region: this.props.selectedRegionID ?? '',
+      root_pass: this.props.password,
+      stackscript_data: this.props.selectedUDFs,
+
+      // StackScripts
+      stackscript_id: this.props.selectedStackScriptID,
+      tags: this.props.tags
+        ? this.props.tags.map((eachTag) => eachTag.label)
+        : [],
+      type: this.props.selectedTypeID ?? '',
+    };
+
+    if (
+      regionSupportsVPCs &&
+      this.props.selectedVPCId !== undefined &&
+      this.props.selectedVPCId !== -1
+    ) {
+      const vpcInterfaceData: InterfacePayload = {
+        ip_ranges: this.props.additionalIPv4RangesForVPC
+          .map((ipRange) => ipRange.address)
+          .filter((ipRange) => ipRange !== ''),
+        ipam_address: null,
+        ipv4: {
+          nat_1_1: this.props.assignPublicIPv4Address ? 'any' : undefined,
+          vpc: this.props.autoassignIPv4WithinVPC
+            ? undefined
+            : this.props.vpcIPv4AddressOfLinode,
+        },
+        label: null,
+        primary: true,
+        purpose: 'vpc',
+        subnet_id: this.props.selectedSubnetId,
+        vpc_id: this.props.selectedVPCId,
+      };
+
+      interfaces.unshift(vpcInterfaceData);
+    }
+
+    if (
+      regionSupportsVLANs &&
+      this.props.selectedImageID &&
+      Boolean(this.props.vlanLabel)
+    ) {
+      // The region must support VLANs and an image and VLAN
+      // must be selected
+      interfaces.push({
+        ipam_address: this.props.ipamAddress,
+        label: this.props.vlanLabel,
+        purpose: 'vlan',
+      });
+    }
+
+    if (this.props.userData) {
+      payload['metadata'] = {
+        user_data: utoa(this.props.userData),
+      };
+    }
+
+    const vpcAssigned = interfaces.some(
+      (_interface) => _interface.purpose === 'vpc'
+    );
+    const vlanAssigned = interfaces.some(
+      (_interface) => _interface.purpose === 'vlan'
+    );
+
+    // Only submit 'interfaces' in the payload if there are VPCs
+    // or VLANs
+    if (interfaces.length > 0) {
+      // Determine position of the default public interface
+
+      // Case 1: VLAN assigned, no VPC assigned
+      if (!vpcAssigned) {
+        interfaces.unshift(defaultPublicInterface);
+      }
+
+      // Case 2: VPC assigned, no VLAN assigned, Private IP enabled
+      if (!vlanAssigned && this.props.privateIPEnabled) {
+        interfaces.push(defaultPublicInterface);
+      }
+
+      // Case 3: VPC and VLAN assigned + Private IP enabled
+      if (vpcAssigned && vlanAssigned && this.props.privateIPEnabled) {
+        interfaces.push(defaultPublicInterface);
+      }
+
+      payload['interfaces'] = interfaces;
+    }
+
+    return payload;
+  };
+
+  handleAnalyticsFormError = (
+    errorMap: Partial<Record<string, string | undefined>>
+  ) => {
+    const { selectedTab } = this.state;
+    const selectedTabName = this.tabs[selectedTab].title as LinodeCreateType;
+
+    if (!errorMap) {
+      return;
+    }
+    if (errorMap.region) {
+      sendLinodeCreateFormErrorEvent(
+        'Region not selected',
+        selectedTabName ?? 'Distributions',
+        'v1'
+      );
+    }
+    if (errorMap.type) {
+      sendLinodeCreateFormErrorEvent(
+        'Plan not selected',
+        selectedTabName ?? 'Distributions',
+        'v1'
+      );
+    }
+    if (errorMap.root_pass) {
+      sendLinodeCreateFormErrorEvent(
+        'Password not created',
+        selectedTabName ?? 'Distributions',
+        'v1'
+      );
+    }
+  };
+
+  handleClickCreateUsingCommandLine = () => {
+    const payload = {
+      authorized_users: this.props.authorized_users,
+      backup_id: this.props.selectedBackupID,
+      backups_enabled: this.props.backupsEnabled,
+      booted: true,
+      image: this.props.selectedImageID,
+      label: this.props.label,
+      private_ip: this.props.privateIPEnabled,
+      region: this.props.selectedRegionID ?? '',
+      root_pass: this.props.password,
+      stackscript_data: this.props.selectedUDFs,
+      // StackScripts
+      stackscript_id: this.props.selectedStackScriptID,
+
+      tags: this.props.tags
+        ? this.props.tags.map((eachTag) => eachTag.label)
+        : [],
+      type: this.props.selectedTypeID ?? '',
+    };
+    sendApiAwarenessClickEvent('Button', 'Create Using Command Line');
+    this.props.checkValidation(payload);
+  };
+
+  handleTabChange = (index: number) => {
+    const prevTabIndex = this.state.selectedTab;
+
+    this.props.resetCreationState();
+
+    /** set the tab in redux state */
+    this.props.setTab(this.tabs[index].type);
+
+    /** Reset the plan panel since types may have shifted */
+
+    this.setState({
+      planKey: v4(),
+      selectedTab: index,
+    });
+
+    // Do not fire the form event if a user is not switching to a different tab.
+    // Prevents a double-firing on Marketplace because we manually handle the tab change.
+    if (prevTabIndex !== index) {
+      sendLinodeCreateFormStepEvent({
+        action: 'click',
+        category: 'tab',
+        createType:
+          (this.tabs[prevTabIndex].title as LinodeCreateType) ??
+          'Distributions',
+        label: `${this.tabs[index].title} Tab`,
+        version: 'v1',
+      });
+    }
+  };
+
+  mounted: boolean = false;
+
+  setNumberOfNodesForAppCluster = (num: number) => {
+    this.setState({
+      numberOfNodes: num,
+    });
+  };
+
+  stackScriptTabs: CreateTab[] = [
+    {
+      routeName: `${this.props.match.url}?type=StackScripts&subtype=Account`,
+      title: 'Account StackScripts',
+      type: 'fromStackScript',
+    },
+    {
+      routeName: `${this.props.match.url}?type=StackScripts&subtype=Community`,
+      title: 'Community StackScripts',
+      type: 'fromStackScript',
+    },
+  ];
+
+  tabs: CreateTab[] = [
+    {
+      routeName: `${this.props.match.url}?type=Distributions`,
+      title: 'Distributions',
+      type: 'fromImage',
+    },
+    {
+      routeName: `${this.props.match.url}?type=One-Click`,
+      title: 'Marketplace',
+      type: 'fromApp',
+    },
+    {
+      routeName: `${this.props.match.url}?type=StackScripts`,
+      title: 'StackScripts',
+      type: 'fromStackScript',
+    },
+    {
+      routeName: `${this.props.match.url}?type=Images`,
+      title: 'Images',
+      type: 'fromImage',
+    },
+    {
+      routeName: `${this.props.match.url}?type=Backups`,
+      title: 'Backups',
+      type: 'fromBackup',
+    },
+    {
+      routeName: `${this.props.match.url}?type=Clone%20Linode`,
+      title: 'Clone Linode',
+      type: 'fromLinode',
+    },
+  ];
+
   constructor(props: LinodeCreateComponentProps) {
     super(props);
 
     /** Get the query params as an object, excluding the "?" */
-    const queryParams = getQueryParamsFromQueryString(location.search);
+    const queryParams = getQueryParamsFromQueryString<LinodeCreateQueryParams>(
+      location.search
+    );
 
     const _tabs: LinodeCreateType[] = [
       'Distributions',
@@ -612,10 +937,10 @@ export class LinodeCreate extends React.PureComponent<
                     imagePanelTitle="Choose an Image"
                     imagesData={imagesData}
                     regionsData={regionsData!}
+                    selectedRegionID={selectedRegionID}
                     typesData={typesData!}
                     userCannotCreateLinode={userCannotCreateLinode}
                     variant={'private'}
-                    selectedRegionID={selectedRegionID}
                     {...rest}
                   />
                 </SafeTabPanel>
@@ -888,329 +1213,6 @@ export class LinodeCreate extends React.PureComponent<
       </StyledForm>
     );
   }
-
-  createLinode = () => {
-    const payload = this.getPayload();
-    const { selectedTab } = this.state;
-    const selectedTabName = this.tabs[selectedTab].title as LinodeCreateType;
-
-    try {
-      CreateLinodeSchema.validateSync(payload, {
-        abortEarly: true,
-      });
-      this.setState({ hasError: false });
-    } catch (e) {
-      this.setState({ hasError: true }, () => {
-        scrollErrorIntoViewV2(this.createLinodeFormRef);
-      });
-    }
-    this.props.handleSubmitForm(payload, this.props.selectedLinodeID);
-    sendLinodeCreateFormSubmitEvent(
-      'Create Linode',
-      selectedTabName ?? 'Distributions',
-      'v1'
-    );
-  };
-
-  createLinodeFormRef = React.createRef<HTMLFormElement>();
-
-  filterTypes = () => {
-    const { createType, typesData } = this.props;
-    const { selectedTab } = this.state;
-    const currentTypes = filterCurrentTypes(typesData?.map(extendType));
-
-    return ['fromBackup', 'fromImage'].includes(createType) && selectedTab !== 0
-      ? currentTypes.filter((t) => t.class !== 'metal')
-      : currentTypes;
-  };
-
-  getPayload = () => {
-    const selectedRegion = this.props.selectedRegionID || '';
-
-    const regionSupportsVLANs = doesRegionSupportFeature(
-      selectedRegion,
-      this.props.regionsData,
-      'Vlans'
-    );
-
-    const regionSupportsVPCs = doesRegionSupportFeature(
-      this.props.selectedRegionID ?? '',
-      this.props.regionsData,
-      'VPCs'
-    );
-
-    const regionSupportsDiskEncryption = doesRegionSupportFeature(
-      this.props.selectedRegionID ?? '',
-      this.props.regionsData,
-      'Disk Encryption'
-    );
-
-    const hasDiskEncryptionAccountCapability = this.props.account.data?.capabilities?.includes(
-      'Disk Encryption'
-    );
-
-    const isDiskEncryptionFeatureEnabled =
-      this.props.flags.linodeDiskEncryption &&
-      hasDiskEncryptionAccountCapability;
-
-    const diskEncryptionPayload: EncryptionStatus = this.props
-      .diskEncryptionEnabled
-      ? 'enabled'
-      : 'disabled';
-
-    const placement_group_payload: CreateLinodePlacementGroupPayload = {
-      id: this.props.placementGroupSelection?.id ?? -1,
-    };
-
-    // eslint-disable-next-line sonarjs/no-unused-collection
-    const interfaces: InterfacePayload[] = [];
-
-    const payload = {
-      authorized_users: this.props.authorized_users,
-      backup_id: this.props.selectedBackupID,
-      backups_enabled: this.props.backupsEnabled,
-      booted: true,
-      disk_encryption:
-        isDiskEncryptionFeatureEnabled && regionSupportsDiskEncryption
-          ? diskEncryptionPayload
-          : undefined,
-      firewall_id:
-        this.props.firewallId !== -1 ? this.props.firewallId : undefined,
-      image: this.props.selectedImageID,
-      label: this.props.label,
-      placement_group:
-        placement_group_payload.id !== -1 ? placement_group_payload : undefined,
-      private_ip: this.props.privateIPEnabled,
-      region: this.props.selectedRegionID ?? '',
-      root_pass: this.props.password,
-      stackscript_data: this.props.selectedUDFs,
-
-      // StackScripts
-      stackscript_id: this.props.selectedStackScriptID,
-      tags: this.props.tags
-        ? this.props.tags.map((eachTag) => eachTag.label)
-        : [],
-      type: this.props.selectedTypeID ?? '',
-    };
-
-    if (
-      regionSupportsVPCs &&
-      this.props.selectedVPCId !== undefined &&
-      this.props.selectedVPCId !== -1
-    ) {
-      const vpcInterfaceData: InterfacePayload = {
-        ip_ranges: this.props.additionalIPv4RangesForVPC
-          .map((ipRange) => ipRange.address)
-          .filter((ipRange) => ipRange !== ''),
-        ipam_address: null,
-        ipv4: {
-          nat_1_1: this.props.assignPublicIPv4Address ? 'any' : undefined,
-          vpc: this.props.autoassignIPv4WithinVPC
-            ? undefined
-            : this.props.vpcIPv4AddressOfLinode,
-        },
-        label: null,
-        primary: true,
-        purpose: 'vpc',
-        subnet_id: this.props.selectedSubnetId,
-        vpc_id: this.props.selectedVPCId,
-      };
-
-      interfaces.unshift(vpcInterfaceData);
-    }
-
-    if (
-      regionSupportsVLANs &&
-      this.props.selectedImageID &&
-      Boolean(this.props.vlanLabel)
-    ) {
-      // The region must support VLANs and an image and VLAN
-      // must be selected
-      interfaces.push({
-        ipam_address: this.props.ipamAddress,
-        label: this.props.vlanLabel,
-        purpose: 'vlan',
-      });
-    }
-
-    if (this.props.userData) {
-      payload['metadata'] = {
-        user_data: utoa(this.props.userData),
-      };
-    }
-
-    const vpcAssigned = interfaces.some(
-      (_interface) => _interface.purpose === 'vpc'
-    );
-    const vlanAssigned = interfaces.some(
-      (_interface) => _interface.purpose === 'vlan'
-    );
-
-    // Only submit 'interfaces' in the payload if there are VPCs
-    // or VLANs
-    if (interfaces.length > 0) {
-      // Determine position of the default public interface
-
-      // Case 1: VLAN assigned, no VPC assigned
-      if (!vpcAssigned) {
-        interfaces.unshift(defaultPublicInterface);
-      }
-
-      // Case 2: VPC assigned, no VLAN assigned, Private IP enabled
-      if (!vlanAssigned && this.props.privateIPEnabled) {
-        interfaces.push(defaultPublicInterface);
-      }
-
-      // Case 3: VPC and VLAN assigned + Private IP enabled
-      if (vpcAssigned && vlanAssigned && this.props.privateIPEnabled) {
-        interfaces.push(defaultPublicInterface);
-      }
-
-      payload['interfaces'] = interfaces;
-    }
-
-    return payload;
-  };
-
-  handleAnalyticsFormError = (
-    errorMap: Partial<Record<string, string | undefined>>
-  ) => {
-    const { selectedTab } = this.state;
-    const selectedTabName = this.tabs[selectedTab].title as LinodeCreateType;
-
-    if (!errorMap) {
-      return;
-    }
-    if (errorMap.region) {
-      sendLinodeCreateFormErrorEvent(
-        'Region not selected',
-        selectedTabName ?? 'Distributions',
-        'v1'
-      );
-    }
-    if (errorMap.type) {
-      sendLinodeCreateFormErrorEvent(
-        'Plan not selected',
-        selectedTabName ?? 'Distributions',
-        'v1'
-      );
-    }
-    if (errorMap.root_pass) {
-      sendLinodeCreateFormErrorEvent(
-        'Password not created',
-        selectedTabName ?? 'Distributions',
-        'v1'
-      );
-    }
-  };
-
-  handleClickCreateUsingCommandLine = () => {
-    const payload = {
-      authorized_users: this.props.authorized_users,
-      backup_id: this.props.selectedBackupID,
-      backups_enabled: this.props.backupsEnabled,
-      booted: true,
-      image: this.props.selectedImageID,
-      label: this.props.label,
-      private_ip: this.props.privateIPEnabled,
-      region: this.props.selectedRegionID ?? '',
-      root_pass: this.props.password,
-      stackscript_data: this.props.selectedUDFs,
-      // StackScripts
-      stackscript_id: this.props.selectedStackScriptID,
-
-      tags: this.props.tags
-        ? this.props.tags.map((eachTag) => eachTag.label)
-        : [],
-      type: this.props.selectedTypeID ?? '',
-    };
-    sendApiAwarenessClickEvent('Button', 'Create Using Command Line');
-    this.props.checkValidation(payload);
-  };
-
-  handleTabChange = (index: number) => {
-    const prevTabIndex = this.state.selectedTab;
-
-    this.props.resetCreationState();
-
-    /** set the tab in redux state */
-    this.props.setTab(this.tabs[index].type);
-
-    /** Reset the plan panel since types may have shifted */
-
-    this.setState({
-      planKey: v4(),
-      selectedTab: index,
-    });
-
-    // Do not fire the form event if a user is not switching to a different tab.
-    // Prevents a double-firing on Marketplace because we manually handle the tab change.
-    if (prevTabIndex !== index) {
-      sendLinodeCreateFormStepEvent({
-        action: 'click',
-        category: 'tab',
-        createType:
-          (this.tabs[prevTabIndex].title as LinodeCreateType) ??
-          'Distributions',
-        label: `${this.tabs[index].title} Tab`,
-        version: 'v1',
-      });
-    }
-  };
-
-  mounted: boolean = false;
-
-  setNumberOfNodesForAppCluster = (num: number) => {
-    this.setState({
-      numberOfNodes: num,
-    });
-  };
-
-  stackScriptTabs: CreateTab[] = [
-    {
-      routeName: `${this.props.match.url}?type=StackScripts&subtype=Account`,
-      title: 'Account StackScripts',
-      type: 'fromStackScript',
-    },
-    {
-      routeName: `${this.props.match.url}?type=StackScripts&subtype=Community`,
-      title: 'Community StackScripts',
-      type: 'fromStackScript',
-    },
-  ];
-
-  tabs: CreateTab[] = [
-    {
-      routeName: `${this.props.match.url}?type=Distributions`,
-      title: 'Distributions',
-      type: 'fromImage',
-    },
-    {
-      routeName: `${this.props.match.url}?type=One-Click`,
-      title: 'Marketplace',
-      type: 'fromApp',
-    },
-    {
-      routeName: `${this.props.match.url}?type=StackScripts`,
-      title: 'StackScripts',
-      type: 'fromStackScript',
-    },
-    {
-      routeName: `${this.props.match.url}?type=Images`,
-      title: 'Images',
-      type: 'fromImage',
-    },
-    {
-      routeName: `${this.props.match.url}?type=Backups`,
-      title: 'Backups',
-      type: 'fromBackup',
-    },
-    {
-      routeName: `${this.props.match.url}?type=Clone%20Linode`,
-      title: 'Clone Linode',
-      type: 'fromLinode',
-    },
-  ];
 }
 
 export const defaultPublicInterface: InterfacePayload = {

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
@@ -106,9 +106,9 @@ import type { RegionsProps } from 'src/containers/regions.container';
 import type { WithTypesProps } from 'src/containers/types.container';
 import type { WithLinodesProps } from 'src/containers/withLinodes.container';
 import type { LinodeCreateType } from 'src/features/Linodes/LinodesCreate/types';
+import type { LinodeCreateQueryParams } from 'src/features/Linodes/types';
 import type { CreateTypes } from 'src/store/linodeCreate/linodeCreate.actions';
 import type { ExtendedIP } from 'src/utilities/ipUtils';
-import type { LinodeCreateQueryParams } from 'src/utilities/queryParams';
 
 export interface LinodeCreateProps {
   additionalIPv4RangesForVPC: ExtendedIP[];

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -205,140 +205,6 @@ const isNonDefaultImageType = (prevType: string, type: string) => {
 };
 
 class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
-  componentDidMount() {
-    // Allowed apps include the base set of original apps + anything LD tells us to show
-    if (nonImageCreateTypes.includes(this.props.createType)) {
-      // If we're navigating directly to e.g. the clone page, don't select an image by default
-      this.setState({ selectedImageID: undefined });
-    }
-  }
-
-  componentDidUpdate(prevProps: CombinedProps) {
-    /**
-     * When switching to a creation flow where
-     * having a pre-selected image is problematic,
-     * deselect it.
-     */
-    if (isNonDefaultImageType(prevProps.createType, this.props.createType)) {
-      this.setState({ selectedImageID: undefined });
-    }
-
-    // Update search params for Linode Clone
-    if (prevProps.location.search !== this.props.history.location.search) {
-      const { showGDPRCheckbox } = getGDPRDetails({
-        agreements: this.props.agreements?.data,
-        profile: this.props.profile.data,
-        regions: this.props.regionsData,
-        selectedRegionId: this.params.regionID,
-      });
-
-      this.params = getQueryParamsFromQueryString(
-        this.props.location.search
-      ) as Record<string, string>;
-
-      this.setState({
-        showGDPRCheckbox,
-      });
-    }
-  }
-
-  render() {
-    const {
-      grants,
-      profile,
-      regionsData,
-      typesData,
-      ...restOfProps
-    } = this.props;
-    const { udfs: selectedUDFs, ...restOfState } = this.state;
-
-    const extendedTypeData = typesData?.map(extendType);
-
-    const userCannotCreateLinode =
-      Boolean(profile.data?.restricted) && !grants.data?.global.add_linodes;
-
-    return (
-      <React.Fragment>
-        <DocumentTitleSegment segment="Create a Linode" />
-        <ProductInformationBanner bannerLocation="LinodeCreate" />
-        <Grid className="m0" container spacing={0}>
-          <LandingHeader
-            onDocsClick={() => {
-              sendLinodeCreateFlowDocsClickEvent('Getting Started');
-              sendLinodeCreateFormStepEvent({
-                action: 'click',
-                category: 'link',
-                createType:
-                  (this.params.type as LinodeCreateType) ?? 'Distributions',
-                label: 'Getting Started',
-                version: 'v1',
-              });
-            }}
-            docsLabel="Getting Started"
-            docsLink="https://www.linode.com/docs/guides/platform/get-started/"
-            title="Create"
-          />
-          <LinodeCreate
-            accountBackupsEnabled={
-              this.props.accountSettings.data?.backups_enabled ?? false
-            }
-            toggleAutoassignIPv4WithinVPCEnabled={
-              this.toggleAutoassignIPv4WithinVPCEnabled
-            }
-            autoassignIPv4WithinVPC={this.state.autoassignIPv4WithinVPCEnabled}
-            checkValidation={this.checkValidation}
-            diskEncryptionEnabled={this.state.diskEncryptionEnabled ?? false}
-            firewallId={this.state.selectedfirewallId}
-            handleAgreementChange={this.handleAgreementChange}
-            handleFirewallChange={this.handleFirewallChange}
-            handleIPv4RangesForVPC={this.handleVPCIPv4RangesChange}
-            handlePlacementGroupChange={this.setPlacementGroupSelection}
-            handleSelectUDFs={this.setUDFs}
-            handleShowApiAwarenessModal={this.handleShowApiAwarenessModal}
-            handleSubmitForm={this.submitForm}
-            handleSubnetChange={this.handleSubnetChange}
-            handleVLANChange={this.handleVLANChange}
-            handleVPCIPv4Change={this.handleVPCIPv4Change}
-            imageDisplayInfo={this.getImageInfo()}
-            ipamAddress={this.state.vlanIPAMAddress}
-            label={this.generateLabel()}
-            placementGroupSelection={this.state.placementGroupSelection}
-            regionDisplayInfo={this.getRegionInfo()}
-            regionsData={regionsData}
-            resetCreationState={this.clearCreationState}
-            selectedRegionID={this.state.selectedRegionID}
-            selectedUDFs={selectedUDFs}
-            selectedVPCId={this.state.selectedVPCId}
-            setAuthorizedUsers={this.setAuthorizedUsers}
-            setBackupID={this.setBackupID}
-            setSelectedVPC={this.handleVPCChange}
-            toggleAssignPublicIPv4Address={this.toggleAssignPublicIPv4Address}
-            toggleBackupsEnabled={this.toggleBackupsEnabled}
-            toggleDiskEncryptionEnabled={this.toggleDiskEncryptionEnabled}
-            togglePrivateIPEnabled={this.togglePrivateIPEnabled}
-            typeDisplayInfo={this.getTypeInfo()}
-            typesData={extendedTypeData}
-            updateDiskSize={this.setDiskSize}
-            updateImageID={this.setImageID}
-            updateLabel={this.updateCustomLabel}
-            updateLinodeID={this.setLinodeID}
-            updatePassword={this.setPassword}
-            updateRegionID={this.setRegionID}
-            updateStackScript={this.setStackScript}
-            updateTags={this.setTags}
-            updateTypeID={this.setTypeID}
-            updateUserData={this.setUserData}
-            userCannotCreateLinode={userCannotCreateLinode}
-            vlanLabel={this.state.attachedVLANLabel}
-            vpcIPv4AddressOfLinode={this.state.vpcIPv4AddressOfLinode}
-            {...restOfProps}
-            {...restOfState}
-          />
-        </Grid>
-      </React.Fragment>
-    );
-  }
-
   checkValidation: LinodeCreateValidation = (payload) => {
     try {
       CreateLinodeSchema.validateSync(payload, { abortEarly: false });
@@ -958,6 +824,138 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
   updateCustomLabel = (customLabel: string) => {
     this.setState({ customLabel });
   };
+
+  componentDidMount() {
+    // Allowed apps include the base set of original apps + anything LD tells us to show
+    if (nonImageCreateTypes.includes(this.props.createType)) {
+      // If we're navigating directly to e.g. the clone page, don't select an image by default
+      this.setState({ selectedImageID: undefined });
+    }
+  }
+
+  componentDidUpdate(prevProps: CombinedProps) {
+    /**
+     * When switching to a creation flow where
+     * having a pre-selected image is problematic,
+     * deselect it.
+     */
+    if (isNonDefaultImageType(prevProps.createType, this.props.createType)) {
+      this.setState({ selectedImageID: undefined });
+    }
+
+    // Update search params for Linode Clone
+    if (prevProps.location.search !== this.props.history.location.search) {
+      const { showGDPRCheckbox } = getGDPRDetails({
+        agreements: this.props.agreements?.data,
+        profile: this.props.profile.data,
+        regions: this.props.regionsData,
+        selectedRegionId: this.params.regionID,
+      });
+
+      this.params = getQueryParamsFromQueryString(this.props.location.search);
+
+      this.setState({
+        showGDPRCheckbox,
+      });
+    }
+  }
+
+  render() {
+    const {
+      grants,
+      profile,
+      regionsData,
+      typesData,
+      ...restOfProps
+    } = this.props;
+    const { udfs: selectedUDFs, ...restOfState } = this.state;
+
+    const extendedTypeData = typesData?.map(extendType);
+
+    const userCannotCreateLinode =
+      Boolean(profile.data?.restricted) && !grants.data?.global.add_linodes;
+
+    return (
+      <React.Fragment>
+        <DocumentTitleSegment segment="Create a Linode" />
+        <ProductInformationBanner bannerLocation="LinodeCreate" />
+        <Grid className="m0" container spacing={0}>
+          <LandingHeader
+            onDocsClick={() => {
+              sendLinodeCreateFlowDocsClickEvent('Getting Started');
+              sendLinodeCreateFormStepEvent({
+                action: 'click',
+                category: 'link',
+                createType:
+                  (this.params.type as LinodeCreateType) ?? 'Distributions',
+                label: 'Getting Started',
+                version: 'v1',
+              });
+            }}
+            docsLabel="Getting Started"
+            docsLink="https://www.linode.com/docs/guides/platform/get-started/"
+            title="Create"
+          />
+          <LinodeCreate
+            accountBackupsEnabled={
+              this.props.accountSettings.data?.backups_enabled ?? false
+            }
+            toggleAutoassignIPv4WithinVPCEnabled={
+              this.toggleAutoassignIPv4WithinVPCEnabled
+            }
+            autoassignIPv4WithinVPC={this.state.autoassignIPv4WithinVPCEnabled}
+            checkValidation={this.checkValidation}
+            diskEncryptionEnabled={this.state.diskEncryptionEnabled ?? false}
+            firewallId={this.state.selectedfirewallId}
+            handleAgreementChange={this.handleAgreementChange}
+            handleFirewallChange={this.handleFirewallChange}
+            handleIPv4RangesForVPC={this.handleVPCIPv4RangesChange}
+            handlePlacementGroupChange={this.setPlacementGroupSelection}
+            handleSelectUDFs={this.setUDFs}
+            handleShowApiAwarenessModal={this.handleShowApiAwarenessModal}
+            handleSubmitForm={this.submitForm}
+            handleSubnetChange={this.handleSubnetChange}
+            handleVLANChange={this.handleVLANChange}
+            handleVPCIPv4Change={this.handleVPCIPv4Change}
+            imageDisplayInfo={this.getImageInfo()}
+            ipamAddress={this.state.vlanIPAMAddress}
+            label={this.generateLabel()}
+            placementGroupSelection={this.state.placementGroupSelection}
+            regionDisplayInfo={this.getRegionInfo()}
+            regionsData={regionsData}
+            resetCreationState={this.clearCreationState}
+            selectedRegionID={this.state.selectedRegionID}
+            selectedUDFs={selectedUDFs}
+            selectedVPCId={this.state.selectedVPCId}
+            setAuthorizedUsers={this.setAuthorizedUsers}
+            setBackupID={this.setBackupID}
+            setSelectedVPC={this.handleVPCChange}
+            toggleAssignPublicIPv4Address={this.toggleAssignPublicIPv4Address}
+            toggleBackupsEnabled={this.toggleBackupsEnabled}
+            toggleDiskEncryptionEnabled={this.toggleDiskEncryptionEnabled}
+            togglePrivateIPEnabled={this.togglePrivateIPEnabled}
+            typeDisplayInfo={this.getTypeInfo()}
+            typesData={extendedTypeData}
+            updateDiskSize={this.setDiskSize}
+            updateImageID={this.setImageID}
+            updateLabel={this.updateCustomLabel}
+            updateLinodeID={this.setLinodeID}
+            updatePassword={this.setPassword}
+            updateRegionID={this.setRegionID}
+            updateStackScript={this.setStackScript}
+            updateTags={this.setTags}
+            updateTypeID={this.setTypeID}
+            updateUserData={this.setUserData}
+            userCannotCreateLinode={userCannotCreateLinode}
+            vlanLabel={this.state.attachedVLANLabel}
+            vpcIPv4AddressOfLinode={this.state.vpcIPv4AddressOfLinode}
+            {...restOfProps}
+            {...restOfState}
+          />
+        </Grid>
+      </React.Fragment>
+    );
+  }
 }
 
 interface CreateType {

--- a/packages/manager/src/features/Linodes/LinodesCreate/VPCCreateDrawer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/VPCCreateDrawer.tsx
@@ -13,7 +13,7 @@ import { useCreateVPC } from 'src/hooks/useCreateVPC';
 import { sendLinodeCreateFormStepEvent } from 'src/utilities/analytics/formEventAnalytics';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 
-import type { LinodeCreateQueryParams } from 'src/utilities/queryParams';
+import type { LinodeCreateQueryParams } from 'src/features/Linodes/types';
 
 interface Props {
   handleSelectVPC: (vpcId: number) => void;

--- a/packages/manager/src/features/Linodes/LinodesCreate/VPCCreateDrawer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/VPCCreateDrawer.tsx
@@ -13,7 +13,7 @@ import { useCreateVPC } from 'src/hooks/useCreateVPC';
 import { sendLinodeCreateFormStepEvent } from 'src/utilities/analytics/formEventAnalytics';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 
-import type { LinodeCreateType } from './types';
+import type { LinodeCreateQueryParams } from 'src/utilities/queryParams';
 
 interface Props {
   handleSelectVPC: (vpcId: number) => void;
@@ -25,7 +25,9 @@ interface Props {
 export const VPCCreateDrawer = (props: Props) => {
   const theme = useTheme();
   const { handleSelectVPC, onClose, open, selectedRegion } = props;
-  const queryParams = getQueryParamsFromQueryString(location.search);
+  const queryParams = getQueryParamsFromQueryString<LinodeCreateQueryParams>(
+    location.search
+  );
 
   const {
     formik,
@@ -85,8 +87,7 @@ export const VPCCreateDrawer = (props: Props) => {
                 sendLinodeCreateFormStepEvent({
                   action: 'click',
                   category: 'button',
-                  createType:
-                    (queryParams.type as LinodeCreateType) ?? 'Distributions',
+                  createType: queryParams.type ?? 'Distributions',
                   formStepName: 'Create VPC Drawer',
                   label: 'Create VPC',
                   version: 'v1',

--- a/packages/manager/src/features/Linodes/LinodesCreate/VPCPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/VPCPanel.tsx
@@ -28,8 +28,8 @@ import { REGION_CAVEAT_HELPER_TEXT } from './constants';
 import { VPCCreateDrawer } from './VPCCreateDrawer';
 
 import type { Item } from 'src/components/EnhancedSelect';
+import type { LinodeCreateQueryParams } from 'src/features/Linodes/types';
 import type { ExtendedIP } from 'src/utilities/ipUtils';
-import type { LinodeCreateQueryParams } from 'src/utilities/queryParams';
 
 export interface VPCPanelProps {
   additionalIPv4RangesForVPC: ExtendedIP[];

--- a/packages/manager/src/features/Linodes/LinodesCreate/VPCPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/VPCPanel.tsx
@@ -27,9 +27,9 @@ import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
 import { REGION_CAVEAT_HELPER_TEXT } from './constants';
 import { VPCCreateDrawer } from './VPCCreateDrawer';
 
-import type { LinodeCreateType } from './types';
 import type { Item } from 'src/components/EnhancedSelect';
 import type { ExtendedIP } from 'src/utilities/ipUtils';
+import type { LinodeCreateQueryParams } from 'src/utilities/queryParams';
 
 export interface VPCPanelProps {
   additionalIPv4RangesForVPC: ExtendedIP[];
@@ -95,7 +95,9 @@ export const VPCPanel = (props: VPCPanelProps) => {
   );
 
   const { data: vpcsData, error, isLoading } = useAllVPCsQuery();
-  const params = getQueryParamsFromQueryString(location.search);
+  const params = getQueryParamsFromQueryString<LinodeCreateQueryParams>(
+    location.search
+  );
 
   React.useEffect(() => {
     if (subnetError || vpcIPv4Error) {
@@ -152,7 +154,7 @@ export const VPCPanel = (props: VPCPanelProps) => {
             sendLinodeCreateFormStepEvent({
               action: 'click',
               category: 'link',
-              createType: (params.type as LinodeCreateType) ?? 'Distributions',
+              createType: params.type ?? 'Distributions',
               formStepName: 'VPC Panel',
               label: 'Learn more',
               version: 'v1',
@@ -196,8 +198,7 @@ export const VPCPanel = (props: VPCPanelProps) => {
               sendLinodeCreateFormStepEvent({
                 action: 'click',
                 category: 'select',
-                createType:
-                  (params.type as LinodeCreateType) ?? 'Distributions',
+                createType: params.type ?? 'Distributions',
                 formStepName: 'VPC Panel',
                 label: 'Assign VPC',
                 version: 'v1',
@@ -236,8 +237,7 @@ export const VPCPanel = (props: VPCPanelProps) => {
                     sendLinodeCreateFormStepEvent({
                       action: 'click',
                       category: 'button',
-                      createType:
-                        (params.type as LinodeCreateType) ?? 'Distributions',
+                      createType: params.type ?? 'Distributions',
                       formStepName: 'VPC Panel',
                       label: 'Create VPC',
                       version: 'v1',

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetail.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetail.tsx
@@ -14,6 +14,8 @@ import { SuspenseLoader } from 'src/components/SuspenseLoader';
 import { useLinodeQuery } from 'src/queries/linodes/linodes';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 
+import type { LinodeConfigAndDiskQueryParams } from 'src/utilities/queryParams';
+
 const LinodesDetailHeader = React.lazy(
   () => import('./LinodesDetailHeader/LinodeDetailHeader')
 );
@@ -27,7 +29,9 @@ const LinodeDetail = () => {
   const { linodeId } = useParams<{ linodeId: string }>();
   const location = useLocation();
 
-  const queryParams = getQueryParamsFromQueryString(location.search);
+  const queryParams = getQueryParamsFromQueryString<LinodeConfigAndDiskQueryParams>(
+    location.search
+  );
 
   const id = Number(linodeId);
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetail.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetail.tsx
@@ -14,7 +14,7 @@ import { SuspenseLoader } from 'src/components/SuspenseLoader';
 import { useLinodeQuery } from 'src/queries/linodes/linodes';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 
-import type { LinodeConfigAndDiskQueryParams } from 'src/utilities/queryParams';
+import type { LinodeConfigAndDiskQueryParams } from 'src/features/Linodes/types';
 
 const LinodesDetailHeader = React.lazy(
   () => import('./LinodesDetailHeader/LinodeDetailHeader')

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -37,7 +37,8 @@ import { UpgradeVolumesDialog } from './UpgradeVolumesDialog';
 
 import type { APIError } from '@linode/api-v4/lib/types';
 import type { Action } from 'src/features/Linodes/PowerActionsDialogOrDrawer';
-import type { BaseQueryParams, BooleanString } from 'src/utilities/queryParams';
+import type { BooleanString } from 'src/features/Linodes/types';
+import type { BaseQueryParams } from 'src/utilities/queryParams';
 
 interface QueryParams extends BaseQueryParams {
   delete: BooleanString;

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -1,4 +1,3 @@
-import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 
@@ -9,10 +8,7 @@ import { ProductInformationBanner } from 'src/components/ProductInformationBanne
 import { TagDrawer } from 'src/components/TagCell/TagDrawer';
 import { LinodeEntityDetail } from 'src/features/Linodes/LinodeEntityDetail';
 import { MigrateLinode } from 'src/features/Linodes/MigrateLinode/MigrateLinode';
-import {
-  Action,
-  PowerActionsDialog,
-} from 'src/features/Linodes/PowerActionsDialogOrDrawer';
+import { PowerActionsDialog } from 'src/features/Linodes/PowerActionsDialogOrDrawer';
 import { useEditableLabelState } from 'src/hooks/useEditableLabelState';
 import { useIsResourceRestricted } from 'src/hooks/useIsResourceRestricted';
 import {
@@ -39,6 +35,19 @@ import { MutationNotification } from './MutationNotification';
 import Notifications from './Notifications';
 import { UpgradeVolumesDialog } from './UpgradeVolumesDialog';
 
+import type { APIError } from '@linode/api-v4/lib/types';
+import type { Action } from 'src/features/Linodes/PowerActionsDialogOrDrawer';
+import type { BaseQueryParams, BooleanString } from 'src/utilities/queryParams';
+
+interface QueryParams extends BaseQueryParams {
+  delete: BooleanString;
+  migrate: BooleanString;
+  rebuild: BooleanString;
+  rescue: BooleanString;
+  resize: BooleanString;
+  upgrade: BooleanString;
+}
+
 const LinodeDetailHeader = () => {
   // Several routes that used to have dedicated pages (e.g. /resize, /rescue)
   // now show their content in modals instead. The logic below facilitates handling
@@ -46,7 +55,9 @@ const LinodeDetailHeader = () => {
   // logic changes the URL) to determine if a modal should be open when this component
   // is first rendered.
   const location = useLocation();
-  const queryParams = getQueryParamsFromQueryString(location.search);
+  const queryParams = getQueryParamsFromQueryString<QueryParams>(
+    location.search
+  );
 
   const match = useRouteMatch<{ linodeId: string; subpath: string }>({
     path: '/linodes/:linodeId/:subpath?',

--- a/packages/manager/src/features/Linodes/LinodesLanding/DisplayLinodes.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/DisplayLinodes.tsx
@@ -4,16 +4,12 @@ import { useLocation } from 'react-router-dom';
 
 import GridView from 'src/assets/icons/grid-view.svg';
 import GroupByTag from 'src/assets/icons/group-by-tag.svg';
-import { OrderByProps } from 'src/components/OrderBy';
-import Paginate, { PaginationProps } from 'src/components/Paginate';
-import { getMinimumPageSizeForNumberOfItems } from 'src/components/PaginationFooter/PaginationFooter';
+import Paginate from 'src/components/Paginate';
 import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFooter';
+import { getMinimumPageSizeForNumberOfItems } from 'src/components/PaginationFooter/PaginationFooter';
 import { TableBody } from 'src/components/TableBody';
 import { Tooltip } from 'src/components/Tooltip';
-import { Action } from 'src/features/Linodes/PowerActionsDialogOrDrawer';
-import { DialogType } from 'src/features/Linodes/types';
 import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
-import { LinodeWithMaintenance } from 'src/utilities/linodes';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 
 import {
@@ -23,6 +19,16 @@ import {
 import TableWrapper from './TableWrapper';
 
 import type { Config } from '@linode/api-v4/lib/linodes';
+import type { OrderByProps } from 'src/components/OrderBy';
+import type { PaginationProps } from 'src/components/Paginate';
+import type { Action } from 'src/features/Linodes/PowerActionsDialogOrDrawer';
+import type { DialogType } from 'src/features/Linodes/types';
+import type { LinodeWithMaintenance } from 'src/utilities/linodes';
+import type { BaseQueryParams } from 'src/utilities/queryParams';
+
+interface QueryParams extends BaseQueryParams {
+  page: string;
+}
 
 export interface RenderLinodesProps
   extends PaginationProps<LinodeWithMaintenance> {
@@ -87,7 +93,7 @@ export const DisplayLinodes = React.memo((props: DisplayLinodesProps) => {
   const maxPageNumber = Math.ceil(count / pageSize);
 
   const { search } = useLocation();
-  const params = getQueryParamsFromQueryString(search);
+  const params = getQueryParamsFromQueryString<QueryParams>(search);
   const queryPage = Math.min(Number(params.page), maxPageNumber) || 1;
 
   return (

--- a/packages/manager/src/features/Linodes/types.ts
+++ b/packages/manager/src/features/Linodes/types.ts
@@ -1,3 +1,6 @@
+import type { LinodeCreateType } from 'src/features/Linodes/LinodesCreate/types';
+import type { BaseQueryParams } from 'src/utilities/queryParams';
+
 export type DialogType =
   | 'delete'
   | 'detach_vlan'
@@ -7,8 +10,20 @@ export type DialogType =
   | 'rescue'
   | 'resize'
   | 'upgrade_volumes';
+
 export type OpenDialog = (
   type: DialogType,
   linodeID: number,
   linodeLabel?: string
 ) => void;
+
+export interface LinodeCreateQueryParams extends BaseQueryParams {
+  type: LinodeCreateType;
+}
+
+export interface LinodeConfigAndDiskQueryParams extends BaseQueryParams {
+  selectedDisk: string;
+  selectedLinode: string;
+}
+
+export type BooleanString = 'false' | 'true';

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
@@ -14,7 +14,8 @@ import { SupportTicketDialog } from './SupportTicketDialog';
 import TicketList from './TicketList';
 
 import type { AttachmentError } from '../SupportTicketDetail/SupportTicketDetail';
-import type { BaseQueryParams, BooleanString } from 'src/utilities/queryParams';
+import type { BooleanString } from 'src/features/Linodes/types';
+import type { BaseQueryParams } from 'src/utilities/queryParams';
 
 interface QueryParams extends BaseQueryParams {
   drawerOpen: BooleanString;

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
@@ -14,6 +14,11 @@ import { SupportTicketDialog } from './SupportTicketDialog';
 import TicketList from './TicketList';
 
 import type { AttachmentError } from '../SupportTicketDetail/SupportTicketDetail';
+import type { BaseQueryParams, BooleanString } from 'src/utilities/queryParams';
+
+interface QueryParams extends BaseQueryParams {
+  drawerOpen: BooleanString;
+}
 
 const tabs = ['open', 'closed'];
 
@@ -22,7 +27,9 @@ const SupportTicketsLanding = () => {
   const history = useHistory();
 
   /** ?drawerOpen=true to allow external links to go directly to the ticket drawer */
-  const parsedParams = getQueryParamsFromQueryString(location.search);
+  const parsedParams = getQueryParamsFromQueryString<QueryParams>(
+    location.search
+  );
 
   const stateParams = location.state;
 

--- a/packages/manager/src/features/VPCs/VPCCreate/FormComponents/SubnetContent.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/FormComponents/SubnetContent.tsx
@@ -14,7 +14,7 @@ import {
 } from './VPCCreateForm.styles';
 
 import type { APIError } from '@linode/api-v4';
-import type { LinodeCreateQueryParams } from 'src/utilities/queryParams';
+import type { LinodeCreateQueryParams } from 'src/features/Linodes/types';
 import type { SubnetFieldState } from 'src/utilities/subnets';
 
 interface Props {

--- a/packages/manager/src/features/VPCs/VPCCreate/FormComponents/SubnetContent.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/FormComponents/SubnetContent.tsx
@@ -1,4 +1,3 @@
-import { APIError } from '@linode/api-v4';
 import * as React from 'react';
 import { useLocation } from 'react-router-dom';
 
@@ -6,7 +5,6 @@ import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
 import { sendLinodeCreateFormStepEvent } from 'src/utilities/analytics/formEventAnalytics';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
-import { SubnetFieldState } from 'src/utilities/subnets';
 
 import { VPC_CREATE_FORM_SUBNET_HELPER_TEXT } from '../../constants';
 import { MultipleSubnetInput } from '../MultipleSubnetInput';
@@ -15,7 +13,9 @@ import {
   StyledHeaderTypography,
 } from './VPCCreateForm.styles';
 
-import type { LinodeCreateType } from 'src/features/Linodes/LinodesCreate/types';
+import type { APIError } from '@linode/api-v4';
+import type { LinodeCreateQueryParams } from 'src/utilities/queryParams';
+import type { SubnetFieldState } from 'src/utilities/subnets';
 
 interface Props {
   disabled?: boolean;
@@ -30,7 +30,9 @@ export const SubnetContent = (props: Props) => {
 
   const location = useLocation();
   const isFromLinodeCreate = location.pathname.includes('/linodes/create');
-  const queryParams = getQueryParamsFromQueryString(location.search);
+  const queryParams = getQueryParamsFromQueryString<LinodeCreateQueryParams>(
+    location.search
+  );
 
   return (
     <>
@@ -45,8 +47,7 @@ export const SubnetContent = (props: Props) => {
             sendLinodeCreateFormStepEvent({
               action: 'click',
               category: 'link',
-              createType:
-                (queryParams.type as LinodeCreateType) ?? 'Distributions',
+              createType: queryParams.type ?? 'Distributions',
               formStepName: 'VPC Subnets',
               label: 'Learn more',
               version: 'v1',

--- a/packages/manager/src/features/VPCs/VPCCreate/FormComponents/VPCTopSectionContent.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/FormComponents/VPCTopSectionContent.tsx
@@ -1,19 +1,19 @@
-import { Region } from '@linode/api-v4';
-import { FormikErrors } from 'formik';
 import * as React from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { Link } from 'src/components/Link';
 import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
 import { TextField } from 'src/components/TextField';
-import { CreateVPCFieldState } from 'src/hooks/useCreateVPC';
 import { sendLinodeCreateFormStepEvent } from 'src/utilities/analytics/formEventAnalytics';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 
 import { VPC_CREATE_FORM_VPC_HELPER_TEXT } from '../../constants';
 import { StyledBodyTypography } from './VPCCreateForm.styles';
 
-import type { LinodeCreateType } from 'src/features/Linodes/LinodesCreate/types';
+import type { Region } from '@linode/api-v4';
+import type { FormikErrors } from 'formik';
+import type { CreateVPCFieldState } from 'src/hooks/useCreateVPC';
+import type { LinodeCreateQueryParams } from 'src/utilities/queryParams';
 
 interface Props {
   disabled?: boolean;
@@ -28,7 +28,9 @@ export const VPCTopSectionContent = (props: Props) => {
   const { disabled, errors, isDrawer, onChangeField, regions, values } = props;
   const location = useLocation();
   const isFromLinodeCreate = location.pathname.includes('/linodes/create');
-  const queryParams = getQueryParamsFromQueryString(location.search);
+  const queryParams = getQueryParamsFromQueryString<LinodeCreateQueryParams>(
+    location.search
+  );
 
   return (
     <>
@@ -40,8 +42,7 @@ export const VPCTopSectionContent = (props: Props) => {
             sendLinodeCreateFormStepEvent({
               action: 'click',
               category: 'link',
-              createType:
-                (queryParams.type as LinodeCreateType) ?? 'Distributions',
+              createType: queryParams.type ?? 'Distributions',
               formStepName: 'Create VPC Drawer',
               label: 'Learn more',
               version: 'v1',

--- a/packages/manager/src/features/VPCs/VPCCreate/FormComponents/VPCTopSectionContent.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/FormComponents/VPCTopSectionContent.tsx
@@ -12,8 +12,8 @@ import { StyledBodyTypography } from './VPCCreateForm.styles';
 
 import type { Region } from '@linode/api-v4';
 import type { FormikErrors } from 'formik';
+import type { LinodeCreateQueryParams } from 'src/features/Linodes/types';
 import type { CreateVPCFieldState } from 'src/hooks/useCreateVPC';
-import type { LinodeCreateQueryParams } from 'src/utilities/queryParams';
 
 interface Props {
   disabled?: boolean;

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -23,7 +23,7 @@ import {
 
 import type { PlanSelectionType } from './types';
 import type { LinodeTypeClass, Region } from '@linode/api-v4';
-import type { LinodeCreateType } from 'src/features/Linodes/LinodesCreate/types';
+import type { LinodeCreateQueryParams } from 'src/utilities/queryParams';
 
 export interface PlansPanelProps {
   className?: string;
@@ -79,7 +79,9 @@ export const PlansPanel = (props: PlansPanelProps) => {
 
   const flags = useFlags();
   const location = useLocation();
-  const params = getQueryParamsFromQueryString(location.search);
+  const params = getQueryParamsFromQueryString<LinodeCreateQueryParams>(
+    location.search
+  );
 
   const { data: regionAvailabilities } = useRegionAvailabilityQuery(
     selectedRegionID || '',
@@ -97,8 +99,7 @@ export const PlansPanel = (props: PlansPanelProps) => {
   );
 
   const hideDistributedRegions =
-    !flags.gecko2?.enabled ||
-    !isDistributedRegionSupported(params.type as LinodeCreateType);
+    !flags.gecko2?.enabled || !isDistributedRegionSupported(params.type);
 
   const showDistributedRegionPlanTable =
     !hideDistributedRegions &&

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -23,7 +23,7 @@ import {
 
 import type { PlanSelectionType } from './types';
 import type { LinodeTypeClass, Region } from '@linode/api-v4';
-import type { LinodeCreateQueryParams } from 'src/utilities/queryParams';
+import type { LinodeCreateQueryParams } from 'src/features/Linodes/types';
 
 export interface PlansPanelProps {
   className?: string;

--- a/packages/manager/src/hooks/useOrder.ts
+++ b/packages/manager/src/hooks/useOrder.ts
@@ -7,8 +7,10 @@ import {
   useMutatePreferences,
   usePreferences,
 } from 'src/queries/profile/preferences';
-import { OrderSet } from 'src/types/ManagerPreferences';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
+
+import type { OrderSet } from 'src/types/ManagerPreferences';
+import type { BaseQueryParams } from 'src/utilities/queryParams';
 
 export type Order = 'asc' | 'desc';
 
@@ -34,12 +36,14 @@ export const useOrder = (
   const { mutateAsync: updatePreferences } = useMutatePreferences();
   const location = useLocation();
   const history = useHistory();
-  const params = getQueryParamsFromQueryString(location.search);
+  const params = getQueryParamsFromQueryString<BaseQueryParams>(
+    location.search
+  );
 
   const initialOrder = getInitialValuesFromUserPreferences(
     preferenceKey || '',
     preferences || {},
-    params as Record<string, string>,
+    params,
     initial?.orderBy,
     initial?.order,
     prefix

--- a/packages/manager/src/layouts/LoginAsCustomerCallback.tsx
+++ b/packages/manager/src/layouts/LoginAsCustomerCallback.tsx
@@ -7,17 +7,21 @@
  */
 
 import { PureComponent } from 'react';
-import { MapDispatchToProps, connect } from 'react-redux';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 
 import { handleStartSession } from 'src/store/authentication/authentication.actions';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
+
+import type { MapDispatchToProps } from 'react-redux';
+import type { RouteComponentProps } from 'react-router-dom';
+import type { BaseQueryParams } from 'src/utilities/queryParams';
 
 interface LoginAsCustomerCallbackProps
   extends DispatchProps,
     RouteComponentProps {}
 
-interface QueryParams {
+interface QueryParams extends BaseQueryParams {
   access_token: string;
   destination: string;
   expires_in: string;
@@ -45,9 +49,9 @@ export class LoginAsCustomerCallback extends PureComponent<LoginAsCustomerCallba
       return history.push('/');
     }
 
-    const hashParams = (getQueryParamsFromQueryString(
+    const hashParams = getQueryParamsFromQueryString<QueryParams>(
       location.hash.substr(1)
-    ) as unknown) as QueryParams;
+    );
 
     const {
       access_token: accessToken,

--- a/packages/manager/src/layouts/OAuth.test.tsx
+++ b/packages/manager/src/layouts/OAuth.test.tsx
@@ -2,10 +2,12 @@ import { isEmpty } from 'ramda';
 
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 
+import type { OAuthQueryParams } from './OAuth';
+
 describe('layouts/OAuth', () => {
   describe('parseQueryParams', () => {
     it('parses query params of the expected format', () => {
-      const res = getQueryParamsFromQueryString(
+      const res = getQueryParamsFromQueryString<OAuthQueryParams>(
         'entity=key&color=bronze&weight=20%20grams'
       );
       expect(res.entity).toBe('key');
@@ -14,12 +16,12 @@ describe('layouts/OAuth', () => {
     });
 
     it('returns an empty object for an empty string', () => {
-      const res = getQueryParamsFromQueryString('');
+      const res = getQueryParamsFromQueryString<OAuthQueryParams>('');
       expect(isEmpty(res)).toBe(true);
     });
 
     it("doesn't truncate values that include =", () => {
-      const res = getQueryParamsFromQueryString(
+      const res = getQueryParamsFromQueryString<OAuthQueryParams>(
         'access_token=123456&return=https://localhost:3000/oauth/callback?returnTo=/asdf'
       );
       expect(res.access_token).toBe('123456');

--- a/packages/manager/src/layouts/OAuth.tsx
+++ b/packages/manager/src/layouts/OAuth.tsx
@@ -1,14 +1,18 @@
 import { Component } from 'react';
-import { MapDispatchToProps, connect } from 'react-redux';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 
 import { handleStartSession } from 'src/store/authentication/authentication.actions';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 import { authentication } from 'src/utilities/storage';
 
+import type { MapDispatchToProps } from 'react-redux';
+import type { RouteComponentProps } from 'react-router-dom';
+import type { BaseQueryParams } from 'src/utilities/queryParams';
+
 interface OAuthCallbackPageProps extends DispatchProps, RouteComponentProps {}
 
-interface OAuthQueryParams {
+export interface OAuthQueryParams extends BaseQueryParams {
   access_token: string; // token for auth
   expires_in: string; // amount of time (in seconds) the token has before expiry
   return: string;
@@ -49,9 +53,9 @@ export class OAuthCallbackPage extends Component<OAuthCallbackPageProps> {
       return history.push('/');
     }
 
-    const hashParams = (getQueryParamsFromQueryString(
+    const hashParams = getQueryParamsFromQueryString<OAuthQueryParams>(
       location.hash.substr(1)
-    ) as unknown) as OAuthQueryParams;
+    );
 
     const {
       access_token: accessToken,

--- a/packages/manager/src/utilities/queryParams.ts
+++ b/packages/manager/src/utilities/queryParams.ts
@@ -1,19 +1,6 @@
-import type { LinodeCreateType } from 'src/features/Linodes/LinodesCreate/types';
-
 export interface BaseQueryParams {
   [key: string]: string;
 }
-
-export interface LinodeCreateQueryParams extends BaseQueryParams {
-  type: LinodeCreateType;
-}
-
-export interface LinodeConfigAndDiskQueryParams extends BaseQueryParams {
-  selectedDisk: string;
-  selectedLinode: string;
-}
-
-export type BooleanString = 'false' | 'true';
 
 /**
  * Parses a query string (aka search string) and returns its values

--- a/packages/manager/src/utilities/queryParams.ts
+++ b/packages/manager/src/utilities/queryParams.ts
@@ -8,6 +8,13 @@ export interface LinodeCreateQueryParams extends BaseQueryParams {
   type: LinodeCreateType;
 }
 
+export interface LinodeConfigAndDiskQueryParams extends BaseQueryParams {
+  selectedDisk: string;
+  selectedLinode: string;
+}
+
+export type BooleanString = 'false' | 'true';
+
 /**
  * Parses a query string (aka search string) and returns its values
  * as key value pairs.

--- a/packages/manager/src/utilities/queryParams.ts
+++ b/packages/manager/src/utilities/queryParams.ts
@@ -1,3 +1,13 @@
+import type { LinodeCreateType } from 'src/features/Linodes/LinodesCreate/types';
+
+export interface BaseQueryParams {
+  [key: string]: string;
+}
+
+export interface LinodeCreateQueryParams extends BaseQueryParams {
+  type: LinodeCreateType;
+}
+
 /**
  * Parses a query string (aka search string) and returns its values
  * as key value pairs.
@@ -11,8 +21,9 @@
  * getQueryParamsFromQueryString('?query=false&this=that')
  * // { query: 'false', this: 'that' }
  */
-export const getQueryParamsFromQueryString = (queryString: string) =>
-  Object.fromEntries(new URLSearchParams(queryString));
+export const getQueryParamsFromQueryString = <T extends BaseQueryParams>(
+  queryString: string
+): T => Object.fromEntries(new URLSearchParams(queryString)) as T;
 
 /**
  * Gets the value of a single query parameter by its name

--- a/packages/manager/tsconfig.json
+++ b/packages/manager/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Language and Environment */
     "jsx": "react",
-    "lib": ["dom", "es2020"],
+    "lib": ["dom", "dom.iterable", "es2020"],
     "target": "es5",
 
     /* Modules */


### PR DESCRIPTION
## Description 📝
Follow up to @jaalah's comment in https://github.com/linode/manager/pull/10479 about improving the type safety of getQueryParamsFromQueryString and removing the casting. The big diff is mostly from ESLint shuffling imports and code around

## Changes  🔄
List any change relevant to the reviewer.
- Type safe `getQueryParamsFromQueryString`
- Added `dom.iterable` to tsconfig.json

## How to test 🧪
### Verification steps
(How to verify changes)
- There should be no UI changes or regressions compared to prod

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support