### PR TITLE
fix: [M3-8739] - Fix MSW 2.0 initial mock store and support ticket seeder bugs

### DIFF
--- a/packages/manager/.changeset/pr-11090-tech-stories-1728605016946.md
+++ b/packages/manager/.changeset/pr-11090-tech-stories-1728605016946.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Fix MSW 2.0 initial mock store and support ticket seeder bugs ([#11090](https://github.com/linode/manager/pull/11090))

--- a/packages/manager/src/mocks/mockState.ts
+++ b/packages/manager/src/mocks/mockState.ts
@@ -43,7 +43,8 @@ export const emptyStore: MockState = {
 export const createInitialMockStore = async (): Promise<MockState> => {
   const mockState = await mswDB.getStore('mockState');
 
-  if (mockState) {
+  // If the keys in the mockState and emptyStore don't match, discard the current mockState because we've introduced new store values.
+  if (mockState && Object.keys(mockState) === Object.keys(emptyStore)) {
     return mockState;
   }
 

--- a/packages/manager/src/mocks/mockState.ts
+++ b/packages/manager/src/mocks/mockState.ts
@@ -43,9 +43,15 @@ export const emptyStore: MockState = {
 export const createInitialMockStore = async (): Promise<MockState> => {
   const mockState = await mswDB.getStore('mockState');
 
-  // If the keys in the mockState and emptyStore don't match, discard the current mockState because we've introduced new store values.
-  if (mockState && Object.keys(mockState) === Object.keys(emptyStore)) {
-    return mockState;
+  if (mockState) {
+    const mockStateKeys = Object.keys(mockState);
+    const emptyStoreKeys = Object.keys(emptyStore);
+
+    // Return the existing mockState if it includes all keys from the empty store;
+    // else, discard the existing mockState because we've introduced new values.
+    if (emptyStoreKeys.every((key) => mockStateKeys.includes(key))) {
+      return mockState;
+    }
   }
 
   return emptyStore;

--- a/packages/manager/src/mocks/presets/crud/seeds/utils.ts
+++ b/packages/manager/src/mocks/presets/crud/seeds/utils.ts
@@ -22,6 +22,9 @@ export const removeSeeds = async (seederId: MockSeeder['id']) => {
     case 'volumes:crud':
       await mswDB.deleteAll('volumes', mockState, 'seedState');
       break;
+    case 'support-tickets:crud':
+      await mswDB.deleteAll('supportTickets', mockState, 'seedState');
+      break;
     default:
       break;
   }

--- a/packages/manager/src/mocks/presets/crud/seeds/utils.ts
+++ b/packages/manager/src/mocks/presets/crud/seeds/utils.ts
@@ -5,6 +5,7 @@ import type { MockSeeder, MockState } from 'src/mocks/types';
 
 /**
  * Removes the seeds from the database.
+ * This function is called upon unchecking an individual seeder in the MSW.
  *
  * @param seederId - The ID of the seeder to remove.
  *


### PR DESCRIPTION
## Description 📝
This PR fixes an existing bug in the way the MSW2.0 was creating the initial mock store. It made itself known after #10937 was merged because that's the first time that many of us already had an existing store, and now new values were being added to it.

🐛 Bug:
When we are trying to create our initial mock store and access `initialContext.supportReplies` or `initialContext.supportTickets`, developers were encountering a console error and white screen if they *already had an existing IndexedDB* that did not have `supportReplies` or `supportTickets` in the mockStore. This could be worked around by clearing the Application data in the browser console to reset the IndexedDB, but it would continue to happen in the future with every new set of values we track in the store.

❓ Why:
This was happening due to the logic in `createInitialMockStore`. We already had old mock state (even when it is just a bunch of empty lists), so we return it as `initialContext`. It doesn't include `supportReplies` or `supportTickets`. When we have new values, we need the `initialContext` to be the emptyStore, which has the empty key-value pair for those new values.
 
🔧 Fix: 
Adding a conditional check ensure the mockState and emptyStore keys are the same before returning that mockState. If the keys aren't the same, there's new entities to include in the mock store, so disregard the old store.

## Changes  🔄
- Update the conditional check in `createInitialMockStore` to return an emptyStore if there's new values to create in the store
- This PR *also* fixes a seeder bug by adding a missing switch case to the `removeSeeder` function for consistency - it was an oversight in the original PR.

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Go to http://localhost.com:3000/ and make sure the MSW is off.

### Reproduction steps
- Go to `packages/manager/src/mocks/types.ts` and make `supportTickets` and `supportReplies` optional types.
- Go to `packages/manager/src/mocks/mockState.ts` and comment out `supportReplies` and `supportTickets` in the `emptyStore`.
- On http://localhost:3000, open the browser dev tools > Application tab > Storage > clear site data
- Open the Cloud Manager dev tools and toggle on the MSW
- Observe the page crash and the console error
- Observe that your IndexedDB is missing those `supportReplies` and `supportTickets` (browser dev tools > Application > Storage > IndexedDB > mockState

![image (8)](https://github.com/user-attachments/assets/c334a248-b925-412f-a55a-e1d5723e05ee)

### Verification steps
(How to verify changes)
- **For the mock store bug**: 
   - Revert the code changes you made to reproduce the issue: `git restore .`
   - Refresh (🔁 ) your mockState in the browser dev console
   - Observe that the error is gone, Cloud Manager loads, and your IndexedDB now has empty lists for `supportReplies` and `supportTickets`
   - Create a mock support ticket
   - Confirm that your mock support ticket is visible in mockState
   - Turn off the MSW
   - Turn back on the MSW and confirm your previously created mock support ticket is still in mockState

![Screenshot 2024-10-11 at 4 05 40 PM](https://github.com/user-attachments/assets/d322497d-0cb8-4db9-b651-651cc46614d0)

- **For the seeder bug**: Repeat the steps in the video below for "This Branch" and confirm that your seeded store updates to remove seeded data for support tickets if the checkbox is unchecked.
<details><summary>Video</summary>
<p>

| Develop | This Branch  |
| -------- | -------- |
| <video src="https://github.com/user-attachments/assets/9757f41c-2a5e-4022-92f0-b505549a1108"/> | <video src="https://github.com/user-attachments/assets/ac02f413-5411-4508-9c22-d64f054e2c25"/> |

</p>
</details> 

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

