### PR TITLE
fix: [M3-8788] - Only run coverage comment job on non-drafts

### DIFF
--- a/.github/workflows/coverage_comment.yml
+++ b/.github/workflows/coverage_comment.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   comment:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/coverage_comment.yml
+++ b/.github/workflows/coverage_comment.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   comment:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     steps:

--- a/packages/manager/.changeset/pr-11161-fixed-1729827835443.md
+++ b/packages/manager/.changeset/pr-11161-fixed-1729827835443.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Only run 'Coverage Comment' GHA on non-drafts ([#11161](https://github.com/linode/manager/pull/11161))


### PR DESCRIPTION
## Description 📝
https://github.com/linode/manager/actions/workflows/coverage_comment.yml?query=is:failure

The "Coverage Comment" GHA depends on the "Code Coverage" workflow to be completed. However that job is designed to not run on draft, so every time a draft gets updates this job fails, because apparently it assumes the job is completed when it never runs.

This flag should fix this and remove some noise when running on drafts.

There unfortunately isn't a way to check this works until this is merged but I have confidence this should do it, and if not we can always do a quick revert

## Changes  🔄
- Add a flag to the "Coverage Comment" GHA to make sure it only runs if the workflow it depends on actually succeeds 

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
