### PR TITLE
feat: [UIE-8089] - DBaaS Resize GA

### DIFF
--- a/packages/api-v4/.changeset/pr-11040-changed-1727911382574.md
+++ b/packages/api-v4/.changeset/pr-11040-changed-1727911382574.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Changed
+---
+
+Databases types to have UpdateDatabasePayload include cluster_size and export the Engines type ([#11040](https://github.com/linode/manager/pull/11040))

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -12,7 +12,7 @@ export interface DatabaseClusterSizeObject {
   price: DatabasePriceObject;
 }
 
-type Engines = Record<Engine, DatabaseClusterSizeObject[]>;
+export type Engines = Record<Engine, DatabaseClusterSizeObject[]>;
 export interface DatabaseType extends BaseType {
   class: DatabaseTypeClass;
   engines: Engines;
@@ -197,6 +197,7 @@ export type Database = BaseDatabase &
   Partial<MongoDatabase>;
 
 export interface UpdateDatabasePayload {
+  cluster_size?: number;
   label?: string;
   allow_list?: string[];
   updates?: UpdatesSchedule;

--- a/packages/manager/.changeset/pr-11040-added-1727911099315.md
+++ b/packages/manager/.changeset/pr-11040-added-1727911099315.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Number of Nodes selector for DBaaS GA Resize ([#11040](https://github.com/linode/manager/pull/11040))

--- a/packages/manager/cypress/e2e/core/databases/resize-database.spec.ts
+++ b/packages/manager/cypress/e2e/core/databases/resize-database.spec.ts
@@ -149,7 +149,7 @@ describe('Resizing existing clusters', () => {
                 if (!desiredPlanPrice) {
                   throw new Error('Unable to find mock plan type');
                 }
-                cy.get('[data-testid="summary"]').within(() => {
+                cy.get('[data-testid="resizeSummary"]').within(() => {
                   cy.contains(`${nodeType.label}`).should('be.visible');
                   cy.contains(`$${desiredPlanPrice.monthly}/month`).should(
                     'be.visible'

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -188,7 +188,7 @@ const getEngineOptions = (engines: DatabaseEngine[]) => {
   );
 };
 
-interface NodePricing {
+export interface NodePricing {
   double: DatabasePriceObject | undefined;
   multi: DatabasePriceObject | undefined;
   single: DatabasePriceObject | undefined;

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.test.tsx
@@ -133,161 +133,248 @@ describe('database resize', () => {
     });
   });
 
-  describe('on rendering of page ', () => {
-    describe('and isDatabasesGAEnabled is true', () => {
-      describe('and the Shared CPU tab is preselected', () => {
-        it('should render set node section', async () => {
-          const flags = {
-            dbaasV2: {
-              beta: false,
-              enabled: true,
-            },
-          };
-          const mockDatabase = databaseFactory.build({
-            cluster_size: 3,
-            type: 'g6-nanode-1',
-          });
-          const { getByTestId, getByText } = renderWithTheme(
-            <DatabaseResize database={mockDatabase} />,
-            { flags }
-          );
-
-          expect(getByTestId(loadingTestId)).toBeInTheDocument();
-          await waitForElementToBeRemoved(getByTestId(loadingTestId));
-
-          expect(getByText('Set Number of Nodes')).toBeDefined();
-          expect(
-            getByText('Please select a plan or set the number of nodes.')
-          ).toBeDefined();
-        });
-
-        it('should render the correct number of node radio buttons and associated costs', async () => {
-          const flags = {
-            dbaasV2: {
-              beta: false,
-              enabled: true,
-            },
-          };
-          const mockDatabase = databaseFactory.build({
-            cluster_size: 3,
-            type: 'g6-nanode-1',
-          });
-          const { getByTestId } = renderWithTheme(
-            <DatabaseResize database={mockDatabase} />,
-            { flags }
-          );
-          await waitForElementToBeRemoved(getByTestId(loadingTestId));
-          const nodeRadioBtns = getByTestId('database-nodes');
-          expect(nodeRadioBtns.children.length).toBe(2);
-          expect(nodeRadioBtns).toHaveTextContent('$60/month $0.09/hr');
-          expect(nodeRadioBtns).toHaveTextContent('$140/month $0.21/hr');
-        });
-
-        it('should preselect cluster size in Set Number of Nodes', async () => {
-          const flags = {
-            dbaasV2: {
-              beta: false,
-              enabled: true,
-            },
-          };
-          const mockDatabase = databaseFactory.build({
-            cluster_size: 3,
-            type: 'g6-nanode-1',
-          });
-          const { getByTestId } = renderWithTheme(
-            <DatabaseResize database={mockDatabase} />,
-            { flags }
-          );
-          await waitForElementToBeRemoved(getByTestId(loadingTestId));
-          const selectedNodeRadioButton = getByTestId(
-            `database-node-${mockDatabase.cluster_size}`
-          ).children[0].children[0] as HTMLInputElement;
-          expect(selectedNodeRadioButton).toBeChecked();
-        });
-
-        it('should disable visible lower node selections', async () => {
-          const flags = {
-            dbaasV2: {
-              beta: false,
-              enabled: true,
-            },
-          };
-          const mockDatabase = databaseFactory.build({
-            cluster_size: 3,
-            type: 'g6-nanode-1',
-          });
-          const { getByTestId } = renderWithTheme(
-            <DatabaseResize database={mockDatabase} />,
-            { flags }
-          );
-          await waitForElementToBeRemoved(getByTestId(loadingTestId));
-          const selectedNodeRadioButton = getByTestId(`database-node-1`)
-            .children[0].children[0] as HTMLInputElement;
-          expect(selectedNodeRadioButton).toBeDisabled();
-        });
-
-        it('should set price enable the resize button when a new number of nodes is selected', async () => {
-          const flags = {
-            dbaasV2: {
-              beta: false,
-              enabled: true,
-            },
-          };
-          const mockDatabase = databaseFactory.build({
-            cluster_size: 1,
-            type: 'g6-nanode-1',
-          });
-          const { getByTestId, getByText } = renderWithTheme(
-            <DatabaseResize database={mockDatabase} />,
-            { flags }
-          );
-          await waitForElementToBeRemoved(getByTestId(loadingTestId));
-          // Mock clicking 3 Nodes option
-          const selectedNodeRadioButton = getByTestId(`database-node-3`)
-            .children[0].children[0] as HTMLInputElement;
-          fireEvent.click(selectedNodeRadioButton);
-          const resizeButton = getByText(/Resize Database Cluster/i).closest(
-            'button'
-          );
-          expect(resizeButton).toBeEnabled();
-
-          const expectedSummaryText =
-            'Nanode 1 GB 3 Nodes: $140/month or $0.21/hour';
-          const summary = getByTestId(`summary`);
-          expect(summary).toHaveTextContent(expectedSummaryText);
-        });
-
-        it('should disable the resize button if node selection is set back to current', async () => {
-          const flags = {
-            dbaasV2: {
-              beta: false,
-              enabled: true,
-            },
-          };
-          const mockDatabase = databaseFactory.build({
-            cluster_size: 1,
-            type: 'g6-nanode-1',
-          });
-          const { getByTestId, getByText } = renderWithTheme(
-            <DatabaseResize database={mockDatabase} />,
-            { flags }
-          );
-          await waitForElementToBeRemoved(getByTestId(loadingTestId));
-          // Mock clicking 3 Nodes option
-          const threeNodesRadioButton = getByTestId(`database-node-3`)
-            .children[0].children[0] as HTMLInputElement;
-          fireEvent.click(threeNodesRadioButton);
-          const resizeButton = getByText(/Resize Database Cluster/i).closest(
-            'button'
-          );
-          expect(resizeButton).toBeEnabled();
-          // Mock clicking 1 Node option
-          const oneNodeRadioButton = getByTestId(`database-node-1`).children[0]
-            .children[0] as HTMLInputElement;
-          fireEvent.click(oneNodeRadioButton);
-          expect(resizeButton).toBeDisabled();
-        });
+  describe('on rendering of page and isDatabasesGAEnabled is true and the Shared CPU tab is preselected ', () => {
+    it('should render set node section', async () => {
+      const flags = {
+        dbaasV2: {
+          beta: false,
+          enabled: true,
+        },
+      };
+      const mockDatabase = databaseFactory.build({
+        cluster_size: 3,
+        type: 'g6-nanode-1',
       });
+      const { getByTestId, getByText } = renderWithTheme(
+        <DatabaseResize database={mockDatabase} />,
+        { flags }
+      );
+
+      expect(getByTestId(loadingTestId)).toBeInTheDocument();
+      await waitForElementToBeRemoved(getByTestId(loadingTestId));
+
+      expect(getByText('Set Number of Nodes')).toBeDefined();
+      expect(
+        getByText('Please select a plan or set the number of nodes.')
+      ).toBeDefined();
+    });
+
+    it('should render the correct number of node radio buttons, associated costs, and summary', async () => {
+      const flags = {
+        dbaasV2: {
+          beta: false,
+          enabled: true,
+        },
+      };
+      const mockDatabase = databaseFactory.build({
+        cluster_size: 3,
+        type: 'g6-nanode-1',
+      });
+      const { getByTestId } = renderWithTheme(
+        <DatabaseResize database={mockDatabase} />,
+        { flags }
+      );
+      await waitForElementToBeRemoved(getByTestId(loadingTestId));
+      const nodeRadioBtns = getByTestId('database-nodes');
+      expect(nodeRadioBtns.children.length).toBe(2);
+      expect(nodeRadioBtns).toHaveTextContent('$60/month $0.09/hr');
+      expect(nodeRadioBtns).toHaveTextContent('$140/month $0.21/hr');
+
+      const expectedCurrentSummary =
+        'Current Cluster: Nanode 1 GB $60/month 3 Nodes - HA $140/month';
+      const currentSummary = getByTestId('currentSummary');
+      expect(currentSummary).toHaveTextContent(expectedCurrentSummary);
+
+      const expectedResizeSummary =
+        'Resized Cluster: Please select a plan or set the number of nodes.';
+      const resizeSummary = getByTestId('resizeSummary');
+      expect(resizeSummary).toHaveTextContent(expectedResizeSummary);
+    });
+
+    it('should preselect cluster size in Set Number of Nodes', async () => {
+      const flags = {
+        dbaasV2: {
+          beta: false,
+          enabled: true,
+        },
+      };
+      const mockDatabase = databaseFactory.build({
+        cluster_size: 3,
+        type: 'g6-nanode-1',
+      });
+      const { getByTestId } = renderWithTheme(
+        <DatabaseResize database={mockDatabase} />,
+        { flags }
+      );
+      await waitForElementToBeRemoved(getByTestId(loadingTestId));
+      const selectedNodeRadioButton = getByTestId(
+        `database-node-${mockDatabase.cluster_size}`
+      ).children[0].children[0] as HTMLInputElement;
+      expect(selectedNodeRadioButton).toBeChecked();
+    });
+
+    it('should disable visible lower node selections', async () => {
+      const flags = {
+        dbaasV2: {
+          beta: false,
+          enabled: true,
+        },
+      };
+      const mockDatabase = databaseFactory.build({
+        cluster_size: 3,
+        type: 'g6-nanode-1',
+      });
+      const { getByTestId } = renderWithTheme(
+        <DatabaseResize database={mockDatabase} />,
+        { flags }
+      );
+      await waitForElementToBeRemoved(getByTestId(loadingTestId));
+      const selectedNodeRadioButton = getByTestId('database-node-1').children[0]
+        .children[0] as HTMLInputElement;
+      expect(selectedNodeRadioButton).toBeDisabled();
+    });
+
+    it('should set price, enable resize button, and update resize summary when a new number of nodes is selected', async () => {
+      const flags = {
+        dbaasV2: {
+          beta: false,
+          enabled: true,
+        },
+      };
+      const mockDatabase = databaseFactory.build({
+        cluster_size: 1,
+        type: 'g6-nanode-1',
+      });
+      const { getByTestId, getByText } = renderWithTheme(
+        <DatabaseResize database={mockDatabase} />,
+        { flags }
+      );
+      await waitForElementToBeRemoved(getByTestId(loadingTestId));
+      // Mock clicking 3 Nodes option
+      const selectedNodeRadioButton = getByTestId('database-node-3').children[0]
+        .children[0] as HTMLInputElement;
+      fireEvent.click(selectedNodeRadioButton);
+      const resizeButton = getByText(/Resize Database Cluster/i).closest(
+        'button'
+      ) as HTMLButtonElement;
+      expect(resizeButton.disabled).toBeFalsy();
+
+      const expectedSummaryText =
+        'Resized Cluster: Nanode 1 GB $60/month 3 Nodes - HA $140/month';
+      const summary = getByTestId('resizeSummary');
+      expect(summary).toHaveTextContent(expectedSummaryText);
+    });
+
+    it('should disable the resize button if node selection is set back to current', async () => {
+      const flags = {
+        dbaasV2: {
+          beta: false,
+          enabled: true,
+        },
+      };
+      const mockDatabase = databaseFactory.build({
+        cluster_size: 1,
+        type: 'g6-nanode-1',
+      });
+      const { getByTestId, getByText } = renderWithTheme(
+        <DatabaseResize database={mockDatabase} />,
+        { flags }
+      );
+      await waitForElementToBeRemoved(getByTestId(loadingTestId));
+      // Mock clicking 3 Nodes option
+      const threeNodesRadioButton = getByTestId('database-node-3').children[0]
+        .children[0] as HTMLInputElement;
+      fireEvent.click(threeNodesRadioButton);
+      const resizeButton = getByText(/Resize Database Cluster/i).closest(
+        'button'
+      );
+      expect(resizeButton).toBeEnabled();
+      // Mock clicking 1 Node option
+      const oneNodeRadioButton = getByTestId('database-node-1').children[0]
+        .children[0] as HTMLInputElement;
+      fireEvent.click(oneNodeRadioButton);
+      expect(resizeButton).toBeDisabled();
+    });
+
+    describe('on rendering of page and isDatabasesGAEnabled is true and the Dedicated CPU tab is preselected', () => {
+      beforeEach(() => {
+        // Mock database types
+        const mockDedicatedTypes = [
+          databaseTypeFactory.build({
+            class: 'dedicated',
+            disk: 81920,
+            id: 'g6-dedicated-2',
+            label: 'Dedicated 4 GB',
+            memory: 4096,
+          }),
+          databaseTypeFactory.build({
+            class: 'dedicated',
+            disk: 163840,
+            id: 'g6-dedicated-4',
+            label: 'Dedicated 8 GB',
+            memory: 8192,
+          }),
+        ];
+        server.use(
+          http.get('*/databases/types', () => {
+            return HttpResponse.json(makeResourcePage([...mockDedicatedTypes]));
+          })
+        );
+      });
+      it('should render node selection for dedicated tab with default summary', async () => {
+        const mockDatabase = databaseFactory.build({
+          type: 'g6-dedicated-2',
+          cluster_size: 3,
+        });
+
+        const flags = {
+          dbaasV2: {
+            beta: false,
+            enabled: true,
+          },
+        };
+
+        const { getByTestId } = renderWithTheme(
+          <DatabaseResize database={mockDatabase} />,
+          { flags }
+        );
+        expect(getByTestId(loadingTestId)).toBeInTheDocument();
+        await waitForElementToBeRemoved(getByTestId(loadingTestId));
+        expect(getByTestId('database-nodes')).toBeDefined();
+        expect(getByTestId('database-node-1')).toBeDefined();
+        expect(getByTestId('database-node-2')).toBeDefined();
+        expect(getByTestId('database-node-3')).toBeDefined();
+      });
+    });
+
+    it('should disable lower node selections', async () => {
+      const mockDatabase = databaseFactory.build({
+        type: 'g6-dedicated-2',
+        cluster_size: 3,
+      });
+
+      const flags = {
+        dbaasV2: {
+          beta: false,
+          enabled: true,
+        },
+      };
+
+      const { getByTestId } = renderWithTheme(
+        <DatabaseResize database={mockDatabase} />,
+        { flags }
+      );
+      expect(getByTestId(loadingTestId)).toBeInTheDocument();
+      await waitForElementToBeRemoved(getByTestId(loadingTestId));
+      expect(
+        getByTestId('database-node-1').children[0].children[0]
+      ).toBeDisabled();
+      expect(
+        getByTestId('database-node-2').children[0].children[0]
+      ).toBeDisabled();
+      expect(
+        getByTestId('database-node-3').children[0].children[0]
+      ).toBeEnabled();
     });
   });
 

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.test.tsx
@@ -1,5 +1,4 @@
 import {
-  fireEvent,
   queryByAttribute,
   waitForElementToBeRemoved,
 } from '@testing-library/react';
@@ -7,12 +6,17 @@ import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import { Router } from 'react-router-dom';
 
-import { databaseFactory, databaseTypeFactory } from 'src/factories';
+import {
+  accountFactory,
+  databaseFactory,
+  databaseTypeFactory,
+} from 'src/factories';
 import { makeResourcePage } from 'src/mocks/serverHandlers';
 import { HttpResponse, http, server } from 'src/mocks/testServer';
 import { mockMatchMedia, renderWithTheme } from 'src/utilities/testHelpers';
 
 import { DatabaseResize } from './DatabaseResize';
+import userEvent from '@testing-library/user-event';
 
 const loadingTestId = 'circle-progress';
 
@@ -25,6 +29,29 @@ describe('database resize', () => {
   });
 
   it('should render a loading state', async () => {
+    // Mock database types
+    const standardTypes = [
+      databaseTypeFactory.build({
+        class: 'nanode',
+        id: 'g6-nanode-1',
+        label: `Nanode 1 GB`,
+        memory: 1024,
+      }),
+      ...databaseTypeFactory.buildList(7, { class: 'standard' }),
+    ];
+
+    server.use(
+      http.get('*/databases/types', () => {
+        return HttpResponse.json(
+          makeResourcePage([...standardTypes, ...dedicatedTypes])
+        );
+      }),
+      http.get('*/account', () => {
+        const account = accountFactory.build();
+        return HttpResponse.json(account);
+      })
+    );
+
     const { getByTestId } = renderWithTheme(
       <DatabaseResize database={database} />
     );
@@ -49,6 +76,10 @@ describe('database resize', () => {
         return HttpResponse.json(
           makeResourcePage([...standardTypes, ...dedicatedTypes])
         );
+      }),
+      http.get('*/account', () => {
+        const account = accountFactory.build();
+        return HttpResponse.json(account);
       })
     );
 
@@ -86,6 +117,10 @@ describe('database resize', () => {
           return HttpResponse.json(
             makeResourcePage([...standardTypes, ...dedicatedTypes])
           );
+        }),
+        http.get('*/account', () => {
+          const account = accountFactory.build();
+          return HttpResponse.json(account);
         })
       );
     });
@@ -111,13 +146,13 @@ describe('database resize', () => {
       );
       await waitForElementToBeRemoved(getByTestId(loadingTestId));
       const getById = queryByAttribute.bind(null, 'id');
-      fireEvent.click(getById(container, examplePlanType));
+      await userEvent.click(getById(container, examplePlanType));
       const resizeButton = getByText(/Resize Database Cluster/i);
       expect(resizeButton.closest('button')).toHaveAttribute(
         'aria-disabled',
         'false'
       );
-      fireEvent.click(resizeButton);
+      await userEvent.click(resizeButton);
       getByText(`Resize Database Cluster ${database.label}?`);
     });
 
@@ -134,6 +169,42 @@ describe('database resize', () => {
   });
 
   describe('on rendering of page and isDatabasesGAEnabled is true and the Shared CPU tab is preselected ', () => {
+    beforeEach(() => {
+      // Mock database types
+      const standardTypes = [
+        databaseTypeFactory.build({
+          class: 'nanode',
+          id: 'g6-nanode-1',
+          label: `New DBaaS - Nanode 1 GB`,
+          memory: 1024,
+        }),
+        ...databaseTypeFactory.buildList(7, { class: 'standard' }),
+      ];
+      const mockDedicatedTypes = [
+        databaseTypeFactory.build({
+          class: 'dedicated',
+          disk: 81920,
+          id: 'g6-dedicated-2',
+          label: 'Dedicated 4 GB',
+          memory: 4096,
+        }),
+      ];
+
+      server.use(
+        http.get('*/databases/types', () => {
+          return HttpResponse.json(
+            makeResourcePage([...mockDedicatedTypes, ...standardTypes])
+          );
+        }),
+        http.get('*/account', () => {
+          const account = accountFactory.build({
+            capabilities: ['Managed Databases', 'Managed Databases Beta'],
+          });
+          return HttpResponse.json(account);
+        })
+      );
+    });
+
     it('should render set node section', async () => {
       const flags = {
         dbaasV2: {
@@ -144,6 +215,7 @@ describe('database resize', () => {
       const mockDatabase = databaseFactory.build({
         cluster_size: 3,
         type: 'g6-nanode-1',
+        engine: 'mysql',
       });
       const { getByTestId, getByText } = renderWithTheme(
         <DatabaseResize database={mockDatabase} />,
@@ -181,7 +253,7 @@ describe('database resize', () => {
       expect(nodeRadioBtns).toHaveTextContent('$140/month $0.21/hr');
 
       const expectedCurrentSummary =
-        'Current Cluster: Nanode 1 GB $60/month 3 Nodes - HA $140/month';
+        'Current Cluster: New DBaaS - Nanode 1 GB $60/month 3 Nodes - HA $140/month';
       const currentSummary = getByTestId('currentSummary');
       expect(currentSummary).toHaveTextContent(expectedCurrentSummary);
 
@@ -253,14 +325,14 @@ describe('database resize', () => {
       // Mock clicking 3 Nodes option
       const selectedNodeRadioButton = getByTestId('database-node-3').children[0]
         .children[0] as HTMLInputElement;
-      fireEvent.click(selectedNodeRadioButton);
+      await userEvent.click(selectedNodeRadioButton);
       const resizeButton = getByText(/Resize Database Cluster/i).closest(
         'button'
       ) as HTMLButtonElement;
       expect(resizeButton.disabled).toBeFalsy();
 
       const expectedSummaryText =
-        'Resized Cluster: Nanode 1 GB $60/month 3 Nodes - HA $140/month';
+        'Resized Cluster: New DBaaS - Nanode 1 GB $60/month 3 Nodes - HA $140/month';
       const summary = getByTestId('resizeSummary');
       expect(summary).toHaveTextContent(expectedSummaryText);
     });
@@ -284,7 +356,7 @@ describe('database resize', () => {
       // Mock clicking 3 Nodes option
       const threeNodesRadioButton = getByTestId('database-node-3').children[0]
         .children[0] as HTMLInputElement;
-      fireEvent.click(threeNodesRadioButton);
+      await userEvent.click(threeNodesRadioButton);
       const resizeButton = getByText(/Resize Database Cluster/i).closest(
         'button'
       );
@@ -292,59 +364,79 @@ describe('database resize', () => {
       // Mock clicking 1 Node option
       const oneNodeRadioButton = getByTestId('database-node-1').children[0]
         .children[0] as HTMLInputElement;
-      fireEvent.click(oneNodeRadioButton);
+      await userEvent.click(oneNodeRadioButton);
       expect(resizeButton).toBeDisabled();
     });
+  });
 
-    describe('on rendering of page and isDatabasesGAEnabled is true and the Dedicated CPU tab is preselected', () => {
-      beforeEach(() => {
-        // Mock database types
-        const mockDedicatedTypes = [
-          databaseTypeFactory.build({
-            class: 'dedicated',
-            disk: 81920,
-            id: 'g6-dedicated-2',
-            label: 'Dedicated 4 GB',
-            memory: 4096,
-          }),
-          databaseTypeFactory.build({
-            class: 'dedicated',
-            disk: 163840,
-            id: 'g6-dedicated-4',
-            label: 'Dedicated 8 GB',
-            memory: 8192,
-          }),
-        ];
-        server.use(
-          http.get('*/databases/types', () => {
-            return HttpResponse.json(makeResourcePage([...mockDedicatedTypes]));
-          })
-        );
+  describe('on rendering of page and isDatabasesGAEnabled is true and the Dedicated CPU tab is preselected', () => {
+    beforeEach(() => {
+      // Mock database types
+      const mockDedicatedTypes = [
+        databaseTypeFactory.build({
+          class: 'dedicated',
+          disk: 81920,
+          id: 'g6-dedicated-2',
+          label: 'Dedicated 4 GB',
+          memory: 4096,
+        }),
+        databaseTypeFactory.build({
+          class: 'dedicated',
+          disk: 163840,
+          id: 'g6-dedicated-4',
+          label: 'Dedicated 8 GB',
+          memory: 8192,
+        }),
+      ];
+
+      // Mock database types
+      const standardTypes = [
+        databaseTypeFactory.build({
+          class: 'nanode',
+          id: 'g6-nanode-1',
+          label: `New DBaaS - Nanode 1 GB`,
+          memory: 1024,
+        }),
+      ];
+
+      server.use(
+        http.get('*/databases/types', () => {
+          return HttpResponse.json(
+            makeResourcePage([...mockDedicatedTypes, ...standardTypes])
+          );
+        }),
+        http.get('*/account', () => {
+          const account = accountFactory.build({
+            capabilities: ['Managed Databases', 'Managed Databases Beta'],
+          });
+          return HttpResponse.json(account);
+        })
+      );
+    });
+
+    it('should render node selection for dedicated tab with default summary', async () => {
+      const mockDatabase = databaseFactory.build({
+        type: 'g6-dedicated-2',
+        cluster_size: 3,
       });
-      it('should render node selection for dedicated tab with default summary', async () => {
-        const mockDatabase = databaseFactory.build({
-          type: 'g6-dedicated-2',
-          cluster_size: 3,
-        });
 
-        const flags = {
-          dbaasV2: {
-            beta: false,
-            enabled: true,
-          },
-        };
+      const flags = {
+        dbaasV2: {
+          beta: false,
+          enabled: true,
+        },
+      };
 
-        const { getByTestId } = renderWithTheme(
-          <DatabaseResize database={mockDatabase} />,
-          { flags }
-        );
-        expect(getByTestId(loadingTestId)).toBeInTheDocument();
-        await waitForElementToBeRemoved(getByTestId(loadingTestId));
-        expect(getByTestId('database-nodes')).toBeDefined();
-        expect(getByTestId('database-node-1')).toBeDefined();
-        expect(getByTestId('database-node-2')).toBeDefined();
-        expect(getByTestId('database-node-3')).toBeDefined();
-      });
+      const { getByTestId } = renderWithTheme(
+        <DatabaseResize database={mockDatabase} />,
+        { flags }
+      );
+      expect(getByTestId(loadingTestId)).toBeInTheDocument();
+      await waitForElementToBeRemoved(getByTestId(loadingTestId));
+      expect(getByTestId('database-nodes')).toBeDefined();
+      expect(getByTestId('database-node-1')).toBeDefined();
+      expect(getByTestId('database-node-2')).toBeDefined();
+      expect(getByTestId('database-node-3')).toBeDefined();
     });
 
     it('should disable lower node selections', async () => {
@@ -410,6 +502,10 @@ describe('database resize', () => {
       server.use(
         http.get('*/databases/types', () => {
           return HttpResponse.json(makeResourcePage([...dedicatedTypes]));
+        }),
+        http.get('*/account', () => {
+          const account = accountFactory.build();
+          return HttpResponse.json(account);
         })
       );
       const { getByTestId } = renderWithTheme(
@@ -429,6 +525,26 @@ describe('database resize', () => {
       type: 'g6-dedicated-8',
     });
     it('should disable Shared Plans Tab', async () => {
+      const standardTypes = [
+        databaseTypeFactory.build({
+          class: 'nanode',
+          id: 'g6-nanode-1',
+          label: `Nanode 1 GB`,
+          memory: 1024,
+        }),
+      ];
+      server.use(
+        http.get('*/databases/types', () => {
+          return HttpResponse.json(
+            makeResourcePage([...dedicatedTypes, ...standardTypes])
+          );
+        }),
+        http.get('*/account', () => {
+          const account = accountFactory.build();
+          return HttpResponse.json(account);
+        })
+      );
+
       const { getByTestId, getByText } = renderWithTheme(
         <DatabaseResize database={database} />
       );

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.tsx
@@ -54,12 +54,12 @@ const useStyles = makeStyles()((theme: Theme) => ({
   summarySpanBorder: {
     borderRight: `1px solid ${theme.borderColors.borderTypography}`,
     color: theme.textColors.tableStatic,
-    paddingRight: '10px',
-    marginRight: '10px;',
-    marginLeft: '10px;',
+    paddingRight: theme.spacing(1),
+    marginRight: theme.spacing(1),
+    marginLeft: theme.spacing(1),
   },
   nodeSpanSpacing: {
-    marginRight: '10px',
+    marginRight: theme.spacing(1),
   },
 }));
 
@@ -363,7 +363,7 @@ export const DatabaseResize = ({ database, disabled = false }: Props) => {
       <span className={classes.nodeSpanSpacing}>
         {' '}
         {database.cluster_size} Node
-        {database.cluster_size > 1 ? 's - HA ' : ' - HA '}
+        {database.cluster_size > 1 ? 's - HA ' : ' '}
       </span>
       {currentNodePrice}
     </Box>

--- a/packages/manager/src/features/Databases/utilities.ts
+++ b/packages/manager/src/features/Databases/utilities.ts
@@ -60,8 +60,12 @@ export const useIsDatabasesEnabled = () => {
         account?.capabilities ?? []
       );
 
+    const isDatabasesGA =
+      flags.dbaasV2?.enabled && flags.dbaasV2.beta === false;
+
     return {
       isDatabasesEnabled: isDatabasesV1Enabled || isDatabasesV2Enabled,
+      isDatabasesGAEnabled: isDatabasesV1Enabled && isDatabasesGA,
       isDatabasesV1Enabled,
       isDatabasesV2Beta: isDatabasesV2Enabled && flags.dbaasV2?.beta,
       isDatabasesV2Enabled,

--- a/packages/manager/src/features/components/PlansPanel/types.ts
+++ b/packages/manager/src/features/components/PlansPanel/types.ts
@@ -1,5 +1,9 @@
-import type { BaseType, RegionPriceObject } from '@linode/api-v4';
+import type { BaseType, Engines, RegionPriceObject } from '@linode/api-v4';
 import type { ExtendedType } from 'src/utilities/extendType';
+
+export interface PlanSelectionWithDatabaseType extends PlanSelectionType {
+  engines: Engines;
+}
 
 export interface PlanSelectionType extends BaseType {
   class: ExtendedType['class'];


### PR DESCRIPTION
## Description 📝
DBaaS Resize GA

## Changes  🔄
List any change relevant to the reviewer.
- Added Number of Nodes selector to the Database Resize tab
- The node selection is cleared if they have 2 nodes option selected and try to switch to a plans tab where it is unavailable.
- Updated newly added Node selector so that the plan is cleared if 2 nodes option is selected for a plan that does not have it.
- Updated summary so that both current and resize cluster pricing summaries are displayed for comparison

## Target release date 🗓️
10/14/24

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Before](https://github.com/user-attachments/assets/e8b04cfc-4826-4157-a393-2cf5c120ea30)| ![After](https://github.com/user-attachments/assets/e10f84bf-4fb6-48eb-872d-6bcad414d1af)|

## How to test 🧪

### Prerequisites
(How to setup test environment)
- For testing this change, ensure that DBaaS v2 is enabled, Beta is turned off, and the user has the "Managed Databases" account capability

### Verification steps
(How to verify changes)
- Navigate to the Databases section.
- Select the New Databases tab and click into one of the databases to see your details
- Navigate to the Resize tab
- Scroll down below the plans selection to view the Number of Nodes section is visible
- Verify that the correct node options are visible in the different tabs (ie. Dedicated vs Shared, etc)
- Verify that your current cluster size is selected and that lower sizes are disabled
- Verify that making a higher node selection enables the Resize button
- Verify that updated summary is visible and updates with selection
- Make an invalid selection for the 2 node option to see the summary remove the current selection

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
