### PR TITLE
refactor: [M3-8375] - Replace `uuid` with `crypto.randomUUID`

### DIFF
--- a/packages/manager/.changeset/pr-10712-tech-stories-1721922098470.md
+++ b/packages/manager/.changeset/pr-10712-tech-stories-1721922098470.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Replace `uuid` with `crypto.randomUUID` ([#10712](https://github.com/linode/manager/pull/10712))

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -165,7 +165,6 @@
     "@types/recompose": "^0.30.0",
     "@types/redux-mock-store": "^1.0.1",
     "@types/throttle-debounce": "^1.0.0",
-    "@types/uuid": "^3.4.3",
     "@types/yup": "^0.29.13",
     "@types/zxcvbn": "^4.4.0",
     "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -1,4 +1,7 @@
-import {
+import Factory from 'src/factories/factoryProxy';
+import { pickRandom, randomDate } from 'src/utilities/random';
+
+import type {
   Database,
   DatabaseBackup,
   DatabaseEngine,
@@ -7,11 +10,7 @@ import {
   DatabaseType,
   MySQLReplicationType,
   PostgresReplicationType,
-} from '@linode/api-v4/lib/databases/types';
-import Factory from 'src/factories/factoryProxy';
-import { v4 } from 'uuid';
-
-import { pickRandom, randomDate } from 'src/utilities/random';
+} from '@linode/api-v4';
 
 // These are not all of the possible statuses, but these are some common ones.
 export const possibleStatuses: DatabaseStatus[] = [
@@ -205,7 +204,7 @@ export const databaseFactory = Factory.Sync.makeFactory<Database>({
 export const databaseBackupFactory = Factory.Sync.makeFactory<DatabaseBackup>({
   created: Factory.each(() => randomDate().toISOString()),
   id: Factory.each((i) => i),
-  label: Factory.each(() => `backup-${v4()}`),
+  label: Factory.each(() => `backup-${crypto.randomUUID()}`),
   type: pickRandom(['snapshot', 'auto']),
 });
 

--- a/packages/manager/src/factories/entityTransfers.ts
+++ b/packages/manager/src/factories/entityTransfers.ts
@@ -1,10 +1,8 @@
-import {
-  EntityTransfer,
-  TransferEntities,
-} from '@linode/api-v4/lib/entity-transfers/types';
-import Factory from 'src/factories/factoryProxy';
 import { DateTime } from 'luxon';
-import { v4 } from 'uuid';
+
+import Factory from 'src/factories/factoryProxy';
+
+import type { EntityTransfer, TransferEntities } from '@linode/api-v4';
 
 export const transferEntitiesFactory = Factory.Sync.makeFactory<TransferEntities>(
   {
@@ -18,6 +16,6 @@ export const entityTransferFactory = Factory.Sync.makeFactory<EntityTransfer>({
   expiry: DateTime.utc().plus({ days: 1 }).toISO(),
   is_sender: true,
   status: 'pending',
-  token: Factory.each(() => v4()),
+  token: Factory.each(() => crypto.randomUUID()),
   updated: DateTime.utc().toISO(),
 });

--- a/packages/manager/src/factories/kubernetesCluster.ts
+++ b/packages/manager/src/factories/kubernetesCluster.ts
@@ -1,13 +1,13 @@
-import {
+import Factory from 'src/factories/factoryProxy';
+
+import type {
   KubeNodePoolResponse,
   KubernetesCluster,
   KubernetesDashboardResponse,
   KubernetesEndpointResponse,
   KubernetesVersion,
   PoolNodeResponse,
-} from '@linode/api-v4/lib/kubernetes/types';
-import Factory from 'src/factories/factoryProxy';
-import { v4 } from 'uuid';
+} from '@linode/api-v4';
 
 export const kubeLinodeFactory = Factory.Sync.makeFactory<PoolNodeResponse>({
   id: Factory.each((id) => `id-${id}`),
@@ -44,13 +44,13 @@ export const kubernetesClusterFactory = Factory.Sync.makeFactory<KubernetesClust
 
 export const kubeEndpointFactory = Factory.Sync.makeFactory<KubernetesEndpointResponse>(
   {
-    endpoint: `https://${v4()}`,
+    endpoint: `https://${crypto.randomUUID()}`,
   }
 );
 
 export const kubernetesDashboardUrlFactory = Factory.Sync.makeFactory<KubernetesDashboardResponse>(
   {
-    url: `https://${v4()}`,
+    url: `https://${crypto.randomUUID()}`,
   }
 );
 

--- a/packages/manager/src/factories/statusPage.ts
+++ b/packages/manager/src/factories/statusPage.ts
@@ -1,7 +1,6 @@
 import Factory from 'src/factories/factoryProxy';
-import { v4 } from 'uuid';
 
-import {
+import type {
   Incident,
   IncidentPage,
   IncidentResponse,
@@ -23,7 +22,7 @@ export const pageFactory = Factory.Sync.makeFactory<IncidentPage>({
 export const incidentUpdateFactory = Factory.Sync.makeFactory<IncidentUpdate>({
   affected_components: [
     {
-      code: v4(),
+      code: crypto.randomUUID(),
       name:
         'Linode Kubernetes Engine - US-East (Newark) Linode Kubernetes Engine',
       new_status: 'major_outage',
@@ -37,7 +36,7 @@ export const incidentUpdateFactory = Factory.Sync.makeFactory<IncidentUpdate>({
   deliver_notifications: true,
   display_at: DATE,
   id: Factory.each((i) => String(i)),
-  incident_id: v4(),
+  incident_id: crypto.randomUUID(),
   status: 'investigating',
   tweet_id: Math.floor(Math.random() * 1000000),
   updated_at: DATE,
@@ -50,7 +49,7 @@ export const incidentFactory = Factory.Sync.makeFactory<Incident>({
   incident_updates: incidentUpdateFactory.buildList(5),
   monitoring_at: DATE,
   name: 'Service Issue - Linode Kubernetes Engine',
-  page_id: v4(),
+  page_id: crypto.randomUUID(),
   resolved_at: DATE,
   shortlink: 'https://stspg.io/gm27wxnn653m',
   started_at: DATE,

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
@@ -4,7 +4,6 @@ import Grid from '@mui/material/Unstable_Grid2';
 import cloneDeep from 'lodash.clonedeep';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { v4 } from 'uuid';
 
 import { AccessPanel } from 'src/components/AccessPanel/AccessPanel';
 import { Box } from 'src/components/Box';
@@ -463,7 +462,7 @@ export class LinodeCreate extends React.PureComponent<
     /** Reset the plan panel since types may have shifted */
 
     this.setState({
-      planKey: v4(),
+      planKey: crypto.randomUUID(),
       selectedTab: index,
     });
 
@@ -566,7 +565,7 @@ export class LinodeCreate extends React.PureComponent<
     this.state = {
       hasError: false,
       numberOfNodes: 0,
-      planKey: v4(),
+      planKey: crypto.randomUUID(),
       selectedTab: preSelectedTab !== -1 ? preSelectedTab : 0,
       stackScriptSelectedTab:
         preSelectedTab === 2 && location.search.search('Community') > -1

--- a/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.tsx
@@ -3,7 +3,6 @@ import { styled, useTheme } from '@mui/material/styles';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
-import { v4 } from 'uuid';
 
 import { Box } from 'src/components/Box';
 import { Divider } from 'src/components/Divider';
@@ -42,11 +41,15 @@ export const DisplaySettings = () => {
   }, [emailRef, location.state]);
 
   // Used as React keys to force-rerender forms.
-  const [emailResetToken, setEmailResetToken] = React.useState(v4());
-  const [usernameResetToken, setUsernameResetToken] = React.useState(v4());
+  const [emailResetToken, setEmailResetToken] = React.useState(
+    crypto.randomUUID()
+  );
+  const [usernameResetToken, setUsernameResetToken] = React.useState(
+    crypto.randomUUID()
+  );
 
   const updateUsername = (newUsername: string) => {
-    setEmailResetToken(v4());
+    setEmailResetToken(crypto.randomUUID());
     // Default to empty string... but I don't believe this is possible.
     return updateUser(profile?.username ?? '', {
       username: newUsername,
@@ -54,7 +57,7 @@ export const DisplaySettings = () => {
   };
 
   const updateEmail = (newEmail: string) => {
-    setUsernameResetToken(v4());
+    setUsernameResetToken(crypto.randomUUID());
     return updateProfile({ email: newEmail });
   };
 

--- a/packages/manager/src/session.ts
+++ b/packages/manager/src/session.ts
@@ -1,5 +1,4 @@
 import Axios from 'axios';
-import { v4 } from 'uuid';
 
 import { APP_ROOT, CLIENT_ID, LOGIN_ROOT } from 'src/constants';
 import {
@@ -52,7 +51,7 @@ export const genOAuthEndpoint = (
  * @returns {string} - OAuth authorization endpoint URL
  */
 export const prepareOAuthEndpoint = (redirectUri: string, scope = '*') => {
-  const nonce = v4();
+  const nonce = crypto.randomUUID();
   authentication.nonce.set(nonce);
   return genOAuthEndpoint(redirectUri, scope, nonce);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4480,11 +4480,6 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.2.tgz#6dd61e43ef60b34086287f83683a5c1b2dc53d20"
   integrity sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==
 
-"@types/uuid@^3.4.3":
-  version "3.4.13"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.13.tgz#fe890e517fb840620be284ee213e81d702b1f76b"
-  integrity sha512-pAeZeUbLE4Z9Vi9wsWV2bYPTweEHeJJy0G4pEjOA/FSvy1Ad5U5Km8iDV6TKre1mjBiVNfAdVHKruP8bAh4Q5A==
-
 "@types/uuid@^9.0.1":
   version "9.0.8"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"


### PR DESCRIPTION
## Description 📝

- Replaces the `uuid` package 📦  with the built in `crypto.randomUUID` function 
  - I'm just doing this to decrease dependence on packages ⬇️  in favor of built in functions
- All major browsers [support](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID#browser_compatibility) `crypto.randomUUID` so we should be good from a compatibility standpoint  ✔️ 
- Node and other runtimes like Bun support `crypto.randomUUID` so we should be good from a compatibility standpoint ✔️ 

## How to test 🧪

- Verify all unit tests and cypress tests pass ✅ 
- Verify all touched features still work as expected 👁️ 

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support