### PR TITLE
fix: [UIE-8181] - DBaaS enable restricted beta users

### DIFF
--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -95,6 +95,7 @@ export interface Flags {
   databaseResize: boolean;
   databases: boolean;
   dbaasV2: BetaFeatureFlag;
+  dbaasV2MonitorMetrics: BetaFeatureFlag;
   disableLargestGbPlans: boolean;
   disallowImageUploadToNonObjRegions: boolean;
   gecko2: GeckoFeatureFlag;

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -78,7 +78,7 @@ export const DatabaseBackups = (props: Props) => {
     databaseId: string;
     engine: Engine;
   }>();
-  const { isV2GAUser } = useIsDatabasesEnabled();
+  const { isDatabasesV2GA } = useIsDatabasesEnabled();
 
   const [isRestoreDialogOpen, setIsRestoreDialogOpen] = React.useState(false);
   const [selectedDate, setSelectedDate] = React.useState<DateTime | null>(null);
@@ -86,7 +86,7 @@ export const DatabaseBackups = (props: Props) => {
     null
   );
   const [versionOption, setVersionOption] = React.useState<VersionOption>(
-    isV2GAUser ? 'newest' : 'dateTime'
+    isDatabasesV2GA ? 'newest' : 'dateTime'
   );
 
   const {
@@ -143,7 +143,7 @@ export const DatabaseBackups = (props: Props) => {
       <Divider spacingBottom={25} spacingTop={25} />
       <Typography variant="h2">Restore a Backup</Typography>
       <StyledTypography>
-        {isV2GAUser ? (
+        {isDatabasesV2GA ? (
           <span>
             The newest full backup plus incremental is selected by default. Or,
             select any date and time within the last 10 days you want to create
@@ -159,7 +159,7 @@ export const DatabaseBackups = (props: Props) => {
       {unableToRestoreCopy && (
         <Notice spacingTop={16} text={unableToRestoreCopy} variant="info" />
       )}
-      {isV2GAUser && (
+      {isDatabasesV2GA && (
         <RadioGroup
           aria-label="type"
           name="type"

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.test.tsx
@@ -168,7 +168,7 @@ describe('database resize', () => {
     });
   });
 
-  describe('on rendering of page and isDatabasesGAEnabled is true and the Shared CPU tab is preselected ', () => {
+  describe('on rendering of page and isDatabasesV2GA is true and the Shared CPU tab is preselected ', () => {
     beforeEach(() => {
       // Mock database types
       const standardTypes = [
@@ -369,7 +369,7 @@ describe('database resize', () => {
     });
   });
 
-  describe('on rendering of page and isDatabasesGAEnabled is true and the Dedicated CPU tab is preselected', () => {
+  describe('on rendering of page and isDatabasesV2GA is true and the Dedicated CPU tab is preselected', () => {
     beforeEach(() => {
       // Mock database types
       const mockDedicatedTypes = [

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.tsx
@@ -97,10 +97,7 @@ export const DatabaseResize = ({ database, disabled = false }: Props) => {
   ] = React.useState(false);
 
   const [selectedTab, setSelectedTab] = React.useState(0);
-  const {
-    isDatabasesV2Enabled,
-    isDatabasesGAEnabled,
-  } = useIsDatabasesEnabled();
+  const { isDatabasesV2Enabled, isDatabasesV2GA } = useIsDatabasesEnabled();
   const [clusterSize, setClusterSize] = React.useState<ClusterSize | undefined>(
     database.cluster_size
   );
@@ -122,11 +119,7 @@ export const DatabaseResize = ({ database, disabled = false }: Props) => {
   const onResize = () => {
     const payload: UpdateDatabasePayload = {};
 
-    if (
-      clusterSize &&
-      clusterSize > database.cluster_size &&
-      isDatabasesGAEnabled
-    ) {
+    if (clusterSize && clusterSize > database.cluster_size && isDatabasesV2GA) {
       payload.cluster_size = clusterSize;
     }
 
@@ -163,30 +156,26 @@ export const DatabaseResize = ({ database, disabled = false }: Props) => {
         {summaryText ? (
           <>
             <StyledPlanSummarySpan>
-              {isDatabasesGAEnabled
+              {isDatabasesV2GA
                 ? 'Resized Cluster: ' + summaryText.plan
                 : summaryText.plan}
             </StyledPlanSummarySpan>{' '}
-            {isDatabasesGAEnabled ? (
+            {isDatabasesV2GA ? (
               <span
-                className={
-                  isDatabasesGAEnabled ? classes.summarySpanBorder : ''
-                }
+                className={isDatabasesV2GA ? classes.summarySpanBorder : ''}
               >
                 {summaryText.basePrice}
               </span>
             ) : null}
-            <span
-              className={isDatabasesGAEnabled ? classes.nodeSpanSpacing : ''}
-            >
+            <span className={isDatabasesV2GA ? classes.nodeSpanSpacing : ''}>
               {' '}
               {summaryText.numberOfNodes} Node
               {summaryText.numberOfNodes > 1 ? 's' : ''}
-              {!isDatabasesGAEnabled ? ': ' : ' - HA '}
+              {!isDatabasesV2GA ? ': ' : ' - HA '}
             </span>
             {summaryText.price}
           </>
-        ) : isDatabasesGAEnabled ? (
+        ) : isDatabasesV2GA ? (
           <>
             <StyledPlanSummarySpan>Resized Cluster:</StyledPlanSummarySpan>{' '}
             Please select a plan or set the number of nodes.
@@ -263,7 +252,7 @@ export const DatabaseResize = ({ database, disabled = false }: Props) => {
     setSummaryText({
       numberOfNodes: clusterSize,
       plan: formatStorageUnits(selectedPlanType.label),
-      price: isDatabasesGAEnabled
+      price: isDatabasesV2GA
         ? `$${price?.monthly}/month`
         : `$${price?.monthly}/month or $${price?.hourly}/hour`,
       basePrice: currentPlanPrice,
@@ -287,7 +276,7 @@ export const DatabaseResize = ({ database, disabled = false }: Props) => {
     }
     const engineType = database.engine.split('/')[0] as Engine;
     // When only a higher node selection is made and plan has not been changed
-    if (isDatabasesGAEnabled && nodeSelected && isSamePlanSelected) {
+    if (isDatabasesV2GA && nodeSelected && isSamePlanSelected) {
       setSummaryAndPrices(database.type, engineType, dbTypes);
     }
     // No plan selection or plan selection is unchanged
@@ -357,7 +346,7 @@ export const DatabaseResize = ({ database, disabled = false }: Props) => {
       <StyledPlanSummarySpan>
         Current Cluster: {currentPlan?.heading}
       </StyledPlanSummarySpan>{' '}
-      <span className={isDatabasesGAEnabled ? classes.summarySpanBorder : ''}>
+      <span className={isDatabasesV2GA ? classes.summarySpanBorder : ''}>
         {currentPlanPrice}
       </span>
       <span className={classes.nodeSpanSpacing}>
@@ -379,7 +368,7 @@ export const DatabaseResize = ({ database, disabled = false }: Props) => {
     );
     setSelectedTab(initialTab);
 
-    if (isDatabasesGAEnabled) {
+    if (isDatabasesV2GA) {
       const engineType = database.engine.split('/')[0] as Engine;
       const nodePricingDetails = {
         double: currentPlan?.engines[engineType]?.find(
@@ -418,7 +407,7 @@ export const DatabaseResize = ({ database, disabled = false }: Props) => {
       return;
     }
     // Clear plan and related info when when 2 nodes option is selected for incompatible plan.
-    if (isDatabasesGAEnabled && selectedTab === 0 && clusterSize === 2) {
+    if (isDatabasesV2GA && selectedTab === 0 && clusterSize === 2) {
       setClusterSize(undefined);
       setPlanSelected(undefined);
       setNodePricing(undefined);
@@ -536,7 +525,7 @@ export const DatabaseResize = ({ database, disabled = false }: Props) => {
           tabDisabledMessage="Resizing a 2-nodes cluster is only allowed with Dedicated plans."
           types={displayTypes}
         />
-        {isDatabasesGAEnabled && (
+        {isDatabasesV2GA && (
           <>
             <Divider spacingBottom={20} spacingTop={20} />
 
@@ -573,13 +562,13 @@ export const DatabaseResize = ({ database, disabled = false }: Props) => {
       <Paper sx={{ marginTop: 2 }}>
         <Typography
           sx={(theme) => ({
-            marginBottom: isDatabasesGAEnabled ? theme.spacing(2) : 0,
+            marginBottom: isDatabasesV2GA ? theme.spacing(2) : 0,
           })}
           variant="h2"
         >
-          Summary {isDatabasesGAEnabled ? database.label : ''}
+          Summary {isDatabasesV2GA ? database.label : ''}
         </Typography>
-        {isDatabasesGAEnabled && currentPlan ? currentSummary : null}
+        {isDatabasesV2GA && currentPlan ? currentSummary : null}
         {resizeSummary}
       </Paper>
       <StyledGrid>

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
@@ -10,20 +10,23 @@ import {
   linkAnalyticsEvent,
   youtubeLinkData,
 } from 'src/features/Databases/DatabaseLanding/DatabaseLandingEmptyStateData';
+import DatabaseLogo from 'src/features/Databases/DatabaseLanding/DatabaseLogo';
 import { useIsDatabasesEnabled } from 'src/features/Databases/utilities';
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 import { sendEvent } from 'src/utilities/analytics/utils';
 
 export const DatabaseEmptyState = () => {
   const { push } = useHistory();
-  const { isDatabasesV2Enabled, isV2GAUser } = useIsDatabasesEnabled();
+  const { isDatabasesV2Enabled, isDatabasesV2GA } = useIsDatabasesEnabled();
 
   const isRestricted = useRestrictedGlobalGrantCheck({
     globalGrantType: 'add_databases',
   });
 
-  if (!isDatabasesV2Enabled || !isV2GAUser) {
-    headers.logo = '';
+  if (isDatabasesV2Enabled || isDatabasesV2GA) {
+    headers.logo = (
+      <DatabaseLogo sx={{ marginBottom: '20px', marginTop: '-10px' }} />
+    );
   }
 
   return (

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -37,9 +37,9 @@ const DatabaseLanding = () => {
 
   const {
     isDatabasesV2Enabled,
-    isV2ExistingBetaUser,
-    isV2GAUser,
-    isV2NewBetaUser,
+    isUserExistingBeta,
+    isDatabasesV2GA,
+    isUserNewBeta,
   } = useIsDatabasesEnabled();
 
   const { isLoading: isTypeLoading } = useDatabaseTypesQuery({
@@ -47,7 +47,7 @@ const DatabaseLanding = () => {
   });
 
   const isDefaultEnabled =
-    isV2ExistingBetaUser || isV2NewBetaUser || isV2GAUser;
+    isUserExistingBeta || isUserNewBeta || isDatabasesV2GA;
 
   const {
     handleOrderChange: newDatabaseHandleOrderChange,
@@ -97,7 +97,7 @@ const DatabaseLanding = () => {
     ['+order_by']: legacyDatabaseOrderBy,
   };
 
-  if (isV2ExistingBetaUser || isV2GAUser) {
+  if (isUserExistingBeta || isDatabasesV2GA) {
     legacyDatabasesFilter['platform'] = 'rdbms-legacy';
   }
 
@@ -111,7 +111,7 @@ const DatabaseLanding = () => {
       page_size: legacyDatabasesPagination.pageSize,
     },
     legacyDatabasesFilter,
-    !isV2NewBetaUser
+    !isUserNewBeta
   );
 
   const error = newDatabasesError || legacyDatabasesError;
@@ -134,7 +134,7 @@ const DatabaseLanding = () => {
     return <DatabaseEmptyState />;
   }
 
-  const isV2Enabled = isDatabasesV2Enabled || isV2GAUser;
+  const isV2Enabled = isDatabasesV2Enabled || isDatabasesV2GA;
   const showTabs = isV2Enabled && !!legacyDatabases?.data.length;
   const isNewDatabase = isV2Enabled && !!newDatabases?.data.length;
 

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLandingEmptyStateData.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLandingEmptyStateData.tsx
@@ -1,6 +1,3 @@
-import React from 'react';
-
-import DatabaseLogo from 'src/features/Databases/DatabaseLanding/DatabaseLogo';
 import {
   docsLink,
   guidesMoreLinkText,
@@ -17,7 +14,6 @@ import type {
 export const headers: ResourcesHeaders = {
   description:
     "Deploy popular database engines such as MySQL and PostgreSQL using Linode's performant, reliable, and fully managed database solution.",
-  logo: <DatabaseLogo sx={{ marginBottom: '20px', marginTop: '-10px' }} />,
   subtitle: 'Fully managed cloud database clusters',
   title: 'Databases',
 };

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLandingTable.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLandingTable.tsx
@@ -38,7 +38,7 @@ const DatabaseLandingTable = ({
   orderBy,
 }: Props) => {
   const { data: events } = useInProgressEvents();
-  const { isV2GAUser } = useIsDatabasesEnabled();
+  const { isDatabasesV2GA } = useIsDatabasesEnabled();
 
   const dbPlatformType = isNewDatabase ? 'new' : 'legacy';
   const pagination = usePagination(1, preferenceKey, dbPlatformType);
@@ -146,7 +146,7 @@ const DatabaseLandingTable = ({
                 Created
               </TableSortCell>
             </Hidden>
-            {isV2GAUser && isNewDatabase && <TableCell></TableCell>}
+            {isDatabasesV2GA && isNewDatabase && <TableCell></TableCell>}
           </TableRow>
         </TableHead>
         <TableBody>

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLogo.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLogo.tsx
@@ -17,7 +17,7 @@ interface Props {
 export const DatabaseLogo = ({ sx }: Props) => {
   const theme = useTheme();
 
-  const { isV2GAUser } = useIsDatabasesEnabled();
+  const { isDatabasesV2GA } = useIsDatabasesEnabled();
   return (
     <Box
       display="flex"
@@ -25,7 +25,7 @@ export const DatabaseLogo = ({ sx }: Props) => {
       sx={sx ? sx : { margin: '20px' }}
     >
       <Typography sx={{ display: 'inline-block', textAlign: 'center' }}>
-        {!isV2GAUser && (
+        {!isDatabasesV2GA && (
           <BetaChip
             sx={{
               backgroundColor:
@@ -42,7 +42,7 @@ export const DatabaseLogo = ({ sx }: Props) => {
           sx={{
             color: theme.palette.mode === 'light' ? theme.color.headline : '',
             display: 'flex',
-            marginTop: !isV2GAUser ? theme.spacing(1) : '',
+            marginTop: !isDatabasesV2GA ? theme.spacing(1) : '',
           }}
           component="span"
         >

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
@@ -66,7 +66,7 @@ export const DatabaseRow = ({
   const plan = types?.find((t: DatabaseType) => t.id === type);
   const formattedPlan = plan && formatStorageUnits(plan.label);
   const actualRegion = regions?.find((r) => r.id === region);
-  const { isV2GAUser } = useIsDatabasesEnabled();
+  const { isDatabasesV2GA } = useIsDatabasesEnabled();
 
   const configuration =
     cluster_size === 1 ? (
@@ -107,7 +107,7 @@ export const DatabaseRow = ({
               })}
         </TableCell>
       </Hidden>
-      {isV2GAUser && isNewDatabase && (
+      {isDatabasesV2GA && isNewDatabase && (
         <TableCell actionCell>
           <DatabaseActionMenu
             databaseEngine={engine}

--- a/packages/manager/src/features/Databases/utilities.test.ts
+++ b/packages/manager/src/features/Databases/utilities.test.ts
@@ -2,7 +2,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { DateTime } from 'luxon';
 
 import { AccountCapability } from '@linode/api-v4';
-import { accountFactory } from 'src/factories';
+import { accountFactory, databaseTypeFactory } from 'src/factories';
 import { TimeOption } from 'src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups';
 import {
   isDateOutsideBackup,
@@ -10,7 +10,6 @@ import {
   toISOString,
   useIsDatabasesEnabled,
 } from 'src/features/Databases/utilities';
-import { makeResourcePage } from 'src/mocks/serverHandlers';
 import { HttpResponse, http, server } from 'src/mocks/testServer';
 import { wrapWithTheme } from 'src/utilities/testHelpers';
 
@@ -28,8 +27,16 @@ const setup = (capabilities: AccountCapability[], flags: any) => {
   });
 };
 
+const queryMocks = vi.hoisted(() => ({
+  useDatabaseTypesQuery: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('src/queries/databases/databases', () => ({
+  useDatabaseTypesQuery: queryMocks.useDatabaseTypesQuery,
+}));
+
 describe('useIsDatabasesEnabled', () => {
-  it('should return false for an unrestricted user without the account capability', async () => {
+  it('should return correctly for non V1/V2 user', async () => {
     const { result } = setup([], { dbaasV2: { beta: true, enabled: true } });
     await waitFor(() => {
       expect(result.current.isDatabasesEnabled).toBe(false);
@@ -37,14 +44,14 @@ describe('useIsDatabasesEnabled', () => {
       expect(result.current.isDatabasesV2Enabled).toBe(false);
 
       expect(result.current.isDatabasesV2Beta).toBe(false);
-      expect(result.current.isV2ExistingBetaUser).toBe(false);
-      expect(result.current.isV2NewBetaUser).toBe(false);
+      expect(result.current.isUserExistingBeta).toBe(false);
+      expect(result.current.isUserNewBeta).toBe(false);
 
-      expect(result.current.isV2GAUser).toBe(false);
+      expect(result.current.isDatabasesV2GA).toBe(false);
     });
   });
 
-  it('should return true for an unrestricted user with the account capability V1', async () => {
+  it('should return correctly for V1 user', async () => {
     const { result } = setup(['Managed Databases'], {
       dbaasV2: { beta: false, enabled: false },
     });
@@ -55,14 +62,14 @@ describe('useIsDatabasesEnabled', () => {
       expect(result.current.isDatabasesV2Enabled).toBe(false);
 
       expect(result.current.isDatabasesV2Beta).toBe(false);
-      expect(result.current.isV2ExistingBetaUser).toBe(false);
-      expect(result.current.isV2NewBetaUser).toBe(false);
+      expect(result.current.isUserExistingBeta).toBe(false);
+      expect(result.current.isUserNewBeta).toBe(false);
 
-      expect(result.current.isV2GAUser).toBe(false);
+      expect(result.current.isDatabasesV2GA).toBe(false);
     });
   });
 
-  it('should return true for a new unrestricted user with the account capability V2 and beta feature flag', async () => {
+  it('should return correctly for V2 new user beta', async () => {
     const { result } = setup(['Managed Databases Beta'], {
       dbaasV2: { beta: true, enabled: true },
     });
@@ -73,16 +80,16 @@ describe('useIsDatabasesEnabled', () => {
       expect(result.current.isDatabasesV2Enabled).toBe(true);
 
       expect(result.current.isDatabasesV2Beta).toBe(true);
-      expect(result.current.isV2ExistingBetaUser).toBe(false);
-      expect(result.current.isV2NewBetaUser).toBe(true);
+      expect(result.current.isUserExistingBeta).toBe(false);
+      expect(result.current.isUserNewBeta).toBe(true);
 
-      expect(result.current.isV2GAUser).toBe(false);
+      expect(result.current.isDatabasesV2GA).toBe(false);
     });
   });
 
-  it('should return false for a new unrestricted user with the account capability V2 and no beta feature flag', async () => {
+  it('should return correctly for V2 new user no beta', async () => {
     const { result } = setup(['Managed Databases Beta'], {
-      dbaasV2: { beta: true, enabled: false },
+      dbaasV2: { beta: false, enabled: false },
     });
 
     await waitFor(() => {
@@ -91,14 +98,14 @@ describe('useIsDatabasesEnabled', () => {
       expect(result.current.isDatabasesV2Enabled).toBe(false);
 
       expect(result.current.isDatabasesV2Beta).toBe(false);
-      expect(result.current.isV2ExistingBetaUser).toBe(false);
-      expect(result.current.isV2NewBetaUser).toBe(false);
+      expect(result.current.isUserExistingBeta).toBe(false);
+      expect(result.current.isUserNewBeta).toBe(false);
 
-      expect(result.current.isV2GAUser).toBe(false);
+      expect(result.current.isDatabasesV2GA).toBe(false);
     });
   });
 
-  it('should return true for an existing unrestricted user with the account capability V1 & V2 and beta feature flag', async () => {
+  it('should return correctly for V1 & V2 existing user beta', async () => {
     const { result } = setup(['Managed Databases', 'Managed Databases Beta'], {
       dbaasV2: { beta: true, enabled: true },
     });
@@ -109,14 +116,14 @@ describe('useIsDatabasesEnabled', () => {
       expect(result.current.isDatabasesV2Enabled).toBe(true);
 
       expect(result.current.isDatabasesV2Beta).toBe(true);
-      expect(result.current.isV2ExistingBetaUser).toBe(true);
-      expect(result.current.isV2NewBetaUser).toBe(false);
+      expect(result.current.isUserExistingBeta).toBe(true);
+      expect(result.current.isUserNewBeta).toBe(false);
 
-      expect(result.current.isV2GAUser).toBe(false);
+      expect(result.current.isDatabasesV2GA).toBe(false);
     });
   });
 
-  it('should return true for an existing unrestricted user with the account capability V1 and no beta feature flag', async () => {
+  it('should return correctly for V1 existing user GA', async () => {
     const { result } = setup(['Managed Databases'], {
       dbaasV2: { beta: false, enabled: true },
     });
@@ -127,45 +134,195 @@ describe('useIsDatabasesEnabled', () => {
       expect(result.current.isDatabasesV2Enabled).toBe(false);
 
       expect(result.current.isDatabasesV2Beta).toBe(false);
-      expect(result.current.isV2ExistingBetaUser).toBe(false);
-      expect(result.current.isV2NewBetaUser).toBe(false);
+      expect(result.current.isUserExistingBeta).toBe(false);
+      expect(result.current.isUserNewBeta).toBe(false);
 
-      expect(result.current.isV2GAUser).toBe(true);
+      expect(result.current.isDatabasesV2GA).toBe(true);
     });
   });
 
-  it('should return true for a restricted user who can not load account but can load database engines', async () => {
+  it('should return correctly for V1 restricted user non-beta', async () => {
     server.use(
       http.get('*/v4/account', () => {
         return HttpResponse.json({}, { status: 403 });
-      }),
-      http.get('*/v4beta/databases/engines', () => {
-        return HttpResponse.json(makeResourcePage([]));
       })
     );
 
-    const { result } = renderHook(() => useIsDatabasesEnabled(), {
-      wrapper: wrapWithTheme,
+    // default
+    queryMocks.useDatabaseTypesQuery.mockReturnValueOnce({
+      data: null,
     });
 
-    await waitFor(() => expect(result.current.isDatabasesEnabled).toBe(true));
+    // legacy
+    queryMocks.useDatabaseTypesQuery.mockReturnValueOnce({
+      data: databaseTypeFactory.buildList(1),
+    });
+
+    const flags = { dbaasV2: { beta: true, enabled: true } };
+
+    const { result } = renderHook(() => useIsDatabasesEnabled(), {
+      wrapper: (ui) => wrapWithTheme(ui, { flags }),
+    });
+
+    expect(queryMocks.useDatabaseTypesQuery).toHaveBeenNthCalledWith(
+      1,
+      ...[{ platform: 'rdbms-default' }, true]
+    );
+
+    expect(queryMocks.useDatabaseTypesQuery).toHaveBeenNthCalledWith(
+      2,
+      ...[{ platform: 'rdbms-legacy' }, true]
+    );
+
+    await waitFor(() => {
+      expect(result.current.isDatabasesEnabled).toBe(true);
+      expect(result.current.isDatabasesV1Enabled).toBe(true);
+      expect(result.current.isDatabasesV2Enabled).toBe(false);
+
+      expect(result.current.isDatabasesV2Beta).toBe(false);
+      expect(result.current.isUserExistingBeta).toBe(false);
+      expect(result.current.isUserNewBeta).toBe(false);
+
+      expect(result.current.isDatabasesV2GA).toBe(false);
+    });
   });
 
-  it('should return false for a restricted user who can not load account and database engines', async () => {
+  it('should return correctly for V1 & V2 restricted user existing beta', async () => {
     server.use(
       http.get('*/v4/account', () => {
         return HttpResponse.json({}, { status: 403 });
-      }),
-      http.get('*/v4beta/databases/engines', () => {
-        return HttpResponse.json({}, { status: 404 });
       })
     );
 
-    const { result } = renderHook(() => useIsDatabasesEnabled(), {
-      wrapper: wrapWithTheme,
+    // default
+    queryMocks.useDatabaseTypesQuery.mockReturnValueOnce({
+      data: databaseTypeFactory.buildList(1),
     });
 
-    await waitFor(() => expect(result.current.isDatabasesEnabled).toBe(false));
+    // legacy
+    queryMocks.useDatabaseTypesQuery.mockReturnValueOnce({
+      data: databaseTypeFactory.buildList(1),
+    });
+
+    const flags = { dbaasV2: { beta: true, enabled: true } };
+
+    const { result } = renderHook(() => useIsDatabasesEnabled(), {
+      wrapper: (ui) => wrapWithTheme(ui, { flags }),
+    });
+
+    expect(queryMocks.useDatabaseTypesQuery).toHaveBeenNthCalledWith(
+      1,
+      ...[{ platform: 'rdbms-default' }, true]
+    );
+
+    expect(queryMocks.useDatabaseTypesQuery).toHaveBeenNthCalledWith(
+      2,
+      ...[{ platform: 'rdbms-legacy' }, true]
+    );
+
+    await waitFor(() => {
+      expect(result.current.isDatabasesEnabled).toBe(true);
+      expect(result.current.isDatabasesV1Enabled).toBe(true);
+      expect(result.current.isDatabasesV2Enabled).toBe(true);
+
+      expect(result.current.isDatabasesV2Beta).toBe(true);
+      expect(result.current.isUserExistingBeta).toBe(true);
+      expect(result.current.isUserNewBeta).toBe(false);
+
+      expect(result.current.isDatabasesV2GA).toBe(false);
+    });
+  });
+
+  it('should return correctly for V2 restricted user new beta', async () => {
+    server.use(
+      http.get('*/v4/account', () => {
+        return HttpResponse.json({}, { status: 403 });
+      })
+    );
+
+    // default
+    queryMocks.useDatabaseTypesQuery.mockReturnValueOnce({
+      data: databaseTypeFactory.buildList(1),
+    });
+
+    // legacy
+    queryMocks.useDatabaseTypesQuery.mockReturnValueOnce({
+      data: null,
+    });
+
+    const flags = { dbaasV2: { beta: true, enabled: true } };
+
+    const { result } = renderHook(() => useIsDatabasesEnabled(), {
+      wrapper: (ui) => wrapWithTheme(ui, { flags }),
+    });
+
+    expect(queryMocks.useDatabaseTypesQuery).toHaveBeenNthCalledWith(
+      1,
+      ...[{ platform: 'rdbms-default' }, true]
+    );
+
+    expect(queryMocks.useDatabaseTypesQuery).toHaveBeenNthCalledWith(
+      2,
+      ...[{ platform: 'rdbms-legacy' }, true]
+    );
+
+    await waitFor(() => {
+      expect(result.current.isDatabasesEnabled).toBe(true);
+      expect(result.current.isDatabasesV1Enabled).toBe(false);
+      expect(result.current.isDatabasesV2Enabled).toBe(true);
+
+      expect(result.current.isDatabasesV2Beta).toBe(true);
+      expect(result.current.isUserExistingBeta).toBe(false);
+      expect(result.current.isUserNewBeta).toBe(true);
+
+      expect(result.current.isDatabasesV2GA).toBe(false);
+    });
+  });
+
+  it('should return correctly for V2 restricted user GA', async () => {
+    server.use(
+      http.get('*/v4/account', () => {
+        return HttpResponse.json({}, { status: 403 });
+      })
+    );
+
+    // default
+    queryMocks.useDatabaseTypesQuery.mockReturnValueOnce({
+      data: databaseTypeFactory.buildList(1),
+    });
+
+    // legacy
+    queryMocks.useDatabaseTypesQuery.mockReturnValueOnce({
+      data: null,
+    });
+
+    const flags = { dbaasV2: { beta: false, enabled: true } };
+
+    const { result } = renderHook(() => useIsDatabasesEnabled(), {
+      wrapper: (ui) => wrapWithTheme(ui, { flags }),
+    });
+
+    expect(queryMocks.useDatabaseTypesQuery).toHaveBeenNthCalledWith(
+      1,
+      ...[{ platform: 'rdbms-default' }, true]
+    );
+
+    expect(queryMocks.useDatabaseTypesQuery).toHaveBeenNthCalledWith(
+      2,
+      ...[{ platform: 'rdbms-legacy' }, true]
+    );
+
+    await waitFor(() => {
+      expect(result.current.isDatabasesEnabled).toBe(true);
+      expect(result.current.isDatabasesV1Enabled).toBe(false);
+      expect(result.current.isDatabasesV2Enabled).toBe(true);
+
+      expect(result.current.isDatabasesV2Beta).toBe(false);
+      expect(result.current.isUserExistingBeta).toBe(false);
+      expect(result.current.isUserNewBeta).toBe(false);
+
+      expect(result.current.isDatabasesV2GA).toBe(true);
+    });
   });
 });
 

--- a/packages/manager/src/queries/databases/databases.ts
+++ b/packages/manager/src/queries/databases/databases.ts
@@ -187,9 +187,13 @@ export const useDatabaseEnginesQuery = (enabled: boolean = false) =>
     enabled,
   });
 
-export const useDatabaseTypesQuery = (filter: Filter = {}) =>
+export const useDatabaseTypesQuery = (
+  filter: Filter = {},
+  enabled: boolean = true
+) =>
   useQuery<DatabaseType[], APIError[]>({
     ...databaseQueries.types._ctx.all(filter),
+    enabled,
   });
 
 export const useDatabaseCredentialsQuery = (


### PR DESCRIPTION
## Description 📝
Allow restricted DBaaS users to access beta

## Changes  🔄
List any change relevant to the reviewer.
- Allow a restricted user without access to /account but has access to DBaaS to access DBaaS
- Call /types instead of /engines call in order to pass relative filter to check for V1 vs V2 access
- Rename useIsDatabasesEnabled properties for consistency and understandability

## Target release date 🗓️
10/28/24

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-10-16 at 1 08 39 PM](https://github.com/user-attachments/assets/66d34489-f1da-4d83-b657-bb9eb7121b38)| ![Screenshot 2024-10-16 at 1 08 26 PM](https://github.com/user-attachments/assets/56df4851-2904-4cd3-ad2e-6fc210e660f3)|

## How to test 🧪

### Prerequisites
- Restricted user without /account access but has DBaaS access

### Reproduction steps
- Go to create page

### Verification steps
- Verify user has access to beta (2 node option)

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
