### PR TITLE
fix: [UIE-8009] - DBaaS backups disable invalid dates

### DIFF
--- a/packages/api-v4/.changeset/pr-10988-changed-1727197910740.md
+++ b/packages/api-v4/.changeset/pr-10988-changed-1727197910740.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Changed
+---
+
+DBaaS restore method name ([#10988](https://github.com/linode/manager/pull/10988))

--- a/packages/api-v4/src/databases/databases.ts
+++ b/packages/api-v4/src/databases/databases.ts
@@ -244,13 +244,12 @@ export const legacyRestoreWithBackup = (
   );
 
 /**
- * newRestoreWithBackup for the New Database
+ * restoreWithBackup for the New Database
  *
  * Fully restore a backup to the cluster
  */
-export const newRestoreWithBackup = (
+export const restoreWithBackup = (
   engine: Engine,
-  label: string,
   fork: {
     source: number;
     restore_time?: string;
@@ -259,7 +258,7 @@ export const newRestoreWithBackup = (
   Request<{}>(
     setURL(`${API_ROOT}/databases/${encodeURIComponent(engine)}/instances`),
     setMethod('POST'),
-    setData({ fork, label })
+    setData({ fork })
   );
 
 /**

--- a/packages/manager/.changeset/pr-10988-fixed-1727119069361.md
+++ b/packages/manager/.changeset/pr-10988-fixed-1727119069361.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+DBaaS backups disable invalid dates ([#10988](https://github.com/linode/manager/pull/10988))

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -10,6 +10,7 @@ import { Box } from 'src/components/Box';
 import { Button } from 'src/components/Button/Button';
 import { Divider } from 'src/components/Divider';
 import Select from 'src/components/EnhancedSelect/Select';
+import { Notice } from 'src/components/Notice/Notice';
 import { Paper } from 'src/components/Paper';
 import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
@@ -71,13 +72,13 @@ export const DatabaseBackups = (props: Props) => {
     isLoading: isDatabaseLoading,
   } = useDatabaseQuery(engine, id);
 
-  const isNewDatabase = database?.platform === 'rdbms-default';
+  const isDefaultDatabase = database?.platform === 'rdbms-default';
 
   const {
     data: backups,
     error: backupsError,
     isLoading: isBackupsLoading,
-  } = useDatabaseBackupsQuery(engine, id);
+  } = useDatabaseBackupsQuery(engine, id, !isDefaultDatabase);
 
   const { handleOrderChange, order, orderBy } = useOrder({
     order: 'desc',
@@ -132,6 +133,10 @@ export const DatabaseBackups = (props: Props) => {
     ? DateTime.fromISO(database.oldest_restore_time)
     : null;
 
+  const unableToRestoreCopy = !oldestBackup
+    ? 'You can restore a backup after the first backup is completed.'
+    : '';
+
   const onRestoreNewDatabase = (selectedDate: DateTime | null) => {
     const day = selectedDate?.toISODate();
     const time = selectedTime?.toISOTime({ includeOffset: false });
@@ -143,7 +148,7 @@ export const DatabaseBackups = (props: Props) => {
     setIsRestoreDialogOpen(true);
   };
 
-  return isNewDatabase ? (
+  return isDefaultDatabase ? (
     <Paper style={{ marginTop: 16 }}>
       <Typography variant="h2">Summary</Typography>
       <StyledTypography>
@@ -183,6 +188,9 @@ export const DatabaseBackups = (props: Props) => {
         Select a date and time within the last 10 days you want to create a fork
         from.
       </StyledTypography>
+      {unableToRestoreCopy && (
+        <Notice spacingTop={16} text={unableToRestoreCopy} variant="info" />
+      )}
       <Grid container justifyContent="flex-start" mt={2}>
         <Grid item lg={3} md={4} xs={12}>
           <Typography variant="h3">Date</Typography>

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/RestoreLegacyFromBackupDialog.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/RestoreLegacyFromBackupDialog.tsx
@@ -5,7 +5,7 @@ import { useHistory } from 'react-router-dom';
 import { Notice } from 'src/components/Notice/Notice';
 import { TypeToConfirmDialog } from 'src/components/TypeToConfirmDialog/TypeToConfirmDialog';
 import { Typography } from 'src/components/Typography';
-import { useRestoreFromBackupMutation } from 'src/queries/databases/databases';
+import { useLegacyRestoreFromBackupMutation } from 'src/queries/databases/databases';
 import { useProfile } from 'src/queries/profile/profile';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { formatDate } from 'src/utilities/formatDate';
@@ -30,7 +30,11 @@ export const RestoreLegacyFromBackupDialog = (props: Props) => {
     error,
     isPending,
     mutateAsync: restore,
-  } = useRestoreFromBackupMutation(database.engine, database.id, backup?.id);
+  } = useLegacyRestoreFromBackupMutation(
+    database.engine,
+    database.id,
+    backup?.id
+  );
 
   const handleRestoreDatabase = () => {
     restore().then(() => {

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/RestoreNewFromBackupDialog.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/RestoreNewFromBackupDialog.tsx
@@ -6,7 +6,7 @@ import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Dialog } from 'src/components/Dialog/Dialog';
 import { Notice } from 'src/components/Notice/Notice';
 import { Typography } from 'src/components/Typography';
-import { useNewRestoreFromBackupMutation } from 'src/queries/databases/databases';
+import { useRestoreFromBackupMutation } from 'src/queries/databases/databases';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 import type { Database } from '@linode/api-v4/lib/databases';
@@ -28,9 +28,8 @@ export const RestoreNewFromBackupDialog = (props: Props) => {
     restoreTime &&
     `${restoreTime?.split('T')[0]} ${restoreTime?.split('T')[1].slice(0, 5)}`;
 
-  const { error, mutateAsync: restore } = useNewRestoreFromBackupMutation(
+  const { error, mutateAsync: restore } = useRestoreFromBackupMutation(
     database.engine,
-    `${database.label}(FORK ${formatedDate})`,
     {
       restore_time: restoreTime,
       source: database.id,

--- a/packages/manager/src/features/Databases/utilities.test.ts
+++ b/packages/manager/src/features/Databases/utilities.test.ts
@@ -135,8 +135,8 @@ describe('isOutsideBackupTimeframe', () => {
     expect(isOutsideBackupTimeframe(date, oldestBackup)).toBe(false);
   });
 
-  it('should return false if there is no oldest backup', () => {
+  it('should return true if there is no oldest backup', () => {
     const date = DateTime.now().minus({ days: 3 });
-    expect(isOutsideBackupTimeframe(date, null)).toBe(false);
+    expect(isOutsideBackupTimeframe(date, null)).toBe(true);
   });
 });

--- a/packages/manager/src/features/Databases/utilities.ts
+++ b/packages/manager/src/features/Databases/utilities.ts
@@ -57,7 +57,7 @@ export const useIsDatabasesEnabled = () => {
  * Checks if a given date is outside the timeframe between the oldest backup and today.
  *
  * @param {DateTime} date - The date you want to check.
- * @param {DateTime | null} oldestBackup - The date of the oldest backup. If there are no backups (i.e., `null`), the function will return `false`.
+ * @param {DateTime | null} oldestBackup - The date of the oldest backup. If there are no backups (i.e., `null`), the function will return `true`.
  * @returns {boolean}
  *   - `true` if the date is before the oldest backup or after today.
  *   - `false` if the date is within the range between the oldest backup and today.
@@ -66,10 +66,11 @@ export const isOutsideBackupTimeframe = (
   date: DateTime,
   oldestBackup: DateTime | null
 ) => {
-  const today = DateTime.now().startOf('day');
   if (!oldestBackup) {
-    return false;
+    return true;
   }
+
+  const today = DateTime.now().startOf('day');
   const backupStart = oldestBackup.startOf('day');
   const dateStart = date.startOf('day');
 

--- a/packages/manager/src/queries/databases/databases.ts
+++ b/packages/manager/src/queries/databases/databases.ts
@@ -6,8 +6,8 @@ import {
   getDatabases,
   getEngineDatabase,
   legacyRestoreWithBackup,
-  newRestoreWithBackup,
   resetDatabaseCredentials,
+  restoreWithBackup,
   updateDatabase,
 } from '@linode/api-v4/lib/databases';
 import { createQueryKeys } from '@lukemorales/query-key-factory';
@@ -160,10 +160,15 @@ export const useDeleteDatabaseMutation = (engine: Engine, id: number) => {
   });
 };
 
-export const useDatabaseBackupsQuery = (engine: Engine, id: number) =>
-  useQuery<ResourcePage<DatabaseBackup>, APIError[]>(
-    databaseQueries.database(engine, id)._ctx.backups
-  );
+export const useDatabaseBackupsQuery = (
+  engine: Engine,
+  id: number,
+  enabled: boolean = false
+) =>
+  useQuery<ResourcePage<DatabaseBackup>, APIError[]>({
+    ...databaseQueries.database(engine, id)._ctx.backups,
+    enabled,
+  });
 
 export const useDatabaseEnginesQuery = (enabled: boolean = false) =>
   useQuery<DatabaseEngine[], APIError[]>({
@@ -202,7 +207,7 @@ export const useDatabaseCredentialsMutation = (engine: Engine, id: number) => {
   });
 };
 
-export const useRestoreFromBackupMutation = (
+export const useLegacyRestoreFromBackupMutation = (
   engine: Engine,
   databaseId: number,
   backupId: number
@@ -221,9 +226,8 @@ export const useRestoreFromBackupMutation = (
   });
 };
 
-export const useNewRestoreFromBackupMutation = (
+export const useRestoreFromBackupMutation = (
   engine: Engine,
-  label: string,
   fork: {
     restore_time?: string;
     source: number;
@@ -231,7 +235,7 @@ export const useNewRestoreFromBackupMutation = (
 ) => {
   const queryClient = useQueryClient();
   return useMutation<{}, APIError[]>({
-    mutationFn: () => newRestoreWithBackup(engine, label, fork),
+    mutationFn: () => restoreWithBackup(engine, fork),
     onSuccess() {
       queryClient.invalidateQueries({
         queryKey: databaseQueries.databases.queryKey,


### PR DESCRIPTION
## Description 📝
Fixes for DBaaS Backups tabs

## Changes  🔄
List any change relevant to the reviewer.
- Disable dates when there are no backups to restore from
- Avoid unnecessary API call
- Remove custom label

## Target release date 🗓️
9/30/24

![Screenshot 2024-09-23 at 2 24 11 PM](https://github.com/user-attachments/assets/c5e8af11-7a63-4514-85a6-614688c31859)

![Screenshot 2024-09-23 at 2 23 48 PM](https://github.com/user-attachments/assets/e9315807-568b-4627-8b80-5c4251e5d34f)


## How to test 🧪

### Prerequisites
- Managed Databases Beta account capability

### Reproduction steps
- Create a new DB
- Navigate to Backups while it's still provisioning, or just activated.

### Verification steps
- You cannot select a date
- An info banner displays

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
