### PR TITLE
change: [M3-8429] - Add a "Sizing a pull request" section to `CONTRIBUTING.md`

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Feel free to open an issue to report a bug or request a feature.
 1. Fork this repository.
 2. Clone your fork to your local machine.
 3. Create a branch from `develop`, e.g. `$ git checkout develop && git pull && git checkout -b feature/my-feature`.
-4. Make your changes, commit them following the standards below, and then push them to your fork.
+4. Make your [small, focused](#sizing-a-pull-request) changes, commit them following the standards below, and then push them to your fork.
 5. Commit message format standard: `<commit type>: [JIRA-ticket-number] - <description>`
 
     **Commit Types:**
@@ -53,6 +53,23 @@ Follow these best practices to write a good changeset:
 - Use the `Upcoming Features` section for ongoing project work that is behind a feature flag. If additional changes are being made that are not feature flagged, add another changeset to describe that work.
 - Add changesets for `docs/` documentation changes in the `manager` package, as this is generally best-fit.
 - Generally, if the code change is a fix for a previous change that has been merged to `develop` but was never released to production, we don't need to include a changeset.
+
+## Sizing a pull request
+
+A good PR is small.
+
+Examples of ‘small’:
+
+- Changing a docker file
+- Updating a dependency ([Example 1](https://github.com/linode/manager/pull/10291), [Example 2](https://github.com/linode/manager/pull/10212))
+- Fixing 1 bug ([Example 1](https://github.com/linode/manager/pull/10583), [Example 2](https://github.com/linode/manager/pull/9726))
+- Creating 1 new component with unit test coverage ([Example](https://github.com/linode/manager/pull/9520))
+- Adding a new util with unit test coverage
+
+Diff size: A good PR is less than 500 changes, closer to [200](https://github.com/google/eng-practices/blob/master/review/developer/small-cls.md).
+
+A good PR does **exactly one thing**, and is clear about what that is in the description.
+Break down *additional* things in your PR into multiple PRs (like you would do with tickets).
 
 ## Docs
 

--- a/packages/manager/.changeset/pr-10764-added-1723149902254.md
+++ b/packages/manager/.changeset/pr-10764-added-1723149902254.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Documentation for 'Sizing a pull request' to contribution guidelines ([#10764](https://github.com/linode/manager/pull/10764))


### PR DESCRIPTION
## Description 📝
This is an action item from Cafe. (8/8/24)

Some good internal guidelines exist about writing good, small PRs. It would be useful for these to live in our public developer docs too, for ease of referencing and linking in PR reviews.

## Changes  🔄
- Adds the 'Sizing a pull request' section to our contributing docs page
- Links that section in the 'Submitting a pull request' section

## Preview 📷
![Screenshot 2024-08-08 at 1 34 12 PM](https://github.com/user-attachments/assets/768b8b4b-d67d-46ba-b535-db74dd902e1d)

## How to test 🧪

### Verification steps
(How to verify changes)
- Read the diff (or pull the PR and `yarn docs`, then go to http://localhost:5173/manager/CONTRIBUTING.html#sizing-a-pull-request to view it locally.
- If there are any better or additional examples to include, we can definitely do that.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

