### PR TITLE
fix: [UIE-8150]  - DBaaS empty landing page show logo for V2

### DIFF
--- a/packages/manager/.changeset/pr-10993-fixed-1727189409908.md
+++ b/packages/manager/.changeset/pr-10993-fixed-1727189409908.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+DBaaS V2 logo on empty landing ([#10993](https://github.com/linode/manager/pull/10993))

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
@@ -13,13 +13,19 @@ import {
   linkAnalyticsEvent,
   youtubeLinkData,
 } from './DatabaseLandingEmptyStateData';
+import { useIsDatabasesEnabled } from 'src/features/Databases/utilities';
 
 export const DatabaseEmptyState = () => {
   const { push } = useHistory();
+  const { isDatabasesV2Enabled } = useIsDatabasesEnabled();
 
   const isRestricted = useRestrictedGlobalGrantCheck({
     globalGrantType: 'add_databases',
   });
+
+  if (!isDatabasesV2Enabled) {
+    headers.logo = '';
+  }
 
   return (
     <ResourcesSection


### PR DESCRIPTION
## Description 📝
DBaaS empty landing page show logo for V2

## Changes  🔄
- Use feature flag and account capability to show V2 logo

## Target release date 🗓️
9/39/24

## How to test 🧪

### Prerequisites
- Managed Databases account capability
- Not in V2

### Reproduction steps
- Go to empty landing page

### Verification steps
- No logo for V2 user

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
