### PR TITLE
fix: Image Upload Toast Support Link

### DIFF
--- a/packages/manager/.changeset/pr-10680-fixed-1721142009108.md
+++ b/packages/manager/.changeset/pr-10680-fixed-1721142009108.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Missing support link in some toast notifications ([#10680](https://github.com/linode/manager/pull/10680))

--- a/packages/manager/src/hooks/useToastNotifications.tsx
+++ b/packages/manager/src/hooks/useToastNotifications.tsx
@@ -250,8 +250,9 @@ export const useToastNotifications = (): {
       const failureMessage = getToastMessage(message, event);
 
       if (failureMessage) {
-        const hasSupportLink =
-          failureMessage?.includes('contact Support') ?? false;
+        const hasSupportLink = failureMessage
+          .toLowerCase()
+          .includes('contact support');
 
         const formattedFailureMessage = createFormattedMessage(
           failureMessage,


### PR DESCRIPTION
## Description 📝

- Fixes a bug in `useToastNotifications.tsx` that caused a support ticket link to not show
- The "fix" is basically just to use `toLowerCase` to ignore casing. The event from the API said `contact support`, but Cloud Manager was checking for `contact Support`

## Target release date 🗓️

- July 22, 2024

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-07-15 at 4 52 13 PM](https://github.com/user-attachments/assets/3662a555-af93-4e23-a7f1-ac3a56c52a36) | ![Screenshot 2024-07-15 at 4 52 21 PM](https://github.com/user-attachments/assets/17e7a683-0c52-4f4b-9ee2-fb4e1d33b5e2) |

## How to test 🧪

- `gzip` something that is not an Image
- Try uploading it in **dev**
- Verify the toast you see has a support link and does not appear broken

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support