### PR TITLE
fix: [M3-8617] - Autocomplete Popper re-rendering causing test failures

### DIFF
--- a/packages/manager/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/manager/src/components/Autocomplete/Autocomplete.tsx
@@ -15,7 +15,6 @@ import {
 } from './Autocomplete.styles';
 
 import type { AutocompleteProps } from '@mui/material/Autocomplete';
-import type { SxProps } from '@mui/system';
 import type { TextFieldProps } from 'src/components/TextField';
 
 export interface EnhancedAutocompleteProps<
@@ -42,10 +41,6 @@ export interface EnhancedAutocompleteProps<
   placeholder?: string;
   /** Label for the "select all" option. */
   selectAllLabel?: string;
-  /**
-   * The prop that allows defining CSS style overrides for the PopperComponent.
-   */
-  sxPopperComponent?: SxProps;
   textFieldProps?: Partial<TextFieldProps>;
 }
 
@@ -93,7 +88,6 @@ export const Autocomplete = <
     placeholder,
     renderOption,
     selectAllLabel = '',
-    sxPopperComponent,
     textFieldProps,
     value,
     ...rest
@@ -110,9 +104,6 @@ export const Autocomplete = <
 
   return (
     <MuiAutocomplete
-      PopperComponent={(props) => {
-        return <CustomPopper {...props} sx={sxPopperComponent} />;
-      }}
       options={
         multiple && !disableSelectAll && options.length > 0
           ? optionsWithSelectAll
@@ -172,6 +163,7 @@ export const Autocomplete = <
         );
       }}
       ChipProps={{ deleteIcon: <CloseIcon /> }}
+      PopperComponent={CustomPopper}
       clearOnBlur={clearOnBlur}
       data-qa-autocomplete
       defaultValue={defaultValue}

--- a/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.tsx
@@ -215,6 +215,15 @@ export const CreateAPITokenDrawer = (props: Props) => {
           onChange={(_, selected) =>
             form.setFieldValue('expiry', selected.value)
           }
+          slotProps={{
+            popper: {
+              sx: {
+                '&& .MuiAutocomplete-listbox': {
+                  padding: 0,
+                },
+              },
+            },
+          }}
           sx={{
             '&& .MuiAutocomplete-inputRoot': {
               paddingLeft: 1,
@@ -222,11 +231,6 @@ export const CreateAPITokenDrawer = (props: Props) => {
             },
             '&& .MuiInput-input': {
               padding: '0px 2px',
-            },
-          }}
-          sxPopperComponent={{
-            '&& .MuiAutocomplete-listbox': {
-              padding: 0,
             },
           }}
           disableClearable

--- a/packages/manager/src/features/Profile/AuthenticationSettings/PhoneVerification/PhoneVerification.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/PhoneVerification/PhoneVerification.tsx
@@ -270,13 +270,15 @@ export const PhoneVerification = ({
                     } ${getCountryFlag(country.code)}`,
                     value: country.code,
                   }))}
-                  sxPopperComponent={{
-                    '& .MuiPaper-root.MuiAutocomplete-paper': {
-                      border: '1px solid #3683dc',
-                      maxHeight: '285px',
-                      overflow: 'hidden',
-                      textWrap: 'nowrap',
-                      width: 'fit-content',
+                  slotProps={{
+                    paper: {
+                      sx: {
+                        border: '1px solid #3683dc',
+                        maxHeight: '285px',
+                        overflow: 'hidden',
+                        textWrap: 'nowrap',
+                        width: 'fit-content',
+                      },
                     },
                   }}
                   textFieldProps={{

--- a/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -97,9 +97,13 @@ export const TimezoneForm = (props: Props) => {
       <StyledRootContainer>
         <Stack>
           <Autocomplete
-            sxPopperComponent={{
-              maxHeight: '285px',
-              overflow: 'hidden',
+            slotProps={{
+              popper: {
+                sx: {
+                  maxHeight: '285px',
+                  overflow: 'hidden',
+                },
+              },
             }}
             value={timezoneList.find(
               (option) => option.value === timezoneValue


### PR DESCRIPTION
## Description 📝

- Should hopefully fix the test failures we've recently begun seeing throughout the test suite when Cypress tries to interact with Autocompletes:

  > cy.click() failed because the page updated while this command was executing. Cypress tried to locate elements based on this query:
  > <div.MuiBox-root.css-b5zaes>
We initially found matching element(s), but while waiting for them to become actionable, they disappeared from the page.


- Provides an alternative to @jdamore-linode 's fix https://github.com/linode/manager/pull/10976/commits/a90aba8f714b739b4e085261aef44c652047c294 that was originally in  #10976 
- This PR reverts some changes made in https://github.com/linode/manager/pull/10780  in favor of using MUI's built in `slotProps` to customize components that make up our AutoComplete

## How to test 🧪

- Verify the Phone Number select on http://localhost:3000/profile/auth does not break and that the styles look correct
- Verify Autocompletes throughout the app work as expected