### PR TITLE
change: [UIE-8261] - Update doc links on db landing page empty state

### DIFF
--- a/packages/manager/.changeset/pr-11262-changed-1731701027804.md
+++ b/packages/manager/.changeset/pr-11262-changed-1731701027804.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Update docs links on empty database landing page ([#11262](https://github.com/linode/manager/pull/11262))

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLandingEmptyStateData.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLandingEmptyStateData.tsx
@@ -22,17 +22,18 @@ export const gettingStartedGuides: ResourcesLinkSection = {
   links: [
     {
       text: 'Overview of Managed Databases',
-      to: 'https://techdocs.akamai.com/cloud-computing/docs/managed-databases',
+      to:
+        'https://techdocs.akamai.com/cloud-computing/docs/aiven-database-clusters',
     },
     {
       text: 'Get Started with Managed Databases',
       to:
-        'https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-managed-databases',
+        'https://techdocs.akamai.com/cloud-computing/docs/get-started-new-clusters',
     },
     {
       text: 'Choosing a Database Engine',
       to:
-        'https://techdocs.akamai.com/cloud-computing/docs/database-engines-and-plans',
+        'https://techdocs.akamai.com/cloud-computing/docs/aiven-database-engines',
     },
   ],
   moreInfo: {


### PR DESCRIPTION
## Description 📝

Update doc links on Database landing page empty state

## Changes  🔄
- Updated doc links

## Target release date 🗓️
12/2024

## How to test 🧪

### Prerequisites
- The `showEmpty` case needs to be true, which can be manually set in a local env, but which will also be true if there are no new or legacy databases

### Reproduction steps
- The documentation links are on the page that is presented when there are no databases present - i.e. if you see a table of databases, you won't see these links

### Verification steps
- Visit the links to see if they go to the new locations

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [ x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ x] All unit tests are passing
- [ x] TypeScript compilation succeeded without errors
- [ x] Code passes all linting rules