### PR TITLE
fix: Conditionally check for `PENDO_API_KEY` before Pendo set up

### DIFF
--- a/packages/manager/src/hooks/usePendo.ts
+++ b/packages/manager/src/hooks/usePendo.ts
@@ -42,101 +42,103 @@ export const usePendo = () => {
   const PENDO_URL = `https://cdn.pendo.io/agent/static/${PENDO_API_KEY}/pendo.js`;
 
   React.useEffect(() => {
-    // Adapted Pendo install script for readability
-    // Refer to: https://support.pendo.io/hc/en-us/articles/21362607464987-Components-of-the-install-script#01H6S2EXET8C9FGSHP08XZAE4F
+    if (PENDO_API_KEY) {
+      // Adapted Pendo install script for readability
+      // Refer to: https://support.pendo.io/hc/en-us/articles/21362607464987-Components-of-the-install-script#01H6S2EXET8C9FGSHP08XZAE4F
 
-    // Set up Pendo namespace and queue
-    const pendo = (window['pendo'] = window['pendo'] || {});
-    pendo._q = pendo._q || [];
+      // Set up Pendo namespace and queue
+      const pendo = (window['pendo'] = window['pendo'] || {});
+      pendo._q = pendo._q || [];
 
-    // Define the methods Pendo uses in a queue
-    const methodNames = [
-      'initialize',
-      'identify',
-      'updateOptions',
-      'pageLoad',
-      'track',
-    ];
+      // Define the methods Pendo uses in a queue
+      const methodNames = [
+        'initialize',
+        'identify',
+        'updateOptions',
+        'pageLoad',
+        'track',
+      ];
 
-    // Enqueue methods and their arguments on the Pendo object
-    methodNames.forEach((_, index) => {
-      (function (method) {
-        pendo[method] =
-          pendo[method] ||
-          function () {
-            pendo._q[method === methodNames[0] ? 'unshift' : 'push'](
-              // eslint-disable-next-line prefer-rest-params
-              [method].concat([].slice.call(arguments, 0))
-            );
-          };
-      })(methodNames[index]);
-    });
-
-    // Load Pendo script into the head HTML tag, then initialize Pendo with metadata
-    loadScript(PENDO_URL, {
-      location: 'head',
-    }).then(() => {
-      window.pendo.initialize({
-        account: {
-          id: accountId, // Highly recommended, required if using Pendo Feedback
-          // name:         // Optional
-          // is_paying:    // Recommended if using Pendo Feedback
-          // monthly_value:// Recommended if using Pendo Feedback
-          // planLevel:    // Optional
-          // planPrice:    // Optional
-          // creationDate: // Optional
-
-          // You can add any additional account level key-values here,
-          // as long as it's not one of the above reserved names.
-        },
-        // Controls what URLs we send to Pendo. Refer to: https://agent.pendo.io/advanced/location/.
-        location: {
-          transforms: [
-            {
-              action: 'Clear',
-              attr: 'hash',
-            },
-            {
-              action: 'Clear',
-              attr: 'search',
-            },
-            {
-              action: 'Replace',
-              attr: 'pathname',
-              data(url: string) {
-                const idMatchingRegex = /(\/\d+)/;
-                const bucketPathMatchingRegex = /(buckets\/[^\/]+\/[^\/]+)/;
-                const userPathMatchingRegex = /(users\/).*/;
-                const oauthPathMatchingRegex = /(#access_token).*/;
-
-                if (idMatchingRegex.test(url)) {
-                  // Replace any ids with XXXX and keep the rest of the URL intact
-                  return url.replace(idMatchingRegex, '/XXXX');
-                } else if (bucketPathMatchingRegex.test(url)) {
-                  // Replace the region and bucket names with XXXX and keep the rest of the URL intact
-                  return url.replace(bucketPathMatchingRegex, 'XXXX/XXXX');
-                } else if (oauthPathMatchingRegex.test(url)) {
-                  // Remove everything after access_token/
-                  url.replace(oauthPathMatchingRegex, '$1');
-                } else if (userPathMatchingRegex.test(url)) {
-                  // Remove everything after /users
-                  return url.replace(userPathMatchingRegex, '$1');
-                }
-                return url;
-              },
-            },
-          ],
-        },
-        visitor: {
-          id: visitorId, // Required if user is logged in
-          // email:        // Recommended if using Pendo Feedback, or NPS Email
-          // full_name:    // Recommended if using Pendo Feedback
-          // role:         // Optional
-
-          // You can add any additional visitor level key-values here,
-          // as long as it's not one of the above reserved names.
-        },
+      // Enqueue methods and their arguments on the Pendo object
+      methodNames.forEach((_, index) => {
+        (function (method) {
+          pendo[method] =
+            pendo[method] ||
+            function () {
+              pendo._q[method === methodNames[0] ? 'unshift' : 'push'](
+                // eslint-disable-next-line prefer-rest-params
+                [method].concat([].slice.call(arguments, 0))
+              );
+            };
+        })(methodNames[index]);
       });
-    });
+
+      // Load Pendo script into the head HTML tag, then initialize Pendo with metadata
+      loadScript(PENDO_URL, {
+        location: 'head',
+      }).then(() => {
+        window.pendo.initialize({
+          account: {
+            id: accountId, // Highly recommended, required if using Pendo Feedback
+            // name:         // Optional
+            // is_paying:    // Recommended if using Pendo Feedback
+            // monthly_value:// Recommended if using Pendo Feedback
+            // planLevel:    // Optional
+            // planPrice:    // Optional
+            // creationDate: // Optional
+
+            // You can add any additional account level key-values here,
+            // as long as it's not one of the above reserved names.
+          },
+          // Controls what URLs we send to Pendo. Refer to: https://agent.pendo.io/advanced/location/.
+          location: {
+            transforms: [
+              {
+                action: 'Clear',
+                attr: 'hash',
+              },
+              {
+                action: 'Clear',
+                attr: 'search',
+              },
+              {
+                action: 'Replace',
+                attr: 'pathname',
+                data(url: string) {
+                  const idMatchingRegex = /(\/\d+)/;
+                  const bucketPathMatchingRegex = /(buckets\/[^\/]+\/[^\/]+)/;
+                  const userPathMatchingRegex = /(users\/).*/;
+                  const oauthPathMatchingRegex = /(#access_token).*/;
+
+                  if (idMatchingRegex.test(url)) {
+                    // Replace any ids with XXXX and keep the rest of the URL intact
+                    return url.replace(idMatchingRegex, '/XXXX');
+                  } else if (bucketPathMatchingRegex.test(url)) {
+                    // Replace the region and bucket names with XXXX and keep the rest of the URL intact
+                    return url.replace(bucketPathMatchingRegex, 'XXXX/XXXX');
+                  } else if (oauthPathMatchingRegex.test(url)) {
+                    // Remove everything after access_token/
+                    url.replace(oauthPathMatchingRegex, '$1');
+                  } else if (userPathMatchingRegex.test(url)) {
+                    // Remove everything after /users
+                    return url.replace(userPathMatchingRegex, '$1');
+                  }
+                  return url;
+                },
+              },
+            ],
+          },
+          visitor: {
+            id: visitorId, // Required if user is logged in
+            // email:        // Recommended if using Pendo Feedback, or NPS Email
+            // full_name:    // Recommended if using Pendo Feedback
+            // role:         // Optional
+
+            // You can add any additional visitor level key-values here,
+            // as long as it's not one of the above reserved names.
+          },
+        });
+      });
+    }
   }, [PENDO_URL, accountId, visitorId]);
 };


### PR DESCRIPTION
## Description 📝
We use an environment variable `PENDO_API_KEY` to load the Pendo agent. Without that API key present, we should not do any set up or loading of Pendo. (We handle Adobe Analytics in the same way -my mistake for missing it here.)

## Changes  🔄
- Adds a conditional check for `PENDO_API_KEY` in the usePendo hook to confirm the env var exists before attempting to load the pendo object on the window or make a request to the CDN for the Pendo agent
- Gets rid of a console error

## Target release date 🗓️
10/14/24 - this is pointed at the release branch because it needs to be included in the release.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-10-10 at 3 39 44 PM](https://github.com/user-attachments/assets/8a19a9df-25f4-4915-832b-725e4a5f53c1) | ![Screenshot 2024-10-10 at 3 41 52 PM](https://github.com/user-attachments/assets/75ee9e08-a715-40a8-8e4d-e2feff2bfd68) | 

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Comment out `PENDO_API_KEY` from your `.env` file.

### Reproduction steps
(How to reproduce the issue, if applicable)
- Check out the `develop` branch locally and, with the `PENDO_API_KEY` commented out in your .env, go to http://localhost:3000. Observe the browser console error above. In the Network tab, filter on "All" requests and keyword "pendo". Observe that a request was made to get the Pendo CDN, but it returned a 403 Unauthorized without the API key.

### Verification steps
(How to verify changes)
- Check out this branch and, with the `PENDO_API_KEY` commented out in your .env, go to http://localhost:3000. 
- Clear your Application storage. (If you don't do this, the API KEY can be cached there and the request to the CDN will still succeed.)
- Observe there is no pendo-related browser console error (note: the visible console error in the screenshot is unrelated and preexisting). In the Network tab, observe that no request is made to the Pendo CDN. The usePendo.js requests are the *only* Pendo requests that should be visible.
- Uncomment your commented out `PENDO_API_KEY`. Observe Pendo loads from the CDN as expected.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset) - Note: not adding a changeset or update to the changelog for this one.
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
