### PR TITLE
change: [UIE-8247] - Conditionally give the new docs as the link on database landing page

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -138,6 +138,9 @@ const DatabaseLanding = () => {
   const showTabs = isV2Enabled && !!legacyDatabases?.data.length;
   const isNewDatabase = isV2Enabled && !!newDatabases?.data.length;
   const showSuspend = isDatabasesV2GA && !!newDatabases?.data.length;
+  const docsLink = isV2Enabled
+    ? 'https://techdocs.akamai.com/cloud-computing/docs/aiven-database-clusters'
+    : 'https://techdocs.akamai.com/cloud-computing/docs/managed-databases';
 
   const legacyTable = () => {
     return (
@@ -179,7 +182,7 @@ const DatabaseLanding = () => {
         }}
         createButtonText="Create Database Cluster"
         disabledCreateButton={isRestricted}
-        docsLink="https://techdocs.akamai.com/cloud-computing/docs/managed-databases"
+        docsLink={docsLink}
         onButtonClick={() => history.push('/databases/create')}
         title="Database Clusters"
       />


### PR DESCRIPTION
## Description 📝
Conditionally give the new docs as the link on database landing page

## Changes  🔄
- If the user has access, the new documentation link is used, otherwise the old link is used

## Target release date 🗓️
11/12/24

## How to test 🧪
### Prerequisites
- Managed Databases account capability
- dbaasV2 feature flag set to GA

### Verification steps
- Navigate to the Database landing page
- Click on the "Docs" link
- 
## As an Author I have considered 🤔

*Check all that apply*

- [ x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

