### PR TITLE
test: [M3-8756] - Fix Cypress SMTP support ticket test failure

### DIFF
--- a/packages/manager/.changeset/pr-11106-tests-1729028269027.md
+++ b/packages/manager/.changeset/pr-11106-tests-1729028269027.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix failing SMTP support ticket test by using mock Linode data ([#11106](https://github.com/linode/manager/pull/11106))


### PR DESCRIPTION
## Description 📝
This is a quick fix to get the support ticket `can create an SMTP support ticket` test passing. With today's API release, we introduced a new SMTP Linode capability, and because our test creates a real Linode (which now has this new capability), the SMTP support ticket banner stopped appearing.

This change fixes the test by using a mock Linode that is lacking the SMTP capability. 

## Changes  🔄
- Use mock Linode for SMTP support ticket test

## How to test 🧪
This test is currently failing 100% of the time across all branches, so we can rely on CI for this. The test can be run locally, however, with this command:

```bash
yarn cy:run -s "cypress/e2e/core/helpAndSupport/open-support-ticket.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
