### PR TITLE
feat: [M3-7683] - Disable Create Image button with tooltiptext on Landing Page for restricted users

### DIFF
--- a/packages/manager/.changeset/pr-10671-added-1720708134201.md
+++ b/packages/manager/.changeset/pr-10671-added-1720708134201.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Disable Create Image button with tooltiptext on Landing Page for restricted users ([#10671](https://github.com/linode/manager/pull/10671))

--- a/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.test.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.test.tsx
@@ -2,7 +2,7 @@ import { waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
-import { imageFactory } from 'src/factories';
+import { grantsFactory, imageFactory, profileFactory } from 'src/factories';
 import { makeResourcePage } from 'src/mocks/serverHandlers';
 import { HttpResponse, http, server } from 'src/mocks/testServer';
 import { mockMatchMedia, renderWithTheme } from 'src/utilities/testHelpers';
@@ -251,5 +251,42 @@ describe('Images Landing Table', () => {
     await userEvent.click(getByText('Delete'));
 
     getByText(`Delete Image ${images[0].label}`);
+  });
+
+  it('disables the create button if the user does not have permission to create images', async () => {
+    const images = imageFactory.buildList(3, {
+      regions: [
+        { region: 'us-east', status: 'available' },
+        { region: 'us-southeast', status: 'pending' },
+      ],
+    });
+    server.use(
+      http.get('*/v4/profile', () => {
+        const profile = profileFactory.build({ restricted: true });
+        return HttpResponse.json(profile);
+      }),
+      http.get('*/v4/profile/grants', () => {
+        const grants = grantsFactory.build({ global: { add_images: false } });
+        return HttpResponse.json(grants);
+      }),
+      http.get('*/v4/images', () => {
+        return HttpResponse.json(makeResourcePage(images));
+      })
+    );
+
+    const { getByTestId, getByText } = renderWithTheme(<ImagesLanding />);
+
+    // Loading state should render
+    expect(getByTestId(loadingTestId)).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(getByTestId(loadingTestId));
+
+    const createImageButton = getByText('Create Image').closest('button');
+
+    expect(createImageButton).toBeDisabled();
+    expect(createImageButton).toHaveAttribute(
+      'data-qa-tooltip',
+      "You don't have permissions to create Images. Please contact your account administrator to request the necessary permissions."
+    );
   });
 });

--- a/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.tsx
@@ -95,7 +95,7 @@ export const ImagesLanding = () => {
   const { enqueueSnackbar } = useSnackbar();
   const flags = useFlags();
   const location = useLocation();
-  const isRestricted = useRestrictedGlobalGrantCheck({
+  const isImagesReadOnly = useRestrictedGlobalGrantCheck({
     globalGrantType: 'add_images',
   });
   const queryParams = new URLSearchParams(location.search);
@@ -391,7 +391,7 @@ export const ImagesLanding = () => {
             resourceType: 'Images',
           }),
         }}
-        disabledCreateButton={isRestricted}
+        disabledCreateButton={isImagesReadOnly}
         title="Images"
       />
       <TextField

--- a/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.tsx
@@ -31,6 +31,7 @@ import { Typography } from 'src/components/Typography';
 import { useFlags } from 'src/hooks/useFlags';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 import {
   isEventImageUpload,
   isEventInProgressDiskImagize,
@@ -42,6 +43,7 @@ import {
   useImagesQuery,
 } from 'src/queries/images';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
+import { getRestrictedResourceText } from 'src/features/Account/utils';
 
 import { getEventsForImages } from '../utils';
 import { EditImageDrawer } from './EditImageDrawer';
@@ -93,6 +95,9 @@ export const ImagesLanding = () => {
   const { enqueueSnackbar } = useSnackbar();
   const flags = useFlags();
   const location = useLocation();
+  const isRestricted = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'add_images',
+  });
   const queryParams = new URLSearchParams(location.search);
   const imageLabelFromParam = queryParams.get(searchQueryKey) ?? '';
 
@@ -379,6 +384,14 @@ export const ImagesLanding = () => {
         docsLink="https://www.linode.com/docs/platform/disk-images/linode-images/"
         entity="Image"
         onButtonClick={() => history.push('/images/create')}
+        buttonDataAttrs={{
+          tooltipText: getRestrictedResourceText({
+            action: 'create',
+            isSingular: false,
+            resourceType: 'Images',
+          }),
+        }}
+        disabledCreateButton={isRestricted}
         title="Images"
       />
       <TextField


### PR DESCRIPTION
## Description 📝
To prevent unauthorized access to specific flows and provide clearer guidance, we aim to restrict entry to users without the required permissions.

Here, we are restricting users from creating new Image when they do not have access or have read only access.

## Changes  🔄
 - For restricted users:
   - Disabled Create Image Button on the Landing Page

## Target release date 🗓️


## Preview 📷

| Before  | After   |
| ------- | ------- |
|![07_53_12](https://github.com/linode/manager/assets/174600419/3b2d7260-3ccf-4418-9323-67e9d9c7c6ac)|![07_52_51](https://github.com/linode/manager/assets/174600419/2a792087-481d-4d60-9439-2e3c1a483894)|

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Log into two accounts side by side:
  - An unrestricted admin user account: full access
  - A restricted user account (use Incognito for this)
     - Start with `Read Only` for everything

### Reproduction steps
 - Landing:
    - Observe as restricted user, notice shows and you cannot create Images

### Verification steps
 - After changes, observe tooltips are tailored to the action.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
