### PR TITLE
change: [M3-8807] - Improve Linode Create VPC user experience

### DIFF
--- a/packages/manager/.changeset/pr-11188-added-1730298408749.md
+++ b/packages/manager/.changeset/pr-11188-added-1730298408749.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Pre-select a VPC subnet's on the Linode Create page when the VPC only has one subnet ([#11188](https://github.com/linode/manager/pull/11188))

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-vpc.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-vpc.spec.ts
@@ -189,6 +189,28 @@ describe('Create Linode with VPCs', () => {
       `${mockSubnet.label} (${mockSubnet.ipv4})`
     );
 
+    // Clear the subnet value
+    cy.get('[data-qa-autocomplete="Subnet"]').within(() => {
+      cy.findByLabelText('Clear').click();
+    });
+
+    // Try to submit the form without a subnet selected
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    // Verify a validation error shows
+    cy.findByText('Subnet is required.').should('be.visible');
+
+    cy.findByLabelText('Subnet').should('be.visible').type(mockSubnet.label);
+
+    ui.autocompletePopper
+      .findByTitle(`${mockSubnet.label} (${mockSubnet.ipv4})`)
+      .should('be.visible')
+      .click();
+
     // Check box to assign public IPv4.
     cy.findByText('Assign a public IPv4 address for this Linode')
       .should('be.visible')

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-vpc.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-vpc.spec.ts
@@ -53,7 +53,6 @@ describe('Create Linode with VPCs', () => {
       id: randomNumber(),
       label: randomLabel(),
       region: linodeRegion.id,
-      //
     });
 
     mockGetVPCs([mockVPC]).as('getVPCs');
@@ -70,20 +69,18 @@ describe('Create Linode with VPCs', () => {
     linodeCreatePage.setRootPassword(randomString(32));
 
     // Confirm that mocked VPC is shown in the Autocomplete, and then select it.
-    cy.findByText('Assign VPC').click().type(`${mockVPC.label}`);
+    cy.findByText('Assign VPC').click().type(mockVPC.label);
 
     ui.autocompletePopper
       .findByTitle(mockVPC.label)
       .should('be.visible')
       .click();
 
-    // Confirm that Subnet selection appears and select mock subnet.
-    cy.findByLabelText('Subnet').should('be.visible').type(mockSubnet.label);
-
-    ui.autocompletePopper
-      .findByTitle(`${mockSubnet.label} (${mockSubnet.ipv4})`)
-      .should('be.visible')
-      .click();
+    // Confirm that VPC's subnet gets selected
+    cy.findByLabelText('Subnet').should(
+      'have.value',
+      `${mockSubnet.label} (${mockSubnet.ipv4})`
+    );
 
     // Confirm VPC assignment indicator is shown in Linode summary.
     cy.get('[data-qa-linode-create-summary]')
@@ -179,26 +176,18 @@ describe('Create Linode with VPCs', () => {
 
         // Create VPC with successful API response mocked.
         mockCreateVPC(mockVPC).as('createVpc');
+        mockGetVPCs([mockVPC]);
         vpcCreateDrawer.submit();
       });
 
-    // Attempt to create Linode before selecting a VPC subnet, and confirm
-    // that validation error appears.
-    ui.button
-      .findByTitle('Create Linode')
-      .should('be.visible')
-      .should('be.enabled')
-      .click();
+    // Verify the VPC field gets populated
+    cy.findByLabelText('Assign VPC').should('have.value', mockVPC.label);
 
-    cy.findByText('Subnet is required.').should('be.visible');
-
-    // Confirm that Subnet selection appears and select mock subnet.
-    cy.findByLabelText('Subnet').should('be.visible').type(mockSubnet.label);
-
-    ui.autocompletePopper
-      .findByTitle(`${mockSubnet.label} (${mockSubnet.ipv4})`)
-      .should('be.visible')
-      .click();
+    // Verify the subnet gets populated
+    cy.findByLabelText('Subnet').should(
+      'have.value',
+      `${mockSubnet.label} (${mockSubnet.ipv4})`
+    );
 
     // Check box to assign public IPv4.
     cy.findByText('Assign a public IPv4 address for this Linode')

--- a/packages/manager/src/features/Linodes/LinodeCreate/VPC/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/VPC/VPC.tsx
@@ -114,6 +114,19 @@ export const VPC = () => {
                 }
                 onChange={(e, vpc) => {
                   field.onChange(vpc?.id ?? null);
+
+                  if (vpc && vpc.subnets.length === 1) {
+                    // If the user selectes a VPC with only one subnet,
+                    // preselect that subnet for the user.
+                    setValue('interfaces.0.subnet_id', vpc.subnets[0].id, {
+                      shouldValidate: true,
+                    });
+                  } else {
+                    // Otherwise, just clear the selected subnet
+                    setValue('interfaces.0.subnet_id', null);
+                  }
+
+                  // Capture analytics
                   if (!vpc?.id) {
                     sendLinodeCreateFormInputEvent({
                       ...vpcFormEventOptions,
@@ -306,7 +319,10 @@ export const VPC = () => {
         </Stack>
       </Stack>
       <VPCCreateDrawer
-        handleSelectVPC={(vpcId) => setValue('interfaces.0.vpc_id', vpcId)}
+        onSuccess={(vpc) => {
+          setValue('interfaces.0.vpc_id', vpc.id);
+          setValue('interfaces.0.subnet_id', vpc.subnets[0].id);
+        }}
         onClose={() => setIsCreateDrawerOpen(false)}
         open={isCreateDrawerOpen}
         selectedRegion={regionId}

--- a/packages/manager/src/features/Linodes/LinodeCreate/VPC/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/VPC/VPC.tsx
@@ -116,7 +116,7 @@ export const VPC = () => {
                   field.onChange(vpc?.id ?? null);
 
                   if (vpc && vpc.subnets.length === 1) {
-                    // If the user selectes a VPC with only one subnet,
+                    // If the user selectes a VPC and the VPC only has one subnet,
                     // preselect that subnet for the user.
                     setValue('interfaces.0.subnet_id', vpc.subnets[0].id, {
                       shouldValidate: true,
@@ -321,7 +321,12 @@ export const VPC = () => {
       <VPCCreateDrawer
         onSuccess={(vpc) => {
           setValue('interfaces.0.vpc_id', vpc.id);
-          setValue('interfaces.0.subnet_id', vpc.subnets[0].id);
+
+          if (vpc.subnets.length === 1) {
+            // If the user creates a VPC with just one subnet,
+            // preselect it for them
+            setValue('interfaces.0.subnet_id', vpc.subnets[0].id);
+          }
         }}
         onClose={() => setIsCreateDrawerOpen(false)}
         open={isCreateDrawerOpen}

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
@@ -395,7 +395,6 @@ export const InterfaceSelect = (props: InterfaceSelectProps) => {
             additionalIPv4RangesForVPC={additionalIPv4RangesForVPC ?? []}
             assignPublicIPv4Address={nattedIPv4Address !== undefined}
             autoassignIPv4WithinVPC={vpcIPv4 === undefined}
-            from="linodeConfig"
             handleIPv4RangeChange={handleIPv4RangeChange}
             handleSelectVPC={handleVPCLabelChange}
             handleSubnetChange={handleSubnetChange}

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/VPCPanel.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/VPCPanel.test.tsx
@@ -3,10 +3,10 @@ import * as React from 'react';
 
 import { accountFactory, regionFactory } from 'src/factories';
 import { makeResourcePage } from 'src/mocks/serverHandlers';
-import { http, HttpResponse, server } from 'src/mocks/testServer';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
 import { mockMatchMedia, renderWithTheme } from 'src/utilities/testHelpers';
 
-import { VPCPanel, VPCPanelProps } from './VPCPanel';
+import { VPCPanel } from './VPCPanel';
 
 beforeAll(() => mockMatchMedia());
 
@@ -14,7 +14,6 @@ const props = {
   additionalIPv4RangesForVPC: [],
   assignPublicIPv4Address: false,
   autoassignIPv4WithinVPC: true,
-  from: 'linodeCreate' as VPCPanelProps['from'],
   handleIPv4RangeChange: vi.fn(),
   handleSelectVPC: vi.fn(),
   handleSubnetChange: vi.fn(),
@@ -100,7 +99,7 @@ describe('VPCPanel', () => {
     });
   });
 
-  it('should display helper text if there are no vpcs in the selected region and "from" is "linodeCreate"', async () => {
+  it('should not display helper text if there are no vpcs in the selected region', async () => {
     server.use(
       http.get('*/regions', () => {
         const usEast = regionFactory.build({
@@ -115,33 +114,6 @@ describe('VPCPanel', () => {
     );
 
     const wrapper = renderWithTheme(<VPCPanel {...props} />);
-
-    await waitFor(() => {
-      expect(
-        wrapper.queryByText(
-          'No VPCs exist in the selected region. Click Create VPC to create one.'
-        )
-      ).toBeInTheDocument();
-    });
-  });
-
-  it('should not display helper text if there are no vpcs in the selected region and "from" is "linodeConfig"', async () => {
-    server.use(
-      http.get('*/regions', () => {
-        const usEast = regionFactory.build({
-          capabilities: ['VPCs'],
-          id: 'us-east',
-        });
-        return HttpResponse.json(makeResourcePage([usEast]));
-      }),
-      http.get('*/vpcs', () => {
-        return HttpResponse.json(makeResourcePage([]));
-      })
-    );
-
-    const wrapper = renderWithTheme(
-      <VPCPanel {...props} from="linodeConfig" />
-    );
 
     await waitFor(() => {
       expect(
@@ -149,42 +121,6 @@ describe('VPCPanel', () => {
           'No VPCs exist in the selected region. Click Create VPC to create one.'
         )
       ).not.toBeInTheDocument();
-    });
-  });
-  it('shows helper text for when "from" = "linodeCreate" if the selected region does not support VPCs', async () => {
-    server.use(
-      http.get('*/regions', () => {
-        const usEast = regionFactory.build({
-          capabilities: [],
-          id: 'us-east',
-        });
-        return HttpResponse.json(makeResourcePage([usEast]));
-      })
-    );
-
-    const wrapper = renderWithTheme(<VPCPanel {...props} />);
-
-    await waitFor(() => {
-      expect(
-        wrapper.queryByText('VPC is not available in the selected region.')
-      ).toBeInTheDocument();
-    });
-  });
-  it('should show the "Create VPC" drawer link when from = "linodeCreate" and a region that supports VPCs is selected', async () => {
-    server.use(
-      http.get('*/regions', () => {
-        const usEast = regionFactory.build({
-          capabilities: ['VPCs'],
-          id: 'us-east',
-        });
-        return HttpResponse.json(makeResourcePage([usEast]));
-      })
-    );
-
-    const wrapper = renderWithTheme(<VPCPanel {...props} />);
-
-    await waitFor(() => {
-      expect(wrapper.queryByText('Create VPC')).toBeInTheDocument();
     });
   });
   it('should display an unchecked VPC IPv4 auto-assign checkbox and display the VPC IPv4 input field if there is already a value', async () => {

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/VPCPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/VPCPanel.tsx
@@ -6,10 +6,7 @@ import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
 import { Box } from 'src/components/Box';
 import { Checkbox } from 'src/components/Checkbox';
 import { FormControlLabel } from 'src/components/FormControlLabel';
-import { Link } from 'src/components/Link';
-import { LinkButton } from 'src/components/LinkButton';
 import { Paper } from 'src/components/Paper';
-import { StyledLinkButtonBox } from 'src/components/SelectFirewallPanel/SelectFirewallPanel';
 import { Stack } from 'src/components/Stack';
 import { TextField } from 'src/components/TextField';
 import { TooltipIcon } from 'src/components/TooltipIcon';
@@ -21,23 +18,16 @@ import {
 import { AssignIPRanges } from 'src/features/VPCs/VPCDetail/AssignIPRanges';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { useAllVPCsQuery } from 'src/queries/vpcs/vpcs';
-import { sendLinodeCreateFormInputEvent } from 'src/utilities/analytics/formEventAnalytics';
 import { doesRegionSupportFeature } from 'src/utilities/doesRegionSupportFeature';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
 
-import { VPCCreateDrawer } from '../../../VPCs/VPCCreateDrawer/VPCCreateDrawer';
-
-import type { LinodeCreateQueryParams } from 'src/features/Linodes/types';
-import type { LinodeCreateFormEventOptions } from 'src/utilities/analytics/types';
 import type { ExtendedIP } from 'src/utilities/ipUtils';
 
 export interface VPCPanelProps {
   additionalIPv4RangesForVPC: ExtendedIP[];
   assignPublicIPv4Address: boolean;
   autoassignIPv4WithinVPC: boolean;
-  from: 'linodeConfig' | 'linodeCreate';
   handleIPv4RangeChange: (ranges: ExtendedIP[]) => void;
   handleSelectVPC: (vpcId: number) => void;
   handleSubnetChange: (subnetId: number | undefined) => void;
@@ -62,7 +52,6 @@ export const VPCPanel = (props: VPCPanelProps) => {
     additionalIPv4RangesForVPC,
     assignPublicIPv4Address,
     autoassignIPv4WithinVPC,
-    from,
     handleIPv4RangeChange,
     handleSelectVPC,
     handleSubnetChange,
@@ -92,10 +81,6 @@ export const VPCPanel = (props: VPCPanelProps) => {
     'VPCs'
   );
 
-  const [isVPCCreateDrawerOpen, setIsVPCCreateDrawerOpen] = React.useState(
-    false
-  );
-
   const { data: vpcsData, error, isLoading } = useAllVPCsQuery();
 
   React.useEffect(() => {
@@ -104,20 +89,7 @@ export const VPCPanel = (props: VPCPanelProps) => {
     }
   }, [subnetError, vpcIPv4Error]);
 
-  const params = getQueryParamsFromQueryString<LinodeCreateQueryParams>(
-    location.search
-  );
-  const vpcFormEventOptions: LinodeCreateFormEventOptions = {
-    createType: params.type ?? 'OS',
-    headerName: 'VPC',
-    interaction: 'click',
-    label: 'VPC',
-  };
-
   const vpcs = vpcsData ?? [];
-
-  const fromLinodeCreate = from === 'linodeCreate';
-  const fromLinodeConfig = from === 'linodeConfig';
 
   interface DropdownOption {
     label: string;
@@ -125,17 +97,14 @@ export const VPCPanel = (props: VPCPanelProps) => {
   }
 
   const vpcDropdownOptions: DropdownOption[] = React.useMemo(() => {
-    return vpcs.reduce(
-      (accumulator, vpc) => {
-        return vpc.region === region
-          ? [...accumulator, { label: vpc.label, value: vpc.id }]
-          : accumulator;
-      },
-      fromLinodeCreate ? [{ label: 'None', value: -1 }] : []
-    );
-  }, [vpcs, region, fromLinodeCreate]);
+    return vpcs.reduce((accumulator, vpc) => {
+      return vpc.region === region
+        ? [...accumulator, { label: vpc.label, value: vpc.id }]
+        : accumulator;
+    }, []);
+  }, [vpcs, region]);
 
-  const defaultVPCValue = fromLinodeConfig ? null : vpcDropdownOptions[0];
+  const defaultVPCValue = null;
 
   const subnetDropdownOptions: DropdownOption[] =
     vpcs
@@ -149,264 +118,160 @@ export const VPCPanel = (props: VPCPanelProps) => {
     ? getAPIErrorOrDefault(error, 'Unable to load VPCs')[0].reason
     : undefined;
 
-  const getMainCopyVPC = () => {
-    if (fromLinodeConfig) {
-      return null;
-    }
-    const copy =
-      vpcDropdownOptions.length <= 1
-        ? 'Allow Linode to communicate in an isolated environment.'
-        : 'Assign this Linode to an existing VPC.';
-
-    return (
-      <>
-        {copy}{' '}
-        <Link
-          onClick={() =>
-            fromLinodeCreate &&
-            sendLinodeCreateFormInputEvent({
-              ...vpcFormEventOptions,
-              label: 'Learn more',
-            })
-          }
-          to="https://techdocs.akamai.com/cloud-computing/docs/assign-a-compute-instance-to-a-vpc"
-        >
-          Learn more
-        </Link>
-        .
-      </>
-    );
-  };
-
   return (
-    <>
-      <Paper
-        sx={(theme) => ({
-          ...(fromLinodeCreate && {
-            marginTop: theme.spacing(3),
-          }),
-          ...(fromLinodeConfig && {
-            padding: 0,
-          }),
-        })}
-        data-testid="vpc-panel"
-      >
-        {fromLinodeCreate && (
-          <Typography
-            sx={(theme) => ({ marginBottom: theme.spacing(2) })}
-            variant="h2"
-          >
-            VPC
-          </Typography>
-        )}
-        <Stack>
-          <Typography>{getMainCopyVPC()}</Typography>
-          <Autocomplete
-            onChange={(_, selectedVPC) => {
-              handleSelectVPC(selectedVPC?.value || -1);
-              // Track clearing and changing the value once per page view, configured by inputValue in AA backend.
-              if (selectedVPC?.label === 'None') {
-                sendLinodeCreateFormInputEvent({
-                  ...vpcFormEventOptions,
-                  interaction: 'clear',
-                  subheaderName: 'Assign VPC',
-                  trackOnce: true,
-                });
-              } else {
-                sendLinodeCreateFormInputEvent({
-                  ...vpcFormEventOptions,
-                  interaction: 'change',
-                  subheaderName: 'Assign VPC',
-                  trackOnce: true,
-                });
-              }
-            }}
-            textFieldProps={{
-              tooltipText: REGION_CAVEAT_HELPER_TEXT,
-            }}
-            value={
-              selectedVPCId && selectedVPCId !== -1
-                ? vpcDropdownOptions.find(
-                    (option) => option.value === selectedVPCId
-                  ) ?? null
-                : defaultVPCValue
-            }
-            autoHighlight
-            clearIcon={null}
-            disabled={!regionSupportsVPCs}
-            errorText={vpcIdError ?? vpcError}
-            label={from === 'linodeCreate' ? 'Assign VPC' : 'VPC'}
-            loading={isLoading}
-            noOptionsText="No VPCs exist in this Linode's region."
-            options={vpcDropdownOptions}
-            placeholder={'Select a VPC'}
-          />
-          {from === 'linodeCreate' &&
-            vpcDropdownOptions.length <= 1 &&
-            regionSupportsVPCs && (
-              <Typography sx={(theme) => ({ paddingTop: theme.spacing(1.5) })}>
-                No VPCs exist in the selected region. Click Create VPC to create
-                one.
-              </Typography>
-            )}
-          {from === 'linodeCreate' &&
-            (regionSupportsVPCs ? (
-              <StyledLinkButtonBox>
-                <LinkButton
-                  onClick={() => {
-                    setIsVPCCreateDrawerOpen(true);
-                    sendLinodeCreateFormInputEvent({
-                      ...vpcFormEventOptions,
-                      label: 'Create VPC',
-                    });
-                  }}
-                >
-                  Create VPC
-                </LinkButton>
-              </StyledLinkButtonBox>
-            ) : (
-              region && (
-                <Typography
-                  sx={(theme) => ({ paddingTop: theme.spacing(1.5) })}
-                >
-                  VPC is not available in the selected region.
-                </Typography>
-              )
-            ))}
-
-          {selectedVPCId !== -1 && regionSupportsVPCs && (
-            <Stack data-testid="subnet-and-additional-options-section">
-              <Autocomplete
-                onChange={(_, selectedSubnet) => {
-                  handleSubnetChange(selectedSubnet?.value);
-                }}
-                textFieldProps={{
-                  errorGroup: ERROR_GROUP_STRING,
-                }}
-                value={
-                  subnetDropdownOptions.find(
-                    (option) => option.value === selectedSubnetId
-                  ) ?? null
-                }
-                autoHighlight
-                clearIcon={null}
-                errorText={subnetError}
-                label="Subnet"
-                options={subnetDropdownOptions}
-                placeholder="Select Subnet"
-              />
-              {selectedSubnetId && (
-                <>
-                  <Box
-                    sx={(theme) => ({
-                      marginLeft: '2px',
-                      paddingTop: theme.spacing(),
-                    })}
-                    alignItems="center"
-                    display="flex"
-                    flexDirection="row"
-                  >
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          checked={autoassignIPv4WithinVPC}
-                          onChange={toggleAutoassignIPv4WithinVPCEnabled}
-                        />
-                      }
-                      label={
-                        <Box
-                          alignItems="center"
-                          display="flex"
-                          flexDirection="row"
-                        >
-                          <Typography
-                            noWrap={!isSmallBp && from === 'linodeConfig'}
-                          >
-                            Auto-assign a VPC IPv4 address for this Linode in
-                            the VPC
-                          </Typography>
-                          <TooltipIcon
-                            status="help"
-                            text={VPC_AUTO_ASSIGN_IPV4_TOOLTIP}
-                          />
-                        </Box>
-                      }
-                      data-testid="vpc-ipv4-checkbox"
-                    />
-                  </Box>
-                  {!autoassignIPv4WithinVPC && (
-                    <TextField
-                      errorGroup={ERROR_GROUP_STRING}
-                      errorText={vpcIPv4Error}
-                      label="VPC IPv4"
-                      onChange={(e) => handleVPCIPv4Change(e.target.value)}
-                      required={!autoassignIPv4WithinVPC}
-                      value={vpcIPv4AddressOfLinode}
-                    />
-                  )}
-                  <Box
-                    sx={(theme) => ({
-                      marginLeft: '2px',
-                      marginTop: !autoassignIPv4WithinVPC ? theme.spacing() : 0,
-                    })}
-                    alignItems="center"
-                    display="flex"
-                  >
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          checked={assignPublicIPv4Address}
-                          onChange={toggleAssignPublicIPv4Address}
-                        />
-                      }
-                      label={
-                        <Box
-                          alignItems="center"
-                          display="flex"
-                          flexDirection="row"
-                        >
-                          <Typography>
-                            Assign a public IPv4 address for this Linode
-                          </Typography>
-                          <TooltipIcon
-                            text={
-                              'Access the internet through the public IPv4 address using static 1:1 NAT.'
-                            }
-                            status="help"
-                          />
-                        </Box>
-                      }
-                    />
-                  </Box>
-                  {assignPublicIPv4Address && publicIPv4Error && (
-                    <Typography
-                      sx={(theme) => ({
-                        color: theme.color.red,
-                      })}
-                    >
-                      {publicIPv4Error}
-                    </Typography>
-                  )}
-                  <AssignIPRanges
-                    handleIPRangeChange={handleIPv4RangeChange}
-                    includeDescriptionInTooltip={fromLinodeConfig}
-                    ipRanges={additionalIPv4RangesForVPC}
-                    ipRangesError={vpcIPRangesError}
-                  />
-                </>
-              )}
-            </Stack>
-          )}
-        </Stack>
-      </Paper>
-      {isVPCCreateDrawerOpen && (
-        <VPCCreateDrawer
-          handleSelectVPC={(vpcId: number) => handleSelectVPC(vpcId)}
-          onClose={() => setIsVPCCreateDrawerOpen(false)}
-          open={isVPCCreateDrawerOpen}
-          selectedRegion={region}
+    <Paper
+      sx={{
+        padding: 0,
+      }}
+      data-testid="vpc-panel"
+    >
+      <Stack>
+        <Autocomplete
+          onChange={(_, selectedVPC) => {
+            handleSelectVPC(selectedVPC?.value || -1);
+          }}
+          textFieldProps={{
+            tooltipText: REGION_CAVEAT_HELPER_TEXT,
+          }}
+          value={
+            selectedVPCId && selectedVPCId !== -1
+              ? vpcDropdownOptions.find(
+                  (option) => option.value === selectedVPCId
+                ) ?? null
+              : defaultVPCValue
+          }
+          autoHighlight
+          clearIcon={null}
+          disabled={!regionSupportsVPCs}
+          errorText={vpcIdError ?? vpcError}
+          label={'VPC'}
+          loading={isLoading}
+          noOptionsText="No VPCs exist in this Linode's region."
+          options={vpcDropdownOptions}
+          placeholder={'Select a VPC'}
         />
-      )}
-    </>
+        {selectedVPCId !== -1 && regionSupportsVPCs && (
+          <Stack data-testid="subnet-and-additional-options-section">
+            <Autocomplete
+              onChange={(_, selectedSubnet) => {
+                handleSubnetChange(selectedSubnet?.value);
+              }}
+              textFieldProps={{
+                errorGroup: ERROR_GROUP_STRING,
+              }}
+              value={
+                subnetDropdownOptions.find(
+                  (option) => option.value === selectedSubnetId
+                ) ?? null
+              }
+              autoHighlight
+              clearIcon={null}
+              errorText={subnetError}
+              label="Subnet"
+              options={subnetDropdownOptions}
+              placeholder="Select Subnet"
+            />
+            {selectedSubnetId && (
+              <>
+                <Box
+                  sx={(theme) => ({
+                    marginLeft: '2px',
+                    paddingTop: theme.spacing(),
+                  })}
+                  alignItems="center"
+                  display="flex"
+                  flexDirection="row"
+                >
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={autoassignIPv4WithinVPC}
+                        onChange={toggleAutoassignIPv4WithinVPCEnabled}
+                      />
+                    }
+                    label={
+                      <Box
+                        alignItems="center"
+                        display="flex"
+                        flexDirection="row"
+                      >
+                        <Typography noWrap={!isSmallBp}>
+                          Auto-assign a VPC IPv4 address for this Linode in the
+                          VPC
+                        </Typography>
+                        <TooltipIcon
+                          status="help"
+                          text={VPC_AUTO_ASSIGN_IPV4_TOOLTIP}
+                        />
+                      </Box>
+                    }
+                    data-testid="vpc-ipv4-checkbox"
+                  />
+                </Box>
+                {!autoassignIPv4WithinVPC && (
+                  <TextField
+                    errorGroup={ERROR_GROUP_STRING}
+                    errorText={vpcIPv4Error}
+                    label="VPC IPv4"
+                    onChange={(e) => handleVPCIPv4Change(e.target.value)}
+                    required={!autoassignIPv4WithinVPC}
+                    value={vpcIPv4AddressOfLinode}
+                  />
+                )}
+                <Box
+                  sx={(theme) => ({
+                    marginLeft: '2px',
+                    marginTop: !autoassignIPv4WithinVPC ? theme.spacing() : 0,
+                  })}
+                  alignItems="center"
+                  display="flex"
+                >
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={assignPublicIPv4Address}
+                        onChange={toggleAssignPublicIPv4Address}
+                      />
+                    }
+                    label={
+                      <Box
+                        alignItems="center"
+                        display="flex"
+                        flexDirection="row"
+                      >
+                        <Typography>
+                          Assign a public IPv4 address for this Linode
+                        </Typography>
+                        <TooltipIcon
+                          text={
+                            'Access the internet through the public IPv4 address using static 1:1 NAT.'
+                          }
+                          status="help"
+                        />
+                      </Box>
+                    }
+                  />
+                </Box>
+                {assignPublicIPv4Address && publicIPv4Error && (
+                  <Typography
+                    sx={(theme) => ({
+                      color: theme.color.red,
+                    })}
+                  >
+                    {publicIPv4Error}
+                  </Typography>
+                )}
+                <AssignIPRanges
+                  handleIPRangeChange={handleIPv4RangeChange}
+                  includeDescriptionInTooltip
+                  ipRanges={additionalIPv4RangesForVPC}
+                  ipRangesError={vpcIPRangesError}
+                />
+              </>
+            )}
+          </Stack>
+        )}
+      </Stack>
+    </Paper>
   );
 };

--- a/packages/manager/src/features/VPCs/VPCCreateDrawer/VPCCreateDrawer.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreateDrawer/VPCCreateDrawer.test.tsx
@@ -6,8 +6,8 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 import { VPCCreateDrawer } from './VPCCreateDrawer';
 
 const props = {
-  handleSelectVPC: vi.fn(),
   onClose: vi.fn(),
+  onSuccess: vi.fn(),
   open: true,
 };
 

--- a/packages/manager/src/features/VPCs/VPCCreateDrawer/VPCCreateDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreateDrawer/VPCCreateDrawer.tsx
@@ -11,16 +11,21 @@ import { SubnetContent } from 'src/features/VPCs/VPCCreate/FormComponents/Subnet
 import { VPCTopSectionContent } from 'src/features/VPCs/VPCCreate/FormComponents/VPCTopSectionContent';
 import { useCreateVPC } from 'src/hooks/useCreateVPC';
 
+import type { VPC } from '@linode/api-v4';
+
 interface Props {
-  handleSelectVPC: (vpcId: number) => void;
   onClose: () => void;
+  /**
+   * A function that is called when a VPC is successfully created
+   */
+  onSuccess: (vpc: VPC) => void;
   open: boolean;
   selectedRegion?: string;
 }
 
 export const VPCCreateDrawer = (props: Props) => {
   const theme = useTheme();
-  const { handleSelectVPC, onClose, open, selectedRegion } = props;
+  const { onClose, onSuccess, open, selectedRegion } = props;
 
   const {
     formik,
@@ -33,7 +38,11 @@ export const VPCCreateDrawer = (props: Props) => {
     setGeneralAPIError,
     setGeneralSubnetErrorsFromAPI,
     userCannotAddVPC,
-  } = useCreateVPC({ handleSelectVPC, onDrawerClose: onClose, selectedRegion });
+  } = useCreateVPC({
+    handleSelectVPC: onSuccess,
+    onDrawerClose: onClose,
+    selectedRegion,
+  });
 
   const { errors, handleSubmit, resetForm, setFieldValue, values } = formik;
 

--- a/packages/manager/src/hooks/useCreateVPC.ts
+++ b/packages/manager/src/hooks/useCreateVPC.ts
@@ -16,6 +16,7 @@ import type {
   APIError,
   CreateSubnetPayload,
   CreateVPCPayload,
+  VPC,
 } from '@linode/api-v4';
 import type { LinodeCreateType } from 'src/features/Linodes/LinodeCreate/types';
 import type { SubnetError } from 'src/utilities/formikErrorUtils';
@@ -31,7 +32,7 @@ export interface CreateVPCFieldState {
 }
 
 export interface UseCreateVPCInputs {
-  handleSelectVPC?: (vpcId: number) => void;
+  handleSelectVPC?: (vpc: VPC) => void;
   onDrawerClose?: () => void;
   pushToVPCPage?: boolean;
   selectedRegion?: string;
@@ -135,12 +136,12 @@ export const useCreateVPC = (inputs: UseCreateVPCInputs) => {
     };
 
     try {
-      const response = await createVPC(createVPCPayload);
+      const vpc = await createVPC(createVPCPayload);
       if (pushToVPCPage) {
-        history.push(`/vpcs/${response.id}`);
+        history.push(`/vpcs/${vpc.id}`);
       } else {
         if (handleSelectVPC && onDrawerClose) {
-          handleSelectVPC(response.id);
+          handleSelectVPC(vpc);
           onDrawerClose();
         }
       }


### PR DESCRIPTION
## Description 📝

- Cleans up old VPC code related to Linode Create v1 🧹 
- Preselects the VPC **and the subnet** when creating the VPC while on the Linode Create flow ⌨️ ✨ 
  - Previously, the VPC would only preselect. This PR makes it so the subnet also gets selected
- Preselects a VPC's subnet if the user picks a VPC with only one subnet  ✨ 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/d138a2d5-6082-4368-92ff-dc9c57a71854" /> | <video src="https://github.com/user-attachments/assets/fd7a94d6-b220-4c98-b4b4-4c31e71cd354" /> |

## How to test 🧪

- Check out this PR
- Go to the Linode Create flow
- Test the VPC section of the form 🧪
  - Verify both the VPC and subnet get preselected when you uses the Create VPC drawer to create a VPC
  - Verify error field handling works as expected
  - Verify the clean up done in this PR does not break anything else
  - Verify the subnet gets auto selected when you select a VPC that only has 1 subnet

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support