### PR TITLE
fix: [M3-8158] - Render the correct Avatar icon for `ACTIONS_WITHOUT_USERNAMES`

### DIFF
--- a/packages/manager/.changeset/pr-10923-fixed-1726086511137.md
+++ b/packages/manager/.changeset/pr-10923-fixed-1726086511137.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Incorrect avatar displaying in Notification Center for a small subset of events ([#10923](https://github.com/linode/manager/pull/10923))

--- a/packages/manager/src/features/NotificationCenter/Events/NotificationCenterEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/Events/NotificationCenterEvent.tsx
@@ -63,10 +63,10 @@ export const NotificationCenterEvent = React.memo(
                   ? theme.palette.primary.dark
                   : undefined
               }
-              username={getEventUsername(event)}
+              username={username}
             />
           }
-          gravatar={<NotificationEventGravatar username={event.username} />}
+          gravatar={<NotificationEventGravatar username={username} />}
           height={32}
           width={32}
         />

--- a/packages/manager/src/features/NotificationCenter/Events/NotificationCenterEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/Events/NotificationCenterEvent.tsx
@@ -63,7 +63,7 @@ export const NotificationCenterEvent = React.memo(
                   ? theme.palette.primary.dark
                   : undefined
               }
-              username={event.username ?? 'Linode'}
+              username={getEventUsername(event)}
             />
           }
           gravatar={<NotificationEventGravatar username={event.username} />}


### PR DESCRIPTION
## Description 📝
One more bug fix...

There are a very small number of events that we consider `ACTIONS_WITHOUT_USERNAMES`. Some of these actions have no username, and other we want to override the username with `Linode` - we have a util called `getEventUsername` to do this for us.

We weren't making use of the username from the util correctly in this component, which we assign at [L36](https://github.com/linode/manager/pull/10923/files#diff-f6365682e16359d1aa4ddb5fe6a52aa28748fde917622c7c0689dd5a9b8053bfR36).

Without using this util, if a username existed (as it does for `entity_transfer_create` events), we were rendering the wrong initial in the avatar component. Since this is an 'action without username', we want the username to be Linode and to render the Akamai logo as the avatar.

We were already using this util in the EventRow component on Event Landing page; the bug was just in the Notification Center event.

~No changeset, didn't make it to prod.~ Adding a changeset because this actually was an existing bug in prod, but becomes more obvious once we start using the initialed avatars.

## Changes  🔄
- Uses the  `username` from `getEventUsername` util to correctly identify events whose usernames we are changing and render the correct avatar accordingly.

## Target release date 🗓️
9/16/24

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-09-11 at 12 35 04 PM](https://github.com/user-attachments/assets/f8d3366a-5665-499c-9152-235ec80777a2) | ![Screenshot 2024-09-11 at 12 34 19 PM](https://github.com/user-attachments/assets/fc6eee2c-32d1-4fe9-88c2-6745354272eb) |
| Prod: ![image](https://github.com/user-attachments/assets/d8daadf1-6dc4-44cb-98ee-e9aaa72d44e1) | ![Screenshot 2024-09-11 at 1 25 00 PM](https://github.com/user-attachments/assets/619cf526-7b05-4467-bbdf-1cc72713d4e6) |


## How to test 🧪

### Prerequisites
(How to setup test environment)
- Use an account without a Gravatar.
- In **dev**, trigger a service transfer.

### Reproduction steps
(How to reproduce the issue, if applicable)
- Open the notification center.
- Notice that although the username associated with the service transfer create event shows up as 'Linode' in the notification, the avatar has the first letter of your account username. (This is because the event.username is actually your user when coming from the API.)

### Verification steps
(How to verify changes)
- Check out this PR.
- Open the notification center.
- Notice that by using the util, we now are correctly overriding that `event.username` with `Linode` when passing that prop to the Avatar component. The Akamai logo is displayed as a result.
- Verify that that matches the event in Events Landing.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

