### PR TITLE
test: [M3-8098] - Refactor StackScript create test to be resilient to Image deprecations

### DIFF
--- a/packages/manager/cypress/support/intercepts/images.ts
+++ b/packages/manager/cypress/support/intercepts/images.ts
@@ -30,6 +30,15 @@ export const interceptUploadImage = (): Cypress.Chainable<null> => {
 };
 
 /**
+ * Intercepts GET request to retrieve all images.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptGetAllImages = (): Cypress.Chainable<null> => {
+  return cy.intercept('GET', apiMatcher('images*'));
+};
+
+/**
  * Intercepts GET request to retrieve all images and mocks response.
  *
  * @param images - Array of Image objects with which to mock response.


### PR DESCRIPTION
## Description 📝
Update StackScript create test to be more resilient to the changes that Images may be deprecated on the backend by using real Image data retrieved directly from the API.

## Changes  🔄
- ...
- ...

## How to test 🧪


## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
