### PR TITLE
fix: [M3-8529] - Weblish line wrapping

### DIFF
--- a/packages/manager/.changeset/pr-10893-fixed-1725548041320.md
+++ b/packages/manager/.changeset/pr-10893-fixed-1725548041320.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Weblish line wrapping ([#10893](https://github.com/linode/manager/pull/10893))

--- a/packages/manager/src/features/Lish/Weblish.tsx
+++ b/packages/manager/src/features/Lish/Weblish.tsx
@@ -107,7 +107,7 @@ export class Weblish extends React.Component<Props, State> {
     const { group, label } = linode;
 
     this.terminal = new Terminal({
-      cols: 120,
+      cols: 80,
       cursorBlink: true,
       fontFamily: '"Ubuntu Mono", monospace, sans-serif',
       rows: 40,


### PR DESCRIPTION
## Description 📝
When working on file edits in Weblish, current line wrapping makes it impossible to edit certain lines because of the way our columns are set up. Weblish is visually showing additional characters past 80 columns on the same line while the cursor behaves as though the line is soft wrapped.

## Changes  🔄
- Set Weblish terminal `cols` to `80` to match default LISH over ssh behavior 

## Target release date 🗓️
**9/16/2024**

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/01015715-5e07-4ce2-9308-bfc6d5483f93" /> | <video src="https://github.com/user-attachments/assets/7820e8ab-c261-4e3a-b08f-632f888bab3b" /> |

## How to test 🧪

### Reproduction steps
1. Create Ubuntu 24.04 Nanode in Miami
2. Once provisioned, click Launch LISH Console in Cloud Manager
3. Login through Weblish as root
3. Enter command vim /etc/ssh/sshd_config
4. Try to edit the #Port 22 line with i to enter INSERT mode
5. Observe you cannot use the right arrow key to move the cursor on the line

### Verification steps
- Pull code locally, and very the behavior is now fixed with the steps above

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support


