### PR TITLE
change: [OCA-1411] - Use Passbolt CE full name

### DIFF
--- a/packages/manager/.changeset/pr-10778-changed-1723563275697.md
+++ b/packages/manager/.changeset/pr-10778-changed-1723563275697.md
@@ -2,4 +2,4 @@
 "@linode/manager": Changed
 ---
 
-updates Passbolt CE naming ([#10778](https://github.com/linode/manager/pull/10778))
+Update Passbolt CE naming in Marketplace ([#10778](https://github.com/linode/manager/pull/10778))

--- a/packages/manager/.changeset/pr-10778-changed-1723563275697.md
+++ b/packages/manager/.changeset/pr-10778-changed-1723563275697.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+updates Passbolt CE naming ([#10778](https://github.com/linode/manager/pull/10778))

--- a/packages/manager/src/features/OneClickApps/oneClickAppsv2.ts
+++ b/packages/manager/src/features/OneClickApps/oneClickAppsv2.ts
@@ -2370,21 +2370,22 @@ export const oneClickApps: Record<number, OCA> = {
     website: 'https://nats.io',
   },
   1329430: {
-    alt_description: 'Password Manager',
-    alt_name: 'Passbolt',
+    alt_description: 'Open Source Secrets Manager',
+    alt_name: 'Passbolt CE',
     categories: ['Security'],
     colors: {
       end: 'D40101',
       start: '171717',
     },
-    description: `Passbolt is an open-source password manager designed for teams and businesses. It allows users to securely store, share and manage passwords.`,
+    description: `Passbolt Community Edition is an open-source password manager designed for teams and businesses. It allows users to securely store, share and manage passwords.`,
     logo_url: 'passbolt.svg',
-    name: 'Passbolt',
+    name: 'Passbolt Community Edition',
     related_guides: [
       {
         href:
           'https://www.linode.com/docs/products/tools/marketplace/guides/passbolt/',
-        title: 'Deploy Passbolt through the Linode Marketplace',
+        title:
+          'Deploy Passbolt Community Edition through the Linode Marketplace',
       },
     ],
     summary: 'Open-source password manager for teams and businesses.',

--- a/packages/manager/src/features/OneClickApps/oneClickAppsv2.ts
+++ b/packages/manager/src/features/OneClickApps/oneClickAppsv2.ts
@@ -2369,7 +2369,7 @@ export const oneClickApps: Record<number, OCA> = {
     summary: 'Cloud native application messaging service.',
     website: 'https://nats.io',
   },
-  1329430: {
+  1439640: {
     alt_description: 'Open Source Secrets Manager',
     alt_name: 'Passbolt CE',
     categories: ['Security'],


### PR DESCRIPTION
## Description 📝
Updates Passbolt Community Edition Marketplace App naming to better comply with brand/trademark guidelines.

## Changes  🔄
List any change relevant to the reviewer.
- Adds full text 'Passbolt Community Edition'

## Target release date 🗓️
8/19/24