### PR TITLE
test: [M3-8403] - Avoid cleaning up Volumes whose status is not active in Cypress

### DIFF
--- a/packages/manager/cypress/support/api/volumes.ts
+++ b/packages/manager/cypress/support/api/volumes.ts
@@ -18,7 +18,10 @@ export const deleteAllTestVolumes = async (): Promise<void> => {
   );
 
   const detachDeletePromises = volumes
-    .filter((volume: Volume) => isTestLabel(volume.label))
+    .filter(
+      (volume: Volume) =>
+        isTestLabel(volume.label) && volume.status === 'active'
+    )
     .map(async (volume: Volume) => {
       if (volume.linode_id) {
         await detachVolume(volume.id);


### PR DESCRIPTION
## Description 📝
This updates the Cypress clean up logic for Volumes to avoid attempting to delete any Volumes with statuses other than 'active'. This should work around some failures we're seeing in CI related to stuck volumes that are unable to be deleted via the API, and allow the tests to run and pass while we work to clean up the stuck resources.

## Changes  🔄
- Update Volume clean up logic to avoid attempting to delete non-active Volumes

## How to test 🧪
This is difficult to test manually since it depends on having a stuck Volume (a non-stuck Volume would probably be created too quickly to effectively test this). However, we should be able to compare the CI results with other (failing) runs to see whether or not this change is effective.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
