### PR TITLE
feat: [M3-8741] - Add linter rules for common pr feedback points

### DIFF
--- a/packages/api-v4/.changeset/pr-11258-added-1731996671316.md
+++ b/packages/api-v4/.changeset/pr-11258-added-1731996671316.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Added
+---
+
+Linter rules for common pr feedback points ([#11258](https://github.com/linode/manager/pull/11258))

--- a/packages/api-v4/.eslintrc.json
+++ b/packages/api-v4/.eslintrc.json
@@ -1,20 +1,11 @@
 {
-  "ignorePatterns": [
-    "node_modules",
-    "lib",
-    "index.js",
-    "!.eslintrc.js"
-  ],
+  "ignorePatterns": ["node_modules", "lib", "index.js", "!.eslintrc.js"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2020,
     "warnOnUnsupportedTypeScriptVersion": true
   },
-  "plugins": [
-    "@typescript-eslint",
-    "sonarjs",
-    "prettier"
-  ],
+  "plugins": ["@typescript-eslint", "sonarjs", "prettier"],
   "extends": [
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
@@ -38,10 +29,7 @@
     "array-callback-return": "error",
     "no-invalid-this": "off",
     "no-new-wrappers": "error",
-    "no-restricted-imports": [
-      "error",
-      "rxjs"
-    ],
+    "no-restricted-imports": ["error", "rxjs"],
     "no-console": "error",
     "no-undef-init": "off",
     "radix": "error",
@@ -52,7 +40,7 @@
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-empty-interface": "warn",
     "@typescript-eslint/no-non-null-assertion": "off",
-    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/interface-name-prefix": "off",
     "sonarjs/cognitive-complexity": "warn",
@@ -62,6 +50,7 @@
     "sonarjs/no-redundant-jump": "warn",
     "sonarjs/no-small-switch": "warn",
     "no-multiple-empty-lines": "error",
+    "camelcase": ["warn", { "properties": "always" }],
     "curly": "warn",
     "sort-keys": "off",
     "comma-dangle": "off",
@@ -74,9 +63,7 @@
   },
   "overrides": [
     {
-      "files": [
-        "*ts"
-      ],
+      "files": ["*ts"],
       "rules": {
         "@typescript-eslint/ban-types": [
           "warn",

--- a/packages/api-v4/.eslintrc.json
+++ b/packages/api-v4/.eslintrc.json
@@ -36,7 +36,6 @@
     "@typescript-eslint/no-unused-vars": "off",
     "@typescript-eslint/no-inferrable-types": "off",
     "@typescript-eslint/no-namespace": "warn",
-    "@typescript-eslint/camelcase": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-empty-interface": "warn",
     "@typescript-eslint/no-non-null-assertion": "off",

--- a/packages/manager/.changeset/pr-11258-added-1731996833931.md
+++ b/packages/manager/.changeset/pr-11258-added-1731996833931.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Linter rules for common pr feedback points ([#11258](https://github.com/linode/manager/pull/11258))

--- a/packages/manager/.eslintrc.cjs
+++ b/packages/manager/.eslintrc.cjs
@@ -166,7 +166,7 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/no-empty-interface': 'warn',
-    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-explicit-any': 'warn',
     '@typescript-eslint/no-inferrable-types': 'off',
     '@typescript-eslint/no-namespace': 'warn',
     // this would disallow usage of ! postfix operator on non null types
@@ -175,6 +175,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
     'array-callback-return': 'error',
+    camelcase: ['warn', { properties: 'always' }],
     'comma-dangle': 'off', // Prettier and TS both handle and check for this one
     // radix: Codacy considers it as an error, i put it here to fix it before push
     curly: 'warn',
@@ -274,6 +275,7 @@ module.exports = {
     'react/no-unescaped-entities': 'warn',
     // requires the definition of proptypes for react components
     'react/prop-types': 'off',
+    'react/self-closing-comp': 'warn',
     'react-hooks/exhaustive-deps': 'warn',
     'react-hooks/rules-of-hooks': 'error',
     'react-refresh/only-export-components': 'warn',

--- a/packages/manager/.eslintrc.cjs
+++ b/packages/manager/.eslintrc.cjs
@@ -160,7 +160,6 @@ module.exports = {
   rules: {
     '@linode/cloud-manager/deprecate-formik': 'warn',
     '@linode/cloud-manager/no-custom-fontWeight': 'error',
-    '@typescript-eslint/camelcase': 'off',
     '@typescript-eslint/consistent-type-imports': 'warn',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/packages/ui/.changeset/pr-11258-added-1731997009185.md
+++ b/packages/ui/.changeset/pr-11258-added-1731997009185.md
@@ -1,0 +1,5 @@
+---
+"@linode/ui": Added
+---
+
+Linter rules for common pr feedback points ([#11258](https://github.com/linode/manager/pull/11258))

--- a/packages/ui/.eslintrc.json
+++ b/packages/ui/.eslintrc.json
@@ -23,7 +23,6 @@
     "@typescript-eslint/no-unused-vars": "off",
     "@typescript-eslint/no-inferrable-types": "off",
     "@typescript-eslint/no-namespace": "warn",
-    "@typescript-eslint/camelcase": "off",
     "@typescript-eslint/consistent-type-imports": "warn",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-empty-interface": "warn",

--- a/packages/ui/.eslintrc.json
+++ b/packages/ui/.eslintrc.json
@@ -16,9 +16,25 @@
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:sonarjs/recommended",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "plugin:perfectionist/recommended-natural"
   ],
   "rules": {
+    "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-inferrable-types": "off",
+    "@typescript-eslint/no-namespace": "warn",
+    "@typescript-eslint/camelcase": "off",
+    "@typescript-eslint/consistent-type-imports": "warn",
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-empty-interface": "warn",
+    "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-use-before-define": "off",
+    "@typescript-eslint/interface-name-prefix": "off",
+    "array-callback-return": "error",
+    "camelcase": ["warn", { "properties": "always" }],
+    "comma-dangle": "off",
+    "curly": "warn",
     "no-unused-vars": [
       "warn",
       {
@@ -32,39 +48,67 @@
     "no-throw-literal": "warn",
     "no-loop-func": "error",
     "no-await-in-loop": "error",
-    "array-callback-return": "error",
-    "camelcase": ["warn", { "properties": "always" }],
     "no-invalid-this": "off",
     "no-new-wrappers": "error",
     "no-restricted-imports": ["error", "rxjs"],
     "no-console": "error",
     "no-undef-init": "off",
+    "no-multiple-empty-lines": "error",
+    "no-trailing-spaces": "warn",
+    "no-mixed-requires": "warn",
+    "object-shorthand": "warn",
+    // Perfectionist
+    "perfectionist/sort-array-includes": "warn",
+    "perfectionist/sort-classes": "warn",
+    "perfectionist/sort-enums": "warn",
+    "perfectionist/sort-exports": "warn",
+    "perfectionist/sort-imports": [
+      "warn",
+      {
+        "custom-groups": {
+          "type": {
+            "react": ["react", "react-*"],
+            "src": ["src*"]
+          },
+          "value": {
+            "src": ["src/**/*"]
+          }
+        },
+        "groups": [
+          ["builtin", "libraries", "external"],
+          ["src", "internal"],
+          ["parent", "sibling", "index"],
+          "object",
+          "unknown",
+          ["type", "internal-type", "parent-type", "sibling-type", "index-type"]
+        ],
+        "newlines-between": "always"
+      }
+    ],
+    "perfectionist/sort-interfaces": "warn",
+    "perfectionist/sort-jsx-props": "warn",
+    "perfectionist/sort-map-elements": "warn",
+    "perfectionist/sort-named-exports": "warn",
+    "perfectionist/sort-named-imports": "warn",
+    "perfectionist/sort-object-types": "warn",
+    "perfectionist/sort-objects": "warn",
+    "perfectionist/sort-union-types": "warn",
+    // prettier
+    "prettier/prettier": "warn",
+    // radix
     "radix": "error",
+    // react and jsx specific rules
     "react/self-closing-comp": "warn",
-    "@typescript-eslint/no-unused-vars": "off",
-    "@typescript-eslint/no-inferrable-types": "off",
-    "@typescript-eslint/no-namespace": "warn",
-    "@typescript-eslint/camelcase": "off",
-    "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/no-empty-interface": "warn",
-    "@typescript-eslint/no-non-null-assertion": "off",
-    "@typescript-eslint/no-explicit-any": "warn",
-    "@typescript-eslint/no-use-before-define": "off",
-    "@typescript-eslint/interface-name-prefix": "off",
+    "react/jsx-no-useless-fragment": "warn",
+    "react/no-unescaped-entities": "warn",
+    // sonar
     "sonarjs/cognitive-complexity": "off",
     "sonarjs/no-duplicate-string": "warn",
     "sonarjs/prefer-immediate-return": "warn",
     "sonarjs/no-identical-functions": "warn",
     "sonarjs/no-redundant-jump": "warn",
     "sonarjs/no-small-switch": "warn",
-    "no-multiple-empty-lines": "error",
-    "curly": "warn",
     "sort-keys": "off",
-    "comma-dangle": "off",
-    "no-trailing-spaces": "warn",
-    "no-mixed-requires": "warn",
-    "spaced-comment": "warn",
-    "object-shorthand": "warn",
-    "prettier/prettier": "warn"
+    "spaced-comment": "warn"
   }
 }

--- a/packages/ui/.eslintrc.json
+++ b/packages/ui/.eslintrc.json
@@ -1,10 +1,5 @@
 {
-  "ignorePatterns": [
-    "node_modules",
-    "lib",
-    "index.js",
-    "!.eslintrc.js"
-  ],
+  "ignorePatterns": ["node_modules", "lib", "index.js", "!.eslintrc.js"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2020,
@@ -12,6 +7,7 @@
   },
   "plugins": [
     "@typescript-eslint",
+    "react",
     "sonarjs",
     "prettier",
     "@linode/eslint-plugin-cloud-manager"
@@ -37,15 +33,14 @@
     "no-loop-func": "error",
     "no-await-in-loop": "error",
     "array-callback-return": "error",
+    "camelcase": ["warn", { "properties": "always" }],
     "no-invalid-this": "off",
     "no-new-wrappers": "error",
-    "no-restricted-imports": [
-      "error",
-      "rxjs"
-    ],
+    "no-restricted-imports": ["error", "rxjs"],
     "no-console": "error",
     "no-undef-init": "off",
     "radix": "error",
+    "react/self-closing-comp": "warn",
     "@typescript-eslint/no-unused-vars": "off",
     "@typescript-eslint/no-inferrable-types": "off",
     "@typescript-eslint/no-namespace": "warn",
@@ -53,7 +48,7 @@
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-empty-interface": "warn",
     "@typescript-eslint/no-non-null-assertion": "off",
-    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/interface-name-prefix": "off",
     "sonarjs/cognitive-complexity": "off",

--- a/packages/validation/.changeset/pr-11258-added-1731997101694.md
+++ b/packages/validation/.changeset/pr-11258-added-1731997101694.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Added
+---
+
+Linter rules for common pr feedback points ([#11258](https://github.com/linode/manager/pull/11258))

--- a/packages/validation/.eslintrc.json
+++ b/packages/validation/.eslintrc.json
@@ -36,7 +36,6 @@
     "@typescript-eslint/no-unused-vars": "off",
     "@typescript-eslint/no-inferrable-types": "off",
     "@typescript-eslint/no-namespace": "warn",
-    "@typescript-eslint/camelcase": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-empty-interface": "warn",
     "@typescript-eslint/no-non-null-assertion": "off",

--- a/packages/validation/.eslintrc.json
+++ b/packages/validation/.eslintrc.json
@@ -1,20 +1,11 @@
 {
-  "ignorePatterns": [
-    "node_modules",
-    "lib",
-    "index.js",
-    "!.eslintrc.js"
-  ],
+  "ignorePatterns": ["node_modules", "lib", "index.js", "!.eslintrc.js"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2020,
     "warnOnUnsupportedTypeScriptVersion": true
   },
-  "plugins": [
-    "@typescript-eslint",
-    "sonarjs",
-    "prettier"
-  ],
+  "plugins": ["@typescript-eslint", "sonarjs", "prettier"],
   "extends": [
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
@@ -38,10 +29,7 @@
     "array-callback-return": "error",
     "no-invalid-this": "off",
     "no-new-wrappers": "error",
-    "no-restricted-imports": [
-      "error",
-      "rxjs"
-    ],
+    "no-restricted-imports": ["error", "rxjs"],
     "no-console": "error",
     "no-undef-init": "off",
     "radix": "error",
@@ -52,7 +40,7 @@
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-empty-interface": "warn",
     "@typescript-eslint/no-non-null-assertion": "off",
-    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/interface-name-prefix": "off",
     "sonarjs/cognitive-complexity": "warn",


### PR DESCRIPTION
## Description 📝
Looking through recent contributions from external teams, there are some rules we can consider adding to reduce common feedback points.

note: I didn't find a way to "Enforce boolean values are not used as types (as per the ticket)" because using true/false as types is valid TS behavior.

## Changes  🔄
- Remove existing camelCase rule as it is not working
- Enforce new camelCase rule
- Enforce self closing tags for JSX elements without children
- Enforce no explicit "any"
- Enforce some missing eslint rules in `api-v4`, `manager`, `validation`, and `ui` package

## Target release date 🗓️
N/A

## How to test 🧪
- Ensure any existing violations of the new rules trigger warnings/errors in your IDE
- Ensure everything builds properly

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules