### PR TITLE
fix: [M3-8696] - Explicitly define 'key' prop for Autocomplete instead of spreading

### DIFF
--- a/packages/manager/.changeset/pr-11041-fixed-1727966039153.md
+++ b/packages/manager/.changeset/pr-11041-fixed-1727966039153.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Explicitly define 'key' prop instead of spreading ([#11041](https://github.com/linode/manager/pull/11041))
+Explicitly define 'key' prop for Autocomplete instead of spreading ([#11041](https://github.com/linode/manager/pull/11041))

--- a/packages/manager/.changeset/pr-11041-fixed-1727966039153.md
+++ b/packages/manager/.changeset/pr-11041-fixed-1727966039153.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Explicitly define 'key' prop instead of spreading ([#11041](https://github.com/linode/manager/pull/11041))

--- a/packages/manager/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/manager/src/components/Autocomplete/Autocomplete.tsx
@@ -146,7 +146,7 @@ export const Autocomplete = <
         return renderOption ? (
           renderOption(props, option, state, ownerState)
         ) : (
-          <ListItem {...props} data-qa-option>
+          <ListItem {...props} data-qa-option key={props.key}>
             <>
               <Box
                 sx={{


### PR DESCRIPTION
## Description 📝
A props object containing a "key" prop is being spread into JSX

## Changes  🔄
- Explicitly define 'key' prop instead of spreading

## Target release date 🗓️
Next release

## Preview 📷
![Screenshot 2024-10-03 at 10 31 39 AM](https://github.com/user-attachments/assets/5cbba181-409e-4e37-88d0-e2975a7bc634)

## How to test 🧪

### Reproduction steps
(How to reproduce the issue, if applicable)
- Turn on MSW
- Go to Cloud Pulse
- Select a dashboard
- Observe warning in console

### Verification steps
(How to verify changes)
- View changes or preview link and observe issue is fixed

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support