### PR TITLE
upcoming: [M3-8369] – Add "Encrypt Volume" checkbox in Edit Volume drawer

### DIFF
--- a/packages/manager/.changeset/pr-10787-upcoming-features-1723672538179.md
+++ b/packages/manager/.changeset/pr-10787-upcoming-features-1723672538179.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add 'Encrypt Volume' checkbox in Edit Volume drawer ([#10787](https://github.com/linode/manager/pull/10787))

--- a/packages/manager/src/components/Encryption/constants.tsx
+++ b/packages/manager/src/components/Encryption/constants.tsx
@@ -95,3 +95,6 @@ export const BLOCK_STORAGE_ENCRYPTION_OVERHEAD_CAVEAT =
 
 export const BLOCK_STORAGE_USER_SIDE_ENCRYPTION_CAVEAT =
   'User-side encryption on top of encryption-enabled volumes is discouraged at this time, as it could severely impact your volume performance.';
+
+export const BLOCK_STORAGE_ENCRYPTION_SETTING_IMMUTABLE_COPY =
+  'The encryption setting cannot be changed after creation.';

--- a/packages/manager/src/features/Volumes/EditVolumeDrawer.test.tsx
+++ b/packages/manager/src/features/Volumes/EditVolumeDrawer.test.tsx
@@ -25,7 +25,7 @@ describe('EditVolumeDrawer', () => {
     );
 
     const { getByLabelText } = renderWithTheme(
-      <EditVolumeDrawer onClose={vi.fn} open={true} volume={volume} />,
+      <EditVolumeDrawer onClose={vi.fn} open volume={volume} />,
       {
         flags: { blockStorageEncryption: true },
       }
@@ -49,7 +49,7 @@ describe('EditVolumeDrawer', () => {
     );
 
     const { queryByRole } = renderWithTheme(
-      <EditVolumeDrawer onClose={vi.fn} open={true} volume={volume} />,
+      <EditVolumeDrawer onClose={vi.fn} open volume={volume} />,
       {
         flags: { blockStorageEncryption: false },
       }
@@ -70,7 +70,7 @@ describe('EditVolumeDrawer', () => {
     );
 
     const { queryByRole } = renderWithTheme(
-      <EditVolumeDrawer onClose={vi.fn} open={true} volume={volume} />,
+      <EditVolumeDrawer onClose={vi.fn} open volume={volume} />,
       {
         flags: { blockStorageEncryption: true },
       }

--- a/packages/manager/src/features/Volumes/EditVolumeDrawer.test.tsx
+++ b/packages/manager/src/features/Volumes/EditVolumeDrawer.test.tsx
@@ -1,0 +1,83 @@
+import { waitFor } from '@testing-library/react';
+import * as React from 'react';
+
+import { accountFactory, volumeFactory } from 'src/factories';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { EditVolumeDrawer } from './EditVolumeDrawer';
+
+const accountEndpoint = '*/v4/account';
+const encryptionLabelText = 'Encrypt Volume';
+
+describe('EditVolumeDrawer', () => {
+  /* @TODO BSE: Remove feature flagging/conditionality once BSE is fully rolled out */
+
+  it('should display a disabled checkbox for volume encryption if the user has the account capability and the feature flag is on', async () => {
+    const volume = volumeFactory.build();
+
+    server.use(
+      http.get(accountEndpoint, () => {
+        return HttpResponse.json(
+          accountFactory.build({ capabilities: ['Block Storage Encryption'] })
+        );
+      })
+    );
+
+    const { getByLabelText } = renderWithTheme(
+      <EditVolumeDrawer onClose={vi.fn} open={true} volume={volume} />,
+      {
+        flags: { blockStorageEncryption: true },
+      }
+    );
+
+    await waitFor(() => {
+      expect(getByLabelText(encryptionLabelText)).not.toBeNull();
+      expect(getByLabelText(encryptionLabelText)).toBeDisabled();
+    });
+  });
+
+  it('should not display a checkbox for volume encryption if the user has the account capability but the feature flag is off', async () => {
+    const volume = volumeFactory.build();
+
+    server.use(
+      http.get(accountEndpoint, () => {
+        return HttpResponse.json(
+          accountFactory.build({ capabilities: ['Block Storage Encryption'] })
+        );
+      })
+    );
+
+    const { queryByRole } = renderWithTheme(
+      <EditVolumeDrawer onClose={vi.fn} open={true} volume={volume} />,
+      {
+        flags: { blockStorageEncryption: false },
+      }
+    );
+
+    await waitFor(() => {
+      expect(queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should not display a checkbox for volume encryption if the feature flag is on but the user lacks the account capability', async () => {
+    const volume = volumeFactory.build();
+
+    server.use(
+      http.get(accountEndpoint, () => {
+        return HttpResponse.json(accountFactory.build({ capabilities: [] }));
+      })
+    );
+
+    const { queryByRole } = renderWithTheme(
+      <EditVolumeDrawer onClose={vi.fn} open={true} volume={volume} />,
+      {
+        flags: { blockStorageEncryption: true },
+      }
+    );
+
+    await waitFor(() => {
+      expect(queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/manager/src/features/Volumes/EditVolumeDrawer.tsx
+++ b/packages/manager/src/features/Volumes/EditVolumeDrawer.tsx
@@ -129,13 +129,10 @@ export const EditVolumeDrawer = (props: Props) => {
               marginLeft: '2px',
               marginTop: '16px',
             }}
-            alignItems="center"
-            display="flex"
-            flexDirection="row"
           >
             <Checkbox
               checked={volume?.encryption === 'enabled'}
-              disabled={true}
+              disabled
               text="Encrypt Volume"
               toolTipText={BLOCK_STORAGE_ENCRYPTION_SETTING_IMMUTABLE_COPY}
             />

--- a/packages/manager/src/features/Volumes/EditVolumeDrawer.tsx
+++ b/packages/manager/src/features/Volumes/EditVolumeDrawer.tsx
@@ -1,10 +1,13 @@
-import { Volume } from '@linode/api-v4';
 import { UpdateVolumeSchema } from '@linode/validation';
 import { useFormik } from 'formik';
 import React from 'react';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
+import { Box } from 'src/components/Box';
+import { Checkbox } from 'src/components/Checkbox';
 import { Drawer } from 'src/components/Drawer';
+import { BLOCK_STORAGE_ENCRYPTION_SETTING_IMMUTABLE_COPY } from 'src/components/Encryption/constants';
+import { useIsBlockStorageEncryptionFeatureEnabled } from 'src/components/Encryption/utils';
 import { Notice } from 'src/components/Notice/Notice';
 import { TagsInput } from 'src/components/TagsInput/TagsInput';
 import { TextField } from 'src/components/TextField';
@@ -14,6 +17,8 @@ import {
   handleFieldErrors,
   handleGeneralErrors,
 } from 'src/utilities/formikErrorUtils';
+
+import type { Volume } from '@linode/api-v4';
 
 interface Props {
   onClose: () => void;
@@ -27,6 +32,10 @@ export const EditVolumeDrawer = (props: Props) => {
   const { data: grants } = useGrants();
 
   const { mutateAsync: updateVolume } = useUpdateVolumeMutation();
+
+  const {
+    isBlockStorageEncryptionFeatureEnabled,
+  } = useIsBlockStorageEncryptionFeatureEnabled();
 
   const isReadOnly =
     grants !== undefined &&
@@ -114,6 +123,24 @@ export const EditVolumeDrawer = (props: Props) => {
           name="tags"
           value={values.tags?.map((t) => ({ label: t, value: t })) ?? []}
         />
+        {isBlockStorageEncryptionFeatureEnabled && (
+          <Box
+            sx={{
+              marginLeft: '2px',
+              marginTop: '16px',
+            }}
+            alignItems="center"
+            display="flex"
+            flexDirection="row"
+          >
+            <Checkbox
+              checked={volume?.encryption === 'enabled'}
+              disabled={true}
+              text="Encrypt Volume"
+              toolTipText={BLOCK_STORAGE_ENCRYPTION_SETTING_IMMUTABLE_COPY}
+            />
+          </Box>
+        )}
         <ActionsPanel
           primaryButtonProps={{
             disabled: isReadOnly || !dirty,


### PR DESCRIPTION
## Description 📝
Add a disabled "Encrypt Volume" checkbox in Edit Volume drawer that reflects the volume's encrypted status (i.e., encrypted volumes should have a checked disabled box, and unencrypted volumes should have an unchecked disabled box)

## Target release date 🗓️
9/3/24

## Preview 📷
<details>
<summary>Encrypted volume</summary>

![Screenshot 2024-08-14 at 5 47 38 PM](https://github.com/user-attachments/assets/3dbf4f66-2c15-47e9-9c86-eb983b4ee980)
</details>

<details>
<summary>Unencrypted volume</summary>

![Screenshot 2024-08-14 at 5 47 29 PM](https://github.com/user-attachments/assets/3fe56460-d189-46b7-8847-79b5f5e6b770)

</details>

## How to test 🧪
### Prerequisites
Point at the dev environment with the `blockstorage-encryption` tag on your account

### Verification steps
Confirm the Edit Volume drawer has the BSE checkbox when the feature flag is on, and that the checkbox reflects the volume's encrypted status (i.e., encrypted volumes should have a checked disabled box, and unencrypted volumes should have an unchecked disabled box)

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support