### PR TITLE
fix: [M3-6518] - LKE details page "Delete Pool" button misaligned

### DIFF
--- a/packages/manager/.changeset/pr-10660-fixed-1720504089793.md
+++ b/packages/manager/.changeset/pr-10660-fixed-1720504089793.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fix LKE details page 'Delete Pool' button misalignment ([#10660](https://github.com/linode/manager/pull/10660))

--- a/packages/manager/.changeset/pr-10660-fixed-1720504089793.md
+++ b/packages/manager/.changeset/pr-10660-fixed-1720504089793.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Fix LKE details page 'Delete Pool' button misalignment ([#10660](https://github.com/linode/manager/pull/10660))
+LKE details page 'Delete Pool' button misalignment ([#10660](https://github.com/linode/manager/pull/10660))

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -38,7 +38,6 @@ const useStyles = makeStyles()((theme: Theme) => ({
     paddingRight: 8,
   },
   deletePoolBtn: {
-    marginBottom: 3,
     paddingRight: 8,
   },
 }));


### PR DESCRIPTION
## Description 📝
The "Delete Pool" button on the LKE details page is misaligned and positioned a few pixels higher than the other nearby buttons.
<img width="560" alt="Screenshot 2023-04-24 at 3 08 57 PM" src="https://github.com/linode/manager/assets/172569094/6fa9692f-7b89-4ce7-8075-265767657ca5">


## Changes  🔄
- Removed unnecessary bottom margin for the "Delete Pool" button


## Target release date 🗓️
22nd July 2024

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![before](https://github.com/linode/manager/assets/172569094/3dac3458-cb30-4c4f-89fe-3d2bea19b619) | ![after](https://github.com/linode/manager/assets/172569094/fa90b9a6-849f-423d-abbf-144c483aa605) |

## How to test 🧪

### Reproduction steps
- Create an LKE cluster
- Navigate to the LKE cluster's details page
- Observe that "Delete Pools" button is misaligned with nearby buttons

### Verification steps
(How to verify changes)
- Ensure that it is visually aligned with the other nearby buttons.
- Verify that the "Delete Pool" button is no longer positioned higher than the other buttons.
- Confirm that the unnecessary bottom margin has been removed and that the button is now in line with neighboring buttons.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support