### PR TITLE
feat: [M3-8174] - Add Linode Empty Landing story

### DIFF
--- a/packages/manager/.changeset/pr-11012-added-1727369897345.md
+++ b/packages/manager/.changeset/pr-11012-added-1727369897345.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Linode Empty Landing story ([#11012](https://github.com/linode/manager/pull/11012))

--- a/packages/manager/src/components/EmptyLandingPageResources/ResourcesSection.stories.tsx
+++ b/packages/manager/src/components/EmptyLandingPageResources/ResourcesSection.stories.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import LinodeSvg from 'src/assets/icons/entityIcons/linode.svg';
+import {
+  gettingStartedGuides,
+  headers,
+  linkAnalyticsEvent,
+  youtubeLinkData,
+} from 'src/features/Linodes/LinodesLanding/LinodesLandingEmptyStateData';
+
+import { ResourcesSection } from './ResourcesSection';
+
+import type { Meta, StoryFn, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof ResourcesSection> = {
+  args: {
+    buttonProps: [
+      {
+        children: 'Create Linode',
+        onClick: () => {},
+      },
+    ],
+    descriptionMaxWidth: 500,
+    gettingStartedGuidesData: gettingStartedGuides,
+    headers,
+    icon: LinodeSvg,
+    linkAnalyticsEvent,
+    showTransferDisplay: true,
+    wide: true,
+    youtubeLinkData,
+  },
+  component: ResourcesSection,
+  decorators: [
+    (Story: StoryFn) => (
+      <div style={{ margin: '1em' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  title: 'Features/Entity Landing Page/Placeholders/Entities',
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ResourcesSection>;
+
+export const Linodes: Story = {
+  render: (args) => <ResourcesSection {...args} />,
+};


### PR DESCRIPTION
## Description 📝
Add Linode Empty Landing story under `Features/Entity Landing Page/Placeholders/Entities`

## Preview 📷
![image](https://github.com/user-attachments/assets/15ecc808-5f5e-4aff-b313-50b75e4639b6)

## How to test 🧪
### Verification steps
(How to verify changes)
- Pull this PR and run Storybook locally, navigate to `Features/Entity Landing Page/Placeholders/Entities`

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support