### PR TITLE
fix: [M3-8453] - Update error text color in confirmation dialogs to use theme, refactor styling

### DIFF
--- a/packages/manager/.changeset/pr-10828-changed-1724442933954.md
+++ b/packages/manager/.changeset/pr-10828-changed-1724442933954.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Error text color in confirmation dialogs from being hardcoded to using the theme color ([#10828](https://github.com/linode/manager/pull/10828))

--- a/packages/manager/.changeset/pr-10828-changed-1724442933954.md
+++ b/packages/manager/.changeset/pr-10828-changed-1724442933954.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Error text color in confirmation dialogs from being hardcoded to using the theme color ([#10828](https://github.com/linode/manager/pull/10828))

--- a/packages/manager/.changeset/pr-10828-fixed-1724688319150.md
+++ b/packages/manager/.changeset/pr-10828-fixed-1724688319150.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Inaccessible, non-theme error text color in confirmation dialogs ([#10828](https://github.com/linode/manager/pull/10828))

--- a/packages/manager/.changeset/pr-10828-tests-1724688351092.md
+++ b/packages/manager/.changeset/pr-10828-tests-1724688351092.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add unit tests for Confirmation Dialogs ([#10828](https://github.com/linode/manager/pull/10828))

--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -2,9 +2,12 @@ import { styled } from '@mui/material/styles';
 import * as React from 'react';
 import { useStyles } from 'tss-react/mui';
 
-import { Button, ButtonProps } from 'src/components/Button/Button';
+import { Button } from 'src/components/Button/Button';
 
-import { Box, BoxProps } from '../Box';
+import { Box } from '../Box';
+
+import type { BoxProps } from '../Box';
+import type { ButtonProps } from 'src/components/Button/Button';
 
 interface ActionButtonsProps extends ButtonProps {
   'data-node-idx'?: number;

--- a/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.test.tsx
+++ b/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent } from '@testing-library/react';
+import * as React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { ActionsPanel } from '../ActionsPanel/ActionsPanel';
+import { ConfirmationDialog } from './ConfirmationDialog';
+
+import type { ConfirmationDialogProps } from './ConfirmationDialog';
+
+const props: ConfirmationDialogProps = {
+  onClose: vi.fn(),
+  open: true,
+  title: 'This is a title',
+};
+
+describe('Confirmation Dialog', () => {
+  it('renders the confirmation dialog', () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <ConfirmationDialog {...props} />
+    );
+
+    expect(getByText('This is a title')).toBeVisible();
+    expect(getByTestId('CloseIcon')).toBeVisible();
+  });
+
+  it('renders the dialog children if it is provided', () => {
+    const { getByText } = renderWithTheme(
+      <ConfirmationDialog {...props}>
+        <div>Confirmation dialog children</div>
+      </ConfirmationDialog>
+    );
+
+    expect(getByText('Confirmation dialog children')).toBeVisible();
+  });
+
+  it('renders action items in the footer if they are provided', () => {
+    const { getByText } = renderWithTheme(
+      <ConfirmationDialog
+        {...props}
+        actions={
+          <ActionsPanel
+            primaryButtonProps={{ label: 'Continue' }}
+            secondaryButtonProps={{ label: 'Cancel' }}
+          />
+        }
+      />
+    );
+
+    expect(getByText('Continue')).toBeVisible();
+    expect(getByText('Cancel')).toBeVisible();
+  });
+
+  it('renders the error message if it is provided', () => {
+    const { getByText } = renderWithTheme(
+      <ConfirmationDialog {...props} error={'This is an error'} />
+    );
+
+    expect(getByText('This is an error')).toBeVisible();
+  });
+
+  it('closes the confirmaton dialog if the X button is clicked', () => {
+    const { getByTestId } = renderWithTheme(<ConfirmationDialog {...props} />);
+
+    const closeButton = getByTestId('CloseIcon');
+    expect(closeButton).toBeVisible();
+
+    fireEvent.click(closeButton);
+    expect(props.onClose).toHaveBeenCalled();
+  });
+});

--- a/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.test.tsx
+++ b/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.test.tsx
@@ -24,7 +24,7 @@ describe('Confirmation Dialog', () => {
     expect(getByTestId('CloseIcon')).toBeVisible();
   });
 
-  it('renders the dialog children if it is provided', () => {
+  it("renders the dialog's children if they are provided", () => {
     const { getByText } = renderWithTheme(
       <ConfirmationDialog {...props}>
         <div>Confirmation dialog children</div>

--- a/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -1,34 +1,13 @@
-import Dialog, { DialogProps } from '@mui/material/Dialog';
+import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
-import { Theme } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import * as React from 'react';
-import { makeStyles } from 'tss-react/mui';
 
 import { DialogTitle } from 'src/components/DialogTitle/DialogTitle';
 
-const useStyles = makeStyles()((theme: Theme) => ({
-  actions: {
-    '& button': {
-      marginBottom: 0,
-    },
-    justifyContent: 'flex-end',
-  },
-  dialogContent: {
-    display: 'flex',
-    flexDirection: 'column',
-  },
-  error: {
-    color: '#C44742',
-    marginTop: theme.spacing(2),
-  },
-  root: {
-    '& .MuiDialogTitle-root': {
-      marginBottom: 10,
-    },
-  },
-}));
+import type { DialogProps } from '@mui/material/Dialog';
 
 export interface ConfirmationDialogProps extends DialogProps {
   actions?: ((props: any) => JSX.Element) | JSX.Element;
@@ -48,8 +27,6 @@ export interface ConfirmationDialogProps extends DialogProps {
  *
  */
 export const ConfirmationDialog = (props: ConfirmationDialogProps) => {
-  const { classes } = useStyles();
-
   const {
     actions,
     children,
@@ -61,7 +38,7 @@ export const ConfirmationDialog = (props: ConfirmationDialogProps) => {
   } = props;
 
   return (
-    <Dialog
+    <StyledDialog
       {...dialogProps}
       TransitionProps={{
         ...dialogProps.TransitionProps,
@@ -73,26 +50,52 @@ export const ConfirmationDialog = (props: ConfirmationDialogProps) => {
         }
       }}
       PaperProps={{ role: undefined }}
-      className={classes.root}
       data-qa-dialog
       data-qa-drawer
       data-testid="drawer"
       role="dialog"
     >
       <DialogTitle onClose={onClose} title={title} />
-      <DialogContent className={classes.dialogContent} data-qa-dialog-content>
+      <StyledDialogContent data-qa-dialog-content>
         {children}
-        {error && (
-          <DialogContentText className={`${classes.error} error-for-scroll`}>
-            {error}
-          </DialogContentText>
-        )}
-      </DialogContent>
-      <DialogActions className={classes.actions}>
+        {error && <StyledErrorText>{error}</StyledErrorText>}
+      </StyledDialogContent>
+      <StyledDialogActions>
         {actions && typeof actions === 'function'
           ? actions(dialogProps)
           : actions}
-      </DialogActions>
-    </Dialog>
+      </StyledDialogActions>
+    </StyledDialog>
   );
 };
+
+const StyledDialog = styled(Dialog, {
+  label: 'StyledDialog',
+})({
+  '& .MuiDialogTitle-root': {
+    marginBottom: '10px',
+  },
+});
+
+const StyledDialogActions = styled(DialogActions, {
+  label: 'StyledDialogActions',
+})({
+  '& button': {
+    marginBottom: 0,
+  },
+  justifyContent: 'flex-end',
+});
+
+const StyledDialogContent = styled(DialogContent, {
+  label: 'StyledDialogContent',
+})({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+const StyledErrorText = styled(DialogContentText, {
+  label: 'StyledErrorText',
+})(({ theme }) => ({
+  color: theme.palette.error.dark,
+  marginTop: theme.spacing(2),
+}));

--- a/packages/manager/src/components/Dialog/Dialog.tsx
+++ b/packages/manager/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import _Dialog, { DialogProps as _DialogProps } from '@mui/material/Dialog';
+import _Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import { styled, useTheme } from '@mui/material/styles';
 import * as React from 'react';
@@ -8,6 +8,8 @@ import { DialogTitle } from 'src/components/DialogTitle/DialogTitle';
 import { Notice } from 'src/components/Notice/Notice';
 import { omittedProps } from 'src/utilities/omittedProps';
 import { convertForAria } from 'src/utilities/stringUtils';
+
+import type { DialogProps as _DialogProps } from '@mui/material/Dialog';
 
 export interface DialogProps extends _DialogProps {
   className?: string;


### PR DESCRIPTION
## Description 📝
Update error text color in confirmation dialogs to not be hardcoded, as per discussion. Also added some tests/refactored styling to use styled components while I was at it

## Changes  🔄
- updated error text color to use the theme
- added tests for Confirmation Dialogs
- refactor styling

## Target release date 🗓️
n/a

## Preview
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/e3f47fa6-8246-4e97-a0bb-d34301184145)![image](https://github.com/user-attachments/assets/de4db235-e36f-4528-a3a1-cad37cac6998)| ![image](https://github.com/user-attachments/assets/7aac6aa3-a459-4f18-a271-affb6db4cd8b)![image](https://github.com/user-attachments/assets/c73225f4-9c50-46ed-8e09-57f41a470828)|

## How to test 🧪

### Verification steps
- yarn test components/ConfirmationDialog.test.tsx
- Verify that Confirmation Dialog styling remains the same throughout the app / verify it remains the same on storybook
- Except the error text color, verify the error text color has been changed + is easier to see in dark mode

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
