### PR TITLE
upcoming: [M3-8452, M3-8603] - Add Resource Links & Fix Test Flake

### DIFF
--- a/packages/manager/.changeset/pr-11047-upcoming-features-1728307120334.md
+++ b/packages/manager/.changeset/pr-11047-upcoming-features-1728307120334.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-Added OBJ Gen2 resource links and fixed test flake for bucket creation ([#11047](https://github.com/linode/manager/pull/11047))
+Add OBJ Gen2 resource links and fix test flake for bucket creation ([#11047](https://github.com/linode/manager/pull/11047))

--- a/packages/manager/.changeset/pr-11047-upcoming-features-1728307120334.md
+++ b/packages/manager/.changeset/pr-11047-upcoming-features-1728307120334.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Added OBJ Gen2 resource links and fixed test flake for bucket creation ([#11047](https://github.com/linode/manager/pull/11047))

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.tsx
@@ -218,7 +218,11 @@ export const AccessSelect = React.memo((props: Props) => {
             })}
           >
             CORS (Cross Origin Sharing) is not available for endpoint types E2
-            and E3. <Link to="#">Learn more</Link>.
+            and E3.{' '}
+            <Link to="https://techdocs.akamai.com/cloud-computing/docs/define-access-and-permissions-using-acls-access-control-lists">
+              Learn more
+            </Link>
+            .
           </Typography>
         </Notice>
       )}

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRateLimitTable.tsx
@@ -84,7 +84,11 @@ export const BucketRateLimitTable = ({
         ) : (
           'This endpoint type supports up to 750 Requests Per Second (RPS). '
         )}
-        Understand <Link to="#">bucket rate limits</Link>.
+        Understand{' '}
+        <Link to="https://techdocs.akamai.com/cloud-computing/docs/create-and-manage-buckets">
+          bucket rate limits
+        </Link>
+        .
       </Typography>
 
       {isGen2EndpointType && (

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.tsx
@@ -128,7 +128,7 @@ export const CreateBucketDrawer = (props: Props) => {
   };
 
   const clusterRegion = watchCluster
-    ? regions?.find((region) => watchCluster.includes(region.id))
+    ? regions?.find((region) => watchCluster === region.id)
     : undefined;
 
   const { showGDPRCheckbox } = getGDPRDetails({

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.tsx
@@ -128,7 +128,7 @@ export const CreateBucketDrawer = (props: Props) => {
   };
 
   const clusterRegion = watchCluster
-    ? regions?.find((region) => watchCluster === region.id)
+    ? regions?.find((region) => watchCluster.includes(region.id))
     : undefined;
 
   const { showGDPRCheckbox } = getGDPRDetails({

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OMC_CreateBucketDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OMC_CreateBucketDrawer.tsx
@@ -179,7 +179,7 @@ export const OMC_CreateBucketDrawer = (props: Props) => {
   };
 
   const selectedRegion = watchRegion
-    ? regions?.find((region) => watchRegion.includes(region.id))
+    ? regions?.find((region) => watchRegion === region.id)
     : undefined;
 
   const filteredEndpoints = endpoints?.filter(
@@ -341,7 +341,10 @@ export const OMC_CreateBucketDrawer = (props: Props) => {
                       <Typography component="span">
                         Endpoint types impact the performance, capacity, and
                         rate limits for your bucket. Understand{' '}
-                        <Link to="#">endpoint types</Link>.
+                        <Link to="https://techdocs.akamai.com/cloud-computing/docs/object-storage">
+                          endpoint types
+                        </Link>
+                        .
                       </Typography>
                     ),
                     helperTextPosition: 'top',


### PR DESCRIPTION
## Description 📝
Update OBJ Gen2 resource links and fix issue causing test flake.

## Changes  🔄
- `.includes` was causing test flake because the substring could match several options. IE: If looking for `us-10`, it may return `us-1` or even `us-100`. See `M3-8603`
- Added documentation resource links

## Target release date 🗓️
N/A

## Screenshots
<img width="833" alt="Screenshot 2024-10-04 at 11 53 27 AM" src="https://github.com/user-attachments/assets/a0a15f2d-270b-49d7-b2eb-dc19b18e2246">

## How to test 🧪

### Verification steps
Ensure tests pass and links work!

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support