### PR TITLE
fix: [M3-8337] - Wait for preferences to consider displaying Design Token Banner

### DIFF
--- a/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
+++ b/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
@@ -7,6 +7,7 @@ import { switchAccountSessionContext } from 'src/context/switchAccountSessionCon
 import { SwitchAccountSessionDialog } from 'src/features/Account/SwitchAccounts/SwitchAccountSessionDialog';
 import { useDismissibleNotifications } from 'src/hooks/useDismissibleNotifications';
 import { useFlags } from 'src/hooks/useFlags';
+import { usePreferences } from 'src/queries/profile/preferences';
 import { useProfile } from 'src/queries/profile/profile';
 import { useSecurityQuestions } from 'src/queries/profile/securityQuestions';
 
@@ -23,6 +24,7 @@ import { VerificationDetailsBanner } from './VerificationDetailsBanner';
 export const GlobalNotifications = () => {
   const flags = useFlags();
   const { data: profile } = useProfile();
+  const { isLoading: isPreferencesLoading } = usePreferences();
   const sessionContext = React.useContext(switchAccountSessionContext);
   const sessionExpirationContext = React.useContext(_sessionExpirationContext);
   const isChildUser = profile?.user_type === 'child';
@@ -53,7 +55,7 @@ export const GlobalNotifications = () => {
 
   return (
     <>
-      <DesignUpdateBanner />
+      <DesignUpdateBanner isLoading={isPreferencesLoading} />
       <EmailBounceNotificationSection />
       <RegionStatusBanner />
       <AbuseTicketBanner />

--- a/packages/manager/src/features/GlobalNotifications/TokensUpdateBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/TokensUpdateBanner.tsx
@@ -5,11 +5,16 @@ import { Link } from 'src/components/Link';
 import { Typography } from 'src/components/Typography';
 import { useFlags } from 'src/hooks/useFlags';
 
-export const DesignUpdateBanner = () => {
+interface DesignUpdateBannerProps {
+  isLoading: boolean;
+}
+
+export const DesignUpdateBanner = (props: DesignUpdateBannerProps) => {
+  const { isLoading } = props;
   const flags = useFlags();
   const designUpdateFlag = flags.cloudManagerDesignUpdatesBanner;
 
-  if (!designUpdateFlag || !designUpdateFlag.enabled) {
+  if (isLoading || !designUpdateFlag?.enabled) {
     return null;
   }
   const { key, link } = designUpdateFlag;


### PR DESCRIPTION
## Description 📝
Super simple PR to allow using `isLoading` from `isPreferencesLoading` at the GlobalNotification level.
Often times LD flag value will be available before we have finished fetching account preferences. So the banner will display before being hidden. It's a barely noticeable flash of content but on slower network it could be more visible.

## Changes  🔄
- wait for preferences before deciding to show banner based on flag value

## How to test 🧪

### Prerequisites
- Dismiss Design Token Banner

### Reproduction steps
- Reload page/hard reload page and notice flasg of content with banner sometimes

### Verification steps
- Reload page, banner will never show when dismissed

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

---
## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**
- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

---
