### PR TITLE
test: [M3-8393] - Cypress test for Account Maintenance CSV downloads

### DIFF
--- a/packages/manager/.changeset/pr-10860-tests-1724957257280.md
+++ b/packages/manager/.changeset/pr-10860-tests-1724957257280.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add Cypress test for Account Maintenance CSV downloads ([#10860](https://github.com/linode/manager/pull/10860))

--- a/packages/manager/cypress/support/constants/account.ts
+++ b/packages/manager/cypress/support/constants/account.ts
@@ -29,3 +29,23 @@ export const loginHelperText =
  * Empty state message that appears when there is no item in the login history table.
  */
 export const loginEmptyStateMessageText = 'No account logins';
+
+/**
+ * Downloaded mantainance detail CSV name.
+ */
+export const maintenanceCsvName = (state: string, date: string) => {
+  return `${state}-maintenance-${date}.csv`;
+};
+
+/**
+ * Column labels in mantainance CSV file.
+ */
+export const maintenanceCsvLabels = [
+  'Date',
+  'Entity Label',
+  'Entity Type',
+  'Entity ID',
+  'Reason',
+  'Status',
+  'Type',
+];


### PR DESCRIPTION
## Description 📝
Add Cypress test to the flow of downloading Account Maintenance CSV files.

## Major Changes 🔄
- Add Cypress test that downloads CSV files from account maintenance page.

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/account/account-maintenance.spec.ts"
```