### PR TITLE
fix: [M3-8763] - fix flaky `DatabaseBackups.test.tsx` in coverage job

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,7 +47,9 @@ jobs:
           path: ref_code_coverage.txt
 
   current_branch:
-    if: github.event.pull_request.draft == false
+    # We want to make sure we only run on draft, but also should run even if the base branch coverage job fails
+    # If the base branch coverage job fails, the current branch coverage job will fail as well, but this helps us debug the CI on the current branch
+    if: ${{ always() && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     needs: base_branch
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,8 +47,8 @@ jobs:
           path: ref_code_coverage.txt
 
   current_branch:
-    # We want to make sure we only run on draft, but also should run even if the base branch coverage job fails
-    # If the base branch coverage job fails, the current branch coverage job will fail as well, but this helps us debug the CI on the current branch
+    # We want to make sure we only run on open PRs (not drafts), but also should run even if the base branch coverage job fails.
+    # If the base branch coverage job fails to create a report, the current branch coverage job will fail as well, but this may help us debug the CI on the current branch.
     if: ${{ always() && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     needs: base_branch

--- a/packages/manager/.changeset/pr-11130-fixed-1729536728596.md
+++ b/packages/manager/.changeset/pr-11130-fixed-1729536728596.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Flaky DatabaseBackups.test.tsx in coverage job  ([#11130](https://github.com/linode/manager/pull/11130))

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.test.tsx
@@ -41,19 +41,16 @@ describe('Database Backups', () => {
       expect(queryByText(/loading/i)).not.toBeInTheDocument()
     );
 
-    // Use a more flexible matcher for dates
     await waitFor(
       async () => {
-        const renderedBackups = await findAllByText((content, element) => {
-          // This regex matches any text that looks like a date
+        const renderedBackups = await findAllByText((content) => {
           return /\d{4}-\d{2}-\d{2}/.test(content);
         });
         expect(renderedBackups).toHaveLength(backups.length);
       },
       { timeout: 5000 }
-    ); // Increase timeout if necessary
+    );
 
-    // Verify each backup's formatted date
     await waitFor(
       () => {
         backups.forEach((backup) => {


### PR DESCRIPTION
## Description 📝
Attempting to fix an annoyance with this test **_only_** failing on the `coverage:summary` job in the CI, resulting a failing step. While this is non blocking, it prevents the coverage job from running and therefore update our score.

It is hard to pinpoint when this started happening, but every PR is experiencing this issue so it needs to be fixed.
I am forcing the  `current_branch` to run, so we can still see if `yarn coverage:summary` actually passes without issues on the current branch in case `base_branch` is flaky

## Changes  🔄
- Improve `DatabaseBackups.test.tsx` test
- force `current_branch` coverage step to run

## How to test 🧪

### Verification steps

## Locally
- run `yarn test DatabaseBackups.test.tsx` and verify it passes
- run `yarn coverage:summary` confirmed no flakes/passes 100%

## CI
- confirm coverage > base_branch > `Run Current Branch Coverage` succeeds
- confirm coverage > current_branch > `Run Current Branch Coverage` succeeds

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
