### PR TITLE
fix: [M3-8589] - Flickering on the user profile page when updating the currently signed in user's username

### DIFF
--- a/packages/manager/.changeset/pr-10947-fixed-1726507951785.md
+++ b/packages/manager/.changeset/pr-10947-fixed-1726507951785.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Flickering on the user profile page when updating the currently signed in user's username ([#10947](https://github.com/linode/manager/pull/10947))

--- a/packages/manager/src/queries/account/users.ts
+++ b/packages/manager/src/queries/account/users.ts
@@ -15,6 +15,7 @@ import type {
   Filter,
   Grants,
   Params,
+  Profile,
   ResourcePage,
   User,
 } from '@linode/api-v4';
@@ -65,11 +66,20 @@ export const useUpdateUserMutation = (username: string) => {
         accountQueries.users._ctx.user(user.username).queryKey,
         user
       );
-      // If the currently logged in user updates their user
+
+      // If the currently logged in user updates their user, we need to update the profile
+      // query to reflect the latest data.
       if (username === profile?.username) {
-        queryClient.invalidateQueries({
-          queryKey: profileQueries.profile().queryKey,
-        });
+        queryClient.setQueryData<Profile>(
+          profileQueries.profile().queryKey,
+          (oldProfile) => {
+            if (!oldProfile) {
+              return;
+            }
+
+            return { ...oldProfile, ...user };
+          }
+        );
       }
     },
   });


### PR DESCRIPTION
## Description 📝

- Updates our cache updating logic on the `useUpdateUserMutation` hook to manually update the profile cache rather than invalidating it  🔧 
- This fixes 🔧  the bug :bug: caught by @mjac0bs where the page would exhibit some flickering on the Delete button and Email fields when updating the username of the currently signed in user

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/7b91a532-fca0-44d8-8d2e-91e79a3a3b2e" /> | <video src="https://github.com/user-attachments/assets/1e3191e7-e539-4577-a131-94330ddb6302" /> |


## How to test 🧪

### Prerequisites
- Check out this PR or use the preview link
- Go to the user profile of the **currency signed in user**
  - In my case, this is http://localhost:3000/account/users/banks
- Try updating the username
- Verify there is no flickering at all

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support