### PR TITLE
fix: Add new August Marketplace apps to Linode Create v2

### DIFF
--- a/packages/manager/src/features/OneClickApps/oneClickAppsv2.ts
+++ b/packages/manager/src/features/OneClickApps/oneClickAppsv2.ts
@@ -2457,6 +2457,29 @@ export const oneClickApps: Record<number, OCA> = {
     summary: 'Open source network filesystem.',
     website: 'https://www.gluster.org/',
   },
+  1350845: {
+    alt_description:
+      'Linearly scalable, fault tolerant, open source NoSQL distributed database.',
+    alt_name: 'NoSQL database cluster',
+    categories: ['Databases'],
+    colors: {
+      end: '1486B1',
+      start: '85A355',
+    },
+    description: `Distributed, masterless, replicating NoSQL database cluster.`,
+    isNew: true,
+    logo_url: 'apachecassandra.svg',
+    name: 'Apache Cassandra Cluster',
+    related_guides: [
+      {
+        href:
+          'https://www.linode.com/docs/products/tools/marketplace/guides/apache-cassandra-cluster/',
+        title: 'Deploy Apache Cassandra Cluster through the Linode Marketplace',
+      },
+    ],
+    summary: 'Open source NoSQL database cluster.',
+    website: 'https://cassandra.apache.org/doc/latest/',
+  },
   1366191: {
     alt_description:
       'Highly available, five-node enterprise NoSQL database cluster.',
@@ -2467,7 +2490,6 @@ export const oneClickApps: Record<number, OCA> = {
       start: '333333',
     },
     description: `Couchbase Enterprise Server is a high-performance NoSQL database, built for scale. Couchbase Server is designed with memory-first architecture, built-in cache and workload isolation.`,
-    isNew: true,
     logo_url: 'couchbase.svg',
     name: 'Couchbase Cluster',
     related_guides: [
@@ -2490,7 +2512,6 @@ export const oneClickApps: Record<number, OCA> = {
       start: '00C7D4',
     },
     description: `Apache Kafka supports a wide range of applications from log aggregation to real-time analytics. Kafka provides a foundation for building data pipelines, event-driven architectures, or stream processing applications.`,
-    isNew: true,
     logo_url: 'apachekafka.svg',
     name: 'Apache Kafka Cluster',
     related_guides: [
@@ -2503,28 +2524,6 @@ export const oneClickApps: Record<number, OCA> = {
     summary: 'Open source data streaming.',
     website: 'https://kafka.apache.org/',
   },
-  1350845: {
-    alt_description:
-      'Linearly scalable, fault tolerant, open source NoSQL distributed database.',
-    alt_name: 'NoSQL database cluster',
-    categories: ['Databases'],
-    colors: {
-      end: '1486B1',
-      start: '85A355',
-    },
-    description: `Distributed, masterless, replicating NoSQL database cluster.`,
-    logo_url: 'apachecassandra.svg',
-    name: 'Apache Cassandra Cluster',
-    related_guides: [
-      {
-        href:
-          'https://www.linode.com/docs/products/tools/marketplace/guides/apache-cassandra-cluster/',
-        title: 'Deploy Apache Cassandra Cluster through the Linode Marketplace',
-      },
-    ],
-    summary: 'Open source NoSQL database cluster.',
-    website: 'https://cassandra.apache.org/doc/latest/',
-  },
   1403815: {
     alt_description: 'Open Source key/value datastore.',
     alt_name: 'Caching and message queue database',
@@ -2534,6 +2533,7 @@ export const oneClickApps: Record<number, OCA> = {
       start: 'AAAAAA',
     },
     description: `High performance, BSD license key/value database.`,
+    isNew: true,
     logo_url: 'valkey.svg',
     name: 'Valkey',
     related_guides: [
@@ -2555,6 +2555,7 @@ export const oneClickApps: Record<number, OCA> = {
       start: 'FFBA01',
     },
     description: `OSI approved open source secrets platform.`,
+    isNew: true,
     logo_url: 'openbao.svg',
     name: 'OpenBao',
     related_guides: [
@@ -2576,6 +2577,7 @@ export const oneClickApps: Record<number, OCA> = {
       start: '9D29FB',
     },
     description: `Time series database supporting native query and visualization.`,
+    isNew: true,
     logo_url: 'influxdb.svg',
     name: 'InfluxDB',
     related_guides: [


### PR DESCRIPTION
## Description 📝
Oops, in #10634 we forgot to add the `isNew` field to the `oneClickAppsv2.ts` file that the Linode Create Flow v2 uses.

Currently, v1 works off of the `one-click-apps` feature flag to designate new apps, and v2 requires a code change (feature flag implementation to allow us to override apps is forthcoming)

## Changes  🔄
- Marked the following apps as 'New' for the August release: Apache Cassandra Cluster, OpenBao, Valkey, InfluxDB
- Removed the following apps as 'New' because they were from the June release: Couchbase Cluster, Apache Kafka Cluster

## Target release date 🗓️
8/5/24

## Preview 📷
| Before | After |
| --- | --- |
|![Screenshot 2024-07-24 at 1 27 15 PM](https://github.com/user-attachments/assets/0118c807-5691-424d-809d-70b040e295cb) | ![Screenshot 2024-07-24 at 1 12 54 PM](https://github.com/user-attachments/assets/3ba48cc4-705b-4037-bccc-7b1fe1918785) |

## How to test 🧪

### Verification steps
(How to verify changes)
- Check out this PR.
- Go to http://localhost:3000/linodes/create?type=One-Click, and confirm that the new apps display in the new apps section **with the Linode Create v2 flag on**.
- Go to http://localhost:3000/linodes/create?type=One-Click, and confirm that the new apps display in the new apps section **with the Linode Create v2 flag off**.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset (we don't need a changeset for this - the original PR didn't make it to prod)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
