### PR TITLE
test: [M3-8278] - Cloud Manager changes for Heimdall test pipeline

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ x-e2e-env:
   CY_TEST_SUITE: ${CY_TEST_SUITE}
   CY_TEST_REGION: ${CY_TEST_REGION}
   CY_TEST_TAGS: ${CY_TEST_TAGS}
+  CY_TEST_DISABLE_RETRIES: ${CY_TEST_DISABLE_RETRIES}
 
   # Cypress environment variables for alternative parallelization.
   CY_TEST_SPLIT_RUN: ${CY_TEST_SPLIT_RUN}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ x-e2e-env:
   # Cloud Manager-specific test configuration.
   CY_TEST_SUITE: ${CY_TEST_SUITE}
   CY_TEST_REGION: ${CY_TEST_REGION}
+  CY_TEST_TAGS: ${CY_TEST_TAGS}
 
   # Cypress environment variables for alternative parallelization.
   CY_TEST_SPLIT_RUN: ${CY_TEST_SPLIT_RUN}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,8 +105,19 @@ services:
       timeout: 10s
       retries: 10
 
+  # Generic end-to-end test runner for Cloud's primary testing pipeline.
+  # Configured to run against a local Cloud instance.
   e2e:
     <<: *default-runner
+    environment:
+      <<: *default-env
+      MANAGER_OAUTH: ${MANAGER_OAUTH}
+
+  # End-to-end test runner for Cloud's synthetic monitoring tests.
+  # Configured to run against a remote Cloud instance hosted at some URL.
+  e2e_heimdall:
+    <<: *default-runner
+    depends_on: ~
     environment:
       <<: *default-env
       MANAGER_OAUTH: ${MANAGER_OAUTH}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,7 @@ services:
   # Configured to run against a remote Cloud instance hosted at some URL.
   e2e_heimdall:
     <<: *default-runner
-    depends_on:
+    depends_on: []
     environment:
       <<: *default-env
       MANAGER_OAUTH: ${MANAGER_OAUTH}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,7 @@ services:
   # Configured to run against a remote Cloud instance hosted at some URL.
   e2e_heimdall:
     <<: *default-runner
-    depends_on: ~
+    depends_on:
     environment:
       <<: *default-env
       MANAGER_OAUTH: ${MANAGER_OAUTH}

--- a/docs/development-guide/08-testing.md
+++ b/docs/development-guide/08-testing.md
@@ -215,6 +215,7 @@ Environment variables related to Cypress logging and reporting, as well as repor
 | `CY_TEST_USER_REPORT`           | Log test account information when tests begin | `1`       | Unset; disabled by default |
 | `CY_TEST_JUNIT_REPORT`          | Enable JUnit reporting                        | `1`       | Unset; disabled by default |
 | `CY_TEST_DISABLE_FILE_WATCHING` | Disable file watching in Cypress UI           | `1`       | Unset; disabled by default |
+| `CY_TEST_DISABLE_RETRIES`       | Disable test retries on failure in CI         | `1`       | Unset; disabled by default |
 | `CY_TEST_FAIL_ON_MANAGED`       | Fail affected tests when Managed is enabled   | `1`       | Unset; disabled by default |
 
 ### Writing End-to-End Tests

--- a/packages/manager/.changeset/pr-10713-tech-stories-1722017812325.md
+++ b/packages/manager/.changeset/pr-10713-tech-stories-1722017812325.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Docker Compose changes to facilitate new testing pipeline ([#10713](https://github.com/linode/manager/pull/10713))

--- a/packages/manager/.changeset/pr-10713-tests-1722017832242.md
+++ b/packages/manager/.changeset/pr-10713-tests-1722017832242.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Tag tests for synthetic monitoring ([#10713](https://github.com/linode/manager/pull/10713))

--- a/packages/manager/cypress.config.ts
+++ b/packages/manager/cypress.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
   video: true,
 
   // Only retry test when running via CI.
-  retries: process.env['CI'] ? 2 : 0,
+  retries: process.env['CI'] && !process.env['CY_TEST_DISABLE_RETRIES'] ? 2 : 0,
 
   experimentalMemoryManagement: true,
   e2e: {

--- a/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
@@ -156,6 +156,8 @@ describe('object storage end-to-end tests', () => {
    * - Confirms that deleted buckets are no longer listed on landing page.
    */
   it('can create and delete object storage buckets', () => {
+    cy.tag('purpose:syntheticTesting');
+
     const bucketLabel = randomLabel();
     const bucketRegion = 'Atlanta, GA';
     const bucketCluster = 'us-southeast-1';

--- a/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
@@ -157,7 +157,6 @@ describe('object storage end-to-end tests', () => {
    */
   it('can create and delete object storage buckets', () => {
     cy.tag('purpose:syntheticTesting');
-    throw new Error('Fail');
 
     const bucketLabel = randomLabel();
     const bucketRegion = 'Atlanta, GA';

--- a/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
@@ -157,6 +157,7 @@ describe('object storage end-to-end tests', () => {
    */
   it('can create and delete object storage buckets', () => {
     cy.tag('purpose:syntheticTesting');
+    throw new Error('Fail');
 
     const bucketLabel = randomLabel();
     const bucketRegion = 'Atlanta, GA';

--- a/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
@@ -157,7 +157,6 @@ describe('object storage end-to-end tests', () => {
    */
   it('can create and delete object storage buckets', () => {
     cy.tag('purpose:syntheticTesting');
-    throw new Error('This failure was triggered intentionally.');
 
     const bucketLabel = randomLabel();
     const bucketRegion = 'Atlanta, GA';

--- a/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
@@ -157,6 +157,7 @@ describe('object storage end-to-end tests', () => {
    */
   it('can create and delete object storage buckets', () => {
     cy.tag('purpose:syntheticTesting');
+    throw new Error('This failure was triggered intentionally.');
 
     const bucketLabel = randomLabel();
     const bucketRegion = 'Atlanta, GA';

--- a/packages/manager/cypress/e2e/core/volumes/create-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/create-volume.spec.ts
@@ -27,6 +27,8 @@ describe('volume create flow', () => {
    * - Confirms that volume is listed correctly on volumes landing page.
    */
   it('creates an unattached volume', () => {
+    cy.tag('purpose:syntheticTesting');
+
     const region = chooseRegion();
     const volume = {
       label: randomLabel(),

--- a/packages/manager/cypress/support/util/tag.ts
+++ b/packages/manager/cypress/support/util/tag.ts
@@ -18,6 +18,7 @@ export type TestTag =
   // DC testing purposes even if that is not the primary purpose of the test.
   | 'purpose:dcTesting'
   | 'purpose:smokeTesting'
+  | 'purpose:syntheticTesting'
 
   // Method-related tags.
   // Describe the way the tests operate -- either end-to-end using real API requests,


### PR DESCRIPTION
## Description 📝
This makes a handful of changes to facilitate our testing pipeline for Heimdall, which will run a small subset of our Cypress tests against `cloud.linode.com` repeatedly as a form of synthetic monitoring.

## Changes  🔄
- Adds `CY_TEST_DISABLE_RETRIES` environment variable to allow test retries to be disabled by CI pipelines
- Adds `e2e_heimdall` Docker Compose service
- Passes `CY_TEST_TAGS` environment variable to Docker containers (this was missed in #10475)
- Adds `purpose:syntheticTesting` test tag and assigns it to a couple of tests
  - Note: the tests which will be run for Heimdall will change in the future, but wanted to get these tagged in the meantime so we have something to run from the pipeline

## How to test 🧪
- Confirm via CI that these changes do not break our existing test pipeline
- Confirm that these changes work for the Heimdall pipeline (Jira ticket contains links to some test runs you can refer to)

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
