### PR TITLE
fix: cherry-picked our changes to feature flag rate limit text

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
@@ -59,6 +59,12 @@ export const BucketDetailsDrawer = React.memo(
       account?.capabilities ?? []
     );
 
+    const isObjectStorageGen2Enabled = isFeatureEnabledV2(
+      'Object Storage Endpoint Types',
+      Boolean(flags.objectStorageGen2?.enabled),
+      account?.capabilities ?? []
+    );
+
     // @TODO OBJGen2 - We could clean this up when OBJ Gen2 is in GA.
     const { data: clusters } = useObjectStorageClusters(
       !isObjMultiClusterEnabled
@@ -141,7 +147,7 @@ export const BucketDetailsDrawer = React.memo(
         )}
         {/* @TODO OBJ Multicluster: use region instead of cluster if isObjMultiClusterEnabled
          to getBucketAccess and updateBucketAccess.  */}
-        {
+        {isObjectStorageGen2Enabled && (
           <>
             <Typography data-testid="bucketRateLimit" variant="h3">
               Bucket Rate Limits
@@ -154,9 +160,9 @@ export const BucketDetailsDrawer = React.memo(
                 <Link to="#">Understand bucket rate limits</Link>.
               </Typography>
             )}
+            <Divider spacingBottom={16} spacingTop={16} />
           </>
-        }
-        {<Divider spacingBottom={16} spacingTop={16} />}
+        )}
         {cluster && label && (
           <AccessSelect
             getAccess={() =>


### PR DESCRIPTION
## Description 📝
We had a fix already in place for this [here](https://github.com/linode/manager/pull/10857/files#diff-5b3f25d0c59a76dccfaf45d3eb177bb551652dafbce19b6a60e3258bea88733bR62-R156) but we didn't get it in the release in time.

## Changes  🔄
- Bucket rate limit text should be feature flagged

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-09-03 at 3 24 37 PM](https://github.com/user-attachments/assets/81ae7e62-cf98-4fd3-8d2c-68ffdb896e4b) | ![Screenshot 2024-09-03 at 3 24 23 PM](https://github.com/user-attachments/assets/1cc6f61d-7139-4fca-ac99-85fdd5eb5bb6) |

## How to test 🧪

### Prerequisites
- Turn off Gen2 flag

### Reproduction steps
- With Gen2 flag off
- Observe we erroneously see bucket rate changes

### Verification steps
- Select details for any bucket
- Observe fix is in place.