### PR TITLE
fix: [M3-7324] - LKE Cluster Create Tab Selection Reset Upon Adding Pool

### DIFF
--- a/packages/manager/.changeset/pr-10772-fixed-1723476789978.md
+++ b/packages/manager/.changeset/pr-10772-fixed-1723476789978.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+LKE Cluster Create tab selection reset upon adding pool ([#10772](https://github.com/linode/manager/pull/10772))

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -76,16 +76,12 @@ const Panel = (props: NodePoolPanelProps) => {
 
   const extendedTypes = types.map(extendType);
 
-  const submitForm = (selectedPlanType: string, nodeCount: number) => {
-    /**
-     * Add pool and reset form state.
-     */
+  const addPlan = (selectedPlanType: string, nodeCount: number) => {
     addNodePool({
       count: nodeCount,
       id: Math.random(),
       type: selectedPlanType,
     });
-    setSelectedType(undefined);
   };
 
   const updatePlanCount = (planId: string, newCount: number) => {
@@ -119,7 +115,7 @@ const Panel = (props: NodePoolPanelProps) => {
           header="Add Node Pools"
           isPlanPanelDisabled={isPlanPanelDisabled}
           isSelectedRegionEligibleForPlan={isSelectedRegionEligibleForPlan}
-          onAdd={submitForm}
+          onAdd={addPlan}
           onSelect={(newType: string) => setSelectedType(newType)}
           regionsData={regionsData}
           resetValues={() => null} // In this flow we don't want to clear things on tab changes

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -76,7 +76,7 @@ const Panel = (props: NodePoolPanelProps) => {
 
   const extendedTypes = types.map(extendType);
 
-  const addPlan = (selectedPlanType: string, nodeCount: number) => {
+  const addPool = (selectedPlanType: string, nodeCount: number) => {
     addNodePool({
       count: nodeCount,
       id: Math.random(),
@@ -115,7 +115,7 @@ const Panel = (props: NodePoolPanelProps) => {
           header="Add Node Pools"
           isPlanPanelDisabled={isPlanPanelDisabled}
           isSelectedRegionEligibleForPlan={isSelectedRegionEligibleForPlan}
-          onAdd={addPlan}
+          onAdd={addPool}
           onSelect={(newType: string) => setSelectedType(newType)}
           regionsData={regionsData}
           resetValues={() => null} // In this flow we don't want to clear things on tab changes


### PR DESCRIPTION
## Description 📝
When creating an LKE cluster, if you add a node pool under the "Shared CPU", "High Memory", or "Premium CPU" tab, in some cases Cloud will erroneously reset the user's tab selection back to the "Dedicated CPU" tab.

This only occurs when the node pool size has been modified using the - and + buttons (or by typing in a different value) prior to adding the node pool. If you add a node pool of the default size (3) without first modifying the value, the tab selection does not change.

## Changes  🔄
List any change relevant to the reviewer.
- Remove `setSelectedType(undefined)` to prevent tab reset after adding a node pool.
- Change the function name from `submitForm` to `addPool` for clarity.

## Target release date 🗓️
8/19

## How to test 🧪

### Reproduction steps
1. Navigate to the LKE cluster create page at /kubernetes/create
2. Select a region
3. Click on the "Shared CPU" tab, add a node pool without modifying the size
4. Observe that upon adding the node pool, the "Shared CPU" tab remains selected
5. Click on the "Shared CPU" tab again, modify a node pool size, and then add the node pool
6. Observe that upon adding the node pool, the "Dedicated CPU" tab becomes selected

### Verification steps
- Upon adding a node pool, the tab which is selected should always remain selected.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support