### PR TITLE
upcoming: [M3-8350] - Obj Gen2 - MSW, Factories, Cypress Updates

### DIFF
--- a/packages/manager/.changeset/pr-10720-upcoming-features-1722043886339.md
+++ b/packages/manager/.changeset/pr-10720-upcoming-features-1722043886339.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add new MSW, Factory, and E2E intercepts for OBJ Gen2 ([#10720](https://github.com/linode/manager/pull/10720))

--- a/packages/manager/cypress/e2e/core/objectStorage/access-key.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/access-key.e2e.spec.ts
@@ -2,7 +2,7 @@
  * @file End-to-end tests for Object Storage Access Key operations.
  */
 
-import { createObjectStorageBucketFactory } from 'src/factories/objectStorage';
+import { createObjectStorageBucketFactoryLegacy } from 'src/factories/objectStorage';
 import { authenticate } from 'support/api/authentication';
 import { createBucket } from '@linode/api-v4/lib/object-storage';
 import {
@@ -120,7 +120,7 @@ describe('object storage access key end-to-end tests', () => {
   it('can create an access key with limited access - e2e', () => {
     const bucketLabel = randomLabel();
     const bucketCluster = 'us-east-1';
-    const bucketRequest = createObjectStorageBucketFactory.build({
+    const bucketRequest = createObjectStorageBucketFactoryLegacy.build({
       label: bucketLabel,
       cluster: bucketCluster,
       // Default factory sets `cluster` and `region`, but API does not accept `region` yet.

--- a/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
@@ -4,7 +4,10 @@
 
 import 'cypress-file-upload';
 import { createBucket } from '@linode/api-v4/lib/object-storage';
-import { accountFactory, objectStorageBucketFactory } from 'src/factories';
+import {
+  accountFactory,
+  createObjectStorageBucketFactory,
+} from 'src/factories';
 import { authenticate } from 'support/api/authentication';
 import {
   interceptGetNetworkUtilization,
@@ -55,14 +58,20 @@ const getNonEmptyBucketMessage = (bucketLabel: string) => {
  *
  * @param label - Bucket label.
  * @param cluster - Bucket cluster.
+ * @param cors_enabled - Enable CORS on the bucket: defaults to true for Gen1 and false for Gen2.
  *
  * @returns Promise that resolves to created Bucket.
  */
-const setUpBucket = (label: string, cluster: string) => {
+const setUpBucket = (
+  label: string,
+  cluster: string,
+  cors_enabled: boolean = true
+) => {
   return createBucket(
-    objectStorageBucketFactory.build({
+    createObjectStorageBucketFactory.build({
       label,
       cluster,
+      cors_enabled,
 
       // API accepts either `cluster` or `region`, but not both. Our factory
       // populates both fields, so we have to manually set `region` to `undefined`
@@ -80,14 +89,20 @@ const setUpBucket = (label: string, cluster: string) => {
  *
  * @param label - Bucket label.
  * @param regionId - ID of Bucket region.
+ * @param cors_enabled - Enable CORS on the bucket: defaults to true for Gen1 and false for Gen2.
  *
  * @returns Promise that resolves to created Bucket.
  */
-const setUpBucketMulticluster = (label: string, regionId: string) => {
+const setUpBucketMulticluster = (
+  label: string,
+  regionId: string,
+  cors_enabled: boolean = true
+) => {
   return createBucket(
-    objectStorageBucketFactory.build({
+    createObjectStorageBucketFactory.build({
       label,
       region: regionId,
+      cors_enabled,
 
       // API accepts either `cluster` or `region`, but not both. Our factory
       // populates both fields, so we have to manually set `cluster` to `undefined`

--- a/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/object-storage.e2e.spec.ts
@@ -6,7 +6,8 @@ import 'cypress-file-upload';
 import { createBucket } from '@linode/api-v4/lib/object-storage';
 import {
   accountFactory,
-  createObjectStorageBucketFactory,
+  createObjectStorageBucketFactoryLegacy,
+  createObjectStorageBucketFactoryGen1,
 } from 'src/factories';
 import { authenticate } from 'support/api/authentication';
 import {
@@ -68,7 +69,7 @@ const setUpBucket = (
   cors_enabled: boolean = true
 ) => {
   return createBucket(
-    createObjectStorageBucketFactory.build({
+    createObjectStorageBucketFactoryLegacy.build({
       label,
       cluster,
       cors_enabled,
@@ -99,7 +100,7 @@ const setUpBucketMulticluster = (
   cors_enabled: boolean = true
 ) => {
   return createBucket(
-    createObjectStorageBucketFactory.build({
+    createObjectStorageBucketFactoryGen1.build({
       label,
       region: regionId,
       cors_enabled,

--- a/packages/manager/cypress/support/intercepts/object-storage.ts
+++ b/packages/manager/cypress/support/intercepts/object-storage.ts
@@ -9,6 +9,7 @@ import { paginateResponse } from 'support/util/paginate';
 import { makeResponse } from 'support/util/response';
 
 import type {
+  CreateObjectStorageBucketPayload,
   ObjectStorageBucket,
   ObjectStorageCluster,
   ObjectStorageKey,
@@ -86,7 +87,7 @@ export const interceptCreateBucket = (): Cypress.Chainable<null> => {
  * @returns Cypress chainable.
  */
 export const mockCreateBucket = (
-  bucket: ObjectStorageBucket
+  bucket: CreateObjectStorageBucketPayload
 ): Cypress.Chainable<null> => {
   return cy.intercept(
     'POST',
@@ -477,4 +478,13 @@ export const interceptUpdateBucketAccess = (
     'PUT',
     apiMatcher(`object-storage/buckets/${cluster}/${label}/access`)
   );
+};
+
+/**
+ * Intercepts GET request to get object storage endpoints.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetObjectStorageEndpoints = (): Cypress.Chainable<null> => {
+  return cy.intercept('GET', apiMatcher(`object-storage/endpoints`));
 };

--- a/packages/manager/cypress/support/intercepts/object-storage.ts
+++ b/packages/manager/cypress/support/intercepts/object-storage.ts
@@ -485,6 +485,6 @@ export const interceptUpdateBucketAccess = (
  *
  * @returns Cypress chainable.
  */
-export const mockGetObjectStorageEndpoints = (): Cypress.Chainable<null> => {
+export const interceptGetObjectStorageEndpoints = (): Cypress.Chainable<null> => {
   return cy.intercept('GET', apiMatcher(`object-storage/endpoints`));
 };

--- a/packages/manager/src/factories/objectStorage.ts
+++ b/packages/manager/src/factories/objectStorage.ts
@@ -1,9 +1,10 @@
 import Factory from 'src/factories/factoryProxy';
 
 import type {
-  ObjectStorageBucket,
   CreateObjectStorageBucketPayload,
+  ObjectStorageBucket,
   ObjectStorageCluster,
+  ObjectStorageEndpoint,
   ObjectStorageKey,
   ObjectStorageObject,
 } from '@linode/api-v4/lib/object-storage/types';
@@ -12,12 +13,14 @@ export const objectStorageBucketFactory = Factory.Sync.makeFactory<ObjectStorage
   {
     cluster: 'us-east-1',
     created: '2019-12-12T00:00:00',
+    endpoint_type: 'E1',
     hostname: Factory.each(
       (i) => `obj-bucket-${i}.us-east-1.linodeobjects.com`
     ),
     label: Factory.each((i) => `obj-bucket-${i}`),
     objects: 103,
     region: 'us-east',
+    s3_endpoint: 'us-east-1.linodeobjects.com',
     size: 999999,
   }
 );
@@ -62,7 +65,9 @@ export const objectStorageKeyFactory = Factory.Sync.makeFactory<ObjectStorageKey
     id: Factory.each((id) => id),
     label: Factory.each((id) => `access-key-${id}`),
     limited: false,
-    regions: [{ id: 'us-east', s3_endpoint: 'us-east.com' }],
+    regions: [
+      { endpoint_type: 'E1', id: 'us-east', s3_endpoint: 'us-east.com' },
+    ],
     secret_key: 'PYiAB02QRb53JeUge872CM6wEvBUyRhl3vHn31Ol',
   }
 );
@@ -77,3 +82,11 @@ export const makeObjectsPage = (
 });
 
 export const staticObjects = objectStorageObjectFactory.buildList(250);
+
+export const getObjectStorageEndpointsFactory = Factory.Sync.makeFactory<ObjectStorageEndpoint>(
+  {
+    endpoint_type: 'E2',
+    region: 'us-east',
+    s3_endpoint: 'us-east-1.linodeobjects.com',
+  }
+);

--- a/packages/manager/src/factories/objectStorage.ts
+++ b/packages/manager/src/factories/objectStorage.ts
@@ -83,7 +83,7 @@ export const makeObjectsPage = (
 
 export const staticObjects = objectStorageObjectFactory.buildList(250);
 
-export const getObjectStorageEndpointsFactory = Factory.Sync.makeFactory<ObjectStorageEndpoint>(
+export const objectStorageEndpointsFactory = Factory.Sync.makeFactory<ObjectStorageEndpoint>(
   {
     endpoint_type: 'E2',
     region: 'us-east',

--- a/packages/manager/src/factories/objectStorage.ts
+++ b/packages/manager/src/factories/objectStorage.ts
@@ -62,7 +62,7 @@ export const createObjectStorageBucketFactoryGen1 = Factory.Sync.makeFactory<Cre
 export const createObjectStorageBucketFactoryGen2 = Factory.Sync.makeFactory<CreateObjectStorageBucketPayload>(
   {
     acl: 'private',
-    cors_enabled: true,
+    cors_enabled: false,
     endpoint_type: 'E1',
     label: Factory.each((i) => `obj-bucket-${i}`),
     region: 'us-east',

--- a/packages/manager/src/factories/objectStorage.ts
+++ b/packages/manager/src/factories/objectStorage.ts
@@ -13,22 +13,55 @@ export const objectStorageBucketFactory = Factory.Sync.makeFactory<ObjectStorage
   {
     cluster: 'us-east-1',
     created: '2019-12-12T00:00:00',
-    endpoint_type: 'E1',
     hostname: Factory.each(
       (i) => `obj-bucket-${i}.us-east-1.linodeobjects.com`
     ),
     label: Factory.each((i) => `obj-bucket-${i}`),
     objects: 103,
     region: 'us-east',
-    s3_endpoint: 'us-east-1.linodeobjects.com',
     size: 999999,
   }
 );
 
-export const createObjectStorageBucketFactory = Factory.Sync.makeFactory<CreateObjectStorageBucketPayload>(
+// TODO: OBJ Gen2 - Once we eliminate legacy and Gen1 support, we can rename this to `objectStorageBucketFactory` and set it as the default.
+export const objectStorageBucketFactoryGen2 = Factory.Sync.makeFactory<ObjectStorageBucket>(
+  {
+    cluster: 'us-iad-12',
+    created: '2019-12-12T00:00:00',
+    endpoint_type: 'E3',
+    hostname: Factory.each(
+      (i) => `obj-bucket-${i}.us-iad-12.linodeobjects.com`
+    ),
+    label: Factory.each((i) => `obj-bucket-${i}`),
+    objects: 103,
+    region: 'us-iad',
+    s3_endpoint: 'us-iad-12.linodeobjects.com',
+    size: 999999,
+  }
+);
+
+export const createObjectStorageBucketFactoryLegacy = Factory.Sync.makeFactory<CreateObjectStorageBucketPayload>(
   {
     acl: 'private',
     cluster: 'us-east-1',
+    cors_enabled: true,
+    label: Factory.each((i) => `obj-bucket-${i}`),
+  }
+);
+
+export const createObjectStorageBucketFactoryGen1 = Factory.Sync.makeFactory<CreateObjectStorageBucketPayload>(
+  {
+    acl: 'private',
+    cors_enabled: true,
+    label: Factory.each((i) => `obj-bucket-${i}`),
+    region: 'us-east-1',
+  }
+);
+
+// TODO: OBJ Gen2 - Once we eliminate legacy and Gen1 support, we can rename this to `createObjectStorageBucketFactory` and set it as the default.
+export const createObjectStorageBucketFactoryGen2 = Factory.Sync.makeFactory<CreateObjectStorageBucketPayload>(
+  {
+    acl: 'private',
     cors_enabled: true,
     endpoint_type: 'E1',
     label: Factory.each((i) => `obj-bucket-${i}`),
@@ -59,6 +92,19 @@ export const objectStorageObjectFactory = Factory.Sync.makeFactory<ObjectStorage
 );
 
 export const objectStorageKeyFactory = Factory.Sync.makeFactory<ObjectStorageKey>(
+  {
+    access_key: '4LRW3T5FX5Z55LB3LYQ8',
+    bucket_access: null,
+    id: Factory.each((id) => id),
+    label: Factory.each((id) => `access-key-${id}`),
+    limited: false,
+    regions: [{ id: 'us-east', s3_endpoint: 'us-east.com' }],
+    secret_key: 'PYiAB02QRb53JeUge872CM6wEvBUyRhl3vHn31Ol',
+  }
+);
+
+// TODO: OBJ Gen2 - Once we eliminate legacy and Gen1 support, we can rename this to `objectStorageKeyFactory` and set it as the default.
+export const objectStorageKeyFactoryGen2 = Factory.Sync.makeFactory<ObjectStorageKey>(
   {
     access_key: '4LRW3T5FX5Z55LB3LYQ8',
     bucket_access: null,

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -28,6 +28,7 @@ import {
   eventFactory,
   firewallDeviceFactory,
   firewallFactory,
+  getObjectStorageEndpointsFactory,
   imageFactory,
   incidentResponseFactory,
   invoiceFactory,
@@ -835,6 +836,10 @@ export const handlers = [
       objectStorageOverageTypeFactory.build(),
     ];
     return HttpResponse.json(makeResourcePage(objectStorageTypes));
+  }),
+  http.get('*/v4/object-storage/endpoints', ({}) => {
+    const endpoint = getObjectStorageEndpointsFactory.build();
+    return HttpResponse.json(endpoint);
   }),
   http.get('*object-storage/buckets/*/*/access', async () => {
     await sleep(2000);

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -28,7 +28,7 @@ import {
   eventFactory,
   firewallDeviceFactory,
   firewallFactory,
-  getObjectStorageEndpointsFactory,
+  objectStorageEndpointsFactory,
   imageFactory,
   incidentResponseFactory,
   invoiceFactory,
@@ -61,7 +61,7 @@ import {
   nodeBalancerTypeFactory,
   nodePoolFactory,
   notificationFactory,
-  objectStorageBucketFactory,
+  objectStorageBucketFactoryGen2,
   objectStorageClusterFactory,
   objectStorageKeyFactory,
   objectStorageOverageTypeFactory,
@@ -838,7 +838,7 @@ export const handlers = [
     return HttpResponse.json(makeResourcePage(objectStorageTypes));
   }),
   http.get('*/v4/object-storage/endpoints', ({}) => {
-    const endpoint = getObjectStorageEndpointsFactory.build();
+    const endpoint = objectStorageEndpointsFactory.build();
     return HttpResponse.json(endpoint);
   }),
   http.get('*object-storage/buckets/*/*/access', async () => {
@@ -916,11 +916,11 @@ export const handlers = [
 
     const region = params.region as string;
 
-    objectStorageBucketFactory.resetSequenceNumber();
+    objectStorageBucketFactoryGen2.resetSequenceNumber();
     const page = Number(url.searchParams.get('page') || 1);
     const pageSize = Number(url.searchParams.get('page_size') || 25);
 
-    const buckets = objectStorageBucketFactory.buildList(1, {
+    const buckets = objectStorageBucketFactoryGen2.buildList(1, {
       cluster: `${region}-1`,
       hostname: `obj-bucket-1.${region}.linodeobjects.com`,
       label: `obj-bucket-1`,
@@ -938,11 +938,11 @@ export const handlers = [
     });
   }),
   http.get('*/object-storage/buckets', () => {
-    const buckets = objectStorageBucketFactory.buildList(10);
+    const buckets = objectStorageBucketFactoryGen2.buildList(10);
     return HttpResponse.json(makeResourcePage(buckets));
   }),
   http.post('*/object-storage/buckets', () => {
-    return HttpResponse.json(objectStorageBucketFactory.build());
+    return HttpResponse.json(objectStorageBucketFactoryGen2.build());
   }),
   http.get('*object-storage/clusters', () => {
     const jakartaCluster = objectStorageClusterFactory.build({


### PR DESCRIPTION
## Description 📝
Laying some more groundwork

## Changes  🔄
- The `setUpBucket` and `setUpBucketMulticluster` functions should use the `createObjectStorageBucketFactory` factory instead of `objectStorageBucketFactory`, which is the mocked response for the create request.
- Added new intercept `mockGetObjectStorageEndpoints` which is the new endpoint we're adding for this project.
- Added new factory `getObjectStorageEndpointsFactory`
- Added new MSW endpoint for `/v4/object-storage/endpoints`
- Added `s3_endpoint` and `endpoint_type` which are all optional properties to some factories

## Target release date 🗓️
N/A

## Preview 📷
N/A

## How to test 🧪

### Verification steps
- Ensure existing e2e tests all pass.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
