### PR TITLE
feat:[M3-8330] - Improve API flexibility for useToastNotification

### DIFF
--- a/packages/manager/.changeset/pr-10654-tech-stories-1720468649871.md
+++ b/packages/manager/.changeset/pr-10654-tech-stories-1720468649871.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Improve API flexibility for useToastNotification ([#10654](https://github.com/linode/manager/pull/10654))

--- a/packages/manager/src/hooks/useToastNotifications.tsx
+++ b/packages/manager/src/hooks/useToastNotifications.tsx
@@ -161,7 +161,7 @@ const toasts: Toasts = {
     },
   },
   tax_id_invalid: {
-    failure: { message: 'Tax Identification Number has been verified.' },
+    failure: { message: 'Error validating Tax Identification Number.' },
     invertVariant: true,
     success: {
       message: 'Tax Identification Number could not be verified.',

--- a/packages/manager/src/hooks/useToastNotifications.tsx
+++ b/packages/manager/src/hooks/useToastNotifications.tsx
@@ -18,7 +18,7 @@ const formatLink = (text: string, link: string, handleClick?: () => void) => {
   );
 };
 
-type PersistType = 'both' | 'failure' | 'none' | 'success';
+type PersistType = 'both' | 'failure' | 'success';
 
 interface Toast {
   /**

--- a/packages/manager/src/hooks/useToastNotifications.tsx
+++ b/packages/manager/src/hooks/useToastNotifications.tsx
@@ -18,29 +18,19 @@ const formatLink = (text: string, link: string, handleClick?: () => void) => {
   );
 };
 
-type PersistType = 'both' | 'failure' | 'success';
+interface ToastMessage {
+  link?: JSX.Element;
+  message: ((event: Event) => string | undefined) | string;
+  persist?: boolean;
+}
 
 interface Toast {
-  /**
-   * If defined, this message will be displayed when the event fails.
-   */
-  failure?: ((event: Event) => string | undefined) | string;
+  failure?: ToastMessage;
   /**
    * If true, the toast will be displayed with an error variant.
    */
   invertVariant?: boolean;
-  /**
-   * If defined, this link will be displayed in the toast.
-   */
-  link?: JSX.Element;
-  /**
-   * If defined, the toast will persist until dismissed.
-   */
-  persist?: PersistType;
-  /**
-   * If defined, this message will be displayed when the event succeeds.
-   */
-  success?: ((event: Event) => string | undefined) | string;
+  success?: ToastMessage;
 }
 
 type Toasts = {
@@ -53,144 +43,175 @@ type Toasts = {
  *
  * Use this feature to notify users of *asynchronous tasks* such as migrating a Linode.
  *
- * DO NOT use this feature to notifiy the user of tasks like changing the label of a Linode.
- * Toasts for that can be handeled at the time of making the PUT request.
+ * DO NOT use this feature to notify the user of tasks like changing the label of a Linode.
+ * Toasts for that can be handled at the time of making the PUT request.
  */
 const toasts: Toasts = {
   backups_restore: {
-    failure: (e) => `Backup restoration failed for ${getLabel(e)}.`,
-    link: formatLink(
-      'Learn more about limits and considerations.',
-      'https://www.linode.com/docs/products/storage/backups/#limits-and-considerations'
-    ),
-    persist: 'failure',
+    failure: {
+      link: formatLink(
+        'Learn more about limits and considerations.',
+        'https://www.linode.com/docs/products/storage/backups/#limits-and-considerations'
+      ),
+      message: (e) => `Backup restoration failed for ${getLabel(e)}.`,
+      persist: true,
+    },
   },
   disk_delete: {
-    failure: (e) =>
-      `Unable to delete disk ${getSecondaryLabel(e)} ${
-        getLabel(e) ? ` on ${getLabel(e)}` : ''
-      }. Is it attached to a configuration profile that is in use?`,
-    success: (e) => `Disk ${getSecondaryLabel(e)} successfully deleted.`,
+    failure: {
+      message: (e) =>
+        `Unable to delete disk ${getSecondaryLabel(e)} ${
+          getLabel(e) ? ` on ${getLabel(e)}` : ''
+        }. Is it attached to a configuration profile that is in use?`,
+    },
+    success: {
+      message: (e) => `Disk ${getSecondaryLabel(e)} successfully deleted.`,
+    },
   },
   disk_imagize: {
-    failure: (e) =>
-      `There was a problem creating Image ${getSecondaryLabel(e)}.`,
-    link: formatLink(
-      'Learn more about image technical specifications.',
-      'https://www.linode.com/docs/products/tools/images/#technical-specifications'
-    ),
-    persist: 'failure',
-    success: (e) => `Image ${getSecondaryLabel(e)} successfully created.`,
+    failure: {
+      link: formatLink(
+        'Learn more about image technical specifications.',
+        'https://www.linode.com/docs/products/tools/images/#technical-specifications'
+      ),
+      message: (e) =>
+        `There was a problem creating Image ${getSecondaryLabel(e)}.`,
+      persist: true,
+    },
+
+    success: {
+      message: (e) => `Image ${getSecondaryLabel(e)} successfully created.`,
+    },
   },
   disk_resize: {
-    failure: `Disk resize failed.`,
-    link: formatLink(
-      'Learn more about resizing restrictions.',
-      'https://www.linode.com/docs/products/compute/compute-instances/guides/disks-and-storage/',
-      () =>
-        sendLinodeDiskEvent('Resize', 'Click:link', 'Disk resize failed toast')
-    ),
-    persist: 'failure',
-    success: (e) => `Disk ${getSecondaryLabel(e)} successfully resized.`,
+    failure: {
+      link: formatLink(
+        'Learn more about resizing restrictions.',
+        'https://www.linode.com/docs/products/compute/compute-instances/guides/disks-and-storage/',
+        () =>
+          sendLinodeDiskEvent(
+            'Resize',
+            'Click:link',
+            'Disk resize failed toast'
+          )
+      ),
+      message: `Disk resize failed.`,
+      persist: true,
+    },
+    success: {
+      message: (e) => `Disk ${getSecondaryLabel(e)} successfully resized.`,
+    },
   },
   image_delete: {
-    failure: (e) => `Error deleting Image ${getLabel(e)}.`,
-    success: (e) => `Image ${getLabel(e)} successfully deleted.`,
+    failure: { message: (e) => `Error deleting Image ${getLabel(e)}.` },
+    success: { message: (e) => `Image ${getLabel(e)} successfully deleted.` },
   },
   image_upload: {
-    failure(event) {
-      const isDeletion = event.message === 'Upload canceled.';
+    failure: {
+      message: (e) => {
+        const isDeletion = e.message === 'Upload canceled.';
 
-      if (isDeletion) {
-        return undefined;
-      }
+        if (isDeletion) {
+          return undefined;
+        }
 
-      return `There was a problem uploading image ${getLabel(
-        event
-      )}: ${event.message?.replace(/(\d+)/g, '$1 MB')}`;
+        return `There was a problem uploading image ${getLabel(
+          e
+        )}: ${e.message?.replace(/(\d+)/g, '$1 MB')}`;
+      },
+      persist: true,
     },
-    persist: 'failure',
-    success: (e) => `Image ${getLabel(e)} is now available.`,
+    success: { message: (e) => `Image ${getLabel(e)} is now available.` },
   },
   linode_clone: {
-    failure: (e) => `Error cloning Linode ${getLabel(e)}.`,
-    success: (e) =>
-      `Linode ${getLabel(e)} successfully cloned to ${getSecondaryLabel(e)}.`,
+    failure: { message: (e) => `Error cloning Linode ${getLabel(e)}.` },
+    success: {
+      message: (e) =>
+        `Linode ${getLabel(e)} successfully cloned to ${getSecondaryLabel(e)}.`,
+    },
   },
   linode_migrate: {
-    failure: (e) => `Error migrating Linode ${getLabel(e)}.`,
-    success: (e) => `Linode ${getLabel(e)} successfully migrated.`,
+    failure: { message: (e) => `Error migrating Linode ${getLabel(e)}.` },
+    success: { message: (e) => `Linode ${getLabel(e)} successfully migrated.` },
   },
   linode_migrate_datacenter: {
-    failure: (e) => `Error migrating Linode ${getLabel(e)}.`,
-    success: (e) => `Linode ${getLabel(e)} successfully migrated.`,
+    failure: { message: (e) => `Error migrating Linode ${getLabel(e)}.` },
+    success: { message: (e) => `Linode ${getLabel(e)} successfully migrated.` },
   },
   linode_resize: {
-    failure: (e) => `Error resizing Linode ${getLabel(e)}.`,
-    success: (e) => `Linode ${getLabel(e)} successfully resized.`,
+    failure: { message: (e) => `Error resizing Linode ${getLabel(e)}.` },
+    success: { message: (e) => `Linode ${getLabel(e)} successfully resized.` },
   },
   linode_snapshot: {
-    failure: (e) => `Snapshot backup failed on Linode ${getLabel(e)}.`,
-    link: formatLink(
-      'Learn more about limits and considerations.',
-      'https://www.linode.com/docs/products/storage/backups/#limits-and-considerations'
-    ),
-    persist: 'failure',
+    failure: {
+      link: formatLink(
+        'Learn more about limits and considerations.',
+        'https://www.linode.com/docs/products/storage/backups/#limits-and-considerations'
+      ),
+      message: (e) => `Snapshot backup failed on Linode ${getLabel(e)}.`,
+      persist: true,
+    },
   },
   longviewclient_create: {
-    failure: (e) => `Error creating Longview Client ${getLabel(e)}.`,
-    success: (e) => `Longview Client ${getLabel(e)} successfully created.`,
+    failure: {
+      message: (e) => `Error creating Longview Client ${getLabel(e)}.`,
+    },
+    success: {
+      message: (e) => `Longview Client ${getLabel(e)} successfully created.`,
+    },
   },
   tax_id_invalid: {
-    failure: 'Tax Identification Number has been verified.',
+    failure: { message: 'Tax Identification Number has been verified.' },
     invertVariant: true,
-    persist: 'success',
-    success: 'Tax Identification Number could not be verified.',
+    success: {
+      message: 'Tax Identification Number could not be verified.',
+      persist: true,
+    },
   },
   volume_attach: {
-    failure: (e) => `Error attaching Volume ${getLabel(e)}.`,
-    success: (e) => `Volume ${getLabel(e)} successfully attached.`,
+    failure: { message: (e) => `Error attaching Volume ${getLabel(e)}.` },
+    success: { message: (e) => `Volume ${getLabel(e)} successfully attached.` },
   },
   volume_create: {
-    failure: (e) => `Error creating Volume ${getLabel(e)}.`,
-    success: (e) => `Volume ${getLabel(e)} successfully created.`,
+    failure: { message: (e) => `Error creating Volume ${getLabel(e)}.` },
+    success: { message: (e) => `Volume ${getLabel(e)} successfully created.` },
   },
   volume_delete: {
-    failure: 'Error deleting Volume.',
-    success: 'Volume successfully deleted.',
+    failure: { message: 'Error deleting Volume.' },
+    success: { message: 'Volume successfully deleted.' },
   },
   volume_detach: {
-    failure: (e) => `Error detaching Volume ${getLabel(e)}.`,
-    success: (e) => `Volume ${getLabel(e)} successfully detached.`,
+    failure: { message: (e) => `Error detaching Volume ${getLabel(e)}.` },
+    success: { message: (e) => `Volume ${getLabel(e)} successfully detached.` },
   },
   volume_migrate: {
-    failure: (e) => `Error upgrading Volume ${getLabel(e)}.`,
-    success: (e) => `Volume ${getLabel(e)} successfully upgraded.`,
+    failure: { message: (e) => `Error upgrading Volume ${getLabel(e)}.` },
+    success: { message: (e) => `Volume ${getLabel(e)} successfully upgraded.` },
   },
 };
 
 const getToastMessage = (
   toastMessage: ((event: Event) => string | undefined) | string,
   event: Event
-): string | undefined => {
-  if (typeof toastMessage === 'function') {
-    return toastMessage(event);
-  }
-  return toastMessage;
-};
+): string | undefined =>
+  typeof toastMessage === 'function' ? toastMessage(event) : toastMessage;
 
-const getPersistOption = (
-  persist: PersistType | undefined,
-  success: boolean
-): boolean | undefined => {
-  if (success && (persist === 'success' || persist === 'both')) {
-    return true;
-  }
-  if (!success && (persist === 'failure' || persist === 'both')) {
-    return true;
-  }
-  return undefined;
-};
+const createFormattedMessage = (
+  message: string | undefined,
+  link: JSX.Element | undefined,
+  hasSupportLink: boolean
+) => (
+  <>
+    {message?.replace(/ contact Support/i, '') ?? message}
+    {hasSupportLink && (
+      <>
+        &nbsp;
+        <SupportLink text="contact Support" title={message} />.
+      </>
+    )}
+    {link && <>&nbsp;{link}</>}
+  </>
+);
 
 export const useToastNotifications = (): {
   handleGlobalToast: (event: Event) => void;
@@ -206,34 +227,35 @@ export const useToastNotifications = (): {
     const isSuccessEvent = ['finished', 'notification'].includes(event.status);
 
     if (isSuccessEvent && toastInfo.success) {
-      const successMessage = getToastMessage(toastInfo.success, event);
+      const { link, message, persist } = toastInfo.success;
+      const successMessage = getToastMessage(message, event);
 
-      enqueueSnackbar(successMessage, {
-        persist: getPersistOption(toastInfo.persist, true),
+      const formattedSuccessMessage = createFormattedMessage(
+        successMessage,
+        link,
+        false
+      );
+
+      enqueueSnackbar(formattedSuccessMessage, {
+        persist: persist ?? false,
         variant: toastInfo.invertVariant ? 'error' : 'success',
       });
     }
 
     if (event.status === 'failed' && toastInfo.failure) {
-      const failureMessage = getToastMessage(toastInfo.failure, event);
+      const { link, message, persist } = toastInfo.failure;
+      const failureMessage = getToastMessage(message, event);
       const hasSupportLink =
         failureMessage?.includes('contact Support') ?? false;
 
-      const formattedFailureMessage = (
-        <>
-          {failureMessage?.replace(/ contact Support/i, '') ?? failureMessage}
-          {hasSupportLink && (
-            <>
-              &nbsp;
-              <SupportLink text="contact Support" title={failureMessage} />.
-            </>
-          )}
-          {toastInfo.link && <>&nbsp;{toastInfo.link}</>}
-        </>
+      const formattedFailureMessage = createFormattedMessage(
+        failureMessage,
+        link,
+        hasSupportLink
       );
 
       enqueueSnackbar(formattedFailureMessage, {
-        persist: getPersistOption(toastInfo.persist, false),
+        persist: persist ?? false,
         variant: toastInfo.invertVariant ? 'success' : 'error',
       });
     }


### PR DESCRIPTION
## Description 📝
We need to enhance the API of this hook to increase its flexibility in handling event notifications. For example, we have a new event, `tax_id_invalid`. When this event is successful (indicating the tax ID is invalid), we want to display the error variant and ensure the notification persists. Currently, there's no way to easily inverse the toast variant depending on the event.

## Changes  🔄
- Renamed `persistFailureMessage` to `persist`
- Added `tax_id_invalid` event which is feature flagged
- Added an `invertVariant` property to handle scenarios where a successful negative event should be represented as an `error` variant.
- Added new interface:
```
interface ToastMessage {
  link?: JSX.Element;
  message: ((event: Event) => string | undefined) | string;
  persist?: boolean;
}
```

## Target release date 🗓️
7/22

## How to test 🧪
### Verification steps
(How to verify changes)
- Trigger any of the events listed in the hook
- Example: Create a volume and observe the multiple toasts that appear
- Manually add these properties to `volume_create`:
```
invertVariant: true,
persist: 'success',
```
- Observe the success should now be an error toast and it should be persisted.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support