### PR TITLE
fix: [M3-8533] - Broken firewall rules table

### DIFF
--- a/packages/manager/.changeset/pr-11109-fixed-1729070494828.md
+++ b/packages/manager/.changeset/pr-11109-fixed-1729070494828.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Broken firewall rules table ([#11109](https://github.com/linode/manager/pull/11109))

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
@@ -87,6 +87,11 @@ export const StyledCellItemBox = styled(Box, {
   },
   alignContent: 'center',
   minHeight: '40px',
+  [theme.breakpoints.down('sm')]: {
+    '&:last-child': {
+      paddingLeft: '15px',
+    },
+  },
 }));
 
 export const StyledUlBox = styled(Box, { label: 'StyledUlBox' })(

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
@@ -81,13 +81,12 @@ export const StyledHeaderItemBox = styled(Box, {
 
 export const StyledCellItemBox = styled(Box, {
   label: 'StyledCellItemBox',
-})(() => ({
-  '&:last-child': {
-    paddingRight: '0px',
+})(({ theme }) => ({
+  '&:not(:last-child)': {
+    padding: '0px 15px',
   },
   alignContent: 'center',
   minHeight: '40px',
-  padding: '0px 15px',
 }));
 
 export const StyledUlBox = styled(Box, { label: 'StyledUlBox' })(

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
@@ -75,6 +75,7 @@ export const StyledHeaderItemBox = styled(Box, {
   borderLeft: `1px solid ${theme.borderColors.borderTable}`,
   borderTop: `1px solid ${theme.borderColors.borderTable}`,
   height: '46px',
+  lineHeight: '12px',
   padding: '10px 15px',
 }));
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
@@ -26,10 +26,6 @@ export const sxBox = {
   width: '100%',
 };
 
-export const sxItemSpacing = {
-  padding: `0 8px`,
-};
-
 export const StyledFirewallRuleBox = styled(Box, {
   label: 'StyledFirewallRuleBox',
   shouldForwardProp: omittedProps(['originalIndex', 'ruleId']),
@@ -70,15 +66,27 @@ export const StyledInnerBox = styled(Box, { label: 'StyledInnerBox' })(
 export const StyledHeaderItemBox = styled(Box, {
   label: 'StyledHeaderItemBox',
 })(({ theme }) => ({
-  ...sxItemSpacing,
-  '&:first-child': {
-    borderLeft: `1px solid ${theme.borderColors.borderTable}`,
+  '&:last-child': {
+    borderRight: `1px solid ${theme.borderColors.borderTable}`,
+    paddingRight: '0px',
   },
   alignContent: 'center',
   borderBottom: `1px solid ${theme.borderColors.borderTable}`,
-  borderRight: `1px solid ${theme.borderColors.borderTable}`,
+  borderLeft: `1px solid ${theme.borderColors.borderTable}`,
   borderTop: `1px solid ${theme.borderColors.borderTable}`,
   height: '46px',
+  padding: '10px 15px',
+}));
+
+export const StyledCellItemBox = styled(Box, {
+  label: 'StyledCellItemBox',
+})(() => ({
+  '&:last-child': {
+    paddingRight: '0px',
+  },
+  alignContent: 'center',
+  minHeight: '40px',
+  padding: '0px 15px',
 }));
 
 export const StyledUlBox = styled(Box, { label: 'StyledUlBox' })(

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
@@ -36,6 +36,8 @@ export const StyledFirewallRuleBox = styled(Box, {
 })<StyledFirewallRuleBoxProps>(
   ({ disabled, originalIndex, ruleId, status, theme }) => ({
     borderBottom: `1px solid ${theme.borderColors.borderTable}`,
+    borderLeft: `1px solid ${theme.borderColors.borderTable}`,
+    borderRight: `1px solid ${theme.borderColors.borderTable}`,
     color: theme.textColors.tableStatic,
     fontSize: '0.875rem',
     margin: 0,
@@ -60,12 +62,24 @@ export const StyledFirewallRuleBox = styled(Box, {
 export const StyledInnerBox = styled(Box, { label: 'StyledInnerBox' })(
   ({ theme }) => ({
     backgroundColor: theme.bg.tableHeader,
-    color: theme.textColors.tableHeader,
     fontFamily: theme.font.bold,
     fontSize: '.875rem',
-    height: '46px',
   })
 );
+
+export const StyledHeaderItemBox = styled(Box, {
+  label: 'StyledHeaderItemBox',
+})(({ theme }) => ({
+  ...sxItemSpacing,
+  '&:first-child': {
+    borderLeft: `1px solid ${theme.borderColors.borderTable}`,
+  },
+  alignContent: 'center',
+  borderBottom: `1px solid ${theme.borderColors.borderTable}`,
+  borderRight: `1px solid ${theme.borderColors.borderTable}`,
+  borderTop: `1px solid ${theme.borderColors.borderTable}`,
+  height: '46px',
+}));
 
 export const StyledUlBox = styled(Box, { label: 'StyledUlBox' })(
   ({ theme }) => ({

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -169,7 +169,7 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
               {capitalize(addressColumnLabel)}
             </StyledHeaderItemBox>
           </Hidden>
-          <StyledHeaderItemBox sx={{ width: xsDown ? '30%' : '10%' }}>
+          <StyledHeaderItemBox sx={{ width: xsDown ? '30%' : '12%' }}>
             Action
           </StyledHeaderItemBox>
           <StyledHeaderItemBox flexGrow={1} />
@@ -342,7 +342,7 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
       </Hidden>
       <StyledCellItemBox
         aria-label={`Action: ${action}`}
-        sx={{ width: xsDown ? '30%' : '10%' }}
+        sx={{ width: xsDown ? '30%' : '12%' }}
       >
         {capitalize(action?.toLocaleLowerCase() ?? '')}
       </StyledCellItemBox>
@@ -403,12 +403,12 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
     display: 'grid',
     fontSize: '.875rem',
     gridTemplateAreas: `'one two three four five six'`,
-    gridTemplateColumns: '30% 10% 10% 14% 10% 120px',
+    gridTemplateColumns: '30% 10% 10% 14% 12% 120px',
     height: '40px',
     marginTop: '10px',
     [theme.breakpoints.down('lg')]: {
       gridTemplateAreas: `'one two three four five'`,
-      gridTemplateColumns: '30% 14% 20% 10% 120px',
+      gridTemplateColumns: '30% 14% 20% 12% 120px',
     },
     [theme.breakpoints.down('sm')]: {
       gridTemplateAreas: `'one two'`,

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -25,6 +25,7 @@ import { FirewallRuleActionMenu } from './FirewallRuleActionMenu';
 import {
   MoreStyledLinkButton,
   StyledButtonDiv,
+  StyledCellItemBox,
   StyledDragIndicator,
   StyledErrorDiv,
   StyledFirewallRuleBox,
@@ -36,7 +37,6 @@ import {
   StyledUl,
   StyledUlBox,
   sxBox,
-  sxItemSpacing,
 } from './FirewallRuleTable.styles';
 import { sortPortString } from './shared';
 
@@ -151,7 +151,6 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
         >
           <StyledHeaderItemBox
             sx={{
-              paddingLeft: '27px',
               width: xsDown ? '50%' : '30%',
             }}
           >
@@ -173,7 +172,7 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
           <StyledHeaderItemBox sx={{ width: xsDown ? '30%' : '10%' }}>
             Action
           </StyledHeaderItemBox>
-          <StyledHeaderItemBox sx={{ width: xsDown ? '20%' : '26%' }} />
+          <StyledHeaderItemBox flexGrow={1} />
         </StyledInnerBox>
         <Box sx={{ ...sxBox, flexDirection: 'column' }}>
           <DragDropContext onDragEnd={onDragEnd}>
@@ -296,11 +295,10 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
       ruleId={id}
       status={status}
     >
-      <Box
+      <StyledCellItemBox
         sx={{
-          ...sxItemSpacing,
           overflowWrap: 'break-word',
-          paddingLeft: '8px',
+          paddingLeft: '10px',
           width: xsDown ? '50%' : '30%',
         }}
         aria-label={`Label: ${label}`}
@@ -314,42 +312,41 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
             Add a label
           </MoreStyledLinkButton>
         )}{' '}
-      </Box>
+      </StyledCellItemBox>
       <Hidden lgDown>
-        <Box
+        <StyledCellItemBox
           aria-label={`Protocol: ${protocol}`}
-          sx={{ ...sxItemSpacing, width: '10%' }}
+          sx={{ width: '10%' }}
         >
           {protocol}
           <ConditionalError errors={errors} formField="protocol" />
-        </Box>
+        </StyledCellItemBox>
       </Hidden>
       <Hidden smDown>
-        <Box
+        <StyledCellItemBox
           aria-label={`Ports: ${ports}`}
-          sx={{ ...sxItemSpacing, width: betweenSmAndLg ? '14%' : '10%' }}
+          sx={{ width: betweenSmAndLg ? '14%' : '10%' }}
         >
           {ports === '1-65535' ? 'All Ports' : ports}
           <ConditionalError errors={errors} formField="ports" />
-        </Box>
-        <Box
+        </StyledCellItemBox>
+        <StyledCellItemBox
           sx={{
-            ...sxItemSpacing,
             overflowWrap: 'break-word',
             width: betweenSmAndLg ? '20%' : '14%',
           }}
           aria-label={`Addresses: ${addresses}`}
         >
           {addresses} <ConditionalError errors={errors} formField="addresses" />
-        </Box>
+        </StyledCellItemBox>
       </Hidden>
-      <Box
+      <StyledCellItemBox
         aria-label={`Action: ${action}`}
-        sx={{ ...sxItemSpacing, width: '10%' }}
+        sx={{ width: xsDown ? '30%' : '10%' }}
       >
         {capitalize(action?.toLocaleLowerCase() ?? '')}
-      </Box>
-      <Box sx={{ ...sxItemSpacing, marginLeft: 'auto' }}>
+      </StyledCellItemBox>
+      <StyledCellItemBox sx={{ marginLeft: 'auto' }}>
         {status !== 'NOT_MODIFIED' ? (
           <StyledButtonDiv>
             <StyledFirewallRuleButton
@@ -365,7 +362,7 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
         ) : (
           <FirewallRuleActionMenu {...actionMenuProps} />
         )}
-      </Box>
+      </StyledCellItemBox>
     </StyledFirewallRuleBox>
   );
 });

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -414,8 +414,8 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
       gridTemplateColumns: '30% 14% 20% 10% 120px',
     },
     [theme.breakpoints.down('sm')]: {
-      gridTemplateAreas: `'one two three'`,
-      gridTemplateColumns: '50% 30% 20%',
+      gridTemplateAreas: `'one two'`,
+      gridTemplateColumns: '50% 50%',
     },
     width: '100%',
   };

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -397,7 +397,7 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
   );
 
   // Using a grid here to keep the Select and the helper text aligned
-  // with the last column for screens >= 'lg', and with the Action column for screens < 'lg'.
+  // with the Action column for screens < 'lg', and with the last column for screens >= 'lg'.
   const sxBoxGrid = {
     alignItems: 'center',
     backgroundColor: theme.bg.bgPaper,

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -298,7 +298,7 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
       <StyledCellItemBox
         sx={{
           overflowWrap: 'break-word',
-          paddingLeft: '10px',
+          paddingLeft: '10px !important',
           width: xsDown ? '50%' : '30%',
         }}
         aria-label={`Label: ${label}`}


### PR DESCRIPTION
## Description 📝
The table/list header row in the firewall rules table is not the correct color in dark/light mode. It is hard to tell that it is intended to be a table/list header.

## Changes  🔄
- Changed the Firewall rules table to match our normal tables.
   - Updated the styles to match our normal table colors.
- Updated `PolicyRow` 
  - Changed it to have borders on all sides.
  - Changed the alignment of the Select and helper text to be aligned with the Action column for screens < `lg`, and with the last column for screens >= `lg`.

## Target release date 🗓️
N/A

## Preview 📷
| Breakpoints | Before  | After   |
| ------ | ------- | ------- |
| `lg` | ![Screenshot 2024-10-16 at 1 31 23 PM](https://github.com/user-attachments/assets/14b1036d-9249-49d8-b3f5-e591da5bb6a0) ![Screenshot 2024-10-16 at 1 35 28 PM](https://github.com/user-attachments/assets/73196820-d692-408d-af80-698889d95fdd) | ![Screenshot 2024-10-16 at 1 32 19 PM](https://github.com/user-attachments/assets/984cc1da-488e-49bd-8989-cb21a849c0df) ![Screenshot 2024-10-16 at 1 34 43 PM](https://github.com/user-attachments/assets/4343392c-77c9-473d-b30f-bc7d0a1faddc) |
| between `sm` and `lg` | ![Screenshot 2024-10-16 at 1 38 54 PM](https://github.com/user-attachments/assets/001d3f3e-38a5-4efe-b75b-74f4f0e82c4c) | ![Screenshot 2024-10-16 at 1 37 30 PM](https://github.com/user-attachments/assets/35172314-2300-4a46-8ba6-7951716a29bb) |
| `sm` | ![Screenshot 2024-10-16 at 2 19 32 PM](https://github.com/user-attachments/assets/edf95506-4ce0-48ef-abb5-cc5c71a65755) | ![Screenshot 2024-10-16 at 7 29 38 PM](https://github.com/user-attachments/assets/64098d5c-194a-40f0-ab46-537d29467bb9) | 


## How to test 🧪

### Reproduction steps
(How to reproduce the issue, if applicable)
- Go to any Firewall details page (https://cloud.linode.com/firewalls/948204/rules)
- Observe the broken looking table (in both dark and light mode)

### Verification steps
- Ensure the table is not broken in both dark and light modes.
- Verify table across different screen sizes and ensure it matches our normal table colors.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support