### PR TITLE
upcoming: [M3-6700] - Replace one-off hardcoded black and white color values with colorTokens

### DIFF
--- a/packages/manager/.changeset/pr-11165-upcoming-features-1729872623442.md
+++ b/packages/manager/.changeset/pr-11165-upcoming-features-1729872623442.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-Replace one off hardcoded black and white color values with colorTokens ([#11165](https://github.com/linode/manager/pull/11165))
+Replace one-off hardcoded black and white color values with colorTokens ([#11165](https://github.com/linode/manager/pull/11165))

--- a/packages/manager/.changeset/pr-11165-upcoming-features-1729872623442.md
+++ b/packages/manager/.changeset/pr-11165-upcoming-features-1729872623442.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Replace one off hardcoded black and white color values with colorTokens ([#11165](https://github.com/linode/manager/pull/11165))

--- a/packages/manager/src/GoTo.tsx
+++ b/packages/manager/src/GoTo.tsx
@@ -42,7 +42,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     },
     '& .react-select__option--is-focused': {
       backgroundColor: theme.palette.primary.main,
-      color: 'white',
+      color: theme.colorTokens.Neutrals.White,
     },
     '& .react-select__value-container': {
       '& p': {

--- a/packages/manager/src/components/AkamaiBanner/AkamaiBanner.styles.ts
+++ b/packages/manager/src/components/AkamaiBanner/AkamaiBanner.styles.ts
@@ -9,20 +9,20 @@ import { Stack } from '../Stack';
 
 export const StyledAkamaiLogo = styled(AkamaiLogo, {
   label: 'StyledAkamaiLogo',
-})({
+})(({ theme }) => ({
   '& .akamai-logo-icon': {
-    fill: 'white',
+    fill: theme.colorTokens.Neutrals.White,
   },
   '& .akamai-logo-name': {
     display: 'none',
   },
-});
+}));
 
 export const StyledWarningIcon = styled(Warning, {
   label: 'StyledWarningIcon',
-})({
-  color: 'black',
-});
+})(({ theme }) => ({
+  color: theme.colorTokens.Neutrals.Black,
+}));
 
 export const StyledBanner = styled(Stack, {
   label: 'StyledBanner',
@@ -39,8 +39,12 @@ export const StyledBannerLabel = styled(Box, {
   label: 'StyledBannerLabel',
   shouldForwardProp: omittedProps(['warning']),
 })<{ warning?: boolean }>(({ theme, warning }) => ({
-  backgroundColor: warning ? theme.palette.warning.dark : 'black',
-  color: warning ? 'black' : 'white',
+  backgroundColor: warning
+    ? theme.palette.warning.dark
+    : theme.colorTokens.Neutrals.Black,
+  color: warning
+    ? theme.colorTokens.Neutrals.Black
+    : theme.colorTokens.Neutrals.White,
   padding: theme.spacing(2.3),
   [theme.breakpoints.up('sm')]: {
     textWrap: 'nowrap',

--- a/packages/manager/src/components/ColorPalette/ColorPalette.tsx
+++ b/packages/manager/src/components/ColorPalette/ColorPalette.tsx
@@ -50,7 +50,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
  *
  * If a color does not exist in the current palette and is only used once, consider applying the color conditionally:
  *
- * `theme.name === 'light' ? '#fff' : '#000'`
+ * `theme.name === 'light' ? theme.colorTokens.Neutrals.White : theme.colorTokens.Neutrals.Black`
  */
 export const ColorPalette = () => {
   const { classes } = useStyles();

--- a/packages/manager/src/components/Drawer.tsx
+++ b/packages/manager/src/components/Drawer.tsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
   button: {
     '& :hover, & :focus': {
       backgroundColor: theme.palette.primary.main,
-      color: 'white',
+      color: theme.colorTokens.Neutrals.White,
     },
     '& > span': {
       padding: 2,

--- a/packages/manager/src/components/EnhancedSelect/Select.styles.ts
+++ b/packages/manager/src/components/EnhancedSelect/Select.styles.ts
@@ -169,7 +169,7 @@ export const useStyles = makeStyles()((theme: Theme) => ({
       },
       '&:hover': {
         '& svg': {
-          color: 'white',
+          color: theme.colorTokens.Neutrals.White,
         },
         backgroundColor: theme.palette.primary.main,
       },
@@ -202,7 +202,7 @@ export const useStyles = makeStyles()((theme: Theme) => ({
     },
     '& .react-select__option--is-focused': {
       backgroundColor: theme.palette.primary.main,
-      color: 'white',
+      color: theme.colorTokens.Neutrals.White,
     },
     '& .react-select__option--is-selected': {
       '&.react-select__option--is-focused': {
@@ -251,7 +251,7 @@ export const useStyles = makeStyles()((theme: Theme) => ({
     '& .tag': {
       '&:hover': {
         backgroundColor: theme.palette.primary.main,
-        color: 'white',
+        color: theme.colorTokens.Neutrals.White,
       },
       backgroundColor: theme.bg.lightBlue1,
       color: theme.palette.text.primary,
@@ -377,7 +377,7 @@ export const reactSelectStyles = (theme: Theme) => ({
     },
     '&:hover': {
       '& svg': {
-        color: 'white',
+        color: theme.colorTokens.Neutrals.White,
       },
       backgroundColor: theme.palette.primary.main,
     },
@@ -408,7 +408,7 @@ export const reactSelectStyles = (theme: Theme) => ({
       return {
         ...optionStyles,
         backgroundColor: theme.palette.primary.main,
-        color: 'white',
+        color: theme.colorTokens.Neutrals.White,
       };
     }
     if (state.isSelected) {

--- a/packages/manager/src/components/ImageSelect/ImageOption.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageOption.tsx
@@ -25,17 +25,18 @@ const useStyles = makeStyles()((theme: Theme) => ({
   },
   focused: {
     '& g': {
-      fill: 'white',
+      fill: theme.colorTokens.Neutrals.White,
     },
     backgroundColor: theme.palette.primary.main,
-    color: 'white',
+    color: theme.colorTokens.Neutrals.White,
   },
   root: {
     '& *': {
       lineHeight: '1.2em',
     },
     '& g': {
-      fill: theme.name === 'dark' ? 'white' : '#888f91',
+      fill:
+        theme.name === 'dark' ? theme.colorTokens.Neutrals.White : '#888f91',
     },
     display: 'flex !important',
     flexDirection: 'row',

--- a/packages/manager/src/components/MainContentBanner.tsx
+++ b/packages/manager/src/components/MainContentBanner.tsx
@@ -66,7 +66,7 @@ export const MainContentBanner = React.memo(() => {
       sx={(theme) => ({
         alignItems: 'center',
         backgroundColor: theme.bg.mainContentBanner,
-        color: 'white',
+        color: theme.colorTokens.Neutrals.White,
         display: 'flex',
         justifyContent: 'space-between',
         position: 'sticky',

--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
   button: {
     '& :hover, & :focus': {
       backgroundColor: theme.palette.primary.main,
-      color: 'white',
+      color: theme.colorTokens.Neutrals.White,
     },
     '& > span': {
       padding: 2,

--- a/packages/manager/src/components/Notice/Notice.styles.ts
+++ b/packages/manager/src/components/Notice/Notice.styles.ts
@@ -16,7 +16,7 @@ export const useStyles = makeStyles<
     borderLeft: `5px solid ${theme.palette.error.dark}`,
   },
   icon: {
-    color: 'white',
+    color: theme.colorTokens.Neutrals.White,
     left: -25, // This value must be static regardless of theme selection
     position: 'absolute',
   },

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -96,14 +96,20 @@ export const Placeholder = (props: PlaceholderProps) => {
       fill: theme.palette.primary.main,
     },
     '& .circle': {
-      fill: theme.name === 'light' ? theme.colorTokens.Neutrals.White : '#000',
+      fill:
+        theme.name === 'light'
+          ? theme.colorTokens.Neutrals.White
+          : theme.colorTokens.Neutrals.Black,
     },
     '& .insidePath path': {
       opacity: 0,
       stroke: theme.palette.primary.main,
     },
     '& .outerCircle': {
-      fill: theme.name === 'light' ? theme.colorTokens.Neutrals.White : '#000',
+      fill:
+        theme.name === 'light'
+          ? theme.colorTokens.Neutrals.White
+          : theme.colorTokens.Neutrals.Black,
       stroke: theme.bg.offWhite,
     },
     height: '160px',

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
@@ -69,7 +69,7 @@ const useStyles = makeStyles<void, 'linkItem'>()(
           fill: theme.palette.success.dark,
         },
         [`& .${classes.linkItem}`]: {
-          color: 'white',
+          color: theme.colorTokens.Neutrals.White,
         },
         backgroundImage: 'linear-gradient(98deg, #38584B 1%, #3A5049 166%)',
         border: 'red',

--- a/packages/manager/src/components/PromotionalOfferCard/PromotionalOfferCard.tsx
+++ b/packages/manager/src/components/PromotionalOfferCard/PromotionalOfferCard.tsx
@@ -18,10 +18,10 @@ const useStyles = makeStyles()((theme: Theme) => ({
   button: {
     '&:hover, &:focus': {
       backgroundColor: '#3f8a4e',
-      color: 'white',
+      color: theme.colorTokens.Neutrals.White,
     },
     backgroundColor: '#4FAD62',
-    color: 'white',
+    color: theme.colorTokens.Neutrals.White,
     marginLeft: theme.spacing(2),
     marginRight: theme.spacing(2),
     textAlign: 'center',

--- a/packages/manager/src/components/ShowMore/ShowMore.tsx
+++ b/packages/manager/src/components/ShowMore/ShowMore.tsx
@@ -34,7 +34,7 @@ export const ShowMore = <T extends {}>(props: ShowMoreProps<T>) => {
           anchorEl
             ? {
                 backgroundColor: theme.palette.primary.main,
-                color: 'white',
+                color: theme.colorTokens.Neutrals.White,
               }
             : null
         }
@@ -72,7 +72,7 @@ const StyledChip = styled(Chip)(({ theme }) => ({
   },
   '&:hover': {
     backgroundColor: theme.palette.primary.main,
-    color: 'white',
+    color: theme.colorTokens.Neutrals.White,
   },
   backgroundColor: theme.bg.lightBlue1,
   fontFamily: theme.font.bold,

--- a/packages/manager/src/components/Tag/Tag.styles.ts
+++ b/packages/manager/src/components/Tag/Tag.styles.ts
@@ -48,9 +48,9 @@ export const StyledChip = styled(Chip, {
     '& > span': {
       '&:hover, &:focus': {
         backgroundColor: theme.palette.primary.main,
-        color: 'white',
+        color: theme.colorTokens.Neutrals.White,
       },
-      color: 'white',
+      color: theme.colorTokens.Neutrals.White,
     },
 
     backgroundColor: theme.palette.primary.main,

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/GooglePayButton.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/GooglePayButton.tsx
@@ -34,7 +34,9 @@ const useStyles = makeStyles()((theme: Theme) => ({
     },
     alignItems: 'center',
     backgroundColor:
-      theme.name === 'light' ? '#000' : theme.colorTokens.Neutrals.White,
+      theme.name === 'light'
+        ? theme.colorTokens.Neutrals.Black
+        : theme.colorTokens.Neutrals.White,
     border: 0,
     borderRadius: 4,
     cursor: 'pointer',

--- a/packages/manager/src/features/Databases/DatabaseCreate/EngineOption.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/EngineOption.tsx
@@ -10,7 +10,7 @@ import type { OptionProps } from 'react-select';
 const useStyles = makeStyles()((theme: Theme) => ({
   focused: {
     backgroundColor: theme.palette.primary.main,
-    color: 'white',
+    color: theme.colorTokens.Neutrals.White,
   },
   root: {
     padding: theme.spacing(1),

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ApplicationPlatform.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ApplicationPlatform.tsx
@@ -38,7 +38,10 @@ export const ApplicationPlatform = (props: APLProps) => {
       <FormLabel
         sx={(theme) => ({
           '&&.MuiFormLabel-root.Mui-focused': {
-            color: theme.name === 'dark' ? 'white' : theme.color.black,
+            color:
+              theme.name === 'dark'
+                ? theme.colorTokens.Neutrals.White
+                : theme.color.black,
           },
         })}
       >

--- a/packages/manager/src/features/Kubernetes/CreateCluster/HAControlPlane.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/HAControlPlane.tsx
@@ -61,7 +61,10 @@ export const HAControlPlane = (props: HAControlPlaneProps) => {
       <FormLabel
         sx={(theme) => ({
           '&&.MuiFormLabel-root.Mui-focused': {
-            color: theme.name === 'dark' ? 'white' : theme.color.black,
+            color:
+              theme.name === 'dark'
+                ? theme.colorTokens.Neutrals.White
+                : theme.color.black,
           },
         })}
         id="ha-radio-buttons-group-label"

--- a/packages/manager/src/features/Linodes/LinodeCreate/Tabs/Marketplace/AppDetailDrawer.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Tabs/Marketplace/AppDetailDrawer.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     textAlign: 'center',
   },
   button: {
-    color: 'white !important',
+    color: `${theme.colorTokens.Neutrals.White} !important`,
     margin: theme.spacing(2),
     position: 'absolute',
   },

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchSuggestion.styles.ts
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchSuggestion.styles.ts
@@ -24,7 +24,7 @@ export const StyledWrapperDiv = styled('div', {
     '& .tag': {
       '&:hover': {
         backgroundColor: theme.palette.primary.main,
-        color: 'white',
+        color: theme.colorTokens.Neutrals.White,
       },
       backgroundColor: theme.bg.lightBlue1,
       color: theme.palette.text.primary,

--- a/packages/manager/src/features/TopMenu/TopMenu.tsx
+++ b/packages/manager/src/features/TopMenu/TopMenu.tsx
@@ -1,5 +1,4 @@
 import MenuIcon from '@mui/icons-material/Menu';
-import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 
 import { AppBar } from 'src/components/AppBar';
@@ -33,7 +32,6 @@ export const TopMenu = React.memo((props: TopMenuProps) => {
   const { desktopMenuToggle, isSideMenuOpen, openSideMenu, username } = props;
 
   const { loggedInAsCustomer } = useAuthentication();
-  const theme = useTheme();
 
   const navHoverText = isSideMenuOpen
     ? 'Collapse side menu'
@@ -43,7 +41,10 @@ export const TopMenu = React.memo((props: TopMenuProps) => {
     <React.Fragment>
       {loggedInAsCustomer && (
         <Box bgcolor="pink" padding="1em" textAlign="center">
-          <Typography color={theme.colorTokens.Neutrals.Black} fontSize="1.2em">
+          <Typography
+            color={(theme) => theme.colorTokens.Neutrals.Black}
+            fontSize="1.2em"
+          >
             You are logged in as customer: <strong>{username}</strong>
           </Typography>
         </Box>

--- a/packages/manager/src/features/TopMenu/TopMenu.tsx
+++ b/packages/manager/src/features/TopMenu/TopMenu.tsx
@@ -1,4 +1,5 @@
 import MenuIcon from '@mui/icons-material/Menu';
+import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 
 import { AppBar } from 'src/components/AppBar';
@@ -32,6 +33,7 @@ export const TopMenu = React.memo((props: TopMenuProps) => {
   const { desktopMenuToggle, isSideMenuOpen, openSideMenu, username } = props;
 
   const { loggedInAsCustomer } = useAuthentication();
+  const theme = useTheme();
 
   const navHoverText = isSideMenuOpen
     ? 'Collapse side menu'
@@ -41,7 +43,7 @@ export const TopMenu = React.memo((props: TopMenuProps) => {
     <React.Fragment>
       {loggedInAsCustomer && (
         <Box bgcolor="pink" padding="1em" textAlign="center">
-          <Typography color="black" fontSize="1.2em">
+          <Typography color={theme.colorTokens.Neutrals.Black} fontSize="1.2em">
             You are logged in as customer: <strong>{username}</strong>
           </Typography>
         </Box>

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -131,7 +131,7 @@ const iconCircleAnimation = {
     transition: 'fill .2s ease-in-out .2s',
   },
   '& .insidePath *': {
-    stroke: 'white',
+    stroke: Color.Neutrals.White,
     transition: 'fill .2s ease-in-out .2s, stroke .2s ease-in-out .2s',
   },
   '& .outerCircle': {
@@ -147,7 +147,7 @@ const iconCircleHoverEffect = {
     fill: primaryColors.main,
   },
   '& .insidePath *': {
-    stroke: 'white',
+    stroke: Color.Neutrals.White,
   },
 };
 
@@ -1134,7 +1134,7 @@ export const lightTheme: ThemeOptions = {
     MuiSnackbarContent: {
       styleOverrides: {
         root: {
-          backgroundColor: 'white',
+          backgroundColor: Color.Neutrals.White,
           borderLeft: `6px solid transparent`,
           borderRadius: 4,
           boxShadow: `0 0 5px ${Color.Neutrals[30]}`,
@@ -1156,7 +1156,7 @@ export const lightTheme: ThemeOptions = {
         root: {
           '& $checked': {
             '& .square': {
-              fill: 'white',
+              fill: Color.Neutrals.White,
             },
             // color: `${primaryColors.main} !important`,
             '& input': {
@@ -1175,7 +1175,7 @@ export const lightTheme: ThemeOptions = {
                 borderColor: Color.Neutrals[40],
               },
               '& .square': {
-                fill: 'white',
+                fill: Color.Neutrals.White,
               },
             },
           },
@@ -1188,7 +1188,7 @@ export const lightTheme: ThemeOptions = {
             width: 16,
           },
           '& .square': {
-            fill: 'white',
+            fill: Color.Neutrals.White,
             transition: 'fill 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
           },
           '&:hover, &:focus': {
@@ -1406,7 +1406,7 @@ export const lightTheme: ThemeOptions = {
           opacity: 1,
         },
         tooltip: {
-          backgroundColor: 'white',
+          backgroundColor: Color.Neutrals.White,
           borderRadius: 0,
           boxShadow: `0 0 5px ${Color.Neutrals[50]}`, // TODO: This was the closest color according to our palette
           [breakpoints.up('sm')]: {


### PR DESCRIPTION
## Description 📝

- Follow up to the PR: #11120 
- Replace one-off hardcoded neutral black and white color values with the `colorTokens`.
- `colorTokens` are global tokens, and they are theme-agnostic.


> [!Note]
> `theme.colorTokens.Neutrals.Black` is pitch black (`"#232326"`) in design tokens 

## Changes  🔄
- Replaced `#000` or `black` with ` theme.colorTokens.Neutrals.Black` (`"#232326"`)
- Replaced `#fff` or `white` with `theme.colorTokens.Neutrals.White`

## Target release date 🗓️
N/A

## Preview 📷
- No visual changes for white color
- `#000` or `black` is now pitch black (`"#232326"`) as per neutral black design color token 

## How to test 🧪

### Verification steps
- Ensure everything builds properly

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support