### PR TITLE
change: [M3-8866] - GPU egress transfer copy update

### DIFF
--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
@@ -77,7 +77,7 @@ export const PlanInformation = (props: PlanInformationProps) => {
               >
                 Some plans do not include bundled network transfer. If the
                 transfer allotment is 0, all outbound network transfer is
-                subject to standard charges.
+                subject to charges.
                 <br />
                 <Link to="https://techdocs.akamai.com/cloud-computing/docs/network-transfer-usage-and-costs">
                   Learn more about transfer costs

--- a/packages/manager/src/features/components/PlansPanel/PlanSelectionTable.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelectionTable.tsx
@@ -134,7 +134,7 @@ export const PlanSelectionTable = (props: PlanSelectionTableProps) => {
                 {showTransferTooltip(cellName) &&
                   showTooltip(
                     'help',
-                    'Some plans do not include bundled network transfer. If the transfer allotment is 0, all outbound network transfer is subject to standard charges.'
+                    'Some plans do not include bundled network transfer. If the transfer allotment is 0, all outbound network transfer is subject to charges.'
                   )}
                 {showUsableStorageTooltip(cellName) &&
                   showTooltip(


### PR DESCRIPTION
## Description 📝
Tiny copy change for the upcoming release. Amends  https://github.com/linode/manager/pull/11209

Not having a changeset since the PR mentioned above is part of this release

## Changes  🔄
List any change relevant to the reviewer.
- Remove "standard" from both the egress banner and the table tooltip 

## Target release date 🗓️
⚠️ 11/12/2024

## Preview 📷
![Screenshot 2024-11-08 at 16 35 13](https://github.com/user-attachments/assets/5ac75671-4972-4c2d-b176-0ba1f544b5db)

## How to test 🧪

### Prerequisites

### Verification steps
- Check the GPU tab of the plan selection in the Linode create flow

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
