### PR TITLE
fix: Add Volume button on Cloud Manager Linode page causing browser to freeze

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed:
 
 - DBaaS Landing Page V2 platform error for New Beta Users ([#11024](https://github.com/linode/manager/pull/11024))
+- Add Volume button on Linodes Storage tab causing page crash ([#11032](https://github.com/linode/manager/pull/11032))
 
 ## [2024-09-30] - v1.129.0
 

--- a/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
@@ -36,6 +36,9 @@ export const ConfigSelect = React.memo((props: Props) => {
     return { label: config.label, value: config.id };
   });
 
+  // This used to be in a useEffect. We are reverting that because it caused a
+  // page crash - see [PDI-3054] for more information. Note that [M3-8578] will
+  // need to be looked into again as a result.
   if (configList?.length === 1) {
     const newValue = configList[0].value;
     if (value !== newValue) {

--- a/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
@@ -36,15 +36,12 @@ export const ConfigSelect = React.memo((props: Props) => {
     return { label: config.label, value: config.id };
   });
 
-  // Use useEffect to handle the side effect
-  React.useEffect(() => {
-    if (configList?.length === 1) {
-      const newValue = configList[0].value;
-      if (value !== newValue) {
-        onChange(newValue);
-      }
+  if (configList?.length === 1) {
+    const newValue = configList[0].value;
+    if (value !== newValue) {
+      onChange(newValue);
     }
-  }, [configList, onChange, value]);
+  }
 
   return (
     <FormControl


### PR DESCRIPTION
## Description 📝
Reverts the changes from [this PR](https://github.com/linode/manager/pull/10970) to remove the useEffect so that the page doesn't crash. Note that this means there will be a console error again - we'll have to look into how to handle that issue differently.

## Changes  🔄
- Reverts change to remove useEffect

## Target release date 🗓️
10/2

## How to test 🧪

## reproduction steps
- On the Linode Storage tab, when clicking 'Add Volume', notice how the page freezes afterwards

## Verification steps
- confirm the page freeze no longer happens

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
