### PR TITLE
fix: [UIE-8259] dbaas summary blank read-only host should be N/A

### DIFF
--- a/packages/manager/.changeset/pr-11265-fixed-1731619488790.md
+++ b/packages/manager/.changeset/pr-11265-fixed-1731619488790.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+dbaas summary read-only host field is blank ([#11265](https://github.com/linode/manager/pull/11265))

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.test.tsx
@@ -77,6 +77,27 @@ describe('DatabaseSummaryConnectionDetails', () => {
     });
   });
 
+  it('should display N/A for default DB with blank read-only Host field', async () => {
+    const database = databaseFactory.build({
+      engine: POSTGRESQL,
+      hosts: {
+        primary: DEFAULT_PRIMARY,
+        secondary: undefined,
+        standby: undefined,
+      },
+      id: 99,
+      platform: 'rdbms-default',
+      port: 22496,
+      ssl_connection: true,
+    });
+
+    const { queryAllByText } = renderWithTheme(
+      <DatabaseSummaryConnectionDetails database={database} />
+    );
+
+    expect(queryAllByText('N/A')).toHaveLength(1);
+  });
+
   it('should display correctly for legacy db', async () => {
     queryMocks.useDatabaseCredentialsQuery.mockReturnValue({
       data: {

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -116,16 +116,14 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
     database?.hosts?.standby ?? database?.hosts?.secondary ?? '';
 
   const readOnlyHost = () => {
-    const defaultValue = isLegacy ? '-' : 'not available';
-    const value = readOnlyHostValue ?? defaultValue;
+    const defaultValue = isLegacy ? '-' : 'N/A';
+    const value = readOnlyHostValue ? readOnlyHostValue : defaultValue;
+    const displayCopyTooltip = value !== '-' && value !== 'N/A';
     return (
       <>
         {value}
-        {value && (
-          <CopyTooltip
-            className={classes.inlineCopyToolTip}
-            text={readOnlyHostValue}
-          />
+        {value && displayCopyTooltip && (
+          <CopyTooltip className={classes.inlineCopyToolTip} text={value} />
         )}
         {isLegacy && (
           <TooltipIcon


### PR DESCRIPTION
## Description 📝

Fixing DBaaS summary so that when the read-only host field is displayed and backend does not return a read-only host., N/A is displayed

## Changes  🔄

When read-only host field has no value (secondary/standby), it displays N/A

## Target release date 🗓️

12/10/2024

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![summary-before](https://github.com/user-attachments/assets/d291b0c0-9270-42fa-849f-c75556c9c6dd) | ![summary-after](https://github.com/user-attachments/assets/cb49ac81-7991-4122-88c1-ccea010708ba) |

## How to test 🧪

### Prerequisites

- Create a new database with 1 node which provides this state where the backend does not return a read-only host.

### Reproduction steps

- Create a new database with 1 node.
- Navigate to the database summary and view the empty read-only host field

### Verification steps

- Navigate to the summary new db with 1 node and see that N/A is displayed for read-only hosts field when there is no secondary or standby host for the database from the backend.

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules