### PR TITLE
upcoming: [M3-8455] – Add "Encrypt Volume" checkbox in Clone Volume drawer

### DIFF
--- a/packages/manager/.changeset/pr-10803-upcoming-features-1724100276144.md
+++ b/packages/manager/.changeset/pr-10803-upcoming-features-1724100276144.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add 'Encrypt Volume' checkbox to Clone Volume drawer ([#10803](https://github.com/linode/manager/pull/10803))

--- a/packages/manager/src/components/Encryption/constants.tsx
+++ b/packages/manager/src/components/Encryption/constants.tsx
@@ -98,3 +98,6 @@ export const BLOCK_STORAGE_USER_SIDE_ENCRYPTION_CAVEAT =
 
 export const BLOCK_STORAGE_ENCRYPTION_SETTING_IMMUTABLE_COPY =
   'The encryption setting cannot be changed after creation.';
+
+export const BLOCK_STORAGE_CLONING_INHERITANCE_CAVEAT =
+  'Encryption is inherited from the source volume and cannot be changed when cloning volumes.';

--- a/packages/manager/src/features/Volumes/CloneVolumeDrawer.test.tsx
+++ b/packages/manager/src/features/Volumes/CloneVolumeDrawer.test.tsx
@@ -1,0 +1,83 @@
+import { waitFor } from '@testing-library/react';
+import * as React from 'react';
+
+import { accountFactory, volumeFactory } from 'src/factories';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { CloneVolumeDrawer } from './CloneVolumeDrawer';
+
+const accountEndpoint = '*/v4/account';
+const encryptionLabelText = 'Encrypt Volume';
+
+describe('CloneVolumeDrawer', () => {
+  /* @TODO BSE: Remove feature flagging/conditionality once BSE is fully rolled out */
+
+  it('should display a disabled checkbox for volume encryption if the user has the account capability and the feature flag is on', async () => {
+    const volume = volumeFactory.build();
+
+    server.use(
+      http.get(accountEndpoint, () => {
+        return HttpResponse.json(
+          accountFactory.build({ capabilities: ['Block Storage Encryption'] })
+        );
+      })
+    );
+
+    const { getByLabelText } = renderWithTheme(
+      <CloneVolumeDrawer onClose={vi.fn} open volume={volume} />,
+      {
+        flags: { blockStorageEncryption: true },
+      }
+    );
+
+    await waitFor(() => {
+      expect(getByLabelText(encryptionLabelText)).not.toBeNull();
+      expect(getByLabelText(encryptionLabelText)).toBeDisabled();
+    });
+  });
+
+  it('should not display a checkbox for volume encryption if the user has the account capability but the feature flag is off', async () => {
+    const volume = volumeFactory.build();
+
+    server.use(
+      http.get(accountEndpoint, () => {
+        return HttpResponse.json(
+          accountFactory.build({ capabilities: ['Block Storage Encryption'] })
+        );
+      })
+    );
+
+    const { queryByRole } = renderWithTheme(
+      <CloneVolumeDrawer onClose={vi.fn} open volume={volume} />,
+      {
+        flags: { blockStorageEncryption: false },
+      }
+    );
+
+    await waitFor(() => {
+      expect(queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should not display a checkbox for volume encryption if the feature flag is on but the user lacks the account capability', async () => {
+    const volume = volumeFactory.build();
+
+    server.use(
+      http.get(accountEndpoint, () => {
+        return HttpResponse.json(accountFactory.build({ capabilities: [] }));
+      })
+    );
+
+    const { queryByRole } = renderWithTheme(
+      <CloneVolumeDrawer onClose={vi.fn} open volume={volume} />,
+      {
+        flags: { blockStorageEncryption: true },
+      }
+    );
+
+    await waitFor(() => {
+      expect(queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/manager/src/features/Volumes/CloneVolumeDrawer.tsx
+++ b/packages/manager/src/features/Volumes/CloneVolumeDrawer.tsx
@@ -1,10 +1,13 @@
-import { Volume } from '@linode/api-v4';
 import { CloneVolumeSchema } from '@linode/validation/lib/volumes.schema';
 import { useFormik } from 'formik';
 import * as React from 'react';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
+import { Box } from 'src/components/Box';
+import { Checkbox } from 'src/components/Checkbox';
 import { Drawer } from 'src/components/Drawer';
+import { BLOCK_STORAGE_CLONING_INHERITANCE_CAVEAT } from 'src/components/Encryption/constants';
+import { useIsBlockStorageEncryptionFeatureEnabled } from 'src/components/Encryption/utils';
 import { Notice } from 'src/components/Notice/Notice';
 import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
@@ -21,6 +24,8 @@ import {
 import { PRICES_RELOAD_ERROR_NOTICE_TEXT } from 'src/utilities/pricing/constants';
 
 import { PricePanel } from './VolumeDrawer/PricePanel';
+
+import type { Volume } from '@linode/api-v4';
 interface Props {
   onClose: () => void;
   open: boolean;
@@ -38,6 +43,10 @@ export const CloneVolumeDrawer = (props: Props) => {
 
   const { data: grants } = useGrants();
   const { data: types, isError, isLoading } = useVolumeTypesQuery();
+
+  const {
+    isBlockStorageEncryptionFeatureEnabled,
+  } = useIsBlockStorageEncryptionFeatureEnabled();
 
   // Even if a restricted user has the ability to create Volumes, they
   // can't clone a Volume they only have read only permission on.
@@ -108,6 +117,21 @@ export const CloneVolumeDrawer = (props: Props) => {
           required
           value={values.label}
         />
+        {isBlockStorageEncryptionFeatureEnabled && (
+          <Box
+            sx={{
+              marginLeft: '2px',
+              marginTop: '16px',
+            }}
+          >
+            <Checkbox
+              checked={volume?.encryption === 'enabled'}
+              disabled
+              text="Encrypt Volume"
+              toolTipText={BLOCK_STORAGE_CLONING_INHERITANCE_CAVEAT}
+            />
+          </Box>
+        )}
         <PricePanel
           currentSize={volume?.size ?? -1}
           regionId={volume?.region ?? ''}

--- a/packages/manager/src/features/Volumes/VolumeDrawer/PricePanel.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/PricePanel.tsx
@@ -44,7 +44,7 @@ export const PricePanel = ({ currentSize, regionId, value }: Props) => {
   }
 
   return (
-    <Box marginTop={4}>
+    <Box marginTop={2}>
       <DisplayPrice interval="mo" price={price ? Number(price) : '--.--'} />
     </Box>
   );


### PR DESCRIPTION
## Description 📝
Add a disabled "Encrypt Volume" checkbox in Clone Volume drawer that reflects the existing volume's encrypted status (i.e., encrypted volumes should have a checked disabled box, and unencrypted volumes should have an unchecked disabled box)

## Changes  🔄
- Disabled "Encrypt Volume" checkbox added to Clone Volume drawer
- New unit test coverage for Clone Volume drawe
- Slight spacing adjustment in `PricePanel.tsx`

## Target release date 🗓️
9/3/24

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-08-19 at 4 27 33 PM](https://github.com/user-attachments/assets/151f97af-2847-418f-b717-d0940e7ca827) | ![Screenshot 2024-08-19 at 4 27 22 PM](https://github.com/user-attachments/assets/4a636350-4eef-4200-87be-aee487a23494) |

## How to test 🧪
### Prerequisites
Point at the dev environment with the `blockstorage-encryption` tag on your account

### Verification steps
Confirm the Clone Volume drawer has the BSE checkbox when the feature flag is on, and that the checkbox reflects the volume's encrypted status (i.e., encrypted volumes should have a checked disabled box, and unencrypted volumes should have an unchecked disabled box)

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support