### PR TITLE
fix: TypeScript performance of `BarPercent.tsx`

### DIFF
--- a/packages/manager/.changeset/pr-11076-tech-stories-1728498604542.md
+++ b/packages/manager/.changeset/pr-11076-tech-stories-1728498604542.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Fix TypeScript Performance of `BarPercent.tsx` ([#11076](https://github.com/linode/manager/pull/11076))

--- a/packages/manager/src/components/BarPercent/BarPercent.tsx
+++ b/packages/manager/src/components/BarPercent/BarPercent.tsx
@@ -1,9 +1,10 @@
 import { styled } from '@mui/material/styles';
-import { SxProps } from '@mui/system';
 import * as React from 'react';
 
 import { LinearProgress } from 'src/components/LinearProgress';
 import { omittedProps } from 'src/utilities/omittedProps';
+
+import type { SxProps, Theme } from '@mui/material/styles';
 
 export interface BarPercentProps {
   /** Additional css class to pass to the component */
@@ -16,7 +17,7 @@ export interface BarPercentProps {
   narrow?: boolean;
   /** Applies a `border-radius` to the bar. */
   rounded?: boolean;
-  sx?: SxProps;
+  sx?: SxProps<Theme>;
   /** The value of the progress indicator for the determinate and buffer variants. */
   value: number;
   /** The value for the buffer variant. */


### PR DESCRIPTION
## Description 📝

- Improves the TypeScript type-checking performance on the `BarPercent.tsx` component 🏎️ 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-10-09 at 1 58 53 PM](https://github.com/user-attachments/assets/24efbd90-2b35-43b1-bfc7-45a1dfa7ac41) | ![Screenshot 2024-10-09 at 1 54 17 PM](https://github.com/user-attachments/assets/a04960f2-72ea-477d-914a-68ec31cf3a17) |
| takes 16 seconds to typecheck | takes 14ms to type check 😦| 

## How to test 🧪

- Verify type checking passes in Github Actions
- Verify there are no regressions with the component, it's types, and it's behavior
- Profile this if you want to (`yarn tsc --generateTrace ./trace --incremental false` and inspect with `chrome://tracing`)

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support