### PR TITLE
upcoming: [M3-8411] - Data Visualization Tokens

### DIFF
--- a/packages/manager/.changeset/pr-10739-upcoming-features-1722528251084.md
+++ b/packages/manager/.changeset/pr-10739-upcoming-features-1722528251084.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Added data visualization tokens to theme files ([#10739](https://github.com/linode/manager/pull/10739))

--- a/packages/manager/src/foundations/themes/dark.ts
+++ b/packages/manager/src/foundations/themes/dark.ts
@@ -2,6 +2,7 @@ import {
   Action,
   Badge,
   Button,
+  Chart,
   Color,
   Dropdown,
   Interaction,
@@ -57,6 +58,7 @@ export const customDarkModeOptions = {
     borderTypography: Color.Neutrals[80],
     divider: Color.Neutrals[80],
   },
+  charts: { ...Chart },
   color: {
     black: Color.Neutrals.White,
     blueDTwhite: Color.Neutrals.White,
@@ -197,6 +199,7 @@ export const darkTheme: ThemeOptions = {
   bg: customDarkModeOptions.bg,
   borderColors: customDarkModeOptions.borderColors,
   breakpoints,
+  charts: customDarkModeOptions.charts,
   color: customDarkModeOptions.color,
   components: {
     MuiAppBar: {

--- a/packages/manager/src/foundations/themes/index.ts
+++ b/packages/manager/src/foundations/themes/index.ts
@@ -5,6 +5,8 @@ import { darkTheme } from 'src/foundations/themes/dark';
 import { lightTheme } from 'src/foundations/themes/light';
 import { deepMerge } from 'src/utilities/deepMerge';
 
+import type { Chart as ChartLight } from '@linode/design-language-system';
+import type { Chart as ChartDark } from '@linode/design-language-system/themes/dark';
 import type { latoWeb } from 'src/foundations/fonts';
 // Types & Interfaces
 import type {
@@ -20,6 +22,10 @@ import type {
 } from 'src/foundations/themes/light';
 
 export type ThemeName = 'dark' | 'light';
+
+type ChartLightTypes = typeof ChartLight;
+type ChartDarkTypes = typeof ChartDark;
+type ChartTypes = MergeTypes<ChartLightTypes, ChartDarkTypes>;
 
 type Fonts = typeof latoWeb;
 
@@ -66,6 +72,7 @@ declare module '@mui/material/styles/createTheme' {
     applyTableHeaderStyles?: any;
     bg: BgColors;
     borderColors: BorderColors;
+    charts: ChartTypes;
     color: Colors;
     font: Fonts;
     graphs: any;
@@ -84,6 +91,7 @@ declare module '@mui/material/styles/createTheme' {
     applyTableHeaderStyles?: any;
     bg?: DarkModeBgColors | LightModeBgColors;
     borderColors?: DarkModeBorderColors | LightModeBorderColors;
+    charts: ChartTypes;
     color?: DarkModeColors | LightModeColors;
     font?: Fonts;
     graphs?: any;

--- a/packages/manager/src/foundations/themes/light.ts
+++ b/packages/manager/src/foundations/themes/light.ts
@@ -2,6 +2,7 @@ import {
   Action,
   Border,
   Button,
+  Chart,
   Color,
   Dropdown,
   Interaction,
@@ -15,6 +16,8 @@ import { latoWeb } from 'src/foundations/fonts';
 import type { ThemeOptions } from '@mui/material/styles';
 
 export const inputMaxWidth = 416;
+
+export const charts = { ...Chart } as const;
 
 export const bg = {
   app: Color.Neutrals[5],
@@ -239,6 +242,7 @@ export const lightTheme: ThemeOptions = {
   bg,
   borderColors,
   breakpoints,
+  charts,
   color,
   components: {
     MuiAccordion: {


### PR DESCRIPTION
## Description 📝
Our observability team needs data visualization colors, so we need to expose the colors available in CDS 2.0 for their use, instead of them adding their own colors.

## Changes  🔄
- Adds `Chart` tokens to our theme files

## Target release date 🗓️
N/A

## Preview 📷
**Include a screenshot or screen recording of the change**

:bulb: Use `<video src="" />` tag when including recordings in table.

| Screenshots  | |
| ------- | ------- |
| <img width="382" alt="Screenshot 2024-07-25 at 10 03 05 AM" src="https://github.com/user-attachments/assets/e2751f33-fe20-4401-ad2d-6e9b6f3a5666"> | <img width="161" alt="Screenshot 2024-07-26 at 9 15 30 AM" src="https://github.com/user-attachments/assets/9ebb14d2-030f-4836-85cb-9517e4422e3e"> | 

## How to test 🧪

### Verification steps
- Any component that uses `theme` should be able to access the tokens via `theme.charts.Categorical[2].Primary` (as an example)

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support