### PR TITLE
chore: [M3-8677] – Upgrade `upload-artifact` and `download-artifact` actions to `v4`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
         with:
           name: packages-validation-lib
           path: packages/validation/lib
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: packages-api-v4-lib
           path: packages/api-v4/lib

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,7 +41,7 @@ jobs:
           echo "$pct" > ref_code_coverage.txt
 
       - name: Upload Base Coverage Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ref_code_coverage
           path: ref_code_coverage.txt

--- a/packages/manager/.changeset/pr-11033-tech-stories-1727816117048.md
+++ b/packages/manager/.changeset/pr-11033-tech-stories-1727816117048.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Upgrade `upload-artifact` and `download-artifact` actions from v3 to v4 ([#11033](https://github.com/linode/manager/pull/11033))


### PR DESCRIPTION
## Description 📝
Upgrade `upload-artifact@v3` --->  `upload-artifact@v4` and `download-artifact@v3` ---> `download-artifact@v4`

## Target release date 🗓️
10/14/24

## How to test 🧪
### Verification steps
Our Github Actions checks should all pass ✅
There should be no other instances of `upload-artifact@v3` or `download-artifact@v3` in the codebase ✅

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support