### PR TITLE
change: [M3-6994] - Spell out "Configuration" on Linodes Configurations table

### DIFF
--- a/packages/manager/.changeset/pr-11046-changed-1727990528328.md
+++ b/packages/manager/.changeset/pr-11046-changed-1727990528328.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Spell out "Configuration" on Linodes Configurations table ([#11046](https://github.com/linode/manager/pull/11046))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigs.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigs.tsx
@@ -127,7 +127,7 @@ const LinodeConfigs = () => {
                           handleClick={handleOrderChange}
                           label={'label'}
                         >
-                          <strong>Config</strong>
+                          <strong>Configuration</strong>
                         </TableSortCell>
                         <TableCell
                           sx={{


### PR DESCRIPTION
## Description 📝
This PR changes the text copy of the column header on Linodes Configurations table.

## Changes  🔄
List any change relevant to the reviewer.
- Update the text copy from "Config" to "Configuration"

## Target release date 🗓️
10/14/2024

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-10-03 at 2 10 41 PM](https://github.com/user-attachments/assets/72bc1da6-2c38-47a4-9ceb-fa59ee87e9fa) |  ![Screenshot 2024-10-03 at 2 10 23 PM](https://github.com/user-attachments/assets/9bc133d0-e4b3-47c4-ba5e-9484496d0f0a) |

## How to test 🧪
### Verification steps
- Visit the "Configurations" tab on any given Linode instance and verify that the table headers reads "Configuration"

## As an Author I have considered 🤔
*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
