### PR TITLE
upcoming: [M3-8755] - Add global `font` and `spacing` tokens to theme and refactor design tokens

### DIFF
--- a/packages/manager/.changeset/pr-11171-upcoming-features-1730182630692.md
+++ b/packages/manager/.changeset/pr-11171-upcoming-features-1730182630692.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add global `font` and `spacing` tokens to theme and refactor design tokens ([#11171](https://github.com/linode/manager/pull/11171))

--- a/packages/manager/src/GoTo.tsx
+++ b/packages/manager/src/GoTo.tsx
@@ -42,7 +42,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     },
     '& .react-select__option--is-focused': {
       backgroundColor: theme.palette.primary.main,
-      color: theme.colorTokens.Neutrals.White,
+      color: theme.tokens.color.Neutrals.White,
     },
     '& .react-select__value-container': {
       '& p': {

--- a/packages/manager/src/components/Accordion.tsx
+++ b/packages/manager/src/components/Accordion.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     alignItems: 'center',
     backgroundColor: '#2575d0',
     borderRadius: '50%',
-    color: theme.colorTokens.Neutrals.White,
+    color: theme.tokens.color.Neutrals.White,
     display: 'flex',
     fontFamily: theme.font.bold,
     fontSize: '0.875rem',

--- a/packages/manager/src/components/AkamaiBanner/AkamaiBanner.styles.ts
+++ b/packages/manager/src/components/AkamaiBanner/AkamaiBanner.styles.ts
@@ -11,7 +11,7 @@ export const StyledAkamaiLogo = styled(AkamaiLogo, {
   label: 'StyledAkamaiLogo',
 })(({ theme }) => ({
   '& .akamai-logo-icon': {
-    fill: theme.colorTokens.Neutrals.White,
+    fill: theme.tokens.color.Neutrals.White,
   },
   '& .akamai-logo-name': {
     display: 'none',
@@ -21,7 +21,7 @@ export const StyledAkamaiLogo = styled(AkamaiLogo, {
 export const StyledWarningIcon = styled(Warning, {
   label: 'StyledWarningIcon',
 })(({ theme }) => ({
-  color: theme.colorTokens.Neutrals.Black,
+  color: theme.tokens.color.Neutrals.Black,
 }));
 
 export const StyledBanner = styled(Stack, {
@@ -41,10 +41,10 @@ export const StyledBannerLabel = styled(Box, {
 })<{ warning?: boolean }>(({ theme, warning }) => ({
   backgroundColor: warning
     ? theme.palette.warning.dark
-    : theme.colorTokens.Neutrals.Black,
+    : theme.tokens.color.Neutrals.Black,
   color: warning
-    ? theme.colorTokens.Neutrals.Black
-    : theme.colorTokens.Neutrals.White,
+    ? theme.tokens.color.Neutrals.Black
+    : theme.tokens.color.Neutrals.White,
   padding: theme.spacing(2.3),
   [theme.breakpoints.up('sm')]: {
     textWrap: 'nowrap',

--- a/packages/manager/src/components/ColorPalette/ColorPalette.tsx
+++ b/packages/manager/src/components/ColorPalette/ColorPalette.tsx
@@ -50,7 +50,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
  *
  * If a color does not exist in the current palette and is only used once, consider applying the color conditionally:
  *
- * `theme.name === 'light' ? theme.colorTokens.Neutrals.White : theme.colorTokens.Neutrals.Black`
+ * `theme.name === 'light' ? theme.tokens.color.Neutrals.White : theme.tokens.color.Neutrals.Black`
  */
 export const ColorPalette = () => {
   const { classes } = useStyles();

--- a/packages/manager/src/components/CopyableTextField/CopyableTextField.tsx
+++ b/packages/manager/src/components/CopyableTextField/CopyableTextField.tsx
@@ -65,7 +65,7 @@ const StyledTextField = styled(TextField)(({ theme }) => ({
       color:
         theme.name === 'light'
           ? `${theme.palette.text.primary} !important`
-          : `${theme.colorTokens.Neutrals.White} !important`,
+          : `${theme.tokens.color.Neutrals.White} !important`,
       opacity: theme.name === 'dark' ? 0.5 : 0.8,
     },
     '&& .MuiInput-root': {

--- a/packages/manager/src/components/Drawer.tsx
+++ b/packages/manager/src/components/Drawer.tsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
   button: {
     '& :hover, & :focus': {
       backgroundColor: theme.palette.primary.main,
-      color: theme.colorTokens.Neutrals.White,
+      color: theme.tokens.color.Neutrals.White,
     },
     '& > span': {
       padding: 2,

--- a/packages/manager/src/components/EnhancedSelect/Select.styles.ts
+++ b/packages/manager/src/components/EnhancedSelect/Select.styles.ts
@@ -169,7 +169,7 @@ export const useStyles = makeStyles()((theme: Theme) => ({
       },
       '&:hover': {
         '& svg': {
-          color: theme.colorTokens.Neutrals.White,
+          color: theme.tokens.color.Neutrals.White,
         },
         backgroundColor: theme.palette.primary.main,
       },
@@ -202,7 +202,7 @@ export const useStyles = makeStyles()((theme: Theme) => ({
     },
     '& .react-select__option--is-focused': {
       backgroundColor: theme.palette.primary.main,
-      color: theme.colorTokens.Neutrals.White,
+      color: theme.tokens.color.Neutrals.White,
     },
     '& .react-select__option--is-selected': {
       '&.react-select__option--is-focused': {
@@ -251,7 +251,7 @@ export const useStyles = makeStyles()((theme: Theme) => ({
     '& .tag': {
       '&:hover': {
         backgroundColor: theme.palette.primary.main,
-        color: theme.colorTokens.Neutrals.White,
+        color: theme.tokens.color.Neutrals.White,
       },
       backgroundColor: theme.bg.lightBlue1,
       color: theme.palette.text.primary,
@@ -377,7 +377,7 @@ export const reactSelectStyles = (theme: Theme) => ({
     },
     '&:hover': {
       '& svg': {
-        color: theme.colorTokens.Neutrals.White,
+        color: theme.tokens.color.Neutrals.White,
       },
       backgroundColor: theme.palette.primary.main,
     },
@@ -408,7 +408,7 @@ export const reactSelectStyles = (theme: Theme) => ({
       return {
         ...optionStyles,
         backgroundColor: theme.palette.primary.main,
-        color: theme.colorTokens.Neutrals.White,
+        color: theme.tokens.color.Neutrals.White,
       };
     }
     if (state.isSelected) {

--- a/packages/manager/src/components/ImageSelect/ImageOption.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageOption.tsx
@@ -25,10 +25,10 @@ const useStyles = makeStyles()((theme: Theme) => ({
   },
   focused: {
     '& g': {
-      fill: theme.colorTokens.Neutrals.White,
+      fill: theme.tokens.color.Neutrals.White,
     },
     backgroundColor: theme.palette.primary.main,
-    color: theme.colorTokens.Neutrals.White,
+    color: theme.tokens.color.Neutrals.White,
   },
   root: {
     '& *': {
@@ -36,7 +36,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     },
     '& g': {
       fill:
-        theme.name === 'dark' ? theme.colorTokens.Neutrals.White : '#888f91',
+        theme.name === 'dark' ? theme.tokens.color.Neutrals.White : '#888f91',
     },
     display: 'flex !important',
     flexDirection: 'row',

--- a/packages/manager/src/components/MainContentBanner.tsx
+++ b/packages/manager/src/components/MainContentBanner.tsx
@@ -66,7 +66,7 @@ export const MainContentBanner = React.memo(() => {
       sx={(theme) => ({
         alignItems: 'center',
         backgroundColor: theme.bg.mainContentBanner,
-        color: theme.colorTokens.Neutrals.White,
+        color: theme.tokens.color.Neutrals.White,
         display: 'flex',
         justifyContent: 'space-between',
         position: 'sticky',

--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
   button: {
     '& :hover, & :focus': {
       backgroundColor: theme.palette.primary.main,
-      color: theme.colorTokens.Neutrals.White,
+      color: theme.tokens.color.Neutrals.White,
     },
     '& > span': {
       padding: 2,

--- a/packages/manager/src/components/Notice/Notice.styles.ts
+++ b/packages/manager/src/components/Notice/Notice.styles.ts
@@ -16,7 +16,7 @@ export const useStyles = makeStyles<
     borderLeft: `5px solid ${theme.palette.error.dark}`,
   },
   icon: {
-    color: theme.colorTokens.Neutrals.White,
+    color: theme.tokens.color.Neutrals.White,
     left: -25, // This value must be static regardless of theme selection
     position: 'absolute',
   },

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -98,8 +98,8 @@ export const Placeholder = (props: PlaceholderProps) => {
     '& .circle': {
       fill:
         theme.name === 'light'
-          ? theme.colorTokens.Neutrals.White
-          : theme.colorTokens.Neutrals.Black,
+          ? theme.tokens.color.Neutrals.White
+          : theme.tokens.color.Neutrals.Black,
     },
     '& .insidePath path': {
       opacity: 0,
@@ -108,8 +108,8 @@ export const Placeholder = (props: PlaceholderProps) => {
     '& .outerCircle': {
       fill:
         theme.name === 'light'
-          ? theme.colorTokens.Neutrals.White
-          : theme.colorTokens.Neutrals.Black,
+          ? theme.tokens.color.Neutrals.White
+          : theme.tokens.color.Neutrals.Black,
       stroke: theme.bg.offWhite,
     },
     height: '160px',

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
@@ -29,7 +29,7 @@ const useStyles = makeStyles<void, 'linkItem'>()(
         opacity: 0,
       },
       alignItems: 'center',
-      color: theme.colorTokens.Neutrals.White,
+      color: theme.tokens.color.Neutrals.White,
       display: 'flex',
       fontFamily: 'LatoWebBold',
       fontSize: '0.875rem',
@@ -69,7 +69,7 @@ const useStyles = makeStyles<void, 'linkItem'>()(
           fill: theme.palette.success.dark,
         },
         [`& .${classes.linkItem}`]: {
-          color: theme.colorTokens.Neutrals.White,
+          color: theme.tokens.color.Neutrals.White,
         },
         backgroundImage: 'linear-gradient(98deg, #38584B 1%, #3A5049 166%)',
         border: 'red',

--- a/packages/manager/src/components/PromotionalOfferCard/PromotionalOfferCard.tsx
+++ b/packages/manager/src/components/PromotionalOfferCard/PromotionalOfferCard.tsx
@@ -18,10 +18,10 @@ const useStyles = makeStyles()((theme: Theme) => ({
   button: {
     '&:hover, &:focus': {
       backgroundColor: '#3f8a4e',
-      color: theme.colorTokens.Neutrals.White,
+      color: theme.tokens.color.Neutrals.White,
     },
     backgroundColor: '#4FAD62',
-    color: theme.colorTokens.Neutrals.White,
+    color: theme.tokens.color.Neutrals.White,
     marginLeft: theme.spacing(2),
     marginRight: theme.spacing(2),
     textAlign: 'center',

--- a/packages/manager/src/components/RegionSelect/RegionSelect.styles.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.styles.ts
@@ -115,10 +115,10 @@ export const StyledChip = styled(Chip)(({ theme }) => ({
   },
   '& .MuiChip-deleteIcon.MuiSvgIcon-root': {
     '&:hover': {
-      backgroundColor: theme.colorTokens.Neutrals.White,
+      backgroundColor: theme.tokens.color.Neutrals.White,
       color: '#3683dc',
     },
     backgroundColor: '#3683dc',
-    color: theme.colorTokens.Neutrals.White,
+    color: theme.tokens.color.Neutrals.White,
   },
 }));

--- a/packages/manager/src/components/ShowMore/ShowMore.tsx
+++ b/packages/manager/src/components/ShowMore/ShowMore.tsx
@@ -34,7 +34,7 @@ export const ShowMore = <T extends {}>(props: ShowMoreProps<T>) => {
           anchorEl
             ? {
                 backgroundColor: theme.palette.primary.main,
-                color: theme.colorTokens.Neutrals.White,
+                color: theme.tokens.color.Neutrals.White,
               }
             : null
         }
@@ -72,7 +72,7 @@ const StyledChip = styled(Chip)(({ theme }) => ({
   },
   '&:hover': {
     backgroundColor: theme.palette.primary.main,
-    color: theme.colorTokens.Neutrals.White,
+    color: theme.tokens.color.Neutrals.White,
   },
   backgroundColor: theme.bg.lightBlue1,
   fontFamily: theme.font.bold,

--- a/packages/manager/src/components/Tag/Tag.styles.ts
+++ b/packages/manager/src/components/Tag/Tag.styles.ts
@@ -48,9 +48,9 @@ export const StyledChip = styled(Chip, {
     '& > span': {
       '&:hover, &:focus': {
         backgroundColor: theme.palette.primary.main,
-        color: theme.colorTokens.Neutrals.White,
+        color: theme.tokens.color.Neutrals.White,
       },
-      color: theme.colorTokens.Neutrals.White,
+      color: theme.tokens.color.Neutrals.White,
     },
 
     backgroundColor: theme.palette.primary.main,
@@ -92,7 +92,7 @@ export const StyledDeleteButton = styled(StyledLinkButton, {
   },
   borderBottomRightRadius: 3,
   borderLeft: `1px solid ${
-    theme.name === 'light' ? theme.colorTokens.Neutrals.White : '#2e3238'
+    theme.name === 'light' ? theme.tokens.color.Neutrals.White : '#2e3238'
   }`,
   borderRadius: 0,
   borderTopRightRadius: 3,

--- a/packages/manager/src/components/TagCell/TagCell.tsx
+++ b/packages/manager/src/components/TagCell/TagCell.tsx
@@ -235,7 +235,7 @@ const StyledTag = styled(Tag, {
 const StyledIconButton = styled(IconButton)(({ theme }) => ({
   '&:hover': {
     backgroundColor: theme.palette.primary.main,
-    color: theme.colorTokens.Neutrals.White,
+    color: theme.tokens.color.Neutrals.White,
   },
   backgroundColor: theme.color.tagButtonBg,
   borderRadius: 0,

--- a/packages/manager/src/dev-tools/Preferences.tsx
+++ b/packages/manager/src/dev-tools/Preferences.tsx
@@ -9,7 +9,7 @@ export const Preferences = () => {
       <h4 style={{ marginBottom: 4 }}>Preferences</h4>
       <a
         href="/profile/settings?preferenceEditor=true"
-        style={{ color: theme.colorTokens.Neutrals.White }}
+        style={{ color: theme.tokens.color.Neutrals.White }}
       >
         Open preference Modal
         <LinkIcon

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/GooglePayButton.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/GooglePayButton.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
   button: {
     '& svg': {
       color:
-        theme.name === 'light' ? theme.colorTokens.Neutrals.White : '#616161',
+        theme.name === 'light' ? theme.tokens.color.Neutrals.White : '#616161',
       height: 16,
     },
     '&:hover': {
@@ -35,8 +35,8 @@ const useStyles = makeStyles()((theme: Theme) => ({
     alignItems: 'center',
     backgroundColor:
       theme.name === 'light'
-        ? theme.colorTokens.Neutrals.Black
-        : theme.colorTokens.Neutrals.White,
+        ? theme.tokens.color.Neutrals.Black
+        : theme.tokens.color.Neutrals.White,
     border: 0,
     borderRadius: 4,
     cursor: 'pointer',

--- a/packages/manager/src/features/CancelLanding/CancelLanding.tsx
+++ b/packages/manager/src/features/CancelLanding/CancelLanding.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
   root: {
     '& button': {
       backgroundColor: '#00b159',
-      color: theme.colorTokens.Neutrals.White,
+      color: theme.tokens.color.Neutrals.White,
       marginTop: theme.spacing(8),
     },
     '& h1': {

--- a/packages/manager/src/features/Databases/DatabaseCreate/EngineOption.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/EngineOption.tsx
@@ -10,7 +10,7 @@ import type { OptionProps } from 'react-select';
 const useStyles = makeStyles()((theme: Theme) => ({
   focused: {
     backgroundColor: theme.palette.primary.main,
-    color: theme.colorTokens.Neutrals.White,
+    color: theme.tokens.color.Neutrals.White,
   },
   root: {
     padding: theme.spacing(1),

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.style.ts
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.style.ts
@@ -46,7 +46,7 @@ export const useStyles = makeStyles()((theme: Theme) => ({
     '& span': {
       fontFamily: theme.font.bold,
     },
-    background: theme.interactionTokens.Background.Secondary,
+    background: theme.tokens.interaction.Background.Secondary,
     border: `1px solid ${theme.name === 'light' ? '#ccc' : '#222'}`,
     padding: `${theme.spacing(1)} 15px`,
   },

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ApplicationPlatform.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ApplicationPlatform.tsx
@@ -40,7 +40,7 @@ export const ApplicationPlatform = (props: APLProps) => {
           '&&.MuiFormLabel-root.Mui-focused': {
             color:
               theme.name === 'dark'
-                ? theme.colorTokens.Neutrals.White
+                ? theme.tokens.color.Neutrals.White
                 : theme.color.black,
           },
         })}

--- a/packages/manager/src/features/Kubernetes/CreateCluster/HAControlPlane.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/HAControlPlane.tsx
@@ -63,7 +63,7 @@ export const HAControlPlane = (props: HAControlPlaneProps) => {
           '&&.MuiFormLabel-root.Mui-focused': {
             color:
               theme.name === 'dark'
-                ? theme.colorTokens.Neutrals.White
+                ? theme.tokens.color.Neutrals.White
                 : theme.color.black,
           },
         })}

--- a/packages/manager/src/features/Linodes/LinodeCreate/Tabs/Marketplace/AppDetailDrawer.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Tabs/Marketplace/AppDetailDrawer.tsx
@@ -16,14 +16,14 @@ import type { Theme } from '@mui/material/styles';
 
 const useStyles = makeStyles()((theme: Theme) => ({
   appName: {
-    color: `${theme.colorTokens.Neutrals.White} !important`,
+    color: `${theme.tokens.color.Neutrals.White} !important`,
     fontFamily: theme.font.bold,
     fontSize: '2.2rem',
     lineHeight: '2.5rem',
     textAlign: 'center',
   },
   button: {
-    color: `${theme.colorTokens.Neutrals.White} !important`,
+    color: `${theme.tokens.color.Neutrals.White} !important`,
     margin: theme.spacing(2),
     position: 'absolute',
   },

--- a/packages/manager/src/features/Linodes/LinodeEntityDetail.styles.ts
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetail.styles.ts
@@ -158,7 +158,7 @@ export const StyledTableCell = styled(TableCell, { label: 'StyledTableCell' })(
       fontSize: 15,
     },
     alignItems: 'center',
-    backgroundColor: theme.interactionTokens.Background.Secondary,
+    backgroundColor: theme.tokens.interaction.Background.Secondary,
     color: theme.textColors.tableStatic,
     display: 'flex',
     fontFamily: '"UbuntuMono", monospace, sans-serif',
@@ -181,7 +181,7 @@ export const StyledCopyTooltip = styled(CopyTooltip, {
 export const StyledGradientDiv = styled('div', { label: 'StyledGradientDiv' })(
   ({ theme }) => ({
     '&:after': {
-      backgroundImage: `linear-gradient(to right,  ${theme.bg.bgAccessRowTransparentGradient}, ${theme.interactionTokens.Background.Secondary});`,
+      backgroundImage: `linear-gradient(to right,  ${theme.bg.bgAccessRowTransparentGradient}, ${theme.tokens.interaction.Background.Secondary});`,
       bottom: 0,
       content: '""',
       height: '100%',

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/QRCodeForm.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/QRCodeForm.tsx
@@ -42,7 +42,7 @@ const StyledInstructions = styled(Typography, {
 const StyledQRCodeContainer = styled('div', {
   label: 'StyledQRCodeContainer',
 })(({ theme }) => ({
-  border: `5px solid ${theme.colorTokens.Neutrals.White}`,
+  border: `5px solid ${theme.tokens.color.Neutrals.White}`,
   display: 'inline-block',
   margin: `${theme.spacing(2)} 0`,
 }));

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchSuggestion.styles.ts
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchSuggestion.styles.ts
@@ -24,7 +24,7 @@ export const StyledWrapperDiv = styled('div', {
     '& .tag': {
       '&:hover': {
         backgroundColor: theme.palette.primary.main,
-        color: theme.colorTokens.Neutrals.White,
+        color: theme.tokens.color.Neutrals.White,
       },
       backgroundColor: theme.bg.lightBlue1,
       color: theme.palette.text.primary,

--- a/packages/manager/src/features/TopMenu/TopMenu.tsx
+++ b/packages/manager/src/features/TopMenu/TopMenu.tsx
@@ -42,7 +42,7 @@ export const TopMenu = React.memo((props: TopMenuProps) => {
       {loggedInAsCustomer && (
         <Box bgcolor="pink" padding="1em" textAlign="center">
           <Typography
-            color={(theme) => theme.colorTokens.Neutrals.Black}
+            color={(theme) => theme.tokens.color.Neutrals.Black}
             fontSize="1.2em"
           >
             You are logged in as customer: <strong>{username}</strong>

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.styles.ts
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.styles.ts
@@ -9,7 +9,7 @@ export const StyledActionButton = styled(Button, {
 })(({ theme }) => ({
   '&:hover': {
     backgroundColor: theme.color.blue,
-    color: theme.colorTokens.Neutrals.White,
+    color: theme.tokens.color.Neutrals.White,
   },
   color: theme.textColors.linkActiveLight,
   fontFamily: theme.font.normal,

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.styles.ts
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.styles.ts
@@ -6,7 +6,7 @@ import { TableCell } from 'src/components/TableCell';
 export const StyledChip = styled(Chip, { label: 'StyledChip' })(
   ({ theme }) => ({
     backgroundColor: theme.color.green,
-    color: theme.colorTokens.Neutrals.White,
+    color: theme.tokens.color.Neutrals.White,
     marginLeft: theme.spacing(),
     position: 'relative',
     textTransform: 'uppercase',

--- a/packages/ui/src/foundations/breakpoints.ts
+++ b/packages/ui/src/foundations/breakpoints.ts
@@ -13,6 +13,6 @@ export const breakpoints = createTheme({
       xs: 0,
     },
   },
-  chartTokens: Chart,
+  tokens: { chart: Chart },
   name: 'light',
 }).breakpoints;

--- a/packages/ui/src/foundations/themes/dark.ts
+++ b/packages/ui/src/foundations/themes/dark.ts
@@ -854,7 +854,6 @@ export const darkTheme: ThemeOptions = {
       color: Select.Hover.Text,
     },
   },
-  interactionTokens: Interaction,
   name: 'dark',
   notificationToast,
   palette: {
@@ -875,6 +874,10 @@ export const darkTheme: ThemeOptions = {
     },
   },
   textColors: customDarkModeOptions.textColors,
+  tokens: {
+    // No need to add global tokens here, as they will be inherited from light.ts
+    interaction: Interaction,
+  },
   typography: {
     body1: {
       color: primaryColors.text,

--- a/packages/ui/src/foundations/themes/index.ts
+++ b/packages/ui/src/foundations/themes/index.ts
@@ -8,7 +8,9 @@ import { lightTheme } from './light';
 import type {
   ChartTypes,
   ColorTypes,
+  FontTypes,
   InteractionTypes as InteractionTypesLight,
+  SpacingTypes,
 } from '@linode/design-language-system';
 import type { InteractionTypes as InteractionTypesDark } from '@linode/design-language-system/themes/dark';
 import type { latoWeb } from '../fonts';
@@ -75,7 +77,11 @@ declare module '@mui/material/styles/createTheme' {
     bg: BgColors;
     borderColors: BorderColors;
     chartTokens: ChartTypes;
-    colorTokens: ColorTypes; // Global token: theme agnostic
+    // ---- Global tokens: theme agnostic ----
+    colorTokens: ColorTypes;
+    fontTokens: FontTypes;
+    spacingTokens: SpacingTypes;
+    // ---------------------------------------
     color: Colors;
     font: Fonts;
     graphs: any;
@@ -97,7 +103,11 @@ declare module '@mui/material/styles/createTheme' {
     bg?: DarkModeBgColors | LightModeBgColors;
     borderColors?: DarkModeBorderColors | LightModeBorderColors;
     chartTokens?: ChartTypes;
-    colorTokens?: ColorTypes; // Global token: theme agnostic
+    //  ---- Global tokens: theme agnostic ----
+    colorTokens?: ColorTypes;
+    fontTokens?: FontTypes;
+    spacingTokens?: SpacingTypes;
+    // ----------------------------------------
     color?: DarkModeColors | LightModeColors;
     font?: Fonts;
     graphs?: any;

--- a/packages/ui/src/foundations/themes/index.ts
+++ b/packages/ui/src/foundations/themes/index.ts
@@ -77,11 +77,6 @@ declare module '@mui/material/styles/createTheme' {
     bg: BgColors;
     borderColors: BorderColors;
     chartTokens: ChartTypes;
-    // ---- Global tokens: theme agnostic ----
-    colorTokens: ColorTypes;
-    fontTokens: FontTypes;
-    spacingTokens: SpacingTypes;
-    // ---------------------------------------
     color: Colors;
     font: Fonts;
     graphs: any;
@@ -91,6 +86,13 @@ declare module '@mui/material/styles/createTheme' {
     name: ThemeName;
     notificationToast: NotificationToast;
     textColors: TextColors;
+    tokens: {
+      //  ---- Global tokens: theme agnostic ----
+      color: ColorTypes;
+      font: FontTypes;
+      spacing: SpacingTypes;
+      // ----------------------------------------
+    };
     visually: any;
   }
 
@@ -103,11 +105,6 @@ declare module '@mui/material/styles/createTheme' {
     bg?: DarkModeBgColors | LightModeBgColors;
     borderColors?: DarkModeBorderColors | LightModeBorderColors;
     chartTokens?: ChartTypes;
-    //  ---- Global tokens: theme agnostic ----
-    colorTokens?: ColorTypes;
-    fontTokens?: FontTypes;
-    spacingTokens?: SpacingTypes;
-    // ----------------------------------------
     color?: DarkModeColors | LightModeColors;
     font?: Fonts;
     graphs?: any;
@@ -117,6 +114,13 @@ declare module '@mui/material/styles/createTheme' {
     name: ThemeName;
     notificationToast?: NotificationToast;
     textColors?: DarkModeTextColors | LightModeTextColors;
+    tokens?: {
+      //  ---- Global tokens: theme agnostic ----
+      color: ColorTypes;
+      font: FontTypes;
+      spacing: SpacingTypes;
+      // ----------------------------------------
+    };
     visually?: any;
   }
 }

--- a/packages/ui/src/foundations/themes/index.ts
+++ b/packages/ui/src/foundations/themes/index.ts
@@ -76,13 +76,11 @@ declare module '@mui/material/styles/createTheme' {
     applyTableHeaderStyles?: any;
     bg: BgColors;
     borderColors: BorderColors;
-    chartTokens: ChartTypes;
     color: Colors;
     font: Fonts;
     graphs: any;
     inputMaxWidth: number;
     inputStyles: any;
-    interactionTokens: InteractionTypes;
     name: ThemeName;
     notificationToast: NotificationToast;
     textColors: TextColors;
@@ -92,6 +90,8 @@ declare module '@mui/material/styles/createTheme' {
       font: FontTypes;
       spacing: SpacingTypes;
       // ----------------------------------------
+      chart: ChartTypes;
+      interaction: InteractionTypes;
     };
     visually: any;
   }
@@ -104,22 +104,22 @@ declare module '@mui/material/styles/createTheme' {
     applyTableHeaderStyles?: any;
     bg?: DarkModeBgColors | LightModeBgColors;
     borderColors?: DarkModeBorderColors | LightModeBorderColors;
-    chartTokens?: ChartTypes;
     color?: DarkModeColors | LightModeColors;
     font?: Fonts;
     graphs?: any;
     inputMaxWidth?: number;
     inputStyles?: any;
-    interactionTokens?: InteractionTypes;
     name: ThemeName;
     notificationToast?: NotificationToast;
     textColors?: DarkModeTextColors | LightModeTextColors;
     tokens?: {
       //  ---- Global tokens: theme agnostic ----
-      color: ColorTypes;
-      font: FontTypes;
-      spacing: SpacingTypes;
+      color?: ColorTypes;
+      font?: FontTypes;
+      spacing?: SpacingTypes;
       // ----------------------------------------
+      chart?: ChartTypes;
+      interaction?: InteractionTypes;
     };
     visually?: any;
   }

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -5,9 +5,11 @@ import {
   Chart,
   Color,
   Dropdown,
+  Font,
   Interaction,
   NotificationToast,
   Select,
+  Spacing,
 } from '@linode/design-language-system';
 
 import { breakpoints } from '../breakpoints';
@@ -1462,6 +1464,7 @@ export const lightTheme: ThemeOptions = {
       },
     },
   },
+  fontTokens: Font,
   font: {
     bold: latoWeb.bold,
     normal: latoWeb.normal,
@@ -1630,6 +1633,7 @@ export const lightTheme: ThemeOptions = {
     'none',
     'none',
   ],
+  spacingTokens: Spacing,
   spacing,
   textColors,
   typography: {

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -242,7 +242,6 @@ export const lightTheme: ThemeOptions = {
   borderColors,
   breakpoints,
   chartTokens: Chart,
-  colorTokens: Color,
   color,
   components: {
     MuiAccordion: {
@@ -1464,7 +1463,6 @@ export const lightTheme: ThemeOptions = {
       },
     },
   },
-  fontTokens: Font,
   font: {
     bold: latoWeb.bold,
     normal: latoWeb.normal,
@@ -1633,9 +1631,13 @@ export const lightTheme: ThemeOptions = {
     'none',
     'none',
   ],
-  spacingTokens: Spacing,
   spacing,
   textColors,
+  tokens: {
+    color: Color,
+    font: Font,
+    spacing: Spacing,
+  },
   typography: {
     body1: {
       color: primaryColors.text,

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -241,7 +241,6 @@ export const lightTheme: ThemeOptions = {
   bg,
   borderColors,
   breakpoints,
-  chartTokens: Chart,
   color,
   components: {
     MuiAccordion: {
@@ -1569,7 +1568,6 @@ export const lightTheme: ThemeOptions = {
       color: Select.Hover.Text,
     },
   },
-  interactionTokens: Interaction,
   name: 'light', // @todo remove this because we leverage pallete.mode now
   notificationToast,
   palette: {
@@ -1637,6 +1635,8 @@ export const lightTheme: ThemeOptions = {
     color: Color,
     font: Font,
     spacing: Spacing,
+    chart: Chart,
+    interaction: Interaction,
   },
   typography: {
     body1: {


### PR DESCRIPTION
## Description 📝
Add global font and spacing tokens to theme and refactor `Design Tokens`
  - Global tokens are theme-agnostic
  - We will have follow-up PRs to replace values in the cloud and make use of these tokens
  - Related PR: https://github.com/linode/manager/pull/11120

## Changes  🔄
- Added `font` and `spacing` tokens to theme
- Refactor design tokens: 
    - Changed `theme.*` to `theme.tokens.*`, which are now accessible to components via `theme.tokens.*`
    - Refactor `chart` and `interaction` tokens

## Target release date 🗓️
N/A

## Preview 📷
No visual changes.

## How to test 🧪
- Ensure everything builds properly
- Ensure no visual changes
- Verify these global tokens are accessible to components via `theme.tokens.*`
- Ensure no tokens with `<name>Tokens` naming conventions are being used in the codebase

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support