### PR TITLE
fix: [M3-6516] - Liked Answer/Question Notifications from Community Questions Site

### DIFF
--- a/packages/manager/.changeset/pr-10732-fixed-1722411934254.md
+++ b/packages/manager/.changeset/pr-10732-fixed-1722411934254.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Liked answer/question notifications from Community Questions Site ([#10732](https://github.com/linode/manager/pull/10732))

--- a/packages/manager/src/features/Events/Event.helpers.ts
+++ b/packages/manager/src/features/Events/Event.helpers.ts
@@ -17,6 +17,7 @@ const ACTIONS_WITHOUT_USERNAMES = [
   'entity_transfer_fail',
   'entity_transfer_stale',
   'lassie_reboot',
+  'community_like',
 ];
 
 export const formatEventWithUsername = (

--- a/packages/manager/src/features/Events/eventMessageGenerator.ts
+++ b/packages/manager/src/features/Events/eventMessageGenerator.ts
@@ -73,10 +73,17 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     started: (e) => `Backup restoration started for ${e.entity!.label}`,
   },
   community_like: {
-    notification: (e) =>
-      e.entity?.label
-        ? `A post on "${e.entity.label}" has been liked.`
-        : `There has been a like on your community post.`,
+    notification: (e) => {
+      if (e.entity?.label) {
+        if (e.entity?.label?.includes('liked your answer to')) {
+          return `${e.entity.label} and has been liked`;
+        } else {
+          return `A post on "${e.entity.label}" has been liked.`;
+        }
+      } else {
+        return 'There has been a like on your community post.';
+      }
+    },
   },
   community_mention: {
     notification: (e) =>

--- a/packages/manager/src/features/Events/eventMessageGenerator.ts
+++ b/packages/manager/src/features/Events/eventMessageGenerator.ts
@@ -73,17 +73,10 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     started: (e) => `Backup restoration started for ${e.entity!.label}`,
   },
   community_like: {
-    notification: (e) => {
-      if (e.entity?.label) {
-        if (e.entity?.label?.includes('liked your answer to')) {
-          return `${e.entity.label} and has been liked`;
-        } else {
-          return `A post on "${e.entity.label}" has been liked.`;
-        }
-      } else {
-        return 'There has been a like on your community post.';
-      }
-    },
+    notification: (e) =>
+      e.entity?.label
+        ? `${e.entity.label}`
+        : `There has been a like on your community post.`,
   },
   community_mention: {
     notification: (e) =>


### PR DESCRIPTION
## Description 📝
When an answer/question is "liked" on the Community Questions site, the person wrote that answer/question is sent a notification in Cloud Manager. However, the syntax for that notification doesn't really make sense:

> A post on "1 user liked your answer to: How to Make Payments" has been liked by {author username}.

and 

> A post on "1 user liked your question: How to Make Payments" has been liked by {author username}.


- "A post on "1 user liked your answer to:"" isn't grammatically correct (for both the cases).
- "has been liked by {username}." - Here username is the logged in user and the one who posted the "liked" answer/question, but not the one who actually liked the answer/question.

As discussed with @jaalah-akamai, we come to the conclusion to exclude usernames from community like events.

## Changes  🔄
List any change relevant to the reviewer.
- Exclude usernames from community like events.
  - Added 'community_like' action to ACTIONS_WITHOUT_USERNAMES
- Update the notification message for community like events to ensure it is grammatically correct. 

## Target release date 🗓️
5th Aug, 2024

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-07-31 at 12 32 14 PM](https://github.com/user-attachments/assets/8f9d9231-e328-4220-b4fb-c9b2461bd279) | ![Screenshot 2024-07-31 at 12 31 30 PM](https://github.com/user-attachments/assets/92c23b9b-69d4-4ba4-952f-234955314457) |

## How to test 🧪

### Reproduction steps
 - Get a user who is not you to like one of your answers and the question on the Community Questions site. This generates the event notification.

### Verification steps
- Verify that the notification message for community like events are grammatically correct.
   - Verify the like notifications for both questions and answers.
- Make sure username is removed for community like events. 

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
