### PR TITLE
feat: [M3-8704] - Disable Create Firewall button with tooltip text on Landing Page for restricted users

### DIFF
--- a/packages/manager/.changeset/pr-11094-fixed-1728923124356.md
+++ b/packages/manager/.changeset/pr-11094-fixed-1728923124356.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Disable Create Firewall button with tooltip text on Landing Page for restricted users ([#11094](https://github.com/linode/manager/pull/11094))

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
@@ -19,8 +19,10 @@ import { useFlags } from 'src/hooks/useFlags';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
 import { useSecureVMNoticesEnabled } from 'src/hooks/useSecureVMNoticesEnabled';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 import { useFirewallsQuery } from 'src/queries/firewalls';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { getRestrictedResourceText } from 'src/features/Account/utils';
 
 import { CreateFirewallDrawer } from './CreateFirewallDrawer';
 import { FirewallDialog } from './FirewallDialog';
@@ -72,6 +74,10 @@ const FirewallLanding = () => {
   const selectedFirewall = data?.data.find(
     (firewall) => firewall.id === selectedFirewallId
   );
+
+  const isFirewallsCreationRestricted = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'add_firewalls',
+  });
 
   const openModal = (mode: Mode, id: number) => {
     setSelectedFirewallId(id);
@@ -148,8 +154,16 @@ const FirewallLanding = () => {
         breadcrumbProps={{ pathname: '/firewalls' }}
         docsLink="https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-cloud-firewalls"
         entity="Firewall"
+        disabledCreateButton={isFirewallsCreationRestricted}
         onButtonClick={onOpenCreateDrawer}
         title="Firewalls"
+        buttonDataAttrs={{
+          tooltipText: getRestrictedResourceText({
+            action: 'create',
+            isSingular: false,
+            resourceType: 'Firewalls',
+          }),
+        }}
       />
       <Table aria-label="List of services attached to each firewall">
         <TableHead>


### PR DESCRIPTION
## Description 📝
To prevent unauthorized access to specific flows and provide clearer guidance, we aim to restrict entry to users without the required permissions.

Here, we are restricting users from creating new Firewalls from the Landing Page when they do not have access or have read only access.

## Changes  🔄
List any change relevant to the reviewer.

- For restricted users:
  - Disabled Create Firewall Button on the Landing Page


## Target release date 🗓️

## Preview 📷


| Before | After |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/e6119ef7-be53-4125-ae67-af72b1961902) | ![After](https://github.com/user-attachments/assets/16d8da98-8d93-4c43-930f-714cc06d5f13) |

## How to test 🧪

### Prerequisites
- Log into two accounts side by side:
  - An unrestricted admin user account: full access
  - A restricted user account (use Incognito for this)
    - Start with Read Only for everything

### Reproduction steps
- Landing:
  - Observe as restricted user, notice shows and you cannot create Firewall

### Verification steps

- After changes, observe tooltips are tailored to the action.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
