### PR TITLE
tech story: [M3-8423] - Resolve "Incomplete string escape or encoding" in generate-ansibleConfig.test.ts

### DIFF
--- a/packages/manager/.changeset/pr-10887-tech-stories-1725467686328.md
+++ b/packages/manager/.changeset/pr-10887-tech-stories-1725467686328.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Resolve "Incomplete string escape or encoding" codeQL alert in `generate-ansibleConfig.ts` ([#10887](https://github.com/linode/manager/pull/10887))

--- a/packages/manager/src/utilities/codesnippets/generate-ansibleConfig.test.ts
+++ b/packages/manager/src/utilities/codesnippets/generate-ansibleConfig.test.ts
@@ -43,4 +43,17 @@ describe('generateAnsibleConfig', () => {
 
     expect(generateAnsibleConfig(config)).toEqual(expectedOutput);
   });
+
+  it('should escape backslash characters in YAML strings', () => {
+    const config = {
+      label: 'Linode with ] and also [, }, and \\{',
+      region: 'us-central',
+      root_pass: 'securePass123',
+      type: 'g6-standard-1',
+    };
+
+    const expectedOutput = `- name: Create a new Linode instance.\n  linode.cloud.instance:\n    state: "present"\n    label: "Linode with \\] and also \\[, \\}, and \\\\\\{"\n    type: "g6-standard-1"\n    region: "us-central"\n    root_pass: "securePass123"\n`;
+
+    expect(generateAnsibleConfig(config)).toEqual(expectedOutput);
+  });
 });

--- a/packages/manager/src/utilities/codesnippets/generate-ansibleConfig.test.ts
+++ b/packages/manager/src/utilities/codesnippets/generate-ansibleConfig.test.ts
@@ -44,15 +44,15 @@ describe('generateAnsibleConfig', () => {
     expect(generateAnsibleConfig(config)).toEqual(expectedOutput);
   });
 
-  it('should escape backslash characters in YAML strings', () => {
+  it('should safely escape extra backslash characters in YAML strings', () => {
     const config = {
-      label: 'Linode with ] and also [, }, and \\{',
+      label: 'Linode with ] and also \\[, }, and \\{',
       region: 'us-central',
       root_pass: 'securePass123',
       type: 'g6-standard-1',
     };
 
-    const expectedOutput = `- name: Create a new Linode instance.\n  linode.cloud.instance:\n    state: "present"\n    label: "Linode with \\] and also \\[, \\}, and \\\\\\{"\n    type: "g6-standard-1"\n    region: "us-central"\n    root_pass: "securePass123"\n`;
+    const expectedOutput = `- name: Create a new Linode instance.\n  linode.cloud.instance:\n    state: "present"\n    label: "Linode with \\] and also \\\\\\[, \\}, and \\\\\\{"\n    type: "g6-standard-1"\n    region: "us-central"\n    root_pass: "securePass123"\n`;
 
     expect(generateAnsibleConfig(config)).toEqual(expectedOutput);
   });

--- a/packages/manager/src/utilities/codesnippets/generate-ansibleConfig.ts
+++ b/packages/manager/src/utilities/codesnippets/generate-ansibleConfig.ts
@@ -6,7 +6,7 @@ import type { CreateLinodeRequest } from '@linode/api-v4/lib/linodes';
  * @returns {string} - The safely escaped string.
  */
 function escapeYAMLString(str: string) {
-  return str.replace(/(["':\[\]\{\}])/g, '\\$1').replace(/\n/g, '\\n');
+  return str.replace(/(["':\\\[\\\]\\\{\\\}])/g, '\\$1').replace(/\n/g, '\\n');
 }
 
 /**


### PR DESCRIPTION
## Description 📝
- Resolve codeQL alert due to not escaping backslashes by updating regex
- Added test case for the special characters not yet tested for

## Target release date 🗓️
n/a

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/77148147-ba6c-4ca0-8140-211a2d6c994d) | ![image](https://github.com/user-attachments/assets/50a11d31-c5b3-4f16-9690-4608a4f0463f) |

## How to test 🧪

### Prerequisites
Here are the steps I took to setup codeQL on vscode. Not sure if this is the most straightforward way, but it (seems to have) worked 😅 
- download the codeQL extension on vscode
- follow along to [this guide](https://luisrangelc.medium.com/analyze-vulnerabilities-in-your-code-with-codeql-locally-3e5d31f8ed2)
  - I used the most up to date version (2.18.3) when downloading codeQL CLI this time around, but I remember using the version listed in the guide for a prior ticket, and that had worked too. (I believe VS code also automatically updates the CLI to v2.18.3 for you if you use the guide's version - ty @mjac0bs!)
  - You don't actually need the vscode extension if you follow this guide to completion. I stopped after the creating a database portion and just used the extension from there. Run the create database command in the `manager/src/utilities/codesnippets` package - I had trouble when trying to create a database with the entirety of manager
- Open up `codeql-repo` (naming conventions from the guide ^) in vscode, click on the QL tab in the sidebar, and select the database you just created
![image](https://github.com/user-attachments/assets/95ca09e6-a525-4ce2-8897-e3da1d0d99a3)

### Verification steps
- run the `IncompleteSanitization.ql` query and confirm warning is gone (codeql-repo >> javascript >> ql >> src >> Security >> CWE-116 >> IncompleteSanitization.ql)
![image](https://github.com/user-attachments/assets/0e9ff27e-9975-41de-b0bb-814da75d9d34)

- **NOTE** if you want to run this query on both develop (to see the warning) and this branch (to confirm it's gone), you will need to create DBs for both develop and this branch...the DB does not automatically update

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

