### PR TITLE
fix: [M3-8502] - Allow regions to be searched by ID when Gecko is enabled

### DIFF
--- a/packages/manager/.changeset/pr-10871-fixed-1725373117220.md
+++ b/packages/manager/.changeset/pr-10871-fixed-1725373117220.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Allow regions to be searched by ID when Gecko is enabled ([#10871](https://github.com/linode/manager/pull/10871))

--- a/packages/manager/src/components/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.tsx
@@ -1,4 +1,6 @@
 import { Typography } from '@mui/material';
+import { createFilterOptions } from '@mui/material/Autocomplete';
+
 import * as React from 'react';
 
 import DistributedRegion from 'src/assets/icons/entityIcons/distributed-region.svg';
@@ -116,6 +118,16 @@ export const RegionSelect = <
     return null;
   }, [isGeckoBetaEnabled, isGeckoGAEnabled, selectedRegion]);
 
+  /*
+   * When Gecko is enabled, allow regions to be searched by ID by passing a
+   * custom stringify function.
+   */
+  const filterOptions = isGeckoGAEnabled
+    ? createFilterOptions({
+        stringify: (region: Region) => `${region.label} (${region.id})`,
+      })
+    : undefined;
+
   return (
     <StyledAutocompleteContainer sx={{ width }}>
       <Autocomplete<Region, false, DisableClearable>
@@ -154,6 +166,7 @@ export const RegionSelect = <
         disableClearable={disableClearable}
         disabled={disabled}
         errorText={errorText}
+        filterOptions={filterOptions}
         getOptionDisabled={(option) => Boolean(disabledRegions[option.id])}
         groupBy={(option) => getRegionCountryGroup(option)}
         helperText={helperText}


### PR DESCRIPTION
## Description 📝
This fixes an issue where users cannot search for a region by its ID using a `RegionSelect` when Gecko is enabled due to the layout changes made to our region options.

This fixes the issue by [passing a custom filter](https://mui.com/material-ui/react-autocomplete/#custom-filter) to the `Autocomplete` when Gecko is enabled. There should be no impact when Gecko is not enabled.

## Changes  🔄
- Allow regions to be searched by ID when Gecko is enabled

## Target release date 🗓️
N/A

## Preview 📷
**Include a screenshot or screen recording of the change**

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-09-03 at 10 16 35 AM](https://github.com/user-attachments/assets/76dba525-f49a-49a5-8eb6-0f54ed4fffdc) | ![Screenshot 2024-09-03 at 10 15 53 AM](https://github.com/user-attachments/assets/5f685dd5-9252-4661-8907-4cc360038e58) |

## How to test 🧪

### Reproduction steps
In `develop`:
- `yarn dev`
- Enable MSW with _Core + Distributed_ region preset and Gecko feature flag to enable Gecko
- Go to Linode create page or another page with a region select
- Search for a region by its ID (ex: `id-cgk`)
- Observe that region is not found

### Verification steps
In this branch:
- `yarn dev`
- Enable MSW with _Core + Distributed_ region preset and Gecko feature flag to enable Gecko
- Go to Linode create page or another page with a region select
- Search for a region by its ID (ex: `id-cgk`)
- Confirm that region is found
- Confirm that region select continues working as expected when Gecko is not enabled

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
