### PR TITLE
fix: [M3-8422] - Linode IPv6 rDNS typo

### DIFF
--- a/packages/manager/.changeset/pr-10948-fixed-1726517375013.md
+++ b/packages/manager/.changeset/pr-10948-fixed-1726517375013.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Linode IPv6 Range rDNS typo ([#10948](https://github.com/linode/manager/pull/10948))

--- a/packages/manager/src/components/LinkButton.tsx
+++ b/packages/manager/src/components/LinkButton.tsx
@@ -46,6 +46,7 @@ export const LinkButton = (props: Props) => {
       disabled={isDisabled}
       onClick={onClick}
       style={style}
+      tabIndex={0}
       type="button"
     >
       {children}

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddressRow.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddressRow.tsx
@@ -1,5 +1,4 @@
 import { styled } from '@mui/material/styles';
-import { useTheme } from '@mui/material/styles';
 import { parse as parseIP } from 'ipaddr.js';
 import * as React from 'react';
 
@@ -137,7 +136,6 @@ const RangeRDNSCell = (props: {
   range: IPRange;
 }) => {
   const { linodeId, onViewDetails, range } = props;
-  const theme = useTheme();
 
   const { data: linode } = useLinodeQuery(linodeId);
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddressRow.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddressRow.tsx
@@ -1,10 +1,11 @@
-import { useTheme } from '@mui/material/styles';
 import { styled } from '@mui/material/styles';
+import { useTheme } from '@mui/material/styles';
 import { parse as parseIP } from 'ipaddr.js';
 import * as React from 'react';
 
 import { CircleProgress } from 'src/components/CircleProgress';
 import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
+import { LinkButton } from 'src/components/LinkButton';
 import { TableCell } from 'src/components/TableCell';
 import { Typography } from 'src/components/Typography';
 import { StyledTableRow } from 'src/features/Linodes/LinodeEntityDetail.styles';
@@ -17,7 +18,6 @@ import { LinodeNetworkingActionMenu } from './LinodeNetworkingActionMenu';
 import type { IPAddress, IPRange } from '@linode/api-v4';
 import type { IPv6 } from 'ipaddr.js';
 import type { IPDisplay } from 'src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses';
-import { LinkButton } from 'src/components/LinkButton';
 
 export interface IPAddressRowHandlers {
   handleOpenEditRDNS: (ip: IPAddress) => void;

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddressRow.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddressRow.tsx
@@ -17,6 +17,7 @@ import { LinodeNetworkingActionMenu } from './LinodeNetworkingActionMenu';
 import type { IPAddress, IPRange } from '@linode/api-v4';
 import type { IPv6 } from 'ipaddr.js';
 import type { IPDisplay } from 'src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses';
+import { LinkButton } from 'src/components/LinkButton';
 
 export interface IPAddressRowHandlers {
   handleOpenEditRDNS: (ip: IPAddress) => void;
@@ -169,21 +170,12 @@ const RangeRDNSCell = (props: {
   }
 
   return (
-    <button
+    <LinkButton
       aria-label={`View the ${ipsWithRDNS.length} RDNS Addresses`}
       onClick={onViewDetails}
     >
-      <Typography
-        sx={{
-          '&:hover': {
-            color: theme.palette.primary.light,
-          },
-          color: theme.palette.primary.main,
-        }}
-      >
-        {ipsWithRDNS.length} Addresses
-      </Typography>
-    </button>
+      {ipsWithRDNS.length} Addresses
+    </LinkButton>
   );
 };
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddressRow.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddressRow.tsx
@@ -181,7 +181,7 @@ const RangeRDNSCell = (props: {
           color: theme.palette.primary.main,
         }}
       >
-        {ipsWithRDNS.length} Addresses2
+        {ipsWithRDNS.length} Addresses
       </Typography>
     </button>
   );


### PR DESCRIPTION
## Description 📝

- Fixes RDNS typo on a IPv6 Range row on the Linode Details page 🌎 
- Uses a `<LinkButton />` instead of an un-styled browser button 🔘 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-09-16 at 3 48 59 PM](https://github.com/user-attachments/assets/ac0e2a88-5e84-4c3b-af30-86ea63c8d3c2) | ![Screenshot 2024-09-16 at 3 47 53 PM](https://github.com/user-attachments/assets/f1035647-7d3b-4e1d-8b67-6205e0f9f71f) |

## How to test 🧪

- Setting up RDNS on an IPv6 range is quite a process, I recommend following [this guide 📘](https://techdocs.akamai.com/cloud-computing/docs/configure-rdns-reverse-dns-on-a-compute-instance#ipv6-pools-and-routed-ranges) on setting it up if you want to go through the trouble. The changes are minimal enough that you probably don't need to go through this process. 

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support