### PR TITLE
test: [M3-6615, M3-8507] - Cypress test for empty Linode landing page and restricted user Linode landing page 

### DIFF
--- a/packages/manager/.changeset/pr-10882-tests-1725437459486.md
+++ b/packages/manager/.changeset/pr-10882-tests-1725437459486.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Cypress test for empty Linode landing page and restricted user Linode landing page ([#10882](https://github.com/linode/manager/pull/10882))

--- a/packages/manager/cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
@@ -15,11 +15,17 @@ import { apiMatcher } from 'support/util/intercepts';
 import { chooseRegion, getRegionById } from 'support/util/regions';
 import { authenticate } from 'support/api/authentication';
 import { mockGetLinodes } from 'support/intercepts/linodes';
-import { userPreferencesFactory } from '@src/factories';
+import { userPreferencesFactory, profileFactory } from '@src/factories';
+import { accountUserFactory } from '@src/factories/accountUsers';
+import { grantsFactory } from '@src/factories/grants';
+import { mockGetUser } from 'support/intercepts/account';
 import {
   mockGetUserPreferences,
   mockUpdateUserPreferences,
+  mockGetProfile,
+  mockGetProfileGrants,
 } from 'support/intercepts/profile';
+import { randomLabel } from 'support/util/random';
 
 const mockLinodes = new Array(5).fill(null).map(
   (_item: null, index: number): Linode => {
@@ -32,6 +38,10 @@ const mockLinodes = new Array(5).fill(null).map(
 );
 
 const mockLinodesData = makeResourcePage(mockLinodes);
+
+const emptyLinode: Linode[] = [];
+
+const emptyLinodeData = makeResourcePage(emptyLinode);
 
 const sortByRegion = (a: Linode, b: Linode) => {
   return a.region.localeCompare(b.region);
@@ -384,5 +394,117 @@ describe('linode landing checks', () => {
     cy.findByText('Region:').should('not.exist');
     cy.findByText('Linode ID:').should('not.exist');
     cy.findByText('Created:').should('not.exist');
+  });
+});
+
+describe('linode landing checks for empty state', () => {
+  beforeEach(() => {
+    const mockAccountSettings = accountSettingsFactory.build({
+      managed: false,
+    });
+
+    cy.intercept('GET', apiMatcher('account/settings'), (req) => {
+      req.reply(mockAccountSettings);
+    }).as('getAccountSettings');
+    cy.intercept('GET', apiMatcher('profile')).as('getProfile');
+    cy.intercept('GET', apiMatcher('linode/instances/*'), (req) => {
+      req.reply(emptyLinodeData);
+    });
+    cy.visitWithLogin('/', { preferenceOverrides });
+    cy.wait('@getAccountSettings');
+    cy.url().should('endWith', routes.linodeLanding);
+  });
+
+  it('checks empty state on linode landing page', () => {
+    cy.get('div[data-qa-placeholder-container="resources-section"]').as(
+      'resourcesSection'
+    );
+    cy.get('@resourcesSection')
+      .get('h1[data-qa-header]')
+      .contains('Linodes')
+      .as('linodesHeader');
+
+    // Assert that fields with Linodes and Cloud-based virtual machines text are visible
+    cy.get('@linodesHeader').should('be.visible');
+    cy.get('@linodesHeader')
+      .next('h2')
+      .should('be.visible')
+      .should('have.text', 'Cloud-based virtual machines');
+
+    //Assert that recommended section is visible - Getting Started Guides, Deploy an App and Video Playlist
+    cy.get('@resourcesSection')
+      .contains('h2', 'Getting Started Guides')
+      .should('be.visible');
+    cy.get('@resourcesSection')
+      .contains('h2', 'Deploy an App')
+      .should('be.visible');
+    cy.get('@resourcesSection')
+      .contains('h2', 'Video Playlist')
+      .should('be.visible');
+
+    // Assert that Create Linode button is visible and enabled
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .and('be.enabled');
+
+    // Assert that List of Liondes table does not exist
+    cy.get('table[aria-label="List of Linodes"]').should('not.exist');
+
+    // Assert that Docs link does not exist
+    cy.get(
+      'a[aria-label="Docs - link opens in a new tab"][data-testid="external-link"]'
+    ).should('not.exist');
+
+    // Assert that Download CSV button does not exist
+    cy.get('span[data-testid="loadingIcon"]')
+      .contains('Download CSV')
+      .should('not.exist');
+  });
+});
+
+describe('linode landing checks for restricted user', () => {
+  beforeEach(() => {
+    const mockProfile = profileFactory.build({
+      username: randomLabel(),
+      restricted: true,
+    });
+
+    const mockUser = accountUserFactory.build({
+      username: mockProfile.username,
+      restricted: true,
+      user_type: 'default',
+    });
+
+    const mockGrants = grantsFactory.build({
+      global: {
+        add_linodes: false,
+      },
+    });
+
+    mockGetProfile(mockProfile);
+    mockGetProfileGrants(mockGrants);
+    mockGetUser(mockUser);
+    cy.intercept('GET', apiMatcher('linode/instances/*'), (req) => {
+      req.reply(emptyLinodeData);
+    });
+    cy.visitWithLogin('/', { preferenceOverrides });
+    cy.url().should('endWith', routes.linodeLanding);
+  });
+
+  it('checks restricted user has no access to create linode on linode landing page', () => {
+    // Assert that Create Linode button is visible and disabled
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .and('be.disabled')
+      .trigger('mouseover');
+
+    // Assert that tooltip is visible with message
+    ui.tooltip
+      .findByText(
+        "You don't have permissions to create Linodes. Please contact your account administrator to request the necessary permissions."
+      )
+      .should('be.visible');
   });
 });


### PR DESCRIPTION
## Description 📝
Added cypress test for empty Linode landing page and restricted user Linode landing page  

## Changes  🔄
Added below cypress tests under in spec file - cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
- checks empty state on linode landing page
- checks restricted user has no access to create linode on linode landing page

## PRs
- M3-6615
- M3-8507

## How to test 🧪
`yarn cy:run -s cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts`

### Verification steps
When test executed using this command  `yarn cy:run -s cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts`all tests should pass successfully and you should see new test added as per below screenshot 

![image](https://github.com/user-attachments/assets/1833d68f-9d85-45fb-8e12-1cd246bef08f)


## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
