### PR TITLE
change: [M3-8439] - Tag form events in Linode Create v2

### DIFF
--- a/packages/manager/.changeset/pr-10840-tech-stories-1724713234913.md
+++ b/packages/manager/.changeset/pr-10840-tech-stories-1724713234913.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Tag Linode Create v2 with form events ([#10840](https://github.com/linode/manager/pull/10840))

--- a/packages/manager/src/components/SelectFirewallPanel/SelectFirewallPanel.tsx
+++ b/packages/manager/src/components/SelectFirewallPanel/SelectFirewallPanel.tsx
@@ -1,6 +1,5 @@
 import { styled } from '@mui/material/styles';
 import * as React from 'react';
-import { useLocation } from 'react-router-dom';
 
 import { Box } from 'src/components/Box';
 import { Paper } from 'src/components/Paper';
@@ -10,8 +9,6 @@ import { CreateFirewallDrawer } from 'src/features/Firewalls/FirewallLanding/Cre
 import { useFlags } from 'src/hooks/useFlags';
 import { useSecureVMNoticesEnabled } from 'src/hooks/useSecureVMNoticesEnabled';
 import { useFirewallsQuery } from 'src/queries/firewalls';
-import { sendLinodeCreateFormInputEvent } from 'src/utilities/analytics/formEventAnalytics';
-import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 
 import { AkamaiBanner } from '../AkamaiBanner/AkamaiBanner';
 import { Autocomplete } from '../Autocomplete/Autocomplete';
@@ -19,8 +16,6 @@ import { GenerateFirewallDialog } from '../GenerateFirewallDialog/GenerateFirewa
 import { LinkButton } from '../LinkButton';
 
 import type { Firewall, FirewallDeviceEntityType } from '@linode/api-v4';
-import type { LinodeCreateQueryParams } from 'src/features/Linodes/types';
-import type { LinodeCreateFormEventOptions } from 'src/utilities/analytics/types';
 
 interface Props {
   disabled?: boolean;
@@ -41,18 +36,7 @@ export const SelectFirewallPanel = (props: Props) => {
 
   const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
   const [isFirewallDialogOpen, setIsFirewallDialogOpen] = React.useState(false);
-  const location = useLocation();
-  const isFromLinodeCreate = location.pathname.includes('/linodes/create');
-  const queryParams = getQueryParamsFromQueryString<LinodeCreateQueryParams>(
-    location.search
-  );
 
-  const firewallFormEventOptions: LinodeCreateFormEventOptions = {
-    createType: queryParams.type ?? 'OS',
-    headerName: 'Firewall',
-    interaction: 'click',
-    label: 'Firewall',
-  };
   const flags = useFlags();
 
   const { secureVMNoticesEnabled } = useSecureVMNoticesEnabled();
@@ -61,12 +45,6 @@ export const SelectFirewallPanel = (props: Props) => {
 
   const handleCreateFirewallClick = () => {
     setIsDrawerOpen(true);
-    if (isFromLinodeCreate) {
-      sendLinodeCreateFormInputEvent({
-        ...firewallFormEventOptions,
-        label: 'Create Firewall',
-      });
-    }
   };
 
   const handleFirewallCreated = (firewall: Firewall) => {
@@ -116,25 +94,9 @@ export const SelectFirewallPanel = (props: Props) => {
             />
           )}
         <Autocomplete
-          onChange={(_, selection) => {
-            handleFirewallChange(selection?.value ?? -1);
-            // Track clearing and changing the value once per page view, configured by inputValue in AA backend.
-            if (!selection) {
-              sendLinodeCreateFormInputEvent({
-                ...firewallFormEventOptions,
-                interaction: 'clear',
-                subheaderName: 'Assign Firewall',
-                trackOnce: true,
-              });
-            } else {
-              sendLinodeCreateFormInputEvent({
-                ...firewallFormEventOptions,
-                interaction: 'change',
-                subheaderName: 'Assign Firewall',
-                trackOnce: true,
-              });
-            }
-          }}
+          onChange={(_, selection) =>
+            handleFirewallChange(selection?.value ?? -1)
+          }
           disabled={disabled}
           errorText={error?.[0].reason}
           label="Assign Firewall"

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Actions.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Actions.tsx
@@ -6,6 +6,7 @@ import { Button } from 'src/components/Button/Button';
 import { useFlags } from 'src/hooks/useFlags';
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 import { sendApiAwarenessClickEvent } from 'src/utilities/analytics/customEventAnalytics';
+import { sendLinodeCreateFormInputEvent } from 'src/utilities/analytics/formEventAnalytics';
 import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
 
 import { ApiAwarenessModal } from '../LinodesCreate/ApiAwarenessModal/ApiAwarenessModal';
@@ -35,6 +36,13 @@ export const Actions = () => {
 
   const onOpenAPIAwareness = async () => {
     sendApiAwarenessClickEvent('Button', 'Create Using Command Line');
+    sendLinodeCreateFormInputEvent({
+      createType: 'OS',
+      interaction: 'click',
+      label: isDxToolsAdditionsEnabled
+        ? 'View Code Snippets'
+        : 'Create Using Command Line',
+    });
     if (await trigger()) {
       // If validation is successful, we open the dialog.
       setIsAPIAwarenessModalOpen(true);

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Actions.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Actions.tsx
@@ -10,12 +10,17 @@ import { sendLinodeCreateFormInputEvent } from 'src/utilities/analytics/formEven
 import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
 
 import { ApiAwarenessModal } from '../LinodesCreate/ApiAwarenessModal/ApiAwarenessModal';
-import { getLinodeCreatePayload } from './utilities';
+import {
+  getLinodeCreatePayload,
+  useLinodeCreateQueryParams,
+} from './utilities';
 
 import type { LinodeCreateFormValues } from './utilities';
 
 export const Actions = () => {
   const flags = useFlags();
+
+  const { params } = useLinodeCreateQueryParams();
 
   const [isAPIAwarenessModalOpen, setIsAPIAwarenessModalOpen] = useState(false);
 
@@ -37,7 +42,7 @@ export const Actions = () => {
   const onOpenAPIAwareness = async () => {
     sendApiAwarenessClickEvent('Button', 'Create Using Command Line');
     sendLinodeCreateFormInputEvent({
-      createType: 'OS',
+      createType: params.type ?? 'OS',
       interaction: 'click',
       label: isDxToolsAdditionsEnabled
         ? 'View Code Snippets'

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Details/Details.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Details/Details.tsx
@@ -1,4 +1,3 @@
-import { CreateLinodeRequest } from '@linode/api-v4';
 import React from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
@@ -11,6 +10,8 @@ import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGran
 
 import { useLinodeCreateQueryParams } from '../utilities';
 import { PlacementGroupPanel } from './PlacementGroupPanel';
+
+import type { CreateLinodeRequest } from '@linode/api-v4';
 
 export const Details = () => {
   const { control } = useFormContext<CreateLinodeRequest>();

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Details/PlacementGroupPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Details/PlacementGroupPanel.tsx
@@ -31,7 +31,6 @@ export const PlacementGroupPanel = () => {
     <PlacementGroupsDetailPanel
       handlePlacementGroupChange={(placementGroup) => {
         field.onChange(placementGroup?.id);
-        // Track clearing and changing the value once per page view, configured by inputValue in AA backend.
         if (!placementGroup?.id) {
           sendLinodeCreateFormInputEvent({
             ...placementGroupFormEventOptions,

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Details/PlacementGroupPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Details/PlacementGroupPanel.tsx
@@ -6,7 +6,6 @@ import { sendLinodeCreateFormInputEvent } from 'src/utilities/analytics/formEven
 
 import { useLinodeCreateQueryParams } from '../utilities';
 
-import type { LinodeCreateType } from '../../LinodesCreate/types';
 import type { CreateLinodeRequest } from '@linode/api-v4';
 import type { LinodeCreateFormEventOptions } from 'src/utilities/analytics/types';
 
@@ -20,7 +19,7 @@ export const PlacementGroupPanel = () => {
   const { params } = useLinodeCreateQueryParams();
 
   const placementGroupFormEventOptions: LinodeCreateFormEventOptions = {
-    createType: (params.type as LinodeCreateType) ?? 'OS',
+    createType: params.type ?? 'OS',
     headerName: 'Details',
     interaction: 'change',
     label: 'Placement Group',

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Details/PlacementGroupPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Details/PlacementGroupPanel.tsx
@@ -37,9 +37,7 @@ export const PlacementGroupPanel = () => {
             interaction: 'clear',
           });
         } else {
-          sendLinodeCreateFormInputEvent({
-            ...placementGroupFormEventOptions,
-          });
+          sendLinodeCreateFormInputEvent(placementGroupFormEventOptions);
         }
       }}
       selectedPlacementGroupId={field.value ?? null}

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Details/PlacementGroupPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Details/PlacementGroupPanel.tsx
@@ -2,8 +2,13 @@ import React from 'react';
 import { useController, useWatch } from 'react-hook-form';
 
 import { PlacementGroupsDetailPanel } from 'src/features/PlacementGroups/PlacementGroupsDetailPanel';
+import { sendLinodeCreateFormInputEvent } from 'src/utilities/analytics/formEventAnalytics';
 
+import { useLinodeCreateQueryParams } from '../utilities';
+
+import type { LinodeCreateType } from '../../LinodesCreate/types';
 import type { CreateLinodeRequest } from '@linode/api-v4';
+import type { LinodeCreateFormEventOptions } from 'src/utilities/analytics/types';
 
 export const PlacementGroupPanel = () => {
   const { field } = useController<CreateLinodeRequest>({
@@ -12,11 +17,33 @@ export const PlacementGroupPanel = () => {
 
   const regionId = useWatch<CreateLinodeRequest>({ name: 'region' });
 
+  const { params } = useLinodeCreateQueryParams();
+
+  const placementGroupFormEventOptions: LinodeCreateFormEventOptions = {
+    createType: (params.type as LinodeCreateType) ?? 'OS',
+    headerName: 'Details',
+    interaction: 'change',
+    label: 'Placement Group',
+    subheaderName: 'Placement Groups in Region',
+    trackOnce: true,
+  };
+
   return (
     <PlacementGroupsDetailPanel
-      handlePlacementGroupChange={(placementGroup) =>
-        field.onChange(placementGroup?.id)
-      }
+      handlePlacementGroupChange={(placementGroup) => {
+        field.onChange(placementGroup?.id);
+        // Track clearing and changing the value once per page view, configured by inputValue in AA backend.
+        if (!placementGroup?.id) {
+          sendLinodeCreateFormInputEvent({
+            ...placementGroupFormEventOptions,
+            interaction: 'clear',
+          });
+        } else {
+          sendLinodeCreateFormInputEvent({
+            ...placementGroupFormEventOptions,
+          });
+        }
+      }}
       selectedPlacementGroupId={field.value ?? null}
       selectedRegionId={regionId}
     />

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Firewall.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Firewall.tsx
@@ -20,7 +20,6 @@ import { sendLinodeCreateFormInputEvent } from 'src/utilities/analytics/formEven
 
 import { useLinodeCreateQueryParams } from './utilities';
 
-import type { LinodeCreateType } from '../LinodesCreate/types';
 import type { LinodeCreateFormValues } from './utilities';
 import type { CreateLinodeRequest } from '@linode/api-v4';
 import type { LinodeCreateFormEventOptions } from 'src/utilities/analytics/types';
@@ -76,7 +75,7 @@ export const Firewall = () => {
           <Link
             onClick={() =>
               sendLinodeCreateFormInputEvent({
-                createType: (params.type as LinodeCreateType) ?? 'OS',
+                createType: params.type ?? 'OS',
                 headerName: 'Firewall',
                 interaction: 'click',
                 label: 'Learn more',

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Firewall.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Firewall.tsx
@@ -104,7 +104,7 @@ export const Firewall = () => {
         <Stack spacing={1.5}>
           <Autocomplete
             onChange={(e, firewall) => {
-              onChange(firewall?.id); // Track clearing and changing the value once per page view, configured by inputValue in AA backend.
+              onChange(firewall?.id);
               if (!firewall?.id) {
                 sendLinodeCreateFormInputEvent({
                   ...firewallFormEventOptions,

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Plan.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Plan.tsx
@@ -7,7 +7,10 @@ import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGran
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { useAllTypes } from 'src/queries/types';
 import { sendLinodeCreateFlowDocsClickEvent } from 'src/utilities/analytics/customEventAnalytics';
+import { sendLinodeCreateFormInputEvent } from 'src/utilities/analytics/formEventAnalytics';
 import { extendType } from 'src/utilities/extendType';
+
+import { useLinodeCreateQueryParams } from './utilities';
 
 import type { LinodeCreateFormValues } from './utilities';
 import type { CreateLinodeRequest } from '@linode/api-v4';
@@ -22,6 +25,7 @@ export const Plan = () => {
 
   const { data: regions } = useRegionsQuery();
   const { data: types } = useAllTypes();
+  const { params } = useLinodeCreateQueryParams();
 
   const isLinodeCreateRestricted = useRestrictedGlobalGrantCheck({
     globalGrantType: 'add_linodes',
@@ -33,6 +37,12 @@ export const Plan = () => {
         <DocsLink
           onClick={() => {
             sendLinodeCreateFlowDocsClickEvent('Choosing a Plan');
+            sendLinodeCreateFormInputEvent({
+              createType: params.type ?? 'OS',
+              headerName: 'Linode Plan',
+              interaction: 'click',
+              label: 'Choosing a Plan',
+            });
           }}
           href="https://www.linode.com/docs/guides/choosing-a-compute-instance-plan/"
           label="Choosing a Plan"

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Region.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Region.tsx
@@ -20,6 +20,7 @@ import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGran
 import { useImageQuery } from 'src/queries/images';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { useTypeQuery } from 'src/queries/types';
+import { sendLinodeCreateFormStartEvent } from 'src/utilities/analytics/formEventAnalytics';
 import {
   DIFFERENT_PRICE_STRUCTURE_WARNING,
   DOCS_LINK_LABEL_DC_PRICING,
@@ -150,6 +151,11 @@ export const Region = () => {
 
       setValue('label', label);
     }
+
+    // Begin tracking the Linode Create form - fires once per page view, configured in AA backend.
+    sendLinodeCreateFormStartEvent({
+      createType: params.type ?? 'OS',
+    });
   };
 
   const showCrossDataCenterCloneWarning =
@@ -223,6 +229,13 @@ export const Region = () => {
         </Notice>
       )}
       <RegionSelect
+        onChange={(e, region) => {
+          onChange(region);
+          // Begin tracking the Linode Create form - fires once per page view, configured in AA backend.
+          sendLinodeCreateFormStartEvent({
+            createType: params.type ?? 'OS',
+          });
+        }}
         regionFilter={
           // We don't want the Image Service Gen2 work to abide by Gecko feature flags
           hideDistributedRegions && params.type !== 'Images'
@@ -237,7 +250,6 @@ export const Region = () => {
         disabled={isLinodeCreateRestricted}
         disabledRegions={disabledRegions}
         errorText={fieldState.error?.message}
-        onChange={(e, region) => onChange(region)}
         regions={regions ?? []}
         textFieldProps={{ onBlur: field.onBlur }}
         value={field.value}

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Region.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Region.tsx
@@ -152,7 +152,7 @@ export const Region = () => {
       setValue('label', label);
     }
 
-    // Begin tracking the Linode Create form - fires once per page view, configured in AA backend.
+    // Begin tracking the Linode Create form.
     sendLinodeCreateFormStartEvent({
       createType: params.type ?? 'OS',
     });
@@ -231,7 +231,7 @@ export const Region = () => {
       <RegionSelect
         onChange={(e, region) => {
           onChange(region);
-          // Begin tracking the Linode Create form - fires once per page view, configured in AA backend.
+          // Begin tracking the Linode Create form.
           sendLinodeCreateFormStartEvent({
             createType: params.type ?? 'OS',
           });

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Region.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Region.tsx
@@ -240,13 +240,6 @@ export const Region = () => {
         </Notice>
       )}
       <RegionSelect
-        onChange={(e, region) => {
-          onChange(region);
-          // Begin tracking the Linode Create form.
-          sendLinodeCreateFormStartEvent({
-            createType: params.type ?? 'OS',
-          });
-        }}
         regionFilter={
           // We don't want the Image Service Gen2 work to abide by Gecko feature flags
           hideDistributedRegions && params.type !== 'Images'
@@ -261,6 +254,7 @@ export const Region = () => {
         disabled={isLinodeCreateRestricted}
         disabledRegions={disabledRegions}
         errorText={fieldState.error?.message}
+        onChange={(e, region) => onChange(region)}
         regions={regions ?? []}
         textFieldProps={{ onBlur: field.onBlur }}
         value={field.value}

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Region.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Region.tsx
@@ -20,7 +20,10 @@ import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGran
 import { useImageQuery } from 'src/queries/images';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { useTypeQuery } from 'src/queries/types';
-import { sendLinodeCreateFormStartEvent } from 'src/utilities/analytics/formEventAnalytics';
+import {
+  sendLinodeCreateFormInputEvent,
+  sendLinodeCreateFormStartEvent,
+} from 'src/utilities/analytics/formEventAnalytics';
 import {
   DIFFERENT_PRICE_STRUCTURE_WARNING,
   DOCS_LINK_LABEL_DC_PRICING,
@@ -216,6 +219,14 @@ export const Region = () => {
       <Box display="flex" justifyContent="space-between" mb={1}>
         <Typography variant="h2">Region</Typography>
         <DocsLink
+          onClick={() =>
+            sendLinodeCreateFormInputEvent({
+              createType: params.type ?? 'OS',
+              headerName: 'Region',
+              interaction: 'click',
+              label: DOCS_LINK_LABEL_DC_PRICING,
+            })
+          }
           href="https://www.linode.com/pricing"
           label={DOCS_LINK_LABEL_DC_PRICING}
         />

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.test.tsx
@@ -1,20 +1,26 @@
 import { userEvent } from '@testing-library/user-event';
 import React from 'react';
 
+import { DOCS_LINK_LABEL_DC_PRICING } from 'src/utilities/pricing/constants';
 import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
 
 import { TwoStepRegion } from './TwoStepRegion';
 
 describe('TwoStepRegion', () => {
-  it('should render a heading', () => {
-    const { getAllByText } = renderWithThemeAndHookFormContext({
+  it('should render a heading and docs link', () => {
+    const { getAllByText, getByText } = renderWithThemeAndHookFormContext({
       component: <TwoStepRegion onChange={vi.fn()} />,
     });
 
     const heading = getAllByText('Region')[0];
+    const link = getByText(DOCS_LINK_LABEL_DC_PRICING);
 
     expect(heading).toBeVisible();
     expect(heading.tagName).toBe('H2');
+
+    expect(link).toBeVisible();
+    expect(link).toHaveRole('link');
+    expect(link).toHaveAttribute('href', 'https://www.linode.com/pricing');
   });
 
   it('should render two tabs, Core and Distributed', () => {

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
 import { Box } from 'src/components/Box';
+import { DocsLink } from 'src/components/DocsLink/DocsLink';
 import { Paper } from 'src/components/Paper';
 import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
 import { RegionHelperText } from 'src/components/SelectRegionPanel/RegionHelperText';
@@ -13,16 +14,16 @@ import { Tabs } from 'src/components/Tabs/Tabs';
 import { Typography } from 'src/components/Typography';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { sendLinodeCreateDocsEvent } from 'src/utilities/analytics/customEventAnalytics';
+import { sendLinodeCreateFormInputEvent } from 'src/utilities/analytics/formEventAnalytics';
+import { DOCS_LINK_LABEL_DC_PRICING } from 'src/utilities/pricing/constants';
+
+import { useLinodeCreateQueryParams } from './utilities';
 
 import type { Region as RegionType } from '@linode/api-v4';
 import type {
   RegionFilterValue,
   RegionSelectProps,
 } from 'src/components/RegionSelect/RegionSelect.types';
-import { DocsLink } from 'src/components/DocsLink/DocsLink';
-import { DOCS_LINK_LABEL_DC_PRICING } from 'src/utilities/pricing/constants';
-import { sendLinodeCreateFormInputEvent } from 'src/utilities/analytics/formEventAnalytics';
-import { useLinodeCreateQueryParams } from './utilities';
 
 interface GeographicalAreaOption {
   label: string;
@@ -79,9 +80,7 @@ export const TwoStepRegion = (props: CombinedProps) => {
   return (
     <Paper>
       <Box display="flex" justifyContent="space-between" mb={1}>
-        <Typography data-qa-tp="Region" variant="h2">
-          Region
-        </Typography>
+        <Typography variant="h2">Region</Typography>
         <DocsLink
           onClick={() =>
             sendLinodeCreateFormInputEvent({

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/TwoStepRegion.tsx
@@ -19,6 +19,10 @@ import type {
   RegionFilterValue,
   RegionSelectProps,
 } from 'src/components/RegionSelect/RegionSelect.types';
+import { DocsLink } from 'src/components/DocsLink/DocsLink';
+import { DOCS_LINK_LABEL_DC_PRICING } from 'src/utilities/pricing/constants';
+import { sendLinodeCreateFormInputEvent } from 'src/utilities/analytics/formEventAnalytics';
+import { useLinodeCreateQueryParams } from './utilities';
 
 interface GeographicalAreaOption {
   label: string;
@@ -70,10 +74,27 @@ export const TwoStepRegion = (props: CombinedProps) => {
   );
 
   const { data: regions } = useRegionsQuery();
+  const { params } = useLinodeCreateQueryParams();
 
   return (
     <Paper>
-      <Typography variant="h2">Region</Typography>
+      <Box display="flex" justifyContent="space-between" mb={1}>
+        <Typography data-qa-tp="Region" variant="h2">
+          Region
+        </Typography>
+        <DocsLink
+          onClick={() =>
+            sendLinodeCreateFormInputEvent({
+              createType: params.type ?? 'OS',
+              headerName: 'Region',
+              interaction: 'click',
+              label: DOCS_LINK_LABEL_DC_PRICING,
+            })
+          }
+          href="https://www.linode.com/pricing"
+          label={DOCS_LINK_LABEL_DC_PRICING}
+        />
+      </Box>
       <Tabs>
         <TabList>
           <Tab>Core</Tab>

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/VPC/VPC.tsx
@@ -113,7 +113,6 @@ export const VPC = () => {
                 }
                 onChange={(e, vpc) => {
                   field.onChange(vpc?.id ?? null);
-                  // Track clearing and changing the value once per page view, configured by inputValue in AA backend.
                   if (!vpc?.id) {
                     sendLinodeCreateFormInputEvent({
                       ...vpcFormEventOptions,

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
@@ -22,6 +22,7 @@ import {
 } from 'src/queries/linodes/linodes';
 import {
   sendLinodeCreateFormErrorEvent,
+  sendLinodeCreateFormInputEvent,
   sendLinodeCreateFormSubmitEvent,
 } from 'src/utilities/analytics/formEventAnalytics';
 import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
@@ -204,6 +205,13 @@ export const LinodeCreatev2 = () => {
     <FormProvider {...form}>
       <DocumentTitleSegment segment="Create a Linode" />
       <LandingHeader
+        onDocsClick={() =>
+          sendLinodeCreateFormInputEvent({
+            createType: params.type ?? 'OS',
+            interaction: 'click',
+            label: 'Getting Started',
+          })
+        }
         docsLabel="Getting Started"
         docsLink="https://www.linode.com/docs/guides/platform/get-started/"
         title="Create"

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
@@ -123,7 +123,7 @@ export const LinodeCreatev2 = () => {
       });
 
       sendLinodeCreateFormSubmitEvent({
-        createType: params.type,
+        createType: params.type ?? 'OS',
       });
 
       if (values.hasSignedEUAgreement) {

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
@@ -2,7 +2,7 @@ import { isEmpty } from '@linode/api-v4';
 import * as Sentry from '@sentry/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSnackbar } from 'notistack';
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useHistory } from 'react-router-dom';
 
@@ -20,6 +20,10 @@ import {
   useCloneLinodeMutation,
   useCreateLinodeMutation,
 } from 'src/queries/linodes/linodes';
+import {
+  sendLinodeCreateFormErrorEvent,
+  sendLinodeCreateFormSubmitEvent,
+} from 'src/utilities/analytics/formEventAnalytics';
 import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
 
 import { Actions } from './Actions';
@@ -54,7 +58,7 @@ import { VLAN } from './VLAN';
 import { VPC } from './VPC/VPC';
 
 import type { LinodeCreateFormValues } from './utilities';
-import type { SubmitHandler } from 'react-hook-form';
+import type { FieldErrors, SubmitHandler } from 'react-hook-form';
 
 export const LinodeCreatev2 = () => {
   const { params, setParams } = useLinodeCreateQueryParams();
@@ -117,6 +121,10 @@ export const LinodeCreatev2 = () => {
         values,
       });
 
+      sendLinodeCreateFormSubmitEvent({
+        createType: params.type,
+      });
+
       if (values.hasSignedEUAgreement) {
         updateAccountAgreements({
           eu_model: true,
@@ -134,6 +142,38 @@ export const LinodeCreatev2 = () => {
     }
   };
 
+  const handleAnalyticsFormError = useCallback(
+    (errors: FieldErrors<LinodeCreateFormValues>) => {
+      let errorString = '';
+
+      if (!errors) {
+        return;
+      }
+
+      if (errors.region) {
+        errorString += errors.region.message;
+      }
+      if (errors.type) {
+        errorString += `${errorString.length > 0 ? `|` : ''}${
+          errors.type.message
+        }`;
+      }
+      if (errors.root_pass) {
+        errorString += `${errorString.length > 0 ? `|` : ''}${
+          errors.root_pass.message
+        }`;
+      }
+      if (errors.root) {
+        errorString += `${errorString.length > 0 ? `|` : ''}${
+          errors.root.message
+        }`;
+      }
+
+      sendLinodeCreateFormErrorEvent(errorString, params.type ?? 'OS');
+    },
+    [params.type]
+  );
+
   const previousSubmitCount = useRef<number>(0);
 
   useEffect(() => {
@@ -142,9 +182,10 @@ export const LinodeCreatev2 = () => {
       form.formState.submitCount > previousSubmitCount.current
     ) {
       scrollErrorIntoView(undefined, { behavior: 'smooth' });
+      handleAnalyticsFormError(form.formState.errors);
     }
     previousSubmitCount.current = form.formState.submitCount;
-  }, [form.formState]);
+  }, [form.formState, handleAnalyticsFormError]);
 
   /**
    * Add a Sentry tag when Linode Create v2 is mounted

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
@@ -1,10 +1,12 @@
 import { omit } from 'lodash';
+import { useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { imageQueries } from 'src/queries/images';
 import { linodeQueries } from 'src/queries/linodes/linodes';
 import { stackscriptQueries } from 'src/queries/stackscripts';
 import { sendCreateLinodeEvent } from 'src/utilities/analytics/customEventAnalytics';
+import { sendLinodeCreateFormErrorEvent } from 'src/utilities/analytics/formEventAnalytics';
 import { privateIPRegex } from 'src/utilities/ipUtils';
 import { isNotNullOrUndefined } from 'src/utilities/nullOrUndefined';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
@@ -20,6 +22,7 @@ import type {
   Linode,
 } from '@linode/api-v4';
 import type { QueryClient } from '@tanstack/react-query';
+import type { FieldErrors } from 'react-hook-form';
 
 /**
  * This is the ID of the Image of the default OS.
@@ -501,4 +504,45 @@ export const captureLinodeCreateAnalyticsEvent = async (
       secureVMCompliant,
     });
   }
+};
+
+/**
+ * Custom hook to send a Adobe Analytics form error event with error messages in the Linode Create flow.
+ */
+export const useHandleLinodeCreateAnalyticsFormError = (
+  createType: LinodeCreateType
+) => {
+  const handleLinodeCreateAnalyticsFormError = useCallback(
+    (errors: FieldErrors<LinodeCreateFormValues>) => {
+      let errorString = '';
+
+      if (!errors) {
+        return;
+      }
+
+      if (errors.region) {
+        errorString += errors.region.message;
+      }
+      if (errors.type) {
+        errorString += `${errorString.length > 0 ? `|` : ''}${
+          errors.type.message
+        }`;
+      }
+      if (errors.root_pass) {
+        errorString += `${errorString.length > 0 ? `|` : ''}${
+          errors.root_pass.message
+        }`;
+      }
+      if (errors.root) {
+        errorString += `${errorString.length > 0 ? `|` : ''}${
+          errors.root.message
+        }`;
+      }
+
+      sendLinodeCreateFormErrorEvent(errorString, createType);
+    },
+    [createType]
+  );
+
+  return { handleLinodeCreateAnalyticsFormError };
 };


### PR DESCRIPTION
## Description 📝
This PR tags the UI elements from Linode Create v2 that were not shared with the v1 flow (which was tagged in #10722).

## Changes  🔄
See #10722 for an overview how form events are handled.

## Target release date 🗓️
9/3

## Preview 📷
<details>

<summary>
Screenshots of Main Create Flow Events
</summary>


| Component | Analytics Event |
| --- | --- |
| ![GettingStarted](https://github.com/user-attachments/assets/a722ce92-471d-4b11-bfe2-9cbaa2304e77) | ![gettingStartedEvent](https://github.com/user-attachments/assets/0a815720-9e05-4d08-b7ea-3c3aa60bba89) |
| Current: ![DCPricing](https://github.com/user-attachments/assets/e9f7ab52-8692-4819-87bf-9e9c85f9ec2b) Two step:  ![twoStepRegionSelect](https://github.com/user-attachments/assets/c0a53e83-8592-4373-a718-d0c830391833)  | ![twoStepRegionSelectEvent](https://github.com/user-attachments/assets/aa2c37e8-b6ae-40a3-8fb7-e1ce22c5c9af) |
| ![RegionSelect](https://github.com/user-attachments/assets/0ad1865f-0bcc-422e-a13e-26b194ab6051) | ![selectRegion](https://github.com/user-attachments/assets/0338b8a2-8d38-494a-a51d-c8fc57625795) |
| ![ChoosingPlan](https://github.com/user-attachments/assets/3f9ace8c-ea0c-4505-a530-54e5da967d20) | ![planEvent](https://github.com/user-attachments/assets/f25799d8-cd1c-4c4c-8e6f-84942eaf3cc2) |
| ![PGSelect](https://github.com/user-attachments/assets/5b896e70-7bbe-46fc-8c2b-515e6a65284b) | ![changePG](https://github.com/user-attachments/assets/5fa02306-8994-45fd-912b-a97a8a0341de) ![clearPG](https://github.com/user-attachments/assets/12729358-8d25-4c81-b5d9-40f02a6801df) ![createDrawerPG](https://github.com/user-attachments/assets/48fd302e-b631-4e5e-93ee-91f6599dcab6) |
| ![VPCSelect](https://github.com/user-attachments/assets/bc58a037-5697-4f11-bd5b-3ae484056afe) | ![learnMoreVPC](https://github.com/user-attachments/assets/3e47569f-5834-4900-ae40-2490262dd8e1) ![createDrawerVPC](https://github.com/user-attachments/assets/2f24b8a9-7d6b-4edd-9e39-31f31cf71371) VPC is selected: ![changeVPC](https://github.com/user-attachments/assets/bcb8f7c3-5cfd-42c0-8854-a10d8a11540c) VPC is cleared: ![clearVPC](https://github.com/user-attachments/assets/4857caa2-633e-44d9-8f01-2e2d1e2fdbcd) |
| ![FirewallSelect](https://github.com/user-attachments/assets/96462f0a-f175-4520-adba-0f7232dc865f) | ![learnMoreFirewall](https://github.com/user-attachments/assets/d66fdfc2-f88f-4513-92d7-7f736451540b) ![createDrawerFirewall](https://github.com/user-attachments/assets/07366990-6ac6-4f1b-acf5-43378e44f95b) Firewall is selected: ![changeFirewall](https://github.com/user-attachments/assets/5d02c698-5d03-433a-a58e-a5ed07532352)  Firewall is cleared: ![clearFirewall](https://github.com/user-attachments/assets/bb8b378f-cdfd-4586-b44d-4ca137a88b5d)  |
| ![ActionButtons2](https://github.com/user-attachments/assets/898b5af2-7d45-41ca-b150-9fcbbd7ec7eb) | ![viewCodeSnippets](https://github.com/user-attachments/assets/e3512059-4963-4f3b-8222-4b02021528ab) ![createLinode](https://github.com/user-attachments/assets/b4a0e957-912b-4b65-87f2-51389febfa3a) |
| click 'Create Linode' without filling in required fields | ![formErrorEvent](https://github.com/user-attachments/assets/fb28928e-1926-44ae-992b-5b68f3f786b8) |

</details>

<details>

<summary>
Screenshots of PG Branch Flow Events
</summary>

| Component | Analytics Event |
| --- | --- |
| ![Create PG](https://github.com/user-attachments/assets/46f3db48-753a-40a1-930b-15dffedb8c03) | ![createPG](https://github.com/user-attachments/assets/107de803-2110-4c94-aca5-bc5ddea4fd20) |
</details>

<details>

<summary>
Screenshots of Firewall Branch Flow Events
</summary>

| Component | Analytics Event |
| --- | --- |
| ![Assign services Learn More](https://github.com/user-attachments/assets/54a161c9-cf03-4028-b646-53901e330a9e) | ![learnMoreAssignServicesFirewall](https://github.com/user-attachments/assets/4eb9e88c-4eef-47bb-b833-5d17b451225a) |
| ![Create Firewall](https://github.com/user-attachments/assets/86a1cea1-76dd-40da-acd3-4d5a45f28b61) | ![createFirewall](https://github.com/user-attachments/assets/d5c65ed4-21b1-432d-8cb6-57567e7a1667) |
</details>

<details>

<summary>
Screenshots of VPC Branch Flow Events
</summary>

| Component | Analytics Event |
| --- | --- |
| ![Create VPC Learn More](https://github.com/user-attachments/assets/e620a707-9fd7-47ce-a115-a233b8a59bb8) | ![learnMoreCreateVPC](https://github.com/user-attachments/assets/5cb7dc81-f0bf-4a33-bd69-d644714d6583) |
| ![Subnets Learn More](https://github.com/user-attachments/assets/332d2f24-a4e3-4d98-812e-0becf3f63329) | ![learnMoreSubnetVPC](https://github.com/user-attachments/assets/07f4ce3f-eb9a-43af-b91d-5abb038113cc) |
| ![Create VPC](https://github.com/user-attachments/assets/1defe751-2dfe-4c67-83b3-5836aa70c2bc) | ![createVPC](https://github.com/user-attachments/assets/7a92078c-a9f4-4b06-a423-83f8c75bde0f) |
</details>

## How to test 🧪

### Prerequisites
(How to setup test environment)
- You must have the Adobe Analytics environment set in your `.env`.
- Check out this PR, `yarn dev`, and in the browser console, type `_satellite.setDebug(true)`.

### Verification steps
(How to verify changes)
- Below are the two color-coded keys for what events should be tagged in the flow. Please see the Preview section for the events and confirm they are firing as expected.

| Main Flow | Branching Flows (Drawers) |
| --- | --- |
| ![MainFlowInstructions](https://github.com/user-attachments/assets/8560bacd-2d9a-4861-b32a-851227ef9b8b) ![FireOnce](https://github.com/user-attachments/assets/12a41683-b988-431f-95fc-67be80dedd27) | ![Screenshot 2024-08-02 at 10 15 25 AM](https://github.com/user-attachments/assets/83741eb7-9966-4599-b60c-4a2a2823508d) |

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
