### PR TITLE
change: [M3-6838] - Better "Backups Enabled" default when cloning Linode

### DIFF
--- a/packages/manager/.changeset/pr-10959-changed-1726660002249.md
+++ b/packages/manager/.changeset/pr-10959-changed-1726660002249.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Better 'Backups Enabled' default when cloning Linode ([#10959](https://github.com/linode/manager/pull/10959))

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Backups.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Backups.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useController, useFormContext, useWatch } from 'react-hook-form';
 
 import { Checkbox } from 'src/components/Checkbox';
@@ -20,16 +20,23 @@ import { getBackupsEnabledValue } from './utilities';
 import type { LinodeCreateFormValues } from '../utilities';
 
 export const Backups = () => {
-  const { control } = useFormContext<LinodeCreateFormValues>();
+  const { control, setValue } = useFormContext<LinodeCreateFormValues>();
+
   const { field } = useController({
     control,
     name: 'backups_enabled',
   });
 
-  const [regionId, typeId, diskEncryption] = useWatch({
+  const [linode, regionId, typeId, diskEncryption] = useWatch({
     control,
-    name: ['region', 'type', 'disk_encryption'],
+    name: ['linode', 'region', 'type', 'disk_encryption'],
   });
+
+  const defaultValue = linode?.backups?.enabled ?? false;
+
+  useEffect(() => {
+    setValue('backups_enabled', defaultValue);
+  }, [defaultValue, setValue]);
 
   const isLinodeCreateRestricted = useRestrictedGlobalGrantCheck({
     globalGrantType: 'add_linodes',

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Backups.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Backups.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { useController, useFormContext, useWatch } from 'react-hook-form';
 
 import { Checkbox } from 'src/components/Checkbox';
@@ -20,23 +20,17 @@ import { getBackupsEnabledValue } from './utilities';
 import type { LinodeCreateFormValues } from '../utilities';
 
 export const Backups = () => {
-  const { control, setValue } = useFormContext<LinodeCreateFormValues>();
+  const { control } = useFormContext<LinodeCreateFormValues>();
 
   const { field } = useController({
     control,
     name: 'backups_enabled',
   });
 
-  const [linode, regionId, typeId, diskEncryption] = useWatch({
+  const [regionId, typeId, diskEncryption] = useWatch({
     control,
-    name: ['linode', 'region', 'type', 'disk_encryption'],
+    name: ['region', 'type', 'disk_encryption'],
   });
-
-  const defaultValue = linode?.backups?.enabled ?? false;
-
-  useEffect(() => {
-    setValue('backups_enabled', defaultValue);
-  }, [defaultValue, setValue]);
 
   const isLinodeCreateRestricted = useRestrictedGlobalGrantCheck({
     globalGrantType: 'add_linodes',

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Backups.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/Addons/Backups.tsx
@@ -21,7 +21,6 @@ import type { LinodeCreateFormValues } from '../utilities';
 
 export const Backups = () => {
   const { control } = useFormContext<LinodeCreateFormValues>();
-
   const { field } = useController({
     control,
     name: 'backups_enabled',

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/shared/LinodeSelectTable.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/shared/LinodeSelectTable.tsx
@@ -109,6 +109,7 @@ export const LinodeSelectTable = (props: Props) => {
     reset((prev) => ({
       ...prev,
       backup_id: null,
+      backups_enabled: linode.backups.enabled,
       linode,
       private_ip: hasPrivateIP,
       region: linode.region,

--- a/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreatev2/utilities.ts
@@ -304,6 +304,7 @@ export const defaultValues = async (
 
   const values: LinodeCreateFormValues = {
     backup_id: params.backupID,
+    backups_enabled: linode?.backups.enabled,
     image: getDefaultImageId(params),
     interfaces: defaultInterfaces,
     linode,


### PR DESCRIPTION
## Description 📝
- When cloning a Linode with backups enabled, the "Backups Enabled" checkbox should be checked by default (near the bottom of the Create flow)
- When cloning a Linode with backups disabled, the "Backups Enabled" checkbox should be unchecked by default (near the bottom of the Create flow)

## Changes  🔄
- When cloning a Linode with backups enabled, the "Backups Enabled" checkbox is checked by default.
- When cloning a Linode with backups disabled, the "Backups Enabled" checkbox  is unchecked by default.

## Target release date 🗓️
N/A

## How to test 🧪

### Reproduction steps
-  When cloning a Linode with backups enabled/disabled, the "Backups Enabled" checkbox is unchecked.

### Verification steps
- When cloning a Linode with backups enabled: 
    - Verify the "Backups Enabled" checkbox should be checked by default.
    - Without changing the state of the "Backups Enabled" checkbox, the newly cloned Linode should have backups enabled.
- When cloning a Linode with backups disabled:
  - the "Backups Enabled" checkbox should be unchecked by default.
  - Without changing the state of the "Backups Enabled" checkbox, the newly cloned Linode should have backups disabled.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support