### PR TITLE
fix: [M3-8443] - Enabled login history for unrestricted child accounts

### DIFF
--- a/packages/manager/.changeset/pr-10779-fixed-1723593549058.md
+++ b/packages/manager/.changeset/pr-10779-fixed-1723593549058.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Enabled login history for unrestricted child accounts ([#10779](https://github.com/linode/manager/pull/10779))

--- a/packages/manager/cypress/e2e/core/account/account-login-history.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/account-login-history.spec.ts
@@ -90,13 +90,13 @@ describe('Account login history', () => {
 
   /**
    * - Confirms that a child user can navigate to the Login History page.
-   * - Confirms that a child user cannot see login history data.
+   * - Confirms that a restricted child user cannot see login history data.
    * - Confirms that a child user sees a notice instead.
    */
-  it('child users cannot view login history', () => {
+  it('restricted child users cannot view login history', () => {
     const mockProfile = profileFactory.build({
       username: 'mock-child-user',
-      restricted: false,
+      restricted: true,
       user_type: 'child',
     });
 
@@ -113,6 +113,29 @@ describe('Account login history', () => {
     cy.findByText(
       `You don't have permissions to edit this Account. Please contact your ${PARENT_USER} to request the necessary permissions.`
     );
+  });
+
+  /**
+   * - Confirms that a child user can navigate to the Login History page.
+   * - Confirms that a restricted child user cannot see login history data.
+   * - Confirms that a child user sees a notice instead.
+   */
+  it('Unrestricted child users can view login history', () => {
+    const mockProfile = profileFactory.build({
+      username: 'mock-child-user',
+      restricted: false,
+      user_type: 'child',
+    });
+
+    mockGetProfile(mockProfile).as('getProfile');
+
+    // Navigate to Account Login History page.
+    cy.visitWithLogin('/account/login-history');
+    cy.wait(['@getProfile']);
+
+    // Confirm helper text above table and table are not visible.
+    cy.findByText(loginHelperText).should('exist');
+    cy.findByLabelText('Account Logins').should('exist');
   });
 
   /**

--- a/packages/manager/cypress/e2e/core/account/account-login-history.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/account-login-history.spec.ts
@@ -119,7 +119,7 @@ describe('Account login history', () => {
    * - Confirms that a child user can navigate to the Login History page.
    * - Confirms that a unrestricted child user can see login history data.
    */
-  it('Unrestricted child users can view login history', () => {
+  it('unrestricted child users can view login history', () => {
     const mockProfile = profileFactory.build({
       username: 'mock-child-user',
       restricted: false,

--- a/packages/manager/cypress/e2e/core/account/account-login-history.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/account-login-history.spec.ts
@@ -117,8 +117,7 @@ describe('Account login history', () => {
 
   /**
    * - Confirms that a child user can navigate to the Login History page.
-   * - Confirms that a restricted child user cannot see login history data.
-   * - Confirms that a child user sees a notice instead.
+   * - Confirms that a unrestricted child user can see login history data.
    */
   it('Unrestricted child users can view login history', () => {
     const mockProfile = profileFactory.build({

--- a/packages/manager/src/features/Account/AccountLogins.tsx
+++ b/packages/manager/src/features/Account/AccountLogins.tsx
@@ -1,5 +1,3 @@
-import { AccountLogin } from '@linode/api-v4/lib/account/types';
-import { Theme } from '@mui/material/styles';
 import * as React from 'react';
 import { makeStyles } from 'tss-react/mui';
 
@@ -23,6 +21,9 @@ import { useProfile } from 'src/queries/profile/profile';
 
 import AccountLoginsTableRow from './AccountLoginsTableRow';
 import { getRestrictedResourceText } from './utils';
+
+import type { AccountLogin } from '@linode/api-v4/lib/account/types';
+import type { Theme } from '@mui/material/styles';
 
 const preferenceKey = 'account-logins';
 
@@ -66,10 +67,7 @@ const AccountLogins = () => {
   );
   const { data: profile } = useProfile();
   const isChildUser = profile?.user_type === 'child';
-
-  const isRestrictedChildUser = Boolean(isChildUser);
-  const isAccountAccessRestricted =
-    isRestrictedChildUser || profile?.restricted;
+  const isAccountAccessRestricted = profile?.restricted;
 
   const renderTableContent = () => {
     if (isLoading) {


### PR DESCRIPTION
## Description 📝
Unrestricted child accounts should be treated no different than other unrestricted accounts in that they should see login history.

## Changes  🔄
- Removed condition where we were explicitly disabling it for child users (restricted/unrestricted).

## Target release date 🗓️
❗ 8/19

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-08-13 at 9 58 14 AM](https://github.com/user-attachments/assets/737eb660-5d0c-460e-80d4-1dfd9e124cfd) | ![Screenshot 2024-08-13 at 9 56 12 AM](https://github.com/user-attachments/assets/23ad0e75-0c84-4e07-8a5f-21bd17b3f7f9) |

## How to test 🧪

### Prerequisites
- You need a child account provisioned (see me if you don't already have one)

### Reproduction steps
- Go to login history on a child account and observe that it's disabled with a warning

### Verification steps
- Pull down my branch and observe it's been restored.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support