### PR TITLE
test: Fix `EditImageDrawer.test.tsx` Unit Test Flake

### DIFF
--- a/packages/manager/.changeset/pr-10759-tests-1723040352780.md
+++ b/packages/manager/.changeset/pr-10759-tests-1723040352780.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix `EditImageDrawer.test.tsx` unit test flake ([#10759](https://github.com/linode/manager/pull/10759))

--- a/packages/manager/src/features/Images/ImagesLanding/EditImageDrawer.test.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/EditImageDrawer.test.tsx
@@ -47,7 +47,7 @@ describe('EditImageDrawer', () => {
 
     const tagsInput = getByRole('combobox');
 
-    userEvent.type(tagsInput, 'new-tag');
+    await userEvent.type(tagsInput, 'new-tag');
 
     await waitFor(() => expect(tagsInput).toHaveValue('new-tag'));
 

--- a/packages/manager/src/features/Images/ImagesLanding/EditImageDrawer.test.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/EditImageDrawer.test.tsx
@@ -49,7 +49,7 @@ describe('EditImageDrawer', () => {
 
     await userEvent.type(tagsInput, 'new-tag');
 
-    await waitFor(() => expect(tagsInput).toHaveValue('new-tag'));
+    expect(tagsInput).toHaveValue('new-tag');
 
     fireEvent.click(getByText('Create "new-tag"'));
 


### PR DESCRIPTION
## Description 📝

Fixes unit test flake with `EditImageDrawer.test.tsx` by awaiting the `userEvent.type` call ⌛ 

## Preview 📷

This is the flake I am trying to fix
![Screenshot 2024-08-07 at 10 07 30 AM](https://github.com/user-attachments/assets/bbe60479-4c75-47ad-b9a1-7d6ad981bd8c)

## How to test 🧪

- Verify Github Actions passes ✅ 
- Run the test locally a few times and verify it consistently succeeds ✅ 

```sh
repeat 10 yarn test EditImageDrawer
```

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support