### PR TITLE
fix: [M3-8477] - Event handlers making a proportional number of GET requests to the number of incoming events

### DIFF
--- a/packages/manager/.changeset/pr-10824-fixed-1724428840947.md
+++ b/packages/manager/.changeset/pr-10824-fixed-1724428840947.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Event handlers making a proportional number of GET requests to the number of incoming events ([#10824](https://github.com/linode/manager/pull/10824))

--- a/packages/manager/cypress/e2e/core/notificationsAndEvents/events-fetching.spec.ts
+++ b/packages/manager/cypress/e2e/core/notificationsAndEvents/events-fetching.spec.ts
@@ -4,6 +4,8 @@ import { mockGetVolumes } from 'support/intercepts/volumes';
 
 describe('Event Handlers', () => {
   it('invokes event handlers when new events are polled and makes the correct number of requests', () => {
+    // See https://github.com/linode/manager/pull/10824
+
     mockGetEvents([]).as('getEvents');
     mockGetVolumes([]).as('getInitialVolumes');
 

--- a/packages/manager/cypress/e2e/core/notificationsAndEvents/events-fetching.spec.ts
+++ b/packages/manager/cypress/e2e/core/notificationsAndEvents/events-fetching.spec.ts
@@ -1,0 +1,40 @@
+import { eventFactory } from 'src/factories';
+import { mockGetEvents } from 'support/intercepts/events';
+import { mockGetVolumes } from 'support/intercepts/volumes';
+
+describe('Event Handlers', () => {
+  it('invokes event handlers when new events are polled and makes the correct number of requests', () => {
+    mockGetEvents([]).as('getEvents');
+    mockGetVolumes([]).as('getInitialVolumes');
+
+    cy.visitWithLogin('/volumes');
+
+    // Wait for the initial events fetch and initial volumes fetch
+    cy.wait(['@getEvents', '@getInitialVolumes']);
+
+    // Wait for the first polling interval to happen
+    cy.wait('@getEvents');
+
+    const polledEvents = [
+      eventFactory.build({ action: 'volume_update', status: 'notification' }),
+      eventFactory.build({ action: 'volume_update', status: 'notification' }),
+      eventFactory.build({ action: 'volume_update', status: 'notification' }),
+    ];
+
+    // Pretend a volume was updated 3 times in a row
+    mockGetEvents(polledEvents).as('getEvents');
+
+    // Intercept GET volumes so we can later check how many times it is fetched
+    mockGetVolumes([]).as('getVolumes');
+
+    // Wait for volume update events to be polled
+    cy.wait('@getEvents');
+
+    // On the next interval, mock no new events
+    mockGetEvents([]).as('getEvents');
+    cy.wait('@getEvents');
+
+    // Finally, verify the volume endpoint was only fetched once
+    cy.get('@getVolumes.all').should('have.length', 1);
+  });
+});

--- a/packages/manager/src/queries/account/billing.ts
+++ b/packages/manager/src/queries/account/billing.ts
@@ -29,9 +29,12 @@ export const useAllAccountPayments = (
   });
 };
 
-export const taxIdEventHandler = ({ event, queryClient }: EventHandlerData) => {
+export const taxIdEventHandler = ({
+  event,
+  invalidateQueries,
+}: EventHandlerData) => {
   if (event.action === 'tax_id_invalid' || event.action === 'tax_id_valid') {
-    queryClient.invalidateQueries({
+    invalidateQueries({
       queryKey: accountQueries.notifications.queryKey,
     });
   }

--- a/packages/manager/src/queries/account/oauth.ts
+++ b/packages/manager/src/queries/account/oauth.ts
@@ -70,10 +70,12 @@ export const useUpdateOAuthClientMutation = (id: string) => {
   });
 };
 
-export const oauthClientsEventHandler = ({ queryClient }: EventHandlerData) => {
+export const oauthClientsEventHandler = ({
+  invalidateQueries,
+}: EventHandlerData) => {
   // We may over-fetch because on `onSuccess` also invalidates, but this will be
   // good for UX because Cloud will always be up to date
-  queryClient.invalidateQueries({
+  invalidateQueries({
     queryKey: accountQueries.oauthClients._def,
   });
 };

--- a/packages/manager/src/queries/databases/events.ts
+++ b/packages/manager/src/queries/databases/events.ts
@@ -7,10 +7,10 @@ import type { EventHandlerData } from 'src/hooks/useEventHandlers';
 
 export const databaseEventsHandler = ({
   event,
-  queryClient,
+  invalidateQueries,
 }: EventHandlerData) => {
   if (['failed', 'finished', 'notification'].includes(event.status)) {
-    queryClient.invalidateQueries({
+    invalidateQueries({
       queryKey: databaseQueries.databases.queryKey,
     });
 
@@ -35,7 +35,7 @@ export const databaseEventsHandler = ({
         );
       }
 
-      queryClient.invalidateQueries({
+      invalidateQueries({
         queryKey: databaseQueries.database(engine as Engine, event.entity.id)
           .queryKey,
       });

--- a/packages/manager/src/queries/domains.ts
+++ b/packages/manager/src/queries/domains.ts
@@ -186,7 +186,7 @@ export const useUpdateDomainMutation = () => {
 
 export const domainEventsHandler = ({
   event,
-  queryClient,
+  invalidateQueries,
 }: EventHandlerData) => {
   const domainId = event.entity?.id;
 
@@ -196,17 +196,17 @@ export const domainEventsHandler = ({
 
   if (event.action.startsWith('domain_record')) {
     // Invalidate the domain's records because they may have changed
-    queryClient.invalidateQueries({
+    invalidateQueries({
       queryKey: domainQueries.domain(domainId)._ctx.records.queryKey,
     });
   } else {
     // Invalidate paginated lists
-    queryClient.invalidateQueries({
+    invalidateQueries({
       queryKey: domainQueries.domains.queryKey,
     });
 
     // Invalidate the domain's details
-    queryClient.invalidateQueries({
+    invalidateQueries({
       exact: true,
       queryKey: domainQueries.domain(domainId).queryKey,
     });

--- a/packages/manager/src/queries/firewalls.ts
+++ b/packages/manager/src/queries/firewalls.ts
@@ -408,6 +408,7 @@ export const useUpdateFirewallRulesMutation = (firewallId: number) => {
 
 export const firewallEventsHandler = ({
   event,
+  invalidateQueries,
   queryClient,
 }: EventHandlerData) => {
   if (!event.entity) {
@@ -418,7 +419,7 @@ export const firewallEventsHandler = ({
   switch (event.action) {
     case 'firewall_delete':
       // Invalidate firewall lists
-      queryClient.invalidateQueries({
+      invalidateQueries({
         queryKey: firewallQueries.firewalls.queryKey,
       });
 
@@ -428,7 +429,7 @@ export const firewallEventsHandler = ({
       });
     case 'firewall_create':
       // Invalidate firewall lists
-      queryClient.invalidateQueries({
+      invalidateQueries({
         queryKey: firewallQueries.firewalls.queryKey,
       });
     case 'firewall_device_add':
@@ -438,13 +439,9 @@ export const firewallEventsHandler = ({
 
       // If a Linode is added or removed as a firewall device, invalidate it's firewalls
       if (event.secondary_entity && event.secondary_entity.type === 'linode') {
-        queryClient.invalidateQueries({
-          queryKey: [
-            'linodes',
-            'linode',
-            event.secondary_entity.id,
-            'firewalls',
-          ],
+        invalidateQueries({
+          queryKey: linodeQueries.linode(event.secondary_entity.id)._ctx
+            .firewalls.queryKey,
         });
       }
 
@@ -453,23 +450,19 @@ export const firewallEventsHandler = ({
         event.secondary_entity &&
         event.secondary_entity.type === 'nodebalancer'
       ) {
-        queryClient.invalidateQueries({
-          queryKey: [
-            'nodebalancers',
-            'nodebalancer',
-            event.secondary_entity.id,
-            'firewalls',
-          ],
+        invalidateQueries({
+          queryKey: nodebalancerQueries.nodebalancer(event.secondary_entity.id)
+            ._ctx.firewalls.queryKey,
         });
       }
 
       // Invalidate the firewall
-      queryClient.invalidateQueries({
+      invalidateQueries({
         queryKey: firewallQueries.firewall(event.entity.id).queryKey,
       });
 
       // Invalidate firewall lists
-      queryClient.invalidateQueries({
+      invalidateQueries({
         queryKey: firewallQueries.firewalls.queryKey,
       });
     case 'firewall_disable':
@@ -477,11 +470,11 @@ export const firewallEventsHandler = ({
     case 'firewall_rules_update':
     case 'firewall_update':
       // invalidate the firewall
-      queryClient.invalidateQueries({
+      invalidateQueries({
         queryKey: firewallQueries.firewall(event.entity.id).queryKey,
       });
       // Invalidate firewall lists
-      queryClient.invalidateQueries({
+      invalidateQueries({
         queryKey: firewallQueries.firewalls.queryKey,
       });
   }

--- a/packages/manager/src/queries/images.ts
+++ b/packages/manager/src/queries/images.ts
@@ -174,13 +174,13 @@ export const useUpdateImageRegionsMutation = (imageId: string) => {
 
 export const imageEventsHandler = ({
   event,
-  queryClient,
+  invalidateQueries,
 }: EventHandlerData) => {
   if (['failed', 'finished', 'notification'].includes(event.status)) {
-    queryClient.invalidateQueries({
+    invalidateQueries({
       queryKey: imageQueries.all._def,
     });
-    queryClient.invalidateQueries({ queryKey: imageQueries.paginated._def });
+    invalidateQueries({ queryKey: imageQueries.paginated._def });
 
     if (event.entity) {
       /*
@@ -194,7 +194,7 @@ export const imageEventsHandler = ({
        */
 
       const imageId = `private/${event.entity.id}`;
-      queryClient.invalidateQueries({
+      invalidateQueries({
         queryKey: imageQueries.image(imageId).queryKey,
       });
     }

--- a/packages/manager/src/queries/linodes/events.ts
+++ b/packages/manager/src/queries/linodes/events.ts
@@ -14,6 +14,7 @@ import type { EventHandlerData } from 'src/hooks/useEventHandlers';
  */
 export const linodeEventsHandler = ({
   event,
+  invalidateQueries,
   queryClient,
 }: EventHandlerData) => {
   const linodeId = event.entity?.id;
@@ -29,7 +30,7 @@ export const linodeEventsHandler = ({
   // Some Linode events are an indication that the reponse from /v4/account/notifications
   // has changed, so refetch notifications.
   if (shouldRequestNotifications(event)) {
-    queryClient.invalidateQueries(accountQueries.notifications);
+    invalidateQueries(accountQueries.notifications);
   }
 
   switch (event.action) {
@@ -43,65 +44,63 @@ export const linodeEventsHandler = ({
     case 'linode_resize_warm_create':
     case 'linode_reboot':
     case 'linode_update':
-      queryClient.invalidateQueries(linodeQueries.linodes);
-      queryClient.invalidateQueries({
+      invalidateQueries(linodeQueries.linodes);
+      invalidateQueries({
         exact: true,
         queryKey: linodeQueries.linode(linodeId).queryKey,
       });
       return;
     case 'linode_boot':
     case 'linode_shutdown':
-      queryClient.invalidateQueries(linodeQueries.linodes);
-      queryClient.invalidateQueries({
+      invalidateQueries(linodeQueries.linodes);
+      invalidateQueries({
         exact: true,
         queryKey: linodeQueries.linode(linodeId).queryKey,
       });
       // Ensure configs are fresh when Linode is booted up (see https://github.com/linode/manager/pull/9914)
-      queryClient.invalidateQueries({
+      invalidateQueries({
         queryKey: linodeQueries.linode(linodeId)._ctx.configs.queryKey,
       });
       return;
     case 'linode_snapshot':
-      queryClient.invalidateQueries(linodeQueries.linodes);
-      queryClient.invalidateQueries({
+      invalidateQueries(linodeQueries.linodes);
+      invalidateQueries({
         exact: true,
         queryKey: linodeQueries.linode(linodeId).queryKey,
       });
-      queryClient.invalidateQueries(
-        linodeQueries.linode(linodeId)._ctx.backups
-      );
+      invalidateQueries(linodeQueries.linode(linodeId)._ctx.backups);
       return;
     case 'linode_addip':
     case 'linode_deleteip':
-      queryClient.invalidateQueries(linodeQueries.linodes);
-      queryClient.invalidateQueries({
+      invalidateQueries(linodeQueries.linodes);
+      invalidateQueries({
         queryKey: linodeQueries.linode(linodeId)._ctx.ips.queryKey,
       });
-      queryClient.invalidateQueries({
+      invalidateQueries({
         exact: true,
         queryKey: linodeQueries.linode(linodeId).queryKey,
       });
       return;
     case 'linode_create':
     case 'linode_clone':
-      queryClient.invalidateQueries({
+      invalidateQueries({
         queryKey: linodeQueries.linode(linodeId)._ctx.disks.queryKey,
       });
-      queryClient.invalidateQueries(linodeQueries.linodes);
-      queryClient.invalidateQueries({
+      invalidateQueries(linodeQueries.linodes);
+      invalidateQueries({
         exact: true,
         queryKey: linodeQueries.linode(linodeId).queryKey,
       });
       return;
     case 'linode_rebuild':
-      queryClient.invalidateQueries({
+      invalidateQueries({
         queryKey: linodeQueries.linode(linodeId)._ctx.disks.queryKey,
       });
-      queryClient.invalidateQueries({
+      invalidateQueries({
         queryKey: linodeQueries.linode(linodeId)._ctx.configs.queryKey,
       });
-      queryClient.invalidateQueries(linodeQueries.linodes);
-      queryClient.invalidateQueries({
+      invalidateQueries(linodeQueries.linodes);
+      invalidateQueries({
         exact: true,
         queryKey: linodeQueries.linode(linodeId).queryKey,
       });
@@ -110,20 +109,20 @@ export const linodeEventsHandler = ({
       queryClient.removeQueries({
         queryKey: linodeQueries.linode(linodeId).queryKey,
       });
-      queryClient.invalidateQueries({
+      invalidateQueries({
         queryKey: linodeQueries.linodes.queryKey,
       });
       // A Linode made have been on a Firewall's device list, but now that it is deleted,
       // it will no longer be listed as a device on that firewall. Here, we invalidate outdated firewall data.
-      queryClient.invalidateQueries({ queryKey: firewallQueries._def });
+      invalidateQueries({ queryKey: firewallQueries._def });
       // A Linode may have been attached to a Volume, but deleted. We need to refetch volumes data so that
       // the Volumes table does not show a Volume attached to a non-existant Linode.
-      queryClient.invalidateQueries({ queryKey: volumeQueries.lists.queryKey });
+      invalidateQueries({ queryKey: volumeQueries.lists.queryKey });
       return;
     case 'linode_config_create':
     case 'linode_config_delete':
     case 'linode_config_update':
-      queryClient.invalidateQueries({
+      invalidateQueries({
         queryKey: linodeQueries.linode(linodeId)._ctx.configs.queryKey,
       });
       return;
@@ -136,14 +135,17 @@ export const linodeEventsHandler = ({
  * Disks have their own handler beacuse the actions are not prefixed with "linode_".
  * They are prefixed with "disk_". For example "disk_create" or "disk_delete".
  */
-export const diskEventHandler = ({ event, queryClient }: EventHandlerData) => {
+export const diskEventHandler = ({
+  event,
+  invalidateQueries,
+}: EventHandlerData) => {
   const linodeId = event.entity?.id;
 
   if (!linodeId || ['scheduled', 'started'].includes(event.status)) {
     return;
   }
 
-  queryClient.invalidateQueries({
+  invalidateQueries({
     queryKey: linodeQueries.linode(linodeId)._ctx.disks.queryKey,
   });
 };

--- a/packages/manager/src/queries/nodebalancers.ts
+++ b/packages/manager/src/queries/nodebalancers.ts
@@ -303,7 +303,7 @@ export const useNodeBalancerTypesQuery = () =>
 
 export const nodebalancerEventHandler = ({
   event,
-  queryClient,
+  invalidateQueries,
 }: EventHandlerData) => {
   const nodebalancerId = event.entity?.id;
 
@@ -319,7 +319,7 @@ export const nodebalancerEventHandler = ({
 
   if (event.action.startsWith('nodebalancer_config')) {
     // If the event is about a NodeBalancer's configs, just invalidate the configs
-    queryClient.invalidateQueries({
+    invalidateQueries({
       queryKey: nodebalancerQueries.nodebalancer(nodebalancerId)._ctx
         .configurations.queryKey,
     });
@@ -327,13 +327,13 @@ export const nodebalancerEventHandler = ({
     // If we've made it here, the event is about a NodeBalancer
 
     // Invalidate the specific NodeBalancer
-    queryClient.invalidateQueries({
+    invalidateQueries({
       exact: true,
       queryKey: nodebalancerQueries.nodebalancer(nodebalancerId).queryKey,
     });
 
     // Invalidate all paginated lists
-    queryClient.invalidateQueries({
+    invalidateQueries({
       queryKey: nodebalancerQueries.nodebalancers.queryKey,
     });
   }

--- a/packages/manager/src/queries/profile/profile.ts
+++ b/packages/manager/src/queries/profile/profile.ts
@@ -195,15 +195,15 @@ export const useDeleteSSHKeyMutation = (id: number) => {
   });
 };
 
-export const sshKeyEventHandler = (event: EventHandlerData) => {
+export const sshKeyEventHandler = ({ invalidateQueries }: EventHandlerData) => {
   // This event handler is a bit agressive and will over-fetch, but UX will
   // be great because this will ensure Cloud has up to date data all the time.
 
-  event.queryClient.invalidateQueries({
+  invalidateQueries({
     queryKey: profileQueries.sshKeys._def,
   });
   // also invalidate the /account/users data because that endpoint returns some SSH key data
-  event.queryClient.invalidateQueries({
+  invalidateQueries({
     queryKey: accountQueries.users._ctx.paginated._def,
   });
 };

--- a/packages/manager/src/queries/profile/tokens.ts
+++ b/packages/manager/src/queries/profile/tokens.ts
@@ -90,11 +90,11 @@ export const useRevokeAppAccessTokenMutation = (id: number) => {
   });
 };
 
-export function tokenEventHandler({ queryClient }: EventHandlerData) {
-  queryClient.invalidateQueries({
+export function tokenEventHandler({ invalidateQueries }: EventHandlerData) {
+  invalidateQueries({
     queryKey: profileQueries.appTokens._def,
   });
-  queryClient.invalidateQueries({
+  invalidateQueries({
     queryKey: profileQueries.personalAccessTokens._def,
   });
 }

--- a/packages/manager/src/queries/stackscripts.ts
+++ b/packages/manager/src/queries/stackscripts.ts
@@ -68,16 +68,16 @@ export const useStackScriptsInfiniteQuery = (
 
 export const stackScriptEventHandler = ({
   event,
-  queryClient,
+  invalidateQueries,
 }: EventHandlerData) => {
   // Keep the infinite store up to date
-  queryClient.invalidateQueries({
+  invalidateQueries({
     queryKey: stackscriptQueries.infinite._def,
   });
 
   // If the event has a StackScript entity attached, invalidate it
   if (event.entity?.id) {
-    queryClient.invalidateQueries({
+    invalidateQueries({
       queryKey: stackscriptQueries.stackscript(event.entity.id).queryKey,
     });
   }

--- a/packages/manager/src/queries/support.ts
+++ b/packages/manager/src/queries/support.ts
@@ -112,7 +112,7 @@ export const useSupportTicketCloseMutation = (id: number) => {
 
 export const supportTicketEventHandler = ({
   event,
-  queryClient,
+  invalidateQueries,
 }: EventHandlerData) => {
   /**
    * Ticket events have entities that look like this:
@@ -126,13 +126,13 @@ export const supportTicketEventHandler = ({
    */
 
   // Invalidate paginated support tickets
-  queryClient.invalidateQueries({
+  invalidateQueries({
     queryKey: supportQueries.tickets._def,
   });
 
   if (event.entity) {
     // If there is an entity associated with the event, invalidate that ticket
-    queryClient.invalidateQueries({
+    invalidateQueries({
       queryKey: supportQueries.ticket(event.entity.id).queryKey,
     });
   }

--- a/packages/manager/src/queries/volumes/events.ts
+++ b/packages/manager/src/queries/volumes/events.ts
@@ -10,10 +10,10 @@ import type { EventHandlerData } from 'src/hooks/useEventHandlers';
  */
 export const volumeEventsHandler = ({
   event,
-  queryClient,
+  invalidateQueries,
 }: EventHandlerData) => {
   if (['failed', 'finished', 'notification'].includes(event.status)) {
-    queryClient.invalidateQueries({
+    invalidateQueries({
       queryKey: volumeQueries.lists.queryKey,
     });
   }
@@ -24,7 +24,7 @@ export const volumeEventsHandler = ({
   ) {
     // if a migration finishes, we want to re-request notifications so that the `volume_migration_imminent`
     // notification goes away.
-    queryClient.invalidateQueries({
+    invalidateQueries({
       queryKey: accountQueries.notifications.queryKey,
     });
   }
@@ -33,7 +33,7 @@ export const volumeEventsHandler = ({
     // The API gives us no way to know when a cloned volume transitions from
     // creating to active, so we will just refresh after 10 seconds
     setTimeout(() => {
-      queryClient.invalidateQueries({
+      invalidateQueries({
         queryKey: volumeQueries.lists.queryKey,
       });
     }, 10000);


### PR DESCRIPTION
## Description 📝

- Fixes event handler bug discovered by @jdamore-linode  🔧 

## The Issue 🐛 

- A [React Query change](https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-react-query-4#consistent-behavior-for-cancelrefetch) in v4 makes `invalidateQueries` fire off many GET request if `invalidateQueries` is called many times sequentially

## The Fix 🔧 

- We want to intentionally disable this new behavior (using `cancelRefetch: false`) in our event handlers because our event handlers were built based on the assumption React Query would only fire off one request when `invalidateQueries` was called many times sequentially

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/429b6310-0f74-434b-a3d0-d273ea706106" /> | <video src="https://github.com/user-attachments/assets/102a65b8-508e-47c7-94c6-9b8ee67cb101" /> |
| Notice how the event handers cause 3 repetitive GETs when event handlers are invoked  | Notice how only 1 GET happens when event handlers are invoked  |

## How to test 🧪

### Reproduction steps
- Open the network dev tools
- Within the 16 second polling interval, do something that triggers a new event n times. For example, enable and disable a domain n times.
- When the polling interval fires off verify you see n requests to GET /domains

### Verification steps
- Open the network dev tools
- Within the 16 second polling interval, do something that triggers a new event n times. For example, enable and disable a domain n times.
- When the polling interval fires off verify you don't see any duplicate requests to GET /domains


## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support