### PR TITLE
test: [M3-8744] - Reduce Cypress flakiness in Placement Group deletion tests

### DIFF
--- a/packages/manager/.changeset/pr-11107-tests-1729033939339.md
+++ b/packages/manager/.changeset/pr-11107-tests-1729033939339.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Reduce flakiness of Placement Group deletion Cypress tests ([#11107](https://github.com/linode/manager/pull/11107))

--- a/packages/manager/.changeset/pr-11107-tests-1729036810871.md
+++ b/packages/manager/.changeset/pr-11107-tests-1729036810871.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Reduce Placement Group deletion test flakiness ([#11107](https://github.com/linode/manager/pull/11107))

--- a/packages/manager/.changeset/pr-11107-tests-1729036810871.md
+++ b/packages/manager/.changeset/pr-11107-tests-1729036810871.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Reduce Placement Group deletion test flakiness ([#11107](https://github.com/linode/manager/pull/11107))


### PR DESCRIPTION
## Description 📝
This PR attempts to address a specific trigger of flakiness in the Cypress Placement Group deletion tests, resulting in this failure:

```
CypressError: Timed out retrying after 80050ms: `cy.click()` failed because the page updated while this command was executing. Cypress tried to locate elements based on this query:

(...)
```

Recent improvements to our React Query `useAllLinodesQuery` hook allow components to display cached data while waiting for fresh data to be fetched. In the case of the Placement Group deletion tests, however, this introduced flakiness stemming from re-renders that occur once the HTTP request resolves. This appears to affect the tests only and doesn't impact real users as far as I'm aware.

This works around the React Query behavior by introducing calls to `cy.wait()` for various requests to the Linodes instances endpoint, and by opening the Placement Group deletion modal, closing it, and then re-opening it to ensure that all relevant HTTP requests have resolved by the time the modal has opened, reducing the risk of re-renders occurring during Cypress interactions[1].

1. This is because the Placement Group landing page fetches Linodes upon opening a Placement Group's deletion modal, but has state to keep track of which Placement Group was most recently selected. As a result of this design, opening the deletion modal a second time does not trigger another HTTP request, allowing us to work around the re-render issue.

## Changes  🔄
- `cy.wait` for various requests to the Linodes instances endpoint to resolve
- Open, close, and re-open the deletion modal before attempting to interact with it to reduce the risk of React re-renders during Cypress interactions
- Remove some unneeded assertions for the last test (this has nothing to do with test flake)

## Target release date 🗓️
N/A

## How to test 🧪

⚠️ Note that this test already had very slight flakiness issues before the changes to `useAllLinodesQuery` were added. This PR only seeks to address the recent increase flakiness, so you may still encounter some flakiness when running the tests. You can disregard any failures that do _not_ mention `cy.click` failing.

When I ran this spec on repeat against `develop` last week, I observed that at least one test failed 90% of the time (although I don't think it has been that bad in CI). When I ran the spec 10 times on repeat with these changes in place, I observed only 1 failure (and it was not a `cy.click()` failure).

```
yarn cy:run -s "cypress/e2e/core/placementGroups/delete-placement-groups.spec.ts"
```


## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

