### PR TITLE
fix, test: [M3-8830] - Use unit tested function for Pendo url transformation

### DIFF
--- a/packages/manager/.changeset/pr-11211-tech-stories-1730836470267.md
+++ b/packages/manager/.changeset/pr-11211-tech-stories-1730836470267.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Use unit tested function for Pendo url transformation ([#11211](https://github.com/linode/manager/pull/11211))

--- a/packages/manager/src/hooks/usePendo.test.ts
+++ b/packages/manager/src/hooks/usePendo.test.ts
@@ -1,0 +1,96 @@
+import { transformUrls } from './usePendo';
+
+const ID_URLS = [
+  {
+    expectedTransform: 'https://cloud.linode.com/nodebalancers/XXXX',
+    position: 'end',
+    url: 'https://cloud.linode.com/nodebalancers/123',
+  },
+  {
+    expectedTransform:
+      'https://cloud.linode.com/nodebalancers/XXXX/configurations',
+    position: 'middle',
+    url: 'https://cloud.linode.com/nodebalancers/123/configurations',
+  },
+  {
+    expectedTransform:
+      'https://cloud.linode.com/nodebalancers/XXXX/configurations/XXXX',
+    position: 'multiple',
+    url: 'https://cloud.linode.com/nodebalancers/123/configurations/456',
+  },
+];
+
+const USERNAME_URLS = [
+  {
+    path: 'my-username',
+  },
+  {
+    path: 'my-username/profile',
+  },
+  {
+    path: 'my-username/permissions',
+  },
+  {
+    path: '123-my-username/profile',
+  },
+];
+
+const OBJ_URLS = [
+  {
+    expectedTransform:
+      'http://cloud.linode.com/object-storage/buckets/XXXX/XXXX',
+    path: 'us-west/abc123',
+  },
+  {
+    expectedTransform:
+      'http://cloud.linode.com/object-storage/buckets/XXXX/XXXX/ssl',
+    path: 'us-west/abc123/ssl',
+  },
+  {
+    expectedTransform:
+      'http://cloud.linode.com/object-storage/buckets/XXXX/XXXX',
+    path: 'us-west/123abc',
+  },
+  {
+    expectedTransform:
+      'http://cloud.linode.com/object-storage/buckets/XXXX/XXXX/access',
+    path: 'us-west/123abc/access',
+  },
+];
+
+describe('transformUrls', () => {
+  it.each(ID_URLS)(
+    'replaces id(s) in $position positions in the url path',
+    ({ expectedTransform, url }) => {
+      const actualTransform = transformUrls(url);
+      expect(actualTransform).toEqual(expectedTransform);
+    }
+  );
+
+  it.each(USERNAME_URLS)(
+    'truncates $path from the /users url path',
+    ({ path }) => {
+      const baseUrl = 'https://cloud.linode.com/account/users/';
+      const actualTransform = transformUrls(`${baseUrl}${path}`);
+      expect(actualTransform).toEqual(baseUrl);
+    }
+  );
+
+  it.each(OBJ_URLS)(
+    'replaces the OBJ region and bucket name in the url path ($path)',
+    ({ expectedTransform, path }) => {
+      const baseUrl = 'http://cloud.linode.com/object-storage/buckets/';
+      const actualTransform = transformUrls(`${baseUrl}${path}`);
+      expect(actualTransform).toEqual(expectedTransform);
+    }
+  );
+
+  it('truncates the url after "access_token" in the url path', () => {
+    const url =
+      'https://cloud.linode.com/oauth/callback#access_token=12345&token_type=bearer&expires_in=5678';
+    const actualTransform = transformUrls(url);
+    const expectedTransform =
+      'https://cloud.linode.com/oauth/callback#access_token';
+    expect(actualTransform).toEqual(expectedTransform);
+  });
+});

--- a/packages/manager/src/hooks/usePendo.test.ts
+++ b/packages/manager/src/hooks/usePendo.test.ts
@@ -1,4 +1,4 @@
-import { transformUrls } from './usePendo';
+import { transformUrl } from './usePendo';
 
 const ID_URLS = [
   {
@@ -58,11 +58,11 @@ const OBJ_URLS = [
   },
 ];
 
-describe('transformUrls', () => {
+describe('transformUrl', () => {
   it.each(ID_URLS)(
     'replaces id(s) in $position positions in the url path',
     ({ expectedTransform, url }) => {
-      const actualTransform = transformUrls(url);
+      const actualTransform = transformUrl(url);
       expect(actualTransform).toEqual(expectedTransform);
     }
   );
@@ -71,7 +71,7 @@ describe('transformUrls', () => {
     'truncates $path from the /users url path',
     ({ path }) => {
       const baseUrl = 'https://cloud.linode.com/account/users/';
-      const actualTransform = transformUrls(`${baseUrl}${path}`);
+      const actualTransform = transformUrl(`${baseUrl}${path}`);
       expect(actualTransform).toEqual(baseUrl);
     }
   );
@@ -80,7 +80,7 @@ describe('transformUrls', () => {
     'replaces the OBJ region and bucket name in the url path ($path)',
     ({ expectedTransform, path }) => {
       const baseUrl = 'http://cloud.linode.com/object-storage/buckets/';
-      const actualTransform = transformUrls(`${baseUrl}${path}`);
+      const actualTransform = transformUrl(`${baseUrl}${path}`);
       expect(actualTransform).toEqual(expectedTransform);
     }
   );
@@ -88,7 +88,7 @@ describe('transformUrls', () => {
   it('truncates the url after "access_token" in the url path', () => {
     const url =
       'https://cloud.linode.com/oauth/callback#access_token=12345&token_type=bearer&expires_in=5678';
-    const actualTransform = transformUrls(url);
+    const actualTransform = transformUrl(url);
     const expectedTransform =
       'https://cloud.linode.com/oauth/callback#access_token';
     expect(actualTransform).toEqual(expectedTransform);

--- a/packages/manager/src/hooks/usePendo.test.ts
+++ b/packages/manager/src/hooks/usePendo.test.ts
@@ -93,4 +93,10 @@ describe('transformUrl', () => {
       'https://cloud.linode.com/oauth/callback#access_token';
     expect(actualTransform).toEqual(expectedTransform);
   });
+
+  it('returns the original url if no transformation is needed', () => {
+    const url = 'https://cloud.linode.com/linodes/create';
+    const actualTransform = transformUrl(url);
+    expect(actualTransform).toEqual(url);
+  });
 });

--- a/packages/manager/src/hooks/usePendo.ts
+++ b/packages/manager/src/hooks/usePendo.ts
@@ -34,7 +34,7 @@ const hashUniquePendoId = (id: string | undefined) => {
  * @param url The url of the page.
  * @returns A clean, transformed url of the page.
  */
-export const transformUrls = (url: string) => {
+export const transformUrl = (url: string) => {
   const idMatchingRegex = /(\/\d+)/g;
   const bucketPathMatchingRegex = /(buckets\/[^\/]+\/[^\/]+)/;
   const userPathMatchingRegex = /(users\/).*/;
@@ -143,7 +143,7 @@ export const usePendo = () => {
                 action: 'Replace',
                 attr: 'pathname',
                 data(url: string) {
-                  return transformUrls(url);
+                  return transformUrl(url);
                 },
               },
             ],

--- a/packages/manager/src/hooks/usePendo.ts
+++ b/packages/manager/src/hooks/usePendo.ts
@@ -41,29 +41,21 @@ export const transformUrl = (url: string) => {
   const oauthPathMatchingRegex = /(#access_token).*/;
   let transformedUrl = url;
 
-  if (idMatchingRegex.test(url)) {
-    // Replace any ids with XXXX and keep the rest of the URL intact
-    transformedUrl = url.replace(idMatchingRegex, '/XXXX');
-  }
+  // Replace any ids with XXXX and keep the rest of the URL intact
+  transformedUrl = url.replace(idMatchingRegex, '/XXXX');
 
-  if (bucketPathMatchingRegex.test(transformedUrl)) {
-    // Replace the region and bucket names with XXXX and keep the rest of the URL intact.
-    // Object storage file navigation is truncated via the 'clear search' transform.
-    transformedUrl = transformedUrl.replace(
-      bucketPathMatchingRegex,
-      'buckets/XXXX/XXXX'
-    );
-  }
+  // Replace the region and bucket names with XXXX and keep the rest of the URL intact.
+  // Object storage file navigation is truncated via the 'clear search' transform.
+  transformedUrl = transformedUrl.replace(
+    bucketPathMatchingRegex,
+    'buckets/XXXX/XXXX'
+  );
 
-  if (oauthPathMatchingRegex.test(transformedUrl)) {
-    // Remove everything after access_token
-    transformedUrl = transformedUrl.replace(oauthPathMatchingRegex, '$1');
-  }
+  // Remove everything after access_token
+  transformedUrl = transformedUrl.replace(oauthPathMatchingRegex, '$1');
 
-  if (userPathMatchingRegex.test(transformedUrl)) {
-    // Remove everything after /users
-    transformedUrl = transformedUrl.replace(userPathMatchingRegex, '$1');
-  }
+  // Remove everything after /users
+  transformedUrl = transformedUrl.replace(userPathMatchingRegex, '$1');
   return transformedUrl;
 };
 


### PR DESCRIPTION
## Description 📝
This ticket provides test coverage and corrects two discovered issues with the original URL transforms for Pendo page views:
- `id`s were replaced once, not globally, which would not account for urls with multiple ids (this is rare, but does exist in CM)
- early returns would not apply all needed transforms to the url if multiple were needed

## Changes  🔄
- Created the `transformUrl` function and better documented the purpose of transforms
- Created the `usePendo.test.tsx` file to test `transformUrl()`

## Target release date 🗓️
11/12/24

## How to test 🧪

### Verification steps
(How to verify changes)
Run
``` 
yarn test usePendo
```
and confirm test cases provide full coverage of different possible urls and that the tests pass reliably.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
