### PR TITLE
change: [M3-5785] - Mislabelling of SRV fields in Linode's DNS Manager

### DIFF
--- a/packages/manager/.changeset/pr-10687-changed-1721198360943.md
+++ b/packages/manager/.changeset/pr-10687-changed-1721198360943.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Mislabelling of SRV fields in Linode's DNS Manager ([#10687](https://github.com/linode/manager/pull/10687))

--- a/packages/manager/.changeset/pr-10687-changed-1721198360943.md
+++ b/packages/manager/.changeset/pr-10687-changed-1721198360943.md
@@ -2,4 +2,4 @@
 "@linode/manager": Changed
 ---
 
-Mislabelling of SRV fields in Linode's DNS Manager ([#10687](https://github.com/linode/manager/pull/10687))
+Renamed SRV column headers in Linode's DNS Manager ([#10687](https://github.com/linode/manager/pull/10687))

--- a/packages/manager/.changeset/pr-10687-changed-1721198360943.md
+++ b/packages/manager/.changeset/pr-10687-changed-1721198360943.md
@@ -2,4 +2,4 @@
 "@linode/manager": Changed
 ---
 
-Renamed SRV column headers in Linode's DNS Manager ([#10687](https://github.com/linode/manager/pull/10687))
+Rename SRV column headers in Linode's DNS Manager ([#10687](https://github.com/linode/manager/pull/10687))

--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -584,10 +584,10 @@ class DomainRecords extends React.Component<Props, State> {
     /** SRV Record */
     {
       columns: [
-        { render: (r: DomainRecord) => r.name, title: 'Name' },
+        { render: (r: DomainRecord) => r.name, title: 'Service/Protocol' },
         {
           render: () => this.props.domain.domain,
-          title: 'Domain',
+          title: 'Name',
         },
         {
           render: (r: DomainRecord) => String(r.priority),


### PR DESCRIPTION
## Description 📝
SRV records in the Linode DNS Manager are not labelled correctly, which can lead to confusion for customers and customer support. 

[The format for SRV records](https://en.wikipedia.org/wiki/SRV_record#Record_format) is:

service._protocol.name

In the DNS Manager, we have mislabeled the combined Service/Protocol section as a "Name" field. What would be the "name" portion of the SRV record is improperly labelled as "Domain." To align with the standard formatting for SRV records, I propose that we change the 'Name' field to something like "Service/Protocol" and the 'Domain' field to "Name".

> [!NOTE]
> Please note that the Linode's DNS Manger does not include a name field when entering these records. The current "Domain" field will be populated with whatever domain or subdomain is added to the Linode DNS Manager.

## Changes  🔄

For SRV Record:
  - Renamed the first column header from `Name` to `Service/Protocol`
  - Renamed the second column header from `Domain` to `Name`

## Target release date 🗓️
22 July, 2024

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-07-17 at 11 16 10 AM](https://github.com/user-attachments/assets/8610bd2a-da2c-494c-9782-1b4be8703737) | ![Screenshot 2024-07-17 at 11 15 48 AM](https://github.com/user-attachments/assets/e7fabf76-74b9-4970-a03d-9f8134343e30) |

## How to test 🧪

### Verification steps
(How to verify changes)
- Navigate to http://localhost:3000/domains/:id and locate the SRV record table
- Confirm that the first column header "Name" has been changed to `Service/Protocol` and the second column header "Domain" has been changed to `Name`

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support