### PR TITLE
fix: [M3-7305] - Correct Object Storage folder links containing special characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ lib
 # editor configuration
 .vscode
 .idea
+**/*.iml
 
 # misc
 .DS_Store

--- a/packages/manager/.changeset/pr-10819-fixed-1724404332335.md
+++ b/packages/manager/.changeset/pr-10819-fixed-1724404332335.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Correct Object Storage folder links containing special characters. ([#10819](https://github.com/linode/manager/pull/10819))

--- a/packages/manager/.changeset/pr-10819-fixed-1724404332335.md
+++ b/packages/manager/.changeset/pr-10819-fixed-1724404332335.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Correct Object Storage folder links containing special characters. ([#10819](https://github.com/linode/manager/pull/10819))
+Correct links to Object Storage folders that contain special characters. ([#10819](https://github.com/linode/manager/pull/10819))

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.test.tsx
@@ -7,12 +7,12 @@ import { TableBody } from 'src/components/TableBody';
 
 import {
   FolderTableRow,
-  Props,
+  FolderTableRowProps,
 } from 'src/features/ObjectStorage/BucketDetail/FolderTableRow';
 
 describe('FolderTableRow', () => {
   it('renders a link with URI-encoded special characters', () => {
-    const specialCharsProps: Props = {
+    const specialCharsProps: FolderTableRowProps = {
       displayName: 'folder-with-special-chars...',
       folderName: 'folder-with-special-chars <>#%+{}|^[]`;?:@=&$',
       handleClickDelete: () => {},

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.test.tsx
@@ -1,10 +1,10 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
 
+import { FolderTableRow } from 'src/features/ObjectStorage/BucketDetail/FolderTableRow';
 import { wrapWithTableBody } from 'src/utilities/testHelpers';
 
-import { FolderTableRow } from 'src/features/ObjectStorage/BucketDetail/FolderTableRow';
-import type { FolderTableRowProps } from 'src/features/ObjectStorage/BucketDetail/FolderTableRow'`;
+import type { FolderTableRowProps } from 'src/features/ObjectStorage/BucketDetail/FolderTableRow';
 
 describe('FolderTableRow', () => {
   it('renders a link with URI-encoded special characters', () => {

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.test.tsx
@@ -1,9 +1,7 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
 
-import { wrapWithTheme } from 'src/utilities/testHelpers';
-import { Table } from 'src/components/Table';
-import { TableBody } from 'src/components/TableBody';
+import { wrapWithTableBody } from 'src/utilities/testHelpers';
 
 import {
   FolderTableRow,
@@ -20,13 +18,7 @@ describe('FolderTableRow', () => {
     };
 
     const { getByRole } = render(
-      wrapWithTheme(
-        <Table>
-          <TableBody>
-            <FolderTableRow {...specialCharsProps} />
-          </TableBody>
-        </Table>
-      )
+      wrapWithTableBody(<FolderTableRow {...specialCharsProps} />)
     );
 
     expect(getByRole('link')).toHaveAttribute(

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.test.tsx
@@ -3,10 +3,8 @@ import * as React from 'react';
 
 import { wrapWithTableBody } from 'src/utilities/testHelpers';
 
-import {
-  FolderTableRow,
-  FolderTableRowProps,
-} from 'src/features/ObjectStorage/BucketDetail/FolderTableRow';
+import { FolderTableRow } from 'src/features/ObjectStorage/BucketDetail/FolderTableRow';
+import type { FolderTableRowProps } from 'src/features/ObjectStorage/BucketDetail/FolderTableRow'`;
 
 describe('FolderTableRow', () => {
   it('renders a link with URI-encoded special characters', () => {

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react';
+import * as React from 'react';
+
+import { wrapWithTheme } from 'src/utilities/testHelpers';
+import { Table } from 'src/components/Table';
+import { TableBody } from 'src/components/TableBody';
+
+import {
+  FolderTableRow,
+  Props,
+} from 'src/features/ObjectStorage/BucketDetail/FolderTableRow';
+
+describe('FolderTableRow', () => {
+  it('renders a link with URI-encoded special characters', () => {
+    const specialCharsProps: Props = {
+      displayName: 'folder-with-special-chars...',
+      folderName: 'folder-with-special-chars <>#%+{}|^[]`;?:@=&$',
+      handleClickDelete: () => {},
+      manuallyCreated: false,
+    };
+
+    const { getByRole } = render(
+      wrapWithTheme(
+        <Table>
+          <TableBody>
+            <FolderTableRow {...specialCharsProps} />
+          </TableBody>
+        </Table>
+      )
+    );
+
+    expect(getByRole('link')).toHaveAttribute(
+      'href',
+      '/?prefix=folder-with-special-chars%20%3C%3E%23%25%2B%7B%7D%7C%5E%5B%5D%60%3B%3F%3A%40%3D%26%24'
+    );
+  });
+});

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
@@ -10,7 +10,7 @@ import { TableRow } from 'src/components/TableRow';
 
 import { FolderActionMenu } from './FolderActionMenu';
 
-interface Props {
+export interface Props {
   displayName: string;
   folderName: string;
   handleClickDelete: (objectName: string) => void;
@@ -28,7 +28,10 @@ export const FolderTableRow = (props: Props) => {
             <EntityIcon size={22} variant="folder" />
           </StyledIconWrapper>
           <Grid>
-            <Link className="secondaryLink" to={`?prefix=${folderName}`}>
+            <Link
+              className="secondaryLink"
+              to={`?prefix=${encodeURIComponent(folderName)}`}
+            >
               {displayName}
             </Link>
           </Grid>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
@@ -9,19 +9,26 @@ import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
 
 import { FolderActionMenu } from './FolderActionMenu';
+import { TableRowProps } from '@mui/material';
 
-export interface Props {
+export interface FolderTableRowProps extends TableRowProps {
   displayName: string;
   folderName: string;
   handleClickDelete: (objectName: string) => void;
   manuallyCreated: boolean;
 }
 
-export const FolderTableRow = (props: Props) => {
-  const { displayName, folderName, handleClickDelete } = props;
+export const FolderTableRow = (props: FolderTableRowProps) => {
+  const {
+    displayName,
+    folderName,
+    handleClickDelete,
+    manuallyCreated,
+    ...tableRowProps
+  } = props;
 
   return (
-    <TableRow key={folderName} {...props}>
+    <TableRow key={folderName} {...tableRowProps}>
       <TableCell parentColumn="Object">
         <Grid alignItems="center" container spacing={2} wrap="nowrap">
           <StyledIconWrapper>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
@@ -6,10 +6,9 @@ import { Link } from 'react-router-dom';
 import { EntityIcon } from 'src/components/EntityIcon/EntityIcon';
 import { Hidden } from 'src/components/Hidden';
 import { TableCell } from 'src/components/TableCell';
-import { TableRow } from 'src/components/TableRow';
+import { TableRow, TableRowProps } from 'src/components/TableRow';
 
 import { FolderActionMenu } from './FolderActionMenu';
-import { TableRowProps } from '@mui/material';
 
 export interface FolderTableRowProps extends TableRowProps {
   displayName: string;


### PR DESCRIPTION
## Description 📝
Object Storage bucket folders containing URL special characters could not be opened. After the change, their links navigate to a correct location.

## Changes  🔄
List any change relevant to the reviewer.
- Special characters in folder links are URI-encoded.

## Target release date 🗓️
Any release

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/83612a2f-530a-40c0-ba97-0354cefa4c9d) |![image](https://github.com/user-attachments/assets/86415696-64a6-4e33-841c-b08b84625b09) |

## How to test 🧪

1. Create a folder containing special characters, e.g:
> s3cmd put ./Test.txt s3://sk-test/dir+with+pluses/Test.txt
2. Open that folder in Cloud Manager

When opened, the folder should contain Test.txt file.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
