### PR TITLE
upcoming: [M3-8305] - Display Endpoint Type alongside each endpoint hostname in Regions Column & Hostnames Drawers

### DIFF
--- a/packages/manager/.changeset/pr-10796-upcoming-features-1724152512210.md
+++ b/packages/manager/.changeset/pr-10796-upcoming-features-1724152512210.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Display Endpoint Type alongside each endpoint hostname in Regions Column & Hostnames Drawers ([#10796](https://github.com/linode/manager/pull/10796))

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/AccessKeyTable.styles.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/AccessKeyTable.styles.tsx
@@ -1,0 +1,21 @@
+import { styled } from '@mui/material';
+
+import { TableCell } from 'src/components/TableCell';
+import { omittedProps } from 'src/utilities/omittedProps';
+
+import type { TableCellProps } from 'src/components/TableCell';
+
+interface StyledLastColumnCellProps extends TableCellProps {
+  addPaddingRight?: boolean;
+}
+export const StyledLastColumnCell = styled(TableCell, {
+  shouldForwardProp: omittedProps(['isObjMultiClusterEnabled']),
+})<StyledLastColumnCellProps>(({ addPaddingRight }) => ({
+  '&&:last-child': {
+    'padding-right': addPaddingRight ? '15px' : 0,
+  },
+}));
+
+export const StyledLabelCell = styled(TableCell)(() => ({
+  width: '35%',
+}));

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/AccessKeyTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/AccessKeyTable.tsx
@@ -70,8 +70,18 @@ export const AccessKeyTable = (props: AccessKeyTableProps) => {
                 Regions/S3 Hostnames
               </StyledLabelCell>
             )}
-            {/* empty cell for kebab menu */}
-            <TableCell />
+            <TableCell
+              sx={{
+                ...(isObjMultiClusterEnabled && {
+                  '&&:last-child': {
+                    paddingRight: '15px',
+                  },
+                }),
+              }}
+              data-qa-header-key
+            >
+              Actions
+            </TableCell>
           </TableRow>
         </TableHead>
         <TableBody>

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/AccessKeyTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/AccessKeyTable.tsx
@@ -1,8 +1,3 @@
-import {
-  ObjectStorageKey,
-  ObjectStorageKeyRegions,
-} from '@linode/api-v4/lib/object-storage';
-import { APIError } from '@linode/api-v4/lib/types';
 import { styled } from '@mui/material/styles';
 import React, { useState } from 'react';
 
@@ -16,8 +11,14 @@ import { useFlags } from 'src/hooks/useFlags';
 import { isFeatureEnabledV2 } from 'src/utilities/accountCapabilities';
 
 import { HostNamesDrawer } from '../HostNamesDrawer';
-import { OpenAccessDrawer } from '../types';
 import { AccessKeyTableBody } from './AccessKeyTableBody';
+
+import type { OpenAccessDrawer } from '../types';
+import type {
+  ObjectStorageKey,
+  ObjectStorageKeyRegions,
+} from '@linode/api-v4/lib/object-storage';
+import type { APIError } from '@linode/api-v4/lib/types';
 
 export interface AccessKeyTableProps {
   data: ObjectStorageKey[] | undefined;

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/AccessKeyTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/AccessKeyTable.tsx
@@ -1,9 +1,7 @@
-import { styled } from '@mui/material/styles';
 import React, { useState } from 'react';
 
 import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
-import { TableCell } from 'src/components/TableCell';
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
 import { useAccountManagement } from 'src/hooks/useAccountManagement';
@@ -11,6 +9,7 @@ import { useFlags } from 'src/hooks/useFlags';
 import { isFeatureEnabledV2 } from 'src/utilities/accountCapabilities';
 
 import { HostNamesDrawer } from '../HostNamesDrawer';
+import { StyledLabelCell, StyledLastColumnCell } from './AccessKeyTable.styles';
 import { AccessKeyTableBody } from './AccessKeyTableBody';
 
 import type { OpenAccessDrawer } from '../types';
@@ -70,18 +69,12 @@ export const AccessKeyTable = (props: AccessKeyTableProps) => {
                 Regions/S3 Hostnames
               </StyledLabelCell>
             )}
-            <TableCell
-              sx={{
-                ...(isObjMultiClusterEnabled && {
-                  '&&:last-child': {
-                    paddingRight: '15px',
-                  },
-                }),
-              }}
+            <StyledLastColumnCell
+              addPaddingRight={isObjMultiClusterEnabled}
               data-qa-header-key
             >
               Actions
-            </TableCell>
+            </StyledLastColumnCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -107,7 +100,3 @@ export const AccessKeyTable = (props: AccessKeyTableProps) => {
     </>
   );
 };
-
-const StyledLabelCell = styled(TableCell)(() => ({
-  width: '35%',
-}));

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/AccessKeyTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/AccessKeyTableRow.tsx
@@ -10,6 +10,7 @@ import { useFlags } from 'src/hooks/useFlags';
 import { isFeatureEnabledV2 } from 'src/utilities/accountCapabilities';
 
 import { AccessKeyActionMenu } from './AccessKeyActionMenu';
+import { StyledLastColumnCell } from './AccessKeyTable.styles';
 import { HostNameTableCell } from './HostNameTableCell';
 
 import type { OpenAccessDrawer } from '../types';
@@ -63,22 +64,14 @@ export const AccessKeyTableRow = ({
         />
       )}
 
-      <TableCell
-        sx={{
-          ...(isObjMultiClusterEnabled && {
-            '&&:last-child': {
-              paddingRight: '15px',
-            },
-          }),
-        }}
-      >
+      <StyledLastColumnCell addPaddingRight={isObjMultiClusterEnabled}>
         <AccessKeyActionMenu
           label={storageKeyData.label}
           objectStorageKey={storageKeyData}
           openDrawer={openDrawer}
           openRevokeDialog={openRevokeDialog}
         />
-      </TableCell>
+      </StyledLastColumnCell>
     </TableRow>
   );
 };

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/AccessKeyTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/AccessKeyTableRow.tsx
@@ -1,7 +1,3 @@
-import {
-  ObjectStorageKey,
-  ObjectStorageKeyRegions,
-} from '@linode/api-v4/lib/object-storage';
 import { styled } from '@mui/material/styles';
 import React from 'react';
 
@@ -13,9 +9,14 @@ import { useAccountManagement } from 'src/hooks/useAccountManagement';
 import { useFlags } from 'src/hooks/useFlags';
 import { isFeatureEnabledV2 } from 'src/utilities/accountCapabilities';
 
-import { OpenAccessDrawer } from '../types';
 import { AccessKeyActionMenu } from './AccessKeyActionMenu';
 import { HostNameTableCell } from './HostNameTableCell';
+
+import type { OpenAccessDrawer } from '../types';
+import type {
+  ObjectStorageKey,
+  ObjectStorageKeyRegions,
+} from '@linode/api-v4/lib/object-storage';
 
 type Props = {
   openDrawer: OpenAccessDrawer;
@@ -62,7 +63,15 @@ export const AccessKeyTableRow = ({
         />
       )}
 
-      <TableCell>
+      <TableCell
+        sx={{
+          ...(isObjMultiClusterEnabled && {
+            '&&:last-child': {
+              paddingRight: '15px',
+            },
+          }),
+        }}
+      >
         <AccessKeyActionMenu
           label={storageKeyData.label}
           objectStorageKey={storageKeyData}

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/HostNameTableCell.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable/HostNameTableCell.tsx
@@ -34,10 +34,12 @@ export const HostNameTableCell = ({
   }
   const label = regionsLookup[storageKeyData.regions[0].id]?.label;
   const s3Endpoint = storageKeyData?.regions[0]?.s3_endpoint;
+  const endpointType = storageKeyData?.regions[0]?.endpoint_type;
 
   return (
     <TableCell>
-      {label}: {s3Endpoint}
+      {label}
+      {endpointType && ` (${endpointType})`}: {s3Endpoint}&nbsp;
       {storageKeyData?.regions?.length === 1 && (
         <StyledCopyIcon text={s3Endpoint} />
       )}

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/HostNamesDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/HostNamesDrawer.tsx
@@ -31,13 +31,13 @@ export const HostNamesDrawer = (props: Props) => {
         <CopyAllHostnames
           text={
             regions
-              .map((region) =>
-                region?.endpoint_type
-                  ? `${regionsLookup[region.id]?.label} (${
-                      region.endpoint_type
-                    }): ${region.s3_endpoint}`
-                  : `${regionsLookup[region.id]?.label}: ${region.s3_endpoint}`
-              )
+              .map((region) => {
+                const label = regionsLookup[region.id]?.label;
+                const endpointType = region.endpoint_type
+                  ? ` (${region.endpoint_type})`
+                  : '';
+                return `${label}${endpointType}: ${region.s3_endpoint}`;
+              })
               .join('\n') ?? ''
           }
         />
@@ -49,25 +49,23 @@ export const HostNamesDrawer = (props: Props) => {
           padding: theme.spacing(1),
         })}
       >
-        {regions.map((region, index) => (
-          <CopyableTextField
-            label={
-              region?.endpoint_type
-                ? `${region.id} (${region.endpoint_type}): ${region.s3_endpoint}`
-                : `${region.id}: ${region.s3_endpoint}`
-            }
-            value={
-              region?.endpoint_type
-                ? `${regionsLookup[region.id]?.label} (${
-                    region.endpoint_type
-                  }): ${region.s3_endpoint}`
-                : `${regionsLookup[region.id]?.label}: ${region.s3_endpoint}`
-            }
-            hideLabel
-            key={index}
-            sx={{ border: 'none', maxWidth: '100%' }}
-          />
-        ))}
+        {regions.map((region, index) => {
+          const endpointTypeLabel = region?.endpoint_type
+            ? ` (${region.endpoint_type})`
+            : '';
+
+          return (
+            <CopyableTextField
+              value={`${regionsLookup[region.id]?.label}${endpointTypeLabel}: ${
+                region.s3_endpoint
+              }`}
+              hideLabel
+              key={index}
+              label={`${region.id}${endpointTypeLabel}: ${region.s3_endpoint}`}
+              sx={{ border: 'none', maxWidth: '100%' }}
+            />
+          );
+        })}
       </Box>
     </Drawer>
   );

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/HostNamesDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/HostNamesDrawer.tsx
@@ -1,4 +1,3 @@
-import { ObjectStorageKeyRegions } from '@linode/api-v4';
 import * as React from 'react';
 
 import { Box } from 'src/components/Box';
@@ -8,6 +7,8 @@ import { useRegionsQuery } from 'src/queries/regions/regions';
 import { getRegionsByRegionId } from 'src/utilities/regions';
 
 import { CopyAllHostnames } from './CopyAllHostnames';
+
+import type { ObjectStorageKeyRegions } from '@linode/api-v4';
 
 interface Props {
   onClose: () => void;
@@ -30,9 +31,12 @@ export const HostNamesDrawer = (props: Props) => {
         <CopyAllHostnames
           text={
             regions
-              .map(
-                (region) =>
-                  `${regionsLookup[region.id]?.label}: ${region.s3_endpoint}`
+              .map((region) =>
+                region?.endpoint_type
+                  ? `${regionsLookup[region.id]?.label} (${
+                      region.endpoint_type
+                    }): ${region.s3_endpoint}`
+                  : `${regionsLookup[region.id]?.label}: ${region.s3_endpoint}`
               )
               .join('\n') ?? ''
           }
@@ -47,11 +51,21 @@ export const HostNamesDrawer = (props: Props) => {
       >
         {regions.map((region, index) => (
           <CopyableTextField
+            label={
+              region?.endpoint_type
+                ? `${region.id} (${region.endpoint_type}): ${region.s3_endpoint}`
+                : `${region.id}: ${region.s3_endpoint}`
+            }
+            value={
+              region?.endpoint_type
+                ? `${regionsLookup[region.id]?.label} (${
+                    region.endpoint_type
+                  }): ${region.s3_endpoint}`
+                : `${regionsLookup[region.id]?.label}: ${region.s3_endpoint}`
+            }
             hideLabel
             key={index}
-            label={`${region.id}: ${region.s3_endpoint}`}
             sx={{ border: 'none', maxWidth: '100%' }}
-            value={`${regionsLookup[region.id]?.label}: ${region.s3_endpoint}`}
           />
         ))}
       </Box>


### PR DESCRIPTION

## Description 📝
As a customer, I want to see a list of endpoints, including the type of each endpoint (E0, E1, E2, E3) alongside each endpoint hostname, in various views related to S3 access keys in Cloud Manager. This will help me understand the endpoints in which each newly created or pre-existing S3 access key can be used.

## Changes  🔄
* Add "Action" Table Header for Actions Column
* Endpoint Type Display in Regions Column
  * Display the type of each endpoint alongside each endpoint hostname in the existing Regions column of the top-level list of both pre-existing and new access keys. 
* (Drawer) Endpoint Type Display for Pre-existing Access Keys
  * Show the type of each endpoint alongside the endpoint hostname when displaying the full list of endpoint hostnames for a specific pre-existing access key.


## Target release date 🗓️
N/A

## Preview 📷

- Access Key Landing Page

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/495dc4ba-271e-4aa2-bdbf-dea7565979eb)|![image](https://github.com/user-attachments/assets/2a2b39ae-81cb-4e5b-9283-d32321629e0c)|

- Access Key Hostnames Drawer

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/25a0fb3a-dbec-46e3-800f-b531cebb2214)|![image](https://github.com/user-attachments/assets/5cebf0d6-5073-406d-8013-81a98a61a6ed)|
## How to test 🧪

### Prerequisites
- Test all components for ObjectStorage buckets by toggling the `OBJ Gen2` and the `OBJ Multi-Cluster` feature flags in dev environment

### Reproduction steps
- Go to `serverHandler.ts` file and under the `*object-storage/keys` route, add the `endpoint_type` key-value pair for all `regions` array

### Verification steps
- Turn on MSW
- Navigate to the Access Keys Tab under Object Storage feature
- You should see the last column of the top-level list having a "Actions" header.
- You should find the Endpoint Type alongside each endpoint hostname in the existing Regions column of the top-level list of both pre-existing and new access keys.
- On opening a hostname's Details drawer(only for keys in multiple regions), you should find the endpoint type alongside the endpoint hostname when displaying the full list of endpoint hostnames.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
