### PR TITLE
test: [M3-8319] - Add CM Logout test

### DIFF
--- a/packages/manager/.changeset/pr-10733-tests-1722436583624.md
+++ b/packages/manager/.changeset/pr-10733-tests-1722436583624.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+E2E coverage for Logout flow ([#10733](https://github.com/linode/manager/pull/10733))

--- a/packages/manager/cypress/e2e/core/account/account-logout.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/account-logout.spec.ts
@@ -1,5 +1,6 @@
 import { LOGIN_ROOT } from 'src/constants';
 import { interceptGetAccount } from 'support/intercepts/account';
+import { ui } from 'support/ui';
 
 describe('Logout Test', () => {
   beforeEach(() => {
@@ -17,15 +18,17 @@ describe('Logout Test', () => {
     cy.wait('@getAccount');
 
     // User can click Logout via user menu.
-    cy.findByTestId('nav-group-profile').click();
-    cy.findByTestId('menu-item-Log Out')
+    ui.userMenuButton.find().click();
+    ui.userMenu
+      .find()
       .should('be.visible')
-      .should('be.enabled')
-      .click();
+      .within(() => {
+        cy.findByText('Log Out').should('be.visible').click();
+      });
     // Upon clicking "Log Out", the user is redirected to the login endpoint at <REACT_APP_LOGIN_ROOT>/login
     cy.url().should('equal', `${LOGIN_ROOT}/login`);
     // Using cy.visit to navigate back to Cloud results in another redirect to the login page
-    cy.visit('/login');
-    cy.url().should('endWith', `/login`);
+    cy.visit('/');
+    cy.url().should('startWith', `${LOGIN_ROOT}/login`);
   });
 });

--- a/packages/manager/cypress/e2e/core/account/account-logout.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/account-logout.spec.ts
@@ -1,0 +1,31 @@
+import { LOGIN_ROOT } from 'src/constants';
+import { interceptGetAccount } from 'support/intercepts/account';
+
+describe('Logout Test', () => {
+  beforeEach(() => {
+    cy.tag('purpose:syntheticTesting');
+  });
+
+  /*
+   * - Confirms that Cloud Manager log out functionality works as expected.
+   * - Confirms that the login application is up after account logout.
+   */
+  it('can logout the account and redirect to login endpoint', () => {
+    interceptGetAccount().as('getAccount');
+
+    cy.visitWithLogin('/account');
+    cy.wait('@getAccount');
+
+    // User can click Logout via user menu.
+    cy.findByTestId('nav-group-profile').click();
+    cy.findByTestId('menu-item-Log Out')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+    // Upon clicking "Log Out", the user is redirected to the login endpoint at <REACT_APP_LOGIN_ROOT>/login
+    cy.url().should('equal', `${LOGIN_ROOT}/login`);
+    // Using cy.visit to navigate back to Cloud results in another redirect to the login page
+    cy.visit('/login');
+    cy.url().should('endWith', `/login`);
+  });
+});

--- a/packages/manager/cypress/support/intercepts/account.ts
+++ b/packages/manager/cypress/support/intercepts/account.ts
@@ -37,6 +37,15 @@ export const mockGetAccount = (account: Account): Cypress.Chainable<null> => {
 };
 
 /**
+ * Intercepts GET request to fetch account.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptGetAccount = (): Cypress.Chainable<null> => {
+  return cy.intercept('GET', apiMatcher('account'));
+};
+
+/**
  * Intercepts PUT request to update account and mocks response.
  *
  * @param updatedAccount - Updated account data with which to mock response.


### PR DESCRIPTION
## Description 📝
Create a Cloud Manager end-to-end test which tests the Cloud Manager logout flow. This will confirm that Cloud Manager log out functionality works as expected and implicitly confirm that the login application is up, which is useful from a synthetic testing perspective.

## Changes  🔄
- Add a new test to confirm flow when logout.
- Add a new util function in packages/manager/cypress/support/intercepts/account.ts

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/account/account-logout.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support