### PR TITLE
refactor: [M3-8496] - Remove Placement Group flag and underlying logic

### DIFF
--- a/packages/manager/.changeset/pr-10877-tech-stories-1725397280235.md
+++ b/packages/manager/.changeset/pr-10877-tech-stories-1725397280235.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Delete Placement Groups feature flag conditional rendering ([#10877](https://github.com/linode/manager/pull/10877))

--- a/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
@@ -12,13 +12,6 @@ import {
   mockGetRegionAvailability,
 } from 'support/intercepts/regions';
 import { mockGetLinodeTypes } from 'support/intercepts/linodes';
-import {
-  mockAppendFeatureFlags,
-  mockGetFeatureFlagClientstream,
-} from 'support/intercepts/feature-flags';
-import { makeFeatureFlagData } from 'support/util/feature-flags';
-
-import type { Flags } from 'src/featureFlags';
 
 const mockRegions = [
   regionFactory.build({
@@ -363,12 +356,6 @@ describe('displays specific linode plans for GPU', () => {
     mockGetRegionAvailability(mockRegions[0].id, mockRegionAvailability).as(
       'getRegionAvailability'
     );
-    mockAppendFeatureFlags({
-      placementGroups: makeFeatureFlagData<Flags['gpuv2']>({
-        planDivider: true,
-      }),
-    });
-    mockGetFeatureFlagClientstream();
   });
 
   it('Should render divided tables when GPU divider enabled', () => {

--- a/packages/manager/cypress/e2e/core/placementGroups/create-linode-with-placement-groups.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/create-linode-with-placement-groups.spec.ts
@@ -55,10 +55,6 @@ describe('Linode create flow with Placement Group', () => {
     mockGetRegions(mockRegions).as('getRegions');
     // TODO Remove feature flag mocks when `placementGroups` flag is retired.
     mockAppendFeatureFlags({
-      placementGroups: makeFeatureFlagData<Flags['placementGroups']>({
-        beta: true,
-        enabled: true,
-      }),
       linodeCreateRefactor: makeFeatureFlagData<Flags['linodeCreateRefactor']>(
         false
       ),

--- a/packages/manager/cypress/e2e/core/placementGroups/create-placement-groups.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/create-placement-groups.spec.ts
@@ -1,14 +1,8 @@
-import {
-  mockAppendFeatureFlags,
-  mockGetFeatureFlagClientstream,
-} from 'support/intercepts/feature-flags';
-import { makeFeatureFlagData } from 'support/util/feature-flags';
 import { mockGetAccount } from 'support/intercepts/account';
 import { accountFactory, placementGroupFactory } from 'src/factories';
 import { regionFactory } from 'src/factories';
 import { ui } from 'support/ui/';
 
-import type { Flags } from 'src/featureFlags';
 import { mockGetRegions } from 'support/intercepts/regions';
 import {
   mockCreatePlacementGroup,
@@ -23,14 +17,6 @@ const mockAccount = accountFactory.build();
 
 describe('Placement Group create flow', () => {
   beforeEach(() => {
-    // TODO Remove feature flag mocks when `placementGroups` flag is retired.
-    mockAppendFeatureFlags({
-      placementGroups: makeFeatureFlagData<Flags['placementGroups']>({
-        beta: true,
-        enabled: true,
-      }),
-    });
-    mockGetFeatureFlagClientstream();
     mockGetAccount(mockAccount);
   });
 

--- a/packages/manager/cypress/e2e/core/placementGroups/delete-placement-groups.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/delete-placement-groups.spec.ts
@@ -2,12 +2,6 @@
  * @file Cypress integration tests for VM Placement Groups deletion flows.
  */
 
-import {
-  mockAppendFeatureFlags,
-  mockGetFeatureFlagClientstream,
-} from 'support/intercepts/feature-flags';
-import { makeFeatureFlagData } from 'support/util/feature-flags';
-
 import { mockGetAccount } from 'support/intercepts/account';
 import {
   mockDeletePlacementGroup,
@@ -22,7 +16,6 @@ import {
   placementGroupFactory,
 } from 'src/factories';
 import { headers as emptyStatePageHeaders } from 'src/features/PlacementGroups/PlacementGroupsLanding/PlacementGroupsLandingEmptyStateData';
-import type { Flags } from 'src/featureFlags';
 import { randomLabel, randomNumber } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
 import { ui } from 'support/ui';
@@ -48,14 +41,6 @@ const PlacementGroupErrorMessage = 'An unknown error has occurred.';
 
 describe('Placement Group deletion', () => {
   beforeEach(() => {
-    // TODO Remove feature flag mocks when `placementGroups` flag is retired.
-    mockAppendFeatureFlags({
-      placementGroups: makeFeatureFlagData<Flags['placementGroups']>({
-        beta: true,
-        enabled: true,
-      }),
-    });
-    mockGetFeatureFlagClientstream();
     mockGetAccount(mockAccount);
   });
 

--- a/packages/manager/cypress/e2e/core/placementGroups/placement-groups-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/placement-groups-landing-page.spec.ts
@@ -1,8 +1,3 @@
-import {
-  mockAppendFeatureFlags,
-  mockGetFeatureFlagClientstream,
-} from 'support/intercepts/feature-flags';
-import { makeFeatureFlagData } from 'support/util/feature-flags';
 import { mockGetPlacementGroups } from 'support/intercepts/placement-groups';
 import { ui } from 'support/ui';
 import {
@@ -15,20 +10,11 @@ import { randomLabel, randomNumber } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
 import { mockGetLinodes } from 'support/intercepts/linodes';
 
-import type { Flags } from 'src/featureFlags';
-
 const mockAccount = accountFactory.build();
 
 describe('VM Placement landing page', () => {
   // Mock the VM Placement Groups feature flag to be enabled for each test in this block.
   beforeEach(() => {
-    mockAppendFeatureFlags({
-      placementGroups: makeFeatureFlagData<Flags['placementGroups']>({
-        beta: true,
-        enabled: true,
-      }),
-    });
-    mockGetFeatureFlagClientstream();
     mockGetAccount(mockAccount).as('getAccount');
   });
 

--- a/packages/manager/cypress/e2e/core/placementGroups/placement-groups-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/placement-groups-landing-page.spec.ts
@@ -13,7 +13,6 @@ import { mockGetLinodes } from 'support/intercepts/linodes';
 const mockAccount = accountFactory.build();
 
 describe('VM Placement landing page', () => {
-  // Mock the VM Placement Groups feature flag to be enabled for each test in this block.
   beforeEach(() => {
     mockGetAccount(mockAccount).as('getAccount');
   });

--- a/packages/manager/cypress/e2e/core/placementGroups/placement-groups-linode-assignment.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/placement-groups-linode-assignment.spec.ts
@@ -6,10 +6,6 @@ import {
 } from 'src/factories';
 import { mockGetAccount } from 'support/intercepts/account';
 import {
-  mockAppendFeatureFlags,
-  mockGetFeatureFlagClientstream,
-} from 'support/intercepts/feature-flags';
-import {
   mockGetLinodeDetails,
   mockGetLinodes,
 } from 'support/intercepts/linodes';
@@ -24,12 +20,10 @@ import {
 import { mockGetRegions } from 'support/intercepts/regions';
 import { ui } from 'support/ui';
 import { buildArray } from 'support/util/arrays';
-import { makeFeatureFlagData } from 'support/util/feature-flags';
 import { randomLabel, randomNumber } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
 
 import type { Linode } from '@linode/api-v4';
-import type { Flags } from 'src/featureFlags';
 
 const mockAccount = accountFactory.build();
 
@@ -55,13 +49,6 @@ describe('Placement Groups Linode assignment', () => {
   // Mock the VM Placement Groups feature flag to be enabled for each test in this block.
   // TODO Remove these mocks when `placementGroups` feature flag is retired.
   beforeEach(() => {
-    mockAppendFeatureFlags({
-      placementGroups: makeFeatureFlagData<Flags['placementGroups']>({
-        beta: true,
-        enabled: true,
-      }),
-    });
-    mockGetFeatureFlagClientstream();
     mockGetAccount(mockAccount).as('getAccount');
   });
 

--- a/packages/manager/cypress/e2e/core/placementGroups/placement-groups-linode-assignment.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/placement-groups-linode-assignment.spec.ts
@@ -46,8 +46,6 @@ const mockRegions = regionFactory.buildList(10, {
 });
 
 describe('Placement Groups Linode assignment', () => {
-  // Mock the VM Placement Groups feature flag to be enabled for each test in this block.
-  // TODO Remove these mocks when `placementGroups` feature flag is retired.
   beforeEach(() => {
     mockGetAccount(mockAccount).as('getAccount');
   });

--- a/packages/manager/cypress/e2e/core/placementGroups/placement-groups-navigation.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/placement-groups-navigation.spec.ts
@@ -15,7 +15,6 @@ describe('Placement Groups navigation', () => {
   });
 
   /*
-   * - Confirms that Placement Groups navigation item is shown when feature flag is enabled.
    * - Confirms that clicking Placement Groups navigation item directs user to Placement Groups landing page.
    */
   it('can navigate to Placement Groups landing page', () => {
@@ -26,21 +25,27 @@ describe('Placement Groups navigation', () => {
   });
 
   /*
-   * - Confirms that Placement Groups navigation item is not shown when feature flag is disabled.
+   * - Confirm navigation patterns to the create drawer
    */
-  it('does not show Placement Groups navigation item when feature is disabled', () => {
-    cy.visitWithLogin('/linodes');
-
-    ui.nav.find().within(() => {
-      cy.findByText('Placement Groups').should('not.exist');
-    });
-  });
-
-  /*
-   * - Confirms that manual navigation to Placement Groups landing page with feature is disabled displays Not Found to user.
-   */
-  it('displays Not Found when manually navigating to /placement-groups with feature flag disabled', () => {
+  it.only('can navigate to a placement group details page', () => {
     cy.visitWithLogin('/placement-groups');
-    cy.findByText('Not Found').should('be.visible');
+
+    ui.button
+      .findByTitle('Create Placement Group')
+      .should('be.visible')
+      .click();
+    cy.url().should('endWith', '/placement-groups/create');
+
+    ui.drawer
+      .findByTitle('Create Placement Group')
+      .should('be.visible')
+      .within(() => {
+        ui.button
+          .findByAttribute('aria-label', 'Close drawer')
+          .should('be.visible')
+          .click();
+      });
+
+    cy.url().should('endWith', '/placement-groups');
   });
 });

--- a/packages/manager/cypress/e2e/core/placementGroups/placement-groups-navigation.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/placement-groups-navigation.spec.ts
@@ -2,7 +2,6 @@
  * @file Integration tests for Placement Groups navigation.
  */
 
-import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
 import { mockGetAccount } from 'support/intercepts/account';
 import { accountFactory } from 'src/factories';
 import { ui } from 'support/ui';
@@ -20,15 +19,7 @@ describe('Placement Groups navigation', () => {
    * - Confirms that clicking Placement Groups navigation item directs user to Placement Groups landing page.
    */
   it('can navigate to Placement Groups landing page', () => {
-    mockAppendFeatureFlags({
-      placementGroups: {
-        beta: true,
-        enabled: true,
-      },
-    }).as('getFeatureFlags');
-
     cy.visitWithLogin('/linodes');
-    cy.wait('@getFeatureFlags');
 
     ui.nav.findItemByTitle('Placement Groups').should('be.visible').click();
     cy.url().should('endWith', '/placement-groups');
@@ -38,15 +29,7 @@ describe('Placement Groups navigation', () => {
    * - Confirms that Placement Groups navigation item is not shown when feature flag is disabled.
    */
   it('does not show Placement Groups navigation item when feature is disabled', () => {
-    mockAppendFeatureFlags({
-      placementGroups: {
-        beta: true,
-        enabled: false,
-      },
-    }).as('getFeatureFlags');
-
     cy.visitWithLogin('/linodes');
-    cy.wait('@getFeatureFlags');
 
     ui.nav.find().within(() => {
       cy.findByText('Placement Groups').should('not.exist');
@@ -57,16 +40,7 @@ describe('Placement Groups navigation', () => {
    * - Confirms that manual navigation to Placement Groups landing page with feature is disabled displays Not Found to user.
    */
   it('displays Not Found when manually navigating to /placement-groups with feature flag disabled', () => {
-    mockAppendFeatureFlags({
-      placementGroups: {
-        beta: true,
-        enabled: false,
-      },
-    }).as('getFeatureFlags');
-
     cy.visitWithLogin('/placement-groups');
-    cy.wait('@getFeatureFlags');
-
     cy.findByText('Not Found').should('be.visible');
   });
 });

--- a/packages/manager/cypress/e2e/core/placementGroups/update-placement-group-label.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/update-placement-group-label.spec.ts
@@ -2,11 +2,6 @@
  * @file Integration tests for Placement Group update label flows.
  */
 
-import {
-  mockAppendFeatureFlags,
-  mockGetFeatureFlagClientstream,
-} from 'support/intercepts/feature-flags';
-import { makeFeatureFlagData } from 'support/util/feature-flags';
 import { randomLabel, randomNumber } from 'support/util/random';
 import {
   mockGetPlacementGroups,
@@ -15,7 +10,6 @@ import {
 } from 'support/intercepts/placement-groups';
 import { accountFactory, placementGroupFactory } from 'src/factories';
 import { mockGetAccount } from 'support/intercepts/account';
-import type { Flags } from 'src/featureFlags';
 import { chooseRegion } from 'support/util/regions';
 import { ui } from 'support/ui';
 
@@ -24,13 +18,6 @@ const mockAccount = accountFactory.build();
 describe('Placement Group update label flow', () => {
   // Mock the VM Placement Groups feature flag to be enabled for each test in this block.
   beforeEach(() => {
-    mockAppendFeatureFlags({
-      placementGroups: makeFeatureFlagData<Flags['placementGroups']>({
-        beta: true,
-        enabled: true,
-      }),
-    });
-    mockGetFeatureFlagClientstream();
     mockGetAccount(mockAccount);
   });
 

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -173,7 +173,6 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
           hide: !isPlacementGroupsEnabled,
           href: '/placement-groups',
           icon: <PlacementGroups />,
-          isBeta: flags.placementGroups?.beta,
         },
       ],
       [
@@ -251,7 +250,6 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
       allowMarketplacePrefetch,
       flags.dbaasV2,
       isPlacementGroupsEnabled,
-      flags.placementGroups,
       isACLPEnabled,
     ]
   );

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -28,7 +28,6 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'linodeDiskEncryption', label: 'Linode Disk Encryption (LDE)' },
   { flag: 'objMultiCluster', label: 'OBJ Multi-Cluster' },
   { flag: 'objectStorageGen2', label: 'OBJ Gen2' },
-  { flag: 'placementGroups', label: 'Placement Groups' },
   { flag: 'selfServeBetas', label: 'Self Serve Betas' },
   { flag: 'supportTicketSeverity', label: 'Support Ticket Severity' },
   { flag: 'dbaasV2', label: 'Databases V2 Beta' },

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -107,7 +107,6 @@ export interface Flags {
   objectStorageGen2: BaseFeatureFlag;
   oneClickApps: OneClickApp;
   oneClickAppsDocsOverride: Record<string, Doc[]>;
-  placementGroups: BetaFeatureFlag;
   productInformationBanners: ProductInformationBannerFlag[];
   promos: boolean;
   promotionalOffers: PromotionalOffer[];

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Details/Details.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Details/Details.test.tsx
@@ -41,12 +41,9 @@ describe('Linode Create Details', () => {
     ).toBeVisible();
   });
 
-  it('renders an placement group details if the flag is on', async () => {
+  it('renders an placement group details', async () => {
     const { getByText } = renderWithThemeAndHookFormContext({
       component: <Details />,
-      options: {
-        flags: { placementGroups: { beta: true, enabled: true } },
-      },
     });
 
     await waitFor(() => {
@@ -56,19 +53,6 @@ describe('Linode Create Details', () => {
         )
       ).toBeVisible();
     });
-  });
-
-  it('does not render the placement group select if the flag is off', () => {
-    const { queryByText } = renderWithThemeAndHookFormContext({
-      component: <Details />,
-      options: {
-        flags: { placementGroups: { beta: true, enabled: false } },
-      },
-    });
-
-    expect(
-      queryByText('Select a region above to see available Placement Groups.')
-    ).toBeNull();
   });
 
   it('does not render the tag select when cloning', () => {

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Details/Details.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Details/Details.test.tsx
@@ -41,7 +41,7 @@ describe('Linode Create Details', () => {
     ).toBeVisible();
   });
 
-  it('renders an placement group details', async () => {
+  it('renders a placement group details', async () => {
     const { getByText } = renderWithThemeAndHookFormContext({
       component: <Details />,
     });

--- a/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.test.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/ConfigureForm.test.tsx
@@ -174,10 +174,7 @@ describe('ConfigureForm component with price comparison', () => {
         {...props}
         currentRegion="us-east"
         selectedRegion="us-central"
-      />,
-      {
-        flags: { placementGroups: { beta: true, enabled: true } },
-      }
+      />
     );
 
     // Verify that the PlacementGroupsSelect component is rendered

--- a/packages/manager/src/features/PlacementGroups/utils.test.ts
+++ b/packages/manager/src/features/PlacementGroups/utils.test.ts
@@ -217,12 +217,7 @@ describe('getPlacementGroupLinodes', () => {
 });
 
 describe('useIsPlacementGroupsEnabled', () => {
-  it('returns true if the feature flag is enabled and the account has the Placement Group capability', () => {
-    queryMocks.useFlags.mockReturnValue({
-      placementGroups: {
-        enabled: true,
-      },
-    });
+  it('returns true if the account has the Placement Group capability', () => {
     queryMocks.useAccount.mockReturnValue({
       data: {
         capabilities: ['Placement Group'],
@@ -235,23 +230,6 @@ describe('useIsPlacementGroupsEnabled', () => {
     });
   });
 
-  it('returns false if the feature flag is disabled', () => {
-    queryMocks.useFlags.mockReturnValue({
-      placementGroups: {
-        enabled: false,
-      },
-    });
-    queryMocks.useAccount.mockReturnValue({
-      data: {
-        capabilities: ['Placement Group'],
-      },
-    });
-
-    const { result } = renderHook(() => useIsPlacementGroupsEnabled());
-    expect(result.current).toStrictEqual({
-      isPlacementGroupsEnabled: false,
-    });
-  });
   it('returns false if the account does not have the Placement Group capability', () => {
     queryMocks.useFlags.mockReturnValue({
       placementGroups: {

--- a/packages/manager/src/features/PlacementGroups/utils.ts
+++ b/packages/manager/src/features/PlacementGroups/utils.ts
@@ -132,12 +132,8 @@ export const useIsPlacementGroupsEnabled = (): {
     return { isPlacementGroupsEnabled: false };
   }
 
-  const hasAccountCapability = account?.capabilities?.includes(
-    'Placement Group'
-  );
-  const isFeatureFlagEnabled = flags.placementGroups?.enabled;
   const isPlacementGroupsEnabled = Boolean(
-    hasAccountCapability && isFeatureFlagEnabled
+    account?.capabilities?.includes('Placement Group')
   );
 
   return { isPlacementGroupsEnabled };


### PR DESCRIPTION
## Description 📝
Update CM codebase to remove `placementGroups` flag logic.

This is should bring no changes to the feature nor introduce any regressions

## Changes  🔄
List any change relevant to the reviewer.
- Remove flag
- Remove flag tool
- Update unit & e2e tests

## How to test 🧪

### Prerequisites

### Verification steps

- Verify Placement Groups feature is available as a general feature (main navigation and feature details)
- Confirm tests are accurate and passing without flag logic


## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
