### PR TITLE
fix: [M3-8219] - Firewall rule sources not displaying correctly

### DIFF
--- a/packages/manager/.changeset/pr-10724-fixed-1722289139869.md
+++ b/packages/manager/.changeset/pr-10724-fixed-1722289139869.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Sources not displaying correctly in Firewall Rule drawer ([#10724](https://github.com/linode/manager/pull/10724))

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.utils.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.utils.ts
@@ -6,12 +6,13 @@ import { parseCIDR, parse as parseIP } from 'ipaddr.js';
 import { uniq } from 'ramda';
 
 import {
-  FirewallOptionItem,
   allIPs,
   allIPv4,
   allIPv6,
   allowAllIPv4,
   allowAllIPv6,
+  allowNoneIPv4,
+  allowNoneIPv6,
   allowsAllIPs,
   predefinedFirewallFromRule,
 } from 'src/features/Firewalls/shared';
@@ -25,6 +26,7 @@ import type {
   FirewallRuleProtocol,
   FirewallRuleType,
 } from '@linode/api-v4/lib/firewalls';
+import type { FirewallOptionItem } from 'src/features/Firewalls/shared';
 import type { ExtendedIP } from 'src/utilities/ipUtils';
 
 export const IP_ERROR_MESSAGE = 'Must be a valid IPv4 or IPv6 range.';
@@ -172,11 +174,11 @@ export const getInitialAddressFormValue = (
     return 'all';
   }
 
-  if (allowAllIPv4(addresses)) {
+  if (allowAllIPv4(addresses) && allowNoneIPv6(addresses)) {
     return 'allIPv4';
   }
 
-  if (allowAllIPv6(addresses)) {
+  if (allowAllIPv6(addresses) && allowNoneIPv4(addresses)) {
     return 'allIPv6';
   }
 

--- a/packages/manager/src/features/Firewalls/shared.ts
+++ b/packages/manager/src/features/Firewalls/shared.ts
@@ -1,10 +1,10 @@
-import { Grants, Profile } from '@linode/api-v4';
-import {
+import { truncateAndJoinList } from 'src/utilities/stringUtils';
+
+import type { Grants, Profile } from '@linode/api-v4';
+import type {
   FirewallRuleProtocol,
   FirewallRuleType,
 } from '@linode/api-v4/lib/firewalls/types';
-
-import { truncateAndJoinList } from 'src/utilities/stringUtils';
 
 export type FirewallPreset = 'dns' | 'http' | 'https' | 'mysql' | 'ssh';
 
@@ -197,6 +197,12 @@ export const allowAllIPv4 = (addresses: FirewallRuleType['addresses']) =>
 
 export const allowAllIPv6 = (addresses: FirewallRuleType['addresses']) =>
   addresses?.ipv6?.includes(allIPv6);
+
+export const allowNoneIPv4 = (addresses: FirewallRuleType['addresses']) =>
+  !addresses?.ipv4?.length;
+
+export const allowNoneIPv6 = (addresses: FirewallRuleType['addresses']) =>
+  !addresses?.ipv6?.length;
 
 export const generateRuleLabel = (ruleType?: FirewallPreset) =>
   ruleType ? predefinedFirewalls[ruleType].label : 'Custom';


### PR DESCRIPTION
## Description 📝
Fixes a bug in `FirewallRuleDrawer` causing some addresses not to appear.

## Target release date 🗓️
8/5

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-07-29 at 5 29 03 PM](https://github.com/user-attachments/assets/b3a0f763-4e8f-4e1d-824b-68eb0bdb48ad)  |![Screenshot 2024-07-29 at 5 29 49 PM](https://github.com/user-attachments/assets/78c361d5-bd29-460d-8f69-eaf87611e092)  |

## How to test 🧪

### Reproduction steps
- Create a new rule in a new/existing firewall
- Enter any value for "Label", "Protocol" and "Ports"
- For sources, select "IP / Netmask"
- For the IP addresses, either
    - Add all IPv4 addresses (0.0.0.0/0) and some IPv6 addresses or an IPv6 subnet
    - Add all IPv6 addresses (::/0) and some IPv4 addresses or an IPv4 subnet
- Click "Add Rule" then "Save Changes"
- Edit the new rule that was just created
- Observe "Sources" is set to "All IPv4" or "All IPv6" instead of "IP / Netmask" as expected

## Verification steps
- Follow the same steps as above and verify "Sources" is set to "IP / Netmask" and displays all of the configured IP addresses