### PR TITLE
upcoming: [DI-21814] - ACLP UI - DBaaS instances order by label

### DIFF
--- a/packages/manager/.changeset/pr-11224-upcoming-features-1730983385576.md
+++ b/packages/manager/.changeset/pr-11224-upcoming-features-1730983385576.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+ACLP UI - DBaaS instances order by label ([#11224](https://github.com/linode/manager/pull/11224))

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
@@ -46,16 +46,21 @@ export const CloudPulseResourcesSelect = React.memo(
     const platformFilter =
       resourceType === 'dbaas' ? { platform: 'rdbms-default' } : {};
 
+    const orderFilter: Partial<Filter> =
+      resourceType === 'dbaas' ? { '+order': 'asc', '+order_by': 'label' } : {};
+
     const { data: resources, isLoading, isError } = useResourcesQuery(
       disabled !== undefined ? !disabled : Boolean(region && resourceType),
       resourceType,
       {},
       xFilter
         ? {
-            ...platformFilter,
-            ...xFilter,
+            ...orderFilter, // order by filter
+            ...platformFilter, // platform is a top level filter
+            ...xFilter, // the usual xFilters
           }
         : {
+            ...orderFilter,
             ...platformFilter,
             region,
           }


### PR DESCRIPTION
## Description 📝
Added one new filter - orderFilter for fetching instances in dbass servictype.

## Changes  🔄
- In our resource selection component, OrderFilter is added into the request for fetching databases instances in dbass serviceType. 

## Target release date 🗓️
12-11-2024

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/307c745b-d2ef-4b93-9625-967c7a182d58) | ![image](https://github.com/user-attachments/assets/e50d7c6f-f950-4216-8e59-851cf582aa4d) |

## How to test 🧪

### Verification steps

1. Login as a mock user.
2. Navigate to monitor tab.
3. Select a DBasS dashboard.
4. Open inspect, later select all the filters.
5. In networks tab, go to database instance api call, you should be able to see order_by filter in headers.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [x] 🕛 Scheduling a pair reviewing session
- [x] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
