### PR TITLE
fix: [M3-8052] - Toasts are not consistently dismissible with the 'X' button

### DIFF
--- a/packages/manager/.changeset/pr-11073-fixed-1728472748252.md
+++ b/packages/manager/.changeset/pr-11073-fixed-1728472748252.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Toasts are not consistently dismissible with the 'X' button ([#11073](https://github.com/linode/manager/pull/11073))

--- a/packages/manager/src/components/Snackbar/Snackbar.tsx
+++ b/packages/manager/src/components/Snackbar/Snackbar.tsx
@@ -1,5 +1,5 @@
 import { styled } from '@mui/material/styles';
-import { MaterialDesignContent } from 'notistack';
+import { MaterialDesignContent, closeSnackbar } from 'notistack';
 import { SnackbarProvider } from 'notistack';
 import * as React from 'react';
 
@@ -45,18 +45,11 @@ export const Snackbar = (props: SnackbarProviderProps) => {
    * This pattern is taken from the Notistack docs:
    * https://iamhosseindhv.com/notistack/demos#action-for-all-snackbars
    */
-  const notistackRef: React.Ref<SnackbarProvider> = React.createRef();
-  const onClickDismiss = (key: number | string | undefined) => () => {
-    if (notistackRef.current) {
-      notistackRef.current.closeSnackbar(key);
-    }
-  };
 
   const { children, ...rest } = props;
 
   return (
     <SnackbarProvider
-      ref={notistackRef}
       {...rest}
       Components={{
         default: StyledMaterialDesignContent,
@@ -65,9 +58,9 @@ export const Snackbar = (props: SnackbarProviderProps) => {
         success: StyledMaterialDesignContent,
         warning: StyledMaterialDesignContent,
       }}
-      action={(key) => (
+      action={(snackbarId) => (
         <CloseSnackbar
-          onClick={onClickDismiss(key)}
+          onClick={() => closeSnackbar(snackbarId)}
           text="Dismiss Notification"
         />
       )}


### PR DESCRIPTION
## Description 📝
The close ('X') button on toast notifications is not dismissing the toast in some cases. While most toasts dismiss after 5 seconds so this is not very noticeable, it could pose a problem for any toasts that we do persist (e.g. error toasts) because the toast will be stuck on the page (until refresh).

## Changes  🔄
- Removed `notistackRef` and invoking  `closeSnackbar` method directly within the action prop.

## Target release date 🗓️
N/A

## How to test 🧪

### Reproduction steps
- Volume creation and the 'Volume scheduled for creation' toast is one example:
  - Go to Volumes Create page (https://cloud.linode.com/volumes/create)
  - Submit the form.
  - Observe the 'Volume scheduled for creation' toast and quickly attempt to dismiss the toast by clicking the 'X'.
  - Observe that nothing happens. (Note that the toast does disappear after 5 seconds because it is not persistent.)

### Verification steps
- Verify all types of Toasts:
    - Regardless of whether a toast is persistent or not, it should be immediately dismissible via the close button. 

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support