### PR TITLE
change: [M3-6843] - Move manual snapshot error message to snapshot confirmation dialog

### DIFF
--- a/packages/manager/.changeset/pr-10791-changed-1723820950904.md
+++ b/packages/manager/.changeset/pr-10791-changed-1723820950904.md
@@ -2,4 +2,4 @@
 "@linode/manager": Changed
 ---
 
-Move manual snapshot error message from Linode Backups page to snapshot confirmation dialogue ([#10791](https://github.com/linode/manager/pull/10791))
+Move manual snapshot error message from Linode Backups page to snapshot confirmation dialog ([#10791](https://github.com/linode/manager/pull/10791))

--- a/packages/manager/.changeset/pr-10791-changed-1723820950904.md
+++ b/packages/manager/.changeset/pr-10791-changed-1723820950904.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Move manual snapshot error message from Linode Backups page to snapshot confirmation dialogue ([#10791](https://github.com/linode/manager/pull/10791))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/CaptureSnapshot.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/CaptureSnapshot.tsx
@@ -53,12 +53,6 @@ export const CaptureSnapshot = (props: Props) => {
 
   const hasErrorFor = getErrorMap(['label'], snapshotError);
 
-  React.useEffect(() => {
-    if (isSnapshotConfirmationDialogOpen) {
-      reset();
-    }
-  }, [isSnapshotConfirmationDialogOpen, reset]);
-
   return (
     <Paper>
       <Typography data-qa-manual-heading variant="h2">
@@ -95,6 +89,7 @@ export const CaptureSnapshot = (props: Props) => {
         error={hasErrorFor.none}
         loading={isSnapshotLoading}
         onClose={() => setIsSnapshotConfirmationDialogOpen(false)}
+        onExited={() => reset()}
         onSnapshot={() => snapshotForm.handleSubmit()}
         open={isSnapshotConfirmationDialogOpen}
       />

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/CaptureSnapshot.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/CaptureSnapshot.tsx
@@ -6,7 +6,6 @@ import * as React from 'react';
 import { Box } from 'src/components/Box';
 import { Button } from 'src/components/Button/Button';
 import { FormControl } from 'src/components/FormControl';
-import { Notice } from 'src/components/Notice/Notice';
 import { Paper } from 'src/components/Paper';
 import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
@@ -65,19 +64,14 @@ export const CaptureSnapshot = (props: Props) => {
         manual snapshot will not be overwritten by automatic backups.
       </Typography>
       <FormControl>
-        {hasErrorFor.none && (
-          <Notice spacingBottom={8} variant="error">
-            {hasErrorFor.none}
-          </Notice>
-        )}
         <StyledBox>
           <TextField
-            sx={{ minWidth: 275 }}
             data-qa-manual-name
             errorText={hasErrorFor.label}
             label="Name Snapshot"
             name="label"
             onChange={snapshotForm.handleChange}
+            sx={{ minWidth: 275 }}
             value={snapshotForm.values.label}
           />
           <Button
@@ -91,6 +85,7 @@ export const CaptureSnapshot = (props: Props) => {
         </StyledBox>
       </FormControl>
       <CaptureSnapshotConfirmationDialog
+        error={hasErrorFor.none}
         loading={isSnapshotLoading}
         onClose={() => setIsSnapshotConfirmationDialogOpen(false)}
         onSnapshot={() => snapshotForm.handleSubmit()}

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/CaptureSnapshot.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/CaptureSnapshot.tsx
@@ -30,6 +30,7 @@ export const CaptureSnapshot = (props: Props) => {
     error: snapshotError,
     isLoading: isSnapshotLoading,
     mutateAsync: takeSnapshot,
+    reset,
   } = useLinodeBackupSnapshotMutation(linodeId);
 
   const [
@@ -51,6 +52,12 @@ export const CaptureSnapshot = (props: Props) => {
   });
 
   const hasErrorFor = getErrorMap(['label'], snapshotError);
+
+  React.useEffect(() => {
+    if (isSnapshotConfirmationDialogOpen) {
+      reset();
+    }
+  }, [isSnapshotConfirmationDialogOpen, reset]);
 
   return (
     <Paper>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/CaptureSnapshotConfirmationDialog.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/CaptureSnapshotConfirmationDialog.test.tsx
@@ -9,6 +9,7 @@ const props = {
   error: undefined,
   loading: false,
   onClose: vi.fn(),
+  onExited: vi.fn(),
   onSnapshot: vi.fn(),
   open: true,
 };
@@ -35,6 +36,7 @@ describe('CaptureSnapshotConfirmationDialog', () => {
     expect(title).toBeVisible();
     expect(body).toBeVisible();
   });
+
   it('should send a request to create a snapshot if loading is false', () => {
     const { getByTestId } = renderWithTheme(
       <CaptureSnapshotConfirmationDialog {...props} />
@@ -45,6 +47,7 @@ describe('CaptureSnapshotConfirmationDialog', () => {
     fireEvent.click(takeSnapshotButton);
     expect(props.onSnapshot).toHaveBeenCalled();
   });
+
   it('should not send a request to create a snapshot if loading is true', () => {
     const { getByTestId } = renderWithTheme(
       <CaptureSnapshotConfirmationDialog {...props} loading={true} />
@@ -55,7 +58,8 @@ describe('CaptureSnapshotConfirmationDialog', () => {
     fireEvent.click(takeSnapshotButton);
     expect(props.onSnapshot).not.toHaveBeenCalled();
   });
-  it('should close the dialog', () => {
+
+  it('should close the dialog when the "Cancel" button is clicked', () => {
     const { getByText } = renderWithTheme(
       <CaptureSnapshotConfirmationDialog {...props} />
     );
@@ -65,6 +69,7 @@ describe('CaptureSnapshotConfirmationDialog', () => {
     fireEvent.click(cancelButton);
     expect(props.onClose).toHaveBeenCalled();
   });
+
   it('should render the dialog with an error message', () => {
     const { getByText } = renderWithTheme(
       <CaptureSnapshotConfirmationDialog

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/CaptureSnapshotConfirmationDialog.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/CaptureSnapshotConfirmationDialog.test.tsx
@@ -69,11 +69,11 @@ describe('CaptureSnapshotConfirmationDialog', () => {
     const { getByText } = renderWithTheme(
       <CaptureSnapshotConfirmationDialog
         {...props}
-        error={'fake error message'}
+        error={'mock error message'}
       />
     );
 
-    const errorMessage = getByText('fake error message');
+    const errorMessage = getByText('mock error message');
     expect(errorMessage).toBeVisible();
   });
 });

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/CaptureSnapshotConfirmationDialog.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/CaptureSnapshotConfirmationDialog.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent } from '@testing-library/react';
+import * as React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { CaptureSnapshotConfirmationDialog } from './CaptureSnapshotConfirmationDialog';
+
+const props = {
+  error: undefined,
+  loading: false,
+  onClose: vi.fn(),
+  onSnapshot: vi.fn(),
+  open: true,
+};
+
+describe('CaptureSnapshotConfirmationDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render the dialog', () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <CaptureSnapshotConfirmationDialog {...props} />
+    );
+
+    const takeSnapshotButton = getByTestId('confirm');
+    const cancelButton = getByText('Cancel');
+    const title = getByText('Take a snapshot?');
+    const body = getByText(
+      'Taking a snapshot will back up your Linode in its current state, overriding your previous snapshot. Are you sure?'
+    );
+
+    expect(takeSnapshotButton).toBeVisible();
+    expect(cancelButton).toBeVisible();
+    expect(title).toBeVisible();
+    expect(body).toBeVisible();
+  });
+  it('should send a request to create a snapshot if loading is false', () => {
+    const { getByTestId } = renderWithTheme(
+      <CaptureSnapshotConfirmationDialog {...props} />
+    );
+
+    const takeSnapshotButton = getByTestId('confirm');
+    expect(takeSnapshotButton).toBeVisible();
+    fireEvent.click(takeSnapshotButton);
+    expect(props.onSnapshot).toHaveBeenCalled();
+  });
+  it('should not send a request to create a snapshot if loading is true', () => {
+    const { getByTestId } = renderWithTheme(
+      <CaptureSnapshotConfirmationDialog {...props} loading={true} />
+    );
+
+    const takeSnapshotButton = getByTestId('confirm');
+    expect(takeSnapshotButton).toBeVisible();
+    fireEvent.click(takeSnapshotButton);
+    expect(props.onSnapshot).not.toHaveBeenCalled();
+  });
+  it('should close the dialog', () => {
+    const { getByText } = renderWithTheme(
+      <CaptureSnapshotConfirmationDialog {...props} />
+    );
+
+    const cancelButton = getByText('Cancel');
+    expect(cancelButton).toBeVisible();
+    fireEvent.click(cancelButton);
+    expect(props.onClose).toHaveBeenCalled();
+  });
+  it('should render the dialog with an error message', () => {
+    const { getByText } = renderWithTheme(
+      <CaptureSnapshotConfirmationDialog
+        {...props}
+        error={'fake error message'}
+      />
+    );
+
+    const errorMessage = getByText('fake error message');
+    expect(errorMessage).toBeVisible();
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/CaptureSnapshotConfirmationDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/CaptureSnapshotConfirmationDialog.tsx
@@ -5,7 +5,7 @@ import { ConfirmationDialog } from 'src/components/ConfirmationDialog/Confirmati
 import { Typography } from 'src/components/Typography';
 
 interface Props {
-  error?: string;
+  error: string | undefined;
   loading: boolean;
   onClose: () => void;
   onSnapshot: () => void;

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/CaptureSnapshotConfirmationDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/CaptureSnapshotConfirmationDialog.tsx
@@ -8,12 +8,13 @@ interface Props {
   error: string | undefined;
   loading: boolean;
   onClose: () => void;
+  onExited: () => void;
   onSnapshot: () => void;
   open: boolean;
 }
 
 export const CaptureSnapshotConfirmationDialog = (props: Props) => {
-  const { error, loading, onClose, onSnapshot, open } = props;
+  const { error, loading, onClose, onExited, onSnapshot, open } = props;
 
   const actions = (
     <ActionsPanel
@@ -37,6 +38,7 @@ export const CaptureSnapshotConfirmationDialog = (props: Props) => {
       actions={actions}
       error={error}
       onClose={onClose}
+      onExited={onExited}
       open={open}
       title="Take a snapshot?"
     >

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/LinodeBackups.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/LinodeBackups.tsx
@@ -1,4 +1,3 @@
-import { LinodeBackup, PriceObject } from '@linode/api-v4/lib/linodes';
 import { Box, Stack } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import * as React from 'react';
@@ -23,12 +22,14 @@ import { useRegionsQuery } from 'src/queries/regions/regions';
 import { useTypeQuery } from 'src/queries/types';
 import { getMonthlyBackupsPrice } from 'src/utilities/pricing/backups';
 
-import { BackupTableRow } from './BackupTableRow';
 import { BackupsPlaceholder } from './BackupsPlaceholder';
+import { BackupTableRow } from './BackupTableRow';
 import { CancelBackupsDialog } from './CancelBackupsDialog';
 import { CaptureSnapshot } from './CaptureSnapshot';
 import { RestoreToLinodeDrawer } from './RestoreToLinodeDrawer';
 import { ScheduleSettings } from './ScheduleSettings';
+
+import type { LinodeBackup, PriceObject } from '@linode/api-v4/lib/linodes';
 
 export const LinodeBackups = () => {
   const { linodeId } = useParams<{ linodeId: string }>();


### PR DESCRIPTION
## Description 📝
Moves the manual snapshot error message from the Linode Backups page to the snapshot's confirmation dialog

## Target release date 🗓️
n/a

## Preview 📷
Note - three potential options for displaying the error message - see "Other notes/questions" for more
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/fb110c9a-97a3-4be0-a165-42cf93d837c6)| ![image](https://github.com/user-attachments/assets/76adcaf8-f27e-4108-87da-e1760ef3c775)![image](https://github.com/user-attachments/assets/8ab676f3-b8ca-484f-b018-c09af18f3ea2)![image](https://github.com/user-attachments/assets/4d3561c6-16d4-43fd-8334-88fb5146a6c5)|

## How to test 🧪
- Have a busy linode (a linode that is already creating a snapshot, shutting down, turning on, etc) or a linode with no disk and no config and try to create a snapshot
- Confirm error message is now in the dialog
- Confirm that error message clears when closing and then reopening dialog

## Other notes/questions
- several potential ways to display the snapshot error in the confirmation dialog
  - the first (current) one matches ~the rest~ most of the confirmation dialogs 
  - other two more closely resemble how the error message used to appear. 
  - I'm thinking that the first option is probably the way to go for consistency? but can change it if the other options are preferred
- should we add a toast for disk deletion initiation? [_See internal ticket comments for context_]

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
