### PR TITLE
fix: `AppSelect.test.tsx` test flake

### DIFF
--- a/packages/manager/.changeset/pr-11104-tests-1729020207783.md
+++ b/packages/manager/.changeset/pr-11104-tests-1729020207783.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix `AppSelect.test.tsx` test flake ([#11104](https://github.com/linode/manager/pull/11104))

--- a/packages/manager/src/features/Linodes/LinodeCreate/Tabs/Marketplace/AppSelect.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Tabs/Marketplace/AppSelect.test.tsx
@@ -60,7 +60,9 @@ describe('Marketplace', () => {
 
     await waitFor(() => {
       expect(getByPlaceholderText('Select category')).not.toBeDisabled();
-    });
+      },
+      { timeout: 5_000 }
+    );
 
     const select = getByPlaceholderText('Select category');
 


### PR DESCRIPTION
## Description 📝

- Attempts to fix the `AppSelect.test.tsx` [test flake we've been seeing](https://github.com/linode/manager/actions/runs/11351685589/job/31573480036?pr=11103) in our code coverage jobs 🔧 
- This flake started to show up when https://github.com/linode/manager/pull/11085 was merged. I don't know exactly why this test got slower. It's annoying, but an increase in timeout should be enough to get is back into a healthy state. 
  - We could consider globally increasing async unit test timeout but we should probably discuss the pros and cons of that before we make the change

## How to test 🧪

- Verify test passes locally
- Verify test passes in Github Actions

```
yarn test AppSelect
```

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support