### PR TITLE
refactor: [M3-7444] - Query Key Factory for Status Page

### DIFF
--- a/packages/manager/.changeset/pr-10672-tech-stories-1720709315853.md
+++ b/packages/manager/.changeset/pr-10672-tech-stories-1720709315853.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Query Key Factory for Status Page ([#10672](https://github.com/linode/manager/pull/10672))

--- a/packages/manager/src/queries/statusPage/requests.ts
+++ b/packages/manager/src/queries/statusPage/requests.ts
@@ -1,0 +1,53 @@
+import Axios from 'axios';
+
+import { LINODE_STATUS_PAGE_URL } from 'src/constants';
+import { reportException } from 'src/exceptionReporting';
+
+import type { IncidentResponse, MaintenanceResponse } from './types';
+import type { AxiosError } from 'axios';
+
+/**
+ * Documentation for the Linode-specific status page API can be found at:
+ * https://status.linode.com/api/v2/
+ */
+
+/**
+ * Helper function to handle errors.
+ */
+const handleError = (error: AxiosError, defaultMessage: string) => {
+  // Don't show any errors sent from the status page API to users, but report them to Sentry
+  reportException(error);
+  return Promise.reject([{ reason: defaultMessage }]);
+};
+
+/**
+ * Return a list of incidents with a status of "unresolved."
+ */
+export const getIncidents = async () => {
+  try {
+    const response = await Axios.get<IncidentResponse>(
+      `${LINODE_STATUS_PAGE_URL}/incidents/unresolved.json`
+    );
+    return response.data;
+  } catch (error) {
+    return handleError(error as AxiosError, 'Error retrieving incidents.');
+  }
+};
+
+/**
+ * There are several endpoints for maintenance events; this method will return
+ * a list of the most recent 50 maintenance, inclusive of all statuses.
+ */
+export const getAllMaintenance = async () => {
+  try {
+    const response = await Axios.get<MaintenanceResponse>(
+      `${LINODE_STATUS_PAGE_URL}/scheduled-maintenances.json`
+    );
+    return response.data;
+  } catch (error) {
+    return handleError(
+      error as AxiosError,
+      'Error retrieving maintenance events.'
+    );
+  }
+};

--- a/packages/manager/src/queries/statusPage/statusPage.ts
+++ b/packages/manager/src/queries/statusPage/statusPage.ts
@@ -15,7 +15,7 @@ export const statusPageQueries = createQueryKeys('statusPage', {
   },
   maintenance: {
     queryFn: getAllMaintenance,
-    queryKey: ['status-page-maintenance'],
+    queryKey: null,
   },
 });
 

--- a/packages/manager/src/queries/statusPage/statusPage.ts
+++ b/packages/manager/src/queries/statusPage/statusPage.ts
@@ -1,66 +1,35 @@
-import { APIError } from '@linode/api-v4/lib/types';
-import Axios from 'axios';
-import { UseQueryOptions, useQuery } from '@tanstack/react-query';
-
-import { LINODE_STATUS_PAGE_URL } from 'src/constants';
-import { reportException } from 'src/exceptionReporting';
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+import { useQuery } from '@tanstack/react-query';
 
 import { queryPresets } from '../base';
-import { IncidentResponse, MaintenanceResponse } from './types';
+import { getAllMaintenance, getIncidents } from './requests';
 
-/**
- * Documentation for the Linode-specific statuspage API can be found at:
- * https://status.linode.com/api/v2/
- */
+import type { IncidentResponse, MaintenanceResponse } from './types';
+import type { APIError } from '@linode/api-v4/lib/types';
+import type { UseQueryOptions } from '@tanstack/react-query';
 
-/**
- * Return a list of incidents with a status of "unresolved."
- */
-const getIncidents = () => {
-  return Axios.get<IncidentResponse>(
-    `${LINODE_STATUS_PAGE_URL}/incidents/unresolved.json`
-  )
-    .then((response) => response.data)
-    .catch((error) => {
-      // Don't show any errors sent from the statuspage API to users, but report them to Sentry
-      reportException(error);
-      return Promise.reject([{ reason: 'Error retrieving incidents.' }]);
-    });
-};
+export const statusPageQueries = createQueryKeys('statusPage', {
+  incidents: {
+    queryFn: getIncidents,
+    queryKey: ['status-page-incidents'],
+  },
+  maintenance: {
+    queryFn: getAllMaintenance,
+    queryKey: ['status-page-maintenance'],
+  },
+});
 
-/**
- * There are several endpoints for maintenance events; this method will return
- * a list of the most recent 50 maintenance, inclusive of all statuses.
- */
-const getAllMaintenance = () => {
-  return Axios.get<MaintenanceResponse>(
-    `${LINODE_STATUS_PAGE_URL}/scheduled-maintenances.json`
-  )
-    .then((response) => response.data)
-    .catch((error) => {
-      // Don't show any errors sent from the statuspage API to users, but report them to Sentry
-      reportException(error);
-      return Promise.reject([
-        { reason: 'Error retrieving maintenance events.' },
-      ]);
-    });
-};
+export const useIncidentQuery = () =>
+  useQuery<IncidentResponse, APIError[]>({
+    ...statusPageQueries.incidents,
+    ...queryPresets.shortLived,
+  });
 
-const incidentKey = 'status-page-incidents';
-const maintenanceKey = 'status-page-maintenance';
-
-export const useIncidentQuery = () => {
-  return useQuery<IncidentResponse, APIError[]>(
-    [incidentKey],
-    getIncidents,
-    queryPresets.shortLived
-  );
-};
-
-export const useMaintenanceQuery = (options?: UseQueryOptions<any>) => {
-  return useQuery<MaintenanceResponse, APIError[]>(
-    [maintenanceKey],
-    getAllMaintenance,
-    { ...queryPresets.shortLived, ...(options ?? {}) }
-  );
-};
+export const useMaintenanceQuery = (
+  options?: UseQueryOptions<MaintenanceResponse, APIError[]>
+) =>
+  useQuery<MaintenanceResponse, APIError[]>({
+    ...statusPageQueries.maintenance,
+    ...queryPresets.shortLived,
+    ...(options ?? {}),
+  });

--- a/packages/manager/src/queries/statusPage/statusPage.ts
+++ b/packages/manager/src/queries/statusPage/statusPage.ts
@@ -11,7 +11,7 @@ import type { UseQueryOptions } from '@tanstack/react-query';
 export const statusPageQueries = createQueryKeys('statusPage', {
   incidents: {
     queryFn: getIncidents,
-    queryKey: ['status-page-incidents'],
+    queryKey: null,
   },
   maintenance: {
     queryFn: getAllMaintenance,


### PR DESCRIPTION
## Description 📝
- Updates StatusPage to use a Query Key factory 🏭

## Target release date 🗓️
7/22

## How to test 🧪
- Verify Cypress tests pass ✅
- Verify unit tests pass ✅
- Manually [change](https://github.com/linode/manager/blob/develop/packages/manager/src/features/GlobalNotifications/APIMaintenanceBanner.tsx#L41) `scheduled` to `completed` and see banner still works

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x ] ➕ Adding a changeset
- [] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support