### PR TITLE
upcoming: [M3-8406, M3-8407] - Image Service Gen2 - Fix Image Capability and other tweaks

### DIFF
--- a/packages/api-v4/src/images/types.ts
+++ b/packages/api-v4/src/images/types.ts
@@ -4,7 +4,7 @@ export type ImageStatus =
   | 'deleted'
   | 'pending_upload';
 
-export type ImageCapabilities = 'cloud-init' | 'distributed-images';
+export type ImageCapabilities = 'cloud-init' | 'distributed-sites';
 
 type ImageType = 'manual' | 'automatic';
 

--- a/packages/manager/.changeset/pr-10731-upcoming-features-1722444371850.md
+++ b/packages/manager/.changeset/pr-10731-upcoming-features-1722444371850.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Image Service Gen2 - Fix Image Capability and other tweaks ([#10731](https://github.com/linode/manager/pull/10731))

--- a/packages/manager/cypress/e2e/core/images/manage-image-regions.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/manage-image-regions.spec.ts
@@ -22,7 +22,7 @@ describe('Manage Image Regions', () => {
     const image = imageFactory.build({
       size: 50,
       total_size: 100,
-      capabilities: ['distributed-images'],
+      capabilities: ['distributed-sites'],
       regions: [
         { region: region1.id, status: 'available' },
         { region: region2.id, status: 'available' },

--- a/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
@@ -101,7 +101,7 @@ describe('ImageSelect', () => {
   it('renders a "Indicates compatibility with distributed compute regions." notice if the user has at least one image with the distributed capability', async () => {
     const images = [
       imageFactory.build({ capabilities: [] }),
-      imageFactory.build({ capabilities: ['distributed-images'] }),
+      imageFactory.build({ capabilities: ['distributed-sites'] }),
       imageFactory.build({ capabilities: [] }),
     ];
 

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -122,7 +122,7 @@ export const imagesToGroupedItems = (images: Image[]) => {
                   created,
                   isCloudInitCompatible: capabilities?.includes('cloud-init'),
                   isDistributedCompatible: capabilities?.includes(
-                    'distributed-images'
+                    'distributed-sites'
                   ),
                   // Add suffix 'deprecated' to the image at end of life.
                   label:
@@ -214,7 +214,7 @@ export const ImageSelect = React.memo((props: ImageSelectProps) => {
   const showDistributedCapabilityNotice =
     variant === 'private' &&
     filteredImages.some((image) =>
-      image.capabilities.includes('distributed-images')
+      image.capabilities.includes('distributed-sites')
     );
 
   return (

--- a/packages/manager/src/components/ImageSelectv2/ImageOptionv2.test.tsx
+++ b/packages/manager/src/components/ImageSelectv2/ImageOptionv2.test.tsx
@@ -36,8 +36,8 @@ describe('ImageOptionv2', () => {
       getByLabelText('This image is compatible with cloud-init.')
     ).toBeVisible();
   });
-  it('renders a distributed icon if image has the "distributed-images" capability', () => {
-    const image = imageFactory.build({ capabilities: ['distributed-images'] });
+  it('renders a distributed icon if image has the "distributed-sites" capability', () => {
+    const image = imageFactory.build({ capabilities: ['distributed-sites'] });
 
     const { getByLabelText } = renderWithTheme(
       <ImageOptionv2 image={image} isSelected={false} listItemProps={{}} />

--- a/packages/manager/src/components/ImageSelectv2/ImageOptionv2.tsx
+++ b/packages/manager/src/components/ImageSelectv2/ImageOptionv2.tsx
@@ -35,7 +35,7 @@ export const ImageOptionv2 = ({ image, isSelected, listItemProps }: Props) => {
         <Typography color="inherit">{image.label}</Typography>
       </Stack>
       <Stack alignItems="center" direction="row" spacing={1}>
-        {image.capabilities.includes('distributed-images') && (
+        {image.capabilities.includes('distributed-sites') && (
           <Tooltip title="This image is compatible with distributed compute regions.">
             <div style={{ display: 'flex' }}>
               <DistributedRegionIcon height="24px" width="24px" />

--- a/packages/manager/src/components/RegionSelect/RegionMultiSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionMultiSelect.tsx
@@ -67,6 +67,7 @@ export const RegionMultiSelect = React.memo((props: RegionMultiSelectProps) => {
     selectedIds,
     sortRegionOptions,
     width,
+    disabledRegions: disabledRegionsFromProps,
     ...rest
   } = props;
 
@@ -88,6 +89,9 @@ export const RegionMultiSelect = React.memo((props: RegionMultiSelectProps) => {
   const disabledRegions = regionOptions.reduce<
     Record<string, DisableRegionOption>
   >((acc, region) => {
+    if (disabledRegionsFromProps?.[region.id]) {
+      acc[region.id] = disabledRegionsFromProps[region.id];
+    }
     if (
       isRegionOptionUnavailable({
         accountAvailabilityData: accountAvailability,

--- a/packages/manager/src/components/RegionSelect/RegionSelect.types.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.types.ts
@@ -76,6 +76,7 @@ export interface RegionMultiSelectProps
     selectedRegions: Region[];
   }>;
   currentCapability: Capabilities | undefined;
+  disabledRegions?: Record<string, DisableRegionOption>;
   helperText?: string;
   isClearable?: boolean;
   label?: string;

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.test.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.test.tsx
@@ -133,7 +133,7 @@ describe('SelectRegionPanel on the Clone Flow', () => {
     expect(getByTestId('different-price-structure-notice')).toBeInTheDocument();
   });
 
-  it('should disable distributed regions if the selected image does not have the `distributed-images` capability', async () => {
+  it('should disable distributed regions if the selected image does not have the `distributed-sites` capability', async () => {
     const image = imageFactory.build({ capabilities: [] });
 
     const distributedRegion = regionFactory.build({

--- a/packages/manager/src/features/Images/ImagesLanding/ImageRegions/ImageRegionRow.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImageRegions/ImageRegionRow.tsx
@@ -43,7 +43,7 @@ export const ImageRegionRow = (props: Props) => {
         <Tooltip
           title={
             disableRemoveButton
-              ? 'Your image must be available in at least one region.'
+              ? 'You cannot remove this region because at least one available region must be present.'
               : ''
           }
         >

--- a/packages/manager/src/features/Images/ImagesLanding/ImageRegions/ImageRegionRow.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImageRegions/ImageRegionRow.tsx
@@ -6,6 +6,7 @@ import { Flag } from 'src/components/Flag';
 import { IconButton } from 'src/components/IconButton';
 import { Stack } from 'src/components/Stack';
 import { StatusIcon } from 'src/components/StatusIcon/StatusIcon';
+import { Tooltip } from 'src/components/Tooltip';
 import { Typography } from 'src/components/Typography';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 
@@ -39,14 +40,24 @@ export const ImageRegionRow = (props: Props) => {
         <StatusIcon
           status={IMAGE_REGION_STATUS_TO_STATUS_ICON_STATUS[status]}
         />
-        <IconButton
-          aria-label={`Remove ${region}`}
-          disabled={disableRemoveButton}
-          onClick={onRemove}
-          sx={{ p: 0.5 }}
+        <Tooltip
+          title={
+            disableRemoveButton
+              ? 'Your image must be available in at least one region.'
+              : ''
+          }
         >
-          <Close />
-        </IconButton>
+          <span>
+            <IconButton
+              aria-label={`Remove ${region}`}
+              disabled={disableRemoveButton}
+              onClick={onRemove}
+              sx={{ p: 0.5 }}
+            >
+              <Close />
+            </IconButton>
+          </span>
+        </Tooltip>
       </Stack>
     </Box>
   );

--- a/packages/manager/src/features/Images/ImagesLanding/ImageRegions/ManageImageRegionsForm.test.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImageRegions/ManageImageRegionsForm.test.tsx
@@ -146,7 +146,9 @@ describe('ManageImageRegionsDrawer', () => {
 
     // Verify tooltip shows
     expect(
-      getByLabelText('Your image must be available in at least one region.')
+      getByLabelText(
+        'You cannot remove this region because at least one available region must be present.'
+      )
     ).toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/Images/ImagesLanding/ImageRegions/ManageImageRegionsForm.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImageRegions/ManageImageRegionsForm.tsx
@@ -20,6 +20,7 @@ import type {
   UpdateImageRegionsPayload,
 } from '@linode/api-v4';
 import type { Resolver } from 'react-hook-form';
+import type { DisableRegionOption } from 'src/components/RegionSelect/RegionSelect.types';
 
 interface Props {
   image: Image | undefined;
@@ -73,6 +74,23 @@ export const ManageImageRegionsForm = (props: Props) => {
 
   const values = watch();
 
+  const disabledRegions: Record<string, DisableRegionOption> = {};
+
+  const availableRegions = image?.regions.filter(
+    (regionItem) => regionItem.status === 'available'
+  );
+  const availableRegionIds = availableRegions?.map((r) => r.region);
+
+  const currentlySelectedAvailableRegions = values.regions.filter((r) =>
+    availableRegionIds?.includes(r)
+  );
+
+  if (currentlySelectedAvailableRegions.length === 1) {
+    disabledRegions[currentlySelectedAvailableRegions[0]] = {
+      reason: 'Your image must be available in at least one region.',
+    };
+  }
+
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       {errors.root?.message && (
@@ -93,6 +111,7 @@ export const ManageImageRegionsForm = (props: Props) => {
           })
         }
         currentCapability={undefined}
+        disabledRegions={disabledRegions}
         errorText={errors.regions?.message}
         label="Add Regions"
         placeholder="Select regions or type to search"

--- a/packages/manager/src/features/Images/ImagesLanding/ImageRegions/ManageImageRegionsForm.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImageRegions/ManageImageRegionsForm.tsx
@@ -113,25 +113,34 @@ export const ManageImageRegionsForm = (props: Props) => {
               No Regions Selected
             </Typography>
           )}
-          {values.regions.map((regionId) => (
-            <ImageRegionRow
-              onRemove={() =>
-                setValue(
-                  'regions',
-                  values.regions.filter((r) => r !== regionId),
-                  { shouldDirty: true, shouldValidate: true }
-                )
-              }
-              status={
-                image?.regions.find(
-                  (regionItem) => regionItem.region === regionId
-                )?.status ?? 'unsaved'
-              }
-              disableRemoveButton={values.regions.length <= 1}
-              key={regionId}
-              region={regionId}
-            />
-          ))}
+          {values.regions.map((regionId) => {
+            const status =
+              image?.regions.find(
+                (regionItem) => regionItem.region === regionId
+              )?.status ?? 'unsaved';
+
+            const isLastAvailableRegion =
+              status === 'available' &&
+              image?.regions
+                .filter((r) => values.regions.includes(r.region))
+                .filter((r) => r.status === 'available').length === 1;
+
+            return (
+              <ImageRegionRow
+                onRemove={() =>
+                  setValue(
+                    'regions',
+                    values.regions.filter((r) => r !== regionId),
+                    { shouldDirty: true, shouldValidate: true }
+                  )
+                }
+                disableRemoveButton={isLastAvailableRegion}
+                key={regionId}
+                region={regionId}
+                status={status}
+              />
+            );
+          })}
         </Stack>
       </Paper>
       <ActionsPanel

--- a/packages/manager/src/features/Images/ImagesLanding/ImageRow.test.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImageRow.test.tsx
@@ -16,7 +16,7 @@ beforeAll(() => mockMatchMedia());
 
 describe('Image Table Row', () => {
   const image = imageFactory.build({
-    capabilities: ['cloud-init', 'distributed-images'],
+    capabilities: ['cloud-init', 'distributed-sites'],
     regions: [
       { region: 'us-east', status: 'available' },
       { region: 'us-southeast', status: 'pending' },

--- a/packages/manager/src/features/Images/ImagesLanding/ImageRow.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImageRow.tsx
@@ -16,7 +16,7 @@ import type { Event, Image, ImageCapabilities } from '@linode/api-v4';
 
 const capabilityMap: Record<ImageCapabilities, string> = {
   'cloud-init': 'Cloud-init',
-  'distributed-images': 'Distributed',
+  'distributed-sites': 'Distributed',
 };
 
 interface Props {

--- a/packages/manager/src/features/Images/ImagesLanding/ImagesActionMenu.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImagesActionMenu.tsx
@@ -92,7 +92,7 @@ export const ImagesActionMenu = (props: Props) => {
               ? 'Image is not yet available for use.'
               : undefined,
           },
-          ...(onManageRegions
+          ...(onManageRegions && image.regions && image.regions.length > 0
             ? [
                 {
                   disabled: isImageReadOnly || isDisabled,

--- a/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.tsx
@@ -141,6 +141,13 @@ export const ImagesLanding = () => {
       ...manualImagesFilter,
       is_public: false,
       type: 'manual',
+    },
+    {
+      // Refetch custom images every 30 seconds.
+      // We do this because we have no /v4/account/events we can use
+      // to update Image region statuses. We should make the API
+      // team and Images team implement events for this.
+      refetchInterval: 30_000,
     }
   );
 

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Region.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Region.test.tsx
@@ -175,7 +175,7 @@ describe('Region', () => {
     ).toBeVisible();
   });
 
-  it('should disable distributed regions if the selected image does not have the `distributed-images` capability', async () => {
+  it('should disable distributed regions if the selected image does not have the `distributed-sites` capability', async () => {
     const image = imageFactory.build({ capabilities: [] });
 
     const distributedRegion = regionFactory.build({

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Region.utils.test.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Region.utils.test.ts
@@ -27,7 +27,7 @@ describe('getDisabledRegions', () => {
     const distributedRegion = regionFactory.build({ site_type: 'distributed' });
     const coreRegion = regionFactory.build({ site_type: 'core' });
 
-    const image = imageFactory.build({ capabilities: ['distributed-images'] });
+    const image = imageFactory.build({ capabilities: ['distributed-sites'] });
 
     const result = getDisabledRegions({
       linodeCreateTab: 'Images',

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Region.utils.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Region.utils.ts
@@ -18,11 +18,11 @@ export const getDisabledRegions = (options: DisabledRegionOptions) => {
 
   // On the images tab, we disabled distributed regions if:
   // - The user has selected an Image
-  // - The selected image does not have the `distributed-images` capability
+  // - The selected image does not have the `distributed-sites` capability
   if (
     linodeCreateTab === 'Images' &&
     selectedImage &&
-    !selectedImage.capabilities.includes('distributed-images')
+    !selectedImage.capabilities.includes('distributed-sites')
   ) {
     const disabledRegions: Record<string, DisableRegionOption> = {};
 

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Images.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Images.test.tsx
@@ -36,7 +36,7 @@ describe('Images', () => {
       http.get('*/v4/images', () => {
         const images = [
           imageFactory.build({ capabilities: [] }),
-          imageFactory.build({ capabilities: ['distributed-images'] }),
+          imageFactory.build({ capabilities: ['distributed-sites'] }),
           imageFactory.build({ capabilities: [] }),
         ];
         return HttpResponse.json(makeResourcePage(images));

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Images.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Tabs/Images.tsx
@@ -54,7 +54,7 @@ export const Images = () => {
     // @todo: delete this logic when all Images are "distributed compatible"
     if (
       image &&
-      !image.capabilities.includes('distributed-images') &&
+      !image.capabilities.includes('distributed-sites') &&
       selectedRegion?.site_type === 'distributed'
     ) {
       setValue('region', '');
@@ -77,7 +77,7 @@ export const Images = () => {
 
   // @todo: delete this logic when all Images are "distributed compatible"
   const showDistributedCapabilityNotice = images?.some((image) =>
-    image.capabilities.includes('distributed-images')
+    image.capabilities.includes('distributed-sites')
   );
 
   if (images?.length === 0) {

--- a/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -73,7 +73,7 @@ export const FromImageContent = (props: CombinedProps) => {
     // Clear the region field if the currently selected region is a distributed site and the Image is only core compatible.
     if (
       image &&
-      !image.capabilities.includes('distributed-images') &&
+      !image.capabilities.includes('distributed-sites') &&
       selectedRegion?.site_type === 'distributed'
     ) {
       props.updateRegionID('');

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -443,7 +443,7 @@ export const handlers = [
   }),
   http.get<{ id: string }>('*/v4/images/:id', ({ params }) => {
     const distributedImage = imageFactory.build({
-      capabilities: ['cloud-init', 'distributed-images'],
+      capabilities: ['cloud-init', 'distributed-sites'],
       id: 'private/distributed-image',
       label: 'distributed-image',
       regions: [{ region: 'us-east', status: 'available' }],
@@ -499,7 +499,7 @@ export const handlers = [
     });
     const publicImages = imageFactory.buildList(4, { is_public: true });
     const distributedImage = imageFactory.build({
-      capabilities: ['cloud-init', 'distributed-images'],
+      capabilities: ['cloud-init', 'distributed-sites'],
       id: 'private/distributed-image',
       label: 'distributed-image',
       regions: [{ region: 'us-east', status: 'available' }],

--- a/packages/manager/src/queries/images.ts
+++ b/packages/manager/src/queries/images.ts
@@ -1,9 +1,4 @@
 import {
-  CreateImagePayload,
-  Image,
-  ImageUploadPayload,
-  UpdateImageRegionsPayload,
-  UploadImageResponse,
   createImage,
   deleteImage,
   getImage,
@@ -12,19 +7,26 @@ import {
   updateImageRegions,
   uploadImage,
 } from '@linode/api-v4';
-import {
-  APIError,
-  Filter,
-  Params,
-  ResourcePage,
-} from '@linode/api-v4/lib/types';
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { EventHandlerData } from 'src/hooks/useEventHandlers';
 import { getAll } from 'src/utilities/getAll';
 
 import { profileQueries } from './profile/profile';
+
+import type {
+  APIError,
+  CreateImagePayload,
+  Filter,
+  Image,
+  ImageUploadPayload,
+  Params,
+  ResourcePage,
+  UpdateImageRegionsPayload,
+  UploadImageResponse,
+} from '@linode/api-v4';
+import type { UseQueryOptions } from '@tanstack/react-query';
+import type { EventHandlerData } from 'src/hooks/useEventHandlers';
 
 export const getAllImages = (
   passedParams: Params = {},
@@ -49,10 +51,15 @@ export const imageQueries = createQueryKeys('images', {
   }),
 });
 
-export const useImagesQuery = (params: Params, filters: Filter) =>
+export const useImagesQuery = (
+  params: Params,
+  filters: Filter,
+  options?: UseQueryOptions<ResourcePage<Image>, APIError[]>
+) =>
   useQuery<ResourcePage<Image>, APIError[]>({
     ...imageQueries.paginated(params, filters),
     keepPreviousData: true,
+    ...options,
   });
 
 export const useImageQuery = (imageId: string, enabled = true) =>


### PR DESCRIPTION
## Description 📝

- Replaces incorrect `distributed-images` capability with `distributed-sites` ✏️ 
- Adds polling every 30 seconds to the Images landing table because we don't have any account events we can use to update Region statuses when replication finishes 🔄
- Enforces that least one "available" region is submitted in the Manage Regions Drawer 🟢 

## Target release date 🗓️
8/5

## Preview 📷

### Capability now shows in `dev`
![Screenshot 2024-07-30 at 3 44 38 PM](https://github.com/user-attachments/assets/eeef2247-56c9-42bc-872e-66fbcab38722)


### Enforcing at least one "Available" Region

![Screenshot 2024-07-31 at 1 09 07 PM](https://github.com/user-attachments/assets/7db8a8d1-bbf7-4577-bd6a-17e60dbb628a)

![Screenshot 2024-07-31 at 1 08 59 PM](https://github.com/user-attachments/assets/2ae5adc5-79f0-4424-9b82-02ee2e8e954c)



## How to test 🧪

### Prerequisites
- You need the `image-gen2` account tag 🏷️ 

### Verification steps
- Test the `distributed-sites` capability in `dev` by uploading an Image
  - Verify the new image has the capability once uploaded
- Test the validation / disabled button logic in the "Manage Regions Drawer"
  - I recommend testing this in `staging` by uploading an Image

## As an Author I have considered 🤔


- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support