### PR TITLE
fix: [M3-7149] - Fix textfield tooltip icon focus area

### DIFF
--- a/packages/manager/.changeset/pr-10938-fixed-1726262803311.md
+++ b/packages/manager/.changeset/pr-10938-fixed-1726262803311.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Textarea tooltip icon focus area ([#10938](https://github.com/linode/manager/pull/10938))

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -1,9 +1,6 @@
 import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
-import { Theme, useTheme } from '@mui/material/styles';
-import {
-  default as _TextField,
-  StandardTextFieldProps,
-} from '@mui/material/TextField';
+import { useTheme } from '@mui/material/styles';
+import { default as _TextField } from '@mui/material/TextField';
 import { clamp } from 'ramda';
 import * as React from 'react';
 import { makeStyles } from 'tss-react/mui';
@@ -13,11 +10,13 @@ import { CircleProgress } from 'src/components/CircleProgress';
 import { FormHelperText } from 'src/components/FormHelperText';
 import { InputAdornment } from 'src/components/InputAdornment';
 import { InputLabel } from 'src/components/InputLabel';
-import { TooltipProps } from 'src/components/Tooltip';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { convertToKebabCase } from 'src/utilities/convertToKebobCase';
 
+import type { Theme } from '@mui/material/styles';
+import type { StandardTextFieldProps } from '@mui/material/TextField';
 import type { BoxProps } from 'src/components/Box';
+import type { TooltipProps } from 'src/components/Tooltip';
 
 const useStyles = makeStyles()((theme: Theme) => ({
   absolute: {
@@ -480,8 +479,10 @@ export const TextField = (props: TextFieldProps) => {
         {tooltipText && (
           <TooltipIcon
             sxTooltipIcon={{
+              height: '34px',
               margin: '0px 0px 0px 4px',
-              padding: '6px',
+              padding: '17px',
+              width: '34px',
             }}
             classes={{ popper: tooltipClasses }}
             onMouseEnter={tooltipOnMouseEnter}


### PR DESCRIPTION
## Description 📝
Fixes the focus area for tooltips to be a circle rather than an oval as before.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-09-13 at 5 21 43 PM](https://github.com/user-attachments/assets/5d517e74-1ed0-4b47-942f-6d894e693f68) | ![Screenshot 2024-09-13 at 5 21 32 PM](https://github.com/user-attachments/assets/edfd36fa-ee43-4415-b362-11a446ffa0ab) |

## How to test 🧪
Verify textfield tooltips' focus areas render as a circle and otherwise work as before.