### PR TITLE
fix: Github CLI install link in Contributing guide

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Feel free to open an issue to report a bug or request a feature.
 6. Open a pull request against `develop` and make sure the title follows the same format as the commit message.
 7. If needed, create a changeset to populate our changelog
     - If you don't have the Github CLI installed or need to update it (you need GH CLI 2.21.0 or greater),
-        - install it via `brew`: https://cli.github.com/manual/installation or upgrade with `brew upgrade gh`
+        - install it via `brew`: https://github.com/cli/cli#installation or upgrade with `brew upgrade gh`
         - Once installed, run `gh repo set-default` and pick `linode/manager` (only > 2.21.0)
         - You can also just create the changeset manually, in this case make sure to use the proper formatting for it.
     - Run `yarn changeset`from the root, choose the package to create a changeset for, and provide a description for the change.

--- a/packages/manager/.changeset/pr-10657-fixed-1720475119486.md
+++ b/packages/manager/.changeset/pr-10657-fixed-1720475119486.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Github CLI install link in Contributing guide ([#10657](https://github.com/linode/manager/pull/10657))


### PR DESCRIPTION
## Description 📝
Fix the github CLI link in our contributing guide leading to a 404 error

## How to test 🧪
### Reproduction steps
(How to reproduce the issue, if applicable)
- Go to the old link https://cli.github.com/manual/installation and notice a 404 error

### Verification steps
(How to verify changes)
- Go to the new link https://github.com/cli/cli#installation, there should not be a 404 error

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support