### PR TITLE
fix: [M3-8563 & M3-8566] – Fix BSE capability for linodes & prevent unnecessary API request on Volume Create page

### DIFF
--- a/packages/api-v4/.changeset/pr-10920-added-1726070878408.md
+++ b/packages/api-v4/.changeset/pr-10920-added-1726070878408.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Added
+---
+
+LinodeCapabilities type used for `capabilities` property of Linode interface ([#10920](https://github.com/linode/manager/pull/10920))

--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -19,7 +19,7 @@ export interface Linode {
   id: number;
   alerts: LinodeAlerts;
   backups: LinodeBackups;
-  capabilities?: string[]; // @TODO BSE: Remove optionality once BSE is fully rolled out
+  capabilities?: LinodeCapabilities[]; // @TODO BSE: Remove optionality once BSE is fully rolled out
   created: string;
   disk_encryption?: EncryptionStatus; // @TODO LDE: Remove optionality once LDE is fully rolled out
   region: string;
@@ -53,6 +53,8 @@ export interface LinodeBackups {
   schedule: LinodeBackupSchedule;
   last_successful: string | null;
 }
+
+export type LinodeCapabilities = 'Block Storage Encryption';
 
 export type Window =
   | 'Scheduling'

--- a/packages/manager/.changeset/pr-10920-upcoming-features-1726068029277.md
+++ b/packages/manager/.changeset/pr-10920-upcoming-features-1726068029277.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update BSE capability for Linodes to be `Block Storage Encryption` instead of `blockstorage_encryption` ([#10920](https://github.com/linode/manager/pull/10920))

--- a/packages/manager/cypress/e2e/core/volumes/create-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/create-volume.spec.ts
@@ -140,7 +140,7 @@ describe('volume create flow', () => {
           .click();
 
         // @TODO BSE: once BSE is fully rolled out, check for the notice (selected linode doesn't have
-        // blockstorage_encryption capability + user checked "Encrypt Volume" checkbox) instead of the absence of it
+        // "Block Storage Encryption" capability + user checked "Encrypt Volume" checkbox) instead of the absence of it
         cy.findByText(CLIENT_LIBRARY_UPDATE_COPY).should('not.exist');
 
         cy.findByText('Create Volume').click();
@@ -247,7 +247,7 @@ describe('volume create flow', () => {
     const mockLinode = linodeFactory.build({
       region: mockRegions[0].id,
       id: 123456,
-      capabilities: ['blockstorage_encryption'],
+      capabilities: ['Block Storage Encryption'],
     });
 
     mockGetAccount(mockAccount).as('getAccount');

--- a/packages/manager/src/features/Volumes/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate.tsx
@@ -249,7 +249,7 @@ export const VolumeCreate = () => {
   );
 
   const linodeSupportsBlockStorageEncryption = Boolean(
-    linode?.capabilities?.includes('blockstorage_encryption')
+    linode?.capabilities?.includes('Block Storage Encryption')
   );
 
   const linodeError = touched.linode_id ? errors.linode_id : undefined;

--- a/packages/manager/src/features/Volumes/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate.tsx
@@ -245,7 +245,7 @@ export const VolumeCreate = () => {
 
   const { data: linode } = useLinodeQuery(
     linode_id ?? -1,
-    isBlockStorageEncryptionFeatureEnabled
+    isBlockStorageEncryptionFeatureEnabled && linode_id !== null
   );
 
   const linodeSupportsBlockStorageEncryption = Boolean(

--- a/packages/manager/src/features/Volumes/VolumeDrawer/LinodeVolumeAddDrawer.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/LinodeVolumeAddDrawer.tsx
@@ -33,7 +33,7 @@ export const LinodeVolumeAddDrawer = (props: Props) => {
   } = useIsBlockStorageEncryptionFeatureEnabled();
 
   const linodeSupportsBlockStorageEncryption = Boolean(
-    linode.capabilities?.includes('blockstorage_encryption')
+    linode.capabilities?.includes('Block Storage Encryption')
   );
 
   const toggleMode = (mode: 'attach' | 'create') => {

--- a/packages/manager/src/features/Volumes/VolumeDrawer/LinodeVolumeAttachForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/LinodeVolumeAttachForm.tsx
@@ -102,7 +102,7 @@ export const LinodeVolumeAttachForm = (props: Props) => {
 
   const linodeRequiresClientLibraryUpdate =
     volume?.encryption === 'enabled' &&
-    Boolean(!linode.capabilities?.includes('blockstorage_encryption'));
+    Boolean(!linode.capabilities?.includes('Block Storage Encryption'));
 
   React.useEffect(() => {
     // When the volume is encrypted but the linode requires a client library update, we want to show the client library copy


### PR DESCRIPTION
## Description 📝
- Change BSE capability for Linodes from `blockstorage_encryption` --> `Block Storage Encryption`
- Adjust `enabled` condition passed to `useLinodeQuery()` on Volume Create page so it is true only if `linode_id !== null`

## Target release date 🗓️
9/16/24

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-09-11 at 10 55 05 AM](https://github.com/user-attachments/assets/1acd9090-e124-4df7-b5ae-548b706239aa) | ![Screenshot 2024-09-11 at 11 01 21 AM](https://github.com/user-attachments/assets/af6f7dc0-30c2-494a-a716-977d0ba868ca) |

## How to test 🧪
### Prerequisites
Point at the dev environment with the `blockstorage-encryption` tag on your account

### Verification steps
On the Volume Create page, you should no longer see requests to `linode/instances/-1` before selecting a linode.

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support