### PR TITLE
fix: Image Uploader spelling mistake

### DIFF
--- a/packages/manager/src/components/Uploaders/ImageUploader/ImageUploader.test.tsx
+++ b/packages/manager/src/components/Uploaders/ImageUploader/ImageUploader.test.tsx
@@ -24,7 +24,7 @@ describe('File Uploader', () => {
     ).toBeVisible();
     expect(
       screen.getByText(
-        'The maxiumum compressed file size is 5 GB and the file can’t exceed 6 GB when uncompressed.'
+        'The maximum compressed file size is 5 GB and the file can’t exceed 6 GB when uncompressed.'
       )
     ).toBeVisible();
   });

--- a/packages/manager/src/components/Uploaders/ImageUploader/ImageUploader.tsx
+++ b/packages/manager/src/components/Uploaders/ImageUploader/ImageUploader.tsx
@@ -54,7 +54,7 @@ export const ImageUploader = React.memo((props: Props) => {
               compressed using gzip.
             </Typography>
             <Typography variant="subtitle2">
-              The maxiumum compressed file size is 5 GB and the file can&rsquo;t
+              The maximum compressed file size is 5 GB and the file can&rsquo;t
               exceed 6 GB when uncompressed.
             </Typography>
           </>


### PR DESCRIPTION
## Description 📝

- Change `maxiumum` to `maximum`

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-10-14 at 1 18 01 PM](https://github.com/user-attachments/assets/a652d433-2526-4d8c-9078-223a828fab85) | ![Screenshot 2024-10-14 at 1 18 31 PM](https://github.com/user-attachments/assets/24410c70-65e8-4f76-af0f-313a668ae241) |

## How to test 🧪

- Check spelling on http://localhost:3000/images/create/upload