### PR TITLE
fix: Fix Cypress Test Flakes and Failures

### DIFF
--- a/packages/manager/.changeset/pr-10698-tests-1721417619359.md
+++ b/packages/manager/.changeset/pr-10698-tests-1721417619359.md
@@ -2,4 +2,4 @@
 "@linode/manager": Tests
 ---
 
-`account/betas.spec.ts` Test Flake  ([#10698](https://github.com/linode/manager/pull/10698))
+Mock sidebar as open in some tests to minimize flake ([#10698](https://github.com/linode/manager/pull/10698))

--- a/packages/manager/.changeset/pr-10698-tests-1721417619359.md
+++ b/packages/manager/.changeset/pr-10698-tests-1721417619359.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+`account/betas.spec.ts` Test Flake  ([#10698](https://github.com/linode/manager/pull/10698))

--- a/packages/manager/.changeset/pr-10698-upcoming-features-1721420372481.md
+++ b/packages/manager/.changeset/pr-10698-upcoming-features-1721420372481.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Fix broken Linode Create v2 clone validation ([#10698](https://github.com/linode/manager/pull/10698))

--- a/packages/manager/cypress/e2e/core/account/betas.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/betas.spec.ts
@@ -8,6 +8,7 @@ import {
 } from 'support/intercepts/feature-flags';
 import { makeFeatureFlagData } from 'support/util/feature-flags';
 import { ui } from 'support/ui';
+import { mockGetUserPreferences } from 'support/intercepts/profile';
 
 // TODO Delete feature flag mocks when feature flag is removed.
 describe('Betas landing page', () => {
@@ -22,8 +23,11 @@ describe('Betas landing page', () => {
     }).as('getFeatureFlags');
     mockGetFeatureFlagClientstream().as('getClientStream');
 
+    // Ensure that the Primary Nav is open
+    mockGetUserPreferences({ desktop_sidebar_open: false }).as('getPreferences');
+
     cy.visitWithLogin('/linodes');
-    cy.wait(['@getFeatureFlags', '@getClientStream']);
+    cy.wait(['@getFeatureFlags', '@getClientStream', '@getPreferences']);
 
     ui.nav.findItemByTitle('Betas').should('be.visible').click();
 

--- a/packages/manager/cypress/e2e/core/stackscripts/smoke-community-stackscrips.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/smoke-community-stackscrips.spec.ts
@@ -15,6 +15,7 @@ import { Profile } from '@linode/api-v4';
 import { formatDate } from '@src/utilities/formatDate';
 
 import type { StackScript } from '@linode/api-v4';
+import { mockGetUserPreferences } from 'support/intercepts/profile';
 
 const mockStackScripts: StackScript[] = [
   stackScriptFactory.build({
@@ -262,9 +263,11 @@ describe('Community Stackscripts integration tests', () => {
     const region = chooseRegion({ capabilities: ['Vlans'] });
     const linodeLabel = randomLabel();
 
+    // Ensure that the Primary Nav is open
+    mockGetUserPreferences({ desktop_sidebar_open: false }).as('getPreferences');
     interceptGetStackScripts().as('getStackScripts');
     cy.visitWithLogin('/stackscripts/community');
-    cy.wait('@getStackScripts');
+    cy.wait(['@getStackScripts', '@getPreferences']);
 
     cy.get('[id="search-by-label,-username,-or-description"]')
       .click()

--- a/packages/manager/cypress/e2e/core/vpc/vpc-navigation.spec.ts
+++ b/packages/manager/cypress/e2e/core/vpc/vpc-navigation.spec.ts
@@ -8,6 +8,7 @@ import {
 } from 'support/intercepts/feature-flags';
 import { makeFeatureFlagData } from 'support/util/feature-flags';
 import { ui } from 'support/ui';
+import { mockGetUserPreferences } from 'support/intercepts/profile';
 
 // TODO Remove feature flag mocks when feature flag is removed from codebase.
 describe('VPC navigation', () => {
@@ -21,8 +22,13 @@ describe('VPC navigation', () => {
     }).as('getFeatureFlags');
     mockGetFeatureFlagClientstream().as('getClientStream');
 
+    // Ensure that the Primary Nav is open
+    mockGetUserPreferences({ desktop_sidebar_open: false }).as(
+      'getPreferences'
+    );
+
     cy.visitWithLogin('/linodes');
-    cy.wait(['@getFeatureFlags', '@getClientStream']);
+    cy.wait(['@getFeatureFlags', '@getClientStream', '@getPreferences']);
 
     ui.nav.findItemByTitle('VPC').should('be.visible').click();
 

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/resolvers.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/resolvers.ts
@@ -6,7 +6,6 @@ import { regionQueries } from 'src/queries/regions/regions';
 import { getRegionCountryGroup, isEURegion } from 'src/utilities/formatRegion';
 
 import {
-  CreateLinodeByCloningSchema,
   CreateLinodeFromBackupSchema,
   CreateLinodeFromMarketplaceAppSchema,
   CreateLinodeFromStackScriptSchema,
@@ -37,6 +36,13 @@ export const getLinodeCreateResolver = (
       {},
       { mode: 'async', rawValues: true }
     )(transformedValues, context, options);
+
+    if (tab === 'Clone Linode' && !values.linode) {
+      errors['linode'] = {
+        message: 'You must select a Linode to clone from.',
+        type: 'validate',
+      };
+    }
 
     const regions = await queryClient.ensureQueryData(regionQueries.regions);
 
@@ -74,7 +80,7 @@ export const getLinodeCreateResolver = (
 
 export const linodeCreateResolvers = {
   Backups: CreateLinodeFromBackupSchema,
-  'Clone Linode': CreateLinodeByCloningSchema,
+  'Clone Linode': CreateLinodeSchema,
   Images: CreateLinodeSchema,
   OS: CreateLinodeSchema,
   'One-Click': CreateLinodeFromMarketplaceAppSchema,

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/schemas.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/schemas.ts
@@ -2,15 +2,6 @@ import { CreateLinodeSchema } from '@linode/validation';
 import { number, object } from 'yup';
 
 /**
- * Extends the Linode Create schema to make `linode` required for the Clone Linode tab
- */
-export const CreateLinodeByCloningSchema = CreateLinodeSchema.concat(
-  object({
-    linode: object().required('You must select a Linode to clone from.'),
-  })
-);
-
-/**
  * Extends the Linode Create schema to make backup_id required for the backups tab
  */
 export const CreateLinodeFromBackupSchema = CreateLinodeSchema.concat(


### PR DESCRIPTION
## Description 📝

- `vpc-navigation.spec.ts` & ` smoke-community-stackscrips.spec.ts` & `betas.spec.ts` 
   - Mocks preferences so that the Primary Nav (our sidebar) is open 📂 
  - The test should run faster because preferences are mocked 💨 
- `clone-linode.spec.ts`
  - Fix bug in Linode Create v2 Clone flow causing this test to fail
  - Validation logic was flawed

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/4acc0c61-a993-4575-b9ea-a8f2daeda8fd" /> | <video src="https://github.com/user-attachments/assets/de9e2f8b-4bdb-4b3c-b800-666549f6e949" />  |

## How to test 🧪

- Verify e2es pass ✅ 

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support