### PR TITLE
upcoming: [M3-8367] – Add "Volume Encryption" section to Volume Create page

### DIFF
--- a/packages/manager/.changeset/pr-10750-upcoming-features-1723139035892.md
+++ b/packages/manager/.changeset/pr-10750-upcoming-features-1723139035892.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add Volume Encryption section to Volume Create page ([#10750](https://github.com/linode/manager/pull/10750))

--- a/packages/manager/cypress/e2e/core/volumes/create-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/create-volume.spec.ts
@@ -8,9 +8,6 @@ import { interceptCreateVolume } from 'support/intercepts/volumes';
 import { randomNumber, randomString, randomLabel } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
 import { ui } from 'support/ui';
-import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
-import { accountFactory } from 'src/factories';
-import { mockGetAccount } from 'support/intercepts/account';
 
 // Local storage override to force volume table to list up to 100 items.
 // This is a workaround while we wait to get stuck volumes removed.
@@ -203,47 +200,5 @@ describe('volume create flow', () => {
           });
       }
     );
-  });
-
-  it('should not have a "Volume Encryption" section visible if the feature flag is off and user does not have capability', () => {
-    // Mock feature flag -- @TODO BSE: Remove feature flag once BSE is fully rolled out
-    mockAppendFeatureFlags({
-      blockStorageEncryption: false,
-    }).as('getFeatureFlags');
-
-    // Mock account response
-    const mockAccount = accountFactory.build({
-      capabilities: ['Linodes'],
-    });
-
-    mockGetAccount(mockAccount).as('getAccount');
-
-    // intercept request
-    cy.visitWithLogin('/volumes/create');
-    cy.wait(['@getFeatureFlags', '@getAccount']);
-
-    // Check if section is visible
-    cy.findByText('Encrypt Volume').should('not.exist');
-  });
-
-  it('should have a "Volume Encryption" section visible if feature flag is on and user has the capability', () => {
-    // Mock feature flag -- @TODO BSE: Remove feature flag once BSE is fully rolled out
-    mockAppendFeatureFlags({
-      blockStorageEncryption: true,
-    }).as('getFeatureFlags');
-
-    // Mock account response
-    const mockAccount = accountFactory.build({
-      capabilities: ['Linodes', 'Block Storage Encryption'],
-    });
-
-    mockGetAccount(mockAccount).as('getAccount');
-
-    // intercept request
-    cy.visitWithLogin('/volumes/create');
-    cy.wait(['@getFeatureFlags', '@getAccount']);
-
-    // Check if section is visible
-    cy.findByText('Encrypt Volume').should('exist');
   });
 });

--- a/packages/manager/cypress/e2e/core/volumes/create-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/create-volume.spec.ts
@@ -219,9 +219,7 @@ describe('volume create flow', () => {
     mockGetAccount(mockAccount).as('getAccount');
 
     // intercept request
-    cy.visitWithLogin('/volumes/create', {
-      localStorageOverrides: pageSizeOverride,
-    });
+    cy.visitWithLogin('/volumes/create');
     cy.wait(['@getFeatureFlags', '@getAccount']);
 
     // Check if section is visible
@@ -242,9 +240,7 @@ describe('volume create flow', () => {
     mockGetAccount(mockAccount).as('getAccount');
 
     // intercept request
-    cy.visitWithLogin('/volumes/create', {
-      localStorageOverrides: pageSizeOverride,
-    });
+    cy.visitWithLogin('/volumes/create');
     cy.wait(['@getFeatureFlags', '@getAccount']);
 
     // Check if section is visible

--- a/packages/manager/cypress/e2e/core/volumes/create-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/create-volume.spec.ts
@@ -8,6 +8,10 @@ import { interceptCreateVolume } from 'support/intercepts/volumes';
 import { randomNumber, randomString, randomLabel } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
 import { ui } from 'support/ui';
+import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
+import { accountFactory } from 'src/factories';
+import { mockGetAccount } from 'support/intercepts/account';
+import { headerTestId } from 'src/components/Encryption/Encryption';
 
 // Local storage override to force volume table to list up to 100 items.
 // This is a workaround while we wait to get stuck volumes removed.
@@ -200,5 +204,51 @@ describe('volume create flow', () => {
           });
       }
     );
+  });
+
+  it('should not have a "Volume Encryption" section visible if the feature flag is off and user does not have capability', () => {
+    // Mock feature flag -- @TODO BSE: Remove feature flag once BSE is fully rolled out
+    mockAppendFeatureFlags({
+      blockStorageEncryption: false,
+    }).as('getFeatureFlags');
+
+    // Mock account response
+    const mockAccount = accountFactory.build({
+      capabilities: ['Linodes'],
+    });
+
+    mockGetAccount(mockAccount).as('getAccount');
+
+    // intercept request
+    cy.visitWithLogin('/volumes/create', {
+      localStorageOverrides: pageSizeOverride,
+    });
+    cy.wait(['@getFeatureFlags', '@getAccount']);
+
+    // Check if section is visible
+    cy.get(`[data-testid=${headerTestId}]`).should('not.exist');
+  });
+
+  it('should have a "Volume Encryption" section visible if feature flag is on and user has the capability', () => {
+    // Mock feature flag -- @TODO BSE: Remove feature flag once BSE is fully rolled out
+    mockAppendFeatureFlags({
+      blockStorageEncryption: true,
+    }).as('getFeatureFlags');
+
+    // Mock account response
+    const mockAccount = accountFactory.build({
+      capabilities: ['Linodes', 'Block Storage Encryption'],
+    });
+
+    mockGetAccount(mockAccount).as('getAccount');
+
+    // intercept request
+    cy.visitWithLogin('/volumes/create', {
+      localStorageOverrides: pageSizeOverride,
+    });
+    cy.wait(['@getFeatureFlags', '@getAccount']);
+
+    // Check if section is visible
+    cy.get(`[data-testid="${headerTestId}"]`).should('exist');
   });
 });

--- a/packages/manager/cypress/e2e/core/volumes/create-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/create-volume.spec.ts
@@ -11,7 +11,6 @@ import { ui } from 'support/ui';
 import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
 import { accountFactory } from 'src/factories';
 import { mockGetAccount } from 'support/intercepts/account';
-import { headerTestId } from 'src/components/Encryption/Encryption';
 
 // Local storage override to force volume table to list up to 100 items.
 // This is a workaround while we wait to get stuck volumes removed.
@@ -226,7 +225,7 @@ describe('volume create flow', () => {
     cy.wait(['@getFeatureFlags', '@getAccount']);
 
     // Check if section is visible
-    cy.get(`[data-testid=${headerTestId}]`).should('not.exist');
+    cy.findByText('Encrypt Volume').should('not.exist');
   });
 
   it('should have a "Volume Encryption" section visible if feature flag is on and user has the capability', () => {
@@ -249,6 +248,6 @@ describe('volume create flow', () => {
     cy.wait(['@getFeatureFlags', '@getAccount']);
 
     // Check if section is visible
-    cy.get(`[data-testid="${headerTestId}"]`).should('exist');
+    cy.findByText('Encrypt Volume').should('exist');
   });
 });

--- a/packages/manager/src/components/Encryption/Encryption.tsx
+++ b/packages/manager/src/components/Encryption/Encryption.tsx
@@ -49,7 +49,7 @@ export const Encryption = (props: EncryptionProps) => {
         {descriptionCopy}
       </Typography>
       {notices && notices.length > 0 && (
-        <Notice marginTop="0.875rem" variant="warning">
+        <Notice marginTop="0.875rem" spacingBottom={4} variant="warning">
           <List
             sx={(theme) => ({
               '& > li': {

--- a/packages/manager/src/components/Encryption/Encryption.tsx
+++ b/packages/manager/src/components/Encryption/Encryption.tsx
@@ -1,3 +1,4 @@
+import { List, ListItem } from '@mui/material';
 import * as React from 'react';
 
 import { Box } from 'src/components/Box';
@@ -13,6 +14,7 @@ export interface EncryptionProps {
   entityType?: string;
   error?: string;
   isEncryptEntityChecked: boolean;
+  notices?: string[];
   onChange: (checked: boolean) => void;
 }
 
@@ -28,6 +30,7 @@ export const Encryption = (props: EncryptionProps) => {
     entityType,
     error,
     isEncryptEntityChecked,
+    notices,
     onChange,
   } = props;
 
@@ -45,6 +48,28 @@ export const Encryption = (props: EncryptionProps) => {
       >
         {descriptionCopy}
       </Typography>
+      {notices && notices.length > 0 && (
+        <Notice marginTop="0.875rem" variant="warning">
+          <List
+            sx={(theme) => ({
+              '& > li': {
+                display: notices.length > 1 ? 'list-item' : 'inline',
+                fontSize: '0.875rem',
+                lineHeight: theme.spacing(2),
+                padding: 0,
+                pl: 0,
+                py: 0.5,
+              },
+              listStyle: 'disc',
+              ml: notices.length > 1 ? theme.spacing(2) : 0,
+            })}
+          >
+            {notices.map((notice, i) => (
+              <ListItem key={i}>{notice}</ListItem>
+            ))}
+          </List>
+        </Notice>
+      )}
       <Box
         sx={{
           marginLeft: '4px',

--- a/packages/manager/src/components/Encryption/constants.tsx
+++ b/packages/manager/src/components/Encryption/constants.tsx
@@ -91,7 +91,7 @@ export const BLOCK_STORAGE_ENCRYPTION_UNAVAILABLE_IN_REGION_COPY = `Volume encry
 
 // Caveats
 export const BLOCK_STORAGE_ENCRYPTION_OVERHEAD_CAVEAT =
-  'Please note encryption overhead may impact your volume IOPS performance negatively. This may compound when multiple encryption enabled volumes are attached to the same Linode.';
+  'Please note encryption overhead may impact your volume IOPS performance negatively. This may compound when multiple encryption-enabled volumes are attached to the same Linode.';
 
 export const BLOCK_STORAGE_USER_SIDE_ENCRYPTION_CAVEAT =
-  'User-side encryption on top of encryption enabled volumes is discouraged at this time, as it could severely impact your volume performance.';
+  'User-side encryption on top of encryption-enabled volumes is discouraged at this time, as it could severely impact your volume performance.';

--- a/packages/manager/src/components/Encryption/constants.tsx
+++ b/packages/manager/src/components/Encryption/constants.tsx
@@ -84,8 +84,10 @@ export const BLOCK_STORAGE_ENCRYPTION_GENERAL_DESCRIPTION = (
   </>
 );
 
-export const BLOCK_STORAGE_ENCRYPTION_UNAVAILABLE_IN_REGION_COPY =
-  'Volume encryption is not available in the selected region. Select another region to use Volume encryption.';
+export const BLOCK_STORAGE_CHOOSE_REGION_COPY =
+  'Select a region to use Volume encryption.';
+
+export const BLOCK_STORAGE_ENCRYPTION_UNAVAILABLE_IN_REGION_COPY = `Volume encryption is not available in the selected region. ${BLOCK_STORAGE_CHOOSE_REGION_COPY}`;
 
 // Caveats
 export const BLOCK_STORAGE_ENCRYPTION_OVERHEAD_CAVEAT =

--- a/packages/manager/src/components/Encryption/constants.tsx
+++ b/packages/manager/src/components/Encryption/constants.tsx
@@ -71,3 +71,18 @@ export const ENCRYPT_DISK_REBUILD_LKE_COPY =
 
 export const ENCRYPT_DISK_REBUILD_DISTRIBUTED_COPY =
   'Distributed Compute Instances are secured using disk encryption.';
+
+/* Block Storage Encryption constants */
+const BLOCK_STORAGE_ENCRYPTION_GUIDE_LINK = ''; // @TODO BSE: Update with guide link
+
+export const BLOCK_STORAGE_ENCRYPTION_GENERAL_DESCRIPTION = (
+  <>
+    Secure this volume using data at rest encryption. Data center systems take
+    care of encrypting and decrypting for you. Once a volume is encrypted it
+    cannot be undone.{' '}
+    <Link to={BLOCK_STORAGE_ENCRYPTION_GUIDE_LINK}>Learn more</Link>.
+  </>
+);
+
+export const BLOCK_STORAGE_ENCRYPTION_UNAVAILABLE_IN_REGION_COPY =
+  'Volume encryption is not available in the selected region. Select another region to use Volume encryption.';

--- a/packages/manager/src/components/Encryption/constants.tsx
+++ b/packages/manager/src/components/Encryption/constants.tsx
@@ -86,3 +86,10 @@ export const BLOCK_STORAGE_ENCRYPTION_GENERAL_DESCRIPTION = (
 
 export const BLOCK_STORAGE_ENCRYPTION_UNAVAILABLE_IN_REGION_COPY =
   'Volume encryption is not available in the selected region. Select another region to use Volume encryption.';
+
+// Caveats
+export const BLOCK_STORAGE_ENCRYPTION_OVERHEAD_CAVEAT =
+  'Please note encryption overhead may impact your volume IOPS performance negatively. This may compound when multiple encryption enabled volumes are attached to the same Linode.';
+
+export const BLOCK_STORAGE_USER_SIDE_ENCRYPTION_CAVEAT =
+  'User-side encryption on top of encryption enabled volumes is discouraged at this time, as it could severely impact your volume performance.';

--- a/packages/manager/src/components/Encryption/utils.ts
+++ b/packages/manager/src/components/Encryption/utils.ts
@@ -29,3 +29,32 @@ export const useIsDiskEncryptionFeatureEnabled = (): {
 
   return { isDiskEncryptionFeatureEnabled };
 };
+
+/**
+ * Hook to determine if the Block Storage Encryption feature should be visible to the user.
+ * Based on the user's account capability and the feature flag.
+ *
+ * @returns { boolean } - Whether the Block Storage Encryption feature is enabled for the current user.
+ */
+export const useIsBlockStorageEncryptionFeatureEnabled = (): {
+  isBlockStorageEncryptionFeatureEnabled: boolean;
+} => {
+  const { data: account, error } = useAccount();
+  const flags = useFlags();
+
+  if (error || !flags) {
+    return { isBlockStorageEncryptionFeatureEnabled: false };
+  }
+
+  const hasAccountCapability = account?.capabilities?.includes(
+    'Block Storage Encryption'
+  );
+
+  const isFeatureFlagEnabled = flags.blockStorageEncryption;
+
+  const isBlockStorageEncryptionFeatureEnabled = Boolean(
+    hasAccountCapability && isFeatureFlagEnabled
+  );
+
+  return { isBlockStorageEncryptionFeatureEnabled };
+};

--- a/packages/manager/src/features/Volumes/VolumeCreate.test.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate.test.tsx
@@ -1,51 +1,60 @@
 import * as React from 'react';
 
+import { accountFactory } from 'src/factories';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { VolumeCreate } from './VolumeCreate';
 
-const blockStorageEncryptionEnabledMock = vi.hoisted(() => {
-  return {
-    useIsBlockStorageEncryptionFeatureEnabled: vi.fn(),
-  };
-});
+const accountEndpoint = '*/v4/account';
+const encryptVolumeSectionHeader = 'Encrypt Volume';
 
 describe('VolumeCreate', () => {
-  // @TODO BSE: Remove feature flagging/conditionality once BSE is fully rolled out
-  vi.mock('src/components/Encryption/utils.ts', async () => {
-    const actual = await vi.importActual<any>(
-      'src/components/Encryption/utils.ts'
-    );
-    return {
-      ...actual,
-      __esModule: true,
-      useIsBlockStorageEncryptionFeatureEnabled: blockStorageEncryptionEnabledMock.useIsBlockStorageEncryptionFeatureEnabled.mockImplementation(
-        () => {
-          return {
-            isBlockStorageEncryptionFeatureEnabled: false, // indicates the feature flag is off or account capability is absent
-          };
-        }
-      ),
-    };
-  });
+  /* @TODO BSE: Remove feature flagging/conditionality once BSE is fully rolled out */
 
-  it('should not have a "Volume Encryption" section visible if the feature flag is off and user does not have capability', () => {
-    const { queryByText } = renderWithTheme(<VolumeCreate />);
-
-    expect(queryByText('Encrypt Volume')).not.toBeInTheDocument();
-  });
-
-  it('should have a "Volume Encryption" section visible if feature flag is on and user has the capability', () => {
-    blockStorageEncryptionEnabledMock.useIsBlockStorageEncryptionFeatureEnabled.mockImplementationOnce(
-      () => {
-        return {
-          isBlockStorageEncryptionFeatureEnabled: true,
-        };
-      }
+  it('should not have a "Volume Encryption" section visible if the user has the account capability but the feature flag is off', () => {
+    server.use(
+      http.get(accountEndpoint, () => {
+        return HttpResponse.json(
+          accountFactory.build({ capabilities: ['Block Storage Encryption'] })
+        );
+      })
     );
 
-    const { queryByText } = renderWithTheme(<VolumeCreate />);
+    const { queryByText } = renderWithTheme(<VolumeCreate />, {
+      flags: { blockStorageEncryption: false },
+    });
 
-    expect(queryByText('Encrypt Volume')).toBeInTheDocument();
+    expect(queryByText(encryptVolumeSectionHeader)).not.toBeInTheDocument();
+  });
+
+  it('should not have a "Volume Encryption" section visible if the user does not have the account capability but the feature flag is on', () => {
+    server.use(
+      http.get(accountEndpoint, () => {
+        return HttpResponse.json(accountFactory.build({ capabilities: [] }));
+      })
+    );
+
+    const { queryByText } = renderWithTheme(<VolumeCreate />, {
+      flags: { blockStorageEncryption: true },
+    });
+
+    expect(queryByText(encryptVolumeSectionHeader)).not.toBeInTheDocument();
+  });
+
+  it('should have a "Volume Encryption" section visible if feature flag is on and user has the capability', async () => {
+    server.use(
+      http.get(accountEndpoint, () => {
+        return HttpResponse.json(
+          accountFactory.build({ capabilities: ['Block Storage Encryption'] })
+        );
+      })
+    );
+
+    const { findByText } = renderWithTheme(<VolumeCreate />, {
+      flags: { blockStorageEncryption: true },
+    });
+
+    await findByText(encryptVolumeSectionHeader);
   });
 });

--- a/packages/manager/src/features/Volumes/VolumeCreate.test.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate.test.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { VolumeCreate } from './VolumeCreate';
+
+const blockStorageEncryptionEnabledMock = vi.hoisted(() => {
+  return {
+    useIsBlockStorageEncryptionFeatureEnabled: vi.fn(),
+  };
+});
+
+describe('VolumeCreate', () => {
+  // @TODO BSE: Remove feature flagging/conditionality once BSE is fully rolled out
+  vi.mock('src/components/Encryption/utils.ts', async () => {
+    const actual = await vi.importActual<any>(
+      'src/components/Encryption/utils.ts'
+    );
+    return {
+      ...actual,
+      __esModule: true,
+      useIsBlockStorageEncryptionFeatureEnabled: blockStorageEncryptionEnabledMock.useIsBlockStorageEncryptionFeatureEnabled.mockImplementation(
+        () => {
+          return {
+            isBlockStorageEncryptionFeatureEnabled: false, // indicates the feature flag is off or account capability is absent
+          };
+        }
+      ),
+    };
+  });
+
+  it('should not have a "Volume Encryption" section visible if the feature flag is off and user does not have capability', () => {
+    const { queryByText } = renderWithTheme(<VolumeCreate />);
+
+    expect(queryByText('Encrypt Volume')).not.toBeInTheDocument();
+  });
+
+  it('should have a "Volume Encryption" section visible if feature flag is on and user has the capability', () => {
+    blockStorageEncryptionEnabledMock.useIsBlockStorageEncryptionFeatureEnabled.mockImplementationOnce(
+      () => {
+        return {
+          isBlockStorageEncryptionFeatureEnabled: true,
+        };
+      }
+    );
+
+    const { queryByText } = renderWithTheme(<VolumeCreate />);
+
+    expect(queryByText('Encrypt Volume')).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/Volumes/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate.tsx
@@ -11,7 +11,9 @@ import { Button } from 'src/components/Button/Button';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import {
   BLOCK_STORAGE_ENCRYPTION_GENERAL_DESCRIPTION,
+  BLOCK_STORAGE_ENCRYPTION_OVERHEAD_CAVEAT,
   BLOCK_STORAGE_ENCRYPTION_UNAVAILABLE_IN_REGION_COPY,
+  BLOCK_STORAGE_USER_SIDE_ENCRYPTION_CAVEAT,
 } from 'src/components/Encryption/constants';
 import { Encryption } from 'src/components/Encryption/Encryption';
 import { useIsBlockStorageEncryptionFeatureEnabled } from 'src/components/Encryption/utils';
@@ -444,6 +446,14 @@ export const VolumeCreate = () => {
                 <Encryption
                   disabledReason={
                     BLOCK_STORAGE_ENCRYPTION_UNAVAILABLE_IN_REGION_COPY
+                  }
+                  notices={
+                    encryptVolume
+                      ? [
+                          BLOCK_STORAGE_ENCRYPTION_OVERHEAD_CAVEAT,
+                          BLOCK_STORAGE_USER_SIDE_ENCRYPTION_CAVEAT,
+                        ]
+                      : []
                   }
                   descriptionCopy={BLOCK_STORAGE_ENCRYPTION_GENERAL_DESCRIPTION}
                   disabled={!regionSupportsBlockStorageEncryption}

--- a/packages/manager/src/features/Volumes/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate.tsx
@@ -138,8 +138,6 @@ export const VolumeCreate = () => {
   const [hasSignedAgreement, setHasSignedAgreement] = React.useState(false);
   const { mutateAsync: updateAccountAgreements } = useMutateAccountAgreements();
 
-  const [encryptVolume, setEncryptVolume] = React.useState(false);
-
   const {
     isBlockStorageEncryptionFeatureEnabled,
   } = useIsBlockStorageEncryptionFeatureEnabled();
@@ -185,7 +183,7 @@ export const VolumeCreate = () => {
   } = useFormik({
     initialValues,
     onSubmit: (values, { resetForm, setErrors, setStatus, setSubmitting }) => {
-      const { config_id, label, linode_id, region, size } = values;
+      const { config_id, encryption, label, linode_id, region, size } = values;
 
       setSubmitting(true);
 
@@ -198,9 +196,7 @@ export const VolumeCreate = () => {
         !isBlockStorageEncryptionFeatureEnabled ||
         !regionSupportsBlockStorageEncryption
           ? undefined
-          : encryptVolume
-          ? 'enabled'
-          : 'disabled';
+          : encryption;
 
       createVolume({
         config_id:
@@ -277,8 +273,14 @@ export const VolumeCreate = () => {
     'Block Storage Encryption'
   );
 
-  const toggleVolumeEncryptionEnabled = () => {
-    setEncryptVolume(!encryptVolume);
+  const toggleVolumeEncryptionEnabled = (
+    encryption: VolumeEncryption | undefined
+  ) => {
+    if (encryption === 'enabled') {
+      setFieldValue('encryption', 'disabled');
+    } else {
+      setFieldValue('encryption', 'enabled');
+    }
   };
 
   return (
@@ -451,18 +453,20 @@ export const VolumeCreate = () => {
                       : BLOCK_STORAGE_CHOOSE_REGION_COPY
                   }
                   notices={
-                    encryptVolume
+                    values.encryption === 'enabled'
                       ? [
                           BLOCK_STORAGE_ENCRYPTION_OVERHEAD_CAVEAT,
                           BLOCK_STORAGE_USER_SIDE_ENCRYPTION_CAVEAT,
                         ]
                       : []
                   }
+                  onChange={() =>
+                    toggleVolumeEncryptionEnabled(values.encryption)
+                  }
                   descriptionCopy={BLOCK_STORAGE_ENCRYPTION_GENERAL_DESCRIPTION}
                   disabled={!regionSupportsBlockStorageEncryption}
                   entityType="Volume"
-                  isEncryptEntityChecked={encryptVolume}
-                  onChange={toggleVolumeEncryptionEnabled}
+                  isEncryptEntityChecked={values.encryption === 'enabled'}
                 />
               </Box>
             )}

--- a/packages/manager/src/features/Volumes/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate.tsx
@@ -10,6 +10,7 @@ import { Box } from 'src/components/Box';
 import { Button } from 'src/components/Button/Button';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import {
+  BLOCK_STORAGE_CHOOSE_REGION_COPY,
   BLOCK_STORAGE_ENCRYPTION_GENERAL_DESCRIPTION,
   BLOCK_STORAGE_ENCRYPTION_OVERHEAD_CAVEAT,
   BLOCK_STORAGE_ENCRYPTION_UNAVAILABLE_IN_REGION_COPY,
@@ -445,7 +446,9 @@ export const VolumeCreate = () => {
               <Box>
                 <Encryption
                   disabledReason={
-                    BLOCK_STORAGE_ENCRYPTION_UNAVAILABLE_IN_REGION_COPY
+                    values.region
+                      ? BLOCK_STORAGE_ENCRYPTION_UNAVAILABLE_IN_REGION_COPY
+                      : BLOCK_STORAGE_CHOOSE_REGION_COPY
                   }
                   notices={
                     encryptVolume


### PR DESCRIPTION
## Description 📝
Add "Volume Encryption" section to Volume Create page.

> [!NOTE]
> The wireframes have a warning notice below the Linode dropdown when the selected linode uses an old qemu version. However, the API team has not finalized yet where that data point will be placed, so I created M3-8420 to circle back to that once finalized.

## Changes  🔄
- Unit test coverage added with `VolumeCreate.test.tsx`
- Added support in `Encryption.tsx` for warning notices above checkbox via optional `notices` prop
- Added `useIsBlockStorageEncryptionFeatureEnabled` util, updated constants
- Added "Volume Encryption" section to Volume Create page
 
## Target release date 🗓️
8/19/24

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-08-05 at 4 40 05 PM](https://github.com/user-attachments/assets/f36bfa0f-53dc-44c9-b2a0-c47ed401fd97) | ![Screenshot 2024-08-06 at 2 16 45 PM](https://github.com/user-attachments/assets/f21a7e0d-412e-46fc-93f7-8ae5e0eb5fea) |

<details>
<summary>Notices when checkbox is checked</summary>

![Screenshot 2024-08-05 at 5 28 40 PM](https://github.com/user-attachments/assets/b3fc002f-ea3f-4204-b0e0-8b9fd1604f0d)
</details>

## How to test 🧪
### Prerequisites
Point at the dev environment with the `blockstorage-encryption` tag on your account

### Verification steps
- Confirm that you can create a volume with the indicated encryption status (i.e., unchecked box should result in `encryption: "disabled"` in the payload and a checked box should result in `encryption: "enabled"` in the payload)

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support