### PR TITLE
test: [M3-8890] - Fix flaky DBaaS resize test related to recent factory changes

### DIFF
--- a/packages/manager/.changeset/pr-11238-tests-1731115121832.md
+++ b/packages/manager/.changeset/pr-11238-tests-1731115121832.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix DBaaS resize tests that fail on first attempt and succeed on second ([#11238](https://github.com/linode/manager/pull/11238))

--- a/packages/manager/cypress/e2e/core/databases/resize-database.spec.ts
+++ b/packages/manager/cypress/e2e/core/databases/resize-database.spec.ts
@@ -50,7 +50,7 @@ const resizeDatabase = (initialLabel: string) => {
 describe('Resizing existing clusters', () => {
   databaseConfigurationsResize.forEach(
     (configuration: databaseClusterConfiguration) => {
-      describe(`Resizes a ${configuration.linodeType} ${configuration.engine} v${configuration.version}.x ${configuration.clusterSize}-node cluster`, () => {
+      describe(`Resizes a ${configuration.linodeType} ${configuration.engine} v${configuration.version}.x ${configuration.clusterSize}-node cluster (legacy DBaaS)`, () => {
         /*
          * - Tests active database resize UI flows using mocked data.
          * - Confirms that users can resize an existing database.
@@ -70,6 +70,7 @@ describe('Resizing existing clusters', () => {
             cluster_size: 3,
             status: 'active',
             allow_list: [allowedIp],
+            platform: 'rdbms-legacy',
           });
 
           // Mock account to ensure 'Managed Databases' capability.


### PR DESCRIPTION
## Description 📝
This fixes a few flaky tests in `resize-database.spec.ts` that fail on their first attempt and succeed on their second.

I believe this was caused by recent changes to our `databaseFactory`'s `platform` field. Because the Cypress tests pre-date that field, it inherits the default value from the factory, which is always set to `'rdbms_default'` on the first test attempt and `'rdbms_legacy'` on the second attempt.

Because the new DBaaS v2 changes introduce a couple changes to the resize flow, the tests fail when the value is set to `'rdbms_default'`, so this PR resolves the test by ensuring the mock database's `platform` is `'rdbms_legacy'`.

## Changes  🔄
- Set mock database platform field to `'rdbms_legacy'`

## Target release date 🗓️
N/A

## How to test 🧪

```typescript
yarn cy:run -s "cypress/e2e/core/databases/resize-database.spec.ts"
```

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
