### PR TITLE
fix: [M3-8161] - Fix misaligned DNS banner text

### DIFF
--- a/packages/manager/.changeset/pr-10924-fixed-1726085139068.md
+++ b/packages/manager/.changeset/pr-10924-fixed-1726085139068.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Misaligned DNS banner text ([#10924](https://github.com/linode/manager/pull/10924))

--- a/packages/manager/src/features/Domains/DomainBanner.tsx
+++ b/packages/manager/src/features/Domains/DomainBanner.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import { DismissibleBanner } from 'src/components/DismissibleBanner/DismissibleBanner';
 import { Link } from 'src/components/Link';
+import { Stack } from 'src/components/Stack';
 import { Typography } from 'src/components/Typography';
 
 interface DomainBannerProps {
@@ -29,7 +30,7 @@ export const DomainBanner = React.memo((props: DomainBannerProps) => {
       preferenceKey={KEY}
       variant="warning"
     >
-      <>
+      <Stack>
         <Typography>
           <strong>Your DNS zones are not being served.</strong>
         </Typography>
@@ -38,7 +39,7 @@ export const DomainBanner = React.memo((props: DomainBannerProps) => {
           you have at least one active Linode on your account.{` `}
           <Link to="/linodes/create">You can create one here.</Link>
         </Typography>
-      </>
+      </Stack>
     </StyledDismissibleBanner>
   );
 });
@@ -47,6 +48,6 @@ const StyledDismissibleBanner = styled(DismissibleBanner, {
   label: 'StyledDismissableBanner',
 })(({ theme }) => ({
   '& h3:first-of-type': {
-    marginBottom: theme.spacing(1),
+    margin: theme.spacing(1),
   },
 }));

--- a/packages/manager/src/features/Domains/DomainBanner.tsx
+++ b/packages/manager/src/features/Domains/DomainBanner.tsx
@@ -30,9 +30,9 @@ export const DomainBanner = React.memo((props: DomainBannerProps) => {
       variant="warning"
     >
       <>
-        <StyledTypography>
+        <Typography>
           <strong>Your DNS zones are not being served.</strong>
-        </StyledTypography>
+        </Typography>
         <Typography>
           Your domains will not be served by Linode&rsquo;s nameservers unless
           you have at least one active Linode on your account.{` `}
@@ -42,12 +42,6 @@ export const DomainBanner = React.memo((props: DomainBannerProps) => {
     </StyledDismissibleBanner>
   );
 });
-
-const StyledTypography = styled(Typography, { label: 'StyledTypography' })(
-  ({ theme }) => ({
-    marginBottom: theme.spacing(),
-  })
-);
 
 const StyledDismissibleBanner = styled(DismissibleBanner, {
   label: 'StyledDismissableBanner',


### PR DESCRIPTION
## Description 📝
Fixes an alignment issue in the DNS zones banner. This banner appears in the domains landing when the user has a DNS zone but no Linodes on their account.

## Preview 📷
|Breakpoint|Before|After|
|--|--|--|
|`lg`|![Screenshot 2024-09-11 at 3 59 48 PM](https://github.com/user-attachments/assets/f23954a2-b761-4ff5-bc6e-7551667ff947)|![Screenshot 2024-09-11 at 3 59 56 PM](https://github.com/user-attachments/assets/ce07197a-409c-4019-b935-256f862330ce)|
|`md`|![Screenshot 2024-09-11 at 4 00 28 PM](https://github.com/user-attachments/assets/f0403887-acf1-4ff4-afc2-8773aba8d48e)|![Screenshot 2024-09-11 at 4 00 23 PM](https://github.com/user-attachments/assets/7fd2c62c-e501-4386-89e4-fa844b6e7f2c)
|`sm`|![Screenshot 2024-09-11 at 4 00 45 PM](https://github.com/user-attachments/assets/cc9d5c97-49a9-4d7e-8d05-b82d07c2b069)|![Screenshot 2024-09-11 at 4 00 53 PM](https://github.com/user-attachments/assets/af706279-f726-496c-a987-e09ecc86b01b)|
