### PR TITLE
test: [M3-8137] - Add Cypress integration test to enable Linode Managed

### DIFF
--- a/packages/manager/.changeset/pr-10806-tests-1725030349963.md
+++ b/packages/manager/.changeset/pr-10806-tests-1725030349963.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add Cypress integration test to enable Linode Managed ([#10806](https://github.com/linode/manager/pull/10806))

--- a/packages/manager/cypress/e2e/core/account/account-linode-managed.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/account-linode-managed.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * @file Integration tests for Cloud Manager account enable Linode Managed flows.
+ */
+
+import { profileFactory } from 'src/factories/profile';
+import { accountFactory } from 'src/factories/account';
+import {
+  mockGetAccount,
+  mockEnableLinodeManaged,
+  mockEnableLinodeManagedError,
+} from 'support/intercepts/account';
+import {
+  linodeEnabledMessageText,
+  linodeManagedStateMessageText,
+} from 'support/constants/account';
+import { mockGetProfile } from 'support/intercepts/profile';
+import { ui } from 'support/ui';
+import {
+  visitUrlWithManagedDisabled,
+  visitUrlWithManagedEnabled,
+} from 'support/api/managed';
+
+describe('Account Linode Managed', () => {
+  /*
+   * - Confirms that a user can add linode managed from the Account Settings page.
+   * - Confirms that user is told about the Managed price.
+   * - Confirms that Cloud Manager displays the Managed state.
+   */
+  it('users can enable Linode Managed', () => {
+    const mockAccount = accountFactory.build();
+    const mockProfile = profileFactory.build({
+      username: 'mock-user',
+      restricted: false,
+    });
+
+    mockGetAccount(mockAccount).as('getAccount');
+    mockGetProfile(mockProfile).as('getProfile');
+    mockEnableLinodeManaged().as('enableLinodeManaged');
+
+    // Navigate to Account Settings page, click "Add Linode Managed" button.
+    visitUrlWithManagedDisabled('/account/settings');
+    cy.wait(['@getAccount', '@getProfile']);
+
+    ui.button
+      .findByTitle('Add Linode Managed')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    ui.dialog
+      .findByTitle('Just to confirm...')
+      .should('be.visible')
+      .within(() => {
+        cy.get('h6')
+          .invoke('text')
+          .then((text) => {
+            console.log(`h6 text: ${text.trim()}`);
+            expect(text.trim()).to.equal(linodeEnabledMessageText);
+          });
+
+        // Confirm that submit button is enabled.
+        ui.button
+          .findByTitle('Add Linode Managed')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    cy.wait('@enableLinodeManaged');
+
+    // Confirm that Cloud Manager displays a notice about Linod managed is enabled.
+    cy.findByText(linodeManagedStateMessageText, { exact: false }).should(
+      'be.visible'
+    );
+  });
+
+  /*
+   * - Confirms Cloud Manager behavior when a restricted user attempts to enable Linode Managed.
+   * - Confirms that API error response message is displayed in confirmation dialog.
+   */
+  it('restricted users cannot cancel account', () => {
+    const mockAccount = accountFactory.build();
+    const mockProfile = profileFactory.build({
+      username: 'mock-restricted-user',
+      restricted: true,
+    });
+    const errorMessage = 'Unauthorized';
+
+    mockGetAccount(mockAccount).as('getAccount');
+    mockGetProfile(mockProfile).as('getProfile');
+    mockEnableLinodeManagedError(errorMessage, 403).as('enableLinodeManaged');
+
+    // Navigate to Account Settings page, click "Add Linode Managed" button.
+    visitUrlWithManagedDisabled('/account/settings');
+    cy.wait(['@getAccount', '@getProfile']);
+
+    ui.button
+      .findByTitle('Add Linode Managed')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    ui.dialog
+      .findByTitle('Just to confirm...')
+      .should('be.visible')
+      .within(() => {
+        cy.get('h6')
+          .invoke('text')
+          .then((text) => {
+            console.log(`h6 text: ${text.trim()}`);
+            expect(text.trim()).to.equal(linodeEnabledMessageText);
+          });
+
+        // Confirm that submit button is enabled.
+        ui.button
+          .findByTitle('Add Linode Managed')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+
+        cy.wait('@enableLinodeManaged');
+
+        // Confirm that Cloud Manager displays a notice about Linod managed is enabled.
+        cy.findByText(errorMessage, { exact: false }).should('be.visible');
+      });
+  });
+
+  /*
+   * - Confirms that a user can aonly cancel Linode Managed by opening a support ticket.
+   * - Confirms that user will be redirected to the creating support ticket page.
+   */
+  it('users can only open a support ticket to cancel Linode Managed', () => {
+    const mockAccount = accountFactory.build();
+    const mockProfile = profileFactory.build({
+      username: 'mock-user',
+      restricted: false,
+    });
+
+    mockGetAccount(mockAccount).as('getAccount');
+    mockGetProfile(mockProfile).as('getProfile');
+
+    // Navigate to Account Settings page.
+    visitUrlWithManagedEnabled('/account/settings');
+    cy.wait(['@getAccount', '@getProfile']);
+
+    // Enable button should not exist for users that already enabled Linode Managed.
+    cy.findByText('Add Linode Managed').should('not.exist');
+    cy.findByText(linodeManagedStateMessageText, { exact: false }).should(
+      'be.visible'
+    );
+
+    // Navigate to the 'Open a Support Ticket' page.
+    cy.findByText('Support Ticket').should('be.visible').click();
+    cy.url().should('endWith', '/support/tickets');
+
+    // Confirm that title and category are related to cancelling Linode Managed.
+    cy.get('input[id="title"]')
+      .invoke('val')
+      .then((title) => {
+        expect(title).to.equal('Cancel Linode Managed');
+      });
+    cy.get('input[role="combobox"]')
+      .invoke('val')
+      .then((category) => {
+        expect(category).to.equal('General/Account/Billing');
+      });
+  });
+});

--- a/packages/manager/cypress/e2e/core/account/account-linode-managed.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/account-linode-managed.spec.ts
@@ -30,13 +30,13 @@ describe('Account Linode Managed', () => {
    * - Confirms that user is told about the Managed price.
    * - Confirms that Cloud Manager displays the Managed state.
    */
-  it.only('users can enable Linode Managed', () => {
+  it('users can enable Linode Managed', () => {
     const mockAccount = accountFactory.build();
     const mockProfile = profileFactory.build({
       username: 'mock-user',
       restricted: false,
     });
-    const mockLinodes = new Array(4).fill(null).map(
+    const mockLinodes = new Array(5).fill(null).map(
       (item: null, index: number): Linode => {
         return linodeFactory.build({
           label: `Linode ${index}`,
@@ -93,7 +93,7 @@ describe('Account Linode Managed', () => {
    * - Confirms Cloud Manager behavior when a restricted user attempts to enable Linode Managed.
    * - Confirms that API error response message is displayed in confirmation dialog.
    */
-  it('restricted users cannot cancel account', () => {
+  it('restricted users cannot enable Managed', () => {
     const mockAccount = accountFactory.build();
     const mockProfile = profileFactory.build({
       username: 'mock-restricted-user',
@@ -101,6 +101,7 @@ describe('Account Linode Managed', () => {
     });
     const errorMessage = 'Unauthorized';
 
+    mockGetLinodes([]);
     mockGetAccount(mockAccount).as('getAccount');
     mockGetProfile(mockProfile).as('getProfile');
     mockEnableLinodeManagedError(errorMessage, 403).as('enableLinodeManaged');
@@ -124,17 +125,14 @@ describe('Account Linode Managed', () => {
           .then((text) => {
             expect(text.trim()).to.equal(linodeEnabledMessageText(0));
           });
-
         // Confirm that submit button is enabled.
         ui.button
           .findByTitle('Add Linode Managed')
           .should('be.visible')
           .should('be.enabled')
           .click();
-
         cy.wait('@enableLinodeManaged');
-
-        // Confirm that Cloud Manager displays a notice about Linod managed is enabled.
+        // Confirm that Cloud Manager displays a notice about Linode managed is unauthorized.
         cy.findByText(errorMessage, { exact: false }).should('be.visible');
       });
   });

--- a/packages/manager/cypress/support/constants/account.ts
+++ b/packages/manager/cypress/support/constants/account.ts
@@ -35,3 +35,15 @@ export const loginHelperText =
  * Empty state message that appears when there is no item in the login history table.
  */
 export const loginEmptyStateMessageText = 'No account logins';
+
+/**
+ * Warining message that appears when users is trying to enable Linode Managed.
+ */
+export const linodeEnabledMessageText =
+  'Linode Managed costs an additional $100 per month per Linode.  You currently have 0 Linodes, so Managed will increase your projected monthly bill by $0.';
+
+/**
+ * Message that tells the Linode Managed is enabled.
+ */
+export const linodeManagedStateMessageText =
+  'Managed is already enabled on your account';

--- a/packages/manager/cypress/support/constants/account.ts
+++ b/packages/manager/cypress/support/constants/account.ts
@@ -37,10 +37,13 @@ export const loginHelperText =
 export const loginEmptyStateMessageText = 'No account logins';
 
 /**
- * Warining message that appears when users is trying to enable Linode Managed.
+ * Warning message that appears when users is trying to enable Linode Managed.
  */
-export const linodeEnabledMessageText =
-  'Linode Managed costs an additional $100 per month per Linode.  You currently have 0 Linodes, so Managed will increase your projected monthly bill by $0.';
+export const linodeEnabledMessageText = (count: number): string => {
+  return `Linode Managed costs an additional $100 per month per Linode.  You currently have ${count} Linodes, so Managed will increase your projected monthly bill by $${
+    100 * count
+  }.`;
+};
 
 /**
  * Message that tells the Linode Managed is enabled.

--- a/packages/manager/cypress/support/intercepts/account.ts
+++ b/packages/manager/cypress/support/intercepts/account.ts
@@ -722,3 +722,35 @@ export const mockGetMaintenance = (
 export const interceptGetAccountAvailability = (): Cypress.Chainable<null> => {
   return cy.intercept('GET', apiMatcher('account/availability*'));
 };
+
+/**
+ * Mocks POST request to enable the Linode Managed.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockEnableLinodeManaged = (): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher('account/settings/managed-enable'),
+    makeResponse()
+  );
+};
+
+/**
+ * Mocks POST request to to enable the Linode Managed and mocks an error response.
+ *
+ * @param errorMessage - API error message with which to mock response.
+ * @param statusCode - HTTP status code with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockEnableLinodeManagedError = (
+  errorMessage: string = 'An unknown error has occurred',
+  statusCode: number = 400
+) => {
+  return cy.intercept(
+    'POST',
+    apiMatcher('account/settings/managed-enable'),
+    makeErrorResponse(errorMessage, statusCode)
+  );
+};

--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -117,7 +117,7 @@ export const interceptGetLinodes = (): Cypress.Chainable<null> => {
 export const mockGetLinodes = (linodes: Linode[]): Cypress.Chainable<null> => {
   return cy.intercept(
     'GET',
-    apiMatcher('linode/instances/*'),
+    apiMatcher('linode/instances/**'),
     paginateResponse(linodes)
   );
 };


### PR DESCRIPTION
## Description 📝
Add Cypress test to the flow of enabling account Linode Managed.

## Major Changes 🔄
- Add Cypress test that enable Linode Managed from account settings page.

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/account/account-linode-managed.spec.ts"
```