### PR TITLE
refactor: [M3-6912] - Replace `react-select` with MUI Autocomplete for Longview

### DIFF
--- a/packages/manager/.changeset/pr-10721-tech-stories-1722318698239.md
+++ b/packages/manager/.changeset/pr-10721-tech-stories-1722318698239.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Replace react-select instances with Autocomplete in Longview ([#10721](https://github.com/linode/manager/pull/10721))

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -9,9 +9,9 @@ import { connect } from 'react-redux';
 import { Link, RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 
+import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
 import { DebouncedSearchTextField } from 'src/components/DebouncedSearchTextField';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import { Typography } from 'src/components/Typography';
 import withLongviewClients, {
   Props as LongviewProps,
@@ -42,6 +42,11 @@ interface Props {
   newClientLoading: boolean;
 }
 
+interface SortOption {
+  label: string;
+  value: string;
+}
+
 export type LongviewClientsCombinedProps = Props &
   RouteComponentProps &
   LongviewProps &
@@ -70,8 +75,7 @@ export const LongviewClients = (props: LongviewClientsCombinedProps) => {
   const [selectedClientLabel, setClientLabel] = React.useState<string>('');
 
   /** Handlers/tracking variables for sorting by different client attributes */
-
-  const sortOptions: Item<string>[] = [
+  const sortOptions: SortOption[] = [
     {
       label: 'Client Name',
       value: 'name',
@@ -172,7 +176,7 @@ export const LongviewClients = (props: LongviewClientsCombinedProps) => {
     setQuery(newQuery);
   };
 
-  const handleSortKeyChange = (selected: Item<string>) => {
+  const handleSortKeyChange = (selected: SortOption) => {
     setSortKey(selected.value as SortKey);
   };
 
@@ -208,16 +212,21 @@ export const LongviewClients = (props: LongviewClientsCombinedProps) => {
         </StyledSearchbarGrid>
         <StyledSortSelectGrid>
           <Typography sx={{ minWidth: '65px' }}>Sort by: </Typography>
-          <Select
+          <Autocomplete
+            disableClearable
+            fullWidth
+            label="Sort by"
+            options={sortOptions}
+            onChange={(_, value) => {
+              handleSortKeyChange(value);
+            }}
+            size="small"
+            textFieldProps={{
+              hideLabel: true,
+            }}
             value={sortOptions.find(
               (thisOption) => thisOption.value === sortKey
             )}
-            hideLabel
-            isClearable={false}
-            label="Sort by"
-            onChange={handleSortKeyChange}
-            options={sortOptions}
-            small
           />
         </StyledSortSelectGrid>
       </StyledHeadingGrid>

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -44,7 +44,7 @@ interface Props {
 
 interface SortOption {
   label: string;
-  value: string;
+  value: SortKey;
 }
 
 export type LongviewClientsCombinedProps = Props &
@@ -177,7 +177,7 @@ export const LongviewClients = (props: LongviewClientsCombinedProps) => {
   };
 
   const handleSortKeyChange = (selected: SortOption) => {
-    setSortKey(selected.value as SortKey);
+    setSortKey(selected.value);
   };
 
   // If this value is defined they're not on the free plan


### PR DESCRIPTION
## Description 📝
We want to get rid of our dependency on react-select for accessibility reasons and to consolidate our usage of third-party libraries

## Changes  🔄
List any change relevant to the reviewer.
- Replaced `react-select` with MUI Autocomplete for the Longview feature

## Target release date 🗓️
19th August 2024

## How to test 🧪

### Prerequisites
- Add a few Longview Clients on http://localhost:3000/longview
- Create a few Linodes (if not already present)
- ssh into a linode and install the Longview agent on it with the command given on http://localhost:3000/longview
- Check if the client is running with: `sudo systemctl status longview`. If not (which could likely be the case), start it with `sudo systemctl start longview`. Repeat this for other Linode-Longview Client pairs


### Verification steps
- Navigate to http://localhost:3000/longview and check if the `Sort By` dropdown works as it does on https://cloud.linode.com/longview

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

