### PR TITLE
test: [M3-8544, M3-8545] - Add unit tests for Dialog and DeletionDialog components

### DIFF
--- a/packages/manager/.changeset/pr-10917-tests-1726061618551.md
+++ b/packages/manager/.changeset/pr-10917-tests-1726061618551.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add unit tests for Dialog and DeletionDialog components ([#10917](https://github.com/linode/manager/pull/10917))

--- a/packages/manager/src/components/DeletionDialog/DeletionDialog.test.tsx
+++ b/packages/manager/src/components/DeletionDialog/DeletionDialog.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent } from '@testing-library/react';
+import * as React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { DeletionDialog } from './DeletionDialog';
+
+import type { DeletionDialogProps } from './DeletionDialog';
+
+describe('DeletionDialog', () => {
+  const defaultArgs: DeletionDialogProps = {
+    entity: 'Linode',
+    label: 'my-linode-0',
+    loading: false,
+    onClose: vi.fn(),
+    onDelete: vi.fn(),
+    open: false,
+  };
+
+  it.each([
+    ['not render', false],
+    ['render', true],
+  ])(
+    'should %s a DeletionDialog with the correct title, close button, and action buttons when open is %s',
+    (_, isOpen) => {
+      const { queryByRole, queryByTestId, queryByText } = renderWithTheme(
+        <DeletionDialog {...defaultArgs} open={isOpen} />
+      );
+      const title = queryByText(
+        `Delete ${defaultArgs.entity} ${defaultArgs.label}?`
+      );
+      const dialog = queryByTestId('drawer');
+      const closeButton = queryByRole('button', { name: 'Close' });
+      const cancelButton = queryByTestId('cancel');
+      const deleteButton = queryByTestId('confirm');
+
+      if (isOpen) {
+        expect(title).toBeInTheDocument();
+        expect(dialog).toBeInTheDocument();
+        expect(closeButton).toBeInTheDocument();
+        expect(cancelButton).toBeInTheDocument();
+        expect(deleteButton).toBeInTheDocument();
+        expect(deleteButton).toHaveTextContent(`Delete ${defaultArgs.entity}`);
+      } else {
+        expect(title).not.toBeInTheDocument();
+        expect(dialog).not.toBeInTheDocument();
+        expect(closeButton).not.toBeInTheDocument();
+        expect(cancelButton).not.toBeInTheDocument();
+        expect(deleteButton).not.toBeInTheDocument();
+      }
+    }
+  );
+
+  it('should call onClose when the DeletionDialog close button or Action cancel button is clicked', () => {
+    const { getByRole, getByTestId } = renderWithTheme(
+      <DeletionDialog {...defaultArgs} open={true} />
+    );
+
+    // For close icon button
+    const closeButton = getByRole('button', { name: 'Close' });
+    expect(closeButton).not.toBeDisabled();
+    fireEvent.click(closeButton);
+
+    expect(defaultArgs.onClose).toHaveBeenCalled();
+
+    // For action cancel button
+    const cancelButton = getByTestId('cancel');
+    expect(cancelButton).not.toBeDisabled();
+    fireEvent.click(cancelButton);
+
+    expect(defaultArgs.onClose).toHaveBeenCalled();
+  });
+
+  it('should call onDelete when the DeletionDialog delete button is clicked', () => {
+    const { getByTestId } = renderWithTheme(
+      <DeletionDialog {...defaultArgs} open={true} />
+    );
+
+    const deleteButton = getByTestId('confirm');
+    expect(deleteButton).not.toBeDisabled();
+    fireEvent.click(deleteButton);
+
+    expect(defaultArgs.onDelete).toHaveBeenCalled();
+  });
+
+  it('should render a DeletionDialog with an error message if provided', () => {
+    const { getByText } = renderWithTheme(
+      <DeletionDialog
+        {...defaultArgs}
+        error="Error that will be shown in the dialog."
+        open={true}
+      />
+    );
+
+    expect(getByText('Error that will be shown in the dialog.')).toBeVisible();
+  });
+
+  it('should disable delete button and show loading icon if loading is true', () => {
+    const { getByTestId } = renderWithTheme(
+      <DeletionDialog {...defaultArgs} loading={true} open={true} />
+    );
+
+    const deleteButton = getByTestId('confirm');
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toBeDisabled();
+
+    const loadingSvgIcon = deleteButton.querySelector(
+      '[data-test-id="ReloadIcon"]'
+    );
+
+    expect(loadingSvgIcon).toBeInTheDocument();
+  });
+
+  it('should display the correct warning text in the DeletionDialog', () => {
+    const { getByTestId } = renderWithTheme(
+      <DeletionDialog {...defaultArgs} open={true} />
+    );
+
+    const dialog = getByTestId('drawer');
+    const warningText = `Warning: Deleting this ${defaultArgs.entity} is permanent and can\u2019t be undone.`;
+
+    expect(dialog).toHaveTextContent(warningText);
+  });
+
+  it.each([
+    ['not render', false],
+    ['render', true],
+  ])(
+    'should %s input field with label when typeToConfirm is %s',
+    (_, typeToConfirm) => {
+      const { queryByTestId } = renderWithTheme(
+        <DeletionDialog
+          {...defaultArgs}
+          open={true}
+          typeToConfirm={typeToConfirm}
+        />
+      );
+
+      if (typeToConfirm) {
+        expect(queryByTestId('inputLabelWrapper')).toBeInTheDocument();
+        expect(queryByTestId('textfield-input')).toBeInTheDocument();
+      } else {
+        expect(queryByTestId('inputLabelWrapper')).not.toBeInTheDocument();
+        expect(queryByTestId('textfield-input')).not.toBeInTheDocument();
+      }
+    }
+  );
+});

--- a/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
+++ b/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
@@ -10,9 +10,9 @@ import { titlecase } from 'src/features/Linodes/presentation';
 import { usePreferences } from 'src/queries/profile/preferences';
 import { capitalize } from 'src/utilities/capitalize';
 
-import { DialogProps } from '../Dialog/Dialog';
+import type { DialogProps } from '../Dialog/Dialog';
 
-interface DeletionDialogProps extends Omit<DialogProps, 'title'> {
+export interface DeletionDialogProps extends Omit<DialogProps, 'title'> {
   entity: string;
   error?: string;
   label: string;

--- a/packages/manager/src/components/Dialog/Dialog.test.tsx
+++ b/packages/manager/src/components/Dialog/Dialog.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent } from '@testing-library/react';
+import * as React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { Dialog } from './Dialog';
+
+import type { DialogProps } from './Dialog';
+
+describe('Dialog', () => {
+  const defaultArgs: DialogProps = {
+    onClose: vi.fn(),
+    open: false,
+    title: 'This is a Dialog',
+  };
+
+  it.each([
+    ['not render', false],
+    ['render', true],
+  ])('should %s a Dialog with title when open is %s', (_, isOpen) => {
+    const { queryByTestId, queryByText } = renderWithTheme(
+      <Dialog {...defaultArgs} open={isOpen} />
+    );
+
+    const title = queryByText('This is a Dialog');
+    const dialog = queryByTestId('drawer');
+
+    if (isOpen) {
+      expect(title).toBeInTheDocument();
+      expect(dialog).toBeInTheDocument();
+    } else {
+      expect(title).not.toBeInTheDocument();
+      expect(dialog).not.toBeInTheDocument();
+    }
+  });
+
+  it('should render a Dialog with childrens if provided', () => {
+    const { getByText } = renderWithTheme(
+      <Dialog {...defaultArgs} open={true}>
+        <p>Child items can go here!</p>
+      </Dialog>
+    );
+
+    expect(getByText('Child items can go here!')).toBeInTheDocument();
+  });
+
+  it('should call onClose when the Dialog close button is clicked', () => {
+    const { getByTestId } = renderWithTheme(
+      <Dialog {...defaultArgs} open={true} />
+    );
+
+    const closeButton = getByTestId('CloseIcon').closest('button');
+
+    if (closeButton) {
+      fireEvent.click(closeButton);
+    }
+
+    expect(defaultArgs.onClose).toHaveBeenCalled();
+  });
+
+  it('should render a Dialog with an error message if provided', () => {
+    const { getByText } = renderWithTheme(
+      <Dialog
+        {...defaultArgs}
+        error="Error that will be shown in the dialog."
+        open={true}
+      />
+    );
+
+    expect(getByText('Error that will be shown in the dialog.')).toBeVisible();
+  });
+});

--- a/packages/manager/src/components/Dialog/Dialog.test.tsx
+++ b/packages/manager/src/components/Dialog/Dialog.test.tsx
@@ -45,15 +45,12 @@ describe('Dialog', () => {
   });
 
   it('should call onClose when the Dialog close button is clicked', () => {
-    const { getByTestId } = renderWithTheme(
+    const { getByRole } = renderWithTheme(
       <Dialog {...defaultArgs} open={true} />
     );
 
-    const closeButton = getByTestId('CloseIcon').closest('button');
-
-    if (closeButton) {
-      fireEvent.click(closeButton);
-    }
+    const closeButton = getByRole('button', { name: 'Close' });
+    fireEvent.click(closeButton);
 
     expect(defaultArgs.onClose).toHaveBeenCalled();
   });

--- a/packages/manager/src/components/Dialog/Dialog.test.tsx
+++ b/packages/manager/src/components/Dialog/Dialog.test.tsx
@@ -34,7 +34,7 @@ describe('Dialog', () => {
     }
   });
 
-  it('should render a Dialog with childrens if provided', () => {
+  it('should render a Dialog with children if provided', () => {
     const { getByText } = renderWithTheme(
       <Dialog {...defaultArgs} open={true}>
         <p>Child items can go here!</p>


### PR DESCRIPTION
## Description 📝
Unit test cases for Dialog and DeletionDialog components.

## Changes  🔄
- Add unit test cases for Dialog and DeletionDialog components.

## Target release date 🗓️
N/A

## How to test 🧪

### Verification steps
- Run `yarn test src/components/Dialog src/components/DeletionDialog --reporter verbose` 
- Verify that all the test cases pass.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support