### PR TITLE
fix: [M3-8661] - Fix crash in Volume Create page caused by misconfigured Autocomplete

### DIFF
--- a/packages/manager/.changeset/pr-11001-fixed-1727211401885.md
+++ b/packages/manager/.changeset/pr-11001-fixed-1727211401885.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Crash when switching between Linodes in Volume Create page ([#11001](https://github.com/linode/manager/pull/11001))

--- a/packages/manager/.changeset/pr-11001-fixed-1727211401885.md
+++ b/packages/manager/.changeset/pr-11001-fixed-1727211401885.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Crash when switching between Linodes in Volume Create page ([#11001](https://github.com/linode/manager/pull/11001))

--- a/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
@@ -10,7 +10,7 @@ interface Props {
   linodeId: null | number;
   name: string;
   onBlur: (e: any) => void;
-  onChange: (value: number) => void;
+  onChange: (value: number | undefined) => void;
   value: null | number;
   width?: number;
 }
@@ -63,14 +63,12 @@ export const ConfigSelect = React.memo((props: Props) => {
             : 'No options.'
         }
         onChange={(_, selected) => {
-          onChange(+selected.value);
+          onChange(selected !== null ? +selected?.value : undefined);
         }}
         value={
-          value && value !== -1
-            ? configList?.find((thisConfig) => thisConfig.value === value)
-            : { label: '', value: -1 }
+          configList?.find((thisConfig) => thisConfig.value === value) ?? null
         }
-        disableClearable
+        clearIcon={null}
         id={name}
         isOptionEqualToValue={(option, value) => option.value === value.value}
         label="Config"


### PR DESCRIPTION
## Description 📝
The `ConfigSelect` component uses an Autocomplete whose value is sometimes inadvertently set to `undefined`. This causes a "A component is changing an uncontrolled Autocomplete to be controlled" console error and, more critically, may cause a crash in certain situations.

> [!NOTE]
> This bug only appears in the latest `develop`
> Edit: and I can only reproduce it in the dev environment (not in productions builds e.g., cloud.dev.linode.com)

## Target release date 🗓️
9/30

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/4700dc4b-7b57-49dc-af86-4aea5c6dbfac" /> | <video src="https://github.com/user-attachments/assets/519ce4ff-0b4d-4370-b7b4-6448ed980492" /> |

## How to test 🧪

### Prerequisites
- Two or more Linodes in the same region with exactly one config

### Reproduction steps
- Navigate to the Volume Create page
- Repeatedly switch between two Linodes in the same region with a single config
- This should shortly cause a crash

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support