### PR TITLE
change: [M3-8379] - Disable Region in OS tab for unsupported distributed images

### DIFF
--- a/packages/manager/.changeset/pr-10848-changed-1724869290917.md
+++ b/packages/manager/.changeset/pr-10848-changed-1724869290917.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Disable Region in OS tab for unsupported distributed images ([#10848](https://github.com/linode/manager/pull/10848))

--- a/packages/manager/.changeset/pr-10848-changed-1724869290917.md
+++ b/packages/manager/.changeset/pr-10848-changed-1724869290917.md
@@ -2,4 +2,4 @@
 "@linode/manager": Changed
 ---
 
-Disable Region in OS tab for unsupported distributed images ([#10848](https://github.com/linode/manager/pull/10848))
+Disable Region in OS tab for unsupported distributed images and fix helper text positioning ([#10848](https://github.com/linode/manager/pull/10848))

--- a/packages/manager/src/components/RegionSelect/RegionSelect.styles.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.styles.ts
@@ -45,18 +45,18 @@ export const sxDistributedRegionIcon = {
 
 export const StyledDistributedRegionBox = styled(Box, {
   label: 'StyledDistributedRegionBox',
-  shouldForwardProp: (prop) => prop != 'errorText',
-})<{ errorText: string }>(({ errorText, theme }) => ({
+  shouldForwardProp: (prop) => prop != 'centerChildren',
+})<{ centerChildren: boolean }>(({ centerChildren, theme }) => ({
   '& svg': {
     height: 21,
     marginLeft: 8,
     marginRight: 8,
     width: 24,
   },
-  alignSelf: errorText.length > 0 ? 'center' : 'end',
+  alignSelf: centerChildren ? 'center' : 'end',
   color: 'inherit',
   display: 'flex',
-  marginTop: errorText.length > 0 ? 21 : 0,
+  marginTop: centerChildren ? 21 : 0,
   padding: 8,
   [theme.breakpoints.down('md')]: {
     '& svg': {

--- a/packages/manager/src/components/RegionSelect/RegionSelect.styles.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.styles.ts
@@ -45,24 +45,26 @@ export const sxDistributedRegionIcon = {
 
 export const StyledDistributedRegionBox = styled(Box, {
   label: 'StyledDistributedRegionBox',
-})(({ theme }) => ({
+  shouldForwardProp: (prop) => prop != 'errorText',
+})<{ errorText: string }>(({ errorText, theme }) => ({
   '& svg': {
     height: 21,
     marginLeft: 8,
     marginRight: 8,
     width: 24,
   },
-  alignSelf: 'end',
+  alignSelf: errorText.length > 0 ? 'center' : 'end',
   color: 'inherit',
   display: 'flex',
-  marginLeft: 8,
-  padding: '8px 0',
+  marginTop: errorText.length > 0 ? 21 : 0,
+  padding: 8,
   [theme.breakpoints.down('md')]: {
     '& svg': {
       marginLeft: 0,
     },
     alignSelf: 'start',
-    marginLeft: 0,
+    marginTop: 0,
+    paddingLeft: 0,
   },
 }));
 

--- a/packages/manager/src/components/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.tsx
@@ -167,7 +167,7 @@ export const RegionSelect = <
         value={selectedRegion as Region}
       />
       {showDistributedRegionIconHelperText && ( // @TODO Gecko Beta: Add docs link
-        <StyledDistributedRegionBox errorText={errorText ?? ''}>
+        <StyledDistributedRegionBox centerChildren={Boolean(errorText)}>
           <DistributedRegion />
           <Typography
             data-testid="region-select-distributed-region-text"

--- a/packages/manager/src/components/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.tsx
@@ -167,7 +167,7 @@ export const RegionSelect = <
         value={selectedRegion as Region}
       />
       {showDistributedRegionIconHelperText && ( // @TODO Gecko Beta: Add docs link
-        <StyledDistributedRegionBox>
+        <StyledDistributedRegionBox errorText={errorText ?? ''}>
           <DistributedRegion />
           <Typography
             data-testid="region-select-distributed-region-text"

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -115,7 +115,6 @@ export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
   );
 
   const disabledRegions = getDisabledRegions({
-    linodeCreateTab: params.type,
     regions: regions ?? [],
     selectedImage: image,
   });

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Region.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Region.tsx
@@ -187,7 +187,6 @@ export const Region = () => {
     );
 
   const disabledRegions = getDisabledRegions({
-    linodeCreateTab: params.type,
     regions: regions ?? [],
     selectedImage: image,
   });

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Region.utils.test.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Region.utils.test.ts
@@ -10,7 +10,6 @@ describe('getDisabledRegions', () => {
     const image = imageFactory.build({ capabilities: [] });
 
     const result = getDisabledRegions({
-      linodeCreateTab: 'Images',
       regions: [distributedRegion, coreRegion],
       selectedImage: image,
     });
@@ -30,7 +29,6 @@ describe('getDisabledRegions', () => {
     const image = imageFactory.build({ capabilities: ['distributed-sites'] });
 
     const result = getDisabledRegions({
-      linodeCreateTab: 'Images',
       regions: [distributedRegion, coreRegion],
       selectedImage: image,
     });

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Region.utils.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Region.utils.ts
@@ -1,9 +1,7 @@
-import type { LinodeCreateType } from '../LinodesCreate/types';
 import type { Image, Region } from '@linode/api-v4';
 import type { DisableRegionOption } from 'src/components/RegionSelect/RegionSelect.types';
 
 interface DisabledRegionOptions {
-  linodeCreateTab: LinodeCreateType | undefined;
   regions: Region[];
   selectedImage: Image | undefined;
 }
@@ -14,13 +12,12 @@ interface DisabledRegionOptions {
  * @returns key/value pairs for disabled regions. the key is the region id and the value is why the region is disabled
  */
 export const getDisabledRegions = (options: DisabledRegionOptions) => {
-  const { linodeCreateTab, regions, selectedImage } = options;
+  const { regions, selectedImage } = options;
 
-  // On the images tab, we disabled distributed regions if:
+  // Disable distributed regions if:
   // - The user has selected an Image
   // - The selected image does not have the `distributed-sites` capability
   if (
-    linodeCreateTab === 'Images' &&
     selectedImage &&
     !selectedImage.capabilities.includes('distributed-sites')
   ) {


### PR DESCRIPTION
## Description 📝
Not all Linux Distributions in the Linode Create OS tab support distributed regions. We want to disable a region if the selected OS does not have a distributed capability similar to the Images tab

## Changes  🔄
- Remove specific check for `linodeCreateTab` in `getDisabledRegions` so that any selected image that does not have the `distributed-sites` capability is disabled
- Minor UI positioning fix for distributed helper text w/ region error text

## Preview 📷
| Gecko  | Before | After |
| ------- | ------- | ------- |
| Beta | ![v2-beta-before-os](https://github.com/user-attachments/assets/f8cdba16-1121-4ec4-8d83-448997d256af) | ![v2-beta-after-os](https://github.com/user-attachments/assets/c9d5c0eb-c490-431c-a123-712b854e8172) | 
| Beta | ![image](https://github.com/user-attachments/assets/3acd5bf3-19df-4c04-b6d0-c3a741b8cc06) | ![image](https://github.com/user-attachments/assets/38a643fc-bd8f-4e00-ba2f-8c5231cebb9e) | 
| LA / GA | ![v2-la-before-os](https://github.com/user-attachments/assets/663b6714-02b3-498a-9b8e-28fcbe8aadc1) | ![v2-la-after-os](https://github.com/user-attachments/assets/61a46706-94d8-44a2-a2d7-c2c81bc803ca) | 

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Ensure your account has the `new-dc-testing`, `new-dc-testing-gecko`, `edge_testing` and `edge_compute` customer tags
- Pull this PR and run it locally pointing to dev API

### Reproduction steps
(How to reproduce the issue, if applicable)
- Checkout `develop` locally while pointing to the dev API
- Go to the Linode Create flow
- Notice that distributed regions are not disabled for unsupported distributed images (no distributed icon, e.g. `Debian 11`)

### Verification steps
(How to verify changes)
- Go to the Linode Create flow and verify the `v1` and `v2` flows for Gecko `Beta` & Gecko `LA/GA`
  - To test Gecko Beta locally, you can add the following to `useFlags.ts`:
  - We do not want to change the LD flag globally since other teams rely on it
  -  ...mockFlags,
      gecko2: {
      enabled: true,
      ga: false
    }
- Verify unsupported distributed regions (no distributed icon, e.g. `Debian 11`)
  - Gecko LA/GA: Regions in the Distributed tab should be disabled with tooltip
  - Gecko Beta: Distributed regions in the single dropdown should be disabled with tooltip
- Verify supported distributed regions (distributed icon, e.g. `Ubuntu 24.04 LTS`)
  - Gecko LA/GA: Regions in the Distributed tab should not be disabled
  - Gecko Beta: Distributed regions in the single dropdown should not be disabled

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
