### PR TITLE
refactor: [M3-8421] - Update Linode Types to use a Query Key Factory 

### DIFF
--- a/packages/manager/.changeset/pr-10760-tech-stories-1723236539851.md
+++ b/packages/manager/.changeset/pr-10760-tech-stories-1723236539851.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Query Key Factory for Linode Types ([#10760](https://github.com/linode/manager/pull/10760))

--- a/packages/manager/src/containers/types.container.ts
+++ b/packages/manager/src/containers/types.container.ts
@@ -1,19 +1,13 @@
-import { LinodeType } from '@linode/api-v4';
-import { APIError } from '@linode/api-v4/lib/types';
 import React from 'react';
 
-import { useAllTypes, useSpecificTypes } from 'src/queries/types';
-import { isNotNullOrUndefined } from 'src/utilities/nullOrUndefined';
+import { useAllTypes } from 'src/queries/types';
+
+import type { APIError, LinodeType } from '@linode/api-v4';
 
 export interface WithTypesProps {
   typesData?: LinodeType[];
   typesError?: APIError[];
   typesLoading: boolean;
-}
-
-export interface WithSpecificTypesProps {
-  requestedTypesData: LinodeType[];
-  setRequestedTypes: (types: string[]) => void;
 }
 
 export const withTypes = <Props>(
@@ -31,22 +25,5 @@ export const withTypes = <Props>(
     typesData,
     typesError: typesError ?? undefined,
     typesLoading,
-  });
-};
-
-export const withSpecificTypes = <Props>(
-  Component: React.ComponentType<Props & WithSpecificTypesProps>,
-  enabled = true
-) => (props: Props) => {
-  const [requestedTypes, setRequestedTypes] = React.useState<string[]>([]);
-  const typesQuery = useSpecificTypes(requestedTypes, enabled);
-  const requestedTypesData = typesQuery
-    .map((result) => result.data)
-    .filter(isNotNullOrUndefined);
-
-  return React.createElement(Component, {
-    ...props,
-    requestedTypesData,
-    setRequestedTypes,
   });
 };

--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodeActionMenu/LinodeActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodeActionMenu/LinodeActionMenu.tsx
@@ -1,4 +1,3 @@
-import { LinodeBackups, LinodeType } from '@linode/api-v4/lib/linodes';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import * as React from 'react';
@@ -6,23 +5,21 @@ import { useHistory } from 'react-router-dom';
 
 import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
 import { getIsDistributedRegion } from 'src/components/RegionSelect/RegionSelect.utils';
-import {
-  ActionType,
-  getRestrictedResourceText,
-} from 'src/features/Account/utils';
+import { getRestrictedResourceText } from 'src/features/Account/utils';
 import { lishLaunch } from 'src/features/Lish/lishUtils';
 import { useIsResourceRestricted } from 'src/hooks/useIsResourceRestricted';
 import { useRegionsQuery } from 'src/queries/regions/regions';
-import { useSpecificTypes } from 'src/queries/types';
 import {
   sendLinodeActionEvent,
   sendLinodeActionMenuItemEvent,
   sendMigrationNavigationEvent,
 } from 'src/utilities/analytics/customEventAnalytics';
-import { extendType } from 'src/utilities/extendType';
 
-import { LinodeHandlers } from '../LinodesLanding';
 import { buildQueryStringForLinodeClone } from './LinodeActionMenuUtils';
+
+import type { LinodeHandlers } from '../LinodesLanding';
+import type { LinodeBackups, LinodeType } from '@linode/api-v4';
+import type { ActionType } from 'src/features/Account/utils';
 
 export interface LinodeActionMenuProps extends LinodeHandlers {
   inListView?: boolean;
@@ -53,9 +50,6 @@ export const LinodeActionMenu = (props: LinodeActionMenuProps) => {
     linodeType,
   } = props;
 
-  const typesQuery = useSpecificTypes(linodeType?.id ? [linodeType.id] : []);
-  const type = typesQuery[0]?.data;
-  const extendedType = type ? extendType(type) : undefined;
   const history = useHistory();
   const regions = useRegionsQuery().data ?? [];
   const isBareMetalInstance = linodeType?.class === 'metal';
@@ -138,7 +132,7 @@ export const LinodeActionMenu = (props: LinodeActionMenuProps) => {
             linodeId,
             linodeRegion,
             linodeType?.id ?? null,
-            extendedType ? [extendedType] : null,
+            linodeType ? [linodeType] : undefined,
             regions
           ),
         });

--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodeActionMenu/LinodeActionMenuUtils.ts
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodeActionMenu/LinodeActionMenuUtils.ts
@@ -1,12 +1,10 @@
-import { Region } from '@linode/api-v4/lib';
-
-import { ExtendedType } from 'src/utilities/extendType';
+import type { LinodeType, Region } from '@linode/api-v4';
 
 export const buildQueryStringForLinodeClone = (
   linodeId: number,
   linodeRegion: string,
   linodeType: null | string,
-  types: ExtendedType[] | null | undefined,
+  types: LinodeType[] | null | undefined,
   regions: Region[]
 ): string => {
   const linodeRegionId =

--- a/packages/manager/src/queries/linodes/linodes.ts
+++ b/packages/manager/src/queries/linodes/linodes.ts
@@ -14,6 +14,7 @@ import {
   getLinodeTransfer,
   getLinodeTransferByDate,
   getLinodes,
+  getType,
   linodeBoot,
   linodeReboot,
   linodeShutdown,
@@ -43,6 +44,7 @@ import {
   getAllLinodeConfigs,
   getAllLinodeDisks,
   getAllLinodeKernelsRequest,
+  getAllLinodeTypes,
   getAllLinodesRequest,
 } from './requests';
 
@@ -132,6 +134,19 @@ export const linodeQueries = createQueryKeys('linodes', {
       paginated: (params: Params = {}, filter: Filter = {}) => ({
         queryFn: () => getLinodes(params, filter),
         queryKey: [params, filter],
+      }),
+    },
+    queryKey: null,
+  },
+  types: {
+    contextQueries: {
+      all: {
+        queryFn: getAllLinodeTypes,
+        queryKey: null,
+      },
+      type: (id: string) => ({
+        queryFn: () => getType(id),
+        queryKey: [id],
       }),
     },
     queryKey: null,

--- a/packages/manager/src/queries/linodes/requests.ts
+++ b/packages/manager/src/queries/linodes/requests.ts
@@ -3,6 +3,7 @@ import {
   getLinodeDisks,
   getLinodeFirewalls,
   getLinodeKernels,
+  getLinodeTypes,
   getLinodes,
 } from '@linode/api-v4';
 
@@ -59,3 +60,6 @@ export const getAllLinodeDisks = (id: number) =>
   getAll<Disk>((params, filter) => getLinodeDisks(id, params, filter))().then(
     (data) => data.data
   );
+
+export const getAllLinodeTypes = () =>
+  getAll(getLinodeTypes)().then((results) => results.data);

--- a/packages/manager/src/queries/types.ts
+++ b/packages/manager/src/queries/types.ts
@@ -40,18 +40,5 @@ export const useSpecificTypes = (types: string[], enabled = true) => {
 };
 
 export const useTypeQuery = (type: string, enabled = true) => {
-  const queryClient = useQueryClient();
-
-  return useQuery<LinodeType, APIError[]>({
-    ...linodeQueries.types._ctx.type(type),
-    ...queryPresets.oneTimeFetch,
-    enabled,
-    initialData() {
-      const allTypesFromCache = queryClient.getQueryData<LinodeType[]>(
-        linodeQueries.types._ctx.all.queryKey
-      );
-
-      return allTypesFromCache?.find((t) => t.id === type);
-    },
-  });
+  return useSpecificTypes([type], enabled)[0];
 };

--- a/packages/manager/src/queries/types.ts
+++ b/packages/manager/src/queries/types.ts
@@ -1,40 +1,19 @@
-import { LinodeType, getLinodeTypes, getType } from '@linode/api-v4';
-import { APIError } from '@linode/api-v4/lib/types';
-import {
-  QueryClient,
-  UseQueryOptions,
-  useQueries,
-  useQuery,
-  useQueryClient,
-} from '@tanstack/react-query';
-
-import { getAll } from 'src/utilities/getAll';
+import { useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { queryPresets } from './base';
+import { linodeQueries } from './linodes/linodes';
 
-const queryKey = 'types';
+import type { APIError, LinodeType } from '@linode/api-v4';
+import type { UseQueryOptions } from '@tanstack/react-query';
 
-const getAllTypes = () =>
-  getAll(getLinodeTypes)().then((results) => results.data);
-
-const getSingleType = async (type: string, queryClient: QueryClient) => {
-  const allTypesCache = queryClient.getQueryData<LinodeType[]>(
-    allTypesQueryKey
-  );
-  return (
-    allTypesCache?.find((cachedType) => cachedType.id === type) ?? getType(type)
-  );
-};
-
-const allTypesQueryKey = [queryKey, 'all'];
 export const useAllTypes = (enabled = true) => {
-  return useQuery<LinodeType[], APIError[]>(allTypesQueryKey, getAllTypes, {
+  return useQuery<LinodeType[], APIError[]>({
+    ...linodeQueries.types._ctx.all,
     enabled,
     ...queryPresets.oneTimeFetch,
   });
 };
 
-const specificTypesQueryKey = (type: string) => [queryKey, 'detail', type];
 /**
  * Some Linodes may have types that aren't returned by the /types and /types-legacy endpoints. This
  * hook may be useful in fetching these "shadow plans".
@@ -43,16 +22,36 @@ const specificTypesQueryKey = (type: string) => [queryKey, 'detail', type];
  */
 export const useSpecificTypes = (types: string[], enabled = true) => {
   const queryClient = useQueryClient();
+
   return useQueries({
     queries: types.map<UseQueryOptions<LinodeType, APIError[]>>((type) => ({
-      enabled: Boolean(type) && enabled,
-      queryFn: () => getSingleType(type, queryClient),
-      queryKey: specificTypesQueryKey(type),
+      enabled,
+      ...linodeQueries.types._ctx.type(type),
       ...queryPresets.oneTimeFetch,
+      initialData() {
+        const allTypesFromCache = queryClient.getQueryData<LinodeType[]>(
+          linodeQueries.types._ctx.all.queryKey
+        );
+
+        return allTypesFromCache?.find((t) => t.id === type);
+      },
     })),
   });
 };
 
 export const useTypeQuery = (type: string, enabled = true) => {
-  return useSpecificTypes([type], enabled)[0];
+  const queryClient = useQueryClient();
+
+  return useQuery<LinodeType, APIError[]>({
+    ...linodeQueries.types._ctx.type(type),
+    ...queryPresets.oneTimeFetch,
+    enabled,
+    initialData() {
+      const allTypesFromCache = queryClient.getQueryData<LinodeType[]>(
+        linodeQueries.types._ctx.all.queryKey
+      );
+
+      return allTypesFromCache?.find((t) => t.id === type);
+    },
+  });
 };


### PR DESCRIPTION
## Description 📝

- Updates Linode Type Queries to use the Linodes Query Key Factory 🏭 
- Performs some small clean up 🧹 

## Preview 📷

![Screenshot 2024-08-07 at 12 12 36 PM](https://github.com/user-attachments/assets/c629a2a6-da87-4fdd-ae47-d5cab7c2535d)

## How to test 🧪

- Verify Linode types still load as expected throughout Cloud Manager 👁️ 
- Verify automated testing passes ✅ 

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
