### PR TITLE
upcoming: [M3-8378] - OBJ Cleanup

### DIFF
--- a/packages/api-v4/src/object-storage/types.ts
+++ b/packages/api-v4/src/object-storage/types.ts
@@ -215,8 +215,3 @@ export interface ObjectStorageBucketAccess {
   cors_enabled: boolean | null;
   cors_xml: string | null;
 }
-
-// TODO: This will need to be updated once we have the actual shape of the API response
-export interface UpdateBucketRateLimitPayload {
-  rateLimit: string;
-}

--- a/packages/api-v4/src/object-storage/types.ts
+++ b/packages/api-v4/src/object-storage/types.ts
@@ -215,3 +215,8 @@ export interface ObjectStorageBucketAccess {
   cors_enabled: boolean | null;
   cors_xml: string | null;
 }
+
+// TODO: This will need to be updated once we have the actual shape of the API response
+export interface UpdateBucketRateLimitPayload {
+  rateLimit: string;
+}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.styles.ts
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.styles.ts
@@ -24,14 +24,6 @@ export const StyledRootContainer = styled(Paper, {
   padding: theme.spacing(3),
 }));
 
-export const StyledHelperText = styled(Typography, {
-  label: 'StyledHelperText',
-})(({ theme }) => ({
-  lineHeight: 1.5,
-  paddingBottom: theme.spacing(),
-  paddingTop: theme.spacing(),
-}));
-
 export const StyledActionsPanel = styled(ActionsPanel, {
   label: 'StyledActionsPanel',
 })(() => ({

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -17,14 +17,13 @@ import {
   StyledText,
 } from './BucketProperties.styles';
 
-import type { ObjectStorageBucket } from '@linode/api-v4';
+import type {
+  ObjectStorageBucket,
+  UpdateBucketRateLimitPayload,
+} from '@linode/api-v4';
 
 interface Props {
   bucket: ObjectStorageBucket;
-}
-
-export interface UpdateBucketRateLimitPayload {
-  rateLimit: string;
 }
 
 export const BucketProperties = React.memo((props: Props) => {

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -1,26 +1,17 @@
 import * as React from 'react';
-import { FormProvider, useForm } from 'react-hook-form';
 import { useHistory, useLocation } from 'react-router-dom';
 
-import { Link } from 'src/components/Link';
-import { Notice } from 'src/components/Notice/Notice';
-import { SupportLink } from 'src/components/SupportLink';
-import { Typography } from 'src/components/Typography';
 import { getQueryParamFromQueryString } from 'src/utilities/queryParams';
 
 import { BucketRateLimitTable } from '../BucketLanding/BucketRateLimitTable';
 import { BucketBreadcrumb } from './BucketBreadcrumb';
 import {
   StyledActionsPanel,
-  StyledHelperText,
   StyledRootContainer,
   StyledText,
 } from './BucketProperties.styles';
 
-import type {
-  ObjectStorageBucket,
-  UpdateBucketRateLimitPayload,
-} from '@linode/api-v4';
+import type { ObjectStorageBucket } from '@linode/api-v4';
 
 interface Props {
   bucket: ObjectStorageBucket;
@@ -30,61 +21,32 @@ export const BucketProperties = React.memo((props: Props) => {
   const { bucket } = props;
   const { endpoint_type, hostname, label } = bucket;
 
-  const form = useForm<UpdateBucketRateLimitPayload>({
-    defaultValues: {
-      rateLimit: '1',
-    },
-  });
-
-  const {
-    formState: { errors, isDirty, isSubmitting },
-    handleSubmit,
-  } = form;
-
   const location = useLocation();
   const history = useHistory();
   const prefix = getQueryParamFromQueryString(location.search, 'prefix');
 
-  const onSubmit = () => {
-    // TODO: OBJGen2 - Handle Bucket Rate Limit update logic once the endpoint for updating is available.
-    // The 'data' argument is expected -> data: UpdateBucketRateLimitPayload
-  };
-
   return (
-    <FormProvider {...form}>
+    <>
       <BucketBreadcrumb bucketName={label} history={history} prefix={prefix} />
       <StyledText>{hostname || 'Loading...'}</StyledText>
 
       <StyledRootContainer>
-        <Typography variant="h2">Bucket Rate Limits</Typography>
-
-        {errors.root?.message ? (
-          <Notice text={errors.root?.message} variant="error" />
-        ) : null}
-
-        {/* TODO: OBJGen2 - We need to handle link in upcoming PR */}
-        <StyledHelperText>
-          Specifies the maximum Requests Per Second (RPS) for an Endpoint. To
-          increase it to High,{' '}
-          <SupportLink
-            text="open a support ticket"
-            title="Request to Increase Bucket Rate Limits"
-          />
-          . Understand <Link to="#">bucket rate limits</Link>.
-        </StyledHelperText>
-
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <BucketRateLimitTable endpointType={endpoint_type} />
-          <StyledActionsPanel
-            primaryButtonProps={{
-              disabled: !isDirty,
-              label: 'Save',
-              loading: isSubmitting,
-              type: 'submit',
-            }}
-          />
-        </form>
+        <BucketRateLimitTable
+          typographyProps={{
+            component: 'h3',
+            variant: 'h3',
+          }}
+          endpointType={endpoint_type}
+        />
+        {/* TODO: OBJGen2 - This will be handled once we receive API for bucket rates */}
+        <StyledActionsPanel
+          primaryButtonProps={{
+            disabled: true,
+            label: 'Save',
+            type: 'submit',
+          }}
+        />
       </StyledRootContainer>
-    </FormProvider>
+    </>
   );
 });

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -28,7 +28,7 @@ export const BucketProperties = React.memo((props: Props) => {
   return (
     <>
       <BucketBreadcrumb bucketName={label} history={history} prefix={prefix} />
-      <StyledText>{hostname || 'Loading...'}</StyledText>
+      <StyledText>{hostname}</StyledText>
 
       <StyledRootContainer>
         <BucketRateLimitTable

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
@@ -9,6 +9,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
 import { Divider } from 'src/components/Divider';
 import { Drawer } from 'src/components/Drawer';
+import { FormLabel } from 'src/components/FormLabel';
 import { Link } from 'src/components/Link';
 import { Typography } from 'src/components/Typography';
 import { useAccountManagement } from 'src/hooks/useAccountManagement';
@@ -76,8 +77,7 @@ export const BucketDetailsDrawer = React.memo(
     );
 
     let formattedCreated;
-    const showBucketRateLimitTable =
-      endpoint_type === 'E2' || endpoint_type === 'E3';
+    const isGen2EndpointType = endpoint_type === 'E2' || endpoint_type === 'E3';
 
     // TODO: OBJGen2 - Handle Bucket Rate Limit update logic once the endpoint for updating is available.
     const form = useForm<UpdateBucketRateLimitPayload>({
@@ -153,17 +153,24 @@ export const BucketDetailsDrawer = React.memo(
          to getBucketAccess and updateBucketAccess.  */}
           {
             <>
-              <Typography data-testid="bucketRateLimit" variant="h3">
-                Bucket Rate Limits
-              </Typography>
-              {showBucketRateLimitTable ? (
-                <BucketRateLimitTable endpointType={endpoint_type} />
-              ) : (
-                <Typography>
-                  This endpoint type supports up to 750 Requests Per
-                  Second(RPS). <Link to="#">Understand bucket rate limits</Link>
-                  .
+              <FormLabel>
+                <Typography
+                  data-testid="bucketRateLimit"
+                  marginBottom={1}
+                  marginTop={2}
+                  variant="inherit"
+                >
+                  Bucket Rate Limits
                 </Typography>
+              </FormLabel>
+              <Typography marginBottom={isGen2EndpointType ? 2 : 3}>
+                {isGen2EndpointType
+                  ? 'Specifies the maximum Requests Per Second (RPS) for a bucket. To increase it to High, open a support ticket. '
+                  : 'This endpoint type supports up to 750 Requests Per Second (RPS). '}
+                Understand <Link to="#">bucket rate limits</Link>.
+              </Typography>
+              {isGen2EndpointType && (
+                <BucketRateLimitTable endpointType={endpoint_type} />
               )}
             </>
           }

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
@@ -146,7 +146,13 @@ export const BucketDetailsDrawer = React.memo(
         {/* @TODO OBJ Multicluster: use region instead of cluster if isObjMultiClusterEnabled
          to getBucketAccess and updateBucketAccess.  */}
         {isObjectStorageGen2Enabled && (
-          <BucketRateLimitTable endpointType={endpoint_type} />
+          <BucketRateLimitTable
+            typographyProps={{
+              marginTop: 1,
+              variant: 'inherit',
+            }}
+            endpointType={endpoint_type}
+          />
         )}
         {<Divider spacingBottom={16} spacingTop={16} />}
         {cluster && label && (

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.test.tsx
@@ -6,7 +6,7 @@ import { BucketRateLimitTable } from './BucketRateLimitTable';
 
 // recent bucket rate limit changes cause these tests to fail + bug when opening up Create Bucket drawer.
 // commenting out these tests for now + will investigate in a separate PR (need to investigate further)
-describe.skip('BucketRateLimitTable', () => {
+describe('BucketRateLimitTable', () => {
   it('should render a BucketRateLimitTable', () => {
     const { getAllByRole, getByText, queryByText } = renderWithTheme(
       <BucketRateLimitTable endpointType="E2" />

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
-import { useController, useFormContext } from 'react-hook-form';
 
+import { Box } from 'src/components/Box';
 import { FormControlLabel } from 'src/components/FormControlLabel';
+import { FormLabel } from 'src/components/FormLabel';
+import { Link } from 'src/components/Link';
 import { Radio } from 'src/components/Radio/Radio';
+import { SupportLink } from 'src/components/SupportLink';
 import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
 import { TableCell } from 'src/components/TableCell';
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
+import { Typography } from 'src/components/Typography';
 
-import type {
-  ObjectStorageEndpointTypes,
-  UpdateBucketRateLimitPayload,
-} from '@linode/api-v4';
+import type { ObjectStorageEndpointTypes } from '@linode/api-v4';
+import type { TypographyProps } from 'src/components/Typography';
 
 /**
  * TODO: This component is currently using static data until
@@ -22,6 +24,7 @@ import type {
 
 interface BucketRateLimitTableProps {
   endpointType?: ObjectStorageEndpointTypes;
+  typographyProps?: TypographyProps;
 }
 
 const tableHeaders = ['Limits', 'GET', 'PUT', 'LIST', 'DELETE', 'OTHER'];
@@ -52,66 +55,94 @@ const tableData = ({ endpointType }: BucketRateLimitTableProps) => {
 
 export const BucketRateLimitTable = ({
   endpointType,
+  typographyProps,
 }: BucketRateLimitTableProps) => {
-  const { control } = useFormContext<UpdateBucketRateLimitPayload>();
-  const { field } = useController({
-    control,
-    name: 'rateLimit',
-  });
+  const isGen2EndpointType = endpointType === 'E2' || endpointType === 'E3';
 
   return (
-    <Table data-testid="bucket-rate-limit-table" sx={{ marginBottom: 3 }}>
-      <TableHead>
-        <TableRow>
-          {tableHeaders.map((header, index) => {
-            return (
-              <TableCell
-                sx={{
-                  '&&:last-child': {
-                    paddingRight: 2,
-                  },
-                }}
-                key={`${index}-${header}`}
-              >
-                {header}
-              </TableCell>
-            );
-          })}
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        {tableData({ endpointType }).map((row, rowIndex) => (
-          <TableRow key={rowIndex}>
-            <TableCell>
-              <FormControlLabel
-                control={
-                  <Radio
-                    checked={field.value === row.id}
-                    disabled
-                    onChange={() => field.onChange(row.id)}
-                    value={row.id}
+    <Box>
+      <FormLabel>
+        <Typography
+          data-testid="bucketRateLimit"
+          marginBottom={1}
+          {...typographyProps}
+        >
+          Bucket Rate Limits
+        </Typography>
+      </FormLabel>
+      <Typography marginBottom={isGen2EndpointType ? 2 : 3}>
+        {isGen2EndpointType ? (
+          <>
+            Specifies the maximum Requests Per Second (RPS) for a bucket. To
+            increase it to High,{' '}
+            <SupportLink
+              text="open a support ticket"
+              title="Request to Increase Bucket Rate Limits"
+            />
+            .{' '}
+          </>
+        ) : (
+          'This endpoint type supports up to 750 Requests Per Second (RPS). '
+        )}
+        Understand <Link to="#">bucket rate limits</Link>.
+      </Typography>
+
+      {isGen2EndpointType && (
+        <Table data-testid="bucket-rate-limit-table" sx={{ marginBottom: 3 }}>
+          <TableHead>
+            <TableRow>
+              {tableHeaders.map((header, index) => {
+                return (
+                  <TableCell
+                    sx={{
+                      '&&:last-child': {
+                        paddingRight: 2,
+                      },
+                    }}
+                    key={`${index}-${header}`}
+                  >
+                    {header}
+                  </TableCell>
+                );
+              })}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {tableData({ endpointType }).map((row, rowIndex) => (
+              <TableRow key={rowIndex}>
+                <TableCell>
+                  <FormControlLabel
+                    control={
+                      <Radio
+                        // TODO: OBJGen2 - This will be handled once we receive API for bucket rates
+                        checked={rowIndex === 0}
+                        disabled
+                        onChange={() => null}
+                        value={row.id}
+                      />
+                    }
+                    label={row.label}
                   />
-                }
-                label={row.label}
-              />
-            </TableCell>
-            {row.values.map((value, index) => {
-              return (
-                <TableCell
-                  sx={{
-                    '&&:last-child': {
-                      paddingRight: 2,
-                    },
-                  }}
-                  key={`${index}-${value}`}
-                >
-                  {value}
                 </TableCell>
-              );
-            })}
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+                {row.values.map((value, index) => {
+                  return (
+                    <TableCell
+                      sx={{
+                        '&&:last-child': {
+                          paddingRight: 2,
+                        },
+                      }}
+                      key={`${index}-${value}`}
+                    >
+                      {value}
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </Box>
   );
 };

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
@@ -17,7 +17,7 @@ import type { ObjectStorageEndpointTypes } from '@linode/api-v4';
 import type { TypographyProps } from 'src/components/Typography';
 
 /**
- * TODO: This component is currently using static data until
+ * TODO: [IMPORTANT NOTE]: This component is currently using static data until
  * and API endpoint is available to return rate limits for
  * each endpoint type.
  */
@@ -114,7 +114,6 @@ export const BucketRateLimitTable = ({
                   <FormControlLabel
                     control={
                       <Radio
-                        // TODO: OBJGen2 - This will be handled once we receive API for bucket rates
                         checked={rowIndex === 0}
                         disabled
                         onChange={() => null}

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
@@ -9,8 +9,10 @@ import { TableCell } from 'src/components/TableCell';
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
 
-import type { UpdateBucketRateLimitPayload } from '../BucketDetail/BucketProperties';
-import type { ObjectStorageEndpointTypes } from '@linode/api-v4';
+import type {
+  ObjectStorageEndpointTypes,
+  UpdateBucketRateLimitPayload,
+} from '@linode/api-v4';
 
 /**
  * TODO: This component is currently using static data until
@@ -19,7 +21,7 @@ import type { ObjectStorageEndpointTypes } from '@linode/api-v4';
  */
 
 interface BucketRateLimitTableProps {
-  endpointType: ObjectStorageEndpointTypes | undefined;
+  endpointType?: ObjectStorageEndpointTypes;
 }
 
 const tableHeaders = ['Limits', 'GET', 'PUT', 'LIST', 'DELETE', 'OTHER'];

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OMC_CreateBucketDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OMC_CreateBucketDrawer.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, waitFor } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
 import * as React from 'react';
 
 import { objectStorageEndpointsFactory } from 'src/factories';
@@ -42,7 +42,7 @@ describe('OMC_CreateBucketDrawer', () => {
   });
 
   it(
-    'should display the endpoint selector if endpoints exist',
+    'should not display the endpoint selector if regions is not selected',
     server.boundary(async () => {
       server.use(
         http.get('*/v4/object-storage/endpoints', () => {
@@ -58,7 +58,7 @@ describe('OMC_CreateBucketDrawer', () => {
         })
       );
 
-      const { getByText, queryByText } = renderWithThemeAndHookFormContext({
+      const { queryByText } = renderWithThemeAndHookFormContext({
         component: <OMC_CreateBucketDrawer {...props} />,
         options: {
           flags: {
@@ -71,19 +71,6 @@ describe('OMC_CreateBucketDrawer', () => {
       expect(
         queryByText('Object Storage Endpoint Type')
       ).not.toBeInTheDocument();
-
-      await waitFor(
-        () =>
-          expect(getByText('Object Storage Endpoint Type')).toBeInTheDocument(),
-        {
-          timeout: 2000,
-        }
-      );
-
-      // Additional verification after waitFor
-      const endpointTypeElement = getByText('Object Storage Endpoint Type');
-      expect(endpointTypeElement).toBeVisible();
-      expect(endpointTypeElement.tagName).toBe('LABEL');
     })
   );
 

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OMC_CreateBucketDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OMC_CreateBucketDrawer.tsx
@@ -6,7 +6,6 @@ import { Controller, useForm } from 'react-hook-form';
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
 import { Drawer } from 'src/components/Drawer';
-import { FormLabel } from 'src/components/FormLabel';
 import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
 import { TextField } from 'src/components/TextField';
@@ -236,11 +235,6 @@ export const OMC_CreateBucketDrawer = (props: Props) => {
     );
   }, [filteredEndpointOptions, watch]);
 
-  const isGen2EndpointType =
-    selectedEndpointOption &&
-    selectedEndpointOption.endpoint_type !== 'E0' &&
-    selectedEndpointOption.endpoint_type !== 'E1';
-
   const { showGDPRCheckbox } = getGDPRDetails({
     agreements,
     profile,
@@ -334,7 +328,7 @@ export const OMC_CreateBucketDrawer = (props: Props) => {
           name="region"
         />
         {selectedRegion?.id && <OveragePricing regionId={selectedRegion.id} />}
-        {Boolean(endpoints) && (
+        {Boolean(endpoints) && selectedRegion && (
           <>
             <Controller
               render={({ field }) => (
@@ -365,24 +359,9 @@ export const OMC_CreateBucketDrawer = (props: Props) => {
               control={control}
               name="endpoint_type"
             />
-            {selectedEndpointOption && (
-              <>
-                <FormLabel>
-                  <Typography marginBottom={1} marginTop={2} variant="inherit">
-                    Bucket Rate Limits
-                  </Typography>
-                </FormLabel>
-                <Typography marginBottom={isGen2EndpointType ? 2 : 3}>
-                  {isGen2EndpointType
-                    ? 'Specifies the maximum Requests Per Second (RPS) for a bucket. To increase it to High, open a support ticket. '
-                    : 'This endpoint type supports up to 750 Requests Per Second (RPS). '}
-                  Understand <Link to="#">bucket rate limits</Link>.
-                </Typography>
-              </>
-            )}
-            {isGen2EndpointType && (
+            {Boolean(endpoints) && selectedEndpointOption && (
               <BucketRateLimitTable
-                endpointType={selectedEndpointOption.endpoint_type}
+                endpointType={selectedEndpointOption?.endpoint_type}
               />
             )}
           </>

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OMC_CreateBucketDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OMC_CreateBucketDrawer.tsx
@@ -361,6 +361,10 @@ export const OMC_CreateBucketDrawer = (props: Props) => {
             />
             {Boolean(endpoints) && selectedEndpointOption && (
               <BucketRateLimitTable
+                typographyProps={{
+                  marginTop: 1,
+                  variant: 'inherit',
+                }}
                 endpointType={selectedEndpointOption?.endpoint_type}
               />
             )}


### PR DESCRIPTION
## Related
- [x] https://github.com/linode/manager/pull/10797

## Changes  🔄
- Removed our react hook form logic for `BucketRateLimitTable` and corresponding files. This is far from being ready and it introduced complexity since this component is used in 3 different places. This will most likely be a 2025 initiative to add this logic in when it's ready.
    - By removing this, we fixed an issue where app was crashing when trying to display the bucket rate table in any of the drawers for E2/E3. 
- Moved the "Bucket Rate Limits" title and corresponding helper text into `BucketRateLimitTable.tsx` since we were repeating that in 3 different places.
- The Create Bucket drawer now displays each additional step once we have the preceding information selected.
   - Once we select a region, we'll show endpoint types
   - Once we select endpoint types, we'll show bucket rate limits (except for E0/E1 of course) 

## Target release date 🗓️
N/A

## How to test 🧪

### Prerequisites
- Enable multi-cluster and gen2 flags
- Enable MSW

### Reproduction steps
(How to reproduce the issue, if applicable)
- When selecting a E2/E3 endpoint type bucket, app would crash because we didn't implement our form logic to `BucketDetailsDrawer`

### Verification steps
(How to verify changes)
- Pull down branch or preview link

- Select "Details" for any E2/E3 endpoint bucket:
   - Drawer should open and bucket rate limits table should show

- Create a bucket and observe:
   - Once a region is selected, endpoint types show
   - Once we select endpoint types, bucket rate limits show (except for E0/E1 of course) 

- Go to bucket details page and then properties tab
   - Ensure title, description, and table all look good
   - Do this for E0 -> E3 endpoint types

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support