### PR TITLE
test: [M3-8478] - Fix Cypress StackScript Linode deploy test flake

### DIFF
--- a/packages/manager/.changeset/pr-10826-tests-1724431261722.md
+++ b/packages/manager/.changeset/pr-10826-tests-1724431261722.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Resolve StackScript Linode deploy test flake ([#10826](https://github.com/linode/manager/pull/10826))

--- a/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
@@ -5,6 +5,7 @@ import {
   pollLinodeDiskSize,
 } from 'support/util/polling';
 import { randomLabel, randomString, randomPhrase } from 'support/util/random';
+import { interceptGetAccountAvailability } from 'support/intercepts/account';
 import {
   interceptCreateStackScript,
   interceptGetStackScripts,
@@ -13,7 +14,7 @@ import { interceptCreateLinode } from 'support/intercepts/linodes';
 import { ui } from 'support/ui';
 import { createLinodeRequestFactory } from 'src/factories';
 import { createImage, getLinodeDisks, resizeLinodeDisk } from '@linode/api-v4';
-import { chooseRegion } from 'support/util/regions';
+import { chooseRegion, getRegionByLabel } from 'support/util/regions';
 import { SimpleBackoffMethod } from 'support/util/backoff';
 import { cleanUp } from 'support/util/cleanup';
 import { createTestLinode } from 'support/util/linodes';
@@ -31,6 +32,20 @@ const stackScriptErrorNoShebang =
 // StackScript error that is expected to appear when UDFs with non-alphanumeric names are supplied.
 const stackScriptErrorUdfAlphanumeric =
   'UDF names can only contain alphanumeric and underscore characters.';
+
+/**
+ * Sets the StackScript field's value programmatically rather than via simulated typing.
+ *
+ * Cypress's typing operation is slow for long strings, so we can save several
+ * seconds by setting the value directly, then simulating a couple keystrokes.
+ *
+ * @param script - Script contents to input.
+ */
+const inputStackScript = (script: string) => {
+  cy.get('[data-qa-textfield-label="Script"]').should('be.visible').click();
+
+  cy.focused().invoke('val', script).type(' {backspace}');
+};
 
 /**
  * Fills out the StackScript creation form.
@@ -66,11 +81,8 @@ const fillOutStackscriptForm = (
 
   cy.findByText(`${targetImage}`).should('be.visible').click();
 
-  // Insert a script with invalid UDF data.
-  cy.get('[data-qa-textfield-label="Script"]')
-    .should('be.visible')
-    .click()
-    .type(script);
+  // Insert a script.
+  inputStackScript(script);
 };
 
 /**
@@ -84,9 +96,14 @@ const fillOutStackscriptForm = (
  */
 const fillOutLinodeForm = (label: string, regionName: string) => {
   const password = randomString(32);
+  const region = getRegionByLabel(regionName);
 
   ui.regionSelect.find().click();
-  ui.regionSelect.findItemByRegionLabel(regionName).click();
+  ui.regionSelect
+    .findItemByRegionLabel(regionName)
+    .should('be.visible')
+    .click();
+  ui.regionSelect.find().should('have.value', `${region.label} (${region.id})`);
 
   cy.findByText('Linode Label')
     .should('be.visible')
@@ -173,6 +190,7 @@ describe('Create stackscripts', () => {
     interceptCreateStackScript().as('createStackScript');
     interceptGetStackScripts().as('getStackScripts');
     interceptCreateLinode().as('createLinode');
+    interceptGetAccountAvailability().as('getAvailability');
 
     cy.visitWithLogin('/stackscripts/create');
 
@@ -196,11 +214,7 @@ describe('Create stackscripts', () => {
     cy.findByText(stackScriptErrorNoShebang).should('be.visible');
 
     cy.fixture(stackscriptUdfInvalidPath).then((stackScriptUdfInvalid) => {
-      cy.get('[data-qa-textfield-label="Script"]')
-        .should('be.visible')
-        .click()
-        .type('{selectall}{backspace}')
-        .type(stackScriptUdfInvalid);
+      inputStackScript(stackScriptUdfInvalid);
     });
 
     ui.buttonGroup
@@ -214,11 +228,7 @@ describe('Create stackscripts', () => {
 
     // Insert a script with valid UDF data and submit StackScript create form.
     cy.fixture(stackscriptUdfPath).then((stackScriptUdf) => {
-      cy.get('[data-qa-textfield-label="Script"]')
-        .should('be.visible')
-        .click()
-        .type('{selectall}{backspace}')
-        .type(stackScriptUdf);
+      inputStackScript(stackScriptUdf);
     });
 
     ui.buttonGroup
@@ -249,6 +259,9 @@ describe('Create stackscripts', () => {
       .should('be.enabled')
       .click();
 
+    // Wait for availability to be retrieved before interacting with form.
+    cy.wait('@getAvailability');
+
     // Fill out Linode creation form, confirm UDF fields behave as expected.
     fillOutLinodeForm(linodeLabel, linodeRegion.label);
 
@@ -273,7 +286,10 @@ describe('Create stackscripts', () => {
 
     // Confirm that Linode has been created and is provisioning.
     cy.findByText(linodeLabel).should('be.visible');
-    cy.findByText('PROVISIONING').should('be.visible');
+
+    // In rare cases, the Linode can provision quicker than this assertion happens,
+    // so we want to account for cases where it's already booting or even running.
+    cy.findByText(/(PROVISIONING|BOOTING|RUNNING)/).should('be.visible');
   });
 
   /*

--- a/packages/manager/cypress/support/intercepts/account.ts
+++ b/packages/manager/cypress/support/intercepts/account.ts
@@ -678,3 +678,12 @@ export const mockGetMaintenance = (
     }
   });
 };
+
+/**
+ * Intercepts GET request to fetch account region availability.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptGetAccountAvailability = (): Cypress.Chainable<null> => {
+  return cy.intercept('GET', apiMatcher('account/availability*'));
+};

--- a/packages/manager/cypress/support/ui/autocomplete.ts
+++ b/packages/manager/cypress/support/ui/autocomplete.ts
@@ -32,11 +32,17 @@ export const autocompletePopper = {
     title: string,
     options?: SelectorMatcherOptions
   ): Cypress.Chainable => {
-    return cy
-      .document()
-      .its('body')
-      .find('[data-qa-autocomplete-popper]')
-      .findByText(title, options);
+    return (
+      cy
+        .document()
+        .its('body')
+        .find('[data-qa-autocomplete-popper]')
+        .findByText(title, options)
+        // Scroll to the desired item before yielding.
+        // Apply a negative top offset to account for cases where the desired
+        // item may be obscured by the drop-down sticky category heading.
+        .scrollIntoView({ offset: { left: 0, top: -45 } })
+    );
   },
 };
 


### PR DESCRIPTION
## Description 📝
This resolves some causes of test flakiness in the StackScript Linode deploy test in `create-stackscript.spec.ts`.

There seem to be two main causes of flake for this test in CI, and this PR attempts to fix both:

- Attempting to find a region in the region drop-down without scrolling to it first
- Issues selecting a region quickly upon page load

I also changed the way that StackScripts get entered into the create form. Using `cy.type()` to input the script is slow and adds several seconds to our test runtime, so I've circumvented it by setting the field's value directly.

I ran the test on repeat 30 times (with the other test skipped) and it passed each time.

(cc @mjac0bs -- I'm curious if you continue seeing failures with these changes? No worries if you don't have time to take a look!)

## Changes  🔄

- Scroll to desired region before attempting to select it from drop-down
- Wait for request to account availability endpoint to resolve before interacting with region select
  - ℹ️ It's not clear to me if interacting with the region select before this request resolves is what causes the region selection issue, or if waiting for this request to resolve only fixes it incidentally

## How to test 🧪
Because this test doesn't fail every time, CI may not be the most reliable way to gauge the effectiveness of this change.

You can run the test locally with this command (feel free to skip the other test since it's a slow one and isn't related to these changes):

```bash
yarn cy:run -s "cypress/e2e/core/stackscripts/create-stackscripts.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
