### PR TITLE
upcoming: [DI-21104] - Page size fix for get all query in DBaaS

### DIFF
--- a/packages/manager/.changeset/pr-11004-upcoming-features-1727265141600.md
+++ b/packages/manager/.changeset/pr-11004-upcoming-features-1727265141600.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Pass page size paramter as 100 for DBaaS instances getAll query. ([#11004](https://github.com/linode/manager/pull/11004))

--- a/packages/manager/src/queries/databases/requests.ts
+++ b/packages/manager/src/queries/databases/requests.ts
@@ -24,7 +24,7 @@ export const getAllDatabases = (
         { ...params, ...passedParams },
         { ...filter, ...passedFilter }
       ),
-    100 // DBaaS supports a maximum of 100 page per call
+    100 // DBaaS supports a maximum of 100 page size per call
   )().then((data) => data.data);
 
 export const getAllDatabaseEngines = () =>

--- a/packages/manager/src/queries/databases/requests.ts
+++ b/packages/manager/src/queries/databases/requests.ts
@@ -18,8 +18,13 @@ export const getAllDatabases = (
   passedParams: Params = {},
   passedFilter: Filter = {}
 ) =>
-  getAll<DatabaseInstance>((params, filter) =>
-    getDatabases({ ...params, ...passedParams }, { ...filter, ...passedFilter })
+  getAll<DatabaseInstance>(
+    (params, filter) =>
+      getDatabases(
+        { ...params, ...passedParams },
+        { ...filter, ...passedFilter }
+      ),
+    100 // DBaaS supports a maximum of 100 page per call
   )().then((data) => data.data);
 
 export const getAllDatabaseEngines = () =>


### PR DESCRIPTION
## Description 📝
The DBaaS instances endpoint supports a maximum of 100 as page size per request, which in the alpha env UI for cloudpulse getting called with 500 as page size.

## Changes  🔄

1. Changed the getAll query to accept a page size of 100.

## Target release date 🗓️
01-10-2024

## Preview 📷
| Before  | After   |
| ------- | ------- |
|![Screenshot 2024-09-25 at 5 17 25 PM](https://github.com/user-attachments/assets/ae17cc24-ae4b-433a-9a0a-44f138e69591)||
|![Screenshot 2024-09-25 at 5 14 14 PM](https://github.com/user-attachments/assets/e23772f7-9e56-41f6-877a-19a352c3677f)|![Screenshot 2024-09-25 at 5 13 13 PM](https://github.com/user-attachments/assets/58286d13-2da3-4af0-b8ee-9a7718c3493a)|

## How to test 🧪

1. Login as mock user
2. Go to the monitor page 
3. Open the network tab
4. Select DBaaS related dashboard and it's filter
5. In the network, you can see an instance API call with page size 100

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
