### PR TITLE
chore: [M3-7014] - Remove `isVLAN` code

### DIFF
--- a/packages/manager/.changeset/pr-11065-tech-stories-1728392959296.md
+++ b/packages/manager/.changeset/pr-11065-tech-stories-1728392959296.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Removed unnecessary isVLAN code from codebase ([#11065](https://github.com/linode/manager/pull/11065))

--- a/packages/manager/src/features/Linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -45,7 +45,6 @@ interface DisplayGroupedLinodesProps
   data: LinodeWithMaintenance[];
   display: 'grid' | 'list';
   handleRegionFilter: (regionFilter: RegionFilter) => void;
-  isVLAN?: boolean;
   linodeViewPreference: 'grid' | 'list';
   linodesAreGrouped: boolean;
   openDialog: (type: DialogType, linodeID: number, linodeLabel: string) => void;
@@ -67,7 +66,6 @@ export const DisplayGroupedLinodes = (props: DisplayGroupedLinodesProps) => {
     display,
     handleOrderChange,
     handleRegionFilter,
-    isVLAN,
     linodeViewPreference,
     linodesAreGrouped,
     order,
@@ -86,7 +84,6 @@ export const DisplayGroupedLinodes = (props: DisplayGroupedLinodesProps) => {
   const tableWrapperProps = {
     dataLength,
     handleOrderChange,
-    isVLAN,
     order,
     orderBy,
     someLinodesHaveMaintenance: props.someLinodesHaveMaintenance,
@@ -190,7 +187,6 @@ export const DisplayGroupedLinodes = (props: DisplayGroupedLinodesProps) => {
                     handleOrderChange,
                     handlePageChange,
                     handlePageSizeChange,
-                    isVLAN,
                     order,
                     orderBy,
                     page,
@@ -264,7 +260,6 @@ export const DisplayGroupedLinodes = (props: DisplayGroupedLinodesProps) => {
                       handleOrderChange,
                       handlePageChange,
                       handlePageSizeChange,
-                      isVLAN,
                       order,
                       orderBy,
                       page,

--- a/packages/manager/src/features/Linodes/LinodesLanding/SortableTableHead.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/SortableTableHead.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import GridView from 'src/assets/icons/grid-view.svg';
 import { GroupByTagToggle } from 'src/components/GroupByTagToggle';
 import { Hidden } from 'src/components/Hidden';
-import { OrderByProps } from 'src/components/OrderBy';
 import { TableCell } from 'src/components/TableCell';
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
@@ -13,11 +12,12 @@ import { Tooltip } from 'src/components/Tooltip';
 
 import { StyledToggleButton } from './DisplayLinodes.styles';
 
+import type { OrderByProps } from 'src/components/OrderBy';
+
 // There's nothing very scientific about the widths across the breakpoints
 // here, just a lot of trial and error based on maximum expected column sizes.
 
 interface Props {
-  isVLAN?: boolean;
   linodeViewPreference: 'grid' | 'list';
   linodesAreGrouped: boolean;
   toggleGroupLinodes: () => boolean;
@@ -33,7 +33,6 @@ export const SortableTableHead = <T,>(props: SortableTableHeadProps<T>) => {
 
   const {
     handleOrderChange,
-    isVLAN,
     linodeViewPreference,
     linodesAreGrouped,
     order,
@@ -85,82 +84,68 @@ export const SortableTableHead = <T,>(props: SortableTableHeadProps<T>) => {
         >
           Status
         </TableSortCell>
-        {isVLAN ? (
+        <Hidden smDown>
           <TableSortCell
-            active={isActive('_vlanIP')}
+            sx={{
+              ...theme.applyTableHeaderStyles,
+              [theme.breakpoints.only('sm')]: {
+                width: '15%',
+              },
+              width: '14%',
+            }}
+            active={isActive('type')}
             direction={order}
             handleClick={handleOrderChange}
-            label="_vlanIP"
+            label="type"
           >
-            VLAN IP
+            Plan
           </TableSortCell>
-        ) : null}
-        {isVLAN ? null : (
-          <>
-            <Hidden smDown>
-              <TableSortCell
-                sx={{
-                  ...theme.applyTableHeaderStyles,
-                  [theme.breakpoints.only('sm')]: {
-                    width: '15%',
-                  },
-                  width: '14%',
-                }}
-                active={isActive('type')}
-                direction={order}
-                handleClick={handleOrderChange}
-                label="type"
-              >
-                Plan
-              </TableSortCell>
-              <TableSortCell
-                active={isActive('ipv4[0]')}
-                direction={order}
-                handleClick={handleOrderChange}
-                label="ipv4[0]" // we want to sort by the first ipv4
-                noWrap
-              >
-                Public IP Address
-              </TableSortCell>
-              <Hidden lgDown>
-                <TableSortCell
-                  sx={{
-                    ...theme.applyTableHeaderStyles,
-                    [theme.breakpoints.down('sm')]: {
-                      width: '18%',
-                    },
-                    width: '14%',
-                  }}
-                  active={isActive('region')}
-                  data-qa-sort-region={order}
-                  direction={order}
-                  handleClick={handleOrderChange}
-                  label="region"
-                >
-                  Region
-                </TableSortCell>
-              </Hidden>
-            </Hidden>
-            <Hidden lgDown>
-              <TableSortCell
-                sx={{
-                  ...theme.applyTableHeaderStyles,
-                  [theme.breakpoints.down('sm')]: {
-                    width: '18%',
-                  },
-                  width: '14%',
-                }}
-                active={isActive('backups:last_successful')}
-                direction={order}
-                handleClick={handleOrderChange}
-                label="backups:last_successful"
-                noWrap
-              >
-                Last Backup
-              </TableSortCell>
-            </Hidden>
-          </>
-        )}
+          <TableSortCell
+            active={isActive('ipv4[0]')}
+            direction={order}
+            handleClick={handleOrderChange}
+            label="ipv4[0]" // we want to sort by the first ipv4
+            noWrap
+          >
+            Public IP Address
+          </TableSortCell>
+          <Hidden lgDown>
+            <TableSortCell
+              sx={{
+                ...theme.applyTableHeaderStyles,
+                [theme.breakpoints.down('sm')]: {
+                  width: '18%',
+                },
+                width: '14%',
+              }}
+              active={isActive('region')}
+              data-qa-sort-region={order}
+              direction={order}
+              handleClick={handleOrderChange}
+              label="region"
+            >
+              Region
+            </TableSortCell>
+          </Hidden>
+        </Hidden>
+        <Hidden lgDown>
+          <TableSortCell
+            sx={{
+              ...theme.applyTableHeaderStyles,
+              [theme.breakpoints.down('sm')]: {
+                width: '18%',
+              },
+              width: '14%',
+            }}
+            active={isActive('backups:last_successful')}
+            direction={order}
+            handleClick={handleOrderChange}
+            label="backups:last_successful"
+            noWrap
+          >
+            Last Backup
+          </TableSortCell>
+        </Hidden>
         <TableCell sx={{ padding: '0 !important' }}>
           <div
             style={{

--- a/packages/manager/src/features/Linodes/LinodesLanding/TableWrapper.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/TableWrapper.tsx
@@ -1,15 +1,16 @@
 import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 
-import { OrderByProps } from 'src/components/OrderBy';
-import { Table, TableProps } from 'src/components/Table';
+import { Table } from 'src/components/Table';
 
 import { SortableTableHead } from './SortableTableHead';
+
+import type { OrderByProps } from 'src/components/OrderBy';
+import type { TableProps } from 'src/components/Table';
 
 interface Props {
   children: React.ReactNode;
   dataLength: number;
-  isVLAN?: boolean;
   linodeViewPreference: 'grid' | 'list';
   linodesAreGrouped: boolean;
   tableProps?: TableProps;
@@ -23,7 +24,6 @@ const TableWrapper = <T,>(props: TableWrapperProps<T>) => {
   const {
     dataLength,
     handleOrderChange,
-    isVLAN,
     linodeViewPreference,
     linodesAreGrouped,
     order,
@@ -45,7 +45,6 @@ const TableWrapper = <T,>(props: TableWrapperProps<T>) => {
         >
           <SortableTableHead
             handleOrderChange={handleOrderChange}
-            isVLAN={isVLAN}
             linodeViewPreference={linodeViewPreference}
             linodesAreGrouped={linodesAreGrouped}
             order={order}


### PR DESCRIPTION
## Description 📝
Removes all redundant `isVLAN` logic from the codebase.

## Changes  🔄
List any change relevant to the reviewer.
- All instances of `isVLAN` are removed.
- Removed `VLAN IP` table column since the `isVLAN` prop will not exit anymore.

## Target release date 🗓️
10/14/2024

## Preview 📷
There are no changes to preview since the direction for this offering shifted. This PR simply removes logic that was left behind.

## How to test 🧪
### Verification steps
(How to verify changes)
- Verify that there are no visual regressions in the `LinodesLanding` table.
- Verify that all `isVLAN` logic is removed from the codebase.


## As an Author I have considered 🤔
*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
