### PR TITLE
upcoming: [M3-8301] - Updated Bucket Rate Limits

### DIFF
--- a/packages/manager/.changeset/pr-10790-upcoming-features-1724031092075.md
+++ b/packages/manager/.changeset/pr-10790-upcoming-features-1724031092075.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Updated Bucket Rate Limits ([#10790](https://github.com/linode/manager/pull/10790))

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
@@ -20,22 +20,26 @@ interface BucketRateLimitTableProps {
 }
 
 const tableHeaders = ['Limits', 'GET', 'PUT', 'LIST', 'DELETE', 'OTHER'];
-const tableData = ({ endpointType }: BucketRateLimitTableProps) => [
-  {
-    checked: true,
-    values: ['1000', '000', '000', '000', '000'],
-  },
-  {
-    checked: false,
-    values: [
-      endpointType === 'E3' ? '20000' : '5000',
-      '000',
-      '000',
-      '000',
-      '000',
-    ],
-  },
-];
+const tableData = ({ endpointType }: BucketRateLimitTableProps) => {
+  const isE3 = endpointType === 'E3';
+
+  return [
+    {
+      checked: true,
+      values: ['2000', '500', '100', '200', '400'],
+    },
+    {
+      checked: false,
+      values: [
+        isE3 ? '20000' : '5000',
+        isE3 ? '2000' : '1000',
+        isE3 ? '400' : '200',
+        isE3 ? '400' : '200',
+        isE3 ? '1000' : '800',
+      ],
+    },
+  ];
+};
 
 export const BucketRateLimitTable = ({
   endpointType,


### PR DESCRIPTION
## Changes  🔄
- Updated static bucket rate limits with latest numbers

## Target release date 🗓️
N/A

## Preview 📷
<img width="455" alt="Screenshot 2024-08-18 at 9 30 51 PM" src="https://github.com/user-attachments/assets/d6cbf33b-0c13-483d-8981-00877ac325c5">

## How to test 🧪

### Prerequisites
- Turn on `OBJGen2` feature flag in dev tools

### Verification steps
- Go through each endpoint and verify the numbers display correctly

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support