### PR TITLE
test: [LKEAPIFW-529] - Update LKE create tests for ACL defaults change

### DIFF
--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -503,13 +503,12 @@ describe('LKE Cluster Creation with ACL', () => {
         .should('be.visible')
         .click();
 
-      // Disable ACL
+      // Confirm that ACL is disabled by default.
       cy.contains('Control Plane ACL').should('be.visible');
       ui.toggle
         .find()
-        .should('have.attr', 'data-qa-toggle', 'true')
-        .should('be.visible')
-        .click();
+        .should('have.attr', 'data-qa-toggle', 'false')
+        .should('be.visible');
 
       // Add a node pool
       cy.log(`Adding ${nodeCount}x ${getLkePlanName(clusterPlan)} node(s)`);
@@ -614,12 +613,16 @@ describe('LKE Cluster Creation with ACL', () => {
         .should('be.visible')
         .click();
 
-      // Confirm ACL section
+      // Confirm ACL is disabled by default, then enable it.
       cy.contains('Control Plane ACL').should('be.visible');
       ui.toggle
         .find()
-        .should('have.attr', 'data-qa-toggle', 'true')
-        .should('be.visible');
+        .should('have.attr', 'data-qa-toggle', 'false')
+        .should('be.visible')
+        .click();
+
+      ui.toggle.find().should('have.attr', 'data-qa-toggle', 'true');
+
       // Add some IPv4s and an IPv6
       cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0')
         .should('be.visible')
@@ -733,11 +736,22 @@ describe('LKE Cluster Creation with ACL', () => {
         .should('be.visible')
         .click();
 
+      // Enable ACL
+      cy.contains('Control Plane ACL').should('be.visible');
+      ui.toggle
+        .find()
+        .should('have.attr', 'data-qa-toggle', 'false')
+        .should('be.visible')
+        .click();
+
+      ui.toggle.find().should('have.attr', 'data-qa-toggle', 'true');
+
       // Confirm ACL IPv4 validation works as expected
       cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0')
         .should('be.visible')
         .click()
         .type('invalid ip');
+
       // click out of textbox and confirm error is visible
       cy.contains('Control Plane ACL').should('be.visible').click();
       cy.contains('Must be a valid IPv4 address.').should('be.visible');


### PR DESCRIPTION
## Description 📝
Quick fix to a few tests in `lke-create.spec.ts` to coincide with the change made by #11234, which disabled the ACL toggle by default on the LKE create page.

I don't believe any changeset is needed for this PR since it's a quick follow-up to #11234, which hasn't been released yet.

## Changes  🔄
- Update ACL tests in `lke-create.spec.ts` to account for the ACL default change

## Target release date 🗓️
This is meant for v1.32.0 (2024-11-12), but it's not absolutely crucial since there's no underlying bug and we have a good understanding of why the tests are failing. Still, it would be nice to get this merged for the release if we can

## How to test 🧪

This test has a 100% failure rate. You can reproduce by checking out the `release-v1.132.0` test, building Cloud, and running the `lke-create.spec.ts` tests, and confirm that this fixes it by observing the test results in CI.

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
