### PR TITLE
change: [M3-8622] - Update Images empty state as part of Image Service Gen2

### DIFF
--- a/packages/manager/.changeset/pr-10985-changed-1727105394355.md
+++ b/packages/manager/.changeset/pr-10985-changed-1727105394355.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Update Images empty state as part of Image Service Gen2 ([#10985](https://github.com/linode/manager/pull/10985))

--- a/packages/manager/cypress/e2e/core/images/images-empty-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/images-empty-landing-page.spec.ts
@@ -15,7 +15,7 @@ describe('Images empty landing page', () => {
 
     // confirms helper text
     cy.findByText(
-      'Store custom Linux images so you can rapidly deploy compute instances that are preconfigured with what you need.'
+      'Store custom Linux images to rapidly deploy compute instances preconfigured with what you need.'
     ).should('be.visible');
 
     // checks that guides are visible

--- a/packages/manager/cypress/e2e/core/images/images-empty-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/images-empty-landing-page.spec.ts
@@ -15,7 +15,7 @@ describe('Images empty landing page', () => {
 
     // confirms helper text
     cy.findByText(
-      'Store your own custom Linux images, enabling you to rapidly deploy Linode Compute Instances preconfigured with the software and settings you require.'
+      'Store custom Linux images so you can rapidly deploy compute instances that are preconfigured with what you need.'
     ).should('be.visible');
 
     // checks that guides are visible

--- a/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.test.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.test.tsx
@@ -114,7 +114,7 @@ describe('Images Landing Table', () => {
 
     await waitForElementToBeRemoved(getByTestId(loadingTestId));
     expect(
-      getByText((text) => text.includes('Store your own custom Linux images'))
+      getByText((text) => text.includes('Store custom Linux images'))
     ).toBeInTheDocument();
   });
 

--- a/packages/manager/src/features/Images/ImagesLanding/ImagesLandingEmptyStateData.ts
+++ b/packages/manager/src/features/Images/ImagesLanding/ImagesLandingEmptyStateData.ts
@@ -11,7 +11,7 @@ import type {
 
 export const headers: ResourcesHeaders = {
   description:
-    'Store custom Linux images so you can rapidly deploy compute instances that are preconfigured with what you need.',
+    'Store custom Linux images to rapidly deploy compute instances preconfigured with what you need.',
   subtitle: '',
   title: 'Images',
 };

--- a/packages/manager/src/features/Images/ImagesLanding/ImagesLandingEmptyStateData.ts
+++ b/packages/manager/src/features/Images/ImagesLanding/ImagesLandingEmptyStateData.ts
@@ -11,7 +11,7 @@ import type {
 
 export const headers: ResourcesHeaders = {
   description:
-    'Store your own custom Linux images, enabling you to rapidly deploy Linode Compute Instances preconfigured with the software and settings you require.',
+    'Store custom Linux images so you can rapidly deploy compute instances that are preconfigured with what you need.',
   subtitle: '',
   title: 'Images',
 };


### PR DESCRIPTION
## Description 📝

- Updates the Images Landing page empty state based on UX's request as part of Image Service Gen 2 💾 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-09-23 at 11 25 37 AM](https://github.com/user-attachments/assets/7cec51ab-036a-457b-ae00-7a5208a84ba1) | ![Screenshot 2024-09-23 at 11 25 02 AM](https://github.com/user-attachments/assets/3a9effb7-8334-40cf-81e2-457db3c35a8c) |

## How to test 🧪

- Check new copy for correctness 👀 
- Verify all automated testing passes ✅ 

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support