### PR TITLE
fix: [M3-5753] - Linode Create v2 not handling deprecated and EOL Images 

### DIFF
--- a/packages/manager/src/components/ImageSelectv2/ImageOptionv2.test.tsx
+++ b/packages/manager/src/components/ImageSelectv2/ImageOptionv2.test.tsx
@@ -7,7 +7,7 @@ import { ImageOptionv2 } from './ImageOptionv2';
 
 describe('ImageOptionv2', () => {
   it('renders the image label', () => {
-    const image = imageFactory.build();
+    const image = imageFactory.build({ eol: null });
 
     const { getByText } = renderWithTheme(
       <ImageOptionv2 image={image} isSelected={false} listItemProps={{}} />
@@ -48,5 +48,28 @@ describe('ImageOptionv2', () => {
         'This image is compatible with distributed compute regions.'
       )
     ).toBeVisible();
+  });
+
+  it('renders (deprecated) if the image is deprecated', () => {
+    const image = imageFactory.build({ deprecated: true });
+
+    const { getByText } = renderWithTheme(
+      <ImageOptionv2 image={image} isSelected={false} listItemProps={{}} />
+    );
+
+    expect(getByText(`${image.label} (deprecated)`)).toBeVisible();
+  });
+
+  it('renders (deprecated) if the image is past its end-of-life', () => {
+    const image = imageFactory.build({
+      deprecated: false,
+      eol: '2015-01-01T00:00:00',
+    });
+
+    const { getByText } = renderWithTheme(
+      <ImageOptionv2 image={image} isSelected={false} listItemProps={{}} />
+    );
+
+    expect(getByText(`${image.label} (deprecated)`)).toBeVisible();
   });
 });

--- a/packages/manager/src/components/ImageSelectv2/ImageOptionv2.tsx
+++ b/packages/manager/src/components/ImageSelectv2/ImageOptionv2.tsx
@@ -9,6 +9,7 @@ import { OSIcon } from '../OSIcon';
 import { Stack } from '../Stack';
 import { Tooltip } from '../Tooltip';
 import { Typography } from '../Typography';
+import { isImageDeprecated } from './utilities';
 
 import type { Image } from '@linode/api-v4';
 
@@ -32,7 +33,9 @@ export const ImageOptionv2 = ({ image, isSelected, listItemProps }: Props) => {
     >
       <Stack alignItems="center" direction="row" spacing={2}>
         <OSIcon fontSize="1.8em" lineHeight="1.8em" os={image.vendor} />
-        <Typography color="inherit">{image.label}</Typography>
+        <Typography color="inherit">
+          {image.label} {isImageDeprecated(image) && '(deprecated)'}
+        </Typography>
       </Stack>
       <Stack alignItems="center" direction="row" spacing={1}>
         {image.capabilities.includes('distributed-sites') && (

--- a/packages/manager/src/components/ImageSelectv2/ImageSelectv2.test.tsx
+++ b/packages/manager/src/components/ImageSelectv2/ImageSelectv2.test.tsx
@@ -24,7 +24,7 @@ describe('ImageSelectv2', () => {
   });
 
   it('should render items returned by the API', async () => {
-    const images = imageFactory.buildList(5);
+    const images = imageFactory.buildList(5, { eol: null });
 
     server.use(
       http.get('*/v4/images', () => {
@@ -44,7 +44,7 @@ describe('ImageSelectv2', () => {
   });
 
   it('should call onChange when a value is selected', async () => {
-    const image = imageFactory.build();
+    const image = imageFactory.build({ eol: null });
     const onChange = vi.fn();
 
     server.use(

--- a/packages/manager/src/components/ImageSelectv2/utilities.test.ts
+++ b/packages/manager/src/components/ImageSelectv2/utilities.test.ts
@@ -1,0 +1,82 @@
+import { Settings } from 'luxon';
+
+import { imageFactory } from 'src/factories';
+
+import { isImageDeprecated, isImageTooFarPastEOL } from './utilities';
+
+describe('isImageTooFarPastEOL', () => {
+  it('should return false if the image does not have an `eol`', () => {
+    const image = imageFactory.build({ eol: null });
+
+    expect(isImageTooFarPastEOL(image)).toBe(false);
+  });
+
+  it("should return true if it is more than 6 months past the Image's `eol`", () => {
+    // Mock the current date
+    Settings.now = () => new Date(2018, 1, 1).valueOf();
+
+    expect(
+      isImageTooFarPastEOL(imageFactory.build({ eol: '2015-01-01T00:00:00' }))
+    ).toBe(true);
+
+    expect(
+      isImageTooFarPastEOL(imageFactory.build({ eol: '2017-07-01T00:00:00' }))
+    ).toBe(true);
+  });
+
+  it("should return false if it is not 6 months past the image's `eol`", () => {
+    // Mock the current date
+    Settings.now = () => new Date(2018, 1, 1).valueOf();
+
+    expect(
+      isImageTooFarPastEOL(imageFactory.build({ eol: '2018-04-01T00:00:00' }))
+    ).toBe(false);
+
+    expect(
+      isImageTooFarPastEOL(imageFactory.build({ eol: '2018-08-01T00:00:00' }))
+    ).toBe(false);
+
+    expect(
+      isImageTooFarPastEOL(imageFactory.build({ eol: '2032-01-01T00:00:00' }))
+    ).toBe(false);
+  });
+});
+
+describe('isImageDeprecated', () => {
+  it('should return true image is `deprecated` according to the API', () => {
+    const image = imageFactory.build({ deprecated: true, eol: null });
+
+    expect(isImageDeprecated(image)).toBe(true);
+  });
+
+  it('should return false image is not `deprecated` and the image does not have an `eol`', () => {
+    const image = imageFactory.build({ deprecated: false, eol: null });
+
+    expect(isImageDeprecated(image)).toBe(false);
+  });
+
+  it("should return true if the current date is after the image's `eol` (the image is past its EOL)", () => {
+    // Mock the current date
+    Settings.now = () => new Date(2018, 5, 1).valueOf();
+
+    const image = imageFactory.build({
+      deprecated: false,
+      eol: '2018-01-01T00:00:00',
+    });
+
+    expect(isImageDeprecated(image)).toBe(true);
+  });
+
+  it("should return false if the current date is before the image's `eol` (the image is not past its EOL)", () => {
+    // Mock the current date
+    Settings.now = () => new Date(2018, 1, 1).valueOf();
+
+    // Image with an end-of-life that is in the future compared to the mocked current date
+    const image = imageFactory.build({
+      deprecated: false,
+      eol: '2019-05-02T00:00:00',
+    });
+
+    expect(isImageDeprecated(image)).toBe(false);
+  });
+});

--- a/packages/manager/src/components/ImageSelectv2/utilities.ts
+++ b/packages/manager/src/components/ImageSelectv2/utilities.ts
@@ -1,5 +1,8 @@
-import { ImageSelectVariant } from './ImageSelectv2';
+import { DateTime } from 'luxon';
 
+import { MAX_MONTHS_EOL_FILTER } from 'src/constants';
+
+import type { ImageSelectVariant } from './ImageSelectv2';
 import type { Image } from '@linode/api-v4';
 
 /**
@@ -21,11 +24,11 @@ export const getAPIFilterForImageSelect = (
 };
 
 /**
- * Using API filter, I can't think of a way to filter out
- * LKE images that we don't want customers to see.
+ * Unfortunately, we can't use API filtering for all of our filtering needs.
  *
- * This function exists to filter out public Kubernetes images
- * for the Images Select.
+ * This function exists to...
+ * - filter out public Kubernetes images for the Images Select
+ * - filter out images that are too far past their end-of-life date
  *
  * Please use API filtering (getAPIFilterForImageSelect) when possible!
  */
@@ -33,7 +36,55 @@ export const getFilteredImagesForImageSelect = (
   images: Image[] | undefined,
   variant: ImageSelectVariant | undefined
 ) => {
-  return variant === 'private'
-    ? images
-    : images?.filter((image) => !image.id.includes('kube'));
+  if (variant === 'public') {
+    // For public images, we filter out LKE images and images that are > 6 months part their `eol`
+    return images?.filter(
+      (image) => !image.id.includes('kube') && !isImageTooFarPastEOL(image)
+    );
+  }
+
+  return images;
+};
+
+/**
+ * Returns whether or not an image is too far past its end-of-life based on MAX_MONTHS_EOL_FILTER
+ *
+ * This function is intended to be used to filter out end-of-life images based on
+ * an internal policy. See `M3-5753` for context.
+ *
+ * @param image an image from the API
+ * @returns true if the given image is more than 6 months past its end-of-life
+ */
+export const isImageTooFarPastEOL = (image: Image) => {
+  if (image.eol === null) {
+    return false;
+  }
+
+  const imageEOL = DateTime.fromISO(image.eol);
+  const now = DateTime.now();
+
+  const differenceInMonths = now.diff(imageEOL, 'months').months;
+
+  // console.log("Image's EOL was", differenceInMonths, "months ago");
+
+  return differenceInMonths > MAX_MONTHS_EOL_FILTER;
+};
+
+/**
+ * Returns whether or not an image is deprecated
+ *
+ * Unfortunately, as per `M3-5753`, we can't just simpily check `deprecated` on the `Image`,
+ * we must also factor in the EOL date.
+ */
+export const isImageDeprecated = (image: Image) => {
+  if (image.eol === null) {
+    // If the image does not have an EOL, just use the `deprecated` field returned by the API
+    return image.deprecated;
+  }
+
+  const isImageEOL =
+    DateTime.fromISO(image.eol).toUnixInteger() <
+    DateTime.now().toUnixInteger();
+
+  return image.deprecated || isImageEOL;
 };


### PR DESCRIPTION
## Description 📝

This PR addresses functionality that was missed on Linode Create v2

## Changes  🔄
- Adds `(deprecated)` to Linux distributions that are deprecated on Linode Create v2
- Hides Linux distributions that are > 6 months past their EOL (end of life) on Linode Create 🙈

## Target release date 🗓️

9/16/2024

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-09-10 at 1 07 04 PM](https://github.com/user-attachments/assets/bd86b1f0-edf8-44f3-8d16-88620aa556eb) | ![Screenshot 2024-09-10 at 1 06 52 PM](https://github.com/user-attachments/assets/0f4c94c3-34fd-4d0d-8c45-6f0367ebf573) |

## How to test 🧪

- Go to http://localhost:3000/linodes/create
- Test the Image/distribution/OS select component and verify the following is true (see M3-5753 for context on why it works like this)
  - Images that have `deprecated: true` show `(deprecated)`
  - Images that are past their `eol` date show `(deprecated)`
  - Images that are > 6 months past their `eol` are not shown in the select 
- Using our local dev tools, toggle between Linode Create v1 and v2 and verify they behave the same
  - You may see `(deprecated)` on a few more options on v2 because we now also respect the  `deprecated ` field returned by the API in addition to the `eol`
-  Verify that private images (on the `Images` tab of Linode Create) are not negatively affected by this change
 
## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support