### PR TITLE
upcoming: [M3-8378] - Add Bucket Management `Properties` Tab for Object Storage Gen2

### DIFF
--- a/packages/manager/.changeset/pr-10795-upcoming-features-1724084768188.md
+++ b/packages/manager/.changeset/pr-10795-upcoming-features-1724084768188.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-Enhance bucket management Properties Tab for object storage gen2 ([#10795](https://github.com/linode/manager/pull/10795))
+Add bucket management Properties Tab for object storage gen2 ([#10795](https://github.com/linode/manager/pull/10795))

--- a/packages/manager/.changeset/pr-10795-upcoming-features-1724084768188.md
+++ b/packages/manager/.changeset/pr-10795-upcoming-features-1724084768188.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Enhance bucket management Properties Tab for object storage gen2 ([#10795](https://github.com/linode/manager/pull/10795))

--- a/packages/manager/.changeset/pr-10795-upcoming-features-1724084768188.md
+++ b/packages/manager/.changeset/pr-10795-upcoming-features-1724084768188.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-Add bucket management Properties Tab for object storage gen2 ([#10795](https://github.com/linode/manager/pull/10795))
+Add bucket management Properties Tab for Object Storage Gen2 ([#10795](https://github.com/linode/manager/pull/10795))

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.styles.ts
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.styles.ts
@@ -37,4 +37,5 @@ export const StyledActionsPanel = styled(ActionsPanel, {
 })(() => ({
   display: 'flex',
   justifyContent: 'right',
+  padding: 0,
 }));

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.styles.ts
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.styles.ts
@@ -1,5 +1,6 @@
 import { styled } from '@mui/material/styles';
 
+import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Paper } from 'src/components/Paper';
 import { Typography } from 'src/components/Typography';
 
@@ -27,5 +28,13 @@ export const StyledHelperText = styled(Typography, {
   label: 'StyledHelperText',
 })(({ theme }) => ({
   lineHeight: 1.5,
+  paddingBottom: theme.spacing(),
   paddingTop: theme.spacing(),
+}));
+
+export const StyledActionsPanel = styled(ActionsPanel, {
+  label: 'StyledActionsPanel',
+})(() => ({
+  display: 'flex',
+  justifyContent: 'right',
 }));

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.styles.ts
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.styles.ts
@@ -1,0 +1,28 @@
+import { styled } from '@mui/material/styles';
+
+import { Paper } from 'src/components/Paper';
+import { Typography } from 'src/components/Typography';
+
+export const StyledText = styled(Typography, {
+  label: 'StyledText',
+})(({ theme }) => ({
+  lineHeight: 0.5,
+  paddingLeft: 16,
+  [theme.breakpoints.down('md')]: {
+    lineHeight: 1,
+  },
+}));
+
+export const StyledRootContainer = styled(Paper, {
+  label: 'StyledRootContainer',
+})(({ theme }) => ({
+  marginTop: 25,
+  padding: theme.spacing(3),
+}));
+
+export const StyledHelperText = styled(Typography, {
+  label: 'StyledHelperText',
+})(({ theme }) => ({
+  lineHeight: 1.5,
+  paddingTop: theme.spacing(),
+}));

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.styles.ts
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.styles.ts
@@ -7,8 +7,11 @@ export const StyledText = styled(Typography, {
   label: 'StyledText',
 })(({ theme }) => ({
   lineHeight: 0.5,
-  paddingLeft: 16,
-  [theme.breakpoints.down('md')]: {
+  paddingLeft: 8,
+  [theme.breakpoints.down('lg')]: {
+    marginLeft: 8,
+  },
+  [theme.breakpoints.down('sm')]: {
     lineHeight: 1,
   },
 }));

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -35,17 +35,12 @@ export const BucketProperties = React.memo((props: Props) => {
 
   const { data: buckets } = useObjectStorageBuckets();
 
-  //   console.log('hey', buckets)
-  //   console.log('c', bucketName, clusterId)
-
   const bucket = buckets?.buckets.find((bucket) => {
     if (isObjMultiClusterEnabled) {
       return bucket.label === bucketName && bucket.region === clusterId;
     }
     return bucket.label === bucketName && bucket.cluster === clusterId;
   });
-
-  //   console.log('test', bucket)
 
   return (
     <>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -4,6 +4,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 
 import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
+import { SupportLink } from 'src/components/SupportLink';
 import { Typography } from 'src/components/Typography';
 import { useFlags } from 'src/hooks/useFlags';
 import { useAccount } from 'src/queries/account/account';
@@ -91,7 +92,7 @@ export const BucketProperties = React.memo((props: Props) => {
         {/* TODO: OBJGen2 - We need to handle link in upcoming PR */}
         <StyledHelperText>
           Specifies the maximum Requests Per Second (RPS) for an Endpoint. To
-          increase it to High, open a <Link to="#">support ticket</Link>.
+          increase it to High, <SupportLink text="open a support ticket" />.
           Understand <Link to="#">bucket rate limits</Link>.
         </StyledHelperText>
 

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -27,6 +27,7 @@ interface Props {
 
 export const BucketProperties = React.memo((props: Props) => {
   const { bucketName, clusterId, endpointType } = props;
+
   const [updateRateLimitLoading] = React.useState(false);
   const [defaultRateLimit, setDefaultRateLimitData] = React.useState<
     null | string
@@ -70,7 +71,7 @@ export const BucketProperties = React.memo((props: Props) => {
         history={history}
         prefix={prefix}
       />
-      <StyledText>{bucket?.hostname}</StyledText>
+      <StyledText>{bucket?.hostname || 'Loading...'}</StyledText>
 
       <StyledRootContainer>
         <Typography variant="h2">Bucket Rate Limits</Typography>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -1,5 +1,6 @@
 import { ObjectStorageEndpointTypes } from '@linode/api-v4';
 import * as React from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 
 import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
@@ -39,6 +40,8 @@ export const BucketProperties = React.memo((props: Props) => {
   const [rateLimitError] = React.useState('');
   const [updateRateLimitError] = React.useState('');
 
+  const location = useLocation();
+  const history = useHistory();
   const prefix = getQueryParamFromQueryString(location.search, 'prefix');
   const flags = useFlags();
   const { data: account } = useAccount();

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -52,7 +52,9 @@ export const BucketProperties = React.memo((props: Props) => {
     return bucket.label === bucketName && bucket.cluster === clusterId;
   });
 
-  // TODO: OBJGen2 - Handle Get properties (to set default/initial value) once the endpoint for retrieving Bucket Rate Limits is available.
+  // TODO: OBJGen2 - Handle Get properties (to set default/initial value) once the endpoint
+  // for retrieving Bucket Rate Limits is available.
+  //
   // React.useEffect(() => {
   // }, []);
 

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+
+import { Link } from 'src/components/Link';
+import { Typography } from 'src/components/Typography';
+import { useFlags } from 'src/hooks/useFlags';
+import { useAccount } from 'src/queries/account/account';
+import { useObjectStorageBuckets } from 'src/queries/object-storage/queries';
+import { isFeatureEnabledV2 } from 'src/utilities/accountCapabilities';
+import { getQueryParamFromQueryString } from 'src/utilities/queryParams';
+
+import { BucketBreadcrumb } from './BucketBreadcrumb';
+import {
+  StyledHelperText,
+  StyledRootContainer,
+  StyledText,
+} from './BucketProperties.styles';
+// import type { ACLType } from '@linode/api-v4/lib/object-storage';
+
+interface Props {
+  bucketName: string;
+  clusterId: string;
+}
+
+export const BucketProperties = React.memo((props: Props) => {
+  const { bucketName, clusterId } = props;
+  const prefix = getQueryParamFromQueryString(location.search, 'prefix');
+  const flags = useFlags();
+  const { data: account } = useAccount();
+
+  const isObjMultiClusterEnabled = isFeatureEnabledV2(
+    'Object Storage Access Key Regions',
+    Boolean(flags.objMultiCluster),
+    account?.capabilities ?? []
+  );
+
+  const { data: buckets } = useObjectStorageBuckets();
+
+  //   console.log('hey', buckets)
+  //   console.log('c', bucketName, clusterId)
+
+  const bucket = buckets?.buckets.find((bucket) => {
+    if (isObjMultiClusterEnabled) {
+      return bucket.label === bucketName && bucket.region === clusterId;
+    }
+    return bucket.label === bucketName && bucket.cluster === clusterId;
+  });
+
+  //   console.log('test', bucket)
+
+  return (
+    <>
+      <BucketBreadcrumb
+        bucketName={bucketName}
+        history={history}
+        prefix={prefix}
+      />
+      <StyledText>{bucket?.hostname}</StyledText>
+
+      <StyledRootContainer>
+        <Typography variant="h2">Bucket Rate Limits</Typography>
+        <StyledHelperText>
+          Specifies the maximum Requests Per Second (RPS) for an Endpoint. To
+          increase it to High, open a <Link to="#">support ticket</Link>.
+          Understand <Link to="#">bucket rate limits</Link>.
+        </StyledHelperText>
+      </StyledRootContainer>
+    </>
+  );
+});

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -28,7 +28,9 @@ interface Props {
 export const BucketProperties = React.memo((props: Props) => {
   const { bucketName, clusterId, endpointType } = props;
   const [updateRateLimitLoading] = React.useState(false);
-  const [selectedRateLimit, setSelectedRateLimit] = React.useState<string>('1');
+  const [selectedRateLimit, setSelectedRateLimit] = React.useState<
+    null | string
+  >(null);
   const [updateRateLimitSuccess] = React.useState(false);
   const [rateLimitError] = React.useState('');
   const [updateRateLimitError] = React.useState('');
@@ -51,12 +53,6 @@ export const BucketProperties = React.memo((props: Props) => {
     }
     return bucket.label === bucketName && bucket.cluster === clusterId;
   });
-
-  // TODO: OBJGen2 - Handle Get properties (to set default/initial value) once the endpoint
-  // for retrieving Bucket Rate Limits is available.
-  //
-  // React.useEffect(() => {
-  // }, []);
 
   const handleSubmit = () => {
     // TODO: OBJGen2 - Handle Bucket Rate Limit update logic once the endpoint for updating is available.

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -52,7 +52,7 @@ export const BucketProperties = React.memo((props: Props) => {
     return bucket.label === bucketName && bucket.cluster === clusterId;
   });
 
-  // TODO: OBJGen2 - Handle Get properties once the endpoint for retrieving Bucket Rate Limits is available.
+  // TODO: OBJGen2 - Handle Get properties (to set default/initial value) once the endpoint for retrieving Bucket Rate Limits is available.
   // React.useEffect(() => {
   // }, []);
 

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -52,12 +52,12 @@ export const BucketProperties = React.memo((props: Props) => {
     return bucket.label === bucketName && bucket.cluster === clusterId;
   });
 
-  // TODO: OBJGen2 - Handle Get Bucket Rate Limit properties here.
+  // TODO: OBJGen2 - Handle Get properties once the endpoint for retrieving Bucket Rate Limits is available.
   // React.useEffect(() => {
   // }, []);
 
   const handleSubmit = () => {
-    // TODO: OBJGen2 - Handle update Bucket Rate Limit logic here.
+    // TODO: OBJGen2 - Handle Bucket Rate Limit update logic once the endpoint for updating is available.
   };
 
   const errorText = rateLimitError || updateRateLimitError;

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -1,3 +1,4 @@
+import { ObjectStorageEndpointTypes } from '@linode/api-v4';
 import * as React from 'react';
 
 import { Link } from 'src/components/Link';
@@ -8,21 +9,26 @@ import { useObjectStorageBuckets } from 'src/queries/object-storage/queries';
 import { isFeatureEnabledV2 } from 'src/utilities/accountCapabilities';
 import { getQueryParamFromQueryString } from 'src/utilities/queryParams';
 
+import { BucketRateLimitTable } from '../BucketLanding/BucketRateLimitTable';
 import { BucketBreadcrumb } from './BucketBreadcrumb';
 import {
+  StyledActionsPanel,
   StyledHelperText,
   StyledRootContainer,
   StyledText,
 } from './BucketProperties.styles';
-// import type { ACLType } from '@linode/api-v4/lib/object-storage';
 
 interface Props {
   bucketName: string;
   clusterId: string;
+  endpointType?: ObjectStorageEndpointTypes;
 }
 
 export const BucketProperties = React.memo((props: Props) => {
-  const { bucketName, clusterId } = props;
+  const { bucketName, clusterId, endpointType } = props;
+  const [updateRateLimitLoading] = React.useState(false);
+  const [selectedRateLimit, setSelectedRateLimit] = React.useState<string>('1');
+
   const prefix = getQueryParamFromQueryString(location.search, 'prefix');
   const flags = useFlags();
   const { data: account } = useAccount();
@@ -42,6 +48,14 @@ export const BucketProperties = React.memo((props: Props) => {
     return bucket.label === bucketName && bucket.cluster === clusterId;
   });
 
+  // TODO: OBJGen2 - Handle Get Bucket Rate Limit properties here.
+  // React.useEffect(() => {
+  // }, []);
+
+  const handleSubmit = () => {
+    // TODO: OBJGen2 - Handle update Bucket Rate Limit logic here.
+  };
+
   return (
     <>
       <BucketBreadcrumb
@@ -53,11 +67,30 @@ export const BucketProperties = React.memo((props: Props) => {
 
       <StyledRootContainer>
         <Typography variant="h2">Bucket Rate Limits</Typography>
+        {/* TODO: OBJGen2 - We need to handle link in upcoming PR */}
         <StyledHelperText>
           Specifies the maximum Requests Per Second (RPS) for an Endpoint. To
           increase it to High, open a <Link to="#">support ticket</Link>.
           Understand <Link to="#">bucket rate limits</Link>.
         </StyledHelperText>
+        <BucketRateLimitTable
+          onRateLimitChange={(selectedLimit: string) => {
+            setSelectedRateLimit(selectedLimit);
+          }}
+          endpointType={endpointType}
+          selectedRateLimit={selectedRateLimit}
+        />
+        <StyledActionsPanel
+          primaryButtonProps={{
+            disabled: !selectedRateLimit,
+            label: 'Save',
+            loading: updateRateLimitLoading,
+            onClick: () => {
+              handleSubmit();
+            },
+          }}
+          style={{ padding: 0 }}
+        />
       </StyledRootContainer>
     </>
   );

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -104,7 +104,6 @@ export const BucketProperties = React.memo((props: Props) => {
               loading: isSubmitting,
               type: 'submit',
             }}
-            style={{ padding: 0 }}
           />
         </form>
       </StyledRootContainer>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -2,6 +2,7 @@ import { ObjectStorageEndpointTypes } from '@linode/api-v4';
 import * as React from 'react';
 
 import { Link } from 'src/components/Link';
+import { Notice } from 'src/components/Notice/Notice';
 import { Typography } from 'src/components/Typography';
 import { useFlags } from 'src/hooks/useFlags';
 import { useAccount } from 'src/queries/account/account';
@@ -28,6 +29,9 @@ export const BucketProperties = React.memo((props: Props) => {
   const { bucketName, clusterId, endpointType } = props;
   const [updateRateLimitLoading] = React.useState(false);
   const [selectedRateLimit, setSelectedRateLimit] = React.useState<string>('1');
+  const [updateRateLimitSuccess] = React.useState(false);
+  const [rateLimitError] = React.useState('');
+  const [updateRateLimitError] = React.useState('');
 
   const prefix = getQueryParamFromQueryString(location.search, 'prefix');
   const flags = useFlags();
@@ -56,6 +60,8 @@ export const BucketProperties = React.memo((props: Props) => {
     // TODO: OBJGen2 - Handle update Bucket Rate Limit logic here.
   };
 
+  const errorText = rateLimitError || updateRateLimitError;
+
   return (
     <>
       <BucketBreadcrumb
@@ -67,6 +73,14 @@ export const BucketProperties = React.memo((props: Props) => {
 
       <StyledRootContainer>
         <Typography variant="h2">Bucket Rate Limits</Typography>
+        {updateRateLimitSuccess ? (
+          <Notice
+            text={`Bucket properties updated successfully.`}
+            variant="success"
+          />
+        ) : null}
+
+        {errorText ? <Notice text={errorText} variant="error" /> : null}
         {/* TODO: OBJGen2 - We need to handle link in upcoming PR */}
         <StyledHelperText>
           Specifies the maximum Requests Per Second (RPS) for an Endpoint. To

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -6,10 +6,7 @@ import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
 import { SupportLink } from 'src/components/SupportLink';
 import { Typography } from 'src/components/Typography';
-import { useFlags } from 'src/hooks/useFlags';
-import { useAccount } from 'src/queries/account/account';
 import { useObjectStorageBuckets } from 'src/queries/object-storage/queries';
-import { isFeatureEnabledV2 } from 'src/utilities/accountCapabilities';
 import { getQueryParamFromQueryString } from 'src/utilities/queryParams';
 
 import { BucketRateLimitTable } from '../BucketLanding/BucketRateLimitTable';
@@ -50,21 +47,10 @@ export const BucketProperties = React.memo((props: Props) => {
   const location = useLocation();
   const history = useHistory();
   const prefix = getQueryParamFromQueryString(location.search, 'prefix');
-  const flags = useFlags();
-  const { data: account } = useAccount();
 
-  const isObjMultiClusterEnabled = isFeatureEnabledV2(
-    'Object Storage Access Key Regions',
-    Boolean(flags.objMultiCluster),
-    account?.capabilities ?? []
-  );
+  const { data: bucketsData } = useObjectStorageBuckets();
 
-  const { data: buckets } = useObjectStorageBuckets();
-
-  const bucket = buckets?.buckets.find((bucket) => {
-    if (isObjMultiClusterEnabled) {
-      return bucket.label === bucketName && bucket.region === clusterId;
-    }
+  const bucket = bucketsData?.buckets.find((bucket) => {
     return bucket.label === bucketName && bucket.cluster === clusterId;
   });
 

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -28,6 +28,9 @@ interface Props {
 export const BucketProperties = React.memo((props: Props) => {
   const { bucketName, clusterId, endpointType } = props;
   const [updateRateLimitLoading] = React.useState(false);
+  const [defaultRateLimit, setDefaultRateLimitData] = React.useState<
+    null | string
+  >(null);
   const [selectedRateLimit, setSelectedRateLimit] = React.useState<
     null | string
   >(null);
@@ -79,6 +82,7 @@ export const BucketProperties = React.memo((props: Props) => {
         ) : null}
 
         {errorText ? <Notice text={errorText} variant="error" /> : null}
+
         {/* TODO: OBJGen2 - We need to handle link in upcoming PR */}
         <StyledHelperText>
           Specifies the maximum Requests Per Second (RPS) for an Endpoint. To
@@ -86,7 +90,10 @@ export const BucketProperties = React.memo((props: Props) => {
           Understand <Link to="#">bucket rate limits</Link>.
         </StyledHelperText>
         <BucketRateLimitTable
-          onRateLimitChange={(selectedLimit: string) => {
+          onDefaultRateLimit={(defaultLimit) => {
+            setDefaultRateLimitData(defaultLimit);
+          }}
+          onRateLimitChange={(selectedLimit) => {
             setSelectedRateLimit(selectedLimit);
           }}
           endpointType={endpointType}
@@ -94,7 +101,7 @@ export const BucketProperties = React.memo((props: Props) => {
         />
         <StyledActionsPanel
           primaryButtonProps={{
-            disabled: !selectedRateLimit,
+            disabled: selectedRateLimit === defaultRateLimit,
             label: 'Save',
             loading: updateRateLimitLoading,
             onClick: () => {

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -92,8 +92,12 @@ export const BucketProperties = React.memo((props: Props) => {
         {/* TODO: OBJGen2 - We need to handle link in upcoming PR */}
         <StyledHelperText>
           Specifies the maximum Requests Per Second (RPS) for an Endpoint. To
-          increase it to High, <SupportLink text="open a support ticket" />.
-          Understand <Link to="#">bucket rate limits</Link>.
+          increase it to High,{' '}
+          <SupportLink
+            text="open a support ticket"
+            title="Request to Increase Bucket Rate Limits"
+          />
+          . Understand <Link to="#">bucket rate limits</Link>.
         </StyledHelperText>
 
         <form onSubmit={handleSubmit(onSubmit)}>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -6,7 +6,6 @@ import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
 import { SupportLink } from 'src/components/SupportLink';
 import { Typography } from 'src/components/Typography';
-import { useObjectStorageBuckets } from 'src/queries/object-storage/queries';
 import { getQueryParamFromQueryString } from 'src/utilities/queryParams';
 
 import { BucketRateLimitTable } from '../BucketLanding/BucketRateLimitTable';
@@ -18,12 +17,10 @@ import {
   StyledText,
 } from './BucketProperties.styles';
 
-import type { ObjectStorageEndpointTypes } from '@linode/api-v4';
+import type { ObjectStorageBucket } from '@linode/api-v4';
 
 interface Props {
-  bucketName: string;
-  clusterId: string;
-  endpointType?: ObjectStorageEndpointTypes;
+  bucket: ObjectStorageBucket;
 }
 
 export interface UpdateBucketRateLimitPayload {
@@ -31,7 +28,8 @@ export interface UpdateBucketRateLimitPayload {
 }
 
 export const BucketProperties = React.memo((props: Props) => {
-  const { bucketName, clusterId, endpointType } = props;
+  const { bucket } = props;
+  const { endpoint_type, hostname, label } = bucket;
 
   const form = useForm<UpdateBucketRateLimitPayload>({
     defaultValues: {
@@ -48,12 +46,6 @@ export const BucketProperties = React.memo((props: Props) => {
   const history = useHistory();
   const prefix = getQueryParamFromQueryString(location.search, 'prefix');
 
-  const { data: bucketsData } = useObjectStorageBuckets();
-
-  const bucket = bucketsData?.buckets.find((bucket) => {
-    return bucket.label === bucketName && bucket.cluster === clusterId;
-  });
-
   const onSubmit = () => {
     // TODO: OBJGen2 - Handle Bucket Rate Limit update logic once the endpoint for updating is available.
     // The 'data' argument is expected -> data: UpdateBucketRateLimitPayload
@@ -61,12 +53,8 @@ export const BucketProperties = React.memo((props: Props) => {
 
   return (
     <FormProvider {...form}>
-      <BucketBreadcrumb
-        bucketName={bucketName}
-        history={history}
-        prefix={prefix}
-      />
-      <StyledText>{bucket?.hostname || 'Loading...'}</StyledText>
+      <BucketBreadcrumb bucketName={label} history={history} prefix={prefix} />
+      <StyledText>{hostname || 'Loading...'}</StyledText>
 
       <StyledRootContainer>
         <Typography variant="h2">Bucket Rate Limits</Typography>
@@ -87,7 +75,7 @@ export const BucketProperties = React.memo((props: Props) => {
         </StyledHelperText>
 
         <form onSubmit={handleSubmit(onSubmit)}>
-          <BucketRateLimitTable endpointType={endpointType} />
+          <BucketRateLimitTable endpointType={endpoint_type} />
           <StyledActionsPanel
             primaryButtonProps={{
               disabled: !isDirty,

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
@@ -59,10 +59,11 @@ export const BucketDetailLanding = React.memo((props: Props) => {
   };
   const { bucketName, clusterId } = props.match.params;
 
-  const { endpoint_type: endpointType } =
-    bucketsData?.buckets.find(({ label }) => label === bucketName) ?? {};
+  const bucket = bucketsData?.buckets.find(({ label }) => label === bucketName);
 
-  const isSSLEnabled = endpointType !== 'E2' && endpointType === 'E3';
+  const { endpoint_type } = bucket ?? {};
+
+  const isSSLEnabled = endpoint_type !== 'E2' && endpoint_type === 'E3';
 
   const tabs = [
     {
@@ -125,22 +126,18 @@ export const BucketDetailLanding = React.memo((props: Props) => {
         <React.Suspense fallback={<SuspenseLoader />}>
           <TabPanels>
             <SafeTabPanel index={0}>
-              <ObjectList {...props} endpointType={endpointType} />
+              <ObjectList {...props} endpointType={endpoint_type} />
             </SafeTabPanel>
             <SafeTabPanel index={1}>
               <BucketAccess
                 bucketName={bucketName}
                 clusterId={clusterId}
-                endpointType={endpointType}
+                endpointType={endpoint_type}
               />
             </SafeTabPanel>
-            {flags.objectStorageGen2?.enabled && (
+            {flags.objectStorageGen2?.enabled && bucket && (
               <SafeTabPanel index={2}>
-                <BucketProperties
-                  bucketName={bucketName}
-                  clusterId={clusterId}
-                  endpointType={endpointType}
-                />
+                <BucketProperties bucket={bucket} />
               </SafeTabPanel>
             )}
             <SafeTabPanel index={tabs.length - 1}>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
@@ -73,10 +73,14 @@ export const BucketDetailLanding = React.memo((props: Props) => {
       routeName: `${props.match.url}/access`,
       title: 'Access',
     },
-    {
-      routeName: `${props.match.url}/properties`,
-      title: 'Properties',
-    },
+    ...(flags.objectStorageGen2
+      ? [
+          {
+            routeName: `${props.match.url}/properties`,
+            title: 'Properties',
+          },
+        ]
+      : []),
     ...(!isSSLEnabled
       ? [
           {
@@ -130,14 +134,16 @@ export const BucketDetailLanding = React.memo((props: Props) => {
                 endpointType={endpointType}
               />
             </SafeTabPanel>
-            <SafeTabPanel index={2}>
-              <BucketProperties
-                bucketName={bucketName}
-                clusterId={clusterId}
-                endpointType={endpointType}
-              />
-            </SafeTabPanel>
-            <SafeTabPanel index={3}>
+            {flags.objectStorageGen2 && (
+              <SafeTabPanel index={2}>
+                <BucketProperties
+                  bucketName={bucketName}
+                  clusterId={clusterId}
+                  endpointType={endpointType}
+                />
+              </SafeTabPanel>
+            )}
+            <SafeTabPanel index={tabs.length - 1}>
               <BucketSSL bucketName={bucketName} clusterId={clusterId} />
             </SafeTabPanel>
           </TabPanels>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
@@ -27,6 +27,11 @@ const BucketSSL = React.lazy(() =>
     default: module.BucketSSL,
   }))
 );
+const BucketProperties = React.lazy(() =>
+  import('./BucketProperties').then((module) => ({
+    default: module.BucketProperties,
+  }))
+);
 
 interface MatchProps {
   bucketName: string;
@@ -67,6 +72,10 @@ export const BucketDetailLanding = React.memo((props: Props) => {
     {
       routeName: `${props.match.url}/access`,
       title: 'Access',
+    },
+    {
+      routeName: `${props.match.url}/properties`,
+      title: 'Properties',
     },
     ...(!isSSLEnabled
       ? [
@@ -122,6 +131,9 @@ export const BucketDetailLanding = React.memo((props: Props) => {
               />
             </SafeTabPanel>
             <SafeTabPanel index={2}>
+              <BucketProperties bucketName={bucketName} clusterId={clusterId} />
+            </SafeTabPanel>
+            <SafeTabPanel index={3}>
               <BucketSSL bucketName={bucketName} clusterId={clusterId} />
             </SafeTabPanel>
           </TabPanels>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
@@ -73,7 +73,7 @@ export const BucketDetailLanding = React.memo((props: Props) => {
       routeName: `${props.match.url}/access`,
       title: 'Access',
     },
-    ...(flags.objectStorageGen2
+    ...(flags.objectStorageGen2?.enabled
       ? [
           {
             routeName: `${props.match.url}/properties`,
@@ -134,7 +134,7 @@ export const BucketDetailLanding = React.memo((props: Props) => {
                 endpointType={endpointType}
               />
             </SafeTabPanel>
-            {flags.objectStorageGen2 && (
+            {flags.objectStorageGen2?.enabled && (
               <SafeTabPanel index={2}>
                 <BucketProperties
                   bucketName={bucketName}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
@@ -131,7 +131,11 @@ export const BucketDetailLanding = React.memo((props: Props) => {
               />
             </SafeTabPanel>
             <SafeTabPanel index={2}>
-              <BucketProperties bucketName={bucketName} clusterId={clusterId} />
+              <BucketProperties
+                bucketName={bucketName}
+                clusterId={clusterId}
+                endpointType={endpointType}
+              />
             </SafeTabPanel>
             <SafeTabPanel index={3}>
               <BucketSSL bucketName={bucketName} clusterId={clusterId} />

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Radio } from 'src/components/Radio/Radio';
 import { Table } from 'src/components/Table';
@@ -18,7 +18,13 @@ import type { ObjectStorageEndpointTypes } from '@linode/api-v4';
 interface BucketRateLimitTableProps {
   endpointType: ObjectStorageEndpointTypes | undefined;
   onRateLimitChange?: (selectedLimit: string) => void;
-  selectedRateLimit?: string;
+  selectedRateLimit?: null | string;
+}
+
+interface RateLimit {
+  checked: boolean;
+  id: string;
+  values: string[];
 }
 
 const tableHeaders = ['Limits', 'GET', 'PUT', 'LIST', 'DELETE', 'OTHER'];
@@ -47,6 +53,16 @@ const tableData = (endpointType: BucketRateLimitTableProps['endpointType']) => {
 
 export const BucketRateLimitTable = (props: BucketRateLimitTableProps) => {
   const { endpointType, onRateLimitChange, selectedRateLimit } = props;
+  const [rateLimits, setRateLimits] = useState<RateLimit[] | null>(null);
+
+  React.useEffect(() => {
+    const data = tableData(endpointType);
+    setRateLimits(data);
+
+    // Set default/inital value
+    const defaultRateLimit = data.find((rl: any) => rl.checked)?.id || '1';
+    onRateLimitChange?.(defaultRateLimit);
+  }, [endpointType]);
 
   return (
     <Table sx={{ marginBottom: 3 }}>
@@ -69,7 +85,7 @@ export const BucketRateLimitTable = (props: BucketRateLimitTableProps) => {
         </TableRow>
       </TableHead>
       <TableBody>
-        {tableData(endpointType).map((row, rowIndex) => (
+        {rateLimits?.map((row, rowIndex) => (
           <TableRow key={rowIndex}>
             <TableCell>
               <Radio

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
@@ -38,14 +38,14 @@ const tableData = (endpointType: BucketRateLimitTableProps['endpointType']) => {
     {
       checked: true,
       id: '1',
-      label: 'Basic',
-      values: ['2,000', '500', '100', '200', '400'],
+        label: 'Basic',
+        values: ['2,000', '500', '100', '200', '400'],
     },
     {
       checked: false,
       id: '2',
-      label: 'High',
-    values: [
+        label: 'High',
+      values: [
         isE3 ? '20,000' : '5,000',
         isE3 ? '2,000' : '1,000',
         isE3 ? '400' : '200',

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
@@ -17,19 +17,23 @@ import type { ObjectStorageEndpointTypes } from '@linode/api-v4';
 
 interface BucketRateLimitTableProps {
   endpointType: ObjectStorageEndpointTypes | undefined;
+  onRateLimitChange?: (selectedLimit: string) => void;
+  selectedRateLimit?: string;
 }
 
 const tableHeaders = ['Limits', 'GET', 'PUT', 'LIST', 'DELETE', 'OTHER'];
-const tableData = ({ endpointType }: BucketRateLimitTableProps) => {
+const tableData = (endpointType: BucketRateLimitTableProps['endpointType']) => {
   const isE3 = endpointType === 'E3';
 
   return [
     {
       checked: true,
+      id: '1',
       values: ['2,000', '500', '100', '200', '400'],
     },
     {
       checked: false,
+      id: '2',
       values: [
         isE3 ? '20,000' : '5,000',
         isE3 ? '2,000' : '1,000',
@@ -41,45 +45,14 @@ const tableData = ({ endpointType }: BucketRateLimitTableProps) => {
   ];
 };
 
-export const BucketRateLimitTable = ({
-  endpointType,
-}: BucketRateLimitTableProps) => (
-  <Table
-    sx={{
-      marginBottom: 3,
-    }}
-  >
-    <TableHead>
-      <TableRow>
-        {tableHeaders.map((header, index) => {
-          return (
-            <TableCell
-              sx={{
-                '&&:last-child': {
-                  paddingRight: 2,
-                },
-              }}
-              key={`${index}-${header}`}
-            >
-              {header}
-            </TableCell>
-          );
-        })}
-      </TableRow>
-    </TableHead>
-    <TableBody>
-      {tableData({ endpointType }).map((row, rowIndex) => (
-        <TableRow key={rowIndex}>
-          <TableCell>
-            <Radio
-              checked={row.checked}
-              disabled
-              name="limit-selection"
-              onChange={() => {}}
-              value="2"
-            />
-          </TableCell>
-          {row.values.map((value, index) => {
+export const BucketRateLimitTable = (props: BucketRateLimitTableProps) => {
+  const { endpointType, onRateLimitChange, selectedRateLimit } = props;
+
+  return (
+    <Table sx={{ marginBottom: 3 }}>
+      <TableHead>
+        <TableRow>
+          {tableHeaders.map((header, index) => {
             return (
               <TableCell
                 sx={{
@@ -87,14 +60,42 @@ export const BucketRateLimitTable = ({
                     paddingRight: 2,
                   },
                 }}
-                key={`${index}-${value}`}
+                key={`${index}-${header}`}
               >
-                {value}
+                {header}
               </TableCell>
             );
           })}
         </TableRow>
-      ))}
-    </TableBody>
-  </Table>
-);
+      </TableHead>
+      <TableBody>
+        {tableData(endpointType).map((row, rowIndex) => (
+          <TableRow key={rowIndex}>
+            <TableCell>
+              <Radio
+                checked={selectedRateLimit === row.id}
+                name="limit-selection"
+                onChange={() => onRateLimitChange?.(row.id)}
+                value={row.id}
+              />
+            </TableCell>
+            {row.values.map((value, index) => {
+              return (
+                <TableCell
+                  sx={{
+                    '&&:last-child': {
+                      paddingRight: 2,
+                    },
+                  }}
+                  key={`${index}-${value}`}
+                >
+                  {value}
+                </TableCell>
+              );
+            })}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useController, useFormContext, useWatch } from 'react-hook-form';
+import { useController, useFormContext } from 'react-hook-form';
 
 import { FormControlLabel } from 'src/components/FormControlLabel';
 import { Radio } from 'src/components/Radio/Radio';
@@ -56,7 +56,6 @@ export const BucketRateLimitTable = ({
     control,
     name: 'rateLimit',
   });
-  const rateLimitValue = useWatch({ control, name: 'rateLimit' });
 
   return (
     <Table sx={{ marginBottom: 3 }}>
@@ -85,7 +84,7 @@ export const BucketRateLimitTable = ({
               <FormControlLabel
                 control={
                   <Radio
-                    checked={rateLimitValue === row.id}
+                    checked={field.value === row.id}
                     disabled
                     onChange={() => field.onChange(row.id)}
                     value={row.id}

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
@@ -58,10 +58,6 @@ export const BucketRateLimitTable = ({
   });
   const rateLimitValue = useWatch({ control, name: 'rateLimit' });
 
-  const rateLimits = React.useMemo(() => tableData({ endpointType }), [
-    endpointType,
-  ]);
-
   return (
     <Table sx={{ marginBottom: 3 }}>
       <TableHead>
@@ -83,7 +79,7 @@ export const BucketRateLimitTable = ({
         </TableRow>
       </TableHead>
       <TableBody>
-        {rateLimits?.map((row, rowIndex) => (
+        {tableData({ endpointType }).map((row, rowIndex) => (
           <TableRow key={rowIndex}>
             <TableCell>
               <FormControlLabel

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
@@ -30,13 +30,13 @@ const tableData = ({ endpointType }: BucketRateLimitTableProps) => {
     {
       checked: true,
       id: '1',
-        label: 'Basic',
-        values: ['2,000', '500', '100', '200', '400'],
+      label: 'Basic',
+      values: ['2,000', '500', '100', '200', '400'],
     },
     {
       checked: false,
       id: '2',
-        label: 'High',
+      label: 'High',
       values: [
         isE3 ? '20,000' : '5,000',
         isE3 ? '2,000' : '1,000',

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 
+import { Hidden } from 'src/components/Hidden';
 import { Radio } from 'src/components/Radio/Radio';
 import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
@@ -24,6 +25,7 @@ interface BucketRateLimitTableProps {
 interface RateLimit {
   checked: boolean;
   id: string;
+  label: string;
   values: string[];
 }
 
@@ -35,12 +37,14 @@ const tableData = (endpointType: BucketRateLimitTableProps['endpointType']) => {
     {
       checked: true,
       id: '1',
+      label: 'Basic',
       values: ['2,000', '500', '100', '200', '400'],
     },
     {
       checked: false,
       id: '2',
-      values: [
+      label: 'High',
+    values: [
         isE3 ? '20,000' : '5,000',
         isE3 ? '2,000' : '1,000',
         isE3 ? '400' : '200',
@@ -59,7 +63,7 @@ export const BucketRateLimitTable = (props: BucketRateLimitTableProps) => {
     const data = tableData(endpointType);
     setRateLimits(data);
 
-    // Set default/inital value
+    // Set default/initial value
     const defaultRateLimit = data.find((rl: any) => rl.checked)?.id || '1';
     onRateLimitChange?.(defaultRateLimit);
   }, [endpointType]);
@@ -94,6 +98,7 @@ export const BucketRateLimitTable = (props: BucketRateLimitTableProps) => {
                 onChange={() => onRateLimitChange?.(row.id)}
                 value={row.id}
               />
+              <Hidden smDown>{row.label}</Hidden>
             </TableCell>
             {row.values.map((value, index) => {
               return (

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
@@ -18,6 +18,7 @@ import type { ObjectStorageEndpointTypes } from '@linode/api-v4';
 
 interface BucketRateLimitTableProps {
   endpointType: ObjectStorageEndpointTypes | undefined;
+  onDefaultRateLimit?: (defaultLimit: string) => void;
   onRateLimitChange?: (selectedLimit: string) => void;
   selectedRateLimit?: null | string;
 }
@@ -56,15 +57,23 @@ const tableData = (endpointType: BucketRateLimitTableProps['endpointType']) => {
 };
 
 export const BucketRateLimitTable = (props: BucketRateLimitTableProps) => {
-  const { endpointType, onRateLimitChange, selectedRateLimit } = props;
+  const {
+    endpointType,
+    onDefaultRateLimit,
+    onRateLimitChange,
+    selectedRateLimit,
+  } = props;
   const [rateLimits, setRateLimits] = useState<RateLimit[] | null>(null);
 
   React.useEffect(() => {
     const data = tableData(endpointType);
     setRateLimits(data);
 
-    // Set default/initial value
+    // Set Default value.
     const defaultRateLimit = data.find((rl: any) => rl.checked)?.id || '1';
+    onDefaultRateLimit?.(defaultRateLimit);
+
+    // Set Selected value as Default value initially.
     onRateLimitChange?.(defaultRateLimit);
   }, [endpointType]);
 


### PR DESCRIPTION
## Description 📝
We aim to enhance our bucket management interface by introducing a new "Properties" tab. This tab will display the current rate limits for each bucket and include functionality to modify these limits in future updates.

## Changes  🔄
- Add Bucket Management Properties Tab for Object Storage Gen2.

## Target release date 🗓️
N/A

## Preview 📷
![Screenshot 2024-08-22 at 1 05 48 AM](https://github.com/user-attachments/assets/4c256444-5e3f-4e6d-b7c9-f82cda10c1c0)

## How to test 🧪

### Prerequisites
- Enable MSW and ensure OBJ Gen2 flag is enabled.

### Verification steps
> [!Note]
> - The endpoints for retrieving and updating Bucket Rate Limits are currently unavailable.
> - Hardcoded values are being used to retrieve Bucket Rate Limits data.

- Navigate to http://localhost:3000/object-storage/buckets
- Select a bucket.
- When on details page, verify that the new 'Properties' tab is rendered.
- Verify that the user interface correctly displays the retrieved Bucket Rate Limits data.
- Verify that the functionality to update Bucket Rate Limits has been implemented and is ready for integration with the API endpoints when they become available.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support