### PR TITLE
change: [M3-8461] - Improve validation error when a backup is not selected.

### DIFF
--- a/packages/manager/.changeset/pr-11147-changed-1729684531663.md
+++ b/packages/manager/.changeset/pr-11147-changed-1729684531663.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Improve validation error when a backup is not selected ([#11147](https://github.com/linode/manager/pull/11147))

--- a/packages/manager/src/features/Linodes/LinodeCreate/Tabs/Backups/BackupSelect.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Tabs/Backups/BackupSelect.tsx
@@ -86,7 +86,7 @@ export const BackupSelect = () => {
       <Stack spacing={2}>
         <Typography variant="h2">Select Backup</Typography>
         {fieldState.error?.message && (
-          <Notice text={'A backup is required'} variant="error" />
+          <Notice text={fieldState.error.message} variant="error" />
         )}
         {renderContent()}
       </Stack>

--- a/packages/manager/src/features/Linodes/LinodeCreate/Tabs/Backups/BackupSelect.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Tabs/Backups/BackupSelect.tsx
@@ -86,7 +86,7 @@ export const BackupSelect = () => {
       <Stack spacing={2}>
         <Typography variant="h2">Select Backup</Typography>
         {fieldState.error?.message && (
-          <Notice text={fieldState.error.message} variant="error" />
+          <Notice text={'A backup is required'} variant="error" />
         )}
         {renderContent()}
       </Stack>

--- a/packages/manager/src/features/Linodes/LinodeCreate/schemas.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreate/schemas.ts
@@ -6,7 +6,9 @@ import { number, object } from 'yup';
  */
 export const CreateLinodeFromBackupSchema = CreateLinodeSchema.concat(
   object({
-    backup_id: number().required('You must select a Backup.'),
+    backup_id: number()
+      .transform((value) => (isNaN(value) ? undefined : value))
+      .required('You must select a Backup.'),
   })
 );
 


### PR DESCRIPTION
## Description 📝
To get a better understanding of the error Notice when a backup is not selected while creating a Linode v2.

Here, we are adding the error text if a user didn't selected any backup of the Linode for improving validation.

## Changes  🔄
List any change relevant to the reviewer.

- If backup is not selected:
  - error Notice for selecting the backup will shown. 

## Target release date 🗓️

## Preview 📷

| Before | After |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/b84d4270-c8a7-44ab-8173-314b0e7ac3ff) | ![After](https://github.com/user-attachments/assets/900c494d-ed0e-46f9-b2c5-ea0e87fdb3dc) |

## How to test 🧪

### Prerequisites
- You should have at least one Linode in your account before Reproduction :

### Reproduction steps
- Ensure you are on Linode Create v2.
- Go to the backups tab.
- Select a Linode (do not select a backup).
- Submit the form.
- Observe the error shown in the screenshot.

### Verification steps

- After submitting, observe the error shown in the screenshot.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
