### PR TITLE
feat: [M3-8705] - Disable Create Longview Client button with tooltip text on Landing Page for restricted Users.

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
@@ -19,6 +19,8 @@ import withLongviewClients from 'src/containers/longview.container';
 import { useAPIRequest } from 'src/hooks/useAPIRequest';
 import { useAccountSettings } from 'src/queries/account/settings';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
+import { getRestrictedResourceText } from 'src/features/Account/utils';
 
 import { SubscriptionDialog } from './SubscriptionDialog';
 
@@ -70,6 +72,10 @@ export const LongviewLanding = (props: LongviewLandingProps) => {
       title: 'Plan Details',
     },
   ];
+
+  const isLongviewCreationRestricted = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'add_longview',
+  });
 
   const matches = (p: string) => {
     return Boolean(matchPath(p, { path: props.location.pathname }));
@@ -134,6 +140,14 @@ export const LongviewLanding = (props: LongviewLandingProps) => {
         onButtonClick={handleAddClient}
         removeCrumbX={1}
         title="Longview"
+        disabledCreateButton={isLongviewCreationRestricted}
+        buttonDataAttrs={{
+          tooltipText: getRestrictedResourceText({
+            action: 'create',
+            isSingular: false,
+            resourceType: 'Longview Clients',
+          }),
+        }}
       />
       <StyledTabs
         index={Math.max(


### PR DESCRIPTION
## Description 📝
To prevent unauthorized access to specific flows and provide clearer guidance, we aim to restrict entry to users without the required permissions.

Here, we are restricting users from creating new Longview Client on the Landing Page when they do not have access 

## Changes  🔄
List any change relevant to the reviewer.

- For restricted users:
  - Disabled Create Longview Clients Button on the Landing Page


## Target release date 🗓️

## Preview 📷


| Before | After |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/644c6590-55d2-4321-952a-9e4f197e42ff) | ![After](https://github.com/user-attachments/assets/7eb629d2-c628-42e9-8c90-5a6da96fa07e) |

## How to test 🧪

### Prerequisites
- Log into two accounts side by side:
  - An unrestricted admin user account: full access
  - A restricted user account (use Incognito for this)

### Reproduction steps
- Landing:
  - Observe as restricted user, notice shows and you cannot create Clients

### Verification steps

- After changes, observe tooltips are tailored to the action.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
