### PR TITLE
test: [M3-8619] - Fix Cypress test flake in `create-linode-from-image.spec.ts`

### DIFF
--- a/packages/manager/.changeset/pr-10983-tests-1726865807776.md
+++ b/packages/manager/.changeset/pr-10983-tests-1726865807776.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Improve region selection RegEx to resolve test failures when selecting certain regions ([#10983](https://github.com/linode/manager/pull/10983))

--- a/packages/manager/cypress/support/ui/autocomplete.ts
+++ b/packages/manager/cypress/support/ui/autocomplete.ts
@@ -4,6 +4,23 @@ import type { SelectorMatcherOptions } from '@testing-library/cypress';
 import type { Region } from '@linode/api-v4';
 
 /**
+ * Returns a regular expression object to match against region select items.
+ *
+ * This expression accounts for these cases:
+ * - Gecko LA is disabled (region ID is present in line with label)
+ * - Gecko LA is enabled (region ID is not in line with label, rendered in separate element)
+ * - Avoids selecting similarly named regions (e.g. "UK, London" and "UK, London 2")
+ *
+ * @param region - Region for which to return RegEx.
+ *
+ * @returns Regular expression object to match menu item of given Region.
+ */
+// TODO Remove this and use exact string matching once Gecko feature flag is retired.
+const getRegionItemRegEx = (region: Region) => {
+  return new RegExp(`${region.label}(\\s?\\(${region.id}\\)|$)`);
+};
+
+/**
  * Autocomplete UI element.
  */
 export const autocomplete = {
@@ -90,9 +107,7 @@ export const regionSelect = {
    */
   findItemByRegionId: (regionId: string, searchRegions?: Region[]) => {
     const region = getRegionById(regionId, searchRegions);
-    return autocompletePopper.findByTitle(
-      new RegExp(`${region.label}\\s?(\(${region.id}\))?`)
-    );
+    return autocompletePopper.findByTitle(getRegionItemRegEx(region));
   },
 
   /**
@@ -107,8 +122,6 @@ export const regionSelect = {
    */
   findItemByRegionLabel: (regionLabel: string, searchRegions?: Region[]) => {
     const region = getRegionByLabel(regionLabel, searchRegions);
-    return autocompletePopper.findByTitle(
-      new RegExp(`${region.label}\\s?(\(${region.id}\))?`)
-    );
+    return autocompletePopper.findByTitle(getRegionItemRegEx(region));
   },
 };


### PR DESCRIPTION
## Description 📝
This fixes the intermittent test failures we've been seeing in `create-linode-from-image.spec.ts`, and possibly other specs, which occur when Cypress tries to select a region with a name that's similar to another region. Specifically, tests in this spec fail consistently when trying to select _UK, London_ (`eu-west`) because _UK, London 2_ (`gb-lon`) also gets matched.

This issue was triggered by recent changes to our region select UI helpers, intended to facilitate region selection when Gecko is enabled (#10888).

## Changes  🔄
- Increases specificity of region selection RegEx to account for regions with similar names

## Target release date 🗓️
N/A

## How to test 🧪

### Reproduction steps
Check out `develop` and build Cloud via `yarn && yarn build && yarn start:manager:ci`, then:

- Run `CY_TEST_REGION='eu-west' yarn cy:run -s "cypress/e2e/core/images/create-linode-from-image.spec.ts"`
  - ℹ️ `CY_TEST_REGION` forces Cypress to select the desired region every time -- normally, a random region is selected
- Observe that all 3 tests fail every time

### Verification steps
Check out this branch and build Cloud via `yarn && yarn build && yarn start:manager:ci`, then:
- Run `CY_TEST_REGION='eu-west' yarn cy:run -s "cypress/e2e/core/images/create-linode-from-image.spec.ts"`
- Run `CY_TEST_REGION='gb-lon' yarn cy:run -s "cypress/e2e/core/images/create-linode-from-image.spec.ts"`
- Confirm that tests pass in both cases
- Optionally confirm that test passes when Gecko LA is enabled and when it's disabled

I ran the spec 15 times in a row (with random regions) and all 3 tests passed every time.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

