### PR TITLE
refactor: [M3-6901, M3-6921] - Replace `react-select` with `Autocomplete` in: components

### DIFF
--- a/packages/manager/.changeset/pr-10706-tech-stories-1721838942488.md
+++ b/packages/manager/.changeset/pr-10706-tech-stories-1721838942488.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Replace 'react-select' with Autocomplete in components ([#10706](https://github.com/linode/manager/pull/10706))

--- a/packages/manager/cypress/e2e/core/billing/billing-invoices.spec.ts
+++ b/packages/manager/cypress/e2e/core/billing/billing-invoices.spec.ts
@@ -302,7 +302,7 @@ describe('Account invoices', () => {
     cy.findByLabelText('Invoice Details').within(() => {
       // Confirm that page size selection is set to "Show 25".
       ui.pagination.findPageSizeSelect().click();
-      ui.select.findItemByText('Show 25').should('be.visible').click();
+      ui.autocompletePopper.findByTitle('Show 25').should('be.visible').click();
 
       // Confirm that pagination controls list exactly 4 pages.
       ui.pagination
@@ -337,7 +337,10 @@ describe('Account invoices', () => {
 
       // Change pagination size selection from "Show 25" to "Show 100".
       ui.pagination.findPageSizeSelect().click();
-      ui.select.findItemByText('Show 100').should('be.visible').click();
+      ui.autocompletePopper
+        .findByTitle('Show 100')
+        .should('be.visible')
+        .click();
 
       // Confirm that all invoice items are listed.
       cy.get('tr').should('have.length', 102);

--- a/packages/manager/cypress/e2e/core/managed/managed-ssh.spec.ts
+++ b/packages/manager/cypress/e2e/core/managed/managed-ssh.spec.ts
@@ -142,7 +142,7 @@ describe('Managed SSH Access tab', () => {
           .type(newUser);
 
         // Set IP address to 'Any'.
-        cy.get('label[for="ip-address"]')
+        cy.findByLabelText('IP Address')
           .should('be.visible')
           .click()
           .type('Any{enter}');

--- a/packages/manager/cypress/e2e/core/nodebalancers/smoke-create-nodebal.spec.ts
+++ b/packages/manager/cypress/e2e/core/nodebalancers/smoke-create-nodebal.spec.ts
@@ -32,7 +32,9 @@ const createNodeBalancerWithUI = (
     .click()
     .clear()
     .type(nodeBal.label);
-  cy.contains('create a tag').click().type(entityTag);
+  cy.findByPlaceholderText(/create a tag/i)
+    .click()
+    .type(entityTag);
 
   if (isDcPricingTest) {
     const newRegion = getRegionById('br-gru');

--- a/packages/manager/cypress/e2e/core/volumes/update-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/update-volume.spec.ts
@@ -51,7 +51,7 @@ describe('volume update flow', () => {
             .click()
             .type(`{selectall}{backspace}${newLabel}`);
 
-          cy.findByText('Type to choose or create a tag.')
+          cy.findByPlaceholderText('Type to choose or create a tag.')
             .should('be.visible')
             .click()
             .type(`${newTags.join('{enter}')}{enter}`);
@@ -72,8 +72,11 @@ describe('volume update flow', () => {
           cy.findByText('Edit Volume').should('be.visible');
           cy.findByDisplayValue(newLabel).should('be.visible');
 
+          // Click the tags input field to see all the selected tags
+          cy.findByRole('combobox').should('be.visible').click();
+
           newTags.forEach((newTag) => {
-            cy.findByText(newTag).should('be.visible');
+            cy.findAllByText(newTag).should('be.visible');
           });
         });
       }

--- a/packages/manager/cypress/support/ui/pagination.ts
+++ b/packages/manager/cypress/support/ui/pagination.ts
@@ -20,7 +20,7 @@ export const pagination = {
     return pagination
       .find()
       .find('[data-qa-pagination-page-size]')
-      .find('[data-qa-enhanced-select]');
+      .find('[data-qa-autocomplete]');
   },
 
   /**

--- a/packages/manager/src/components/IPSelect/IPSelect.tsx
+++ b/packages/manager/src/components/IPSelect/IPSelect.tsx
@@ -1,14 +1,19 @@
 import * as React from 'react';
 
-import Select, { Item } from 'src/components/EnhancedSelect/Select';
+import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
 import { useLinodeQuery } from 'src/queries/linodes/linodes';
 
+interface Option {
+  label: string;
+  value: string;
+}
+
 interface Props {
-  customizeOptions?: (options: Item<string>[]) => Item<string>[];
+  customizeOptions?: (options: Option[]) => Option[];
   errorText?: string;
   handleChange: (ip: string) => void;
   linodeId: number;
-  value: Item<string>;
+  value: Option;
 }
 
 export const IPSelect = (props: Props) => {
@@ -29,7 +34,7 @@ export const IPSelect = (props: Props) => {
   }
 
   // Create React-Select-friendly options.
-  let options: Item<string>[] = ips.map((ip) => ({ label: ip, value: ip }));
+  let options = ips.map((ip) => ({ label: ip, value: ip }));
 
   // If a customizeOptions function was provided, apply it here.
   if (customizeOptions) {
@@ -46,12 +51,12 @@ export const IPSelect = (props: Props) => {
   }
 
   return (
-    <Select
+    <Autocomplete
+      disableClearable
       errorText={errorText}
-      isClearable={false}
-      isLoading={isLoading}
       label="IP Address"
-      onChange={(selected) => handleChange(selected.value)}
+      loading={isLoading}
+      onChange={(_, selected) => handleChange(selected.value)}
       options={options}
       placeholder="Select an IP Address..."
       value={options.find((option) => option.value === value.value)}

--- a/packages/manager/src/components/PaginationFooter/PaginationFooter.tsx
+++ b/packages/manager/src/components/PaginationFooter/PaginationFooter.tsx
@@ -1,8 +1,9 @@
 import { styled, useTheme } from '@mui/material/styles';
 import * as React from 'react';
 
+import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
+
 import { Box } from '../Box';
-import Select from '../EnhancedSelect/Select';
 import { PaginationControls } from '../PaginationControls/PaginationControls';
 
 export const MIN_PAGE_SIZE = 25;
@@ -80,16 +81,13 @@ export const PaginationFooter = (props: Props) => {
       )}
       {!fixedSize ? (
         <PageSizeSelectContainer data-qa-pagination-page-size>
-          <Select
-            defaultValue={defaultPagination}
-            hideLabel
-            isClearable={false}
+          <Autocomplete
+            disableClearable
             label="Number of items to show"
-            medium
-            menuPlacement="top"
-            noMarginTop
-            onChange={({ value }) => handleSizeChange(value)}
+            onChange={(_, selected) => handleSizeChange(selected.value)}
             options={finalOptions}
+            textFieldProps={{ hideLabel: true, noMarginTop: true }}
+            value={defaultPagination}
           />
         </PageSizeSelectContainer>
       ) : null}

--- a/packages/manager/src/components/TagsInput/TagsInput.stories.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.stories.tsx
@@ -29,7 +29,7 @@ export const Default: StoryObj<TagsInputProps> = {
       };
 
       return (
-        <Box sx={{ alignItems: 'center', display: 'flex', height: 300 }}>
+        <Box sx={{ alignItems: 'center', height: 300 }}>
           <TagsInput
             {...args}
             onChange={(selected) => handleUpdateTags(selected)}

--- a/packages/manager/src/components/TagsInput/TagsInput.stories.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.stories.tsx
@@ -6,8 +6,7 @@ import { Box } from 'src/components/Box';
 
 import { TagsInput } from './TagsInput';
 
-import type { TagsInputProps } from './TagsInput';
-import type { Item } from 'src/components/EnhancedSelect/Select';
+import type { Tag, TagsInputProps } from './TagsInput';
 
 export const Default: StoryObj<TagsInputProps> = {
   args: {
@@ -25,7 +24,7 @@ export const Default: StoryObj<TagsInputProps> = {
   render: (args) => {
     const TagsInputWrapper = () => {
       const [, setTags] = useArgs();
-      const handleUpdateTags = (selected: Item[]) => {
+      const handleUpdateTags = (selected: Tag[]) => {
         return setTags({ value: selected });
       };
 

--- a/packages/manager/src/components/TagsInput/TagsInput.test.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.test.tsx
@@ -42,10 +42,17 @@ describe('TagsInput', () => {
       />
     );
 
-    userEvent.click(screen.getByRole('combobox'));
+    const input = screen.getByRole('combobox');
 
-    // Create a new tag by typing in the input field and pressing Enter
-    userEvent.type(screen.getByRole('combobox'), 'new-tag{Enter}');
+    // Typing 'new-tag' in the input field
+    userEvent.type(input, 'new-tag');
+
+    await waitFor(() => expect(input).toHaveValue('new-tag'));
+
+    const createOption = screen.getByText(/Create "/i);
+
+    // Click 'Create "[tag-name]"' option to create a new-tag
+    userEvent.click(createOption);
 
     // Wait for the onChange to be called with the updated value
     await waitFor(() =>
@@ -54,8 +61,5 @@ describe('TagsInput', () => {
         { label: 'new-tag', value: 'new-tag' },
       ])
     );
-
-    // Verify the new tag is displayed
-    expect(screen.getByText('new-tag')).toBeInTheDocument();
   });
 });

--- a/packages/manager/src/components/TagsInput/TagsInput.test.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.test.tsx
@@ -49,9 +49,9 @@ describe('TagsInput', () => {
 
     await waitFor(() => expect(input).toHaveValue('new-tag'));
 
-    const createOption = screen.getByText(/Create "/i);
+    const createOption = screen.getByText('Create "new-tag"');
 
-    // Click 'Create "[tag-name]"' option to create a new-tag
+    // Click 'Create "new-tag"' option to create a new-tag
     userEvent.click(createOption);
 
     // Wait for the onChange to be called with the updated value

--- a/packages/manager/src/components/TagsInput/TagsInput.test.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.test.tsx
@@ -1,5 +1,5 @@
 import * as tags from '@linode/api-v4/lib/tags/tags';
-import { fireEvent, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
@@ -7,43 +7,55 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { TagsInput } from './TagsInput';
 
-vi.mock('src/components/EnhancedSelect/Select');
-const mockGetTags = vi.spyOn<any, any>(tags, 'getTags');
+const mockGetTags = vi.spyOn<any, any>(tags, 'getTags').mockResolvedValue({
+  data: [
+    { label: 'tag-1', value: 'tag-1' },
+    { label: 'tag-2', value: 'tag-2' },
+    { label: 'tag-3', value: 'tag-3' },
+    { label: 'tag-4', value: 'tag-4' },
+    { label: 'tag-5', value: 'tag-5' },
+  ],
+});
 
 describe('TagsInput', () => {
   const onChange = vi.fn();
 
   it('sets account tags based on API request', async () => {
-    const { getByTestId, queryAllByTestId } = renderWithTheme(
+    renderWithTheme(
       <TagsInput
         onChange={onChange}
-        value={['mockvalue'] as any} // We're mocking this component so ignore the Props typing
+        value={[{ label: 'mockValue', value: 'mockValue' }]}
       />
     );
-    fireEvent.click(getByTestId('select'));
-    await waitFor(() =>
-      expect(queryAllByTestId('mock-option')).toHaveLength(5)
-    );
+
+    userEvent.click(screen.getByRole('combobox'));
+
+    await waitFor(() => expect(screen.getAllByText(/tag-/i)).toHaveLength(5));
     await waitFor(() => expect(mockGetTags).toHaveBeenCalledTimes(1));
   });
 
   it('calls onChange handler when the value is updated', async () => {
-    const { findByTestId, queryAllByTestId } = renderWithTheme(
+    renderWithTheme(
       <TagsInput
         onChange={onChange}
-        value={['mockvalue'] as any} // We're mocking this component so ignore the Props typing
+        value={[{ label: 'mockValue', value: 'mockValue' }]}
       />
     );
-    await waitFor(() =>
-      expect(queryAllByTestId('mock-option')).toHaveLength(5)
-    );
 
-    userEvent.selectOptions(await findByTestId('select'), 'tag-2');
+    userEvent.click(screen.getByRole('combobox'));
 
+    // Create a new tag by typing in the input field and pressing Enter
+    userEvent.type(screen.getByRole('combobox'), 'new-tag{Enter}');
+
+    // Wait for the onChange to be called with the updated value
     await waitFor(() =>
       expect(onChange).toHaveBeenCalledWith([
-        { label: 'tag-2', value: 'tag-2' },
+        { label: 'mockValue', value: 'mockValue' },
+        { label: 'new-tag', value: 'new-tag' },
       ])
     );
+
+    // Verify the new tag is displayed
+    expect(screen.getByText('new-tag')).toBeInTheDocument();
   });
 });

--- a/packages/manager/src/components/TagsInput/TagsInput.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.tsx
@@ -175,7 +175,7 @@ export const TagsInput = (props: TagsInputProps) => {
       isOptionEqualToValue={(option, value) => option.value === value.value}
       label={label || 'Add Tags'}
       multiple
-      noOptionsText={'No results'}
+      noOptionsText={'No results.'}
       options={accountTagItems}
       placeholder={value.length === 0 ? 'Type to choose or create a tag.' : ''}
       textFieldProps={{ hideLabel, noMarginTop }}

--- a/packages/manager/src/components/TagsInput/TagsInput.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.tsx
@@ -1,12 +1,11 @@
+import CloseIcon from '@mui/icons-material/Close';
 import { APIError } from '@linode/api-v4/lib/types';
 import { useQueryClient } from '@tanstack/react-query';
 import { concat } from 'ramda';
 import * as React from 'react';
 
-import Select, {
-  Item,
-  NoOptionsMessageProps,
-} from 'src/components/EnhancedSelect/Select';
+import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
+import { Chip } from 'src/components/Chip';
 import { useProfile } from 'src/queries/profile/profile';
 import { updateTagsSuggestionsData, useTagSuggestions } from 'src/queries/tags';
 import { getErrorMap } from 'src/utilities/errorUtils';
@@ -14,6 +13,10 @@ import { getErrorMap } from 'src/utilities/errorUtils';
 export interface Tag {
   label: string;
   value: string;
+}
+
+export interface NoOptionsMessageProps {
+  inputValue: string;
 }
 
 export interface TagsInputProps {
@@ -46,7 +49,7 @@ export interface TagsInputProps {
   /**
    * Callback fired when the value changes.
    */
-  onChange: (selected: Item<string, string>[]) => void;
+  onChange: (selected: Tag[]) => void;
   /**
    * An error to display beneath the input.
    */
@@ -54,21 +57,11 @@ export interface TagsInputProps {
   /**
    * The value of the input.
    */
-  value: Item<string, string>[];
+  value: Tag[];
 }
 
 export const TagsInput = (props: TagsInputProps) => {
-  const {
-    disabled,
-    hideLabel,
-    label,
-    menuPlacement,
-    name,
-    noMarginTop,
-    onChange,
-    tagError,
-    value,
-  } = props;
+  const { disabled, label, onChange, tagError, value } = props;
 
   const [errors, setErrors] = React.useState<APIError[]>([]);
 
@@ -79,7 +72,7 @@ export const TagsInput = (props: TagsInputProps) => {
 
   const queryClient = useQueryClient();
 
-  const accountTagItems: Item[] =
+  const accountTagItems: Tag[] =
     accountTags?.map((tag) => ({
       label: tag.label,
       value: tag.label,
@@ -105,13 +98,28 @@ export const TagsInput = (props: TagsInputProps) => {
     }
   };
 
-  const getEmptyMessage = (value: NoOptionsMessageProps) => {
-    const { value: tags } = props;
-    if (tags.map((tag) => tag.value).includes(value.inputValue)) {
-      return 'This tag is already selected.';
-    } else {
-      return 'No results.';
+  const handleRemoveOption = (tagToRemove: Tag) => {
+    onChange(value.filter((t) => t.value !== tagToRemove.value));
+  };
+
+  const filterOptions = (
+    options: Tag[],
+    { inputValue }: { inputValue: string }
+  ) => {
+    const filtered = options.filter((o) =>
+      o.label.toLowerCase().includes(inputValue.toLowerCase())
+    );
+
+    const isExistingTag = options.some(
+      (o) => o.label.toLowerCase() === inputValue.toLowerCase()
+    );
+    if (inputValue !== '' && !isExistingTag) {
+      filtered.push({
+        label: `Create "${inputValue}"`,
+        value: inputValue,
+      });
     }
+    return filtered;
   };
 
   const errorMap = getErrorMap(['label'], errors);
@@ -128,21 +136,41 @@ export const TagsInput = (props: TagsInputProps) => {
         : undefined);
 
   return (
-    <Select
-      creatable
+    <Autocomplete
+      onChange={(_, newValue, reason, details) => {
+        if (
+          reason === 'selectOption' &&
+          details?.option?.label.startsWith('Create "')
+        ) {
+          createTag(details.option.value);
+        } else {
+          setErrors([]);
+          onChange(newValue);
+        }
+      }}
+      renderTags={(tagValue, getTagProps) => {
+        return tagValue.map((option, index) => (
+          <Chip
+            {...getTagProps({ index })}
+            deleteIcon={<CloseIcon />}
+            key={index}
+            label={option.label}
+            onDelete={() => handleRemoveOption(option)}
+          />
+        ));
+      }}
+      autoHighlight
+      clearOnBlur
+      disableCloseOnSelect={false}
+      disabled={disabled}
       errorText={error}
-      hideLabel={hideLabel}
-      isDisabled={disabled}
-      isMulti={true}
+      filterOptions={filterOptions}
+      isOptionEqualToValue={(option, value) => option.value === value.value}
       label={label || 'Add Tags'}
-      menuPlacement={menuPlacement}
-      name={name}
-      noMarginTop={noMarginTop}
-      noOptionsMessage={getEmptyMessage}
-      onChange={onChange}
-      onCreateOption={createTag}
+      multiple
+      noOptionsText={'No results'}
       options={accountTagItems}
-      placeholder={'Type to choose or create a tag.'}
+      placeholder={value.length === 0 ? 'Type to choose or create a tag.' : ' '}
       value={value}
     />
   );

--- a/packages/manager/src/components/TagsInput/TagsInput.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.tsx
@@ -57,7 +57,15 @@ export interface TagsInputProps {
 }
 
 export const TagsInput = (props: TagsInputProps) => {
-  const { disabled, label, onChange, tagError, value } = props;
+  const {
+    disabled,
+    hideLabel,
+    label,
+    noMarginTop,
+    onChange,
+    tagError,
+    value,
+  } = props;
 
   const [errors, setErrors] = React.useState<APIError[]>([]);
 
@@ -170,6 +178,7 @@ export const TagsInput = (props: TagsInputProps) => {
       noOptionsText={'No results'}
       options={accountTagItems}
       placeholder={value.length === 0 ? 'Type to choose or create a tag.' : ' '}
+      textFieldProps={{ hideLabel, noMarginTop }}
       value={value}
     />
   );

--- a/packages/manager/src/components/TagsInput/TagsInput.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.tsx
@@ -109,12 +109,14 @@ export const TagsInput = (props: TagsInputProps) => {
     const isExistingTag = options.some(
       (o) => o.label.toLowerCase() === inputValue.toLowerCase()
     );
+
     if (inputValue !== '' && !isExistingTag) {
       filtered.push({
         label: `Create "${inputValue}"`,
         value: inputValue,
       });
     }
+
     return filtered;
   };
 
@@ -131,7 +133,6 @@ export const TagsInput = (props: TagsInputProps) => {
         ? 'There was an error retrieving your tags.'
         : undefined);
 
-  // console.log(accountTagItems, value);
   return (
     <Autocomplete
       onChange={(_, newValue, reason, details) => {

--- a/packages/manager/src/components/TagsInput/TagsInput.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.tsx
@@ -15,10 +15,6 @@ export interface Tag {
   value: string;
 }
 
-export interface NoOptionsMessageProps {
-  inputValue: string;
-}
-
 export interface TagsInputProps {
   /**
    * If true, the component is disabled.
@@ -135,14 +131,16 @@ export const TagsInput = (props: TagsInputProps) => {
         ? 'There was an error retrieving your tags.'
         : undefined);
 
+  // console.log(accountTagItems, value);
   return (
     <Autocomplete
       onChange={(_, newValue, reason, details) => {
+        const detailsOption = details?.option;
         if (
           reason === 'selectOption' &&
-          details?.option?.label.startsWith('Create "')
+          detailsOption?.label.includes(`Create "${detailsOption?.value}"`)
         ) {
-          createTag(details.option.value);
+          createTag(detailsOption.value);
         } else {
           setErrors([]);
           onChange(newValue);

--- a/packages/manager/src/components/TagsInput/TagsInput.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.tsx
@@ -177,7 +177,7 @@ export const TagsInput = (props: TagsInputProps) => {
       multiple
       noOptionsText={'No results'}
       options={accountTagItems}
-      placeholder={value.length === 0 ? 'Type to choose or create a tag.' : ' '}
+      placeholder={value.length === 0 ? 'Type to choose or create a tag.' : ''}
       textFieldProps={{ hideLabel, noMarginTop }}
       value={value}
     />

--- a/packages/manager/src/features/Images/ImagesLanding/EditImageDrawer.test.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/EditImageDrawer.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { imageFactory } from 'src/factories';
@@ -32,7 +33,7 @@ describe('EditImageDrawer', () => {
   });
 
   it('should allow editing image details', async () => {
-    const { getByLabelText, getByText } = renderWithTheme(
+    const { getByLabelText, getByRole, getByText } = renderWithTheme(
       <EditImageDrawer {...props} />
     );
 
@@ -44,9 +45,12 @@ describe('EditImageDrawer', () => {
       target: { value: 'test description' },
     });
 
-    fireEvent.change(getByLabelText('Tags'), {
-      target: { value: 'new-tag' },
-    });
+    const tagsInput = getByRole('combobox');
+
+    userEvent.type(tagsInput, 'new-tag');
+
+    await waitFor(() => expect(tagsInput).toHaveValue('new-tag'));
+
     fireEvent.click(getByText('Create "new-tag"'));
 
     fireEvent.click(getByText('Save Changes'));

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Details/Details.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Details/Details.test.tsx
@@ -28,12 +28,17 @@ describe('Linode Create Details', () => {
   });
 
   it('renders an "Add Tags" field', () => {
-    const { getByLabelText, getByText } = renderWithThemeAndHookFormContext({
+    const {
+      getByLabelText,
+      getByPlaceholderText,
+    } = renderWithThemeAndHookFormContext({
       component: <Details />,
     });
 
     expect(getByLabelText('Add Tags')).toBeVisible();
-    expect(getByText('Type to choose or create a tag.')).toBeVisible();
+    expect(
+      getByPlaceholderText('Type to choose or create a tag.')
+    ).toBeVisible();
   });
 
   it('renders an placement group details if the flag is on', async () => {


### PR DESCRIPTION
## Description 📝
We want to get rid of our dependency on react-select for accessibility reasons and to consolidate our usage of third-party libraries.

## Changes  🔄

- Replace `react-select` with Autocomplete component within the `components`.
   - Replace Select with Autocomplete in `IPSelect`,  `PaginationFooter` and `TagsInput` components
   - Added tag creation behavior to Autocomplete in `TagsInput` component
   - Update the stories and unit test cases for `TagsInput` component.
   - Update unit test cases for TagsInput in LinodesCreatev2->Details and EditImageDrawer
   - Update e2e tests
   - Update `support/ui/pagination`

## Target release date 🗓️
5th Aug, 2024

## How to test 🧪

### Verification steps
(How to verify changes)
- Verify all the selects functionality for `IPSelect` component continue to work as expected.
- Verify all the selects functionality for `PaginationFooter` component continue to work as expected.
- Verify all the selects functionality for `TagsInput` component continue to work as expected.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
