### PR TITLE
fix: Marketplace Apache Spark Cluster URL Slug

### DIFF
--- a/packages/manager/.changeset/pr-10965-fixed-1726675687897.md
+++ b/packages/manager/.changeset/pr-10965-fixed-1726675687897.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Fix Marketplace Apache Spark Cluster URL slug to point to correct documentation ([#10965](https://github.com/linode/manager/pull/10965))
+Incorrect URL slug for Apache Spark Cluster Marketplace documentation ([#10965](https://github.com/linode/manager/pull/10965))

--- a/packages/manager/.changeset/pr-10965-fixed-1726675687897.md
+++ b/packages/manager/.changeset/pr-10965-fixed-1726675687897.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fix Marketplace Apache Spark Cluster URL slug to point to correct documentation ([#10965](https://github.com/linode/manager/pull/10965))

--- a/packages/manager/src/features/OneClickApps/oneClickAppsv2.ts
+++ b/packages/manager/src/features/OneClickApps/oneClickAppsv2.ts
@@ -2606,7 +2606,7 @@ export const oneClickApps: Record<number, OCA> = {
     related_guides: [
       {
         href:
-          'https://www.linode.com/docs/marketplace-docs/guides/apache-spark/',
+          'https://www.linode.com/docs/marketplace-docs/guides/apache-spark-cluster/',
         title: 'Deploy Apache Spark through the Linode Marketplace',
       },
     ],


### PR DESCRIPTION
## Description 📝
The documentation for the Apache Spark Marketplace Cluster is located at:
https://www.linode.com/docs/marketplace-docs/guides/apache-spark-cluster/

The current URL is wrong and needs to be fixed at: `packages/manager/src/features/OneClickApps/oneClickAppsv2.ts`

## Changes  🔄
List any change relevant to the reviewer.
- Change slug from `apache-spark` to `apache-spark-cluster`

## Target release date 🗓️
September 30, 2024

## Preview 📷
See the bottom left where the URL slug is:
![Apache Spark URL Slug fix](https://github.com/user-attachments/assets/a59b73d1-2f20-49b7-bc12-7c87fcf78ce6)

| Before  | 
![before screenshot](https://github.com/user-attachments/assets/4c5edfa5-96e0-4ef0-8712-e2aa98eb412e)

| After   |
![apache spark slug url fix](https://github.com/user-attachments/assets/8dd564f2-3a6e-4002-ba38-265ad497d7a1)