### PR TITLE
upcoming: [DI-16642] - Enable ACLP to be shown based on account capabilities

### DIFF
--- a/packages/api-v4/.changeset/pr-10768-upcoming-features-1723463731514.md
+++ b/packages/api-v4/.changeset/pr-10768-upcoming-features-1723463731514.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Upcoming Features
+---
+
+Add 'Akamai Cloud Pulse' in AccountCapability type interface ([#10768](https://github.com/linode/manager/pull/10768))

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -61,6 +61,7 @@ export type BillingSource = 'linode' | 'akamai';
 
 export type AccountCapability =
   | 'Akamai Cloud Load Balancer'
+  | 'Akamai Cloud Pulse'
   | 'Block Storage'
   | 'Block Storage Encryption'
   | 'Cloud Firewall'

--- a/packages/manager/.changeset/pr-10768-upcoming-features-1723464477834.md
+++ b/packages/manager/.changeset/pr-10768-upcoming-features-1723464477834.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Use useIsACLPEnabled function to check aclp enable  ([#10768](https://github.com/linode/manager/pull/10768))

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -8,8 +8,8 @@ import { Box } from 'src/components/Box';
 import { MainContentBanner } from 'src/components/MainContentBanner';
 import { MaintenanceScreen } from 'src/components/MaintenanceScreen';
 import { NotFound } from 'src/components/NotFound';
-import { SIDEBAR_WIDTH } from 'src/components/PrimaryNav/SideMenu';
 import { SideMenu } from 'src/components/PrimaryNav/SideMenu';
+import { SIDEBAR_WIDTH } from 'src/components/PrimaryNav/SideMenu';
 import { SuspenseLoader } from 'src/components/SuspenseLoader';
 import { useDialogContext } from 'src/context/useDialogContext';
 import { Footer } from 'src/features/Footer';
@@ -29,6 +29,7 @@ import { ENABLE_MAINTENANCE_MODE } from './constants';
 import { complianceUpdateContext } from './context/complianceUpdateContext';
 import { sessionExpirationContext } from './context/sessionExpirationContext';
 import { switchAccountSessionContext } from './context/switchAccountSessionContext';
+import { useIsACLPEnabled } from './features/CloudPulse/Utils/utils';
 import { useIsDatabasesEnabled } from './features/Databases/utilities';
 import { useIsPlacementGroupsEnabled } from './features/PlacementGroups/utils';
 import { useGlobalErrors } from './hooks/useGlobalErrors';
@@ -226,9 +227,7 @@ export const MainContent = () => {
   const { data: accountSettings } = useAccountSettings();
   const defaultRoot = accountSettings?.managed ? '/managed' : '/linodes';
 
-  const showCloudPulse = Boolean(flags.aclp?.enabled);
-  // the followed comment is for later use, the showCloudPulse will be removed and isACLPEnabled will be used
-  // const { isACLPEnabled } = useIsACLPEnabled();
+  const { isACLPEnabled } = useIsACLPEnabled();
 
   /**
    * this is the case where the user has successfully completed signup
@@ -357,7 +356,7 @@ export const MainContent = () => {
                             <Route component={BetaRoutes} path="/betas" />
                           )}
                           <Route component={VPC} path="/vpcs" />
-                          {showCloudPulse && (
+                          {isACLPEnabled && (
                             <Route
                               component={CloudPulse}
                               path="/monitor/cloudpulse"

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { accountFactory } from 'src/factories';
-import * as flags from 'src/hooks/useFlags';
 import { HttpResponse, http, server } from 'src/mocks/testServer';
 import { queryClientFactory } from 'src/queries/base';
 import { renderWithTheme, wrapWithTheme } from 'src/utilities/testHelpers';

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -84,14 +84,16 @@ describe('PrimaryNav', () => {
       })
     );
 
-    vi.spyOn(flags, 'useFlags').mockReturnValue({
+    const flags = {
       aclp: {
         beta: false,
         enabled: true,
       },
-    });
+    };
 
-    const { findByText } = renderWithTheme(<PrimaryNav {...props} />);
+    const { findByText } = renderWithTheme(<PrimaryNav {...props} />, {
+      flags,
+    });
 
     const monitorNavItem = await findByText('Monitor');
 

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { accountFactory } from 'src/factories';
+import * as flags from 'src/hooks/useFlags';
 import { HttpResponse, http, server } from 'src/mocks/testServer';
 import { queryClientFactory } from 'src/queries/base';
 import { renderWithTheme, wrapWithTheme } from 'src/utilities/testHelpers';
@@ -70,5 +71,30 @@ describe('PrimaryNav', () => {
     const databaseNavItem = await findByText('Databases');
 
     expect(databaseNavItem).toBeVisible();
+  });
+
+  it('should show Monitor menu item if the user has the account capability', async () => {
+    const account = accountFactory.build({
+      capabilities: ['Akamai Cloud Pulse'],
+    });
+
+    server.use(
+      http.get('*/account', () => {
+        return HttpResponse.json(account);
+      })
+    );
+
+    vi.spyOn(flags, 'useFlags').mockReturnValue({
+      aclp: {
+        beta: false,
+        enabled: true,
+      },
+    });
+
+    const { findByText } = renderWithTheme(<PrimaryNav {...props} />);
+
+    const monitorNavItem = await findByText('Monitor');
+
+    expect(monitorNavItem).toBeVisible();
   });
 });

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -25,6 +25,7 @@ import AkamaiLogo from 'src/assets/logo/akamai-logo.svg';
 import { BetaChip } from 'src/components/BetaChip/BetaChip';
 import { Box } from 'src/components/Box';
 import { Divider } from 'src/components/Divider';
+import { useIsACLPEnabled } from 'src/features/CloudPulse/Utils/utils';
 import { useIsDatabasesEnabled } from 'src/features/Databases/utilities';
 import { useIsPlacementGroupsEnabled } from 'src/features/PlacementGroups/utils';
 import { useFlags } from 'src/hooks/useFlags';
@@ -104,9 +105,7 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
   const allowMarketplacePrefetch =
     !oneClickApps && !oneClickAppsLoading && !oneClickAppsError;
 
-  const showCloudPulse = Boolean(flags.aclp?.enabled);
-  // the followed comment is for later use, the showCloudPulse will be removed and isACLPEnabled will be used
-  // const { isACLPEnabled } = useIsACLPEnabled();
+  const { isACLPEnabled } = useIsACLPEnabled();
 
   const { isPlacementGroupsEnabled } = useIsPlacementGroupsEnabled();
   const { isDatabasesEnabled } = useIsDatabasesEnabled();
@@ -212,7 +211,7 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
         },
         {
           display: 'Monitor',
-          hide: !showCloudPulse,
+          hide: !isACLPEnabled,
           href: '/monitor/cloudpulse',
           icon: <CloudPulse />,
           isBeta: flags.aclp?.beta,
@@ -253,7 +252,7 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
       flags.databaseBeta,
       isPlacementGroupsEnabled,
       flags.placementGroups,
-      showCloudPulse,
+      isACLPEnabled,
     ]
   );
 
@@ -307,7 +306,6 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
         return (
           <div key={idx}>
             <Divider
-              spacingTop={isManaged ? (idx === 0 ? 0 : 11) : idx === 1 ? 0 : 11}
               sx={(theme) => ({
                 borderColor:
                   theme.name === 'light'
@@ -316,6 +314,7 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
               })}
               className={classes.divider}
               spacingBottom={11}
+              spacingTop={isManaged ? (idx === 0 ? 0 : 11) : idx === 1 ? 0 : 11}
             />
             {filteredLinks.map((thisLink) => {
               const props = {

--- a/packages/manager/src/factories/account.ts
+++ b/packages/manager/src/factories/account.ts
@@ -37,6 +37,7 @@ export const accountFactory = Factory.Sync.makeFactory<Account>({
   balance_uninvoiced: 0.0,
   billing_source: 'linode',
   capabilities: [
+    'Akamai Cloud Pulse',
     'Block Storage',
     'Cloud Firewall',
     'Disk Encryption',

--- a/packages/manager/src/features/CloudPulse/Utils/utils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/utils.ts
@@ -1,6 +1,7 @@
 import { convertData } from 'src/features/Longview/shared/formatters';
 import { useFlags } from 'src/hooks/useFlags';
 import { useAccount } from 'src/queries/account/account';
+import { isFeatureEnabledV2 } from 'src/utilities/accountCapabilities';
 
 import type { TimeDuration } from '@linode/api-v4';
 import type {
@@ -22,10 +23,11 @@ export const useIsACLPEnabled = (): {
     return { isACLPEnabled: false };
   }
 
-  const hasAccountCapability = account?.capabilities?.includes('CloudPulse');
-  const isFeatureFlagEnabled = flags.aclp?.enabled;
-
-  const isACLPEnabled = Boolean(hasAccountCapability && isFeatureFlagEnabled);
+  const isACLPEnabled = isFeatureEnabledV2(
+    'Akamai Cloud Pulse',
+    Boolean(flags.aclp?.enabled),
+    account?.capabilities ?? []
+  );
 
   return { isACLPEnabled };
 };


### PR DESCRIPTION
## Description 📝
Added account capabilities check for user to restrict access to Cloud Pulse page.

## Changes  🔄
List any change relevant to the reviewer.
1. Modified AccountCapability to add 'Akamai Cloud Pulse' key.
2. Modified PrimaryNav.tsx & MainContent.tsx to check ACLP enabled based on feature flag & account capability

## Target release date 🗓️
20 August 2024

## Preview 📷
**Include a screenshot or screen recording of the change**

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
|![Screenshot 2024-08-12 at 4 55 11 PM](https://github.com/user-attachments/assets/9deac601-4282-4679-90cb-2ae2b4952c53)|![Screenshot 2024-08-12 at 4 55 27 PM](https://github.com/user-attachments/assets/050e46f4-38f6-44a4-aa72-6dca968aea99)|


## How to test 🧪
You can switch between mock user & normal user and visualize the difference


*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

