### PR TITLE
fix: [M3-8696] - Autocomplete renderOption prop console warning

### DIFF
--- a/packages/manager/.changeset/pr-11140-fixed-1729625688555.md
+++ b/packages/manager/.changeset/pr-11140-fixed-1729625688555.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Autocomplete renderOption prop console warning ([#11140](https://github.com/linode/manager/pull/11140))

--- a/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
+++ b/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
@@ -103,12 +103,14 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
         handlePlacementGroupChange(selectedOption ?? null);
       }}
       renderOption={(props, option, { selected }) => {
+        const { key, ...rest } = props;
+
         return (
           <PlacementGroupSelectOption
             disabled={isDisabledPlacementGroup(option, selectedRegion)}
-            key={option.id}
+            key={key}
             label={option.label}
-            props={props}
+            props={rest}
             selected={selected}
             value={option}
           />

--- a/packages/manager/src/components/RegionSelect/RegionMultiSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionMultiSelect.tsx
@@ -106,17 +106,22 @@ export const RegionMultiSelect = React.memo((props: RegionMultiSelectProps) => {
             onChange(selectedOptions?.map((region) => region.id) ?? [])
           }
           renderOption={(props, option, { selected }) => {
+            const { key, ...rest } = props;
             if (!option.site_type) {
               // Render options like "Select All / Deselect All"
-              return <StyledListItem {...props}>{option.label}</StyledListItem>;
+              return (
+                <StyledListItem {...rest} key={key}>
+                  {option.label}
+                </StyledListItem>
+              );
             }
 
             // Render regular options
             return (
               <RegionOption
                 disabledOptions={disabledRegions[option.id]}
-                key={option.id}
-                props={props}
+                key={key}
+                props={rest}
                 region={option}
                 selected={selected}
               />

--- a/packages/manager/src/components/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.tsx
@@ -136,14 +136,18 @@ export const RegionSelect = <
         getOptionLabel={(region) =>
           isGeckoLAEnabled ? region.label : `${region.label} (${region.id})`
         }
-        renderOption={(props, region) => (
-          <RegionOption
-            disabledOptions={disabledRegions[region.id]}
-            key={region.id}
-            props={props}
-            region={region}
-          />
-        )}
+        renderOption={(props, region) => {
+          const { key, ...rest } = props;
+
+          return (
+            <RegionOption
+              disabledOptions={disabledRegions[region.id]}
+              key={key}
+              props={rest}
+              region={region}
+            />
+          );
+        }}
         sx={(theme) => ({
           [theme.breakpoints.up('md')]: {
             width: '416px',

--- a/packages/manager/src/components/TagCell/AddTag.tsx
+++ b/packages/manager/src/components/TagCell/AddTag.tsx
@@ -79,9 +79,15 @@ export const AddTag = (props: AddTagProps) => {
           handleAddTag(typeof value == 'string' ? value : value.label);
         }
       }}
-      renderOption={(props, option) => (
-        <li {...props}>{option.displayLabel ?? option.label}</li>
-      )}
+      renderOption={(props, option) => {
+        const { key, ...rest } = props;
+
+        return (
+          <li {...rest} key={key}>
+            {option.displayLabel ?? option.label}
+          </li>
+        );
+      }}
       disableClearable
       forcePopupIcon
       label={'Create or Select a Tag'}

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -214,11 +214,14 @@ export const DatabaseBackups = (props: Props) => {
               onChange={(_, newTime) => setSelectedTime(newTime)}
               options={TIME_OPTIONS}
               placeholder="Choose a time"
-              renderOption={(props, option) => (
-                <li {...props} key={option.value}>
-                  {option.label}
-                </li>
-              )}
+              renderOption={(props, option) => {
+                const { key, ...rest } = props;
+                return (
+                  <li {...rest} key={key}>
+                    {option.label}
+                  </li>
+                );
+              }}
               textFieldProps={{
                 dataAttrs: {
                   'data-qa-time-select': true,

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/KernelSelect.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/KernelSelect.tsx
@@ -33,8 +33,9 @@ export const KernelSelect = React.memo((props: KernelSelectProps) => {
   return (
     <Autocomplete
       renderOption={(props, kernel) => {
+        const { key, ...rest } = props;
         return (
-          <li {...props} data-testid="kernel-option">
+          <li {...rest} data-testid="kernel-option" key={key}>
             {kernel.label}
           </li>
         );

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/ServiceTargets/LinodeOrIPSelect.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/ServiceTargets/LinodeOrIPSelect.tsx
@@ -95,13 +95,14 @@ export const LinodeOrIPSelect = (props: Props) => {
         }
       }}
       renderOption={(props, option, state) => {
+        const { key, ...rest } = props;
         const region =
           regions?.find((r) => r.id === option.region)?.label ?? option.region;
 
         const isCustomIp = option === customIpPlaceholder;
 
         return (
-          <li {...props}>
+          <li {...rest} key={key}>
             <Stack flexGrow={1}>
               <Box>
                 <b>{isCustomIp ? 'Custom IP' : option.label}</b>

--- a/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
+++ b/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
@@ -62,29 +62,32 @@ export const ConfigNodeIPSelect = React.memo((props: Props) => {
 
   return (
     <Autocomplete
-      renderOption={(props, option, { selected }) => (
-        <li {...props} key={props.key}>
-          <Box
-            alignItems="center"
-            display="flex"
-            flexDirection="row"
-            gap={1}
-            justifyContent="space-between"
-            width="100%"
-          >
-            <Stack>
-              <Typography
-                color="inherit"
-                fontFamily={(theme) => theme.font.bold}
-              >
-                {option.label}
-              </Typography>
-              <Typography color="inherit">{option.linode.label}</Typography>
-            </Stack>
-            {selected && <SelectedIcon visible />}
-          </Box>
-        </li>
-      )}
+      renderOption={(props, option, { selected }) => {
+        const { key, ...rest } = props;
+        return (
+          <li {...rest} key={key}>
+            <Box
+              alignItems="center"
+              display="flex"
+              flexDirection="row"
+              gap={1}
+              justifyContent="space-between"
+              width="100%"
+            >
+              <Stack>
+                <Typography
+                  color="inherit"
+                  fontFamily={(theme) => theme.font.bold}
+                >
+                  {option.label}
+                </Typography>
+                <Typography color="inherit">{option.linode.label}</Typography>
+              </Stack>
+              {selected && <SelectedIcon visible />}
+            </Box>
+          </li>
+        );
+      }}
       disabled={disabled}
       errorText={errorText ?? error?.[0].reason}
       id={inputId}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerSelect.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerSelect.tsx
@@ -132,8 +132,9 @@ export const NodeBalancerSelect = (
       renderOption={
         renderOption
           ? (props, option, { selected }) => {
+              const { key, ...rest } = props;
               return (
-                <li {...props} data-qa-linode-option>
+                <li {...rest} data-qa-linode-option key={key}>
                   {renderOption(option, selected)}
                 </li>
               );

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupTypeSelect.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupTypeSelect.tsx
@@ -28,6 +28,7 @@ export const PlacementGroupTypeSelect = (props: Props) => {
         setFieldValue('placement_group_type', value?.value ?? '');
       }}
       renderOption={(props, option) => {
+        const { key, ...rest } = props;
         const isDisabledMenuItem = option.value === 'affinity:local';
 
         return (
@@ -49,10 +50,10 @@ export const PlacementGroupTypeSelect = (props: Props) => {
             enterDelay={200}
             enterNextDelay={200}
             enterTouchDelay={200}
-            key={option.value}
+            key={key}
           >
             <ListItem
-              {...props}
+              {...rest}
               className={
                 isDisabledMenuItem
                   ? `${props.className} Mui-disabled`

--- a/packages/ui/src/foundations/themes/dark.ts
+++ b/packages/ui/src/foundations/themes/dark.ts
@@ -222,6 +222,11 @@ export const darkTheme: ThemeOptions = {
           '.MuiChip-deleteIcon': { color: primaryColors.text },
           backgroundColor: customDarkModeOptions.bg.lightBlue1,
         },
+        input: {
+          '&::selection': {
+            backgroundColor: customDarkModeOptions.bg.appBar,
+          },
+        },
       },
     },
     MuiBackdrop: {

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -347,7 +347,7 @@ export const lightTheme: ThemeOptions = {
             opacity: 1,
           },
           '&::selection': {
-            backgroundColor: color.grey7,
+            backgroundColor: 'transparent',
           },
         },
         inputRoot: {

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -347,7 +347,7 @@ export const lightTheme: ThemeOptions = {
             opacity: 1,
           },
           '&::selection': {
-            backgroundColor: 'transparent',
+            backgroundColor: color.grey10,
           },
         },
         inputRoot: {


### PR DESCRIPTION
## Description 📝
Fixes this annoying little bugger when overriding `renderOption` in `AutoComplete`.

![Screenshot 2024-10-22 at 15 05 09](https://github.com/user-attachments/assets/d19bea86-c3f8-4311-b8f7-916e1ac5525d)

It was already fixed when not overriding in https://github.com/linode/manager/pull/11041/files, alas we needed a fix when passing `renderOption`. I did not find it possible to do it from the component so we need to remember to do it every time we declare `renderOptions`. Should be straight forward when implementing a new Autocomplete when checking the console.

## Changes  🔄
- Destructure props for every renderOption instance
  - ⚠️ `ImageSelect` is handled [here](https://github.com/linode/manager/pull/11058/files#diff-b1e748ce0fa210ca98b102dbbd16ae5030d118bae8a8422ecfb17584e0c96713R161), not in this PR
- Fix the annoying text selection highlight in Autocomplete 

## How to test 🧪

### Verification steps
(How to verify changes)
- Verify that all `<Autocomplete />` with `renderOption` modified in this PR (except for ImageSelect - see description) don't display the console error when being opened

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
