### PR TITLE
upcoming: [M3-8328] - Add Analytics Events to Linode Create v2

### DIFF
--- a/packages/manager/.changeset/pr-10649-upcoming-features-1720453076417.md
+++ b/packages/manager/.changeset/pr-10649-upcoming-features-1720453076417.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add Analytics Events to Linode Create v2 ([#10649](https://github.com/linode/manager/pull/10649))

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Actions.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Actions.tsx
@@ -1,14 +1,16 @@
-import { CreateLinodeRequest } from '@linode/api-v4';
 import React, { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { Box } from 'src/components/Box';
 import { Button } from 'src/components/Button/Button';
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
+import { sendApiAwarenessClickEvent } from 'src/utilities/analytics/customEventAnalytics';
 import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
 
 import { ApiAwarenessModal } from '../LinodesCreate/ApiAwarenessModal/ApiAwarenessModal';
 import { getLinodeCreatePayload } from './utilities';
+
+import type { CreateLinodeRequest } from '@linode/api-v4';
 
 export const Actions = () => {
   const [isAPIAwarenessModalOpen, setIsAPIAwarenessModalOpen] = useState(false);
@@ -24,6 +26,7 @@ export const Actions = () => {
   });
 
   const onOpenAPIAwareness = async () => {
+    sendApiAwarenessClickEvent('Button', 'Create Using Command Line');
     if (await trigger()) {
       // If validation is successful, we open the dialog.
       setIsAPIAwarenessModalOpen(true);

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
@@ -96,9 +96,9 @@ export const LinodeCreatev2 = () => {
       });
 
       captureLinodeCreateAnalyticsEvent({
-        values,
         queryClient,
         type: params.type ?? 'Distributions',
+        values,
       });
     } catch (errors) {
       for (const error of errors) {

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
@@ -96,7 +96,7 @@ export const LinodeCreatev2 = () => {
       });
 
       captureLinodeCreateAnalyticsEvent({
-        payload,
+        values,
         queryClient,
         type: params.type ?? 'Distributions',
       });

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
@@ -1,4 +1,6 @@
 import { isEmpty } from '@linode/api-v4';
+import { useQueryClient } from '@tanstack/react-query';
+import { useSnackbar } from 'notistack';
 import React, { useEffect, useRef } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useHistory } from 'react-router-dom';
@@ -35,6 +37,7 @@ import { Marketplace } from './Tabs/Marketplace/Marketplace';
 import { StackScripts } from './Tabs/StackScripts/StackScripts';
 import { UserData } from './UserData/UserData';
 import {
+  captureLinodeCreateAnalyticsEvent,
   defaultValues,
   defaultValuesMap,
   getLinodeCreatePayload,
@@ -50,7 +53,6 @@ import type { SubmitHandler } from 'react-hook-form';
 
 export const LinodeCreatev2 = () => {
   const { params, setParams } = useLinodeCreateQueryParams();
-  const formRef = useRef<HTMLFormElement>(null);
 
   const form = useForm<LinodeCreateFormValues>({
     defaultValues,
@@ -60,9 +62,10 @@ export const LinodeCreatev2 = () => {
   });
 
   const history = useHistory();
-
+  const queryClient = useQueryClient();
   const { mutateAsync: createLinode } = useCreateLinodeMutation();
   const { mutateAsync: cloneLinode } = useCloneLinodeMutation();
+  const { enqueueSnackbar } = useSnackbar();
 
   const currentTabIndex = getTabIndex(params.type);
 
@@ -87,6 +90,16 @@ export const LinodeCreatev2 = () => {
           : await createLinode(payload);
 
       history.push(`/linodes/${linode.id}`);
+
+      enqueueSnackbar(`Your Linode ${linode.label} is being created.`, {
+        variant: 'success',
+      });
+
+      captureLinodeCreateAnalyticsEvent({
+        payload,
+        queryClient,
+        type: params.type ?? 'Distributions',
+      });
     } catch (errors) {
       for (const error of errors) {
         if (error.field) {
@@ -118,7 +131,7 @@ export const LinodeCreatev2 = () => {
         docsLink="https://www.linode.com/docs/guides/platform/get-started/"
         title="Create"
       />
-      <form onSubmit={form.handleSubmit(onSubmit)} ref={formRef}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
         <Error />
         <Stack gap={3}>
           <Tabs index={currentTabIndex} onChange={onTabChange}>

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
@@ -355,10 +355,11 @@ export const captureLinodeCreateAnalyticsEvent = async (
   }
 
   if (type === 'Clone Linode' && values.linode) {
-    // @todo use Linode Query key factory when implemented
+    const linodeId = values.linode.id;
+    // @todo use Linode query key factory when it is implemented
     const linode = await queryClient.ensureQueryData({
-      queryFn: () => getLinode(values.linode!.id),
-      queryKey: ['linodes', 'linode', values.linode.id, 'details'],
+      queryFn: () => getLinode(linodeId),
+      queryKey: ['linodes', 'linode', linodeId, 'details'],
     });
 
     sendCreateLinodeEvent('clone', values.type, {

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
@@ -337,9 +337,9 @@ export const defaultValuesMap: Record<LinodeCreateType, CreateLinodeRequest> = {
 };
 
 interface LinodeCreateAnalyticsEventOptions {
-  payload: LinodeCreateFormValues;
   queryClient: QueryClient;
   type: LinodeCreateType;
+  values: LinodeCreateFormValues;
 }
 
 /**
@@ -348,38 +348,38 @@ interface LinodeCreateAnalyticsEventOptions {
 export const captureLinodeCreateAnalyticsEvent = async (
   options: LinodeCreateAnalyticsEventOptions
 ) => {
-  const { payload, queryClient, type } = options;
+  const { queryClient, type, values } = options;
 
-  if (type === 'Backups' && payload.backup_id) {
-    sendCreateLinodeEvent('backup', String(payload.backup_id));
+  if (type === 'Backups' && values.backup_id) {
+    sendCreateLinodeEvent('backup', String(values.backup_id));
   }
 
-  if (type === 'Clone Linode' && payload.linode) {
+  if (type === 'Clone Linode' && values.linode) {
     // @todo use Linode Query key factory when implemented
     const linode = await queryClient.ensureQueryData({
-      queryFn: () => getLinode(payload.linode!.id),
-      queryKey: ['linodes', 'linode', payload.linode.id, 'details'],
+      queryFn: () => getLinode(values.linode!.id),
+      queryKey: ['linodes', 'linode', values.linode.id, 'details'],
     });
 
-    sendCreateLinodeEvent('clone', payload.type, {
+    sendCreateLinodeEvent('clone', values.type, {
       isLinodePoweredOff: linode.status === 'offline',
     });
   }
 
   if (type === 'Distributions' || type === 'Images') {
-    sendCreateLinodeEvent('image', payload.image ?? undefined);
+    sendCreateLinodeEvent('image', values.image ?? undefined);
   }
 
-  if (type === 'StackScripts' && payload.stackscript_id) {
+  if (type === 'StackScripts' && values.stackscript_id) {
     const stackscript = await queryClient.ensureQueryData(
-      stackscriptQueries.stackscript(payload.stackscript_id)
+      stackscriptQueries.stackscript(values.stackscript_id)
     );
     sendCreateLinodeEvent('stackscript', stackscript.label);
   }
 
-  if (type === 'One-Click' && payload.stackscript_id) {
+  if (type === 'One-Click' && values.stackscript_id) {
     const stackscript = await queryClient.ensureQueryData(
-      stackscriptQueries.stackscript(payload.stackscript_id)
+      stackscriptQueries.stackscript(values.stackscript_id)
     );
     sendCreateLinodeEvent('one-click', stackscript.label);
   }

--- a/packages/manager/src/queries/stackscripts.ts
+++ b/packages/manager/src/queries/stackscripts.ts
@@ -24,7 +24,7 @@ export const getAllOCAsRequest = (passedParams: Params = {}) =>
     getOneClickApps({ ...params, ...passedParams })
   )().then((data) => data.data);
 
-const stackscriptQueries = createQueryKeys('stackscripts', {
+export const stackscriptQueries = createQueryKeys('stackscripts', {
   infinite: (filter: Filter = {}) => ({
     queryFn: ({ pageParam }) =>
       getStackScripts({ page: pageParam, page_size: 25 }, filter),

--- a/packages/manager/src/utilities/analytics/customEventAnalytics.ts
+++ b/packages/manager/src/utilities/analytics/customEventAnalytics.ts
@@ -113,7 +113,7 @@ export const sendCreateNodeBalancerEvent = (eventLabel: string): void => {
 // LinodeCreateContainer.tsx
 export const sendCreateLinodeEvent = (
   eventAction: string,
-  eventLabel: string,
+  eventLabel: string | undefined,
   eventData?: CustomAnalyticsData
 ): void => {
   sendEvent({


### PR DESCRIPTION
## Description 📝

- This PR adds custom analytics events to Linode Create v2
- This PR's goal is to copy over **only events UX wanted to retain** from Linode Create v1
  - View [this doc](https://docs.google.com/spreadsheets/d/1gSYxVvRUm8bES_iiej9_Q_s7rQ-ooHLEsbjZwrluUoU/edit?gid=0#gid=0) to see what events are kept / not kept 📄 
  - The events that are retained _should_ work the same way as they did on Linode Create v1

## How to test 🧪

### Prerequisites
- Enable `Linode Create v2` feature flag 🇺🇸 
- Run `_satellite.setDebug(true)` in your browser's console ⌨️ 
- Refresh the page 🔄

### Verification steps
- Create various Linodes on different tabs of the Linode Create flow
  - Verify Analytics events fire for each creation
  - **Verify those analytics events match what Linode Create v1 would capture**

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support