### PR TITLE
feat: [M3-6715] - Allow sorting by amount on billing activity table

### DIFF
--- a/packages/manager/.changeset/pr-10941-added-1726492437722.md
+++ b/packages/manager/.changeset/pr-10941-added-1726492437722.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Allow sorting by amount on billing activity table ([#10941](https://github.com/linode/manager/pull/10941))

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -320,8 +320,8 @@ export const BillingActivityPanel = React.memo((props: Props) => {
       if (orderBy === 'total') {
         return order === 'asc' ? a.total - b.total : b.total - a.total;
       }
-      // If no valid 'orderBy' is provided, return the data as is.
-      return 0;
+      // Default: If no valid 'orderBy' is provided, sort the data by date in descending order.
+      return new Date(b.date).getTime() - new Date(a.date).getTime();
     });
 
     const start = (pagination.page - 1) * pagination.pageSize;

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -315,7 +315,11 @@ export const BillingActivityPanel = React.memo((props: Props) => {
 
   const getOrderedPaginatedData = (data: ActivityFeedItem[]) => {
     const orderedData = data.sort((a, b) => {
-      return order === 'asc' ? a.total - b.total : b.total - a.total;
+      if (orderBy === 'total') {
+        return order === 'asc' ? a.total - b.total : b.total - a.total;
+      }
+      // If no valid 'orderBy' is provided, return the data as is.
+      return 0;
     });
 
     const start = (pagination.page - 1) * pagination.pageSize;

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -335,7 +335,7 @@ export const BillingActivityPanel = React.memo((props: Props) => {
     if (accountPaymentsError || accountInvoicesError) {
       return (
         <TableRowError
-          colSpan={5}
+          colSpan={4}
           message={'There was an error retrieving your billing activity.'}
         />
       );
@@ -343,7 +343,7 @@ export const BillingActivityPanel = React.memo((props: Props) => {
     if (orderedPaginatedData.length == 0) {
       return (
         <TableRowEmpty
-          colSpan={5}
+          colSpan={4}
           message="No Billing & Payment History found."
         />
       );

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -172,6 +172,8 @@ const AkamaiBillingInvoiceText = (
 // <BillingActivityPanel />
 // =============================================================================
 
+const NUM_COLS = 4;
+
 export interface Props {
   accountActiveSince?: string;
 }
@@ -330,20 +332,20 @@ export const BillingActivityPanel = React.memo((props: Props) => {
 
   const renderTableContent = () => {
     if (accountPaymentsLoading || accountInvoicesLoading) {
-      return <TableRowLoading columns={4} rows={1} />;
+      return <TableRowLoading columns={NUM_COLS} rows={1} />;
     }
     if (accountPaymentsError || accountInvoicesError) {
       return (
         <TableRowError
-          colSpan={4}
-          message={'There was an error retrieving your billing activity.'}
+          colSpan={NUM_COLS}
+          message="There was an error retrieving your billing activity."
         />
       );
     }
-    if (orderedPaginatedData.length == 0) {
+    if (orderedPaginatedData.length === 0) {
       return (
         <TableRowEmpty
-          colSpan={4}
+          colSpan={NUM_COLS}
           message="No Billing & Payment History found."
         />
       );

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -313,7 +313,7 @@ export const BillingActivityPanel = React.memo((props: Props) => {
   const data =
     selectedTransactionType.value === 'all' ? combinedData : filteredData;
 
-  const getOrderedPaginatedData = (data: ActivityFeedItem[]) => {
+  const orderedPaginatedData = React.useMemo(() => {
     const orderedData = data.sort((a, b) => {
       if (orderBy === 'total') {
         return order === 'asc' ? a.total - b.total : b.total - a.total;
@@ -326,9 +326,7 @@ export const BillingActivityPanel = React.memo((props: Props) => {
     const end = start + pagination.pageSize;
 
     return orderedData.slice(start, end);
-  };
-
-  const orderedPaginatedData = getOrderedPaginatedData(data);
+  }, [data, orderBy, order, pagination.page, pagination.pageSize]);
 
   const renderTableContent = () => {
     if (accountPaymentsLoading || accountInvoicesLoading) {

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -11,6 +11,7 @@ import { Currency } from 'src/components/Currency';
 import { DateTimeDisplay } from 'src/components/DateTimeDisplay';
 import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
 import { Link } from 'src/components/Link';
+import { createDisplayPage } from 'src/components/Paginate';
 import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFooter';
 import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
@@ -324,10 +325,12 @@ export const BillingActivityPanel = React.memo((props: Props) => {
       return new Date(b.date).getTime() - new Date(a.date).getTime();
     });
 
-    const start = (pagination.page - 1) * pagination.pageSize;
-    const end = start + pagination.pageSize;
+    const displayPage = createDisplayPage<ActivityFeedItem>(
+      pagination.page,
+      pagination.pageSize
+    );
 
-    return orderedData.slice(start, end);
+    return displayPage(orderedData);
   }, [data, orderBy, order, pagination.page, pagination.pageSize]);
 
   const renderTableContent = () => {


### PR DESCRIPTION
## Description 📝
As a user, when I click the "Amount" column header, the Billing Activity table should be ordered by the amount column.

Related discussion: https://github.com/linode/manager/pull/9271#discussion_r1232608976

> [!Note]
> We are considering client-side ordering.

## Changes  🔄
List any change relevant to the reviewer.
- Add client-side ordering by total amount for the "Amount" column.
- Default to ordering by date when no valid 'orderBy' value is provided.
- Change to client-side pagination on the billing activity table.

## Target release date 🗓️
N/A

## How to test 🧪

### Prerequisites
- Test with real data or turn MSW 'ON' & set it to `Legacy MSW Handlers`

### Verification steps
- Verify that sorting by 'Amount' on the billing activity table works correctly (for both - Invoices and Payments data).
- Verify that the data is ordered by 'date' by default (when no valid 'orderBy' value is provided).
- Verify that pagination on the billing activity table is working as expected.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support