### PR TITLE
test: Unskip Placement Group navigation test by removing `.only`

### DIFF
--- a/packages/manager/.changeset/pr-11272-tests-1731954049354.md
+++ b/packages/manager/.changeset/pr-11272-tests-1731954049354.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Unskip Placement Group landing page navigation test ([#11272](https://github.com/linode/manager/pull/11272))

--- a/packages/manager/cypress/e2e/core/placementGroups/placement-groups-navigation.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/placement-groups-navigation.spec.ts
@@ -27,7 +27,7 @@ describe('Placement Groups navigation', () => {
   /*
    * - Confirm navigation patterns to the create drawer
    */
-  it.only('can navigate to a placement group details page', () => {
+  it('can navigate to a placement group details page', () => {
     cy.visitWithLogin('/placement-groups');
 
     ui.button


### PR DESCRIPTION
## Description 📝

Quick little fix to unskip a Placement Group nav test caused by a stray `.only`. No real urgency or significance to this, just noticed it earlier today during DC testing.

## Changes  🔄

- Unskip `can navigate to Placement Groups landing page` PG nav test by removing `.only` on other test

## Target release date 🗓️

N/A

## How to test 🧪

### Reproduction steps

Run and build Cloud via `yarn && yarn build && yarn start:manager:ci`, then run the Placement Group navigation tests via:

```
yarn cy:run -s "cypress/e2e/core/placementGroups/placement-groups-navigation.spec.ts"
```

Observe:
- [x] The first test, `can navigate to Placement Groups landing page` is skipped

### Verification steps

Run and build Cloud, then run the Placement Group navigation tests and observe:

- [x] The first test, `can navigate to Placement Groups landing page` is not skipped

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support
