### PR TITLE
fix: [UIE-8007] - DBaaS display host in summary details

### DIFF
--- a/packages/manager/.changeset/pr-11182-fixed-1730212323309.md
+++ b/packages/manager/.changeset/pr-11182-fixed-1730212323309.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Dislay host in DBaaS summary details ([#11182](https://github.com/linode/manager/pull/11182))

--- a/packages/manager/.changeset/pr-11182-fixed-1730212323309.md
+++ b/packages/manager/.changeset/pr-11182-fixed-1730212323309.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Dislay host in DBaaS summary details ([#11182](https://github.com/linode/manager/pull/11182))

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2024-10-29] - v1.131.1
+
+
+### Fixed:
+
+- Hostnames not showing the Database detail page ([#11182](https://github.com/linode/manager/pull/11182))
+
 ## [2024-10-28] - v1.131.0
 
 

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed:
 
-- Hostnames not showing the Database detail page ([#11182](https://github.com/linode/manager/pull/11182))
+- Hostnames not showing on the Database details page ([#11182](https://github.com/linode/manager/pull/11182))
 
 ## [2024-10-28] - v1.131.0
 

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.131.0",
+  "version": "1.131.1",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/legacy/DatabaseSummaryConnectionDetailsLegacy.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/legacy/DatabaseSummaryConnectionDetailsLegacy.tsx
@@ -127,9 +127,6 @@ const sxTooltipIcon = {
 const privateHostCopy =
   'A private network host and a private IP can only be used to access a Database Cluster from Linodes in the same data center and will not incur transfer costs.';
 
-const mongoHostHelperCopy =
-  'This is a public hostname. Coming soon: connect to your MongoDB clusters using private IPs';
-
 /**
  * Deprecated @since DBaaS V2 GA. Will be removed remove post GA release ~ Dec 2024
  * TODO (UIE-8214) remove POST GA
@@ -287,48 +284,29 @@ export const DatabaseSummaryConnectionDetailsLegacy = (props: Props) => {
           )}
         </Box>
         <Box>
-          <Typography>
-            <span>hosts</span> ={' '}
-            {(!database.peers || database.peers.length === 0) && (
-              <span className={classes.provisioningText}>
-                Your hostnames will appear here once they are available.
-              </span>
-            )}
-          </Typography>
-          {database.peers &&
-            database.peers.length > 0 &&
-            database.peers.map((hostname, i) => (
-              <Box
-                alignItems="center"
-                display="flex"
-                flexDirection="row"
-                key={hostname}
-              >
-                <Typography
-                  style={{
-                    marginBottom: 0,
-                    marginLeft: 16,
-                    marginTop: 0,
-                  }}
-                >
+          <Box alignItems="center" display="flex" flexDirection="row">
+            {database.hosts?.primary ? (
+              <>
+                <Typography>
+                  <span>host</span> ={' '}
                   <span style={{ fontFamily: theme.font.normal }}>
-                    {hostname}
-                  </span>
+                    {database.hosts?.primary}
+                  </span>{' '}
                 </Typography>
                 <CopyTooltip
                   className={classes.inlineCopyToolTip}
-                  text={hostname}
+                  text={database.hosts?.primary}
                 />
-                {/*  Display the helper text on the first hostname */}
-                {i === 0 && (
-                  <TooltipIcon
-                    status="help"
-                    sxTooltipIcon={sxTooltipIcon}
-                    text={mongoHostHelperCopy}
-                  />
-                )}
-              </Box>
-            ))}
+              </>
+            ) : (
+              <Typography>
+                <span>host</span> ={' '}
+                <span className={classes.provisioningText}>
+                  Your hostname will appear here once it is available.
+                </span>
+              </Typography>
+            )}
+          </Box>
         </Box>
         {readOnlyHost && (
           <Box alignItems="center" display="flex" flexDirection="row">


### PR DESCRIPTION
## Description 📝
Fix the display of host in DBaaS summary details

## Changes  🔄
List any change relevant to the reviewer.
- Remove MongoDB related code as it is no longer supported
- Correctly show primary host in details

## Target release date 🗓️
11/12/24

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![alpha](https://github.com/user-attachments/assets/db67e35b-e041-4d0c-9ea3-83c076118e77) | ![fix](https://github.com/user-attachments/assets/7e35a2cd-f465-4946-9beb-df5b908a4690) |

## How to test 🧪

### Prerequisites
- Managed Databases Beta capability
- dbaasV2 feature flag

### Reproduction steps
- Navigate to database summary details page

### Verification steps
- Host is displayed

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
