### PR TITLE
fix: [M3-8213] - Use correct spelling of Ukrainian capital

### DIFF
--- a/packages/manager/.changeset/pr-10777-fixed-1723516402764.md
+++ b/packages/manager/.changeset/pr-10777-fixed-1723516402764.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Incorrect spelling of Ukraine's capital ([#10777](https://github.com/linode/manager/pull/10777))

--- a/packages/manager/cypress/e2e/core/billing/smoke-billing-activity.spec.ts
+++ b/packages/manager/cypress/e2e/core/billing/smoke-billing-activity.spec.ts
@@ -328,7 +328,7 @@ describe('Billing Activity Feed', () => {
     const timeZonesList = [
       { key: 'America/New_York', human: 'Eastern Time - New York' },
       { key: 'GMT', human: 'Coordinated Universal Time' },
-      { key: 'Asia/Honk_Kong', human: 'Hong Kong Standard Time' },
+      { key: 'Asia/Hong_Kong', human: 'Hong Kong Standard Time' },
     ];
 
     const mockProfile = profileFactory.build();

--- a/packages/manager/src/assets/timezones/timezones.ts
+++ b/packages/manager/src/assets/timezones/timezones.ts
@@ -1031,8 +1031,8 @@ export default [
     offset: 2,
   },
   {
-    label: 'Eastern European Time - Kiev',
-    name: 'Europe/Kiev',
+    label: 'Eastern European Time - Kyiv',
+    name: 'Europe/Kyiv',
     offset: 2,
   },
   {


### PR DESCRIPTION
## Description 📝
Kyiv is the correct name and direct translation from Ukrainian language.

## Changes  🔄
- Corrects `Kiev` to `Kyiv` in `timezones.ts`, which populates the Profile timezone selector.
- Corrects timezone-related typo (this one non-customer-facing) in `smoke-billing-activity.spec.ts` - I just happened to notice this.

## Target release date 🗓️
8/19

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![before](https://github.com/user-attachments/assets/1a2197af-7ee1-4097-8dc5-acf28fd197eb) | ![after](https://github.com/user-attachments/assets/516cea11-90ce-4ae5-b93e-27c266fe45f4) |

## How to test 🧪

### Reproduction steps
(How to reproduce the issue, if applicable)
- Go to https://cloud.linode.com/profile/display.
- In the timezone selector, search 'Kiev' and observe the incorrect spelling.

### Verification steps
(How to verify changes)
- Check out this PR.
- Go to http://localhost:3000/profile/display.
- In the timezone selector, search 'Kiev' and observe no result. Then search `Kyiv` and confirm it is a result for (`GMT +3:00 Eastern European Time`).

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
