### PR TITLE
test: [M3-8454] - Cypress test for Secure VMs firewall generation

### DIFF
--- a/packages/manager/.changeset/pr-10802-tests-1724271249856.md
+++ b/packages/manager/.changeset/pr-10802-tests-1724271249856.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Secure VMs firewall generation ([#10802](https://github.com/linode/manager/pull/10802))

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-firewall.spec.ts
@@ -37,7 +37,7 @@ describe('Create Linode with Firewall', () => {
    * - Confirms that Firewall is reflected in create summary section.
    * - Confirms that outgoing Linode Create API request specifies the selected Firewall to be attached.
    */
-  it.skip('can assign existing Firewall during Linode Create flow', () => {
+  it('can assign existing Firewall during Linode Create flow', () => {
     const linodeRegion = chooseRegion({ capabilities: ['Cloud Firewall'] });
 
     const mockFirewall = firewallFactory.build({
@@ -102,7 +102,7 @@ describe('Create Linode with Firewall', () => {
    * - Confirms that Firewall is reflected in create summary section.
    * - Confirms that outgoing Linode Create API request specifies the selected Firewall to be attached.
    */
-  it.skip('can assign new Firewall during Linode Create flow', () => {
+  it('can assign new Firewall during Linode Create flow', () => {
     const linodeRegion = chooseRegion({ capabilities: ['Cloud Firewall'] });
 
     const mockFirewall = firewallFactory.build({
@@ -273,10 +273,7 @@ describe('Create Linode with Firewall', () => {
       });
     cy.wait('@createFirewall');
 
-    ui.autocompletePopper
-      .findByTitle(mockFirewall.label)
-      .should('be.visible')
-      .click();
+    cy.findByText(mockFirewall.label).should('be.visible');
 
     // Confirm Firewall assignment indicator is shown in Linode summary.
     cy.get('[data-qa-linode-create-summary]')

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-firewall.spec.ts
@@ -1,4 +1,8 @@
-import { linodeFactory, firewallFactory } from 'src/factories';
+import {
+  linodeFactory,
+  firewallFactory,
+  firewallTemplateFactory,
+} from 'src/factories';
 import {
   mockAppendFeatureFlags,
   mockGetFeatureFlagClientstream,
@@ -10,6 +14,7 @@ import {
 import {
   mockGetFirewalls,
   mockCreateFirewall,
+  mockGetTemplate,
 } from 'support/intercepts/firewalls';
 import { ui } from 'support/ui';
 import { linodeCreatePage } from 'support/ui/pages';
@@ -31,7 +36,7 @@ describe('Create Linode with Firewall', () => {
    * - Confirms that Firewall is reflected in create summary section.
    * - Confirms that outgoing Linode Create API request specifies the selected Firewall to be attached.
    */
-  it('can assign existing Firewall during Linode Create flow', () => {
+  it.skip('can assign existing Firewall during Linode Create flow', () => {
     const linodeRegion = chooseRegion({ capabilities: ['Cloud Firewall'] });
 
     const mockFirewall = firewallFactory.build({
@@ -96,7 +101,7 @@ describe('Create Linode with Firewall', () => {
    * - Confirms that Firewall is reflected in create summary section.
    * - Confirms that outgoing Linode Create API request specifies the selected Firewall to be attached.
    */
-  it('can assign new Firewall during Linode Create flow', () => {
+  it.skip('can assign new Firewall during Linode Create flow', () => {
     const linodeRegion = chooseRegion({ capabilities: ['Cloud Firewall'] });
 
     const mockFirewall = firewallFactory.build({
@@ -148,6 +153,118 @@ describe('Create Linode with Firewall', () => {
 
     // Confirm that mocked Firewall is shown in the Autocomplete, and then select it.
     cy.findByText('Assign Firewall').click().type(`${mockFirewall.label}`);
+
+    ui.autocompletePopper
+      .findByTitle(mockFirewall.label)
+      .should('be.visible')
+      .click();
+
+    // Confirm Firewall assignment indicator is shown in Linode summary.
+    cy.get('[data-qa-linode-create-summary]')
+      .scrollIntoView()
+      .within(() => {
+        cy.findByText('Firewall Assigned').should('be.visible');
+      });
+
+    // Create Linode and confirm contents of outgoing API request payload.
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.wait('@createLinode').then((xhr) => {
+      const requestPayload = xhr.request.body;
+      const firewallId = requestPayload['firewall_id'];
+      expect(firewallId).to.equal(mockFirewall.id);
+    });
+
+    // Confirm redirect to new Linode.
+    cy.url().should('endWith', `/linodes/${mockLinode.id}`);
+    // Confirm toast notification should appear on Linode create.
+    ui.toast.assertMessage(`Your Linode ${mockLinode.label} is being created.`);
+  });
+
+  /*
+   * - Mocks the internal header to enable the Generate Compliant Firewall banner.
+   * - Confirms that Firewall is reflected in create summary section.
+   * - Confirms that outgoing Linode Create API request specifies the selected Firewall to be attached.
+   */
+  it('can generate and assign a compliant Firewall during Linode Create flow', () => {
+    cy.intercept(
+      {
+        middleware: true,
+        url: /\/v4(?:beta)?\/.*/,
+      },
+      (req) => {
+        // Re-add internal-only header
+        req.on('response', (res) => {
+          res.headers['akamai-internal-account'] = '*';
+        });
+      }
+    );
+
+    const linodeRegion = chooseRegion({ capabilities: ['Cloud Firewall'] });
+
+    const mockFirewall = firewallFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+    });
+
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+    });
+
+    const mockTemplate = firewallTemplateFactory.build({
+      slug: 'akamai-non-prod',
+    });
+
+    mockCreateFirewall(mockFirewall).as('createFirewall');
+    mockGetFirewalls([mockFirewall]).as('getFirewall');
+    mockGetTemplate(mockTemplate).as('getTemplate');
+    mockCreateLinode(mockLinode).as('createLinode');
+    mockGetLinodeDetails(mockLinode.id, mockLinode);
+
+    cy.visitWithLogin('/linodes/create');
+
+    linodeCreatePage.setLabel(mockLinode.label);
+    linodeCreatePage.selectImage('Debian 11');
+    linodeCreatePage.selectRegionById(linodeRegion.id);
+    linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
+    linodeCreatePage.setRootPassword(randomString(32));
+
+    // Creating the linode without a firewall should display a warning.
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.disabled');
+
+    cy.findByLabelText(
+      'I am authorized to create a Linode without a Cloud Firewall'
+    ).click();
+
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled');
+
+    cy.findByText('Generate Compliant Firewall').should('be.visible').click();
+
+    ui.dialog
+      .findByTitle('Generate an Akamai Compliant Firewall')
+      .should('be.visible')
+      .within(() => {
+        cy.findByText('Generate Firewall Now')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+        cy.findByText('Generating Firewall');
+        cy.findByText('Complete!');
+        cy.findByText('OK').should('be.visible').should('be.enabled').click();
+      });
+    cy.wait('@getFirewall');
 
     ui.autocompletePopper
       .findByTitle(mockFirewall.label)

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-firewall.spec.ts
@@ -37,7 +37,7 @@ describe('Create Linode with Firewall', () => {
    * - Confirms that Firewall is reflected in create summary section.
    * - Confirms that outgoing Linode Create API request specifies the selected Firewall to be attached.
    */
-  it('can assign existing Firewall during Linode Create flow', () => {
+  it.skip('can assign existing Firewall during Linode Create flow', () => {
     const linodeRegion = chooseRegion({ capabilities: ['Cloud Firewall'] });
 
     const mockFirewall = firewallFactory.build({
@@ -102,7 +102,7 @@ describe('Create Linode with Firewall', () => {
    * - Confirms that Firewall is reflected in create summary section.
    * - Confirms that outgoing Linode Create API request specifies the selected Firewall to be attached.
    */
-  it('can assign new Firewall during Linode Create flow', () => {
+  it.skip('can assign new Firewall during Linode Create flow', () => {
     const linodeRegion = chooseRegion({ capabilities: ['Cloud Firewall'] });
 
     const mockFirewall = firewallFactory.build({
@@ -237,6 +237,12 @@ describe('Create Linode with Firewall', () => {
     linodeCreatePage.setRootPassword(randomString(32));
 
     // Creating the linode without a firewall should display a warning.
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
     ui.button
       .findByTitle('Create Linode')
       .should('be.visible')

--- a/packages/manager/cypress/support/intercepts/firewalls.ts
+++ b/packages/manager/cypress/support/intercepts/firewalls.ts
@@ -1,9 +1,10 @@
 /**
  * @file Cypress intercepts and mocks for Firewall API requests.
  */
-import type { Firewall } from '@linode/api-v4';
 import { apiMatcher } from 'support/util/intercepts';
 import { paginateResponse } from 'support/util/paginate';
+
+import type { Firewall, FirewallTemplate } from '@linode/api-v4';
 
 /**
  * Intercepts GET request to fetch Firewalls.
@@ -78,5 +79,22 @@ export const interceptUpdateFirewallLinodes = (
   return cy.intercept(
     'POST',
     apiMatcher(`networking/firewalls/${firewallId}/devices`)
+  );
+};
+
+/**
+ * Intercepts GET request to fetch a Firewall template and mocks response.
+ *
+ * @param template - Template with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetTemplate = (
+  template: FirewallTemplate
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher('networking/firewalls/templates/*'),
+    template
   );
 };

--- a/packages/manager/cypress/support/intercepts/firewalls.ts
+++ b/packages/manager/cypress/support/intercepts/firewalls.ts
@@ -1,6 +1,7 @@
 /**
  * @file Cypress intercepts and mocks for Firewall API requests.
  */
+import { makeErrorResponse } from 'support/util/errors';
 import { apiMatcher } from 'support/util/intercepts';
 import { paginateResponse } from 'support/util/paginate';
 
@@ -43,6 +44,25 @@ export const mockCreateFirewall = (
   firewall: Firewall
 ): Cypress.Chainable<null> => {
   return cy.intercept('POST', apiMatcher('networking/firewalls*'), firewall);
+};
+
+/**
+ * Intercepts POST request to create a Firewall and mocks an error response.
+ *
+ * @param errorMessage - Error message to be included in the mocked HTTP response.
+ * @param statusCode - HTTP status code for mocked error response. Default is `400`.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockCreateFirewallError = (
+  errorMessage: string,
+  statusCode: number = 400
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`networking/firewalls*`),
+    makeErrorResponse(errorMessage, statusCode)
+  );
 };
 
 /**


### PR DESCRIPTION
## Description 📝
Add Cypress tests to verify the flow to generate compliant firewalls in the Linode Create form.

This flow can also be initiated from the banners in `FirewallLanding` and `FirewallDetails` but since those are already covered by unit tests, and the component is shared, I decided to only write tests for generating firewalls through the Linode create flow.

## Target release date 🗓️
9/3

## How to test 🧪

- Verify Cypress tests pass

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support