### PR TITLE
feat: [M3-8703] - Disable Create VPC button with tooltip text on empty state Landing Page for restricted users

### DIFF
--- a/packages/manager/src/features/VPCs/VPCLanding/VPCEmptyState.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCEmptyState.tsx
@@ -4,6 +4,8 @@ import { useHistory } from 'react-router-dom';
 import VPC from 'src/assets/icons/entityIcons/vpc.svg';
 import { ResourcesSection } from 'src/components/EmptyLandingPageResources/ResourcesSection';
 import { gettingStartedGuides } from 'src/features/VPCs/VPCLanding/VPCLandingEmptyStateData';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
+import { getRestrictedResourceText } from 'src/features/Account/utils';
 import { sendEvent } from 'src/utilities/analytics/utils';
 
 import { headers, linkAnalyticsEvent } from './VPCEmptyStateData';
@@ -11,11 +13,16 @@ import { headers, linkAnalyticsEvent } from './VPCEmptyStateData';
 export const VPCEmptyState = () => {
   const { push } = useHistory();
 
+  const isVPCReadOnly = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'add_vpcs',
+  });
+
   return (
     <ResourcesSection
       buttonProps={[
         {
           children: 'Create VPC',
+          disabled: isVPCReadOnly,
           onClick: () => {
             sendEvent({
               action: 'Click:button',
@@ -24,6 +31,11 @@ export const VPCEmptyState = () => {
             });
             push('/vpcs/create');
           },
+          tooltipText: getRestrictedResourceText({
+            action: 'create',
+            isSingular: false,
+            resourceType: 'VPCs',
+          }),
         },
       ]}
       gettingStartedGuidesData={gettingStartedGuides}


### PR DESCRIPTION
## Description 📝
To prevent unauthorized access to specific flows and provide clearer guidance, we aim to restrict entry to users without the required permissions.

Here, we are restricting users from creating new VPC from the Empty State Landing Page when they do not have access or have read only access.

## Changes  🔄
List any change relevant to the reviewer.

- For restricted users:
  - Disabled Create VPC Button on the Empty Landing Page


## Target release date 🗓️

## Preview 📷


| Before | After |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/3fe1175e-ad58-4687-b61e-96fcc566f8a2) | ![After](https://github.com/user-attachments/assets/02e03608-959a-4c69-86cd-af0e3d7b6cb5) |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites
- Log into two accounts side by side:
  - An unrestricted admin user account: full access
  - A restricted user account (use Incognito for this)
    - Start with Read Only for everything

### Reproduction steps
- Landing:
  - Observe as restricted user, notice shows and you cannot create VPC

### Verification steps

- After changes, observe tooltips are tailored to the action.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
