### PR TITLE
test: [M3-8725] - Add cypress tests for updating ACL in LKE clusters (LKE ACL integration part 2)

### DIFF
--- a/packages/manager/.changeset/pr-11131-tests-1729627189739.md
+++ b/packages/manager/.changeset/pr-11131-tests-1729627189739.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Added cypress tests for updating ACL in LKE clusters ([#11131](https://github.com/linode/manager/pull/11131))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -1904,7 +1904,25 @@ describe('LKE ACL updates', () => {
         .findByTitle('Control Plane ACL')
         .should('be.visible')
         .within(() => {
-          // Confirm ACL IP validation works as expected
+          // Confirm ACL IP validation works as expected for IPv4
+          cy.findByPlaceholderText('0.0.0.0/0')
+            .should('be.visible')
+            .click()
+            .type('invalid ip');
+          // click out of textbox and confirm error is visible
+          cy.contains('Addresses').should('be.visible').click();
+          cy.contains('Must be a valid IPv4 address.').should('be.visible');
+          // enter valid IP
+          cy.findByPlaceholderText('0.0.0.0/0')
+            .should('be.visible')
+            .click()
+            .clear()
+            .type('10.0.0.0/24');
+          // Click out of textbox and confirm error is gone
+          cy.contains('Addresses').should('be.visible').click();
+          cy.contains('Must be a valid IPv4 address.').should('not.exist');
+
+          // Confirm ACL IP validation works as expected for IPv6
           cy.findByPlaceholderText('::/0')
             .should('be.visible')
             .click()

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -1351,10 +1351,13 @@ describe('LKE cluster updates', () => {
   });
 });
 
-describe.only('LKE ACL updates', () => {
+describe('LKE ACL updates', () => {
   const mockCluster = kubernetesClusterFactory.build();
   const mockRevisionId = randomString(20);
 
+  /**
+   * - Confirms LKE ACL is only rendered if an account has the corresponding capability
+   */
   it('does not show ACL without the LKE ACL capability', () => {
     mockGetAccount(
       accountFactory.build({

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -1,10 +1,14 @@
 import {
+  accountFactory,
   kubernetesClusterFactory,
   nodePoolFactory,
   kubeLinodeFactory,
   linodeFactory,
+  kubernetesControlPlaneACLFactory,
+  kubernetesControlPlaneACLOptionsFactory,
 } from 'src/factories';
 import { extendType } from 'src/utilities/extendType';
+import { mockGetAccount } from 'support/intercepts/account';
 import { latestKubernetesVersion } from 'support/constants/lke';
 import {
   mockGetCluster,
@@ -21,6 +25,10 @@ import {
   mockGetDashboardUrl,
   mockGetApiEndpoints,
   mockGetClusters,
+  mockUpdateControlPlaneACL,
+  mockGetControlPlaneACL,
+  mockUpdateControlPlaneACLError,
+  mockGetControlPlaneACLError,
 } from 'support/intercepts/lke';
 import {
   mockGetLinodeType,
@@ -33,6 +41,7 @@ import { randomIp, randomLabel } from 'support/util/random';
 import { getRegionById } from 'support/util/regions';
 import { dcPricingMockLinodeTypes } from 'support/constants/dc-specific-pricing';
 import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
+import { randomString } from 'support/util/random';
 
 const mockNodePools = nodePoolFactory.buildList(2);
 
@@ -1338,6 +1347,569 @@ describe('LKE cluster updates', () => {
 
       // Confirm total price is still $0 in Kube Specs.
       cy.findByText('$0.00/month').should('be.visible');
+    });
+  });
+});
+
+// NOTE TO SELF COPIES MAY CHANGE (but the structure will remain the same)
+describe('LKE ACL updates', () => {
+  const mockCluster = kubernetesClusterFactory.build();
+  const mockRevisionId = randomString(20);
+
+  it('does not show ACL without the LKE ACL capability', () => {
+    mockGetAccount(
+      accountFactory.build({
+        capabilities: [],
+      })
+    ).as('getAccount');
+
+    mockGetCluster(mockCluster).as('getCluster');
+    cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
+    cy.wait(['@getAccount', '@getCluster']);
+
+    cy.contains('Control Plane ACL').should('not.exist');
+  });
+
+  describe('with LKE ACL account capability', () => {
+    beforeEach(() => {
+      mockGetAccount(
+        accountFactory.build({
+          capabilities: ['LKE Network Access Control List (IP ACL)'],
+        })
+      ).as('getAccount');
+    });
+
+    /**
+     * - Confirms ACL can be enabled from the summary page
+     * - Confirms revision ID can be updated
+     * - Confirms both IPv4 and IPv6 can be updated and that summary page and drawer updates as a result
+     */
+    it('can enable ACL on an LKE cluster with ACL pre-installed and edit IPs', () => {
+      const mockACLOptions = kubernetesControlPlaneACLOptionsFactory.build({
+        enabled: false,
+        addresses: { ipv4: ['10.0.3.0/24'], ipv6: undefined },
+      });
+      const mockUpdatedACLOptions1 = kubernetesControlPlaneACLOptionsFactory.build(
+        {
+          enabled: true,
+          'revision-id': mockRevisionId,
+          addresses: { ipv4: ['10.0.0.0/24'], ipv6: undefined },
+        }
+      );
+      const mockControlPaneACL = kubernetesControlPlaneACLFactory.build({
+        acl: mockACLOptions,
+      });
+      const mockUpdatedControlPlaneACL1 = kubernetesControlPlaneACLFactory.build(
+        {
+          acl: mockUpdatedACLOptions1,
+        }
+      );
+
+      mockGetCluster(mockCluster).as('getCluster');
+      mockGetControlPlaneACL(mockCluster.id, mockControlPaneACL).as(
+        'getControlPlaneACL'
+      );
+      mockUpdateControlPlaneACL(mockCluster.id, mockUpdatedControlPlaneACL1).as(
+        'updateControlPlaneACL'
+      );
+
+      cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
+      cy.wait(['@getAccount', '@getCluster', '@getControlPlaneACL']);
+
+      // confirm summary panel
+      cy.contains('Control Plane ACL').should('be.visible');
+      ui.button
+        .findByTitle('Enable')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+
+      ui.drawer
+        .findByTitle('Control Plane ACL')
+        .should('be.visible')
+        .within(() => {
+          // Confirm submit button is disabled if form has not been changed
+          ui.button
+            .findByTitle('Update')
+            .should('be.visible')
+            .should('not.be.enabled');
+
+          cy.contains(
+            "Control Plane ACL secures network access to your LKE cluster's control plane. When not enabled, any public IP address can be used to access your control plane. When enabled, all network access is denied except for the IP addresses and CIDR ranges defined on the ACL."
+          ).should('be.visible');
+
+          // confirm Enabled section and toggle on 'Enabled'
+          cy.contains('Control Plane ACL').should('be.visible');
+          cy.contains(
+            'Once enabled, all network access is denied except for the IP addresses and CIDR ranges defined on the ACL.'
+          ).should('be.visible');
+          cy.findByText('Enable Control Plane ACL');
+          ui.toggle
+            .find()
+            .should('have.attr', 'data-qa-toggle', 'false')
+            .should('be.visible')
+            .click();
+
+          // confirm submit button is now enabled
+          ui.button
+            .findByTitle('Update')
+            .should('be.visible')
+            .should('be.enabled');
+
+          // confirm Revision ID section and edit Revision ID
+          cy.findAllByText('Revision ID').should('have.length', 2);
+          cy.contains(
+            'A unique identifing string for this particular revision to the ACL, used by clients to track events related to ACL update requests and enforcement. This defaults to a randomly generated string but can be edited if you prefer to specify your own string to use for tracking this change.'
+          ).should('be.visible');
+          cy.findByLabelText('Revision ID').should(
+            'have.value',
+            mockACLOptions['revision-id']
+          );
+          cy.findByLabelText('Revision ID').clear().type(mockRevisionId);
+
+          // confirm Addresses section
+          cy.findByText('Addresses').should('be.visible');
+          cy.findByText(
+            "A list of allowed IPv4 and IPv6 addresses and CIDR ranges. This cluster's control plane will only be accessible from IP addresses within this list."
+          ).should('be.visible');
+          cy.findByText('IPv4 Addresses or CIDRs').should('be.visible');
+          cy.findByText('Add IPv4 Address')
+            .should('be.visible')
+            .should('be.enabled');
+          // confirm current IPv4 value and enter new IP
+          cy.findByDisplayValue('10.0.3.0/24')
+            .should('be.visible')
+            .click()
+            .clear()
+            .type('10.0.0.0/24');
+          cy.findByText('IPv6 Addresses or CIDRs').should('be.visible');
+          cy.findByPlaceholderText('::/0').should('be.visible');
+          cy.findByText('Add IPv6 Address')
+            .should('be.visible')
+            .should('be.enabled');
+
+          // submit
+          ui.button
+            .findByTitle('Update')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      cy.wait(['@updateControlPlaneACL']);
+
+      // confirm summary panel updates
+      cy.contains('Control Plane ACL').should('be.visible');
+      cy.findByText('Enable').should('not.exist');
+      ui.button
+        .findByTitle('Enabled (1 IP Address)')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+
+      // update mocks
+      const mockUpdatedACLOptions2 = kubernetesControlPlaneACLOptionsFactory.build(
+        {
+          enabled: true,
+          'revision-id': mockRevisionId,
+          addresses: {
+            ipv4: ['10.0.0.0/24'],
+            ipv6: [
+              '8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e',
+              'f4a2:b849:4a24:d0d9:15f0:704b:f943:718f',
+            ],
+          },
+        }
+      );
+      const mockUpdatedControlPlaneACL2 = kubernetesControlPlaneACLFactory.build(
+        {
+          acl: mockUpdatedACLOptions2,
+        }
+      );
+      mockUpdateControlPlaneACL(mockCluster.id, mockUpdatedControlPlaneACL2).as(
+        'updateControlPlaneACL'
+      );
+
+      // confirm data within drawer is updated and edit IPs again
+      ui.drawer
+        .findByTitle('Control Plane ACL')
+        .should('be.visible')
+        .within(() => {
+          // Confirm submit button is disabled if form has not been changed
+          ui.button
+            .findByTitle('Update')
+            .should('be.visible')
+            .should('not.be.enabled');
+
+          // confirm enable toggle was updated
+          ui.toggle
+            .find()
+            .should('have.attr', 'data-qa-toggle', 'true')
+            .should('be.visible');
+
+          // confirm Revision ID was updated
+          cy.findByLabelText('Revision ID').should(
+            'have.value',
+            mockRevisionId
+          );
+
+          // update IPv6 addresses
+          cy.findByDisplayValue('10.0.0.0/24').should('be.visible');
+          cy.findByPlaceholderText('::/0')
+            .should('be.visible')
+            .click()
+            .type('8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e');
+          cy.findByText('Add IPv6 Address')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+          cy.get('[id="domain-transfer-ip-1"]')
+            .should('be.visible')
+            .click()
+            .type('f4a2:b849:4a24:d0d9:15f0:704b:f943:718f');
+
+          // submit
+          ui.button
+            .findByTitle('Update')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      cy.wait(['@updateControlPlaneACL']);
+
+      // confirm summary panel updates
+      cy.contains('Control Plane ACL').should('be.visible');
+      cy.findByText('Enable').should('not.exist');
+      ui.button
+        .findByTitle('Enabled (3 IP Addresses)')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+
+      // confirm data within drawer is updated again
+      ui.drawer
+        .findByTitle('Control Plane ACL')
+        .should('be.visible')
+        .within(() => {
+          // confirm updated IPv6 addresses display
+          cy.findByDisplayValue(
+            '8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e'
+          ).should('be.visible');
+          cy.findByDisplayValue(
+            'f4a2:b849:4a24:d0d9:15f0:704b:f943:718f'
+          ).should('be.visible');
+        });
+    });
+
+    /**
+     * - Confirms ACL can be disabled from the summary page
+     * - Confirms both IPv4 and IPv6 can be updated and that drawer updates as a result
+     */
+    it('can disable ACL and edit IPs', () => {
+      const mockACLOptions = kubernetesControlPlaneACLOptionsFactory.build({
+        enabled: true,
+        addresses: { ipv4: undefined, ipv6: undefined },
+      });
+      const mockUpdatedACLOptions1 = kubernetesControlPlaneACLOptionsFactory.build(
+        {
+          enabled: false,
+          addresses: {
+            ipv4: ['10.0.0.0/24'],
+            ipv6: ['8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e'],
+          },
+        }
+      );
+      const mockControlPaneACL = kubernetesControlPlaneACLFactory.build({
+        acl: mockACLOptions,
+      });
+      const mockUpdatedControlPlaneACL1 = kubernetesControlPlaneACLFactory.build(
+        {
+          acl: mockUpdatedACLOptions1,
+        }
+      );
+
+      mockGetCluster(mockCluster).as('getCluster');
+      mockGetControlPlaneACL(mockCluster.id, mockControlPaneACL).as(
+        'getControlPlaneACL'
+      );
+      mockUpdateControlPlaneACL(mockCluster.id, mockUpdatedControlPlaneACL1).as(
+        'updateControlPlaneACL'
+      );
+
+      cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
+      cy.wait(['@getAccount', '@getCluster', '@getControlPlaneACL']);
+
+      // confirm summary panel
+      cy.contains('Control Plane ACL').should('be.visible');
+      ui.button
+        .findByTitle('Enabled (0 IP Addresses)')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+
+      ui.drawer
+        .findByTitle('Control Plane ACL')
+        .should('be.visible')
+        .within(() => {
+          // Confirm submit button is disabled if form has not been changed
+          ui.button
+            .findByTitle('Update')
+            .should('be.visible')
+            .should('not.be.enabled');
+
+          cy.contains(
+            "Control Plane ACL secures network access to your LKE cluster's control plane. When not enabled, any public IP address can be used to access your control plane. When enabled, all network access is denied except for the IP addresses and CIDR ranges defined on the ACL."
+          ).should('be.visible');
+
+          // confirm Enabled section and toggle off 'Enabled'
+          cy.contains('Control Plane ACL').should('be.visible');
+          cy.contains(
+            'Once enabled, all network access is denied except for the IP addresses and CIDR ranges defined on the ACL.'
+          ).should('be.visible');
+          cy.findByText('Enable Control Plane ACL');
+          ui.toggle
+            .find()
+            .should('have.attr', 'data-qa-toggle', 'true')
+            .should('be.visible')
+            .click();
+
+          // confirm submit button is now enabled
+          ui.button
+            .findByTitle('Update')
+            .should('be.visible')
+            .should('be.enabled');
+
+          // confirm Revision ID section exists
+          cy.findAllByText('Revision ID').should('have.length', 2);
+          cy.contains(
+            'A unique identifing string for this particular revision to the ACL, used by clients to track events related to ACL update requests and enforcement. This defaults to a randomly generated string but can be edited if you prefer to specify your own string to use for tracking this change.'
+          ).should('be.visible');
+          cy.findByLabelText('Revision ID').should(
+            'have.value',
+            mockACLOptions['revision-id']
+          );
+
+          // confirm Addresses section
+          cy.findByText('Addresses').should('be.visible');
+          cy.findByText(
+            "A list of allowed IPv4 and IPv6 addresses and CIDR ranges. This cluster's control plane will only be accessible from IP addresses within this list."
+          ).should('be.visible');
+          cy.findByText('IPv4 Addresses or CIDRs').should('be.visible');
+          // update IPv4
+          cy.findByPlaceholderText('0.0.0.0/0')
+            .should('be.visible')
+            .click()
+            .type('10.0.0.0/24');
+          cy.findByText('Add IPv4 Address')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+          cy.findByText('IPv6 Addresses or CIDRs').should('be.visible');
+          // update IPv6
+          cy.findByPlaceholderText('::/0')
+            .should('be.visible')
+            .click()
+            .type('8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e');
+          cy.findByText('Add IPv6 Address')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+
+          // submit
+          ui.button
+            .findByTitle('Update')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      cy.wait(['@updateControlPlaneACL']);
+
+      // confirm summary panel updates
+      cy.contains('Control Plane ACL').should('be.visible');
+      cy.findByText('Enabled (O IP Addresses)').should('not.exist');
+      ui.button
+        .findByTitle('Enable')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+
+      // confirm data within drawer is updated
+      ui.drawer
+        .findByTitle('Control Plane ACL')
+        .should('be.visible')
+        .within(() => {
+          // confirm enable toggle was updated
+          ui.toggle
+            .find()
+            .should('have.attr', 'data-qa-toggle', 'false')
+            .should('be.visible');
+
+          // confirm updated IP addresses display
+          cy.findByDisplayValue('10.0.0.0/24').should('be.visible');
+          cy.findByDisplayValue(
+            '8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e'
+          ).should('be.visible');
+        });
+    });
+
+    /**
+     * - Confirms ACL can be enabled from the summary page when cluster does not have ACL pre-installed
+     * - Confirms drawer appearance when APL is not pre-installed
+     * - Confirms that request to correct endpoint is sent
+     */
+    it('can enable ACL on an LKE cluster with ACL not pre-installed and edit IPs', () => {
+      const mockACLOptions = kubernetesControlPlaneACLOptionsFactory.build({
+        enabled: true,
+        addresses: { ipv4: ['10.0.0.0/24'] },
+      });
+      const mockControlPaneACL = kubernetesControlPlaneACLFactory.build({
+        acl: mockACLOptions,
+      });
+
+      mockGetCluster(mockCluster).as('getCluster');
+      mockGetControlPlaneACLError(mockCluster.id).as('getControlPlaneACLError');
+      mockUpdateCluster(mockCluster.id, {
+        ...mockCluster,
+        control_plane: mockControlPaneACL,
+      }).as('updateCluster');
+      mockGetClusterPools(mockCluster.id, mockNodePools).as('getNodePools');
+
+      cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
+      cy.wait([
+        '@getAccount',
+        '@getCluster',
+        '@getControlPlaneACLError',
+        '@getNodePools',
+      ]);
+
+      cy.contains('Control Plane ACL').should('be.visible');
+      cy.findAllByTestId('circle-progress').should('be.visible');
+
+      // query retries once if failed
+      cy.wait('@getControlPlaneACLError');
+
+      ui.button
+        .findByTitle('Enable')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+
+      mockGetControlPlaneACL(mockCluster.id, mockControlPaneACL).as(
+        'getControlPlaneACL'
+      );
+
+      ui.drawer
+        .findByTitle('Control Plane ACL')
+        .should('be.visible')
+        .within(() => {
+          // Enable ACL
+          ui.toggle
+            .find()
+            .should('have.attr', 'data-qa-toggle', 'false')
+            .should('be.visible')
+            .click();
+
+          // Confirm revision ID section does not exist
+          cy.contains('Revision ID').should('not.exist');
+          cy.contains(
+            'A unique identifing string for this particular revision to the ACL, used by clients to track events related to ACL update requests and enforcement. This defaults to a randomly generated string but can be edited if you prefer to specify your own string to use for tracking this change.'
+          ).should('not.exist');
+
+          // Add IP addresses
+          cy.findByPlaceholderText('0.0.0.0/0')
+            .should('be.visible')
+            .click()
+            .type('10.0.0.0/24');
+
+          cy.findByPlaceholderText('::/0')
+            .should('be.visible')
+            .click()
+            .type('8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e');
+
+          // submit
+          ui.button
+            .findByTitle('Update')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      cy.wait(['@updateCluster', '@getControlPlaneACL']);
+
+      // confirm summary panel updates
+      cy.contains('Control Plane ACL').should('be.visible');
+      cy.findByText('Enabled (2 IP Addresses)').should('be.exist');
+    });
+
+    /**
+     * - Confirms IP validation error appears when a bad IP is entered
+     * - Confirms IP validation error disappears when a valid IP is entered
+     * - Confirms API error appears as expected and doesn't crash the page
+     */
+    it('can handle validation and API errors', () => {
+      const mockACLOptions = kubernetesControlPlaneACLOptionsFactory.build({
+        enabled: true,
+        addresses: { ipv4: undefined, ipv6: undefined },
+      });
+      const mockControlPaneACL = kubernetesControlPlaneACLFactory.build({
+        acl: mockACLOptions,
+      });
+      const mockErrorMessage = 'Control Plane ACL error: failed to update ACL';
+
+      mockGetCluster(mockCluster).as('getCluster');
+      mockGetControlPlaneACL(mockCluster.id, mockControlPaneACL).as(
+        'getControlPlaneACL'
+      );
+
+      mockUpdateControlPlaneACLError(mockCluster.id, mockErrorMessage, 400).as(
+        'updateControlPlaneACLError'
+      );
+
+      cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
+      cy.wait(['@getAccount', '@getCluster', '@getControlPlaneACL']);
+
+      // confirm summary panel
+      cy.contains('Control Plane ACL').should('be.visible');
+      ui.button
+        .findByTitle('Enabled (0 IP Addresses)')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+
+      ui.drawer
+        .findByTitle('Control Plane ACL')
+        .should('be.visible')
+        .within(() => {
+          // Confirm ACL IP validation works as expected
+          cy.findByPlaceholderText('::/0')
+            .should('be.visible')
+            .click()
+            .type('invalid ip');
+          // click out of textbox and confirm error is visible
+          cy.findByText('Addresses').should('be.visible').click();
+          cy.contains('Must be a valid IPv6 address.').should('be.visible');
+          // enter valid IP
+          cy.findByPlaceholderText('::/0')
+            .should('be.visible')
+            .click()
+            .clear()
+            .type('8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e');
+          // Click out of textbox and confirm error is gone
+          cy.findByText('Addresses').should('be.visible').click();
+          cy.contains('Must be a valid IPv6 address.').should('not.exist');
+
+          // submit
+          ui.button
+            .findByTitle('Update')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      cy.wait(['@updateControlPlaneACLError']);
+      cy.contains(mockErrorMessage).should('be.visible');
     });
   });
 });

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -1351,7 +1351,7 @@ describe('LKE cluster updates', () => {
   });
 });
 
-describe('LKE ACL updates', () => {
+describe.only('LKE ACL updates', () => {
   const mockCluster = kubernetesClusterFactory.build();
   const mockRevisionId = randomString(20);
 
@@ -1461,7 +1461,7 @@ describe('LKE ACL updates', () => {
           // confirm Revision ID section and edit Revision ID
           cy.findAllByText('Revision ID').should('have.length', 2);
           cy.contains(
-            'A unique identifing string for this particular revision to the ACL, used by clients to track events related to ACL update requests and enforcement. This defaults to a randomly generated string but can be edited if you prefer to specify your own string to use for tracking this change.'
+            'A unique identifying string for this particular revision to the ACL, used by clients to track events related to ACL update requests and enforcement. This defaults to a randomly generated string but can be edited if you prefer to specify your own string to use for tracking this change.'
           ).should('be.visible');
           cy.findByLabelText('Revision ID').should(
             'have.value',
@@ -1685,7 +1685,7 @@ describe('LKE ACL updates', () => {
           // confirm Revision ID section exists
           cy.findAllByText('Revision ID').should('have.length', 2);
           cy.contains(
-            'A unique identifing string for this particular revision to the ACL, used by clients to track events related to ACL update requests and enforcement. This defaults to a randomly generated string but can be edited if you prefer to specify your own string to use for tracking this change.'
+            'A unique identifying string for this particular revision to the ACL, used by clients to track events related to ACL update requests and enforcement. This defaults to a randomly generated string but can be edited if you prefer to specify your own string to use for tracking this change.'
           ).should('be.visible');
           cy.findByLabelText('Revision ID').should(
             'have.value',
@@ -1824,7 +1824,7 @@ describe('LKE ACL updates', () => {
           // Confirm revision ID section does not exist
           cy.contains('Revision ID').should('not.exist');
           cy.contains(
-            'A unique identifing string for this particular revision to the ACL, used by clients to track events related to ACL update requests and enforcement. This defaults to a randomly generated string but can be edited if you prefer to specify your own string to use for tracking this change.'
+            'A unique identifying string for this particular revision to the ACL, used by clients to track events related to ACL update requests and enforcement. This defaults to a randomly generated string but can be edited if you prefer to specify your own string to use for tracking this change.'
           ).should('not.exist');
 
           // Confirm Addresses section and add IP addresses

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -1351,7 +1351,7 @@ describe('LKE cluster updates', () => {
   });
 });
 
-describe.only('LKE ACL updates', () => {
+describe('LKE ACL updates', () => {
   const mockCluster = kubernetesClusterFactory.build();
   const mockRevisionId = randomString(20);
 

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -1351,8 +1351,7 @@ describe('LKE cluster updates', () => {
   });
 });
 
-// NOTE TO SELF COPIES MAY CHANGE (but the structure will remain the same)
-describe('LKE ACL updates', () => {
+describe.only('LKE ACL updates', () => {
   const mockCluster = kubernetesClusterFactory.build();
   const mockRevisionId = randomString(20);
 
@@ -1435,13 +1434,13 @@ describe('LKE ACL updates', () => {
             .should('not.be.enabled');
 
           cy.contains(
-            "Control Plane ACL secures network access to your LKE cluster's control plane. When not enabled, any public IP address can be used to access your control plane. When enabled, all network access is denied except for the IP addresses and CIDR ranges defined on the ACL."
+            "Control Plane ACL secures network access to your LKE cluster's control plane. Use this form to enable or disable the ACL on your LKE cluster, update the list of allowed IP addresses, and adjust other settings."
           ).should('be.visible');
 
-          // confirm Enabled section and toggle on 'Enabled'
-          cy.contains('Control Plane ACL').should('be.visible');
+          // confirm Activation Status section and toggle on 'Enable'
+          cy.contains('Activation Status').should('be.visible');
           cy.contains(
-            'Once enabled, all network access is denied except for the IP addresses and CIDR ranges defined on the ACL.'
+            'Enable or disable the Control Plane ACL. If the ACL is not enabled, any public IP address can be used to access your control plane. Once enabled, all network access is denied except for the IP addresses and CIDR ranges defined on the ACL.'
           ).should('be.visible');
           cy.findByText('Enable Control Plane ACL');
           ui.toggle
@@ -1659,13 +1658,13 @@ describe('LKE ACL updates', () => {
             .should('not.be.enabled');
 
           cy.contains(
-            "Control Plane ACL secures network access to your LKE cluster's control plane. When not enabled, any public IP address can be used to access your control plane. When enabled, all network access is denied except for the IP addresses and CIDR ranges defined on the ACL."
+            "Control Plane ACL secures network access to your LKE cluster's control plane. Use this form to enable or disable the ACL on your LKE cluster, update the list of allowed IP addresses, and adjust other settings."
           ).should('be.visible');
 
-          // confirm Enabled section and toggle off 'Enabled'
-          cy.contains('Control Plane ACL').should('be.visible');
+          // confirm Activation Status section and toggle off 'Enable'
+          cy.contains('Activation Status').should('be.visible');
           cy.contains(
-            'Once enabled, all network access is denied except for the IP addresses and CIDR ranges defined on the ACL.'
+            'Enable or disable the Control Plane ACL. If the ACL is not enabled, any public IP address can be used to access your control plane. Once enabled, all network access is denied except for the IP addresses and CIDR ranges defined on the ACL.'
           ).should('be.visible');
           cy.findByText('Enable Control Plane ACL');
           ui.toggle
@@ -1804,7 +1803,15 @@ describe('LKE ACL updates', () => {
         .findByTitle('Control Plane ACL')
         .should('be.visible')
         .within(() => {
-          // Enable ACL
+          cy.contains(
+            "Control Plane ACL secures network access to your LKE cluster's control plane. Use this form to enable or disable the ACL on your LKE cluster, update the list of allowed IP addresses, and adjust other settings."
+          ).should('be.visible');
+
+          // Confirm Activation Status section and Enable ACL
+          cy.contains('Activation Status').should('be.visible');
+          cy.contains(
+            'Enable or disable the Control Plane ACL. If the ACL is not enabled, any public IP address can be used to access your control plane. Once enabled, all network access is denied except for the IP addresses and CIDR ranges defined on the ACL.'
+          ).should('be.visible');
           ui.toggle
             .find()
             .should('have.attr', 'data-qa-toggle', 'false')
@@ -1817,7 +1824,14 @@ describe('LKE ACL updates', () => {
             'A unique identifing string for this particular revision to the ACL, used by clients to track events related to ACL update requests and enforcement. This defaults to a randomly generated string but can be edited if you prefer to specify your own string to use for tracking this change.'
           ).should('not.exist');
 
-          // Add IP addresses
+          // Confirm Addresses section and add IP addresses
+          cy.findByText('Addresses').should('be.visible');
+          cy.findByText(
+            "A list of allowed IPv4 and IPv6 addresses and CIDR ranges. This cluster's control plane will only be accessible from IP addresses within this list."
+          ).should('be.visible');
+          cy.findByText('IPv4 Addresses or CIDRs').should('be.visible');
+          cy.findByText('IPv6 Addresses or CIDRs').should('be.visible');
+
           cy.findByPlaceholderText('0.0.0.0/0')
             .should('be.visible')
             .click()
@@ -1827,6 +1841,11 @@ describe('LKE ACL updates', () => {
             .should('be.visible')
             .click()
             .type('8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e');
+
+          // Confirm installation notice is displayed
+          cy.contains(
+            'Control Plane ACL has not yet been installed on this cluster. During installation, it may take up to 15 minutes for the access control list to be fully enforced.'
+          ).should('be.visible');
 
           // submit
           ui.button

--- a/packages/manager/cypress/support/intercepts/lke.ts
+++ b/packages/manager/cypress/support/intercepts/lke.ts
@@ -419,7 +419,7 @@ export const mockGetControlPlaneACLError = (
 /**
  * Intercepts PUT request for a cluster's Control Plane ACL and mocks the response
  *
- * @param clusterId - Numberic ID of LKE cluster for which to mock response.
+ * @param clusterId - Numeric ID of LKE cluster for which to mock response.
  * @param controlPlaneACL - control plane ACL data for which to mock response
  *
  * @returns Cypress chainable

--- a/packages/manager/cypress/support/intercepts/lke.ts
+++ b/packages/manager/cypress/support/intercepts/lke.ts
@@ -438,7 +438,7 @@ export const mockUpdateControlPlaneACL = (
 /**
  * Intercepts PUT request for a cluster's Control Plane ACL and mocks the response
  *
- * @param clusterId - Numberic ID of LKE cluster for which to mock response.
+ * @param clusterId - Numeric ID of LKE cluster for which to mock response.
  * @param errorMessage - Optional error message with which to mock response.
  * @param statusCode - HTTP status code with which to mock response.
  *

--- a/packages/manager/cypress/support/intercepts/lke.ts
+++ b/packages/manager/cypress/support/intercepts/lke.ts
@@ -398,7 +398,7 @@ export const mockGetControlPlaneACL = (
 /**
  * Intercepts GET request for a cluster's Control Plane ACL and mocks an error response
  *
- * @param clusterId - Numberic ID of LKE cluster for which to mock response.
+ * @param clusterId - Numeric ID of LKE cluster for which to mock response.
  * @param errorMessage - Optional error message with which to mock response.
  * @param statusCode - HTTP status code with which to mock response.
  *

--- a/packages/manager/cypress/support/intercepts/lke.ts
+++ b/packages/manager/cypress/support/intercepts/lke.ts
@@ -362,7 +362,7 @@ export const mockGetApiEndpoints = (
 /**
  * Intercepts DELETE request to reset Kubeconfig and mocks the response.
  *
- * @param clusterId - Numberic ID of LKE cluster for which to mock response.
+ * @param clusterId - Numeric ID of LKE cluster for which to mock response.
  *
  * @returns Cypress chainable.
  */

--- a/packages/manager/cypress/support/intercepts/lke.ts
+++ b/packages/manager/cypress/support/intercepts/lke.ts
@@ -7,6 +7,7 @@ import {
   kubernetesDashboardUrlFactory,
 } from '@src/factories';
 import { kubernetesVersions } from 'support/constants/lke';
+import { makeErrorResponse } from 'support/util/errors';
 import { apiMatcher } from 'support/util/intercepts';
 import { paginateResponse } from 'support/util/paginate';
 import { randomDomainName } from 'support/util/random';
@@ -16,6 +17,7 @@ import type {
   KubeConfigResponse,
   KubeNodePoolResponse,
   KubernetesCluster,
+  KubernetesControlPlaneACLPayload,
   KubernetesVersion,
 } from '@linode/api-v4';
 
@@ -154,6 +156,25 @@ export const mockCreateCluster = (
     'POST',
     apiMatcher('lke/clusters'),
     makeResponse(cluster)
+  );
+};
+
+/**
+ * Intercepts POST request to create an LKE cluster and mocks an error response.
+ *
+ * @param errorMessage - Optional error message with which to mock response.
+ * @param statusCode - HTTP status code with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockCreateClusterError = (
+  errorMessage: string = 'An unknown error occurred.',
+  statusCode: number = 500
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher('lke/clusters'),
+    makeErrorResponse(errorMessage, statusCode)
   );
 };
 
@@ -352,5 +373,85 @@ export const mockResetKubeconfig = (
     'DELETE',
     apiMatcher(`lke/clusters/${clusterId}/kubeconfig`),
     makeResponse({})
+  );
+};
+
+/**
+ * Intercepts GET request for a cluster's Control Plane ACL and mocks the response
+ *
+ * @param clusterId - Numberic ID of LKE cluster for which to mock response.
+ * @param controlPlaneACL - control plane ACL data for which to mock response
+ *
+ * @returns Cypress chainable
+ */
+export const mockGetControlPlaneACL = (
+  clusterId: number,
+  controlPlaneACL: KubernetesControlPlaneACLPayload
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher(`/lke/clusters/${clusterId}/control_plane_acl`),
+    makeResponse(controlPlaneACL)
+  );
+};
+
+/**
+ * Intercepts GET request for a cluster's Control Plane ACL and mocks an error response
+ *
+ * @param clusterId - Numberic ID of LKE cluster for which to mock response.
+ * @param errorMessage - Optional error message with which to mock response.
+ * @param statusCode - HTTP status code with which to mock response.
+ *
+ * @returns Cypress chainable
+ */
+export const mockGetControlPlaneACLError = (
+  clusterId: number,
+  errorMessage: string = 'An unknown error occurred.',
+  statusCode: number = 500
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher(`/lke/clusters/${clusterId}/control_plane_acl`),
+    makeErrorResponse(errorMessage, statusCode)
+  );
+};
+
+/**
+ * Intercepts PUT request for a cluster's Control Plane ACL and mocks the response
+ *
+ * @param clusterId - Numberic ID of LKE cluster for which to mock response.
+ * @param controlPlaneACL - control plane ACL data for which to mock response
+ *
+ * @returns Cypress chainable
+ */
+export const mockUpdateControlPlaneACL = (
+  clusterId: number,
+  controlPlaneACL: KubernetesControlPlaneACLPayload
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'PUT',
+    apiMatcher(`/lke/clusters/${clusterId}/control_plane_acl`),
+    makeResponse(controlPlaneACL)
+  );
+};
+
+/**
+ * Intercepts PUT request for a cluster's Control Plane ACL and mocks the response
+ *
+ * @param clusterId - Numberic ID of LKE cluster for which to mock response.
+ * @param errorMessage - Optional error message with which to mock response.
+ * @param statusCode - HTTP status code with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockUpdateControlPlaneACLError = (
+  clusterId: number,
+  errorMessage: string = 'An unknown error occurred.',
+  statusCode: number = 500
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'PUT',
+    apiMatcher(`/lke/clusters/${clusterId}/control_plane_acl`),
+    makeErrorResponse(errorMessage, statusCode)
   );
 };

--- a/packages/manager/cypress/support/intercepts/lke.ts
+++ b/packages/manager/cypress/support/intercepts/lke.ts
@@ -379,7 +379,7 @@ export const mockResetKubeconfig = (
 /**
  * Intercepts GET request for a cluster's Control Plane ACL and mocks the response
  *
- * @param clusterId - Numberic ID of LKE cluster for which to mock response.
+ * @param clusterId - Numeric ID of LKE cluster for which to mock response.
  * @param controlPlaneACL - control plane ACL data for which to mock response
  *
  * @returns Cypress chainable

--- a/packages/manager/src/factories/kubernetesCluster.ts
+++ b/packages/manager/src/factories/kubernetesCluster.ts
@@ -1,13 +1,17 @@
-import {
+import { v4 } from 'uuid';
+
+import Factory from 'src/factories/factoryProxy';
+
+import type {
+  ControlPlaneACLOptions,
   KubeNodePoolResponse,
   KubernetesCluster,
+  KubernetesControlPlaneACLPayload,
   KubernetesDashboardResponse,
   KubernetesEndpointResponse,
   KubernetesVersion,
   PoolNodeResponse,
 } from '@linode/api-v4/lib/kubernetes/types';
-import Factory from 'src/factories/factoryProxy';
-import { v4 } from 'uuid';
 
 export const kubeLinodeFactory = Factory.Sync.makeFactory<PoolNodeResponse>({
   id: Factory.each((id) => `id-${id}`),
@@ -71,5 +75,23 @@ export const kubernetesAPIResponse = Factory.Sync.makeFactory<KubernetesCluster>
 export const kubernetesVersionFactory = Factory.Sync.makeFactory<KubernetesVersion>(
   {
     id: '1.24',
+  }
+);
+
+export const kubernetesControlPlaneACLOptionsFactory = Factory.Sync.makeFactory<ControlPlaneACLOptions>(
+  {
+    addresses: {
+      ipv4: ['10.0.0.0/24', '10.0.1.0/24'],
+      ipv6: ['8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e'],
+    },
+    enabled: true,
+    'revision-id': '67497a9c5fc8491889a7ef8107493e92',
+  }
+);
+export const kubernetesControlPlaneACLFactory = Factory.Sync.makeFactory<KubernetesControlPlaneACLPayload>(
+  {
+    acl: {
+      ...kubernetesControlPlaneACLOptionsFactory.build(),
+    },
   }
 );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeControlPaneACLDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeControlPaneACLDrawer.tsx
@@ -203,8 +203,8 @@ export const KubeControlPlaneACLDrawer = (props: Props) => {
               <>
                 <Typography variant="h3">Revision ID</Typography>
                 <StyledTypography variant="body1">
-                  A unique identifing string for this particular revision to the
-                  ACL, used by clients to track events related to ACL update
+                  A unique identifying string for this particular revision to
+                  the ACL, used by clients to track events related to ACL update
                   requests and enforcement. This defaults to a randomly
                   generated string but can be edited if you prefer to specify
                   your own string to use for tracking this change.


### PR DESCRIPTION
## Description 📝
Adds tests for updating an LKE cluster's ACL from the summary/details page
Part 1: #10968 
Part 2: #11131
Part 3: #11132 

## Changes  🔄
- tests added:
  - Confirming ACL doesn't exist without the corresponding account capability
  - Confirming enabling ACL from the summary page (+ updating IPs)
  - Confirming disabling ACL from the summary page (+ updating IPs)
  - Confirming enabling when ACL is not 'pre-installed'
  - Confirming error/validation handling
- add related mock intercepts
- add relevant factories (some files will cause merge conflicts with part 3, #11132  - will fix as needed)

## Target release date 🗓️
10/28

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/kubernetes/lke-update.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
