### PR TITLE
fix: [UIE-8007] - DBaaS Summary tab display correct user and readonly host

### DIFF
--- a/packages/api-v4/.changeset/pr-10989-fixed-1727118907870.md
+++ b/packages/api-v4/.changeset/pr-10989-fixed-1727118907870.md
@@ -1,0 +1,5 @@
+---
+'@linode/api-v4': Fixed
+---
+
+Include `standby` field in `DatabaseHosts` interface ([#10989](https://github.com/linode/manager/pull/10989))

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -54,7 +54,8 @@ export interface DatabaseCredentials {
 
 interface DatabaseHosts {
   primary: string;
-  secondary: string;
+  secondary?: string;
+  standby?: string;
 }
 
 export interface SSLFields {

--- a/packages/manager/.changeset/pr-10989-fixed-1727118993352.md
+++ b/packages/manager/.changeset/pr-10989-fixed-1727118993352.md
@@ -1,0 +1,5 @@
+---
+'@linode/manager': Fixed
+---
+
+Database Detail page Summary tab display of username and read-only host ([#10989](https://github.com/linode/manager/pull/10989))

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -180,10 +180,17 @@ export const databaseInstanceFactory = Factory.Sync.makeFactory<DatabaseInstance
     ),
     created: '2021-12-09T17:15:12',
     engine: Factory.each((i) => ['mysql', 'postgresql'][i % 2] as Engine),
-    hosts: {
-      primary: 'db-mysql-primary-0.b.linodeb.net',
-      secondary: 'db-mysql-secondary-0.b.linodeb.net',
-    },
+    hosts: Factory.each((i) =>
+      adb10(i)
+        ? {
+            primary: 'db-mysql-primary-0.b.linodeb.net',
+            secondary: 'db-mysql-secondary-0.b.linodeb.net',
+          }
+        : {
+            primary: 'db-mysql-primary-0.b.linodeb.net',
+            standby: 'db-mysql-secondary-0.b.linodeb.net',
+          }
+    ),
     id: Factory.each((i) => i),
     instance_uri: '',
     label: Factory.each((i) => `example.com-database-${i}`),
@@ -213,10 +220,17 @@ export const databaseFactory = Factory.Sync.makeFactory<Database>({
   created: '2021-12-09T17:15:12',
   encrypted: false,
   engine: 'mysql',
-  hosts: {
-    primary: 'db-mysql-primary-0.b.linodeb.net',
-    secondary: 'db-mysql-secondary-0.b.linodeb.net',
-  },
+  hosts: Factory.each((i) =>
+    adb10(i)
+      ? {
+          primary: 'db-mysql-primary-0.b.linodeb.net',
+          secondary: 'db-mysql-secondary-0.b.linodeb.net',
+        }
+      : {
+          primary: 'db-mysql-primary-0.b.linodeb.net',
+          standby: 'db-mysql-secondary-0.b.linodeb.net',
+        }
+  ),
   id: Factory.each((i) => i),
   label: Factory.each((i) => `database-${i}`),
   members: {

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -146,6 +146,13 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
     refetch: getDatabaseCredentials,
   } = useDatabaseCredentialsQuery(database.engine, database.id);
 
+  const username =
+    database.platform === 'rdbms-default'
+      ? 'akmadmin'
+      : database.engine === 'postgresql'
+      ? 'linpostgres'
+      : DB_ROOT_USERNAME;
+
   const password =
     showCredentials && credentials ? credentials?.password : '••••••••••';
 
@@ -191,7 +198,7 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
 
   const disableShowBtn = ['failed', 'provisioning'].includes(database.status);
   const disableDownloadCACertificateBtn = database.status === 'provisioning';
-  // const connectionDetailsCopy = `username = ${credentials?.username}\npassword = ${credentials?.password}\nhost = ${database.host}\nport = ${database.port}\ssl = ${ssl}`;
+  const readOnlyHost = database?.hosts?.standby || database?.hosts?.secondary;
 
   const credentialsBtn = (handleClick: () => void, btnText: string) => {
     return (
@@ -235,8 +242,7 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
       </Typography>
       <Box className={classes.connectionDetailsCtn} data-qa-connection-details>
         <Typography>
-          <span>username</span> ={' '}
-          {database.engine === 'postgresql' ? 'linpostgres' : DB_ROOT_USERNAME}
+          <span>username</span> = {username}
         </Typography>
         <Box display="flex">
           <Typography>
@@ -356,7 +362,7 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
             </>
           )}
         </Box>
-        {database.hosts.secondary ? (
+        {readOnlyHost ? (
           <Box alignItems="center" display="flex" flexDirection="row">
             <Typography>
               {database.platform === 'rdbms-default' ? (
@@ -364,11 +370,11 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
               ) : (
                 <span>private network host</span>
               )}
-              = {database.hosts.secondary}
+              = {readOnlyHost}
             </Typography>
             <CopyTooltip
               className={classes.inlineCopyToolTip}
-              text={database.hosts.secondary}
+              text={readOnlyHost}
             />
             <TooltipIcon
               status="help"


### PR DESCRIPTION
## Description 📝
DBaaS Summary tab display correct user and readonly host

## Changes  🔄
List any change relevant to the reviewer.
- Display correct username for V2
- Display correct read-only host for V2

## Target release date 🗓️
9/30/24

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-09-23 at 3 12 16 PM](https://github.com/user-attachments/assets/4d057872-4574-4cf8-9f53-60535c515e23) | ![Screenshot 2024-09-23 at 3 12 27 PM](https://github.com/user-attachments/assets/7f5802ab-4784-47a8-94c2-4e665208a82a) |

## How to test 🧪

### Prerequisites
- Managed Databases Beta account capability

### Reproduction steps
- Create new DB
- Go to summary tab

### Verification steps
- Username is correct
- readonly host displays

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
