### PR TITLE
change: [M3-8346] – UI modications for LKE Details summary panel & Node Pool tables

### DIFF
--- a/packages/manager/.changeset/pr-10685-changed-1721235038298.md
+++ b/packages/manager/.changeset/pr-10685-changed-1721235038298.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+UI improvements to LKE Detail summary panel and Node Pool tables ([#10685](https://github.com/linode/manager/pull/10685))

--- a/packages/manager/src/components/EntityDetail/EntityDetail.tsx
+++ b/packages/manager/src/components/EntityDetail/EntityDetail.tsx
@@ -1,13 +1,14 @@
-import Grid from '@mui/material/Unstable_Grid2';
 import { styled } from '@mui/material/styles';
+import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 
 import { omittedProps } from '../../utilities/omittedProps';
 
 export interface EntityDetailProps {
   body?: JSX.Element;
-  footer: JSX.Element;
+  footer?: JSX.Element;
   header: JSX.Element;
+  noBodyBottomBorder?: boolean;
 }
 
 /**
@@ -18,22 +19,38 @@ export interface EntityDetailProps {
  * Provide a Header, Body, and Footer and this component provides the proper positioning for each.
  */
 export const EntityDetail = (props: EntityDetailProps) => {
-  const { body, footer, header } = props;
+  const { body, footer, header, noBodyBottomBorder } = props;
 
   return (
     <>
       {header}
-      {body !== undefined && <GridBody xs={12}>{body}</GridBody>}
-      <GridFooter body={body} xs={12}>
-        {footer}
-      </GridFooter>
+      {body !== undefined && (
+        <GridBody
+          footer={footer}
+          noBodyBottomBorder={noBodyBottomBorder}
+          xs={12}
+        >
+          {body}
+        </GridBody>
+      )}
+      {footer !== undefined && (
+        <GridFooter body={body} xs={12}>
+          {footer}
+        </GridFooter>
+      )}
     </>
   );
 };
 
-const GridBody = styled(Grid)(({ theme }) => ({
+const GridBody = styled(Grid, {
+  label: 'EntityDetailGridBody',
+  shouldForwardProp: omittedProps(['footer', 'noBodyBottomBorder']),
+})<Partial<EntityDetailProps>>(({ theme, ...props }) => ({
   backgroundColor: theme.bg.bgPaper,
-  borderBottom: `1px solid ${theme.borderColors.borderTable}`,
+  borderBottom:
+    props.footer === undefined && props.noBodyBottomBorder
+      ? undefined
+      : `1px solid ${theme.borderColors.borderTable}`, // @TODO LKE-E: This conditional can be removed when/if the footer is introduced in M3-8348
   borderTop: `1px solid ${theme.borderColors.borderTable}`,
   paddingBottom: theme.spacing(),
   paddingRight: theme.spacing(),

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -1,15 +1,20 @@
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { useTheme } from '@mui/material/styles';
 import Grid from '@mui/material/Unstable_Grid2';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
 import { makeStyles } from 'tss-react/mui';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
-import { Button } from 'src/components/Button/Button';
+import { Box } from 'src/components/Box';
 import { Chip } from 'src/components/Chip';
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
-import { Paper } from 'src/components/Paper';
+import { EntityDetail } from 'src/components/EntityDetail/EntityDetail';
+import { EntityHeader } from 'src/components/EntityHeader/EntityHeader';
+import { LinkButton } from 'src/components/LinkButton';
+import { Stack } from 'src/components/Stack';
 import { TagCell } from 'src/components/TagCell/TagCell';
+import { Typography } from 'src/components/Typography';
 import { KubeClusterSpecs } from 'src/features/Kubernetes/KubernetesClusterDetail/KubeClusterSpecs';
 import { useIsResourceRestricted } from 'src/hooks/useIsResourceRestricted';
 import {
@@ -43,21 +48,14 @@ const useStyles = makeStyles()((theme: Theme) => ({
       height: 14,
       marginLeft: 4,
     },
+    alignItems: 'center',
+    display: 'flex',
   },
   deleteClusterBtn: {
-    paddingRight: '0px',
+    padding: `0 0 0 ${theme.spacing(2)}`,
     [theme.breakpoints.up('md')]: {
       paddingRight: '8px',
     },
-  },
-  mainGridContainer: {
-    position: 'relative',
-  },
-  root: {
-    marginBottom: theme.spacing(3),
-    padding: `${theme.spacing(2.5)} ${theme.spacing(1)} ${theme.spacing(
-      2.5
-    )} ${theme.spacing(3)}`,
   },
   tags: {
     // Tags Panel wrapper
@@ -103,8 +101,12 @@ interface Props {
 
 export const KubeSummaryPanel = React.memo((props: Props) => {
   const { cluster } = props;
+
   const { classes } = useStyles();
+  const theme = useTheme();
+
   const { enqueueSnackbar } = useSnackbar();
+
   const [drawerOpen, setDrawerOpen] = React.useState<boolean>(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
 
@@ -153,69 +155,102 @@ export const KubeSummaryPanel = React.memo((props: Props) => {
     });
   };
 
+  const sxSpacing = {
+    paddingLeft: theme.spacing(3),
+    paddingRight: theme.spacing(1),
+  };
+
+  const sxMainGridContainer = {
+    paddingBottom: theme.spacing(2.5),
+    paddingTop: theme.spacing(2),
+    position: 'relative',
+  };
+
   return (
-    <>
-      <Paper className={classes.root}>
-        <Grid className={classes.mainGridContainer} container spacing={2}>
-          <KubeClusterSpecs cluster={cluster} />
-          <Grid container direction="column" lg={4} xs={12}>
-            <KubeConfigDisplay
-              clusterId={cluster.id}
-              clusterLabel={cluster.label}
-              handleOpenDrawer={handleOpenDrawer}
-              isResettingKubeConfig={isResettingKubeConfig}
-              setResetKubeConfigDialogOpen={setResetKubeConfigDialogOpen}
-            />
-          </Grid>
+    <Stack sx={{ marginBottom: theme.spacing(3) }}>
+      <EntityDetail
+        body={
           <Grid
             container
-            direction="column"
-            justifyContent="space-between"
-            lg={5}
-            xs={12}
+            spacing={2}
+            sx={{ ...sxSpacing, ...sxMainGridContainer }}
           >
-            <Grid className={classes.actionRow}>
-              {cluster.control_plane.high_availability && (
-                <Chip
-                  label="HA CLUSTER"
-                  size="small"
-                  sx={(theme) => ({ borderColor: theme.color.green })}
-                  variant="outlined"
+            <KubeClusterSpecs cluster={cluster} />
+            <Grid container direction="column" lg={4} xs={12}>
+              <KubeConfigDisplay
+                clusterId={cluster.id}
+                clusterLabel={cluster.label}
+                handleOpenDrawer={handleOpenDrawer}
+                isResettingKubeConfig={isResettingKubeConfig}
+                setResetKubeConfigDialogOpen={setResetKubeConfigDialogOpen}
+              />
+            </Grid>
+            <Grid
+              container
+              direction="column"
+              justifyContent="space-between"
+              lg={5}
+              xs={12}
+            >
+              <Grid className={classes.actionRow}>
+                {cluster.control_plane.high_availability && (
+                  <Chip
+                    label="HA CLUSTER"
+                    size="small"
+                    sx={(theme) => ({ borderColor: theme.color.green })}
+                    variant="outlined"
+                  />
+                )}
+              </Grid>
+              <Grid className={classes.tags}>
+                <TagCell
+                  disabled={isClusterReadOnly}
+                  entityLabel={cluster.label}
+                  tags={cluster.tags}
+                  updateTags={handleUpdateTags}
+                  view="inline"
                 />
-              )}
-              <Button
+              </Grid>
+            </Grid>
+          </Grid>
+        }
+        header={
+          <EntityHeader>
+            <Box
+              sx={{
+                ...sxSpacing,
+                paddingBottom: theme.spacing(),
+                paddingTop: theme.spacing(),
+              }}
+            >
+              <Typography variant="h2">Summary</Typography>
+            </Box>
+            <Box
+              display="flex"
+              justifyContent="end"
+              sx={{ paddingTop: theme.spacing() }}
+            >
+              <LinkButton
                 onClick={() => {
                   window.open(dashboard?.url, '_blank');
                 }}
-                buttonType="secondary"
                 className={classes.dashboard}
-                compactY
-                disabled={Boolean(dashboardError) || !dashboard}
+                isDisabled={Boolean(dashboardError) || !dashboard}
               >
                 Kubernetes Dashboard
                 <OpenInNewIcon />
-              </Button>
-              <Button
-                buttonType="secondary"
+              </LinkButton>
+              <LinkButton
                 className={classes.deleteClusterBtn}
-                compactY
                 onClick={() => setIsDeleteDialogOpen(true)}
               >
                 Delete Cluster
-              </Button>
-            </Grid>
-            <Grid className={classes.tags}>
-              <TagCell
-                disabled={isClusterReadOnly}
-                entityLabel={cluster.label}
-                tags={cluster.tags}
-                updateTags={handleUpdateTags}
-                view="inline"
-              />
-            </Grid>
-          </Grid>
-        </Grid>
-      </Paper>
+              </LinkButton>
+            </Box>
+          </EntityHeader>
+        }
+        noBodyBottomBorder
+      />
 
       <KubeConfigDrawer
         closeDrawer={() => setDrawerOpen(false)}
@@ -259,6 +294,6 @@ export const KubeSummaryPanel = React.memo((props: Props) => {
         will no longer be able to access this cluster via your previous
         Kubeconfig file. This action cannot be undone.
       </ConfirmationDialog>
-    </>
+    </Stack>
   );
 });

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -7,11 +7,11 @@ import { makeStyles } from 'tss-react/mui';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Box } from 'src/components/Box';
+import { StyledActionButton } from 'src/components/Button/StyledActionButton';
 import { Chip } from 'src/components/Chip';
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
 import { EntityDetail } from 'src/components/EntityDetail/EntityDetail';
 import { EntityHeader } from 'src/components/EntityHeader/EntityHeader';
-import { LinkButton } from 'src/components/LinkButton';
 import { Stack } from 'src/components/Stack';
 import { TagCell } from 'src/components/TagCell/TagCell';
 import { Typography } from 'src/components/Typography';
@@ -52,7 +52,6 @@ const useStyles = makeStyles()((theme: Theme) => ({
     display: 'flex',
   },
   deleteClusterBtn: {
-    padding: `0 0 0 ${theme.spacing(2)}`,
     [theme.breakpoints.up('md')]: {
       paddingRight: '8px',
     },
@@ -225,27 +224,23 @@ export const KubeSummaryPanel = React.memo((props: Props) => {
             >
               <Typography variant="h2">Summary</Typography>
             </Box>
-            <Box
-              display="flex"
-              justifyContent="end"
-              sx={{ paddingTop: theme.spacing() }}
-            >
-              <LinkButton
+            <Box display="flex" justifyContent="end">
+              <StyledActionButton
                 onClick={() => {
                   window.open(dashboard?.url, '_blank');
                 }}
                 className={classes.dashboard}
-                isDisabled={Boolean(dashboardError) || !dashboard}
+                disabled={Boolean(dashboardError) || !dashboard}
               >
                 Kubernetes Dashboard
                 <OpenInNewIcon />
-              </LinkButton>
-              <LinkButton
+              </StyledActionButton>
+              <StyledActionButton
                 className={classes.deleteClusterBtn}
                 onClick={() => setIsDeleteDialogOpen(true)}
               >
                 Delete Cluster
-              </LinkButton>
+              </StyledActionButton>
             </Box>
           </EntityHeader>
         }

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -1,9 +1,10 @@
-import { Theme } from '@mui/material/styles';
 import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 import { makeStyles } from 'tss-react/mui';
 
-import { Button } from 'src/components/Button/Button';
+import { Box } from 'src/components/Box';
+import { StyledActionButton } from 'src/components/Button/StyledActionButton';
+import { Paper } from 'src/components/Paper';
 import { Tooltip } from 'src/components/Tooltip';
 import { Typography } from 'src/components/Typography';
 
@@ -14,6 +15,7 @@ import type {
   PoolNodeResponse,
 } from '@linode/api-v4/lib/kubernetes';
 import type { EncryptionStatus } from '@linode/api-v4/lib/linodes/types';
+import type { Theme } from '@mui/material/styles';
 
 interface Props {
   autoscaler: AutoscaleSettings;
@@ -60,82 +62,75 @@ export const NodePool = (props: Props) => {
   const { classes } = useStyles();
 
   return (
-    <Grid
-      alignItems="center"
-      container
-      data-qa-node-pool-id={poolId}
-      data-qa-node-pool-section
-      justifyContent="space-between"
-      spacing={2}
-    >
-      <Grid>
-        <Typography variant="h2">{typeLabel}</Typography>
-      </Grid>
-      <Grid
+    <Grid data-qa-node-pool-id={poolId} data-qa-node-pool-section>
+      <Paper
         sx={{
+          alignItems: 'center',
           display: 'flex',
+          flexWrap: 'wrap',
+          justifyContent: 'space-between',
+          pl: 2,
+          pr: 0.5,
+          py: 0,
         }}
       >
-        <Button
-          buttonType="secondary"
-          className={`${autoscaler.enabled ? classes.button : ''}`}
-          compactY
-          onClick={() => openAutoscalePoolDialog(poolId)}
+        <Box>
+          <Typography variant="h2">{typeLabel}</Typography>
+        </Box>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+          }}
         >
-          Autoscale Pool
-        </Button>
-        {autoscaler.enabled ? (
-          <Typography className={classes.autoscaleText}>
-            {`(Min ${autoscaler.min} / Max ${autoscaler.max})`}
-          </Typography>
-        ) : null}
-        <Button
-          buttonType="secondary"
-          compactY
-          onClick={() => handleClickResize(poolId)}
-        >
-          Resize Pool
-        </Button>
-        <Button
-          buttonType="secondary"
-          compactY
-          onClick={() => openRecycleAllNodesDialog(poolId)}
-        >
-          Recycle Pool Nodes
-        </Button>
-        <Tooltip
-          disableFocusListener={!isOnlyNodePool}
-          disableHoverListener={!isOnlyNodePool}
-          disableTouchListener={!isOnlyNodePool}
-          title="Clusters must contain at least one node pool."
-        >
-          <div>
-            <Button
-              buttonType="secondary"
-              className={classes.deletePoolBtn}
-              compactY
-              disabled={isOnlyNodePool}
-              onClick={() => openDeletePoolDialog(poolId)}
-            >
-              Delete Pool
-            </Button>
-          </div>
-        </Tooltip>
-      </Grid>
-      <Grid
-        sx={{
-          paddingTop: 0,
-        }}
-        xs={12}
-      >
-        <NodeTable
-          encryptionStatus={encryptionStatus}
-          nodes={nodes}
-          openRecycleNodeDialog={openRecycleNodeDialog}
-          poolId={poolId}
-          typeLabel={typeLabel}
-        />
-      </Grid>
+          <StyledActionButton
+            compactY
+            onClick={() => openAutoscalePoolDialog(poolId)}
+          >
+            Autoscale Pool
+          </StyledActionButton>
+          {autoscaler.enabled ? (
+            <Typography className={classes.autoscaleText}>
+              {`(Min ${autoscaler.min} / Max ${autoscaler.max})`}
+            </Typography>
+          ) : null}
+          <StyledActionButton
+            compactY
+            onClick={() => handleClickResize(poolId)}
+          >
+            Resize Pool
+          </StyledActionButton>
+          <StyledActionButton
+            compactY
+            onClick={() => openRecycleAllNodesDialog(poolId)}
+          >
+            Recycle Pool Nodes
+          </StyledActionButton>
+          <Tooltip
+            disableFocusListener={!isOnlyNodePool}
+            disableHoverListener={!isOnlyNodePool}
+            disableTouchListener={!isOnlyNodePool}
+            title="Clusters must contain at least one node pool."
+          >
+            <div>
+              <StyledActionButton
+                compactY
+                disabled={isOnlyNodePool}
+                onClick={() => openDeletePoolDialog(poolId)}
+              >
+                Delete Pool
+              </StyledActionButton>
+            </div>
+          </Tooltip>
+        </Box>
+      </Paper>
+      <NodeTable
+        encryptionStatus={encryptionStatus}
+        nodes={nodes}
+        openRecycleNodeDialog={openRecycleNodeDialog}
+        poolId={poolId}
+        typeLabel={typeLabel}
+      />
     </Grid>
   );
 };

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -1,4 +1,3 @@
-import { Theme } from '@mui/material/styles';
 import Grid from '@mui/material/Unstable_Grid2';
 import React, { useState } from 'react';
 import { Waypoint } from 'react-waypoint';
@@ -7,7 +6,7 @@ import { makeStyles } from 'tss-react/mui';
 import { Button } from 'src/components/Button/Button';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
-import { Paper } from 'src/components/Paper';
+import { Stack } from 'src/components/Stack';
 import { Typography } from 'src/components/Typography';
 import { useAllKubernetesNodePoolQuery } from 'src/queries/kubernetes';
 import { useSpecificTypes } from 'src/queries/types';
@@ -23,6 +22,7 @@ import { RecycleNodeDialog } from './RecycleNodeDialog';
 import { ResizeNodePoolDrawer } from './ResizeNodePoolDrawer';
 
 import type { Region } from '@linode/api-v4';
+import type { Theme } from '@mui/material/styles';
 
 const useStyles = makeStyles()((theme: Theme) => ({
   button: {
@@ -145,7 +145,7 @@ export const NodePoolsDisplay = (props: Props) => {
           </Button>
         </Grid>
       </Grid>
-      <Paper>
+      <Stack>
         {poolsError ? (
           <ErrorState errorText={poolsError?.[0].reason} />
         ) : (
@@ -162,7 +162,10 @@ export const NodePoolsDisplay = (props: Props) => {
                   thisPoolType?.formattedLabel ?? 'Unknown type';
 
                 return (
-                  <div key={id}>
+                  <Stack
+                    key={id}
+                    sx={(theme) => ({ paddingBottom: theme.spacing(2) })}
+                  >
                     <NodePool
                       openAutoscalePoolDialog={(poolId) => {
                         setSelectedPoolId(poolId);
@@ -188,7 +191,7 @@ export const NodePoolsDisplay = (props: Props) => {
                       poolId={thisPool.id}
                       typeLabel={typeLabel}
                     />
-                  </div>
+                  </Stack>
                 );
               })}
               {pools?.length > numPoolsToDisplay && (
@@ -245,7 +248,7 @@ export const NodePoolsDisplay = (props: Props) => {
             />
           </Grid>
         )}
-      </Paper>
+      </Stack>
     </>
   );
 };


### PR DESCRIPTION
## Description 📝
Some UI improvements for the LKE Details summary panel and Node Pool tables

> [!NOTE]
> There is an existing issue noticeable in dark mode for `LinodeEntityDetailBody` where the border above the VPC section in the Linode Detail header extends past the left bounds of the table. I created M3-8354 to track this.

## Changes  🔄
- Add a header to the LKE Details summary panel containing "Summary" and the `Kubernetes Dashboard` and `Delete Cluster` buttons
  - Remove secondary button styling from buttons
- Remove the `<Paper />` behind the entire Node Pools section, replaced with a paper behind each Node Pool table
- Place each Node Pool's plan and action buttons in a header, adjusting the styling of the action buttons to text instead of secondary buttons

## Target release date 🗓️
7/22/24

## Preview 📷
| Before  | After |
| ------------- | ------------- |
| ![Screenshot 2024-07-17 at 10 31 10 AM](https://github.com/user-attachments/assets/069eda9e-0324-4c6f-97ab-6e49128658a5)  | ![Screenshot 2024-07-17 at 10 30 18 AM](https://github.com/user-attachments/assets/1a7c7ad4-4396-4e22-8266-d6dd75a4fefc) |
|  ![Screenshot 2024-07-17 at 10 32 30 AM](https://github.com/user-attachments/assets/bf9267a4-b4a7-4bb1-9db8-8785cce06dfd) | ![Screenshot 2024-07-17 at 10 32 30 AM](https://github.com/user-attachments/assets/bf9267a4-b4a7-4bb1-9db8-8785cce06dfd) | ![Screenshot 2024-07-17 at 10 36 45 AM](https://github.com/user-attachments/assets/e20c3572-bc4e-4f7a-8331-f8b54948e567) |

## How to test 🧪
### Verification steps
Verify the changes described above for the LKE Details summary panel and the individual Node Pools tables.

Additionally, confirm there are no adverse impacts to the Linode Details header, since this PR made some modifications to `EntityDetail.tsx` which is used in `LinodeEntityDetail.tsx`.

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support