### PR TITLE
test: [M3-8114] - Clean up Linodes, LKE clusters, and Firewalls after test run

### DIFF
--- a/packages/manager/.changeset/pr-11028-tests-1727799211177.md
+++ b/packages/manager/.changeset/pr-11028-tests-1727799211177.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Clean up Linodes, LKE clusters, and Firewalls created by Cypress tests when runs finish ([#11028](https://github.com/linode/manager/pull/11028))

--- a/packages/manager/cypress/support/e2e.ts
+++ b/packages/manager/cypress/support/e2e.ts
@@ -63,8 +63,10 @@ import { deleteInternalHeader } from './setup/delete-internal-header';
 import { mockFeatureFlagClientstream } from './setup/feature-flag-clientstream';
 import { mockAccountRequest } from './setup/mock-account-request';
 import { trackApiRequests } from './setup/request-tracking';
+import { postRunCleanUp } from './setup/post-run-cleanup';
 
 trackApiRequests();
 mockAccountRequest();
 mockFeatureFlagClientstream();
 deleteInternalHeader();
+postRunCleanUp();

--- a/packages/manager/cypress/support/setup/post-run-cleanup.ts
+++ b/packages/manager/cypress/support/setup/post-run-cleanup.ts
@@ -1,0 +1,17 @@
+import { authenticate } from 'support/api/authentication';
+import { cleanUp } from 'support/util/cleanup';
+
+/**
+ * Deletes test Linodes, LKE Clusters, and Firewalls after the run finishes.
+ *
+ * Note that in some cases this function may fail to clean up all relevant
+ * resources. For example, if the test run itself is cancelled mid-run or
+ * if any of the API requests fail during the clean up process, resources
+ * may still be left behind.
+ */
+export const postRunCleanUp = () => {
+  authenticate();
+  after(() => {
+    cleanUp(['linodes', 'lke-clusters', 'firewalls']);
+  });
+};


### PR DESCRIPTION
## Description 📝
This adds a quick-n-dirty clean up pass that will run after all the Cypress tests run in order to clean up Linodes, LKE Clusters, and Firewalls created by the tests.

This should resolve most cases where resources get left behind after a job finishes, but it's not a totally foolproof solution. Resources may not be cleaned up completely if Cypress crashes mid-run (or if the CI job itself is cancelled), or if any API errors occur during the course of clean up.

Once we've had this solution in place for a while, we can evaluate whether any additional measures are necessary.

## Changes  🔄
- Adds an `after` hook that does Linode, LKE Cluster, and Firewall clean up after a run

## Target release date 🗓️
N/A

## How to test / Verification steps 🧪
We can rely on CI by letting the job run, signing into the test accounts, and observing whether there are any leftover Linodes, LKE clusters, or Firewalls left behind with the `cy-test-` prefix.

Alternatively, we can test the changes locally by manually creating some resources prefixed with `cy-test-`, running a couple tests via `yarn cy:run -s "path/to/spec/or/specs/to/run.spec.ts"` or `yarn cy:debug`, and observing whether or not the resources get cleaned up.

To be extra thorough, you can add some `throw new Error('Fail')`s into the tests you run to confirm that this clean up happens even when there are test failures.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
