### PR TITLE
test: [M3-8471] - Allow Cypress region selection to work with Gecko options improvements

### DIFF
--- a/packages/manager/.changeset/pr-10888-tests-1725482771826.md
+++ b/packages/manager/.changeset/pr-10888-tests-1725482771826.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Update region selection helpers to account for upcoming Gecko improvements ([#10888](https://github.com/linode/manager/pull/10888))

--- a/packages/manager/cypress/support/ui/autocomplete.ts
+++ b/packages/manager/cypress/support/ui/autocomplete.ts
@@ -33,7 +33,7 @@ export const autocompletePopper = {
    * Finds an item within an autocomplete popper that has the given title.
    */
   findByTitle: (
-    title: string,
+    title: string | RegExp,
     options?: SelectorMatcherOptions
   ): Cypress.Chainable => {
     return (
@@ -90,7 +90,9 @@ export const regionSelect = {
    */
   findItemByRegionId: (regionId: string, searchRegions?: Region[]) => {
     const region = getRegionById(regionId, searchRegions);
-    return autocompletePopper.findByTitle(`${region.label} (${region.id})`);
+    return autocompletePopper.findByTitle(
+      new RegExp(`${region.label}\\s?(\(${region.id}\))?`)
+    );
   },
 
   /**
@@ -105,6 +107,8 @@ export const regionSelect = {
    */
   findItemByRegionLabel: (regionLabel: string, searchRegions?: Region[]) => {
     const region = getRegionByLabel(regionLabel, searchRegions);
-    return autocompletePopper.findByTitle(`${region.label} (${region.id})`);
+    return autocompletePopper.findByTitle(
+      new RegExp(`${region.label}\\s?(\(${region.id}\))?`)
+    );
   },
 };


### PR DESCRIPTION
## Description 📝
This updates the `ui.regionSelect.findItemById()` and `ui.regionSelect.findItemByLabel()` helpers so that they work when the upcoming Gecko changes are enabled and disabled. Previously, these helpers would fail to select a region when Gecko is enabled due to the layout improvements made to the region selection options.

## Changes  🔄

- Use RegEx to let `ui.regionSelect.findItemById()` and `ui.regionSelect.findItemByLabel()` work with and without Gecko

## Target release date 🗓️
N/A

## How to test 🧪

### Prerequisites:
Use a test account with Gecko enabled and set `MANAGER_OAUTH` in `.env` to a PAT belonging to the account, and run Cloud against a LaunchDarkly environment where the Gecko feature flag is enabled.

### Reproduction steps
On `develop`:

- Build & serve Cloud via `yarn && yarn build && yarn start:manager:ci`
- Run `yarn cy:debug`
- Search for the `gdpr-agreement.spec.ts` spec and run it
- Observe that it fails when attempting to select a region

### Verification steps
On this branch:

- Build & serve Cloud via `yarn && yarn build && yarn start:manager:ci`
- Run `yarn cy:debug`
- Search for the `gdpr-agreement.spec.ts` spec and run it
- Confirm that test passes
- (Optional) Repeat steps with Gecko disabled, confirm tests still pass
  - ℹ️ Our CI will fail if there are any issues when Gecko is not enabled

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
