### PR TITLE
fix: [M3-8774 ] - Faux bold in Safari with `<strong />` & `<b />` tags

### DIFF
--- a/packages/manager/.changeset/pr-11149-fixed-1729690586892.md
+++ b/packages/manager/.changeset/pr-11149-fixed-1729690586892.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Faux bold in Safari with <strong /> & <b /> tags ([#11149](https://github.com/linode/manager/pull/11149))

--- a/packages/manager/src/index.css
+++ b/packages/manager/src/index.css
@@ -16,6 +16,12 @@ body {
   margin: 0;
   padding: 0 !important;
   font-family: 'LatoWeb', sans-serif;
+
+  strong,
+  b {
+  font-family: 'LatoWebBold', sans-serif;
+    font-weight: normal;
+  }
 }
 
 body.searchOverlay #main-content {
@@ -150,12 +156,6 @@ a.h-u:hover {
 
 .secondaryLink:hover {
   text-decoration: underline;
-}
-
-strong,
-b {
-  font-family: 'LatoWebBold', sans-serif;
-  font-weight: normal;
 }
 
 .visually-hidden {

--- a/packages/manager/src/index.css
+++ b/packages/manager/src/index.css
@@ -17,9 +17,8 @@ body {
   padding: 0 !important;
   font-family: 'LatoWeb', sans-serif;
 
-  strong,
-  b {
-  font-family: 'LatoWebBold', sans-serif;
+  strong, b {
+    font-family: 'LatoWebBold', sans-serif;
     font-weight: normal;
   }
 }


### PR DESCRIPTION
## Description 📝
It does appear global CSS isn't picked up in Safari for `<strong>` and `<b>` tags, resulting in faux bold. This seems to happen systematically during DOM injection

![Private User Image](https://github.com/user-attachments/assets/89dd4afd-0808-449f-8a84-b627d37913c3)

The issue seems to stem from the browser having higher specificity over our global CSS declaration. This PR nests our `strong` & `b` CSS declaration to increase specificity, which seems to fix the problem overall

## Changes  🔄
- Increase CSS specificity for `strong` & `b` for Safari

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-10-23 at 09 28 17](https://github.com/user-attachments/assets/b78b2bd6-3177-463a-82a1-0a291568128e) | ![Screenshot 2024-10-23 at 09 28 55](https://github.com/user-attachments/assets/89e643b5-abe6-416f-994b-05c438cc0dcb) |

## How to test 🧪

### Verification steps
- Pull code and verify fix in notification menu, toast notifications etc

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support


