### PR TITLE
change: [M3-8329] - Clean up Gravatar analytics events

### DIFF
--- a/packages/manager/.changeset/pr-10661-removed-1720547888843.md
+++ b/packages/manager/.changeset/pr-10661-removed-1720547888843.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Removed
+---
+
+Gravatar analytics events ([#10661](https://github.com/linode/manager/pull/10661))

--- a/packages/manager/src/components/GravatarByEmail.tsx
+++ b/packages/manager/src/components/GravatarByEmail.tsx
@@ -2,18 +2,11 @@ import Avatar from '@mui/material/Avatar';
 import * as React from 'react';
 
 import UserIcon from 'src/assets/icons/account.svg';
-import { sendHasGravatarEvent } from 'src/utilities/analytics/customEventAnalytics';
-import { waitForAdobeAnalyticsToBeLoaded } from 'src/utilities/analytics/utils';
 import { getGravatarUrl } from 'src/utilities/gravatar';
 
 export const DEFAULT_AVATAR_SIZE = 28;
 
 interface Props {
-  /**
-   * Captures a "has gravatar" event when when the component is mounted
-   * @default false
-   */
-  captureAnalytics?: boolean;
   className?: string;
   email: string;
   height?: number;
@@ -22,7 +15,6 @@ interface Props {
 
 export const GravatarByEmail = (props: Props) => {
   const {
-    captureAnalytics,
     className,
     email,
     height = DEFAULT_AVATAR_SIZE,
@@ -30,12 +22,6 @@ export const GravatarByEmail = (props: Props) => {
   } = props;
 
   const url = getGravatarUrl(email);
-
-  React.useEffect(() => {
-    if (captureAnalytics) {
-      checkForGravatarAndSendEvent(url);
-    }
-  }, []);
 
   return (
     <Avatar
@@ -48,28 +34,3 @@ export const GravatarByEmail = (props: Props) => {
     </Avatar>
   );
 };
-
-/**
- * Given a Gravatar URL, this function waits for Adobe Analytics
- * to load (if it is not already loaded) and captures an Analytics
- * event saying whether or not the user has a Gravatar.
- *
- * Make sure the URL passed has `?d=404`
- */
-async function checkForGravatarAndSendEvent(url: string) {
-  try {
-    await waitForAdobeAnalyticsToBeLoaded();
-
-    const response = await fetch(url);
-
-    if (response.status === 200) {
-      sendHasGravatarEvent(true);
-    }
-    if (response.status === 404) {
-      sendHasGravatarEvent(false);
-    }
-  } catch (error) {
-    // Analytics didn't load or the fetch to Gravatar
-    // failed. Event won't be logged.
-  }
-}

--- a/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.tsx
@@ -16,10 +16,10 @@ import { Typography } from 'src/components/Typography';
 import { RESTRICTED_FIELD_TOOLTIP } from 'src/features/Account/constants';
 import { useNotificationsQuery } from 'src/queries/account/notifications';
 import { useMutateProfile, useProfile } from 'src/queries/profile/profile';
-import { ApplicationState } from 'src/store';
-import { sendManageGravatarEvent } from 'src/utilities/analytics/customEventAnalytics';
 
 import { TimezoneForm } from './TimezoneForm';
+
+import type { ApplicationState } from 'src/store';
 
 export const DisplaySettings = () => {
   const theme = useTheme();
@@ -111,11 +111,7 @@ export const DisplaySettings = () => {
                 Create, upload, and manage your globally recognized avatar from
                 a single place with Gravatar.
               </StyledProfileCopy>
-              <StyledAddImageLink
-                external
-                onClick={() => sendManageGravatarEvent()}
-                to="https://en.gravatar.com/"
-              >
+              <StyledAddImageLink external to="https://en.gravatar.com/">
                 Manage photo
               </StyledAddImageLink>
             </div>

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -209,7 +209,7 @@ export const UserMenu = React.memo(() => {
             isProxyUser ? (
               <GravatarForProxy />
             ) : (
-              <GravatarByEmail captureAnalytics email={profile?.email ?? ''} />
+              <GravatarByEmail email={profile?.email ?? ''} />
             )
           }
           sx={(theme) => ({

--- a/packages/manager/src/utilities/analytics/customEventAnalytics.ts
+++ b/packages/manager/src/utilities/analytics/customEventAnalytics.ts
@@ -452,24 +452,6 @@ export const sendUpdateLinodeLabelEvent = (
   });
 };
 
-// GravatarByEmail.tsx
-export const sendHasGravatarEvent = (hasGravatar: boolean) => {
-  sendEvent({
-    action: 'Load',
-    category: 'Gravatar',
-    label: hasGravatar ? 'Has Gravatar' : 'Does not have Gravatar',
-  });
-};
-
-// DisplaySettings.tsx
-export const sendManageGravatarEvent = () => {
-  sendEvent({
-    action: 'Click:link',
-    category: 'Gravatar',
-    label: 'Manage photo',
-  });
-};
-
 // SelectLinodePanel.tsx
 // LinodeSelectTable.tsx
 export const sendLinodePowerOffEvent = (category: string) => {


### PR DESCRIPTION
## Description 📝
In #10389, we tagged Gravatar components to determine whether we can justify sunsetting support for it. Now that we have collected data for a period of time and this Product decision has been made, we can save analytics calls and costs by untagging Gravatar-related analytics.

## Changes  🔄
- Removes analytics events `sendHasGravatarEvent` and `sendManageGravatarEvent`

## Target release date 🗓️
7/22

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Ensure your `REACT_APP_ADOBE_ANALYTICS_URL` environment variable is set in `.env`
- Run `window._satellite.setDebug(true)` in your browser console
- Refresh your page

### Verification steps
(How to verify changes)
| Before  | After   |
| ------- | ------- |
| When the page loads, verify you **do not** see an analytics event like this if you have a Gravatar| ![Screenshot 2024-04-18 at 3 57 07 PM](https://github.com/linode/manager/assets/115251059/bf1ab9e9-b062-445c-9a3f-27c9e73ee8a4) |
| When the page loads, verify you **do not** see an event like this if you *don't* have a Gravatar | ![Screenshot 2024-04-18 at 4 01 36 PM](https://github.com/linode/manager/assets/115251059/092477e7-abf9-4bc0-9d72-5cd1ede7c9c6) |
| Verify you **do not** see this event when you click `Manage Photo` on the `http://localhost:3000/profile/display` page | ![Screenshot 2024-04-18 at 4 04 14 PM](https://github.com/linode/manager/assets/115251059/515a2a3c-72a9-4cd0-9a68-41e529ea0372) |

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
