### PR TITLE
feat: [M3-8837] - Add LKE-E feature flag

### DIFF
--- a/packages/api-v4/.changeset/pr-11259-upcoming-features-1731690339160.md
+++ b/packages/api-v4/.changeset/pr-11259-upcoming-features-1731690339160.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Upcoming Features
+---
+
+Add v4beta/account endpoint and update Capabilities for LKE-E ([#11259](https://github.com/linode/manager/pull/11259))

--- a/packages/api-v4/src/account/account.ts
+++ b/packages/api-v4/src/account/account.ts
@@ -36,6 +36,18 @@ export const getAccountInfo = () => {
 };
 
 /**
+ * getAccountInfoBeta
+ *
+ * Return beta endpoint account information,
+ * including contact and billing info.
+ *
+ * @TODO LKE-E - M3-8838: Clean up after released to GA, if not otherwise in use
+ */
+export const getAccountInfoBeta = () => {
+  return Request<Account>(setURL(`${BETA_API_ROOT}/account`), setMethod('GET'));
+};
+
+/**
  * getNetworkUtilization
  *
  * Return your current network transfer quota and usage.

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -68,6 +68,7 @@ export type AccountCapability =
   | 'CloudPulse'
   | 'Disk Encryption'
   | 'Kubernetes'
+  | 'Kubernetes Enterprise'
   | 'Linodes'
   | 'LKE HA Control Planes'
   | 'LKE Network Access Control List (IP ACL)'

--- a/packages/manager/.changeset/pr-11259-upcoming-features-1731690367042.md
+++ b/packages/manager/.changeset/pr-11259-upcoming-features-1731690367042.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add feature flag and hook for LKE-E enablement ([#11259](https://github.com/linode/manager/pull/11259))

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -27,6 +27,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'imageServiceGen2', label: 'Image Service Gen2' },
   { flag: 'imageServiceGen2Ga', label: 'Image Service Gen2 GA' },
   { flag: 'linodeDiskEncryption', label: 'Linode Disk Encryption (LDE)' },
+  { flag: 'lkeEnterprise', label: 'LKE-Enterprise' },
   { flag: 'objMultiCluster', label: 'OBJ Multi-Cluster' },
   { flag: 'objectStorageGen2', label: 'OBJ Gen2' },
   { flag: 'selfServeBetas', label: 'Self Serve Betas' },

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -64,6 +64,11 @@ interface AclpFlag {
   enabled: boolean;
 }
 
+interface LkeEnterpriseFlag extends BaseFeatureFlag {
+  ga: boolean;
+  la: boolean;
+}
+
 export interface CloudPulseResourceTypeMapFlag {
   dimensionKey: string;
   maxResourceSelections?: number;
@@ -109,6 +114,7 @@ export interface Flags {
   imageServiceGen2Ga: boolean;
   ipv6Sharing: boolean;
   linodeDiskEncryption: boolean;
+  lkeEnterprise: LkeEnterpriseFlag;
   mainContentBanner: MainContentBanner;
   marketplaceAppOverrides: MarketplaceAppOverride[];
   metadata: boolean;

--- a/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
@@ -29,8 +29,8 @@ vi.mock('src/queries/account/account', () => {
   };
 });
 
-vi.mock('src/queries/account/betas/apl', () => {
-  const actual = vi.importActual('src/queries/account/betas/:betaId');
+vi.mock('src/queries/account/betas', () => {
+  const actual = vi.importActual('src/queries/account/betas');
   return {
     ...actual,
     useAccountBetaQuery: queryMocks.useAccountBetaQuery,
@@ -173,15 +173,15 @@ describe('useIsLkeEnterpriseEnabled', () => {
     queryMocks.useFlags.mockReturnValue({
       lkeEnterprise: {
         enabled: true,
-        la: true,
         ga: true,
+        la: true,
       },
     });
 
     const { result } = renderHook(() => useIsLkeEnterpriseEnabled());
     expect(result.current).toStrictEqual({
-      isLkeEnterpriseLAEnabled: false,
       isLkeEnterpriseGAEnabled: false,
+      isLkeEnterpriseLAEnabled: false,
     });
   });
 
@@ -194,15 +194,15 @@ describe('useIsLkeEnterpriseEnabled', () => {
     queryMocks.useFlags.mockReturnValue({
       lkeEnterprise: {
         enabled: true,
-        la: true,
         ga: false,
+        la: true,
       },
     });
 
     const { result } = renderHook(() => useIsLkeEnterpriseEnabled());
     expect(result.current).toStrictEqual({
-      isLkeEnterpriseLAEnabled: true,
       isLkeEnterpriseGAEnabled: false,
+      isLkeEnterpriseLAEnabled: true,
     });
   });
 

--- a/packages/manager/src/mocks/presets/extra/account/lkeEnterpriseEnabled.ts
+++ b/packages/manager/src/mocks/presets/extra/account/lkeEnterpriseEnabled.ts
@@ -1,0 +1,33 @@
+// New file at `src/mocks/presets/extra/account/lkeEnterpriseEnabled.ts` or similar
+
+import { http } from 'msw';
+
+import { accountFactory } from 'src/factories';
+import { makeResponse } from 'src/mocks/utilities/response';
+
+import type { MockPresetExtra } from 'src/mocks/types';
+
+const mockLkeEnabledCapability = () => {
+  return [
+    http.get('*/v4*/account', async ({ request }) => {
+      return makeResponse(
+        accountFactory.build({
+          capabilities: [
+            // Other account capabilities might be necessary here, too...
+            // TODO Make a `defaultAccountCapabilities` factory.
+            'Kubernetes',
+            'Kubernetes Enterprise',
+          ],
+        })
+      );
+    }),
+  ];
+};
+
+export const lkeEnterpriseEnabledPreset: MockPresetExtra = {
+  desc: 'Mock account with LKE Enterprise capability',
+  group: { id: 'Account', type: 'select' },
+  handlers: [mockLkeEnabledCapability],
+  id: 'account:lke-enterprise-enabled',
+  label: 'LKE Enterprise Enabled',
+};

--- a/packages/manager/src/mocks/presets/index.ts
+++ b/packages/manager/src/mocks/presets/index.ts
@@ -6,6 +6,7 @@ import { baselineCrudPreset } from './baseline/crud';
 import { baselineLegacyPreset } from './baseline/legacy';
 import { baselineNoMocksPreset } from './baseline/noMocks';
 import { childAccountPreset } from './extra/account/childAccount';
+import { lkeEnterpriseEnabledPreset } from './extra/account/lkeEnterpriseEnabled';
 import { managedDisabledPreset } from './extra/account/managedDisabled';
 import { managedEnabledPreset } from './extra/account/managedEnabled';
 import { parentAccountPreset } from './extra/account/parentAccount';
@@ -43,6 +44,7 @@ export const extraMockPresets: MockPresetExtra[] = [
   childAccountPreset,
   linodeLimitsPreset,
   lkeLimitsPreset,
+  lkeEnterpriseEnabledPreset,
   managedEnabledPreset,
   managedDisabledPreset,
   coreAndDistributedRegionsPreset,

--- a/packages/manager/src/mocks/types.ts
+++ b/packages/manager/src/mocks/types.ts
@@ -52,6 +52,7 @@ export type MockPresetExtraGroup = {
 };
 export type MockPresetExtraId =
   | 'account:child-proxy'
+  | 'account:lke-enterprise-enabled'
   | 'account:managed-disabled'
   | 'account:managed-enabled'
   | 'account:parent'

--- a/packages/manager/src/queries/account/account.ts
+++ b/packages/manager/src/queries/account/account.ts
@@ -11,6 +11,7 @@ import {
 import { useSnackbar } from 'notistack';
 
 import { useIsTaxIdEnabled } from 'src/features/Account/utils';
+import { useFlags } from 'src/hooks/useFlags';
 import { useGrants, useProfile } from 'src/queries/profile/profile';
 
 import { queryPresets } from '../base';
@@ -33,6 +34,21 @@ export const useAccount = () => {
     ...queryPresets.oneTimeFetch,
     ...queryPresets.noRetry,
     enabled: !profile?.restricted,
+  });
+};
+
+/**
+ * @TODO LKE-E - M3-8838: Clean up after released to GA, if not otherwise in use
+ */
+export const useAccountBeta = () => {
+  const { data: profile } = useProfile();
+  const flags = useFlags();
+
+  return useQuery<Account, APIError[]>({
+    ...accountQueries.accountBeta,
+    ...queryPresets.oneTimeFetch,
+    ...queryPresets.noRetry,
+    enabled: !profile?.restricted && flags.lkeEnterprise?.enabled,
   });
 };
 

--- a/packages/manager/src/queries/account/queries.ts
+++ b/packages/manager/src/queries/account/queries.ts
@@ -3,6 +3,7 @@ import {
   getAccountBeta,
   getAccountBetas,
   getAccountInfo,
+  getAccountInfoBeta,
   getAccountLogins,
   getAccountMaintenance,
   getAccountSettings,
@@ -30,6 +31,13 @@ import type { Filter, Params, RequestOptions } from '@linode/api-v4';
 export const accountQueries = createQueryKeys('account', {
   account: {
     queryFn: getAccountInfo,
+    queryKey: null,
+  },
+  /**
+   * @TODO LKE-E - M3-8838: Clean up after released to GA, if not otherwise in use
+   */
+  accountBeta: {
+    queryFn: getAccountInfoBeta,
     queryKey: null,
   },
   agreements: {


### PR DESCRIPTION
## Description 📝

We will need a feature flag in Launch Darkly to gate access to the UI changes for LKE-Enterprise. 

## Changes  🔄

- The `lkeEnterprise` flag exists in Launch Darkly.
   - The flag is EVERYTHING OFF in staging and prod environments and Feature ON, LA ON, GA OFF in the dev environment.
- The flag is added to the dev tools feature flag list.
- An account preset is added to the MSW to mock the capability.
- `useIsLkeEnterpriseEnabled` hook handles the enablement of the feature.
   - Since there is an account capability to enable the feature, the necessary account beta endpoint updates are included.
   - Test coverage was added for this hook.


## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have the LKE-E customer tag on your account (prod account is fine). See the internal LKE-Enterprise project tracker to find this.
OR
- Do not add the LKE-E customer tag on your account and use the MSW preset instead. (Thanks Joe)
![Screenshot 2024-11-18 at 12 44 47 PM](https://github.com/user-attachments/assets/4d28f94d-1a1b-40a2-8756-1cfc769948a3)

### Verification steps

(How to verify changes)

- [ ] Read the diff since there are no UI changes yet.
- [ ] Ensure that unit test coverage passes:
```
yarn test kubeUtils
```
- [ ] Confirm that the LKE-E feature flag is present in dev tools.
- [ ] If you want to test the hook in code, manually add the hook to a page like `KubernetesLanding.tsx`, console.log the return value, and confirm you see a v4beta/account network request.
```
  const { isLkeEnterpriseLAEnabled } = useIsLkeEnterpriseEnabled();
  console.log({ isLkeEnterpriseLAEnabled });
```

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
