### PR TITLE
[M3-8424] - Cater to dependabot moods

### DIFF
--- a/packages/manager/.changeset/pr-11031-added-1727814054762.md
+++ b/packages/manager/.changeset/pr-11031-added-1727814054762.md
@@ -1,5 +1,5 @@
 ---
-"@linode/manager": Added
+"@linode/manager": Tech Stories
 ---
 
 Validate redirect and login URLs via URL constructor ([#11031](https://github.com/linode/manager/pull/11031))

--- a/packages/manager/.changeset/pr-11031-added-1727814054762.md
+++ b/packages/manager/.changeset/pr-11031-added-1727814054762.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Validate redirect and login URLs via URL constructor ([#11031](https://github.com/linode/manager/pull/11031))

--- a/packages/manager/cypress/e2e/core/general/account-login-redirect.spec.ts
+++ b/packages/manager/cypress/e2e/core/general/account-login-redirect.spec.ts
@@ -17,4 +17,27 @@ describe('account login redirect', () => {
     cy.url().should('contain', `${LOGIN_ROOT}/login?`, { exact: false });
     cy.findByText('Please log in to continue.').should('be.visible');
   });
+
+  /**
+   * This test validates that the encoded redirect param is valid and can be properly decoded when the user is redirected to our application.
+   */
+  it('should redirect the user to the page they were on if the redirect param is present and valid', () => {
+    cy.visitWithLogin('/linodes/create?type=Images');
+    cy.url().should('contain', '/linodes/create');
+
+    cy.clearLocalStorage('authentication/token');
+    cy.reload();
+    cy.url().should(
+      'contain',
+      'returnTo%253D%252Flinodes%252Fcreate%253Ftype%253DImages'
+    );
+    cy.url().then((url) => {
+      // We need to decode the URL twice to get the original redirect URL.
+      // The first decoding is done by the browser, the second by Cypress.
+      const decodedOnce = decodeURIComponent(url);
+      const decodedTwice = decodeURIComponent(decodedOnce);
+
+      expect(decodedTwice).to.contain('/linodes/create?type=Images');
+    });
+  });
 });

--- a/packages/manager/src/session.ts
+++ b/packages/manager/src/session.ts
@@ -25,14 +25,24 @@ export const genOAuthEndpoint = (
   const localStorageOverrides = getEnvLocalStorageOverrides();
   const clientID = localStorageOverrides?.clientID ?? CLIENT_ID;
   const loginRoot = localStorageOverrides?.loginRoot ?? LOGIN_ROOT;
+  const redirect_uri = `${APP_ROOT}/oauth/callback?returnTo=${redirectUri}`;
 
   if (!clientID) {
     throw new Error('No CLIENT_ID specified.');
   }
 
+  try {
+    // Validate the redirect_uri via URL constructor
+    // It does not really do that much since our protocol is a safe constant,
+    // but it prevents common warnings with security scanning tools thinking otherwise.
+    new URL(redirect_uri);
+  } catch (error) {
+    throw new Error('Invalid redirect URI');
+  }
+
   const query = {
     client_id: clientID,
-    redirect_uri: `${APP_ROOT}/oauth/callback?returnTo=${redirectUri}`,
+    redirect_uri,
     response_type: 'token',
     scope,
     state: nonce,

--- a/packages/manager/src/store/authentication/authentication.requests.ts
+++ b/packages/manager/src/store/authentication/authentication.requests.ts
@@ -1,9 +1,11 @@
 import { LOGIN_ROOT } from 'src/constants';
-import { RevokeTokenSuccess, revokeToken } from 'src/session';
-import { ThunkActionCreator } from 'src/store/types';
+import { revokeToken } from 'src/session';
 import { getEnvLocalStorageOverrides } from 'src/utilities/storage';
 
 import { handleLogout as _handleLogout } from './authentication.actions';
+
+import type { RevokeTokenSuccess } from 'src/session';
+import type { ThunkActionCreator } from 'src/store/types';
 
 /**
  * Revokes auth token used to make HTTP requests
@@ -21,7 +23,12 @@ export const handleLogout: ThunkActionCreator<
 > = ({ client_id, token }) => (dispatch) => {
   const localStorageOverrides = getEnvLocalStorageOverrides();
 
-  const loginURL = localStorageOverrides?.loginRoot ?? LOGIN_ROOT;
+  let loginURL;
+  try {
+    loginURL = new URL(localStorageOverrides?.loginRoot ?? LOGIN_ROOT);
+  } catch (_) {
+    loginURL = LOGIN_ROOT;
+  }
 
   return revokeToken(client_id, token)
     .then((response) => {


### PR DESCRIPTION
## Description 📝
This PR attempts to get rid of the following dependabot warning
- https://github.com/linode/manager/security/code-scanning/105
- https://github.com/linode/manager/security/code-scanning/106
- https://github.com/linode/manager/security/code-scanning/107

which I will dismiss if this does not satisfy their uncontrollable urge to report issues that we know to be safe.
It's ok! i used that occasion to add a CY test that checks the proper encoding/decoding of the redirect URL since the last [PR](https://github.com/linode/manager/pull/11008) trying to fix this had to be reverted.

## Changes  🔄
List any change relevant to the reviewer.
- validate redirect and login URLs via URL constructor
- test encoding/decoding of the redirect URL via CY addition

## How to test 🧪

### Verification steps 
> [!NOTE]
> This is a smoke verification, since this contribution should not modify existing behavior

- navigate to `/linodes/create?type=Images` (for instance) or any other page than root
- delete `authentication/token` from local storage to be redirected to permission screen
- reload page
- confirm permissions (click on "Accept and Continue")
- confirm being redirected to the right page/URL

repeat steps above with logging out instead of deleting the auth token

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
