### PR TITLE
feat: [M3-8704] - Disable Create Firewalls button with tooltip text on empty state Landing Page for restricted users.

### DIFF
--- a/packages/manager/.changeset/pr-11093-fixed-1728898767762.md
+++ b/packages/manager/.changeset/pr-11093-fixed-1728898767762.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Disable Create Firewall button with tooltip text on empty state Landing Page for restricted users ([#11093](https://github.com/linode/manager/pull/11093))

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLandingEmptyState.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLandingEmptyState.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 
 import FirewallIcon from 'src/assets/icons/entityIcons/firewall.svg';
 import { ResourcesSection } from 'src/components/EmptyLandingPageResources/ResourcesSection';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
+import { getRestrictedResourceText } from 'src/features/Account/utils';
 import { sendEvent } from 'src/utilities/analytics/utils';
 
 import {
@@ -18,11 +20,16 @@ interface Props {
 export const FirewallLandingEmptyState = (props: Props) => {
   const { openAddFirewallDrawer } = props;
 
+  const isFirewallsCreationRestricted = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'add_firewalls',
+  });
+
   return (
     <ResourcesSection
       buttonProps={[
         {
           children: 'Create Firewall',
+          disabled: isFirewallsCreationRestricted,
           onClick: () => {
             sendEvent({
               action: 'Click:button',
@@ -31,6 +38,11 @@ export const FirewallLandingEmptyState = (props: Props) => {
             });
             openAddFirewallDrawer();
           },
+          tooltipText: getRestrictedResourceText({
+            action: 'create',
+            isSingular: false,
+            resourceType: 'Firewalls',
+          }),
         },
       ]}
       gettingStartedGuidesData={gettingStartedGuides}


### PR DESCRIPTION
## Description 📝
To prevent unauthorized access to specific flows and provide clearer guidance, we aim to restrict entry to users without the required permissions.

Here, we are restricting users from creating new Firewalls from the Empty State Landing Page when they do not have access or have read only access.

## Changes  🔄
List any change relevant to the reviewer.

- For restricted users:
  - Disabled Create Firewalls Button on the Empty Landing Page


## Target release date 🗓️

## Preview 📷


| Before | After |
| ------ | ----- |
|  ![Before](https://github.com/user-attachments/assets/fd3af110-b03b-4ad0-bade-ad5c72a701bf) | ![After](https://github.com/user-attachments/assets/5872496b-03cf-41b8-a5fe-907ba79b097f) |

## How to test 🧪

### Prerequisites
- Log into two accounts side by side:
  - An unrestricted admin user account: full access
  - A restricted user account (use Incognito for this)
    - Start with Read Only for everything

### Reproduction steps
- Landing:
  - Observe as restricted user, notice shows and you cannot create Firewalls

### Verification steps

- After changes, observe tooltips are tailored to the action.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
