### PR TITLE
upcoming: [M3-8308] - Add bucket rate limit info to Object Storage Bucket Details drawer

### DIFF
--- a/packages/manager/.changeset/pr-10821-upcoming-features-1724414057285.md
+++ b/packages/manager/.changeset/pr-10821-upcoming-features-1724414057285.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add bucket rate limit info to Object Storage Bucket Details drawer ([#10821](https://github.com/linode/manager/pull/10821))

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
@@ -22,6 +22,7 @@ import { truncateMiddle } from 'src/utilities/truncate';
 import { readableBytes } from 'src/utilities/unitConversions';
 
 import { AccessSelect } from '../BucketDetail/AccessSelect';
+import { BucketRateLimitTable } from './BucketRateLimitTable';
 
 import type {
   ACLType,
@@ -73,6 +74,8 @@ export const BucketDetailsDrawer = React.memo(
     );
 
     let formattedCreated;
+    const showBucketRateLimitTable =
+      endpoint_type === 'E2' || endpoint_type === 'E3';
 
     try {
       if (created) {
@@ -138,6 +141,22 @@ export const BucketDetailsDrawer = React.memo(
         )}
         {/* @TODO OBJ Multicluster: use region instead of cluster if isObjMultiClusterEnabled
          to getBucketAccess and updateBucketAccess.  */}
+        {
+          <>
+            <Typography data-testid="createdTime" variant="h3">
+              Bucket Rate Limits
+            </Typography>
+            {showBucketRateLimitTable ? (
+              <BucketRateLimitTable endpointType={endpoint_type} />
+            ) : (
+              <Typography>
+                This endpoint type supports up to 750 Reqeusts Per Second(RPS).{' '}
+                <Link to="#">Understand bucket rate limits</Link>.
+              </Typography>
+            )}
+          </>
+        }
+        {<Divider spacingBottom={16} spacingTop={16} />}
         {cluster && label && (
           <AccessSelect
             getAccess={() =>

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
@@ -143,7 +143,7 @@ export const BucketDetailsDrawer = React.memo(
          to getBucketAccess and updateBucketAccess.  */}
         {
           <>
-            <Typography data-testid="createdTime" variant="h3">
+            <Typography data-testid="bucketRateLimit" variant="h3">
               Bucket Rate Limits
             </Typography>
             {showBucketRateLimitTable ? (

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
@@ -150,7 +150,7 @@ export const BucketDetailsDrawer = React.memo(
               <BucketRateLimitTable endpointType={endpoint_type} />
             ) : (
               <Typography>
-                This endpoint type supports up to 750 Reqeusts Per Second(RPS).{' '}
+                This endpoint type supports up to 750 Requests Per Second(RPS).{' '}
                 <Link to="#">Understand bucket rate limits</Link>.
               </Typography>
             )}


### PR DESCRIPTION
## Description 📝
Add bucket rate limit info to bucket details drawer

## Changes  🔄
In Bucket Details drawer:
- For legacy buckets, add the bucket rate limit of 750 RPS
- For E2/E3 buckets, add bucket rate limit table

## Target release date 🗓️
N/A

## Preview 📷


| Before  | Legacy Bucket| E2&E3 Bucket |
| ------- | ------- | ------- |
| ![image](https://github.com/user-attachments/assets/9c534e55-9254-446c-982d-d589aa8cddd0)|![04_47_08](https://github.com/user-attachments/assets/7254d053-a8b8-415a-9f6d-6a38e8de4e99)|![04_47_24](https://github.com/user-attachments/assets/e2976416-73cb-45df-aa76-648cb8f7fe24)|

## How to test 🧪

### Prerequisites
- Test all components for ObjectStorage buckets by toggling the `OBJ Gen2` feature flag in dev environment

### Verification steps
- Turn on MSW
- Go to Object Storage landing page
- On opening a bucket's Details drawer, you should find a bucket rate limit table for `E2` and `E3` buckets, and a `bucket rate limit of 750RPS` text for legacy buckets 

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
