### PR TITLE
poc: Ensure Cloud Manager never polls for events in the past

### DIFF
--- a/packages/manager/src/queries/events/event.helpers.ts
+++ b/packages/manager/src/queries/events/event.helpers.ts
@@ -196,7 +196,7 @@ export const getMinimumDateToPollFrom = (
   }
 
   // The first event in our cache should be the user's event with the highest ID at all times.
-  // @note This does not necessarily it has the most recent "created" date
+  // This does not necessarily mean the event has the most recent "created" date
   const firstEvent = events[0];
   const firstEventCreatedDate = DateTime.fromISO(firstEvent.created, {
     zone: 'utc',

--- a/packages/manager/src/queries/events/event.helpers.ts
+++ b/packages/manager/src/queries/events/event.helpers.ts
@@ -1,7 +1,8 @@
+import { DateTime } from 'luxon';
+
 import { EVENTS_LIST_FILTER } from 'src/features/Events/constants';
 
 import type { Event, EventAction, Filter } from '@linode/api-v4';
-import { DateTime } from 'luxon';
 
 export const isInProgressEvent = (event: Event) => {
   if (event.percent_complete === null) {

--- a/packages/manager/src/queries/events/events.ts
+++ b/packages/manager/src/queries/events/events.ts
@@ -113,8 +113,6 @@ export const useEventsPoller = () => {
 
   const [mountTimestamp] = useState(DateTime.now().setZone('utc'));
 
-  // .toFormat(ISO_DATETIME_NO_TZ_FORMAT)
-
   useQuery({
     enabled: hasFetchedInitialEvents,
     onSuccess(events) {

--- a/packages/manager/src/queries/events/events.ts
+++ b/packages/manager/src/queries/events/events.ts
@@ -6,7 +6,7 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 import { DateTime } from 'luxon';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 
 import { ISO_DATETIME_NO_TZ_FORMAT, POLLING_INTERVALS } from 'src/constants';
 import { EVENTS_LIST_FILTER } from 'src/features/Events/constants';


### PR DESCRIPTION
## Description 📝


Changes events polling logic to ensure that the `created` `date` in the polling X-Filter  (`{ "created": {"+gte": date } }`) is never in the past 📆 

> [!warning]
> I have not done any testing on this yet. We'll want to make sure we really think this through. There could be some negative sideeffets of making this change that I haven't thought of. 

## How to test 🧪

- Test on an account affected by the bug where recent events are have incorrect create times (in the past)
- Ensure polling still works as expected on various accounts
- Ensure polling still work on an account with 0 events


## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support