### PR TITLE
fix: [7305] - Correct Object Storage folder links containing special characters.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ lib
 # editor configuration
 .vscode
 .idea
+**/*.iml
 
 # misc
 .DS_Store

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react';
+import * as React from 'react';
+
+import { wrapWithTheme } from 'src/utilities/testHelpers';
+import { Table } from 'src/components/Table';
+import { TableBody } from 'src/components/TableBody';
+
+import {
+  FolderTableRow,
+  Props,
+} from 'src/features/ObjectStorage/BucketDetail/FolderTableRow';
+
+describe('FolderTableRow', () => {
+  it('renders a link with URI-encoded special characters', () => {
+    const specialCharsProps: Props = {
+      displayName: 'folder-with-special-chars...',
+      folderName: 'folder-with-special-chars <>#%+{}|^[]`;?:@=&$',
+      handleClickDelete: () => {},
+      manuallyCreated: false,
+    };
+
+    const { getByRole } = render(
+      wrapWithTheme(
+        <Table>
+          <TableBody>
+            <FolderTableRow {...specialCharsProps} />
+          </TableBody>
+        </Table>
+      )
+    );
+
+    expect(getByRole('link')).toHaveAttribute(
+      'href',
+      '/?prefix=folder-with-special-chars%20%3C%3E%23%25%2B%7B%7D%7C%5E%5B%5D%60%3B%3F%3A%40%3D%26%24'
+    );
+  });
+});

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
@@ -10,7 +10,7 @@ import { TableRow } from 'src/components/TableRow';
 
 import { FolderActionMenu } from './FolderActionMenu';
 
-interface Props {
+export interface Props {
   displayName: string;
   folderName: string;
   handleClickDelete: (objectName: string) => void;
@@ -28,7 +28,10 @@ export const FolderTableRow = (props: Props) => {
             <EntityIcon size={22} variant="folder" />
           </StyledIconWrapper>
           <Grid>
-            <Link className="secondaryLink" to={`?prefix=${folderName}`}>
+            <Link
+              className="secondaryLink"
+              to={`?prefix=${encodeURIComponent(folderName)}`}
+            >
               {displayName}
             </Link>
           </Grid>


### PR DESCRIPTION
## Description 📝
Object Storage bucket folders containing URL special characters could not be opened. After the change, their links navigate to a correct location.

## Changes  🔄
List any change relevant to the reviewer.
- Special characters in folder links are URI-encoded.

## Target release date 🗓️
Unknown.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| 
![image](https://github.com/user-attachments/assets/59316dd5-c7c5-4a52-925a-d509ba5933ec) | ![image](https://github.com/user-attachments/assets/95b151ef-ed14-4206-8871-def82a55f3dc) |

## How to test 🧪
1. Create a folder containing special characters, e.g:
> s3cmd put ./Test.txt s3://sk-test/dir+with+pluses/Test.txt
2. Open that folder in Cloud Manager

When opened, the folder should contain Test.txt file.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
