### PR TITLE
feat: [UIE-8006] - DBaaS 2.0 Create

### DIFF
--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -28,15 +28,15 @@ export interface DatabaseEngine {
 }
 
 export type DatabaseStatus =
+  | 'active'
+  | 'degraded'
+  | 'failed'
   | 'provisioning'
   | 'resizing'
-  | 'active'
-  | 'suspending'
-  | 'suspended'
-  | 'resuming'
   | 'restoring'
-  | 'failed'
-  | 'degraded';
+  | 'resuming'
+  | 'suspended'
+  | 'suspending';
 
 export type DatabaseBackupType = 'snapshot' | 'auto';
 

--- a/packages/manager/.changeset/pr-10872-upcoming-features-1725396256315.md
+++ b/packages/manager/.changeset/pr-10872-upcoming-features-1725396256315.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+DBaaS V2 create enhancements ([#10872](https://github.com/linode/manager/pull/10872))

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -80,7 +80,7 @@ describe('PrimaryNav', () => {
     );
 
     const databaseNavItem = await findByText('Databases');
-    let betaChip: any;
+    let betaChip: HTMLElement | null;
     try {
       betaChip = await findByTestId('betaChip');
     } catch (e) {
@@ -149,7 +149,7 @@ describe('PrimaryNav', () => {
     );
 
     const databaseNavItem = await findByText('Databases');
-    let betaChip: any;
+    let betaChip: HTMLElement | null;
     try {
       betaChip = await findByTestId('betaChip');
     } catch (e) {

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -54,7 +54,7 @@ describe('PrimaryNav', () => {
     expect(getByTestId(queryString).getAttribute('aria-current')).toBe('false');
   });
 
-  it('should show Databases menu item if the user has the account capability', async () => {
+  it('should show Databases menu item if the user has the account capability V1', async () => {
     const account = accountFactory.build({
       capabilities: ['Managed Databases'],
     });
@@ -66,6 +66,33 @@ describe('PrimaryNav', () => {
     );
 
     const { findByText } = renderWithTheme(<PrimaryNav {...props} />);
+
+    const databaseNavItem = await findByText('Databases');
+
+    expect(databaseNavItem).toBeVisible();
+  });
+
+  it('should show Databases menu item if the user has the account capability V2', async () => {
+    const account = accountFactory.build({
+      capabilities: ['Managed Databases V2'],
+    });
+
+    server.use(
+      http.get('*/account', () => {
+        return HttpResponse.json(account);
+      })
+    );
+
+    const flags = {
+      dbaasV2: {
+        beta: true,
+        enabled: true,
+      },
+    };
+
+    const { findByText } = renderWithTheme(<PrimaryNav {...props} />, {
+      flags,
+    });
 
     const databaseNavItem = await findByText('Databases');
 

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -7,6 +7,8 @@ import { renderWithTheme, wrapWithTheme } from 'src/utilities/testHelpers';
 
 import PrimaryNav from './PrimaryNav';
 
+import type { Flags } from 'src/featureFlags';
+
 const props = {
   closeMenu: vi.fn(),
   isCollapsed: false,
@@ -65,14 +67,14 @@ describe('PrimaryNav', () => {
       })
     );
 
-    const flags = {
+    const flags: Partial<Flags> = {
       dbaasV2: {
         beta: true,
         enabled: true,
       },
     };
 
-    const { findByTestId, findByText } = renderWithTheme(
+    const { findByText, queryByTestId } = renderWithTheme(
       <PrimaryNav {...props} />,
       {
         flags,
@@ -80,15 +82,9 @@ describe('PrimaryNav', () => {
     );
 
     const databaseNavItem = await findByText('Databases');
-    let betaChip: HTMLElement | null;
-    try {
-      betaChip = await findByTestId('betaChip');
-    } catch (e) {
-      betaChip = null;
-    }
 
     expect(databaseNavItem).toBeVisible();
-    expect(betaChip).toBeNull();
+    expect(queryByTestId('betaChip')).toBeNull();
   });
 
   it('should show Databases menu item if the user has the account capability V2 Beta', async () => {
@@ -102,7 +98,7 @@ describe('PrimaryNav', () => {
       })
     );
 
-    const flags = {
+    const flags: Partial<Flags> = {
       dbaasV2: {
         beta: true,
         enabled: true,
@@ -134,14 +130,14 @@ describe('PrimaryNav', () => {
       })
     );
 
-    const flags = {
+    const flags: Partial<Flags> = {
       dbaasV2: {
         beta: false,
         enabled: true,
       },
     };
 
-    const { findByTestId, findByText } = renderWithTheme(
+    const { findByText, queryByTestId } = renderWithTheme(
       <PrimaryNav {...props} />,
       {
         flags,
@@ -149,15 +145,9 @@ describe('PrimaryNav', () => {
     );
 
     const databaseNavItem = await findByText('Databases');
-    let betaChip: HTMLElement | null;
-    try {
-      betaChip = await findByTestId('betaChip');
-    } catch (e) {
-      betaChip = null;
-    }
 
     expect(databaseNavItem).toBeVisible();
-    expect(betaChip).toBeNull();
+    expect(queryByTestId('betaChip')).toBeNull();
   });
 
   it('should show Databases menu item if the user has the account capability V2', async () => {
@@ -171,7 +161,7 @@ describe('PrimaryNav', () => {
       })
     );
 
-    const flags = {
+    const flags: Partial<Flags> = {
       dbaasV2: {
         beta: true,
         enabled: true,

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -65,11 +65,99 @@ describe('PrimaryNav', () => {
       })
     );
 
-    const { findByText } = renderWithTheme(<PrimaryNav {...props} />);
+    const flags = {
+      dbaasV2: {
+        beta: true,
+        enabled: true,
+      },
+    };
+
+    const { findByTestId, findByText } = renderWithTheme(
+      <PrimaryNav {...props} />,
+      {
+        flags,
+      }
+    );
 
     const databaseNavItem = await findByText('Databases');
+    let betaChip: any;
+    try {
+      betaChip = await findByTestId('betaChip');
+    } catch (e) {
+      betaChip = null;
+    }
 
     expect(databaseNavItem).toBeVisible();
+    expect(betaChip).toBeNull();
+  });
+
+  it('should show Databases menu item if the user has the account capability V2 Beta', async () => {
+    const account = accountFactory.build({
+      capabilities: ['Managed Databases V2'],
+    });
+
+    server.use(
+      http.get('*/account', () => {
+        return HttpResponse.json(account);
+      })
+    );
+
+    const flags = {
+      dbaasV2: {
+        beta: true,
+        enabled: true,
+      },
+    };
+
+    const { findByTestId, findByText } = renderWithTheme(
+      <PrimaryNav {...props} />,
+      {
+        flags,
+      }
+    );
+
+    const databaseNavItem = await findByText('Databases');
+    const betaChip = await findByTestId('betaChip');
+
+    expect(databaseNavItem).toBeVisible();
+    expect(betaChip).toBeVisible();
+  });
+
+  it('should show Databases menu item if the user has the account capability V2', async () => {
+    const account = accountFactory.build({
+      capabilities: ['Managed Databases V2'],
+    });
+
+    server.use(
+      http.get('*/account', () => {
+        return HttpResponse.json(account);
+      })
+    );
+
+    const flags = {
+      dbaasV2: {
+        beta: false,
+        enabled: true,
+      },
+    };
+
+    const { findByTestId, findByText } = renderWithTheme(
+      <PrimaryNav {...props} />,
+      {
+        flags,
+      }
+    );
+
+    const databaseNavItem = await findByText('Databases');
+    let betaChip: any;
+    try {
+      betaChip = await findByTestId('betaChip');
+    } catch (e) {
+      betaChip = null;
+    }
+
+    expect(databaseNavItem).toBeVisible();
+    expect(betaChip).toBeNull();
   });
 
   it('should show Databases menu item if the user has the account capability V2', async () => {

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -108,7 +108,7 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
   const { isACLPEnabled } = useIsACLPEnabled();
 
   const { isPlacementGroupsEnabled } = useIsPlacementGroupsEnabled();
-  const { isDatabasesEnabled } = useIsDatabasesEnabled();
+  const { isDatabasesEnabled, isDatabasesV2Enabled } = useIsDatabasesEnabled();
 
   const prefetchMarketplace = () => {
     if (!enableMarketplacePrefetch) {

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -108,7 +108,7 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
   const { isACLPEnabled } = useIsACLPEnabled();
 
   const { isPlacementGroupsEnabled } = useIsPlacementGroupsEnabled();
-  const { isDatabasesEnabled, isDatabasesV2Enabled } = useIsDatabasesEnabled();
+  const { isDatabasesEnabled, isDatabasesV2Beta } = useIsDatabasesEnabled();
 
   const prefetchMarketplace = () => {
     if (!enableMarketplacePrefetch) {
@@ -187,7 +187,7 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
           hide: !isDatabasesEnabled,
           href: '/databases',
           icon: <Database />,
-          isBeta: flags.dbaasV2?.beta,
+          isBeta: isDatabasesV2Beta,
         },
         {
           activeLinks: ['/kubernetes/create'],
@@ -247,9 +247,9 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       isDatabasesEnabled,
+      isDatabasesV2Beta,
       isManaged,
       allowMarketplacePrefetch,
-      flags.dbaasV2,
       isPlacementGroupsEnabled,
       flags.placementGroups,
       isACLPEnabled,

--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -27,7 +27,7 @@ interface TabbedPanelProps {
   copy?: string;
   docsLink?: JSX.Element;
   error?: JSX.Element | string;
-  handleTabChange?: () => void;
+  handleTabChange?: (index: number) => void;
   header: string;
   initTab?: number;
   innerClass?: string;
@@ -66,7 +66,7 @@ const TabbedPanel = React.memo((props: TabbedPanelProps) => {
   const tabChangeHandler = (index: number) => {
     setTabIndex(index);
     if (handleTabChange) {
-      handleTabChange();
+      handleTabChange(index);
     }
   };
 

--- a/packages/manager/src/factories/account.ts
+++ b/packages/manager/src/factories/account.ts
@@ -45,7 +45,7 @@ export const accountFactory = Factory.Sync.makeFactory<Account>({
     'Linodes',
     'LKE HA Control Planes',
     'Machine Images',
-    'Managed Databases V2',
+    'Managed Databases',
     'NodeBalancers',
     'Object Storage Access Key Regions',
     'Object Storage Endpoint Types',

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -16,14 +16,16 @@ import type {
   PostgresReplicationType,
 } from '@linode/api-v4/lib/databases/types';
 
-// These are not all of the possible statuses, but these are some common ones.
 export const possibleStatuses: DatabaseStatus[] = [
-  'provisioning',
   'active',
-  'failed',
   'degraded',
-  'restoring',
+  'failed',
+  'provisioning',
   'resizing',
+  'restoring',
+  'resuming',
+  'suspended',
+  'suspending',
 ];
 
 export const possibleMySQLReplicationTypes: MySQLReplicationType[] = [

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.test.tsx
@@ -3,11 +3,10 @@ import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import { Router } from 'react-router-dom';
 
-import { databaseTypeFactory } from 'src/factories';
+import { accountFactory, databaseTypeFactory } from 'src/factories';
 import { makeResourcePage } from 'src/mocks/serverHandlers';
 import { HttpResponse, http, server } from 'src/mocks/testServer';
-import { renderWithTheme } from 'src/utilities/testHelpers';
-import { mockMatchMedia } from 'src/utilities/testHelpers';
+import { mockMatchMedia, renderWithTheme } from 'src/utilities/testHelpers';
 
 import DatabaseCreate from './DatabaseCreate';
 
@@ -77,6 +76,82 @@ describe('Database Create', () => {
     const radioBtn = getAllByText('Nanode 1 GB')[0];
     fireEvent.click(radioBtn);
     expect(nodeRadioBtns).toHaveTextContent('$60/month $0.09/hr');
+    expect(nodeRadioBtns).toHaveTextContent('$140/month $0.21/hr');
+  });
+
+  it('should display the correct nodes for account with Managed Databases', async () => {
+    server.use(
+      http.get('*/account', () => {
+        const account = accountFactory.build({
+          capabilities: ['Managed Databases'],
+        });
+        return HttpResponse.json(account);
+      })
+    );
+
+    // Mock route history so the Plan Selection table displays prices without requiring a region in the DB Create flow.
+    const history = createMemoryHistory();
+    history.push('databases/create');
+
+    const { getAllByText, getByTestId } = renderWithTheme(
+      <Router history={history}>
+        <DatabaseCreate />
+      </Router>
+    );
+
+    await waitForElementToBeRemoved(getByTestId(loadingTestId));
+
+    // default to $0 if no plan is selected
+    const nodeRadioBtns = getByTestId('database-nodes');
+    expect(nodeRadioBtns).toHaveTextContent('$0/month $0/hr');
+
+    // update node pricing if a plan is selected
+    const radioBtn = getAllByText('Nanode 1 GB')[0];
+    fireEvent.click(radioBtn);
+    expect(nodeRadioBtns).toHaveTextContent('$60/month $0.09/hr');
+    expect(nodeRadioBtns).not.toHaveTextContent('$100/month $0.15/hr');
+    expect(nodeRadioBtns).toHaveTextContent('$140/month $0.21/hr');
+  });
+
+  it('should display the correct nodes for account with Managed Databases V2', async () => {
+    server.use(
+      http.get('*/account', () => {
+        const account = accountFactory.build({
+          capabilities: ['Managed Databases V2'],
+        });
+        return HttpResponse.json(account);
+      })
+    );
+
+    // Mock route history so the Plan Selection table displays prices without requiring a region in the DB Create flow.
+    const history = createMemoryHistory();
+    history.push('databases/create');
+
+    const flags = {
+      dbaasV2: {
+        beta: true,
+        enabled: true,
+      },
+    };
+
+    const { getAllByText, getByTestId } = renderWithTheme(
+      <Router history={history}>
+        <DatabaseCreate />
+      </Router>,
+      { flags }
+    );
+
+    await waitForElementToBeRemoved(getByTestId(loadingTestId));
+
+    // default to $0 if no plan is selected
+    const nodeRadioBtns = getByTestId('database-nodes');
+    expect(nodeRadioBtns).toHaveTextContent('$0/month $0/hr');
+
+    // update node pricing if a plan is selected
+    const radioBtn = getAllByText('Nanode 1 GB')[0];
+    fireEvent.click(radioBtn);
+    expect(nodeRadioBtns).toHaveTextContent('$60/month $0.09/hr');
+    expect(nodeRadioBtns).toHaveTextContent('$100/month $0.15/hr');
     expect(nodeRadioBtns).toHaveTextContent('$140/month $0.21/hr');
   });
 });

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -32,10 +32,11 @@ import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
 import { PlansPanel } from 'src/features/components/PlansPanel/PlansPanel';
 import { EngineOption } from 'src/features/Databases/DatabaseCreate/EngineOption';
+import { DatabaseLogo } from 'src/features/Databases/DatabaseLanding/DatabaseLogo';
 import { databaseEngineMap } from 'src/features/Databases/DatabaseLanding/DatabaseRow';
+import { useIsDatabasesEnabled } from 'src/features/Databases/utilities';
 import { enforceIPMasks } from 'src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.utils';
 import { typeLabelDetails } from 'src/features/Linodes/presentation';
-import { useFlags } from 'src/hooks/useFlags';
 import {
   useCreateDatabaseMutation,
   useDatabaseEnginesQuery,
@@ -62,6 +63,9 @@ import type { Theme } from '@mui/material/styles';
 import type { Item } from 'src/components/EnhancedSelect/Select';
 import type { PlanSelectionType } from 'src/features/components/PlansPanel/types';
 import type { ExtendedIP } from 'src/utilities/ipUtils';
+
+const V1 = 'Managed Databases';
+const V2 = `Managed Databases V2`;
 
 const useStyles = makeStyles()((theme: Theme) => ({
   btnCtn: {
@@ -187,6 +191,7 @@ const getEngineOptions = (engines: DatabaseEngine[]) => {
 };
 
 interface NodePricing {
+  double: DatabasePriceObject | undefined;
   multi: DatabasePriceObject | undefined;
   single: DatabasePriceObject | undefined;
 }
@@ -194,7 +199,6 @@ interface NodePricing {
 const DatabaseCreate = () => {
   const { classes } = useStyles();
   const history = useHistory();
-  const flags = useFlags();
 
   const {
     data: regionsData,
@@ -214,12 +218,15 @@ const DatabaseCreate = () => {
     isLoading: typesLoading,
   } = useDatabaseTypesQuery();
 
+  const { isDatabasesV2Beta, isDatabasesV2Enabled } = useIsDatabasesEnabled();
+
   const formRef = React.useRef<HTMLFormElement>(null);
   const { mutateAsync: createDatabase } = useCreateDatabaseMutation();
 
   const [nodePricing, setNodePricing] = React.useState<NodePricing>();
   const [createError, setCreateError] = React.useState<string>();
   const [ipErrorsFromAPI, setIPErrorsFromAPI] = React.useState<APIError[]>();
+  const [selectedTab, setSelectedTab] = React.useState(0);
 
   const engineOptions = React.useMemo(() => {
     if (!engines) {
@@ -356,33 +363,46 @@ const DatabaseCreate = () => {
     });
   }, [dbtypes, selectedEngine]);
 
-  const labelToolTip = (
-    <div className={classes.labelToolTipCtn}>
-      <strong>Label must:</strong>
-      <ul>
-        <li>Begin with an alpha character</li>
-        <li>Contain only alpha characters or single hyphens</li>
-        <li>Be between 3 - 32 characters</li>
-      </ul>
-    </div>
-  );
+  const nodeOptions = React.useMemo(() => {
+    const hasDedicated = displayTypes.some(
+      (type) => type.class === 'dedicated'
+    );
 
-  const nodeOptions = [
-    {
-      label: (
-        <Typography>
-          1 Node {` `}
-          <br />
-          <span style={{ fontSize: '12px' }}>
-            {`$${nodePricing?.single?.monthly || 0}/month $${
-              nodePricing?.single?.hourly || 0
-            }/hr`}
-          </span>
-        </Typography>
-      ),
-      value: 1,
-    },
-    {
+    const options = [
+      {
+        label: (
+          <Typography>
+            1 Node {` `}
+            <br />
+            <span style={{ fontSize: '12px' }}>
+              {`$${nodePricing?.single?.monthly || 0}/month $${
+                nodePricing?.single?.hourly || 0
+              }/hr`}
+            </span>
+          </Typography>
+        ),
+        value: 1,
+      },
+    ];
+
+    if (hasDedicated && selectedTab === 0 && isDatabasesV2Enabled) {
+      options.push({
+        label: (
+          <Typography>
+            2 Nodes - High Availability
+            <br />
+            <span style={{ fontSize: '12px' }}>
+              {`$${nodePricing?.double?.monthly || 0}/month $${
+                nodePricing?.double?.hourly || 0
+              }/hr`}
+            </span>
+          </Typography>
+        ),
+        value: 2,
+      });
+    }
+
+    options.push({
       label: (
         <Typography>
           3 Nodes - High Availability (recommended)
@@ -395,8 +415,25 @@ const DatabaseCreate = () => {
         </Typography>
       ),
       value: 3,
-    },
-  ];
+    });
+
+    return options;
+  }, [selectedTab, nodePricing, displayTypes, isDatabasesV2Enabled]);
+
+  const labelToolTip = (
+    <div className={classes.labelToolTipCtn}>
+      <strong>Label must:</strong>
+      <ul>
+        <li>Begin with an alpha character</li>
+        <li>Contain only alpha characters or single hyphens</li>
+        <li>Be between 3 - 32 characters</li>
+      </ul>
+    </div>
+  );
+
+  const handleTabChange = (index: number) => {
+    setSelectedTab(index);
+  };
 
   React.useEffect(() => {
     if (values.type.length === 0 || !dbtypes) {
@@ -411,6 +448,9 @@ const DatabaseCreate = () => {
     const engineType = values.engine.split('/')[0] as Engine;
 
     setNodePricing({
+      double: type.engines[engineType].find(
+        (cluster: DatabaseClusterSizeObject) => cluster.quantity === 2
+      )?.price,
       multi: type.engines[engineType].find(
         (cluster: DatabaseClusterSizeObject) => cluster.quantity === 3
       )?.price,
@@ -453,7 +493,7 @@ const DatabaseCreate = () => {
             },
           ],
           labelOptions: {
-            suffixComponent: flags.dbaasV2?.beta ? (
+            suffixComponent: isDatabasesV2Beta ? (
               <BetaChip className={classes.chip} component="span" />
             ) : null,
           },
@@ -501,7 +541,7 @@ const DatabaseCreate = () => {
         </Grid>
         <Grid>
           <RegionSelect
-            currentCapability="Managed Databases"
+            currentCapability={isDatabasesV2Enabled ? V2 : V1}
             disableClearable
             errorText={errors.region}
             onChange={(e, region) => setFieldValue('region', region.id)}
@@ -519,6 +559,7 @@ const DatabaseCreate = () => {
             className={classes.selectPlanPanel}
             data-qa-select-plan
             error={errors.type}
+            handleTabChange={handleTabChange}
             header="Choose a Plan"
             isCreate
             regionsData={regionsData}
@@ -620,6 +661,7 @@ const DatabaseCreate = () => {
           Create Database Cluster
         </Button>
       </Grid>
+      {isDatabasesV2Enabled && <DatabaseLogo />}
     </form>
   );
 };

--- a/packages/manager/src/features/Databases/utilities.test.ts
+++ b/packages/manager/src/features/Databases/utilities.test.ts
@@ -29,6 +29,7 @@ describe('useIsDatabasesEnabled', () => {
     await waitFor(() => {
       expect(result.current.isDatabasesEnabled).toBe(true);
       expect(result.current.isDatabasesV1Enabled).toBe(true);
+      expect(result.current.isDatabasesV2Beta).toBe(false);
       expect(result.current.isDatabasesV2Enabled).toBe(false);
     });
   });
@@ -54,6 +55,7 @@ describe('useIsDatabasesEnabled', () => {
     await waitFor(() => {
       expect(result.current.isDatabasesEnabled).toBe(true);
       expect(result.current.isDatabasesV1Enabled).toBe(false);
+      expect(result.current.isDatabasesV2Beta).toBe(true);
       expect(result.current.isDatabasesV2Enabled).toBe(true);
     });
   });

--- a/packages/manager/src/features/Databases/utilities.ts
+++ b/packages/manager/src/features/Databases/utilities.ts
@@ -39,6 +39,7 @@ export const useIsDatabasesEnabled = () => {
     return {
       isDatabasesEnabled: isDatabasesV1Enabled || isDatabasesV2Enabled,
       isDatabasesV1Enabled,
+      isDatabasesV2Beta: isDatabasesV2Enabled && flags.dbaasV2?.beta,
       isDatabasesV2Enabled,
     };
   }

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -35,6 +35,7 @@ export interface PlansPanelProps {
   disabledTabs?: string[];
   docsLink?: JSX.Element;
   error?: string;
+  handleTabChange?: (index: number) => void;
   header?: string;
   isCreate?: boolean;
   linodeID?: number | undefined;
@@ -66,6 +67,7 @@ export const PlansPanel = (props: PlansPanelProps) => {
     disabledSmallerPlans,
     docsLink,
     error,
+    handleTabChange,
     header,
     isCreate,
     linodeID,
@@ -223,6 +225,7 @@ export const PlansPanel = (props: PlansPanelProps) => {
       data-qa-select-plan
       docsLink={docsLink}
       error={error}
+      handleTabChange={handleTabChange}
       header={header || 'Linode Plan'}
       initTab={initialTab >= 0 ? initialTab : 0}
       innerClass={props.tabbedPanelInnerClass}


### PR DESCRIPTION
## Description 📝
DBaaS 2.0 enhancements to create page

## Changes  🔄
- New 2 node option for dedicated CPUs
- Expose handleTabChange in PanelsPanel to show/hide 2 node option

## Target release date 🗓️
9/10/24

## How to test 🧪

### Prerequisites
- "Managed Databases V2" capability
- dbaasV2 flag enabled

### Verification steps
- 2 node option will appear on create page

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
