### PR TITLE
fix: [M3-8466] - Improve validation rules for create bucket schema

### DIFF
--- a/packages/validation/.changeset/pr-10842-fixed-1724786185430.md
+++ b/packages/validation/.changeset/pr-10842-fixed-1724786185430.md
@@ -2,4 +2,4 @@
 "@linode/validation": Fixed
 ---
 
-Error validation for letter casing now correctly appears for labels. ([#10842](https://github.com/linode/manager/pull/10842))
+Error validation for letter casing when creating object storage bucket now correctly appears for labels. ([#10842](https://github.com/linode/manager/pull/10842))

--- a/packages/validation/.changeset/pr-10842-fixed-1724786185430.md
+++ b/packages/validation/.changeset/pr-10842-fixed-1724786185430.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Fixed
+---
+
+Error validation for letter casing now correctly appears for labels. ([#10842](https://github.com/linode/manager/pull/10842))

--- a/packages/validation/src/buckets.schema.ts
+++ b/packages/validation/src/buckets.schema.ts
@@ -8,6 +8,10 @@ export const CreateBucketSchema = object()
       label: string()
         .required('Label is required.')
         .matches(/^\S*$/, 'Label must not contain spaces.')
+        .matches(
+          /^[a-z0-9.-]*$/,
+          'Label must consist only of lowercase letters, numbers, . (period), and - (dash).'
+        )
         .min(3, 'Label must be between 3 and 63 characters.')
         .max(63, 'Label must be between 3 and 63 characters.')
         .test(


### PR DESCRIPTION
## Description 📝
The API currently returns an error when creating buckets, incorrectly checking for 'name' instead of 'label'. While a fix for this issue is planned for the future, we can improve our validation in the interim. 

## Changes  🔄
- Update schema to account for existing validation requirements

## Target release date 🗓️
N/A

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-08-21 at 10 46 24 AM](https://github.com/user-attachments/assets/8c8a9e15-b8d6-417d-934a-19261ccf0504) | ![Screenshot 2024-08-27 at 3 00 11 PM](https://github.com/user-attachments/assets/980da849-9ff3-4963-8fd1-f06cafe8ea60) |

## How to test 🧪

### Prerequisites
- Ensure multicluster flag is enabled

### Reproduction steps
- Try creating a bucket with a capital letter in the name
- Observe the request silently fails

### Verification steps
- Checkout this branch
- Follow reproduction steps
- Observe validation is working as intended

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support