### PR TITLE
add: [M3-8630] - Add default root hostname for TXT records

### DIFF
--- a/packages/manager/.changeset/pr-11022-added-1727879935382.md
+++ b/packages/manager/.changeset/pr-11022-added-1727879935382.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Add default root hostname for TXT records ([#11022](https://github.com/linode/manager/pull/11022))

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.test.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.test.tsx
@@ -25,6 +25,14 @@ describe('Domain record helper methods', () => {
       expect(shouldResolve('AAAA', 'target')).toBe(false);
     });
 
+    it('should return true for the name of an TXT record', () => {
+      expect(shouldResolve('TXT', 'name')).toBe(true);
+    });
+
+    it('should return false for other fields of an TXT', () => {
+      expect(shouldResolve('TXT', 'target')).toBe(false);
+    });
+
     // @todo: test for fields we know will be ignored under all cases, once we know what those are.
   });
 

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -886,6 +886,8 @@ export const shouldResolve = (type: string, field: string) => {
       return field === 'target';
     case 'CNAME':
       return field === 'target';
+    case 'TXT':
+      return field === 'name';
     default:
       return false;
   }

--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -549,7 +549,10 @@ class DomainRecords extends React.Component<Props, State> {
     /** TXT Record */
     {
       columns: [
-        { render: (r: DomainRecord) => r.name, title: 'Hostname' },
+        {
+          render: (r: DomainRecord) => r.name || this.props.domain.domain,
+          title: 'Hostname',
+        },
         {
           render: (r: DomainRecord) => truncateEnd(r.target, 100),
           title: 'Value',


### PR DESCRIPTION
## Description 📝
For A/AAA records we default to the root hostname if left empty or by using `@`, but we do not do the same for TXT record hostnames. Due to this discrepancy, there has been confusion to whether a TXT record for their root domain was applying correctly, or whether the A/AAAA records they were creating would apply to something like `example.com.example.com`.

## Changes  🔄
- TXT has been added as a case in the `shouldResolve`  function
- TXT hostname now defaults to root domain hostname

## Target release date 🗓️
N/A

## Preview 📷
https://github.com/user-attachments/assets/8383f622-ed04-474f-b61b-c2e303c2d17b

## How to test 🧪

### Reproduction steps
- Create domain in cloud manager
- Add an A record for that domain leaving the hostname field blank or using @
- Create a TXT record for that domain leaving the hostname field blank or using @
- Notice the difference in "hostname" column after those records have been saved.
   - The "hostname" column for A/AAAA/MX records reflects the root domain, while the hostname column for TXT records remains blank.

### Verification steps
- Checkout branch or view preview link
- Observe TXT hostname populated accordingly.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support