### PR TITLE
change: [M3-8210] - Storybook nav organization POC

### DIFF
--- a/packages/manager/.changeset/pr-10809-changed-1724354812801.md
+++ b/packages/manager/.changeset/pr-10809-changed-1724354812801.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Storybook nav organization ([#10809](https://github.com/linode/manager/pull/10809))

--- a/packages/manager/.storybook/preview.tsx
+++ b/packages/manager/.storybook/preview.tsx
@@ -61,7 +61,14 @@ const preview: Preview = {
     options: {
       storySort: {
         method: 'alphabetical',
-        order: ['Intro', 'Design System', 'Icons', 'Components', 'Features'],
+        order: [
+          'Intro',
+          'Design System',
+          'Icons',
+          'Foundations',
+          'Components',
+          'Features',
+        ],
       },
     },
     viewport: {

--- a/packages/manager/.storybook/preview.tsx
+++ b/packages/manager/.storybook/preview.tsx
@@ -61,7 +61,7 @@ const preview: Preview = {
     options: {
       storySort: {
         method: 'alphabetical',
-        order: ['Intro', 'Core Styles', 'Components', 'Features'],
+        order: ['Intro', 'Design System', 'Icons', 'Components', 'Features'],
       },
     },
     viewport: {

--- a/packages/manager/src/assets/logo/akamai-logo-color.svg
+++ b/packages/manager/src/assets/logo/akamai-logo-color.svg
@@ -1,4 +1,4 @@
-<svg id="edugKZmyB8q1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 719.656 293.2663" shape-rendering="geometricPrecision" text-rendering="geometricPrecision">
+<svg width="88" id="edugKZmyB8q1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 719.656 293.2663" shape-rendering="geometricPrecision" text-rendering="geometricPrecision">
   <g clip-path="url(#edugKZmyB8q12)" class="akamai-logo-name">
     <g>
       <path d="M719.656,151.8506c0,8.4509-6.8525,15.2819-15.2729,15.2819-8.4437,0-15.2818-6.831-15.2818-15.2819c0-8.4276,6.8381-15.2658,15.2818-15.2658c8.4204,0,15.2729,6.8382,15.2729,15.2658" fill="#f93"/>

--- a/packages/manager/src/components/Accordion.stories.tsx
+++ b/packages/manager/src/components/Accordion.stories.tsx
@@ -5,7 +5,7 @@ import { Accordion } from './Accordion';
 
 const meta: Meta<typeof Accordion> = {
   component: Accordion,
-  title: 'Components/Accordion',
+  title: 'Foundations/Accordion',
 };
 
 type Story = StoryObj<typeof Accordion>;

--- a/packages/manager/src/components/BetaChip/BetaChip.stories.tsx
+++ b/packages/manager/src/components/BetaChip/BetaChip.stories.tsx
@@ -12,6 +12,6 @@ export const Default: StoryObj<BetaChipProps> = {
 const meta: Meta<BetaChipProps> = {
   args: { color: 'default' },
   component: BetaChip,
-  title: 'Components/Chip/BetaChip',
+  title: 'Foundations/Chip/BetaChip',
 };
 export default meta;

--- a/packages/manager/src/components/Box.stories.tsx
+++ b/packages/manager/src/components/Box.stories.tsx
@@ -5,7 +5,7 @@ import { Box } from './Box';
 
 const meta: Meta<typeof Box> = {
   component: Box,
-  title: 'Components/Box',
+  title: 'Foundations/Box',
 };
 
 type Story = StoryObj<typeof Box>;

--- a/packages/manager/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/manager/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -6,7 +6,7 @@ import { Breadcrumb } from './Breadcrumb';
 
 const meta: Meta<typeof Breadcrumb> = {
   component: Breadcrumb,
-  title: 'Components/Breadcrumb',
+  title: 'Foundations/Breadcrumb',
 };
 
 type Story = StoryObj<typeof Breadcrumb>;

--- a/packages/manager/src/components/Button/Button.stories.tsx
+++ b/packages/manager/src/components/Button/Button.stories.tsx
@@ -35,7 +35,7 @@ const meta: Meta<typeof Button> = {
     tooltipText: '',
   },
   component: Button,
-  title: 'Components/Button',
+  title: 'Foundations/Button',
 };
 
 export default meta;

--- a/packages/manager/src/components/Button/StyledTagButton.stories.tsx
+++ b/packages/manager/src/components/Button/StyledTagButton.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof StyledTagButton> = {
     onClick: () => null,
   },
   component: StyledTagButton,
-  title: 'Components/TagButton',
+  title: 'Components/Tags/TagButton',
 };
 
 export default meta;

--- a/packages/manager/src/components/Checkbox.stories.tsx
+++ b/packages/manager/src/components/Checkbox.stories.tsx
@@ -5,7 +5,7 @@ import { Checkbox } from './Checkbox';
 
 const meta: Meta<typeof Checkbox> = {
   component: Checkbox,
-  title: 'Components/Checkbox',
+  title: 'Foundations/Checkbox',
 };
 
 type Story = StoryObj<typeof Checkbox>;

--- a/packages/manager/src/components/Chip.stories.tsx
+++ b/packages/manager/src/components/Chip.stories.tsx
@@ -66,6 +66,6 @@ export const WithDeleteButton: StoryObj<ChipProps> = {
 const meta: Meta<ChipProps> = {
   args: { label: 'Chip', onDelete: undefined },
   component: Chip,
-  title: 'Components/Chip',
+  title: 'Foundations/Chip',
 };
 export default meta;

--- a/packages/manager/src/components/Currency/Currency.stories.tsx
+++ b/packages/manager/src/components/Currency/Currency.stories.tsx
@@ -24,7 +24,7 @@ const meta: Meta<typeof Currency> = {
     },
   },
   component: Currency,
-  title: 'Components/Typography/Currency',
+  title: 'Foundations/Typography/Currency',
 };
 
 export default meta;

--- a/packages/manager/src/components/DateTimeDisplay/DateTimeDisplay.stories.tsx
+++ b/packages/manager/src/components/DateTimeDisplay/DateTimeDisplay.stories.tsx
@@ -24,7 +24,7 @@ const meta: Meta<typeof DateTimeDisplay> = {
     },
   },
   component: DateTimeDisplay,
-  title: 'Components/Typography/Date Time Display',
+  title: 'Foundations/Typography/Date Time Display',
 };
 
 export default meta;

--- a/packages/manager/src/components/Divider.stories.tsx
+++ b/packages/manager/src/components/Divider.stories.tsx
@@ -5,7 +5,7 @@ import { Divider } from 'src/components/Divider';
 
 const meta: Meta<typeof Divider> = {
   component: Divider,
-  title: 'Components/Divider',
+  title: 'Foundations/Divider',
 };
 
 type Story = StoryObj<typeof Divider>;

--- a/packages/manager/src/components/DocsLink/DocsLink.stories.tsx
+++ b/packages/manager/src/components/DocsLink/DocsLink.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<DocsLinkProps> = {
     label: 'Custom Doc Link Label',
   },
   component: DocsLink,
-  title: 'Components/Link/DocsLink',
+  title: 'Foundations/Link/DocsLink',
 };
 
 export default meta;

--- a/packages/manager/src/components/EditableText/EditableText.stories.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.stories.tsx
@@ -44,7 +44,7 @@ export const WithSuffix: Story = {
 
 const meta: Meta<typeof EditableText> = {
   component: EditableText,
-  title: 'Components/Editable Text',
+  title: 'Components/Input/Editable Text',
 };
 
 export default meta;

--- a/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.stories.tsx
+++ b/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.stories.tsx
@@ -31,7 +31,7 @@ const meta: Meta<typeof EnhancedNumberInput> = {
   },
   args: {},
   component: EnhancedNumberInput,
-  title: 'Components/EnhancedNumberInput',
+  title: 'Components/Input/EnhancedNumberInput',
 };
 
 export default meta;

--- a/packages/manager/src/components/EntityIcon/EntityIcon.stories.tsx
+++ b/packages/manager/src/components/EntityIcon/EntityIcon.stories.tsx
@@ -10,7 +10,7 @@ import type { EntityVariants } from 'src/components/EntityIcon/EntityIcon';
 const meta: Meta<typeof EntityIcon> = {
   args: { variant: 'linode' },
   component: EntityIcon,
-  title: 'Components/EntityIcon',
+  title: 'Icons/EntityIcon',
 };
 
 export default meta;

--- a/packages/manager/src/components/Flag.stories.tsx
+++ b/packages/manager/src/components/Flag.stories.tsx
@@ -5,7 +5,7 @@ import { Flag } from './Flag';
 
 const meta: Meta<typeof Flag> = {
   component: Flag,
-  title: 'Components/Flag',
+  title: 'Icons/Flag',
 };
 
 type Story = StoryObj<typeof Flag>;

--- a/packages/manager/src/components/InlineMenuAction/InlineMenuAction.stories.tsx
+++ b/packages/manager/src/components/InlineMenuAction/InlineMenuAction.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta<typeof InlineMenuAction> = {
     tooltipAnalyticsEvent: action('tooltipAnalyticsEvent'),
   },
   component: InlineMenuAction,
-  title: 'Components/InlineMenuAction',
+  title: 'Components/Action Menu/InlineMenuAction',
 };
 
 export default meta;

--- a/packages/manager/src/components/Link.stories.tsx
+++ b/packages/manager/src/components/Link.stories.tsx
@@ -130,7 +130,7 @@ const meta: Meta<LinkProps> = {
     to: '/internal-link',
   },
   component: Link,
-  title: 'Components/Link',
+  title: 'Foundations/Link',
 };
 
 export default meta;

--- a/packages/manager/src/components/OSIcon.stories.tsx
+++ b/packages/manager/src/components/OSIcon.stories.tsx
@@ -22,7 +22,7 @@ export const Alpine: StoryObj<typeof OSIcon> = {
 
 const meta: Meta<typeof OSIcon> = {
   component: OSIcon,
-  title: 'Components/OS Icon',
+  title: 'Icons/OS Icon',
 };
 
 export default meta;

--- a/packages/manager/src/components/Paper.stories.tsx
+++ b/packages/manager/src/components/Paper.stories.tsx
@@ -5,7 +5,7 @@ import { Paper } from './Paper';
 
 const meta: Meta<typeof Paper> = {
   component: Paper,
-  title: 'Components/Paper',
+  title: 'Foundations/Paper',
 };
 
 type Story = StoryObj<typeof Paper>;

--- a/packages/manager/src/components/PasswordInput/HideShowText.stories.tsx
+++ b/packages/manager/src/components/PasswordInput/HideShowText.stories.tsx
@@ -6,7 +6,7 @@ import { HideShowText } from './HideShowText';
 
 const meta: Meta<typeof HideShowText> = {
   component: HideShowText,
-  title: 'Components/Hide Show Text',
+  title: 'Components/Input/Hide Show Text',
 };
 
 type Story = StoryObj<typeof HideShowText>;

--- a/packages/manager/src/components/PasswordInput/PasswordInput.stories.tsx
+++ b/packages/manager/src/components/PasswordInput/PasswordInput.stories.tsx
@@ -6,7 +6,7 @@ import PasswordInput from './PasswordInput';
 
 const meta: Meta<typeof PasswordInput> = {
   component: PasswordInput,
-  title: 'Components/Password Input',
+  title: 'Components/Input/Password Input',
 };
 
 type Story = StoryObj<typeof PasswordInput>;

--- a/packages/manager/src/components/Radio/Radio.stories.tsx
+++ b/packages/manager/src/components/Radio/Radio.stories.tsx
@@ -27,7 +27,7 @@ const meta: Meta<RadioProps> = {
       </Box>
     ),
   ],
-  title: 'Components/Radio',
+  title: 'Foundations/Radio',
 };
 
 type Story = StoryObj<RadioProps>;

--- a/packages/manager/src/components/ShowMoreExpansion/ShowMoreExpansion.stories.tsx
+++ b/packages/manager/src/components/ShowMoreExpansion/ShowMoreExpansion.stories.tsx
@@ -26,7 +26,7 @@ const meta: Meta<ShowMoreExpansionProps> = {
     name: 'Show More',
   },
   component: ShowMoreExpansion,
-  title: 'Components/Accordion/ShowMoreExpansion',
+  title: 'Foundations/Accordion/ShowMoreExpansion',
 };
 
 export default meta;

--- a/packages/manager/src/components/Stack.stories.tsx
+++ b/packages/manager/src/components/Stack.stories.tsx
@@ -55,7 +55,7 @@ export const WithDivider: StoryObj<typeof Stack> = {
 
 const meta: Meta<typeof Stack> = {
   component: Stack,
-  title: 'Components/Stack',
+  title: 'Foundations/Stack',
 };
 
 export default meta;

--- a/packages/manager/src/components/StatusIcon/StatusIcon.stories.tsx
+++ b/packages/manager/src/components/StatusIcon/StatusIcon.stories.tsx
@@ -5,7 +5,7 @@ import { StatusIcon } from './StatusIcon';
 
 const meta: Meta<typeof StatusIcon> = {
   component: StatusIcon,
-  title: 'Components/StatusIcon',
+  title: 'Icons/StatusIcon',
 };
 
 type Story = StoryObj<typeof StatusIcon>;

--- a/packages/manager/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/manager/src/components/Tabs/Tabs.stories.tsx
@@ -71,6 +71,6 @@ const meta: Meta<TabsProps> = {
     onChange: () => null,
   },
   component: Tabs,
-  title: 'Components/Tabs',
+  title: 'Foundations/Tabs',
 };
 export default meta;

--- a/packages/manager/src/components/TextField.stories.tsx
+++ b/packages/manager/src/components/TextField.stories.tsx
@@ -6,7 +6,7 @@ import { TextField } from './TextField';
 
 const meta: Meta<typeof TextField> = {
   component: TextField,
-  title: 'Components/TextField',
+  title: 'Foundations/TextField',
 };
 
 type Story = StoryObj<typeof TextField>;

--- a/packages/manager/src/components/Toggle/Toggle.stories.tsx
+++ b/packages/manager/src/components/Toggle/Toggle.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<ToggleProps> = {
     disabled: false,
   },
   component: Toggle,
-  title: 'Components/Toggle',
+  title: 'Foundations/Toggle',
 };
 
 export default meta;

--- a/packages/manager/src/components/Typography.stories.tsx
+++ b/packages/manager/src/components/Typography.stories.tsx
@@ -5,7 +5,7 @@ import { Typography } from './Typography';
 
 const meta: Meta<typeof Typography> = {
   component: Typography,
-  title: 'Components/Typography',
+  title: 'Foundations/Typography',
 };
 
 type Story = StoryObj<typeof Typography>;


### PR DESCRIPTION
## Description 📝
POC to clean up the side nav in Storybook by reorganizing the hierarchy/component stories, and making the logo smaller

## Changes  🔄
List any change relevant to the reviewer.
- Smaller Akamai logo
- Add `Icons` and `Foundations` section
- Move `Design System` section to the top
- Move relevant components to the new sections and consolidate related components into folders

## Preview 📷
| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/9a0216ce-1cc0-4cd0-8a88-236d222eaee1" /> | <video src="https://github.com/user-attachments/assets/f6fc95a1-1ea5-425d-b3b8-182fff1602aa" /> |

## How to test 🧪
### Verification steps
(How to verify changes)
- Pull this PR locally and run `yarn storybook`
- Compare to https://design.linode.com/ 

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support