### PR TITLE
upcoming: [M3-8301] - New TextFieldHelperText Component

### DIFF
--- a/packages/manager/.changeset/pr-10738-added-1722456106442.md
+++ b/packages/manager/.changeset/pr-10738-added-1722456106442.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+New TextFieldHelperText component ([#10738](https://github.com/linode/manager/pull/10738))

--- a/packages/manager/src/components/TextField/TextFieldHelperText.stories.tsx
+++ b/packages/manager/src/components/TextField/TextFieldHelperText.stories.tsx
@@ -1,0 +1,73 @@
+import { action } from '@storybook/addon-actions';
+import React from 'react';
+
+import { TextFieldHelperText } from 'src/components/TextField/TextFieldHelperText';
+
+import type { Meta, StoryFn, StoryObj } from '@storybook/react';
+import type { TextFieldHelperTextProps } from 'src/components/TextField/TextFieldHelperText';
+
+// Story Config ========================================================
+
+const meta: Meta<TextFieldHelperTextProps> = {
+  component: TextFieldHelperText,
+  decorators: [
+    (Story: StoryFn) => (
+      <div style={{ marginLeft: '2em', minHeight: 270 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  title: 'Components/TextField/TextFieldHelperText',
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TextFieldHelperText>;
+
+// Story Definitions ==========================================================
+
+export const Default: Story = {
+  args: {
+    content: [
+      'Endpoint types impact the performance, capacity, and rate limits for your bucket. Understand ',
+      {
+        onClick: action('onClick'),
+        text: 'endpoint types',
+        to: '#',
+      },
+      '.',
+    ],
+  },
+};
+
+export const MultipleLinks: Story = {
+  args: {
+    content: [
+      'This is a text with ',
+      {
+        onClick: action('onClick1'),
+        text: 'multiple links',
+        to: '#',
+      },
+      '. You can click on ',
+      {
+        onClick: action('onClick2'),
+        text: 'this link',
+        to: '#',
+      },
+      ' or ',
+      {
+        onClick: action('onClick3'),
+        text: 'that link',
+        to: '#',
+      },
+      '.',
+    ],
+  },
+};
+
+export const NoLinks: Story = {
+  args: {
+    content: ['This is a simple text without any links.'],
+  },
+};

--- a/packages/manager/src/components/TextField/TextFieldHelperText.test.tsx
+++ b/packages/manager/src/components/TextField/TextFieldHelperText.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, screen } from '@testing-library/react';
+import React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { TextFieldHelperText } from './TextFieldHelperText';
+
+const LINK_TEXT = 'endpoint types';
+const URL = '/path/to/endpoint-types';
+const TEXT_BEFORE = 'Understand';
+const TEXT_AFTER = 'for better performance.';
+
+describe('TextFieldHelperText', () => {
+  test('renders the component with textBefore, link, and textAfter', () => {
+    const handleClick = vi.fn();
+
+    renderWithTheme(
+      <TextFieldHelperText
+        content={[
+          TEXT_BEFORE + ' ',
+          { onClick: handleClick, text: LINK_TEXT, to: URL },
+          ' ' + TEXT_AFTER,
+        ]}
+      />
+    );
+
+    expect(screen.getByText(TEXT_BEFORE, { exact: false })).toBeInTheDocument();
+
+    const linkElement = screen.getByText(LINK_TEXT);
+
+    expect(linkElement).toBeInTheDocument();
+    expect(linkElement.closest('a')).toHaveAttribute('href', URL);
+    expect(screen.getByText(TEXT_AFTER, { exact: false })).toBeInTheDocument();
+
+    fireEvent.click(linkElement);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('renders the component with link and textAfter', () => {
+    const handleClick = vi.fn();
+
+    renderWithTheme(
+      <TextFieldHelperText
+        content={[
+          { onClick: handleClick, text: LINK_TEXT, to: URL },
+          ' ' + TEXT_AFTER,
+        ]}
+      />
+    );
+
+    const linkElement = screen.getByText(LINK_TEXT);
+
+    expect(linkElement).toBeInTheDocument();
+    expect(linkElement.closest('a')).toHaveAttribute('href', URL);
+    expect(screen.getByText(TEXT_AFTER, { exact: false })).toBeInTheDocument();
+
+    fireEvent.click(linkElement);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('renders the component with only link', () => {
+    const handleClick = vi.fn();
+
+    renderWithTheme(
+      <TextFieldHelperText
+        content={[{ onClick: handleClick, text: LINK_TEXT, to: URL }]}
+      />
+    );
+
+    const linkElement = screen.getByText(LINK_TEXT);
+
+    expect(linkElement).toBeInTheDocument();
+    expect(linkElement.closest('a')).toHaveAttribute('href', URL);
+
+    fireEvent.click(linkElement);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('renders multiple links', () => {
+    const handleClick1 = vi.fn();
+    const handleClick2 = vi.fn();
+
+    renderWithTheme(
+      <TextFieldHelperText
+        content={[
+          'Text before ',
+          { onClick: handleClick1, text: 'Link 1', to: '/link1' },
+          ' text between ',
+          { onClick: handleClick2, text: 'Link 2', to: '/link2' },
+          ' text after',
+        ]}
+      />
+    );
+
+    const link1 = screen.getByText('Link 1');
+    const link2 = screen.getByText('Link 2');
+
+    expect(link1).toBeInTheDocument();
+    expect(link2).toBeInTheDocument();
+    expect(link1.closest('a')).toHaveAttribute('href', '/link1');
+    expect(link2.closest('a')).toHaveAttribute('href', '/link2');
+
+    fireEvent.click(link1);
+    expect(handleClick1).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(link2);
+    expect(handleClick2).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/manager/src/components/TextField/TextFieldHelperText.tsx
+++ b/packages/manager/src/components/TextField/TextFieldHelperText.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+
+import { Box } from 'src/components/Box';
+import { Link } from 'src/components/Link';
+import { Typography } from 'src/components/Typography';
+
+import type { BoxProps } from 'src/components/Box';
+
+export interface LinkItem {
+  /**
+   * Callback function to be called when the link is clicked.
+   */
+  onClick?: () => void;
+  /**
+   * The text to be displayed as the link.
+   */
+  text: string;
+  /**
+   * The URL to which the link points.
+   */
+  to: string;
+}
+
+export interface TextFieldHelperTextOwnProps {
+  /**
+   * An array of content items. Each item can be a string or a LinkItem.
+   */
+  content: (LinkItem | string)[];
+}
+
+export type TextFieldHelperTextProps = TextFieldHelperTextOwnProps &
+  Omit<BoxProps, keyof TextFieldHelperTextOwnProps>;
+
+export const TextFieldHelperText = ({
+  content,
+  ...rest
+}: TextFieldHelperTextProps) => {
+  return (
+    <Box {...rest}>
+      <Typography variant="body1">
+        {content.map((item, index) => {
+          if (typeof item === 'string') {
+            return <React.Fragment key={index}>{item}</React.Fragment>;
+          } else {
+            return (
+              <Link key={index} onClick={item.onClick} to={item.to}>
+                {item.text}
+              </Link>
+            );
+          }
+        })}
+      </Typography>
+    </Box>
+  );
+};


### PR DESCRIPTION
## Description 📝
There was a need for OBJ Gen2 to implement custom helper text with links. To avoid duplicating `RegionHelperText`, I decided to create a generic component that can replace `RegionHelperText` and accommodate any future needs.

## Changes  🔄
- The API is straightforward. It takes an array of strings or links, allowing you to build the helper text as needed.
- Added component unit tests
- Added storybook stories

## Target release date 🗓️
N/A

## Preview 📷
See storybook for examples, but with the API you could build text that looks like this:
![Screenshot 2024-07-31 at 3 50 00 PM](https://github.com/user-attachments/assets/644be716-e899-459b-88ab-3d0c9db2b938)

### Verification steps
- `yarn storybook`
- `yarn test src/components/TextField/TextFieldHelperText.test.tsx`

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support