### PR TITLE
fix: [M3-7915] - Update Linode Migrate Datacenter Started message to be generic

### DIFF
--- a/packages/manager/.changeset/pr-10901-fixed-1725632415734.md
+++ b/packages/manager/.changeset/pr-10901-fixed-1725632415734.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Linode Migrate Datacenter Create event message to be more generic ([#10901](https://github.com/linode/manager/pull/10901))
+Linode Migrate Datacenter Create event message referring to the wrong region to be more generic ([#10901](https://github.com/linode/manager/pull/10901))

--- a/packages/manager/.changeset/pr-10901-fixed-1725632415734.md
+++ b/packages/manager/.changeset/pr-10901-fixed-1725632415734.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Linode Migrate Datacenter Create event message to be more generic ([#10901](https://github.com/linode/manager/pull/10901))

--- a/packages/manager/.changeset/pr-10901-fixed-1725632415734.md
+++ b/packages/manager/.changeset/pr-10901-fixed-1725632415734.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Linode Migrate Datacenter Create event message referring to the wrong region to be more generic ([#10901](https://github.com/linode/manager/pull/10901))
+Linode Migrate Datacenter Started event message referring to the wrong region to be more generic ([#10901](https://github.com/linode/manager/pull/10901))

--- a/packages/manager/src/features/Events/factories/linode.tsx
+++ b/packages/manager/src/features/Events/factories/linode.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { Link } from 'src/components/Link';
 import { useLinodeQuery } from 'src/queries/linodes/linodes';
-import { useRegionsQuery } from 'src/queries/regions/regions';
 import { useTypeQuery } from 'src/queries/types';
 import { formatStorageUnits } from 'src/utilities/formatStorageUnits';
 
@@ -290,7 +289,12 @@ export const linode: PartialEventMap<'linode'> = {
         <strong>migrated</strong>.
       </>
     ),
-    started: (e) => <LinodeMigrateDataCenterMessage event={e} />,
+    started: (e) => (
+      <>
+        Linode <EventLink event={e} to="entity" /> is being{' '}
+        <strong>migrated</strong> to a new region.
+      </>
+    ),
   },
   linode_migrate_datacenter_create: {
     notification: (e) => (
@@ -535,26 +539,6 @@ export const linode: PartialEventMap<'linode'> = {
       </>
     ),
   },
-};
-
-const LinodeMigrateDataCenterMessage = ({ event }: { event: Event }) => {
-  const { data: linode } = useLinodeQuery(event.entity?.id ?? -1);
-  const { data: regions } = useRegionsQuery();
-  const region = regions?.find((r) => r.id === linode?.region);
-
-  return (
-    <>
-      Linode <EventLink event={event} to="entity" /> is being{' '}
-      <strong>migrated</strong>
-      {region && (
-        <>
-          {' '}
-          to <strong>{region.label}</strong>
-        </>
-      )}
-      .
-    </>
-  );
 };
 
 const LinodeResizeStartedMessage = ({ event }: { event: Event }) => {


### PR DESCRIPTION
## Description 📝
Previously, this event message would say 'Linode migrating to X region', where X region is the region the linode is currently in, not the one it's being migrated to. We are updating this message to be generic -- see internal ticket for details.

- Since this message is now generic, we don't need to override the event message anymore

## Target release date 🗓️
n/a

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/e0f733eb-985b-483c-9965-639e42df6a68) | ![image](https://github.com/user-attachments/assets/7a1d6462-9964-48ce-b4ce-2565e27e3f44) |

## How to test 🧪

### Reproduction steps
(How to reproduce the issue, if applicable)
- Migrate a linode to a new region, and note how the message says 'Linode migrating to [original] region' once migration begins

### Verification steps
- Confirm event message is now generic

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
