### PR TITLE
change: [M3-8533, M3-8761] - Fix firewall rules table and Replace `react-beautiful-dnd` with `dnd-kit` lib

### DIFF
--- a/packages/manager/.changeset/pr-11109-fixed-1729070494828.md
+++ b/packages/manager/.changeset/pr-11109-fixed-1729070494828.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Broken firewall rules table ([#11109](https://github.com/linode/manager/pull/11109))

--- a/packages/manager/.changeset/pr-11109-fixed-1729070494828.md
+++ b/packages/manager/.changeset/pr-11109-fixed-1729070494828.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Broken firewall rules table ([#11109](https://github.com/linode/manager/pull/11109))

--- a/packages/manager/.changeset/pr-11127-changed-1729515938754.md
+++ b/packages/manager/.changeset/pr-11127-changed-1729515938754.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Replace `react-beautiful-dnd` with `dnd-kit` library ([#11127](https://github.com/linode/manager/pull/11127))

--- a/packages/manager/.changeset/pr-11127-fixed-1729515738287.md
+++ b/packages/manager/.changeset/pr-11127-fixed-1729515738287.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Broken firewall rules table ([#11127](https://github.com/linode/manager/pull/11127))

--- a/packages/manager/.changeset/pr-11127-fixed-1730275015638.md
+++ b/packages/manager/.changeset/pr-11127-fixed-1730275015638.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Table component styling issue for `noOverflow` property ([#11127](https://github.com/linode/manager/pull/11127))

--- a/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
@@ -222,7 +222,7 @@ describe('update firewall', () => {
       // Confirm that the inbound rules are listed on edit page with expected configuration
       cy.findByText(inboundRule.label!)
         .should('be.visible')
-        .closest('li')
+        .closest('tr')
         .within(() => {
           cy.findByText(inboundRule.protocol).should('be.visible');
           cy.findByText(inboundRule.ports!).should('be.visible');
@@ -237,7 +237,7 @@ describe('update firewall', () => {
       // Confirm that the outbound rules are listed on edit page with expected configuration
       cy.findByText(outboundRule.label!)
         .should('be.visible')
-        .closest('li')
+        .closest('tr')
         .within(() => {
           cy.findByText(outboundRule.protocol).should('be.visible');
           cy.findByText(outboundRule.ports!).should('be.visible');

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -64,7 +64,6 @@
     "qrcode.react": "^0.8.0",
     "ramda": "~0.25.0",
     "react": "^18.2.0",
-    "react-beautiful-dnd": "^13.0.0",
     "react-csv": "^2.0.3",
     "react-dom": "^18.2.0",
     "react-dropzone": "~11.2.0",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -14,6 +14,9 @@
     "url": "https://github.com/Linode/manager.git"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.1.0",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@hookform/resolvers": "2.9.11",

--- a/packages/manager/src/components/Table/Table.styles.ts
+++ b/packages/manager/src/components/Table/Table.styles.ts
@@ -13,27 +13,26 @@ export const StyledTableWrapper = styled('div', {
     'spacingTop',
   ]),
 })<TableProps>(({ theme, ...props }) => ({
+  '& thead': {
+    '& th': {
+      '&:first-of-type': {
+        borderLeft: 'none',
+      },
+      '&:last-of-type': {
+        borderRight: 'none',
+      },
+      backgroundColor: theme.bg.tableHeader,
+      borderBottom: `1px solid ${theme.borderColors.borderTable}`,
+      borderRight: `1px solid ${theme.borderColors.borderTable}`,
+      borderTop: `1px solid ${theme.borderColors.borderTable}`,
+      fontFamily: theme.font.bold,
+      padding: '10px 15px',
+    },
+  },
   marginBottom: props.spacingBottom !== undefined ? props.spacingBottom : 0,
   marginTop: props.spacingTop !== undefined ? props.spacingTop : 0,
-  ...(!props.noOverflow && {
-    '& thead': {
-      '& th': {
-        '&:first-of-type': {
-          borderLeft: 'none',
-        },
-        '&:last-of-type': {
-          borderRight: 'none',
-        },
-        backgroundColor: theme.bg.tableHeader,
-        borderBottom: `1px solid ${theme.borderColors.borderTable}`,
-        borderRight: `1px solid ${theme.borderColors.borderTable}`,
-        borderTop: `1px solid ${theme.borderColors.borderTable}`,
-        fontFamily: theme.font.bold,
-        padding: '10px 15px',
-      },
-    },
-    overflowX: 'auto',
-    overflowY: 'hidden',
+  ...(props.noOverflow && {
+    overflow: 'hidden',
   }),
   ...(props.noBorder && {
     '& thead th': {

--- a/packages/manager/src/components/Table/Table.styles.ts
+++ b/packages/manager/src/components/Table/Table.styles.ts
@@ -31,8 +31,9 @@ export const StyledTableWrapper = styled('div', {
   },
   marginBottom: props.spacingBottom !== undefined ? props.spacingBottom : 0,
   marginTop: props.spacingTop !== undefined ? props.spacingTop : 0,
-  ...(props.noOverflow && {
-    overflow: 'hidden',
+  ...(!props.noOverflow && {
+    overflowX: 'auto',
+    overflowY: 'hidden',
   }),
   ...(props.noBorder && {
     '& thead th': {

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
@@ -74,6 +74,7 @@ export const StyledHeaderItemBox = styled(Box, {
   borderLeft: `1px solid ${theme.borderColors.borderTable}`,
   borderTop: `1px solid ${theme.borderColors.borderTable}`,
   height: '46px',
+  lineHeight: '12px',
   padding: '10px 15px',
 }));
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
@@ -25,7 +25,6 @@ export const StyledTableRow = styled(TableRow, {
   shouldForwardProp: omittedProps(['originalIndex', 'ruleIndex']),
 })<StyledFirewallRuleTableRowProps>(
   ({ disabled, originalIndex, ruleIndex, status, theme }) => ({
-    cursor: 'grab',
     // Conditional styles
     // Highlight the row if it's been modified or reordered. ruleIndex is the current index,
     // so if it doesn't match the original index we know that the rule has been moved.

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
@@ -35,6 +35,8 @@ export const StyledFirewallRuleBox = styled(Box, {
 })<StyledFirewallRuleBoxProps>(
   ({ disabled, originalIndex, ruleId, status, theme }) => ({
     borderBottom: `1px solid ${theme.borderColors.borderTable}`,
+    borderLeft: `1px solid ${theme.borderColors.borderTable}`,
+    borderRight: `1px solid ${theme.borderColors.borderTable}`,
     color: theme.textColors.tableStatic,
     fontSize: '0.875rem',
     margin: 0,
@@ -59,12 +61,24 @@ export const StyledFirewallRuleBox = styled(Box, {
 export const StyledInnerBox = styled(Box, { label: 'StyledInnerBox' })(
   ({ theme }) => ({
     backgroundColor: theme.bg.tableHeader,
-    color: theme.textColors.tableHeader,
     fontFamily: theme.font.bold,
     fontSize: '.875rem',
-    height: '46px',
   })
 );
+
+export const StyledHeaderItemBox = styled(Box, {
+  label: 'StyledHeaderItemBox',
+})(({ theme }) => ({
+  ...sxItemSpacing,
+  '&:first-child': {
+    borderLeft: `1px solid ${theme.borderColors.borderTable}`,
+  },
+  alignContent: 'center',
+  borderBottom: `1px solid ${theme.borderColors.borderTable}`,
+  borderRight: `1px solid ${theme.borderColors.borderTable}`,
+  borderTop: `1px solid ${theme.borderColors.borderTable}`,
+  height: '46px',
+}));
 
 export const StyledUlBox = styled(Box, { label: 'StyledUlBox' })(
   ({ theme }) => ({

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
@@ -4,7 +4,6 @@ import { styled } from '@mui/material/styles';
 import DragIndicator from 'src/assets/icons/drag-indicator.svg';
 import { Button } from 'src/components/Button/Button';
 import { StyledLinkButton } from 'src/components/Button/StyledLinkButton';
-import { Table } from 'src/components/Table';
 import { TableRow } from 'src/components/TableRow';
 
 import type { FirewallRuleTableRowProps } from './FirewallRuleTable';
@@ -20,11 +19,6 @@ interface StyledFirewallRuleTableRowProps
   extends FirewallRuleTableRowPropsWithRuleIndex {
   status: FirewallRuleTableRowProps['status'];
 }
-
-export const StyledTable = styled(Table, { label: 'StyledTable' })(() => ({
-  // Prevents horizontal scrolling while dragging rows.
-  overflow: 'hidden',
-}));
 
 export const StyledTableRow = styled(TableRow, {
   label: 'StyledTableRow',

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
@@ -19,6 +19,7 @@ interface StyledFirewallRuleTableRowProps
   status: FirewallRuleTableRowProps['status'];
 }
 
+// Note: Use 'tr' instead of 'TableRow' here for a smoother draggable user experience.
 export const StyledTableRow = styled('tr', {
   label: 'StyledTableRow',
   shouldForwardProp: omittedProps(['originalIndex', 'ruleIndex']),

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
@@ -4,6 +4,7 @@ import { styled } from '@mui/material/styles';
 import DragIndicator from 'src/assets/icons/drag-indicator.svg';
 import { Button } from 'src/components/Button/Button';
 import { StyledLinkButton } from 'src/components/Button/StyledLinkButton';
+import { Table } from 'src/components/Table';
 import { TableRow } from 'src/components/TableRow';
 
 import type { FirewallRuleTableRowProps } from './FirewallRuleTable';
@@ -19,6 +20,11 @@ interface StyledFirewallRuleTableRowProps
   extends FirewallRuleTableRowPropsWithRuleIndex {
   status: FirewallRuleTableRowProps['status'];
 }
+
+export const StyledTable = styled(Table, { label: 'StyledTable' })(() => ({
+  // Prevents horizontal scrolling while dragging rows.
+  overflow: 'hidden',
+}));
 
 export const StyledTableRow = styled(TableRow, {
   label: 'StyledTableRow',

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
@@ -4,42 +4,30 @@ import { styled } from '@mui/material/styles';
 import DragIndicator from 'src/assets/icons/drag-indicator.svg';
 import { Button } from 'src/components/Button/Button';
 import { StyledLinkButton } from 'src/components/Button/StyledLinkButton';
+import { TableRow } from 'src/components/TableRow';
 
 import type { FirewallRuleTableRowProps } from './FirewallRuleTable';
 
 type StyledFirewallRuleButtonProps = Pick<FirewallRuleTableRowProps, 'status'>;
 
-interface FirewallRuleTableRowPropsWithRuleId
+interface FirewallRuleTableRowPropsWithRuleIndex
   extends Pick<FirewallRuleTableRowProps, 'disabled' | 'originalIndex'> {
-  ruleId: number;
+  ruleIndex: number;
 }
 
-interface StyledFirewallRuleBoxProps
-  extends FirewallRuleTableRowPropsWithRuleId {
+interface StyledFirewallRuleTableRowProps
+  extends FirewallRuleTableRowPropsWithRuleIndex {
   status: FirewallRuleTableRowProps['status'];
 }
 
-export const sxBox = {
-  alignItems: 'center',
-  display: 'flex',
-  width: '100%',
-};
-
-export const StyledFirewallRuleBox = styled(Box, {
-  label: 'StyledFirewallRuleBox',
-  shouldForwardProp: omittedProps(['originalIndex', 'ruleId']),
-})<StyledFirewallRuleBoxProps>(
-  ({ disabled, originalIndex, ruleId, status, theme }) => ({
-    borderBottom: `1px solid ${theme.borderColors.borderTable}`,
-    borderLeft: `1px solid ${theme.borderColors.borderTable}`,
-    borderRight: `1px solid ${theme.borderColors.borderTable}`,
-    color: theme.textColors.tableStatic,
-    fontSize: '0.875rem',
-    margin: 0,
-    ...sxBox,
-
+export const StyledTableRow = styled(TableRow, {
+  label: 'StyledTableRow',
+  shouldForwardProp: omittedProps(['originalIndex', 'ruleIndex']),
+})<StyledFirewallRuleTableRowProps>(
+  ({ disabled, originalIndex, ruleIndex, status, theme }) => ({
+    cursor: 'grab',
     // Conditional styles
-    // Highlight the row if it's been modified or reordered. ID is the current index,
+    // Highlight the row if it's been modified or reordered. ruleIndex is the current index,
     // so if it doesn't match the original index we know that the rule has been moved.
     ...(status === 'PENDING_DELETION' || disabled
       ? {
@@ -47,7 +35,7 @@ export const StyledFirewallRuleBox = styled(Box, {
           backgroundColor: 'rgba(247, 247, 247, 0.25)',
         }
       : {}),
-    ...(status === 'MODIFIED' || status === 'NEW' || originalIndex !== ruleId
+    ...(status === 'MODIFIED' || status === 'NEW' || originalIndex !== ruleIndex
       ? { backgroundColor: theme.bg.lightBlue1 }
       : {}),
     ...(status === 'NOT_MODIFIED' ? { backgroundColor: theme.bg.bgPaper } : {}),
@@ -59,51 +47,6 @@ export const StyledInnerBox = styled(Box, { label: 'StyledInnerBox' })(
     backgroundColor: theme.bg.tableHeader,
     fontFamily: theme.font.bold,
     fontSize: '.875rem',
-  })
-);
-
-export const StyledHeaderItemBox = styled(Box, {
-  label: 'StyledHeaderItemBox',
-})(({ theme }) => ({
-  '&:last-child': {
-    borderRight: `1px solid ${theme.borderColors.borderTable}`,
-    paddingRight: '0px',
-  },
-  alignContent: 'center',
-  borderBottom: `1px solid ${theme.borderColors.borderTable}`,
-  borderLeft: `1px solid ${theme.borderColors.borderTable}`,
-  borderTop: `1px solid ${theme.borderColors.borderTable}`,
-  height: '46px',
-  lineHeight: '12px',
-  padding: '10px 15px',
-}));
-
-export const StyledCellItemBox = styled(Box, {
-  label: 'StyledCellItemBox',
-})(({ theme }) => ({
-  '&:not(:last-child)': {
-    padding: '0px 15px',
-  },
-  alignContent: 'center',
-  minHeight: '40px',
-  [theme.breakpoints.down('sm')]: {
-    '&:last-child': {
-      paddingLeft: '15px',
-    },
-  },
-}));
-
-export const StyledUlBox = styled(Box, { label: 'StyledUlBox' })(
-  ({ theme }) => ({
-    alignItems: 'center',
-    backgroundColor: theme.bg.bgPaper,
-    borderBottom: `1px solid ${theme.borderColors.borderTable}`,
-    color: theme.textColors.tableStatic,
-    display: 'flex',
-    fontSize: '0.875rem',
-    justifyContent: 'center',
-    padding: theme.spacing(1),
-    width: '100%',
   })
 );
 
@@ -165,12 +108,4 @@ export const StyledDragIndicator = styled(DragIndicator, {
   marginRight: theme.spacing(1.5),
   position: 'relative',
   top: 2,
-}));
-
-export const StyledUl = styled('ul', { label: 'StyledUl' })(({ theme }) => ({
-  backgroundColor: theme.color.border3,
-  listStyle: 'none',
-  margin: 0,
-  paddingLeft: 0,
-  width: '100%',
 }));

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
@@ -25,10 +25,6 @@ export const sxBox = {
   width: '100%',
 };
 
-export const sxItemSpacing = {
-  padding: `0 8px`,
-};
-
 export const StyledFirewallRuleBox = styled(Box, {
   label: 'StyledFirewallRuleBox',
   shouldForwardProp: omittedProps(['originalIndex', 'ruleId']),
@@ -69,15 +65,27 @@ export const StyledInnerBox = styled(Box, { label: 'StyledInnerBox' })(
 export const StyledHeaderItemBox = styled(Box, {
   label: 'StyledHeaderItemBox',
 })(({ theme }) => ({
-  ...sxItemSpacing,
-  '&:first-child': {
-    borderLeft: `1px solid ${theme.borderColors.borderTable}`,
+  '&:last-child': {
+    borderRight: `1px solid ${theme.borderColors.borderTable}`,
+    paddingRight: '0px',
   },
   alignContent: 'center',
   borderBottom: `1px solid ${theme.borderColors.borderTable}`,
-  borderRight: `1px solid ${theme.borderColors.borderTable}`,
+  borderLeft: `1px solid ${theme.borderColors.borderTable}`,
   borderTop: `1px solid ${theme.borderColors.borderTable}`,
   height: '46px',
+  padding: '10px 15px',
+}));
+
+export const StyledCellItemBox = styled(Box, {
+  label: 'StyledCellItemBox',
+})(() => ({
+  '&:last-child': {
+    paddingRight: '0px',
+  },
+  alignContent: 'center',
+  minHeight: '40px',
+  padding: '0px 15px',
 }));
 
 export const StyledUlBox = styled(Box, { label: 'StyledUlBox' })(

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
@@ -4,7 +4,6 @@ import { styled } from '@mui/material/styles';
 import DragIndicator from 'src/assets/icons/drag-indicator.svg';
 import { Button } from 'src/components/Button/Button';
 import { StyledLinkButton } from 'src/components/Button/StyledLinkButton';
-import { TableRow } from 'src/components/TableRow';
 
 import type { FirewallRuleTableRowProps } from './FirewallRuleTable';
 
@@ -20,7 +19,7 @@ interface StyledFirewallRuleTableRowProps
   status: FirewallRuleTableRowProps['status'];
 }
 
-export const StyledTableRow = styled(TableRow, {
+export const StyledTableRow = styled('tr', {
   label: 'StyledTableRow',
   shouldForwardProp: omittedProps(['originalIndex', 'ruleIndex']),
 })<StyledFirewallRuleTableRowProps>(

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
@@ -86,6 +86,11 @@ export const StyledCellItemBox = styled(Box, {
   },
   alignContent: 'center',
   minHeight: '40px',
+  [theme.breakpoints.down('sm')]: {
+    '&:last-child': {
+      paddingLeft: '15px',
+    },
+  },
 }));
 
 export const StyledUlBox = styled(Box, { label: 'StyledUlBox' })(

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
@@ -80,13 +80,12 @@ export const StyledHeaderItemBox = styled(Box, {
 
 export const StyledCellItemBox = styled(Box, {
   label: 'StyledCellItemBox',
-})(() => ({
-  '&:last-child': {
-    paddingRight: '0px',
+})(({ theme }) => ({
+  '&:not(:last-child)': {
+    padding: '0px 15px',
   },
   alignContent: 'center',
   minHeight: '40px',
-  padding: '0px 15px',
 }));
 
 export const StyledUlBox = styled(Box, { label: 'StyledUlBox' })(

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.styles.ts
@@ -29,10 +29,7 @@ export const StyledTableRow = styled(TableRow, {
     // Highlight the row if it's been modified or reordered. ruleIndex is the current index,
     // so if it doesn't match the original index we know that the rule has been moved.
     ...(status === 'PENDING_DELETION' || disabled
-      ? {
-          '& td': { color: '#D2D3D4' },
-          backgroundColor: 'rgba(247, 247, 247, 0.25)',
-        }
+      ? { backgroundColor: theme.color.grey7 }
       : {}),
     ...(status === 'MODIFIED' || status === 'NEW' || originalIndex !== ruleIndex
       ? { backgroundColor: theme.bg.lightBlue1 }
@@ -51,15 +48,10 @@ export const StyledInnerBox = styled(Box, { label: 'StyledInnerBox' })(
 
 export const StyledFirewallRuleButton = styled('button', {
   label: 'StyledFirewallRuleButton',
-})<StyledFirewallRuleButtonProps>(({ status, theme }) => ({
+})<StyledFirewallRuleButtonProps>(() => ({
   backgroundColor: 'transparent',
   border: 'none',
   cursor: 'pointer',
-
-  // Conditional styles
-  ...(status !== 'PENDING_DELETION'
-    ? { backgroundColor: theme.bg.lightBlue1 }
-    : {}),
 }));
 
 export const StyledFirewallTableButton = styled(Button, {

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.test.tsx
@@ -1,5 +1,6 @@
 import { firewallRuleToRowData } from './FirewallRuleTable';
-import { ExtendedFirewallRule } from './firewallRuleEditor';
+
+import type { ExtendedFirewallRule } from './firewallRuleEditor';
 
 describe('Firewall rule table tests', () => {
   describe('firewallRuleToRowData', () => {

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -165,7 +165,7 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
               {capitalize(addressColumnLabel)}
             </StyledHeaderItemBox>
           </Hidden>
-          <StyledHeaderItemBox sx={{ width: xsDown ? '30%' : '10%' }}>
+          <StyledHeaderItemBox sx={{ width: xsDown ? '30%' : '12%' }}>
             Action
           </StyledHeaderItemBox>
           <StyledHeaderItemBox flexGrow={1} />
@@ -339,7 +339,7 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
       </Hidden>
       <StyledCellItemBox
         aria-label={`Action: ${action}`}
-        sx={{ width: xsDown ? '30%' : '10%' }}
+        sx={{ width: xsDown ? '30%' : '12%' }}
       >
         {capitalize(action?.toLocaleLowerCase() ?? '')}
       </StyledCellItemBox>
@@ -400,12 +400,12 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
     display: 'grid',
     fontSize: '.875rem',
     gridTemplateAreas: `'one two three four five six'`,
-    gridTemplateColumns: '30% 10% 10% 14% 10% 120px',
+    gridTemplateColumns: '30% 10% 10% 14% 12% 120px',
     height: '40px',
     marginTop: '10px',
     [theme.breakpoints.down('lg')]: {
       gridTemplateAreas: `'one two three four five'`,
-      gridTemplateColumns: '30% 14% 20% 10% 120px',
+      gridTemplateColumns: '30% 14% 20% 12% 120px',
     },
     [theme.breakpoints.down('sm')]: {
       gridTemplateAreas: `'one two'`,

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -193,7 +193,6 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
                 <Hidden smDown>
                   <TableCell sx={{ width: '15%' }}>Port Range</TableCell>
                   <TableCell sx={{ width: '15%' }}>
-                    {' '}
                     {capitalize(addressColumnLabel)}
                   </TableCell>
                 </Hidden>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -27,6 +27,7 @@ import {
   StyledFirewallRuleButton,
   StyledFirewallTableButton,
   StyledHeaderDiv,
+  StyledHeaderItemBox,
   StyledInnerBox,
   StyledUl,
   StyledUlBox,
@@ -40,7 +41,6 @@ import type { ExtendedFirewallRule, RuleStatus } from './firewallRuleEditor';
 import type { Category, FirewallRuleError } from './shared';
 import type { FirewallPolicyType } from '@linode/api-v4/lib/firewalls/types';
 import type { Theme } from '@mui/material/styles';
-import type { DropResult } from 'react-beautiful-dnd';
 import type { FirewallOptionItem } from 'src/features/Firewalls/shared';
 
 interface RuleRow {
@@ -98,6 +98,7 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
 
   const theme: Theme = useTheme();
   const xsDown = useMediaQuery(theme.breakpoints.down('sm'));
+  const betweenSmAndLg = useMediaQuery(theme.breakpoints.between('sm', 'lg'));
 
   const addressColumnLabel =
     category === 'inbound' ? 'sources' : 'destinations';
@@ -144,32 +145,31 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
           sx={sxBox}
           tabIndex={0}
         >
-          <Box
+          <StyledHeaderItemBox
             sx={{
-              ...sxItemSpacing,
               paddingLeft: '27px',
-              width: xsDown ? '50%' : '32%',
+              width: xsDown ? '50%' : '30%',
             }}
           >
             Label
-          </Box>
+          </StyledHeaderItemBox>
           <Hidden lgDown>
-            <Box sx={{ ...sxItemSpacing, width: '10%' }}>Protocol</Box>
+            <StyledHeaderItemBox sx={{ width: '10%' }}>
+              Protocol
+            </StyledHeaderItemBox>
           </Hidden>
           <Hidden smDown>
-            <Box
-              sx={{
-                ...sxItemSpacing,
-                width: '15%',
-              }}
-            >
+            <StyledHeaderItemBox sx={{ width: betweenSmAndLg ? '14%' : '10%' }}>
               Port Range
-            </Box>
-            <Box sx={{ ...sxItemSpacing, width: '15%' }}>
+            </StyledHeaderItemBox>
+            <StyledHeaderItemBox sx={{ width: betweenSmAndLg ? '20%' : '14%' }}>
               {capitalize(addressColumnLabel)}
-            </Box>
+            </StyledHeaderItemBox>
           </Hidden>
-          <Box sx={{ ...sxItemSpacing, width: '5%' }}>Action</Box>
+          <StyledHeaderItemBox sx={{ width: xsDown ? '30%' : '10%' }}>
+            Action
+          </StyledHeaderItemBox>
+          <StyledHeaderItemBox sx={{ width: xsDown ? '20%' : '26%' }} />
         </StyledInnerBox>
         <Box sx={{ ...sxBox, flexDirection: 'column' }}>
           <DragDropContext onDragEnd={onDragEnd}>
@@ -256,6 +256,7 @@ export interface FirewallRuleTableRowProps extends RuleRow {
 const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
   const theme: Theme = useTheme();
   const xsDown = useMediaQuery(theme.breakpoints.down('sm'));
+  const betweenSmAndLg = useMediaQuery(theme.breakpoints.between('sm', 'lg'));
 
   const {
     action,
@@ -296,7 +297,7 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
           ...sxItemSpacing,
           overflowWrap: 'break-word',
           paddingLeft: '8px',
-          width: xsDown ? '50%' : '32%',
+          width: xsDown ? '50%' : '30%',
         }}
         aria-label={`Label: ${label}`}
       >
@@ -322,14 +323,18 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
       <Hidden smDown>
         <Box
           aria-label={`Ports: ${ports}`}
-          sx={{ ...sxItemSpacing, width: '15%' }}
+          sx={{ ...sxItemSpacing, width: betweenSmAndLg ? '14%' : '10%' }}
         >
           {ports === '1-65535' ? 'All Ports' : ports}
           <ConditionalError errors={errors} formField="ports" />
         </Box>
         <Box
+          sx={{
+            ...sxItemSpacing,
+            overflowWrap: 'break-word',
+            width: betweenSmAndLg ? '20%' : '14%',
+          }}
           aria-label={`Addresses: ${addresses}`}
-          sx={{ ...sxItemSpacing, overflowWrap: 'break-word', width: '15%' }}
         >
           <MaskableText text={addresses} />
           <ConditionalError errors={errors} formField="addresses" />
@@ -337,7 +342,7 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
       </Hidden>
       <Box
         aria-label={`Action: ${action}`}
-        sx={{ ...sxItemSpacing, width: '5%' }}
+        sx={{ ...sxItemSpacing, width: '10%' }}
       >
         {capitalize(action?.toLocaleLowerCase() ?? '')}
       </Box>
@@ -389,33 +394,32 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
   );
 
   // Using a grid here to keep the Select and the helper text aligned
-  // with the Action column.
+  // with the last column for screens >= 'lg', and with the Action column for screens < 'lg'.
   const sxBoxGrid = {
     alignItems: 'center',
     backgroundColor: theme.bg.bgPaper,
-    borderBottom: `1px solid ${theme.borderColors.borderTable}`,
+    border: `1px solid ${theme.borderColors.borderTable}`,
     color: theme.textColors.tableStatic,
     display: 'grid',
     fontSize: '.875rem',
-    gridTemplateAreas: `'one two three four five'`,
-    gridTemplateColumns: '32% 10% 10% 15% 120px',
+    gridTemplateAreas: `'one two three four five six'`,
+    gridTemplateColumns: '30% 10% 10% 14% 10% 120px',
     height: '40px',
     marginTop: '10px',
     [theme.breakpoints.down('lg')]: {
-      gridTemplateAreas: `'one two three four'`,
-      gridTemplateColumns: '32% 15% 15% 120px',
+      gridTemplateAreas: `'one two three four five'`,
+      gridTemplateColumns: '30% 14% 20% 10% 120px',
     },
     [theme.breakpoints.down('sm')]: {
-      gridTemplateAreas: `'one two'`,
-      gridTemplateColumns: '50% 50%',
+      gridTemplateAreas: `'one two three'`,
+      gridTemplateColumns: '50% 30% 20%',
     },
     width: '100%',
   };
 
   const sxBoxPolicyText = {
-    gridArea: '1 / 1 / 1 / 5',
+    gridArea: '1 / 1 / 1 / 6',
     padding: '0px 15px 0px 15px',
-
     textAlign: 'right',
     [theme.breakpoints.down('lg')]: {
       gridArea: '1 / 1 / 1 / 4',
@@ -426,7 +430,7 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
   };
 
   const sxBoxPolicySelect = {
-    gridArea: 'five',
+    gridArea: 'six',
     [theme.breakpoints.down('lg')]: {
       gridArea: 'four',
     },

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -294,7 +294,7 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
       <StyledCellItemBox
         sx={{
           overflowWrap: 'break-word',
-          paddingLeft: '10px',
+          paddingLeft: '10px !important',
           width: xsDown ? '50%' : '30%',
         }}
         aria-label={`Label: ${label}`}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -1,7 +1,9 @@
 import {
   DndContext,
+  MouseSensor,
   PointerSensor,
   TouchSensor,
+  closestCorners,
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
@@ -144,7 +146,12 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
-        distance: 8,
+        distance: 4,
+      },
+    }),
+    useSensor(MouseSensor, {
+      activationConstraint: {
+        distance: 4,
       },
     }),
     useSensor(TouchSensor)
@@ -166,7 +173,11 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
         aria-label={`${category} Rules List`}
         sx={{ margin: 0, width: '100%' }}
       >
-        <DndContext onDragEnd={onDragEnd} sensors={sensors}>
+        <DndContext
+          collisionDetection={closestCorners}
+          onDragEnd={onDragEnd}
+          sensors={sensors}
+        >
           <Table>
             <TableHead aria-label={`${category} Rules List Headers`}>
               <TableRow>
@@ -280,9 +291,15 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
     transform,
   } = useSortable({ id });
 
-  const style = {
+  // dnd-kit styles
+  const styles = {
+    '& td': {
+      // Highly recommend to set the `touch-action: none` for all the draggable elements-
+      // in order to prevent scrolling on mobile devices.
+      // refer to https://docs.dndkit.com/api-documentation/sensors/pointer#touch-action
+      touchAction: 'none',
+    },
     cursor: isDragging ? 'grabbing' : 'grab',
-    touchAction: 'none',
     transform: CSS.Transform.toString(transform),
   };
 
@@ -297,7 +314,7 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
       status={status}
       {...attributes}
       {...listeners}
-      sx={style}
+      sx={styles}
     >
       <TableCell aria-label={`Label: ${label}`}>
         <StyledDragIndicator aria-label="Drag indicator icon" />

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -111,6 +111,9 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
     triggerUndo,
   } = props;
 
+  const theme = useTheme();
+  const smDown = useMediaQuery(theme.breakpoints.down('sm'));
+
   const addressColumnLabel =
     category === 'inbound' ? 'sources' : 'destinations';
 
@@ -181,15 +184,20 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
           <Table>
             <TableHead aria-label={`${category} Rules List Headers`}>
               <TableRow>
-                <TableCell>Label</TableCell>
+                <TableCell sx={{ width: smDown ? '50%' : '28%' }}>
+                  Label
+                </TableCell>
                 <Hidden lgDown>
-                  <TableCell>Protocol</TableCell>
+                  <TableCell sx={{ width: '10%' }}>Protocol</TableCell>
                 </Hidden>
                 <Hidden smDown>
-                  <TableCell>Port Range</TableCell>
-                  <TableCell> {capitalize(addressColumnLabel)}</TableCell>
+                  <TableCell sx={{ width: '15%' }}>Port Range</TableCell>
+                  <TableCell sx={{ width: '15%' }}>
+                    {' '}
+                    {capitalize(addressColumnLabel)}
+                  </TableCell>
                 </Hidden>
-                <TableCell>Action</TableCell>
+                <TableCell sx={{ width: '10%' }}>Action</TableCell>
                 <TableCell />
               </TableRow>
             </TableHead>
@@ -395,7 +403,8 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
     </span>
   );
 
-  // Using a grid here to keep the Select and the helper text aligned.
+  // Using a grid here to keep the Select and the helper text aligned
+  // with with the Action column for screens < 'sm', and with the last column for screens >= 'sm'.
   const sxBoxGrid = {
     alignItems: 'center',
     backgroundColor: theme.bg.bgPaper,
@@ -404,16 +413,16 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
     display: 'grid',
     fontSize: '.875rem',
     gridTemplateAreas: `'one two three four five six'`,
-    gridTemplateColumns: '22% 10% 10% 16% 10% 120px',
+    gridTemplateColumns: '28% 10% 15% 15% 10% 120px',
     height: '40px',
     marginTop: '10px',
     [theme.breakpoints.down('lg')]: {
       gridTemplateAreas: `'one two three four five'`,
-      gridTemplateColumns: '22% 10% 16% 10% 120px',
+      gridTemplateColumns: '28% 15% 15% 10% 120px',
     },
     [theme.breakpoints.down('sm')]: {
       gridTemplateAreas: `'one two'`,
-      gridTemplateColumns: '60% 40%',
+      gridTemplateColumns: '50% 50%',
     },
     width: '100%',
   };
@@ -423,7 +432,7 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
     padding: '0px 15px 0px 15px',
     textAlign: 'right',
     [theme.breakpoints.down('lg')]: {
-      gridArea: '1 / 1 / 1 / 4',
+      gridArea: '1 / 1 / 1 / 5',
     },
     [theme.breakpoints.down('sm')]: {
       gridArea: 'one',
@@ -433,7 +442,7 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
   const sxBoxPolicySelect = {
     gridArea: 'six',
     [theme.breakpoints.down('lg')]: {
-      gridArea: 'four',
+      gridArea: 'five',
     },
     [theme.breakpoints.down('sm')]: {
       gridArea: 'two',

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -312,6 +312,8 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
     triggerOpenRuleDrawerForEditing,
   };
 
+  const theme = useTheme();
+
   const {
     active,
     attributes,
@@ -331,6 +333,11 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
       // in order to prevent scrolling on mobile devices.
       // refer to https://docs.dndkit.com/api-documentation/sensors/pointer#touch-action
       touchAction: 'none',
+    },
+    ':focus': {
+      backgroundColor: isActive
+        ? theme.tokens.background.Neutralsubtle
+        : theme.tokens.background.Normal,
     },
     cursor: isActive ? 'grabbing' : 'grab',
     position: 'relative',

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -1,6 +1,7 @@
 import {
   DndContext,
   MouseSensor,
+  KeyboardSensor,
   PointerSensor,
   TouchSensor,
   closestCorners,
@@ -162,7 +163,8 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
         distance: 4,
       },
     }),
-    useSensor(TouchSensor)
+    useSensor(TouchSensor),
+    useSensor(KeyboardSensor)
   );
 
   return (

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -114,6 +114,8 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
 
   const theme = useTheme();
   const smDown = useMediaQuery(theme.breakpoints.down('sm'));
+  const mdDown = useMediaQuery(theme.breakpoints.down('md'));
+  const lgDown = useMediaQuery(theme.breakpoints.down('lg'));
 
   const addressColumnLabel =
     category === 'inbound' ? 'sources' : 'destinations';
@@ -191,7 +193,17 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
           <Table>
             <TableHead aria-label={`${category} Rules List Headers`}>
               <TableRow>
-                <TableCell sx={{ width: smDown ? '50%' : '26%' }}>
+                <TableCell
+                  sx={{
+                    width: smDown
+                      ? '65%'
+                      : mdDown
+                      ? '50%'
+                      : lgDown
+                      ? '32%'
+                      : '26%',
+                  }}
+                >
                   Label
                 </TableCell>
                 <Hidden lgDown>
@@ -337,7 +349,7 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
       {...listeners}
       sx={rowStyles}
     >
-      <TableCell aria-label={`Label: ${label}`} sx={{ whiteSpace: 'nowrap' }}>
+      <TableCell aria-label={`Label: ${label}`}>
         <StyledDragIndicator aria-label="Drag indicator icon" />
         {label || (
           <MoreStyledLinkButton
@@ -405,9 +417,9 @@ const policyOptions: FirewallOptionItem<FirewallPolicyType>[] = [
 export const PolicyRow = React.memo((props: PolicyRowProps) => {
   const { category, disabled, handlePolicyChange, policy } = props;
   const theme = useTheme();
-  const mdDown = useMediaQuery(theme.breakpoints.down('lg'));
+  const lgDown = useMediaQuery(theme.breakpoints.down('lg'));
 
-  const helperText = mdDown ? (
+  const helperText = lgDown ? (
     <strong>{capitalize(category)} policy:</strong>
   ) : (
     <span>
@@ -417,7 +429,7 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
   );
 
   // Using a grid here to keep the Select and the helper text aligned
-  // with the Action column for screens < 'sm', and with the last column for screens >= 'sm'.
+  // with the Action column for screens < 'md', and with the last column for screens >= 'md'.
   const sxBoxGrid = {
     alignItems: 'center',
     backgroundColor: theme.bg.bgPaper,
@@ -431,11 +443,15 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
     marginTop: '10px',
     [theme.breakpoints.down('lg')]: {
       gridTemplateAreas: `'one two three four five'`,
-      gridTemplateColumns: '26% 15% 15% 10% 120px',
+      gridTemplateColumns: '32% 15% 15% 10% 120px',
+    },
+    [theme.breakpoints.down('md')]: {
+      gridTemplateAreas: `'one two three four'`,
+      gridTemplateColumns: '50% 15% 15% 20%',
     },
     [theme.breakpoints.down('sm')]: {
       gridTemplateAreas: `'one two'`,
-      gridTemplateColumns: '50% 50%',
+      gridTemplateColumns: '65% 35%',
     },
     width: '100%',
   };
@@ -447,6 +463,9 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
     [theme.breakpoints.down('lg')]: {
       gridArea: '1 / 1 / 1 / 5',
     },
+    [theme.breakpoints.down('md')]: {
+      gridArea: '1 / 1 / 1 / 4',
+    },
     [theme.breakpoints.down('sm')]: {
       gridArea: 'one',
     },
@@ -456,6 +475,9 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
     gridArea: 'six',
     [theme.breakpoints.down('lg')]: {
       gridArea: 'five',
+    },
+    [theme.breakpoints.down('md')]: {
+      gridArea: 'four',
     },
     [theme.breakpoints.down('sm')]: {
       gridArea: 'two',

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -21,6 +21,7 @@ import { FirewallRuleActionMenu } from './FirewallRuleActionMenu';
 import {
   MoreStyledLinkButton,
   StyledButtonDiv,
+  StyledCellItemBox,
   StyledDragIndicator,
   StyledErrorDiv,
   StyledFirewallRuleBox,
@@ -32,7 +33,6 @@ import {
   StyledUl,
   StyledUlBox,
   sxBox,
-  sxItemSpacing,
 } from './FirewallRuleTable.styles';
 import { sortPortString } from './shared';
 
@@ -147,7 +147,6 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
         >
           <StyledHeaderItemBox
             sx={{
-              paddingLeft: '27px',
               width: xsDown ? '50%' : '30%',
             }}
           >
@@ -169,7 +168,7 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
           <StyledHeaderItemBox sx={{ width: xsDown ? '30%' : '10%' }}>
             Action
           </StyledHeaderItemBox>
-          <StyledHeaderItemBox sx={{ width: xsDown ? '20%' : '26%' }} />
+          <StyledHeaderItemBox flexGrow={1} />
         </StyledInnerBox>
         <Box sx={{ ...sxBox, flexDirection: 'column' }}>
           <DragDropContext onDragEnd={onDragEnd}>
@@ -292,11 +291,10 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
       ruleId={id}
       status={status}
     >
-      <Box
+      <StyledCellItemBox
         sx={{
-          ...sxItemSpacing,
           overflowWrap: 'break-word',
-          paddingLeft: '8px',
+          paddingLeft: '10px',
           width: xsDown ? '50%' : '30%',
         }}
         aria-label={`Label: ${label}`}
@@ -310,27 +308,26 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
             Add a label
           </MoreStyledLinkButton>
         )}{' '}
-      </Box>
+      </StyledCellItemBox>
       <Hidden lgDown>
-        <Box
+        <StyledCellItemBox
           aria-label={`Protocol: ${protocol}`}
-          sx={{ ...sxItemSpacing, width: '10%' }}
+          sx={{ width: '10%' }}
         >
           {protocol}
           <ConditionalError errors={errors} formField="protocol" />
-        </Box>
+        </StyledCellItemBox>
       </Hidden>
       <Hidden smDown>
-        <Box
+        <StyledCellItemBox
           aria-label={`Ports: ${ports}`}
-          sx={{ ...sxItemSpacing, width: betweenSmAndLg ? '14%' : '10%' }}
+          sx={{ width: betweenSmAndLg ? '14%' : '10%' }}
         >
           {ports === '1-65535' ? 'All Ports' : ports}
           <ConditionalError errors={errors} formField="ports" />
-        </Box>
-        <Box
+        </StyledCellItemBox>
+        <StyledCellItemBox
           sx={{
-            ...sxItemSpacing,
             overflowWrap: 'break-word',
             width: betweenSmAndLg ? '20%' : '14%',
           }}
@@ -338,15 +335,15 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
         >
           <MaskableText text={addresses} />
           <ConditionalError errors={errors} formField="addresses" />
-        </Box>
+        </StyledCellItemBox>
       </Hidden>
-      <Box
+      <StyledCellItemBox
         aria-label={`Action: ${action}`}
-        sx={{ ...sxItemSpacing, width: '10%' }}
+        sx={{ width: xsDown ? '30%' : '10%' }}
       >
         {capitalize(action?.toLocaleLowerCase() ?? '')}
-      </Box>
-      <Box sx={{ ...sxItemSpacing, marginLeft: 'auto' }}>
+      </StyledCellItemBox>
+      <StyledCellItemBox sx={{ marginLeft: 'auto' }}>
         {status !== 'NOT_MODIFIED' ? (
           <StyledButtonDiv>
             <StyledFirewallRuleButton
@@ -362,7 +359,7 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
         ) : (
           <FirewallRuleActionMenu {...actionMenuProps} />
         )}
-      </Box>
+      </StyledCellItemBox>
     </StyledFirewallRuleBox>
   );
 });

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -411,8 +411,8 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
       gridTemplateColumns: '30% 14% 20% 10% 120px',
     },
     [theme.breakpoints.down('sm')]: {
-      gridTemplateAreas: `'one two three'`,
-      gridTemplateColumns: '50% 30% 20%',
+      gridTemplateAreas: `'one two'`,
+      gridTemplateColumns: '50% 50%',
     },
     width: '100%',
   };

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -140,6 +140,11 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
       const destinationIndex = getRowDataIndex(Number(over.id));
       triggerReorder(sourceIndex, destinationIndex);
     }
+
+    // Remove focus from the initial position when the drag ends.
+    if (document.activeElement) {
+      (document.activeElement as HTMLElement).blur();
+    }
   };
 
   const onPolicyChange = (newPolicy: FirewallPolicyType) => {
@@ -181,7 +186,7 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
           onDragEnd={onDragEnd}
           sensors={sensors}
         >
-          <Table>
+          <Table sx={{ overflow: 'hidden' }}>
             <TableHead aria-label={`${category} Rules List Headers`}>
               <TableRow>
                 <TableCell sx={{ width: smDown ? '50%' : '26%' }}>
@@ -299,7 +304,7 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
   } = useSortable({ id });
 
   // dnd-kit styles
-  const styles = {
+  const rowStyles = {
     '& td': {
       // Highly recommend to set the `touch-action: none` for all the draggable elements-
       // in order to prevent scrolling on mobile devices.
@@ -308,6 +313,7 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
     },
     cursor: isDragging ? 'grabbing' : 'grab',
     transform: CSS.Transform.toString(transform),
+    zIndex: isDragging ? 999 : 'auto',
   };
 
   return (
@@ -321,7 +327,7 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
       status={status}
       {...attributes}
       {...listeners}
-      sx={styles}
+      sx={rowStyles}
     >
       <TableCell aria-label={`Label: ${label}`}>
         <StyledDragIndicator aria-label="Drag indicator icon" />
@@ -403,7 +409,7 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
   );
 
   // Using a grid here to keep the Select and the helper text aligned
-  // with with the Action column for screens < 'sm', and with the last column for screens >= 'sm'.
+  // with the Action column for screens < 'sm', and with the last column for screens >= 'sm'.
   const sxBoxGrid = {
     alignItems: 'center',
     backgroundColor: theme.bg.bgPaper,

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -272,9 +272,17 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
     triggerOpenRuleDrawerForEditing,
   };
 
-  const { attributes, listeners, setNodeRef, transform } = useSortable({ id });
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    isDragging,
+  } = useSortable({ id });
 
   const style = {
+    cursor: isDragging ? 'grabbing' : 'grab',
+    touchAction: 'none',
     transform: CSS.Transform.toString(transform),
   };
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -23,6 +23,7 @@ import Undo from 'src/assets/icons/undo.svg';
 import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
 import { Hidden } from 'src/components/Hidden';
 import { MaskableText } from 'src/components/MaskableText/MaskableText';
+import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
 import { TableCell } from 'src/components/TableCell';
 import { TableHead } from 'src/components/TableHead';
@@ -45,7 +46,6 @@ import {
   StyledFirewallRuleButton,
   StyledFirewallTableButton,
   StyledHeaderDiv,
-  StyledTable,
   StyledTableRow,
 } from './FirewallRuleTable.styles';
 import { sortPortString } from './shared';
@@ -186,7 +186,7 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
           onDragEnd={onDragEnd}
           sensors={sensors}
         >
-          <StyledTable>
+          <Table>
             <TableHead aria-label={`${category} Rules List Headers`}>
               <TableRow>
                 <TableCell sx={{ width: smDown ? '50%' : '26%' }}>
@@ -239,7 +239,7 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
                 </SortableContext>
               )}
             </TableBody>
-          </StyledTable>
+          </Table>
         </DndContext>
         <PolicyRow
           category={category}
@@ -313,7 +313,7 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
     },
     cursor: isDragging ? 'grabbing' : 'grab',
     transform: CSS.Transform.toString(transform),
-    zIndex: isDragging ? 999 : 'auto',
+    zIndex: isDragging ? 999 : 0,
   };
 
   return (
@@ -329,7 +329,7 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
       {...listeners}
       sx={rowStyles}
     >
-      <TableCell aria-label={`Label: ${label}`}>
+      <TableCell aria-label={`Label: ${label}`} sx={{ whiteSpace: 'nowrap' }}>
         <StyledDragIndicator aria-label="Drag indicator icon" />
         {label || (
           <MoreStyledLinkButton

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -1,13 +1,14 @@
 import {
   DndContext,
-  MouseSensor,
   KeyboardSensor,
+  MouseSensor,
   PointerSensor,
   TouchSensor,
   closestCorners,
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import {
   SortableContext,
   useSortable,
@@ -166,7 +167,9 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
       },
     }),
     useSensor(TouchSensor),
-    useSensor(KeyboardSensor)
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
   );
 
   return (

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -8,9 +8,9 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
-import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import {
   SortableContext,
+  sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -190,7 +190,7 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
           onDragEnd={onDragEnd}
           sensors={sensors}
         >
-          <Table>
+          <Table noOverflow>
             <TableHead aria-label={`${category} Rules List Headers`}>
               <TableRow>
                 <TableCell

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -184,7 +184,7 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
           <Table>
             <TableHead aria-label={`${category} Rules List Headers`}>
               <TableRow>
-                <TableCell sx={{ width: smDown ? '50%' : '28%' }}>
+                <TableCell sx={{ width: smDown ? '50%' : '26%' }}>
                   Label
                 </TableCell>
                 <Hidden lgDown>
@@ -413,12 +413,12 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
     display: 'grid',
     fontSize: '.875rem',
     gridTemplateAreas: `'one two three four five six'`,
-    gridTemplateColumns: '28% 10% 15% 15% 10% 120px',
+    gridTemplateColumns: '26% 10% 15% 15% 10% 120px',
     height: '40px',
     marginTop: '10px',
     [theme.breakpoints.down('lg')]: {
       gridTemplateAreas: `'one two three four five'`,
-      gridTemplateColumns: '28% 15% 15% 10% 120px',
+      gridTemplateColumns: '26% 15% 15% 10% 120px',
     },
     [theme.breakpoints.down('sm')]: {
       gridTemplateAreas: `'one two'`,

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -394,7 +394,7 @@ export const PolicyRow = React.memo((props: PolicyRowProps) => {
   );
 
   // Using a grid here to keep the Select and the helper text aligned
-  // with the last column for screens >= 'lg', and with the Action column for screens < 'lg'.
+  // with the Action column for screens < 'lg', and with the last column for screens >= 'lg'.
   const sxBoxGrid = {
     alignItems: 'center',
     backgroundColor: theme.bg.bgPaper,

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -319,9 +319,9 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
     },
     cursor: isDragging ? 'grabbing' : 'grab',
     position: 'relative',
-    transform: CSS.Transform.toString(transform),
+    transform: CSS.Translate.toString(transform),
     transition: isActive ? transition : 'none',
-    zIndex: isDragging ? 999 : 0,
+    zIndex: isDragging ? 9999 : 0,
   } as const;
 
   return (

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -23,7 +23,6 @@ import Undo from 'src/assets/icons/undo.svg';
 import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
 import { Hidden } from 'src/components/Hidden';
 import { MaskableText } from 'src/components/MaskableText/MaskableText';
-import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
 import { TableCell } from 'src/components/TableCell';
 import { TableHead } from 'src/components/TableHead';
@@ -46,6 +45,7 @@ import {
   StyledFirewallRuleButton,
   StyledFirewallTableButton,
   StyledHeaderDiv,
+  StyledTable,
   StyledTableRow,
 } from './FirewallRuleTable.styles';
 import { sortPortString } from './shared';
@@ -186,7 +186,7 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
           onDragEnd={onDragEnd}
           sensors={sensors}
         >
-          <Table sx={{ overflow: 'hidden' }}>
+          <StyledTable>
             <TableHead aria-label={`${category} Rules List Headers`}>
               <TableRow>
                 <TableCell sx={{ width: smDown ? '50%' : '26%' }}>
@@ -239,7 +239,7 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
                 </SortableContext>
               )}
             </TableBody>
-          </Table>
+          </StyledTable>
         </DndContext>
         <PolicyRow
           category={category}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -274,10 +274,10 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
 
   const {
     attributes,
+    isDragging,
     listeners,
     setNodeRef,
     transform,
-    isDragging,
   } = useSortable({ id });
 
   const style = {

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -1,6 +1,5 @@
 import {
   DndContext,
-  KeyboardSensor,
   MouseSensor,
   PointerSensor,
   TouchSensor,
@@ -38,6 +37,7 @@ import {
   predefinedFirewallFromRule as ruleToPredefinedFirewall,
 } from 'src/features/Firewalls/shared';
 import { capitalize } from 'src/utilities/capitalize';
+import { CustomKeyboardSensor } from 'src/utilities/CustomKeyboardSensor';
 
 import { FirewallRuleActionMenu } from './FirewallRuleActionMenu';
 import {
@@ -167,7 +167,7 @@ export const FirewallRuleTable = (props: FirewallRuleTableProps) => {
       },
     }),
     useSensor(TouchSensor),
-    useSensor(KeyboardSensor, {
+    useSensor(CustomKeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
     })
   );
@@ -332,7 +332,7 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
       // refer to https://docs.dndkit.com/api-documentation/sensors/pointer#touch-action
       touchAction: 'none',
     },
-    cursor: isDragging ? 'grabbing' : 'grab',
+    cursor: isActive ? 'grabbing' : 'grab',
     position: 'relative',
     transform: CSS.Translate.toString(transform),
     transition: isActive ? transition : 'none',

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -296,12 +296,16 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
   };
 
   const {
+    active,
     attributes,
     isDragging,
     listeners,
     setNodeRef,
     transform,
+    transition,
   } = useSortable({ id });
+
+  const isActive = Boolean(active);
 
   // dnd-kit styles
   const rowStyles = {
@@ -312,17 +316,19 @@ const FirewallRuleTableRow = React.memo((props: FirewallRuleTableRowProps) => {
       touchAction: 'none',
     },
     cursor: isDragging ? 'grabbing' : 'grab',
+    position: 'relative',
     transform: CSS.Transform.toString(transform),
+    transition: isActive ? transition : 'none',
     zIndex: isDragging ? 999 : 0,
-  };
+  } as const;
 
   return (
     <StyledTableRow
       aria-label={label ?? `firewall rule ${id}`}
       disabled={disabled}
-      domRef={setNodeRef}
       key={id}
       originalIndex={originalIndex}
+      ref={setNodeRef}
       ruleIndex={index}
       status={status}
       {...attributes}

--- a/packages/manager/src/utilities/CustomKeyboardSensor.ts
+++ b/packages/manager/src/utilities/CustomKeyboardSensor.ts
@@ -146,6 +146,12 @@ export class CustomKeyboardSensor implements SensorInstance {
     this.windowListeners.add(EventName.Resize, this.handleCancel);
     this.windowListeners.add(EventName.VisibilityChange, this.handleCancel);
 
+    // Add focus style when draggable element is dragging.
+    const activator = this.props.activeNode.node.current;
+    if (activator) {
+      activator.style.outline = '1px dashed grey';
+    }
+
     setTimeout(() => {
       this.listeners.add(EventName.Keydown, this.handleKeyDown);
     });
@@ -154,6 +160,12 @@ export class CustomKeyboardSensor implements SensorInstance {
   private detach() {
     this.listeners.removeAll();
     this.windowListeners.removeAll();
+
+    // Clear focus style when draggable element is dropped
+    const dropTarget = this.props.activeNode.node.current;
+    if (dropTarget) {
+      dropTarget.style.outline = 'none';
+    }
   }
 
   private handleCancel(event: Event) {

--- a/packages/manager/src/utilities/CustomKeyboardSensor.ts
+++ b/packages/manager/src/utilities/CustomKeyboardSensor.ts
@@ -1,4 +1,4 @@
-// Customizing KeybordSensor from dnd-kit to meet our requirements.
+// Customizing KeyboardSensor from dnd-kit to meet our requirements.
 // - Prevent scrolling while using keyboard keys.
 
 import { KeyboardCode, defaultCoordinates } from '@dnd-kit/core';
@@ -111,7 +111,6 @@ export class CustomKeyboardSensor implements SensorInstance {
           }
 
           event.preventDefault();
-
           onActivation?.({ event: event.nativeEvent });
 
           return true;

--- a/packages/manager/src/utilities/CustomKeyboardSensor.ts
+++ b/packages/manager/src/utilities/CustomKeyboardSensor.ts
@@ -1,0 +1,239 @@
+// Customizing KeybordSensor from dnd-kit to meet our requirements.
+// - Prevent scrolling while using keyboard keys.
+
+import { KeyboardCode, defaultCoordinates } from '@dnd-kit/core';
+import {
+  add as getAdjustedCoordinates,
+  subtract as getCoordinatesDelta,
+  getOwnerDocument,
+  getWindow,
+  isKeyboardEvent,
+} from '@dnd-kit/utilities';
+
+import type {
+  Activators,
+  KeyboardCodes,
+  KeyboardCoordinateGetter,
+  KeyboardSensorOptions,
+  KeyboardSensorProps,
+  SensorInstance,
+} from '@dnd-kit/core';
+import type { Coordinates } from '@dnd-kit/utilities';
+
+class Listeners {
+  private listeners: [
+    string,
+    EventListenerOrEventListenerObject,
+    AddEventListenerOptions | boolean | undefined
+  ][] = [];
+
+  public removeAll = () => {
+    this.listeners.forEach((listener) =>
+      this.target?.removeEventListener(...listener)
+    );
+  };
+
+  constructor(private target: EventTarget | null) {}
+
+  public add<T extends Event>(
+    eventName: string,
+    handler: (event: T) => void,
+    options?: AddEventListenerOptions | boolean
+  ) {
+    // eslint-disable-next-line scanjs-rules/call_addEventListener
+    this.target?.addEventListener(eventName, handler as EventListener, options);
+    this.listeners.push([eventName, handler as EventListener, options]);
+  }
+}
+
+const defaultKeyboardCodes: KeyboardCodes = {
+  cancel: [KeyboardCode.Esc],
+  end: [KeyboardCode.Space, KeyboardCode.Enter],
+  start: [KeyboardCode.Space, KeyboardCode.Enter],
+};
+
+const defaultKeyboardCoordinateGetter: KeyboardCoordinateGetter = (
+  event,
+  { currentCoordinates }
+) => {
+  switch (event.code) {
+    case KeyboardCode.Right:
+      return {
+        ...currentCoordinates,
+        x: currentCoordinates.x + 25,
+      };
+    case KeyboardCode.Left:
+      return {
+        ...currentCoordinates,
+        x: currentCoordinates.x - 25,
+      };
+    case KeyboardCode.Down:
+      return {
+        ...currentCoordinates,
+        y: currentCoordinates.y + 25,
+      };
+    case KeyboardCode.Up:
+      return {
+        ...currentCoordinates,
+        y: currentCoordinates.y - 25,
+      };
+  }
+
+  return undefined;
+};
+
+enum EventName {
+  Click = 'click',
+  ContextMenu = 'contextmenu',
+  DragStart = 'dragstart',
+  Keydown = 'keydown',
+  Resize = 'resize',
+  SelectionChange = 'selectionchange',
+  VisibilityChange = 'visibilitychange',
+}
+
+export class CustomKeyboardSensor implements SensorInstance {
+  static activators: Activators<KeyboardSensorOptions> = [
+    {
+      eventName: 'onKeyDown' as const,
+      handler: (
+        event: React.KeyboardEvent,
+        { keyboardCodes = defaultKeyboardCodes, onActivation },
+        { active }
+      ) => {
+        const { code } = event.nativeEvent;
+
+        if (keyboardCodes.start.includes(code)) {
+          const activator = active.activatorNode.current;
+
+          if (activator && event.target !== activator) {
+            return false;
+          }
+
+          event.preventDefault();
+
+          onActivation?.({ event: event.nativeEvent });
+
+          return true;
+        }
+
+        return false;
+      },
+    },
+  ];
+  private listeners: Listeners;
+  private referenceCoordinates: Coordinates | undefined;
+  private windowListeners: Listeners;
+
+  public autoScrollEnabled = false;
+
+  constructor(private props: KeyboardSensorProps) {
+    const {
+      event: { target },
+    } = props;
+
+    this.props = props;
+    this.listeners = new Listeners(getOwnerDocument(target));
+    this.windowListeners = new Listeners(getWindow(target));
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleCancel = this.handleCancel.bind(this);
+
+    this.attach();
+  }
+
+  private attach() {
+    this.handleStart();
+
+    this.windowListeners.add(EventName.Resize, this.handleCancel);
+    this.windowListeners.add(EventName.VisibilityChange, this.handleCancel);
+
+    setTimeout(() => {
+      this.listeners.add(EventName.Keydown, this.handleKeyDown);
+    });
+  }
+
+  private detach() {
+    this.listeners.removeAll();
+    this.windowListeners.removeAll();
+  }
+
+  private handleCancel(event: Event) {
+    const { onCancel } = this.props;
+
+    event.preventDefault();
+    this.detach();
+    onCancel();
+  }
+
+  private handleEnd(event: Event) {
+    const { onEnd } = this.props;
+
+    event.preventDefault();
+    this.detach();
+    onEnd();
+  }
+
+  private handleKeyDown(event: Event) {
+    if (isKeyboardEvent(event)) {
+      const { active, context, options } = this.props;
+      const {
+        coordinateGetter = defaultKeyboardCoordinateGetter,
+        keyboardCodes = defaultKeyboardCodes,
+      } = options;
+      const { code } = event;
+
+      if (keyboardCodes.end.includes(code)) {
+        this.handleEnd(event);
+        return;
+      }
+
+      if (keyboardCodes.cancel.includes(code)) {
+        this.handleCancel(event);
+        return;
+      }
+
+      const { collisionRect } = context.current;
+      const currentCoordinates = collisionRect
+        ? { x: collisionRect.left, y: collisionRect.top }
+        : defaultCoordinates;
+
+      if (!this.referenceCoordinates) {
+        this.referenceCoordinates = currentCoordinates;
+      }
+
+      const newCoordinates = coordinateGetter(event, {
+        active,
+        context: context.current,
+        currentCoordinates,
+      });
+
+      if (newCoordinates) {
+        const scrollDelta = {
+          x: 0,
+          y: 0,
+        };
+
+        this.handleMove(
+          event,
+          getAdjustedCoordinates(
+            getCoordinatesDelta(newCoordinates, this.referenceCoordinates),
+            scrollDelta
+          )
+        );
+      }
+    }
+  }
+
+  private handleMove(event: Event, coordinates: Coordinates) {
+    const { onMove } = this.props;
+
+    event.preventDefault();
+    onMove(coordinates);
+  }
+
+  private handleStart() {
+    const { onStart } = this.props;
+
+    onStart(defaultCoordinates);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2469,7 +2469,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-redux@^7.1.20", "@types/react-redux@~7.1.7":
+"@types/react-redux@~7.1.7":
   version "7.1.34"
   resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.34.tgz#83613e1957c481521e6776beeac4fd506d11bd0e"
   integrity sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==
@@ -4023,13 +4023,6 @@ crypt@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
-
-css-box-model@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
-  integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
-  dependencies:
-    tiny-invariant "^1.0.6"
 
 css-line-break@^2.1.0:
   version "2.1.0"
@@ -7239,7 +7232,7 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
-memoize-one@^5.0.0, memoize-one@^5.1.1:
+memoize-one@^5.0.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
   integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
@@ -8307,11 +8300,6 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-raf-schd@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
-  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
-
 raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -8338,19 +8326,6 @@ raw-body@2.5.2:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
-
-react-beautiful-dnd@^13.0.0:
-  version "13.1.1"
-  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz#b0f3087a5840920abf8bb2325f1ffa46d8c4d0a2"
-  integrity sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==
-  dependencies:
-    "@babel/runtime" "^7.9.2"
-    css-box-model "^1.2.0"
-    memoize-one "^5.1.1"
-    raf-schd "^4.0.2"
-    react-redux "^7.2.0"
-    redux "^4.0.4"
-    use-memo-one "^1.1.1"
 
 react-colorful@^5.1.2:
   version "5.6.1"
@@ -8436,7 +8411,7 @@ react-is@^16.10.2, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^17.0.1, react-is@^17.0.2:
+react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
@@ -8457,18 +8432,6 @@ react-number-format@^3.5.0:
   integrity sha512-HsO11fH6WiugtJflrMQn3/Yhq2J4uEWLxrKCQbI1gSGAOwIhUsOGJJeP8Vci/U4A7xK5SjC95ngZU8//Nuz3Gg==
   dependencies:
     prop-types "^15.6.0"
-
-react-redux@^7.2.0:
-  version "7.2.9"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.9.tgz#09488fbb9416a4efe3735b7235055442b042481d"
-  integrity sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==
-  dependencies:
-    "@babel/runtime" "^7.15.4"
-    "@types/react-redux" "^7.1.20"
-    hoist-non-react-statics "^3.3.2"
-    loose-envify "^1.4.0"
-    prop-types "^15.7.2"
-    react-is "^17.0.2"
 
 react-redux@~7.1.3:
   version "7.1.3"
@@ -9621,7 +9584,7 @@ through@^2.3.6, through@^2.3.8, through@~2.3.4:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
-tiny-invariant@^1.0.2, tiny-invariant@^1.0.6, tiny-invariant@^1.3.1, tiny-invariant@^1.3.3:
+tiny-invariant@^1.0.2, tiny-invariant@^1.3.1, tiny-invariant@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
@@ -10071,11 +10034,6 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
-
-use-memo-one@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.3.tgz#2fd2e43a2169eabc7496960ace8c79efef975e99"
-  integrity sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==
 
 use-sync-external-store@^1.2.2:
   version "1.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -426,6 +426,37 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@dnd-kit/accessibility@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.1.0.tgz#1054e19be276b5f1154ced7947fc0cb5d99192e0"
+  integrity sha512-ea7IkhKvlJUv9iSHJOnxinBcoOI3ppGnnL+VDJ75O45Nss6HtZd8IdN8touXPDtASfeI2T2LImb8VOZcL47wjQ==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-6.1.0.tgz#e81a3d10d9eca5d3b01cbf054171273a3fe01def"
+  integrity sha512-J3cQBClB4TVxwGo3KEjssGEXNJqGVWx17aRTZ1ob0FliR5IjYgTxl5YJbKTzA6IzrtelotH19v6y7uoIRUZPSg==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.1.0"
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/sortable/-/sortable-8.0.0.tgz#086b7ac6723d4618a4ccb6f0227406d8a8862a96"
+  integrity sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.2.tgz#5a32b6af356dc5f74d61b37d6f7129a4040ced7b"
+  integrity sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==
+  dependencies:
+    tslib "^2.0.0"
+
 "@emotion/babel-plugin@^11.12.0":
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz#7b43debb250c313101b3f885eba634f1d723fcc2"


### PR DESCRIPTION
## Description 📝
While working on ticket M3-8533 & PR #11109, we decided to implement/use semantic markup for the Firewall rules table to improve consistency and accessibility, rather than applying a styling band-aid to div grids to make it look like our normal tables. The `react-beautiful-dnd` library has made us rely on div(Box) grids instead of our normal tables, which complicates using semantic tables/grid layouts because of the draggable elements. Plus, this library has been deprecated (announcement: https://github.com/atlassian/react-beautiful-dnd/issues/2672).

To solve these problems and make better use of our normal tables, switching to `dnd-kit`(https://dndkit.com/) would be the great idea, which is more popular, supports grid layouts better, and can replace `react-beautiful-dnd`. This will help us use our semantic tables properly and fix the issues with the Firewall rules table in both dark and light modes.

## Changes  🔄
List any change relevant to the reviewer.
- Used Normal tables instead of Div Box grids
- Updated `PolicyRow` 
  - Changed it to have borders on all sides.
  - Changed the alignment of the Select and helper text to be aligned with the Action column for screens < 'md', and with the last column for screens >= 'md'.
- Replaced `react-beautiful-dnd` with `dnd-kit` lib
- Fix `<Table />` styling for `noOverflow` property

## Target release date 🗓️
N/A

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-10-21 at 6 21 23 PM](https://github.com/user-attachments/assets/dec8e128-2ed0-4296-b1a9-994a1f56277c) | ![Screenshot 2024-10-21 at 6 20 12 PM](https://github.com/user-attachments/assets/7dfb572c-7d74-4137-bded-9ab97cb3c837) |
| ![Screenshot 2024-10-21 at 6 22 28 PM](https://github.com/user-attachments/assets/835833bc-77ae-4121-b902-2a191ab8d5d0) | ![Screenshot 2024-10-21 at 6 23 24 PM](https://github.com/user-attachments/assets/97d5a3e2-4779-4b95-acab-c12af8f27898) |

## How to test 🧪

### Prerequisites
- Clear cache or test in Incognito. 

### Reproduction steps
- Go to any Firewall details page (https://cloud.linode.com/firewalls/948204/rules)
- Observe the broken looking table (in both dark and light mode)

### Verification steps
- Ensure the table is not broken in both dark and light modes.
- Verify table across different screen sizes and ensure it matches our normal table colors.
- Ensure the drag and drop functionality work as expected in different screen sizes.
- Verify all firewall rule actions work as expected.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support