### PR TITLE
fix: Better sanitize Pendo URLs

### DIFF
--- a/packages/manager/.changeset/pr-11079-tech-stories-1728504676937.md
+++ b/packages/manager/.changeset/pr-11079-tech-stories-1728504676937.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Improve Pendo URL sanitization ([#11079](https://github.com/linode/manager/pull/11079))

--- a/packages/manager/src/hooks/usePendo.ts
+++ b/packages/manager/src/hooks/usePendo.ts
@@ -104,17 +104,22 @@ export const usePendo = () => {
               action: 'Replace',
               attr: 'pathname',
               data(url: string) {
-                const idMatchingRegex = /\d+$/;
+                const idMatchingRegex = /(\/\d+)/;
+                const bucketMatchingRegex = /(buckets\/[^\/]+\/[^\/]+)/;
                 const userPathMatchingRegex = /(users\/).*/;
-                const oauthPathMatchingRegex = /oauth\/callback#access_token/;
-                if (
-                  idMatchingRegex.test(url) ||
-                  oauthPathMatchingRegex.test(url)
-                ) {
-                  // Removes everything after the last /
-                  return url.replace(/\/[^\/]*$/, '/');
+                const oauthPathMatchingRegex = /(#access_token).*/;
+
+                if (idMatchingRegex.test(url)) {
+                  // Replace any ids with XXXX and keep the rest of the URL intact
+                  return url.replace(idMatchingRegex, '/XXXX');
+                } else if (bucketMatchingRegex.test(url)) {
+                  // Replace the region and bucket names with XXXX and keep the rest of the URL intact
+                  return url.replace(bucketMatchingRegex, 'XXXX/XXXX');
+                } else if (oauthPathMatchingRegex.test(url)) {
+                  // Remove everything after access_token/
+                  url.replace(oauthPathMatchingRegex, '$1');
                 } else if (userPathMatchingRegex.test(url)) {
-                  // Removes everything after /users
+                  // Remove everything after /users
                   return url.replace(userPathMatchingRegex, '$1');
                 }
                 return url;

--- a/packages/manager/src/hooks/usePendo.ts
+++ b/packages/manager/src/hooks/usePendo.ts
@@ -105,16 +105,16 @@ export const usePendo = () => {
               attr: 'pathname',
               data(url: string) {
                 const idMatchingRegex = /(\/\d+)/;
-                const bucketMatchingRegex = /(buckets\/[^\/]+\/[^\/]+)/;
+                const bucketPathMatchingRegex = /(buckets\/[^\/]+\/[^\/]+)/;
                 const userPathMatchingRegex = /(users\/).*/;
                 const oauthPathMatchingRegex = /(#access_token).*/;
 
                 if (idMatchingRegex.test(url)) {
                   // Replace any ids with XXXX and keep the rest of the URL intact
                   return url.replace(idMatchingRegex, '/XXXX');
-                } else if (bucketMatchingRegex.test(url)) {
+                } else if (bucketPathMatchingRegex.test(url)) {
                   // Replace the region and bucket names with XXXX and keep the rest of the URL intact
-                  return url.replace(bucketMatchingRegex, 'XXXX/XXXX');
+                  return url.replace(bucketPathMatchingRegex, 'XXXX/XXXX');
                 } else if (oauthPathMatchingRegex.test(url)) {
                   // Remove everything after access_token/
                   url.replace(oauthPathMatchingRegex, '$1');


### PR DESCRIPTION
## Description 📝
After looking at Pendo data to observe what we were collecting, we should better sanitize the data in our URLs with regex that covers more cases (e.g. when the id of the entity was not the last part of the path - `/linodes/12345/storage`; when the entity does not have an id, but a name (buckets)).

## Target release date 🗓️
10/14

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Follow the instructions here: https://github.com/linode/manager/pull/10982

### Reproduction steps
(How to reproduce the issue, if applicable)
- Notice in the dev environment that navigating to places like your Linode's storage tab or LKE cluster details page would include IDs  in the normalizedURL because the regex wasn't specific enough.
- Same goes for OBJ details pages - included the region and bucket name. (For example: click on the 'Access' tab.)

### Verification steps
(How to verify changes)
- Confirm the above is fixed by looking at the requests in the browser console filtering on "pendo".

Examples of what you should be seeing:
![Screenshot 2024-10-09 at 1 23 53 PM](https://github.com/user-attachments/assets/232b367b-01dc-4941-967d-e941f2635fd9)
![Screenshot 2024-10-09 at 1 24 09 PM](https://github.com/user-attachments/assets/b9433dff-9492-4051-8f54-05b442f3a984)
![Screenshot 2024-10-09 at 1 24 27 PM](https://github.com/user-attachments/assets/221d3702-d692-4c5e-b8e0-c2991291c59a)

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support