### PR TITLE
hotfix: Distributed Images Incorrect Capability

### DIFF
--- a/packages/api-v4/CHANGELOG.md
+++ b/packages/api-v4/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2024-07-25] - v0.122.1
+
+### Fixed:
+
+- Incorrect Image capability of `distributed-images` by changing it to `distributed-sites` ([#10717](https://github.com/linode/manager/pull/10717))
+
 ## [2024-07-22] - v0.122.0
 
 ### Changed:

--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/api-v4",
-  "version": "0.122.0",
+  "version": "0.122.1",
   "homepage": "https://github.com/linode/manager/tree/develop/packages/api-v4",
   "bugs": {
     "url": "https://github.com/linode/manager/issues"

--- a/packages/api-v4/src/images/types.ts
+++ b/packages/api-v4/src/images/types.ts
@@ -4,7 +4,7 @@ export type ImageStatus =
   | 'deleted'
   | 'pending_upload';
 
-export type ImageCapabilities = 'cloud-init' | 'distributed-images';
+export type ImageCapabilities = 'cloud-init' | 'distributed-sites';
 
 type ImageType = 'manual' | 'automatic';
 

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2024-07-25] - v1.124.1
+
+### Fixed:
+
+- Incorrect Image capability of `distributed-images` by changing it to `distributed-sites` ([#10717](https://github.com/linode/manager/pull/10717))
+
+
 ## [2024-07-22] - v1.124.0
 
 ### Added:

--- a/packages/manager/cypress/e2e/core/images/manage-image-regions.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/manage-image-regions.spec.ts
@@ -22,7 +22,7 @@ describe('Manage Image Regions', () => {
     const image = imageFactory.build({
       size: 50,
       total_size: 100,
-      capabilities: ['distributed-images'],
+      capabilities: ['distributed-sites'],
       regions: [
         { region: region1.id, status: 'available' },
         { region: region2.id, status: 'available' },

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.124.0",
+  "version": "1.124.1",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
@@ -101,7 +101,7 @@ describe('ImageSelect', () => {
   it('renders a "Indicates compatibility with distributed compute regions." notice if the user has at least one image with the distributed capability', async () => {
     const images = [
       imageFactory.build({ capabilities: [] }),
-      imageFactory.build({ capabilities: ['distributed-images'] }),
+      imageFactory.build({ capabilities: ['distributed-sites'] }),
       imageFactory.build({ capabilities: [] }),
     ];
 

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -122,7 +122,7 @@ export const imagesToGroupedItems = (images: Image[]) => {
                   created,
                   isCloudInitCompatible: capabilities?.includes('cloud-init'),
                   isDistributedCompatible: capabilities?.includes(
-                    'distributed-images'
+                    'distributed-sites'
                   ),
                   // Add suffix 'deprecated' to the image at end of life.
                   label:
@@ -214,7 +214,7 @@ export const ImageSelect = React.memo((props: ImageSelectProps) => {
   const showDistributedCapabilityNotice =
     variant === 'private' &&
     filteredImages.some((image) =>
-      image.capabilities.includes('distributed-images')
+      image.capabilities.includes('distributed-sites')
     );
 
   return (

--- a/packages/manager/src/components/ImageSelectv2/ImageOptionv2.test.tsx
+++ b/packages/manager/src/components/ImageSelectv2/ImageOptionv2.test.tsx
@@ -36,8 +36,8 @@ describe('ImageOptionv2', () => {
       getByLabelText('This image is compatible with cloud-init.')
     ).toBeVisible();
   });
-  it('renders a distributed icon if image has the "distributed-images" capability', () => {
-    const image = imageFactory.build({ capabilities: ['distributed-images'] });
+  it('renders a distributed icon if image has the "distributed-sites" capability', () => {
+    const image = imageFactory.build({ capabilities: ['distributed-sites'] });
 
     const { getByLabelText } = renderWithTheme(
       <ImageOptionv2 image={image} isSelected={false} listItemProps={{}} />

--- a/packages/manager/src/components/ImageSelectv2/ImageOptionv2.tsx
+++ b/packages/manager/src/components/ImageSelectv2/ImageOptionv2.tsx
@@ -35,7 +35,7 @@ export const ImageOptionv2 = ({ image, isSelected, listItemProps }: Props) => {
         <Typography color="inherit">{image.label}</Typography>
       </Stack>
       <Stack alignItems="center" direction="row" spacing={1}>
-        {image.capabilities.includes('distributed-images') && (
+        {image.capabilities.includes('distributed-sites') && (
           <Tooltip title="This image is compatible with distributed compute regions.">
             <div style={{ display: 'flex' }}>
               <DistributedRegionIcon height="24px" width="24px" />

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.test.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.test.tsx
@@ -133,7 +133,7 @@ describe('SelectRegionPanel on the Clone Flow', () => {
     expect(getByTestId('different-price-structure-notice')).toBeInTheDocument();
   });
 
-  it('should disable distributed regions if the selected image does not have the `distributed-images` capability', async () => {
+  it('should disable distributed regions if the selected image does not have the `distributed-sites` capability', async () => {
     const image = imageFactory.build({ capabilities: [] });
 
     const distributedRegion = regionFactory.build({

--- a/packages/manager/src/features/Images/ImagesLanding/ImageRow.test.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImageRow.test.tsx
@@ -16,7 +16,7 @@ beforeAll(() => mockMatchMedia());
 
 describe('Image Table Row', () => {
   const image = imageFactory.build({
-    capabilities: ['cloud-init', 'distributed-images'],
+    capabilities: ['cloud-init', 'distributed-sites'],
     regions: [
       { region: 'us-east', status: 'available' },
       { region: 'us-southeast', status: 'pending' },

--- a/packages/manager/src/features/Images/ImagesLanding/ImageRow.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImageRow.tsx
@@ -16,7 +16,7 @@ import type { Event, Image, ImageCapabilities } from '@linode/api-v4';
 
 const capabilityMap: Record<ImageCapabilities, string> = {
   'cloud-init': 'Cloud-init',
-  'distributed-images': 'Distributed',
+  'distributed-sites': 'Distributed',
 };
 
 interface Props {

--- a/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.tsx
@@ -141,6 +141,12 @@ export const ImagesLanding = () => {
       ...manualImagesFilter,
       is_public: false,
       type: 'manual',
+    },
+    {
+      // We refetch on an interval because we have no events that tell us
+      // when a image replication has finished.
+      // We should make the API / Image Service team implement new events for this.
+      refetchInterval: 20_000,
     }
   );
 

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Region.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Region.test.tsx
@@ -175,7 +175,7 @@ describe('Region', () => {
     ).toBeVisible();
   });
 
-  it('should disable distributed regions if the selected image does not have the `distributed-images` capability', async () => {
+  it('should disable distributed regions if the selected image does not have the `distributed-sites` capability', async () => {
     const image = imageFactory.build({ capabilities: [] });
 
     const distributedRegion = regionFactory.build({

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Region.utils.test.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Region.utils.test.ts
@@ -27,7 +27,7 @@ describe('getDisabledRegions', () => {
     const distributedRegion = regionFactory.build({ site_type: 'distributed' });
     const coreRegion = regionFactory.build({ site_type: 'core' });
 
-    const image = imageFactory.build({ capabilities: ['distributed-images'] });
+    const image = imageFactory.build({ capabilities: ['distributed-sites'] });
 
     const result = getDisabledRegions({
       linodeCreateTab: 'Images',

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Region.utils.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Region.utils.ts
@@ -18,11 +18,11 @@ export const getDisabledRegions = (options: DisabledRegionOptions) => {
 
   // On the images tab, we disabled distributed regions if:
   // - The user has selected an Image
-  // - The selected image does not have the `distributed-images` capability
+  // - The selected image does not have the `distributed-sites` capability
   if (
     linodeCreateTab === 'Images' &&
     selectedImage &&
-    !selectedImage.capabilities.includes('distributed-images')
+    !selectedImage.capabilities.includes('distributed-sites')
   ) {
     const disabledRegions: Record<string, DisableRegionOption> = {};
 

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Images.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Images.test.tsx
@@ -36,7 +36,7 @@ describe('Images', () => {
       http.get('*/v4/images', () => {
         const images = [
           imageFactory.build({ capabilities: [] }),
-          imageFactory.build({ capabilities: ['distributed-images'] }),
+          imageFactory.build({ capabilities: ['distributed-sites'] }),
           imageFactory.build({ capabilities: [] }),
         ];
         return HttpResponse.json(makeResourcePage(images));

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Images.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Images.tsx
@@ -40,7 +40,7 @@ export const Images = () => {
     // @todo: delete this logic when all Images are "distributed compatible"
     if (
       image &&
-      !image.capabilities.includes('distributed-images') &&
+      !image.capabilities.includes('distributed-sites') &&
       selectedRegion?.site_type === 'distributed'
     ) {
       setValue('region', '');
@@ -54,7 +54,7 @@ export const Images = () => {
 
   // @todo: delete this logic when all Images are "distributed compatible"
   const showDistributedCapabilityNotice = images?.some((image) =>
-    image.capabilities.includes('distributed-images')
+    image.capabilities.includes('distributed-sites')
   );
 
   return (

--- a/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -73,7 +73,7 @@ export const FromImageContent = (props: CombinedProps) => {
     // Clear the region field if the currently selected region is a distributed site and the Image is only core compatible.
     if (
       image &&
-      !image.capabilities.includes('distributed-images') &&
+      !image.capabilities.includes('distributed-sites') &&
       selectedRegion?.site_type === 'distributed'
     ) {
       props.updateRegionID('');

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -610,7 +610,7 @@ export const handlers = [
   }),
   http.get<{ id: string }>('*/v4/images/:id', ({ params }) => {
     const distributedImage = imageFactory.build({
-      capabilities: ['cloud-init', 'distributed-images'],
+      capabilities: ['cloud-init', 'distributed-sites'],
       id: 'private/distributed-image',
       label: 'distributed-image',
       regions: [{ region: 'us-east', status: 'available' }],
@@ -666,7 +666,7 @@ export const handlers = [
     });
     const publicImages = imageFactory.buildList(4, { is_public: true });
     const distributedImage = imageFactory.build({
-      capabilities: ['cloud-init', 'distributed-images'],
+      capabilities: ['cloud-init', 'distributed-sites'],
       id: 'private/distributed-image',
       label: 'distributed-image',
       regions: [{ region: 'us-east', status: 'available' }],

--- a/packages/manager/src/queries/images.ts
+++ b/packages/manager/src/queries/images.ts
@@ -19,7 +19,12 @@ import {
   ResourcePage,
 } from '@linode/api-v4/lib/types';
 import { createQueryKeys } from '@lukemorales/query-key-factory';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  UseQueryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 
 import { EventHandlerData } from 'src/hooks/useEventHandlers';
 import { getAll } from 'src/utilities/getAll';
@@ -49,10 +54,15 @@ export const imageQueries = createQueryKeys('images', {
   }),
 });
 
-export const useImagesQuery = (params: Params, filters: Filter) =>
+export const useImagesQuery = (
+  params: Params,
+  filters: Filter,
+  options?: UseQueryOptions<ResourcePage<Image>, APIError[]>
+) =>
   useQuery<ResourcePage<Image>, APIError[]>({
     ...imageQueries.paginated(params, filters),
     keepPreviousData: true,
+    ...options,
   });
 
 export const useImageQuery = (imageId: string, enabled = true) =>


### PR DESCRIPTION
## Description 📝

- Turns out we had the wrong Image capability for distributed images 💾 🌎 
  - The capability should be `distributed-sites`, **not** `distributed-images`.
- Adds change-log entries and bumps versions of `manager` and `api-v4`📝 ⬆️  

## How to test 🧪

- As far as I know, there is no environment where this can be easily tested 😞 
- Test Image Service Gen2 features with the MSW 👁️  and verify automated testing passes ✅ 