### PR TITLE
change: [M3-7676] - Remove VPC Details dismissible warning banner

### DIFF
--- a/packages/manager/.changeset/pr-11050-removed-1728374181106.md
+++ b/packages/manager/.changeset/pr-11050-removed-1728374181106.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Removed
+---
+
+VPC Details dismissible warning banner ([#11050](https://github.com/linode/manager/pull/11050))

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.tsx
@@ -7,7 +7,6 @@ import { useParams } from 'react-router-dom';
 import { Box } from 'src/components/Box';
 import { StyledLinkButton } from 'src/components/Button/StyledLinkButton';
 import { CircleProgress } from 'src/components/CircleProgress/CircleProgress';
-import { DismissibleBanner } from 'src/components/DismissibleBanner/DismissibleBanner';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { EntityHeader } from 'src/components/EntityHeader/EntityHeader';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
@@ -17,7 +16,6 @@ import { useRegionsQuery } from 'src/queries/regions/regions';
 import { useVPCQuery } from 'src/queries/vpcs/vpcs';
 import { truncate } from 'src/utilities/truncate';
 
-import { REBOOT_LINODE_WARNING_VPCDETAILS } from '../constants';
 import { getUniqueLinodesFromSubnets } from '../utils';
 import { VPCDeleteDialog } from '../VPCLanding/VPCDeleteDialog';
 import { VPCEditDrawer } from '../VPCLanding/VPCEditDrawer';
@@ -199,17 +197,6 @@ const VPCDetail = () => {
           Subnets ({vpc.subnets.length})
         </Typography>
       </Box>
-      {numLinodes > 0 && (
-        <DismissibleBanner
-          preferenceKey={`reboot-linodes-warning-banner`}
-          sx={{ marginBottom: theme.spacing(2) }}
-          variant="warning"
-        >
-          <Typography variant="body1">
-            {REBOOT_LINODE_WARNING_VPCDETAILS}
-          </Typography>
-        </DismissibleBanner>
-      )}
       <VPCSubnetsTable vpcId={vpc.id} vpcRegion={vpc.region} />
     </>
   );


### PR DESCRIPTION
## Description 📝
The dismissible warning banner `Assigned or unassigned Linodes will not take affect until the Linodes are rebooted.`that is displayed when a Linode is either assigned to or unassigned from a VPC subnet can be removed. 

## Changes  🔄
- Removed the dismissible warning banner `Assigned or unassigned Linodes will not take affect until the Linodes are rebooted.` from the VPC Detail page.

## Target release date 🗓️
14/10 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/6429c756-dd13-45b8-8856-93bb2b43c112)| ![image](https://github.com/user-attachments/assets/ff7482e6-64cf-4b37-b15c-6878ce3eda54)|

## How to test 🧪

### Verification steps
- Navigate to `localhost:3000/vpc/:vpc_id`
- Create a subnet if it is not already present
- Assign a Linode to this subnet
- Verify that the dismissible warning banner is not displayed.
- Unassign the Linode from this subnet
- Verify that the dismissible warning banner is not displayed.
 

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

