### PR TITLE
refactor: [M3-8746] – Move `inputMaxWidth` into `Theme`

### DIFF
--- a/packages/manager/src/features/Linodes/LinodeCreate/Security.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Security.tsx
@@ -1,4 +1,3 @@
-import { inputMaxWidth } from '@linode/ui';
 import React from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 
@@ -56,7 +55,11 @@ export const Security = () => {
         Security
       </Typography>
       <React.Suspense
-        fallback={<Skeleton sx={{ height: '89px', maxWidth: inputMaxWidth }} />}
+        fallback={
+          <Skeleton
+            sx={(theme) => ({ height: '89px', maxWidth: theme.inputMaxWidth })}
+          />
+        }
       >
         <Controller
           render={({ field, fieldState }) => (

--- a/packages/manager/src/features/Linodes/LinodeCreate/VPC/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/VPC/VPC.tsx
@@ -1,4 +1,3 @@
-import { inputMaxWidth } from '@linode/ui';
 import React, { useState } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 
@@ -133,7 +132,9 @@ export const VPC = () => {
                 }}
                 textFieldProps={{
                   sx: (theme) => ({
-                    [theme.breakpoints.up('sm')]: { minWidth: inputMaxWidth },
+                    [theme.breakpoints.up('sm')]: {
+                      minWidth: theme.inputMaxWidth,
+                    },
                   }),
                   tooltipText: REGION_CAVEAT_HELPER_TEXT,
                 }}

--- a/packages/ui/.changeset/pr-11116-changed-1729114321677.md
+++ b/packages/ui/.changeset/pr-11116-changed-1729114321677.md
@@ -1,0 +1,5 @@
+---
+"@linode/ui": Changed
+---
+
+Moved `inputMaxWidth` into `Theme` ([#11116](https://github.com/linode/manager/pull/11116))

--- a/packages/ui/src/foundations/themes/index.ts
+++ b/packages/ui/src/foundations/themes/index.ts
@@ -2,7 +2,7 @@ import { createTheme } from '@mui/material/styles';
 
 // Themes & Brands
 import { darkTheme } from './dark';
-import { lightTheme, inputMaxWidth as _inputMaxWidth } from './light';
+import { lightTheme } from './light';
 
 import type {
   ChartTypes,
@@ -76,6 +76,7 @@ declare module '@mui/material/styles/createTheme' {
     color: Colors;
     font: Fonts;
     graphs: any;
+    inputMaxWidth: number;
     inputStyles: any;
     interactionTokens: InteractionTypes;
     name: ThemeName;
@@ -96,6 +97,7 @@ declare module '@mui/material/styles/createTheme' {
     color?: DarkModeColors | LightModeColors;
     font?: Fonts;
     graphs?: any;
+    inputMaxWidth?: number;
     inputStyles?: any;
     interactionTokens?: InteractionTypes;
     name: ThemeName;
@@ -105,6 +107,5 @@ declare module '@mui/material/styles/createTheme' {
   }
 }
 
-export const inputMaxWidth = _inputMaxWidth;
 export const light = createTheme(lightTheme);
 export const dark = createTheme(lightTheme, darkTheme);

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -15,7 +15,7 @@ import { latoWeb } from '../fonts';
 
 import type { ThemeOptions } from '@mui/material/styles';
 
-export const inputMaxWidth = 416;
+const inputMaxWidth = 416;
 
 export const bg = {
   app: Color.Neutrals[5],
@@ -1526,6 +1526,7 @@ export const lightTheme: ThemeOptions = {
     },
     yellow: `rgba(255, 220, 125, ${graphTransparency})`,
   },
+  inputMaxWidth,
   inputStyles: {
     default: {
       backgroundColor: Select.Default.Background,


### PR DESCRIPTION
## Description 📝
Follow-up to https://github.com/linode/manager/pull/11092 -- move `inputMaxWidth` into `Theme` so we can reference it as `theme.inputMaxWidth` as opposed to exporting & importing the `inputMaxWidth` variable

## Changes  🔄
- Add `inputMaxWidth` to `Theme`
- Replace uses of `inputMaxWidth` variable in components with `theme.inputMaxWidth`

## Target release date 🗓️
10/28/24

## How to test 🧪
### Verification steps
Confirm there are no width regressions for the VPC and Security sections in the Linode Create flow

## As an Author I have considered 🤔
- [X] 👀 Doing a self review
- [X] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [X] 🤏 Splitting feature into small PRs
- [X] ➕ Adding a changeset
- [X] 🧪 Providing/Improving test coverage
- [X] 🔐 Removing all sensitive information from the code and PR description
- [X] 🚩 Using a feature flag to protect the release
- [X] 👣 Providing comprehensive reproduction steps
- [X] 📑 Providing or updating our documentation
- [X] 🕛 Scheduling a pair reviewing session
- [X] 📱 Providing mobile support
- [X] ♿  Providing accessibility support