### PR TITLE
upcoming: [M3-8613] - Restrict Image Upload to regions with Object Storage

### DIFF
--- a/packages/manager/.changeset/pr-11038-upcoming-features-1727969322447.md
+++ b/packages/manager/.changeset/pr-11038-upcoming-features-1727969322447.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Restrict Image Upload to regions with Object Storage ([#11038](https://github.com/linode/manager/pull/11038))

--- a/packages/manager/cypress/e2e/core/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/machine-image-upload.spec.ts
@@ -112,7 +112,7 @@ const assertProcessing = (label: string, id: string) => {
  * @param label - Label to apply to uploaded image.
  */
 const uploadImage = (label: string) => {
-  const region = chooseRegion();
+  const region = chooseRegion({ capabilities: ['Object Storage'] });
   const upload = 'machine-images/test-image.gz';
   cy.visitWithLogin('/images/create/upload');
   getClick('[id="label"][data-testid="textfield-input"]').type(label);

--- a/packages/manager/src/components/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.tsx
@@ -50,6 +50,7 @@ export const RegionSelect = <
     disabledRegions: disabledRegionsFromProps,
     errorText,
     helperText,
+    ignoreAccountAvailability,
     label,
     onChange,
     placeholder,
@@ -67,7 +68,7 @@ export const RegionSelect = <
   const {
     data: accountAvailability,
     isLoading: accountAvailabilityLoading,
-  } = useAllAccountAvailabilitiesQuery();
+  } = useAllAccountAvailabilitiesQuery(!ignoreAccountAvailability);
 
   const regionOptions = getRegionOptions({
     currentCapability,
@@ -86,6 +87,7 @@ export const RegionSelect = <
       acc[region.id] = disabledRegionsFromProps[region.id];
     }
     if (
+      !ignoreAccountAvailability &&
       isRegionOptionUnavailable({
         accountAvailabilityData: accountAvailability,
         currentCapability,

--- a/packages/manager/src/components/RegionSelect/RegionSelect.types.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.types.ts
@@ -44,8 +44,6 @@ export interface RegionSelectProps<
    * The specified capability to filter the regions on. Any region that does not have the `currentCapability` will not appear in the RegionSelect dropdown.
    * Only use `undefined` for situations where there is no relevant capability for the RegionSelect - this will not filter any of the regions passed in.
    * Otherwise, a capability should always be passed in.
-   *
-   * See `ImageUpload.tsx` for an example of a RegionSelect with an undefined `currentCapability` - there is no capability associated with Images yet.
    */
   currentCapability: Capabilities | undefined;
   /**
@@ -53,6 +51,11 @@ export interface RegionSelectProps<
    */
   disabledRegions?: Record<string, DisableRegionOption>;
   helperText?: string;
+  /**
+   * Ignores account availability information when rendering region options
+   * @default false
+   */
+  ignoreAccountAvailability?: boolean;
   label?: string;
   regionFilter?: RegionFilterValue;
   regions: Region[];

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -95,6 +95,7 @@ export interface Flags {
   databases: boolean;
   dbaasV2: BetaFeatureFlag;
   disableLargestGbPlans: boolean;
+  disallowImageUploadToNonObjRegions: boolean;
   gecko2: GeckoFeatureFlag;
   gpuv2: gpuV2;
   imageServiceGen2: boolean;

--- a/packages/manager/src/features/Images/ImagesCreate/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/ImageUpload.tsx
@@ -269,6 +269,7 @@ export const ImageUpload = () => {
                   }}
                   disableClearable
                   errorText={fieldState.error?.message}
+                  ignoreAccountAvailability
                   label="Region"
                   onChange={(e, region) => field.onChange(region.id)}
                   regionFilter="core" // Images service will not be supported for Gecko Beta

--- a/packages/manager/src/features/Images/ImagesCreate/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/ImageUpload.tsx
@@ -255,6 +255,11 @@ export const ImageUpload = () => {
             <Controller
               render={({ field, fieldState }) => (
                 <RegionSelect
+                  currentCapability={
+                    flags.disallowImageUploadToNonObjRegions
+                      ? 'Object Storage'
+                      : undefined
+                  }
                   disabled={
                     isImageCreateRestricted || form.formState.isSubmitting
                   }
@@ -262,7 +267,6 @@ export const ImageUpload = () => {
                     inputRef: field.ref,
                     onBlur: field.onBlur,
                   }}
-                  currentCapability={undefined}
                   disableClearable
                   errorText={fieldState.error?.message}
                   label="Region"


### PR DESCRIPTION
## Description 📝

- Adds a feature flag that allows us to only show regions with Object Storage capability on the Image Upload page 🌎 
  - Image Service Gen2 uses Object Storage as a storage backend, so that's why we use that capability
  - We using a flag because we will coordinate with API and let customers know before we make this change 🎏 
- This is part of the Image Service Gen2 effort 💾 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-10-02 at 11 35 44 AM](https://github.com/user-attachments/assets/11dffba3-01de-467a-8f3d-6873c825d49f) | ![Screenshot 2024-10-02 at 11 36 06 AM](https://github.com/user-attachments/assets/9263618a-0244-4b82-94cc-9e24115d9d2a) |

## How to test 🧪

- Use Launch Darkly to toggle the flag
- Verify regions get filtered appropriately 
  - **Flag Off:**  Should show all core regions
  - **Flag On:** Should only  show regions with Object Storage

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support