### PR TITLE
fix: [M3-8553] - DisplayPrice story crash when Currency component's `minimumFractionDigits` is negative

### DIFF
--- a/packages/manager/.changeset/pr-10913-fixed-1725955539025.md
+++ b/packages/manager/.changeset/pr-10913-fixed-1725955539025.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-DisplayPrice story crash when Currency component's minimumFractionDigits is Negative ([#10913](https://github.com/linode/manager/pull/10913))
+DisplayPrice story crash when Currency component's minimumFractionDigits is negative ([#10913](https://github.com/linode/manager/pull/10913))

--- a/packages/manager/.changeset/pr-10913-fixed-1725955539025.md
+++ b/packages/manager/.changeset/pr-10913-fixed-1725955539025.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+DisplayPrice story crash when Currency component's minimumFractionDigits is Negative ([#10913](https://github.com/linode/manager/pull/10913))

--- a/packages/manager/src/components/Currency/Currency.test.tsx
+++ b/packages/manager/src/components/Currency/Currency.test.tsx
@@ -8,69 +8,79 @@ import { Currency } from './Currency';
 describe('Currency Component', () => {
   it('displays a given quantity in USD', () => {
     const { getByText, rerender } = renderWithTheme(<Currency quantity={5} />);
-    getByText('$5.00');
+    expect(getByText('$5.00')).toBeVisible();
     rerender(<Currency quantity={99.99} />);
-    getByText('$99.99');
+    expect(getByText('$99.99')).toBeVisible();
     rerender(<Currency quantity={0} />);
-    getByText('$0.00');
+    expect(getByText('$0.00')).toBeVisible();
   });
 
   it('handles negative quantities', () => {
     const { getByText, rerender } = renderWithTheme(<Currency quantity={-5} />);
-    getByText('-$5.00');
+    expect(getByText('-$5.00')).toBeVisible();
     rerender(<Currency quantity={-99.99} />);
-    getByText('-$99.99');
+    expect(getByText('-$99.99')).toBeVisible();
     rerender(<Currency quantity={-0.01} />);
-    getByText('-$0.01');
+    expect(getByText('-$0.01')).toBeVisible();
   });
 
   it('wraps in parentheses', () => {
     const { getByText, rerender } = renderWithTheme(
       <Currency quantity={5} wrapInParentheses />
     );
-    getByText('($5.00)');
+    expect(getByText('($5.00)')).toBeVisible();
     rerender(<Currency quantity={-5} wrapInParentheses />);
-    getByText('-($5.00)');
+    expect(getByText('-($5.00)')).toBeVisible();
     rerender(<Currency quantity={0} wrapInParentheses />);
-    getByText('($0.00)');
+    expect(getByText('($0.00)')).toBeVisible();
   });
 
   it('handles custom number of decimal places', () => {
     const { getByText, rerender } = renderWithTheme(
       <Currency decimalPlaces={3} quantity={5} />
     );
-    getByText('$5.000');
+    expect(getByText('$5.000')).toBeVisible();
     rerender(<Currency decimalPlaces={3} quantity={99.999} />);
-    getByText('$99.999');
+    expect(getByText('$99.999')).toBeVisible();
     rerender(<Currency decimalPlaces={3} quantity={-5} />);
-    getByText('-$5.000');
+    expect(getByText('-$5.000')).toBeVisible();
   });
 
   it('handles custom default values', () => {
     const { getByText } = renderWithTheme(
       <Currency quantity={UNKNOWN_PRICE} />
     );
-    getByText(`$${UNKNOWN_PRICE}`);
+    expect(getByText(`$${UNKNOWN_PRICE}`)).toBeVisible();
   });
 
   it('groups by comma', () => {
     const { getByText, rerender } = renderWithTheme(
       <Currency quantity={1000} />
     );
-    getByText('$1,000.00');
+    expect(getByText('$1,000.00')).toBeVisible();
     rerender(<Currency quantity={100000} />);
-    getByText('$100,000.00');
+    expect(getByText('$100,000.00')).toBeVisible();
   });
 
   it('displays --.-- when passed in as a quantity', () => {
     const { getByText } = renderWithTheme(<Currency quantity={'--.--'} />);
-    getByText('$--.--');
+    expect(getByText('$--.--')).toBeVisible();
   });
 
   it('applies the passed in data attributes', () => {
     const { getByTestId } = renderWithTheme(
       <Currency dataAttrs={{ 'data-testid': 'currency-test' }} quantity={3} />
     );
-    getByTestId('currency-test');
+    expect(getByTestId('currency-test')).toBeInTheDocument();
+  });
+
+  it('should display price with default 2 decimal places if decimalPlaces is negative or undefined', () => {
+    const { getByText, rerender } = renderWithTheme(
+      <Currency decimalPlaces={-1} quantity={99} />
+    );
+    expect(getByText('$99.00')).toBeVisible();
+
+    rerender(<Currency quantity={99} />);
+    expect(getByText('$99.00')).toBeVisible();
   });
 });

--- a/packages/manager/src/components/Currency/Currency.tsx
+++ b/packages/manager/src/components/Currency/Currency.tsx
@@ -22,11 +22,15 @@ interface CurrencyFormatterProps {
 }
 
 export const Currency = (props: CurrencyFormatterProps) => {
-  const { dataAttrs, quantity, wrapInParentheses } = props;
+  const { dataAttrs, decimalPlaces, quantity, wrapInParentheses } = props;
+
+  // Use the default value (2) when decimalPlaces is negative or undefined.
+  const minimumFractionDigits =
+    decimalPlaces !== undefined && decimalPlaces >= 0 ? decimalPlaces : 2;
 
   const formatter = new Intl.NumberFormat('en-US', {
     currency: 'USD',
-    minimumFractionDigits: props.decimalPlaces ?? 2,
+    minimumFractionDigits,
     style: 'currency',
   });
 


### PR DESCRIPTION
## Description 📝
The Storybook for DisplayPrice is crashing when the `minimumFractionDigits` in the Currency component is set with a negative value.

This PR addresses the issue by updating the Currency component to handle negative decimalPlaces props correctly. Specifically, it ensures that the `minimumFractionDigits` defaults to 2 when the `decimalPlaces `prop is `negative` or `undefined`.

## Changes  🔄
- Handle negative decimalPlaces prop in Currency component to fix DisplayPrice story
   - The `minimumFractionDigits` in the Currency component will now use the default value (2) when `decimalPlaces` prop is `negative` or `undefined`.
- Add a unit test case to cover the above scenario.
- Update all other unit test cases for more clarity.

## Target release date 🗓️
N/A

## How to test 🧪

### Reproduction steps
- Go to the DisplayPrice storybook
- Enter a negative value for decimalPlaces prop

### Verification steps
- Run storybook locally and verify that the Story for DisplayPrice should not crash when the decimalPlaces prop is negative.
- Confirm that the The `minimumFractionDigits` in the Currency component uses the default value (2) when `decimalPlaces` prop is `negative` or `undefined`.
- Verify that all the unit test cases pass.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support