### PR TITLE
fix: Re-enable CORS for Legacy/Gen1 Endpoints

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2024-08-22] - v1.126.1
+
+### Fix:
+
+- Re-enable CORS for Legacy/Gen1 Endpoints ([#10812](https://github.com/linode/manager/pull/10812))
+
 ## [2024-08-19] - v1.126.0
 
 ### Added:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.126.0",
+  "version": "1.126.1",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
 import { renderWithTheme } from 'src/utilities/testHelpers';
@@ -7,53 +7,90 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 import { AccessSelect } from './AccessSelect';
 
 import type { Props } from './AccessSelect';
+import type { ObjectStorageEndpointTypes } from '@linode/api-v4';
+
+const CORS_ENABLED_TEXT = 'CORS Enabled';
+const AUTHENTICATED_READ_TEXT = 'Authenticated Read';
 
 vi.mock('src/components/EnhancedSelect/Select');
 
-const mockGetAccess = vi.fn();
-const mockUpdateAccess = vi.fn();
+const mockGetAccess = vi.fn().mockResolvedValue({
+  acl: 'private',
+  cors_enabled: true,
+});
+const mockUpdateAccess = vi.fn().mockResolvedValue({});
 
-const props: Props = {
+const defaultProps: Props = {
   endpointType: 'E1',
-  getAccess: mockGetAccess.mockResolvedValue({
-    acl: 'private',
-    cors_enabled: true,
-  }),
+  getAccess: mockGetAccess,
   name: 'my-object-name',
-  updateAccess: mockUpdateAccess.mockResolvedValue({}),
+  updateAccess: mockUpdateAccess,
   variant: 'bucket',
 };
 
 describe('AccessSelect', () => {
-  it('shows the access and CORS toggle for bucket variant', async () => {
-    renderWithTheme(<AccessSelect {...props} />);
-    const aclSelect = screen.getByRole('combobox');
+  const renderComponent = (props: Partial<Props> = {}) =>
+    renderWithTheme(<AccessSelect {...defaultProps} {...props} />);
 
-    // Confirm that combobox input field value is 'Private'.
-    await waitFor(() => {
-      expect(aclSelect).toBeEnabled();
-      expect(aclSelect).toHaveValue('Private');
-    });
-
-    // Confirm that 'Private' is selected upon opening the Autocomplete drop-down.
-    act(() => {
-      fireEvent.click(aclSelect);
-      fireEvent.change(aclSelect, { target: { value: 'P' } });
-    });
-
-    expect(screen.getByText('Private').closest('li')!).toHaveAttribute(
-      'aria-selected',
-      'true'
-    );
-
-    expect(screen.getByLabelText('CORS Enabled')).toBeInTheDocument();
-    expect(
-      screen.getByRole('checkbox', { name: 'CORS Enabled' })
-    ).toBeChecked();
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
+  it.each([
+    ['bucket', 'E0', true],
+    ['bucket', 'E1', true],
+    ['bucket', 'E2', false],
+    ['bucket', 'E3', false],
+    ['object', 'E0', true],
+    ['object', 'E1', true],
+    ['object', 'E2', false],
+    ['object', 'E3', false],
+  ])(
+    'shows correct UI for %s variant and %s endpoint type',
+    async (variant, endpointType, shouldShowCORS) => {
+      renderComponent({
+        endpointType: endpointType as ObjectStorageEndpointTypes,
+        variant: variant as 'bucket' | 'object',
+      });
+
+      const aclSelect = screen.getByRole('combobox');
+
+      await waitFor(() => {
+        expect(aclSelect).toBeEnabled();
+        expect(aclSelect).toHaveValue('Private');
+      });
+
+      act(() => {
+        fireEvent.click(aclSelect);
+        fireEvent.change(aclSelect, { target: { value: 'P' } });
+      });
+
+      expect(screen.getByText('Private').closest('li')).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+
+      if (shouldShowCORS) {
+        await waitFor(() => {
+          expect(screen.getByLabelText(CORS_ENABLED_TEXT)).toBeInTheDocument();
+        });
+        await waitFor(() => {
+          expect(
+            screen.getByRole('checkbox', { name: CORS_ENABLED_TEXT })
+          ).toBeChecked();
+        });
+      } else {
+        await waitFor(() => {
+          expect(
+            screen.queryByLabelText(CORS_ENABLED_TEXT)
+          ).not.toBeInTheDocument();
+        });
+      }
+    }
+  );
+
   it('updates the access and CORS settings and submits the appropriate values', async () => {
-    renderWithTheme(<AccessSelect {...props} />);
+    renderComponent();
 
     const aclSelect = screen.getByRole('combobox');
     const saveButton = screen.getByText('Save').closest('button')!;
@@ -63,48 +100,43 @@ describe('AccessSelect', () => {
       expect(aclSelect).toHaveValue('Private');
     });
 
-    const corsToggle = screen.getByRole('checkbox', { name: 'CORS Enabled' });
-
-    // Verify initial state
+    // Wait for CORS toggle to appear and be checked
+    const corsToggle = await screen.findByRole('checkbox', {
+      name: CORS_ENABLED_TEXT,
+    });
     expect(corsToggle).toBeChecked();
 
     act(() => {
+      // Open the dropdown
       fireEvent.click(aclSelect);
-      fireEvent.change(aclSelect, { target: { value: 'Authenticated Read' } });
+
+      // Type to filter options
+      fireEvent.change(aclSelect, {
+        target: { value: AUTHENTICATED_READ_TEXT },
+      });
     });
 
-    userEvent.click(screen.getByText('Authenticated Read'));
-    userEvent.click(corsToggle);
+    // Wait for and select the "Authenticated Read" option
+    const authenticatedReadOption = await screen.findByText(
+      AUTHENTICATED_READ_TEXT
+    );
+    await userEvent.click(authenticatedReadOption);
+
+    await userEvent.click(corsToggle);
 
     await waitFor(() => {
-      expect(screen.getByRole('combobox')).toHaveValue('Authenticated Read');
+      expect(aclSelect).toHaveValue(AUTHENTICATED_READ_TEXT);
       expect(corsToggle).not.toBeChecked();
       expect(saveButton).toBeEnabled();
     });
 
-    fireEvent.click(saveButton);
+    await userEvent.click(saveButton);
     expect(mockUpdateAccess).toHaveBeenCalledWith('authenticated-read', false);
 
-    // Test toggling CORS back on
-    userEvent.click(corsToggle);
+    await userEvent.click(corsToggle);
+    await waitFor(() => expect(corsToggle).toBeChecked());
 
-    await waitFor(() => {
-      expect(corsToggle).toBeChecked();
-    });
-
-    fireEvent.click(saveButton);
+    await userEvent.click(saveButton);
     expect(mockUpdateAccess).toHaveBeenCalledWith('authenticated-read', true);
-  });
-
-  it('does not show CORS toggle for E2 and E3 endpoint types', async () => {
-    renderWithTheme(<AccessSelect {...props} endpointType="E2" />);
-    await waitFor(() => {
-      expect(screen.queryByLabelText('CORS Enabled')).not.toBeInTheDocument();
-    });
-
-    renderWithTheme(<AccessSelect {...props} endpointType="E3" />);
-    await waitFor(() => {
-      expect(screen.queryByLabelText('CORS Enabled')).not.toBeInTheDocument();
-    });
   });
 });

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.tsx
@@ -142,7 +142,9 @@ export const AccessSelect = React.memo((props: Props) => {
     : 'CORS Disabled';
 
   const isCorsEnabled =
-    variant === 'bucket' && endpointType !== 'E2' && endpointType !== 'E3';
+    (variant === 'bucket' || variant === 'object') &&
+    endpointType !== 'E2' &&
+    endpointType !== 'E3';
 
   const selectedOption =
     _options.find((thisOption) => thisOption.value === selectedACL) ??

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.tsx
@@ -141,7 +141,7 @@ export const AccessSelect = React.memo((props: Props) => {
     ? 'CORS Enabled'
     : 'CORS Disabled';
 
-  const isCorsEnabled =
+  const isCorsAvailable =
     (variant === 'bucket' || variant === 'object') &&
     endpointType !== 'E2' &&
     endpointType !== 'E3';
@@ -187,7 +187,7 @@ export const AccessSelect = React.memo((props: Props) => {
         ) : null}
       </div>
 
-      {isCorsEnabled ? (
+      {isCorsAvailable ? (
         <FormControlLabel
           control={
             <Toggle
@@ -201,7 +201,7 @@ export const AccessSelect = React.memo((props: Props) => {
         />
       ) : null}
 
-      {isCorsEnabled ? (
+      {isCorsAvailable ? (
         <Typography>
           Whether Cross-Origin Resource Sharing is enabled for all origins. For
           more fine-grained control of CORS, please use another{' '}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
@@ -103,6 +103,7 @@ export const ObjectDetailsDrawer = React.memo(
               updateAccess={(acl: ACLType) =>
                 updateObjectACL(clusterId, bucketName, name, acl)
               }
+              endpointType={endpointType}
               name={name}
               variant="object"
             />

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -102,6 +102,7 @@ import type {
   CreateObjectStorageKeyPayload,
   FirewallStatus,
   NotificationType,
+  ObjectStorageEndpointTypes,
   SecurityQuestionsPayload,
   TokenRequest,
   UpdateImageRegionsPayload,
@@ -970,9 +971,13 @@ export const handlers = [
     const pageSize = Number(url.searchParams.get('page_size') || 25);
 
     const randomBucketNumber = getRandomWholeNumber(1, 500);
+    const randomEndpointType = `E${Math.floor(
+      Math.random() * 4
+    )}` as ObjectStorageEndpointTypes;
 
     const buckets = objectStorageBucketFactoryGen2.buildList(1, {
       cluster: `${region}-1`,
+      endpoint_type: randomEndpointType,
       hostname: `obj-bucket-${randomBucketNumber}.${region}.linodeobjects.com`,
       label: `obj-bucket-${randomBucketNumber}`,
       region,


### PR DESCRIPTION
## Description 📝
In `AccessSelect` we were not checking for both `object` and `bucket` variants when determining to disable CORS. Fortunately CORS is enabled by default for all objects, so this is low impact, but it requires a hotfix.

## Changes  🔄
- Main fix is in [AccessSelect component](https://github.com/linode/manager/pull/10812/files#diff-09da555b7ce00d83c9a46a23ba01b3ca2254fc84576479e447cf4be93b29b4fdR145-R147) where we're checking for both `variant === 'bucket' || variant === 'object'` to enable or disable CORS.
- Other changes to `ObjectDetailsDrawer.tsx` and `serverHandlers.ts` are to confirm changes are working elsewhere.

## Target release date 🗓️
8/22

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-08-22 at 11 08 35 AM](https://github.com/user-attachments/assets/9b13d987-e815-4683-87e9-244239e0e567) | ![Screenshot 2024-08-22 at 9 48 38 AM](https://github.com/user-attachments/assets/4a6fc591-3d40-4186-b490-8f63ed25757a) |


## How to test 🧪

### Prerequisites


### Reproduction steps
(How to reproduce the issue, if applicable)
- In Prod, create a bucket (non-Gen2 since it's not available yet) in any region and add an object
- Select the object to open the object drawer
- Observe CORS is not rendered

### Verification steps
(How to verify changes)
- Follow the same steps from `Reproduction steps`.
- Observe that CORS toggle should be re-enabled
- Confirm other places where AccessSelect are correct
   - Bucket Details Drawer: Select "Details" for any bucket
   - Bucket Details > Access Tab: Select a bucket and go to the "Access" tab

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support