### PR TITLE
refactor: [M3-6901, M3-6917] Replace Select with Autocomplete in: firewalls

### DIFF
--- a/packages/manager/.changeset/pr-10701-tech-stories-1721805039188.md
+++ b/packages/manager/.changeset/pr-10701-tech-stories-1721805039188.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Replace Select with Autocomplete component on Firewalls' Add Inbound/Outbound rule drawer ([#10701](https://github.com/linode/manager/pull/10701))

--- a/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
@@ -77,10 +77,9 @@ const addFirewallRules = (rule: FirewallRuleType, direction: string) => {
     .should('be.visible')
     .within(() => {
       const port = rule.ports ? rule.ports : '22';
-      cy.get('[data-qa-enhanced-select="Select a rule preset..."]').type(
+      cy.get('[data-qa-rule-select="true"]').type(
         portPresetMap[port] + '{enter}'
       );
-
       const label = rule.label ? rule.label : 'test-label';
       const description = rule.description
         ? rule.description

--- a/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
@@ -77,7 +77,7 @@ const addFirewallRules = (rule: FirewallRuleType, direction: string) => {
     .should('be.visible')
     .within(() => {
       const port = rule.ports ? rule.ports : '22';
-      cy.get('[data-qa-rule-select="true"]').type(
+      cy.findByPlaceholderText('Select a rule preset...').type(
         portPresetMap[port] + '{enter}'
       );
       const label = rule.label ? rule.label : 'test-label';

--- a/packages/manager/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/manager/src/components/Autocomplete/Autocomplete.tsx
@@ -38,6 +38,8 @@ export interface EnhancedAutocompleteProps<
   placeholder?: string;
   /** Label for the "select all" option. */
   selectAllLabel?: string;
+  /** Removes "select all" option for mutliselect */
+  disableSelectAll?: boolean;
   textFieldProps?: Partial<TextFieldProps>;
 }
 
@@ -86,6 +88,7 @@ export const Autocomplete = <
     selectAllLabel = '',
     textFieldProps,
     value,
+    disableSelectAll = false,
     ...rest
   } = props;
 
@@ -166,7 +169,11 @@ export const Autocomplete = <
       multiple={multiple}
       noOptionsText={noOptionsText || <i>You have no options to choose from</i>}
       onBlur={onBlur}
-      options={multiple && options.length > 0 ? optionsWithSelectAll : options}
+      options={
+        multiple && !disableSelectAll && options.length > 0
+          ? optionsWithSelectAll
+          : options
+      }
       popupIcon={<KeyboardArrowDownIcon />}
       value={value}
       {...rest}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
@@ -1,5 +1,4 @@
 import { FirewallPolicyType } from '@linode/api-v4/lib/firewalls/types';
-import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
@@ -29,8 +28,6 @@ const mockOnSubmit = vi.fn();
 
 const baseItems = [PORT_PRESETS['22'], PORT_PRESETS['443']];
 
-vi.mock('src/components/EnhancedSelect/Select');
-
 const props: FirewallRuleDrawerProps = {
   category: 'inbound',
   isOpen: true,
@@ -48,21 +45,23 @@ describe('AddRuleDrawer', () => {
   });
 
   it('disables the port input when the ICMP protocol is selected', async () => {
-    renderWithTheme(
+    const { getByText, getByPlaceholderText } = renderWithTheme(
       <FirewallRuleDrawer {...props} category="inbound" mode="create" />
     );
-    expect(screen.getByLabelText('Ports')).not.toBeDisabled();
-    await userEvent.selectOptions(screen.getByLabelText('Protocol'), 'ICMP');
-    expect(screen.getByLabelText('Ports')).toBeDisabled();
+    expect(getByPlaceholderText('Select a port...')).not.toBeDisabled();
+    await userEvent.click(getByPlaceholderText('Select a protocol...'));
+    await userEvent.click(getByText('ICMP'));
+    expect(getByPlaceholderText('Select a port...')).toBeDisabled();
   });
 
   it('disables the port input when the IPENCAP protocol is selected', async () => {
-    renderWithTheme(
+    const { getByText, getByPlaceholderText } = renderWithTheme(
       <FirewallRuleDrawer {...props} category="inbound" mode="create" />
     );
-    expect(screen.getByLabelText('Ports')).not.toBeDisabled();
-    await userEvent.selectOptions(screen.getByLabelText('Protocol'), 'IPENCAP');
-    expect(screen.getByLabelText('Ports')).toBeDisabled();
+    expect(getByPlaceholderText('Select a port...')).not.toBeDisabled();
+    await userEvent.click(getByPlaceholderText('Select a protocol...'));
+    await userEvent.click(getByText('IPENCAP'));
+    expect(getByPlaceholderText('Select a port...')).toBeDisabled();
   });
 });
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -24,7 +24,7 @@ import type {
   FirewallRuleProtocol,
   FirewallRuleType,
 } from '@linode/api-v4/lib/firewalls';
-import type { Item } from 'src/components/EnhancedSelect/Select';
+import { FirewallOptionItem } from '../../shared';
 import type { ExtendedIP } from 'src/utilities/ipUtils';
 
 // =============================================================================
@@ -41,9 +41,11 @@ export const FirewallRuleDrawer = React.memo(
     const [ips, setIPs] = React.useState<ExtendedIP[]>([{ address: '' }]);
 
     // Firewall Ports, like IPs, are tracked separately. The form.values state value
-    // tracks the custom user input; the Item[] array of port presets in the multi-select
+    // tracks the custom user input; the FirewallOptionItem[] array of port presets in the multi-select
     // is stored here.
-    const [presetPorts, setPresetPorts] = React.useState<Item<string>[]>([]);
+    const [presetPorts, setPresetPorts] = React.useState<
+      FirewallOptionItem<string>[]
+    >([]);
 
     // Reset state. If we're in EDIT mode, set IPs to the addresses of the rule we're modifying
     // (along with any errors we may have).

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.types.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.types.ts
@@ -5,7 +5,7 @@ import type {
   FirewallRuleType,
 } from '@linode/api-v4/lib/firewalls';
 import type { FormikProps } from 'formik';
-import type { Item } from 'src/components/EnhancedSelect/Select';
+import { FirewallOptionItem } from '../../shared';
 import type { ExtendedIP } from 'src/utilities/ipUtils';
 
 export type FirewallRuleDrawerMode = 'create' | 'edit';
@@ -34,8 +34,8 @@ export interface FirewallRuleFormProps extends FormikProps<FormState> {
   category: Category;
   ips: ExtendedIP[];
   mode: FirewallRuleDrawerMode;
-  presetPorts: Item<string>[];
+  presetPorts: FirewallOptionItem<string>[];
   ruleErrors?: FirewallRuleError[];
   setIPs: (ips: ExtendedIP[]) => void;
-  setPresetPorts: (selected: Item<string>[]) => void;
+  setPresetPorts: (selected: FirewallOptionItem<string>[]) => void;
 }

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.utils.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.utils.ts
@@ -6,6 +6,7 @@ import { parseCIDR, parse as parseIP } from 'ipaddr.js';
 import { uniq } from 'ramda';
 
 import {
+  FirewallOptionItem,
   allIPs,
   allIPv4,
   allIPv6,
@@ -24,7 +25,6 @@ import type {
   FirewallRuleProtocol,
   FirewallRuleType,
 } from '@linode/api-v4/lib/firewalls';
-import type { Item } from 'src/components/EnhancedSelect';
 import type { ExtendedIP } from 'src/utilities/ipUtils';
 
 export const IP_ERROR_MESSAGE = 'Must be a valid IPv4 or IPv6 range.';
@@ -239,7 +239,7 @@ export const getInitialIPs = (
  * output: '22, 443, 1313-1515, 8080'
  */
 export const itemsToPortString = (
-  items: Item<string>[],
+  items: FirewallOptionItem<string>[],
   portInput?: string
 ): string | undefined => {
   // If a user has selected ALL, just return that; anything else in the string
@@ -261,11 +261,11 @@ export const itemsToPortString = (
 /**
  *
  * Inverse of itemsToPortString. Takes a string from an API response (or row value)
- * and converts it to Item<string>[] and a custom input string.
+ * and converts it to FirewallOptionItem<string>[] and a custom input string.
  */
 export const portStringToItems = (
   portString?: string
-): [Item<string>[], string] => {
+): [FirewallOptionItem<string>[], string] => {
   // Handle empty input
   if (!portString) {
     return [[], ''];
@@ -277,7 +277,7 @@ export const portStringToItems = (
   }
 
   const ports = portString.split(',').map((p) => p.trim());
-  const items: Item<string>[] = [];
+  const items: FirewallOptionItem<string>[] = [];
   const customInput: string[] = [];
 
   ports.forEach((thisPort) => {

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleForm.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleForm.tsx
@@ -207,6 +207,11 @@ export const FirewallRuleForm = React.memo((props: FirewallRuleFormProps) => {
       )}
       <Autocomplete
         autoHighlight
+        textFieldProps={{
+          dataAttrs: {
+            'data-qa-rule-select': true,
+          },
+        }}
         aria-label="Preset for firewall rule"
         disableClearable
         label="Preset"
@@ -241,6 +246,9 @@ export const FirewallRuleForm = React.memo((props: FirewallRuleFormProps) => {
           InputProps: {
             required: true,
           },
+          dataAttrs: {
+            'data-qa-protocol-select': true,
+          },
         }}
         autoHighlight
         aria-label="Select rule protocol."
@@ -261,12 +269,16 @@ export const FirewallRuleForm = React.memo((props: FirewallRuleFormProps) => {
           InputProps: {
             required: true,
           },
+          dataAttrs: {
+            'data-qa-port-select': true,
+          },
         }}
+        autoHighlight
         disabled={['ICMP', 'IPENCAP'].includes(values.protocol)}
         errorText={generalPortError}
         multiple
         label="Ports"
-        placeholder="Select a protocol..."
+        placeholder="Select a port..."
         onChange={(_, selected) => handlePortPresetChange(selected)}
         options={portOptions}
         value={presetPorts}
@@ -288,7 +300,11 @@ export const FirewallRuleForm = React.memo((props: FirewallRuleFormProps) => {
           InputProps: {
             required: true,
           },
+          dataAttrs: {
+            'data-qa-address-source-select': true,
+          },
         }}
+        autoHighlight
         aria-label={`Select rule ${addressesLabel}s.`}
         errorText={errors.addresses}
         disableClearable

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleForm.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleForm.tsx
@@ -275,10 +275,12 @@ export const FirewallRuleForm = React.memo((props: FirewallRuleFormProps) => {
         }}
         autoHighlight
         disabled={['ICMP', 'IPENCAP'].includes(values.protocol)}
+        disableSelectAll
         errorText={generalPortError}
         multiple
         label="Ports"
-        placeholder="Select a port..."
+        // If options are selected, hide the placeholder
+        placeholder={presetPorts.length > 0 ? ' ' : 'Select a port...'}
         onChange={(_, selected) => handlePortPresetChange(selected)}
         options={portOptions}
         value={presetPorts}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleForm.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleForm.tsx
@@ -2,7 +2,7 @@ import { styled } from '@mui/material/styles';
 import * as React from 'react';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
-import Select from 'src/components/EnhancedSelect';
+import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
 import { FormControlLabel } from 'src/components/FormControlLabel';
 import { MultipleIPInput } from 'src/components/MultipleIPInput/MultipleIPInput';
 import { Notice } from 'src/components/Notice/Notice';
@@ -11,6 +11,7 @@ import { RadioGroup } from 'src/components/RadioGroup';
 import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
 import {
+  FirewallOptionItem,
   addressOptions,
   firewallOptionItemsShort,
   portPresets,
@@ -23,7 +24,6 @@ import { enforceIPMasks } from './FirewallRuleDrawer.utils';
 import { PORT_PRESETS, PORT_PRESETS_ITEMS } from './shared';
 
 import type { FirewallRuleFormProps } from './FirewallRuleDrawer.types';
-import type { Item } from 'src/components/EnhancedSelect/Select';
 import type { ExtendedIP } from 'src/utilities/ipUtils';
 
 const ipNetmaskTooltipText =
@@ -83,7 +83,7 @@ export const FirewallRuleForm = React.memo((props: FirewallRuleFormProps) => {
 
   // These handlers are all memoized because the form was laggy when I tried them inline.
   const handleTypeChange = React.useCallback(
-    (item: Item | null) => {
+    (item: FirewallOptionItem | null) => {
       const selectedType = item?.value;
 
       // If the user re-selects the same preset or selectedType is undefined, don't do anything
@@ -128,9 +128,9 @@ export const FirewallRuleForm = React.memo((props: FirewallRuleFormProps) => {
   );
 
   const handleProtocolChange = React.useCallback(
-    (item: Item | null) => {
-      setFieldValue('protocol', item?.value);
-      if (item?.value === 'ICMP' || item?.value === 'IPENCAP') {
+    (item: string) => {
+      setFieldValue('protocol', item);
+      if (item === 'ICMP' || item === 'IPENCAP') {
         // Submitting the form with ICMP or IPENCAP and defined ports causes an error
         setFieldValue('ports', '');
         setPresetPorts([]);
@@ -140,8 +140,8 @@ export const FirewallRuleForm = React.memo((props: FirewallRuleFormProps) => {
   );
 
   const handleAddressesChange = React.useCallback(
-    (item: Item | null) => {
-      setFieldValue('addresses', item?.value);
+    (item: string) => {
+      setFieldValue('addresses', item);
       // Reset custom IPs
       setIPs([{ address: '' }]);
     },
@@ -169,7 +169,7 @@ export const FirewallRuleForm = React.memo((props: FirewallRuleFormProps) => {
   };
 
   const handlePortPresetChange = React.useCallback(
-    (items: Item<string>[]) => {
+    (items: FirewallOptionItem<string>[]) => {
       // If the user is selecting "ALL", it doesn't make sense
       // to show additional selections.
       if (
@@ -191,7 +191,7 @@ export const FirewallRuleForm = React.memo((props: FirewallRuleFormProps) => {
     return (
       addressOptions.find(
         (thisOption) => thisOption.value === values.addresses
-      ) || null
+      ) || undefined
     );
   }, [values]);
 
@@ -205,13 +205,13 @@ export const FirewallRuleForm = React.memo((props: FirewallRuleFormProps) => {
           variant="error"
         />
       )}
-      <Select
+      <Autocomplete
+        autoHighlight
         aria-label="Preset for firewall rule"
-        isClearable={false}
+        disableClearable
         label="Preset"
-        name="type"
         onBlur={handleBlur}
-        onChange={handleTypeChange}
+        onChange={(_, selected) => handleTypeChange(selected)}
         options={firewallOptionItemsShort}
         placeholder="Select a rule preset..."
       />
@@ -236,32 +236,39 @@ export const FirewallRuleForm = React.memo((props: FirewallRuleFormProps) => {
         placeholder="Enter a description..."
         value={values.description}
       />
-      <Select
+      <Autocomplete
+        textFieldProps={{
+          InputProps: {
+            required: true,
+          },
+        }}
+        autoHighlight
         aria-label="Select rule protocol."
         errorText={errors.protocol}
-        isClearable={false}
+        disableClearable
         label="Protocol"
-        name="protocol"
         onBlur={handleBlur}
-        onChange={handleProtocolChange}
+        onChange={(_, selected) => handleProtocolChange(selected.value)}
         options={protocolOptions}
         placeholder="Select a protocol..."
-        required
         value={protocolOptions.find((p) => p.value === values.protocol)}
       />
-      <Select
+      <Autocomplete
         textFieldProps={{
           helperText: ['ICMP', 'IPENCAP'].includes(values.protocol)
             ? `Ports are not allowed for ${values.protocol} protocols.`
             : undefined,
+          InputProps: {
+            required: true,
+          },
         }}
         disabled={['ICMP', 'IPENCAP'].includes(values.protocol)}
         errorText={generalPortError}
-        isMulti
+        multiple
         label="Ports"
-        onChange={handlePortPresetChange}
+        placeholder="Select a protocol..."
+        onChange={(_, selected) => handlePortPresetChange(selected)}
         options={portOptions}
-        required
         value={presetPorts}
       />
       {hasCustomInput ? (
@@ -276,17 +283,22 @@ export const FirewallRuleForm = React.memo((props: FirewallRuleFormProps) => {
           value={values.ports}
         />
       ) : null}
-      <Select
+      <Autocomplete
+        textFieldProps={{
+          InputProps: {
+            required: true,
+          },
+        }}
         aria-label={`Select rule ${addressesLabel}s.`}
         errorText={errors.addresses}
-        isClearable={false}
+        disableClearable
         label={`${capitalize(addressesLabel)}s`}
-        name="addresses"
         onBlur={handleBlur}
-        onChange={handleAddressesChange}
+        onChange={(_, selected) => {
+          handleAddressesChange(selected.value);
+        }}
         options={addressOptions}
         placeholder={`Select ${addressesLabel}s...`}
-        required
         value={addressesValue}
       />
       {/* Show this field only if "IP / Netmask has been selected." */}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -12,11 +12,12 @@ import {
 } from 'react-beautiful-dnd';
 
 import Undo from 'src/assets/icons/undo.svg';
+import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
 import { Box } from 'src/components/Box';
-import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import { Hidden } from 'src/components/Hidden';
 import { Typography } from 'src/components/Typography';
 import {
+  FirewallOptionItem,
   generateAddressesLabel,
   generateRuleLabel,
   predefinedFirewallFromRule as ruleToPredefinedFirewall,
@@ -369,7 +370,7 @@ interface PolicyRowProps {
   policy: FirewallPolicyType;
 }
 
-const policyOptions: Item<FirewallPolicyType>[] = [
+const policyOptions: FirewallOptionItem<FirewallPolicyType>[] = [
   { label: 'Accept', value: 'ACCEPT' },
   { label: 'Drop', value: 'DROP' },
 ];
@@ -439,18 +440,18 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
     <Box sx={sxBoxGrid}>
       <Box sx={sxBoxPolicyText}>{helperText}</Box>
       <Box sx={sxBoxPolicySelect}>
-        <Select
-          onChange={(selected: Item<FirewallPolicyType>) =>
-            handlePolicyChange(selected.value)
-          }
+        <Autocomplete
+          textFieldProps={{
+            hideLabel: true,
+          }}
+          autoHighlight
+          onChange={(_, selected) => handlePolicyChange(selected?.value)}
           value={policyOptions.find(
             (thisOption) => thisOption.value === policy
           )}
           disabled={disabled}
-          hideLabel
-          isClearable={false}
+          disableClearable
           label={`${category} policy`}
-          menuPlacement="top"
           options={policyOptions}
         />
       </Box>

--- a/packages/manager/src/features/Firewalls/shared.ts
+++ b/packages/manager/src/features/Firewalls/shared.ts
@@ -4,11 +4,14 @@ import {
   FirewallRuleType,
 } from '@linode/api-v4/lib/firewalls/types';
 
-import { Item } from 'src/components/EnhancedSelect/Select';
 import { truncateAndJoinList } from 'src/utilities/stringUtils';
 
 export type FirewallPreset = 'dns' | 'http' | 'https' | 'mysql' | 'ssh';
 
+export interface FirewallOptionItem<T = number | string, L = string> {
+  label: L;
+  value: T;
+}
 // Predefined Firewall options for Select components (long-form).
 export const firewallOptionItemsLong = [
   {
@@ -57,7 +60,7 @@ export const firewallOptionItemsShort = [
   },
 ];
 
-export const protocolOptions: Item<FirewallRuleProtocol>[] = [
+export const protocolOptions: FirewallOptionItem<FirewallRuleProtocol>[] = [
   { label: 'TCP', value: 'TCP' },
   { label: 'UDP', value: 'UDP' },
   { label: 'ICMP', value: 'ICMP' },


### PR DESCRIPTION
## Description 📝
We want to get rid of our dependency on react-select for accessibility reasons and to consolidate our usage of third-party libraries.

## Changes  🔄
- Replaced all instances of `Select` with `Autocomplete` in the `Firewall` feature.

## How to test 🧪
### Verification steps
(How to verify changes)
- Navigate to http://localhost:3000/firewalls/{firewall_id}
- Open the `Add an Inbound Rule` Drawer 
- Verify the select input fields remains unchanged when using Autocomplete

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
