### PR TITLE
test: [M3-8718] - Fix conflicting shorthand flags for TOD script

### DIFF
--- a/scripts/tod-payload/index.ts
+++ b/scripts/tod-payload/index.ts
@@ -17,7 +17,7 @@ program
   .option('-v, --appVersion <str>', 'Application version')
   .option('-t, --appTeam <str>', 'Application team name')
   .option('-f, --fail', 'Treat payload as failure')
-  .option('-t, --tag <str>', 'Optional tag for run')
+  .option('-T, --tag <str>', 'Optional tag for run')
 
   .action((junitPath: string) => {
     return main(junitPath);


### PR DESCRIPTION
## Description 📝
Our Heimdall pipeline began failing with the following error message after the v1.129.0 release:

```
+ yarn --silent generate-tod ./packages/manager/cypress/results --appName 'Cloud Manager' --appTeam 'Cloud Manager' --appVersion 1.129.1 --appBuild 7003 --appBuildUrl '(redacted)'
/(redacted)/node_modules/commander/lib/command.js:602
      throw new Error(`Cannot add option '${option.flags}'${this._name && ` to command '${this._name}'`} due to conflicting flag '${matchingFlag}'
            ^
Error: Cannot add option '-t, --tag <str>' to command 'tod-payload' due to conflicting flag '-t'
-  already used by option '-t, --appTeam <str>'
    at Command._registerOption ((redacted)/node_modules/commander/lib/command.js:602:13)
    at Command.addOption ((redacted)/node_modules/commander/lib/command.js:643:10)
    at Command._optionEx ((redacted)/node_modules/commander/lib/command.js:735:17)
    at Command.option ((redacted)/node_modules/commander/lib/command.js:761:17)
    at Object.<anonymous> ((redacted)/scripts/tod-payload/index.ts:20:4)
    at Module._compile (node:internal/modules/cjs/loader:1159:14)
    at Module.m._compile ((redacted)/packages/manager/node_modules/ts-node/src/index.ts:1618:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1213:10)
    at Object.require.extensions.<computed> [as .ts] ((redacted)/packages/manager/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1037:32)
script returned exit code 1 
```

This happens when using the `yarn generate-tod` command to generate the JUnit test result payload which gets sent to Heimdall.

I'm not sure what triggered this (guessing some dependency change resulting in a newer version of Commander being exposed to the script), but it's pointing out a legitimate bug in the script so figured I'd fix here. Interestingly, I haven't been able to reproduce when running `yarn generate-tod` locally, so if I have time I'll try to do some investigating to understand why that is.

I'll also run our pipeline against this branch to confirm that it resolves the issue before merging.

## Changes  🔄
- Use `-T` shorthand flag for `--tags` param

## Target release date 🗓️
10/14 release if possible

## How to test 🧪


## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
