### PR TITLE
test: [M3-8565] - Add unit tests for rest of NodeBalancers package

### DIFF
--- a/packages/manager/.changeset/pr-10945-tests-1726507532580.md
+++ b/packages/manager/.changeset/pr-10945-tests-1726507532580.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add unit tests for rest of NodeBalancers package ([#10945](https://github.com/linode/manager/pull/10945))

--- a/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
+++ b/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
@@ -1,4 +1,3 @@
-import { Linode } from '@linode/api-v4/lib/linodes';
 import { Box } from '@mui/material';
 import * as React from 'react';
 
@@ -6,6 +5,7 @@ import { SelectedIcon } from 'src/components/Autocomplete/Autocomplete.styles';
 import { LinodeSelect } from 'src/features/Linodes/LinodeSelect/LinodeSelect';
 import { privateIPRegex } from 'src/utilities/ipUtils';
 
+import type { Linode } from '@linode/api-v4/lib/linodes';
 import type { TextFieldProps } from 'src/components/TextField';
 
 interface ConfigNodeIPSelectProps {

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.test.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent } from '@testing-library/react';
+import * as React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { NodeBalancerConfigNode } from './NodeBalancerConfigNode';
+
+import type { NodeBalancerConfigNodeProps } from './NodeBalancerConfigNode';
+
+const props: NodeBalancerConfigNodeProps = {
+  configIdx: 1,
+  disabled: false,
+  forEdit: true,
+  idx: 1,
+  node: {
+    address: 'some address',
+    label: 'some label',
+  },
+  onNodeAddressChange: vi.fn(),
+  onNodeLabelChange: vi.fn(),
+  onNodeModeChange: vi.fn(),
+  onNodePortChange: vi.fn(),
+  onNodeWeightChange: vi.fn(),
+  removeNode: vi.fn(),
+};
+
+describe('NodeBalancerConfigNode', () => {
+  it('removes the node', () => {
+    const { getByText } = renderWithTheme(
+      <NodeBalancerConfigNode {...props} />
+    );
+
+    fireEvent.click(getByText('Remove'));
+    expect(props.removeNode).toHaveBeenCalled();
+  });
+});

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.test.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.test.tsx
@@ -7,15 +7,17 @@ import { NodeBalancerConfigNode } from './NodeBalancerConfigNode';
 
 import type { NodeBalancerConfigNodeProps } from './NodeBalancerConfigNode';
 
+const node = {
+  address: 'some address',
+  label: 'some label',
+};
+
 const props: NodeBalancerConfigNodeProps = {
   configIdx: 1,
   disabled: false,
   forEdit: true,
   idx: 1,
-  node: {
-    address: 'some address',
-    label: 'some label',
-  },
+  node,
   onNodeAddressChange: vi.fn(),
   onNodeLabelChange: vi.fn(),
   onNodeModeChange: vi.fn(),
@@ -25,6 +27,44 @@ const props: NodeBalancerConfigNodeProps = {
 };
 
 describe('NodeBalancerConfigNode', () => {
+  it('renders the NodeBAlancerConfigNode', () => {
+    const { getByLabelText, getByText, queryByText } = renderWithTheme(
+      <NodeBalancerConfigNode {...props} />
+    );
+
+    expect(getByLabelText('Label')).toBeVisible();
+    expect(getByLabelText('Port')).toBeVisible();
+    expect(getByLabelText('Weight')).toBeVisible();
+    expect(getByText('Mode')).toBeVisible();
+    expect(getByText('Remove')).toBeVisible();
+    expect(queryByText('Status')).not.toBeInTheDocument();
+  });
+
+  it('renders the node status', () => {
+    const { getByText } = renderWithTheme(
+      <NodeBalancerConfigNode {...props} node={{ ...node, status: 'DOWN' }} />
+    );
+
+    expect(getByText('Status')).toBeVisible();
+    expect(getByText('DOWN')).toBeVisible();
+  });
+
+  it('cannot change the mode if the node is not for edit', () => {
+    const { queryByText } = renderWithTheme(
+      <NodeBalancerConfigNode {...props} forEdit={false} />
+    );
+
+    expect(queryByText('Mode')).not.toBeInTheDocument();
+  });
+
+  it('cannot remove the node if the node is not for edit or is the first node', () => {
+    const { queryByText } = renderWithTheme(
+      <NodeBalancerConfigNode {...props} forEdit={false} idx={0} />
+    );
+
+    expect(queryByText('Remove')).not.toBeInTheDocument();
+  });
+
   it('removes the node', () => {
     const { getByText } = renderWithTheme(
       <NodeBalancerConfigNode {...props} />

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.test.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.test.tsx
@@ -27,7 +27,7 @@ const props: NodeBalancerConfigNodeProps = {
 };
 
 describe('NodeBalancerConfigNode', () => {
-  it('renders the NodeBAlancerConfigNode', () => {
+  it('renders the NodeBalancerConfigNode', () => {
     const { getByLabelText, getByText, queryByText } = renderWithTheme(
       <NodeBalancerConfigNode {...props} />
     );

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
@@ -1,5 +1,5 @@
-import Grid from '@mui/material/Unstable_Grid2';
 import { styled } from '@mui/material/styles';
+import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 
 import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
@@ -13,8 +13,8 @@ import { Typography } from 'src/components/Typography';
 import { getErrorMap } from 'src/utilities/errorUtils';
 
 import { ConfigNodeIPSelect } from './ConfigNodeIPSelect';
-import { NodeBalancerConfigNodeFields } from './types';
 
+import type { NodeBalancerConfigNodeFields } from './types';
 import type { NodeBalancerConfigNodeMode } from '@linode/api-v4';
 
 export interface NodeBalancerConfigNodeProps {

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.test.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.test.tsx
@@ -70,7 +70,17 @@ export const nbConfigPanelMockPropsForTest: NodeBalancerConfigPanelProps = {
   sslCertificate: '',
 };
 
-const activeHealthChecks = ['Interval', 'Timeout', 'Attempts'];
+const activeHealthChecksFormInputs = ['Interval', 'Timeout', 'Attempts'];
+
+const activeHealthChecksHelperText = [
+  'Seconds between health check probes',
+  'Seconds to wait before considering the probe a failure. 1-30. Must be less than check_interval.',
+  'Number of failed probes before taking a node out of rotation. 1-30',
+];
+
+const sslCertificate = 'ssl-certificate';
+const privateKey = 'private-key';
+const proxyProtocol = 'Proxy Protocol';
 
 describe('NodeBalancerConfigPanel', () => {
   it('renders the NodeBalancerConfigPanel', () => {
@@ -79,6 +89,7 @@ describe('NodeBalancerConfigPanel', () => {
       getByText,
       queryByLabelText,
       queryByTestId,
+      queryByText,
     } = renderWithTheme(
       <NodeBalancerConfigPanel {...nbConfigPanelMockPropsForTest} />
     );
@@ -111,14 +122,17 @@ describe('NodeBalancerConfigPanel', () => {
     expect(getByText('Add a Node')).toBeVisible();
     expect(getByText('Backend Nodes')).toBeVisible();
 
-    activeHealthChecks.forEach((type) => {
-      expect(queryByLabelText(type)).not.toBeInTheDocument();
+    activeHealthChecksFormInputs.forEach((formLabel) => {
+      expect(queryByLabelText(formLabel)).not.toBeInTheDocument();
     });
-    expect(queryByTestId('ssl-certificate')).not.toBeInTheDocument();
-    expect(queryByTestId('private-key')).not.toBeInTheDocument();
+    activeHealthChecksHelperText.forEach((helperText) => {
+      expect(queryByText(helperText)).not.toBeInTheDocument();
+    });
+    expect(queryByTestId(sslCertificate)).not.toBeInTheDocument();
+    expect(queryByTestId(privateKey)).not.toBeInTheDocument();
     expect(queryByTestId('http-path')).not.toBeInTheDocument();
     expect(queryByTestId('http-body')).not.toBeInTheDocument();
-    expect(queryByLabelText('Proxy Protocol')).not.toBeInTheDocument();
+    expect(queryByLabelText(proxyProtocol)).not.toBeInTheDocument();
   });
 
   it('renders form fields specific to the HTTPS protocol', () => {
@@ -129,9 +143,9 @@ describe('NodeBalancerConfigPanel', () => {
       />
     );
 
-    expect(getByTestId('ssl-certificate')).toBeVisible();
-    expect(getByTestId('private-key')).toBeVisible();
-    expect(queryByLabelText('Proxy Protocol')).not.toBeInTheDocument();
+    expect(getByTestId(sslCertificate)).toBeVisible();
+    expect(getByTestId(privateKey)).toBeVisible();
+    expect(queryByLabelText(proxyProtocol)).not.toBeInTheDocument();
   });
 
   it('renders form fields specific to the TCP protocol', () => {
@@ -142,51 +156,65 @@ describe('NodeBalancerConfigPanel', () => {
       />
     );
 
-    expect(getByLabelText('Proxy Protocol')).toBeVisible();
-    expect(queryByTestId('ssl-certificate')).not.toBeInTheDocument();
-    expect(queryByTestId('private-key')).not.toBeInTheDocument();
+    expect(getByLabelText(proxyProtocol)).toBeVisible();
+    expect(queryByTestId(sslCertificate)).not.toBeInTheDocument();
+    expect(queryByTestId(privateKey)).not.toBeInTheDocument();
   });
 
   it('renders fields specific to the Active Health Check type of TCP Connection', () => {
-    const { getByLabelText, queryByTestId } = renderWithTheme(
+    const { getByLabelText, getByText, queryByTestId } = renderWithTheme(
       <NodeBalancerConfigPanel
         {...nbConfigPanelMockPropsForTest}
         healthCheckType="connection"
       />
     );
 
-    activeHealthChecks.forEach((type) => {
-      expect(getByLabelText(type)).toBeVisible();
+    activeHealthChecksFormInputs.forEach((formLabel) => {
+      expect(getByLabelText(formLabel)).toBeVisible();
+    });
+    activeHealthChecksHelperText.forEach((helperText) => {
+      expect(getByText(helperText)).toBeVisible();
     });
     expect(queryByTestId('http-path')).not.toBeInTheDocument();
     expect(queryByTestId('http-body')).not.toBeInTheDocument();
   });
 
   it('renders fields specific to the Active Health Check type of HTTP Status', () => {
-    const { getByLabelText, getByTestId, queryByTestId } = renderWithTheme(
+    const {
+      getByLabelText,
+      getByTestId,
+      getByText,
+      queryByTestId,
+    } = renderWithTheme(
       <NodeBalancerConfigPanel
         {...nbConfigPanelMockPropsForTest}
         healthCheckType="http"
       />
     );
 
-    activeHealthChecks.forEach((type) => {
-      expect(getByLabelText(type)).toBeVisible();
+    activeHealthChecksFormInputs.forEach((formLabel) => {
+      expect(getByLabelText(formLabel)).toBeVisible();
+    });
+    activeHealthChecksHelperText.forEach((helperText) => {
+      expect(getByText(helperText)).toBeVisible();
     });
     expect(getByTestId('http-path')).toBeVisible();
     expect(queryByTestId('http-body')).not.toBeInTheDocument();
   });
 
   it('renders fields specific to the Active Health Check type of HTTP Body', () => {
-    const { getByLabelText, getByTestId } = renderWithTheme(
+    const { getByLabelText, getByTestId, getByText } = renderWithTheme(
       <NodeBalancerConfigPanel
         {...nbConfigPanelMockPropsForTest}
         healthCheckType="http_body"
       />
     );
 
-    activeHealthChecks.forEach((type) => {
-      expect(getByLabelText(type)).toBeVisible();
+    activeHealthChecksFormInputs.forEach((formLabel) => {
+      expect(getByLabelText(formLabel)).toBeVisible();
+    });
+    activeHealthChecksHelperText.forEach((helperText) => {
+      expect(getByText(helperText)).toBeVisible();
     });
     expect(getByTestId('http-path')).toBeVisible();
     expect(getByTestId('http-body')).toBeVisible();

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.test.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.test.tsx
@@ -28,7 +28,7 @@ const node: NodeBalancerConfigNodeFields = {
   weight: 100,
 };
 
-const props: NodeBalancerConfigPanelProps = {
+export const nbConfigPanelMockPropsForTest: NodeBalancerConfigPanelProps = {
   addNode: vi.fn(),
   algorithm: 'roundrobin',
   checkBody: '',
@@ -79,7 +79,9 @@ describe('NodeBalancerConfigPanel', () => {
       getByText,
       queryByLabelText,
       queryByTestId,
-    } = renderWithTheme(<NodeBalancerConfigPanel {...props} />);
+    } = renderWithTheme(
+      <NodeBalancerConfigPanel {...nbConfigPanelMockPropsForTest} />
+    );
 
     expect(getByLabelText('Protocol')).toBeVisible();
     expect(getByLabelText('Algorithm')).toBeVisible();
@@ -121,7 +123,10 @@ describe('NodeBalancerConfigPanel', () => {
 
   it('renders form fields specific to the HTTPS protocol', () => {
     const { getByTestId, queryByLabelText } = renderWithTheme(
-      <NodeBalancerConfigPanel {...props} protocol="https" />
+      <NodeBalancerConfigPanel
+        {...nbConfigPanelMockPropsForTest}
+        protocol="https"
+      />
     );
 
     expect(getByTestId('ssl-certificate')).toBeVisible();
@@ -131,7 +136,10 @@ describe('NodeBalancerConfigPanel', () => {
 
   it('renders form fields specific to the TCP protocol', () => {
     const { getByLabelText, queryByTestId } = renderWithTheme(
-      <NodeBalancerConfigPanel {...props} protocol="tcp" />
+      <NodeBalancerConfigPanel
+        {...nbConfigPanelMockPropsForTest}
+        protocol="tcp"
+      />
     );
 
     expect(getByLabelText('Proxy Protocol')).toBeVisible();
@@ -141,7 +149,10 @@ describe('NodeBalancerConfigPanel', () => {
 
   it('renders fields specific to the Active Health Check type of TCP Connection', () => {
     const { getByLabelText, queryByTestId } = renderWithTheme(
-      <NodeBalancerConfigPanel {...props} healthCheckType="connection" />
+      <NodeBalancerConfigPanel
+        {...nbConfigPanelMockPropsForTest}
+        healthCheckType="connection"
+      />
     );
 
     activeHealthChecks.forEach((type) => {
@@ -153,7 +164,10 @@ describe('NodeBalancerConfigPanel', () => {
 
   it('renders fields specific to the Active Health Check type of HTTP Status', () => {
     const { getByLabelText, getByTestId, queryByTestId } = renderWithTheme(
-      <NodeBalancerConfigPanel {...props} healthCheckType="http" />
+      <NodeBalancerConfigPanel
+        {...nbConfigPanelMockPropsForTest}
+        healthCheckType="http"
+      />
     );
 
     activeHealthChecks.forEach((type) => {
@@ -165,7 +179,10 @@ describe('NodeBalancerConfigPanel', () => {
 
   it('renders fields specific to the Active Health Check type of HTTP Body', () => {
     const { getByLabelText, getByTestId } = renderWithTheme(
-      <NodeBalancerConfigPanel {...props} healthCheckType="http_body" />
+      <NodeBalancerConfigPanel
+        {...nbConfigPanelMockPropsForTest}
+        healthCheckType="http_body"
+      />
     );
 
     activeHealthChecks.forEach((type) => {
@@ -177,7 +194,7 @@ describe('NodeBalancerConfigPanel', () => {
 
   it('renders the relevant helper text for the Round Robin algorithm', () => {
     const { getByText, queryByText } = renderWithTheme(
-      <NodeBalancerConfigPanel {...props} />
+      <NodeBalancerConfigPanel {...nbConfigPanelMockPropsForTest} />
     );
 
     expect(getByText(ROUND_ROBIN_ALGORITHM_HELPER_TEXT)).toBeVisible();
@@ -189,7 +206,10 @@ describe('NodeBalancerConfigPanel', () => {
 
   it('renders the relevant helper text for the Least Connections algorithm', () => {
     const { getByText, queryByText } = renderWithTheme(
-      <NodeBalancerConfigPanel {...props} algorithm={'leastconn'} />
+      <NodeBalancerConfigPanel
+        {...nbConfigPanelMockPropsForTest}
+        algorithm={'leastconn'}
+      />
     );
 
     expect(getByText(LEAST_CONNECTIONS_ALGORITHM_HELPER_TEXT)).toBeVisible();
@@ -201,7 +221,10 @@ describe('NodeBalancerConfigPanel', () => {
 
   it('renders the relevant helper text for the Source algorithm', () => {
     const { getByText, queryByText } = renderWithTheme(
-      <NodeBalancerConfigPanel {...props} algorithm={'source'} />
+      <NodeBalancerConfigPanel
+        {...nbConfigPanelMockPropsForTest}
+        algorithm={'source'}
+      />
     );
 
     expect(getByText(SOURCE_ALGORITHM_HELPER_TEXT)).toBeVisible();
@@ -215,17 +238,17 @@ describe('NodeBalancerConfigPanel', () => {
 
   it('adds another backend node', () => {
     const { getByText } = renderWithTheme(
-      <NodeBalancerConfigPanel {...props} />
+      <NodeBalancerConfigPanel {...nbConfigPanelMockPropsForTest} />
     );
 
     const addNodeButton = getByText('Add a Node');
     fireEvent.click(addNodeButton);
-    expect(props.addNode).toHaveBeenCalled();
+    expect(nbConfigPanelMockPropsForTest.addNode).toHaveBeenCalled();
   });
 
   it('cannot remove a backend node if there is only one node', () => {
     const { queryByText } = renderWithTheme(
-      <NodeBalancerConfigPanel {...props} />
+      <NodeBalancerConfigPanel {...nbConfigPanelMockPropsForTest} />
     );
 
     expect(queryByText('Remove')).not.toBeInTheDocument();
@@ -233,31 +256,37 @@ describe('NodeBalancerConfigPanel', () => {
 
   it('removes a backend node', () => {
     const { getByText } = renderWithTheme(
-      <NodeBalancerConfigPanel {...props} nodes={[{ ...node }, node]} />
+      <NodeBalancerConfigPanel
+        {...nbConfigPanelMockPropsForTest}
+        nodes={[{ ...node }, node]}
+      />
     );
 
     const removeNodeButton = getByText('Remove');
     fireEvent.click(removeNodeButton);
-    expect(props.removeNode).toHaveBeenCalled();
+    expect(nbConfigPanelMockPropsForTest.removeNode).toHaveBeenCalled();
   });
 
   it('deletes the configuration panel', () => {
     const { getByText } = renderWithTheme(
-      <NodeBalancerConfigPanel {...props} />
+      <NodeBalancerConfigPanel {...nbConfigPanelMockPropsForTest} />
     );
 
     const deleteConfigButton = getByText('Delete');
     fireEvent.click(deleteConfigButton);
-    expect(props.onDelete).toHaveBeenCalled();
+    expect(nbConfigPanelMockPropsForTest.onDelete).toHaveBeenCalled();
   });
 
   it('saves the input after editing the configuration', () => {
     const { getByText } = renderWithTheme(
-      <NodeBalancerConfigPanel {...props} forEdit={true} />
+      <NodeBalancerConfigPanel
+        {...nbConfigPanelMockPropsForTest}
+        forEdit={true}
+      />
     );
 
     const editConfigButton = getByText('Save');
     fireEvent.click(editConfigButton);
-    expect(props.onSave).toHaveBeenCalled();
+    expect(nbConfigPanelMockPropsForTest.onSave).toHaveBeenCalled();
   });
 });

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.test.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.test.tsx
@@ -5,7 +5,7 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 import NodeBalancerCreate from './NodeBalancerCreate';
 
 // Note: see nodeblaancers-create-in-complex-form.spec.ts for an e2e test of this flow
-describe('NodeBalancerCreate unit tests', () => {
+describe('NodeBalancerCreate', () => {
   it('renders all parts of the NodeBalancerCreate page', () => {
     const { getAllByText, getByLabelText, getByText } = renderWithTheme(
       <NodeBalancerCreate />

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.test.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.test.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import NodeBalancerCreate from './NodeBalancerCreate';
+
+// Note: see nodeblaancers-create-in-complex-form.spec.ts for an e2e test of this flow
+describe('NodeBalancerCreate unit tests', () => {
+  it('renders all parts of the NodeBalancerCreate page', () => {
+    const { getAllByText, getByLabelText, getByText } = renderWithTheme(
+      <NodeBalancerCreate />
+    );
+
+    // confirm nodebalancer fields render
+    expect(getByLabelText('NodeBalancer Label')).toBeVisible();
+    expect(getByLabelText('Add Tags')).toBeVisible();
+    expect(getByLabelText('Region')).toBeVisible();
+
+    // confirm Firewall panel renders
+    expect(getByLabelText('Assign Firewall')).toBeVisible();
+    expect(getByText('Create Firewall')).toBeVisible();
+    expect(
+      getByText(
+        /Assign an existing Firewall to this NodeBalancer to control inbound network traffic./
+      )
+    ).toBeVisible();
+
+    // confirm default configuration renders - only confirming headers, as we have additional
+    // unit tests to check the functionality of the NodeBalancerConfigPanel
+    expect(getByText('Configuration - Port 80')).toBeVisible();
+    expect(getByText('Active Health Checks')).toBeVisible();
+    expect(getAllByText('Passive Checks')).toHaveLength(2);
+    expect(getByText('Backend Nodes')).toBeVisible();
+
+    // confirm summary renders
+    expect(getByText('Summary')).toBeVisible();
+    expect(getByText('Configs')).toBeVisible();
+    expect(getByText('Nodes')).toBeVisible();
+    expect(getByText('Create NodeBalancer')).toBeVisible();
+  });
+});

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDeleteDialog.test.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDeleteDialog.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent } from '@testing-library/react';
+import * as React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { NodeBalancerDeleteDialog } from './NodeBalancerDeleteDialog';
+
+const props = {
+  id: 1,
+  label: 'nb-1',
+  onClose: vi.fn(),
+  open: true,
+};
+
+describe('NodeBalancerDeleteDialog', () => {
+  it('renders the NodeBalancerDeleteDialog', () => {
+    const { getByText } = renderWithTheme(
+      <NodeBalancerDeleteDialog {...props} />
+    );
+
+    expect(
+      getByText('Deleting this NodeBalancer is permanent and can’t be undone.')
+    ).toBeVisible();
+    expect(
+      getByText(
+        'Traffic will no longer be routed through this NodeBalancer. Please check your DNS settings and either provide the IP address of another active NodeBalancer, or route traffic directly to your Linode.'
+      )
+    ).toBeVisible();
+    expect(getByText('Delete nb-1?')).toBeVisible();
+    expect(getByText('NodeBalancer Label')).toBeVisible();
+    expect(getByText('Cancel')).toBeVisible();
+    expect(getByText('Delete')).toBeVisible();
+  });
+
+  it('calls the onClose function of the dialog', () => {
+    const { getByText } = renderWithTheme(
+      <NodeBalancerDeleteDialog {...props} />
+    );
+
+    fireEvent.click(getByText('Cancel'));
+    expect(props.onClose).toHaveBeenCalled();
+  });
+});

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerPassiveCheck.test.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerPassiveCheck.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent } from '@testing-library/react';
+import * as React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { nbConfigPanelMockPropsForTest } from './NodeBalancerConfigPanel.test';
+import { PassiveCheck } from './NodeBalancerPassiveCheck';
+
+describe('NodeBalancer PassiveCheck', () => {
+  it('renders the passive check', () => {
+    const { getAllByText, getByText } = renderWithTheme(
+      <PassiveCheck {...nbConfigPanelMockPropsForTest} />
+    );
+
+    expect(getAllByText('Passive Checks')).toHaveLength(2);
+    expect(
+      getByText(
+        'Enable passive checks based on observing communication with back-end nodes.'
+      )
+    ).toBeVisible();
+  });
+
+  it('calls onCheckPassiveChange when the check is toggled', () => {
+    const { getByLabelText } = renderWithTheme(
+      <PassiveCheck {...nbConfigPanelMockPropsForTest} />
+    );
+
+    const passiveChecksToggle = getByLabelText('Passive Checks');
+    expect(passiveChecksToggle).toBeInTheDocument();
+
+    fireEvent.click(passiveChecksToggle);
+    expect(
+      nbConfigPanelMockPropsForTest.onCheckPassiveChange
+    ).toHaveBeenCalled();
+  });
+});

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerSelect.test.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerSelect.test.tsx
@@ -1,4 +1,3 @@
-import { NodeBalancer } from '@linode/api-v4';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -7,6 +6,8 @@ import { nodeBalancerFactory } from 'src/factories';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { NodeBalancerSelect } from './NodeBalancerSelect';
+
+import type { NodeBalancer } from '@linode/api-v4';
 
 const fakeNodeBalancerData = nodeBalancerFactory.build({
   id: 1,


### PR DESCRIPTION
## Description 📝
- Adds unit tests for the rest of NodeBalancers package to improve test coverage and confirm things render as expected


## Target release date 🗓️
n/a

## How to test 🧪
- `yarn test NodeBalancers` - confirm all tests pass

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
