### PR TITLE
Fix location of `**` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 ## Overview
 
-This repository is home to the Akamai Connected **[Cloud Manager](https://cloud.linode.com)** and related [`@linode/api-v4`](packages/api-v4/) and [`@linode/validation`](packages/validation/) Typescript packages.
+This repository is home to the Akamai Connected [**Cloud Manager**](https://cloud.linode.com) and related [`@linode/api-v4`](packages/api-v4/) and [`@linode/validation`](packages/validation/) Typescript packages.
 
 ## Developing Locally
 


### PR DESCRIPTION
This PR fixes the README to contain the **bold** within the link.