### PR TITLE
test: [M3-8550] - Add unit tests for EntityHeader component

### DIFF
--- a/packages/manager/src/components/EntityHeader/EntityHeader.test.tsx
+++ b/packages/manager/src/components/EntityHeader/EntityHeader.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { EntityHeader } from './EntityHeader';
+
+import { HeaderProps } from './EntityHeader';
+
+const mockText = 'Hello world';
+
+const defaultProps: HeaderProps = {
+  title: mockText,
+};
+
+describe('EntityHeader', () => {
+  it('should render title with variant when isSummaryView is True', () => {
+    const { getByRole } = renderWithTheme(
+      <EntityHeader variant="h2" isSummaryView {...defaultProps} />
+    );
+    const heading = getByRole('heading', { level: 2 });
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveTextContent(mockText);
+  });
+
+  it('should not render title when isSummaryView is False', () => {
+    const { queryByText } = renderWithTheme(
+      <EntityHeader isSummaryView={false} {...defaultProps} />
+    );
+    expect(queryByText(mockText)).not.toBeInTheDocument();
+  });
+
+  it('should render children if provided', () => {
+    const { getByText } = renderWithTheme(
+      <EntityHeader {...defaultProps}>
+        <div>Child items can go here!</div>
+      </EntityHeader>
+    );
+    expect(getByText('Child items can go here!')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description 📝
Unit test cases for EntityHeader components.

## Changes  🔄

- Add unit test cases for EntityHeader components.

## Target release date 🗓️
N/A

## How to test 🧪

### Verification steps
(How to verify changes)
- Run `yarn test src/components/EntityHeader --reporter verbose`
- Verify that all the test cases pass.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

