### PR TITLE
fix: [M3-8726] - Users unable to upgrade Kubernetes version from landing page

### DIFF
--- a/packages/manager/.changeset/pr-11056-fixed-1728428139880.md
+++ b/packages/manager/.changeset/pr-11056-fixed-1728428139880.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Users unable to upgrade Kubernetes version from landing page ([#11056](https://github.com/linode/manager/pull/11056))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -20,6 +20,7 @@ import {
   mockRecycleAllNodes,
   mockGetDashboardUrl,
   mockGetApiEndpoints,
+  mockGetClusters,
 } from 'support/intercepts/lke';
 import {
   mockGetLinodeType,
@@ -113,7 +114,7 @@ describe('LKE cluster updates', () => {
    * - Confirms that Kubernetes upgrade prompt is shown when not up-to-date.
    * - Confirms that Kubernetes upgrade prompt is hidden when up-to-date.
    */
-  it('can upgrade Kubernetes engine version', () => {
+  it('can upgrade kubernetes version from the details page', () => {
     const oldVersion = '1.25';
     const newVersion = '1.26';
 
@@ -213,6 +214,61 @@ describe('LKE cluster updates', () => {
     cy.findByText(`Version ${newVersion}`);
 
     ui.toast.findByMessage('Recycle started successfully.');
+  });
+
+  it('can upgrade the kubernetes version from the landing page', () => {
+    const oldVersion = '1.25';
+    const newVersion = '1.26';
+
+    const cluster = kubernetesClusterFactory.build({
+      k8s_version: oldVersion,
+    });
+
+    const updatedCluster = { ...cluster, k8s_version: newVersion };
+
+    mockGetClusters([cluster]).as('getClusters');
+    mockGetKubernetesVersions([newVersion, oldVersion]).as('getVersions');
+    mockUpdateCluster(cluster.id, updatedCluster).as('updateCluster');
+    mockRecycleAllNodes(cluster.id).as('recycleAllNodes');
+
+    cy.visitWithLogin(`/kubernetes/clusters`);
+
+    cy.wait(['@getClusters', '@getVersions']);
+
+    cy.findByText(oldVersion).should('be.visible');
+
+    cy.findByText('UPGRADE').should('be.visible').should('be.enabled').click();
+
+    ui.dialog
+      .findByTitle(
+        `Step 1: Upgrade ${cluster.label} to Kubernetes ${newVersion}`
+      )
+      .should('be.visible');
+
+    ui.button
+      .findByTitle('Upgrade Version')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    mockGetClusters([updatedCluster]).as('getClusters');
+    cy.wait(['@updateCluster', '@getClusters']);
+
+    ui.dialog
+      .findByTitle('Step 2: Recycle All Cluster Nodes')
+      .should('be.visible');
+
+    ui.button
+      .findByTitle('Recycle All Nodes')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.wait('@recycleAllNodes');
+
+    ui.toast.assertMessage('Recycle started successfully.');
+
+    cy.findByText(newVersion).should('be.visible');
   });
 
   /*

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -245,13 +245,14 @@ describe('LKE cluster updates', () => {
       )
       .should('be.visible');
 
+    mockGetClusters([updatedCluster]).as('getClusters');
+
     ui.button
       .findByTitle('Upgrade Version')
       .should('be.visible')
       .should('be.enabled')
       .click();
 
-    mockGetClusters([updatedCluster]).as('getClusters');
     cy.wait(['@updateCluster', '@getClusters']);
 
     ui.dialog

--- a/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
@@ -98,7 +98,7 @@ export const KubernetesLanding = () => {
 
   const isRestricted = profile?.restricted ?? false;
 
-  const { data, error, isFetching } = useKubernetesClustersQuery(
+  const { data, error, isLoading } = useKubernetesClustersQuery(
     {
       page: pagination.page,
       page_size: pagination.pageSize,
@@ -157,7 +157,7 @@ export const KubernetesLanding = () => {
     );
   }
 
-  if (isFetching) {
+  if (isLoading) {
     return <CircleProgress />;
   }
 


### PR DESCRIPTION
## Description 📝

- Fixes a bug 🐛 preventing users from upgrading their Kubernetes cluster from the Kubernetes landing page ⬆️ 
- I believe the bug was caused by https://github.com/linode/manager/pull/10756 
  - Specifically switching `isLoading` ➡️ `isFetching` - see comment for explanation
- Adds Cypress test that would have caught this bug 🧪 
  - (the test uses mocked API data)
## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/87004463-9c6d-4176-847d-d001e454f79c" /> | <video src="https://github.com/user-attachments/assets/eea9b226-7002-4a12-b4d0-074d858beebf" /> |

## How to test 🧪

### Reproduction steps
- Spin up a Kubernetes cluster that is **not** on the latest version
- Attempt the upgrade flow **on the Kubernetes landing page**
- Observe that when clicking "Upgrade Version", the dialog will not proceed to step 2

### Verification steps
- Spin up a Kubernetes cluster that is **not** on the latest version
- Test the upgrade flow **on the Kubernetes landing page**
- Verify you see step 1 and step 2

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support