### PR TITLE
feat: [M3-8703] - Disable VPC Action Buttons for Restricted Users when they do not have access or have read-only access.

### DIFF
--- a/packages/manager/src/features/VPCs/VPCLanding/VPCRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCRow.tsx
@@ -9,7 +9,7 @@ import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { getRestrictedResourceText } from 'src/features/Account/utils';
-import { useIsResourceRestricted } from 'src/hooks/useIsResourceRestricted';
+import { useGrants } from 'src/queries/profile/profile';
 
 interface Props {
   handleDeleteVPC: () => void;
@@ -27,11 +27,14 @@ export const VPCRow = ({ handleDeleteVPC, handleEditVPC, vpc }: Props) => {
     0
   );
 
-  const isVPCReadOnly = useIsResourceRestricted({
-    grantLevel: 'read_only',
-    grantType: 'vpc',
-    id: vpc.id,
-  });
+  const { data: grants } = useGrants();
+
+  const isVPCReadOnly =
+    grants &&
+    (grants['vpc'].some(
+      (grant) => grant.id === vpc.id && grant.permissions === 'read_only'
+    ) ||
+      !grants['vpc'].some((grant) => grant.id === vpc.id));
 
   const actions: Action[] = [
     {


### PR DESCRIPTION
## Description 📝
To prevent unauthorized access to specific flows and provide clearer guidance, we aim to restrict entry to users without the required permissions.

Here, we are disabling VPC Action buttons when they do not have access or have read-only access.

## Changes  🔄
- For restricted users:
  - Disabled VPC Action buttons (edit, delete)

## Target release date 🗓️

## Preview 📷

### Before
<video src="https://github.com/user-attachments/assets/78639cc5-219d-4c96-a132-471fab69ed83" controls width="300"></video>

### After
<video src="https://github.com/user-attachments/assets/afcf3c56-c928-43c7-9a30-76441d932aac" controls width="300"></video>

## How to test 🧪

### Prerequisites
(How to setup test environment)

- Log into two accounts side by side:
  - An unrestricted admin user account: full access
  - A restricted user account (use Incognito for this)
    - Start with Read Only for everything
    - or Start with None Permission.

### Reproduction steps

- Observe as restricted user:
  - Action buttons will be disabled and will display their own corresponding tooltiptext notice message.

### Verification steps

- After the changes, observe that the action buttons and the tooltips are tailored to the action.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support