### PR TITLE
fix: Region filter for Core tab in Linode Create v2

### DIFF
--- a/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.test.tsx
@@ -38,7 +38,7 @@ describe('TwoStepRegion', () => {
     expect(select).toBeEnabled();
   });
 
-  it('should display core regions in the Core tab region select', async () => {
+  it('should only display core regions in the Core tab region select', async () => {
     const {
       getByPlaceholderText,
       getByRole,

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.test.tsx
@@ -38,6 +38,44 @@ describe('TwoStepRegion', () => {
     expect(select).toBeEnabled();
   });
 
+  it('should display core regions in the Core tab region select', async () => {
+    const {
+      getByPlaceholderText,
+      getByRole,
+    } = renderWithThemeAndHookFormContext({
+      component: <TwoStepRegion onChange={vi.fn()} />,
+    });
+
+    const select = getByPlaceholderText('Select a Region');
+    await userEvent.click(select);
+
+    const dropdown = getByRole('listbox');
+    expect(dropdown.innerHTML).toContain('US, Newark');
+    expect(dropdown.innerHTML).not.toContain(
+      'US, Gecko Distributed Region Test'
+    );
+  });
+
+  it('should only display distributed regions in the Distributed tab region select', async () => {
+    const {
+      getAllByRole,
+      getByPlaceholderText,
+      getByRole,
+    } = renderWithThemeAndHookFormContext({
+      component: <TwoStepRegion onChange={vi.fn()} />,
+    });
+
+    const tabs = getAllByRole('tab');
+    await userEvent.click(tabs[1]);
+
+    const select = getByPlaceholderText('Select a Region');
+    await userEvent.click(select);
+
+    const dropdown = getByRole('listbox');
+    expect(dropdown.innerHTML).toContain('US, Gecko Distributed Region Test');
+    expect(dropdown.innerHTML).not.toContain('US, Newark');
+  });
+
   it('should render a Geographical Area select with All pre-selected and a Region Select for the Distributed tab', async () => {
     const { getAllByRole } = renderWithThemeAndHookFormContext({
       component: <TwoStepRegion onChange={vi.fn()} />,

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.tsx
@@ -93,7 +93,7 @@ export const TwoStepRegion = (props: CombinedProps) => {
               disabledRegions={disabledRegions}
               errorText={errorText}
               onChange={(e, region) => onChange(region)}
-              regionFilter={regionFilter}
+              regionFilter="core"
               regions={regions ?? []}
               showDistributedRegionIconHelperText={false}
               value={value}


### PR DESCRIPTION
## Description 📝
Fix the regionFilter for the Linode Create v2 Core region select (I missed this while copy-pasting 😅 )

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/8dd2b661-0576-4acd-8360-03223628ac7a) | ![image](https://github.com/user-attachments/assets/e0b9773f-2413-4fb3-87b6-838277513f97) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Ensure your account has the `new-dc-testing`, `edge_testing` and `edge_compute` customer tags

### Reproduction steps
(How to reproduce the issue, if applicable)
- On develop or a different branch, go to the Linode Create v2 flow and click on the region select in the Core tab. Observe distributed regions displayed instead

### Verification steps
(How to verify changes)
- On this branch, go to the Linode Create v2 flow and click on the region select in the Core tab. Oberserve Core regions displayed as expected

```
yarn test TwoStepRegion
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support