### PR TITLE
upcoming: [M3-8295] - Add feature flag and capability for OBJ Gen2

### DIFF
--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -61,9 +61,9 @@ export type BillingSource = 'linode' | 'akamai';
 
 export type AccountCapability =
   | 'Akamai Cloud Load Balancer'
-  | 'CloudPulse'
   | 'Block Storage'
   | 'Cloud Firewall'
+  | 'CloudPulse'
   | 'Disk Encryption'
   | 'Kubernetes'
   | 'Linodes'
@@ -72,6 +72,7 @@ export type AccountCapability =
   | 'Managed Databases'
   | 'NodeBalancers'
   | 'Object Storage Access Key Regions'
+  | 'Object Storage Endpoint Types'
   | 'Object Storage'
   | 'Placement Group'
   | 'Support Ticket Severity'

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -29,6 +29,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'linodeCreateRefactor', label: 'Linode Create v2' },
   { flag: 'linodeDiskEncryption', label: 'Linode Disk Encryption (LDE)' },
   { flag: 'objMultiCluster', label: 'OBJ Multi-Cluster' },
+  { flag: 'objectStorageGen2', label: 'OBJ Gen2' },
   { flag: 'placementGroups', label: 'Placement Groups' },
   { flag: 'selfServeBetas', label: 'Self Serve Betas' },
   { flag: 'supportTicketSeverity', label: 'Support Ticket Severity' },

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -96,6 +96,7 @@ export interface Flags {
   mainContentBanner: MainContentBanner;
   metadata: boolean;
   objMultiCluster: boolean;
+  objectStorageGen2: BaseFeatureFlag;
   oneClickApps: OneClickApp;
   oneClickAppsDocsOverride: Record<string, Doc[]>;
   placementGroups: BetaFeatureFlag;


### PR DESCRIPTION
## Description 📝
The `Object Storage Endpoint Types` item in the `capabilities` array is new. If present, the new API features will be enabled, and Cloud Manager will use the new UX. If absent, the new API features are disabled, and Cloud Manager will use the pre-gen2 UX. 

## Changes  🔄
No visual changes

## Target release date 🗓️
Next release 7/22

## How to test 🧪

### Verification steps
(How to verify changes)
- Ensure flag shows in dev tools (default state off)
- Feel free to use flag to test that it works

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support