### PR TITLE
feat: [M3-8833] - Update API types and mock data for VPU plans

### DIFF
--- a/packages/api-v4/.changeset/pr-11256-added-1731689702399.md
+++ b/packages/api-v4/.changeset/pr-11256-added-1731689702399.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Added
+---
+
+New VPU related fields and capabilities to API types ([#11256](https://github.com/linode/manager/pull/11256))

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -74,6 +74,7 @@ export type AccountCapability =
   | 'Machine Images'
   | 'Managed Databases'
   | 'Managed Databases Beta'
+  | 'NETINT Quadra T1U'
   | 'NodeBalancers'
   | 'Object Storage Access Key Regions'
   | 'Object Storage Endpoint Types'

--- a/packages/api-v4/src/linodes/actions.ts
+++ b/packages/api-v4/src/linodes/actions.ts
@@ -110,7 +110,7 @@ export const resizeLinode = (linodeId: number, data: ResizeLinodePayload) =>
  * automatically appended to the root user's authorized keys file.
  */
 export const rebuildLinode = (linodeId: number, data: RebuildRequest) =>
-  Request<{}>(
+  Request<Linode>(
     setURL(
       `${API_ROOT}/linode/instances/${encodeURIComponent(linodeId)}/rebuild`
     ),

--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -13,6 +13,7 @@ export interface LinodeSpecs {
   vcpus: number;
   transfer: number;
   gpus: number;
+  accelerated_devices: number;
 }
 
 export interface Linode {
@@ -322,6 +323,7 @@ export interface LinodeType extends BaseType {
   successor: string | null;
   network_out: number;
   gpus: number;
+  accelerated_devices: number;
   price: PriceObject;
   region_prices: RegionPriceObject[];
   addons: {
@@ -330,6 +332,7 @@ export interface LinodeType extends BaseType {
 }
 
 export type LinodeTypeClass =
+  | 'accelerated'
   | 'nanode'
   | 'standard'
   | 'dedicated'

--- a/packages/api-v4/src/regions/types.ts
+++ b/packages/api-v4/src/regions/types.ts
@@ -15,6 +15,7 @@ export type Capabilities =
   | 'Managed Databases'
   | 'Metadata'
   | 'NodeBalancers'
+  | 'NETINT Quadra T1U'
   | 'Object Storage'
   | 'Placement Group'
   | 'Premium Plans'

--- a/packages/manager/.changeset/pr-11256-changed-1731689770913.md
+++ b/packages/manager/.changeset/pr-11256-changed-1731689770913.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Updated types based on new VPU fields and added mock data ([#11256](https://github.com/linode/manager/pull/11256))

--- a/packages/manager/src/__data__/linodes.ts
+++ b/packages/manager/src/__data__/linodes.ts
@@ -34,6 +34,7 @@ export const linode1: Linode = {
   region: 'us-east',
   site_type: 'core',
   specs: {
+    accelerated_devices: 0,
     disk: 20480,
     gpus: 0,
     memory: 1024,
@@ -81,6 +82,7 @@ export const linode2: Linode = {
   region: 'us-east',
   site_type: 'core',
   specs: {
+    accelerated_devices: 0,
     disk: 30720,
     gpus: 0,
     memory: 2048,
@@ -128,6 +130,7 @@ export const linode3: Linode = {
   region: 'us-east',
   site_type: 'core',
   specs: {
+    accelerated_devices: 0,
     disk: 30720,
     gpus: 0,
     memory: 2048,
@@ -175,6 +178,7 @@ export const linode4: Linode = {
   region: 'eu-west',
   site_type: 'core',
   specs: {
+    accelerated_devices: 0,
     disk: 30720,
     gpus: 0,
     memory: 2048,

--- a/packages/manager/src/components/EntityHeader/EntityHeader.stories.tsx
+++ b/packages/manager/src/components/EntityHeader/EntityHeader.stories.tsx
@@ -60,6 +60,7 @@ export const Default: Story = {
               },
             }}
             linodeType={{
+              accelerated_devices: 0,
               addons: {
                 backups: {
                   price: {

--- a/packages/manager/src/factories/account.ts
+++ b/packages/manager/src/factories/account.ts
@@ -47,6 +47,7 @@ export const accountFactory = Factory.Sync.makeFactory<Account>({
     'Machine Images',
     'Managed Databases',
     'Managed Databases Beta',
+    'NETINT Quadra T1U',
     'NodeBalancers',
     'Object Storage Access Key Regions',
     'Object Storage Endpoint Types',

--- a/packages/manager/src/factories/linodes.ts
+++ b/packages/manager/src/factories/linodes.ts
@@ -26,6 +26,7 @@ export const linodeAlertsFactory = Factory.Sync.makeFactory<LinodeAlerts>({
 });
 
 export const linodeSpecsFactory = Factory.Sync.makeFactory<LinodeSpecs>({
+  accelerated_devices: 1,
   disk: 51200,
   gpus: 0,
   memory: 2048,
@@ -163,6 +164,7 @@ export const linodeTransferFactory = Factory.Sync.makeFactory<RegionalNetworkUti
 );
 
 export const linodeTypeFactory = Factory.Sync.makeFactory<LinodeType>({
+  accelerated_devices: 0,
   addons: {
     backups: {
       price: {
@@ -218,6 +220,7 @@ export const dedicatedTypeFactory = linodeTypeFactory.extend({
 });
 
 export const proDedicatedTypeFactory = Factory.Sync.makeFactory<LinodeType>({
+  accelerated_devices: 0,
   addons: {
     backups: {
       price: {

--- a/packages/manager/src/factories/types.ts
+++ b/packages/manager/src/factories/types.ts
@@ -9,6 +9,7 @@ import type {
 import type { ExtendedType } from 'src/utilities/extendType';
 
 export const typeFactory = Factory.Sync.makeFactory<LinodeType>({
+  accelerated_devices: 0,
   addons: {
     backups: {
       price: {
@@ -87,6 +88,7 @@ export const planSelectionTypeFactory = Factory.Sync.makeFactory<PlanWithAvailab
 export const extendedTypeFactory = Factory.Sync.makeFactory<
   ExtendedType & PlanSelectionAvailabilityTypes
 >({
+  accelerated_devices: 0,
   addons: {
     backups: {
       price: {

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -2,11 +2,12 @@ import { Notice } from '@linode/ui';
 import * as React from 'react';
 import { useLocation } from 'react-router-dom';
 
+import { isDistributedRegionSupported } from 'src/components/RegionSelect/RegionSelect.utils';
 import { getIsDistributedRegion } from 'src/components/RegionSelect/RegionSelect.utils';
 import { useIsGeckoEnabled } from 'src/components/RegionSelect/RegionSelect.utils';
-import { isDistributedRegionSupported } from 'src/components/RegionSelect/RegionSelect.utils';
 import { TabbedPanel } from 'src/components/TabbedPanel/TabbedPanel';
 import { useFlags } from 'src/hooks/useFlags';
+import { useAccount } from 'src/queries/account/account';
 import { useRegionAvailabilityQuery } from 'src/queries/regions/regions';
 import { plansNoticesUtils } from 'src/utilities/planNotices';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
@@ -87,6 +88,9 @@ export const PlansPanel = (props: PlansPanelProps) => {
     location.search
   );
 
+  const { data: account } = useAccount();
+  const hasVPUCapability = account?.capabilities?.includes('NETINT Quadra T1U');
+
   const { data: regionAvailabilities } = useRegionAvailabilityQuery(
     selectedRegionID || '',
     Boolean(flags.soldOutChips) && selectedRegionID !== undefined
@@ -94,7 +98,9 @@ export const PlansPanel = (props: PlansPanelProps) => {
 
   const _types = types.filter(
     (type) =>
-      !type.id.includes('dedicated-edge') && !type.id.includes('nanode-edge')
+      !type.id.includes('dedicated-edge') &&
+      !type.id.includes('nanode-edge') &&
+      (!hasVPUCapability ? type.class !== 'accelerated' : true)
   );
   const _plans = getPlanSelectionsByPlanType(
     flags.disableLargestGbPlans

--- a/packages/manager/src/features/components/PlansPanel/constants.ts
+++ b/packages/manager/src/features/components/PlansPanel/constants.ts
@@ -25,6 +25,7 @@ export const GPU_COMPUTE_INSTANCES_LINK =
   'https://techdocs.akamai.com/cloud-computing/docs/gpu-compute-instances';
 
 export const DEDICATED_512_GB_PLAN: ExtendedType = {
+  accelerated_devices: 0,
   addons: {
     backups: {
       price: {
@@ -83,6 +84,7 @@ export const DEDICATED_512_GB_PLAN: ExtendedType = {
 };
 
 export const PREMIUM_512_GB_PLAN: ExtendedType = {
+  accelerated_devices: 0,
   addons: {
     backups: {
       price: {

--- a/packages/manager/src/features/components/PlansPanel/utils.test.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.test.ts
@@ -29,6 +29,10 @@ const nanode = typeFactory.build({ class: 'nanode', id: 'g6-nanode-1' });
 const premium = typeFactory.build({ class: 'premium', id: 'g6-premium-2' });
 const highmem = typeFactory.build({ class: 'highmem', id: 'g6-highmem-1' });
 const gpu = typeFactory.build({ class: 'gpu', id: 'g6-gpu-1' });
+const accelerated = typeFactory.build({
+  class: 'accelerated',
+  id: 'accelerated-1',
+});
 
 describe('getPlanSelectionsByPlanType', () => {
   it('should return an object with plans grouped by type', () => {
@@ -60,6 +64,7 @@ describe('getPlanSelectionsByPlanType', () => {
       nanode,
       dedicated,
       prodedicated,
+      accelerated,
     ]);
     const expectedOrder = planTypeOrder;
 

--- a/packages/manager/src/features/components/PlansPanel/utils.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.ts
@@ -1,5 +1,4 @@
 import { arrayToList } from 'src/utilities/arrayToList';
-import { ExtendedType } from 'src/utilities/extendType';
 
 import {
   DEDICATED_512_GB_PLAN,
@@ -10,12 +9,12 @@ import {
   PREMIUM_512_GB_PLAN,
   SMALLER_PLAN_DISABLED_COPY,
 } from './constants';
-import {
+
+import type {
   DisabledTooltipReasons,
   PlanSelectionType,
   PlanWithAvailability,
 } from './types';
-
 import type {
   Capabilities,
   LinodeTypeClass,
@@ -23,6 +22,7 @@ import type {
   RegionAvailability,
 } from '@linode/api-v4';
 import type { Flags } from 'src/featureFlags';
+import type { ExtendedType } from 'src/utilities/extendType';
 
 export type PlansTypes<T> = Record<LinodeTypeClass, T[]>;
 
@@ -42,6 +42,7 @@ export const planTypeOrder: (
   'gpu',
   'metal',
   'premium',
+  'accelerated',
 ];
 
 /**
@@ -165,11 +166,13 @@ export const getIsLimitedAvailability = ({
 };
 
 export const planTabInfoContent = {
+  // TODO: to be further handled in M3-8834
   accelerated: {
     dataId: 'data-qa-accelerated',
     key: 'accelerated',
-    title: 'TBD - M3-8834',
-    typography: 'TBD - M3-8834',
+    title: 'Accelerated',
+    typography:
+      'Accelerated instances leverage ASICs to accelerate specialized tasks such as video transcoding, media processing, and other compute heavy workloads.',
   },
   dedicated: {
     dataId: 'data-qa-dedicated',

--- a/packages/manager/src/features/components/PlansPanel/utils.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.ts
@@ -165,6 +165,12 @@ export const getIsLimitedAvailability = ({
 };
 
 export const planTabInfoContent = {
+  accelerated: {
+    dataId: 'data-qa-accelerated',
+    key: 'accelerated',
+    title: 'TBD - M3-8834',
+    typography: 'TBD - M3-8834',
+  },
   dedicated: {
     dataId: 'data-qa-dedicated',
     key: 'dedicated',

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -400,6 +400,12 @@ const gpuTypesRX = linodeTypeFactory.buildList(7, {
   gpus: 1,
   transfer: 5000,
 });
+const acceleratedType = linodeTypeFactory.buildList(7, {
+  accelerated_devices: 1,
+  class: 'accelerated',
+  label: 'Netint Quadra T1U X',
+  transfer: 0,
+});
 const proxyAccountUser = accountUserFactory.build({
   email: 'partner@proxy.com',
   last_login: null,
@@ -595,6 +601,7 @@ export const handlers = [
         ...dedicatedTypes,
         ...gpuTypesAda,
         ...gpuTypesRX,
+        ...acceleratedType,
         proDedicatedType,
       ])
     );

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1244,7 +1244,6 @@ export const handlers = [
       active_promotions: promoFactory.buildList(1),
       active_since: '2022-11-30',
       balance: 50,
-      capabilities: ['NETINT Quadra T1U'],
       company: 'Mock Company',
     });
     return HttpResponse.json(account);

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1244,6 +1244,7 @@ export const handlers = [
       active_promotions: promoFactory.buildList(1),
       active_since: '2022-11-30',
       balance: 50,
+      capabilities: ['NETINT Quadra T1U'],
       company: 'Mock Company',
     });
     return HttpResponse.json(account);


### PR DESCRIPTION
## Description 📝
Updates api types and mocks data so that Accelerated plans show up when using MSW

Accelerated plans will be hidden behind an account capability - we currently do not plan to use a feature flag

## Changes  🔄
- introduce new account and region capability
- update types and fix type errors
- add Accelerated mock data so that tab shows up

## Target release date 🗓️
12/10

## Preview 📷
![image](https://github.com/user-attachments/assets/cf23e276-b738-4b92-843e-5d85b505ea7c)

## How to test 🧪
- [ ] Confirm API types match API spec (see linked ticket)
- [ ] when using MSW, confirm tab for accelerated devices shows up (Went a bit into M3-8834 to get the mocked data to show up; M3-8834 will continue to make the plans panel look like the figma). NOTE: there is a bug/weird thing happening, where when you first select an accelerated plan, the panel will switch to the 'Premium CPU' tab. This happens if any column is after the 'Premium CPU' tab, not just the 'accelerated' tab... looking into this, but might move to m3-8834 + opening up this PR for review as well

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
