### PR TITLE
refactor: [M3-8908] - Optimize Events Polling following changes from incident

### DIFF
--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -112,15 +112,13 @@ export const EventsLanding = (props: Props) => {
         </TableHead>
         <TableBody>{renderTableBody()}</TableBody>
       </Table>
-      {!isFetching && hasNextPage ? (
+      {!isFetching && hasNextPage && (
         <Waypoint onEnter={() => fetchNextPage()}>
           <div />
         </Waypoint>
-      ) : (
-        events &&
-        events.length > 0 && (
-          <StyledTypography>No more events to show</StyledTypography>
-        )
+      )}
+      {events && events.length > 0 && !isFetching && !hasNextPage && (
+        <StyledTypography>No more events to show</StyledTypography>
       )}
     </>
   );

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -46,6 +46,7 @@ export const EventsLanding = (props: Props) => {
     hasNextPage,
     isFetchingNextPage,
     isLoading,
+    isFetching,
   } = useEventsInfiniteQuery(filter);
 
   const renderTableBody = () => {
@@ -111,7 +112,7 @@ export const EventsLanding = (props: Props) => {
         </TableHead>
         <TableBody>{renderTableBody()}</TableBody>
       </Table>
-      {hasNextPage ? (
+      {!isFetching && hasNextPage ? (
         <Waypoint onEnter={() => fetchNextPage()}>
           <div />
         </Waypoint>

--- a/packages/manager/src/features/TopMenu/NotificationMenu/NotificationMenu.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationMenu/NotificationMenu.tsx
@@ -37,7 +37,10 @@ export const NotificationMenu = () => {
   const notificationContext = React.useContext(_notificationContext);
 
   const { data } = useEventsInfiniteQuery();
+
+  // Just use the first page of events because we `slice` to get the first 20 events anyway
   const events = data?.pages[0].data ?? [];
+
   const { mutateAsync: markEventsAsSeen } = useMarkEventsAsSeen();
 
   const numNotifications =

--- a/packages/manager/src/features/TopMenu/NotificationMenu/NotificationMenu.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationMenu/NotificationMenu.tsx
@@ -22,7 +22,7 @@ import { usePrevious } from 'src/hooks/usePrevious';
 import { useNotificationsQuery } from 'src/queries/account/notifications';
 import { isInProgressEvent } from 'src/queries/events/event.helpers';
 import {
-  useInitialEventsQuery,
+  useEventsInfiniteQuery,
   useMarkEventsAsSeen,
 } from 'src/queries/events/events';
 import { rotate360 } from 'src/styles/keyframes';
@@ -36,8 +36,8 @@ export const NotificationMenu = () => {
   const formattedNotifications = useFormattedNotifications();
   const notificationContext = React.useContext(_notificationContext);
 
-  const { data, events } = useInitialEventsQuery();
-  const eventsData = data?.data ?? [];
+  const { data } = useEventsInfiniteQuery();
+  const events = data?.pages[0].data ?? [];
   const { mutateAsync: markEventsAsSeen } = useMarkEventsAsSeen();
 
   const numNotifications =
@@ -152,8 +152,8 @@ export const NotificationMenu = () => {
           </Box>
           <Divider spacingBottom={0} />
 
-          {eventsData.length > 0 ? (
-            eventsData
+          {events.length > 0 ? (
+            events
               .slice(0, 20)
               .map((event) => (
                 <NotificationCenterEvent

--- a/packages/manager/src/queries/events/events.ts
+++ b/packages/manager/src/queries/events/events.ts
@@ -149,11 +149,15 @@ export const useEventsPoller = () => {
   const { data: events } = useQuery({
     enabled: hasFetchedInitialEvents,
     queryFn: () => {
-      const data = queryClient.getQueryData<ResourcePage<Event>>([
+      const data = queryClient.getQueryData<InfiniteData<ResourcePage<Event>>>([
         'events',
-        'initial',
+        'infinite',
+        EVENTS_LIST_FILTER,
       ]);
-      const events = data?.data;
+      const events = data?.pages.reduce(
+        (events, page) => [...events, ...page.data],
+        []
+      );
 
       // If the user has events, poll for new events based on the most recent event's created time.
       // If the user has no events, poll events from the time the app mounted.
@@ -234,7 +238,6 @@ export const useMarkEventsAsSeen = () => {
   return useMutation<{}, APIError[], number>({
     mutationFn: (eventId) => markEventSeen(eventId),
     onSuccess: (_, eventId) => {
-
       // Update Infinite Queries
       queryClient.setQueriesData<InfiniteData<ResourcePage<Event>>>(
         { queryKey: ['events', 'infinite'] },

--- a/packages/manager/src/queries/events/events.ts
+++ b/packages/manager/src/queries/events/events.ts
@@ -69,7 +69,7 @@ export const useEventsInfiniteQuery = (filter: Filter = EVENTS_LIST_FILTER) => {
         // If there is no data in the cache yet at this query key,
         // it likely means that this is the initial fetch. For the
         // initial fetch, we have been asked to use `created` to limit
-        // the timeframe we fetch initial events for to a small window.
+        // the timeframe for our initial fetch to a small window.
         // See M3-8450 for context.
         return getEvents(
           {},

--- a/packages/manager/src/queries/events/events.ts
+++ b/packages/manager/src/queries/events/events.ts
@@ -66,6 +66,11 @@ export const useEventsInfiniteQuery = (filter: Filter = EVENTS_LIST_FILTER) => {
         filter,
       ]);
       if (data === undefined) {
+        // If there is no data in the cache yet at this query key,
+        // it likely means that this is the initial fetch. For the
+        // initial fetch, we have been asked to use `created` to limit
+        // the timeframe we fetch initial events for to a small window.
+        // See M3-8450 for context.
         return getEvents(
           {},
           {

--- a/packages/manager/src/queries/events/events.ts
+++ b/packages/manager/src/queries/events/events.ts
@@ -241,7 +241,7 @@ export const useMarkEventsAsSeen = () => {
   const queryClient = useQueryClient();
 
   return useMutation<{}, APIError[], number>({
-    mutationFn: (eventId) => markEventSeen(eventId),
+    mutationFn: markEventSeen,
     onSuccess: (_, eventId) => {
       // Update Infinite Queries
       queryClient.setQueriesData<InfiniteData<ResourcePage<Event>>>(


### PR DESCRIPTION
## Description 📝

- Cleans up events caching logic following https://github.com/linode/manager/pull/10899 🧹 

## Changes  🔄

- Removes the `useInitialEventsQuery` hook and moves all logic into `useEventsInfiniteQuery`, similar to the implementation before #10899
- Adds logic to `useEventsInfiniteQuery` that ensures the first fetch always limited to a 7 day window 📆 

## Preview 📷

> [!note]
> No UI changes expected

## How to test 🧪

- Test the Events landing page in general
  - Test on an account with 0 events
  - Test infinite scrolling
  - Test on an account with 0 events within the last 7 days, but events past that 7 day period
- Test the activity feed on a Linode details page
- Verify events polling works as expected
  - For example, if you shutdown a Linode, you should see the percentage for that every update every few seconds
- Verify events get marked as seen as expected

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules
