### PR TITLE
fix: [M3-8391] - Account maintenance CSV download in the first attempt

### DIFF
--- a/packages/manager/.changeset/pr-11025-fixed-1727790118989.md
+++ b/packages/manager/.changeset/pr-11025-fixed-1727790118989.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Download Account Maintenance CSVs on the first attempt ([#11025](https://github.com/linode/manager/pull/11025))

--- a/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
+++ b/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import { Theme } from '@mui/material/styles';
 import * as React from 'react';
 import { makeStyles } from 'tss-react/mui';
 
@@ -28,6 +27,7 @@ import {
 import { MaintenanceTableRow } from './MaintenanceTableRow';
 
 import type { AccountMaintenance, Filter } from '@linode/api-v4';
+import type { Theme } from '@mui/material/styles';
 
 const preferenceKey = 'account-maintenance';
 
@@ -136,7 +136,9 @@ const MaintenanceTable = ({ type }: Props) => {
 
   const downloadCSV = async () => {
     await getCSVData();
-    csvRef.current.link.click();
+    setTimeout(() => {
+      csvRef.current.link.click();
+    }, 0);
   };
 
   return (

--- a/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
+++ b/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
@@ -136,6 +136,7 @@ const MaintenanceTable = ({ type }: Props) => {
 
   const downloadCSV = async () => {
     await getCSVData();
+    // This approach is not particularly elegant, but setTimeout may be the best way to make this click async without adding a lot of logic.
     setTimeout(() => {
       csvRef.current.link.click();
     }, 0);


### PR DESCRIPTION
## Description 📝
When downloading CSVs on the Account Maintenance page at /account/maintenance, the generated CSV always contains empty data on the first attempt to download (per page load). The user must download the CSV a second time in order for the data to be populated.

## Changes  🔄
- Fixed the account maintenance CSV download on the first attempt

## Target release date 🗓️
N/A


## How to test 🧪

### Verification steps
- Enable MSW 
- Navigate to http://localhost:3000/account/maintenance
- Click on the 'Download CSV' button in the Pending/Complete section
- You must be able to view a populated csv file in the first attempt of downloading

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
