### PR TITLE
Revert "fix: [M3-8424] - Fix CodeQL alerts for `DOM text reinterpreted as HTML`"

### DIFF
--- a/packages/manager/.changeset/pr-11008-fixed-1727297819528.md
+++ b/packages/manager/.changeset/pr-11008-fixed-1727297819528.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Fix CodeQL alerts for DOM text reinterpreted as HTML ([#11008](https://github.com/linode/manager/pull/11008))

--- a/packages/manager/src/session.ts
+++ b/packages/manager/src/session.ts
@@ -32,9 +32,7 @@ export const genOAuthEndpoint = (
 
   const query = {
     client_id: clientID,
-    redirect_uri: `${APP_ROOT}/oauth/callback?returnTo=${encodeURIComponent(
-      redirectUri
-    )}`,
+    redirect_uri: `${APP_ROOT}/oauth/callback?returnTo=${redirectUri}`,
     response_type: 'token',
     scope,
     state: nonce,

--- a/packages/manager/src/store/authentication/authentication.requests.ts
+++ b/packages/manager/src/store/authentication/authentication.requests.ts
@@ -1,11 +1,9 @@
 import { LOGIN_ROOT } from 'src/constants';
-import { revokeToken } from 'src/session';
+import { RevokeTokenSuccess, revokeToken } from 'src/session';
+import { ThunkActionCreator } from 'src/store/types';
 import { getEnvLocalStorageOverrides } from 'src/utilities/storage';
 
 import { handleLogout as _handleLogout } from './authentication.actions';
-
-import type { RevokeTokenSuccess } from 'src/session';
-import type { ThunkActionCreator } from 'src/store/types';
 
 /**
  * Revokes auth token used to make HTTP requests


### PR DESCRIPTION
Reverts linode/manager#11008

This PR introduces a bad bug with redirect behavior. to repro

- navigate to /linodes or any other page than root
- delete `authentication/token` from local storage to be redirected to auth screen
- reload page
- confirm auth
- notice the redirected path contains encoded characters now