### PR TITLE
fix: [M3-8337] - User Preferences not being cached properly when the app loads 

### DIFF
--- a/packages/manager/.changeset/pr-10663-fixed-1720582006219.md
+++ b/packages/manager/.changeset/pr-10663-fixed-1720582006219.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+User Preferences not properly being cached when the app loads ([#10663](https://github.com/linode/manager/pull/10663))

--- a/packages/manager/src/hooks/useInitialRequests.ts
+++ b/packages/manager/src/hooks/useInitialRequests.ts
@@ -1,4 +1,3 @@
-import { getUserPreferences } from '@linode/api-v4/lib/profile';
 import { useQueryClient } from '@tanstack/react-query';
 import * as React from 'react';
 
@@ -47,8 +46,6 @@ export const useInitialRequests = () => {
    * 1. App begins load; users see splash screen
    * 2. Initial requests (in makeInitialRequests) are made (account, profile, etc.)
    * 3. Initial requests complete; app is marked as done loading
-   * 4. As splash screen goes away, secondary requests (in makeSecondaryRequests -- Linodes, types, regions)
-   * are kicked off
    */
   const makeInitialRequests = async () => {
     // When loading Lish we avoid all this extra data loading
@@ -57,26 +54,13 @@ export const useInitialRequests = () => {
       return;
     }
 
-    // Initial Requests: Things we need immediately (before rendering the app)
-    const dataFetchingPromises: Promise<any>[] = [
-      // Fetch user's account information
-      queryClient.prefetchQuery(accountQueries.account),
-
-      // Is a user managed
-      queryClient.prefetchQuery(accountQueries.settings),
-
-      // Username and whether a user is restricted
-      queryClient.prefetchQuery(profileQueries.profile()),
-
-      // preferences
-      queryClient.prefetchQuery({
-        queryFn: getUserPreferences,
-        queryKey: ['preferences'],
-      }),
-    ];
-
     try {
-      await Promise.all(dataFetchingPromises);
+      await Promise.all([
+        queryClient.prefetchQuery(accountQueries.account),
+        queryClient.prefetchQuery(accountQueries.settings),
+        queryClient.prefetchQuery(profileQueries.profile()),
+        queryClient.prefetchQuery(profileQueries.preferences),
+      ]);
     } finally {
       setIsLoading(false);
     }

--- a/packages/manager/src/hooks/useInitialRequests.ts
+++ b/packages/manager/src/hooks/useInitialRequests.ts
@@ -55,6 +55,7 @@ export const useInitialRequests = () => {
     }
 
     try {
+      // Initial Requests: Things we want immediately (before rendering the app)
       await Promise.all([
         queryClient.prefetchQuery(accountQueries.account),
         queryClient.prefetchQuery(accountQueries.settings),


### PR DESCRIPTION
## Description 📝

- I forgot to do this in https://github.com/linode/manager/pull/10543 😣
- Updates `useInitialRequests` to use the preferences query key factory 🏭  so that it stores prefetched preferences in the correct query key 🔑 
- This _should_ fix what @johnwcallahan observed because preferences will properly loaded before the splash screen is hidden 👁️ 🚫 
  - > when I refresh https://cloud.linode.com/linodes, I briefly see the CDS banner before it disappears (I have previously dismissed it)

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-07-09 at 11 21 00 PM](https://github.com/linode/manager/assets/115251059/c4764c4e-1489-4c2f-9f67-5b31a321aed1) | ![Screenshot 2024-07-09 at 11 20 26 PM](https://github.com/linode/manager/assets/115251059/ee4bcaff-7f8b-4f19-916e-05a7956c2e67) |

## How to test 🧪

- Verify only 1️⃣  fetch to `/v4/profile/preferences` happens when the app loads 💻 
- Verify preferences are only stored with the query key `["profile",   "preferences"]` using the TanStack Query dev tools 🧰 

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support