### PR TITLE
fix: [M3-8409] - Community Notifications in Event Messages v2 Refactor

### DIFF
--- a/packages/manager/.changeset/pr-10742-fixed-1722601990368.md
+++ b/packages/manager/.changeset/pr-10742-fixed-1722601990368.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Community Like notfications in event messages v2 ([#10742](https://github.com/linode/manager/pull/10742))

--- a/packages/manager/.changeset/pr-10742-fixed-1722601990368.md
+++ b/packages/manager/.changeset/pr-10742-fixed-1722601990368.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Community Like notfications in event messages v2 refactor ([#10742](https://github.com/linode/manager/pull/10742))
+Community notfications in event messages v2 refactor ([#10742](https://github.com/linode/manager/pull/10742))

--- a/packages/manager/.changeset/pr-10742-fixed-1722601990368.md
+++ b/packages/manager/.changeset/pr-10742-fixed-1722601990368.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Community Like notfications in event messages v2 ([#10742](https://github.com/linode/manager/pull/10742))
+Community Like notfications in event messages v2 refactor ([#10742](https://github.com/linode/manager/pull/10742))

--- a/packages/manager/src/features/Events/Event.helpers.ts
+++ b/packages/manager/src/features/Events/Event.helpers.ts
@@ -9,7 +9,7 @@ export const maybeRemoveTrailingPeriod = (string: string) => {
   return string;
 };
 
-const ACTIONS_WITHOUT_USERNAMES = [
+export const ACTIONS_WITHOUT_USERNAMES = [
   'entity_transfer_accept',
   'entity_transfer_accept_recipient',
   'entity_transfer_cancel',

--- a/packages/manager/src/features/Events/Event.helpers.ts
+++ b/packages/manager/src/features/Events/Event.helpers.ts
@@ -18,6 +18,8 @@ export const ACTIONS_WITHOUT_USERNAMES: EventAction[] = [
   'entity_transfer_stale',
   'lassie_reboot',
   'community_like',
+  'community_mention',
+  'community_question_reply',
 ];
 
 export const formatEventWithUsername = (

--- a/packages/manager/src/features/Events/Event.helpers.ts
+++ b/packages/manager/src/features/Events/Event.helpers.ts
@@ -9,7 +9,7 @@ export const maybeRemoveTrailingPeriod = (string: string) => {
   return string;
 };
 
-export const ACTIONS_WITHOUT_USERNAMES = [
+export const ACTIONS_WITHOUT_USERNAMES: EventAction[] = [
   'entity_transfer_accept',
   'entity_transfer_accept_recipient',
   'entity_transfer_cancel',

--- a/packages/manager/src/features/Events/EventRowV2.tsx
+++ b/packages/manager/src/features/Events/EventRowV2.tsx
@@ -10,7 +10,11 @@ import { TableRow } from 'src/components/TableRow';
 import { getEventTimestamp } from 'src/utilities/eventUtils';
 
 import { StyledGravatar } from './EventRow.styles';
-import { formatProgressEvent, getEventMessage } from './utils';
+import {
+  formatProgressEvent,
+  getEventMessage,
+  getEventUsername,
+} from './utils';
 
 import type { Event } from '@linode/api-v4/lib/account';
 
@@ -25,7 +29,7 @@ export const EventRowV2 = (props: EventRowProps) => {
   const { action, message, username } = {
     action: event.action,
     message: getEventMessage(event),
-    username: event.username,
+    username: getEventUsername(event),
   };
 
   if (!message) {
@@ -51,8 +55,8 @@ export const EventRowV2 = (props: EventRowProps) => {
       <Hidden smDown>
         <TableCell data-qa-event-username-cell parentColumn="Username">
           <Box alignItems="center" display="flex" gap={1}>
-            <StyledGravatar username={username ?? ''} />
-            {username ?? 'Linode'}
+            <StyledGravatar username={username === 'Linode' ? '' : username} />
+            {username}
           </Box>
         </TableCell>
       </Hidden>

--- a/packages/manager/src/features/Events/eventMessageGenerator.ts
+++ b/packages/manager/src/features/Events/eventMessageGenerator.ts
@@ -87,7 +87,7 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   community_question_reply: {
     notification: (e) =>
       e.entity?.label
-        ? `There has been a reply to your thread "${e.entity.label}".`
+        ? `There has been a reply to your thread: ${e.entity.label}.`
         : `There has been a reply to your thread.`,
   },
   credit_card_updated: {

--- a/packages/manager/src/features/Events/factories/community.tsx
+++ b/packages/manager/src/features/Events/factories/community.tsx
@@ -8,10 +8,7 @@ export const community: PartialEventMap<'community'> = {
   community_like: {
     notification: (e) =>
       e.entity?.label ? (
-        <>
-          A post on <EventLink event={e} to="entity" /> has been{' '}
-          <strong>liked</strong>.
-        </>
+        <EventLink event={e} to="entity" />
       ) : (
         <>
           There has been a <strong>like</strong> on your community post.

--- a/packages/manager/src/features/Events/utils.test.tsx
+++ b/packages/manager/src/features/Events/utils.test.tsx
@@ -5,6 +5,7 @@ import {
   formatEventTimeRemaining,
   formatProgressEvent,
   getEventMessage,
+  getEventUsername,
 } from './utils';
 
 import type { Event } from '@linode/api-v4';
@@ -84,6 +85,61 @@ describe('getEventMessage', () => {
     expect(boldedWords).toHaveLength(2);
     expect(boldedWords[0]).toHaveTextContent('not');
     expect(boldedWords[1]).toHaveTextContent('created');
+  });
+});
+
+describe('getEventUsername', () => {
+  it('returns the username if it exists and action is not in ACTIONS_WITHOUT_USERNAMES', () => {
+    const mockEvent: Event = eventFactory.build({
+      action: 'linode_create',
+      entity: {
+        id: 123,
+        label: 'test-linode',
+      },
+      status: 'finished',
+      username: 'test-user',
+    });
+
+    expect(getEventUsername(mockEvent)).toBe('test-user');
+  });
+
+  it('returns "Linode" if the username exists but action is in ACTIONS_WITHOUT_USERNAMES', () => {
+    const mockEvent: Event = eventFactory.build({
+      action: 'community_like',
+      entity: {
+        id: 234,
+        label: '1 user liked your answer to: this question?',
+        url: 'https://google.com/',
+      },
+      status: 'notification',
+      username: 'test-user',
+    });
+
+    expect(getEventUsername(mockEvent)).toBe('Linode');
+  });
+
+  it('returns "Linode" if the username does not exist', () => {
+    const mockEvent: Event = eventFactory.build({
+      status: 'notification',
+      username: null,
+    });
+
+    expect(getEventUsername(mockEvent)).toBe('Linode');
+  });
+
+  it('returns "Linode" if the username does not exist and action is in ACTIONS_WITHOUT_USERNAMES', () => {
+    const mockEvent: Event = eventFactory.build({
+      action: 'community_like',
+      entity: {
+        id: 234,
+        label: '1 user liked your answer to: this question?',
+        url: 'https://google.com/',
+      },
+      status: 'notification',
+      username: null,
+    });
+
+    expect(getEventUsername(mockEvent)).toBe('Linode');
   });
 });
 

--- a/packages/manager/src/features/Events/utils.tsx
+++ b/packages/manager/src/features/Events/utils.tsx
@@ -7,6 +7,7 @@ import { getEventTimestamp } from 'src/utilities/eventUtils';
 import { eventMessages } from './factory';
 
 import type { Event } from '@linode/api-v4';
+import { ACTIONS_WITHOUT_USERNAMES } from './Event.helpers';
 
 type EventMessageManualInput = {
   action: Event['action'];
@@ -44,6 +45,17 @@ export function getEventMessage(
 
   return message ? message(event as Event) : null;
 }
+
+/**
+ * The event username Getter.
+ * Returns the username from event or 'Linode' if username is null or excluded by action.
+ */
+export const getEventUsername = (event: Event) => {
+  if (event.username && !ACTIONS_WITHOUT_USERNAMES.includes(event.action)) {
+    return event.username;
+  }
+  return 'Linode';
+};
 
 /**
  * Format the time remaining for an event.

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderEventV2.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderEventV2.tsx
@@ -58,7 +58,7 @@ export const RenderEventV2 = React.memo((props: RenderEventProps) => {
           />
         )}
         <Typography sx={{ fontSize: '0.8rem' }}>
-          {progressEventDisplay + ' | ' + username}
+          {progressEventDisplay} | {username}
         </Typography>
       </Box>
     </RenderEventStyledBox>

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderEventV2.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderEventV2.tsx
@@ -6,6 +6,7 @@ import { Typography } from 'src/components/Typography';
 import {
   formatProgressEvent,
   getEventMessage,
+  getEventUsername,
 } from 'src/features/Events/utils';
 
 import {
@@ -26,6 +27,7 @@ export const RenderEventV2 = React.memo((props: RenderEventProps) => {
   const { classes, cx } = useRenderEventStyles();
   const unseenEventClass = cx({ [classes.unseenEventV2]: !event.seen });
   const message = getEventMessage(event);
+  const username = getEventUsername(event);
 
   /**
    * Some event types may not be handled by our system (or new types or new ones may be added that we haven't caught yet).
@@ -56,7 +58,7 @@ export const RenderEventV2 = React.memo((props: RenderEventProps) => {
           />
         )}
         <Typography sx={{ fontSize: '0.8rem' }}>
-          {progressEventDisplay} | {event.username ?? 'Linode'}
+          {progressEventDisplay + ' | ' + username}
         </Typography>
       </Box>
     </RenderEventStyledBox>


### PR DESCRIPTION
## Description 📝

Improve Community Like Notifications in Event Messages v2 Refactor.

When an answer/question is "liked" on the Community Questions site, the person wrote that answer/question is sent a notification in Cloud Manager. However, the syntax for that notification doesn't really make sense in Event Messages v2:
![v2 Events Landing showing username and full message](https://github.com/user-attachments/assets/f5e902f7-d0a4-4bf3-a34a-5b64120bc5b3)

> [!NOTE]
> Default 'Linode' is kept as it is because it was already defined as a fallback when the username is `null` in Event Messages v2.

## Changes  🔄
In Event Messages v2:
- Exclude usernames from community like events.
- Add username getter utility that returns usernames from event or 'Linode' if username is null or excluded by action.
- Update the notification message for community like events to ensure it is grammatically correct.

## Target release date 🗓️
8/19

## Preview 📷

| Before (v2) | After (v2)   |
| ------- | ------- |
| ![v2 notification menu before](https://github.com/user-attachments/assets/fca99b71-2998-425d-a02c-f0f40c141004) | ![v2 notfication menu after](https://github.com/user-attachments/assets/7ad0be52-de7d-4fea-b588-94f66721e398) |
| ![v2 events landing page before](https://github.com/user-attachments/assets/bed00fc5-f510-4e7f-9d83-c95213625176) | ![v2 events landing page after](https://github.com/user-attachments/assets/7f4558cb-395e-479b-a085-8437bb079380) |

## How to test 🧪

### Reproduction steps
With the **Event Messages v2 flag** ON locally:
 - Get a user who is not you to like one of your answers and the question on the Community Questions site. This generates the event notification.

### Verification steps
- Verify that the notification message for community like events for both question and answers are grammatically correct in Event Messages v2.
-  For both the 'Events Landing page' and 'Notification Menu':
    - Verify that Event Messages v1 will not display the username in notification message for actions added in `ACTIONS_WITHOUT_USERNAMES` or when `username` is null. 
    - Verify Event Messages v2 will display 'Linode' as a fallback for actions added in `ACTIONS_WITHOUT_USERNAMES` or when `username` is null.
 
## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support