### PR TITLE
test: [M3-8419] - Fix failing stackscript deploy test

### DIFF
--- a/packages/manager/.changeset/pr-10757-tests-1722971426093.md
+++ b/packages/manager/.changeset/pr-10757-tests-1722971426093.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Update StackScript Deploy test ([#10757](https://github.com/linode/manager/pull/10757))

--- a/packages/manager/cypress/e2e/core/stackscripts/smoke-community-stackscrips.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/smoke-community-stackscrips.spec.ts
@@ -330,7 +330,11 @@ describe('Community Stackscripts integration tests', () => {
     cy.get('[id="vpn-password"]').should('have.value', vpnPassword);
 
     // Choose an image
-    cy.findByPlaceholderText('Choose an image').should('be.visible').click();
+    cy.findByPlaceholderText('Choose an image')
+      .should('be.visible')
+      .click()
+      .type(image);
+    ui.autocompletePopper.findByTitle(image).should('be.visible').click();
 
     cy.findByText(image).should('be.visible').click();
 


### PR DESCRIPTION
## Description 📝
Our "deploys a new linode as expected" test in "smoke-community-stackscripts.spec.ts" has recently started failing when Cypress attempts to select "AlmaLinux 9" as the Image for the Linode being deployed. The test assumes that "AlmaLinux 9" will be visible immediately after opening the Images dropdown, but this is no longer the case.

## Changes  🔄
- Update "Choose an image" by typing the Image name in the autocomplete and then attempting to find the entry.

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/stackscripts/smoke-community-stackscrips.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support