### PR TITLE
refactor: [M3-6901, M3-6914] - Replace Select with Autocomplete in: kubernetes

### DIFF
--- a/packages/manager/.changeset/pr-10673-tech-stories-1720710990405.md
+++ b/packages/manager/.changeset/pr-10673-tech-stories-1720710990405.md
@@ -2,4 +2,4 @@
 "@linode/manager": Tech Stories
 ---
 
-Replace Select with Autocomplete in: kubernetes ([#10673](https://github.com/linode/manager/pull/10673))
+Replace Select with Autocomplete component on Kubernetes Create page ([#10673](https://github.com/linode/manager/pull/10673))

--- a/packages/manager/.changeset/pr-10673-tech-stories-1720710990405.md
+++ b/packages/manager/.changeset/pr-10673-tech-stories-1720710990405.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Replace Select with Autocomplete in: kubernetes ([#10673](https://github.com/linode/manager/pull/10673))

--- a/packages/manager/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/manager/src/components/Autocomplete/Autocomplete.tsx
@@ -16,12 +16,6 @@ import {
 
 import type { AutocompleteProps } from '@mui/material/Autocomplete';
 
-export interface Item<T = number | string, L = string> {
-  data?: any;
-  label: L;
-  value: T;
-}
-
 export interface EnhancedAutocompleteProps<
   T extends { label: string },
   Multiple extends boolean | undefined = undefined,

--- a/packages/manager/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/manager/src/components/Autocomplete/Autocomplete.tsx
@@ -16,6 +16,12 @@ import {
 
 import type { AutocompleteProps } from '@mui/material/Autocomplete';
 
+export interface Item<T = number | string, L = string> {
+  data?: any;
+  label: L;
+  value: T;
+}
+
 export interface EnhancedAutocompleteProps<
   T extends { label: string },
   Multiple extends boolean | undefined = undefined,

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -245,6 +245,9 @@ export const CreateCluster = () => {
           </StyledRegionSelectStack>
           <Divider sx={{ marginTop: 4 }} />
           <Autocomplete
+            isOptionEqualToValue={(option, value) =>
+              option.value === value.value
+            }
             onChange={(_, selected: Item<string>) => {
               setVersion(selected);
             }}

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -120,7 +120,6 @@ export const CreateCluster = () => {
     const { push } = history;
     setErrors(undefined);
     setSubmitting(true);
-    const k8s_version = version ?? undefined;
 
     // Only type and count to the API.
     const node_pools = nodePools.map(
@@ -129,7 +128,7 @@ export const CreateCluster = () => {
 
     const payload: CreateKubeClusterPayload = {
       control_plane: { high_availability: highAvailability ?? false },
-      k8s_version,
+      k8s_version: version,
       label,
       node_pools,
       region: selectedRegionId,

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -56,7 +56,6 @@ import type {
   KubeNodePoolResponse,
 } from '@linode/api-v4/lib/kubernetes';
 import type { APIError } from '@linode/api-v4/lib/types';
-import type { Item } from 'src/components/Autocomplete/Autocomplete';
 
 export const CreateCluster = () => {
   const { classes } = useStyles();
@@ -65,7 +64,7 @@ export const CreateCluster = () => {
   >();
   const [nodePools, setNodePools] = React.useState<KubeNodePoolResponse[]>([]);
   const [label, setLabel] = React.useState<string | undefined>();
-  const [version, setVersion] = React.useState<Item<string> | undefined>();
+  const [version, setVersion] = React.useState<string | undefined>();
   const [errors, setErrors] = React.useState<APIError[] | undefined>();
   const [submitting, setSubmitting] = React.useState<boolean>(false);
   const [hasAgreed, setAgreed] = React.useState<boolean>(false);
@@ -113,7 +112,7 @@ export const CreateCluster = () => {
 
   React.useEffect(() => {
     if (versions.length > 0) {
-      setVersion(getLatestVersion(versions));
+      setVersion(getLatestVersion(versions).value);
     }
   }, [versionData]);
 
@@ -121,7 +120,7 @@ export const CreateCluster = () => {
     const { push } = history;
     setErrors(undefined);
     setSubmitting(true);
-    const k8s_version = version ? version.value : undefined;
+    const k8s_version = version ?? undefined;
 
     // Only type and count to the API.
     const node_pools = nodePools.map(
@@ -245,18 +244,15 @@ export const CreateCluster = () => {
           </StyledRegionSelectStack>
           <Divider sx={{ marginTop: 4 }} />
           <Autocomplete
-            isOptionEqualToValue={(option, value) =>
-              option.value === value.value
-            }
-            onChange={(_, selected: Item<string>) => {
-              setVersion(selected);
+            onChange={(_, selected) => {
+              setVersion(selected?.value);
             }}
             disableClearable={!!version}
             errorText={errorMap.k8s_version}
             label="Kubernetes Version"
             options={versions}
             placeholder={' '}
-            value={version ?? null}
+            value={versions.find((v) => v.value === version) ?? null}
           />
           <Divider sx={{ marginTop: 4 }} />
           {showHighAvailability ? (

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -4,10 +4,10 @@ import { pick, remove, update } from 'ramda';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 
+import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
 import { Box } from 'src/components/Box';
 import { DocsLink } from 'src/components/DocsLink/DocsLink';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-import Select from 'src/components/EnhancedSelect/Select';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { LandingHeader } from 'src/components/LandingHeader';
 import { Notice } from 'src/components/Notice/Notice';
@@ -56,7 +56,7 @@ import type {
   KubeNodePoolResponse,
 } from '@linode/api-v4/lib/kubernetes';
 import type { APIError } from '@linode/api-v4/lib/types';
-import type { Item } from 'src/components/EnhancedSelect/Select';
+import type { Item } from 'src/components/Autocomplete/Autocomplete';
 
 export const CreateCluster = () => {
   const { classes } = useStyles();
@@ -244,16 +244,16 @@ export const CreateCluster = () => {
             </StyledDocsLinkContainer>
           </StyledRegionSelectStack>
           <Divider sx={{ marginTop: 4 }} />
-          <Select
-            onChange={(selected: Item<string>) => {
+          <Autocomplete
+            onChange={(_, selected: Item<string>) => {
               setVersion(selected);
             }}
+            disableClearable={!!version}
             errorText={errorMap.k8s_version}
-            isClearable={false}
             label="Kubernetes Version"
             options={versions}
             placeholder={' '}
-            value={version || null}
+            value={version ?? null}
           />
           <Divider sx={{ marginTop: 4 }} />
           {showHighAvailability ? (


### PR DESCRIPTION
## Description 📝
We want to get rid of our dependency on react-select for accessibility reasons and to consolidate our usage of third-party libraries.

## Changes  🔄
- Replaced `Select` with Autocomplete in `CreateCluster` component. 
- The `Item` type previously imported from `EnhancedSelect/Select` has been added to `Autocomplete/Autocomplete`
    - It simplifies imports and improves code maintainability.
- Added `disableClearable` prop condition to `Autocomplete` to prevent uncontrolled behavior with an initial empty value.

## Target release date 🗓️
22nd July, 2024

## How to test 🧪

### Verification steps
(How to verify changes)
- Navigate to http://localhost:3000/kubernetes/create 
- Verify 'Kubernetes Version' dropdown functionality remains unchanged when using `Autocomplete`. 
- Verify that the `disableClearable` prop condition is correctly applied to `Autocomplete` to prevent uncontrolled behavior when the initial value is empty.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support