### PR TITLE
fix: [M3-8467] - Improve validation rules for create bucket schema

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OMC_CreateBucketDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OMC_CreateBucketDrawer.tsx
@@ -124,7 +124,7 @@ export const OMC_CreateBucketDrawer = (props: Props) => {
       region: '',
       s3_endpoint: undefined,
     },
-    mode: 'onChange',
+    mode: 'onBlur',
     resolver: yupResolver(CreateBucketSchema),
   });
 

--- a/packages/validation/.changeset/pr-10842-fixed-1724786185430.md
+++ b/packages/validation/.changeset/pr-10842-fixed-1724786185430.md
@@ -2,4 +2,4 @@
 "@linode/validation": Fixed
 ---
 
-Error validation for letter casing when creating object storage bucket now correctly appears for labels. ([#10842](https://github.com/linode/manager/pull/10842))
+Lack of `label` error validation for letter casing when creating Object Storage bucket. ([#10842](https://github.com/linode/manager/pull/10842))

--- a/packages/validation/.changeset/pr-10842-fixed-1724786185430.md
+++ b/packages/validation/.changeset/pr-10842-fixed-1724786185430.md
@@ -2,4 +2,4 @@
 "@linode/validation": Fixed
 ---
 
-Lack of `label` error validation for letter casing when creating Object Storage bucket. ([#10842](https://github.com/linode/manager/pull/10842))
+Lack of `label` error validation for letter casing and symbols when creating Object Storage bucket ([#10842](https://github.com/linode/manager/pull/10842), [#10847](https://github.com/linode/manager/pull/10847))

--- a/packages/validation/src/buckets.schema.ts
+++ b/packages/validation/src/buckets.schema.ts
@@ -7,16 +7,16 @@ export const CreateBucketSchema = object()
     {
       label: string()
         .required('Label is required.')
+        .min(3, 'Label must be between 3 and 63 characters.')
         .matches(/^\S*$/, 'Label must not contain spaces.')
-        .matches(
-          /^(?!.*[.-]{2})[a-z0-9.-]+$/,
-          'Label must contain only lowercase letters, numbers, periods (.), and hyphens (-). Adjacent periods and hyphens are not allowed.'
-        )
         .matches(
           /^[a-z0-9].*[a-z0-9]$/,
           'Label must start and end with a letter or number.'
         )
-        .min(3, 'Label must be between 3 and 63 characters.')
+        .matches(
+          /^(?!.*[.-]{2})[a-z0-9.-]+$/,
+          'Label must contain only lowercase letters, numbers, periods (.), and hyphens (-). Adjacent periods and hyphens are not allowed.'
+        )
         .max(63, 'Label must be between 3 and 63 characters.')
         .test(
           'unique-label',

--- a/packages/validation/src/buckets.schema.ts
+++ b/packages/validation/src/buckets.schema.ts
@@ -9,8 +9,12 @@ export const CreateBucketSchema = object()
         .required('Label is required.')
         .matches(/^\S*$/, 'Label must not contain spaces.')
         .matches(
-          /^[a-z0-9.-]*$/,
-          'Label must consist only of lowercase letters, numbers, . (period), and - (dash).'
+          /^(?!.*[.-]{2})[a-z0-9.-]+$/,
+          'Label must contain only lowercase letters, numbers, periods (.), and hyphens (-). Adjacent periods and hyphens are not allowed.'
+        )
+        .matches(
+          /^[a-z0-9].*[a-z0-9]$/,
+          'Label must start and end with a letter or number.'
         )
         .min(3, 'Label must be between 3 and 63 characters.')
         .max(63, 'Label must be between 3 and 63 characters.')


### PR DESCRIPTION
## Description 📝
The API currently returns an error when creating buckets, incorrectly checking for 'name' instead of 'label'. While a fix for this issue is planned for the future, we can improve our validation in the interim. 

## Changes  🔄
- Update schema to account for existing validation requirements

## Target release date 🗓️
N/A

## How to test 🧪

### Prerequisites
- Ensure multicluster flag is enabled

### Reproduction steps
- Try creating a bucket with a capital letter in the name
- Observe the request silently fails

### Verification steps
- Checkout this branch
- Follow reproduction steps
- Test for `-test`, `test--`, `test.-` `Test`
- Observe validation is working as intended

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support