### PR TITLE
fix: BucketRateLimitTable bug causing page crashes on Object Storage Bucket Create/Details drawer

### DIFF
--- a/packages/manager/.changeset/pr-10849-fixed-1724872423210.md
+++ b/packages/manager/.changeset/pr-10849-fixed-1724872423210.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Page crash when viewing BucketRateLimitTable on Bucket Create and Bucket Details drawer ([#10849](https://github.com/linode/manager/pull/10849))

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useController } from 'react-hook-form';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useHistory, useLocation } from 'react-router-dom';
 
@@ -35,6 +36,12 @@ export const BucketProperties = React.memo((props: Props) => {
     defaultValues: {
       rateLimit: '1',
     },
+  });
+
+  const { control } = form;
+  const { field } = useController({
+    control,
+    name: 'rateLimit',
   });
 
   const {
@@ -75,7 +82,7 @@ export const BucketProperties = React.memo((props: Props) => {
         </StyledHelperText>
 
         <form onSubmit={handleSubmit(onSubmit)}>
-          <BucketRateLimitTable endpointType={endpoint_type} />
+          <BucketRateLimitTable endpointType={endpoint_type} field={field} />
           <StyledActionsPanel
             primaryButtonProps={{
               disabled: !isDirty,

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.test.tsx
@@ -4,9 +4,7 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { BucketRateLimitTable } from './BucketRateLimitTable';
 
-// recent bucket rate limit changes cause these tests to fail + bug when opening up Create Bucket drawer.
-// commenting out these tests for now + will investigate in a separate PR (need to investigate further)
-describe.skip('BucketRateLimitTable', () => {
+describe('BucketRateLimitTable', () => {
   it('should render a BucketRateLimitTable', () => {
     const { getAllByRole, getByText, queryByText } = renderWithTheme(
       <BucketRateLimitTable endpointType="E2" />

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useController, useFormContext } from 'react-hook-form';
 
 import { FormControlLabel } from 'src/components/FormControlLabel';
 import { Radio } from 'src/components/Radio/Radio';
@@ -11,6 +10,7 @@ import { TableRow } from 'src/components/TableRow';
 
 import type { UpdateBucketRateLimitPayload } from '../BucketDetail/BucketProperties';
 import type { ObjectStorageEndpointTypes } from '@linode/api-v4';
+import type { ControllerRenderProps } from 'react-hook-form';
 
 /**
  * TODO: This component is currently using static data until
@@ -20,6 +20,7 @@ import type { ObjectStorageEndpointTypes } from '@linode/api-v4';
 
 interface BucketRateLimitTableProps {
   endpointType: ObjectStorageEndpointTypes | undefined;
+  field?: ControllerRenderProps<UpdateBucketRateLimitPayload, 'rateLimit'>;
 }
 
 const tableHeaders = ['Limits', 'GET', 'PUT', 'LIST', 'DELETE', 'OTHER'];
@@ -50,13 +51,8 @@ const tableData = ({ endpointType }: BucketRateLimitTableProps) => {
 
 export const BucketRateLimitTable = ({
   endpointType,
+  field,
 }: BucketRateLimitTableProps) => {
-  const { control } = useFormContext<UpdateBucketRateLimitPayload>();
-  const { field } = useController({
-    control,
-    name: 'rateLimit',
-  });
-
   return (
     <Table data-testid="bucket-rate-limit-table" sx={{ marginBottom: 3 }}>
       <TableHead>
@@ -81,17 +77,27 @@ export const BucketRateLimitTable = ({
         {tableData({ endpointType }).map((row, rowIndex) => (
           <TableRow key={rowIndex}>
             <TableCell>
-              <FormControlLabel
-                control={
-                  <Radio
-                    checked={field.value === row.id}
-                    disabled
-                    onChange={() => field.onChange(row.id)}
-                    value={row.id}
-                  />
-                }
-                label={row.label}
-              />
+              {field ? (
+                <FormControlLabel
+                  control={
+                    <Radio
+                      checked={field.value === row.id}
+                      disabled
+                      onChange={() => field.onChange(row.id)}
+                      value={row.id}
+                    />
+                  }
+                  label={row.label}
+                />
+              ) : (
+                <Radio
+                  checked={row.checked}
+                  disabled
+                  name="limit-selection"
+                  onChange={() => {}}
+                  value="2"
+                />
+              )}
             </TableCell>
             {row.values.map((value, index) => {
               return (


### PR DESCRIPTION
## Description 📝
- Quick fix to prevent the 'Oh snap' error from occurring due to no form context when on the Object Storage Create/Details drawer - this just restores the table's behavior to what it used to be on the Create/Details drawer

## Target release date 🗓️
n/a

## How to test 🧪

### Reproduction steps
- with MSW and OBJ Gen2 flag enabled, navigate to Object Storage landing page
  - Create Bucket drawer: select a region with endpoints (Seattle) and click either endpoint E2 or E2
  - Bucket details drawer: click on the details button for a bucket with endpoint type E2 or E3
- oh snap'd

### Verification steps
- Verify page no longer crashes when opening up bucket details drawer and bucket create drawer for steps above
- verify Bucket Properties page still works as expected
- `yarn test BucketRateLimitTable.test.tsx`

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
