### PR TITLE
test: [M3-8486] - Allow using Cypress region selection helpers with mock regions

### DIFF
--- a/packages/manager/.changeset/pr-10832-tests-1724681646686.md
+++ b/packages/manager/.changeset/pr-10832-tests-1724681646686.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Allow region select helpers to be used with mock data ([#10832](https://github.com/linode/manager/pull/10832))

--- a/packages/manager/cypress/support/ui/autocomplete.ts
+++ b/packages/manager/cypress/support/ui/autocomplete.ts
@@ -1,7 +1,11 @@
 import { getRegionById, getRegionByLabel } from 'support/util/regions';
 
 import type { SelectorMatcherOptions } from '@testing-library/cypress';
+import type { Region } from '@linode/api-v4';
 
+/**
+ * Autocomplete UI element.
+ */
 export const autocomplete = {
   /**
    * Finds a autocomplete popper that has the given title.
@@ -45,12 +49,25 @@ export const autocompletePopper = {
  */
 export const regionSelect = {
   /**
-   * Finds and open the region select input.
+   * Finds a region select input.
+   *
+   * This finds any element with the `region-select` test ID. In cases where
+   * more than one region select may be on the screen, consider narrowing
+   * your selection before using this helper.
+   *
+   * @returns Cypress chainable.
    */
   find: (): Cypress.Chainable => {
     return cy.get('[data-testid="region-select"] input');
   },
 
+  /**
+   * Finds a region select input by its current value.
+   *
+   * @param selectedRegion - Current selection for desired Region Select.
+   *
+   * @returns Cypress chainable.
+   */
   findBySelectedItem: (selectedRegion: string) => {
     return cy.get(`[value="${selectedRegion}"]`);
   },
@@ -60,12 +77,13 @@ export const regionSelect = {
    *
    * This assumes that the Region Select menu is already open.
    *
-   * @param regionId - ID of region for which to find Region Select menu item.
+   * @param regionId - ID of region to find in selection drop-down.
+   * @param searchRegions - Optional array of regions from which to search.
    *
    * @returns Cypress chainable.
    */
-  findItemByRegionId: (regionId: string) => {
-    const region = getRegionById(regionId);
+  findItemByRegionId: (regionId: string, searchRegions?: Region[]) => {
+    const region = getRegionById(regionId, searchRegions);
     return autocompletePopper.findByTitle(`${region.label} (${region.id})`);
   },
 
@@ -74,12 +92,13 @@ export const regionSelect = {
    *
    * This assumes that the Region Select menu is already open.
    *
-   * @param regionLabel - Region label.
+   * @param regionLabel - Label of region to find in selection drop-down.
+   * @param searchRegions - Optional array of regions from which to search.
    *
    * @returns Cypress chainable.
    */
-  findItemByRegionLabel: (regionLabel: string) => {
-    const region = getRegionByLabel(regionLabel);
+  findItemByRegionLabel: (regionLabel: string, searchRegions?: Region[]) => {
+    const region = getRegionByLabel(regionLabel, searchRegions);
     return autocompletePopper.findByTitle(`${region.label} (${region.id})`);
   },
 };


### PR DESCRIPTION
## Description 📝

This is a tiny change that allows the `ui.regionSelect.findItemByRegionId()` and `ui.regionSelect.findItemByRegionLabel()` helpers to be used with mock regions. I also made some small doc comment improvements.

I'm doing this in preparation for some Cypress docs improvements that will encourage the use of these helpers.

## Changes  🔄

- Add optional `searchRegions` parameter to `ui.regionSelect.findItemByRegionId` and `ui.regionSelect.findItemByRegionLabel` that allows mock regions to be used with helpers
- Small doc improvements

## How to test 🧪
This doesn't make any changes to any tests, and the changes to the helpers should not impact the behavior of any of our tests. We can rely on CI to ensure that nothing is broken by these changes.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
