### PR TITLE
fix: [UIE-8165] - DBaaS remove 512 GB plan selection

### DIFF
--- a/packages/manager/.changeset/pr-11036-changed-1727881220211.md
+++ b/packages/manager/.changeset/pr-11036-changed-1727881220211.md
@@ -1,0 +1,5 @@
+---
+'@linode/manager': Changed
+---
+
+Remove the 512GB plan selection from DBaaS ([#11036](https://github.com/linode/manager/pull/11036))

--- a/packages/manager/src/features/components/PlansPanel/constants.ts
+++ b/packages/manager/src/features/components/PlansPanel/constants.ts
@@ -1,4 +1,3 @@
-import type { PlanSelectionType } from './types';
 import type { ExtendedType } from 'src/utilities/extendType';
 
 export const LIMITED_AVAILABILITY_COPY =
@@ -78,70 +77,6 @@ export const DEDICATED_512_GB_PLAN: ExtendedType = {
   ],
   successor: null,
   transfer: 12000,
-  vcpus: 64,
-};
-
-export const DBAAS_DEDICATED_512_GB_PLAN: PlanSelectionType = {
-  class: 'dedicated',
-  disk: 7372800,
-  // engines: {
-  //   mysql: [
-  //     {
-  //       price: {
-  //         hourly: 12.48,
-  //         monthly: 8320,
-  //       },
-  //       quantity: 1,
-  //     },
-  //     {
-  //       price: {
-  //         hourly: 24.96,
-  //         monthly: 16640,
-  //       },
-  //       quantity: 2,
-  //     },
-  //     {
-  //       price: {
-  //         hourly: 37.44,
-  //         monthly: 24960,
-  //       },
-  //       quantity: 3,
-  //     },
-  //   ],
-  //   postgresql: [
-  //     {
-  //       price: {
-  //         hourly: 12.48,
-  //         monthly: 8320,
-  //       },
-  //       quantity: 1,
-  //     },
-  //     {
-  //       price: {
-  //         hourly: 24.96,
-  //         monthly: 16640,
-  //       },
-  //       quantity: 2,
-  //     },
-  //     {
-  //       price: {
-  //         hourly: 37.44,
-  //         monthly: 24960,
-  //       },
-  //       quantity: 3,
-  //     },
-  //   ],
-  // },
-  formattedLabel: 'Dedicated 512 GB',
-  heading: 'Dedicated 512 GB',
-  id: 'g6-dedicated-64',
-  label: 'DBaaS - Dedicated 512GB',
-  memory: 524288,
-  price: {
-    hourly: 12.48,
-    monthly: 8320,
-  },
-  subHeadings: ['$8320/mo ($12.48/hr)', '64 CPU, 7200 GB Storage, 512 GB RAM'],
   vcpus: 64,
 };
 

--- a/packages/manager/src/features/components/PlansPanel/utils.test.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.test.ts
@@ -10,6 +10,7 @@ import {
   getIsLimitedAvailability,
   getPlanSelectionsByPlanType,
   planTypeOrder,
+  replaceOrAppendPlaceholder512GbPlans,
 } from './utils';
 
 import type { PlanSelectionType } from './types';
@@ -415,6 +416,41 @@ describe('extractPlansInformation', () => {
       const result = getDisabledPlanReasonCopy({} as any);
 
       expect(result).toBe(PLAN_IS_CURRENTLY_UNAVAILABLE_COPY);
+    });
+  });
+
+  describe('replaceOrAppendPlaceholder512GbPlans', () => {
+    it('should not append to DBaaS plans', () => {
+      const plans = [
+        {
+          id: 'g6-dedicated-56',
+          label: 'DBaaS - Dedicated 256GB',
+        },
+      ] as PlanSelectionType[];
+      const results = replaceOrAppendPlaceholder512GbPlans(plans);
+      expect(results.length).toEqual(1);
+    });
+
+    it('should append to Linode plans', () => {
+      const plans = [
+        {
+          id: 'g6-dedicated-56',
+          label: 'Dedicated 256GB',
+        },
+      ] as PlanSelectionType[];
+      const results = replaceOrAppendPlaceholder512GbPlans(plans);
+      expect(results.length).toEqual(3);
+    });
+
+    it('should replace the Linode plan', () => {
+      const plans = [
+        {
+          id: 'not-the-right-id',
+          label: 'Premium 512GB',
+        },
+      ] as PlanSelectionType[];
+      const results = replaceOrAppendPlaceholder512GbPlans(plans);
+      expect(results[0].id).toEqual('g7-premium-64');
     });
   });
 });

--- a/packages/manager/src/features/components/PlansPanel/utils.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.ts
@@ -2,7 +2,6 @@ import { arrayToList } from 'src/utilities/arrayToList';
 import { ExtendedType } from 'src/utilities/extendType';
 
 import {
-  DBAAS_DEDICATED_512_GB_PLAN,
   DEDICATED_512_GB_PLAN,
   LIMITED_AVAILABILITY_COPY,
   PLAN_IS_CURRENTLY_UNAVAILABLE_COPY,
@@ -223,7 +222,11 @@ export const planTabInfoContent = {
 export const replaceOrAppendPlaceholder512GbPlans = (
   types: (ExtendedType | PlanSelectionType)[]
 ) => {
+  // DBaaS does not currently offer a 512 GB plan
   const isInDatabasesFlow = types.some((type) => type.label.includes('DBaaS'));
+  if (isInDatabasesFlow) {
+    return types;
+  }
 
   // Function to replace or append a specific plan
   const replaceOrAppendPlan = <T extends ExtendedType | PlanSelectionType>(
@@ -239,13 +242,9 @@ export const replaceOrAppendPlaceholder512GbPlans = (
     }
   };
 
-  if (isInDatabasesFlow) {
-    replaceOrAppendPlan('DBaaS - Dedicated 512GB', DBAAS_DEDICATED_512_GB_PLAN);
-  } else {
-    // For Linodes and LKE
-    replaceOrAppendPlan('Dedicated 512GB', DEDICATED_512_GB_PLAN);
-    replaceOrAppendPlan('Premium 512GB', PREMIUM_512_GB_PLAN);
-  }
+  // For Linodes and LKE
+  replaceOrAppendPlan('Dedicated 512GB', DEDICATED_512_GB_PLAN);
+  replaceOrAppendPlan('Premium 512GB', PREMIUM_512_GB_PLAN);
 
   return types;
 };


### PR DESCRIPTION
## Description 📝
Remove the 512 GB plan option from DBaaS

## Changes  🔄
List any change relevant to the reviewer.
- Only show types returned by the DBaaS backend types API

## Target release date 🗓️
10/14/24

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-10-02 at 10 53 16 AM](https://github.com/user-attachments/assets/49e7faec-a1a4-4207-b7b5-129abd655597) | 
![Screenshot 2024-10-02 at 10 55 54 AM](https://github.com/user-attachments/assets/89b704ef-d77a-46e3-b043-9c54a8ebcddb)
 |

## How to test 🧪

### Prerequisites
- "Managed Databases Beta" account capability

### Reproduction steps
- Create a database or navigate to an existing database resize tab

### Verification steps
- The 512GB plan is not visible

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
