### PR TITLE
change: [M3-8599] - Disable 'Save' button in Change Avatar Color dialog until color is changed

### DIFF
--- a/packages/manager/.changeset/pr-10963-changed-1726672295505.md
+++ b/packages/manager/.changeset/pr-10963-changed-1726672295505.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Disable 'Save' button in Change Avatar Color dialog until color is changed ([#10963](https://github.com/linode/manager/pull/10963))

--- a/packages/manager/src/features/Profile/DisplaySettings/AvatarColorPickerDialog.test.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/AvatarColorPickerDialog.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
 import { renderWithTheme } from 'src/utilities/testHelpers';
@@ -14,25 +15,46 @@ const mockProps: AvatarColorPickerDialogProps = {
 
 describe('AvatarColorPicker', () => {
   it('should render a dialog with a title, color picker, and avatar components', () => {
-    const {
-      getByLabelText,
-      getByRole,
-      getByTestId,
-      getByTitle,
-    } = renderWithTheme(<AvatarColorPickerDialog {...mockProps} />);
+    const { getByLabelText, getByTestId, getByTitle } = renderWithTheme(
+      <AvatarColorPickerDialog {...mockProps} />
+    );
 
     expect(getByTitle('Change Avatar Color')).toBeVisible();
     expect(getByLabelText('Avatar color picker')).toBeVisible();
     expect(getByTestId('avatar')).toBeVisible();
-    expect(getByRole('button', { name: 'Save' })).toBeDisabled();
   });
 
-  it('calls onClose when Close button is clicked', async () => {
-    const { getByText } = renderWithTheme(
+  it('calls onClose when Close/X buttons are clicked', async () => {
+    const { getAllByRole } = renderWithTheme(
       <AvatarColorPickerDialog {...mockProps} />
     );
 
-    await fireEvent.click(getByText('Close'));
+    const closeButtons = getAllByRole('button', { name: 'Close' });
+    closeButtons.forEach(async (button) => {
+      await userEvent.click(button);
+      expect(mockProps.handleClose).toHaveBeenCalled();
+    });
+  });
+
+  it('confirms when Save button is enabled and the dialog closes when Save is clicked', async () => {
+    const { getByLabelText, getByRole } = renderWithTheme(
+      <AvatarColorPickerDialog {...mockProps} />
+    );
+
+    const saveButton = getByRole('button', { name: 'Save' });
+
+    expect(saveButton).toBeDisabled();
+
+    fireEvent.input(getByLabelText('Avatar color picker'), {
+      target: { value: '#333333' },
+    });
+
+    // Verify save button becomes enabled after changing the color
+    expect(saveButton).toBeEnabled();
+
+    await userEvent.click(saveButton);
+
+    // Verify dialog closes after saving
     expect(mockProps.handleClose).toHaveBeenCalled();
   });
 });

--- a/packages/manager/src/features/Profile/DisplaySettings/AvatarColorPickerDialog.test.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/AvatarColorPickerDialog.test.tsx
@@ -14,13 +14,17 @@ const mockProps: AvatarColorPickerDialogProps = {
 
 describe('AvatarColorPicker', () => {
   it('should render a dialog with a title, color picker, and avatar components', () => {
-    const { getByLabelText, getByTestId, getByTitle } = renderWithTheme(
-      <AvatarColorPickerDialog {...mockProps} />
-    );
+    const {
+      getByLabelText,
+      getByRole,
+      getByTestId,
+      getByTitle,
+    } = renderWithTheme(<AvatarColorPickerDialog {...mockProps} />);
 
     expect(getByTitle('Change Avatar Color')).toBeVisible();
     expect(getByLabelText('Avatar color picker')).toBeVisible();
     expect(getByTestId('avatar')).toBeVisible();
+    expect(getByRole('button', { name: 'Save' })).toBeDisabled();
   });
 
   it('calls onClose when Close button is clicked', async () => {
@@ -29,15 +33,6 @@ describe('AvatarColorPicker', () => {
     );
 
     await fireEvent.click(getByText('Close'));
-    expect(mockProps.handleClose).toHaveBeenCalled();
-  });
-
-  it('closes when Save button is clicked', async () => {
-    const { getByText } = renderWithTheme(
-      <AvatarColorPickerDialog {...mockProps} />
-    );
-
-    await fireEvent.click(getByText('Save'));
     expect(mockProps.handleClose).toHaveBeenCalled();
   });
 });

--- a/packages/manager/src/features/Profile/DisplaySettings/AvatarColorPickerDialog.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/AvatarColorPickerDialog.tsx
@@ -51,6 +51,7 @@ export const AvatarColorPickerDialog = (
 
       <ActionsPanel
         primaryButtonProps={{
+          disabled: !avatarColor || preferences?.avatarColor === avatarColor,
           label: 'Save',
           onClick: () => {
             if (avatarColor) {


### PR DESCRIPTION
## Description 📝
Internal feedback: a user can forget to hit 'Save' once they've made their color selection.

Enabling the primary action button only if the color is changed makes the enabled Save button a more visible call to action for the user, reminding them to click it once they've selected a color.

## Changes  🔄
- Disables the Save button on the `AvatarColorPickerDialog` 

## Target release date 🗓️
9/30/24

## Preview 📷

| Color not changed | Color changed |
|--------|--------|
| ![Screenshot 2024-09-18 at 7 55 50 AM](https://github.com/user-attachments/assets/b15c7d73-5694-4c3d-8bbb-d5fb819f1ab8) | ![Screenshot 2024-09-18 at 7 56 05 AM](https://github.com/user-attachments/assets/e47ef60d-1d8b-4b1b-8644-9573e2ab2396) |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Use an account without a Gravatar or repro the issue in the dev environment, where Gravatars are no more.

### Reproduction steps
(How to reproduce the issue, if applicable)
- Go to https://cloud.linode.com/profile/display and click the `Change Avatar Color` button.
- Observe that the Save button is enabled.

### Verification steps
(How to verify changes)
- .Go to http://localhost:3000/profile/display and click the `Change Avatar Color` button.
- Observe that the Save button is disabled as long as the preview avatar color in the dialog matches the existing avatar color.
- Use the color picker to select a different color.
- Observe that the Save button is enabled.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
