### PR TITLE
change: [M3-8456] - Update LISH experience based on feedback

### DIFF
--- a/packages/manager/.changeset/pr-10789-changed-1724075831126.md
+++ b/packages/manager/.changeset/pr-10789-changed-1724075831126.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Open LISH in a popup window rather than a new tab ([#10789](https://github.com/linode/manager/pull/10789))

--- a/packages/manager/.changeset/pr-10789-changed-1724075913480.md
+++ b/packages/manager/.changeset/pr-10789-changed-1724075913480.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Use static number of rows in column in LISH to prevent resize and cursor positioning problems ([#10789](https://github.com/linode/manager/pull/10789))

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -82,7 +82,6 @@
     "typescript-fsa": "^3.0.0",
     "typescript-fsa-reducers": "^1.2.0",
     "@xterm/xterm": "^5.5.0",
-    "@xterm/addon-fit": "^0.10.0",
     "yup": "^0.32.9",
     "zxcvbn": "^4.4.2"
   },

--- a/packages/manager/src/features/Lish/Weblish.tsx
+++ b/packages/manager/src/features/Lish/Weblish.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable scanjs-rules/call_addEventListener */
-import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import * as React from 'react';
 
@@ -23,8 +22,6 @@ type CombinedProps = Props &
   Pick<LinodeLishData, 'weblish_url' | 'ws_protocols'>;
 
 export class Weblish extends React.Component<CombinedProps, State> {
-  fitAddon: FitAddon;
-
   mounted: boolean = false;
   socket: WebSocket;
 
@@ -113,25 +110,16 @@ export class Weblish extends React.Component<CombinedProps, State> {
     const { group, label } = linode;
 
     this.terminal = new Terminal({
+      cols: 120,
       cursorBlink: true,
       fontFamily: '"Ubuntu Mono", monospace, sans-serif',
+      rows: 40,
       screenReaderMode: true,
     });
-
-    this.fitAddon = new FitAddon();
-    this.terminal.loadAddon(this.fitAddon);
 
     this.terminal.onData((data: string) => this.socket.send(data));
     const terminalDiv = document.getElementById('terminal');
     this.terminal.open(terminalDiv as HTMLElement);
-
-    window.onresize = () => {
-      this.fitAddon.fit();
-    };
-
-    setInterval(() => {
-      this.fitAddon.fit();
-    }, 2000);
 
     this.terminal.writeln('\x1b[32mLinode Lish Console\x1b[m');
 

--- a/packages/manager/src/features/Lish/lishUtils.ts
+++ b/packages/manager/src/features/Lish/lishUtils.ts
@@ -1,6 +1,7 @@
 export const lishLaunch = (linodeId: number) => {
   window.open(
     `${window.location.protocol}//${window.location.host}/linodes/${linodeId}/lish/weblish`,
-    `weblish_con_${linodeId}`
+    `weblish_con_${linodeId}`,
+    'width=1080,height=730,toolbar=0,resizable=1'
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4789,11 +4789,6 @@
     loupe "^2.3.7"
     pretty-format "^29.7.0"
 
-"@xterm/addon-fit@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@xterm/addon-fit/-/addon-fit-0.10.0.tgz#bebf87fadd74e3af30fdcdeef47030e2592c6f55"
-  integrity sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==
-
 "@xterm/xterm@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@xterm/xterm/-/xterm-5.5.0.tgz#275fb8f6e14afa6e8a0c05d4ebc94523ff775396"


### PR DESCRIPTION
## Description 📝

- I made some changes to LISH in https://github.com/linode/manager/pull/10689 that ended up making the experience a bit worse
- This PR addresses changes based on internal feedback and customer feedback 👤 

## Changes  🔄
- Make LISH use a constant size because we need backend support to properly implement resizing 🖥️ 
- Make LISH open in a popup rather than in a new tab 🖥️ 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-08-19 at 9 48 16 AM](https://github.com/user-attachments/assets/b9d740c0-2d7e-4b51-b4ab-d5b6c39feed0) | ![Screenshot 2024-08-19 at 9 47 18 AM](https://github.com/user-attachments/assets/c303583c-8eb6-45a7-98c9-8cc62b007385) |

## How to test 🧪

- Verify LISH opens in a new window rather than a new tab 
- Verify LISH uses a static number of rows and columns and terminal output and cursor position works / looks correct 
  - Basically, just verify that the resizing logic is removed and that we use the same size we used previously in https://github.com/linode/manager/pull/10689 

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support