### PR TITLE
test: [M3-8810] - Fix DBaaS failures when v2 feature flag is enabled

### DIFF
--- a/packages/manager/.changeset/pr-11190-tests-1730312266172.md
+++ b/packages/manager/.changeset/pr-11190-tests-1730312266172.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Allow DBaaS resize test to pass when DBaaS v2 is enabled ([#11190](https://github.com/linode/manager/pull/11190))

--- a/packages/manager/cypress/e2e/core/databases/resize-database.spec.ts
+++ b/packages/manager/cypress/e2e/core/databases/resize-database.spec.ts
@@ -19,6 +19,7 @@ import {
   mockDatabaseNodeTypes,
 } from 'support/constants/databases';
 import { accountFactory } from '@src/factories';
+import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
 
 /**
  * Resizes a current database cluster to a larger plan size.
@@ -79,6 +80,12 @@ describe('Resizing existing clusters', () => {
           if (!databaseType) {
             throw new Error(`Unknown database type ${database.type}`);
           }
+          mockAppendFeatureFlags({
+            dbaasV2: {
+              enabled: false,
+              beta: false,
+            },
+          });
           mockGetAccount(accountFactory.build()).as('getAccount');
           mockGetDatabase(database).as('getDatabase');
           mockGetDatabaseTypes(mockDatabaseNodeTypes).as('getDatabaseTypes');

--- a/packages/manager/cypress/e2e/core/databases/resize-database.spec.ts
+++ b/packages/manager/cypress/e2e/core/databases/resize-database.spec.ts
@@ -19,7 +19,6 @@ import {
   mockDatabaseNodeTypes,
 } from 'support/constants/databases';
 import { accountFactory } from '@src/factories';
-import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
 
 /**
  * Resizes a current database cluster to a larger plan size.
@@ -80,12 +79,6 @@ describe('Resizing existing clusters', () => {
           if (!databaseType) {
             throw new Error(`Unknown database type ${database.type}`);
           }
-          mockAppendFeatureFlags({
-            dbaasV2: {
-              enabled: false,
-              beta: false,
-            },
-          });
           mockGetAccount(accountFactory.build()).as('getAccount');
           mockGetDatabase(database).as('getDatabase');
           mockGetDatabaseTypes(mockDatabaseNodeTypes).as('getDatabaseTypes');
@@ -159,9 +152,6 @@ describe('Resizing existing clusters', () => {
                 cy.get('[data-testid="resizeSummary"]').within(() => {
                   cy.contains(`${nodeType.label}`).should('be.visible');
                   cy.contains(`$${desiredPlanPrice.monthly}/month`).should(
-                    'be.visible'
-                  );
-                  cy.contains(`$${desiredPlanPrice.hourly}/hour`).should(
                     'be.visible'
                   );
                 });


### PR DESCRIPTION
## Description 📝
We've been seeing DBaaS resize test failures on every test run as a result of a DBaaS feature flag change earlier today. Since this feature flag will be enabled more often as testing continues, this PR seeks to make the test pass regardless of the value of the flag.

It does this by removing an assertion that's only relevant when the feature flag is disabled. The DBaaS team is invited to refactor these tests if this assertion is crucial, but otherwise we'll proceed with this as a quick fix.

## Changes  🔄
Remove assertion to allow DBaaS resize tests to pass regardless of state of v2 feature flag.

## How to test 🧪
We can rely on CI for this, but you're welcome to run the test locally as well.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
