### PR TITLE
upcoming: [M3-8604] – Update URL for Volume Encryption guide

### DIFF
--- a/packages/manager/.changeset/pr-10973-upcoming-features-1726768912614.md
+++ b/packages/manager/.changeset/pr-10973-upcoming-features-1726768912614.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update URL for Volume Encryption guide ([#10973](https://github.com/linode/manager/pull/10973))

--- a/packages/manager/src/components/Encryption/constants.tsx
+++ b/packages/manager/src/components/Encryption/constants.tsx
@@ -73,7 +73,8 @@ export const ENCRYPT_DISK_REBUILD_DISTRIBUTED_COPY =
   'Distributed Compute Instances are secured using disk encryption.';
 
 /* Block Storage Encryption constants */
-const BLOCK_STORAGE_ENCRYPTION_GUIDE_LINK = ''; // @TODO BSE: Update with guide link
+const BLOCK_STORAGE_ENCRYPTION_GUIDE_LINK =
+  'https://techdocs.akamai.com/cloud-computing/docs/volumes-disk-encryption';
 
 export const BLOCK_STORAGE_ENCRYPTION_GENERAL_DESCRIPTION = (
   <>


### PR DESCRIPTION
## Description 📝
Update URL for Volume Encryption guide

## Target release date 🗓️
9/30/24

## How to test 🧪
### Prerequisites
Point at the dev environment with the `blockstorage-encryption` tag on your account

### Verification steps
The guide is linked to on the Volume Create page and in the Linode Details > Storage tab > Create and Attach Volume drawer. The "Learn more" text should link to the set URL.

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support