### PR TITLE
fix: [M3-8500] - Restricted users without account access unable to create Linodes on Linode Create v2

### DIFF
--- a/packages/manager/.changeset/pr-10846-fixed-1724859567426.md
+++ b/packages/manager/.changeset/pr-10846-fixed-1724859567426.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Restricted users without account access unable to create Linodes on Linode Create v2 ([#10846](https://github.com/linode/manager/pull/10846))

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/index.tsx
@@ -20,6 +20,7 @@ import {
   useCloneLinodeMutation,
   useCreateLinodeMutation,
 } from 'src/queries/linodes/linodes';
+import { useProfile } from 'src/queries/profile/profile';
 import {
   sendLinodeCreateFormInputEvent,
   sendLinodeCreateFormSubmitEvent,
@@ -58,18 +59,21 @@ import {
 import { VLAN } from './VLAN';
 import { VPC } from './VPC/VPC';
 
-import type { LinodeCreateFormValues } from './utilities';
+import type {
+  LinodeCreateFormContext,
+  LinodeCreateFormValues,
+} from './utilities';
 import type { SubmitHandler } from 'react-hook-form';
 
 export const LinodeCreatev2 = () => {
   const { params, setParams } = useLinodeCreateQueryParams();
+  const { secureVMNoticesEnabled } = useSecureVMNoticesEnabled();
+  const { data: profile } = useProfile();
 
   const queryClient = useQueryClient();
 
-  const { secureVMNoticesEnabled } = useSecureVMNoticesEnabled();
-
-  const form = useForm<LinodeCreateFormValues>({
-    context: { secureVMNoticesEnabled },
+  const form = useForm<LinodeCreateFormValues, LinodeCreateFormContext>({
+    context: { profile, secureVMNoticesEnabled },
     defaultValues: () => defaultValues(params, queryClient),
     mode: 'onBlur',
     resolver: getLinodeCreateResolver(params.type, queryClient),

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/resolvers.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/resolvers.ts
@@ -13,14 +13,17 @@ import {
 import { getLinodeCreatePayload } from './utilities';
 
 import type { LinodeCreateType } from '../LinodesCreate/types';
-import type { LinodeCreateFormValues } from './utilities';
+import type {
+  LinodeCreateFormContext,
+  LinodeCreateFormValues,
+} from './utilities';
 import type { QueryClient } from '@tanstack/react-query';
 import type { FieldErrors, Resolver } from 'react-hook-form';
 
 export const getLinodeCreateResolver = (
   tab: LinodeCreateType | undefined,
   queryClient: QueryClient
-): Resolver<LinodeCreateFormValues, { secureVMNoticesEnabled: boolean }> => {
+): Resolver<LinodeCreateFormValues, LinodeCreateFormContext> => {
   const schema = linodeCreateResolvers[tab ?? 'OS'];
   return async (values, context, options) => {
     const transformedValues = getLinodeCreatePayload(structuredClone(values));
@@ -46,7 +49,7 @@ export const getLinodeCreateResolver = (
       getRegionCountryGroup(selectedRegion)
     );
 
-    if (hasSelectedAnEURegion) {
+    if (hasSelectedAnEURegion && !context?.profile?.restricted) {
       const agreements = await queryClient.ensureQueryData(
         accountQueries.agreements
       );

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
@@ -20,6 +20,7 @@ import type {
   CreateLinodeRequest,
   InterfacePayload,
   Linode,
+  Profile,
 } from '@linode/api-v4';
 import type { QueryClient } from '@tanstack/react-query';
 import type { FieldErrors } from 'react-hook-form';
@@ -258,6 +259,18 @@ export interface LinodeCreateFormValues extends CreateLinodeRequest {
    * The currently selected Linode
    */
   linode?: Linode | null;
+}
+
+export interface LinodeCreateFormContext {
+  /**
+   * Profile data is used in the Linode Create v2 resolver because
+   * restricted users are subject to different validation.
+   */
+  profile: Profile | undefined;
+  /**
+   * Used for dispaying warnings to internal Akamai employees.
+   */
+  secureVMNoticesEnabled: boolean;
 }
 
 /**


### PR DESCRIPTION
## Description 📝

- Updates Linode Create v2 to be in parity with Linode Create v1 when it comes to a restricted user creating a Linode in an EU region

## The Bug 🐛 

- On Linode Create v2, if a user with `add_linodes` access, but with no account/billing permissions tried to create a LInode, they would see an infinite loading spinner. This is because Cloud Manager was trying to GET `/v4/account/agreemeents`, but failed to because the endpoint will 403 for this restricted user.

## The Fix 🔧 

- Allow restricted users with `add_linodes` access but with no account/billing permissions to create Linodes regardless of the account's agreements. 
- This seems questionable, but this is what Linode Create v1 intentionally did. See https://github.com/linode/manager/pull/7901 

## Target release date 🗓️
9/3/24

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-08-28 at 11 14 54 AM](https://github.com/user-attachments/assets/6c704d24-54c8-465d-8d8f-b19fba7db2f9) | <video src="https://github.com/user-attachments/assets/58b8c653-3cac-491f-9ae1-783f55c29df3" /> |
| User would see an infinite loading spinner | User can create a Linode | 

## How to test 🧪

### Prerequisites
- Create a restricted user on your account with the following permissions
  - `add_linodes: true` (`Can add Linodes to this account` in the UI)
  - `account_access: null` (No billing access in the UI)

### Reproduction steps
- Login as the restricted user
- Try to create a LInode in an EU region
- Observe an infinite loading spinner when you click "Create Linode" button

### Verification steps
- Repeat the "Reproduction steps" with this PR checked out
- Rather than seeing an infinite loading spinner, you should be able to successfully create a Linode in an EU region

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support