### PR TITLE
test: [M3-8601] - Fix NodeBalancer `nodebalancers-create-in-complex-form.spec.ts` Cypress test flake

### DIFF
--- a/packages/manager/.changeset/pr-10981-tests-1726863454562.md
+++ b/packages/manager/.changeset/pr-10981-tests-1726863454562.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix test flake in `nodebalancers-create-in-complex-form.spec.ts` ([#10981](https://github.com/linode/manager/pull/10981))

--- a/packages/manager/cypress/e2e/core/nodebalancers/nodebalancers-create-in-complex-form.spec.ts
+++ b/packages/manager/cypress/e2e/core/nodebalancers/nodebalancers-create-in-complex-form.spec.ts
@@ -1,7 +1,7 @@
 import { entityTag } from 'support/constants/cypress';
 import { createTestLinode } from 'support/util/linodes';
 import { randomLabel } from 'support/util/random';
-import { chooseRegion, getRegionById } from 'support/util/regions';
+import { chooseRegion } from 'support/util/regions';
 import { ui } from 'support/ui';
 import { cleanUp } from 'support/util/cleanup';
 import { authenticate } from 'support/api/authentication';
@@ -19,173 +19,197 @@ describe('create NodeBalancer to test the submission of multiple nodes and multi
    * - Confirms NodeBalancer create flow when adding multiple Backend Nodes.
    * - Confirms Summary field displays correct Node number.
    */
-  it('creates a NodeBalancer with multiple Backend Nodes', async () => {
+  it('creates a NodeBalancer with multiple Backend Nodes', () => {
     const region = chooseRegion();
     const linodePayload = {
       region: region.id,
       // NodeBalancers require Linodes with private IPs.
       private_ip: true,
     };
-    const linode: Linode = await createTestLinode(linodePayload);
-    const nodeBal = nodeBalancerFactory.build({
-      label: randomLabel(),
-      region: region.id,
-      ipv4: linode.ipv4[1],
-    });
 
     const linodePayload_2 = {
       region: region.id,
       private_ip: true,
     };
-    const linode_2: Linode = await createTestLinode(linodePayload_2);
-    const nodeBal_2 = nodeBalancerFactory.build({
-      label: randomLabel(),
-      region: region.id,
-      ipv4: linode_2.ipv4[1],
-    });
-    const regionName = getRegionById(nodeBal.region).label;
 
-    // catch request
-    interceptCreateNodeBalancer().as('createNodeBalancer');
-    cy.visitWithLogin('/nodebalancers/create');
-    cy.get('[id="nodebalancer-label"]')
-      .should('be.visible')
-      .click()
-      .clear()
-      .type(nodeBal.label);
-    cy.findByPlaceholderText(/create a tag/i)
-      .click()
-      .type(entityTag);
+    const createTestLinodes = async () => {
+      return Promise.all([
+        createTestLinode(linodePayload),
+        createTestLinode(linodePayload_2),
+      ]);
+    };
 
-    // this will create the NB in newark, where the default Linode was created
-    ui.regionSelect.find().click().clear().type(`${regionName}{enter}`);
+    cy.defer(createTestLinodes, 'Creating 2 test Linodes').then(
+      ([linode, linode2]: [Linode, Linode]) => {
+        const nodeBal = nodeBalancerFactory.build({
+          label: randomLabel(),
+          region: region.id,
+          ipv4: linode.ipv4[1],
+        });
 
-    // node backend config
-    cy.findByText('Label').click().type(randomLabel());
-    cy.findByLabelText('IP Address')
-      .should('be.visible')
-      .click()
-      .type(nodeBal.ipv4);
-    ui.autocompletePopper
-      .findByTitle(nodeBal.ipv4)
-      .should('be.visible')
-      .click();
-    cy.findByLabelText('Weight')
-      .should('be.visible')
-      .click()
-      .clear()
-      .type('50');
+        const nodeBal_2 = nodeBalancerFactory.build({
+          label: randomLabel(),
+          region: region.id,
+          ipv4: linode2.ipv4[1],
+        });
 
-    // Add a backend node
-    cy.get('[data-testid="Button"]').contains('Add a Node').click();
-    cy.findAllByText('Label').last().click().type(randomLabel());
-    cy.findAllByText('IP Address')
-      .last()
-      .should('be.visible')
-      .click()
-      .type(nodeBal_2.ipv4);
-    ui.autocompletePopper
-      .findByTitle(nodeBal_2.ipv4)
-      .should('be.visible')
-      .click();
-    cy.get('[data-testid="textfield-input"]')
-      .last()
-      .should('be.visible')
-      .click()
-      .clear()
-      .type('50');
+        interceptCreateNodeBalancer().as('createNodeBalancer');
+        cy.visitWithLogin('/nodebalancers/create');
+        cy.get('[id="nodebalancer-label"]')
+          .should('be.visible')
+          .click()
+          .clear()
+          .type(nodeBal.label);
+        cy.findByPlaceholderText(/create a tag/i)
+          .click()
+          .type(entityTag);
 
-    // Confirm Summary info
-    cy.get('[data-qa-summary="true"]').within(() => {
-      cy.contains(`Nodes 2`).should('be.visible');
-    });
+        // this will create the NB in newark, where the default Linode was created
+        ui.regionSelect.find().click().clear().type(`${region.label}{enter}`);
 
-    cy.get('[data-qa-deploy-nodebalancer]').click();
-    cy.wait('@createNodeBalancer').its('response.statusCode').should('eq', 200);
+        // node backend config
+        cy.findByText('Label').click().type(randomLabel());
+        cy.findByLabelText('IP Address')
+          .should('be.visible')
+          .click()
+          .type(nodeBal.ipv4);
+        ui.autocompletePopper
+          .findByTitle(nodeBal.ipv4)
+          .should('be.visible')
+          .click();
+        cy.findByLabelText('Weight')
+          .should('be.visible')
+          .click()
+          .clear()
+          .type('50');
+
+        // Add a backend node
+        cy.get('[data-testid="Button"]').contains('Add a Node').click();
+        cy.findAllByText('Label').last().click().type(randomLabel());
+        cy.findAllByText('IP Address')
+          .last()
+          .should('be.visible')
+          .click()
+          .type(nodeBal_2.ipv4);
+        ui.autocompletePopper
+          .findByTitle(nodeBal_2.ipv4)
+          .should('be.visible')
+          .click();
+        cy.get('[data-testid="textfield-input"]')
+          .last()
+          .should('be.visible')
+          .click()
+          .clear()
+          .type('50');
+
+        // Confirm Summary info
+        cy.get('[data-qa-summary="true"]').within(() => {
+          cy.contains(`Nodes 2`).should('be.visible');
+        });
+
+        cy.get('[data-qa-deploy-nodebalancer]').click();
+        cy.wait('@createNodeBalancer')
+          .its('response.statusCode')
+          .should('eq', 200);
+      }
+    );
   });
 
   /*
    * - Confirms NodeBalancer create flow when adding additional config.
    * - Confirms Summary field displays correct Config number.
    */
-  it('creates a NodeBalancer with an additional config', async () => {
+  it('creates a NodeBalancer with an additional config', () => {
     const region = chooseRegion();
     const linodePayload = {
       region: region.id,
       // NodeBalancers require Linodes with private IPs.
       private_ip: true,
     };
-    const linode: Linode = await createTestLinode(linodePayload);
-    const nodeBal = nodeBalancerFactory.build({
-      label: randomLabel(),
-      region: region.id,
-      ipv4: linode.ipv4[1],
-    });
 
     const linodePayload_2 = {
       region: region.id,
       private_ip: true,
     };
-    const linode_2: Linode = await createTestLinode(linodePayload_2);
-    const nodeBal_2 = nodeBalancerFactory.build({
-      label: randomLabel(),
-      region: region.id,
-      ipv4: linode_2.ipv4[1],
-    });
-    const regionName = getRegionById(nodeBal.region).label;
 
-    // catch request
-    interceptCreateNodeBalancer().as('createNodeBalancer');
+    const createTestLinodes = async () => {
+      return Promise.all([
+        createTestLinode(linodePayload),
+        createTestLinode(linodePayload_2),
+      ]);
+    };
 
-    cy.visitWithLogin('/nodebalancers/create');
-    cy.get('[id="nodebalancer-label"]')
-      .should('be.visible')
-      .click()
-      .clear()
-      .type(nodeBal.label);
-    cy.findByPlaceholderText(/create a tag/i)
-      .click()
-      .type(entityTag);
+    cy.defer(createTestLinodes, 'Creating 2 test Linodes').then(
+      ([linode, linode2]: [Linode, Linode]) => {
+        const nodeBal = nodeBalancerFactory.build({
+          label: randomLabel(),
+          region: region.id,
+          ipv4: linode.ipv4[1],
+        });
 
-    // This will create the NB in newark, where the default Linode was created
-    ui.regionSelect.find().click().clear().type(`${regionName}{enter}`);
+        const nodeBal_2 = nodeBalancerFactory.build({
+          label: randomLabel(),
+          region: region.id,
+          ipv4: linode2.ipv4[1],
+        });
 
-    // Node backend config
-    cy.findByText('Label').click().type(randomLabel());
-    cy.findByLabelText('IP Address')
-      .should('be.visible')
-      .click()
-      .type(nodeBal.ipv4);
-    ui.autocompletePopper
-      .findByTitle(nodeBal.ipv4)
-      .should('be.visible')
-      .click();
+        interceptCreateNodeBalancer().as('createNodeBalancer');
+        cy.visitWithLogin('/nodebalancers/create');
+        cy.get('[id="nodebalancer-label"]')
+          .should('be.visible')
+          .click()
+          .clear()
+          .type(nodeBal.label);
+        cy.findByPlaceholderText(/create a tag/i)
+          .click()
+          .type(entityTag);
 
-    // Add another configuration
-    cy.get('[data-testid="Button"]')
-      .contains('Add another Configuration')
-      .click();
-    cy.get('[data-qa-panel="Configuration - Port "]').within(() => {
-      cy.get('[data-testid="textfield-input"]').first().click().type('8080');
-    });
-    cy.findAllByText('Label').last().click().type(randomLabel());
-    cy.findAllByText('IP Address')
-      .last()
-      .should('be.visible')
-      .click()
-      .type(nodeBal_2.ipv4);
-    ui.autocompletePopper
-      .findByTitle(nodeBal_2.ipv4)
-      .should('be.visible')
-      .click();
+        // This will create the NB in newark, where the default Linode was created
+        ui.regionSelect.find().click().clear().type(`${region.label}{enter}`);
 
-    // Confirm Summary info
-    cy.get('[data-qa-summary="true"]').within(() => {
-      cy.contains('Configs 2').should('be.visible');
-    });
+        // Node backend config
+        cy.findByText('Label').click().type(randomLabel());
+        cy.findByLabelText('IP Address')
+          .should('be.visible')
+          .click()
+          .type(nodeBal.ipv4);
+        ui.autocompletePopper
+          .findByTitle(nodeBal.ipv4)
+          .should('be.visible')
+          .click();
 
-    cy.get('[data-qa-deploy-nodebalancer]').click();
-    cy.wait('@createNodeBalancer').its('response.statusCode').should('eq', 200);
+        // Add another configuration
+        cy.get('[data-testid="Button"]')
+          .contains('Add another Configuration')
+          .click();
+        cy.get('[data-qa-panel="Configuration - Port "]').within(() => {
+          cy.get('[data-testid="textfield-input"]')
+            .first()
+            .click()
+            .type('8080');
+        });
+        cy.findAllByText('Label').last().click().type(randomLabel());
+        cy.findAllByText('IP Address')
+          .last()
+          .should('be.visible')
+          .click()
+          .type(nodeBal_2.ipv4);
+        ui.autocompletePopper
+          .findByTitle(nodeBal_2.ipv4)
+          .should('be.visible')
+          .click();
+
+        // Confirm Summary info
+        cy.get('[data-qa-summary="true"]').within(() => {
+          cy.contains('Configs 2').should('be.visible');
+        });
+
+        cy.get('[data-qa-deploy-nodebalancer]').click();
+        cy.wait('@createNodeBalancer')
+          .its('response.statusCode')
+          .should('eq', 200);
+      }
+    );
   });
 
   /*
@@ -193,59 +217,63 @@ describe('create NodeBalancer to test the submission of multiple nodes and multi
    * - Confirms Label field displays error if label is empty in additional config.
    * - Confirms IP field displays error if ip is empty in additional config.
    */
-  it('displays errors during adding new config', async () => {
+  it('displays errors during adding new config', () => {
     const region = chooseRegion();
     const linodePayload = {
       region: region.id,
       // NodeBalancers require Linodes with private IPs.
       private_ip: true,
     };
-    const linode: Linode = await createTestLinode(linodePayload);
-    const nodeBal = nodeBalancerFactory.build({
-      label: randomLabel(),
-      region: region.id,
-      ipv4: linode.ipv4[1],
+
+    cy.defer(
+      () => createTestLinode(linodePayload),
+      'Creating test Linode'
+    ).then((linode: Linode) => {
+      const nodeBal = nodeBalancerFactory.build({
+        label: randomLabel(),
+        region: region.id,
+        ipv4: linode.ipv4[1],
+      });
+
+      cy.visitWithLogin('/nodebalancers/create');
+      cy.get('[id="nodebalancer-label"]')
+        .should('be.visible')
+        .click()
+        .clear()
+        .type(nodeBal.label);
+      cy.findByPlaceholderText(/create a tag/i)
+        .click()
+        .type(entityTag);
+
+      // This will create the NB in newark, where the default Linode was created
+      ui.regionSelect.find().click().clear().type(`${region.label}{enter}`);
+
+      // Node backend config
+      cy.findByText('Label').click().type(randomLabel());
+      cy.findByLabelText('IP Address')
+        .should('be.visible')
+        .click()
+        .type(nodeBal.ipv4);
+      ui.autocompletePopper
+        .findByTitle(nodeBal.ipv4)
+        .should('be.visible')
+        .click();
+
+      // Add another configuration
+      cy.get('[data-testid="Button"]')
+        .contains('Add another Configuration')
+        .click();
+      cy.get('[data-qa-panel="Configuration - Port "]').within(() => {
+        cy.get('[data-testid="textfield-input"]').first().click().type('80');
+      });
+      cy.get('[data-qa-deploy-nodebalancer]').click();
+
+      // Confirm error displays
+      cy.contains('Port must be unique').scrollIntoView().should('be.visible');
+      cy.contains('Label is required').scrollIntoView().should('be.visible');
+      cy.contains('Must be a valid private IPv4 address.')
+        .scrollIntoView()
+        .should('be.visible');
     });
-    const regionName = getRegionById(nodeBal.region).label;
-
-    cy.visitWithLogin('/nodebalancers/create');
-    cy.get('[id="nodebalancer-label"]')
-      .should('be.visible')
-      .click()
-      .clear()
-      .type(nodeBal.label);
-    cy.findByPlaceholderText(/create a tag/i)
-      .click()
-      .type(entityTag);
-
-    // This will create the NB in newark, where the default Linode was created
-    ui.regionSelect.find().click().clear().type(`${regionName}{enter}`);
-
-    // Node backend config
-    cy.findByText('Label').click().type(randomLabel());
-    cy.findByLabelText('IP Address')
-      .should('be.visible')
-      .click()
-      .type(nodeBal.ipv4);
-    ui.autocompletePopper
-      .findByTitle(nodeBal.ipv4)
-      .should('be.visible')
-      .click();
-
-    // Add another configuration
-    cy.get('[data-testid="Button"]')
-      .contains('Add another Configuration')
-      .click();
-    cy.get('[data-qa-panel="Configuration - Port "]').within(() => {
-      cy.get('[data-testid="textfield-input"]').first().click().type('80');
-    });
-    cy.get('[data-qa-deploy-nodebalancer]').click();
-
-    // Confirm error displays
-    cy.contains('Port must be unique').scrollIntoView().should('be.visible');
-    cy.contains('Label is required').scrollIntoView().should('be.visible');
-    cy.contains('Must be a valid private IPv4 address.')
-      .scrollIntoView()
-      .should('be.visible');
   });
 });


### PR DESCRIPTION
## Description 📝
This attempts to resolve the test flake in `nodebalancers-create-in-complex-form.spec.ts`. The root of the issue is our execution of async code in the Cypress test without wrapping it in `cy.defer` -- this caused the Cypress tests to execute and fail rapidly without allowing Cypress to actually run and evaluate all of the `cy.*` commands in the queue.

The HTTP 429 errors we see in our CI are a symptom of this issue rather than a cause.


## Changes  🔄
- Wrap async operations in `cy.defer`, remove `async` keyword from `it(...)` calls

## Target release date 🗓️
N/A

## How to test 🧪

### Reproduction steps
Check out `develop`, build and serve Cloud via `yarn && yarn build && yarn start:manager:ci`

- Run `yarn cy:run -s "cypress/e2e/core/nodebalancers/nodebalancers-create-in-complex-form.spec.ts"`
- Observe intermittent failures (it may not fail on your first try but does fail pretty frequently) and obscure error messages

### Verification steps
Check out this branch, build and serve Cloud via `yarn && yarn build && yarn start:manager:ci`

- Run `yarn cy:run -s "cypress/e2e/core/nodebalancers/nodebalancers-create-in-complex-form.spec.ts"`
- Observe test is stable. Repeat as needed to build confidence. (I ran it 15 times in a row without any failures)

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
