### PR TITLE
feat: [M3-8581] - GPUv2 Plan Selection Egress Banner

### DIFF
--- a/packages/manager/.changeset/pr-10956-added-1727103260742.md
+++ b/packages/manager/.changeset/pr-10956-added-1727103260742.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+GPUv2 Plan Selection Egress Banner ([#10956](https://github.com/linode/manager/pull/10956))

--- a/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
@@ -368,7 +368,7 @@ describe('displays specific linode plans for GPU', () => {
     // Should display two separate tables
     cy.findByText('GPU').click();
     cy.get(linodePlansPanel).within(() => {
-      cy.findAllByRole('alert').should('have.length', 1);
+      cy.findAllByRole('alert').should('have.length', 2);
       cy.get(notices.unavailable).should('be.visible');
 
       cy.findByRole('table', {

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -70,6 +70,7 @@ export interface CloudPulseResourceTypeMapFlag {
 }
 
 interface gpuV2 {
+  egressBanner: boolean;
   planDivider: boolean;
 }
 

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
@@ -1,11 +1,11 @@
-import { LinodeTypeClass } from '@linode/api-v4/lib/linodes';
-import { Theme, useTheme } from '@mui/material/styles';
+import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 
 import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
 import { Typography } from 'src/components/Typography';
 import { StyledNoticeTypography } from 'src/features/Linodes/LinodesCreate/PlansAvailabilityNotice.styles';
+import { useFlags } from 'src/hooks/useFlags';
 
 import { PlansAvailabilityNotice } from '../../Linodes/LinodesCreate/PlansAvailabilityNotice';
 import {
@@ -19,6 +19,8 @@ import { MetalNotice } from './MetalNotice';
 import { planTabInfoContent } from './utils';
 
 import type { Region } from '@linode/api-v4';
+import type { LinodeTypeClass } from '@linode/api-v4/lib/linodes';
+import type { Theme } from '@mui/material/styles';
 
 export interface PlanInformationProps {
   disabledClasses?: LinodeTypeClass[];
@@ -40,20 +42,34 @@ export const PlanInformation = (props: PlanInformationProps) => {
     planType,
     regionsData,
   } = props;
-
+  const theme = useTheme();
   const getDisabledClass = (thisClass: LinodeTypeClass) => {
     return Boolean(disabledClasses?.includes(thisClass));
   };
+  const showGPUEgressBanner = Boolean(useFlags().gpuv2?.egressBanner);
 
   return (
     <>
       {planType === 'gpu' ? (
-        <PlansAvailabilityNotice
-          hasSelectedRegion={hasSelectedRegion}
-          isSelectedRegionEligibleForPlan={isSelectedRegionEligibleForPlan}
-          planType={planType}
-          regionsData={regionsData || []}
-        />
+        <>
+          {showGPUEgressBanner && (
+            <Notice variant="info">
+              <Typography fontFamily={theme.font.bold} fontSize="1rem">
+                New GPU instances are now generally available. Deploy an RTX
+                4000 Ada GPU instance in select core compute regions in North
+                America, Europe, and Asia. Receive 1 TB of free included network
+                transfer for a limited time.{' '}
+                <Link to="/docs/guides/gpu-egress-banner">Learn more</Link>.
+              </Typography>
+            </Notice>
+          )}
+          <PlansAvailabilityNotice
+            hasSelectedRegion={hasSelectedRegion}
+            isSelectedRegionEligibleForPlan={isSelectedRegionEligibleForPlan}
+            planType={planType}
+            regionsData={regionsData || []}
+          />
+        </>
       ) : null}
       {planType === 'metal' ? (
         <MetalNotice

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
@@ -57,9 +57,10 @@ export const PlanInformation = (props: PlanInformationProps) => {
               <Typography fontFamily={theme.font.bold} fontSize="1rem">
                 New GPU instances are now generally available. Deploy an RTX
                 4000 Ada GPU instance in select core compute regions in North
-                America, Europe, and Asia. Receive 1 TB of free included network
-                transfer for a limited time.{' '}
-                <Link to="/docs/guides/gpu-egress-banner">Learn more</Link>.
+                America, Europe, and Asia. <br />
+                Receive 1 TB of free included network transfer for a limited
+                time. {/* TODO: Add link to GPU egress banner */}
+                <Link to="#">Learn more</Link>.
               </Typography>
             </Notice>
           )}

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 
 import { Link } from 'src/components/Link';
@@ -42,7 +41,6 @@ export const PlanInformation = (props: PlanInformationProps) => {
     planType,
     regionsData,
   } = props;
-  const theme = useTheme();
   const getDisabledClass = (thisClass: LinodeTypeClass) => {
     return Boolean(disabledClasses?.includes(thisClass));
   };
@@ -53,8 +51,11 @@ export const PlanInformation = (props: PlanInformationProps) => {
       {planType === 'gpu' ? (
         <>
           {showGPUEgressBanner && (
-            <Notice variant="info">
-              <Typography fontFamily={theme.font.bold} fontSize="1rem">
+            <Notice spacingBottom={8} variant="info">
+              <Typography
+                fontFamily={(theme: Theme) => theme.font.bold}
+                fontSize="1rem"
+              >
                 New GPU instances are now generally available. Deploy an RTX
                 4000 Ada GPU instance in select core compute regions in North
                 America, Europe, and Asia. <br />
@@ -121,7 +122,6 @@ interface ClassDescriptionCopyProps {
 
 export const ClassDescriptionCopy = (props: ClassDescriptionCopyProps) => {
   const { planType } = props;
-  const theme = useTheme();
   let planTypeLabel: null | string;
   let docLink: null | string;
 
@@ -153,7 +153,10 @@ export const ClassDescriptionCopy = (props: ClassDescriptionCopyProps) => {
 
   return planTypeLabel && docLink ? (
     <Typography
-      sx={{ marginBottom: theme.spacing(3), marginTop: theme.spacing(1) }}
+      sx={(theme: Theme) => ({
+        marginBottom: theme.spacing(3),
+        marginTop: theme.spacing(1),
+      })}
     >
       {
         planTabInfoContent[planType as keyof typeof planTabInfoContent]

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
@@ -59,8 +59,11 @@ export const PlanInformation = (props: PlanInformationProps) => {
                 4000 Ada GPU instance in select core compute regions in North
                 America, Europe, and Asia. <br />
                 Receive 1 TB of free included network transfer for a limited
-                time. {/* TODO: Add link to GPU egress banner */}
-                <Link to="#">Learn more</Link>.
+                time.{' '}
+                <Link to="https://www.linode.com/blog/compute/new-gpus-nvidia-rtx-4000-ada-generation">
+                  Learn more
+                </Link>
+                .
               </Typography>
             </Notice>
           )}


### PR DESCRIPTION
## Description 📝
Small PR to add a GPUv2 Banner for the 9/30 new GPU plans launch. This is the MVP for the initial launch, before modifying the Plans Panel to account for transfer and billing changes.

> [!NOTE]
> This is very much a temp banner, which is the reason for not adding the banner to the existing e2e coverage. It will be removed in an upcoming M2 update.

## Changes  🔄
- Add new `egressBanner` property to the `GPUv2` flag object
- Add new banner behind flag conditional

## Target release date 🗓️
**9/30/2024**

## Preview 📷
![Linodes create](https://github.com/user-attachments/assets/aba89b1e-e241-47f5-83bb-a1de96613f15)

## How to test 🧪

> [!IMPORTANT]
> You may want the `gpuv2beta` flag on your account to get the new GPUv2 plans to show up, but it is not a requirement for testing the display of the banner

### Verification steps
- Make sure the `gpuv2` flag is on
- Navigate to the Linode Create flow, and verify the following:
  - This notice shall be consistent for the entire length of the promotion regardless of region if the user selects the GPU plan type
  - The notice should display wether the user has picked a region or not
  - This notice shall appear at the top, first sequentially before any other notices as relevant
  - The banner should not impact the logic / display of the other banners 

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support


