### PR TITLE
upcoming: [M3-8426] - Add Sentry Tag for Linode Create v2

### DIFF
--- a/packages/manager/.changeset/pr-10763-upcoming-features-1723138942196.md
+++ b/packages/manager/.changeset/pr-10763-upcoming-features-1723138942196.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add Sentry Tag for Linode Create v2 ([#10763](https://github.com/linode/manager/pull/10763))

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
@@ -1,4 +1,5 @@
 import { isEmpty } from '@linode/api-v4';
+import * as Sentry from '@sentry/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSnackbar } from 'notistack';
 import React, { useEffect, useRef } from 'react';
@@ -138,6 +139,19 @@ export const LinodeCreatev2 = () => {
     }
     previousSubmitCount.current = form.formState.submitCount;
   }, [form.formState]);
+
+  /**
+   * Add a Sentry tag when Linode Create v2 is mounted
+   * so we differentiate errors.
+   *
+   * @todo remove once Linode Create v2 is live for all users
+   */
+  useEffect(() => {
+    Sentry.setTag('Linode Create Version', 'v2');
+    return () => {
+      Sentry.setTag('Linode Create Version', undefined);
+    };
+  }, []);
 
   return (
     <FormProvider {...form}>


### PR DESCRIPTION
## Description 📝

Adds a Sentry tag when Linode Create v2 is mounted 🏷️  so we can know if a Sentry error originated from the v2 Linode Create flow 

## Preview 📷

| Linode Create v1 Error  | Linode Create v2 Error   |
| ------- | ------- |
| ![Screenshot 2024-08-08 at 1 28 45 PM](https://github.com/user-attachments/assets/9f89abc9-2ef2-4545-a832-b311c4c08e4d) | ![Screenshot 2024-08-08 at 1 26 15 PM](https://github.com/user-attachments/assets/bb85727d-aa3d-4eb1-bbec-60a50e0821d2) |
| no tag | has an extra tag we can query by |

## How to test 🧪

### Prerequisites
- Make sure you have `REACT_APP_SENTRY_URL` in your env
  - If you need this value, ask me for it! 

### Verification steps
- You can test this by adding `throw new Error("...")` in components on the Linode Create v1 and Linode Create v2
- This should cause Cloud Manager to crash and report the error to sentry
- If you are on Linode Create v2 you should see the sentry tag
- If you are on Linode Create v1 you should not see any extra tag

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support