### PR TITLE
upcoming: [M3-8576] – Fix "Create Voliume" button state when "Encrypt Volume" checkbox is checked

### DIFF
--- a/packages/manager/src/features/Volumes/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate.tsx
@@ -502,7 +502,7 @@ export const VolumeCreate = () => {
             <Button
               disabled={
                 disabled ||
-                (isBlockStorageEncryptionFeatureEnabled && // @TODO BSE: Once BSE is fully rolled out, remove feature flag condition
+                (isBlockStorageEncryptionFeatureEnabled && // @TODO BSE: Once BSE is fully rolled out, remove feature enabled check/condition
                   linode_id !== null &&
                   !linodeSupportsBlockStorageEncryption &&
                   values.encryption === 'enabled')

--- a/packages/manager/src/features/Volumes/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate.tsx
@@ -297,7 +297,7 @@ export const VolumeCreate = () => {
 
   const shouldDisplayClientLibraryCopy =
     isBlockStorageEncryptionFeatureEnabled &&
-    values.linode_id !== null &&
+    linode_id !== null &&
     !linodeSupportsBlockStorageEncryption;
 
   return (
@@ -502,7 +502,8 @@ export const VolumeCreate = () => {
             <Button
               disabled={
                 disabled ||
-                (isBlockStorageEncryptionFeatureEnabled &&
+                (isBlockStorageEncryptionFeatureEnabled && // @TODO BSE: Once BSE is fully rolled out, remove feature flag condition
+                  linode_id !== null &&
                   !linodeSupportsBlockStorageEncryption &&
                   values.encryption === 'enabled')
               }


### PR DESCRIPTION
## Description 📝
The "Create Volume" button should only be disabled when the "Encrypt Volume" checkbox is checked _if_ the user has selected a linode that requires a client library update before an encrypted volume can be attached. Otherwise, the button should be enabled.

## Target release date 🗓️
9/30/24

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-09-12 at 10 33 01 AM](https://github.com/user-attachments/assets/8f37cc4c-ed1b-4931-9fa6-78c8839e0e23) | ![Screenshot 2024-09-12 at 10 33 11 AM](https://github.com/user-attachments/assets/0660af4d-4659-42d9-8c6c-a80bd5ff726f) |

## How to test 🧪
### Prerequisites
Point at the dev environment with the `blockstorage-encryption` tag on your account

### Reproduction steps
On the `develop` branch/on the dev site, you will see the "Create Volume" button disabled on the Volume Create page if you check the "Encrypt Volume" checkbox (even if you don't select a linode).

### Verification steps
If you check the "Encrypt Volume" checkbox and don't select a linode, the "Create Volume" button should remain enabled.

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support