### PR TITLE
add: N/A - Infer type for `value` to `number` in `expiry_year` validation

### DIFF
--- a/packages/validation/src/account.schema.ts
+++ b/packages/validation/src/account.schema.ts
@@ -42,7 +42,7 @@ export const CreditCardSchema = object({
     .min(13, 'Credit card number must be between 13 and 23 characters.')
     .max(23, 'Credit card number must be between 13 and 23 characters.'),
   expiry_year: number()
-    .test('length', 'Expiration year must be 2 or 4 digits.', (value) =>
+    .test('length', 'Expiration year must be 2 or 4 digits.', (value: number) =>
       [2, 4].includes(String(value).length)
     )
     .required('Expiration year is required.')


### PR DESCRIPTION
## Description 📝

In the `CreditCardSchema` validation, the `expiry_year` field has a test to ensure the expiration year is 2 or 4 digits. The test function takes a `value` parameter, which is inferred to be a number type.

## Changes  🔄

- Modified file: `packages/validation/src/account.schema.ts`
- Change the parameter from `value` with no type, into `value: number`.

## Target release date 🗓️

It's just a refactor, not critical.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![](https://i.imgur.com/cUy71h6.png) | ![](https://i.imgur.com/R0rpGiQ.png) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- ...
- ...

### Reproduction steps
(How to reproduce the issue, if applicable)
- ...
- ...

### Verification steps
(How to verify changes)
- ...
- ...

## As an Author I have considered 🤔

*Check all that apply*

- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
