### PR TITLE
fix: [M3-8773] - Duplicate punctuation on `image_upload` event message

### DIFF
--- a/packages/manager/.changeset/pr-11148-fixed-1729687116230.md
+++ b/packages/manager/.changeset/pr-11148-fixed-1729687116230.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Duplicate punctuation on `image_upload` event message ([#11148](https://github.com/linode/manager/pull/11148))

--- a/packages/manager/src/features/Events/factories/image.tsx
+++ b/packages/manager/src/features/Events/factories/image.tsx
@@ -52,7 +52,7 @@ export const image: PartialEventMap<'image'> = {
         <>
           Image <EventLink event={e} to="entity" /> could <strong>not</strong>{' '}
           be <strong>uploaded</strong>:{' '}
-          <FormattedEventMessage message={message} />.
+          <FormattedEventMessage message={message} />
         </>
       );
     },


### PR DESCRIPTION
## Description 📝

- Removes the `.` we add after the API event message for Image Upload events to fix duplicate punctuation 🔧 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-10-23 at 8 20 43 AM](https://github.com/user-attachments/assets/ea3c3367-96dd-42f2-853b-b1c87cdbddc1)  | ![Screenshot 2024-10-23 at 8 31 28 AM](https://github.com/user-attachments/assets/1b221e99-b4d4-4243-9c50-6a54ea3ac31f) |

## How to test 🧪

- Begin uploading an image
- Cancel the upload
- Delete the Image related to the canceled upload
- Observe the toast notification 👁️

https://github.com/user-attachments/assets/ef0b0237-129a-46ce-9ef1-db484caae589

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support