### PR TITLE
fix: [M3-8519] - Objects Table Refreshing Logic

### DIFF
--- a/packages/manager/.changeset/pr-10927-fixed-1726139552414.md
+++ b/packages/manager/.changeset/pr-10927-fixed-1726139552414.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Objects Table Refreshing Logic Fixed ([#10927](https://github.com/linode/manager/pull/10927))

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -1,5 +1,5 @@
 import { getObjectList, getObjectURL } from '@linode/api-v4/lib/object-storage';
-import { useQueryClient } from '@tanstack/react-query';
+import { InfiniteData, useQueryClient } from '@tanstack/react-query';
 import produce from 'immer';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
@@ -21,14 +21,12 @@ import { OBJECT_STORAGE_DELIMITER } from 'src/constants';
 import { useFlags } from 'src/hooks/useFlags';
 import { useAccount } from 'src/queries/account/account';
 import {
+  getObjectBucketObjectsQueryKey,
   objectStorageQueries,
   useObjectBucketObjectsInfiniteQuery,
   useObjectStorageBuckets,
 } from 'src/queries/object-storage/queries';
-import {
-  fetchBucketAndUpdateCache,
-  prefixToQueryKey,
-} from 'src/queries/object-storage/utilities';
+import { fetchBucketAndUpdateCache } from 'src/queries/object-storage/utilities';
 import { isFeatureEnabledV2 } from 'src/utilities/accountCapabilities';
 import { sendDownloadObjectEvent } from 'src/utilities/analytics/customEventAnalytics';
 import { getQueryParamFromQueryString } from 'src/utilities/queryParams';
@@ -237,11 +235,7 @@ export const BucketDetail = (props: Props) => {
       pageParams: string[];
       pages: ObjectStorageObjectList[];
     }>(
-      [
-        ...objectStorageQueries.bucket(clusterId, bucketName)._ctx.objects
-          .queryKey,
-        ...prefixToQueryKey(prefix),
-      ],
+      getObjectBucketObjectsQueryKey(clusterId, bucketName, prefix),
       (data) => ({
         pageParams: data?.pageParams || [],
         pages,
@@ -279,7 +273,11 @@ export const BucketDetail = (props: Props) => {
   };
 
   const addOneFile = (objectName: string, sizeInBytes: number) => {
-    if (!data) {
+    const currentData = queryClient.getQueryData<
+      InfiniteData<ObjectStorageObjectList>
+    >(getObjectBucketObjectsQueryKey(clusterId, bucketName, prefix));
+
+    if (!currentData) {
       return;
     }
 
@@ -291,13 +289,13 @@ export const BucketDetail = (props: Props) => {
       size: sizeInBytes,
     };
 
-    for (let i = 0; i < data.pages.length; i++) {
-      const foundObjectIndex = data.pages[i].data.findIndex(
+    for (let i = 0; i < currentData.pages.length; i++) {
+      const foundObjectIndex = currentData.pages[i].data.findIndex(
         (_object) => _object.name === object.name
       );
       if (foundObjectIndex !== -1) {
-        const copy = [...data.pages];
-        const pageCopy = [...data.pages[i].data];
+        const copy = [...currentData.pages];
+        const pageCopy = [...currentData.pages[i].data];
 
         pageCopy[foundObjectIndex] = object;
 
@@ -309,7 +307,7 @@ export const BucketDetail = (props: Props) => {
       }
     }
 
-    const copy = [...data.pages];
+    const copy = [...currentData.pages];
     const dataCopy = [...copy[copy.length - 1].data];
 
     dataCopy.push(object);
@@ -322,7 +320,11 @@ export const BucketDetail = (props: Props) => {
   };
 
   const addOneFolder = (objectName: string) => {
-    if (!data) {
+    const currentData = queryClient.getQueryData<
+      InfiniteData<ObjectStorageObjectList>
+    >(getObjectBucketObjectsQueryKey(clusterId, bucketName, prefix));
+
+    if (!currentData) {
       return;
     }
 
@@ -334,7 +336,7 @@ export const BucketDetail = (props: Props) => {
       size: null,
     };
 
-    for (const page of data.pages) {
+    for (const page of currentData.pages) {
       if (page.data.find((object) => object.name === folder.name)) {
         // If a folder already exists in the store, invalidate that store for that specific
         // prefix. Due to how invalidateQueries works, all subdirectories also get invalidated.
@@ -349,7 +351,7 @@ export const BucketDetail = (props: Props) => {
       }
     }
 
-    const copy = [...data.pages];
+    const copy = [...currentData.pages];
     const dataCopy = [...copy[copy.length - 1].data];
 
     dataCopy.push(folder);

--- a/packages/manager/src/queries/object-storage/queries.ts
+++ b/packages/manager/src/queries/object-storage/queries.ts
@@ -268,6 +268,15 @@ export const useDeleteBucketWithRegionMutation = () => {
   });
 };
 
+export const getObjectBucketObjectsQueryKey = (
+  clusterId: string,
+  bucket: string,
+  prefix: string
+) => [
+  ...objectStorageQueries.bucket(clusterId, bucket)._ctx.objects.queryKey,
+  ...prefixToQueryKey(prefix),
+];
+
 export const useObjectBucketObjectsInfiniteQuery = (
   clusterId: string,
   bucket: string,
@@ -282,10 +291,7 @@ export const useObjectBucketObjectsInfiniteQuery = (
         clusterId,
         params: { delimiter, marker: pageParam as string | undefined, prefix },
       }),
-    queryKey: [
-      ...objectStorageQueries.bucket(clusterId, bucket)._ctx.objects.queryKey,
-      ...prefixToQueryKey(prefix),
-    ],
+    queryKey: getObjectBucketObjectsQueryKey(clusterId, bucket, prefix),
   });
 
 export const useCreateObjectUrlMutation = (


### PR DESCRIPTION
## Description 📝
After uploading several files into the object storage, file table was not updated correctly. In the provided fix, fresh data from the store is used during the store overriding.

## Changes  🔄
- Object buckets query key moved into a separate getter function and exported.
- Fresh store data is used during the overriding process.

## How to test 🧪
- Open the "Object Storage" page.
- Upload several files using drop area or browse button.
- Look at how the table is being updated after each file is uploaded.


## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
