### PR TITLE
fix: [M3-8361] - Fix column headers for Automatic Images

### DIFF
--- a/packages/manager/.changeset/pr-10696-fixed-1721397985714.md
+++ b/packages/manager/.changeset/pr-10696-fixed-1721397985714.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Column headers for Automatic Images ([#10696](https://github.com/linode/manager/pull/10696))

--- a/packages/manager/.changeset/pr-10696-fixed-1721397985714.md
+++ b/packages/manager/.changeset/pr-10696-fixed-1721397985714.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Column headers for Automatic Images ([#10696](https://github.com/linode/manager/pull/10696))

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - User Preferences not properly being cached when the app loads ([#10663](https://github.com/linode/manager/pull/10663))
 - Blank toast notification when canceling an image upload ([#10664](https://github.com/linode/manager/pull/10664))
 - Missing support link in some toast notifications ([#10680](https://github.com/linode/manager/pull/10680))
+- Column headers for Automatic Images ([#10696](https://github.com/linode/manager/pull/10696))
 
 ### Removed:
 

--- a/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.tsx
@@ -28,6 +28,7 @@ import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
 import { TableSortCell } from 'src/components/TableSortCell';
 import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
+import { getRestrictedResourceText } from 'src/features/Account/utils';
 import { useFlags } from 'src/hooks/useFlags';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
@@ -43,7 +44,6 @@ import {
   useImagesQuery,
 } from 'src/queries/images';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
-import { getRestrictedResourceText } from 'src/features/Account/utils';
 
 import { getEventsForImages } from '../utils';
 import { EditImageDrawer } from './EditImageDrawer';
@@ -381,9 +381,6 @@ export const ImagesLanding = () => {
     <React.Fragment>
       <DocumentTitleSegment segment="Images" />
       <LandingHeader
-        docsLink="https://www.linode.com/docs/platform/disk-images/linode-images/"
-        entity="Image"
-        onButtonClick={() => history.push('/images/create')}
         buttonDataAttrs={{
           tooltipText: getRestrictedResourceText({
             action: 'create',
@@ -392,6 +389,9 @@ export const ImagesLanding = () => {
           }),
         }}
         disabledCreateButton={isImagesReadOnly}
+        docsLink="https://www.linode.com/docs/platform/disk-images/linode-images/"
+        entity="Image"
+        onButtonClick={() => history.push('/images/create')}
         title="Images"
       />
       <TextField
@@ -532,6 +532,14 @@ export const ImagesLanding = () => {
               <Hidden smDown>
                 <TableCell>Status</TableCell>
               </Hidden>
+              <TableSortCell
+                active={automaticImagesOrderBy === 'size'}
+                direction={automaticImagesOrder}
+                handleClick={handleAutomaticImagesOrderChange}
+                label="size"
+              >
+                Size
+              </TableSortCell>
               <Hidden smDown>
                 <TableSortCell
                   active={automaticImagesOrderBy === 'created'}
@@ -542,14 +550,6 @@ export const ImagesLanding = () => {
                   Created
                 </TableSortCell>
               </Hidden>
-              <TableSortCell
-                active={automaticImagesOrderBy === 'size'}
-                direction={automaticImagesOrder}
-                handleClick={handleAutomaticImagesOrderChange}
-                label="size"
-              >
-                Size
-              </TableSortCell>
               <Hidden smDown>
                 <TableCell>Expires</TableCell>
               </Hidden>


### PR DESCRIPTION
## Description 📝
Fixes the "Created" and "Size" headers pointing to the wrong columns in the Automatic Images section of `ImagesLanding`. This bug was introduced in #10545.

## Target release date 🗓️
ASAP

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-07-19 at 10 12 19 AM](https://github.com/user-attachments/assets/21dfb87f-020c-41fe-b36f-fee439ccf081) | ![Screenshot 2024-07-19 at 10 12 03 AM](https://github.com/user-attachments/assets/5670dba5-3b12-4c9d-8092-53b05f16120c) |

## How to test 🧪

### Verification steps
Navigate to the images landing and verify that the Automatic Images headers point to the correct columns under all breakpoints (sm, md and lg).