### PR TITLE
test: [M3-8359] - Make Existing Linode Create Cypress Tests work for Linode Create v2

### DIFF
--- a/packages/manager/.changeset/pr-10695-tests-1721358768207.md
+++ b/packages/manager/.changeset/pr-10695-tests-1721358768207.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Make Existing Linode Create Cypress Test Compatible with Linode Create v2 ([#10695](https://github.com/linode/manager/pull/10695))

--- a/packages/manager/cypress/e2e/core/general/gdpr-agreement.spec.ts
+++ b/packages/manager/cypress/e2e/core/general/gdpr-agreement.spec.ts
@@ -4,6 +4,8 @@ import { regionFactory } from '@src/factories';
 import { randomString, randomLabel } from 'support/util/random';
 import { mockGetRegions } from 'support/intercepts/regions';
 import { mockGetAccountAgreements } from 'support/intercepts/account';
+import { mockAppendFeatureFlags, mockGetFeatureFlagClientstream } from 'support/intercepts/feature-flags';
+import { makeFeatureFlagData } from 'support/util/feature-flags';
 
 import type { Region } from '@linode/api-v4';
 
@@ -94,6 +96,14 @@ describe('GDPR agreement', () => {
   });
 
   it('needs the agreement checked to validate the form', () => {
+    // This test does not apply to Linode Create v2 because
+    // Linode Create v2 allows you to press "Create Linode"
+    // without checking the GDPR checkbox. (The user will
+    // get a validation error if they have not agreed).
+    mockAppendFeatureFlags({
+      linodeCreateRefactor: makeFeatureFlagData(false),
+    });
+    mockGetFeatureFlagClientstream();
     mockGetRegions(mockRegions).as('getRegions');
     mockGetAccountAgreements({
       privacy_policy: false,

--- a/packages/manager/cypress/e2e/core/images/create-linode-from-image.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/create-linode-from-image.spec.ts
@@ -1,4 +1,4 @@
-import { containsClick, fbtClick, fbtVisible, getClick } from 'support/helpers';
+import { fbtClick, fbtVisible, getClick } from 'support/helpers';
 import { apiMatcher } from 'support/util/intercepts';
 import { randomLabel, randomNumber, randomString } from 'support/util/random';
 import { mockGetAllImages } from 'support/intercepts/images';
@@ -33,14 +33,17 @@ const createLinodeWithImageMock = (url: string, preselectedImage: boolean) => {
   cy.visitWithLogin(url);
 
   cy.wait('@mockImage');
+
   if (!preselectedImage) {
-    cy.get('[data-qa-enhanced-select="Choose an image"]').within(() => {
-      containsClick('Choose an image');
-    });
-    cy.get(`[data-qa-image-select-item="${mockImage.id}"]`).within(() => {
-      cy.get('span').should('have.class', 'fl-tux');
-      fbtClick(mockImage.label);
-    });
+    cy.findByPlaceholderText('Choose an image')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.findByText(mockImage.label)
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
   }
 
   ui.regionSelect.find().click();
@@ -49,7 +52,13 @@ const createLinodeWithImageMock = (url: string, preselectedImage: boolean) => {
   fbtClick('Shared CPU');
   getClick('[id="g6-nanode-1"][type="radio"]');
   cy.get('[id="root-password"]').type(randomString(32));
-  getClick('[data-qa-deploy-linode="true"]');
+
+  ui.button
+    .findByTitle('Create Linode')
+    .scrollIntoView()
+    .should('be.visible')
+    .should('be.enabled')
+    .click();
 
   cy.wait('@mockLinodeRequest');
 

--- a/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
@@ -340,11 +340,13 @@ describe('Create Linode', () => {
     ui.toast.assertMessage('Successfully created SSH key.');
 
     // When a user creates an SSH key, the list of SSH keys for each user updates to show the new key for the signed in user
-    cy.findAllByText(sshPublicKeyLabel).should('be.visible');
+    cy.findByText(sshPublicKeyLabel, { exact: false }).should('be.visible');
 
     getClick('#linode-label').clear().type(linodeLabel);
     cy.get('#root-password').type(rootpass);
-    getClick('[data-qa-deploy-linode]');
+
+    ui.button.findByTitle("Create Linode").click();
+
     cy.wait('@linodeCreated').its('response.statusCode').should('eq', 200);
     fbtVisible(linodeLabel);
     cy.contains('RUNNING', { timeout: 300000 }).should('be.visible');

--- a/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
@@ -294,15 +294,14 @@ describe('Create Linode', () => {
     getVisible('[data-testid="vpc-panel"]').within(() => {
       containsVisible('Assign this Linode to an existing VPC.');
       // select VPC
-      cy.get('[data-qa-enhanced-select="None"]')
+      cy.findByLabelText('Assign VPC')
         .should('be.visible')
-        .click()
-        .type(`${mockVPC.label}{enter}`);
+        .focus()
+        .type(`${mockVPC.label}{downArrow}{enter}`);
       // select subnet
-      cy.findByText('Select Subnet')
+      cy.findByPlaceholderText('Select Subnet')
         .should('be.visible')
-        .click()
-        .type(`${mockSubnet.label}{enter}`);
+        .type(`${mockSubnet.label}{downArrow}{enter}`)
     });
 
     // The drawer opens when clicking "Add an SSH Key" button

--- a/packages/manager/cypress/e2e/core/linodes/legacy-create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/legacy-create-linode.spec.ts
@@ -505,20 +505,21 @@ describe('create linode', () => {
     getVisible('[data-testid="vpc-panel"]').within(() => {
       containsVisible('Assign this Linode to an existing VPC.');
       // select VPC
-      cy.get('[data-qa-enhanced-select="None"]')
+      cy.findByLabelText('Assign VPC')
         .should('be.visible')
-        .click()
-        .type(`${mockVPC.label}{enter}`);
+        .focus()
+        .type(`${mockVPC.label}{downArrow}{enter}`);
       // select subnet
-      cy.findByText('Select Subnet')
+      cy.findByPlaceholderText('Select Subnet')
         .should('be.visible')
-        .click()
-        .type(`${mockSubnet.label}{enter}`);
+        .type(`${mockSubnet.label}{downArrow}{enter}`);
     });
 
     getClick('#linode-label').clear().type(linodeLabel);
     cy.get('#root-password').type(rootpass);
-    getClick('[data-qa-deploy-linode]');
+
+    ui.button.findByTitle('Create Linode').click();
+
     cy.wait('@linodeCreated').its('response.statusCode').should('eq', 200);
     fbtVisible(linodeLabel);
     cy.contains('RUNNING', { timeout: 300000 }).should('be.visible');

--- a/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
+++ b/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
@@ -49,14 +49,14 @@ describe('OneClick Apps (OCA)', () => {
       // Check the content of the OCA listing
       cy.findByTestId('one-click-apps-container').within(() => {
         // Check that all sections are present (note: New apps can be empty so not asserting its presence)
-        cy.findByTestId('Popular apps').should('exist');
-        cy.findByTestId('All apps').should('exist');
+        cy.findByText('Popular apps').should('be.visible');
+        cy.findByText('All apps').should('be.visible');
 
         trimmedApps.forEach((stackScript) => {
           const { decodedLabel, label } = handleAppLabel(stackScript);
 
           // Check that every OCA is listed with the correct label
-          cy.get(`[data-qa-select-card-heading="${label}"]`).should('exist');
+          cy.get(`[data-qa-select-card-heading="${label.trim()}"]`).should('exist');
 
           // Check that every OCA has a drawer match
           // This validates the regex in `mapStackScriptLabelToOCA`
@@ -76,7 +76,7 @@ describe('OneClick Apps (OCA)', () => {
       const candidateLabel = handleAppLabel(trimmedApps[0]).label;
 
       const stackScriptCandidate = cy
-        .get(`[data-qa-selection-card-info="${candidateLabel}"]`)
+        .get(`[data-qa-selection-card-info="${candidateLabel.trim()}"]`)
         .first();
       stackScriptCandidate.should('exist').click();
 
@@ -92,7 +92,7 @@ describe('OneClick Apps (OCA)', () => {
       }
 
       ui.drawer
-        .findByTitle(trimmedApps[0].label)
+        .findByTitle(trimmedApps[0].label.trim())
         .should('be.visible')
         .within(() => {
           containsVisible(app.description);
@@ -113,7 +113,7 @@ describe('OneClick Apps (OCA)', () => {
           'have.length.below',
           initialNumberOfApps
         );
-        cy.get(`[data-qa-selection-card-info="${candidateLabel}"]`).should(
+        cy.get(`[data-qa-selection-card-info="${candidateLabel.trim()}"]`).should(
           'be.visible'
         );
       });

--- a/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
+++ b/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
@@ -168,6 +168,7 @@ describe('OneClick Apps (OCA)', () => {
 
     mockGetStackScripts([stackScripts]).as('getStackScripts');
     mockAppendFeatureFlags({
+      linodeCreateRefactor: makeFeatureFlagData(false),
       oneClickApps: makeFeatureFlagData({
         401709: 'E2E Test App',
       }),
@@ -181,7 +182,7 @@ describe('OneClick Apps (OCA)', () => {
 
     cy.findByTestId('one-click-apps-container').within(() => {
       // Since it is mock data we can assert the New App section is present
-      cy.findByTestId('New apps').should('exist');
+      cy.findByText('New apps').should('be.visible');
 
       // Check that the app is listed and select it
       cy.get('[data-qa-selection-card="true"]').should('have.length', 3);

--- a/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
@@ -351,22 +351,16 @@ describe('Create stackscripts', () => {
         .click();
 
       // Confirm that expected images are present in "Choose an image" drop-down.
-      cy.findByText('Choose an image').should('be.visible').click();
+      cy.findByPlaceholderText('Choose an image').should('be.visible').click();
 
       imageSamples.forEach((imageSample) => {
         const imageLabel = imageSample.label;
-        const imageSelector = imageSample.sel;
 
-        cy.get(`[data-qa-image-select-item="${imageSelector}"]`)
-          .scrollIntoView()
-          .should('be.visible')
-          .within(() => {
-            cy.findByText(imageLabel).should('be.visible');
-          });
+        cy.findByText(imageLabel).scrollIntoView().should('be.visible');
       });
 
       // Select private image.
-      cy.get(`[data-qa-image-select-item="${privateImage.id}"]`)
+      cy.findByText(privateImage.label)
         .scrollIntoView()
         .should('be.visible')
         .click();

--- a/packages/manager/cypress/e2e/core/stackscripts/smoke-community-stackscrips.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/smoke-community-stackscrips.spec.ts
@@ -5,7 +5,6 @@ import {
   mockGetStackScripts,
   mockGetStackScript,
 } from 'support/intercepts/stackscripts';
-import { containsClick } from 'support/helpers';
 import { ui } from 'support/ui';
 import { randomLabel, randomString } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
@@ -326,9 +325,9 @@ describe('Community Stackscripts integration tests', () => {
     cy.get('[id="vpn-password"]').should('have.value', vpnPassword);
 
     // Choose an image
-    cy.get('[data-qa-enhanced-select="Choose an image"]').within(() => {
-      containsClick('Choose an image').type(`${image}{enter}`);
-    });
+    cy.findByPlaceholderText('Choose an image').should('be.visible').click();
+
+    cy.findByText(image).should('be.visible').click();
 
     // Choose a region
     ui.button
@@ -370,7 +369,10 @@ describe('Community Stackscripts integration tests', () => {
       .should('be.visible')
       .should('be.enabled')
       .click();
-    cy.contains('Password does not meet complexity requirements.');
+
+    cy.findByText('Password does not meet', { exact: false }).should(
+      'be.visible'
+    );
 
     cy.get('[id="root-password"]').clear().type(fairPassword);
     ui.button
@@ -378,7 +380,10 @@ describe('Community Stackscripts integration tests', () => {
       .should('be.visible')
       .should('be.enabled')
       .click();
-    cy.contains('Password does not meet complexity requirements.');
+
+    cy.findByText('Password does not meet', { exact: false }).should(
+      'be.visible'
+    );
 
     // Only strong password is allowed to rebuild the linode
     cy.get('[id="root-password"]').type(rootPassword);

--- a/packages/manager/src/components/EnhancedSelect/components/SelectControl.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/SelectControl.tsx
@@ -8,6 +8,7 @@ type Props = ControlProps<any, any>;
 const SelectControl: React.FC<Props> = (props) => {
   return (
     <TextField
+      placeholder={props.selectProps.placeholder}
       InputProps={{
         inputComponent: 'div',
         inputProps: {

--- a/packages/manager/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/manager/src/components/PasswordInput/PasswordInput.tsx
@@ -1,11 +1,11 @@
-import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 import zxcvbn from 'zxcvbn';
 
-import { TextFieldProps } from 'src/components/TextField';
-
 import { StrengthIndicator } from '../PasswordInput/StrengthIndicator';
+import { Stack } from '../Stack';
 import { HideShowText } from './HideShowText';
+
+import type { TextFieldProps } from 'src/components/TextField';
 
 interface Props extends TextFieldProps {
   disabledReason?: JSX.Element | string;
@@ -26,25 +26,21 @@ const PasswordInput = (props: Props) => {
   const strength = React.useMemo(() => maybeStrength(value), [value]);
 
   return (
-    <Grid container spacing={1}>
-      <Grid xs={12}>
-        <HideShowText
-          {...rest}
-          fullWidth
-          required={required}
-          tooltipText={disabledReason}
-          value={value}
-        />
-      </Grid>
+    <Stack spacing={1}>
+      <HideShowText
+        {...rest}
+        fullWidth
+        required={required}
+        tooltipText={disabledReason}
+        value={value}
+      />
       {!hideValidation && (
-        <Grid xs={12}>
-          <StrengthIndicator
-            hideStrengthLabel={hideStrengthLabel}
-            strength={strength}
-          />
-        </Grid>
+        <StrengthIndicator
+          hideStrengthLabel={hideStrengthLabel}
+          strength={strength}
+        />
       )}
-    </Grid>
+    </Stack>
   );
 };
 

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Backups.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Backups.tsx
@@ -108,6 +108,7 @@ export const Backups = () => {
       }
       checked={checked}
       control={<Checkbox />}
+      data-testid="backups"
       onChange={field.onChange}
     />
   );

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Security.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Security.tsx
@@ -67,6 +67,7 @@ export const Security = () => {
               label="Root Password"
               name="password"
               noMarginTop
+              id="linode-password"
               onBlur={field.onBlur}
               onChange={field.onChange}
               placeholder="Enter a password."

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Images.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Images.tsx
@@ -2,10 +2,13 @@ import React from 'react';
 import { useController, useFormContext, useWatch } from 'react-hook-form';
 
 import DistributedRegionIcon from 'src/assets/icons/entityIcons/distributed-region.svg';
+import ImageIcon from 'src/assets/icons/entityIcons/image.svg';
 import { Box } from 'src/components/Box';
 import { ImageSelectv2 } from 'src/components/ImageSelectv2/ImageSelectv2';
 import { getAPIFilterForImageSelect } from 'src/components/ImageSelectv2/utilities';
+import { Link } from 'src/components/Link';
 import { Paper } from 'src/components/Paper';
+import { Placeholder } from 'src/components/Placeholder/Placeholder';
 import { Stack } from 'src/components/Stack';
 import { Typography } from 'src/components/Typography';
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
@@ -56,6 +59,20 @@ export const Images = () => {
   const showDistributedCapabilityNotice = images?.some((image) =>
     image.capabilities.includes('distributed-images')
   );
+
+  if (images?.length === 0) {
+    return (
+      <Paper>
+        <Placeholder icon={ImageIcon} isEntity title="My Images">
+          <Typography variant="subtitle1">
+            You don&rsquo;t have any private Images. Visit the{' '}
+            <Link to="/images">Images section</Link> to create an Image from one
+            of your Linode&rsquo;s disks.
+          </Typography>
+        </Placeholder>
+      </Paper>
+    );
+  }
 
   return (
     <Paper>

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Marketplace/AppDetailDrawer.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Marketplace/AppDetailDrawer.tsx
@@ -117,6 +117,7 @@ export const AppDetailDrawerv2 = (props: Props) => {
                   text: selectedApp.name,
                 }),
               }}
+              data-qa-drawer-title={selectedApp.name}
               className={classes.appName}
               data-testid="app-name"
               variant="h2"

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Marketplace/AppSelectionCard.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Marketplace/AppSelectionCard.tsx
@@ -48,6 +48,13 @@ export const AppSelectionCard = (props: Props) => {
     }
   };
 
+  const displayLabel = decode(
+    label
+      .replace(' Null One-Click', '')
+      .replace(' One-Click', '')
+      .replace(' Cluster', '')
+  ).trim();
+
   const renderIcon =
     iconUrl === ''
       ? () => <span className="fl-tux" />
@@ -55,7 +62,8 @@ export const AppSelectionCard = (props: Props) => {
 
   const renderVariant = () => (
     <IconButton
-      aria-label={`Info for "${label}"`}
+      aria-label={`Info for "${displayLabel}"`}
+      data-qa-selection-card-info={displayLabel}
       onClick={handleInfoClick}
       onKeyDown={handleKeyPress}
     >
@@ -66,13 +74,6 @@ export const AppSelectionCard = (props: Props) => {
   const headingDecoration = label.includes('Cluster') ? (
     <Chip label="CLUSTER" size="small" />
   ) : undefined;
-
-  const displayLabel = decode(
-    label
-      .replace('Null One-Click', '')
-      .replace('One-Click', '')
-      .replace('Cluster', '')
-  );
 
   return (
     <SelectionCard

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Marketplace/Marketplace.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Marketplace/Marketplace.tsx
@@ -15,7 +15,7 @@ export const Marketplace = () => {
   };
 
   return (
-    <Stack spacing={2}>
+    <Stack data-testid="one-click-apps-container" spacing={2}>
       <AppSelect onOpenDetailsDrawer={onOpenDetailsDrawer} />
       <UserDefinedFields onOpenDetailsDrawer={onOpenDetailsDrawer} />
       <StackScriptImages />

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
@@ -73,7 +73,7 @@ export const VPC = () => {
       : 'Assign this Linode to an existing VPC.';
 
   return (
-    <Paper>
+    <Paper data-testid="vpc-panel">
       <Stack spacing={2}>
         <Typography variant="h2">VPC</Typography>
         <Typography>

--- a/packages/manager/src/features/Linodes/LinodesCreate/SelectionCardWrapper.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/SelectionCardWrapper.tsx
@@ -77,7 +77,7 @@ export const SelectionCardWrapper = (props: Props) => {
     <InfoGrid xs={2}>
       <Info
         aria-label={`Info for "${label}"`}
-        data-qa-selection-card-info={label}
+        data-qa-selection-card-info={label.trim()}
         onClick={handleInfoClick}
         onKeyDown={handleKeyPress}
         role="button"
@@ -99,7 +99,7 @@ export const SelectionCardWrapper = (props: Props) => {
       checked={checked}
       data-qa-selection-card
       disabled={disabled}
-      heading={label}
+      heading={label.trim()}
       headingDecoration={labelDecoration}
       id={`app-${String(id)}`}
       key={id}

--- a/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -289,7 +289,7 @@ export class FromAppsContent extends React.Component<CombinedProps, State> {
         <AppDetailDrawer
           onClose={this.closeDrawer}
           open={this.state.detailDrawerOpen}
-          stackScriptLabel={this.state.selectedScriptForDrawer}
+          stackScriptLabel={this.state.selectedScriptForDrawer.trim()}
         />
       </React.Fragment>
     );

--- a/packages/manager/src/features/Linodes/index.tsx
+++ b/packages/manager/src/features/Linodes/index.tsx
@@ -32,7 +32,11 @@ export const LinodesRoutes = () => {
 
   // Hold this feature flag in state so that the user's Linode creation
   // isn't interupted when the flag is toggled.
-  const [isLinodeCreateV2Enabled] = useState(flags.linodeCreateRefactor);
+  const [isLinodeCreateV2EnabledStale] = useState(flags.linodeCreateRefactor);
+
+  const isLinodeCreateV2Enabled = import.meta.env.DEV
+    ? flags.linodeCreateRefactor
+    : isLinodeCreateV2EnabledStale;
 
   return (
     <React.Suspense fallback={<SuspenseLoader />}>

--- a/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
+++ b/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
@@ -156,7 +156,7 @@ export const AppDetailDrawer: React.FunctionComponent<Props> = (props) => {
                 }),
               }}
               className={classes.appName}
-              data-qa-drawer-title={stackScriptLabel}
+              data-qa-drawer-title={stackScriptLabel.trim()}
               data-testid="app-name"
               variant="h2"
             />

--- a/packages/manager/src/features/OneClickApps/oneClickAppsv2.ts
+++ b/packages/manager/src/features/OneClickApps/oneClickAppsv2.ts
@@ -13,6 +13,7 @@ export const oneClickApps: Record<number, OCA> = {
     ...oneClickAppFactory.build({
       name: 'E2E Test App',
     }),
+    isNew: true,
   },
   401697: {
     alt_description: 'Popular website content management system.',


### PR DESCRIPTION
## Description 📝

- Doing this so Cypress tests still pass when the Linode Create v2 flow is toggled on ✅ 
- Makes Existing Linode Create Cypress Tests work for both Linode Create v1 and v2 🔧 
  - I'm doing this because currently, enabling Linode Create v2 in dev, causes many cypress failures.
  - This shouldn't be the case because Linode Create v2 should in parity with Linode Create v1, but the problem is that some cypress test use selectors that are specific to old components like EnhancedSelect.
  - This PR just updates the tests to use more generic selectors so that **they work for both flows** 
  - Alternatively, we could duplicated these tests, adapt them work for v2, and manually specify the flag to use, but I decided against this because I think it would be a lot more messy and confusing

## How to test 🧪

- There isn't a great way to test this locally unless you manually go into the code and mock the Linode Create v2 feature flag as **enabled**
- I used [this](https://linode.slack.com/archives/CL1L0ML7Q/p1720031512448079) to know what tests to fix. This link will show you what tests failed when we last tried turning on Linode Create v2 in dev

## Before (Linode Create v2 turned **ON** in dev)
![Screenshot 2024-07-19 at 1 41 23 AM](https://github.com/user-attachments/assets/30c57489-1ff7-4932-bd4c-e4d052c60a23)

## After (Linode Create v2 turned **ON** in dev)

![Screenshot 2024-07-19 at 1 38 37 AM](https://github.com/user-attachments/assets/d751a6eb-1029-436e-8f4f-780befacc028)

> [!note]
> The remaining GDPR tests should start passing when https://github.com/linode/manager/pull/10692 is merged in

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support