### PR TITLE
change: [M3-8450] - Lower Events historical data fetching to 7 days 

### DIFF
--- a/packages/manager/.changeset/pr-10899-changed-1725595024930.md
+++ b/packages/manager/.changeset/pr-10899-changed-1725595024930.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Lower Events historical data fetching to 7 days ([#10899](https://github.com/linode/manager/pull/10899))

--- a/packages/manager/cypress/e2e/core/notificationsAndEvents/events-fetching.spec.ts
+++ b/packages/manager/cypress/e2e/core/notificationsAndEvents/events-fetching.spec.ts
@@ -110,7 +110,10 @@ describe('Event fetching and polling', () => {
 
     const mockEvent = eventFactory.build({
       id: randomNumber(10000, 99999),
-      created: DateTime.now().minus({ minutes: 5 }).toISO(),
+      created: DateTime.now()
+        .minus({ minutes: 5 })
+        .startOf('second') // Helps with matching the timestamp at the start of the second
+        .toFormat("yyyy-MM-dd'T'HH:mm:ss"),
       duration: null,
       rate: null,
       percent_complete: null,
@@ -172,7 +175,10 @@ describe('Event fetching and polling', () => {
 
     const mockEventBasic = eventFactory.build({
       id: randomNumber(10000, 99999),
-      created: DateTime.now().minus({ minutes: 5 }).toISO(),
+      created: DateTime.now()
+        .minus({ minutes: 5 })
+        .startOf('second') // Helps with matching the timestamp at the start of the second
+        .toFormat("yyyy-MM-dd'T'HH:mm:ss"),
       duration: null,
       rate: null,
       percent_complete: null,

--- a/packages/manager/cypress/e2e/core/notificationsAndEvents/events-fetching.spec.ts
+++ b/packages/manager/cypress/e2e/core/notificationsAndEvents/events-fetching.spec.ts
@@ -1,6 +1,215 @@
-import { eventFactory } from 'src/factories';
+/**
+ * @file Integration tests for Cloud Manager's events fetching and polling behavior.
+ */
+
 import { mockGetEvents } from 'support/intercepts/events';
+import { DateTime } from 'luxon';
+import { eventFactory } from 'src/factories';
+import { randomNumber } from 'support/util/random';
+import { Interception } from 'cypress/types/net-stubbing';
 import { mockGetVolumes } from 'support/intercepts/volumes';
+
+describe('Event fetching and polling', () => {
+  /**
+   * - Confirms that Cloud Manager makes a request to the events endpoint on page load.
+   * - Confirms API filters are applied to the request to limit the number and type of events retrieved.
+   */
+  it('Makes initial fetch to events endpoint', () => {
+    mockGetEvents([]).as('getEvents');
+    cy.visitWithLogin('/');
+    cy.wait('@getEvents').then((xhr) => {
+      const filters = xhr.request.headers['x-filter'];
+      const lastWeekTimestamp = DateTime.now().minus({ weeks: 1 }).toISODate();
+
+      /*
+       * Confirm that initial fetch request contains filters to achieve
+       * each of the following behaviors:
+       *
+       * - Exclude `profile_update` events.
+       * - Retrieve a maximum of 25 events.
+       * - Sort events by their created date.
+       * - Only retrieve events created within the past week.
+       */
+      expect(filters).to.contain('"+neq":"profile_update"');
+      //expect(filters).to.contain('"+limit":25');
+      //expect(filters).to.contain('"+order_by":"created"');
+      expect(filters).to.contain('"+order_by":"id"');
+      expect(filters).to.contain(`"created":{"+gt":"${lastWeekTimestamp}`);
+    });
+  });
+
+  /**
+   * - Confirms that Cloud Manager makes subsequent events requests after the initial request.
+   * - Confirms API filters are applied to polling requests which differ from the initial request.
+   */
+  it('Polls events endpoint after initial fetch', () => {
+    const mockEvent = eventFactory.build({
+      id: randomNumber(10000, 99999),
+      created: DateTime.now().minus({ minutes: 5 }).toISO(),
+      duration: null,
+      rate: null,
+      percent_complete: null,
+    });
+
+    mockGetEvents([mockEvent]).as('getEvents');
+    cy.visitWithLogin('/');
+
+    cy.wait(['@getEvents', '@getEvents']);
+    cy.get('@getEvents.all').then((xhrRequests: unknown) => {
+      // Cypress types for `cy.get().then(...)` seem to be wrong.
+      // Types suggest that `cy.get()` can only yield a jQuery HTML element, but
+      // when the alias is an HTTP route it yields the request and response data.
+      const secondRequest = (xhrRequests as Interception<any, any>[])[1];
+      const filters = secondRequest.request.headers['x-filter'];
+
+      /*
+       * Confirm that polling fetch request contains filters to achieve
+       * each of the following behaviors:
+       *
+       * - Exclude `profile_update` events.
+       * - Only retrieve events created more recently than the most recent event in the initial fetch.
+       * - Exclude the most recent event that was included in the initial fetch.
+       * - Sort events by their ID (TODO).
+       */
+      expect(filters).to.contain('"action":{"+neq":"profile_update"}');
+      expect(filters).to.contain(`"created":{"+gte":"${mockEvent.created}"}`);
+      expect(filters).to.contain(`{"id":{"+neq":${mockEvent.id}}}]`);
+      expect(filters).to.contain('"+order_by":"id"');
+    });
+  });
+
+  /**
+   * - Confirms that Cloud Manager polls the events endpoint 16 times per second.
+   * - Confirms that Cloud Manager makes a request to the events endpoint after 16 seconds.
+   * - Confirms that Cloud Manager does not make a request to the events endpoint before 16 seconds have passed.
+   * - Confirms Cloud polling rate when there are no in-progress events.
+   */
+  it.skip('Polls events at a 16-second interval', () => {
+    // Expect Cloud to poll the events endpoint every 16 seconds,
+    // and configure the test to check if a request has been made
+    // every simulated second for 16 samples total.
+    const expectedPollingInterval = 16_000;
+    const pollingSamples = 16;
+
+    const mockEvent = eventFactory.build({
+      id: randomNumber(10000, 99999),
+      created: DateTime.now().minus({ minutes: 5 }).toISO(),
+      duration: null,
+      rate: null,
+      percent_complete: null,
+    });
+
+    // Visit Cloud Manager, and wait for Cloud to fire its first two
+    // requests to the `events` endpoint: the initial request, and the
+    // initial polling request.
+    mockGetEvents([mockEvent]).as('getEventsInitialFetches');
+    cy.clock();
+    cy.visitWithLogin('/');
+    cy.tick(10000);
+
+    // Wait for Cloud to make its initial 2 requests to the events endpoint
+    // before we begin monitoring polling intervals.
+    cy.wait(['@getEventsInitialFetches', '@getEventsInitialFetches']);
+
+    // Set up intercept and mock for subsequent events requests.
+    mockGetEvents([mockEvent]).as('getEventsPoll');
+
+    // Simulate a time lapse of 16 seconds, asserting that no request
+    // has been made to the events endpoint during the interim.
+    for (let i = 0; i < pollingSamples; i += 1) {
+      cy.log(
+        `Confirming that Cloud has not made events request... (${
+          i + 1
+        }/${pollingSamples})`
+      );
+      cy.get('@getEventsPoll.all').should('have.length', 0);
+      cy.tick(expectedPollingInterval / pollingSamples, { log: false });
+
+      // Give Cloud Manager a chance to fire a request by waiting 50ms.
+      // Without this wait, we can get false positives because Cypress won't
+      // recognize the request to the events endpoint even if Cloud fires one.
+      // Adding this call to `cy.wait` ensures that Cypress intercepts any
+      // outgoing events requests that might be made erroneously.
+      cy.wait(50, { log: false });
+    }
+
+    // Confirm that Cloud makes expected polling request now that expected
+    // interval has passed.
+    cy.wait('@getEventsPoll');
+    cy.get('@getEventsPoll.all').should('have.length', 1);
+  });
+
+  /**
+   * - Confirms that Cloud Manager polls the events endpoint 2 times per second when there are in-progress events.
+   * - Confirms that Cloud Manager makes a request to the events endpoint after 2 seconds.
+   * - Confirms that Cloud Manager does not make a request to the events endpoint before 2 seconds have passed.
+   * - Confirms Cloud polling rate when there are in-progress events.
+   */
+  it.skip('Polls in-progress events at a 2-second interval', () => {
+    // When in-progress events are present, expect Cloud to poll the
+    // events endpoint every 2 seconds, and configure the test to check
+    // if a request has been made every simulated tenth of a second for
+    // 20 samples total.
+    const expectedPollingInterval = 2_000;
+    const pollingSamples = 20;
+
+    const mockEventBasic = eventFactory.build({
+      id: randomNumber(10000, 99999),
+      created: DateTime.now().minus({ minutes: 5 }).toISO(),
+      duration: null,
+      rate: null,
+      percent_complete: null,
+    });
+
+    const mockEventInProgress = eventFactory.build({
+      id: randomNumber(10000, 99999),
+      created: DateTime.now().minus({ minutes: 6 }).toISO(),
+      duration: 0,
+      rate: null,
+      percent_complete: 50,
+    });
+
+    const mockEvents = [mockEventBasic, mockEventInProgress];
+
+    // Visit Cloud Manager, and wait for Cloud to fire its first two
+    // requests to the `events` endpoint: the initial request, and the
+    // initial polling request.
+    mockGetEvents(mockEvents).as('getEventsInitialFetches');
+    cy.clock();
+    cy.visitWithLogin('/');
+    cy.tick(10000);
+
+    // Wait for Cloud to make its initial 2 requests to the events endpoint
+    // before we begin monitoring polling intervals.
+    cy.wait(['@getEventsInitialFetches', '@getEventsInitialFetches']);
+
+    mockGetEvents(mockEvents).as('getEventsPoll');
+
+    // Simulate a time lapse of 16 seconds, asserting that no request
+    // has been made to the events endpoint during the interim.
+    for (let i = 0; i < pollingSamples; i += 1) {
+      cy.log(
+        `Confirming that Cloud has not made events request... (${
+          i + 1
+        }/${pollingSamples})`
+      );
+      cy.get('@getEventsPoll.all').should('have.length', 0);
+      cy.tick(expectedPollingInterval / pollingSamples, { log: false });
+
+      // Give Cloud Manager a chance to fire a request by waiting 50ms.
+      // Without this wait, we can get false positives because Cypress won't
+      // recognize the request to the events endpoint even if Cloud fires one.
+      // Adding this call to `cy.wait` ensures that Cypress intercepts any
+      // outgoing events requests that might be made erroneously.
+      cy.wait(50, { log: false });
+    }
+
+    // Confirm that Cloud makes expected polling request now that expected
+    // interval has passed.
+    cy.wait('@getEventsPoll');
+    cy.get('@getEventsPoll.all').should('have.length', 1);
+  });
+});
 
 describe('Event Handlers', () => {
   it('invokes event handlers when new events are polled and makes the correct number of requests', () => {

--- a/packages/manager/cypress/e2e/core/notificationsAndEvents/events-menu.spec.ts
+++ b/packages/manager/cypress/e2e/core/notificationsAndEvents/events-menu.spec.ts
@@ -229,7 +229,7 @@ describe('Notifications Menu', () => {
    * - Confirms event seen logic for non-typical event ordering edge case.
    * - Confirms that Cloud marks the correct event as seen even when it's not the first result.
    */
-  it.skip('Marks events in menu as seen with duplicate created dates and out-of-order IDs', () => {
+  it('Marks events in menu as seen with duplicate created dates and out-of-order IDs', () => {
     /*
      * When several events are triggered simultaneously, they may have the
      * same `created` timestamp. Cloud asks for events to be sorted by created
@@ -266,8 +266,10 @@ describe('Notifications Menu', () => {
       });
     });
 
-    // Get the highest event ID from the array of mock events.
-    const highestEventId = Math.max(...mockEvents.map((event) => event.id));
+    // Sort the mockEvents array by id in descending order to simulate API response
+    mockEvents.sort((a, b) => b.id - a.id);
+
+    const highestEventId = mockEvents[0].id;
 
     mockGetEvents(mockEvents).as('getEvents');
     mockMarkEventSeen(highestEventId).as('markEventsSeen');

--- a/packages/manager/cypress/e2e/core/notificationsAndEvents/events-menu.spec.ts
+++ b/packages/manager/cypress/e2e/core/notificationsAndEvents/events-menu.spec.ts
@@ -1,0 +1,307 @@
+/**
+ * @file Integration tests for Cloud Manager's events menu.
+ */
+
+import { mockGetEvents, mockMarkEventSeen } from 'support/intercepts/events';
+import { ui } from 'support/ui';
+import { eventFactory } from 'src/factories';
+import { buildArray } from 'support/util/arrays';
+import { DateTime } from 'luxon';
+import { randomLabel, randomNumber } from 'support/util/random';
+
+describe('Notifications Menu', () => {
+  /*
+   * - Confirms that the notification menu shows all events when 20 or fewer exist.
+   */
+  it('Shows all recent events when there are 20 or fewer', () => {
+    const mockEvents = buildArray(randomNumber(1, 20), (index) => {
+      return eventFactory.build({
+        action: 'linode_delete',
+        // The response from the API will be ordered by created date, descending.
+        created: DateTime.local().minus({ minutes: index }).toISO(),
+        percent_complete: null,
+        rate: null,
+        seen: false,
+        duration: null,
+        status: 'scheduled',
+        entity: {
+          id: 1000 + index,
+          label: `my-linode-${index}`,
+          type: 'linode',
+          url: `/v4/linode/instances/${1000 + index}`,
+        },
+        username: randomLabel(),
+      });
+    });
+
+    mockGetEvents(mockEvents).as('getEvents');
+    cy.visitWithLogin('/');
+    cy.wait('@getEvents');
+
+    ui.appBar.find().within(() => {
+      cy.findByLabelText('Notifications')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+    });
+
+    cy.get('[data-qa-notification-menu]')
+      .should('be.visible')
+      .within(() => {
+        // Confirm that all mocked events are shown in the notification menu.
+        mockEvents.forEach((event) => {
+          cy.get(`[data-qa-event="${event.id}"]`)
+            .scrollIntoView()
+            .should('be.visible');
+        });
+      });
+  });
+
+  /*
+   * - Confirms that the notification menu shows no more than 20 events.
+   * - Confirms that only the most recently created events are shown.
+   */
+  it('Shows the 20 most recently created events', () => {
+    const mockEvents = buildArray(25, (index) => {
+      return eventFactory.build({
+        action: 'linode_delete',
+        // The response from the API will be ordered by created date, descending.
+        created: DateTime.local().minus({ minutes: index }).toISO(),
+        percent_complete: null,
+        rate: null,
+        seen: false,
+        duration: null,
+        status: 'scheduled',
+        entity: {
+          id: 1000 + index,
+          label: `my-linode-${index}`,
+          type: 'linode',
+          url: `/v4/linode/instances/${1000 + index}`,
+        },
+        username: randomLabel(),
+      });
+    });
+
+    const shownEvents = mockEvents.slice(0, 20);
+    const hiddenEvents = mockEvents.slice(20);
+
+    mockGetEvents(mockEvents).as('getEvents');
+    cy.visitWithLogin('/');
+    cy.wait('@getEvents');
+
+    ui.appBar.find().within(() => {
+      cy.findByLabelText('Notifications')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+    });
+
+    cy.get('[data-qa-notification-menu]')
+      .should('be.visible')
+      .within(() => {
+        // Confirm that first 20 events in response are displayed.
+        shownEvents.forEach((event) => {
+          cy.get(`[data-qa-event="${event.id}"]`)
+            .scrollIntoView()
+            .should('be.visible');
+        });
+
+        // Confirm that last 5 events in response are not displayed.
+        hiddenEvents.forEach((event) => {
+          cy.get(`[data-qa-event="${event.id}"]`).should('not.exist');
+        });
+      });
+  });
+
+  /*
+   * - Confirms that notification menu contains a notice when no recent events exist.
+   */
+  it('Shows notice when there are no recent events', () => {
+    mockGetEvents([]).as('getEvents');
+    cy.visitWithLogin('/');
+    cy.wait('@getEvents');
+
+    // Find and click Notifications button in Cloud's top app bar.
+    ui.appBar.find().within(() => {
+      cy.findByLabelText('Notifications')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+    });
+
+    cy.get('[data-qa-notification-menu]')
+      .should('be.visible')
+      .within(() => {
+        // Use RegEx here to account for cases where the period is and is not present.
+        // Period is displayed in Notifications Menu v2, but omitted in v1.
+        cy.findByText(/No recent events to display\.?/).should('be.visible');
+      });
+  });
+
+  /*
+   * - Confirms that events in menu are marked as seen upon viewing.
+   * - Uses typical mock data setup where IDs are ordered (descending) and all create dates are unique.
+   * - Confirms that events are reflected in the UI as being seen or unseen.
+   */
+  it('Marks events in menu as seen', () => {
+    const mockEvents = buildArray(10, (index) => {
+      return eventFactory.build({
+        // The event with the highest ID is expected to come first in the array.
+        id: 5000 - index,
+        action: 'linode_delete',
+        // The response from the API will be ordered by created date, descending.
+        created: DateTime.local().minus({ minutes: index }).toISO(),
+        percent_complete: null,
+        seen: false,
+        rate: null,
+        duration: null,
+        status: 'scheduled',
+        entity: {
+          id: 1000 + index,
+          label: `my-linode-${index}`,
+          type: 'linode',
+          url: `/v4/linode/instances/${1000 + index}`,
+        },
+        username: randomLabel(),
+      });
+    });
+
+    // In this case, we know that the first event in the mocked events response
+    // will contain the highest event ID.
+    const highestEventId = mockEvents[0].id;
+
+    mockGetEvents(mockEvents).as('getEvents');
+    mockMarkEventSeen(highestEventId).as('markEventsSeen');
+
+    cy.visitWithLogin('/');
+    cy.wait('@getEvents');
+
+    // Find and click Notifications button in Cloud's top app bar.
+    ui.appBar.find().within(() => {
+      cy.findByLabelText('Notifications')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+    });
+
+    // Confirm notification menu opens
+    cy.get('[data-qa-notification-menu]')
+      .should('be.visible')
+      .within(() => {
+        // Confirm that UI reflects that every event is unseen.
+        cy.get('[data-qa-event-seen="false"]').should('have.length', 10);
+      });
+
+    // Dismiss the notifications menu by clicking the bell button again.
+    ui.appBar.find().within(() => {
+      // This time we have to pass `force: true` to cy.click()
+      // because otherwise Cypress thinks the element is blocked because
+      // of the notifications menu popover.
+      cy.findByLabelText('Notifications')
+        .should('be.visible')
+        .should('be.enabled')
+        .click({ force: true });
+    });
+
+    // Confirm that Cloud fires a request to the `/events/:id/seen` endpoint,
+    // where `id` corresponds to the mocked event with the highest ID.
+    // If Cloud attempts to mark the wrong event ID as seen, this assertion
+    // will fail.
+    cy.log(`Waiting for request to '/events/${highestEventId}/seen'`);
+    cy.wait('@markEventsSeen');
+
+    ui.appBar.find().within(() => {
+      cy.findByLabelText('Notifications')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+    });
+
+    cy.get('[data-qa-notification-menu]')
+      .should('be.visible')
+      .within(() => {
+        // Confirm that UI reflects that every event is now seen.
+        cy.get('[data-qa-event-seen="true"]').should('have.length', 10);
+      });
+  });
+
+  /*
+   * - Confirms event seen logic for non-typical event ordering edge case.
+   * - Confirms that Cloud marks the correct event as seen even when it's not the first result.
+   */
+  it.skip('Marks events in menu as seen with duplicate created dates and out-of-order IDs', () => {
+    /*
+     * When several events are triggered simultaneously, they may have the
+     * same `created` timestamp. Cloud asks for events to be sorted by created
+     * date when fetching from the API, but when events have identical timestamps,
+     * there is no guarantee in which order they will be returned.
+     *
+     * As a result, we have to account for cases where the most recent event
+     * in reality (e.g. as determined by its ID) is not returned first by the API.
+     * This is especially relevant when marking events as 'seen', as we have
+     * to explicitly mark the event with the highest ID as seen when the user
+     * closes their notification menu.
+     */
+    const createTime = DateTime.local().minus({ minutes: 2 }).toISO();
+    const mockEvents = buildArray(10, (index) => {
+      return eventFactory.build({
+        // Events are not guaranteed to be ordered by ID; simulate this by using random IDs.
+        id: randomNumber(1000, 9999),
+        action: 'linode_delete',
+        // To simulate multiple events occurring simultaneously, give all
+        // events the same created timestamp.
+        created: createTime,
+        percent_complete: null,
+        seen: false,
+        rate: null,
+        duration: null,
+        status: 'scheduled',
+        entity: {
+          id: 1000 + index,
+          label: `my-linode-${index}`,
+          type: 'linode',
+          url: `/v4/linode/instances/${1000 + index}`,
+        },
+        username: randomLabel(),
+      });
+    });
+
+    // Get the highest event ID from the array of mock events.
+    const highestEventId = Math.max(...mockEvents.map((event) => event.id));
+
+    mockGetEvents(mockEvents).as('getEvents');
+    mockMarkEventSeen(highestEventId).as('markEventsSeen');
+
+    cy.visitWithLogin('/');
+    cy.wait('@getEvents');
+
+    // Find and click Notifications button in Cloud's top app bar.
+    ui.appBar.find().within(() => {
+      cy.findByLabelText('Notifications')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+    });
+
+    // Confirm notification menu opens; we don't care about its contents.
+    cy.get('[data-qa-notification-menu]').should('be.visible');
+
+    // Dismiss the notifications menu by clicking the bell button again.
+    ui.appBar.find().within(() => {
+      // This time we have to pass `force: true` to cy.click()
+      // because otherwise Cypress thinks the element is blocked because
+      // of the notifications menu popover.
+      cy.findByLabelText('Notifications')
+        .should('be.visible')
+        .should('be.enabled')
+        .click({ force: true });
+    });
+
+    // Confirm that Cloud fires a request to the `/events/:id/seen` endpoint,
+    // where `id` corresponds to the mocked event with the highest ID.
+    // If Cloud attempts to mark the wrong event ID as seen, this assertion
+    // will fail.
+    cy.log(`Waiting for request to '/events/${highestEventId}/seen'`);
+    cy.wait('@markEventsSeen');
+  });
+});

--- a/packages/manager/cypress/support/intercepts/events.ts
+++ b/packages/manager/cypress/support/intercepts/events.ts
@@ -24,6 +24,35 @@ export const mockGetEvents = (events: Event[]): Cypress.Chainable => {
 };
 
 /**
+ * Intercepts polling GET request to fetch events and mocks response.
+ *
+ * Unlike `mockGetEvents`, this utility only intercepts outgoing requests that
+ * occur while Cloud Manager is polling for events.
+ *
+ * @param events - Array of Events with which to mock response.
+ * @param pollingTimestamp - Timestamp to find when identifying polling requests.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetEventsPolling = (
+  events: Event[],
+  pollingTimestamp: string
+): Cypress.Chainable => {
+  return cy.intercept('GET', apiMatcher('account/events*'), (req) => {
+    console.log({ headers: req.headers });
+    if (
+      req.headers['x-filter'].includes(
+        `{"created":{"+gte":"${pollingTimestamp}"}}`
+      )
+    ) {
+      req.reply(paginateResponse(events));
+    } else {
+      req.continue();
+    }
+  });
+};
+
+/**
  * Intercepts POST request to mark an event as seen and mocks response.
  *
  * @param eventId - ID of the event for which to intercept request.

--- a/packages/manager/cypress/support/intercepts/events.ts
+++ b/packages/manager/cypress/support/intercepts/events.ts
@@ -2,9 +2,11 @@
  * @file Mocks and intercepts related to notification and event handling.
  */
 
-import type { Event, Notification } from '@linode/api-v4';
 import { apiMatcher } from 'support/util/intercepts';
 import { paginateResponse } from 'support/util/paginate';
+import { makeResponse } from 'support/util/response';
+
+import type { Event, Notification } from '@linode/api-v4';
 
 /**
  * Intercepts GET request to fetch events and mocks response.
@@ -18,6 +20,21 @@ export const mockGetEvents = (events: Event[]): Cypress.Chainable => {
     'GET',
     apiMatcher('account/events*'),
     paginateResponse(events)
+  );
+};
+
+/**
+ * Intercepts POST request to mark an event as seen and mocks response.
+ *
+ * @param eventId - ID of the event for which to intercept request.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockMarkEventSeen = (eventId: number): Cypress.Chainable => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`account/events/${eventId}/seen`),
+    makeResponse({})
   );
 };
 

--- a/packages/manager/cypress/support/ui/app-bar.ts
+++ b/packages/manager/cypress/support/ui/app-bar.ts
@@ -1,0 +1,13 @@
+/**
+ * UI helpers for Cloud Manager top app bar.
+ */
+export const appBar = {
+  /**
+   * Finds the app bar.
+   *
+   * @returns Cypress chainable.
+   */
+  find: () => {
+    return cy.get('[data-qa-appbar]');
+  },
+};

--- a/packages/manager/cypress/support/ui/index.ts
+++ b/packages/manager/cypress/support/ui/index.ts
@@ -1,5 +1,6 @@
 import * as accordion from './accordion';
 import * as actionMenu from './action-menu';
+import * as appBar from './app-bar';
 import * as autocomplete from './autocomplete';
 import * as breadcrumb from './breadcrumb';
 import * as buttons from './buttons';
@@ -21,6 +22,7 @@ import * as userMenu from './user-menu';
 export const ui = {
   ...accordion,
   ...actionMenu,
+  ...appBar,
   ...autocomplete,
   ...breadcrumb,
   ...buttons,

--- a/packages/manager/src/features/NotificationCenter/Events/NotificationCenterEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/Events/NotificationCenterEvent.tsx
@@ -44,6 +44,8 @@ export const NotificationCenterEvent = React.memo(
     return (
       <NotificationEventStyledBox
         className={unseenEventClass}
+        data-qa-event={event.id}
+        data-qa-event-seen={event.seen}
         data-testid={event.action}
       >
         <NotificationEventGravatar username={event.username} />

--- a/packages/manager/src/features/TopMenu/NotificationMenu/NotificationMenu.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationMenu/NotificationMenu.tsx
@@ -23,7 +23,7 @@ import { usePrevious } from 'src/hooks/usePrevious';
 import { useNotificationsQuery } from 'src/queries/account/notifications';
 import { isInProgressEvent } from 'src/queries/events/event.helpers';
 import {
-  useEventsInfiniteQuery,
+  useInitialEventsQuery,
   useMarkEventsAsSeen,
 } from 'src/queries/events/events';
 import { rotate360 } from 'src/styles/keyframes';
@@ -37,7 +37,8 @@ export const NotificationMenu = () => {
   const formattedNotifications = useFormattedNotifications();
   const notificationContext = React.useContext(_notificationContext);
 
-  const { data, events } = useEventsInfiniteQuery();
+  const { data, events } = useInitialEventsQuery();
+  const eventsData = data?.data ?? [];
   const { mutateAsync: markEventsAsSeen } = useMarkEventsAsSeen();
 
   const numNotifications =
@@ -132,6 +133,7 @@ export const NotificationMenu = () => {
           },
         }}
         anchorEl={anchorRef.current}
+        data-qa-notification-menu
         id={id}
         onClose={handleClose}
         open={notificationContext.menuOpen}
@@ -150,13 +152,22 @@ export const NotificationMenu = () => {
             </LinkButton>
           </Box>
           <Divider spacingBottom={0} />
-          {data?.pages[0].data.slice(0, 20).map((event) => (
-            <NotificationCenterEvent
-              event={event}
-              key={event.id}
-              onClose={handleClose}
-            />
-          ))}
+
+          {eventsData.length > 0 ? (
+            eventsData
+              .slice(0, 20)
+              .map((event) => (
+                <NotificationCenterEvent
+                  event={event}
+                  key={event.id}
+                  onClose={handleClose}
+                />
+              ))
+          ) : (
+            <Box pt={2} px={2}>
+              No recent events to display
+            </Box>
+          )}
         </Box>
       </Popover>
     </>

--- a/packages/manager/src/features/TopMenu/TopMenu.tsx
+++ b/packages/manager/src/features/TopMenu/TopMenu.tsx
@@ -46,7 +46,7 @@ export const TopMenu = React.memo((props: TopMenuProps) => {
           </Typography>
         </Box>
       )}
-      <AppBar>
+      <AppBar data-qa-appbar>
         <Toolbar
           sx={(theme) => ({
             '&.MuiToolbar-root': {


### PR DESCRIPTION
This PR is a replacement for https://github.com/linode/manager/pull/10785 which had become difficult to rebase.

It is essentially the same PR including fixes and cleanup for the new e2e tests.

## Description 📝
This change optimizes Cloud Manager's event querying by reducing the historical data range. 

Specifically, it limits the event query timeframe from the current 90 days to a more focused 7-day period. 

- This is true for the default Cloud Manager query that also populates the Notification Center
- The `/events` page still queries 90 day and isn't affected by this PR

This adjustment aims to improve query performance and reduce unnecessary data retrieval while still providing relevant recent event information.

## Changes  🔄
- Previously we fetched the first 100 events but returned almost 500 results/records. These events pull from the last 90 days. Now we're returning events from the last 7 days.

## Target release date 🗓️
**Next Release: 9/16/2024**

## How to test 🧪
>[!note]
We are working to have this fully covered via E2E tests in an upcoming PR cc: @jdamore-linode 

### Prerequisites
- Checkout branch and observe you network tab

### Verification steps
- Go to http://localhost:3000/events
- Observe that initial load returns at most 25 events
- As you scroll observe subsequent queries fetch next 25
- Ensure there aren't any redundant events
- Ensure you're able to reach the end of your events list (90 days worth of events)

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support