### PR TITLE
feat: [UIE-8194] - DBaaS Upgrades and Maintenance 4

### DIFF
--- a/packages/manager/.changeset/pr-11199-upcoming-features-1730465428837.md
+++ b/packages/manager/.changeset/pr-11199-upcoming-features-1730465428837.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+DBaaS major minor updates integration ([#11199](https://github.com/linode/manager/pull/11199))

--- a/packages/manager/src/features/Databases/DatabaseCreate/utilities.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/utilities.tsx
@@ -4,8 +4,7 @@ import React from 'react';
 import MongoDBIcon from 'src/assets/icons/mongodb.svg';
 import MySQLIcon from 'src/assets/icons/mysql.svg';
 import PostgreSQLIcon from 'src/assets/icons/postgresql.svg';
-
-import { databaseEngineMap } from '../DatabaseLanding/DatabaseRow';
+import { getDatabasesDescription } from 'src/features/Databases/utilities';
 
 import type { DatabaseEngine } from '@linode/api-v4';
 
@@ -101,9 +100,10 @@ export const getEngineOptions = (engines: DatabaseEngine[]) => {
             .map((engineObject) => ({
               ...engineObject,
               flag: engineIcons[engineObject.engine],
-              label: `${databaseEngineMap[engineObject.engine]} v${
-                engineObject.version
-              }`,
+              label: getDatabasesDescription({
+                engine: engineObject.engine,
+                version: engineObject.version,
+              }),
               value: `${engineObject.engine}/${engineObject.version}`,
             }))
             .sort((a, b) => (a.version > b.version ? -1 : 1)),

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResizeCurrentConfiguration.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResizeCurrentConfiguration.tsx
@@ -5,13 +5,13 @@ import * as React from 'react';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { TooltipIcon } from 'src/components/TooltipIcon';
+import { DatabaseEngineVersion } from 'src/features/Databases/DatabaseEngineVersion';
 import { useDatabaseTypesQuery } from 'src/queries/databases/databases';
 import { useInProgressEvents } from 'src/queries/events/events';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { formatStorageUnits } from 'src/utilities/formatStorageUnits';
 import { convertMegabytesTo } from 'src/utilities/unitConversions';
 
-import { databaseEngineMap } from '../../DatabaseLanding/DatabaseRow';
 import { DatabaseStatusDisplay } from '../DatabaseStatusDisplay';
 import {
   StyledStatusBox,
@@ -24,17 +24,12 @@ import {
 import type { Region } from '@linode/api-v4';
 import type {
   Database,
-  DatabaseInstance,
   DatabaseType,
 } from '@linode/api-v4/lib/databases/types';
 
 interface Props {
   database: Database;
 }
-
-export const getDatabaseVersionNumber = (
-  version: DatabaseInstance['version']
-) => version.split('/')[1];
 
 export const DatabaseResizeCurrentConfiguration = ({ database }: Props) => {
   const {
@@ -94,7 +89,13 @@ export const DatabaseResizeCurrentConfiguration = ({ database }: Props) => {
           </StyledSummaryTextBox>
           <StyledSummaryTextTypography>
             <span style={{ fontFamily: theme.font.bold }}>Version</span>{' '}
-            {databaseEngineMap[database.engine]} v{database.version}
+            <DatabaseEngineVersion
+              databaseEngine={database.engine}
+              databaseID={database.id}
+              databasePendingUpdates={database.updates.pending}
+              databasePlatform={database.platform}
+              databaseVersion={database.version}
+            />
           </StyledSummaryTextTypography>
           <StyledSummaryTextTypography>
             <span style={{ fontFamily: theme.font.bold }}>Nodes</span>{' '}

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.tsx
@@ -10,7 +10,7 @@ import {
   StyledLabelTypography,
   StyledValueGrid,
 } from 'src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.style';
-import { databaseEngineMap } from 'src/features/Databases/DatabaseLanding/DatabaseRow';
+import { DatabaseEngineVersion } from 'src/features/Databases/DatabaseEngineVersion';
 import { useDatabaseTypesQuery } from 'src/queries/databases/databases';
 import { useInProgressEvents } from 'src/queries/events/events';
 import { useRegionsQuery } from 'src/queries/regions/regions';
@@ -101,7 +101,13 @@ export const DatabaseSummaryClusterConfiguration = (props: Props) => {
           <StyledLabelTypography>Engine</StyledLabelTypography>
         </Grid>
         <StyledValueGrid lg={1.5} md={4} xs={8}>
-          {databaseEngineMap[database.engine]} v{database.version}
+          <DatabaseEngineVersion
+            databaseEngine={database.engine}
+            databaseID={database.id}
+            databasePendingUpdates={database.updates.pending}
+            databasePlatform={database.platform}
+            databaseVersion={database.version}
+          />
         </StyledValueGrid>
         <Grid lg={1} md={2} xs={4}>
           <StyledLabelTypography>Region</StyledLabelTypography>

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/legacy/DatabaseSummaryClusterConfigurationLegacy.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/legacy/DatabaseSummaryClusterConfigurationLegacy.tsx
@@ -5,7 +5,7 @@ import { makeStyles } from 'tss-react/mui';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { Typography } from 'src/components/Typography';
 import { DatabaseStatusDisplay } from 'src/features/Databases/DatabaseDetail/DatabaseStatusDisplay';
-import { databaseEngineMap } from 'src/features/Databases/DatabaseLanding/DatabaseRow';
+import { DatabaseEngineVersion } from 'src/features/Databases/DatabaseEngineVersion';
 import { useDatabaseTypesQuery } from 'src/queries/databases/databases';
 import { useInProgressEvents } from 'src/queries/events/events';
 import { useRegionsQuery } from 'src/queries/regions/regions';
@@ -94,7 +94,13 @@ export const DatabaseSummaryClusterConfigurationLegacy = (props: Props) => {
         </Box>
         <Box display="flex">
           <Typography className={classes.label}>Version</Typography>
-          {databaseEngineMap[database.engine]} v{database.version}
+          <DatabaseEngineVersion
+            databaseEngine={database.engine}
+            databaseID={database.id}
+            databasePendingUpdates={database.updates.pending}
+            databasePlatform={database.platform}
+            databaseVersion={database.version}
+          />
         </Box>
         <Box display="flex">
           <Typography className={classes.label}>Nodes</Typography>

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
@@ -6,6 +6,7 @@ import { Hidden } from 'src/components/Hidden';
 import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
 import { DatabaseStatusDisplay } from 'src/features/Databases/DatabaseDetail/DatabaseStatusDisplay';
+import { DatabaseEngineVersion } from 'src/features/Databases/DatabaseEngineVersion';
 import { DatabaseActionMenu } from 'src/features/Databases/DatabaseLanding/DatabaseActionMenu';
 import { useIsDatabasesEnabled } from 'src/features/Databases/utilities';
 import { useDatabaseTypesQuery } from 'src/queries/databases/databases';
@@ -19,16 +20,8 @@ import type { Event } from '@linode/api-v4';
 import type {
   DatabaseInstance,
   DatabaseType,
-  Engine,
 } from '@linode/api-v4/lib/databases/types';
 import type { ActionHandlers } from 'src/features/Databases/DatabaseLanding/DatabaseActionMenu';
-
-export const databaseEngineMap: Record<Engine, string> = {
-  mongodb: 'MongoDB',
-  mysql: 'MySQL',
-  postgresql: 'PostgreSQL',
-  redis: 'Redis',
-};
 
 interface Props {
   database: DatabaseInstance;
@@ -53,9 +46,11 @@ export const DatabaseRow = ({
     engine,
     id,
     label,
+    platform,
     region,
     status,
     type,
+    updates,
     version,
   } = database;
 
@@ -101,7 +96,15 @@ export const DatabaseRow = ({
       <Hidden smDown>
         <TableCell>{configuration}</TableCell>
       </Hidden>
-      <TableCell>{`${databaseEngineMap[engine]} v${version}`}</TableCell>
+      <TableCell>
+        <DatabaseEngineVersion
+          databaseEngine={engine}
+          databaseID={id}
+          databasePendingUpdates={updates.pending}
+          databasePlatform={platform}
+          databaseVersion={version}
+        />
+      </TableCell>
       <Hidden mdDown>
         <TableCell>{actualRegion?.label ?? region}</TableCell>
       </Hidden>


### PR DESCRIPTION
## Description 📝
DBaaS Upgrades and Maintenance 4 of 4

## Changes  🔄
- Integration of components into settings, create, resize, landing, summary

## Target release date 🗓️
11/12/24

## Preview 📷
![integration](https://github.com/user-attachments/assets/4eb52f68-4f66-4abe-b8ed-138331debeda)

## How to test 🧪

### Prerequisites
- Managed Databases
- dbaasV2 feature flag set for GA
- Default DB created e.g. postgresql 13

### Verification steps
- Verify you can upgrade to postgresql 14, 15, 16
- View maintenance

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
