### PR TITLE
test: [M3-8517] - Cloud changes for component test CI

### DIFF
--- a/Jenkinsfile-component-tests.groovy
+++ b/Jenkinsfile-component-tests.groovy
@@ -1,0 +1,3 @@
+library 'ui-builder'
+
+testManagerComponents()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,15 @@ services:
       <<: *default-env
       MANAGER_OAUTH: ${MANAGER_OAUTH}
 
+  # Component test runner.
+  component:
+    <<: *default-runner
+    depends_on: []
+    environment:
+      CY_TEST_DISABLE_RETRIES: 1
+    entrypoint: ['yarn', 'cy:component:run']
+
+
   # End-to-end test runner for Cloud's synthetic monitoring tests.
   # Configured to run against a remote Cloud instance hosted at some URL.
   e2e_heimdall:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,7 +123,8 @@ services:
     <<: *default-runner
     depends_on: []
     environment:
-      CY_TEST_DISABLE_RETRIES: 1
+      CY_TEST_DISABLE_RETRIES: ${CY_TEST_DISABLE_RETRIES}
+      CY_TEST_JUNIT_REPORT: ${CY_TEST_JUNIT_REPORT}
     entrypoint: ['yarn', 'cy:component:run']
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,8 @@ x-e2e-runners:
       condition: service_healthy
   env_file: ./packages/manager/.env
   volumes: *default-volumes
+  # TODO Stop using entrypoint, use CMD instead.
+  # (Or just make `yarn` the entrypoint, but either way stop forcing `cy:e2e`).
   entrypoint: ['yarn', 'cy:e2e']
 
 services:
@@ -119,6 +121,7 @@ services:
       MANAGER_OAUTH: ${MANAGER_OAUTH}
 
   # Component test runner.
+  # Does not require any Cloud Manager environment to run.
   component:
     <<: *default-runner
     depends_on: []
@@ -126,7 +129,6 @@ services:
       CY_TEST_DISABLE_RETRIES: ${CY_TEST_DISABLE_RETRIES}
       CY_TEST_JUNIT_REPORT: ${CY_TEST_JUNIT_REPORT}
     entrypoint: ['yarn', 'cy:component:run']
-
 
   # End-to-end test runner for Cloud's synthetic monitoring tests.
   # Configured to run against a remote Cloud instance hosted at some URL.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "cy:ci": "yarn cy:e2e",
     "cy:debug": "yarn workspace linode-manager cy:debug",
     "cy:component": "yarn workspace linode-manager cy:component",
+    "cy:component:run": "yarn workspace linode-manager cy:component:run",
     "cy:rec-snap": "yarn workspace linode-manager cy:rec-snap",
     "changeset": "node scripts/changelog/changeset.mjs",
     "generate-changelogs": "node scripts/changelog/generate-changelogs.mjs",

--- a/packages/manager/.changeset/pr-10926-tests-1726156342482.md
+++ b/packages/manager/.changeset/pr-10926-tests-1726156342482.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Support running component tests via CI ([#10926](https://github.com/linode/manager/pull/10926))

--- a/packages/manager/cypress.config.ts
+++ b/packages/manager/cypress.config.ts
@@ -63,7 +63,7 @@ export default defineConfig({
       return setupPlugins(on, config, [
         loadEnvironmentConfig,
         discardPassedTestRecordings,
-        enableJunitReport('Component'),
+        enableJunitReport('Component', true),
       ]);
     },
   },

--- a/packages/manager/cypress.config.ts
+++ b/packages/manager/cypress.config.ts
@@ -85,7 +85,7 @@ export default defineConfig({
         regionOverrideCheck,
         logTestTagInfo,
         splitCypressRun,
-        enableJunitReport,
+        enableJunitReport(),
         generateTestWeights,
       ]);
     },

--- a/packages/manager/cypress.config.ts
+++ b/packages/manager/cypress.config.ts
@@ -58,6 +58,14 @@ export default defineConfig({
     specPattern: './cypress/component/**/*.spec.tsx',
     viewportWidth: 500,
     viewportHeight: 500,
+
+    setupNodeEvents(on, config) {
+      return setupPlugins(on, config, [
+        loadEnvironmentConfig,
+        discardPassedTestRecordings,
+        enableJunitReport('Component'),
+      ]);
+    },
   },
 
   e2e: {

--- a/packages/manager/cypress/component/poc/region-select.spec.tsx
+++ b/packages/manager/cypress/component/poc/region-select.spec.tsx
@@ -397,9 +397,9 @@ componentTests('RegionSelect', (mount) => {
           .should('be.visible');
       });
       regionsWithoutObj.forEach((region) => {
-        ui.autocompletePopper
-          .findByTitle(`${region.label} (${region.id})`)
-          .should('not.exist');
+        ui.autocompletePopper.find().within(() => {
+          cy.findByText(`${region.label} (${region.id})`).should('not.exist');
+        });
       });
     });
 

--- a/packages/manager/cypress/support/component/index.html
+++ b/packages/manager/cypress/support/component/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <link rel="stylesheet" type="text/css" href="fonts/fonts.css">
     <title>Cloud Manager Components</title>
   </head>
   <body>

--- a/packages/manager/cypress/support/component/setup.tsx
+++ b/packages/manager/cypress/support/component/setup.tsx
@@ -30,9 +30,6 @@ import { ThemeName } from 'src/foundations/themes';
 
 import 'cypress-axe';
 
-// Load fonts using Vite rather than HTML `<link />`.
-import '../../../public/fonts/fonts.css';
-
 /**
  * Mounts a component with a Cloud Manager theme applied.
  *

--- a/packages/manager/cypress/support/plugins/junit-report.ts
+++ b/packages/manager/cypress/support/plugins/junit-report.ts
@@ -17,7 +17,10 @@ const capitalize = (str: string): string => {
  *
  * @returns Cypress configuration object.
  */
-export const enableJunitReport = (suiteName?: string): CypressPlugin => {
+export const enableJunitReport = (
+  suiteName?: string,
+  jenkinsMode: boolean = false
+): CypressPlugin => {
   return (_on, config) => {
     if (!!config.env[envVarName]) {
       // Use `suiteName` if it is specified.
@@ -37,7 +40,7 @@ export const enableJunitReport = (suiteName?: string): CypressPlugin => {
         mochaFile: 'cypress/results/test-results-[hash].xml',
         rootSuiteTitle: 'Cloud Manager Cypress Tests',
         testsuitesTitle: testSuiteName,
-        jenkinsMode: false,
+        jenkinsMode,
       };
     }
     return config;

--- a/packages/manager/cypress/support/plugins/junit-report.ts
+++ b/packages/manager/cypress/support/plugins/junit-report.ts
@@ -8,27 +8,38 @@ const capitalize = (str: string): string => {
 };
 
 /**
- * Enables and configures JUnit reporting when `CY_TEST_JUNIT_REPORT` is defined.
+ * Returns a plugin to enable JUnit reporting when `CY_TEST_JUNIT_REPORT` is defined.
+ *
+ * If no suite name is specified, this function will attempt to determine the
+ * suite name using the Cypress configuration object.
+ *
+ * @param suiteName - Optional suite name in the JUnit output.
  *
  * @returns Cypress configuration object.
  */
-export const enableJunitReport: CypressPlugin = (_on, config) => {
-  if (!!config.env[envVarName]) {
-    const testSuite = config.env['cypress_test_suite'] || 'core';
-    const testSuiteName = `${capitalize(testSuite)} Test Suite`;
+export const enableJunitReport = (suiteName?: string): CypressPlugin => {
+  return (_on, config) => {
+    if (!!config.env[envVarName]) {
+      // Use `suiteName` if it is specified.
+      // Otherwise, attempt to determine the test suite name using
+      // our Cypress configuration.
+      const testSuite = suiteName || config.env['cypress_test_suite'] || 'core';
 
-    // Cypress doesn't know to look for modules in the root `node_modules`
-    // directory, so we have to pass a relative path.
-    // See also: https://github.com/cypress-io/cypress/issues/6406
-    config.reporter = '../../node_modules/mocha-junit-reporter';
+      const testSuiteName = `${capitalize(testSuite)} Test Suite`;
 
-    // See also: https://www.npmjs.com/package/mocha-junit-reporter#full-configuration-options
-    config.reporterOptions = {
-      mochaFile: 'cypress/results/test-results-[hash].xml',
-      rootSuiteTitle: 'Cloud Manager Cypress Tests',
-      testsuitesTitle: testSuiteName,
-      jenkinsMode: false,
-    };
-  }
-  return config;
+      // Cypress doesn't know to look for modules in the root `node_modules`
+      // directory, so we have to pass a relative path.
+      // See also: https://github.com/cypress-io/cypress/issues/6406
+      config.reporter = '../../node_modules/mocha-junit-reporter';
+
+      // See also: https://www.npmjs.com/package/mocha-junit-reporter#full-configuration-options
+      config.reporterOptions = {
+        mochaFile: 'cypress/results/test-results-[hash].xml',
+        rootSuiteTitle: 'Cloud Manager Cypress Tests',
+        testsuitesTitle: testSuiteName,
+        jenkinsMode: false,
+      };
+    }
+    return config;
+  };
 };

--- a/packages/manager/cypress/support/plugins/junit-report.ts
+++ b/packages/manager/cypress/support/plugins/junit-report.ts
@@ -41,6 +41,7 @@ export const enableJunitReport = (
         rootSuiteTitle: 'Cloud Manager Cypress Tests',
         testsuitesTitle: testSuiteName,
         jenkinsMode,
+        suiteTitleSeparatedBy: jenkinsMode ? '→' : ' ',
       };
     }
     return config;

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -100,6 +100,7 @@
     "cy:e2e": "cypress run --headless -b chrome",
     "cy:debug": "cypress open --e2e",
     "cy:component": "cypress open --component",
+    "cy:component:run": "cypress run --component --headless -b chrome",
     "cy:rec-snap": "cypress run --headless -b chrome --env visualRegMode=record --spec ./cypress/integration/**/*visual*.spec.ts",
     "typecheck": "tsc --noEmit && tsc -p cypress --noEmit",
     "coverage": "vitest run --coverage && open coverage/index.html",


### PR DESCRIPTION
## Description 📝
This PR contains the changes needed to get the Cloud Manager component tests running via CI. There isn't too much testing that can be done for this, but I did add some information to the ticket related to validating these changes.

## Changes  🔄
- Added `yarn cy:component:run` command to run component tests via the CLI
- Enables JUnit generation for component tests
- Discards passed test recordings for component tests
- Adds a Docker Compose service for running component tests
- Fixes a region select test failure related to recent util changes

## How to test 🧪
- Run `yarn cy:component:run` and make sure tests run and pass
- See the ticket comments for more info about testing and validation

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
