### PR TITLE
fix: [M3-8158] - Fix inaccurate Gravatar sunset banner date and rendering for users without Gravatar

### DIFF
--- a/packages/manager/src/features/GlobalNotifications/GravatarSunsetBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/GravatarSunsetBanner.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 export const GravatarSunsetBanner = (props: Props) => {
   const { email } = props;
-  const GRAVATAR_DEPRECATION_DATE = 'September 28th, 2024';
+  const GRAVATAR_DEPRECATION_DATE = 'September 30th, 2024';
 
   const hasGravatar = useGravatar(email);
 

--- a/packages/manager/src/features/GlobalNotifications/GravatarSunsetBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/GravatarSunsetBanner.tsx
@@ -12,9 +12,9 @@ export const GravatarSunsetBanner = (props: Props) => {
   const { email } = props;
   const GRAVATAR_DEPRECATION_DATE = 'September 30th, 2024';
 
-  const hasGravatar = useGravatar(email);
+  const { hasGravatar, isLoadingGravatar } = useGravatar(email);
 
-  if (!hasGravatar) {
+  if (isLoadingGravatar || !hasGravatar) {
     return;
   }
   return (


### PR DESCRIPTION
## Description 📝
I merged #10859 and, of course, promptly noticed that there were a couple of bugs in the banner. 🤦🏼‍♀️ 

No changeset since this hasn't been released.

## Changes  🔄
- Change the September 28 date to September 30, an actual Monday and day of the release
- Check for `isLoadingGravatar` from the `useGravatar` hook to avoid unintentionally displaying the banner to users without a Gravatar - we made some updates to `useGravatar` in the previous PR to use a cache and this was impacting the banner

## Target release date 🗓️
9/16/24

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-09-11 at 7 55 01 AM](https://github.com/user-attachments/assets/5edf166f-754f-4de1-875d-3063b25e5af7) | ![Screenshot 2024-09-11 at 8 04 18 AM](https://github.com/user-attachments/assets/3681f0fd-6657-43a1-a7b7-08639a85416c) ![Screenshot 2024-09-11 at 8 07 10 AM](https://github.com/user-attachments/assets/897e8fac-599d-49a1-a239-f964cc834430) |

## How to test 🧪

### Reproduction steps
(How to reproduce the issue, if applicable)
- Log into dev as a user without a Gravatar and notice the wrong date and the banner displays when it shouldn't be visible to you

### Verification steps
(How to verify changes)
- Repeat the above but on this branch and confirm the banner is not visible
- Log in as a user with a Gravatar and confirm you see the banner with the correct date

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
