### PR TITLE
change: [M#-8735] - Increase Cloud Manager `node.js` memory allocation (development jobs)

### DIFF
--- a/packages/manager/.changeset/pr-11084-changed-1728577518914.md
+++ b/packages/manager/.changeset/pr-11084-changed-1728577518914.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Increase Cloud Manager node.js memory allocation (development jobs) ([#11084](https://github.com/linode/manager/pull/11084))

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -86,7 +86,7 @@
     "zxcvbn": "^4.4.2"
   },
   "scripts": {
-    "start": "concurrently --raw \"vite\" \"tsc --watch --preserveWatchOutput\"",
+    "start": "concurrently --raw \"NODE_OPTIONS='--max-old-space-size=4096' vite\" \"NODE_OPTIONS='--max-old-space-size=4096' tsc --watch --preserveWatchOutput\"",
     "start:expose": "concurrently --raw \"vite --host\" \"tsc --watch --preserveWatchOutput\"",
     "start:ci": "vite preview --port 3000 --host",
     "lint": "yarn run eslint . --ext .js,.ts,.tsx --quiet",
@@ -95,7 +95,7 @@
     "precommit": "lint-staged && yarn typecheck",
     "test": "vitest run",
     "test:debug": "node --inspect-brk scripts/test.js --runInBand",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "NODE_OPTIONS='--max-old-space-size=4096' storybook dev -p 6006",
     "storybook-static": "storybook build -c .storybook -o .out",
     "build-storybook": "storybook build",
     "cy:run": "cypress run -b chrome",


### PR DESCRIPTION
## Description 📝
Small PR to increase the memory allocation for Node.js for vite, TS compiler and storybook

![Screenshot 2024-10-10 at 12 13 37](https://github.com/user-attachments/assets/5715fcf2-89c5-4c0a-9458-742b7b56adc3)

## Changes  🔄
- Increase Node memory allocation (approximately 2GB before, to 4GB) for
- vite
- tsc
- storybook

## How to test 🧪

### Verification steps
- run `yarn start` or `yarn up`
- run `yarn storybook`
- make few changes across the codebase, save a bunch of things
- confirm no heap memory allocation in the console

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
