### PR TITLE
change: [UIE-8254] - Add tooltip for ipv6 for new db clusters

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -63,6 +63,16 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
   const password =
     showCredentials && credentials ? credentials?.password : '••••••••••';
 
+  const hostTooltipComponentProps = {
+    tooltip: {
+      style: {
+        minWidth: 285,
+      },
+    },
+  };
+  const HOST_TOOLTIP_COPY =
+    'Use the IPv6 address (AAAA record) for this hostname to avoid network transfer charges when connecting to this database from Linodes within the same region.';
+
   const handleShowPasswordClick = () => {
     setShowPassword((showCredentials) => !showCredentials);
   };
@@ -226,6 +236,14 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
                 className={classes.inlineCopyToolTip}
                 text={database.hosts?.primary}
               />
+              {!isLegacy && (
+                <TooltipIcon
+                  status="help"
+                  sxTooltipIcon={sxTooltipIcon}
+                  componentsProps={hostTooltipComponentProps}
+                  text={HOST_TOOLTIP_COPY}
+                />
+              )}
             </>
           ) : (
             <Typography>


### PR DESCRIPTION
## Description 📝
Add a tooltip for Host on the Connection Details screen.

## Changes  🔄
- Added the tooltip.

## Target release date 🗓️
11/12/2024

## Preview 📷

| Before  | After   |
| ------- | ------- |
|  ![Screenshot 2024-11-07 at 2 59 08 PM](https://github.com/user-attachments/assets/4d070f7f-ad72-4b05-8ab7-951a9e54f7ca) | ![Screenshot 2024-11-07 at 2 58 10 PM](https://github.com/user-attachments/assets/8977a017-a2cf-419e-91e9-5a659242e8d4) |


## How to test 🧪
### Verification steps
(How to verify changes)
- Navigate to Database Landing page and view connection details

## As an Author I have considered 🤔

*Check all that apply*

- [ x] 👀 Doing a self review
- [ x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ x] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support