### PR TITLE
change: [M3-8857] - Update PULL_REQUEST_TEMPLATE (Part 2)

### DIFF
--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,20 @@
 ## Description 📝
+
 Highlight the Pull Request's context and intentions.
 
 ## Changes  🔄
-List any change relevant to the reviewer.
+
+List any change(s) relevant to the reviewer.
+
 - ...
 - ...
 
 ## Target release date 🗓️
+
 Please specify a release date to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.
 
 ## Preview 📷
+
 **Include a screenshot or screen recording of the change.**
 
 :lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.
@@ -23,38 +28,53 @@ Please specify a release date to guarantee timely review of this PR. If exact da
 ## How to test 🧪
 
 ### Prerequisites
+
 (How to setup test environment)
+
 - ...
 - ...
 
 ### Reproduction steps
+
 (How to reproduce the issue, if applicable)
-- ...
-- ...
+
+- [ ] ...
+- [ ] ...
 
 ### Verification steps
+
 (How to verify changes)
-- ...
-- ...
 
-## As an Author I have considered 🤔
+- [ ] ...
+- [ ] ...
 
-*Check all that apply*
+## As an Author, I have considered 🤔
 
-- [ ] 👀 Doing a self review
-- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
-- [ ] 🤏 Splitting feature into small PRs
-- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
-- [ ] 🧪 Providing/Improving test coverage
-- [ ] 🔐 Removing all sensitive information from the code and PR description
-- [ ] 🚩 Using a feature flag to protect the release
-- [ ] 👣 Providing comprehensive reproduction steps
-- [ ] 📑 Providing or updating our documentation
-- [ ] 🕛 Scheduling a pair reviewing session
-- [ ] 📱 Providing mobile support
-- [ ] ♿  Providing accessibility support
+- 👀 Doing a self review
+- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
+- 🤏 Splitting feature into small PRs
+- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
+- 🧪 Providing/improving test coverage
+- 🔐 Removing all sensitive information from the code and PR description
+- 🚩 Using a feature flag to protect the release
+- 👣 Providing comprehensive reproduction steps
+- 📑 Providing or updating our documentation
+- 🕛 Scheduling a pair reviewing session
+- 📱 Providing mobile support
+- ♿  Providing accessibility support
+
+<br/>
+
+- [ ] I have read and considered all applicable items listed above.
+
+## As an Author, before moving this PR from Draft to Open, I confirmed ✅
+
+- [ ] All unit tests are passing
+- [ ] TypeScript compilation succeeded without errors
+- [ ] Code passes all linting rules
 
 ---
+
 ## Commit message and pull request title format standards
 
 > **Note**: Remove this section before opening the pull request
@@ -63,6 +83,7 @@ Please specify a release date to guarantee timely review of this PR. If exact da
 `<commit type>: [JIRA-ticket-number] - <description>`
 
 **Commit Types:**
+
 - `feat`: New feature for the user (not a part of the code, or ci, ...).
 - `fix`: Bugfix for the user (not a fix to build something, ...).
 - `change`: Modifying an existing visual UI instance. Such as a component or a feature.

--- a/packages/manager/.changeset/pr-11236-tech-stories-1731104032752.md
+++ b/packages/manager/.changeset/pr-11236-tech-stories-1731104032752.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Update PULL_REQUEST_TEMPLATE ([#11219](https://github.com/linode/manager/pull/11219), [#11236](https://github.com/linode/manager/pull/11236))


### PR DESCRIPTION
## Description 📝
As developers, we want to provide better clarity to our PR template.

## Changes  🔄
- Turn Author consideration checklist to bullets
- Add Author confirmation checklist of technical requirements before marking a PR as Open

## Preview 📷
![Screenshot 2024-11-08 at 2 10 17 PM](https://github.com/user-attachments/assets/6361eed8-2b3d-4350-b839-fcd234037087)


## How to test 🧪

### Verification steps
(How to verify changes)
- Read the diff and self review.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [x] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
