### PR TITLE
refractor: [M3-8437] -  Prepare for React Query v5

### DIFF
--- a/docs/tooling/react-query.md
+++ b/docs/tooling/react-query.md
@@ -119,7 +119,9 @@ export const useLinodeUpdateMutation = (id: number) => {
     mutationFn: (data) => updateLinode(id, data),
     onSuccess(linode) {
       // Invalidate all paginated pages in the cache.
-      queryClient.invalidateQueries(linodeQueries.paginated._def);
+      queryClient.invalidateQueries({
+        queryKey: linodeQueries.paginated._def
+      });
       // Because we have the updated Linode, we can manually set the cache for the `useLinode` query.
       queryClient.setQueryData(linodeQueries.linode(id).queryKey, linode);
     },
@@ -132,7 +134,9 @@ export const useDeleteLinodeMutation = (id: number) => {
     mutationFn: () => deleteLinode(id),
     onSuccess() {
       // Invalidate all paginated pages in the cache.
-      queryClient.invalidateQueries(linodeQueries.paginated._def);
+      queryClient.invalidateQueries({
+        queryKey: linodeQueries.paginated._def
+      });
       // Remove the deleted linode from the cache
       queryClient.removeQueries(linodeQueries.linode(id).queryKey);
     },
@@ -145,7 +149,9 @@ export const useCreateLinodeMutation = () => {
     mutationFn: createLinode,
     onSuccess(linode) {
       // Invalidate all paginated pages in the cache. We don't know what page the new Linode will be on.
-      queryClient.invalidateQueries(linodeQueries.paginated._def);
+      queryClient.invalidateQueries({
+        queryKey: linodeQueries.paginated._def
+      });
       // Because we have the new Linode, we can manually set the cache for the `useLinode` query.
       queryClient.setQueryData(linodeQueries.linode(id).queryKey, linode);
     },

--- a/packages/manager/.changeset/pr-10767-tech-stories-1723554692779.md
+++ b/packages/manager/.changeset/pr-10767-tech-stories-1723554692779.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Prepare for React Query v5 ([#10767](https://github.com/linode/manager/pull/10767))

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PayPalButton.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PayPalButton.tsx
@@ -179,7 +179,9 @@ export const PayPalButton = (props: Props) => {
         setProcessing(false);
       });
       if (response) {
-        queryClient.invalidateQueries(accountQueries.payments._def);
+        queryClient.invalidateQueries({
+          queryKey: accountQueries.payments._def,
+        });
 
         setSuccess(
           `Payment for $${response.usd} successfully submitted with PayPal`,

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -189,7 +189,9 @@ export const PaymentDrawer = (props: Props) => {
           true,
           response.warnings
         );
-        queryClient.invalidateQueries(accountQueries.payments._def);
+        queryClient.invalidateQueries({
+          queryKey: accountQueries.payments._def,
+        });
       })
       .catch((errorResponse) => {
         setSubmitting(false);

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PromoDialog.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PromoDialog.tsx
@@ -51,7 +51,9 @@ const PromoDialog = (props: Props) => {
         enqueueSnackbar('Successfully applied promo to your account.', {
           variant: 'success',
         });
-        queryClient.invalidateQueries(accountQueries.account.queryKey);
+        queryClient.invalidateQueries({
+          queryKey: accountQueries.account.queryKey,
+        });
         onClose();
       })
       .catch((error: APIError[]) => {

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddCreditCardForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddCreditCardForm.tsx
@@ -82,7 +82,9 @@ const AddCreditCardForm = (props: Props) => {
       enqueueSnackbar('Successfully added Credit Card', {
         variant: 'success',
       });
-      queryClient.invalidateQueries(accountQueries.paymentMethods.queryKey);
+      queryClient.invalidateQueries({
+        queryKey: accountQueries.paymentMethods.queryKey,
+      });
       onClose();
     } catch (errors) {
       handleAPIErrors(errors, setFieldError, setError);

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PayPalChip.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PayPalChip.tsx
@@ -115,7 +115,9 @@ export const PayPalChip = (props: Props) => {
       type: 'payment_method_nonce',
     })
       .then(() => {
-        queryClient.invalidateQueries(accountQueries.paymentMethods.queryKey);
+        queryClient.invalidateQueries({
+          queryKey: accountQueries.paymentMethods.queryKey,
+        });
 
         onClose();
 

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
@@ -63,7 +63,9 @@ const PaymentInformation = (props: Props) => {
       .then(() => {
         setDeleteLoading(false);
         closeDeleteDialog();
-        queryClient.invalidateQueries(accountQueries.paymentMethods.queryKey);
+        queryClient.invalidateQueries({
+          queryKey: accountQueries.paymentMethods.queryKey,
+        });
       })
       .catch((e: APIError[]) => {
         setDeleteLoading(false);

--- a/packages/manager/src/features/Billing/GooglePayProvider.ts
+++ b/packages/manager/src/features/Billing/GooglePayProvider.ts
@@ -114,7 +114,9 @@ export const gPay = async (
       nonce,
       usd: transactionInfo.totalPrice as string,
     });
-    queryClient.invalidateQueries(accountQueries.payments._def);
+    queryClient.invalidateQueries({
+      queryKey: accountQueries.payments._def,
+    });
     const message = {
       text: `Payment for $${transactionInfo.totalPrice} successfully submitted with Google Pay`,
       variant: 'success' as VariantType,
@@ -128,7 +130,9 @@ export const gPay = async (
       is_default: true,
       type: 'payment_method_nonce',
     });
-    queryClient.invalidateQueries(accountQueries.paymentMethods.queryKey);
+    queryClient.invalidateQueries({
+      queryKey: accountQueries.paymentMethods.queryKey,
+    });
     setMessage({
       text: 'Successfully added Google Pay',
       variant: 'success',

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersCreate/EntityTransfersCreate.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersCreate/EntityTransfersCreate.tsx
@@ -70,7 +70,9 @@ export const EntityTransfersCreate = () => {
         const entityCount = countByEntity(transfer.entities);
         sendEntityTransferCreateEvent(entityCount);
 
-        queryClient.invalidateQueries([queryKey]);
+        queryClient.invalidateQueries({
+          queryKey: [queryKey],
+        });
         push({ pathname: '/account/service-transfers', state: { transfer } });
       },
     }).catch((_) => null);

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferCancelDialog.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferCancelDialog.tsx
@@ -55,7 +55,9 @@ export const ConfirmTransferCancelDialog = React.memo((props: Props) => {
         sendEntityTransferCancelEvent();
 
         // Refresh the query for Entity Transfers.
-        queryClient.invalidateQueries([queryKey]);
+        queryClient.invalidateQueries({
+          queryKey: [queryKey],
+        });
 
         onClose();
         setSubmitting(false);

--- a/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
@@ -30,7 +30,9 @@ export const ComplianceUpdateModal = () => {
       .then(() => {
         complianceModelContext.close();
         // Re-request notifications so the GDPR notification goes away.
-        queryClient.invalidateQueries(accountQueries.notifications.queryKey);
+        queryClient.invalidateQueries({
+          queryKey: accountQueries.notifications.queryKey,
+        });
       })
       .catch((err) => {
         const errorMessage = getErrorStringOrDefault(

--- a/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.tsx
@@ -304,7 +304,9 @@ export const ImagesLanding = () => {
     imageLabel: string,
     imageDescription: string
   ) => {
-    queryClient.invalidateQueries(imageQueries.paginated._def);
+    queryClient.invalidateQueries({
+      queryKey: imageQueries.paginated._def,
+    });
     history.push('/images/create/upload', {
       imageDescription,
       imageLabel,
@@ -312,7 +314,9 @@ export const ImagesLanding = () => {
   };
 
   const onCancelFailedClick = () => {
-    queryClient.invalidateQueries(imageQueries.paginated._def);
+    queryClient.invalidateQueries({
+      queryKey: imageQueries.paginated._def,
+    });
   };
 
   const deployNewLinode = (imageID: string) => {

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -25,7 +25,6 @@ import { withQueryClient } from 'src/containers/withQueryClient.container';
 import withAgreements from 'src/features/Account/Agreements/withAgreements';
 import { hasPlacementGroupReachedCapacity } from 'src/features/PlacementGroups/utils';
 import { reportAgreementSigningError } from 'src/queries/account/agreements';
-import { vpcQueries } from 'src/queries/vpcs/vpcs';
 import {
   sendCreateLinodeEvent,
   sendLinodeCreateFlowDocsClickEvent,

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -84,6 +84,7 @@ import type { CreateTypes } from 'src/store/linodeCreate/linodeCreate.actions';
 import type { MapState } from 'src/store/types';
 import type { ExtendedType } from 'src/utilities/extendType';
 import type { ExtendedIP } from 'src/utilities/ipUtils';
+import { accountQueries } from 'src/queries/account/queries';
 
 const DEFAULT_IMAGE = 'linode/debian11';
 
@@ -738,7 +739,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
           signAgreement(agreeData)
             .then(() => {
               this.props.queryClient.setQueryData<Agreements>(
-                ['account', 'agreements'],
+                accountQueries.agreements.queryKey,
                 (prev) => ({
                   ...(prev ?? {}),
                   ...agreeData,
@@ -765,19 +766,6 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
 
         /** reset the Events polling */
         this.props.checkForNewEvents();
-
-        // If a VPC was assigned, invalidate the query so that the relevant VPC data
-        // gets displayed in the LinodeEntityDetail
-        if (
-          this.state.selectedVPCId !== undefined &&
-          this.state.selectedVPCId !== -1
-        ) {
-          this.props.queryClient.invalidateQueries(vpcQueries.all.queryKey);
-          this.props.queryClient.invalidateQueries(vpcQueries.paginated._def);
-          this.props.queryClient.invalidateQueries(
-            vpcQueries.vpc(this.state.selectedVPCId).queryKey
-          );
-        }
 
         /** send the user to the Linode detail page */
         this.props.history.push(`/linodes/${response.id}`);

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
@@ -398,14 +398,15 @@ export const LinodeConfigDialog = (props: Props) => {
     const actionType = Boolean(config) ? 'updated' : 'created';
     const handleSuccess = () => {
       formik.setSubmitting(false);
-      queryClient.invalidateQueries(['linode', 'configs', props.linodeId]);
       // If there's any chance a VLAN changed here, make sure our query data is up to date
       if (
         configData.interfaces?.some(
           (thisInterface) => thisInterface.purpose === 'vlan'
         )
       ) {
-        queryClient.invalidateQueries(vlanQueries._def);
+        queryClient.invalidateQueries({
+          queryKey: vlanQueries._def,
+        });
       }
 
       // Ensure VPC query data is up-to-date
@@ -414,9 +415,15 @@ export const LinodeConfigDialog = (props: Props) => {
       )?.vpc_id;
 
       if (vpcId) {
-        queryClient.invalidateQueries(vpcQueries.all.queryKey);
-        queryClient.invalidateQueries(vpcQueries.paginated._def);
-        queryClient.invalidateQueries(vpcQueries.vpc(vpcId).queryKey);
+        queryClient.invalidateQueries({
+          queryKey: vpcQueries.all.queryKey,
+        });
+        queryClient.invalidateQueries({
+          queryKey: vpcQueries.paginated._def,
+        });
+        queryClient.invalidateQueries({
+          queryKey: vpcQueries.vpc(vpcId).queryKey,
+        });
       }
 
       enqueueSnackbar(

--- a/packages/manager/src/features/Linodes/LinodesLanding/DeleteLinodeDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/DeleteLinodeDialog.tsx
@@ -47,15 +47,18 @@ export const DeleteLinodeDialog = (props: Props) => {
     // @TODO VPC: potentially revisit using the linodeEventsHandler in linode/events.ts to invalidate queries rather than here
     // See PR #9814 for more details
     if (vpcIds.length > 0) {
-      queryClient.invalidateQueries(vpcQueries.all.queryKey);
-      queryClient.invalidateQueries(vpcQueries.paginated._def);
-      // invalidate data for specific vpcs this linode is assigned to
-      vpcIds.forEach((vpcId) => {
-        queryClient.invalidateQueries(vpcQueries.vpc(vpcId).queryKey);
-        queryClient.invalidateQueries(
-          vpcQueries.vpc(vpcId)._ctx.subnets.queryKey
-        );
+      queryClient.invalidateQueries({
+        queryKey: vpcQueries.all.queryKey,
       });
+      queryClient.invalidateQueries({
+        queryKey: vpcQueries.paginated._def,
+      });
+      // invalidate data for specific vpcs this linode is assigned to
+      for (const vpcId of vpcIds) {
+        queryClient.invalidateQueries({
+          queryKey: vpcQueries.vpc(vpcId).queryKey,
+        });
+      }
     }
     onClose();
     checkForNewEvents();

--- a/packages/manager/src/features/Profile/AuthenticationSettings/PhoneVerification/PhoneVerification.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/PhoneVerification/PhoneVerification.tsx
@@ -98,7 +98,9 @@ export const PhoneVerification = ({
       );
     } else {
       // Cloud Manager does not know about the country, so lets refetch the user's phone number so we know it's displaying correctly
-      queryClient.invalidateQueries(profileQueries.profile().queryKey);
+      queryClient.invalidateQueries({
+        queryKey: profileQueries.profile().queryKey,
+      });
     }
 
     // reset form states

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
@@ -61,7 +61,9 @@ export const TwoFactor = (props: TwoFactorProps) => {
    */
   const handleEnableSuccess = (scratchCode: string) => {
     // Refetch Profile with React Query so profile is up to date
-    queryClient.invalidateQueries(profileQueries.profile().queryKey);
+    queryClient.invalidateQueries({
+      queryKey: profileQueries.profile().queryKey,
+    });
     setSuccess('Two-factor authentication has been enabled.');
     setShowQRCode(false);
     setTwoFactorEnabled(true);

--- a/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -161,7 +161,9 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
           return;
         }
         if (profile.data?.restricted) {
-          queryClient.invalidateQueries(profileQueries.grants.queryKey);
+          queryClient.invalidateQueries({
+            queryKey: profileQueries.grants.queryKey,
+          });
         }
         this.setState({ isSubmitting: false });
         this.resetAllFields();

--- a/packages/manager/src/features/Users/UserDetail.tsx
+++ b/packages/manager/src/features/Users/UserDetail.tsx
@@ -144,9 +144,9 @@ export const UserDetail = () => {
           refreshProfile();
         } else {
           // Invalidate the paginated store
-          queryClient.invalidateQueries(
-            accountQueries.users._ctx.paginated._def
-          );
+          queryClient.invalidateQueries({
+            queryKey: accountQueries.users._ctx.paginated._def,
+          });
           // set the user in the store
           queryClient.setQueryData<User>(
             accountQueries.users._ctx.user(user.username).queryKey,

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -297,9 +297,9 @@ class UserPermissions extends React.Component<CombinedProps, State> {
             restricted: user.restricted,
           });
           // refresh the data on /account/users so it is accurate
-          this.props.queryClient.invalidateQueries(
-            accountQueries.users._ctx.paginated._def
-          );
+          this.props.queryClient.invalidateQueries({
+            queryKey: accountQueries.users._ctx.paginated._def,
+          });
           // Update the user directly in the cache
           this.props.queryClient.setQueryData<User>(
             accountQueries.users._ctx.user(user.username).queryKey,

--- a/packages/manager/src/hooks/useUnassignLinode.ts
+++ b/packages/manager/src/hooks/useUnassignLinode.ts
@@ -37,7 +37,7 @@ export const useUnassignLinode = () => {
       linodeQueries.linode(linodeId)._ctx.configs.queryKey,
     ];
     await Promise.all(
-      queryKeys.map((key) => queryClient.invalidateQueries(key))
+      queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key }))
     );
   };
 

--- a/packages/manager/src/queries/account/betas.ts
+++ b/packages/manager/src/queries/account/betas.ts
@@ -27,10 +27,14 @@ export const useCreateAccountBetaMutation = () => {
     onSuccess() {
       // Refetch the paginated list of account betas. If we just enrolled in a beta,
       // it will show up in account betas.
-      queryClient.invalidateQueries(accountQueries.betas._ctx.paginated._def);
+      queryClient.invalidateQueries({
+        queryKey: accountQueries.betas._ctx.paginated._def,
+      });
       // Refetch all regions data because enrolling in betas can enable new regions
       // or region capabilities.
-      queryClient.invalidateQueries(regionQueries._def);
+      queryClient.invalidateQueries({
+        queryKey: regionQueries._def,
+      });
     },
   });
 };

--- a/packages/manager/src/queries/account/oauth.ts
+++ b/packages/manager/src/queries/account/oauth.ts
@@ -35,7 +35,9 @@ export const useDeleteOAuthClientMutation = (id: string) => {
   return useMutation<{}, APIError[]>({
     mutationFn: () => deleteOAuthClient(id),
     onSuccess() {
-      queryClient.invalidateQueries(accountQueries.oauthClients._def);
+      queryClient.invalidateQueries({
+        queryKey: accountQueries.oauthClients._def,
+      });
     },
   });
 };
@@ -49,7 +51,9 @@ export const useCreateOAuthClientMutation = () => {
   return useMutation<OAuthClientWithSecret, APIError[], OAuthClientRequest>({
     mutationFn: createOAuthClient,
     onSuccess() {
-      queryClient.invalidateQueries(accountQueries.oauthClients._def);
+      queryClient.invalidateQueries({
+        queryKey: accountQueries.oauthClients._def,
+      });
     },
   });
 };
@@ -59,7 +63,9 @@ export const useUpdateOAuthClientMutation = (id: string) => {
   return useMutation<OAuthClient, APIError[], Partial<OAuthClientRequest>>({
     mutationFn: (data) => updateOAuthClient(id, data),
     onSuccess() {
-      queryClient.invalidateQueries(accountQueries.oauthClients._def);
+      queryClient.invalidateQueries({
+        queryKey: accountQueries.oauthClients._def,
+      });
     },
   });
 };
@@ -67,5 +73,7 @@ export const useUpdateOAuthClientMutation = (id: string) => {
 export const oauthClientsEventHandler = ({ queryClient }: EventHandlerData) => {
   // We may over-fetch because on `onSuccess` also invalidates, but this will be
   // good for UX because Cloud will always be up to date
-  queryClient.invalidateQueries(accountQueries.oauthClients._def);
+  queryClient.invalidateQueries({
+    queryKey: accountQueries.oauthClients._def,
+  });
 };

--- a/packages/manager/src/queries/account/users.ts
+++ b/packages/manager/src/queries/account/users.ts
@@ -50,10 +50,12 @@ export const useAccountUserDeleteMutation = (username: string) => {
   const queryClient = useQueryClient();
   return useMutation<{}, APIError[]>(() => deleteUser(username), {
     onSuccess() {
-      queryClient.invalidateQueries(accountQueries.users._ctx.paginated._def);
-      queryClient.removeQueries(
-        accountQueries.users._ctx.user(username).queryKey
-      );
+      queryClient.invalidateQueries({
+        queryKey: accountQueries.users._ctx.paginated._def,
+      });
+      queryClient.removeQueries({
+        queryKey: accountQueries.users._ctx.user(username).queryKey,
+      });
     },
   });
 };

--- a/packages/manager/src/queries/cloudpulse/metrics.ts
+++ b/packages/manager/src/queries/cloudpulse/metrics.ts
@@ -45,8 +45,10 @@ export const useCloudPulseMetricsQuery = (
         );
         if (currentJWEtokenCache?.token === obj.authToken) {
           queryClient.invalidateQueries(
-            queryFactory.token(serviceType, { resource_ids: [] }).queryKey,
-            {},
+            {
+              queryKey: queryFactory.token(serviceType, { resource_ids: [] })
+                .queryKey,
+            },
             {
               cancelRefetch: true,
             }

--- a/packages/manager/src/queries/databases/databases.ts
+++ b/packages/manager/src/queries/databases/databases.ts
@@ -128,7 +128,9 @@ export const useCreateDatabaseMutation = () => {
         database
       );
       // If a restricted user creates an entity, we must make sure grants are up to date.
-      queryClient.invalidateQueries(profileQueries.grants.queryKey);
+      queryClient.invalidateQueries({
+        queryKey: profileQueries.grants.queryKey,
+      });
     },
   });
 };

--- a/packages/manager/src/queries/images.ts
+++ b/packages/manager/src/queries/images.ts
@@ -73,13 +73,17 @@ export const useCreateImageMutation = () => {
   return useMutation<Image, APIError[], CreateImagePayload>({
     mutationFn: createImage,
     onSuccess(image) {
-      queryClient.invalidateQueries(imageQueries.paginated._def);
+      queryClient.invalidateQueries({
+        queryKey: imageQueries.paginated._def,
+      });
       queryClient.setQueryData<Image>(
         imageQueries.image(image.id).queryKey,
         image
       );
       // If a restricted user creates an entity, we must make sure grants are up to date.
-      queryClient.invalidateQueries(profileQueries.grants.queryKey);
+      queryClient.invalidateQueries({
+        queryKey: profileQueries.grants.queryKey,
+      });
     },
   });
 };
@@ -94,7 +98,9 @@ export const useUpdateImageMutation = () => {
     mutationFn: ({ description, imageId, label, tags }) =>
       updateImage(imageId, { description, label, tags }),
     onSuccess(image) {
-      queryClient.invalidateQueries(imageQueries.paginated._def);
+      queryClient.invalidateQueries({
+        queryKey: imageQueries.paginated._def,
+      });
       queryClient.setQueryData<Image>(
         imageQueries.image(image.id).queryKey,
         image
@@ -105,17 +111,17 @@ export const useUpdateImageMutation = () => {
 
 export const useDeleteImageMutation = () => {
   const queryClient = useQueryClient();
-  return useMutation<{}, APIError[], { imageId: string }>(
-    ({ imageId }) => deleteImage(imageId),
-    {
-      onSuccess(_, variables) {
-        queryClient.invalidateQueries(imageQueries.paginated._def);
-        queryClient.removeQueries(
-          imageQueries.image(variables.imageId).queryKey
-        );
-      },
-    }
-  );
+  return useMutation<{}, APIError[], { imageId: string }>({
+    mutationFn: ({ imageId }) => deleteImage(imageId),
+    onSuccess(_, variables) {
+      queryClient.invalidateQueries({
+        queryKey: imageQueries.paginated._def,
+      });
+      queryClient.removeQueries({
+        queryKey: imageQueries.image(variables.imageId).queryKey,
+      });
+    },
+  });
 };
 
 export const useAllImagesQuery = (
@@ -133,8 +139,12 @@ export const useUploadImageMutation = () => {
   return useMutation<UploadImageResponse, APIError[], ImageUploadPayload>({
     mutationFn: uploadImage,
     onSuccess(data) {
-      queryClient.invalidateQueries(imageQueries.paginated._def);
-      queryClient.invalidateQueries(imageQueries.all._def);
+      queryClient.invalidateQueries({
+        queryKey: imageQueries.paginated._def,
+      });
+      queryClient.invalidateQueries({
+        queryKey: imageQueries.all._def,
+      });
       queryClient.setQueryData<Image>(
         imageQueries.image(data.image.id).queryKey,
         data.image
@@ -148,8 +158,12 @@ export const useUpdateImageRegionsMutation = (imageId: string) => {
   return useMutation<Image, APIError[], UpdateImageRegionsPayload>({
     mutationFn: (data) => updateImageRegions(imageId, data),
     onSuccess(image) {
-      queryClient.invalidateQueries(imageQueries.paginated._def);
-      queryClient.invalidateQueries(imageQueries.all._def);
+      queryClient.invalidateQueries({
+        queryKey: imageQueries.paginated._def,
+      });
+      queryClient.invalidateQueries({
+        queryKey: imageQueries.all._def,
+      });
       queryClient.setQueryData<Image>(
         imageQueries.image(image.id).queryKey,
         image
@@ -163,8 +177,10 @@ export const imageEventsHandler = ({
   queryClient,
 }: EventHandlerData) => {
   if (['failed', 'finished', 'notification'].includes(event.status)) {
-    queryClient.invalidateQueries(imageQueries.all._def);
-    queryClient.invalidateQueries(imageQueries.paginated._def);
+    queryClient.invalidateQueries({
+      queryKey: imageQueries.all._def,
+    });
+    queryClient.invalidateQueries({ queryKey: imageQueries.paginated._def });
 
     if (event.entity) {
       /*
@@ -178,7 +194,9 @@ export const imageEventsHandler = ({
        */
 
       const imageId = `private/${event.entity.id}`;
-      queryClient.invalidateQueries(imageQueries.image(imageId).queryKey);
+      queryClient.invalidateQueries({
+        queryKey: imageQueries.image(imageId).queryKey,
+      });
     }
   }
 };

--- a/packages/manager/src/queries/linodes/backups.ts
+++ b/packages/manager/src/queries/linodes/backups.ts
@@ -22,7 +22,9 @@ export const useLinodeBackupsEnableMutation = (id: number) => {
   return useMutation<{}, APIError[]>({
     mutationFn: () => enableBackups(id),
     onSuccess() {
-      queryClient.invalidateQueries(linodeQueries.linodes);
+      queryClient.invalidateQueries({
+        queryKey: linodeQueries.linodes.queryKey,
+      });
       queryClient.invalidateQueries({
         exact: true,
         queryKey: linodeQueries.linode(id).queryKey,
@@ -36,7 +38,9 @@ export const useLinodeBackupsCancelMutation = (id: number) => {
   return useMutation<{}, APIError[]>({
     mutationFn: () => cancelBackups(id),
     onSuccess() {
-      queryClient.invalidateQueries(linodeQueries.linodes);
+      queryClient.invalidateQueries({
+        queryKey: linodeQueries.linodes.queryKey,
+      });
       queryClient.invalidateQueries({
         exact: true,
         queryKey: linodeQueries.linode(id).queryKey,
@@ -50,8 +54,12 @@ export const useLinodeBackupSnapshotMutation = (id: number) => {
   return useMutation<{}, APIError[], { label: string }>({
     mutationFn: ({ label }) => takeSnapshot(id, label),
     onSuccess() {
-      queryClient.invalidateQueries(linodeQueries.linodes);
-      queryClient.invalidateQueries(linodeQueries.linode(id)._ctx.backups);
+      queryClient.invalidateQueries({
+        queryKey: linodeQueries.linodes.queryKey,
+      });
+      queryClient.invalidateQueries({
+        queryKey: linodeQueries.linode(id)._ctx.backups.queryKey,
+      });
       queryClient.invalidateQueries({
         exact: true,
         queryKey: linodeQueries.linode(id).queryKey,

--- a/packages/manager/src/queries/linodes/configs.ts
+++ b/packages/manager/src/queries/linodes/configs.ts
@@ -28,9 +28,9 @@ export const useLinodeConfigDeleteMutation = (
   return useMutation<{}, APIError[]>({
     mutationFn: () => deleteLinodeConfig(linodeId, configId),
     onSuccess() {
-      queryClient.invalidateQueries(
-        linodeQueries.linode(linodeId)._ctx.configs
-      );
+      queryClient.invalidateQueries({
+        queryKey: linodeQueries.linode(linodeId)._ctx.configs.queryKey,
+      });
     },
   });
 };
@@ -40,9 +40,9 @@ export const useLinodeConfigCreateMutation = (linodeId: number) => {
   return useMutation<Config, APIError[], LinodeConfigCreationData>({
     mutationFn: (data) => createLinodeConfig(linodeId, data),
     onSuccess() {
-      queryClient.invalidateQueries(
-        linodeQueries.linode(linodeId)._ctx.configs
-      );
+      queryClient.invalidateQueries({
+        queryKey: linodeQueries.linode(linodeId)._ctx.configs.queryKey,
+      });
     },
   });
 };
@@ -55,9 +55,9 @@ export const useLinodeConfigUpdateMutation = (
   return useMutation<Config, APIError[], Partial<LinodeConfigCreationData>>({
     mutationFn: (data) => updateLinodeConfig(linodeId, configId, data),
     onSuccess() {
-      queryClient.invalidateQueries(
-        linodeQueries.linode(linodeId)._ctx.configs
-      );
+      queryClient.invalidateQueries({
+        queryKey: linodeQueries.linode(linodeId)._ctx.configs.queryKey,
+      });
     },
   });
 };

--- a/packages/manager/src/queries/linodes/linodes.ts
+++ b/packages/manager/src/queries/linodes/linodes.ts
@@ -237,11 +237,16 @@ export const useDeleteLinodeMutation = (id: number) => {
       // If the linode is assigned to a placement group,
       // we need to invalidate the placement group queries
       if (placementGroupId) {
-        queryClient.invalidateQueries(
-          placementGroupQueries.placementGroup(placementGroupId).queryKey
-        );
-        queryClient.invalidateQueries(placementGroupQueries.all._def);
-        queryClient.invalidateQueries(placementGroupQueries.paginated._def);
+        queryClient.invalidateQueries({
+          queryKey: placementGroupQueries.placementGroup(placementGroupId)
+            .queryKey,
+        });
+        queryClient.invalidateQueries({
+          queryKey: placementGroupQueries.all._def,
+        });
+        queryClient.invalidateQueries({
+          queryKey: placementGroupQueries.paginated._def,
+        });
       }
     },
   });
@@ -282,12 +287,17 @@ export const useCreateLinodeMutation = () => {
       // If the Linode is assigned to a placement group on creation,
       // we need to invalidate the placement group queries
       if (variables.placement_group?.id) {
-        queryClient.invalidateQueries(
-          placementGroupQueries.placementGroup(variables.placement_group.id)
-            .queryKey
-        );
-        queryClient.invalidateQueries(placementGroupQueries.all._def);
-        queryClient.invalidateQueries(placementGroupQueries.paginated._def);
+        queryClient.invalidateQueries({
+          queryKey: placementGroupQueries.placementGroup(
+            variables.placement_group.id
+          ).queryKey,
+        });
+        queryClient.invalidateQueries({
+          queryKey: placementGroupQueries.all._def,
+        });
+        queryClient.invalidateQueries({
+          queryKey: placementGroupQueries.paginated._def,
+        });
       }
 
       // If the Linode is attached to a firewall on creation, invalidate the firewall
@@ -420,12 +430,17 @@ export const useLinodeMigrateMutation = (id: number) => {
       });
 
       if (variables.placement_group?.id) {
-        queryClient.invalidateQueries(
-          placementGroupQueries.placementGroup(variables.placement_group.id)
-            .queryKey
-        );
-        queryClient.invalidateQueries(placementGroupQueries.all._def);
-        queryClient.invalidateQueries(placementGroupQueries.paginated._def);
+        queryClient.invalidateQueries({
+          queryKey: placementGroupQueries.placementGroup(
+            variables.placement_group.id
+          ).queryKey,
+        });
+        queryClient.invalidateQueries({
+          queryKey: placementGroupQueries.all._def,
+        });
+        queryClient.invalidateQueries({
+          queryKey: placementGroupQueries.paginated._def,
+        });
       }
     },
   });

--- a/packages/manager/src/queries/placementGroups.ts
+++ b/packages/manager/src/queries/placementGroups.ts
@@ -92,16 +92,22 @@ export const useCreatePlacementGroup = () => {
 
   return useMutation<PlacementGroup, APIError[], CreatePlacementGroupPayload>({
     mutationFn: createPlacementGroup,
-    onSuccess: (placementGroup) => {
-      queryClient.invalidateQueries(placementGroupQueries.paginated._def);
-      queryClient.invalidateQueries(placementGroupQueries.all._def);
+    onSuccess(placementGroup) {
+      queryClient.invalidateQueries({
+        queryKey: placementGroupQueries.paginated._def,
+      });
+      queryClient.invalidateQueries({
+        queryKey: placementGroupQueries.all._def,
+      });
       queryClient.setQueryData<PlacementGroup>(
         placementGroupQueries.placementGroup(placementGroup.id).queryKey,
         placementGroup
       );
 
       // If a restricted user creates an entity, we must make sure grants are up to date.
-      queryClient.invalidateQueries(profileQueries.grants.queryKey);
+      queryClient.invalidateQueries({
+        queryKey: profileQueries.grants.queryKey,
+      });
     },
   });
 };
@@ -111,10 +117,14 @@ export const useMutatePlacementGroup = (id: number) => {
 
   return useMutation<PlacementGroup, APIError[], UpdatePlacementGroupPayload>({
     mutationFn: (data) => updatePlacementGroup(id, data),
-    onSuccess: (placementGroup) => {
-      queryClient.invalidateQueries(placementGroupQueries.paginated._def);
-      queryClient.invalidateQueries(placementGroupQueries.all._def);
-      queryClient.setQueryData(
+    onSuccess(placementGroup) {
+      queryClient.invalidateQueries({
+        queryKey: placementGroupQueries.paginated._def,
+      });
+      queryClient.invalidateQueries({
+        queryKey: placementGroupQueries.all._def,
+      });
+      queryClient.setQueryData<PlacementGroup>(
         placementGroupQueries.placementGroup(id).queryKey,
         placementGroup
       );
@@ -127,12 +137,16 @@ export const useDeletePlacementGroup = (id: number) => {
 
   return useMutation<{}, APIError[]>({
     mutationFn: () => deletePlacementGroup(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries(placementGroupQueries.paginated._def);
-      queryClient.invalidateQueries(placementGroupQueries.all._def);
-      queryClient.removeQueries(
-        placementGroupQueries.placementGroup(id).queryKey
-      );
+    onSuccess() {
+      queryClient.invalidateQueries({
+        queryKey: placementGroupQueries.paginated._def,
+      });
+      queryClient.invalidateQueries({
+        queryKey: placementGroupQueries.all._def,
+      });
+      queryClient.removeQueries({
+        queryKey: placementGroupQueries.placementGroup(id).queryKey,
+      });
     },
   });
 };
@@ -147,11 +161,16 @@ export const useAssignLinodesToPlacementGroup = (placementGroupId: number) => {
   >({
     mutationFn: (req) => assignLinodesToPlacementGroup(placementGroupId, req),
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries(placementGroupQueries.paginated._def);
-      queryClient.invalidateQueries(placementGroupQueries.all._def);
-      queryClient.invalidateQueries(
-        placementGroupQueries.placementGroup(placementGroupId).queryKey
-      );
+      queryClient.invalidateQueries({
+        queryKey: placementGroupQueries.paginated._def,
+      });
+      queryClient.invalidateQueries({
+        queryKey: placementGroupQueries.all._def,
+      });
+      queryClient.invalidateQueries({
+        queryKey: placementGroupQueries.placementGroup(placementGroupId)
+          .queryKey,
+      });
 
       queryClient.invalidateQueries(linodeQueries.linodes);
 
@@ -177,11 +196,16 @@ export const useUnassignLinodesFromPlacementGroup = (
     mutationFn: (req) =>
       unassignLinodesFromPlacementGroup(placementGroupId, req),
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries(placementGroupQueries.paginated._def);
-      queryClient.invalidateQueries(placementGroupQueries.all._def);
-      queryClient.invalidateQueries(
-        placementGroupQueries.placementGroup(placementGroupId).queryKey
-      );
+      queryClient.invalidateQueries({
+        queryKey: placementGroupQueries.paginated._def,
+      });
+      queryClient.invalidateQueries({
+        queryKey: placementGroupQueries.all._def,
+      });
+      queryClient.invalidateQueries({
+        queryKey: placementGroupQueries.placementGroup(placementGroupId)
+          .queryKey,
+      });
 
       queryClient.invalidateQueries(linodeQueries.linodes);
 

--- a/packages/manager/src/queries/profile/profile.ts
+++ b/packages/manager/src/queries/profile/profile.ts
@@ -152,9 +152,13 @@ export const useCreateSSHKeyMutation = () => {
   return useMutation<SSHKey, APIError[], { label: string; ssh_key: string }>({
     mutationFn: createSSHKey,
     onSuccess() {
-      queryClient.invalidateQueries(profileQueries.sshKeys._def);
+      queryClient.invalidateQueries({
+        queryKey: profileQueries.sshKeys._def,
+      });
       // also invalidate the /account/users data because that endpoint returns some SSH key data
-      queryClient.invalidateQueries(accountQueries.users._ctx.paginated._def);
+      queryClient.invalidateQueries({
+        queryKey: accountQueries.users._ctx.paginated._def,
+      });
     },
   });
 };
@@ -164,9 +168,13 @@ export const useUpdateSSHKeyMutation = (id: number) => {
   return useMutation<SSHKey, APIError[], { label: string }>({
     mutationFn: (data) => updateSSHKey(id, data),
     onSuccess() {
-      queryClient.invalidateQueries(profileQueries.sshKeys._def);
+      queryClient.invalidateQueries({
+        queryKey: profileQueries.sshKeys._def,
+      });
       // also invalidate the /account/users data because that endpoint returns some SSH key data
-      queryClient.invalidateQueries(accountQueries.users._ctx.paginated._def);
+      queryClient.invalidateQueries({
+        queryKey: accountQueries.users._ctx.paginated._def,
+      });
     },
   });
 };
@@ -176,9 +184,13 @@ export const useDeleteSSHKeyMutation = (id: number) => {
   return useMutation<{}, APIError[]>({
     mutationFn: () => deleteSSHKey(id),
     onSuccess() {
-      queryClient.invalidateQueries(profileQueries.sshKeys._def);
+      queryClient.invalidateQueries({
+        queryKey: profileQueries.sshKeys._def,
+      });
       // also invalidate the /account/users data because that endpoint returns some SSH key data
-      queryClient.invalidateQueries(accountQueries.users._ctx.paginated._def);
+      queryClient.invalidateQueries({
+        queryKey: accountQueries.users._ctx.paginated._def,
+      });
     },
   });
 };
@@ -187,9 +199,13 @@ export const sshKeyEventHandler = (event: EventHandlerData) => {
   // This event handler is a bit agressive and will over-fetch, but UX will
   // be great because this will ensure Cloud has up to date data all the time.
 
-  event.queryClient.invalidateQueries(profileQueries.sshKeys._def);
+  event.queryClient.invalidateQueries({
+    queryKey: profileQueries.sshKeys._def,
+  });
   // also invalidate the /account/users data because that endpoint returns some SSH key data
-  event.queryClient.invalidateQueries(accountQueries.users._ctx.paginated._def);
+  event.queryClient.invalidateQueries({
+    queryKey: accountQueries.users._ctx.paginated._def,
+  });
 };
 
 export const useTrustedDevicesQuery = (params?: Params, filter?: Filter) =>
@@ -203,7 +219,9 @@ export const useRevokeTrustedDeviceMutation = (id: number) => {
   return useMutation<{}, APIError[]>({
     mutationFn: () => deleteTrustedDevice(id),
     onSuccess() {
-      queryClient.invalidateQueries(profileQueries.trustedDevices._def);
+      queryClient.invalidateQueries({
+        queryKey: profileQueries.trustedDevices._def,
+      });
     },
   });
 };
@@ -213,9 +231,13 @@ export const useDisableTwoFactorMutation = () => {
   return useMutation<{}, APIError[]>({
     mutationFn: disableTwoFactor,
     onSuccess() {
-      queryClient.invalidateQueries(profileQueries.profile().queryKey);
+      queryClient.invalidateQueries({
+        queryKey: profileQueries.profile().queryKey,
+      });
       // also invalidate the /account/users data because that endpoint returns 2FA status for each user
-      queryClient.invalidateQueries(accountQueries.users._ctx.paginated._def);
+      queryClient.invalidateQueries({
+        queryKey: accountQueries.users._ctx.paginated._def,
+      });
     },
   });
 };

--- a/packages/manager/src/queries/profile/tokens.ts
+++ b/packages/manager/src/queries/profile/tokens.ts
@@ -40,8 +40,10 @@ export const useCreatePersonalAccessTokenMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<Token, APIError[], TokenRequest>({
     mutationFn: createPersonalAccessToken,
-    onSuccess: () => {
-      queryClient.invalidateQueries(profileQueries.personalAccessTokens._def);
+    onSuccess() {
+      queryClient.invalidateQueries({
+        queryKey: profileQueries.personalAccessTokens._def,
+      });
     },
   });
 };
@@ -50,8 +52,10 @@ export const useUpdatePersonalAccessTokenMutation = (id: number) => {
   const queryClient = useQueryClient();
   return useMutation<Token, APIError[], Partial<TokenRequest>>({
     mutationFn: (data) => updatePersonalAccessToken(id, data),
-    onSuccess: () => {
-      queryClient.invalidateQueries(profileQueries.personalAccessTokens._def);
+    onSuccess() {
+      queryClient.invalidateQueries({
+        queryKey: profileQueries.personalAccessTokens._def,
+      });
     },
   });
 };
@@ -62,7 +66,9 @@ export const useRevokePersonalAccessTokenMutation = (id: number) => {
     onSuccess() {
       // Wait 1 second to invalidate cache after deletion because API needs time
       setTimeout(() => {
-        queryClient.invalidateQueries(profileQueries.personalAccessTokens._def);
+        queryClient.invalidateQueries({
+          queryKey: profileQueries.personalAccessTokens._def,
+        });
       }, 1000);
     },
   });
@@ -74,7 +80,10 @@ export const useRevokeAppAccessTokenMutation = (id: number) => {
     onSuccess() {
       // Wait 1 second to invalidate cache after deletion because API needs time
       setTimeout(
-        () => queryClient.invalidateQueries(profileQueries.appTokens._def),
+        () =>
+          queryClient.invalidateQueries({
+            queryKey: profileQueries.appTokens._def,
+          }),
         1000
       );
     },
@@ -82,6 +91,10 @@ export const useRevokeAppAccessTokenMutation = (id: number) => {
 };
 
 export function tokenEventHandler({ queryClient }: EventHandlerData) {
-  queryClient.invalidateQueries(profileQueries.appTokens._def);
-  queryClient.invalidateQueries(profileQueries.personalAccessTokens._def);
+  queryClient.invalidateQueries({
+    queryKey: profileQueries.appTokens._def,
+  });
+  queryClient.invalidateQueries({
+    queryKey: profileQueries.personalAccessTokens._def,
+  });
 }

--- a/packages/manager/src/queries/stackscripts.ts
+++ b/packages/manager/src/queries/stackscripts.ts
@@ -71,12 +71,14 @@ export const stackScriptEventHandler = ({
   queryClient,
 }: EventHandlerData) => {
   // Keep the infinite store up to date
-  queryClient.invalidateQueries(stackscriptQueries.infinite._def);
+  queryClient.invalidateQueries({
+    queryKey: stackscriptQueries.infinite._def,
+  });
 
   // If the event has a StackScript entity attached, invalidate it
   if (event.entity?.id) {
-    queryClient.invalidateQueries(
-      stackscriptQueries.stackscript(event.entity.id).queryKey
-    );
+    queryClient.invalidateQueries({
+      queryKey: stackscriptQueries.stackscript(event.entity.id).queryKey,
+    });
   }
 };

--- a/packages/manager/src/queries/vpcs/vpcs.ts
+++ b/packages/manager/src/queries/vpcs/vpcs.ts
@@ -87,10 +87,14 @@ export const useCreateVPCMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<VPC, APIError[], CreateVPCPayload>({
     mutationFn: createVPC,
-    onSuccess: (VPC) => {
-      queryClient.invalidateQueries(vpcQueries.all.queryKey);
-      queryClient.invalidateQueries(vpcQueries.paginated._def);
-      queryClient.setQueryData(vpcQueries.vpc(VPC.id).queryKey, VPC);
+    onSuccess(vpc) {
+      queryClient.invalidateQueries({
+        queryKey: vpcQueries.all.queryKey,
+      });
+      queryClient.invalidateQueries({
+        queryKey: vpcQueries.paginated._def,
+      });
+      queryClient.setQueryData<VPC>(vpcQueries.vpc(vpc.id).queryKey, vpc);
     },
   });
 };
@@ -99,9 +103,11 @@ export const useUpdateVPCMutation = (id: number) => {
   const queryClient = useQueryClient();
   return useMutation<VPC, APIError[], UpdateVPCPayload>({
     mutationFn: (data) => updateVPC(id, data),
-    onSuccess: (VPC) => {
-      queryClient.invalidateQueries(vpcQueries.paginated._def);
-      queryClient.setQueryData<VPC>(vpcQueries.vpc(VPC.id).queryKey, VPC);
+    onSuccess(vpc) {
+      queryClient.invalidateQueries({
+        queryKey: vpcQueries.paginated._def,
+      });
+      queryClient.setQueryData<VPC>(vpcQueries.vpc(vpc.id).queryKey, vpc);
     },
   });
 };
@@ -110,9 +116,13 @@ export const useDeleteVPCMutation = (id: number) => {
   const queryClient = useQueryClient();
   return useMutation<{}, APIError[]>({
     mutationFn: () => deleteVPC(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries(vpcQueries.all.queryKey);
-      queryClient.invalidateQueries(vpcQueries.paginated._def);
+    onSuccess() {
+      queryClient.invalidateQueries({
+        queryKey: vpcQueries.all.queryKey,
+      });
+      queryClient.invalidateQueries({
+        queryKey: vpcQueries.paginated._def,
+      });
       queryClient.removeQueries(vpcQueries.vpc(id).queryKey);
     },
   });
@@ -135,14 +145,17 @@ export const useCreateSubnetMutation = (vpcId: number) => {
   const queryClient = useQueryClient();
   return useMutation<Subnet, APIError[], CreateSubnetPayload>({
     mutationFn: (data) => createSubnet(vpcId, data),
-    onSuccess: () => {
+    onSuccess() {
       // New subnet created --> refresh the VPC queries (all, paginated, & individual), plus the /subnets VPC query
-      queryClient.invalidateQueries(vpcQueries.all.queryKey);
-      queryClient.invalidateQueries(vpcQueries.paginated._def);
-      queryClient.invalidateQueries(vpcQueries.vpc(vpcId).queryKey);
-      queryClient.invalidateQueries(
-        vpcQueries.vpc(vpcId)._ctx.subnets.queryKey
-      );
+      queryClient.invalidateQueries({
+        queryKey: vpcQueries.all.queryKey,
+      });
+      queryClient.invalidateQueries({
+        queryKey: vpcQueries.paginated._def,
+      });
+      queryClient.invalidateQueries({
+        queryKey: vpcQueries.vpc(vpcId).queryKey,
+      });
     },
   });
 };
@@ -151,14 +164,17 @@ export const useUpdateSubnetMutation = (vpcId: number, subnetId: number) => {
   const queryClient = useQueryClient();
   return useMutation<Subnet, APIError[], ModifySubnetPayload>({
     mutationFn: (data) => modifySubnet(vpcId, subnetId, data),
-    onSuccess: () => {
+    onSuccess() {
       // New subnet created --> refresh the VPC queries (all, paginated, & individual), plus the /subnets VPC query
-      queryClient.invalidateQueries(vpcQueries.all.queryKey);
-      queryClient.invalidateQueries(vpcQueries.paginated._def);
-      queryClient.invalidateQueries(vpcQueries.vpc(vpcId).queryKey);
-      queryClient.invalidateQueries(
-        vpcQueries.vpc(vpcId)._ctx.subnets.queryKey
-      );
+      queryClient.invalidateQueries({
+        queryKey: vpcQueries.all.queryKey,
+      });
+      queryClient.invalidateQueries({
+        queryKey: vpcQueries.paginated._def,
+      });
+      queryClient.invalidateQueries({
+        queryKey: vpcQueries.vpc(vpcId).queryKey,
+      });
     },
   });
 };
@@ -167,14 +183,17 @@ export const useDeleteSubnetMutation = (vpcId: number, subnetId: number) => {
   const queryClient = useQueryClient();
   return useMutation<{}, APIError[]>({
     mutationFn: () => deleteSubnet(vpcId, subnetId),
-    onSuccess: () => {
+    onSuccess() {
       // New subnet created --> refresh the VPC queries (all, paginated, & individual), plus the /subnets VPC query
-      queryClient.invalidateQueries(vpcQueries.all.queryKey);
-      queryClient.invalidateQueries(vpcQueries.paginated._def);
-      queryClient.invalidateQueries(vpcQueries.vpc(vpcId).queryKey);
-      queryClient.invalidateQueries(
-        vpcQueries.vpc(vpcId)._ctx.subnets.queryKey
-      );
+      queryClient.invalidateQueries({
+        queryKey: vpcQueries.all.queryKey,
+      });
+      queryClient.invalidateQueries({
+        queryKey: vpcQueries.paginated._def,
+      });
+      queryClient.invalidateQueries({
+        queryKey: vpcQueries.vpc(vpcId).queryKey,
+      });
     },
   });
 };


### PR DESCRIPTION
## Description 📝

- Just a simple PR to continue to prepare for React Query v4 to v5 📦 
- The PR migrates to the "[single object notation](https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5#supports-a-single-signature-one-object)" so there is less to fix when we finally bump the version 🔄

## How to test 🧪

- Verify all automated testing passes ✅ 
- Check the diff for mistakes 👀 
- Most changes are find/replace, but I'll self review anything that is more complicated than that

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support