### PR TITLE
fix: [M3-7916] - Typo with Toast Success Notification For Updating Reverse DNS

### DIFF
--- a/packages/manager/cypress/e2e/core/linodes/linode-network.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/linode-network.spec.ts
@@ -1,0 +1,89 @@
+import type { Linode } from '@linode/api-v4';
+
+import { createLinodeRequestFactory } from '@src/factories';
+
+import { authenticate } from 'support/api/authentication';
+import { interceptGetLinode } from 'support/intercepts/linodes';
+import { interceptUpdateIPAddress } from 'support/intercepts/networking';
+import { cleanUp } from 'support/util/cleanup';
+import { createTestLinode } from 'support/util/linodes';
+import { randomLabel } from 'support/util/random';
+import { chooseRegion } from 'support/util/regions';
+import { ui } from 'support/ui';
+
+authenticate();
+describe('linode networking', () => {
+  before(() => {
+    cleanUp('linodes');
+  });
+
+  /**
+   * - Confirms flow for editing the RDNS of an IP address
+   * - Confirms toast message upon editing RDNS
+   */
+  it('can edit the RDNS of an IP address', () => {
+    const createLinodeRequest = createLinodeRequestFactory.build({
+      label: randomLabel(),
+      region: chooseRegion().id,
+      backups_enabled: false,
+      booted: false,
+    });
+
+    cy.defer(
+      () => createTestLinode(createLinodeRequest),
+      'creating Linode'
+    ).then((linode: Linode) => {
+      interceptGetLinode(linode.id).as('getLinode');
+
+      cy.visitWithLogin(`linodes/${linode.id}/networking`);
+      cy.wait(['@getLinode']);
+
+      cy.findByLabelText('IPv4 Addresses')
+        .should('be.visible')
+        .within(() => {
+          // confirm table headers
+          cy.get('thead').findByText('Address').should('be.visible');
+          cy.get('thead').findByText('Type').should('be.visible');
+          cy.get('thead').findByText('Default Gateway').should('be.visible');
+          cy.get('thead').findByText('Subnet Mask').should('be.visible');
+          cy.get('thead').findByText('Reverse DNS').should('be.visible');
+        });
+
+      const linodeIPv4 = linode.ipv4.length > 0 ? linode.ipv4[0] : '';
+      interceptUpdateIPAddress(linodeIPv4).as('updateIPAddress');
+
+      // confirm row for Linode's (first) IPv4 exists and open up the RDNS drawer
+      cy.get(`[data-qa-ip="${linodeIPv4}"]`)
+        .should('be.visible')
+        .closest('tr')
+        .within(() => {
+          cy.findByText('IPv4 – Public').should('be.visible');
+
+          // open up the edit RDNS drawer
+          cy.get('[data-testid="action-menu-item-edit-rdns"]')
+            .should('be.visible')
+            .click();
+        });
+
+      // confirm RDNS drawer is visible
+      ui.drawer
+        .findByTitle('Edit Reverse DNS')
+        .should('be.visible')
+        .within(() => {
+          cy.findByText('Leave this field blank to reset RDNS').should(
+            'be.visible'
+          );
+
+          // click Save button
+          cy.findByText('Save')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      // confirm RDNS toast message
+      cy.wait('@updateIPAddress');
+      ui.toast.assertMessage(`Successfully updated RDNS for ${linodeIPv4}`);
+    });
+  });
+});

--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -4,9 +4,9 @@
 
 import { makeErrorResponse } from 'support/util/errors';
 import { apiMatcher } from 'support/util/intercepts';
+import { linodeVlanNoInternetConfig } from 'support/util/linodes';
 import { paginateResponse } from 'support/util/paginate';
 import { makeResponse } from 'support/util/response';
-import { linodeVlanNoInternetConfig } from 'support/util/linodes';
 
 import type { Disk, Kernel, Linode, LinodeType, Volume } from '@linode/api-v4';
 
@@ -482,7 +482,8 @@ export const mockGetLinodeKernel = (
   );
 };
 
-/* Intercepts POST request to get a Linode Resize.
+/**
+ * Intercepts POST request to get a Linode Resize.
  *
  * @param linodeId - ID of Linode to fetch.
  *

--- a/packages/manager/cypress/support/intercepts/networking.ts
+++ b/packages/manager/cypress/support/intercepts/networking.ts
@@ -1,0 +1,14 @@
+import { apiMatcher } from 'support/util/intercepts';
+
+/**
+ * Intercepts PUT request to update an IP address.
+ *
+ * @param address - the IP address to update
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptUpdateIPAddress = (
+  address: string
+): Cypress.Chainable<null> => {
+  return cy.intercept('PUT', apiMatcher(`/networking/ips/${address}`));
+};

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditIPRDNSDrawer.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditIPRDNSDrawer.test.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { EditIPRDNSDrawer } from './EditIPRDNSDrawer';
+
+const props = {
+  ip: undefined,
+  onClose: vi.fn(),
+  open: true,
+}
+
+describe('EditIPRDNSDrawer', () => {
+  it('renders the drawer correctly', () => {
+
+  });
+
+  it('closes the drawer', () => {
+
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditIPRDNSDrawer.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditIPRDNSDrawer.test.tsx
@@ -1,21 +1,39 @@
+import { fireEvent } from '@testing-library/react';
 import * as React from 'react';
 
+import { ipAddressFactory } from 'src/factories';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { EditIPRDNSDrawer } from './EditIPRDNSDrawer';
 
 const props = {
-  ip: undefined,
+  ip: ipAddressFactory.build({ rdns: '' }),
   onClose: vi.fn(),
   open: true,
-}
+};
 
 describe('EditIPRDNSDrawer', () => {
   it('renders the drawer correctly', () => {
+    const { getAllByRole, getByText } = renderWithTheme(
+      <EditIPRDNSDrawer {...props} />
+    );
 
+    // confirm drawer title and form fields render
+    expect(getByText('Edit Reverse DNS')).toBeVisible();
+    expect(getByText('Leave this field blank to reset RDNS')).toBeVisible();
+    expect(getByText('Enter a domain name')).toBeVisible();
+
+    // confirm buttons render
+    expect(getAllByRole('button')).toHaveLength(3);
+    expect(getByText('Cancel')).toBeVisible();
+    expect(getByText('Save')).toBeVisible();
   });
 
   it('closes the drawer', () => {
+    const { getByText } = renderWithTheme(<EditIPRDNSDrawer {...props} />);
 
+    const cancelButton = getByText('Cancel');
+    fireEvent.click(cancelButton);
+    expect(props.onClose).toHaveBeenCalled();
   });
 });

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditIPRDNSDrawer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditIPRDNSDrawer.tsx
@@ -45,17 +45,20 @@ export const EditIPRDNSDrawer = (props: Props) => {
     },
   });
 
-  React.useEffect(() => {
-    if (open) {
-      reset();
-      formik.resetForm();
-    }
-  }, [open]);
+  const onExited = () => {
+    formik.resetForm();
+    reset();
+  };
 
   const errorMap = getErrorMap(['rdns'], error);
 
   return (
-    <Drawer onClose={onClose} open={open} title="Edit Reverse DNS">
+    <Drawer
+      onClose={onClose}
+      open={open}
+      title="Edit Reverse DNS"
+      onExited={onExited}
+    >
       <form onSubmit={formik.handleSubmit}>
         {Boolean(errorMap.none) && (
           <Notice variant="error">{errorMap.none}</Notice>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditIPRDNSDrawer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditIPRDNSDrawer.tsx
@@ -38,7 +38,7 @@ export const EditIPRDNSDrawer = (props: Props) => {
         address: ip?.address ?? '',
         rdns: values.rdns === '' ? null : values.rdns,
       });
-      enqueueSnackbar(`Successfully updated RNS for ${ip?.address}`, {
+      enqueueSnackbar(`Successfully updated RDNS for ${ip?.address}`, {
         variant: 'success',
       });
       onClose();

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditIPRDNSDrawer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditIPRDNSDrawer.tsx
@@ -1,4 +1,3 @@
-import { IPAddress } from '@linode/api-v4/lib/networking';
 import { useFormik } from 'formik';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
@@ -10,6 +9,8 @@ import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
 import { useLinodeIPMutation } from 'src/queries/linodes/networking';
 import { getErrorMap } from 'src/utilities/errorUtils';
+
+import type { IPAddress } from '@linode/api-v4/lib/networking';
 
 interface Props {
   ip: IPAddress | undefined;
@@ -55,9 +56,9 @@ export const EditIPRDNSDrawer = (props: Props) => {
   return (
     <Drawer
       onClose={onClose}
+      onExited={onExited}
       open={open}
       title="Edit Reverse DNS"
-      onExited={onExited}
     >
       <form onSubmit={formik.handleSubmit}>
         {Boolean(errorMap.none) && (

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditIPRDNSDrawer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditIPRDNSDrawer.tsx
@@ -84,7 +84,7 @@ export const EditIPRDNSDrawer = (props: Props) => {
             loading: isPending,
             type: 'submit',
           }}
-          secondaryButtonProps={{ label: 'cancel', onClick: onClose }}
+          secondaryButtonProps={{ label: 'Cancel', onClick: onClose }}
           style={{ marginTop: 16 }}
         />
       </form>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditRangeRDNSDrawer.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditRangeRDNSDrawer.test.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { EditRangeRDNSDrawer } from './EditRangeRDNSDrawer';
+
+const props = {
+  linodeId: 1,
+  onClose: vi.fn(),
+  open: true,
+  range: undefined,
+}
+
+describe('EditRangeRDNSDrawer', () => {
+  it('renders the drawer correctly', () => {
+
+  });
+
+  it('closes the drawer', () => {
+
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditRangeRDNSDrawer.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditRangeRDNSDrawer.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/react';
 import * as React from 'react';
 
 import { renderWithTheme } from 'src/utilities/testHelpers';
@@ -9,14 +10,31 @@ const props = {
   onClose: vi.fn(),
   open: true,
   range: undefined,
-}
+};
 
 describe('EditRangeRDNSDrawer', () => {
   it('renders the drawer correctly', () => {
+    const { getAllByRole, getByText } = renderWithTheme(
+      <EditRangeRDNSDrawer {...props} />
+    );
 
+    // confirm drawer title and fields render
+    expect(getByText('Edit Reverse DNS')).toBeVisible();
+    expect(getByText('Enter an IPv6 address')).toBeVisible();
+    expect(getByText('Enter a domain name')).toBeVisible();
+    expect(getByText('Leave this field blank to reset RDNS')).toBeVisible();
+
+    // confirm buttons render
+    expect(getAllByRole('button')).toHaveLength(3);
+    expect(getByText('Close')).toBeVisible();
+    expect(getByText('Save')).toBeVisible();
   });
 
   it('closes the drawer', () => {
+    const { getByText } = renderWithTheme(<EditRangeRDNSDrawer {...props} />);
 
+    const cancelButton = getByText('Close');
+    fireEvent.click(cancelButton);
+    expect(props.onClose).toHaveBeenCalled();
   });
 });

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditRangeRDNSDrawer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditRangeRDNSDrawer.tsx
@@ -70,17 +70,20 @@ export const EditRangeRDNSDrawer = (props: Props) => {
 
   const theme = useTheme();
 
-  React.useEffect(() => {
-    if (open) {
-      formik.resetForm();
-      reset();
-    }
-  }, [open]);
+  const onExited = () => {
+    formik.resetForm();
+    reset();
+  };
 
   const errorMap = getErrorMap(['rdns'], error);
 
   return (
-    <Drawer onClose={onClose} open={open} title="Edit Reverse DNS">
+    <Drawer
+      onClose={onClose}
+      onExited={onExited}
+      open={open}
+      title="Edit Reverse DNS"
+    >
       <form onSubmit={formik.handleSubmit}>
         {Boolean(errorMap.none) && (
           <Notice data-qa-error style={{ marginTop: 16 }} variant="error">
@@ -133,7 +136,7 @@ export const EditRangeRDNSDrawer = (props: Props) => {
             Existing Records
           </Typography>
           {ips.map((ip) => (
-            <div style={{ marginTop: theme.spacing(2) }} key={ip.address}>
+            <div key={ip.address} style={{ marginTop: theme.spacing(2) }}>
               <Typography>{ip.address}</Typography>
               <Typography>{ip.rdns || ''}</Typography>
             </div>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditRangeRDNSDrawer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/EditRangeRDNSDrawer.tsx
@@ -61,7 +61,7 @@ export const EditRangeRDNSDrawer = (props: Props) => {
         address: values.address ?? '',
         rdns: values.rdns === '' ? null : values.rdns,
       });
-      enqueueSnackbar(`Successfully updated RNS for ${range?.range}`, {
+      enqueueSnackbar(`Successfully updated RDNS for ${range?.range}`, {
         variant: 'success',
       });
       onClose();


### PR DESCRIPTION
## Description 📝
- fix typo with toast success notification when updating reverse DNS

## Changes  🔄
- fix typo
- add e2e test to confirm typo is fixed
- added some unit tests
- other small cleanup

## Target release date 🗓️
n/a

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/c334abc7-edf6-4adf-abbc-baa3432b49ec) | ![image](https://github.com/user-attachments/assets/dac5d0d2-815a-4371-a6fc-859398dfee4e) |

## How to test 🧪

### Verification steps
- yarn cy:run -s cypress/e2e/core/linodes/linode-network.spec.ts
- Confirm toast says RDNS when updating RDNS in a Linode's network tab

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
