### PR TITLE
fix: [M3-8894] - Linode Create crash when selected a Linode with a `type` that is `null`

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - UI bugs on the Object Storage bucket and access key landing pages ([#11187](https://github.com/linode/manager/pull/11187))
 - Animation for VPC subnet drawers ([#11195](https://github.com/linode/manager/pull/11195))
 - DBaaS enable creation of two node clusters ([#11218](https://github.com/linode/manager/pull/11218))
+- Crash on the Linode Create flow when a Linode with a `type` of `null` is selected ([#11247](https://github.com/linode/manager/pull/11247))
 
 ### Tech Stories:
 

--- a/packages/manager/src/features/Linodes/LinodeCreate/Region.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Region.tsx
@@ -76,7 +76,7 @@ export const Region = React.memo(() => {
 
   const { data: type } = useTypeQuery(
     selectedLinode?.type ?? '',
-    Boolean(selectedLinode)
+    Boolean(selectedLinode?.type)
   );
 
   const isLinodeCreateRestricted = useRestrictedGlobalGrantCheck({

--- a/packages/manager/src/queries/types.ts
+++ b/packages/manager/src/queries/types.ts
@@ -25,7 +25,7 @@ export const useSpecificTypes = (types: string[], enabled = true) => {
 
   return useQueries({
     queries: types.map<UseQueryOptions<LinodeType, APIError[]>>((type) => ({
-      enabled,
+      enabled: enabled && Boolean(type),
       ...linodeQueries.types._ctx.type(type),
       ...queryPresets.oneTimeFetch,
       initialData() {


### PR DESCRIPTION
## Description 📝

- Fixes a crash on the Linode Create flow when selecting a Linode to clone from when the Linode's `type` is `null`
- See [this](https://linode.slack.com/archives/C4V05M8TS/p1731403292097249) for context

## Explanation 

This PR ensures that `useTypeQuery` is only enabled if the type ID is truthy (not an empty string).  If the query gets enabled with an empty string, it would fetch `/v4/linode/types/`, which would unexpectedly store a paginated list of types in the cache where we expect a type object.

## How to test 🧪

- View the internal ticket M3-8894
- Login as that customer
- Copy that Admin bearer token to your local Cloud Manager
- Test this PR with the Linode mentioned in the internal ticket

## As an Author I have considered 🤔

- [ ] 👀 Doing a self review
- [ ] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [ ] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support