### PR TITLE
fix: [M3-7558] - Update guide link for Secure Your Server Marketplace app

### DIFF
--- a/packages/manager/.changeset/pr-10782-fixed-1723574317048.md
+++ b/packages/manager/.changeset/pr-10782-fixed-1723574317048.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Guide link for Secure Your Server app on Marketplace ([#10782](https://github.com/linode/manager/pull/10782))

--- a/packages/manager/src/features/OneClickApps/oneClickAppsv2.ts
+++ b/packages/manager/src/features/OneClickApps/oneClickAppsv2.ts
@@ -825,7 +825,8 @@ export const oneClickApps: Record<number, OCA> = {
     name: 'Secure Your Server',
     related_guides: [
       {
-        href: 'https://www.linode.com/docs/guides/set-up-and-secure/',
+        href:
+          'https://www.linode.com/docs/products/tools/marketplace/guides/secure-your-server/',
         title: 'Securing your Server',
       },
     ],

--- a/packages/manager/src/features/OneClickApps/oneClickAppsv2.ts
+++ b/packages/manager/src/features/OneClickApps/oneClickAppsv2.ts
@@ -827,7 +827,7 @@ export const oneClickApps: Record<number, OCA> = {
       {
         href:
           'https://www.linode.com/docs/products/tools/marketplace/guides/secure-your-server/',
-        title: 'Securing your Server',
+        title: 'Secure Your Server through the Linode Marketplace',
       },
     ],
     summary: `Harden your Linode before you deploy with the Secure Your Server One-Click App.`,


### PR DESCRIPTION
## Description 📝
Fixes link for Secure Your Server app

## Target release date 🗓️
n/a

## How to test 🧪

### Reproduction steps
- Navigate to marketplace and search for "Secure Your Server" app. Link incorrectly goes to 'secure your server' guide - https://www.linode.com/docs/products/compute/compute-instances/guides/set-up-and-secure/

### Verification steps
- Confirm link for app now goes to https://www.linode.com/docs/products/tools/marketplace/guides/secure-your-server/

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
