### PR TITLE
hotfix: [APL-343] - APL summary panel is not being loaded in staging 

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2024-10-29] - v1.131.1
+## [2024-11-05] - v1.131.2
 
 
 ### Fixed:
 
-- Hostnames not showing on the Database details page ([#11182](https://github.com/linode/manager/pull/11182))
+- APL summary panel not being loaded consistently ([#11207](https://github.com/linode/manager/pull/11207))
 
 ## [2024-10-28] - v1.131.0
 

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -11,6 +11,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - APL summary panel not being loaded consistently ([#11207](https://github.com/linode/manager/pull/11207))
 
+## [2024-10-29] - v1.131.1
+
+
+### Fixed:
+
+- Hostnames not showing on the Database details page ([#11182](https://github.com/linode/manager/pull/11182))
+
 ## [2024-10-28] - v1.131.0
 
 

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.131.1",
+  "version": "1.131.2",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/legacy/DatabaseSummaryConnectionDetailsLegacy.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/legacy/DatabaseSummaryConnectionDetailsLegacy.tsx
@@ -127,9 +127,6 @@ const sxTooltipIcon = {
 const privateHostCopy =
   'A private network host and a private IP can only be used to access a Database Cluster from Linodes in the same data center and will not incur transfer costs.';
 
-const mongoHostHelperCopy =
-  'This is a public hostname. Coming soon: connect to your MongoDB clusters using private IPs';
-
 /**
  * Deprecated @since DBaaS V2 GA. Will be removed remove post GA release ~ Dec 2024
  * TODO (UIE-8214) remove POST GA
@@ -287,48 +284,29 @@ export const DatabaseSummaryConnectionDetailsLegacy = (props: Props) => {
           )}
         </Box>
         <Box>
-          <Typography>
-            <span>hosts</span> ={' '}
-            {(!database.peers || database.peers.length === 0) && (
-              <span className={classes.provisioningText}>
-                Your hostnames will appear here once they are available.
-              </span>
-            )}
-          </Typography>
-          {database.peers &&
-            database.peers.length > 0 &&
-            database.peers.map((hostname, i) => (
-              <Box
-                alignItems="center"
-                display="flex"
-                flexDirection="row"
-                key={hostname}
-              >
-                <Typography
-                  style={{
-                    marginBottom: 0,
-                    marginLeft: 16,
-                    marginTop: 0,
-                  }}
-                >
+          <Box alignItems="center" display="flex" flexDirection="row">
+            {database.hosts?.primary ? (
+              <>
+                <Typography>
+                  <span>host</span> ={' '}
                   <span style={{ fontFamily: theme.font.normal }}>
-                    {hostname}
-                  </span>
+                    {database.hosts?.primary}
+                  </span>{' '}
                 </Typography>
                 <CopyTooltip
                   className={classes.inlineCopyToolTip}
-                  text={hostname}
+                  text={database.hosts?.primary}
                 />
-                {/*  Display the helper text on the first hostname */}
-                {i === 0 && (
-                  <TooltipIcon
-                    status="help"
-                    sxTooltipIcon={sxTooltipIcon}
-                    text={mongoHostHelperCopy}
-                  />
-                )}
-              </Box>
-            ))}
+              </>
+            ) : (
+              <Typography>
+                <span>host</span> ={' '}
+                <span className={classes.provisioningText}>
+                  Your hostname will appear here once it is available.
+                </span>
+              </Typography>
+            )}
+          </Box>
         </Box>
         {readOnlyHost && (
           <Box alignItems="center" display="flex" flexDirection="row">

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/legacy/DatabaseSummaryConnectionDetailsLegacy.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/legacy/DatabaseSummaryConnectionDetailsLegacy.tsx
@@ -127,6 +127,9 @@ const sxTooltipIcon = {
 const privateHostCopy =
   'A private network host and a private IP can only be used to access a Database Cluster from Linodes in the same data center and will not incur transfer costs.';
 
+const mongoHostHelperCopy =
+  'This is a public hostname. Coming soon: connect to your MongoDB clusters using private IPs';
+
 /**
  * Deprecated @since DBaaS V2 GA. Will be removed remove post GA release ~ Dec 2024
  * TODO (UIE-8214) remove POST GA
@@ -284,29 +287,48 @@ export const DatabaseSummaryConnectionDetailsLegacy = (props: Props) => {
           )}
         </Box>
         <Box>
-          <Box alignItems="center" display="flex" flexDirection="row">
-            {database.hosts?.primary ? (
-              <>
-                <Typography>
-                  <span>host</span> ={' '}
+          <Typography>
+            <span>hosts</span> ={' '}
+            {(!database.peers || database.peers.length === 0) && (
+              <span className={classes.provisioningText}>
+                Your hostnames will appear here once they are available.
+              </span>
+            )}
+          </Typography>
+          {database.peers &&
+            database.peers.length > 0 &&
+            database.peers.map((hostname, i) => (
+              <Box
+                alignItems="center"
+                display="flex"
+                flexDirection="row"
+                key={hostname}
+              >
+                <Typography
+                  style={{
+                    marginBottom: 0,
+                    marginLeft: 16,
+                    marginTop: 0,
+                  }}
+                >
                   <span style={{ fontFamily: theme.font.normal }}>
-                    {database.hosts?.primary}
-                  </span>{' '}
+                    {hostname}
+                  </span>
                 </Typography>
                 <CopyTooltip
                   className={classes.inlineCopyToolTip}
-                  text={database.hosts?.primary}
+                  text={hostname}
                 />
-              </>
-            ) : (
-              <Typography>
-                <span>host</span> ={' '}
-                <span className={classes.provisioningText}>
-                  Your hostname will appear here once it is available.
-                </span>
-              </Typography>
-            )}
-          </Box>
+                {/*  Display the helper text on the first hostname */}
+                {i === 0 && (
+                  <TooltipIcon
+                    status="help"
+                    sxTooltipIcon={sxTooltipIcon}
+                    text={mongoHostHelperCopy}
+                  />
+                )}
+              </Box>
+            ))}
         </Box>
         {readOnlyHost && (
           <Box alignItems="center" display="flex" flexDirection="row">

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ApplicationPlatform.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ApplicationPlatform.tsx
@@ -19,7 +19,7 @@ export const APLCopy = () => (
   <Typography>
     Add a pre-paved path to build, deploy, monitor and secure applications.
     <br />
-    <Link to="https://otomi.io">
+    <Link to="https://techdocs.akamai.com/cloud-computing/docs/application-platform">
       Learn more about Application Platform for LKE.
     </Link>
   </Typography>

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -87,7 +87,7 @@ export const CreateCluster = () => {
   const regionsData = data ?? [];
   const history = useHistory();
   const { data: account } = useAccount();
-  const showAPL = useAPLAvailability();
+  const { showAPL } = useAPLAvailability();
   const { showHighAvailability } = getKubeHighAvailability(account);
   const { showControlPlaneACL } = getKubeControlPlaneACL(account);
   const [ipV4Addr, setIPv4Addr] = React.useState<ExtendedIP[]>([

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/APLSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/APLSummaryPanel.tsx
@@ -49,7 +49,7 @@ const checkConsoleURL = async (
     } catch (error) {
       setStatus({
         message:
-          'APL is still being provisioned, please check back in a minute.',
+          'Installation still in progress; please check back in a minute.',
         resolved: false,
       });
     }
@@ -85,9 +85,7 @@ export const APLSummaryPanel = React.memo((props: Props) => {
     <Paper className={classes.root}>
       <Grid className={classes.mainGridContainer} container spacing={2}>
         <Grid>
-          <Typography className={classes.label}>
-            APL Console Endpoint:
-          </Typography>
+          <Typography className={classes.label}>Portal Endpoint:</Typography>
           {status.resolved ? (
             <Link to={status.url}>{status.url}</Link>
           ) : (

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/APLSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/APLSummaryPanel.tsx
@@ -37,26 +37,21 @@ const checkConsoleURL = async (
   setStatus: React.Dispatch<React.SetStateAction<StatusState>>
 ) => {
   const consoleURL = `https://console.lke${cluster.id}.akamai-apl.net`;
-
+  const healthCheckURL = `https://auth.lke${cluster.id}.akamai-apl.net/ready`;
   const pollURL = async () => {
     try {
-      const response = await axios.get(consoleURL);
+      const response = await axios.get(healthCheckURL);
 
       if (response.status === 302 || response.status === 200) {
         clearInterval(interval); // Stop the polling
         setStatus({ resolved: true, url: consoleURL });
       }
     } catch (error) {
-      if (error.response && error.response.status === 404) {
-        setStatus({
-          message:
-            'APL is still being deployed, please check back in a minute.',
-          resolved: false,
-        });
-      } else {
-        clearInterval(interval); // Stop the polling
-        setStatus({ resolved: true, url: consoleURL });
-      }
+      setStatus({
+        message:
+          'APL is still being provisioned, please check back in a minute.',
+        resolved: false,
+      });
     }
   };
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/APLSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/APLSummaryPanel.tsx
@@ -42,7 +42,7 @@ const checkConsoleURL = async (
     try {
       const response = await axios.get(consoleURL);
 
-      if (response.status === 200) {
+      if (response.status === 302 || response.status === 200) {
         clearInterval(interval); // Stop the polling
         setStatus({ resolved: true, url: consoleURL });
       }
@@ -53,6 +53,9 @@ const checkConsoleURL = async (
             'APL is still being deployed, please check back in a minute.',
           resolved: false,
         });
+      } else {
+        clearInterval(interval); // Stop the polling
+        setStatus({ resolved: true, url: consoleURL });
       }
     }
   };

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -28,7 +28,7 @@ export const KubernetesClusterDetail = () => {
   const { clusterID } = useParams<{ clusterID: string }>();
   const id = Number(clusterID);
   const location = useLocation();
-  const showAPL = useAPLAvailability();
+  const { showAPL } = useAPLAvailability();
 
   const { data: cluster, error, isLoading } = useKubernetesClusterQuery(id);
   const { data: regionsData } = useRegionsQuery();

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -13,7 +13,6 @@ import { useAccount } from 'src/queries/account/account';
 import {
   useKubernetesClusterMutation,
   useKubernetesClusterQuery,
-  useKubernetesClusterQueryBeta,
 } from 'src/queries/kubernetes';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
@@ -31,11 +30,7 @@ export const KubernetesClusterDetail = () => {
   const location = useLocation();
   const showAPL = useAPLAvailability();
 
-  const kubernetesClusterBetaQuery = useKubernetesClusterQueryBeta(id);
-  const kubernetesClusterQuery = useKubernetesClusterQuery(id);
-  const { data: cluster, error, isLoading } = showAPL
-    ? kubernetesClusterBetaQuery
-    : kubernetesClusterQuery;
+  const { data: cluster, error, isLoading } = useKubernetesClusterQuery(id);
   const { data: regionsData } = useRegionsQuery();
 
   const { mutateAsync: updateKubernetesCluster } = useKubernetesClusterMutation(

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -13,6 +13,7 @@ import { useAccount } from 'src/queries/account/account';
 import {
   useKubernetesClusterMutation,
   useKubernetesClusterQuery,
+  useKubernetesClusterQueryBeta,
 } from 'src/queries/kubernetes';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
@@ -30,23 +31,16 @@ export const KubernetesClusterDetail = () => {
   const location = useLocation();
   const showAPL = useAPLAvailability();
 
-  const {
-    data: cluster,
-    error,
-    isLoading,
-    refetch,
-  } = useKubernetesClusterQuery(id, showAPL);
+  const kubernetesClusterBetaQuery = useKubernetesClusterQueryBeta(id);
+  const kubernetesClusterQuery = useKubernetesClusterQuery(id);
+  const { data: cluster, error, isLoading } = showAPL
+    ? kubernetesClusterBetaQuery
+    : kubernetesClusterQuery;
   const { data: regionsData } = useRegionsQuery();
 
   const { mutateAsync: updateKubernetesCluster } = useKubernetesClusterMutation(
     id
   );
-
-  React.useEffect(() => {
-    if (showAPL) {
-      refetch();
-    }
-  }, [refetch, showAPL]);
 
   const {
     isClusterHighlyAvailable,

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -122,9 +122,9 @@ export const KubernetesClusterDetail = () => {
         <>
           <LandingHeader
             docsLabel="Docs"
-            docsLink="https://otomi.io/docs/get-started/overview"
+            docsLink="https://apl-docs.net/"
             removeCrumbX={[1, 2, 3]}
-            title="Application platform for LKE"
+            title="Application Platform for LKE"
           />
           <Grid>
             <APLSummaryPanel cluster={cluster} />

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -30,12 +30,23 @@ export const KubernetesClusterDetail = () => {
   const location = useLocation();
   const showAPL = useAPLAvailability();
 
-  const { data: cluster, error, isLoading } = useKubernetesClusterQuery(id);
+  const {
+    data: cluster,
+    error,
+    isLoading,
+    refetch,
+  } = useKubernetesClusterQuery(id, showAPL);
   const { data: regionsData } = useRegionsQuery();
 
   const { mutateAsync: updateKubernetesCluster } = useKubernetesClusterMutation(
     id
   );
+
+  React.useEffect(() => {
+    if (showAPL) {
+      refetch();
+    }
+  }, [refetch, showAPL]);
 
   const {
     isClusterHighlyAvailable,

--- a/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
@@ -88,7 +88,7 @@ describe('helper functions', () => {
         wrapper: (ui) => wrapWithTheme(ui, { flags: { apl: true } }),
       });
       await waitFor(() => {
-        expect(result.current).toBe(true);
+        expect(result.current.showAPL).toBe(true);
       });
     });
   });

--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -119,15 +119,14 @@ export const useAPLAvailability = () => {
   const flags = useFlags();
 
   // Only fetch the account beta if the APL flag is enabled
-  const { data: beta } = useAccountBetaQuery('apl', Boolean(flags.apl));
+  const { data: beta, isLoading } = useAccountBetaQuery(
+    'apl',
+    Boolean(flags.apl)
+  );
 
-  if (!beta) {
-    return false;
-  }
+  const showAPL = beta !== undefined && getBetaStatus(beta) === 'active';
 
-  const betaStatus = getBetaStatus(beta);
-
-  return betaStatus === 'active';
+  return { isLoading: flags.apl && isLoading, showAPL };
 };
 
 export const getKubeControlPlaneACL = (

--- a/packages/manager/src/features/components/PlansPanel/constants.ts
+++ b/packages/manager/src/features/components/PlansPanel/constants.ts
@@ -8,7 +8,8 @@ export const PLAN_NOT_AVAILABLE_IN_REGION_COPY =
   "This plan isn't available for the selected region.";
 export const PLAN_IS_CURRENTLY_UNAVAILABLE_COPY =
   'This plan is currently unavailable.';
-export const PLAN_IS_TOO_SMALL_FOR_APL_COPY = 'This plan is too small for APL';
+export const PLAN_IS_TOO_SMALL_FOR_APL_COPY =
+  'This plan is too small for Application Platform for LKE.';
 
 export const LIMITED_AVAILABILITY_LINK =
   'https://www.linode.com/global-infrastructure/availability/';

--- a/packages/manager/src/features/components/PlansPanel/utils.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.ts
@@ -301,7 +301,8 @@ export const extractPlansInformation = ({
           (disabledPlan) => disabledPlan.id === plan.id
         )
       );
-      const planIsTooSmallForAPL = isAPLEnabled && Boolean(plan.memory < 16000);
+      const planIsTooSmallForAPL =
+        isAPLEnabled && Boolean(plan.memory < 8000 || plan.vcpus < 4);
 
       return {
         ...plan,

--- a/packages/manager/src/queries/account/betas.ts
+++ b/packages/manager/src/queries/account/betas.ts
@@ -47,6 +47,7 @@ export const useCreateAccountBetaMutation = () => {
 export const useAccountBetaQuery = (id: string, enabled: boolean = false) => {
   return useQuery<AccountBeta, APIError[]>({
     enabled,
+    retry: false,
     ...accountQueries.betas._ctx.beta(id),
   });
 };

--- a/packages/manager/src/queries/kubernetes.ts
+++ b/packages/manager/src/queries/kubernetes.ts
@@ -108,8 +108,7 @@ export const kubernetesQueries = createQueryKeys('kubernetes', {
   },
 });
 
-export const useKubernetesClusterQuery = (id: number) => {
-  const showAPL = useAPLAvailability();
+export const useKubernetesClusterQuery = (id: number, showAPL: boolean) => {
   return useQuery<KubernetesCluster, APIError[]>({
     ...kubernetesQueries.cluster(id),
     queryFn: showAPL

--- a/packages/manager/src/queries/kubernetes.ts
+++ b/packages/manager/src/queries/kubernetes.ts
@@ -115,10 +115,12 @@ export const kubernetesQueries = createQueryKeys('kubernetes', {
 });
 
 export const useKubernetesClusterQuery = (id: number) => {
-  const showAPL = useAPLAvailability();
-  return useQuery<KubernetesCluster, APIError[]>(
-    kubernetesQueries.cluster(id)._ctx.cluster(showAPL)
-  );
+  const { isLoading: isAPLAvailabilityLoading, showAPL } = useAPLAvailability();
+
+  return useQuery<KubernetesCluster, APIError[]>({
+    ...kubernetesQueries.cluster(id)._ctx.cluster(showAPL),
+    enabled: !isAPLAvailabilityLoading,
+  });
 };
 
 export const useKubernetesClustersQuery = (

--- a/packages/manager/src/queries/kubernetes.ts
+++ b/packages/manager/src/queries/kubernetes.ts
@@ -30,7 +30,6 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 
-import { useAPLAvailability } from 'src/features/Kubernetes/kubeUtils';
 import { getAll } from 'src/utilities/getAll';
 
 import { queryPresets } from './base';
@@ -108,12 +107,18 @@ export const kubernetesQueries = createQueryKeys('kubernetes', {
   },
 });
 
-export const useKubernetesClusterQuery = (id: number, showAPL: boolean) => {
+export const useKubernetesClusterQuery = (id: number) => {
   return useQuery<KubernetesCluster, APIError[]>({
     ...kubernetesQueries.cluster(id),
-    queryFn: showAPL
-      ? () => getKubernetesClusterBeta(id) // necessary to call BETA_API_ROOT in a seperate function based on feature flag
-      : () => getKubernetesCluster(id),
+    queryFn: () => getKubernetesCluster(id),
+  });
+};
+
+export const useKubernetesClusterQueryBeta = (id: number) => {
+  return useQuery<KubernetesCluster, APIError[]>({
+    ...kubernetesQueries.cluster(id),
+    // necessary to call BETA_API_ROOT in a separate function based on feature flag
+    queryFn: () => getKubernetesClusterBeta(id),
   });
 };
 

--- a/packages/manager/src/queries/kubernetes.ts
+++ b/packages/manager/src/queries/kubernetes.ts
@@ -146,7 +146,15 @@ export const useKubernetesClusterMutation = (id: number) => {
         queryClient.invalidateQueries({
           queryKey: kubernetesQueries.cluster(id)._ctx.acl.queryKey,
         });
-        queryClient.setQueryData(kubernetesQueries.cluster(id).queryKey, data);
+        // queryClient.setQueryData<KubernetesCluster>(
+        //   kubernetesQueries.cluster(id).queryKey,
+        //   data
+        // );
+        // Temporary cache update logic for APL
+        queryClient.setQueryData<KubernetesCluster>(
+          kubernetesQueries.cluster(id).queryKey,
+          (oldData) => ({ ...oldData, ...data })
+        );
       },
     }
   );


### PR DESCRIPTION
## Description 📝
There is some unusual behaviour on the staging cluster while testing the APL component on the cluster overview page. It's hard to explain but it seems that only one APL component my exist at the same time and when you refresh the page it disappears and 'moves' to another cluster. This is quite an urgent thing as users cannot consistently go to the APL console like this.

## Preview 📷
See relevant Slack channel

## How to test 🧪
- Make sure that APL feature flag is enabled and user is enrolled in beta
- Create cluster with APL enabled set to true 
- Go to cluster overview page
- When reloading a few times, observe  that APL Summary component is loaded inconsistent. 

**TO BE TESTED ON ALPHA**
It is expected for the APL summary panel to show 'Installation still in progress; please check back in a minute.' on alpha, as we're only checking for the APL prod console URL
