### PR TITLE
fix: [M3-7574] - Fix missing labels for User Permission radio buttons

### DIFF
--- a/packages/manager/.changeset/pr-10908-fixed-1726091771498.md
+++ b/packages/manager/.changeset/pr-10908-fixed-1726091771498.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fix missing radio button labels for User Permissions ([#10908](https://github.com/linode/manager/pull/10908))

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -1,19 +1,11 @@
 import {
-  GlobalGrantTypes,
-  Grant,
-  GrantLevel,
-  GrantType,
-  Grants,
-  User,
   getGrants,
   getUser,
   updateGrants,
   updateUser,
 } from '@linode/api-v4/lib/account';
-import { APIError } from '@linode/api-v4/lib/types';
 import { Paper } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
-import { QueryClient } from '@tanstack/react-query';
 import { enqueueSnackbar } from 'notistack';
 import { compose, flatten, lensPath, omit, set } from 'ramda';
 import * as React from 'react';
@@ -21,9 +13,7 @@ import * as React from 'react';
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Box } from 'src/components/Box';
 import { CircleProgress } from 'src/components/CircleProgress';
-// import { Button } from 'src/components/Button/Button';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-import { Item } from 'src/components/EnhancedSelect/Select';
 import { FormControlLabel } from 'src/components/FormControlLabel';
 import { Notice } from 'src/components/Notice/Notice';
 import { SelectionCard } from 'src/components/SelectionCard/SelectionCard';
@@ -34,14 +24,8 @@ import { TabPanels } from 'src/components/Tabs/TabPanels';
 import { Tabs } from 'src/components/Tabs/Tabs';
 import { Toggle } from 'src/components/Toggle/Toggle';
 import { Typography } from 'src/components/Typography';
-import {
-  WithFeatureFlagProps,
-  withFeatureFlags,
-} from 'src/containers/flags.container';
-import {
-  WithQueryClientProps,
-  withQueryClient,
-} from 'src/containers/withQueryClient.container';
+import { withFeatureFlags } from 'src/containers/flags.container';
+import { withQueryClient } from 'src/containers/withQueryClient.container';
 import { PARENT_USER, grantTypeMap } from 'src/features/Account/constants';
 import { accountQueries } from 'src/queries/account/queries';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
@@ -59,6 +43,20 @@ import {
   StyledUnrestrictedGrid,
 } from './UserPermissions.styles';
 import { UserPermissionsEntitySection } from './UserPermissionsEntitySection';
+
+import type {
+  GlobalGrantTypes,
+  Grant,
+  GrantLevel,
+  GrantType,
+  Grants,
+  User,
+} from '@linode/api-v4/lib/account';
+import type { APIError } from '@linode/api-v4/lib/types';
+import type { QueryClient } from '@tanstack/react-query';
+import type { Item } from 'src/components/EnhancedSelect/Select';
+import type { WithFeatureFlagProps } from 'src/containers/flags.container';
+import type { WithQueryClientProps } from 'src/containers/withQueryClient.container';
 interface Props {
   accountUsername?: string;
   currentUsername?: string;
@@ -91,30 +89,6 @@ interface State {
 type CombinedProps = Props & WithQueryClientProps & WithFeatureFlagProps;
 
 class UserPermissions extends React.Component<CombinedProps, State> {
-  componentDidMount() {
-    this.getUserGrants();
-    this.getUserType();
-  }
-
-  componentDidUpdate(prevProps: CombinedProps) {
-    if (prevProps.currentUsername !== this.props.currentUsername) {
-      this.getUserGrants();
-      this.getUserType();
-    }
-  }
-
-  render() {
-    const { loading } = this.state;
-    const { currentUsername } = this.props;
-
-    return (
-      <div ref={this.formContainerRef}>
-        <DocumentTitleSegment segment={`${currentUsername} - Permissions`} />
-        {loading ? <CircleProgress /> : this.renderBody()}
-      </div>
-    );
-  }
-
   billingPermOnClick = (value: null | string) => () => {
     const lp = lensPath(['grants', 'global', 'account_access']);
     this.setState(set(lp, value));
@@ -679,9 +653,6 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           <Typography data-qa-unrestricted-msg>
             This user has unrestricted access to the account.
           </Typography>
-          {/* <Button buttonType="primary" onClick={this.onChangeRestricted}>
-          Save
-        </Button> */}
         </StyledUnrestrictedGrid>
       </Paper>
     );
@@ -823,6 +794,30 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     setAllPerm: 'null',
     userType: null,
   };
+
+  componentDidMount() {
+    this.getUserGrants();
+    this.getUserType();
+  }
+
+  componentDidUpdate(prevProps: CombinedProps) {
+    if (prevProps.currentUsername !== this.props.currentUsername) {
+      this.getUserGrants();
+      this.getUserType();
+    }
+  }
+
+  render() {
+    const { loading } = this.state;
+    const { currentUsername } = this.props;
+
+    return (
+      <div ref={this.formContainerRef}>
+        <DocumentTitleSegment segment={`${currentUsername} - Permissions`} />
+        {loading ? <CircleProgress /> : this.renderBody()}
+      </div>
+    );
+  }
 }
 
 export default withQueryClient(withFeatureFlags(UserPermissions));

--- a/packages/manager/src/features/Users/UserPermissionsEntitySection.tsx
+++ b/packages/manager/src/features/Users/UserPermissionsEntitySection.tsx
@@ -6,33 +6,37 @@
  * I'll create a tech debt ticket in jira to keep track of this issue.
  */
 
+import { useTheme } from '@mui/material/styles';
 import React from 'react';
-import { Grant, GrantLevel, GrantType } from '@linode/api-v4/lib/account';
+
 import { Box } from 'src/components/Box';
-import { Theme } from '@mui/material/styles';
-import { TableHead } from 'src/components/TableHead';
-import { TableRow } from 'src/components/TableRow';
-import { TableCell } from 'src/components/TableCell';
+import { FormControlLabel } from 'src/components/FormControlLabel';
+import { createDisplayPage } from 'src/components/Paginate';
+import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFooter';
 import { Radio } from 'src/components/Radio/Radio';
 import { TableBody } from 'src/components/TableBody';
-import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFooter';
-import { usePagination } from 'src/hooks/usePagination';
-import { createDisplayPage } from 'src/components/Paginate';
+import { TableCell } from 'src/components/TableCell';
+import { TableHead } from 'src/components/TableHead';
+import { TableRow } from 'src/components/TableRow';
 import { Typography } from 'src/components/Typography';
-import { useTheme } from '@mui/material/styles';
-import { StyledGrantsTable } from './UserPermissionsEntitySection.styles';
 import { grantTypeMap } from 'src/features/Account/constants';
+import { usePagination } from 'src/hooks/usePagination';
+
+import { StyledGrantsTable } from './UserPermissionsEntitySection.styles';
+
+import type { Grant, GrantLevel, GrantType } from '@linode/api-v4/lib/account';
+import type { Theme } from '@mui/material/styles';
 
 interface Props {
   entity: GrantType;
+  entitySetAllTo: (entity: GrantType, value: GrantLevel) => () => void;
   grants: Grant[] | undefined;
   setGrantTo: (entity: string, idx: number, value: GrantLevel) => () => void;
-  entitySetAllTo: (entity: GrantType, value: GrantLevel) => () => void;
   showHeading?: boolean;
 }
 
 export const UserPermissionsEntitySection = React.memo(
-  ({ entity, grants, setGrantTo, entitySetAllTo, showHeading }: Props) => {
+  ({ entity, entitySetAllTo, grants, setGrantTo, showHeading }: Props) => {
     const theme: Theme = useTheme();
     const pagination = usePagination(1);
 
@@ -54,61 +58,79 @@ export const UserPermissionsEntitySection = React.memo(
     };
 
     return (
-      <Box key={entity} paddingBottom="0" marginTop={`${theme.spacing(2)}`}>
+      <Box key={entity} marginTop={`${theme.spacing(2)}`} paddingBottom="0">
         {showHeading && (
           <Typography
-            variant="h3"
             sx={{
-              marginTop: theme.spacing(3),
               marginBottom: theme.spacing(2),
+              marginTop: theme.spacing(3),
             }}
             data-qa-permissions-header={entity}
+            variant="h3"
           >
             {grantTypeMap[entity]}
           </Typography>
         )}
         <StyledGrantsTable aria-label="User Permissions" noBorder>
           <TableHead data-qa-table-head>
-            <TableRow>
+            <TableRow
+              sx={(theme) => ({
+                'span.MuiFormControlLabel-label': {
+                  fontFamily: theme.font.bold,
+                },
+              })}
+            >
               <TableCell>Label</TableCell>
               <TableCell padding="checkbox">
-                {/* eslint-disable-next-line */}
-                <label style={{ marginLeft: -35, cursor: 'pointer' }}>
-                  None
-                  <Radio
-                    name={`${entity}-select-all`}
-                    checked={entityIsAll(null)}
-                    value="null"
-                    onChange={entitySetAllTo(entity, null)}
-                    data-qa-permission-header="None"
-                  />
-                </label>
+                <FormControlLabel
+                  control={
+                    <Radio
+                      inputProps={{
+                        'aria-label': `${entity}s, set-all-permissions-to-none`,
+                      }}
+                      checked={entityIsAll(null)}
+                      data-qa-permission-header="None"
+                      name={`${entity}-select-all`}
+                      onChange={entitySetAllTo(entity, null)}
+                      value="null"
+                    />
+                  }
+                  label="None"
+                />
               </TableCell>
               <TableCell padding="checkbox">
-                {/* eslint-disable-next-line */}
-                <label style={{ marginLeft: -65, cursor: 'pointer' }}>
-                  Read Only
-                  <Radio
-                    name={`${entity}-select-all`}
-                    checked={entityIsAll('read_only')}
-                    value="read_only"
-                    onChange={entitySetAllTo(entity, 'read_only')}
-                    data-qa-permission-header="Read Only"
-                  />
-                </label>
+                <FormControlLabel
+                  control={
+                    <Radio
+                      inputProps={{
+                        'aria-label': `${entity}s, set-all-permissions-to-read-only`,
+                      }}
+                      checked={entityIsAll('read_only')}
+                      data-qa-permission-header="Read Only"
+                      name={`${entity}-select-all`}
+                      onChange={entitySetAllTo(entity, 'read_only')}
+                      value="read_only"
+                    />
+                  }
+                  label="Read Only"
+                />
               </TableCell>
               <TableCell padding="checkbox">
-                {/* eslint-disable-next-line */}
-                <label style={{ marginLeft: -73, cursor: 'pointer' }}>
-                  Read-Write
-                  <Radio
-                    name={`${entity}-select-all`}
-                    checked={entityIsAll('read_write')}
-                    value="read_write"
-                    onChange={entitySetAllTo(entity, 'read_write')}
-                    data-qa-permission-header="Read-Write"
-                  />
-                </label>
+                <FormControlLabel
+                  control={
+                    <Radio
+                      inputProps={{
+                        'aria-label': `${entity}s, set-all-permissions-to-read-write`,
+                      }}
+                      checked={entityIsAll('read_write')}
+                      data-qa-permission-header="Read-Write"
+                      name={`${entity}-select-all`}
+                      onChange={entitySetAllTo(entity, 'read_write')}
+                      value="read_write"
+                    />
+                  }
+                  label="Read-Write"
+                />
               </TableCell>
             </TableRow>
           </TableHead>
@@ -117,7 +139,7 @@ export const UserPermissionsEntitySection = React.memo(
               // Index must be corrected to account for pagination
               const idx = (pagination.page - 1) * pagination.pageSize + _idx;
               return (
-                <TableRow key={grant.id} data-qa-specific-grant={grant.label}>
+                <TableRow data-qa-specific-grant={grant.label} key={grant.id}>
                   <TableCell
                     sx={{
                       '& div': {
@@ -130,34 +152,43 @@ export const UserPermissionsEntitySection = React.memo(
                   >
                     {grant.label}
                   </TableCell>
-                  <TableCell parentColumn="None" padding="checkbox">
+                  <TableCell padding="checkbox" parentColumn="None">
                     <Radio
-                      aria-label={`Disallow access for ${grant.label}`}
-                      name={`${grant.id}-perms`}
+                      inputProps={{
+                        'aria-label': `Disallow access for ${grant.label}`,
+                        name: `${grant.label}-permissions`,
+                      }}
                       checked={grant.permissions === null}
-                      value="null"
-                      onChange={setGrantTo(entity, idx, null)}
                       data-qa-permission="None"
+                      edge="start"
+                      onChange={setGrantTo(entity, idx, null)}
+                      value="null"
                     />
                   </TableCell>
-                  <TableCell parentColumn="Read Only" padding="checkbox">
+                  <TableCell padding="checkbox" parentColumn="Read Only">
                     <Radio
-                      aria-label={`Allow read-only access for ${grant.label}`}
-                      name={`${grant.id}-perms`}
+                      inputProps={{
+                        'aria-label': `Allow read-only access for ${grant.label}`,
+                        name: `${grant.label}-permissions`,
+                      }}
                       checked={grant.permissions === 'read_only'}
-                      value="read_only"
-                      onChange={setGrantTo(entity, idx, 'read_only')}
                       data-qa-permission="Read Only"
+                      edge="start"
+                      onChange={setGrantTo(entity, idx, 'read_only')}
+                      value="read_only"
                     />
                   </TableCell>
-                  <TableCell parentColumn="Read-Write" padding="checkbox">
+                  <TableCell padding="checkbox" parentColumn="Read-Write">
                     <Radio
-                      aria-label={`Allow read-write access for ${grant.label}`}
-                      name={`${grant.id}-perms`}
+                      inputProps={{
+                        'aria-label': `Allow read-write access for ${grant.label}`,
+                        name: `${grant.label}-permissions`,
+                      }}
                       checked={grant.permissions === 'read_write'}
-                      value="read_write"
-                      onChange={setGrantTo(entity, idx, 'read_write')}
                       data-qa-permission="Read-Write"
+                      edge="start"
+                      onChange={setGrantTo(entity, idx, 'read_write')}
+                      value="read_write"
                     />
                   </TableCell>
                 </TableRow>
@@ -167,11 +198,11 @@ export const UserPermissionsEntitySection = React.memo(
         </StyledGrantsTable>
         <PaginationFooter
           count={grants.length}
+          eventCategory={`User Permissions for ${entity}`}
           handlePageChange={pagination.handlePageChange}
           handleSizeChange={pagination.handlePageSizeChange}
           page={pagination.page}
           pageSize={pagination.pageSize}
-          eventCategory={`User Permissions for ${entity}`}
         />
       </Box>
     );


### PR DESCRIPTION
## Description 📝
This PR fixes the problem in which the "None", "Read-Only", and "Read-Write" radio buttons under the "Specific Permissions" of the User Permissions page do not have any label or ARIA label, making it difficult to interact with the page using screen readers.

## Changes  🔄
List any change relevant to the reviewer.
- Replaces native `<label />` element with MUI equivalent components.
- Changes the content used by screen readers to express information to the user.
- Changes the label positioning of the radio buttons in accordance with [Advisory Technique G162](https://www.w3.org/WAI/WCAG21/Techniques/general/G162#example-3-labels-to-the-right-of-radio-buttons) of the WCAG 2.1 standards.

## Target release date 🗓️
09/11/2024

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![m3-7475-before](https://github.com/user-attachments/assets/860c88d1-5814-40f9-8a1a-63c948e26a4e) | ![m3-7475-after](https://github.com/user-attachments/assets/4edbf286-2a01-4c88-b067-cd2e7df64d71) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Visit the User Permissions landing page and activate the VoiceOver Utility (⌘ + F5) on your MAC computer.

### Verification steps
(How to verify changes)
- Use your keyboard to navigate to the Specific Permissions panel and to select different permissions for different entities.
- Pay attention to the audio output of the VoiceOver utility and/or inspect the text transcript to verify the expected output.
- Verify that all Permission-related functionality works as expected.
- Verify that there are no unexpected visual regressions.

## As an Author I have considered 🤔
*Check all that apply*
- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support