### PR TITLE
upcoming: [M3-8215] - Hide monthly network transfer section for distributed regions

### DIFF
--- a/packages/api-v4/.changeset/pr-10714-added-1721926327777.md
+++ b/packages/api-v4/.changeset/pr-10714-added-1721926327777.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Added
+---
+
+site_type to the linode instance type ([#10714](https://github.com/linode/manager/pull/10714))

--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -1,4 +1,4 @@
-import type { Region } from '../regions';
+import type { Region, RegionSite } from '../regions';
 import type { IPAddress, IPRange } from '../networking/types';
 import type { SSHKey } from '../profile/types';
 import type { PlacementGroupPayload } from '../placement-groups/types';
@@ -36,6 +36,7 @@ export interface Linode {
   specs: LinodeSpecs;
   watchdog_enabled: boolean;
   tags: string[];
+  site_type: RegionSite;
 }
 
 export interface LinodeAlerts {

--- a/packages/manager/.changeset/pr-10714-upcoming-features-1721926239567.md
+++ b/packages/manager/.changeset/pr-10714-upcoming-features-1721926239567.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Hide monthly network transfer section ([#10714](https://github.com/linode/manager/pull/10714))

--- a/packages/manager/.changeset/pr-10714-upcoming-features-1721926239567.md
+++ b/packages/manager/.changeset/pr-10714-upcoming-features-1721926239567.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-Hide monthly network transfer section ([#10714](https://github.com/linode/manager/pull/10714))
+Hide monthly network transfer section for distributed regions ([#10714](https://github.com/linode/manager/pull/10714))

--- a/packages/manager/src/__data__/linodes.ts
+++ b/packages/manager/src/__data__/linodes.ts
@@ -1,4 +1,4 @@
-import { Linode } from '@linode/api-v4/lib/linodes';
+import type { Linode } from '@linode/api-v4/lib/linodes';
 
 export const linode1: Linode = {
   alerts: {
@@ -26,12 +26,13 @@ export const linode1: Linode = {
   label: 'test',
   lke_cluster_id: null,
   placement_group: {
-    placement_group_type: 'anti_affinity:local',
     id: 1,
-    placement_group_policy: 'strict',
     label: 'pg-1',
+    placement_group_policy: 'strict',
+    placement_group_type: 'anti_affinity:local',
   },
   region: 'us-east',
+  site_type: 'core',
   specs: {
     disk: 20480,
     gpus: 0,
@@ -72,12 +73,13 @@ export const linode2: Linode = {
   label: 'another-test',
   lke_cluster_id: null,
   placement_group: {
-    placement_group_type: 'anti_affinity:local',
     id: 1,
-    placement_group_policy: 'strict',
     label: 'pg-1',
+    placement_group_policy: 'strict',
+    placement_group_type: 'anti_affinity:local',
   },
   region: 'us-east',
+  site_type: 'core',
   specs: {
     disk: 30720,
     gpus: 0,
@@ -118,12 +120,13 @@ export const linode3: Linode = {
   label: 'another-test',
   lke_cluster_id: null,
   placement_group: {
-    placement_group_type: 'anti_affinity:local',
     id: 1,
-    placement_group_policy: 'strict',
     label: 'pg-1',
+    placement_group_policy: 'strict',
+    placement_group_type: 'anti_affinity:local',
   },
   region: 'us-east',
+  site_type: 'core',
   specs: {
     disk: 30720,
     gpus: 0,
@@ -164,12 +167,13 @@ export const linode4: Linode = {
   label: 'another-test-eu',
   lke_cluster_id: null,
   placement_group: {
-    placement_group_type: 'anti_affinity:local',
     id: 1,
-    placement_group_policy: 'strict',
     label: 'pg-1',
+    placement_group_policy: 'strict',
+    placement_group_type: 'anti_affinity:local',
   },
   region: 'eu-west',
+  site_type: 'core',
   specs: {
     disk: 30720,
     gpus: 0,

--- a/packages/manager/src/components/TransferDisplay/TransferDisplayDialog.tsx
+++ b/packages/manager/src/components/TransferDisplay/TransferDisplayDialog.tsx
@@ -8,9 +8,10 @@ import { Divider } from 'src/components/Divider';
 import { Typography } from 'src/components/Typography';
 
 import { DocsLink } from '../DocsLink/DocsLink';
+import { useIsGeckoEnabled } from '../RegionSelect/RegionSelect.utils';
+import { NETWORK_TRANSFER_QUOTA_DOCS_LINKS } from './constants';
 import { TransferDisplayDialogHeader } from './TransferDisplayDialogHeader';
 import { TransferDisplayUsage } from './TransferDisplayUsage';
-import { NETWORK_TRANSFER_QUOTA_DOCS_LINKS } from './constants';
 import { formatRegionList, getDaysRemaining } from './utils';
 
 import type { RegionTransferPool } from './utils';
@@ -38,6 +39,8 @@ export const TransferDisplayDialog = React.memo(
       regionTransferPools,
     } = props;
     const theme = useTheme();
+    const { isGeckoGAEnabled } = useIsGeckoEnabled();
+
     const daysRemainingInMonth = getDaysRemaining();
     const listOfOtherRegionTransferPools: string[] =
       regionTransferPools.length > 0
@@ -62,7 +65,9 @@ export const TransferDisplayDialog = React.memo(
          *  Global Transfer Pool Display
          */}
         <TransferDisplayDialogHeader
-          tooltipText={`The Global Pool includes transfer associated with active services in your devices' regions${
+          tooltipText={`The Global Pool includes transfer associated with active services in your devices' ${
+            isGeckoGAEnabled ? 'core' : ''
+          } regions${
             listOfOtherRegionTransferPools.length > 0
               ? ` except for ${otherRegionPools}.`
               : '.'

--- a/packages/manager/src/factories/linodes.ts
+++ b/packages/manager/src/factories/linodes.ts
@@ -1,5 +1,9 @@
-import { RegionalNetworkUtilization } from '@linode/api-v4/lib/account';
-import {
+import Factory from 'src/factories/factoryProxy';
+
+import { placementGroupFactory } from './placementGroups';
+
+import type { RegionalNetworkUtilization } from '@linode/api-v4/lib/account';
+import type {
   CreateLinodeRequest,
   Linode,
   LinodeAlerts,
@@ -12,9 +16,6 @@ import {
   Stats,
   StatsData,
 } from '@linode/api-v4/lib/linodes/types';
-import Factory from 'src/factories/factoryProxy';
-
-import { placementGroupFactory } from './placementGroups';
 
 export const linodeAlertsFactory = Factory.Sync.makeFactory<LinodeAlerts>({
   cpu: 10,
@@ -265,11 +266,12 @@ export const linodeFactory = Factory.Sync.makeFactory<Linode>({
   label: Factory.each((i) => `linode-${i}`),
   lke_cluster_id: null,
   placement_group: placementGroupFactory.build({
-    placement_group_type: 'anti_affinity:local',
     id: 1,
     label: 'pg-1',
+    placement_group_type: 'anti_affinity:local',
   }),
   region: 'us-east',
+  site_type: 'core',
   specs: linodeSpecsFactory.build(),
   status: 'running',
   tags: [],

--- a/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 
 import { imageFactory, linodeTypeFactory } from 'src/factories';
-import { http, HttpResponse, server } from 'src/mocks/testServer';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
 import { getMonthlyBackupsPrice } from 'src/utilities/pricing/backups';
 import { renderWithTheme, wrapWithTheme } from 'src/utilities/testHelpers';
 
-import { AddonsPanel, AddonsPanelProps } from './AddonsPanel';
+import { AddonsPanel } from './AddonsPanel';
+
+import type { AddonsPanelProps } from './AddonsPanel';
 
 const type = linodeTypeFactory.build({
   addons: {
@@ -64,12 +66,13 @@ const props: AddonsPanelProps = {
       label: 'test_instance',
       lke_cluster_id: null,
       placement_group: {
-        placement_group_type: 'anti_affinity:local',
         id: 1,
-        placement_group_policy: 'strict',
         label: 'test',
+        placement_group_policy: 'strict',
+        placement_group_type: 'anti_affinity:local',
       },
       region: 'us-central',
+      site_type: 'core',
       specs: {
         disk: 51200,
         gpus: 0,
@@ -110,12 +113,13 @@ const props: AddonsPanelProps = {
       label: 'debian-ca-central',
       lke_cluster_id: null,
       placement_group: {
-        placement_group_type: 'anti_affinity:local',
         id: 1,
-        placement_group_policy: 'strict',
         label: 'test',
+        placement_group_policy: 'strict',
+        placement_group_type: 'anti_affinity:local',
       },
       region: 'ca-central',
+      site_type: 'core',
       specs: {
         disk: 25600,
         gpus: 0,
@@ -155,12 +159,13 @@ const props: AddonsPanelProps = {
       label: 'almalinux-us-west',
       lke_cluster_id: null,
       placement_group: {
-        placement_group_type: 'anti_affinity:local',
         id: 1,
-        placement_group_policy: 'strict',
         label: 'test',
+        placement_group_policy: 'strict',
+        placement_group_type: 'anti_affinity:local',
       },
       region: 'us-west',
+      site_type: 'core',
       specs: {
         disk: 25600,
         gpus: 0,

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
@@ -3,6 +3,7 @@ import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 
 import { Paper } from 'src/components/Paper';
+import { useIsGeckoEnabled } from 'src/components/RegionSelect/RegionSelect.utils';
 import { useLinodeQuery } from 'src/queries/linodes/linodes';
 
 import { DNSResolvers } from './DNSResolvers';
@@ -16,6 +17,7 @@ interface Props {
 export const LinodeNetworkingSummaryPanel = React.memo((props: Props) => {
   // @todo maybe move this query closer to the consuming component
   const { data: linode } = useLinodeQuery(props.linodeId);
+  const { isGeckoGAEnabled } = useIsGeckoEnabled();
   const theme = useTheme();
 
   if (!linode) {
@@ -25,14 +27,16 @@ export const LinodeNetworkingSummaryPanel = React.memo((props: Props) => {
   return (
     <Paper>
       <Grid container spacing={4} sx={{ flexGrow: 1 }}>
-        <Grid md={2.5} sm={6} xs={12}>
-          <NetworkTransfer
-            linodeId={linode.id}
-            linodeLabel={linode.label}
-            linodeRegionId={linode.region}
-            linodeType={linode.type}
-          />
-        </Grid>
+        {isGeckoGAEnabled && linode.site_type === 'distributed' ? null : ( // Distributed compute instances have no transfer pool
+          <Grid md={2.5} sm={6} xs={12}>
+            <NetworkTransfer
+              linodeId={linode.id}
+              linodeLabel={linode.label}
+              linodeRegionId={linode.region}
+              linodeType={linode.type}
+            />
+          </Grid>
+        )}
         <Grid
           sx={{
             [theme.breakpoints.down('md')]: {

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
@@ -24,10 +24,13 @@ export const LinodeNetworkingSummaryPanel = React.memo((props: Props) => {
     return null;
   }
 
+  const hideNetworkTransfer =
+    isGeckoGAEnabled && linode.site_type === 'distributed';
+
   return (
     <Paper>
       <Grid container spacing={4} sx={{ flexGrow: 1 }}>
-        {isGeckoGAEnabled && linode.site_type === 'distributed' ? null : ( // Distributed compute instances have no transfer pool
+        {hideNetworkTransfer ? null : ( // Distributed compute instances have no transfer pool
           <Grid md={2.5} sm={6} xs={12}>
             <NetworkTransfer
               linodeId={linode.id}
@@ -57,7 +60,7 @@ export const LinodeNetworkingSummaryPanel = React.memo((props: Props) => {
             paddingBottom: 0,
           }}
           md={3.5}
-          sm={6}
+          sm={hideNetworkTransfer ? 12 : 6}
           xs={12}
         >
           <DNSResolvers region={linode.region} />

--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
@@ -45,6 +45,7 @@ describe('LinodeRow', () => {
         lke_cluster_id={linode.lke_cluster_id}
         placement_group={linode.placement_group}
         region={linode.region}
+        site_type={linode.site_type}
         specs={linode.specs}
         status={linode.status}
         tags={linode.tags}

--- a/packages/manager/src/features/Linodes/LinodesLanding/ListView.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/ListView.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 
 import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
 
-import { RenderLinodesProps } from './DisplayLinodes';
 import { LinodeRow } from './LinodeRow/LinodeRow';
+
+import type { RenderLinodesProps } from './DisplayLinodes';
 
 export const ListView = (props: RenderLinodesProps) => {
   const { data, openDialog, openPowerActionDialog } = props;
@@ -50,6 +51,7 @@ export const ListView = (props: RenderLinodesProps) => {
           maintenance={linode.maintenance}
           placement_group={linode.placement_group}
           region={linode.region}
+          site_type={linode.site_type}
           specs={linode.specs}
           status={linode.status}
           tags={linode.tags}


### PR DESCRIPTION
## Description 📝
Distributed compute instances have no transfer pool, so the Monthly Network Transfer section is irrelevant. This PR hides that section and expands the Network Transfer History chart to occupy the space.

## Changes  🔄
List any change relevant to the reviewer.
- Hide the monthly network transfer section for Linodes in a distributed region

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/1d95840b-e5e7-4df9-81d4-343b8b22ee80) | ![image](https://github.com/user-attachments/assets/8ee818dc-f890-489b-b0de-1366952111f2) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Ensure your account has the `new-dc-testing`, `edge_testing` and `edge_compute` customer tags
- Create a Linode in a distributed region if you don't already have one

### Verification steps
(How to verify changes)
- Go to a Linode's details page and then navigate to the Network tab
- The Monthly Network Transfer section should not display for Linodes in a distributed region
- The Monthly Network Transfer section should display as normal for Linodes in a core region

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support