### PR TITLE
fix: [M3-8342] - Toast Notifications for Images 

### DIFF
--- a/packages/manager/.changeset/pr-10664-fixed-1720621088378.md
+++ b/packages/manager/.changeset/pr-10664-fixed-1720621088378.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Blank toast notification when canceling an image upload ([#10664](https://github.com/linode/manager/pull/10664))

--- a/packages/manager/src/components/Snackbar/Snackbar.tsx
+++ b/packages/manager/src/components/Snackbar/Snackbar.tsx
@@ -2,7 +2,6 @@ import { styled } from '@mui/material/styles';
 import { MaterialDesignContent } from 'notistack';
 import { SnackbarProvider } from 'notistack';
 import * as React from 'react';
-import { makeStyles } from 'tss-react/mui';
 
 import { CloseSnackbar } from './CloseSnackbar';
 
@@ -30,34 +29,7 @@ const StyledMaterialDesignContent = styled(MaterialDesignContent)(
   })
 );
 
-const useStyles = makeStyles()((theme: Theme) => ({
-  root: {
-    '& .notistack-MuiContent': {
-      color: theme.notificationToast.default.color,
-      fontSize: '0.875rem',
-    },
-    '& .notistack-MuiContent-default': {
-      backgroundColor: theme.notificationToast.default.backgroundColor,
-      borderLeft: theme.notificationToast.default.borderLeft,
-    },
-    [theme.breakpoints.down('md')]: {
-      '& .SnackbarItem-contentRoot': {
-        flexWrap: 'nowrap',
-      },
-      '& .SnackbarItem-message': {
-        display: 'unset',
-      },
-    },
-    [theme.breakpoints.down('sm')]: {
-      '& .SnackbarItem-action': {
-        paddingLeft: 0,
-      },
-    },
-  },
-}));
-
 export const Snackbar = (props: SnackbarProviderProps) => {
-  const { classes } = useStyles();
   /**
    * This pattern is taken from the Notistack docs:
    * https://iamhosseindhv.com/notistack/demos#action-for-all-snackbars
@@ -87,9 +59,6 @@ export const Snackbar = (props: SnackbarProviderProps) => {
           text="Dismiss Notification"
         />
       )}
-      classes={{
-        root: classes.root,
-      }}
     >
       {children}
     </SnackbarProvider>

--- a/packages/manager/src/components/Snackbar/Snackbar.tsx
+++ b/packages/manager/src/components/Snackbar/Snackbar.tsx
@@ -10,6 +10,9 @@ import type { SnackbarProviderProps } from 'notistack';
 
 const StyledMaterialDesignContent = styled(MaterialDesignContent)(
   ({ theme }: { theme: Theme }) => ({
+    '&.notistack-MuiContent': {
+      flexWrap: 'unset',
+    },
     '&.notistack-MuiContent-error': {
       backgroundColor: theme.notificationToast.error.backgroundColor,
       borderLeft: theme.notificationToast.error.borderLeft,

--- a/packages/manager/src/components/Snackbar/Snackbar.tsx
+++ b/packages/manager/src/components/Snackbar/Snackbar.tsx
@@ -11,7 +11,12 @@ import type { SnackbarProviderProps } from 'notistack';
 const StyledMaterialDesignContent = styled(MaterialDesignContent)(
   ({ theme }: { theme: Theme }) => ({
     '&.notistack-MuiContent': {
+      color: theme.notificationToast.default.color,
       flexWrap: 'unset',
+    },
+    '&.notistack-MuiContent-default': {
+      backgroundColor: theme.notificationToast.default.backgroundColor,
+      borderLeft: theme.notificationToast.default.borderLeft,
     },
     '&.notistack-MuiContent-error': {
       backgroundColor: theme.notificationToast.error.backgroundColor,

--- a/packages/manager/src/components/Snackbar/Snackbar.tsx
+++ b/packages/manager/src/components/Snackbar/Snackbar.tsx
@@ -51,6 +51,7 @@ export const Snackbar = (props: SnackbarProviderProps) => {
       ref={notistackRef}
       {...rest}
       Components={{
+        default: StyledMaterialDesignContent,
         error: StyledMaterialDesignContent,
         info: StyledMaterialDesignContent,
         success: StyledMaterialDesignContent,

--- a/packages/manager/src/components/Snackbar/Snackbar.tsx
+++ b/packages/manager/src/components/Snackbar/Snackbar.tsx
@@ -13,6 +13,9 @@ const StyledMaterialDesignContent = styled(MaterialDesignContent)(
     '&.notistack-MuiContent': {
       color: theme.notificationToast.default.color,
       flexWrap: 'unset',
+      [theme.breakpoints.up('md')]: {
+        maxWidth: '400px',
+      },
     },
     '&.notistack-MuiContent-default': {
       backgroundColor: theme.notificationToast.default.backgroundColor,

--- a/packages/manager/src/components/Snackbar/ToastNotifications.stories.tsx
+++ b/packages/manager/src/components/Snackbar/ToastNotifications.stories.tsx
@@ -5,7 +5,10 @@ import { Button } from 'src/components/Button/Button';
 import { Snackbar } from 'src/components/Snackbar/Snackbar';
 import { getEventMessage } from 'src/features/Events/utils';
 
+import { Stack } from '../Stack';
+
 import type { Meta, StoryObj } from '@storybook/react';
+import type { VariantType } from 'notistack';
 
 /**
  * #### Timing
@@ -55,23 +58,10 @@ function Template(args: any) {
   );
 }
 
-function MyButton(args: any) {
-  const { onClick, sx, variant } = args;
-  const handleClick = () => {
-    // just call the onClick with the provided variant
-    onClick(variant);
-  };
-  return (
-    <Button buttonType="primary" onClick={handleClick} sx={sx}>
-      {variant}
-    </Button>
-  );
-}
-
 function Example() {
   const { enqueueSnackbar } = useSnackbar();
-  const variants = ['default', 'success', 'warning', 'error', 'info'];
-  const showToast = (variant: any) =>
+  const variants = ['default', 'success', 'warning', 'error', 'info'] as const;
+  const showToast = (variant: VariantType) =>
     enqueueSnackbar(
       'Toast message. This will auto destruct after five seconds.',
       {
@@ -79,22 +69,17 @@ function Example() {
       }
     );
   return (
-    // eslint-disable-next-line react/jsx-no-useless-fragment
-    <>
-      {variants.map((eachVariant) => {
-        // map over each variant and show a button for each
-        return (
-          <MyButton
-            sx={{
-              margin: '0 5px',
-            }}
-            key={eachVariant}
-            onClick={showToast}
-            variant={eachVariant}
-          />
-        );
-      })}
-    </>
+    <Stack direction="row" flexWrap="wrap" gap={1}>
+      {variants.map((variant) => (
+        <Button
+          buttonType="primary"
+          key={variant}
+          onClick={() => showToast(variant)}
+        >
+          {variant}
+        </Button>
+      ))}
+    </Stack>
   );
 }
 
@@ -120,24 +105,52 @@ export const WithEventMessage: Story = {
         status: 'notification',
       });
 
-      const showToast = (variant: any) =>
-        enqueueSnackbar(message, {
-          variant,
-        });
       return (
-        <MyButton
-          sx={{
-            margin: 2,
-          }}
-          onClick={showToast}
-          variant={'success'}
-        />
+        <Button
+          buttonType="primary"
+          onClick={() => enqueueSnackbar(message, { variant: 'success' })}
+        >
+          Toast with Event
+        </Button>
       );
     };
 
     return (
       <Snackbar {...args}>
         <WithEventMessage />
+      </Snackbar>
+    );
+  },
+};
+
+export const WithLongMessage: Story = {
+  args: {
+    anchorOrigin: { horizontal: 'right', vertical: 'bottom' },
+    hideIconVariant: true,
+    maxSnack: 5,
+  },
+  render: (args) => {
+    const WithLongMessage = () => {
+      const { enqueueSnackbar } = useSnackbar();
+
+      return (
+        <Button
+          onClick={() =>
+            enqueueSnackbar(
+              'Tax Identification Number could not be verified. Please check your Tax ID for accuracy or contact customer support for assistance.',
+              { variant: 'error' }
+            )
+          }
+          buttonType="primary"
+        >
+          Toast with Long Message
+        </Button>
+      );
+    };
+
+    return (
+      <Snackbar {...args}>
+        <WithLongMessage />
       </Snackbar>
     );
   },

--- a/packages/manager/src/hooks/useToastNotifications.tsx
+++ b/packages/manager/src/hooks/useToastNotifications.tsx
@@ -3,10 +3,10 @@ import * as React from 'react';
 
 import { Link } from 'src/components/Link';
 import { SupportLink } from 'src/components/SupportLink';
+import { Typography } from 'src/components/Typography';
 import { sendLinodeDiskEvent } from 'src/utilities/analytics/customEventAnalytics';
 
 import type { Event, EventAction } from '@linode/api-v4';
-import { Typography } from 'src/components/Typography';
 
 export const getLabel = (event: Event) => event.entity?.label ?? '';
 export const getSecondaryLabel = (event: Event) =>
@@ -231,34 +231,39 @@ export const useToastNotifications = (): {
       const { link, message, persist } = toastInfo.success;
       const successMessage = getToastMessage(message, event);
 
-      const formattedSuccessMessage = createFormattedMessage(
-        successMessage,
-        link,
-        false
-      );
+      if (successMessage) {
+        const formattedSuccessMessage = createFormattedMessage(
+          successMessage,
+          link,
+          false
+        );
 
-      enqueueSnackbar(formattedSuccessMessage, {
-        persist: persist ?? false,
-        variant: toastInfo.invertVariant ? 'error' : 'success',
-      });
+        enqueueSnackbar(formattedSuccessMessage, {
+          persist: persist ?? false,
+          variant: toastInfo.invertVariant ? 'error' : 'success',
+        });
+      }
     }
 
     if (event.status === 'failed' && toastInfo.failure) {
       const { link, message, persist } = toastInfo.failure;
       const failureMessage = getToastMessage(message, event);
-      const hasSupportLink =
-        failureMessage?.includes('contact Support') ?? false;
 
-      const formattedFailureMessage = createFormattedMessage(
-        failureMessage,
-        link,
-        hasSupportLink
-      );
+      if (failureMessage) {
+        const hasSupportLink =
+          failureMessage?.includes('contact Support') ?? false;
 
-      enqueueSnackbar(formattedFailureMessage, {
-        persist: persist ?? false,
-        variant: toastInfo.invertVariant ? 'success' : 'error',
-      });
+        const formattedFailureMessage = createFormattedMessage(
+          failureMessage,
+          link,
+          hasSupportLink
+        );
+
+        enqueueSnackbar(formattedFailureMessage, {
+          persist: persist ?? false,
+          variant: toastInfo.invertVariant ? 'success' : 'error',
+        });
+      }
     }
   };
 

--- a/packages/manager/src/hooks/useToastNotifications.tsx
+++ b/packages/manager/src/hooks/useToastNotifications.tsx
@@ -1,10 +1,12 @@
-import { Event, EventAction } from '@linode/api-v4/lib/account/types';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
 
 import { Link } from 'src/components/Link';
 import { SupportLink } from 'src/components/SupportLink';
+import { Typography } from 'src/components/Typography';
 import { sendLinodeDiskEvent } from 'src/utilities/analytics/customEventAnalytics';
+
+import type { Event, EventAction } from '@linode/api-v4';
 
 export const getLabel = (event: Event) => event.entity?.label ?? '';
 export const getSecondaryLabel = (event: Event) =>
@@ -174,26 +176,28 @@ export const useToastNotifications = () => {
           ? toastInfo.failure(event)
           : toastInfo.failure;
 
-      const hasSupportLink =
-        failureMessage?.includes('contact Support') ?? false;
+      if (failureMessage) {
+        const hasSupportLink =
+          failureMessage?.includes('contact Support') ?? false;
 
-      const formattedFailureMessage = (
-        <>
-          {failureMessage?.replace(/ contact Support/i, '') ?? failureMessage}
-          {hasSupportLink ? (
-            <>
-              &nbsp;
-              <SupportLink text="contact Support" title={failureMessage} />.
-            </>
-          ) : null}
-          {toastInfo.link ? <>&nbsp;{toastInfo.link}</> : null}
-        </>
-      );
+        const formattedFailureMessage = (
+          <Typography>
+            {failureMessage?.replace(/ contact Support/i, '') ?? failureMessage}
+            {hasSupportLink ? (
+              <>
+                &nbsp;
+                <SupportLink text="contact Support" title={failureMessage} />.
+              </>
+            ) : null}
+            {toastInfo.link ? <>&nbsp;{toastInfo.link}</> : null}
+          </Typography>
+        );
 
-      enqueueSnackbar(formattedFailureMessage, {
-        persist: toastInfo.persistFailureMessage,
-        variant: 'error',
-      });
+        enqueueSnackbar(formattedFailureMessage, {
+          persist: toastInfo.persistFailureMessage,
+          variant: 'error',
+        });
+      }
     }
   };
 


### PR DESCRIPTION
## Description 📝

- Removes some unnecessary styles for our Toast implementation 🗑️ 
- Fixes flaw with `useToastNotifications` that caused toasts to show up with no message 🔧 
- Improves how content wraps inside of toast notifications 🎨 
- Adds a `maxWidth` to Toast Notifications on larger screens so that they don't take up the full width of the screen
  - See the `WithLongMessage` Storybook story 📖 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/115251059/4970469b-4215-4951-9843-aa6404c956ac" /> | <video src="https://github.com/linode/manager/assets/115251059/79742e20-8b9c-44ef-a51a-e2e9f8bae9cb" /> |
| <video src="https://github.com/linode/manager/assets/115251059/0aeef353-615a-4379-acc8-e9d66a5f71e2" /> | <video src="https://github.com/linode/manager/assets/115251059/0ee71317-3107-4120-805d-a8b6768617f6" /> |

## How to test 🧪

- Use `yarn storybook` and verify that all Toast variants look correct in both light 🌞  and dark mode 🌚 
- Test canceling an uploaded image that is the "processing" state ⛔️
- Test the error toast that shows when an Image fails to capture from a Linode 👀 
  - I'm currently able to reproduce this in dev when trying to capture an image from a powered on Alpine Linux Linode, but your milage may vary 

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support