### PR TITLE
upcoming: [M3-8401] - Add support for Two-step region select in Linode Create v2

### DIFF
--- a/packages/manager/.changeset/pr-10723-upcoming-features-1722286306937.md
+++ b/packages/manager/.changeset/pr-10723-upcoming-features-1722286306937.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add support for Two-step region select in Linode Create v2 ([#10723](https://github.com/linode/manager/pull/10723))

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Region.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Region.tsx
@@ -184,7 +184,25 @@ export const Region = () => {
   });
 
   if (showTwoStepRegion) {
-    return <TwoStepRegion />;
+    return (
+      <TwoStepRegion
+        regionFilter={
+          // We don't want the Image Service Gen2 work to abide by Gecko feature flags
+          hideDistributedRegions && params.type !== 'Images'
+            ? 'core'
+            : undefined
+        }
+        showDistributedRegionIconHelperText={
+          showDistributedRegionIconHelperText
+        }
+        disabled={isLinodeCreateRestricted}
+        disabledRegions={disabledRegions}
+        errorText={fieldState.error?.message}
+        onChange={onChange}
+        textFieldProps={{ onBlur: field.onBlur }}
+        value={field.value}
+      />
+    );
   }
 
   return (

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Region.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Region.tsx
@@ -9,7 +9,10 @@ import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
 import { Paper } from 'src/components/Paper';
 import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
-import { isDistributedRegionSupported } from 'src/components/RegionSelect/RegionSelect.utils';
+import {
+  isDistributedRegionSupported,
+  useIsGeckoEnabled,
+} from 'src/components/RegionSelect/RegionSelect.utils';
 import { RegionHelperText } from 'src/components/SelectRegionPanel/RegionHelperText';
 import { Typography } from 'src/components/Typography';
 import { useFlags } from 'src/hooks/useFlags';
@@ -25,6 +28,7 @@ import { isLinodeTypeDifferentPriceInSelectedRegion } from 'src/utilities/pricin
 
 import { CROSS_DATA_CENTER_CLONE_WARNING } from '../LinodesCreate/constants';
 import { getDisabledRegions } from './Region.utils';
+import { TwoStepRegion } from './TwoStepRegion';
 import {
   getGeneratedLinodeLabel,
   useLinodeCreateQueryParams,
@@ -77,6 +81,10 @@ export const Region = () => {
   });
 
   const { data: regions } = useRegionsQuery();
+
+  const { isGeckoGAEnabled } = useIsGeckoEnabled();
+  const showTwoStepRegion =
+    isGeckoGAEnabled && isDistributedRegionSupported(params.type ?? 'OS');
 
   const onChange = async (region: RegionType) => {
     const values = getValues();
@@ -174,6 +182,10 @@ export const Region = () => {
     regions: regions ?? [],
     selectedImage: image,
   });
+
+  if (showTwoStepRegion) {
+    return <TwoStepRegion />;
+  }
 
   return (
     <Paper>

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Summary/Summary.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Summary/Summary.tsx
@@ -5,6 +5,7 @@ import { useFormContext, useWatch } from 'react-hook-form';
 
 import { Divider } from 'src/components/Divider';
 import { Paper } from 'src/components/Paper';
+import { useIsGeckoEnabled } from 'src/components/RegionSelect/RegionSelect.utils';
 import { Stack } from 'src/components/Stack';
 import { Typography } from 'src/components/Typography';
 import { useImageQuery } from 'src/queries/images';
@@ -55,7 +56,8 @@ export const Summary = () => {
     ],
   });
 
-  const { data: regions } = useRegionsQuery();
+  const { isGeckoGAEnabled } = useIsGeckoEnabled();
+  const { data: regions } = useRegionsQuery(isGeckoGAEnabled);
   const { data: type } = useTypeQuery(typeId ?? '', Boolean(typeId));
   const { data: image } = useImageQuery(imageId ?? '', Boolean(imageId));
 

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.test.tsx
@@ -1,0 +1,57 @@
+import { userEvent } from '@testing-library/user-event';
+import React from 'react';
+
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
+
+import { TwoStepRegion } from './TwoStepRegion';
+
+describe('TwoStepRegion', () => {
+  it('should render a heading', () => {
+    const { getAllByText } = renderWithThemeAndHookFormContext({
+      component: <TwoStepRegion />,
+    });
+
+    const heading = getAllByText('Region')[0];
+
+    expect(heading).toBeVisible();
+    expect(heading.tagName).toBe('H2');
+  });
+
+  it('should render two tabs, Core and Distributed', () => {
+    const { getAllByRole } = renderWithThemeAndHookFormContext({
+      component: <TwoStepRegion />,
+    });
+
+    const tabs = getAllByRole('tab');
+    expect(tabs[0]).toHaveTextContent('Core');
+    expect(tabs[1]).toHaveTextContent('Distributed');
+  });
+
+  it('should render a Region Select for the Core tab', () => {
+    const { getByPlaceholderText } = renderWithThemeAndHookFormContext({
+      component: <TwoStepRegion />,
+    });
+
+    const select = getByPlaceholderText('Select a Region');
+
+    expect(select).toBeVisible();
+    expect(select).toBeEnabled();
+  });
+
+  it('should render a Geographical Area select with All pre-selected and a Region Select for the Distributed tab', async () => {
+    const { getAllByRole } = renderWithThemeAndHookFormContext({
+      component: <TwoStepRegion />,
+    });
+
+    const tabs = getAllByRole('tab');
+    await userEvent.click(tabs[1]);
+
+    const inputs = getAllByRole('combobox');
+    const geographicalAreaSelect = inputs[0];
+    const regionSelect = inputs[1];
+
+    expect(geographicalAreaSelect).toHaveAttribute('value', 'All');
+    expect(regionSelect).toHaveAttribute('placeholder', 'Select a Region');
+    expect(regionSelect).toBeEnabled();
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.test.tsx
@@ -8,7 +8,7 @@ import { TwoStepRegion } from './TwoStepRegion';
 describe('TwoStepRegion', () => {
   it('should render a heading', () => {
     const { getAllByText } = renderWithThemeAndHookFormContext({
-      component: <TwoStepRegion />,
+      component: <TwoStepRegion onChange={vi.fn()} />,
     });
 
     const heading = getAllByText('Region')[0];
@@ -19,7 +19,7 @@ describe('TwoStepRegion', () => {
 
   it('should render two tabs, Core and Distributed', () => {
     const { getAllByRole } = renderWithThemeAndHookFormContext({
-      component: <TwoStepRegion />,
+      component: <TwoStepRegion onChange={vi.fn()} />,
     });
 
     const tabs = getAllByRole('tab');
@@ -29,7 +29,7 @@ describe('TwoStepRegion', () => {
 
   it('should render a Region Select for the Core tab', () => {
     const { getByPlaceholderText } = renderWithThemeAndHookFormContext({
-      component: <TwoStepRegion />,
+      component: <TwoStepRegion onChange={vi.fn()} />,
     });
 
     const select = getByPlaceholderText('Select a Region');
@@ -40,7 +40,7 @@ describe('TwoStepRegion', () => {
 
   it('should render a Geographical Area select with All pre-selected and a Region Select for the Distributed tab', async () => {
     const { getAllByRole } = renderWithThemeAndHookFormContext({
-      component: <TwoStepRegion />,
+      component: <TwoStepRegion onChange={vi.fn()} />,
     });
 
     const tabs = getAllByRole('tab');

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.tsx
@@ -109,7 +109,7 @@ export const TwoStepRegion = () => {
     'distributed'
   );
 
-  const { data: regions } = useRegionsQuery();
+  const { data: regions } = useRegionsQuery(true);
 
   const onChange = async (region: RegionType) => {
     const values = getValues();

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.tsx
@@ -1,0 +1,253 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useFlags } from 'launchdarkly-react-client-sdk';
+import * as React from 'react';
+import { useController, useFormContext, useWatch } from 'react-hook-form';
+
+import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
+import { Box } from 'src/components/Box';
+import { useIsDiskEncryptionFeatureEnabled } from 'src/components/DiskEncryption/utils';
+import { Paper } from 'src/components/Paper';
+import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
+import { isDistributedRegionSupported } from 'src/components/RegionSelect/RegionSelect.utils';
+import { RegionHelperText } from 'src/components/SelectRegionPanel/RegionHelperText';
+import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
+import { Tab } from 'src/components/Tabs/Tab';
+import { TabList } from 'src/components/Tabs/TabList';
+import { TabPanels } from 'src/components/Tabs/TabPanels';
+import { Tabs } from 'src/components/Tabs/Tabs';
+import { Typography } from 'src/components/Typography';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
+import { useImageQuery } from 'src/queries/images';
+import { useRegionsQuery } from 'src/queries/regions/regions';
+import { sendLinodeCreateDocsEvent } from 'src/utilities/analytics/customEventAnalytics';
+
+import { getDisabledRegions } from './Region.utils';
+import {
+  getGeneratedLinodeLabel,
+  useLinodeCreateQueryParams,
+} from './utilities';
+
+import type { LinodeCreateFormValues } from './utilities';
+import type { Region as RegionType } from '@linode/api-v4';
+import type { RegionFilterValue } from 'src/components/RegionSelect/RegionSelect.types';
+
+interface GeographicalAreaOption {
+  label: string;
+  value: RegionFilterValue;
+}
+
+const GEOGRAPHICAL_AREA_OPTIONS: GeographicalAreaOption[] = [
+  {
+    label: 'All',
+    value: 'distributed-ALL',
+  },
+  {
+    label: 'North America',
+    value: 'distributed-NA',
+  },
+  {
+    label: 'Africa',
+    value: 'distributed-AF',
+  },
+  {
+    label: 'Asia',
+    value: 'distributed-AS',
+  },
+  {
+    label: 'Europe',
+    value: 'distributed-EU',
+  },
+  {
+    label: 'Oceania',
+    value: 'distributed-OC',
+  },
+  {
+    label: 'South America',
+    value: 'distributed-SA',
+  },
+];
+
+export const TwoStepRegion = () => {
+  const {
+    isDiskEncryptionFeatureEnabled,
+  } = useIsDiskEncryptionFeatureEnabled();
+
+  const flags = useFlags();
+  const queryClient = useQueryClient();
+
+  const { params } = useLinodeCreateQueryParams();
+
+  const {
+    control,
+    formState: {
+      dirtyFields: { label: isLabelFieldDirty },
+    },
+    getValues,
+    setValue,
+  } = useFormContext<LinodeCreateFormValues>();
+
+  const { field, fieldState } = useController({
+    control,
+    name: 'region',
+  });
+
+  const [selectedImage] = useWatch({
+    control,
+    name: ['image'],
+  });
+
+  const { data: image } = useImageQuery(
+    selectedImage ?? '',
+    Boolean(selectedImage)
+  );
+
+  const isLinodeCreateRestricted = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'add_linodes',
+  });
+
+  const [regionFilter, setRegionFilter] = React.useState<RegionFilterValue>(
+    'distributed'
+  );
+
+  const { data: regions } = useRegionsQuery();
+
+  const onChange = async (region: RegionType) => {
+    const values = getValues();
+
+    field.onChange(region.id);
+
+    if (values.hasSignedEUAgreement) {
+      // Reset the EU agreement checkbox if they checked it so they have to re-agree when they change regions
+      setValue('hasSignedEUAgreement', false);
+    }
+
+    if (values.interfaces?.[0].vpc_id) {
+      // If a VPC is selected, clear it because VPCs are region specific
+      setValue('interfaces.0.vpc_id', null);
+      setValue('interfaces.0.subnet_id', null);
+    }
+
+    if (values.interfaces?.[1].label) {
+      // If a VLAN is selected, clear it because VLANs are region specific
+      setValue('interfaces.1.label', null);
+      setValue('interfaces.1.ipam_address', null);
+    }
+
+    if (
+      values.metadata?.user_data &&
+      !region.capabilities.includes('Metadata')
+    ) {
+      // Clear metadata only if the new region does not support it
+      setValue('metadata.user_data', null);
+    }
+
+    if (values.placement_group?.id) {
+      // If a placement group is selected, clear it because they are region specific
+      setValue('placement_group.id', 0);
+    }
+
+    // Because distributed regions do not support some features,
+    // we must disable those features here. Keep in mind, we should
+    // prevent the user from enabling these features in their respective components.
+    if (region.site_type === 'distributed') {
+      setValue('backups_enabled', false);
+      setValue('private_ip', false);
+    }
+
+    if (isDiskEncryptionFeatureEnabled) {
+      // Enable disk encryption by default if the region supports it
+      const defaultDiskEncryptionValue = region.capabilities.includes(
+        'Disk Encryption'
+      )
+        ? 'enabled'
+        : undefined;
+
+      setValue('disk_encryption', defaultDiskEncryptionValue);
+    }
+
+    if (!isLabelFieldDirty) {
+      // Auto-generate the Linode label because the region is included in the generated label
+      const label = await getGeneratedLinodeLabel({
+        queryClient,
+        tab: params.type ?? 'OS',
+        values: { ...values, region: region.id },
+      });
+
+      setValue('label', label);
+    }
+  };
+
+  const hideDistributedRegions =
+    !flags.gecko2?.enabled ||
+    flags.gecko2?.ga ||
+    !isDistributedRegionSupported(params.type ?? 'OS');
+
+  const disabledRegions = getDisabledRegions({
+    linodeCreateTab: params.type,
+    regions: regions ?? [],
+    selectedImage: image,
+  });
+
+  return (
+    <Paper>
+      <Typography variant="h2">Region</Typography>
+      <Tabs>
+        <TabList>
+          <Tab>Core</Tab>
+          <Tab>Distributed</Tab>
+        </TabList>
+        <TabPanels>
+          <SafeTabPanel index={0}>
+            <Box marginTop={2}>
+              <RegionHelperText
+                onClick={() => sendLinodeCreateDocsEvent('Speedtest')}
+              />
+            </Box>
+            <RegionSelect
+              regionFilter={
+                // We don't want the Image Service Gen2 work to abide by Gecko feature flags
+                hideDistributedRegions && params.type !== 'Images'
+                  ? 'core'
+                  : undefined
+              }
+              currentCapability="Linodes"
+              disableClearable
+              disabled={isLinodeCreateRestricted}
+              disabledRegions={disabledRegions}
+              errorText={fieldState.error?.message}
+              onChange={(e, region) => onChange(region)}
+              regions={regions ?? []}
+              showDistributedRegionIconHelperText={false}
+              value={field.value}
+            />
+          </SafeTabPanel>
+          <SafeTabPanel index={1}>
+            <Autocomplete
+              onChange={(_, selectedOption) => {
+                if (selectedOption?.value) {
+                  setRegionFilter(selectedOption.value);
+                }
+              }}
+              defaultValue={GEOGRAPHICAL_AREA_OPTIONS[0]}
+              disableClearable
+              label="Geographical Area"
+              options={GEOGRAPHICAL_AREA_OPTIONS}
+            />
+            <RegionSelect
+              currentCapability="Linodes"
+              disableClearable
+              disabled={isLinodeCreateRestricted}
+              disabledRegions={disabledRegions}
+              errorText={fieldState.error?.message}
+              onChange={(e, region) => onChange(region)}
+              regionFilter={regionFilter}
+              regions={regions ?? []}
+              showDistributedRegionIconHelperText={false}
+              value={field.value}
+            />
+          </SafeTabPanel>
+        </TabPanels>
+      </Tabs>
+    </Paper>
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.tsx
@@ -1,14 +1,9 @@
-import { useQueryClient } from '@tanstack/react-query';
-import { useFlags } from 'launchdarkly-react-client-sdk';
 import * as React from 'react';
-import { useController, useFormContext, useWatch } from 'react-hook-form';
 
 import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
 import { Box } from 'src/components/Box';
-import { useIsDiskEncryptionFeatureEnabled } from 'src/components/DiskEncryption/utils';
 import { Paper } from 'src/components/Paper';
 import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
-import { isDistributedRegionSupported } from 'src/components/RegionSelect/RegionSelect.utils';
 import { RegionHelperText } from 'src/components/SelectRegionPanel/RegionHelperText';
 import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
 import { Tab } from 'src/components/Tabs/Tab';
@@ -16,20 +11,14 @@ import { TabList } from 'src/components/Tabs/TabList';
 import { TabPanels } from 'src/components/Tabs/TabPanels';
 import { Tabs } from 'src/components/Tabs/Tabs';
 import { Typography } from 'src/components/Typography';
-import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
-import { useImageQuery } from 'src/queries/images';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { sendLinodeCreateDocsEvent } from 'src/utilities/analytics/customEventAnalytics';
 
-import { getDisabledRegions } from './Region.utils';
-import {
-  getGeneratedLinodeLabel,
-  useLinodeCreateQueryParams,
-} from './utilities';
-
-import type { LinodeCreateFormValues } from './utilities';
 import type { Region as RegionType } from '@linode/api-v4';
-import type { RegionFilterValue } from 'src/components/RegionSelect/RegionSelect.types';
+import type {
+  RegionFilterValue,
+  RegionSelectProps,
+} from 'src/components/RegionSelect/RegionSelect.types';
 
 interface GeographicalAreaOption {
   label: string;
@@ -67,126 +56,20 @@ const GEOGRAPHICAL_AREA_OPTIONS: GeographicalAreaOption[] = [
   },
 ];
 
-export const TwoStepRegion = () => {
-  const {
-    isDiskEncryptionFeatureEnabled,
-  } = useIsDiskEncryptionFeatureEnabled();
+interface Props {
+  onChange: (region: RegionType) => void;
+}
 
-  const flags = useFlags();
-  const queryClient = useQueryClient();
+type CombinedProps = Props & Omit<Partial<RegionSelectProps>, 'onChange'>;
 
-  const { params } = useLinodeCreateQueryParams();
-
-  const {
-    control,
-    formState: {
-      dirtyFields: { label: isLabelFieldDirty },
-    },
-    getValues,
-    setValue,
-  } = useFormContext<LinodeCreateFormValues>();
-
-  const { field, fieldState } = useController({
-    control,
-    name: 'region',
-  });
-
-  const [selectedImage] = useWatch({
-    control,
-    name: ['image'],
-  });
-
-  const { data: image } = useImageQuery(
-    selectedImage ?? '',
-    Boolean(selectedImage)
-  );
-
-  const isLinodeCreateRestricted = useRestrictedGlobalGrantCheck({
-    globalGrantType: 'add_linodes',
-  });
+export const TwoStepRegion = (props: CombinedProps) => {
+  const { disabled, disabledRegions, errorText, onChange, value } = props;
 
   const [regionFilter, setRegionFilter] = React.useState<RegionFilterValue>(
     'distributed'
   );
 
   const { data: regions } = useRegionsQuery(true);
-
-  const onChange = async (region: RegionType) => {
-    const values = getValues();
-
-    field.onChange(region.id);
-
-    if (values.hasSignedEUAgreement) {
-      // Reset the EU agreement checkbox if they checked it so they have to re-agree when they change regions
-      setValue('hasSignedEUAgreement', false);
-    }
-
-    if (values.interfaces?.[0].vpc_id) {
-      // If a VPC is selected, clear it because VPCs are region specific
-      setValue('interfaces.0.vpc_id', null);
-      setValue('interfaces.0.subnet_id', null);
-    }
-
-    if (values.interfaces?.[1].label) {
-      // If a VLAN is selected, clear it because VLANs are region specific
-      setValue('interfaces.1.label', null);
-      setValue('interfaces.1.ipam_address', null);
-    }
-
-    if (
-      values.metadata?.user_data &&
-      !region.capabilities.includes('Metadata')
-    ) {
-      // Clear metadata only if the new region does not support it
-      setValue('metadata.user_data', null);
-    }
-
-    if (values.placement_group?.id) {
-      // If a placement group is selected, clear it because they are region specific
-      setValue('placement_group.id', 0);
-    }
-
-    // Because distributed regions do not support some features,
-    // we must disable those features here. Keep in mind, we should
-    // prevent the user from enabling these features in their respective components.
-    if (region.site_type === 'distributed') {
-      setValue('backups_enabled', false);
-      setValue('private_ip', false);
-    }
-
-    if (isDiskEncryptionFeatureEnabled) {
-      // Enable disk encryption by default if the region supports it
-      const defaultDiskEncryptionValue = region.capabilities.includes(
-        'Disk Encryption'
-      )
-        ? 'enabled'
-        : undefined;
-
-      setValue('disk_encryption', defaultDiskEncryptionValue);
-    }
-
-    if (!isLabelFieldDirty) {
-      // Auto-generate the Linode label because the region is included in the generated label
-      const label = await getGeneratedLinodeLabel({
-        queryClient,
-        tab: params.type ?? 'OS',
-        values: { ...values, region: region.id },
-      });
-
-      setValue('label', label);
-    }
-  };
-
-  const hideDistributedRegions =
-    !flags.gecko2?.enabled ||
-    flags.gecko2?.ga ||
-    !isDistributedRegionSupported(params.type ?? 'OS');
-
-  const disabledRegions = getDisabledRegions({
-    linodeCreateTab: params.type,
-    regions: regions ?? [],
-    selectedImage: image,
-  });
 
   return (
     <Paper>
@@ -204,21 +87,16 @@ export const TwoStepRegion = () => {
               />
             </Box>
             <RegionSelect
-              regionFilter={
-                // We don't want the Image Service Gen2 work to abide by Gecko feature flags
-                hideDistributedRegions && params.type !== 'Images'
-                  ? 'core'
-                  : undefined
-              }
               currentCapability="Linodes"
               disableClearable
-              disabled={isLinodeCreateRestricted}
+              disabled={disabled}
               disabledRegions={disabledRegions}
-              errorText={fieldState.error?.message}
+              errorText={errorText}
               onChange={(e, region) => onChange(region)}
+              regionFilter={regionFilter}
               regions={regions ?? []}
               showDistributedRegionIconHelperText={false}
-              value={field.value}
+              value={value}
             />
           </SafeTabPanel>
           <SafeTabPanel index={1}>
@@ -236,14 +114,14 @@ export const TwoStepRegion = () => {
             <RegionSelect
               currentCapability="Linodes"
               disableClearable
-              disabled={isLinodeCreateRestricted}
+              disabled={disabled}
               disabledRegions={disabledRegions}
-              errorText={fieldState.error?.message}
+              errorText={errorText}
               onChange={(e, region) => onChange(region)}
               regionFilter={regionFilter}
               regions={regions ?? []}
               showDistributedRegionIconHelperText={false}
-              value={field.value}
+              value={value}
             />
           </SafeTabPanel>
         </TabPanels>

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
@@ -7,10 +7,6 @@ import { useHistory } from 'react-router-dom';
 
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { LandingHeader } from 'src/components/LandingHeader';
-import {
-  isDistributedRegionSupported,
-  useIsGeckoEnabled,
-} from 'src/components/RegionSelect/RegionSelect.utils';
 import { Stack } from 'src/components/Stack';
 import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
 import { Tab } from 'src/components/Tabs/Tab';
@@ -42,7 +38,6 @@ import { Images } from './Tabs/Images';
 import { Marketplace } from './Tabs/Marketplace/Marketplace';
 import { OperatingSystems } from './Tabs/OperatingSystems';
 import { StackScripts } from './Tabs/StackScripts/StackScripts';
-import { TwoStepRegion } from './TwoStepRegion';
 import { UserData } from './UserData/UserData';
 import {
   captureLinodeCreateAnalyticsEvent,
@@ -72,10 +67,6 @@ export const LinodeCreatev2 = () => {
 
   const history = useHistory();
   const { enqueueSnackbar } = useSnackbar();
-
-  const { isGeckoGAEnabled } = useIsGeckoEnabled();
-  const showTwoStepRegion =
-    isGeckoGAEnabled && isDistributedRegionSupported(params.type ?? 'OS');
 
   const { mutateAsync: createLinode } = useCreateLinodeMutation();
   const { mutateAsync: cloneLinode } = useCloneLinodeMutation();
@@ -189,8 +180,7 @@ export const LinodeCreatev2 = () => {
               </SafeTabPanel>
             </TabPanels>
           </Tabs>
-          {params.type !== 'Backups' && !showTwoStepRegion && <Region />}
-          {params.type !== 'Backups' && showTwoStepRegion && <TwoStepRegion />}
+          {params.type !== 'Backups' && <Region />}
           <Plan />
           <Details />
           {params.type !== 'Clone Linode' && <Security />}

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
@@ -7,6 +7,10 @@ import { useHistory } from 'react-router-dom';
 
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { LandingHeader } from 'src/components/LandingHeader';
+import {
+  isDistributedRegionSupported,
+  useIsGeckoEnabled,
+} from 'src/components/RegionSelect/RegionSelect.utils';
 import { Stack } from 'src/components/Stack';
 import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
 import { Tab } from 'src/components/Tabs/Tab';
@@ -38,6 +42,7 @@ import { Images } from './Tabs/Images';
 import { Marketplace } from './Tabs/Marketplace/Marketplace';
 import { OperatingSystems } from './Tabs/OperatingSystems';
 import { StackScripts } from './Tabs/StackScripts/StackScripts';
+import { TwoStepRegion } from './TwoStepRegion';
 import { UserData } from './UserData/UserData';
 import {
   captureLinodeCreateAnalyticsEvent,
@@ -67,6 +72,10 @@ export const LinodeCreatev2 = () => {
 
   const history = useHistory();
   const { enqueueSnackbar } = useSnackbar();
+
+  const { isGeckoGAEnabled } = useIsGeckoEnabled();
+  const showTwoStepRegion =
+    isGeckoGAEnabled && isDistributedRegionSupported(params.type ?? 'OS');
 
   const { mutateAsync: createLinode } = useCreateLinodeMutation();
   const { mutateAsync: cloneLinode } = useCloneLinodeMutation();
@@ -180,7 +189,8 @@ export const LinodeCreatev2 = () => {
               </SafeTabPanel>
             </TabPanels>
           </Tabs>
-          {params.type !== 'Backups' && <Region />}
+          {params.type !== 'Backups' && !showTwoStepRegion && <Region />}
+          {params.type !== 'Backups' && showTwoStepRegion && <TwoStepRegion />}
           <Plan />
           <Details />
           {params.type !== 'Clone Linode' && <Security />}


### PR DESCRIPTION
## Description 📝
Add support for the two-step Gecko GA region select in the Linode Create v2 flow

## Changes  🔄
- Add `TwoStepRegion.tsx` for Linode Create v2

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/fba73318-fa94-428f-ba21-858b79a86841) | ![image](https://github.com/user-attachments/assets/4c5972ce-f921-42c7-9ff3-5318acfb1ab3) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Ensure your account has the `new-dc-testing`, `edge_testing` and `edge_compute` customer tags

### Verification steps
(How to verify changes)
- There should be no visual or functional differences between v1 and v2 Create flows

```
yarn test TwoStepRegion
```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support