### PR TITLE
upcoming: [DI-21811] - Post processing of missing timestamp data across dimensions in ACLP charts

### DIFF
--- a/packages/manager/.changeset/pr-11225-upcoming-features-1730983728586.md
+++ b/packages/manager/.changeset/pr-11225-upcoming-features-1730983728586.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add post processing for missing timestamp data across dimensions in ACLP charts  ([#11225](https://github.com/linode/manager/pull/11225))

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -372,7 +372,7 @@ export const fillMissingTimeStampsAcrossDimensions = (...arraysToBeFilled: [numb
 
     // Step 3.2: Build the synchronized array by checking if a key exists
     return sortedTimestamps.map(key => {
-      // If the current array has the key, use its value; otherwise, set it to 0
+      // If the current array has the key, use its value; otherwise, set it to null, so that the gap is properly visible
       return [key, map.get(key) ?? null] as [number, number | null];
     });
   });

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -348,25 +348,30 @@ export const getAutocompleteWidgetStyles = (theme: Theme) => ({
   },
 });
 
-export const synchronizeArrays = (...arrays: [number, number | null][][]): [number, number | null][][] => {
+/**
+ * This method handles the existing issue in chart JS, and it will deleted when the recharts migration is completed
+ * @param arraysToBeFilled The list of dimension data to be filled
+ * @returns The list of dimension data filled with null values for missing timestamps
+ */
+export const synchronizeArrays = (arraysToBeFilled: [number, number | null][][]): [number, number | null][][] => {
   // Step 1: Collect all unique keys from all arrays
   const allTimestamps = new Set<number>();
 
   // Collect keys from each array
-  arrays.forEach(array => {
+  arraysToBeFilled.forEach(array => {
     array.forEach(([timeStamp]) => allTimestamps.add(timeStamp));
   });
 
   // Step 2: Sort the timestamps to maintain chronological order
-  const sortedKeys = Array.from(allTimestamps).sort((a, b) => a - b);
+  const sortedTimestamps = Array.from(allTimestamps).sort((a, b) => a - b);
 
   // Step 3: Synchronize the arrays to have null values for all missing timestamps
-  return arrays.map(array => {
+  return arraysToBeFilled.map(array => {
     // Step 3.1: Convert the array into a map for fast lookup
     const map = new Map(array.map(([key, value]) => [key, value]));
 
     // Step 3.2: Build the synchronized array by checking if a key exists
-    return sortedKeys.map(key => {
+    return sortedTimestamps.map(key => {
       // If the current array has the key, use its value; otherwise, set it to 0
       return [key, map.get(key) ?? null] as [number, number | null];
     });

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -355,6 +355,9 @@ export const getAutocompleteWidgetStyles = (theme: Theme) => ({
  */
 // TODO: CloudPulse - delete when recharts migration completed
 export const fillMissingTimeStampsAcrossDimensions = (...arraysToBeFilled: [number, number | null][][]): [number, number | null][][] => {
+
+  if (arraysToBeFilled.length === 0) return [];
+
   // Step 1: Collect all unique keys from all arrays
   const allTimestamps = new Set<number>();
 

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -353,7 +353,7 @@ export const getAutocompleteWidgetStyles = (theme: Theme) => ({
  * @param arraysToBeFilled The list of dimension data to be filled
  * @returns The list of dimension data filled with null values for missing timestamps
  */
-export const synchronizeArrays = (arraysToBeFilled: [number, number | null][][]): [number, number | null][][] => {
+export const synchronizeArrays = (...arraysToBeFilled: [number, number | null][][]): [number, number | null][][] => {
   // Step 1: Collect all unique keys from all arrays
   const allTimestamps = new Set<number>();
 

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -353,6 +353,7 @@ export const getAutocompleteWidgetStyles = (theme: Theme) => ({
  * @param arraysToBeFilled The list of dimension data to be filled
  * @returns The list of dimension data filled with null values for missing timestamps
  */
+// TODO: CloudPulse - delete when recharts migration completed
 export const fillMissingTimeStampsAcrossDimensions = (...arraysToBeFilled: [number, number | null][][]): [number, number | null][][] => {
   // Step 1: Collect all unique keys from all arrays
   const allTimestamps = new Set<number>();

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -357,7 +357,7 @@ export const fillMissingTimeStampsAcrossDimensions = (...arraysToBeFilled: [numb
   // Step 1: Collect all unique keys from all arrays
   const allTimestamps = new Set<number>();
 
-  // Collect timeStamps from each array, array[0], contains the number timestamp
+  // Collect timestamps from each array, array[0], contains the number timestamp
   arraysToBeFilled.forEach(array => {
     array.forEach(([timeStamp]) => allTimestamps.add(timeStamp));
   });

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -357,7 +357,7 @@ export const fillMissingTimeStampsAcrossDimensions = (...arraysToBeFilled: [numb
   // Step 1: Collect all unique keys from all arrays
   const allTimestamps = new Set<number>();
 
-  // Collect keys from each array
+  // Collect timeStamps from each array, array[0], contains the number timestamp
   arraysToBeFilled.forEach(array => {
     array.forEach(([timeStamp]) => allTimestamps.add(timeStamp));
   });

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -353,7 +353,7 @@ export const getAutocompleteWidgetStyles = (theme: Theme) => ({
  * @param arraysToBeFilled The list of dimension data to be filled
  * @returns The list of dimension data filled with null values for missing timestamps
  */
-export const synchronizeArrays = (...arraysToBeFilled: [number, number | null][][]): [number, number | null][][] => {
+export const fillMissingTimeStampsAcrossDimensions = (...arraysToBeFilled: [number, number | null][][]): [number, number | null][][] => {
   // Step 1: Collect all unique keys from all arrays
   const allTimestamps = new Set<number>();
 

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -347,3 +347,28 @@ export const getAutocompleteWidgetStyles = (theme: Theme) => ({
     width: '90px',
   },
 });
+
+export const synchronizeArrays = (...arrays: [number, number | null][][]): [number, number | null][][] => {
+  // Step 1: Collect all unique keys from all arrays
+  const allTimestamps = new Set<number>();
+
+  // Collect keys from each array
+  arrays.forEach(array => {
+    array.forEach(([timeStamp]) => allTimestamps.add(timeStamp));
+  });
+
+  // Step 2: Sort the timestamps to maintain chronological order
+  const sortedKeys = Array.from(allTimestamps).sort((a, b) => a - b);
+
+  // Step 3: Synchronize the arrays to have null values for all missing timestamps
+  return arrays.map(array => {
+    // Step 3.1: Convert the array into a map for fast lookup
+    const map = new Map(array.map(([key, value]) => [key, value]));
+
+    // Step 3.2: Build the synchronized array by checking if a key exists
+    return sortedKeys.map(key => {
+      // If the current array has the key, use its value; otherwise, set it to 0
+      return [key, map.get(key) ?? null] as [number, number | null];
+    });
+  });
+}

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
@@ -10,7 +10,7 @@ import { useProfile } from 'src/queries/profile/profile';
 import {
   generateGraphData,
   getCloudPulseMetricRequest,
-  synchronizeArrays,
+  fillMissingTimeStampsAcrossDimensions,
 } from '../Utils/CloudPulseWidgetUtils';
 import { AGGREGATE_FUNCTION, SIZE, TIME_GRANULARITY } from '../Utils/constants';
 import { constructAdditionalRequestFilters } from '../Utils/FilterBuilder';
@@ -259,7 +259,7 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
     data = generatedData.dimensions;
 
     // add missing timestamps across all the dimensions
-    const filledArrays = synchronizeArrays(...data.map(data => data.data));
+    const filledArrays = fillMissingTimeStampsAcrossDimensions(...data.map(data => data.data));
 
     //update the chart data with updated arrays
     filledArrays.forEach((arr, index) => {


### PR DESCRIPTION
## Description 📝
When the charts of ACLP for DBaaS has multiple dimensions some of the timestamps are missing across dimensions and charts are plotted wrong. Fixed by adding missing timestamps across dimensions with null value

## Changes  🔄
List any change relevant to the reviewer.

1. Identify missing timestamps across dimensions data and add null value for those in each dimension

## Target release date 🗓️
12-11-2024

## Preview 📷
| Hover showing two data for gapped plots | Hover showing correct data |
|----|----|
|![Screenshot 2024-11-07 at 6 04 58 PM](https://github.com/user-attachments/assets/7ba30cb1-d87d-4cfd-9a73-bbc9a046ab15)|![Screenshot 2024-11-07 at 6 05 14 PM](https://github.com/user-attachments/assets/620aa395-f14e-4e51-be7e-6cb2e77b4b0d)|

## How to test 🧪

1. Login a mock user
2. Navigate to monitor page
3. Select dashboard and required filters
4. Even after post processing data should be visible correctly
5. Now replace the /metrics response constant in serverHandler.ts with the following
```
const response = {
      "data": {
        "result": [
          {
            "metric": {
              "cluster_id": "13418",
              "node_id": "primary-2"
            },
            "values": [
              [
                1730378400,
                "1.9846498107367672"
              ],
              [
                1730378700,
                "1.9490296676332808"
              ],
              [
                1730379000,
                "2.0869928900041823"
              ],
              [
                1730379300,
                "1.9540595252036872"
              ],
              [
                1730379600,
                "1.91288829401595"
              ],
              [
                1730379900,
                "2.0290340124670543"
              ],
              [
                1730380200,
                "1.9769679056409113"
              ],
            ]
          },
          {
            "metric": {
              "cluster_id": "13418",
              "node_id": "primary-4"
            },
            "values": [
              [
                1730895300,
                "1.4555706379868436"
              ],
              [
                1730895600,
                "0.8093735390369332"
              ],
              [
                1730895900,
                "0.6355631598714684"
              ],
              [
                1730896200,
                "0.5127285167168687"
              ],
              [
                1730896500,
                "0.5039695949469535"
              ],
              [
                1730896800,
                "0.5102423964287203"
              ],
              [
                1730897100,
                "0.5102125955344925"
              ],
            ]
          }
        ],
        "resultType": "matrix"
      },
      "isPartial": false,
      "stats": {
        "executionTimeMsec": 22,
        "seriesFetched": "78"
      },
      "status": "success"
    };
```
After this you can see two plats with gaps correctly displayed, same data in develop branch without post processing has issues

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [x] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [x] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
