### PR TITLE
feat: [UIE-8196] - DBaaS create encourage users to add IP allow_list

### DIFF
--- a/packages/manager/.changeset/pr-11124-upcoming-features-1729198459249.md
+++ b/packages/manager/.changeset/pr-11124-upcoming-features-1729198459249.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+DBaaS encourage setting access controls during create ([#11124](https://github.com/linode/manager/pull/11124))

--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.test.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent } from '@testing-library/react';
 import * as React from 'react';
 
 import { renderWithTheme } from 'src/utilities/testHelpers';
-
 import { MultipleIPInput } from './MultipleIPInput';
 
 const baseProps = {
@@ -51,5 +50,44 @@ describe('MultipleIPInput', () => {
       { address: 'ip1' },
       { address: 'ip3' },
     ]);
+  });
+
+  it('should enable all actions by default', async () => {
+    const props = {
+      ...baseProps,
+      ips: [{ address: 'ip1' }, { address: 'ip2' }],
+    };
+    const { getByTestId, getByLabelText, getByText } = renderWithTheme(
+      <MultipleIPInput {...props} />
+    );
+    const ip0 = getByLabelText('domain-transfer-ip-0');
+    const ip1 = getByLabelText('domain-transfer-ip-1');
+    const closeButton = getByTestId('delete-ip-1').closest('button');
+    const addButton = getByText('Add an IP').closest('button');
+
+    expect(ip0).toBeEnabled();
+    expect(ip1).toBeEnabled();
+    expect(closeButton).toBeEnabled();
+    expect(addButton).toBeEnabled();
+  });
+
+  it('should disable all actions', async () => {
+    const props = {
+      ...baseProps,
+      disabled: true,
+      ips: [{ address: 'ip1' }, { address: 'ip2' }],
+    };
+    const { getByTestId, getByLabelText, getByText } = renderWithTheme(
+      <MultipleIPInput {...props} />
+    );
+    const ip0 = getByLabelText('domain-transfer-ip-0');
+    const ip1 = getByLabelText('domain-transfer-ip-1');
+    const closeButton = getByTestId('delete-ip-1').closest('button');
+    const addButton = getByText('Add an IP').closest('button');
+
+    expect(ip0).toBeDisabled();
+    expect(ip1).toBeDisabled();
+    expect(closeButton).toBeDisabled();
+    expect(addButton).toBeDisabled();
   });
 });

--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
@@ -60,6 +60,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
 interface Props {
   buttonText?: string;
   className?: string;
+  disabled?: boolean;
   error?: string;
   forDatabaseAccessControls?: boolean;
   forVPCIPv4Ranges?: boolean;
@@ -78,6 +79,7 @@ export const MultipleIPInput = React.memo((props: Props) => {
   const {
     buttonText,
     className,
+    disabled,
     error,
     forDatabaseAccessControls,
     forVPCIPv4Ranges,
@@ -137,6 +139,7 @@ export const MultipleIPInput = React.memo((props: Props) => {
       buttonType="secondary"
       className={classes.addIP}
       compactX
+      disabled={disabled}
       onClick={addNewInput}
     >
       {buttonText ?? 'Add an IP'}
@@ -184,6 +187,7 @@ export const MultipleIPInput = React.memo((props: Props) => {
             <TextField
               InputProps={{
                 'aria-label': `${title} ip-address-${idx}`,
+                disabled,
                 ...props.inputProps,
               }}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -206,6 +210,7 @@ export const MultipleIPInput = React.memo((props: Props) => {
             {(idx > 0 || forDatabaseAccessControls || forVPCIPv4Ranges) && (
               <Button
                 className={classes.button}
+                disabled={disabled}
                 onClick={() => removeInput(idx)}
               >
                 <Close data-testid={`delete-ip-${idx}`} />

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -21,8 +21,6 @@ import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { FormControl } from 'src/components/FormControl';
 import { FormControlLabel } from 'src/components/FormControlLabel';
 import { LandingHeader } from 'src/components/LandingHeader';
-import { Link } from 'src/components/Link';
-import { MultipleIPInput } from 'src/components/MultipleIPInput/MultipleIPInput';
 import { Notice } from 'src/components/Notice/Notice';
 import { Paper } from 'src/components/Paper';
 import { Radio } from 'src/components/Radio/Radio';
@@ -47,7 +45,7 @@ import { useRegionsQuery } from 'src/queries/regions/regions';
 import { formatStorageUnits } from 'src/utilities/formatStorageUnits';
 import { handleAPIErrors } from 'src/utilities/formikErrorUtils';
 import { getSelectedOptionFromGroupedOptions } from 'src/utilities/getSelectedOptionFromGroupedOptions';
-import { ipFieldPlaceholder, validateIPs } from 'src/utilities/ipUtils';
+import { validateIPs } from 'src/utilities/ipUtils';
 import { scrollErrorIntoViewV2 } from 'src/utilities/scrollErrorIntoViewV2';
 
 import type {
@@ -64,6 +62,7 @@ import type { Theme } from '@mui/material/styles';
 import type { Item } from 'src/components/EnhancedSelect/Select';
 import type { PlanSelectionType } from 'src/features/components/PlansPanel/types';
 import type { ExtendedIP } from 'src/utilities/ipUtils';
+import { DatabaseCreateAccessControls } from './DatabaseCreateAccessControls';
 
 const useStyles = makeStyles()((theme: Theme) => ({
   btnCtn: {
@@ -622,44 +621,12 @@ const DatabaseCreate = () => {
           </FormControl>
         </Grid>
         <Divider spacingBottom={12} spacingTop={26} />
-        <Grid>
-          <Typography style={{ marginBottom: 4 }} variant="h2">
-            Add Access Controls
-          </Typography>
-          <Typography>
-            Add any IPv4 address or range that should be authorized to access
-            this cluster.
-          </Typography>
-          <Typography>
-            By default, all public and private connections are denied.{' '}
-            <Link to="https://techdocs.akamai.com/cloud-computing/docs/manage-access-controls">
-              Learn more
-            </Link>
-            .
-          </Typography>
-          <Typography style={{ marginTop: 16 }}>
-            You can add or modify access controls after your database cluster is
-            active.{' '}
-          </Typography>
-          <Grid style={{ marginTop: 24, maxWidth: 450 }}>
-            {ipErrorsFromAPI
-              ? ipErrorsFromAPI.map((apiError: APIError) => (
-                  <Notice
-                    key={apiError.reason}
-                    text={apiError.reason}
-                    variant="error"
-                  />
-                ))
-              : null}
-            <MultipleIPInput
-              ips={values.allow_list}
-              onBlur={handleIPBlur}
-              onChange={(address) => setFieldValue('allow_list', address)}
-              placeholder={ipFieldPlaceholder}
-              title="Allowed IP Address(es) or Range(s)"
-            />
-          </Grid>
-        </Grid>
+        <DatabaseCreateAccessControls
+          errors={ipErrorsFromAPI}
+          ips={values.allow_list}
+          onBlur={handleIPBlur}
+          onChange={(ips: ExtendedIP[]) => setFieldValue('allow_list', ips)}
+        />
       </Paper>
       <Grid className={classes.btnCtn}>
         <Typography className={classes.createText}>

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreateAccessControls.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreateAccessControls.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent } from '@testing-library/react';
+import React from 'react';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import { DatabaseCreateAccessControls } from './DatabaseCreateAccessControls';
+import { IsDatabasesEnabled, useIsDatabasesEnabled } from '../utilities';
+
+vi.mock('src/features/Databases/utilities');
+
+describe('DatabaseCreateAccessControls', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('Should render enabled', () => {
+    vi.mocked(useIsDatabasesEnabled).mockReturnValue({
+      isDatabasesV2GA: true,
+    } as IsDatabasesEnabled);
+
+    const ips = [{ address: '' }];
+    const { container, getAllByText, getAllByTestId } = renderWithTheme(
+      <DatabaseCreateAccessControls
+        ips={ips}
+        onBlur={() => {}}
+        onChange={() => {}}
+      />
+    );
+
+    expect(getAllByText('Add Access Controls')).toHaveLength(1);
+    expect(getAllByTestId('domain-transfer-input')).toHaveLength(1);
+    expect(getAllByTestId('button')).toHaveLength(1);
+
+    const specificRadio = container.querySelector(
+      '[data-qa-dbaas-radio="Specific"]'
+    );
+    const noneRadio = container.querySelector('[data-qa-dbaas-radio="None"]');
+    const enabledButtons = container.querySelectorAll(
+      '[aria-disabled="false"]'
+    );
+
+    expect(specificRadio).toBeInTheDocument();
+    expect(noneRadio).toBeInTheDocument();
+    expect(enabledButtons).toHaveLength(1);
+  });
+
+  it('Should render ips', () => {
+    vi.mocked(useIsDatabasesEnabled).mockReturnValue({
+      isDatabasesV2GA: true,
+    } as IsDatabasesEnabled);
+
+    const ips = [
+      { address: '1.1.1.1/32' },
+      { address: '2.2.2.2' },
+      { address: '3.3.3.3/128' },
+    ];
+    const { container, getAllByText, getAllByTestId } = renderWithTheme(
+      <DatabaseCreateAccessControls
+        ips={ips}
+        onBlur={() => {}}
+        onChange={() => {}}
+      />
+    );
+
+    expect(getAllByText('Add Access Controls')).toHaveLength(1);
+    expect(getAllByTestId('domain-transfer-input')).toHaveLength(3);
+    expect(getAllByTestId('button')).toHaveLength(3);
+
+    const specificRadio = container.querySelector(
+      '[data-qa-dbaas-radio="Specific"]'
+    );
+    const noneRadio = container.querySelector('[data-qa-dbaas-radio="None"]');
+    const enabledButtons = container.querySelectorAll(
+      '[aria-disabled="false"]'
+    );
+
+    expect(specificRadio).toBeInTheDocument();
+    expect(noneRadio).toBeInTheDocument();
+    expect(enabledButtons).toHaveLength(3);
+  });
+
+  it('Should disable ips', () => {
+    vi.mocked(useIsDatabasesEnabled).mockReturnValue({
+      isDatabasesV2GA: true,
+    } as IsDatabasesEnabled);
+
+    const ips = [{ address: '1.1.1.1/32' }];
+    const { container, getAllByText, getAllByTestId } = renderWithTheme(
+      <DatabaseCreateAccessControls
+        ips={ips}
+        onBlur={() => {}}
+        onChange={() => {}}
+      />
+    );
+
+    expect(getAllByText('Add Access Controls')).toHaveLength(1);
+    expect(getAllByTestId('domain-transfer-input')).toHaveLength(1);
+    expect(getAllByTestId('button')).toHaveLength(1);
+
+    let enabledButtons = container.querySelectorAll('[aria-disabled="false"]');
+    expect(enabledButtons).toHaveLength(1);
+
+    const noneRadio = container.querySelector('[data-qa-dbaas-radio="None"]');
+    fireEvent.click(noneRadio as Element);
+
+    enabledButtons = container.querySelectorAll('[aria-disabled="false"]');
+    expect(enabledButtons).toHaveLength(0);
+  });
+});

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreateAccessControls.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreateAccessControls.tsx
@@ -1,0 +1,144 @@
+import type { APIError } from '@linode/api-v4/lib/types';
+import { Theme } from '@mui/material/styles';
+import Grid from '@mui/material/Unstable_Grid2';
+import * as React from 'react';
+import { ChangeEvent, useState } from 'react';
+import { FormControlLabel } from 'src/components/FormControlLabel';
+import { Link } from 'src/components/Link';
+import { MultipleIPInput } from 'src/components/MultipleIPInput/MultipleIPInput';
+import { Notice } from 'src/components/Notice/Notice';
+import { Radio } from 'src/components/Radio/Radio';
+import { RadioGroup } from 'src/components/RadioGroup';
+import { Typography } from 'src/components/Typography';
+import { ExtendedIP, ipFieldPlaceholder } from 'src/utilities/ipUtils';
+import { makeStyles } from 'tss-react/mui';
+import { useIsDatabasesEnabled } from '../utilities';
+
+const useStyles = makeStyles()((theme: Theme) => ({
+  header: {
+    marginBottom: theme.spacing(0.5),
+  },
+  subHeader: {
+    marginTop: theme.spacing(2),
+  },
+  container: {
+    marginTop: theme.spacing(3),
+    maxWidth: 450,
+  },
+  multipleIPInput: {
+    marginLeft: theme.spacing(4),
+  },
+}));
+
+export type AccessOption = 'specific' | 'none';
+
+interface Props {
+  errors?: APIError[];
+  ips: ExtendedIP[];
+  onBlur: (ips: ExtendedIP[]) => void;
+  onChange: (ips: ExtendedIP[]) => void;
+}
+
+export const DatabaseCreateAccessControls = (props: Props) => {
+  const { errors, ips, onBlur, onChange } = props;
+  const { classes } = useStyles();
+  const [accessOption, setAccessOption] = useState<AccessOption>('specific');
+  const { isDatabasesV2GA } = useIsDatabasesEnabled();
+
+  const handleAccessOptionChange = (_: ChangeEvent, value: AccessOption) => {
+    setAccessOption(value);
+    if (value === 'none') {
+      onChange([{ address: '', error: '' }]);
+    }
+  };
+
+  return (
+    <Grid>
+      <Typography className={classes.header} variant="h2">
+        Add Access Controls
+      </Typography>
+      {isDatabasesV2GA ? (
+        <>
+          <Typography>
+            Add IPv4 addresses or ranges that should be authorized to access
+            this cluster. 
+            <Link to="https://techdocs.akamai.com/cloud-computing/docs/manage-access-controls">
+              Learn more
+            </Link>
+            .
+          </Typography>
+          <Typography className={classes.subHeader}>
+            (Note: You can modify access controls after your database cluster is
+            active.)
+          </Typography>
+        </>
+      ) : (
+        <>
+          <Typography>
+            Add any IPv4 address or range that should be authorized to access
+            this cluster.
+          </Typography>
+          <Typography>
+            By default, all public and private connections are denied.{' '}
+            <Link to="https://techdocs.akamai.com/cloud-computing/docs/manage-access-controls">
+              Learn more
+            </Link>
+            .
+          </Typography>
+          <Typography className={classes.subHeader}>
+            You can add or modify access controls after your database cluster is
+            active.{' '}
+          </Typography>
+        </>
+      )}
+      <Grid className={classes.container}>
+        {errors &&
+          errors.map((apiError: APIError) => (
+            <Notice
+              key={apiError.reason}
+              text={apiError.reason}
+              variant="error"
+            />
+          ))}
+        {isDatabasesV2GA ? (
+          <RadioGroup
+            aria-label="type"
+            name="type"
+            onChange={handleAccessOptionChange}
+            value={accessOption}
+          >
+            <FormControlLabel
+              control={<Radio />}
+              data-qa-dbaas-radio="Specific"
+              label="Specific Access (recommended)"
+              value="specific"
+            />
+            <MultipleIPInput
+              className={classes.multipleIPInput}
+              disabled={accessOption === 'none'}
+              ips={ips}
+              onBlur={onBlur}
+              onChange={onChange}
+              placeholder={ipFieldPlaceholder}
+              title="Allowed IP Address(es) or Range(s)"
+            />
+            <FormControlLabel
+              control={<Radio />}
+              data-qa-dbaas-radio="None"
+              label="No Access (Deny connections from all IP addresses)"
+              value="none"
+            />
+          </RadioGroup>
+        ) : (
+          <MultipleIPInput
+            ips={ips}
+            onBlur={onBlur}
+            onChange={onChange}
+            placeholder={ipFieldPlaceholder}
+            title="Allowed IP Address(es) or Range(s)"
+          />
+        )}
+      </Grid>
+    </Grid>
+  );
+};


### PR DESCRIPTION
## Description 📝
DBaaS create encourage users to add IP allow_list

## Changes  🔄
- Access Controls are now wrapped in a radio button group
- User has to explicitly select "None" when adding allow lists
- Add disable prop to MultipleIPInput component to disable all actions with tests
- Refactored the AccessControl from the create page for increased modularity, added tests.

## Target release date 🗓️
10/28/24

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-10-17 at 4 23 20 PM](https://github.com/user-attachments/assets/d97b5d0c-5b2d-466d-ab24-2d2d40beb729) | ![Screenshot 2024-10-17 at 4 22 31 PM](https://github.com/user-attachments/assets/13dbc464-157f-468f-b673-70ad65e69a72) | 
| ![Screenshot 2024-10-17 at 4 26 35 PM](https://github.com/user-attachments/assets/db1d5360-6d6e-481b-8eed-9711cd7caa6a)

## How to test 🧪

### Prerequisites
- Managed Databases account access
- dbaasV2 flag enabled

### Reproduction steps
- Got to the create page

### Verification steps
- There is a radio group option

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
