### PR TITLE
test: [M3-8616] - Fix failures in DBaaS update tests

### DIFF
--- a/docs/development-guide/09-mocking-data.md
+++ b/docs/development-guide/09-mocking-data.md
@@ -41,6 +41,8 @@ const linodeList = linodeFactory.buildList(10, { region: "eu-west" });
 // [{ id: 3, label: 'linode-3', region: 'eu-west' }, ...9 more ]
 ```
 
+Because our factories are used by our dev tools, unit tests, and end-to-end tests, we should avoid creating factories with random or unpredictable default values (e.g. by using utilities like `pickRandom` to assign property values).
+
 ### Intercepting Requests
 
 The [Mock Service Worker](https://mswjs.io/) package intercepts requests at the network level and returns the response you defined in the relevant factory.

--- a/packages/manager/cypress/e2e/core/databases/update-database.spec.ts
+++ b/packages/manager/cypress/e2e/core/databases/update-database.spec.ts
@@ -26,6 +26,7 @@ import {
   mockDatabaseNodeTypes,
 } from 'support/constants/databases';
 import { accountFactory } from '@src/factories';
+import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
 
 /**
  * Updates a database cluster's label.
@@ -142,6 +143,12 @@ const resetRootPassword = () => {
 };
 
 describe('Update database clusters', () => {
+  beforeEach(() => {
+    mockAppendFeatureFlags({
+      dbaasV2: { enabled: false, beta: false },
+    });
+  });
+
   databaseConfigurations.forEach(
     (configuration: databaseClusterConfiguration) => {
       describe(`updates a ${configuration.linodeType} ${configuration.engine} v${configuration.version}.x ${configuration.clusterSize}-node cluster`, () => {

--- a/packages/manager/cypress/e2e/core/databases/update-database.spec.ts
+++ b/packages/manager/cypress/e2e/core/databases/update-database.spec.ts
@@ -144,9 +144,29 @@ const resetRootPassword = () => {
 
 describe('Update database clusters', () => {
   beforeEach(() => {
+    const mockAccount = accountFactory.build({
+      capabilities: [
+        'Akamai Cloud Pulse',
+        'Block Storage',
+        'Cloud Firewall',
+        'Disk Encryption',
+        'Kubernetes',
+        'Linodes',
+        'LKE HA Control Planes',
+        'Machine Images',
+        'Managed Databases',
+        'NodeBalancers',
+        'Object Storage Access Key Regions',
+        'Object Storage Endpoint Types',
+        'Object Storage',
+        'Placement Group',
+        'Vlans',
+      ],
+    });
     mockAppendFeatureFlags({
       dbaasV2: { enabled: false, beta: false },
     });
+    mockGetAccount(mockAccount);
   });
 
   databaseConfigurations.forEach(
@@ -173,10 +193,9 @@ describe('Update database clusters', () => {
             engine: configuration.dbType,
             status: 'active',
             allow_list: [allowedIp],
+            platform: 'rdbms-legacy',
           });
 
-          // Mock account to ensure 'Managed Databases' capability.
-          mockGetAccount(accountFactory.build()).as('getAccount');
           mockGetDatabase(database).as('getDatabase');
           mockGetDatabaseTypes(mockDatabaseNodeTypes).as('getDatabaseTypes');
           mockResetPassword(database.id, database.engine).as(
@@ -189,7 +208,7 @@ describe('Update database clusters', () => {
           ).as('getCredentials');
 
           cy.visitWithLogin(`/databases/${database.engine}/${database.id}`);
-          cy.wait(['@getAccount', '@getDatabase', '@getDatabaseTypes']);
+          cy.wait(['@getDatabase', '@getDatabaseTypes']);
 
           cy.get('[data-qa-cluster-config]').within(() => {
             cy.findByText(configuration.region.label).should('be.visible');
@@ -290,6 +309,7 @@ describe('Update database clusters', () => {
               primary: undefined,
               secondary: undefined,
             },
+            platform: 'rdbms-legacy',
           });
 
           const errorMessage =


### PR DESCRIPTION
## Description 📝
Recent [improvements made for DBaaS v2](https://github.com/linode/manager/pull/10939) began causing intermittent test failures in `update-database.spec.ts`. This PR makes a few changes to resolve these failures:

- Mocks the `dbaasV2` feature flag to be disabled
- Mocks the account so that it is lacking the `Managed Databases Beta` capability
- Updates the test's database mock to force the `platform` field to always reflect the legacy platform
  - ℹ️ This seems to be what actually fixed the test, and appears to take precedence over the DBaaS v2 feature flag and account capability
  - ⛔️ Going forward we might want to discourage using `pickRandom` or any similar utils that make our factories less deterministic since they're used throughout the codebase/tests

## Target release date 🗓️
N/A

## How to test 🧪
We can't rely solely on CI for this since this failure is only intermittent, but running the tests in `update-database.spec.ts` a few times in a row without observing any failures can help increase confidence that the tests are fixed.

```bash
repeat 3 yarn cy:run -s "cypress/e2e/core/databases/update-database.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
  - Thinking a changeset might not be necessary here since these failures didn't make it to a release -- any thoughts?
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
