### PR TITLE
change: [M3-8614] - Update Image Upload dropzone copy as part of Image Service Gen2

### DIFF
--- a/packages/manager/.changeset/pr-10986-changed-1727108550951.md
+++ b/packages/manager/.changeset/pr-10986-changed-1727108550951.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Update Image Upload dropzone copy as part of Image Service Gen2 ([#10986](https://github.com/linode/manager/pull/10986))

--- a/packages/manager/src/components/Uploaders/ImageUploader/ImageUploader.test.tsx
+++ b/packages/manager/src/components/Uploaders/ImageUploader/ImageUploader.test.tsx
@@ -13,25 +13,32 @@ describe('File Uploader', () => {
   it('properly renders the File Uploader', () => {
     const screen = renderWithTheme(<ImageUploader {...props} />);
 
-    const browseFiles = screen.getByText('Browse Files').closest('button');
+    const browseFiles = screen.getByText('Choose File').closest('button');
     expect(browseFiles).toBeVisible();
     expect(browseFiles).toBeEnabled();
-    const text = screen.getByText(
-      'You can browse your device to upload an image file or drop it here.'
-    );
-    expect(text).toBeVisible();
+
+    expect(
+      screen.getByText(
+        'An image file needs to be raw disk format (.img) that’s compressed using gzip.'
+      )
+    ).toBeVisible();
+    expect(
+      screen.getByText(
+        'The maxiumum compressed file size is 5 GB and the file can’t exceed 6 GB when uncompressed.'
+      )
+    ).toBeVisible();
   });
 
   it('disables the dropzone', () => {
     const screen = renderWithTheme(<ImageUploader {...props} disabled />);
 
-    const browseFiles = screen.getByText('Browse Files').closest('button');
+    const browseFiles = screen.getByText('Choose File').closest('button');
     expect(browseFiles).toBeVisible();
     expect(browseFiles).toBeDisabled();
     expect(browseFiles).toHaveAttribute('aria-disabled', 'true');
 
     const text = screen.getByText(
-      'You can browse your device to upload an image file or drop it here.'
+      'An image file needs to be raw disk format (.img) that’s compressed using gzip.'
     );
     expect(text).toBeVisible();
   });

--- a/packages/manager/src/components/Uploaders/ImageUploader/ImageUploader.tsx
+++ b/packages/manager/src/components/Uploaders/ImageUploader/ImageUploader.tsx
@@ -1,7 +1,7 @@
 import { styled } from '@mui/material';
 import { Duration } from 'luxon';
 import * as React from 'react';
-import { DropzoneProps, useDropzone } from 'react-dropzone';
+import { useDropzone } from 'react-dropzone';
 
 import { BarPercent } from 'src/components/BarPercent';
 import { Box } from 'src/components/Box';
@@ -12,6 +12,7 @@ import { MAX_FILE_SIZE_IN_BYTES } from 'src/components/Uploaders/reducer';
 import { readableBytes } from 'src/utilities/unitConversions';
 
 import type { AxiosProgressEvent } from 'axios';
+import type { DropzoneProps } from 'react-dropzone';
 
 interface Props extends Partial<DropzoneProps> {
   /**
@@ -45,18 +46,25 @@ export const ImageUploader = React.memo((props: Props) => {
   return (
     <Dropzone active={isDragActive} {...getRootProps()}>
       <input {...getInputProps()} />
-      <Box display="flex" justifyContent="center">
+      <Stack alignItems="center" justifyContent="center" textAlign="center">
         {acceptedFiles.length === 0 && (
-          <Typography variant="subtitle2">
-            You can browse your device to upload an image file or drop it here.
-          </Typography>
+          <>
+            <Typography variant="subtitle2">
+              An image file needs to be raw disk format (.img) that&rsquo;s
+              compressed using gzip.
+            </Typography>
+            <Typography variant="subtitle2">
+              The maxiumum compressed file size is 5 GB and the file can&rsquo;t
+              exceed 6 GB when uncompressed.
+            </Typography>
+          </>
         )}
         {acceptedFiles.map((file) => (
           <Typography key={file.name} variant="subtitle2">
             {file.name} ({readableBytes(file.size, { base10: true }).formatted})
           </Typography>
         ))}
-      </Box>
+      </Stack>
       {isUploading && (
         <Stack gap={1}>
           <Box width="100%">
@@ -82,7 +90,7 @@ export const ImageUploader = React.memo((props: Props) => {
       {!isUploading && (
         <Box display="flex" justifyContent="center">
           <Button buttonType="primary" disabled={dropzoneProps.disabled}>
-            Browse Files
+            Choose File
           </Button>
         </Box>
       )}

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -189,7 +189,7 @@ export const CreateImageTab = () => {
           <Stack spacing={2}>
             <Typography variant="h2">Select Linode & Disk</Typography>
             <Typography sx={{ maxWidth: { md: '80%', sm: '100%' } }}>
-              Custom images are billed monthly, at $.10/GB. The disk you target
+              Custom images are billed monthly, at $0.10/GB. The disk you target
               for an image needs to meet specific{' '}
               <Link to="https://techdocs.akamai.com/cloud-computing/docs/capture-an-image">
                 requirements

--- a/packages/manager/src/features/Images/ImagesCreate/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/ImageUpload.tsx
@@ -194,7 +194,7 @@ export const ImageUpload = () => {
               Image Details
             </Typography>
             <Typography>
-              Custom images are billed monthly, at $.10/GB. An uploaded image
+              Custom images are billed monthly, at $0.10/GB. An uploaded image
               file needs to meet specific{' '}
               <Link to="https://techdocs.akamai.com/cloud-computing/docs/upload-an-image#requirements-and-considerations">
                 requirements

--- a/packages/manager/src/features/Images/ImagesCreate/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/ImageUpload.tsx
@@ -40,14 +40,14 @@ import { readableBytes } from 'src/utilities/unitConversions';
 
 import { EUAgreementCheckbox } from '../../Account/Agreements/EUAgreementCheckbox';
 import { getRestrictedResourceText } from '../../Account/utils';
+import { uploadImageFile } from '../requests';
 import { ImageUploadSchema, recordImageAnalytics } from './ImageUpload.utils';
-import {
+import { ImageUploadCLIDialog } from './ImageUploadCLIDialog';
+
+import type {
   ImageUploadFormData,
   ImageUploadNavigationState,
 } from './ImageUpload.utils';
-import { ImageUploadCLIDialog } from './ImageUploadCLIDialog';
-import { uploadImageFile } from '../requests';
-
 import type { AxiosError, AxiosProgressEvent } from 'axios';
 
 export const ImageUpload = () => {
@@ -196,7 +196,7 @@ export const ImageUpload = () => {
             <Typography>
               Custom images are billed monthly, at $.10/GB. An uploaded image
               file needs to meet specific{' '}
-              <Link to="https://techdocs.akamai.com/cloud-computing/docs/upload-an-image">
+              <Link to="https://techdocs.akamai.com/cloud-computing/docs/upload-an-image#requirements-and-considerations">
                 requirements
               </Link>
               .
@@ -331,17 +331,6 @@ export const ImageUpload = () => {
                 variant="error"
               />
             )}
-            <Notice spacingBottom={0} variant="warning">
-              <Typography>
-                Image files must be raw disk images (.img) compressed using gzip
-                (.gz). The maximum file size is 5 GB (compressed) and maximum
-                image size is 6 GB (uncompressed).
-              </Typography>
-            </Notice>
-            <Typography sx={{ paddingBlock: 2 }}>
-              Custom Images are billed at $0.10/GB per month based on the
-              uncompressed image size.
-            </Typography>
             <Controller
               render={({ field }) => (
                 <ImageUploader
@@ -379,8 +368,8 @@ export const ImageUpload = () => {
           <Box display="flex" gap={1} justifyContent="flex-end">
             <Button
               buttonType="outlined"
-              onClick={() => setLinodeCLIModalOpen(true)}
               disabled={isImageCreateRestricted}
+              onClick={() => setLinodeCLIModalOpen(true)}
             >
               Upload Using Command Line
             </Button>

--- a/packages/manager/src/features/Images/ImagesLanding/ImageRegions/ManageImageRegionsForm.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImageRegions/ManageImageRegionsForm.tsx
@@ -103,7 +103,7 @@ export const ManageImageReplicasForm = (props: Props) => {
         <Notice text={errors.root.message} variant="error" />
       )}
       <Typography>
-        Custom images are billed monthly, at $.10/GB. Check out{' '}
+        Custom images are billed monthly, at $0.10/GB. Check out{' '}
         <Link to="https://www.linode.com/docs/guides/check-and-clean-linux-disk-space/">
           this guide
         </Link>{' '}


### PR DESCRIPTION
## Description 📝

Makes some minor copy updates and UI tweaks on the Image Upload page based on UX's request 🎨 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-09-23 at 12 07 49 PM](https://github.com/user-attachments/assets/195b07ac-1157-49a8-97c9-05c622cf8ec2) | ![Screenshot 2024-09-23 at 12 06 57 PM](https://github.com/user-attachments/assets/6ecfa99e-eead-4654-8b9d-0341c1144b20) |

## How to test 🧪

- Go to http://localhost:3000/images/create/upload
- Check UI and verify the changes make logical sense 🧠 
- Check copy for spelling ✏️ 
- Check for any UI regressions 👁️ 

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support