### PR TITLE
fix: [M3-8743] - fix aria label of action menu in IP address table row.

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
@@ -59,6 +59,14 @@ export const LinodeNetworkingActionMenu = (props: Props) => {
     ? 'Linodes must have at least one public IP'
     : undefined;
 
+  const getAriaLabel = (): string => {
+    if (ipAddress && 'address' in ipAddress) {
+      return `Action menu for IP Address ${ipAddress?.address}`;
+    } else {
+      return `Action menu for IP Address ${ipAddress?.range}`;
+    }
+  };
+
   const actions = [
     onRemove && ipAddress && !is116Range && deletableIPTypes.includes(ipType)
       ? {
@@ -110,10 +118,7 @@ export const LinodeNetworkingActionMenu = (props: Props) => {
           );
         })}
       {matchesMdDown && (
-        <ActionMenu
-          actionsList={actions}
-          ariaLabel={`Action menu for IP Address ${props.ipAddress}`}
-        />
+        <ActionMenu actionsList={actions} ariaLabel={getAriaLabel()} />
       )}
     </>
   ) : (


### PR DESCRIPTION
## Description 📝
To get a better understanding of the aria label of action menu in IP Address table. Here, we have make it human readable by adding address to the aria label.

## Changes  🔄
List any change relevant to the reviewer.

- For IP Address Table Row:
  - Changed Aria Label to Human readable format.

## Target release date 🗓️

## Preview 📷

| Before | After |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/29a6f4a2-4d0b-4bf8-859a-9494af390ed4) | ![After](https://github.com/user-attachments/assets/f26609d0-5306-4268-b4d1-5b9122379c4e) |

## How to test 🧪

### Prerequisites
- You should have at least one Linode in your account before Reproduction

### Reproduction steps
- Go to the Linode details Page:
  - Then Navigate to Network tab:
    - Observe a aria label of action menu button for IP Address table row.

### Verification steps

- After changes, observe aria label to be more human readable format.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
