### PR TITLE
upcoming: [M3-8370] – Add "Encryption" column to Linode Volumes table

### DIFF
--- a/packages/manager/.changeset/pr-10793-upcoming-features-1723845275155.md
+++ b/packages/manager/.changeset/pr-10793-upcoming-features-1723845275155.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add "Encryption" column to Linode Volumes table ([#10793](https://github.com/linode/manager/pull/10793))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeVolumes.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeVolumes.test.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+
+import { accountFactory, linodeFactory, volumeFactory } from 'src/factories';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { LinodeVolumes } from './LinodeVolumes';
+
+const accountEndpoint = '*/v4/account';
+const linodeInstanceEndpoint = '*/linode/instances/:id';
+const linodeVolumesEndpoint = '*/linode/instances/:id/volumes';
+
+describe('LinodeVolumes', () => {
+  const volumes = volumeFactory.buildList(3);
+
+  it('should render', async () => {
+    server.use(
+      http.get(linodeInstanceEndpoint, () => {
+        return HttpResponse.json(linodeFactory.build());
+      }),
+      http.get(linodeVolumesEndpoint, () => {
+        return HttpResponse.json(makeResourcePage(volumes));
+      })
+    );
+
+    const { findByText } = renderWithTheme(<LinodeVolumes />);
+
+    expect(await findByText('Volumes')).toBeVisible();
+  });
+
+  /* @TODO BSE: Remove feature flagging/conditionality once BSE is fully rolled out */
+  it('should display an "Encryption" column if the user has the account capability and the feature flag is on', async () => {
+    server.use(
+      http.get(accountEndpoint, () => {
+        return HttpResponse.json(
+          accountFactory.build({
+            capabilities: ['Block Storage Encryption'],
+          })
+        );
+      })
+    );
+
+    server.use(
+      http.get(linodeInstanceEndpoint, () => {
+        return HttpResponse.json(linodeFactory.build());
+      }),
+      http.get(linodeVolumesEndpoint, () => {
+        return HttpResponse.json(makeResourcePage(volumes));
+      })
+    );
+
+    const { findByText } = renderWithTheme(<LinodeVolumes />, {
+      flags: { blockStorageEncryption: true },
+    });
+
+    expect(await findByText('Encryption')).toBeVisible();
+  });
+
+  it('should not display an "Encryption" column if the user has the account capability but the feature flag is off', async () => {
+    server.use(
+      http.get(accountEndpoint, () => {
+        return HttpResponse.json(
+          accountFactory.build({
+            capabilities: ['Block Storage Encryption'],
+          })
+        );
+      })
+    );
+
+    server.use(
+      http.get(linodeInstanceEndpoint, () => {
+        return HttpResponse.json(linodeFactory.build());
+      }),
+      http.get(linodeVolumesEndpoint, () => {
+        return HttpResponse.json(makeResourcePage(volumes));
+      })
+    );
+
+    const { queryByText } = renderWithTheme(<LinodeVolumes />, {
+      flags: { blockStorageEncryption: false },
+    });
+
+    expect(queryByText('Encryption')).toBeNull();
+  });
+
+  it('should not display an "Encryption" column if the feature flag is on but the user does not have the account capability', async () => {
+    server.use(
+      http.get(accountEndpoint, () => {
+        return HttpResponse.json(
+          accountFactory.build({
+            capabilities: [],
+          })
+        );
+      })
+    );
+
+    server.use(
+      http.get(linodeInstanceEndpoint, () => {
+        return HttpResponse.json(linodeFactory.build());
+      }),
+      http.get(linodeVolumesEndpoint, () => {
+        return HttpResponse.json(makeResourcePage(volumes));
+      })
+    );
+
+    const { queryByText } = renderWithTheme(<LinodeVolumes />, {
+      flags: { blockStorageEncryption: true },
+    });
+
+    expect(queryByText('Encryption')).toBeNull();
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeVolumes.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeVolumes.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 
 import { Box } from 'src/components/Box';
 import { Button } from 'src/components/Button/Button';
+import { useIsBlockStorageEncryptionFeatureEnabled } from 'src/components/Encryption/utils';
 import { Hidden } from 'src/components/Hidden';
 import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFooter';
 import { Paper } from 'src/components/Paper';
@@ -72,6 +73,10 @@ export const LinodeVolumes = () => {
     },
     filter
   );
+
+  const {
+    isBlockStorageEncryptionFeatureEnabled,
+  } = useIsBlockStorageEncryptionFeatureEnabled();
 
   const [selectedVolumeId, setSelectedVolumeId] = React.useState<number>();
   const [isDetailsDrawerOpen, setIsDetailsDrawerOpen] = React.useState(false);
@@ -153,6 +158,9 @@ export const LinodeVolumes = () => {
               handleResize: () => handleResize(volume),
               handleUpgrade: () => null,
             }}
+            isBlockStorageEncryptionFeatureEnabled={
+              isBlockStorageEncryptionFeatureEnabled
+            }
             isDetailsPageRow
             key={volume.id}
             volume={volume}
@@ -215,6 +223,9 @@ export const LinodeVolumes = () => {
             <Hidden xsDown>
               <TableCell>File System Path</TableCell>
             </Hidden>
+            {isBlockStorageEncryptionFeatureEnabled && (
+              <TableCell>Encryption</TableCell>
+            )}
             <TableCell></TableCell>
           </TableRow>
         </TableHead>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeVolumes.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeVolumes.tsx
@@ -129,6 +129,8 @@ export const LinodeVolumes = () => {
     return null;
   }
 
+  const numColumns = isBlockStorageEncryptionFeatureEnabled ? 6 : 5; // @TODO BSE: set colSpan for <TableRowEmpty /> to 6 once BSE is fully rolled out
+
   const renderTableContent = () => {
     if (isLoading) {
       return (
@@ -143,7 +145,9 @@ export const LinodeVolumes = () => {
     } else if (error) {
       return <TableRowError colSpan={6} message={error[0].reason} />;
     } else if (data?.results === 0) {
-      return <TableRowEmpty colSpan={5} message="No Volumes to display." />;
+      return (
+        <TableRowEmpty colSpan={numColumns} message="No Volumes to display." />
+      );
     } else if (data) {
       return data.data.map((volume) => {
         return (

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeVolumes.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeVolumes.tsx
@@ -138,7 +138,7 @@ export const LinodeVolumes = () => {
           responsive={{
             3: { xsDown: true },
           }}
-          columns={5}
+          columns={numColumns}
           rows={1}
         />
       );

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -141,7 +141,7 @@ export const VolumeTableRow = React.memo((props: Props) => {
       )}
       <TableCell data-qa-volume-size>{volume.size} GB</TableCell>
       {!isVolumesLanding && (
-        <Hidden smDown>
+        <Hidden xsDown>
           <TableCell className={classes.volumePath} data-qa-fs-path>
             {volume.filesystem_path}
           </TableCell>


### PR DESCRIPTION
## Description 📝
Add "Encryption" column to Linode Volumes table

## Target release date 🗓️
9/3/24

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-08-16 at 2 53 04 PM](https://github.com/user-attachments/assets/8363b42f-f041-4371-abe8-2c3e9c9849a1) | ![Screenshot 2024-08-16 at 2 53 40 PM](https://github.com/user-attachments/assets/c9d33304-508e-4f93-b545-691284aebdba) |

## How to test 🧪
### Prerequisites
Point at the dev environment with the `blockstorage-encryption` tag on your account

### Verification steps
Confirm the Linode Volumes table has the "Encryption" column when the feature flag is on. For any listed volumes, the encryption status should be accurate.

Unit test should pass:

```typescript
yarn test linodevolumes
```

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support