### PR TITLE
fix: [UIE-8246] - DBaaS provisioning 2 node clusters

### DIFF
--- a/packages/api-v4/.changeset/pr-11218-removed-1730922731323.md
+++ b/packages/api-v4/.changeset/pr-11218-removed-1730922731323.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Removed
+---
+
+DBaaS deprecated types including MongoDB and Redis ([#11218](https://github.com/linode/manager/pull/11218))

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -20,7 +20,7 @@ export interface DatabaseType extends BaseType {
   engines: Engines;
 }
 
-export type Engine = 'mysql' | 'postgresql' | 'mongodb' | 'redis';
+export type Engine = 'mysql' | 'postgresql';
 
 export interface DatabaseEngine {
   id: string;
@@ -103,6 +103,7 @@ export type ClusterSize = 1 | 2 | 3;
 
 type ReadonlyCount = 0 | 2;
 
+/** @deprecated TODO (UIE-8214) remove POST GA */
 export type MySQLReplicationType = 'none' | 'semi_synch' | 'asynch';
 
 export interface CreateDatabasePayload {
@@ -120,7 +121,10 @@ export interface CreateDatabasePayload {
   type: string;
 }
 
+/** @deprecated TODO (UIE-8214) remove POST GA */
 type DriverTypes = 'jdbc' | 'odbc' | 'php' | 'python' | 'ruby' | 'node.js';
+
+/** @deprecated TODO (UIE-8214) remove POST GA */
 interface ConnectionStrings {
   driver: DriverTypes;
   value: string;
@@ -173,20 +177,24 @@ interface BaseDatabase extends DatabaseInstance {
   used_disk_size_gb?: number;
 }
 
+/** @deprecated TODO (UIE-8214) remove POST GA */
 export interface MySQLDatabase extends BaseDatabase {
   /** @Deprecated used by rdbms-legacy only */
   replication_type?: MySQLReplicationType;
 }
 
+/** @deprecated TODO (UIE-8214) remove POST GA */
 export type PostgresReplicationType = 'none' | 'synch' | 'asynch';
 
-type ReplicationCommitTypes =
+/** @deprecated TODO (UIE-8214) remove POST GA */
+export type ReplicationCommitTypes =
   | 'on'
   | 'local'
   | 'remote_write'
   | 'remote_apply'
   | 'off';
 
+/** @deprecated TODO (UIE-8214) remove POST GA */
 export interface PostgresDatabase extends BaseDatabase {
   /** @Deprecated used by rdbms-legacy only */
   replication_type?: PostgresReplicationType;
@@ -194,22 +202,13 @@ export interface PostgresDatabase extends BaseDatabase {
   replication_commit_type?: ReplicationCommitTypes;
 }
 
-type MongoStorageEngine = 'wiredtiger' | 'mmapv1';
-type MongoCompressionType = 'none' | 'snappy' | 'zlib';
-export interface MongoDatabase extends BaseDatabase {
-  storage_engine: MongoStorageEngine;
-  compression_type: MongoCompressionType;
-  replica_set: string | null;
-  peers: string[];
-}
-
+/** @deprecated TODO (UIE-8214) remove POST GA */
 export type ComprehensiveReplicationType = MySQLReplicationType &
   PostgresReplicationType;
 
 export type Database = BaseDatabase &
   Partial<MySQLDatabase> &
-  Partial<PostgresDatabase> &
-  Partial<MongoDatabase>;
+  Partial<PostgresDatabase>;
 
 export interface UpdateDatabasePayload {
   cluster_size?: number;

--- a/packages/manager/.changeset/pr-11218-fixed-1730922753813.md
+++ b/packages/manager/.changeset/pr-11218-fixed-1730922753813.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+DBaaS enable creation of two node clusters ([#11218](https://github.com/linode/manager/pull/11218))

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -70,29 +70,6 @@ export const databaseTypeFactory = Factory.Sync.makeFactory<DatabaseType>({
   class: 'standard',
   disk: Factory.each((i) => i * 20480),
   engines: {
-    mongodb: [
-      {
-        price: {
-          hourly: 0.03,
-          monthly: 50,
-        },
-        quantity: 1,
-      },
-      {
-        price: {
-          hourly: 0.08,
-          monthly: 88,
-        },
-        quantity: 2,
-      },
-      {
-        price: {
-          hourly: 0.22,
-          monthly: 116,
-        },
-        quantity: 3,
-      },
-    ],
     mysql: [
       {
         price: {
@@ -135,29 +112,6 @@ export const databaseTypeFactory = Factory.Sync.makeFactory<DatabaseType>({
         price: {
           hourly: 0.25,
           monthly: 180,
-        },
-        quantity: 3,
-      },
-    ],
-    redis: [
-      {
-        price: {
-          hourly: 0.08,
-          monthly: 180,
-        },
-        quantity: 1,
-      },
-      {
-        price: {
-          hourly: 0.16,
-          monthly: 360,
-        },
-        quantity: 2,
-      },
-      {
-        price: {
-          hourly: 0.32,
-          monthly: 540,
         },
         quantity: 3,
       },
@@ -254,7 +208,7 @@ export const databaseFactory = Factory.Sync.makeFactory<Database>({
     '2.2.2.2': 'primary',
   },
   oldest_restore_time: '2024-09-15T17:15:12',
-  platform: pickRandom(['rdbms-legacy', 'rdbms-default']),
+  platform: Factory.each((i) => (adb10(i) ? 'rdbms-legacy' : 'rdbms-default')),
   port: 3306,
   region: 'us-east',
   ssl_connection: false,

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseClusterData.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseClusterData.tsx
@@ -19,10 +19,12 @@ import { getEngineOptions } from './utilities';
 
 import type {
   ClusterSize,
-  ComprehensiveReplicationType,
   DatabaseEngine,
   Engine,
+  MySQLReplicationType,
+  PostgresReplicationType,
   Region,
+  ReplicationCommitTypes,
 } from '@linode/api-v4';
 import type { FormikErrors } from 'formik';
 import type { Item } from 'src/components/EnhancedSelect';
@@ -32,14 +34,15 @@ export interface DatabaseCreateValues {
     error: string;
   }[];
   cluster_size: ClusterSize;
-  compression_type: undefined;
   engine: Engine;
   label: string;
   region: string;
-  replication_commit_type: undefined;
-  replication_type: ComprehensiveReplicationType;
-  ssl_connection: boolean;
-  storage_engine: undefined;
+  /** @Deprecated used by rdbms-legacy PostgreSQL only */
+  replication_commit_type?: ReplicationCommitTypes;
+  /** @Deprecated used by rdbms-legacy only */
+  replication_type?: MySQLReplicationType | PostgresReplicationType;
+  /** @Deprecated used by rdbms-legacy only, rdbms-default always uses TLS */
+  ssl_connection?: boolean;
   type: string;
 }
 

--- a/packages/manager/src/features/Databases/utilities.ts
+++ b/packages/manager/src/features/Databases/utilities.ts
@@ -219,10 +219,8 @@ export const toDatabaseFork = (
 };
 
 export const DATABASE_ENGINE_MAP: Record<Engine, string> = {
-  mongodb: 'MongoDB',
   mysql: 'MySQL',
   postgresql: 'PostgreSQL',
-  redis: 'Redis',
 } as const;
 
 export const getDatabasesDescription = (

--- a/packages/validation/src/databases.schema.ts
+++ b/packages/validation/src/databases.schema.ts
@@ -14,37 +14,8 @@ export const createDatabaseSchema = object({
   cluster_size: number()
     .oneOf([1, 2, 3], 'Nodes are required')
     .required('Nodes are required'),
-  replication_type: string().when('engine', {
-    is: (engine: string) => Boolean(engine.match(/mysql|postgres/g)),
-    then: string()
-      .when('engine', {
-        is: (engine: string) => Boolean(engine.match(/mysql/)),
-        then: string().oneOf(['none', 'semi_synch', 'asynch']),
-      })
-      .when('engine', {
-        is: (engine: string) => Boolean(engine.match(/postgres/)),
-        then: string().oneOf(['none', 'synch', 'asynch']),
-      })
-      .optional(),
-    otherwise: string().notRequired().nullable(true),
-  }),
-  replication_commit_type: string().when('engine', {
-    is: (engine: string) => Boolean(engine.match(/postgres/)),
-    then: string()
-      .oneOf(['off', 'on', 'local', 'remote_write', 'remote_apply'])
-      .optional(),
-    otherwise: string().notRequired().nullable(true),
-  }),
-  storage_engine: string().when('engine', {
-    is: (engine: string) => Boolean(engine.match(/mongodb/)),
-    then: string().oneOf(['wiredtiger', 'mmapv1']).notRequired(),
-    otherwise: string().notRequired().nullable(true),
-  }),
-  compression_type: string().when('engine', {
-    is: (engine: string) => Boolean(engine.match(/mongodb/)),
-    then: string().oneOf(['none', 'snappy', 'zlib']).notRequired(),
-    otherwise: string().notRequired().nullable(true),
-  }),
+  replication_type: string().notRequired().nullable(true), // TODO (UIE-8214) remove POST GA
+  replication_commit_type: string().notRequired().nullable(true), // TODO (UIE-8214) remove POST GA
 });
 
 export const updateDatabaseSchema = object({


### PR DESCRIPTION
## Description 📝
Allow users to create 2 node clusters

## Changes  🔄
- Remove deprecated MongoDB and Redis (not supported)
- Modify createDatabaseSchema, deprecated fields no longer required
- Modify DatabaseCreate to conditionally set deprecated fields

## Target release date 🗓️
11/12/24

## How to test 🧪

### Prerequisites
- Managed Databases account capability
- dbaasV2 feature flag set to GA

### Reproduction steps
- Try to create a two node cluster

### Verification steps
- You can successfully create two node clusters

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [x] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
