### PR TITLE
feat: [M3-8703] - Disable Create VPC button with tooltip text on Landing Page for restricted users

### DIFF
--- a/packages/manager/.changeset/pr-11063-added-1728386681970.md
+++ b/packages/manager/.changeset/pr-11063-added-1728386681970.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Disable Create VPC button with tooltip text on Landing Page for restricted users ([#11063](https://github.com/linode/manager/pull/11063)) ([#11063](https://github.com/linode/manager/pull/11063))

--- a/packages/manager/.changeset/pr-11063-added-1728386681970.md
+++ b/packages/manager/.changeset/pr-11063-added-1728386681970.md
@@ -2,4 +2,4 @@
 "@linode/manager": Added
 ---
 
-Disable Create VPC button with tooltip text on Landing Page for restricted users ([#11063](https://github.com/linode/manager/pull/11063)) ([#11063](https://github.com/linode/manager/pull/11063))
+Disable Create VPC button with tooltip text on Landing Page for restricted users ([#11063](https://github.com/linode/manager/pull/11063))

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCLanding.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCLanding.tsx
@@ -75,7 +75,7 @@ const VPCLanding = () => {
     history.push(VPC_CREATE_ROUTE);
   };
 
-  const isVPCSReadOnly = useRestrictedGlobalGrantCheck({
+  const isVPCCreationRestricted = useRestrictedGlobalGrantCheck({
     globalGrantType: 'add_vpcs',
   });
 

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCLanding.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCLanding.tsx
@@ -111,7 +111,7 @@ const VPCLanding = () => {
             resourceType: 'VPCs',
           }),
         }}
-        disabledCreateButton={isVPCSReadOnly}
+        disabledCreateButton={isVPCCreationRestricted}
       />
       <Table>
         <TableHead>

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCLanding.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCLanding.tsx
@@ -16,8 +16,10 @@ import { TableSortCell } from 'src/components/TableSortCell';
 import { VPC_DOCS_LINK, VPC_LABEL } from 'src/features/VPCs/constants';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 import { useVPCsQuery } from 'src/queries/vpcs/vpcs';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { getRestrictedResourceText } from 'src/features/Account/utils';
 
 import { VPCDeleteDialog } from './VPCDeleteDialog';
 import { VPCEditDrawer } from './VPCEditDrawer';
@@ -73,6 +75,10 @@ const VPCLanding = () => {
     history.push(VPC_CREATE_ROUTE);
   };
 
+  const isVPCSReadOnly = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'add_vpcs',
+  });
+
   if (error) {
     return (
       <ErrorState
@@ -98,6 +104,14 @@ const VPCLanding = () => {
         docsLink={VPC_DOCS_LINK}
         onButtonClick={createVPC}
         title={VPC_LABEL}
+        buttonDataAttrs={{
+          tooltipText: getRestrictedResourceText({
+            action: 'create',
+            isSingular: false,
+            resourceType: 'VPCs',
+          }),
+        }}
+        disabledCreateButton={isVPCSReadOnly}
       />
       <Table>
         <TableHead>


### PR DESCRIPTION
## Description 📝
To prevent unauthorized access to specific flows and provide clearer guidance, we aim to restrict entry to users without the required permissions.

Here, we are restricting users from creating new VPC from the Landing Page when they do not have access or have read only access.

## Changes  🔄
List any change relevant to the reviewer.

- For restricted users:
  - Disabled Create VPC Button on the Landing Page


## Target release date 🗓️

## Preview 📷


| Before | After |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/40ed17a1-0c8a-48c9-bc76-01c46e8fb4e4) | ![After](https://github.com/user-attachments/assets/5e61d605-a8bc-47b3-825e-f9b9ad8f8340) |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites
- Log into two accounts side by side:
  - An unrestricted admin user account: full access
  - A restricted user account (use Incognito for this)
    - Start with Read Only for everything

### Reproduction steps
- Landing:
  - Observe as restricted user, notice shows and you cannot create VPC

### Verification steps

- After changes, observe tooltips are tailored to the action.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
