### PR TITLE
fix: sx styling for Textfield component

### DIFF
--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -370,6 +370,7 @@ export const TextField = (props: TextFieldProps) => {
             ...(Boolean(tooltipText) && {
               width: '415px',
             }),
+            ...props.sx,
           }}
           className={className}
           error={!!error || !!errorText}

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -266,6 +266,7 @@ export const TextField = (props: TextFieldProps) => {
           display: 'flex',
           flexWrap: 'wrap',
         }),
+        ...containerProps?.sx,
       }}
     >
       <Box


### PR DESCRIPTION
## Description 📝
Fix styling for textfield on profile/display page as well as other sx bugs

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/15d751ce-5be9-472b-93ee-4fdbba54238b) | ![image](https://github.com/user-attachments/assets/2099a5c8-6e1a-450b-b55f-325e46788aa3) |

## How to test 🧪

Confirm textfield styling looks the same as prod:
- profile/display

Confirm textfield styling looks the same for places that have containerProps
- LinodeCreate - vlan, vpc (** VPC has slight regression that wasn't fixed by this change, looking into it)
- AppSelect
- general check where textfield is used everywhere

## As an Author I have considered 🤔

*Check all that apply*

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
