### PR TITLE
fix: [M3-7684] - Incorrect Error Notice in Volume Drawers for Restricted Users

### DIFF
--- a/packages/manager/.changeset/pr-10646-fixed-1720111189359.md
+++ b/packages/manager/.changeset/pr-10646-fixed-1720111189359.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Incorrect error notification notice on Volume Drawers ([#10646](https://github.com/linode/manager/pull/10646))
+Incorrect error notice in Volume drawers for restricted users ([#10646](https://github.com/linode/manager/pull/10646))

--- a/packages/manager/.changeset/pr-10646-fixed-1720111189359.md
+++ b/packages/manager/.changeset/pr-10646-fixed-1720111189359.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Incorrect error notification notice on Volume Drawers ([#10646](https://github.com/linode/manager/pull/10646))

--- a/packages/manager/src/features/Volumes/AttachVolumeDrawer.tsx
+++ b/packages/manager/src/features/Volumes/AttachVolumeDrawer.tsx
@@ -98,7 +98,7 @@ export const AttachVolumeDrawer = React.memo((props: Props) => {
       <form onSubmit={formik.handleSubmit}>
         {isReadOnly && (
           <Notice
-            text="You don't have permission to edit this volume."
+            text="You don't have permission to attach this volume."
             variant="error"
           />
         )}

--- a/packages/manager/src/features/Volumes/ResizeVolumeDrawer.tsx
+++ b/packages/manager/src/features/Volumes/ResizeVolumeDrawer.tsx
@@ -98,7 +98,7 @@ export const ResizeVolumeDrawer = (props: Props) => {
         {isReadOnly && (
           <Notice
             spacingBottom={0}
-            text="You don't have permission to edit this volume."
+            text="You don't have permission to resize this volume."
             variant="error"
           />
         )}


### PR DESCRIPTION
## Description 📝

To prevent unauthorized access to specific flows and provide clearer guidance, we aim to restrict entry to users without the required permissions. But for these restricted users, error notices in Volume Drawers are currently not tailored to the action: The text 'edit' is incorrectly displayed on Resize Volume drawer and Attach Volume drawer; it should show 'resize' and 'attach' respectively. 

## Changes  🔄

- For restricted users: 
    - Fixed the incorrect error notices by replacing 'edit' with 'resize' and 'edit' with 'attach' on the respective Volume drawers.

## Target release date 🗓️
July 8th, 2024

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![before-resize-volume-drawer](https://github.com/linode/manager/assets/172569094/2033e2bc-1943-46bf-8e01-cead0566df78) | ![after-resize-volume-drawer](https://github.com/linode/manager/assets/172569094/644bc2b6-ba61-40d2-bd41-cc5b9e1f438e)|
| ![before-attach-volume-drawer](https://github.com/linode/manager/assets/172569094/13d844a7-e501-4c30-b4d8-d9b79ff26ba4) | ![after-attach-volume-drawer](https://github.com/linode/manager/assets/172569094/88ad1a7a-ad22-4a7b-8cca-6e694ac54580) |


## How to test 🧪

### Prerequisites
(How to setup test environment)
- Log into two accounts side by side:
     - An unrestricted admin user account: full access
     - A restricted user account (use Incognito for this)
           - Start with `Read Only` for everything


### Reproduction steps
-  As restricted user:
    - Go to Volume action drawers as a `read-only` user, and observe the error notice for each corresponding drawers.

### Verification steps
- After changes, observe error notices in Volume drawers are tailored to the action.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support