### PR TITLE
refactor: [M3-7432] - Update Managed Queries to use Query Key Factory

### DIFF
--- a/packages/manager/.changeset/pr-10679-tech-stories-1721072052210.md
+++ b/packages/manager/.changeset/pr-10679-tech-stories-1721072052210.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Update Managed Queries to use Query Key Factory ([#10679](https://github.com/linode/manager/pull/10679))

--- a/packages/manager/src/queries/managed/managed.ts
+++ b/packages/manager/src/queries/managed/managed.ts
@@ -1,17 +1,4 @@
 import {
-  ContactPayload,
-  CredentialPayload,
-  ManagedContact,
-  ManagedCredential,
-  ManagedIssue,
-  ManagedLinodeSetting,
-  ManagedSSHPubKey,
-  ManagedSSHSetting,
-  ManagedServiceMonitor,
-  ManagedServicePayload,
-  ManagedStats,
-  UpdateCredentialPayload,
-  UpdatePasswordPayload,
   createContact,
   createCredential,
   createServiceMonitor,
@@ -32,8 +19,8 @@ import {
   updateLinodeSettings,
   updatePassword,
   updateServiceMonitor,
-} from '@linode/api-v4/lib/managed';
-import { APIError } from '@linode/api-v4/lib/types';
+} from '@linode/api-v4';
+import { createQueryKeys } from '@lukemorales/query-key-factory';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { getAll } from 'src/utilities/getAll';
@@ -45,169 +32,24 @@ import {
   queryPresets,
 } from '../base';
 import { extendIssues } from './helpers';
-import { ExtendedIssue } from './types';
 
-export const queryKey = 'managed';
-
-export const useManagedSSHKey = () =>
-  useQuery<ManagedSSHPubKey, APIError[]>(
-    [queryKey, 'public-ssh-key'],
-    getSSHPubKey,
-    queryPresets.oneTimeFetch
-  );
-
-export const useAllLinodeSettingsQuery = () =>
-  useQuery<ManagedLinodeSetting[], APIError[]>(
-    [queryKey, 'linode-settings'],
-    getAllLinodeSettings,
-    {
-      // A Linode may have been created or deleted since the last visit.
-      refetchOnMount: 'always',
-    }
-  );
-
-export const useAllManagedCredentialsQuery = () =>
-  useQuery<ManagedCredential[], APIError[]>(
-    [queryKey, 'credentials'],
-    getAllCredentials,
-    queryPresets.oneTimeFetch
-  );
-
-export const useAllManagedContactsQuery = () =>
-  useQuery<ManagedContact[], APIError[]>(
-    [queryKey, 'contacts'],
-    getAllContacts,
-    queryPresets.oneTimeFetch
-  );
-
-export const useAllManagedIssuesQuery = () =>
-  useQuery<ExtendedIssue[], APIError[]>([queryKey, 'issues'], getAllIssues, {
-    refetchInterval: 20000,
-  });
-
-export const useAllManagedMonitorsQuery = () =>
-  useQuery<ManagedServiceMonitor[], APIError[]>(
-    [queryKey, 'monitors'],
-    getAllMonitors,
-    {
-      refetchInterval: 20000,
-    }
-  );
-
-export const useManagedStatsQuery = () =>
-  useQuery<ManagedStats, APIError[]>([queryKey, 'stats'], getManagedStats, {
-    ...queryPresets.shortLived,
-    retry: false,
-  });
-
-export const useDeleteMonitorMutation = () => {
-  const queryClient = useQueryClient();
-  return useMutation<{}, APIError[], { id: number }>(
-    ({ id }) => deleteServiceMonitor(id),
-    itemInListDeletionHandler([queryKey, 'monitors'], queryClient)
-  );
-};
-
-export const useCreateMonitorMutation = () => {
-  const queryClient = useQueryClient();
-  return useMutation<ManagedServiceMonitor, APIError[], ManagedServicePayload>(
-    createServiceMonitor,
-    itemInListCreationHandler([queryKey, 'monitors'], queryClient)
-  );
-};
-
-export const useUpdateMonitorMutation = (id: number) => {
-  const queryClient = useQueryClient();
-  return useMutation<
-    ManagedServiceMonitor,
-    APIError[],
-    Partial<ManagedServicePayload>
-  >(
-    (data) => updateServiceMonitor(id, data),
-    itemInListMutationHandler([queryKey, 'monitors'], queryClient)
-  );
-};
-
-export const useCreateCredentialMutation = () => {
-  const queryClient = useQueryClient();
-  return useMutation<ManagedCredential, APIError[], CredentialPayload>(
-    createCredential,
-    itemInListCreationHandler([queryKey, 'credentials'], queryClient)
-  );
-};
-
-export const useUpdateCredentialPasswordMutation = (id: number) =>
-  useMutation<{}, APIError[], UpdatePasswordPayload>((data) =>
-    updatePassword(id, data)
-  );
-
-export const useUpdateCredentialMutation = (id: number) => {
-  const queryClient = useQueryClient();
-  return useMutation<ManagedCredential, APIError[], UpdateCredentialPayload>(
-    (data) => updateCredential(id, data),
-    itemInListMutationHandler([queryKey, 'credentials'], queryClient)
-  );
-};
-
-export const useDeleteCredentialMutation = () => {
-  const queryClient = useQueryClient();
-  return useMutation<{}, APIError[], { id: number }>(
-    ({ id }) => deleteCredential(id),
-    itemInListDeletionHandler([queryKey, 'credentials'], queryClient)
-  );
-};
-
-export const useCreateContactMutation = () => {
-  const queryClient = useQueryClient();
-  return useMutation<ManagedContact, APIError[], ContactPayload>(
-    createContact,
-    itemInListCreationHandler([queryKey, 'contacts'], queryClient)
-  );
-};
-
-export const useDeleteContactMutation = () => {
-  const queryClient = useQueryClient();
-  return useMutation<{}, APIError[], { id: number }>(
-    ({ id }) => deleteContact(id),
-    itemInListDeletionHandler([queryKey, 'contacts'], queryClient)
-  );
-};
-
-export const useUpdateContactMutation = (id: number) => {
-  const queryClient = useQueryClient();
-  return useMutation<ManagedContact, APIError[], Partial<ContactPayload>>(
-    (data) => updateContact(id, data),
-    itemInListMutationHandler([queryKey, 'contacts'], queryClient)
-  );
-};
-
-export const useUpdateLinodeSettingsMutation = (id: number) => {
-  const queryClient = useQueryClient();
-  return useMutation<
-    ManagedLinodeSetting,
-    APIError[],
-    { ssh: Partial<ManagedSSHSetting> }
-  >(
-    (data) => updateLinodeSettings(id, data),
-    itemInListMutationHandler([queryKey, 'linode-settings'], queryClient)
-  );
-};
-
-export const useEnableMonitorMutation = (id: number) => {
-  const queryClient = useQueryClient();
-  return useMutation<ManagedServiceMonitor, APIError[]>(
-    () => enableServiceMonitor(id),
-    itemInListMutationHandler([queryKey, 'monitors'], queryClient)
-  );
-};
-
-export const useDisableMonitorMutation = (id: number) => {
-  const queryClient = useQueryClient();
-  return useMutation<ManagedServiceMonitor, APIError[]>(
-    () => disableServiceMonitor(id),
-    itemInListMutationHandler([queryKey, 'monitors'], queryClient)
-  );
-};
+import type { ExtendedIssue } from './types';
+import type {
+  APIError,
+  ContactPayload,
+  CredentialPayload,
+  ManagedContact,
+  ManagedCredential,
+  ManagedIssue,
+  ManagedLinodeSetting,
+  ManagedSSHPubKey,
+  ManagedSSHSetting,
+  ManagedServiceMonitor,
+  ManagedServicePayload,
+  ManagedStats,
+  UpdateCredentialPayload,
+  UpdatePasswordPayload,
+} from '@linode/api-v4';
 
 // We need to "Get All" on this request in order to handle Groups
 // as a quasi-independent entity.
@@ -227,3 +69,193 @@ const _getAllIssues = () =>
   getAll<ManagedIssue>(getManagedIssues)().then((res) => res.data);
 
 const getAllIssues = () => _getAllIssues().then((data) => extendIssues(data));
+
+const managedQueries = createQueryKeys('managed', {
+  contacts: {
+    queryFn: getAllContacts,
+    queryKey: null,
+  },
+  credentials: {
+    queryFn: getAllCredentials,
+    queryKey: null,
+  },
+  issues: {
+    queryFn: getAllIssues,
+    queryKey: null,
+  },
+  linodeSettings: {
+    queryFn: getAllLinodeSettings,
+    queryKey: null,
+  },
+  monitors: {
+    queryFn: getAllMonitors,
+    queryKey: null,
+  },
+  sshKey: {
+    queryFn: getSSHPubKey,
+    queryKey: null,
+  },
+  stats: {
+    queryFn: getManagedStats,
+    queryKey: null,
+  },
+});
+
+export const useManagedSSHKey = () =>
+  useQuery<ManagedSSHPubKey, APIError[]>({
+    ...managedQueries.sshKey,
+    ...queryPresets.oneTimeFetch,
+  });
+
+export const useAllLinodeSettingsQuery = () =>
+  useQuery<ManagedLinodeSetting[], APIError[]>({
+    ...managedQueries.linodeSettings,
+    // A Linode may have been created or deleted since the last visit.
+    refetchOnMount: 'always',
+  });
+
+export const useAllManagedCredentialsQuery = () =>
+  useQuery<ManagedCredential[], APIError[]>(managedQueries.credentials);
+
+export const useAllManagedContactsQuery = () =>
+  useQuery<ManagedContact[], APIError[]>(managedQueries.contacts);
+
+export const useAllManagedIssuesQuery = () =>
+  useQuery<ExtendedIssue[], APIError[]>({
+    ...managedQueries.issues,
+    refetchInterval: 20000,
+  });
+
+export const useAllManagedMonitorsQuery = () =>
+  useQuery<ManagedServiceMonitor[], APIError[]>({
+    ...managedQueries.monitors,
+    refetchInterval: 20000,
+  });
+
+export const useManagedStatsQuery = () =>
+  useQuery<ManagedStats, APIError[]>({
+    ...managedQueries.stats,
+    ...queryPresets.shortLived,
+    retry: false,
+  });
+
+export const useDeleteMonitorMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation<{}, APIError[], { id: number }>({
+    mutationFn: ({ id }) => deleteServiceMonitor(id),
+    ...itemInListDeletionHandler(managedQueries.monitors.queryKey, queryClient),
+  });
+};
+
+export const useCreateMonitorMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation<ManagedServiceMonitor, APIError[], ManagedServicePayload>({
+    mutationFn: createServiceMonitor,
+    ...itemInListCreationHandler(managedQueries.monitors.queryKey, queryClient),
+  });
+};
+
+export const useUpdateMonitorMutation = (id: number) => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    ManagedServiceMonitor,
+    APIError[],
+    Partial<ManagedServicePayload>
+  >({
+    mutationFn: (data) => updateServiceMonitor(id, data),
+    ...itemInListMutationHandler(managedQueries.monitors.queryKey, queryClient),
+  });
+};
+
+export const useCreateCredentialMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation<ManagedCredential, APIError[], CredentialPayload>({
+    mutationFn: createCredential,
+    ...itemInListCreationHandler(
+      managedQueries.credentials.queryKey,
+      queryClient
+    ),
+  });
+};
+
+export const useUpdateCredentialPasswordMutation = (id: number) =>
+  useMutation<{}, APIError[], UpdatePasswordPayload>({
+    mutationFn: (data) => updatePassword(id, data),
+  });
+
+export const useUpdateCredentialMutation = (id: number) => {
+  const queryClient = useQueryClient();
+  return useMutation<ManagedCredential, APIError[], UpdateCredentialPayload>({
+    mutationFn: (data) => updateCredential(id, data),
+    ...itemInListMutationHandler(
+      managedQueries.credentials.queryKey,
+      queryClient
+    ),
+  });
+};
+
+export const useDeleteCredentialMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation<{}, APIError[], { id: number }>({
+    mutationFn: ({ id }) => deleteCredential(id),
+    ...itemInListDeletionHandler(
+      managedQueries.credentials.queryKey,
+      queryClient
+    ),
+  });
+};
+
+export const useCreateContactMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation<ManagedContact, APIError[], ContactPayload>({
+    mutationFn: createContact,
+    ...itemInListCreationHandler(managedQueries.contacts.queryKey, queryClient),
+  });
+};
+
+export const useDeleteContactMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation<{}, APIError[], { id: number }>({
+    mutationFn: ({ id }) => deleteContact(id),
+    ...itemInListDeletionHandler(managedQueries.contacts.queryKey, queryClient),
+  });
+};
+
+export const useUpdateContactMutation = (id: number) => {
+  const queryClient = useQueryClient();
+  return useMutation<ManagedContact, APIError[], Partial<ContactPayload>>({
+    mutationFn: (data) => updateContact(id, data),
+    ...itemInListMutationHandler(managedQueries.contacts.queryKey, queryClient),
+  });
+};
+
+export const useUpdateLinodeSettingsMutation = (id: number) => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    ManagedLinodeSetting,
+    APIError[],
+    { ssh: Partial<ManagedSSHSetting> }
+  >({
+    mutationFn: (data) => updateLinodeSettings(id, data),
+    ...itemInListMutationHandler(
+      managedQueries.linodeSettings.queryKey,
+      queryClient
+    ),
+  });
+};
+
+export const useEnableMonitorMutation = (id: number) => {
+  const queryClient = useQueryClient();
+  return useMutation<ManagedServiceMonitor, APIError[]>({
+    mutationFn: () => enableServiceMonitor(id),
+    ...itemInListMutationHandler(managedQueries.monitors.queryKey, queryClient),
+  });
+};
+
+export const useDisableMonitorMutation = (id: number) => {
+  const queryClient = useQueryClient();
+  return useMutation<ManagedServiceMonitor, APIError[]>({
+    mutationFn: () => disableServiceMonitor(id),
+    ...itemInListMutationHandler(managedQueries.monitors.queryKey, queryClient),
+  });
+};


### PR DESCRIPTION
## Description 📝

- Updates Managed Queries to use a query key factory 🏭 
- Fixes breaking changes in preparation for v5 (see [here](https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5))  🔨 
- Doesn't change any application logic, just switches over to the factory 

## How to test 🧪

### Prerequisites
- Use the MSW, use an account with managed enabled, or enable managed on your account

### Verification steps
- Verify managed create, update, and delete actions work as expected 👀 
- Verify all automated testing for managed passes ✅ 

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support