### PR TITLE
test: [M3-7971] - Add new tests for for selecting "All" Scopes

### DIFF
--- a/packages/manager/.changeset/pr-10852-tests-1724937535185.md
+++ b/packages/manager/.changeset/pr-10852-tests-1724937535185.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add new tests for for selecting "All" Scopes ([#10852](https://github.com/linode/manager/pull/10852))

--- a/packages/manager/cypress/e2e/core/account/personal-access-tokens.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/personal-access-tokens.spec.ts
@@ -24,6 +24,8 @@ describe('Personal access tokens', () => {
    * - Confirms that user is shown the token secret upon successful PAT creation
    * - Confirms that new personal access token is shown in list
    * - Confirms that user can open and close "View Scopes" drawer
+   * - Confirm that the “Child account access” grant is not visible in the list of permissions.
+   * - Upon clicking “Create Token”, assert that the outgoing API request payload contains "scopes" value as defined in token.
    */
   it('can create personal access tokens', () => {
     const token = appTokenFactory.build({
@@ -63,6 +65,9 @@ describe('Personal access tokens', () => {
       .findByTitle('Add Personal Access Token')
       .should('be.visible')
       .within(() => {
+        // Confirm that the “Child account access” grant is not visible in the list of permissions.
+        cy.findAllByText('Child Account Access').should('not.exist');
+
         // Confirm submit button is disabled without specifying scopes.
         ui.buttonGroup
           .findButtonByTitle('Create Token')
@@ -147,7 +152,12 @@ describe('Personal access tokens', () => {
       });
 
     // Confirm that new PAT is shown in list and "View Scopes" drawer works.
-    cy.wait('@getTokens');
+    // Upon clicking “Create Token”, assert that the outgoing API request payload contains "scopes" value as defined in token.
+    cy.wait('@getTokens').then((xhr) => {
+      const actualTokenData = xhr.response?.body.data;
+      const actualTokenScopes = actualTokenData[0].scopes;
+      expect(actualTokenScopes).to.equal(token.scopes);
+    });
     cy.findByText(token.label)
       .should('be.visible')
       .closest('tr')

--- a/packages/manager/cypress/e2e/core/parentChild/token-scopes.spec.ts
+++ b/packages/manager/cypress/e2e/core/parentChild/token-scopes.spec.ts
@@ -1,0 +1,211 @@
+import {
+  accountFactory,
+  appTokenFactory,
+  profileFactory,
+} from '@src/factories';
+import { accountUserFactory } from '@src/factories/accountUsers';
+import { DateTime } from 'luxon';
+import {
+  mockGetAccount,
+  mockGetChildAccounts,
+  mockGetUser,
+} from 'support/intercepts/account';
+import {
+  mockCreatePersonalAccessToken,
+  mockGetAppTokens,
+  mockGetPersonalAccessTokens,
+  mockGetProfile,
+} from 'support/intercepts/profile';
+import { ui } from 'support/ui';
+import { randomLabel, randomNumber, randomString } from 'support/util/random';
+
+const mockParentAccount = accountFactory.build({
+  company: 'Parent Company',
+});
+
+const mockParentProfile = profileFactory.build({
+  username: randomLabel(),
+  user_type: 'parent',
+});
+
+const mockParentUser = accountUserFactory.build({
+  username: mockParentProfile.username,
+  user_type: 'parent',
+});
+
+const mockChildAccount = accountFactory.build({
+  company: 'Partner Company',
+});
+
+const mockParentAccountToken = appTokenFactory.build({
+  id: randomNumber(),
+  created: DateTime.now().toISO(),
+  expiry: DateTime.now().plus({ minutes: 15 }).toISO(),
+  label: `${mockParentAccount.company}_proxy`,
+  scopes: '*',
+  token: randomString(32),
+  website: undefined,
+  thumbnail_url: undefined,
+});
+
+describe('Token scopes', () => {
+  /*
+   * Confirm that the “Child account access” grant is not visible in the list of permissions.
+   * Upon clicking “Create Token”, assert that the outgoing API request payload contains "scopes" value as defined in token.
+   */
+  it('Token scopes for parent user with restricted access', () => {
+    mockGetProfile(mockParentProfile);
+    mockGetAccount(mockParentAccount);
+    mockGetChildAccounts([mockChildAccount]);
+    mockGetProfile({ ...mockParentProfile, restricted: true });
+    mockGetUser(mockParentUser);
+
+    mockGetPersonalAccessTokens([]).as('getTokens');
+    mockGetAppTokens([]).as('getAppTokens');
+    mockCreatePersonalAccessToken(mockParentAccountToken).as('createToken');
+
+    cy.visitWithLogin('/profile/tokens');
+    cy.wait(['@getTokens', '@getAppTokens']);
+
+    // Click create button, fill out and submit PAT create form.
+    ui.button
+      .findByTitle('Create a Personal Access Token')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    mockGetPersonalAccessTokens([mockParentAccountToken]).as('getTokens');
+    ui.drawer
+      .findByTitle('Add Personal Access Token')
+      .should('be.visible')
+      .within(() => {
+        // Confirm that the “Child account access” grant is not visible in the list of permissions.
+        cy.findAllByText('Child Account Access').should('not.exist');
+
+        // Specify ALL scopes by selecting the "No Access" Select All radio button.
+        cy.get('[data-qa-perm-rw-radio]').click();
+        cy.get('[data-qa-perm-rw-radio]').should(
+          'have.attr',
+          'data-qa-radio',
+          'true'
+        );
+
+        // Specify a label and re-submit.
+        cy.findByLabelText('Label')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled')
+          .click()
+          .type(mockParentAccountToken.label);
+
+        ui.buttonGroup
+          .findButtonByTitle('Create Token')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    // Confirm that PAT secret dialog is shown and close it.
+    cy.wait('@createToken');
+    ui.dialog
+      .findByTitle('Personal Access Token')
+      .should('be.visible')
+      .within(() => {
+        ui.button
+          .findByTitle('I Have Saved My Personal Access Token')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    // Confirm that new PAT is shown in list and "View Scopes" drawer works.
+    // Upon clicking “Create Token”, assert that the outgoing API request payload contains "scopes" value as defined in token.
+    cy.wait('@getTokens').then((xhr) => {
+      const actualTokenData = xhr.response?.body.data;
+      const actualTokenScopes = actualTokenData[0].scopes;
+      expect(actualTokenScopes).to.equal(mockParentAccountToken.scopes);
+    });
+  });
+
+  /*
+   * Confirm that the “Child account access” grant is visible in the list of permissions.
+   * Upon clicking “Create Token”, assert that the outgoing API request payload contains "scopes" value as defined in token.
+   */
+  it('Token scopes for parent user with unrestricted access', () => {
+    mockGetProfile(mockParentProfile);
+    mockGetAccount(mockParentAccount);
+    mockGetChildAccounts([mockChildAccount]);
+    mockGetProfile({ ...mockParentProfile, restricted: false });
+    mockGetUser(mockParentUser);
+
+    mockGetPersonalAccessTokens([]).as('getTokens');
+    mockGetAppTokens([]).as('getAppTokens');
+    mockCreatePersonalAccessToken(mockParentAccountToken).as('createToken');
+
+    cy.visitWithLogin('/profile/tokens');
+    cy.wait(['@getTokens', '@getAppTokens']);
+
+    // Click create button, fill out and submit PAT create form.
+    ui.button
+      .findByTitle('Create a Personal Access Token')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    mockGetPersonalAccessTokens([mockParentAccountToken]).as('getTokens');
+    ui.drawer
+      .findByTitle('Add Personal Access Token')
+      .should('be.visible')
+      .within(() => {
+        // Confirm that the “Child account access” grant is not visible in the list of permissions.
+        cy.findAllByText('Child Account Access')
+          .scrollIntoView()
+          .should('be.visible');
+
+        // Specify ALL scopes by selecting the "No Access" Select All radio button.
+        cy.get('[data-qa-perm-rw-radio]').click();
+        cy.get('[data-qa-perm-rw-radio]').should(
+          'have.attr',
+          'data-qa-radio',
+          'true'
+        );
+
+        // Specify a label and re-submit.
+        cy.findByLabelText('Label')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled')
+          .click()
+          .type(mockParentAccountToken.label);
+
+        ui.buttonGroup
+          .findButtonByTitle('Create Token')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    // Confirm that PAT secret dialog is shown and close it.
+    cy.wait('@createToken');
+    ui.dialog
+      .findByTitle('Personal Access Token')
+      .should('be.visible')
+      .within(() => {
+        ui.button
+          .findByTitle('I Have Saved My Personal Access Token')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    // Confirm that new PAT is shown in list and "View Scopes" drawer works.
+    // Upon clicking “Create Token”, assert that the outgoing API request payload contains "scopes" value as defined in token.
+    cy.wait('@getTokens').then((xhr) => {
+      const actualTokenData = xhr.response?.body.data;
+      const actualTokenScopes = actualTokenData[0].scopes;
+      expect(actualTokenScopes).to.equal(mockParentAccountToken.scopes);
+    });
+  });
+});


### PR DESCRIPTION
## Description 📝
Ensure that the outgoing API request when creating an API token matches what’s expected for each type of user: regular user, parent user with restricted access, parent user with unrestricted access.

## Changes  🔄
- Add new assertions for regular user in account/personal-access-tokens.spec.ts
- Add new tests for parent user with restricted access and parent user with unrestricted access in parentChild/token-scopes.spec.ts

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/account/personal-access-tokens.spec.ts"
yarn cy:run -s "cypress/e2e/core/parentChild/token-scopes.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support