### PR TITLE
chore: [M3-8662] - Update Github Actions actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
         package: ["linode-manager", "@linode/api-v4", "@linode/validation"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.17"
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
@@ -30,35 +30,32 @@ jobs:
   build-validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.17"
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn --frozen-lockfile
       - run: yarn workspace @linode/validation run build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: packages-validation-lib
-          path: |
-            packages/validation/index.js
-            packages/validation/lib
+          path: packages/validation/lib
 
   publish-validation:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
-    needs:
-      - build-validation
+    needs: build-validation
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: packages-validation-lib
-          path: packages/validation
+          path: packages/validation/lib
       - uses: JS-DevTools/npm-publish@v1
         id: npm-publish
         with:
@@ -80,69 +77,64 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-validation
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.17"
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn --frozen-lockfile
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: packages-validation-lib
-          path: packages/validation
+          path: packages/validation/lib
       - run: yarn workspace @linode/api-v4 run test
 
   build-sdk:
     runs-on: ubuntu-latest
-    needs:
-      - build-validation
+    needs: build-validation
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.17"
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: packages-validation-lib
-          path: packages/validation
+          path: packages/validation/lib
       - run: yarn --frozen-lockfile
       - run: yarn workspace @linode/api-v4 run build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: packages-api-v4-lib
-          path: |
-            packages/api-v4/index.js
-            packages/api-v4/index.node.js
-            packages/api-v4/lib
+          path: packages/api-v4/lib
 
   validate-sdk:
     runs-on: ubuntu-latest
-    needs:
-      - build-sdk
+    needs: build-sdk
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.17"
 
       # Download the validation and api-v4 artifacts (built packages)
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: packages-validation-lib
-          path: packages/validation
-      - uses: actions/download-artifact@v3
+          path: packages/validation/lib
+      - uses: actions/download-artifact@v4
         with:
           name: packages-api-v4-lib
-          path: packages/api-v4
+          path: packages/api-v4/lib
 
       # Create an api-v4 tarball
       - run: cd packages/api-v4 && npm pack --pack-destination ../../
@@ -162,37 +154,36 @@ jobs:
 
   test-manager:
     runs-on: ubuntu-latest
-    needs:
-      - build-sdk
+    needs: build-sdk
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.17"
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: packages-validation-lib
-          path: packages/validation
-      - uses: actions/download-artifact@v3
+          path: packages/validation/lib
+      - uses: actions/download-artifact@v4
         with:
           name: packages-api-v4-lib
-          path: packages/api-v4
+          path: packages/api-v4/lib
       - run: yarn --frozen-lockfile
       - run: yarn workspace linode-manager run test
 
   test-search:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.17"
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
@@ -202,55 +193,53 @@ jobs:
 
   typecheck-manager:
     runs-on: ubuntu-latest
-    needs:
-      - build-sdk
+    needs: build-sdk
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.17"
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: packages-validation-lib
-          path: packages/validation
-      - uses: actions/download-artifact@v3
+          path: packages/validation/lib
+      - uses: actions/download-artifact@v4
         with:
           name: packages-api-v4-lib
-          path: packages/api-v4
+          path: packages/api-v4/lib
       - run: yarn --frozen-lockfile
       - run: yarn workspace linode-manager run typecheck
 
   build-manager:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
-    needs:
-      - build-sdk
+    needs: build-sdk
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.17"
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: packages-validation-lib
-          path: packages/validation
+          path: packages/validation/lib
       - uses: actions/download-artifact@v3
         with:
           name: packages-api-v4-lib
-          path: packages/api-v4
+          path: packages/api-v4/lib
       - run: yarn --frozen-lockfile
       - run: yarn workspace linode-manager run build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: packages-manager-build
           path: packages/manager/build
@@ -264,11 +253,11 @@ jobs:
       # If the validation publish failed we could have mismatched versions and a broken JS client
       - publish-validation
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: packages-api-v4-lib
-          path: packages/api-v4
+          path: packages/api-v4/lib
       - uses: JS-DevTools/npm-publish@v1
         id: npm-publish
         with:
@@ -288,31 +277,30 @@ jobs:
 
   build-storybook:
     runs-on: ubuntu-latest
-    needs:
-      - build-sdk
+    needs: build-sdk
     env:
       NODE_OPTIONS: --max-old-space-size=4096
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.17"
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: packages-validation-lib
-          path: packages/validation
-      - uses: actions/download-artifact@v3
+          path: packages/validation/lib
+      - uses: actions/download-artifact@v4
         with:
           name: packages-api-v4-lib
-          path: packages/api-v4
+          path: packages/api-v4/lib
       - run: yarn --frozen-lockfile
       - run: yarn workspace linode-manager run build-storybook
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: storybook-build
           path: packages/manager/storybook-static
@@ -320,11 +308,10 @@ jobs:
   publish-storybook:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
-    needs:
-      - build-storybook
+    needs: build-storybook
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: storybook-build
           path: storybook/build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,16 +7,16 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }} # The base branch of the PR (develop)
 
       - name: Use Node.js v20.17 LTS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "20.17"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
@@ -52,14 +52,14 @@ jobs:
     needs: base_branch
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js v20.17 LTS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "20.17"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             **/node_modules
@@ -88,13 +88,13 @@ jobs:
           echo "$pct" > current_code_coverage.txt
 
       - name: Upload PR Number Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr_number
           path: pr_number.txt
 
       - name: Upload Current Coverage Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: current_code_coverage
           path: current_code_coverage.txt

--- a/.github/workflows/coverage_badge.yml
+++ b/.github/workflows/coverage_badge.yml
@@ -11,14 +11,14 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js v20.17 LTS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "20.17"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             **/node_modules

--- a/.github/workflows/coverage_comment.yml
+++ b/.github/workflows/coverage_comment.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js v20.17 LTS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "20.17"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.0.21
 
@@ -26,7 +26,7 @@ jobs:
         run: bunx vitepress@1.0.0-rc.35 build docs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs/.vitepress/dist
 
@@ -40,4 +40,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/e2e_schedule_and_push.yml
+++ b/.github/workflows/e2e_schedule_and_push.yml
@@ -26,11 +26,11 @@ jobs:
     steps:
       - name: install command line utilities
         run: sudo apt-get install -y expect
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.17"
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             node_modules
@@ -60,7 +60,7 @@ jobs:
           yarn build
           yarn start:manager:ci &
       - name: Run tests
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           working-directory: packages/manager
           wait-on: "http://localhost:3000"

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: returntocorp/semgrep
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
       # Perform scanning using Semgrep
       # Pass even when it identifies issues or encounters errors.

--- a/packages/manager/.changeset/pr-11009-tech-stories-1727310949305.md
+++ b/packages/manager/.changeset/pr-11009-tech-stories-1727310949305.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Update Github Actions actions ([#11009](https://github.com/linode/manager/pull/11009))


### PR DESCRIPTION
## Description 📝

- Updates our Github Actions actions to resolve some depreciation warnings ⚠️ 
- Makes a minor change to how we upload/download `api-v4` and `validation` assets 📦 
  - See comment below that explains this in more detail

## Preview 📷

| Before  | After   |
| ------- | ------- |
|  ![Screenshot 2024-09-25 at 8 32 01 PM](https://github.com/user-attachments/assets/e5d9d43b-a3c8-4393-8bb3-14a6954b36f1) | ![Screenshot 2024-09-25 at 8 32 24 PM](https://github.com/user-attachments/assets/9331e0d7-83fe-4f52-a396-a28a9c3353bd) |
| `ci.yml` on develop | `ci.yml` on this PR |

## How to test 🧪

- Visually check the diff for errors 👀 
- Verify Github Actions on this PR pass ✅  

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support