### PR TITLE
change: LKE ACL copy and placeholder updates

### DIFF
--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -1485,7 +1485,9 @@ describe('LKE ACL updates', () => {
             .clear()
             .type('10.0.0.0/24');
           cy.findByText('IPv6 Addresses or CIDRs').should('be.visible');
-          cy.findByPlaceholderText('::/0').should('be.visible');
+          cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0').should(
+            'be.visible'
+          );
           cy.findByText('Add IPv6 Address')
             .should('be.visible')
             .should('be.enabled');
@@ -1557,7 +1559,7 @@ describe('LKE ACL updates', () => {
 
           // update IPv6 addresses
           cy.findByDisplayValue('10.0.0.0/24').should('be.visible');
-          cy.findByPlaceholderText('::/0')
+          cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
             .should('be.visible')
             .click()
             .type('8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e');
@@ -1565,7 +1567,7 @@ describe('LKE ACL updates', () => {
             .should('be.visible')
             .should('be.enabled')
             .click();
-          cy.get('[id="domain-transfer-ip-1"]')
+          cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-1')
             .should('be.visible')
             .click()
             .type('f4a2:b849:4a24:d0d9:15f0:704b:f943:718f');
@@ -1699,7 +1701,7 @@ describe('LKE ACL updates', () => {
           ).should('be.visible');
           cy.findByText('IPv4 Addresses or CIDRs').should('be.visible');
           // update IPv4
-          cy.findByPlaceholderText('0.0.0.0/0')
+          cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0')
             .should('be.visible')
             .click()
             .type('10.0.0.0/24');
@@ -1709,7 +1711,7 @@ describe('LKE ACL updates', () => {
             .click();
           cy.findByText('IPv6 Addresses or CIDRs').should('be.visible');
           // update IPv6
-          cy.findByPlaceholderText('::/0')
+          cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
             .should('be.visible')
             .click()
             .type('8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e');
@@ -1835,12 +1837,12 @@ describe('LKE ACL updates', () => {
           cy.findByText('IPv4 Addresses or CIDRs').should('be.visible');
           cy.findByText('IPv6 Addresses or CIDRs').should('be.visible');
 
-          cy.findByPlaceholderText('0.0.0.0/0')
+          cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0')
             .should('be.visible')
             .click()
             .type('10.0.0.0/24');
 
-          cy.findByPlaceholderText('::/0')
+          cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
             .should('be.visible')
             .click()
             .type('8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e');
@@ -1905,7 +1907,7 @@ describe('LKE ACL updates', () => {
         .should('be.visible')
         .within(() => {
           // Confirm ACL IP validation works as expected for IPv4
-          cy.findByPlaceholderText('0.0.0.0/0')
+          cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0')
             .should('be.visible')
             .click()
             .type('invalid ip');
@@ -1913,7 +1915,7 @@ describe('LKE ACL updates', () => {
           cy.contains('Addresses').should('be.visible').click();
           cy.contains('Must be a valid IPv4 address.').should('be.visible');
           // enter valid IP
-          cy.findByPlaceholderText('0.0.0.0/0')
+          cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0')
             .should('be.visible')
             .click()
             .clear()
@@ -1923,7 +1925,7 @@ describe('LKE ACL updates', () => {
           cy.contains('Must be a valid IPv4 address.').should('not.exist');
 
           // Confirm ACL IP validation works as expected for IPv6
-          cy.findByPlaceholderText('::/0')
+          cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
             .should('be.visible')
             .click()
             .type('invalid ip');
@@ -1931,7 +1933,7 @@ describe('LKE ACL updates', () => {
           cy.findByText('Addresses').should('be.visible').click();
           cy.contains('Must be a valid IPv6 address.').should('be.visible');
           // enter valid IP
-          cy.findByPlaceholderText('::/0')
+          cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
             .should('be.visible')
             .click()
             .clear()

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ControlPlaneACLPane.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ControlPlaneACLPane.tsx
@@ -48,8 +48,7 @@ export const ControlPlaneACLPane = (props: ControlPlaneACLProps) => {
         <Typography mb={1} sx={{ width: '85%' }}>
           Enable an access control list (ACL) on your LKE cluster to restrict
           access to your cluster’s control plane. When enabled, only the IP
-          addresses and ranges specified by you can connect to the control
-          plane.
+          addresses and ranges you specify can connect to the control plane.
         </Typography>
         <FormControlLabel
           control={
@@ -76,7 +75,6 @@ export const ControlPlaneACLPane = (props: ControlPlaneACLProps) => {
             ips={ipV4Addr}
             isLinkStyled
             onChange={handleIPv4Change}
-            placeholder="0.0.0.0/0"
             title="IPv4 Addresses or CIDRs"
           />
           <Box marginTop={2}>
@@ -92,7 +90,6 @@ export const ControlPlaneACLPane = (props: ControlPlaneACLProps) => {
               ips={ipV6Addr}
               isLinkStyled
               onChange={handleIPv6Change}
-              placeholder="::/0"
               title="IPv6 Addresses or CIDRs"
             />
           </Box>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeControlPaneACLDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeControlPaneACLDrawer.tsx
@@ -171,9 +171,23 @@ export const KubeControlPlaneACLDrawer = (props: Props) => {
               the ACL on your LKE cluster, update the list of allowed IP
               addresses, and adjust other settings.
             </StyledTypography>
+            {!clusterMigrated && (
+              <Notice spacingBottom={0} spacingTop={16} variant="warning">
+                <StyledTypography
+                  sx={(theme) => ({
+                    fontFamily: theme.font.bold,
+                    fontSize: '15px',
+                  })}
+                >
+                  Control Plane ACL has not yet been installed on this cluster.
+                  During installation, it may take up to 15 minutes for the
+                  access control list to be fully enforced.
+                </StyledTypography>
+              </Notice>
+            )}
             <Divider sx={{ marginBottom: 2, marginTop: 3 }} />
             <Typography variant="h3">Activation Status</Typography>
-            <StyledTypography variant="body1">
+            <StyledTypography topMargin variant="body1">
               Enable or disable the Control Plane ACL. If the ACL is not
               enabled, any public IP address can be used to access your control
               plane. Once enabled, all network access is denied except for the
@@ -202,7 +216,7 @@ export const KubeControlPlaneACLDrawer = (props: Props) => {
             {clusterMigrated && (
               <>
                 <Typography variant="h3">Revision ID</Typography>
-                <StyledTypography variant="body1">
+                <StyledTypography topMargin variant="body1">
                   A unique identifying string for this particular revision to
                   the ACL, used by clients to track events related to ACL update
                   requests and enforcement. This defaults to a randomly
@@ -226,7 +240,11 @@ export const KubeControlPlaneACLDrawer = (props: Props) => {
               </>
             )}
             <Typography variant="h3">Addresses</Typography>
-            <StyledTypography sx={{ marginBottom: 1 }} variant="body1">
+            <StyledTypography
+              topMargin
+              sx={{ marginBottom: 1 }}
+              variant="body1"
+            >
               A list of allowed IPv4 and IPv6 addresses and CIDR ranges. This
               cluster&apos;s control plane will only be accessible from IP
               addresses within this list.
@@ -246,7 +264,6 @@ export const KubeControlPlaneACLDrawer = (props: Props) => {
                     nonExtendedIPs={field.value ?? ['']}
                     onBlur={field.onBlur}
                     onNonExtendedIPChange={field.onChange}
-                    placeholder="0.0.0.0/0"
                     title="IPv4 Addresses or CIDRs"
                   />
                 )}
@@ -263,7 +280,6 @@ export const KubeControlPlaneACLDrawer = (props: Props) => {
                       nonExtendedIPs={field.value ?? ['']}
                       onBlur={field.onBlur}
                       onNonExtendedIPChange={field.onChange}
-                      placeholder="::/0"
                       title="IPv6 Addresses or CIDRs"
                     />
                   )}
@@ -282,15 +298,6 @@ export const KubeControlPlaneACLDrawer = (props: Props) => {
               }}
               secondaryButtonProps={{ label: 'Cancel', onClick: closeDrawer }}
             />
-            {!clusterMigrated && (
-              <Notice spacingTop={24} variant="warning">
-                <StyledTypography>
-                  Control Plane ACL has not yet been installed on this cluster.
-                  During installation, it may take up to 15 minutes for the
-                  access control list to be fully enforced.
-                </StyledTypography>
-              </Notice>
-            )}
           </Stack>
         </form>
       </DrawerContent>
@@ -298,6 +305,9 @@ export const KubeControlPlaneACLDrawer = (props: Props) => {
   );
 };
 
-const StyledTypography = styled(Typography, { label: 'StyledTypography' })({
+const StyledTypography = styled(Typography, {
+  label: 'StyledTypography',
+})<{ topMargin?: boolean }>(({ theme, ...props }) => ({
+  ...(props.topMargin ? { marginTop: theme.spacing(1) } : {}),
   width: '90%',
-});
+}));


### PR DESCRIPTION
## Description 📝
Some small design changes/feedback for LKE ACL after some additional testing

skipping a changeset since LKE ACL isn't in prod yet

## Changes  🔄
- update copy in Create Cluster cc @mjac0bs 
- Remove placeholders from IP fields
- Change notice position in drawer for LKE clusters without ACL pre-'installed'
- Update corresponding tests
NOTE: when this gets merged back to develop, lke-create.spec.ts tests will fail >> will update that after!

## Target release date 🗓️
10/28 🙏 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/91dd5799-ffde-4abf-9b20-c0f60efec0fc) ![image](https://github.com/user-attachments/assets/14032384-e504-4bfb-829c-6ad6ce1d0414) | ![image](https://github.com/user-attachments/assets/683179b8-3106-4827-bccc-a45616e42b0d) ![image](https://github.com/user-attachments/assets/8682a95a-8ddc-4896-949a-92e2f3356fe5) |

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/kubernetes/lke-update.spec.ts"
```
+ confirm copy updated, confirm no more placeholders for IP fields, confirm notice position changed on the install flow ^

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
