### PR TITLE
upcoming: [M3-8357] – Update types and schemas for Block Storage Encryption

### DIFF
--- a/packages/api-v4/.changeset/pr-10716-changed-1721936880921.md
+++ b/packages/api-v4/.changeset/pr-10716-changed-1721936880921.md
@@ -2,4 +2,4 @@
 "@linode/api-v4": Changed
 ---
 
-Linode, Volume, and VolumeRequestPayload interfaces and VolumeStatus and Capabilities types to reflect Block Storage Encryption changes ([#10716](https://github.com/linode/manager/pull/10716))
+Linode, Volume, and VolumeRequestPayload interfaces and VolumeStatus, AccountCapability, and Capabilities types to reflect Block Storage Encryption changes ([#10716](https://github.com/linode/manager/pull/10716))

--- a/packages/api-v4/.changeset/pr-10716-changed-1721936880921.md
+++ b/packages/api-v4/.changeset/pr-10716-changed-1721936880921.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Changed
+---
+
+Linode, Volume, and VolumeRequestPayload interfaces and VolumeStatus and Capabilities types to reflect Block Storage Encryption changes ([#10716](https://github.com/linode/manager/pull/10716))

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -62,6 +62,7 @@ export type BillingSource = 'linode' | 'akamai';
 export type AccountCapability =
   | 'Akamai Cloud Load Balancer'
   | 'Block Storage'
+  | 'Block Storage Encryption'
   | 'Cloud Firewall'
   | 'CloudPulse'
   | 'Disk Encryption'

--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -19,6 +19,7 @@ export interface Linode {
   id: number;
   alerts: LinodeAlerts;
   backups: LinodeBackups;
+  bs_encryption_supported?: boolean; // @TODO BSE: Remove optionality once BSE is fully rolled out
   created: string;
   disk_encryption?: EncryptionStatus; // @TODO LDE: Remove optionality once LDE is fully rolled out
   region: string;

--- a/packages/api-v4/src/regions/types.ts
+++ b/packages/api-v4/src/regions/types.ts
@@ -3,6 +3,7 @@ import { COUNTRY_CODE_TO_CONTINENT_CODE } from './constants';
 export type Capabilities =
   | 'Bare Metal'
   | 'Block Storage'
+  | 'Block Storage Encryption'
   | 'Block Storage Migrations'
   | 'Cloud Firewall'
   | 'Disk Encryption'

--- a/packages/api-v4/src/volumes/types.ts
+++ b/packages/api-v4/src/volumes/types.ts
@@ -1,3 +1,5 @@
+export type VolumeEncryption = 'enabled' | 'disabled';
+
 export interface Volume {
   id: number;
   label: string;
@@ -11,16 +13,18 @@ export interface Volume {
   filesystem_path: string;
   tags: string[];
   hardware_type: VolumeHardwareType;
+  encryption?: VolumeEncryption; // @TODO BSE: Remove optionality once BSE is fully rolled out
 }
 
 type VolumeHardwareType = 'hdd' | 'nvme';
 
 export type VolumeStatus =
-  | 'creating'
   | 'active'
-  | 'resizing'
+  | 'creating'
+  | 'key_rotating'
   | 'migrating'
-  | 'offline';
+  | 'offline'
+  | 'resizing';
 
 export interface VolumeRequestPayload {
   label: string;
@@ -29,6 +33,7 @@ export interface VolumeRequestPayload {
   linode_id?: number;
   config_id?: number;
   tags?: string[];
+  encryption?: VolumeEncryption;
 }
 
 export interface AttachVolumePayload {

--- a/packages/manager/src/features/Volumes/utils.ts
+++ b/packages/manager/src/features/Volumes/utils.ts
@@ -4,6 +4,7 @@ import type { Status } from 'src/components/StatusIcon/StatusIcon';
 export const volumeStatusIconMap: Record<Volume['status'], Status> = {
   active: 'active',
   creating: 'other',
+  key_rotating: 'other',
   migrating: 'other',
   offline: 'inactive',
   resizing: 'other',
@@ -14,7 +15,7 @@ export const volumeStatusIconMap: Record<Volume['status'], Status> = {
  * returns a volume's status with event info taken into account.
  *
  * We do this to provide users with a real-time feeling experience
- * without having to refetch a volume's status agressivly.
+ * without having to refetch a volume's status aggressively.
  *
  * @param status The actual volume status from the volumes endpoint
  * @param event An in-progress event for the volume

--- a/packages/validation/.changeset/pr-10716-changed-1721936121033.md
+++ b/packages/validation/.changeset/pr-10716-changed-1721936121033.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Changed
+---
+
+Include optional 'encryption' field in CreateVolumeSchema ([#10716](https://github.com/linode/manager/pull/10716))

--- a/packages/validation/src/volumes.schema.ts
+++ b/packages/validation/src/volumes.schema.ts
@@ -32,6 +32,7 @@ export const CreateVolumeSchema = object({
     .max(32, 'Label must be 32 characters or less.'),
   config_id: number().nullable().typeError('Config ID must be a number.'),
   tags: array().of(string()),
+  encryption: string().oneOf(['enabled', 'disabled']).notRequired(),
 });
 
 export const CloneVolumeSchema = object({


### PR DESCRIPTION
## Description 📝
Update types and schemas to reflect forthcoming Block Storage Encryption changes.

## Changes  🔄
- Add `encryption` field to `Volume` and `VolumeRequestPayload` interfaces and `key_rotating` value to `VolumeStatus` type in `volumes/types.ts`
- Add `key_rotating` to `volumeStatusIconMap`
- Add optional `encryption` field to `CreateVolumeSchema`
- Add `Block Storage Encryption` to `Capabilities` type in `regions/types.ts` and to `AccountCapability` in `account/types.ts`
- Add `bs_encryption_supported` field to `Linode` interface in `linodes/types.ts`

## Target release date 🗓️
8/5/24

## How to test 🧪
Since there were changes to `CreateVolumeSchema`, ensure that volume creation has not been adversely impacted.

Confirm the changes are in accordance with the API spec linked in the ticket.

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support