### PR TITLE
refactor: [M3-8331] - useToastNotification async toasts

### DIFF
--- a/packages/manager/.changeset/pr-10841-tech-stories-1724763185078.md
+++ b/packages/manager/.changeset/pr-10841-tech-stories-1724763185078.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Refactor useToastNotification async toasts ([#10841](https://github.com/linode/manager/pull/10841))

--- a/packages/manager/cypress/e2e/core/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/machine-image-upload.spec.ts
@@ -81,9 +81,7 @@ const eventIntercept = (
  * @param message - Expected failure message.
  */
 const assertFailed = (label: string, id: string, message: string) => {
-  ui.toast.assertMessage(
-    `There was a problem uploading image ${label}: ${message}`
-  );
+  ui.toast.assertMessage(`Image ${label} could not be uploaded: ${message}`);
 
   cy.get(`[data-qa-image-cell="${id}"]`).within(() => {
     fbtVisible(label);

--- a/packages/manager/cypress/e2e/core/images/smoke-create-image.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/smoke-create-image.spec.ts
@@ -107,6 +107,6 @@ describe('create image (using mocks)', () => {
     cy.wait('@getEvents');
 
     // Verify a success toast shows
-    ui.toast.assertMessage('Image My Config successfully created.');
+    ui.toast.assertMessage('Image My Config has been created.');
   });
 });

--- a/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
@@ -106,7 +106,7 @@ describe('clone linode', () => {
 
       ui.toast.assertMessage(`Your Linode ${newLinodeLabel} is being created.`);
       ui.toast.assertMessage(
-        `Linode ${linode.label} successfully cloned to ${newLinodeLabel}.`,
+        `Linode ${linode.label} has been cloned to ${newLinodeLabel}.`,
         { timeout: CLONE_TIMEOUT }
       );
     });

--- a/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
@@ -381,7 +381,7 @@ describe('Linode Config management', () => {
 
         // Confirm toast message and that UI updates to reflect clone in progress.
         ui.toast.assertMessage(
-          `Linode ${sourceLinode.label} successfully cloned to ${destLinode.label}.`
+          `Linode ${sourceLinode.label} has been cloned to ${destLinode.label}.`
         );
         cy.findByText(/CLONING \(\d+%\)/).should('be.visible');
       });

--- a/packages/manager/cypress/e2e/core/linodes/linode-storage.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/linode-storage.spec.ts
@@ -212,7 +212,7 @@ describe('linode storage tab', () => {
       ui.toast.assertMessage('Disk queued for resizing.');
       // cy.findByText('Resizing', { exact: false }).should('be.visible');
       ui.toast.assertMessage(
-        `A disk on Linode ${linode.label} has been resized.`
+        `A disk ${diskName} on Linode ${linode.label} has been resized.`
       );
     });
   });

--- a/packages/manager/cypress/e2e/core/linodes/linode-storage.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/linode-storage.spec.ts
@@ -212,7 +212,7 @@ describe('linode storage tab', () => {
       ui.toast.assertMessage('Disk queued for resizing.');
       // cy.findByText('Resizing', { exact: false }).should('be.visible');
       ui.toast.assertMessage(
-        `A disk ${diskName} on Linode ${linode.label} has been resized.`
+        `Disk ${diskName} on Linode ${linode.label} has been resized.`
       );
     });
   });

--- a/packages/manager/cypress/e2e/core/linodes/linode-storage.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/linode-storage.spec.ts
@@ -148,7 +148,9 @@ describe('linode storage tab', () => {
       cy.wait('@deleteDisk').its('response.statusCode').should('eq', 200);
       cy.findByText('Deleting', { exact: false }).should('be.visible');
       ui.button.findByTitle('Add a Disk').should('be.enabled');
-      ui.toast.assertMessage(`Disk ${diskName} successfully deleted.`);
+      ui.toast.assertMessage(
+        `Disk ${diskName} on Linode ${linode.label} has been deleted.`
+      );
       cy.findByLabelText('List of Disks').within(() => {
         cy.contains(diskName).should('not.exist');
       });
@@ -209,7 +211,9 @@ describe('linode storage tab', () => {
       cy.wait('@resizeDisk').its('response.statusCode').should('eq', 200);
       ui.toast.assertMessage('Disk queued for resizing.');
       // cy.findByText('Resizing', { exact: false }).should('be.visible');
-      ui.toast.assertMessage(`Disk ${diskName} successfully resized.`);
+      ui.toast.assertMessage(
+        `A disk on Linode ${linode.label} has been resized.`
+      );
     });
   });
 });

--- a/packages/manager/cypress/e2e/core/linodes/resize-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/resize-linode.spec.ts
@@ -186,7 +186,9 @@ describe('resize linode', () => {
         });
 
       // Wait until the disk resize is done.
-      ui.toast.assertMessage(`Disk ${diskName} successfully resized.`);
+      ui.toast.assertMessage(
+        `A disk ${diskName} on Linode ${linode.label} has been resized.`
+      );
 
       interceptLinodeResize(linode.id).as('linodeResize');
       cy.visitWithLogin(`/linodes/${linode.id}?resize=true`);

--- a/packages/manager/cypress/e2e/core/linodes/resize-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/resize-linode.spec.ts
@@ -187,7 +187,7 @@ describe('resize linode', () => {
 
       // Wait until the disk resize is done.
       ui.toast.assertMessage(
-        `A disk ${diskName} on Linode ${linode.label} has been resized.`
+        `Disk ${diskName} on Linode ${linode.label} has been resized.`
       );
 
       interceptLinodeResize(linode.id).as('linodeResize');

--- a/packages/manager/cypress/e2e/core/volumes/attach-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/attach-volume.spec.ts
@@ -114,7 +114,9 @@ describe('volume attach and detach flows', () => {
 
         // Confirm that volume has been attached to Linode.
         cy.wait('@attachVolume').its('response.statusCode').should('eq', 200);
-        ui.toast.assertMessage(`Volume ${volume.label} successfully attached.`);
+        ui.toast.assertMessage(
+          `Volume ${volume.label} has been attached to Linode ${linode.label}.`
+        );
         cy.findByText(volume.label)
           .should('be.visible')
           .closest('tr')

--- a/packages/manager/cypress/e2e/core/volumes/delete-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/delete-volume.spec.ts
@@ -87,7 +87,7 @@ describe('volume delete flow', () => {
         // Confirm that volume is deleted.
         cy.wait('@deleteVolume').its('response.statusCode').should('eq', 200);
         cy.findByText(volume.label).should('not.exist');
-        ui.toast.assertMessage('Volume successfully deleted.');
+        ui.toast.assertMessage(`Volume ${volume.label} has been deleted.`);
       }
     );
   });

--- a/packages/manager/cypress/e2e/core/volumes/upgrade-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/upgrade-volume.spec.ts
@@ -87,7 +87,7 @@ describe('volume upgrade/migration', () => {
 
     cy.findByText('active').should('be.visible');
 
-    ui.toast.assertMessage(`Volume ${volume.label} successfully upgraded.`);
+    ui.toast.assertMessage(`Volume ${volume.label} has been migrated to NVMe.`);
   });
 
   it('can upgrade an attached volume from the volumes landing page', () => {
@@ -178,7 +178,7 @@ describe('volume upgrade/migration', () => {
 
     cy.findByText('active').should('be.visible');
 
-    ui.toast.assertMessage(`Volume ${volume.label} successfully upgraded.`);
+    ui.toast.assertMessage(`Volume ${volume.label} has been migrated to NVMe.`);
   });
 
   it('can upgrade an attached volume from the linode details page', () => {
@@ -265,6 +265,6 @@ describe('volume upgrade/migration', () => {
 
     cy.findByText('active').should('be.visible');
 
-    ui.toast.assertMessage(`Volume ${volume.label} successfully upgraded.`);
+    ui.toast.assertMessage(`Volume ${volume.label} has been migrated to NVMe.`);
   });
 });

--- a/packages/manager/src/features/Events/asyncToasts.test.tsx
+++ b/packages/manager/src/features/Events/asyncToasts.test.tsx
@@ -9,14 +9,10 @@ describe('createToast', () => {
       const result = createToast(options);
       const expected = {
         failure: {
-          invertVariant: false,
           message: expect.any(Function),
-          persist: false,
         },
         success: {
-          invertVariant: false,
           message: expect.any(Function),
-          persist: false,
         },
       };
 
@@ -36,9 +32,7 @@ describe('createToast', () => {
       const result = createToast(options);
       const expected = {
         failure: {
-          invertVariant: false,
           message: expect.any(Function),
-          persist: false,
         },
       };
 
@@ -58,9 +52,7 @@ describe('createToast', () => {
       const result = createToast(options);
       const expected = {
         success: {
-          invertVariant: false,
           message: expect.any(Function),
-          persist: false,
         },
       };
 
@@ -83,9 +75,7 @@ describe('createToast', () => {
     const result = createToast(options);
     const expected = {
       failure: {
-        invertVariant: false,
         message: expect.any(Function),
-        persist: false,
       },
     };
 
@@ -97,9 +87,7 @@ describe('createToast', () => {
     const result = createToast(options);
     const expected = {
       success: {
-        invertVariant: false,
         message: expect.any(Function),
-        persist: false,
       },
     };
 
@@ -114,7 +102,6 @@ describe('createToast', () => {
     const result1 = createToast(failureOnlyOptions);
     const expected1 = {
       failure: {
-        invertVariant: false,
         message: expect.any(Function),
         persist: true,
       },
@@ -137,12 +124,12 @@ describe('createToast', () => {
   });
 
   it('should handle case with both failure and success options with specific values', () => {
-    const options = {
+    const options1 = {
       failure: { invertVariant: true, persist: true },
       success: { invertVariant: true, persist: false },
     };
-    const result = createToast(options);
-    const expected = {
+    const result1 = createToast(options1);
+    const expected1 = {
       failure: {
         invertVariant: true,
         message: expect.any(Function),
@@ -154,7 +141,24 @@ describe('createToast', () => {
         persist: false,
       },
     };
+    expect(result1).toEqual(expected1);
 
-    expect(result).toEqual(expected);
+    const options2 = {
+      failure: { persist: true },
+      success: { invertVariant: true },
+    };
+
+    const result2 = createToast(options2);
+    const expected2 = {
+      failure: {
+        message: expect.any(Function),
+        persist: true,
+      },
+      success: {
+        invertVariant: true,
+        message: expect.any(Function),
+      },
+    };
+    expect(result2).toEqual(expected2);
   });
 });

--- a/packages/manager/src/features/Events/asyncToasts.test.tsx
+++ b/packages/manager/src/features/Events/asyncToasts.test.tsx
@@ -1,0 +1,160 @@
+import { createToast } from './asyncToasts';
+
+describe('createToast', () => {
+  it('should handle case with both failure and success options as true or empty objects', () => {
+    const trueOptions = { failure: true, success: true };
+    const emptyObjectOptions = { failure: {}, success: {} };
+
+    [trueOptions, emptyObjectOptions].forEach((options) => {
+      const result = createToast(options);
+      const expected = {
+        failure: {
+          invertVariant: false,
+          message: expect.any(Function),
+          persist: false,
+        },
+        success: {
+          invertVariant: false,
+          message: expect.any(Function),
+          persist: false,
+        },
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  it('should handle case with only failure option as true or empty object or with success as false', () => {
+    const scenarios = [
+      { failure: true },
+      { failure: {} },
+      { failure: true, success: false },
+      { failure: {}, success: false },
+    ];
+
+    scenarios.forEach((options) => {
+      const result = createToast(options);
+      const expected = {
+        failure: {
+          invertVariant: false,
+          message: expect.any(Function),
+          persist: false,
+        },
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  it('should handle case with only success option as true or empty object or with failure as false', () => {
+    const scenarios = [
+      { success: true },
+      { success: {} },
+      { failure: false, success: true },
+      { failure: false, success: {} },
+    ];
+
+    scenarios.forEach((options) => {
+      const result = createToast(options);
+      const expected = {
+        success: {
+          invertVariant: false,
+          message: expect.any(Function),
+          persist: false,
+        },
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  it('should return an empty object if both failure and success are false or not provided', () => {
+    const falseOptions = { failure: false, success: false };
+    const emptyOptions = {};
+    [falseOptions, emptyOptions].forEach((options) => {
+      const result = createToast(options);
+
+      expect(result).toEqual({});
+    });
+  });
+
+  it('should handle case with failure as true and success as false', () => {
+    const options = { failure: true, success: false };
+    const result = createToast(options);
+    const expected = {
+      failure: {
+        invertVariant: false,
+        message: expect.any(Function),
+        persist: false,
+      },
+    };
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should handle case with success as true and failure as false', () => {
+    const options = { failure: false, success: true };
+    const result = createToast(options);
+    const expected = {
+      success: {
+        invertVariant: false,
+        message: expect.any(Function),
+        persist: false,
+      },
+    };
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should handle cases with specific values for only failure or success options', () => {
+    // Only the failure options with specific values
+    const failureOnlyOptions = {
+      failure: { persist: true },
+    };
+    const result1 = createToast(failureOnlyOptions);
+    const expected1 = {
+      failure: {
+        invertVariant: false,
+        message: expect.any(Function),
+        persist: true,
+      },
+    };
+    expect(result1).toEqual(expected1);
+
+    // Only the success options with specific values
+    const successOnlyOptions = {
+      success: { invertVariant: true, persist: false },
+    };
+    const result2 = createToast(successOnlyOptions);
+    const expected2 = {
+      success: {
+        invertVariant: true,
+        message: expect.any(Function),
+        persist: false,
+      },
+    };
+    expect(result2).toEqual(expected2);
+  });
+
+  it('should handle case with both failure and success options with specific values', () => {
+    const options = {
+      failure: { invertVariant: true, persist: true },
+      success: { invertVariant: true, persist: false },
+    };
+    const result = createToast(options);
+    const expected = {
+      failure: {
+        invertVariant: true,
+        message: expect.any(Function),
+        persist: true,
+      },
+      success: {
+        invertVariant: true,
+        message: expect.any(Function),
+        persist: false,
+      },
+    };
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/packages/manager/src/features/Events/asyncToasts.test.tsx
+++ b/packages/manager/src/features/Events/asyncToasts.test.tsx
@@ -70,30 +70,6 @@ describe('createToast', () => {
     });
   });
 
-  it('should handle case with failure as true and success as false', () => {
-    const options = { failure: true, success: false };
-    const result = createToast(options);
-    const expected = {
-      failure: {
-        message: expect.any(Function),
-      },
-    };
-
-    expect(result).toEqual(expected);
-  });
-
-  it('should handle case with success as true and failure as false', () => {
-    const options = { failure: false, success: true };
-    const result = createToast(options);
-    const expected = {
-      success: {
-        message: expect.any(Function),
-      },
-    };
-
-    expect(result).toEqual(expected);
-  });
-
   it('should handle cases with specific values for only failure or success options', () => {
     // Only the failure options with specific values
     const failureOnlyOptions = {

--- a/packages/manager/src/features/Events/asyncToasts.tsx
+++ b/packages/manager/src/features/Events/asyncToasts.tsx
@@ -20,6 +20,37 @@ type Toasts = {
   [key in EventAction]?: Toast;
 };
 
+const createToastBoth = (
+  options: {
+    invertVariant?: boolean;
+    persistFailure?: boolean;
+    persistSuccess?: boolean;
+  } = {}
+): Toast => ({
+  failure: {
+    message: (e) => getEventMessage(e),
+    persist: options.persistFailure || false,
+  },
+  invertVariant: options.invertVariant || false,
+  success: {
+    message: (e: any) => getEventMessage(e),
+    persist: options.persistSuccess || false,
+  },
+});
+
+const createToastFailureOnly = (
+  options: {
+    invertVariant?: boolean;
+    persistFailure?: boolean;
+  } = {}
+): Toast => ({
+  failure: {
+    message: (e) => getEventMessage(e),
+    persist: options.persistFailure || false,
+  },
+  invertVariant: options.invertVariant || false,
+});
+
 /**
  * This constant defines toast notifications that will be displayed
  * when our events polling system gets a new event.
@@ -30,107 +61,25 @@ type Toasts = {
  * Toasts for that can be handled at the time of making the PUT request.
  */
 export const toasts: Toasts = {
-  backups_restore: {
-    failure: {
-      message: (e) => getEventMessage(e),
-      persist: true,
-    },
-  },
-  disk_delete: {
-    failure: {
-      message: (e) => getEventMessage(e),
-    },
-    success: {
-      message: (e) => getEventMessage(e),
-    },
-  },
-  disk_imagize: {
-    failure: {
-      message: (e) => getEventMessage(e),
-      persist: true,
-    },
-    success: {
-      message: (e) => getEventMessage(e),
-    },
-  },
-  disk_resize: {
-    failure: {
-      message: (e) => getEventMessage(e),
-      persist: true,
-    },
-    success: {
-      message: (e) => getEventMessage(e),
-    },
-  },
-  image_delete: {
-    failure: { message: (e) => getEventMessage(e) },
-    success: { message: (e) => getEventMessage(e) },
-  },
-  image_upload: {
-    failure: {
-      message: (e) => getEventMessage(e),
-      persist: true,
-    },
-    success: { message: (e) => getEventMessage(e) },
-  },
-  linode_clone: {
-    failure: { message: (e) => getEventMessage(e) },
-    success: {
-      message: (e) => getEventMessage(e),
-    },
-  },
-  linode_migrate: {
-    failure: { message: (e) => getEventMessage(e) },
-    success: { message: (e) => getEventMessage(e) },
-  },
-  linode_migrate_datacenter: {
-    failure: { message: (e) => getEventMessage(e) },
-    success: { message: (e) => getEventMessage(e) },
-  },
-  linode_resize: {
-    failure: { message: (e) => getEventMessage(e) },
-    success: { message: (e) => getEventMessage(e) },
-  },
-  linode_snapshot: {
-    failure: {
-      message: (e) => getEventMessage(e),
-      persist: true,
-    },
-  },
-  longviewclient_create: {
-    failure: {
-      message: (e) => getEventMessage(e),
-    },
-    success: {
-      message: (e) => getEventMessage(e),
-    },
-  },
-  tax_id_invalid: {
-    failure: { message: (e) => getEventMessage(e) },
+  backups_restore: createToastFailureOnly({ persistFailure: true }),
+  disk_delete: createToastBoth(),
+  disk_imagize: createToastBoth({ persistFailure: true }),
+  disk_resize: createToastBoth({ persistFailure: true }),
+  image_delete: createToastBoth(),
+  image_upload: createToastBoth({ persistFailure: true }),
+  linode_clone: createToastBoth(),
+  linode_migrate: createToastBoth(),
+  linode_migrate_datacenter: createToastBoth(),
+  linode_resize: createToastBoth(),
+  linode_snapshot: createToastFailureOnly({ persistFailure: true }),
+  longviewclient_create: createToastBoth(),
+  tax_id_invalid: createToastBoth({
     invertVariant: true,
-    success: {
-      message: (e) => getEventMessage(e),
-      persist: true,
-    },
-  },
-  volume_attach: {
-    failure: { message: (e) => getEventMessage(e) },
-    success: { message: (e) => getEventMessage(e) },
-  },
-  volume_create: {
-    failure: { message: (e) => getEventMessage(e) },
-    success: { message: (e) => getEventMessage(e) },
-  },
-  volume_delete: {
-    failure: { message: (e) => getEventMessage(e) },
-    success: { message: (e) => getEventMessage(e) },
-  },
-  volume_detach: {
-    failure: { message: (e) => getEventMessage(e) },
-    success: { message: (e) => getEventMessage(e) },
-  },
-  volume_migrate: {
-    failure: { message: (e) => getEventMessage(e) },
-    success: { message: (e) => getEventMessage(e) },
-  },
+    persistSuccess: true,
+  }),
+  volume_attach: createToastBoth(),
+  volume_create: createToastBoth(),
+  volume_delete: createToastBoth(),
+  volume_detach: createToastBoth(),
+  volume_migrate: createToastBoth(),
 };

--- a/packages/manager/src/features/Events/asyncToasts.tsx
+++ b/packages/manager/src/features/Events/asyncToasts.tsx
@@ -26,30 +26,25 @@ interface ToastOption {
   persist?: boolean;
 }
 
-interface ToastOptionsBase {
+interface ToastOptions {
   failure?: ToastOption | boolean;
   success?: ToastOption | boolean;
 }
 
-/**
- * To ensure that at least one of failure or success is provided while keeping both optional.
- */
-type ToastOptions =
-  | (ToastOptionsBase & { failure: ToastOption | boolean })
-  | (ToastOptionsBase & { success: ToastOption | boolean });
-
-const createToast = (options: ToastOptions) => {
+export const createToast = (options: ToastOptions) => {
   const toastConfig: Toast = {};
 
   if (options.failure) {
     toastConfig.failure = {
       invertVariant:
         typeof options.failure !== 'boolean'
-          ? options.failure.invertVariant
+          ? Boolean(options.failure.invertVariant)
           : false,
       message: (e) => getEventMessage(e),
       persist:
-        typeof options.failure !== 'boolean' ? options.failure.persist : false,
+        typeof options.failure !== 'boolean'
+          ? Boolean(options.failure.persist)
+          : false,
     };
   }
 
@@ -57,11 +52,13 @@ const createToast = (options: ToastOptions) => {
     toastConfig.success = {
       invertVariant:
         typeof options.success !== 'boolean'
-          ? options.success.invertVariant
+          ? Boolean(options.success.invertVariant)
           : false,
       message: (e) => getEventMessage(e),
       persist:
-        typeof options.success !== 'boolean' ? options.success.persist : false,
+        typeof options.success !== 'boolean'
+          ? Boolean(options.success.persist)
+          : false,
     };
   }
 
@@ -91,7 +88,7 @@ export const toasts: Toasts = {
   linode_snapshot: createToast({ failure: { persist: true } }),
   longviewclient_create: createToast({ failure: true, success: true }),
   tax_id_invalid: createToast({
-    failure: { invertVariant: true },
+    failure: true,
     success: { invertVariant: true, persist: true },
   }),
   volume_attach: createToast({ failure: true, success: true }),

--- a/packages/manager/src/features/Events/asyncToasts.tsx
+++ b/packages/manager/src/features/Events/asyncToasts.tsx
@@ -3,16 +3,16 @@ import { getEventMessage } from './utils';
 import type { Event, EventAction } from '@linode/api-v4';
 
 interface ToastMessage {
+  /**
+   * If true, the toast will be displayed with an error variant.
+   */
+  invertVariant?: boolean;
   message: ((event: Event) => JSX.Element | null | string | undefined) | string;
   persist?: boolean;
 }
 
 interface Toast {
   failure?: ToastMessage;
-  /**
-   * If true, the toast will be displayed with an error variant.
-   */
-  invertVariant?: boolean;
   success?: ToastMessage;
 }
 
@@ -20,36 +20,45 @@ type Toasts = {
   [key in EventAction]?: Toast;
 };
 
-const createToastBoth = (
-  options: {
-    invertVariant?: boolean;
-    persistFailure?: boolean;
-    persistSuccess?: boolean;
-  } = {}
-): Toast => ({
-  failure: {
-    message: (e) => getEventMessage(e),
-    persist: options.persistFailure || false,
-  },
-  invertVariant: options.invertVariant || false,
-  success: {
-    message: (e: any) => getEventMessage(e),
-    persist: options.persistSuccess || false,
-  },
-});
+interface ToastOption {
+  invertVariant?: boolean;
+  persist?: boolean;
+}
 
-const createToastFailureOnly = (
-  options: {
-    invertVariant?: boolean;
-    persistFailure?: boolean;
-  } = {}
-): Toast => ({
-  failure: {
-    message: (e) => getEventMessage(e),
-    persist: options.persistFailure || false,
-  },
-  invertVariant: options.invertVariant || false,
-});
+interface ToastOptions {
+  failure?: ToastOption | boolean;
+  success?: ToastOption | boolean;
+}
+
+const createToast = (options: ToastOptions) => {
+  const toastConfig: Toast = {};
+
+  if (options.failure) {
+    toastConfig.failure = {
+      invertVariant:
+        typeof options.failure !== 'boolean'
+          ? options.failure.invertVariant
+          : false,
+      message: (e) => getEventMessage(e),
+      persist:
+        typeof options.failure !== 'boolean' ? options.failure.persist : false,
+    };
+  }
+
+  if (options.success) {
+    toastConfig.success = {
+      invertVariant:
+        typeof options.success !== 'boolean'
+          ? options.success.invertVariant
+          : false,
+      message: (e) => getEventMessage(e),
+      persist:
+        typeof options.success !== 'boolean' ? options.success.persist : false,
+    };
+  }
+
+  return toastConfig;
+};
 
 /**
  * This constant defines toast notifications that will be displayed
@@ -61,25 +70,25 @@ const createToastFailureOnly = (
  * Toasts for that can be handled at the time of making the PUT request.
  */
 export const toasts: Toasts = {
-  backups_restore: createToastFailureOnly({ persistFailure: true }),
-  disk_delete: createToastBoth(),
-  disk_imagize: createToastBoth({ persistFailure: true }),
-  disk_resize: createToastBoth({ persistFailure: true }),
-  image_delete: createToastBoth(),
-  image_upload: createToastBoth({ persistFailure: true }),
-  linode_clone: createToastBoth(),
-  linode_migrate: createToastBoth(),
-  linode_migrate_datacenter: createToastBoth(),
-  linode_resize: createToastBoth(),
-  linode_snapshot: createToastFailureOnly({ persistFailure: true }),
-  longviewclient_create: createToastBoth(),
-  tax_id_invalid: createToastBoth({
-    invertVariant: true,
-    persistSuccess: true,
+  backups_restore: createToast({ failure: { persist: true } }),
+  disk_delete: createToast({ failure: false, success: true }),
+  disk_imagize: createToast({ failure: { persist: true }, success: true }),
+  disk_resize: createToast({ failure: { persist: true }, success: true }),
+  image_delete: createToast({ failure: true, success: true }),
+  image_upload: createToast({ failure: { persist: true }, success: true }),
+  linode_clone: createToast({ failure: true, success: true }),
+  linode_migrate: createToast({ failure: true, success: true }),
+  linode_migrate_datacenter: createToast({ failure: true, success: true }),
+  linode_resize: createToast({ failure: true, success: true }),
+  linode_snapshot: createToast({ failure: { persist: true } }),
+  longviewclient_create: createToast({ failure: true, success: true }),
+  tax_id_invalid: createToast({
+    failure: { invertVariant: true },
+    success: { invertVariant: true, persist: true },
   }),
-  volume_attach: createToastBoth(),
-  volume_create: createToastBoth(),
-  volume_delete: createToastBoth(),
-  volume_detach: createToastBoth(),
-  volume_migrate: createToastBoth(),
+  volume_attach: createToast({ failure: true, success: true }),
+  volume_create: createToast({ failure: true, success: true }),
+  volume_delete: createToast({ failure: true, success: true }),
+  volume_detach: createToast({ failure: true, success: true }),
+  volume_migrate: createToast({ failure: true, success: true }),
 };

--- a/packages/manager/src/features/Events/asyncToasts.tsx
+++ b/packages/manager/src/features/Events/asyncToasts.tsx
@@ -35,11 +35,18 @@ export const createToast = (options: ToastOptions) => {
   const toastConfig: Toast = {};
 
   const getToastMessage = (option: ToastOption | boolean): ToastMessage => {
+    const message: ToastMessage['message'] = (e) => getEventMessage(e);
+
+    if (typeof option === 'boolean') {
+      return { message };
+    }
+
     return {
-      invertVariant:
-        typeof option !== 'boolean' ? Boolean(option.invertVariant) : false,
-      message: (e) => getEventMessage(e),
-      persist: typeof option !== 'boolean' ? Boolean(option.persist) : false,
+      message,
+      ...(option.invertVariant != undefined && {
+        invertVariant: option.invertVariant,
+      }),
+      ...(option.persist != undefined && { persist: option.persist }),
     };
   };
 

--- a/packages/manager/src/features/Events/asyncToasts.tsx
+++ b/packages/manager/src/features/Events/asyncToasts.tsx
@@ -4,7 +4,8 @@ import type { Event, EventAction } from '@linode/api-v4';
 
 interface ToastMessage {
   /**
-   * If true, the toast will be displayed with an error variant.
+   * If true, the toast will be displayed with an error variant for success messages \
+   * or a success variant for error messages.
    */
   invertVariant?: boolean;
   message: ((event: Event) => JSX.Element | null | string | undefined) | string;
@@ -25,10 +26,17 @@ interface ToastOption {
   persist?: boolean;
 }
 
-interface ToastOptions {
+interface ToastOptionsBase {
   failure?: ToastOption | boolean;
   success?: ToastOption | boolean;
 }
+
+/**
+ * To ensure that at least one of failure or success is provided while keeping both optional.
+ */
+type ToastOptions =
+  | (ToastOptionsBase & { failure: ToastOption | boolean })
+  | (ToastOptionsBase & { success: ToastOption | boolean });
 
 const createToast = (options: ToastOptions) => {
   const toastConfig: Toast = {};

--- a/packages/manager/src/features/Events/asyncToasts.tsx
+++ b/packages/manager/src/features/Events/asyncToasts.tsx
@@ -34,32 +34,21 @@ interface ToastOptions {
 export const createToast = (options: ToastOptions) => {
   const toastConfig: Toast = {};
 
-  if (options.failure) {
-    toastConfig.failure = {
+  const getToastMessage = (option: ToastOption | boolean): ToastMessage => {
+    return {
       invertVariant:
-        typeof options.failure !== 'boolean'
-          ? Boolean(options.failure.invertVariant)
-          : false,
+        typeof option !== 'boolean' ? Boolean(option.invertVariant) : false,
       message: (e) => getEventMessage(e),
-      persist:
-        typeof options.failure !== 'boolean'
-          ? Boolean(options.failure.persist)
-          : false,
+      persist: typeof option !== 'boolean' ? Boolean(option.persist) : false,
     };
+  };
+
+  if (options.failure) {
+    toastConfig.failure = getToastMessage(options.failure);
   }
 
   if (options.success) {
-    toastConfig.success = {
-      invertVariant:
-        typeof options.success !== 'boolean'
-          ? Boolean(options.success.invertVariant)
-          : false,
-      message: (e) => getEventMessage(e),
-      persist:
-        typeof options.success !== 'boolean'
-          ? Boolean(options.success.persist)
-          : false,
-    };
+    toastConfig.success = getToastMessage(options.success);
   }
 
   return toastConfig;

--- a/packages/manager/src/features/Events/asyncToasts.tsx
+++ b/packages/manager/src/features/Events/asyncToasts.tsx
@@ -1,0 +1,136 @@
+import { getEventMessage } from './utils';
+
+import type { Event, EventAction } from '@linode/api-v4';
+
+interface ToastMessage {
+  message: ((event: Event) => JSX.Element | null | string | undefined) | string;
+  persist?: boolean;
+}
+
+interface Toast {
+  failure?: ToastMessage;
+  /**
+   * If true, the toast will be displayed with an error variant.
+   */
+  invertVariant?: boolean;
+  success?: ToastMessage;
+}
+
+type Toasts = {
+  [key in EventAction]?: Toast;
+};
+
+/**
+ * This constant defines toast notifications that will be displayed
+ * when our events polling system gets a new event.
+ *
+ * Use this feature to notify users of *asynchronous tasks* such as migrating a Linode.
+ *
+ * DO NOT use this feature to notify the user of tasks like changing the label of a Linode.
+ * Toasts for that can be handled at the time of making the PUT request.
+ */
+export const toasts: Toasts = {
+  backups_restore: {
+    failure: {
+      message: (e) => getEventMessage(e),
+      persist: true,
+    },
+  },
+  disk_delete: {
+    failure: {
+      message: (e) => getEventMessage(e),
+    },
+    success: {
+      message: (e) => getEventMessage(e),
+    },
+  },
+  disk_imagize: {
+    failure: {
+      message: (e) => getEventMessage(e),
+      persist: true,
+    },
+    success: {
+      message: (e) => getEventMessage(e),
+    },
+  },
+  disk_resize: {
+    failure: {
+      message: (e) => getEventMessage(e),
+      persist: true,
+    },
+    success: {
+      message: (e) => getEventMessage(e),
+    },
+  },
+  image_delete: {
+    failure: { message: (e) => getEventMessage(e) },
+    success: { message: (e) => getEventMessage(e) },
+  },
+  image_upload: {
+    failure: {
+      message: (e) => getEventMessage(e),
+      persist: true,
+    },
+    success: { message: (e) => getEventMessage(e) },
+  },
+  linode_clone: {
+    failure: { message: (e) => getEventMessage(e) },
+    success: {
+      message: (e) => getEventMessage(e),
+    },
+  },
+  linode_migrate: {
+    failure: { message: (e) => getEventMessage(e) },
+    success: { message: (e) => getEventMessage(e) },
+  },
+  linode_migrate_datacenter: {
+    failure: { message: (e) => getEventMessage(e) },
+    success: { message: (e) => getEventMessage(e) },
+  },
+  linode_resize: {
+    failure: { message: (e) => getEventMessage(e) },
+    success: { message: (e) => getEventMessage(e) },
+  },
+  linode_snapshot: {
+    failure: {
+      message: (e) => getEventMessage(e),
+      persist: true,
+    },
+  },
+  longviewclient_create: {
+    failure: {
+      message: (e) => getEventMessage(e),
+    },
+    success: {
+      message: (e) => getEventMessage(e),
+    },
+  },
+  tax_id_invalid: {
+    failure: { message: (e) => getEventMessage(e) },
+    invertVariant: true,
+    success: {
+      message: (e) => getEventMessage(e),
+      persist: true,
+    },
+  },
+  volume_attach: {
+    failure: { message: (e) => getEventMessage(e) },
+    success: { message: (e) => getEventMessage(e) },
+  },
+  volume_create: {
+    failure: { message: (e) => getEventMessage(e) },
+    success: { message: (e) => getEventMessage(e) },
+  },
+  volume_delete: {
+    failure: { message: (e) => getEventMessage(e) },
+    success: { message: (e) => getEventMessage(e) },
+  },
+  volume_detach: {
+    failure: { message: (e) => getEventMessage(e) },
+    success: { message: (e) => getEventMessage(e) },
+  },
+  volume_migrate: {
+    failure: { message: (e) => getEventMessage(e) },
+    success: { message: (e) => getEventMessage(e) },
+  },
+};

--- a/packages/manager/src/features/Events/asyncToasts.tsx
+++ b/packages/manager/src/features/Events/asyncToasts.tsx
@@ -43,10 +43,10 @@ export const createToast = (options: ToastOptions) => {
 
     return {
       message,
-      ...(option.invertVariant != undefined && {
+      ...(option.invertVariant !== undefined && {
         invertVariant: option.invertVariant,
       }),
-      ...(option.persist != undefined && { persist: option.persist }),
+      ...(option.persist !== undefined && { persist: option.persist }),
     };
   };
 

--- a/packages/manager/src/features/Events/factories/backup.tsx
+++ b/packages/manager/src/features/Events/factories/backup.tsx
@@ -25,8 +25,9 @@ export const backup: PartialEventMap<'backups'> = {
         Backup could <strong>not</strong> be <strong>restored</strong> for{' '}
         {e.entity!.label}.{' '}
         <Link to="https://www.linode.com/docs/products/storage/backups/#limits-and-considerations">
-          Learn more about limits and considerations.
+          Learn more about limits and considerations
         </Link>
+        .
       </>
     ),
     finished: (e) => (

--- a/packages/manager/src/features/Events/factories/backup.tsx
+++ b/packages/manager/src/features/Events/factories/backup.tsx
@@ -22,7 +22,7 @@ export const backup: PartialEventMap<'backups'> = {
   backups_restore: {
     failed: (e) => (
       <>
-        Backup could <strong>not</strong> be <strong>restored</strong> for
+        Backup could <strong>not</strong> be <strong>restored</strong> for{' '}
         {e.entity!.label}.{' '}
         <Link to="https://www.linode.com/docs/products/storage/backups/#limits-and-considerations">
           Learn more about limits and considerations.

--- a/packages/manager/src/features/Events/factories/disk.tsx
+++ b/packages/manager/src/features/Events/factories/disk.tsx
@@ -144,7 +144,7 @@ export const disk: PartialEventMap<'disk'> = {
   disk_resize: {
     failed: (e) => (
       <>
-        A disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
+        Disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
         <EventLink event={e} to="entity" /> could <strong>not</strong> be{' '}
         <strong>resized</strong>.{' '}
         <Link
@@ -163,26 +163,26 @@ export const disk: PartialEventMap<'disk'> = {
     ),
     finished: (e) => (
       <>
-        A disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
+        Disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
         <EventLink event={e} to="entity" /> has been <strong>resized</strong>.
       </>
     ),
     notification: (e) => (
       <>
-        A disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
+        Disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
         <EventLink event={e} to="entity" /> has been <strong>resized</strong>.
       </>
     ),
     scheduled: (e) => (
       <>
-        A disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
+        Disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
         <EventLink event={e} to="entity" /> is scheduled to be{' '}
         <strong>resized</strong>.
       </>
     ),
     started: (e) => (
       <>
-        A disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
+        Disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
         <EventLink event={e} to="entity" /> is being <strong>resized</strong>.
       </>
     ),

--- a/packages/manager/src/features/Events/factories/disk.tsx
+++ b/packages/manager/src/features/Events/factories/disk.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { Link } from 'src/components/Link';
+import { sendLinodeDiskEvent } from 'src/utilities/analytics/customEventAnalytics';
 
 import { EventLink } from '../EventLink';
 
@@ -140,7 +141,16 @@ export const disk: PartialEventMap<'disk'> = {
       <>
         A disk on Linode <EventLink event={e} to="entity" /> could{' '}
         <strong>not</strong> be <strong>resized</strong>.{' '}
-        <Link to="https://www.linode.com/docs/products/compute/compute-instances/guides/disks-and-storage/">
+        <Link
+          onClick={() => {
+            sendLinodeDiskEvent(
+              'Resize',
+              'Click:link',
+              'Disk resize failed toast'
+            );
+          }}
+          to="https://www.linode.com/docs/products/compute/compute-instances/guides/disks-and-storage/"
+        >
           Learn more
         </Link>
       </>

--- a/packages/manager/src/features/Events/factories/disk.tsx
+++ b/packages/manager/src/features/Events/factories/disk.tsx
@@ -77,32 +77,37 @@ export const disk: PartialEventMap<'disk'> = {
   disk_duplicate: {
     failed: (e) => (
       <>
-        Disk on Linode <EventLink event={e} to="entity" /> could{' '}
-        <strong>not</strong> be <strong>duplicated</strong>.
+        Disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
+        <EventLink event={e} to="entity" /> could <strong>not</strong> be{' '}
+        <strong>duplicated</strong>.
       </>
     ),
     finished: (e) => (
       <>
-        Disk on Linode <EventLink event={e} to="entity" /> has been{' '}
-        <strong>duplicated</strong>.
+        Disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
+        <EventLink event={e} to="entity" /> has been <strong>duplicated</strong>
+        .
       </>
     ),
     notification: (e) => (
       <>
-        Disk on Linode <EventLink event={e} to="entity" /> has been{' '}
-        <strong>duplicated</strong>.
+        Disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
+        <EventLink event={e} to="entity" /> has been <strong>duplicated</strong>
+        .
       </>
     ),
     scheduled: (e) => (
       <>
-        Disk on Linode <EventLink event={e} to="entity" /> is scheduled to be{' '}
+        Disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
+        <EventLink event={e} to="entity" /> is scheduled to be{' '}
         <strong>duplicated</strong>.
       </>
     ),
     started: (e) => (
       <>
-        Disk on Linode <EventLink event={e} to="entity" /> is being{' '}
-        <strong>duplicated</strong>.
+        Disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
+        <EventLink event={e} to="entity" /> is being <strong>duplicated</strong>
+        .
       </>
     ),
   },
@@ -139,8 +144,9 @@ export const disk: PartialEventMap<'disk'> = {
   disk_resize: {
     failed: (e) => (
       <>
-        A disk on Linode <EventLink event={e} to="entity" /> could{' '}
-        <strong>not</strong> be <strong>resized</strong>.{' '}
+        A disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
+        <EventLink event={e} to="entity" /> could <strong>not</strong> be{' '}
+        <strong>resized</strong>.{' '}
         <Link
           onClick={() => {
             sendLinodeDiskEvent(
@@ -155,29 +161,29 @@ export const disk: PartialEventMap<'disk'> = {
         </Link>
       </>
     ),
-
     finished: (e) => (
       <>
-        A disk on Linode <EventLink event={e} to="entity" /> has been{' '}
-        <strong>resized</strong>.
+        A disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
+        <EventLink event={e} to="entity" /> has been <strong>resized</strong>.
       </>
     ),
     notification: (e) => (
       <>
-        A disk on Linode <EventLink event={e} to="entity" /> has been{' '}
-        <strong>resized</strong>.
+        A disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
+        <EventLink event={e} to="entity" /> has been <strong>resized</strong>.
       </>
     ),
     scheduled: (e) => (
       <>
-        A disk on Linode <EventLink event={e} to="entity" /> is scheduled to be{' '}
+        A disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
+        <EventLink event={e} to="entity" /> is scheduled to be{' '}
         <strong>resized</strong>.
       </>
     ),
     started: (e) => (
       <>
-        A disk on Linode <EventLink event={e} to="entity" /> is being{' '}
-        <strong>resized</strong>.
+        A disk <EventLink event={e} to="secondaryEntity" /> on Linode{' '}
+        <EventLink event={e} to="entity" /> is being <strong>resized</strong>.
       </>
     ),
   },

--- a/packages/manager/src/features/Events/factories/disk.tsx
+++ b/packages/manager/src/features/Events/factories/disk.tsx
@@ -112,7 +112,7 @@ export const disk: PartialEventMap<'disk'> = {
         Image <EventLink event={e} to="secondaryEntity" /> could{' '}
         <strong>not</strong> be <strong>created</strong>.{' '}
         <Link to="https://www.linode.com/docs/products/tools/images/#technical-specifications">
-          Learn more about image technical specifications.
+          Learn more about image technical specifications
         </Link>
         .
       </>

--- a/packages/manager/src/features/Events/factories/image.tsx
+++ b/packages/manager/src/features/Events/factories/image.tsx
@@ -53,8 +53,7 @@ export const image: PartialEventMap<'image'> = {
 
     finished: (e) => (
       <>
-        Image <EventLink event={e} to="entity" /> has been{' '}
-        <strong>uploaded</strong>.
+        Image <EventLink event={e} to="entity" /> is now available.
       </>
     ),
     notification: (e) => (

--- a/packages/manager/src/hooks/useToastNotifications.tsx
+++ b/packages/manager/src/hooks/useToastNotifications.tsx
@@ -30,25 +30,25 @@ export const useToastNotifications = (): {
     const isSuccessEvent = ['finished', 'notification'].includes(event.status);
 
     if (isSuccessEvent && toastInfo.success) {
-      const { message, persist } = toastInfo.success;
+      const { invertVariant, message, persist } = toastInfo.success;
       const successMessage = getToastMessage(message, event);
 
       if (successMessage) {
         enqueueSnackbar(successMessage, {
           persist: persist ?? false,
-          variant: toastInfo.invertVariant ? 'error' : 'success',
+          variant: invertVariant ? 'error' : 'success',
         });
       }
     }
 
     if (event.status === 'failed' && toastInfo.failure) {
-      const { message, persist } = toastInfo.failure;
+      const { invertVariant, message, persist } = toastInfo.failure;
       const failureMessage = getToastMessage(message, event);
 
       if (failureMessage) {
         enqueueSnackbar(failureMessage, {
           persist: persist ?? false,
-          variant: toastInfo.invertVariant ? 'success' : 'error',
+          variant: invertVariant ? 'success' : 'error',
         });
       }
     }

--- a/packages/manager/src/hooks/useToastNotifications.tsx
+++ b/packages/manager/src/hooks/useToastNotifications.tsx
@@ -1,219 +1,20 @@
 import { useSnackbar } from 'notistack';
-import * as React from 'react';
 
-import { Link } from 'src/components/Link';
-import { SupportLink } from 'src/components/SupportLink';
-import { Typography } from 'src/components/Typography';
-import { sendLinodeDiskEvent } from 'src/utilities/analytics/customEventAnalytics';
+import { toasts } from 'src/features/Events/asyncToasts';
 
-import type { Event, EventAction } from '@linode/api-v4';
+import type { Event } from '@linode/api-v4';
 
 export const getLabel = (event: Event) => event.entity?.label ?? '';
 export const getSecondaryLabel = (event: Event) =>
   event.secondary_entity?.label ?? '';
-const formatLink = (text: string, link: string, handleClick?: () => void) => {
-  return (
-    <Link onClick={handleClick} to={link}>
-      {text}
-    </Link>
-  );
-};
-
-interface ToastMessage {
-  link?: JSX.Element;
-  message: ((event: Event) => string | undefined) | string;
-  persist?: boolean;
-}
-
-interface Toast {
-  failure?: ToastMessage;
-  /**
-   * If true, the toast will be displayed with an error variant.
-   */
-  invertVariant?: boolean;
-  success?: ToastMessage;
-}
-
-type Toasts = {
-  [key in EventAction]?: Toast;
-};
-
-/**
- * This constant defines toast notifications that will be displayed
- * when our events polling system gets a new event.
- *
- * Use this feature to notify users of *asynchronous tasks* such as migrating a Linode.
- *
- * DO NOT use this feature to notify the user of tasks like changing the label of a Linode.
- * Toasts for that can be handled at the time of making the PUT request.
- */
-const toasts: Toasts = {
-  backups_restore: {
-    failure: {
-      link: formatLink(
-        'Learn more about limits and considerations.',
-        'https://www.linode.com/docs/products/storage/backups/#limits-and-considerations'
-      ),
-      message: (e) => `Backup restoration failed for ${getLabel(e)}.`,
-      persist: true,
-    },
-  },
-  disk_delete: {
-    failure: {
-      message: (e) =>
-        `Unable to delete disk ${getSecondaryLabel(e)} ${
-          getLabel(e) ? ` on ${getLabel(e)}` : ''
-        }. Is it attached to a configuration profile that is in use?`,
-    },
-    success: {
-      message: (e) => `Disk ${getSecondaryLabel(e)} successfully deleted.`,
-    },
-  },
-  disk_imagize: {
-    failure: {
-      link: formatLink(
-        'Learn more about image technical specifications.',
-        'https://www.linode.com/docs/products/tools/images/#technical-specifications'
-      ),
-      message: (e) =>
-        `There was a problem creating Image ${getSecondaryLabel(e)}.`,
-      persist: true,
-    },
-
-    success: {
-      message: (e) => `Image ${getSecondaryLabel(e)} successfully created.`,
-    },
-  },
-  disk_resize: {
-    failure: {
-      link: formatLink(
-        'Learn more about resizing restrictions.',
-        'https://www.linode.com/docs/products/compute/compute-instances/guides/disks-and-storage/',
-        () =>
-          sendLinodeDiskEvent(
-            'Resize',
-            'Click:link',
-            'Disk resize failed toast'
-          )
-      ),
-      message: `Disk resize failed.`,
-      persist: true,
-    },
-    success: {
-      message: (e) => `Disk ${getSecondaryLabel(e)} successfully resized.`,
-    },
-  },
-  image_delete: {
-    failure: { message: (e) => `Error deleting Image ${getLabel(e)}.` },
-    success: { message: (e) => `Image ${getLabel(e)} successfully deleted.` },
-  },
-  image_upload: {
-    failure: {
-      message: (e) => {
-        const isDeletion = e.message === 'Upload canceled.';
-
-        if (isDeletion) {
-          return undefined;
-        }
-
-        return `There was a problem uploading image ${getLabel(
-          e
-        )}: ${e.message?.replace(/(\d+)/g, '$1 MB')}`;
-      },
-      persist: true,
-    },
-    success: { message: (e) => `Image ${getLabel(e)} is now available.` },
-  },
-  linode_clone: {
-    failure: { message: (e) => `Error cloning Linode ${getLabel(e)}.` },
-    success: {
-      message: (e) =>
-        `Linode ${getLabel(e)} successfully cloned to ${getSecondaryLabel(e)}.`,
-    },
-  },
-  linode_migrate: {
-    failure: { message: (e) => `Error migrating Linode ${getLabel(e)}.` },
-    success: { message: (e) => `Linode ${getLabel(e)} successfully migrated.` },
-  },
-  linode_migrate_datacenter: {
-    failure: { message: (e) => `Error migrating Linode ${getLabel(e)}.` },
-    success: { message: (e) => `Linode ${getLabel(e)} successfully migrated.` },
-  },
-  linode_resize: {
-    failure: { message: (e) => `Error resizing Linode ${getLabel(e)}.` },
-    success: { message: (e) => `Linode ${getLabel(e)} successfully resized.` },
-  },
-  linode_snapshot: {
-    failure: {
-      link: formatLink(
-        'Learn more about limits and considerations.',
-        'https://www.linode.com/docs/products/storage/backups/#limits-and-considerations'
-      ),
-      message: (e) => `Snapshot backup failed on Linode ${getLabel(e)}.`,
-      persist: true,
-    },
-  },
-  longviewclient_create: {
-    failure: {
-      message: (e) => `Error creating Longview Client ${getLabel(e)}.`,
-    },
-    success: {
-      message: (e) => `Longview Client ${getLabel(e)} successfully created.`,
-    },
-  },
-  tax_id_invalid: {
-    failure: { message: 'Error validating Tax Identification Number.' },
-    invertVariant: true,
-    success: {
-      message:
-        'Tax Identification Number could not be verified. Please check your Tax ID for accuracy or contact support for assistance.',
-      persist: true,
-    },
-  },
-  volume_attach: {
-    failure: { message: (e) => `Error attaching Volume ${getLabel(e)}.` },
-    success: { message: (e) => `Volume ${getLabel(e)} successfully attached.` },
-  },
-  volume_create: {
-    failure: { message: (e) => `Error creating Volume ${getLabel(e)}.` },
-    success: { message: (e) => `Volume ${getLabel(e)} successfully created.` },
-  },
-  volume_delete: {
-    failure: { message: 'Error deleting Volume.' },
-    success: { message: 'Volume successfully deleted.' },
-  },
-  volume_detach: {
-    failure: { message: (e) => `Error detaching Volume ${getLabel(e)}.` },
-    success: { message: (e) => `Volume ${getLabel(e)} successfully detached.` },
-  },
-  volume_migrate: {
-    failure: { message: (e) => `Error upgrading Volume ${getLabel(e)}.` },
-    success: { message: (e) => `Volume ${getLabel(e)} successfully upgraded.` },
-  },
-};
 
 const getToastMessage = (
-  toastMessage: ((event: Event) => string | undefined) | string,
+  toastMessage:
+    | ((event: Event) => JSX.Element | null | string | undefined)
+    | string,
   event: Event
-): string | undefined =>
+): JSX.Element | null | string | undefined =>
   typeof toastMessage === 'function' ? toastMessage(event) : toastMessage;
-
-const createFormattedMessage = (
-  message: string | undefined,
-  link: JSX.Element | undefined,
-  hasSupportLink: boolean
-) => (
-  <Typography>
-    {message?.replace(/ contact Support/i, '') ?? message}
-    {hasSupportLink && (
-      <>
-        &nbsp;
-        <SupportLink text="contact Support" title={message} />.
-      </>
-    )}
-    {link && <>&nbsp;{link}</>}
-  </Typography>
-);
 
 export const useToastNotifications = (): {
   handleGlobalToast: (event: Event) => void;
@@ -229,17 +30,11 @@ export const useToastNotifications = (): {
     const isSuccessEvent = ['finished', 'notification'].includes(event.status);
 
     if (isSuccessEvent && toastInfo.success) {
-      const { link, message, persist } = toastInfo.success;
+      const { message, persist } = toastInfo.success;
       const successMessage = getToastMessage(message, event);
 
       if (successMessage) {
-        const formattedSuccessMessage = createFormattedMessage(
-          successMessage,
-          link,
-          false
-        );
-
-        enqueueSnackbar(formattedSuccessMessage, {
+        enqueueSnackbar(successMessage, {
           persist: persist ?? false,
           variant: toastInfo.invertVariant ? 'error' : 'success',
         });
@@ -247,21 +42,11 @@ export const useToastNotifications = (): {
     }
 
     if (event.status === 'failed' && toastInfo.failure) {
-      const { link, message, persist } = toastInfo.failure;
+      const { message, persist } = toastInfo.failure;
       const failureMessage = getToastMessage(message, event);
 
       if (failureMessage) {
-        const hasSupportLink = failureMessage
-          .toLowerCase()
-          .includes('contact support');
-
-        const formattedFailureMessage = createFormattedMessage(
-          failureMessage,
-          link,
-          hasSupportLink
-        );
-
-        enqueueSnackbar(formattedFailureMessage, {
+        enqueueSnackbar(failureMessage, {
           persist: persist ?? false,
           variant: toastInfo.invertVariant ? 'success' : 'error',
         });


### PR DESCRIPTION
## Description 📝

`const toasts: Toasts = { ... }`  should be moved to the event directory and map to event messages already defined in our new factory.

## Changes  🔄

- Refactor `useToastNotification`.
- Move `const toasts: Toasts = { ... }` to `Events/asyncToasts.tsx`.
- Map to event messages already defined in our new factory.
- Update the event messages in `Events/factories/disk.tsx`.
- Update e2e test cases.
- Add unit test cases.

## Target release date 🗓️

N/A

## How to test 🧪

### Verification steps

- Verify all the async toasts continue to work as expected.
- Confirm that the formatting and display of messages adhere to the event messages defined in our new `Events/factories`
- Verify that all the test cases pass.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
