### PR TITLE
feat: [M3-8831] - New GPUv2 egress transfer display

### DIFF
--- a/packages/manager/.changeset/pr-11209-added-1730788980490.md
+++ b/packages/manager/.changeset/pr-11209-added-1730788980490.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+New GPUv2 egress transfer helpers ([#11209](https://github.com/linode/manager/pull/11209))

--- a/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
@@ -12,6 +12,7 @@ import {
   mockGetRegionAvailability,
 } from 'support/intercepts/regions';
 import { mockGetLinodeTypes } from 'support/intercepts/linodes';
+import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
 
 const mockRegions = [
   regionFactory.build({
@@ -356,11 +357,18 @@ describe('displays specific linode plans for GPU', () => {
     mockGetRegionAvailability(mockRegions[0].id, mockRegionAvailability).as(
       'getRegionAvailability'
     );
+    mockAppendFeatureFlags({
+      gpuv2: {
+        transferBanner: true,
+        planDivider: true,
+        egressBanner: true,
+      },
+    }).as('getFeatureFlags');
   });
 
   it('Should render divided tables when GPU divider enabled', () => {
     cy.visitWithLogin('/linodes/create');
-
+    cy.wait(['@getRegions', '@getLinodeTypes', '@getFeatureFlags']);
     ui.regionSelect.find().click();
     ui.regionSelect.findItemByRegionLabel(mockRegions[0].label).click();
 
@@ -368,7 +376,7 @@ describe('displays specific linode plans for GPU', () => {
     // Should display two separate tables
     cy.findByText('GPU').click();
     cy.get(linodePlansPanel).within(() => {
-      cy.findAllByRole('alert').should('have.length', 2);
+      cy.findAllByRole('alert').should('have.length', 3);
       cy.get(notices.unavailable).should('be.visible');
 
       cy.findByRole('table', {

--- a/packages/manager/src/components/TableCell/TableCell.tsx
+++ b/packages/manager/src/components/TableCell/TableCell.tsx
@@ -107,7 +107,9 @@ export const TableCell = (props: TableCellProps) => {
           // hide the cell at small breakpoints if it's empty with no parent column
           emptyCell:
             (!parentColumn && !props.children) ||
-            (Array.isArray(props.children) && !props.children[0]),
+            (!parentColumn &&
+              Array.isArray(props.children) &&
+              !props.children[0]),
         },
         className
       )}

--- a/packages/manager/src/components/TableCell/TableCell.tsx
+++ b/packages/manager/src/components/TableCell/TableCell.tsx
@@ -1,12 +1,11 @@
-import {
-  default as _TableCell,
-  TableCellProps as _TableCellProps,
-} from '@mui/material/TableCell';
-import { Theme } from '@mui/material/styles';
+import { default as _TableCell } from '@mui/material/TableCell';
 import * as React from 'react';
 import { makeStyles } from 'tss-react/mui';
 
 import { TooltipIcon } from 'src/components/TooltipIcon';
+
+import type { Theme } from '@mui/material/styles';
+import type { TableCellProps as _TableCellProps } from '@mui/material/TableCell';
 
 const useStyles = makeStyles()((theme: Theme) => ({
   actionCell: {
@@ -106,7 +105,9 @@ export const TableCell = (props: TableCellProps) => {
           [classes.root]: true,
           [classes.sortable]: sortable,
           // hide the cell at small breakpoints if it's empty with no parent column
-          emptyCell: !parentColumn && !props.children,
+          emptyCell:
+            (!parentColumn && !props.children) ||
+            (Array.isArray(props.children) && !props.children[0]),
         },
         className
       )}

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -35,6 +35,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'dbaasV2MonitorMetrics', label: 'Databases V2 Monitor' },
   { flag: 'databaseResize', label: 'Database Resize' },
   { flag: 'apicliButtonCopy', label: 'APICLI Button Copy' },
+  { flag: 'gpuv2', label: 'GPUv2' },
 ];
 
 const renderFlagItems = (

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -35,7 +35,6 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'dbaasV2MonitorMetrics', label: 'Databases V2 Monitor' },
   { flag: 'databaseResize', label: 'Database Resize' },
   { flag: 'apicliButtonCopy', label: 'APICLI Button Copy' },
-  { flag: 'gpuv2', label: 'GPUv2' },
 ];
 
 const renderFlagItems = (

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -72,6 +72,7 @@ export interface CloudPulseResourceTypeMapFlag {
 interface gpuV2 {
   egressBanner: boolean;
   planDivider: boolean;
+  transferBanner: boolean;
 }
 
 interface DesignUpdatesBannerFlag extends BaseFeatureFlag {

--- a/packages/manager/src/features/components/PlansPanel/PlanContainer.styles.ts
+++ b/packages/manager/src/features/components/PlansPanel/PlanContainer.styles.ts
@@ -20,6 +20,7 @@ export const StyledTableCell = styled(TableCell, {
   label: 'StyledTableCell',
   shouldForwardProp: omittedProps(['isPlanCell']),
 })<StyledTableCellPropsProps>(({ theme, ...props }) => ({
+  ...(props.isPlanCell && { width: '20%' }),
   '&.emptyCell': {
     borderRight: 'none',
   },

--- a/packages/manager/src/features/components/PlansPanel/PlanContainer.styles.ts
+++ b/packages/manager/src/features/components/PlansPanel/PlanContainer.styles.ts
@@ -12,15 +12,15 @@ interface StyledTableCellPropsProps extends TableCellProps {
 
 export const StyledTable = styled(Table, {
   label: 'StyledTable',
-})(({ theme }) => ({
+})({
   overflowX: 'hidden',
-}));
+});
 
 export const StyledTableCell = styled(TableCell, {
   label: 'StyledTableCell',
   shouldForwardProp: omittedProps(['isPlanCell']),
 })<StyledTableCellPropsProps>(({ theme, ...props }) => ({
-  ...(props.isPlanCell && { width: '20%' }),
+  ...(props.isPlanCell && { width: '30%' }),
   '&.emptyCell': {
     borderRight: 'none',
   },

--- a/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
@@ -175,7 +175,7 @@ export const PlanContainer = (props: PlanContainerProps) => {
       </Hidden>
       <Hidden lgDown={isCreate} mdDown={!isCreate}>
         <Grid xs={12}>
-          {planSelectionDividers.map((planSelectionDivider, idx) =>
+          {planSelectionDividers.map((planSelectionDivider) =>
             planType === planSelectionDivider.planType &&
             planSelectionDivider.flag ? (
               planSelectionDivider.tables.map((table, idx) => {
@@ -198,8 +198,8 @@ export const PlanContainer = (props: PlanContainerProps) => {
                         shouldDisplayNoRegionSelectedMessage
                       }
                       key={`plan-filter-${idx}`}
-                      plans={plans}
                       planFilter={table.planFilter}
+                      plans={plans}
                       showNetwork={showNetwork}
                       showTransfer={showTransfer}
                     />

--- a/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
@@ -1,4 +1,3 @@
-import { LinodeTypeClass } from '@linode/api-v4/lib/linodes';
 import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 import { useLocation } from 'react-router-dom';
@@ -14,6 +13,7 @@ import { PlanSelectionTable } from './PlanSelectionTable';
 
 import type { PlanWithAvailability } from './types';
 import type { Region } from '@linode/api-v4';
+import type { LinodeTypeClass } from '@linode/api-v4/lib/linodes';
 
 export interface PlanContainerProps {
   allDisabledPlans: PlanWithAvailability[];
@@ -50,7 +50,8 @@ export const PlanContainer = (props: PlanContainerProps) => {
 
   // Show the Transfer column if, for any plan, the api returned data and we're not in the Database Create flow
   const showTransfer =
-    showLimits && plans.some((plan: PlanWithAvailability) => plan.transfer);
+    showLimits &&
+    plans.some((plan: PlanWithAvailability) => plan.transfer !== undefined);
 
   // Show the Network throughput column if, for any plan, the api returned data (currently Bare Metal does not)
   const showNetwork =
@@ -174,7 +175,7 @@ export const PlanContainer = (props: PlanContainerProps) => {
       </Hidden>
       <Hidden lgDown={isCreate} mdDown={!isCreate}>
         <Grid xs={12}>
-          {planSelectionDividers.map((planSelectionDivider) =>
+          {planSelectionDividers.map((planSelectionDivider, idx) =>
             planType === planSelectionDivider.planType &&
             planSelectionDivider.flag ? (
               planSelectionDivider.tables.map((table, idx) => {
@@ -197,6 +198,7 @@ export const PlanContainer = (props: PlanContainerProps) => {
                         shouldDisplayNoRegionSelectedMessage
                       }
                       key={`plan-filter-${idx}`}
+                      plans={plans}
                       planFilter={table.planFilter}
                       showNetwork={showNetwork}
                       showTransfer={showTransfer}

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
@@ -45,6 +45,7 @@ export const PlanInformation = (props: PlanInformationProps) => {
     return Boolean(disabledClasses?.includes(thisClass));
   };
   const showGPUEgressBanner = Boolean(useFlags().gpuv2?.egressBanner);
+  const showTransferBanner = Boolean(useFlags().gpuv2?.transferBanner);
 
   return (
     <>
@@ -63,6 +64,23 @@ export const PlanInformation = (props: PlanInformationProps) => {
                 time.{' '}
                 <Link to="https://www.linode.com/blog/compute/new-gpus-nvidia-rtx-4000-ada-generation">
                   Learn more
+                </Link>
+                .
+              </Typography>
+            </Notice>
+          )}
+          {showTransferBanner && (
+            <Notice spacingBottom={8} variant="warning">
+              <Typography
+                fontFamily={(theme: Theme) => theme.font.bold}
+                fontSize="1rem"
+              >
+                Some plans do not include bundled network transfer. If the
+                transfer allotment is 0, all outbound network transfer is
+                subject to standard charges.
+                <br />
+                <Link to="https://techdocs.akamai.com/cloud-computing/docs/network-transfer-usage-and-costs">
+                  Learn more about transfer costs.
                 </Link>
                 .
               </Typography>

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
@@ -80,7 +80,7 @@ export const PlanInformation = (props: PlanInformationProps) => {
                 subject to standard charges.
                 <br />
                 <Link to="https://techdocs.akamai.com/cloud-computing/docs/network-transfer-usage-and-costs">
-                  Learn more about transfer costs.
+                  Learn more about transfer costs
                 </Link>
                 .
               </Typography>

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -195,7 +195,11 @@ export const PlanSelection = (props: PlanSelectionProps) => {
           </TableCell>
           {showTransfer ? (
             <TableCell center data-qa-transfer>
-              {plan.transfer ? <>{plan.transfer / 1000} TB</> : ''}
+              {plan.transfer !== undefined ? (
+                <>{plan.transfer / 1000} TB</>
+              ) : (
+                ''
+              )}
             </TableCell>
           ) : null}
           {showNetwork ? (

--- a/packages/manager/src/features/components/PlansPanel/PlanSelectionTable.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelectionTable.tsx
@@ -4,10 +4,13 @@ import { TableBody } from 'src/components/TableBody';
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
 import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
+import { TooltipIcon } from 'src/components/TooltipIcon';
+import { useFlags } from 'src/hooks/useFlags';
 import { PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE } from 'src/utilities/pricing/constants';
 
 import { StyledTable, StyledTableCell } from './PlanContainer.styles';
-import { PlanWithAvailability } from './types';
+
+import type { PlanWithAvailability } from './types';
 
 interface PlanSelectionFilterOptionsTable {
   header?: string;
@@ -17,6 +20,7 @@ interface PlanSelectionFilterOptionsTable {
 interface PlanSelectionTableProps {
   filterOptions?: PlanSelectionFilterOptionsTable;
   planFilter?: (plan: PlanWithAvailability) => boolean;
+  plans?: PlanWithAvailability[];
   renderPlanSelection: (
     filterOptions?: PlanSelectionFilterOptionsTable | undefined
   ) => React.JSX.Element[];
@@ -45,11 +49,24 @@ const tableCells = [
 export const PlanSelectionTable = (props: PlanSelectionTableProps) => {
   const {
     filterOptions,
+    plans,
     renderPlanSelection,
     shouldDisplayNoRegionSelectedMessage,
     showNetwork: shouldShowNetwork,
     showTransfer: shouldShowTransfer,
   } = props;
+  const flags = useFlags();
+
+  const showTransferTooltip = (cellName: string) =>
+    plans?.some((plan) => {
+      return (
+        flags.gpuv2?.transferBanner &&
+        plan.class === 'gpu' &&
+        filterOptions?.header?.includes('Ada') &&
+        plan.transfer === 0 &&
+        cellName === 'Transfer'
+      );
+    });
 
   return (
     <StyledTable
@@ -78,6 +95,13 @@ export const PlanSelectionTable = (props: PlanSelectionTableProps) => {
                 {isPlanCell && filterOptions?.header
                   ? filterOptions?.header
                   : cellName}
+                {showTransferTooltip(cellName) && (
+                  <TooltipIcon
+                    status="help"
+                    sxTooltipIcon={{ py: 0 }}
+                    text="Some plans do not include bundled network transfer. If the transfer allotment is 0, all outbound network transfer is subject to standard charges."
+                  />
+                )}
               </StyledTableCell>
             );
           })}

--- a/packages/manager/src/features/components/PlansPanel/PlanSelectionTable.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelectionTable.tsx
@@ -57,15 +57,18 @@ export const PlanSelectionTable = (props: PlanSelectionTableProps) => {
   } = props;
   const flags = useFlags();
 
-  const showTransferTooltip = (cellName: string) =>
-    plans?.some((plan) => {
-      return (
-        flags.gpuv2?.transferBanner &&
-        plan.class === 'gpu' &&
-        filterOptions?.header?.includes('Ada') &&
-        cellName === 'Transfer'
-      );
-    });
+  const showTransferTooltip = React.useCallback(
+    (cellName: string) =>
+      plans?.some((plan) => {
+        return (
+          flags.gpuv2?.transferBanner &&
+          plan.class === 'gpu' &&
+          filterOptions?.header?.includes('Ada') &&
+          cellName === 'Transfer'
+        );
+      }),
+    [plans, filterOptions, flags.gpuv2]
+  );
 
   return (
     <StyledTable
@@ -96,8 +99,14 @@ export const PlanSelectionTable = (props: PlanSelectionTableProps) => {
                   : cellName}
                 {showTransferTooltip(cellName) && (
                   <TooltipIcon
+                    sxTooltipIcon={{
+                      height: 12,
+                      marginTop: '-2px',
+                      ml: 0.5,
+                      px: 0,
+                      py: 0,
+                    }}
                     status="help"
-                    sxTooltipIcon={{ py: 0 }}
                     text="Some plans do not include bundled network transfer. If the transfer allotment is 0, all outbound network transfer is subject to standard charges."
                   />
                 )}

--- a/packages/manager/src/features/components/PlansPanel/PlanSelectionTable.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelectionTable.tsx
@@ -63,7 +63,6 @@ export const PlanSelectionTable = (props: PlanSelectionTableProps) => {
         flags.gpuv2?.transferBanner &&
         plan.class === 'gpu' &&
         filterOptions?.header?.includes('Ada') &&
-        plan.transfer === 0 &&
         cellName === 'Transfer'
       );
     });

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -384,7 +384,17 @@ const nanodeType = linodeTypeFactory.build({ id: 'g6-nanode-1' });
 const standardTypes = linodeTypeFactory.buildList(7);
 const dedicatedTypes = dedicatedTypeFactory.buildList(7);
 const proDedicatedType = proDedicatedTypeFactory.build();
-
+const gpuTypesAda = linodeTypeFactory.buildList(7, {
+  class: 'gpu',
+  gpus: 5,
+  label: 'Ada Lovelace',
+  transfer: 0,
+});
+const gpuTypesRX = linodeTypeFactory.buildList(7, {
+  class: 'gpu',
+  gpus: 1,
+  transfer: 5000,
+});
 const proxyAccountUser = accountUserFactory.build({
   email: 'partner@proxy.com',
   last_login: null,
@@ -578,6 +588,8 @@ export const handlers = [
         nanodeType,
         ...standardTypes,
         ...dedicatedTypes,
+        ...gpuTypesAda,
+        ...gpuTypesRX,
         proDedicatedType,
       ])
     );


### PR DESCRIPTION
## Description 📝
Small PR to implement conditional display of contextual help (banner + tooltip) of the new GPU ada plan split table.

**Context**: API will start returning `0` as trasnfer value for Ada plans

## Changes  🔄
- Fix the potential display of the `0` transfer value in the PlanSelection GPU panel
  - `0` being falsy, it would display empty in the table
  - `0` `plan.transfer` was also being filtered wrongly in `PlanContainer`
- Add a new `showTransferBanner` boolean property to the `gpuv2` feature flag
- Add a Banner to the GPU plan selection panel
- Add a tooltip to the GPU transfer table header
- Add MSW data for helping review
- Adjust e2e smokes

## Target release date 🗓️
⚠️  **11/12/2024**

## Preview 📷
![Screenshot 2024-11-05 at 00 58 25](https://github.com/user-attachments/assets/30a2ba14-3d23-4fba-b5f3-f08ca49061ea)

LD flag variations for reference:
![Screenshot 2024-11-05 at 01 48 54](https://github.com/user-attachments/assets/77effec7-75b5-4196-b877-d9b1b0ae22e6)

## How to test 🧪

### Prerequisites

### Verification steps
- best to verify is using MSW legacy:
  - displays 0 as expected
  - features the new egress transfer banner
  - features a new tooltip for the transfer column (only for gpu Ada plans) 

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support


