### PR TITLE
chore: [M3-8786] - Update and clean up `@types/node` package

### DIFF
--- a/packages/api-v4/.changeset/pr-11157-tech-stories-1729787265807.md
+++ b/packages/api-v4/.changeset/pr-11157-tech-stories-1729787265807.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Tech Stories
+---
+
+Remove `@types/node` dependency ([#11157](https://github.com/linode/manager/pull/11157))

--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -57,7 +57,6 @@
     "lib"
   ],
   "devDependencies": {
-    "@types/node": "^12.7.1",
     "@types/yup": "^0.29.13",
     "axios-mock-adapter": "^1.22.0",
     "concurrently": "^9.0.1",

--- a/packages/manager/.changeset/pr-11157-tech-stories-1729787405590.md
+++ b/packages/manager/.changeset/pr-11157-tech-stories-1729787405590.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Update `@types/node` to `20.17.0` ([#11157](https://github.com/linode/manager/pull/11157))

--- a/packages/manager/cypress/support/plugins/discard-passed-test-recordings.ts
+++ b/packages/manager/cypress/support/plugins/discard-passed-test-recordings.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error for some reason, @node/types is v12 and it probably doesn't have this.
 import fs from 'fs/promises';
 
 import { CypressPlugin } from './plugin';

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -149,7 +149,7 @@
     "@types/markdown-it": "^10.0.2",
     "@types/md5": "^2.1.32",
     "@types/mocha": "^10.0.2",
-    "@types/node": "^12.7.1",
+    "@types/node": "^20.17.0",
     "@types/qrcode.react": "^0.8.0",
     "@types/ramda": "0.25.16",
     "@types/react": "^18.2.55",

--- a/packages/manager/src/hooks/useInterval.tsx
+++ b/packages/manager/src/hooks/useInterval.tsx
@@ -35,7 +35,7 @@ interface UseIntervalReturn {
   /**
    * Reference to the interval timer.
    */
-  intervalRef: React.MutableRefObject<NodeJS.Timer | undefined>;
+  intervalRef: React.MutableRefObject<number | undefined>;
 }
 
 const useInterval = ({
@@ -46,7 +46,7 @@ const useInterval = ({
   startImmediately = false,
   when = true,
 }: UseIntervalOptions): UseIntervalReturn => {
-  const intervalRef = useRef<NodeJS.Timer | undefined>();
+  const intervalRef = useRef<number | undefined>();
 
   // Save the callback to a ref to ensure it has the most recent version
   // without needing to reset the interval each time the callback changes.
@@ -58,7 +58,7 @@ const useInterval = ({
 
   const clearTimer = useCallback(() => {
     if (intervalRef.current) {
-      clearInterval(intervalRef.current);
+      window.clearInterval(intervalRef.current);
 
       // Optionally clear the ref after stopping the interval
       intervalRef.current = undefined;
@@ -84,7 +84,7 @@ const useInterval = ({
         tick();
       }
 
-      intervalRef.current = setInterval(tick, delay);
+      intervalRef.current = window.setInterval(tick, delay);
 
       return clearTimer;
     }

--- a/packages/ui/.changeset/pr-11157-tech-stories-1729787461166.md
+++ b/packages/ui/.changeset/pr-11157-tech-stories-1729787461166.md
@@ -1,0 +1,5 @@
+---
+"@linode/ui": Tech Stories
+---
+
+Remove `@types/node` dependency ([#11157](https://github.com/linode/manager/pull/11157))

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,7 +44,6 @@
     "@testing-library/dom": "^10.1.0",
     "@testing-library/jest-dom": "~6.4.2",
     "@testing-library/react": "~16.0.0",
-    "@types/node": "^12.7.1",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.18",
     "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/packages/validation/.changeset/pr-11157-tech-stories-1729787428923.md
+++ b/packages/validation/.changeset/pr-11157-tech-stories-1729787428923.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Tech Stories
+---
+
+Remove `@types/node` dependency ([#11157](https://github.com/linode/manager/pull/11157))

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -43,7 +43,6 @@
     "yup": "^0.32.9"
   },
   "devDependencies": {
-    "@types/node": "^12.7.1",
     "concurrently": "^9.0.1",
     "eslint": "^6.8.0",
     "eslint-plugin-sonarjs": "^0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2368,10 +2368,12 @@
   dependencies:
     undici-types "~6.19.2"
 
-"@types/node@^12.7.1":
-  version "12.20.55"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
-  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
+"@types/node@^20.17.0":
+  version "20.17.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.0.tgz#d0620ba0fe4cf2a0f12351c7bdd805fc4e1f036b"
+  integrity sha512-a7zRo0f0eLo9K5X9Wp5cAqTUNGzuFLDG2R7C4HY2BhcMAsxgSPuRvAC1ZB6QkuUQXf0YZAgfOX2ZyrBa2n4nHQ==
+  dependencies:
+    undici-types "~6.19.2"
 
 "@types/parse-json@^4.0.0":
   version "4.0.2"


### PR DESCRIPTION
## Description 📝

- Follow up PR for https://github.com/linode/manager/pull/10866
- This PR updates our `@types/node` version to match our Node.js version 📦  It seems to not have been kept up to date
- Removes `@types/node` from our packages that don't need Node.js types 🧹 

## How to test 🧪

- Verify all type-checking passes ✅ 
- Check for regressions in files that were touched 👁️ 

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support