### PR TITLE
fix: [M3-8758] - Use default v8 reporter in `coverage:summary` job

### DIFF
--- a/packages/manager/.changeset/pr-11121-fixed-1729174516467.md
+++ b/packages/manager/.changeset/pr-11121-fixed-1729174516467.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Memory leak error in `coverage:summary` job ([#11121](https://github.com/linode/manager/pull/11121))

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -106,7 +106,7 @@
     "cy:rec-snap": "cypress run --headless -b chrome --env visualRegMode=record --spec ./cypress/integration/**/*visual*.spec.ts",
     "typecheck": "tsc --noEmit && tsc -p cypress --noEmit",
     "coverage": "vitest run --coverage && open coverage/index.html",
-    "coverage:summary": "vitest run --coverage.enabled --reporter=junit --coverage.reporter=json-summary"
+    "coverage:summary": "vitest run --coverage.enabled --coverage.reporter=json-summary"
   },
   "lint-staged": {
     "*.{ts,tsx,js}": [


### PR DESCRIPTION
## Description 📝
Since merging https://github.com/linode/manager/pull/11049 I noticed an issue with the coverage failing often due a potential memory leak when the job starts. After doing a lot of profiling with vitest I wasn't able to find a culprit, and all tests are running just fine and it appears `coverage:summary` is the only one throwing this error (which could be a red herring too).

![Screenshot 2024-10-17 at 10 10 16](https://github.com/user-attachments/assets/18fbd62c-4db5-4fb6-8e62-23c8aac3835f)

Either way, removing the `junit` reporter and using default v8 reporter (like all other vitest jobs) gets rid of the issue and allows the coverage script to run smoothly.

## Changes  🔄
- Use default v8 reporter in `coverage:summary` job

## Target release date 🗓️
Please specify a release date to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## How to test 🧪

### Reproduction steps
- run `yarn coverage:summary` in current `develop` branch, notice the error after a few seconds of running the job, and sometimes getting test errors as a result

### Verification steps
- run `yarn coverage:summary` in this branch, notice no error and job succeeding reliably with v8 reporter

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
