### PR TITLE
fix: [UIE-8084] - DBaaS V2 beta flag

### DIFF
--- a/packages/manager/.changeset/pr-10856-fixed-1724948318555.md
+++ b/packages/manager/.changeset/pr-10856-fixed-1724948318555.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+DBaaS V2 beta chip in PrimaryNav ([#10856](https://github.com/linode/manager/pull/10856))

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -54,7 +54,7 @@ describe('PrimaryNav', () => {
     expect(getByTestId(queryString).getAttribute('aria-current')).toBe('false');
   });
 
-  it('should show Databases menu item if the user has the account capability', async () => {
+  it('should show Databases menu item if the user has the account capability V1', async () => {
     const account = accountFactory.build({
       capabilities: ['Managed Databases'],
     });
@@ -65,11 +65,99 @@ describe('PrimaryNav', () => {
       })
     );
 
-    const { findByText } = renderWithTheme(<PrimaryNav {...props} />);
+    const flags = {
+      dbaasV2: {
+        beta: true,
+        enabled: true,
+      },
+    };
+
+    const { findByTestId, findByText } = renderWithTheme(
+      <PrimaryNav {...props} />,
+      {
+        flags,
+      }
+    );
 
     const databaseNavItem = await findByText('Databases');
+    let betaChip: any;
+    try {
+      betaChip = await findByTestId('betaChip');
+    } catch (e) {
+      betaChip = null;
+    }
 
     expect(databaseNavItem).toBeVisible();
+    expect(betaChip).toBeNull();
+  });
+
+  it('should show Databases menu item if the user has the account capability V2 Beta', async () => {
+    const account = accountFactory.build({
+      capabilities: ['Managed Databases V2'],
+    });
+
+    server.use(
+      http.get('*/account', () => {
+        return HttpResponse.json(account);
+      })
+    );
+
+    const flags = {
+      dbaasV2: {
+        beta: true,
+        enabled: true,
+      },
+    };
+
+    const { findByTestId, findByText } = renderWithTheme(
+      <PrimaryNav {...props} />,
+      {
+        flags,
+      }
+    );
+
+    const databaseNavItem = await findByText('Databases');
+    const betaChip = await findByTestId('betaChip');
+
+    expect(databaseNavItem).toBeVisible();
+    expect(betaChip).toBeVisible();
+  });
+
+  it('should show Databases menu item if the user has the account capability V2', async () => {
+    const account = accountFactory.build({
+      capabilities: ['Managed Databases V2'],
+    });
+
+    server.use(
+      http.get('*/account', () => {
+        return HttpResponse.json(account);
+      })
+    );
+
+    const flags = {
+      dbaasV2: {
+        beta: false,
+        enabled: true,
+      },
+    };
+
+    const { findByTestId, findByText } = renderWithTheme(
+      <PrimaryNav {...props} />,
+      {
+        flags,
+      }
+    );
+
+    const databaseNavItem = await findByText('Databases');
+    let betaChip: any;
+    try {
+      betaChip = await findByTestId('betaChip');
+    } catch (e) {
+      betaChip = null;
+    }
+
+    expect(databaseNavItem).toBeVisible();
+    expect(betaChip).toBeNull();
   });
 
   it('should show Monitor menu item if the user has the account capability', async () => {

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -108,7 +108,7 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
   const { isACLPEnabled } = useIsACLPEnabled();
 
   const { isPlacementGroupsEnabled } = useIsPlacementGroupsEnabled();
-  const { isDatabasesEnabled } = useIsDatabasesEnabled();
+  const { isDatabasesEnabled, isDatabasesV2Beta } = useIsDatabasesEnabled();
 
   const prefetchMarketplace = () => {
     if (!enableMarketplacePrefetch) {
@@ -187,7 +187,7 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
           hide: !isDatabasesEnabled,
           href: '/databases',
           icon: <Database />,
-          isBeta: flags.dbaasV2?.beta,
+          isBeta: isDatabasesV2Beta,
         },
         {
           activeLinks: ['/kubernetes/create'],
@@ -247,9 +247,9 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       isDatabasesEnabled,
+      isDatabasesV2Beta,
       isManaged,
       allowMarketplacePrefetch,
-      flags.dbaasV2,
       isPlacementGroupsEnabled,
       flags.placementGroups,
       isACLPEnabled,

--- a/packages/manager/src/features/Databases/utilities.test.ts
+++ b/packages/manager/src/features/Databases/utilities.test.ts
@@ -29,6 +29,7 @@ describe('useIsDatabasesEnabled', () => {
     await waitFor(() => {
       expect(result.current.isDatabasesEnabled).toBe(true);
       expect(result.current.isDatabasesV1Enabled).toBe(true);
+      expect(result.current.isDatabasesV2Beta).toBe(false);
       expect(result.current.isDatabasesV2Enabled).toBe(false);
     });
   });
@@ -54,6 +55,7 @@ describe('useIsDatabasesEnabled', () => {
     await waitFor(() => {
       expect(result.current.isDatabasesEnabled).toBe(true);
       expect(result.current.isDatabasesV1Enabled).toBe(false);
+      expect(result.current.isDatabasesV2Beta).toBe(true);
       expect(result.current.isDatabasesV2Enabled).toBe(true);
     });
   });

--- a/packages/manager/src/features/Databases/utilities.ts
+++ b/packages/manager/src/features/Databases/utilities.ts
@@ -39,6 +39,7 @@ export const useIsDatabasesEnabled = () => {
     return {
       isDatabasesEnabled: isDatabasesV1Enabled || isDatabasesV2Enabled,
       isDatabasesV1Enabled,
+      isDatabasesV2Beta: isDatabasesV2Enabled && flags.dbaasV2?.beta,
       isDatabasesV2Enabled,
     };
   }


### PR DESCRIPTION
## Description 📝
Fix the Beta Chip in the DBaaS menu

## Changes  🔄
List any change relevant to the reviewer.
- PrimaryNav should show beta chip conditionally
- Databases/utilities 

## Target release date 🗓️
9/10/24

## How to test 🧪

### Verification steps
- Managed Databases capability (no chip)
- Managed Databases V2 capability and flags.dbaasV2.beta and flags.dbaasV2.enabled (chip)
- Managed Databases V2 capability and flags.dbaasV2.beta false and flags.dbaasV2.enabled (no chip)

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
