### PR TITLE
test: [M3-8919] - Fix Linode migration test failure caused by region label conflict

### DIFF
--- a/packages/manager/.changeset/pr-11274-tests-1731956375334.md
+++ b/packages/manager/.changeset/pr-11274-tests-1731956375334.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix Linode migration test failure caused by region label conflicts ([#11274](https://github.com/linode/manager/pull/11274))

--- a/packages/manager/cypress/e2e/core/linodes/migrate-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/migrate-linode.spec.ts
@@ -183,7 +183,6 @@ describe('Migrate linodes', () => {
       cy.findByText('No results').should('be.visible');
     });
 
-    cy.findByText('No results').should('be.visible');
     // Confirm that DC pricing information does not show up
     cy.findByText(dcPricingCurrentPriceLabel).should('not.exist');
     cy.get('[data-testid="current-price-panel"]').should('not.exist');

--- a/packages/manager/cypress/e2e/core/linodes/migrate-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/migrate-linode.spec.ts
@@ -8,7 +8,6 @@ import { ui } from 'support/ui';
 import { apiMatcher } from 'support/util/intercepts';
 import { linodeFactory } from '@src/factories';
 import { mockGetLinodeDetails } from 'support/intercepts/linodes';
-import { getClick, fbtClick } from 'support/helpers';
 import { getRegionById } from 'support/util/regions';
 import {
   dcPricingMockLinodeTypes,
@@ -44,7 +43,7 @@ describe('Migrate linodes', () => {
 
     ui.button.findByTitle('Enter Migration Queue').should('be.disabled');
     cy.findByText(`${initialRegion.label}`).should('be.visible');
-    getClick('[data-qa-checked="false"]');
+    cy.get('[data-qa-checked="false"]').click();
     cy.findByText(`North America: ${initialRegion.label}`).should('be.visible');
 
     ui.regionSelect.find().click();
@@ -59,7 +58,12 @@ describe('Migrate linodes', () => {
       }
     ).as('migrateReq');
 
-    fbtClick('Enter Migration Queue');
+    ui.button
+      .findByTitle('Enter Migration Queue')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
     cy.wait('@migrateReq').its('response.statusCode').should('eq', 200);
   });
 
@@ -93,7 +97,7 @@ describe('Migrate linodes', () => {
 
     ui.button.findByTitle('Enter Migration Queue').should('be.disabled');
     cy.findByText(`${initialRegion.label}`).should('be.visible');
-    getClick('[data-qa-checked="false"]');
+    cy.get('[data-qa-checked="false"]').click();
     cy.findByText(`North America: ${initialRegion.label}`).should('be.visible');
 
     ui.regionSelect.find().click();
@@ -130,7 +134,11 @@ describe('Migrate linodes', () => {
     // intercept migration request and stub it, respond with 200
     mockMigrateLinode(mockLinode.id).as('migrateReq');
 
-    fbtClick('Enter Migration Queue');
+    ui.button
+      .findByTitle('Enter Migration Queue')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
     cy.wait('@migrateReq').its('response.statusCode').should('eq', 200);
   });
 
@@ -164,10 +172,17 @@ describe('Migrate linodes', () => {
 
     ui.button.findByTitle('Enter Migration Queue').should('be.disabled');
     cy.findByText(`${initialRegion.label}`).should('be.visible');
-    getClick('[data-qa-checked="false"]');
+    cy.get('[data-qa-checked="false"]').click();
 
     // Confirm that user cannot select the Linode's current DC when migrating.
-    cy.findByText('New Region').click().type(`${initialRegion.label}{enter}`);
+    // TODO Consider refactoring this flow into its own test.
+    ui.autocomplete.findByLabel('New Region').click().type(initialRegion.id);
+
+    ui.autocompletePopper.find().within(() => {
+      cy.contains(initialRegion.id).should('not.exist');
+      cy.findByText('No results').should('be.visible');
+    });
+
     cy.findByText('No results').should('be.visible');
     // Confirm that DC pricing information does not show up
     cy.findByText(dcPricingCurrentPriceLabel).should('not.exist');


### PR DESCRIPTION
## Description 📝

This fixes a consistent test failure in `migrate-linode.spec.ts` that was triggered by the launch of Frankfurt 2 earlier today. 

The test attempts to confirm that users cannot migrate a Linode to the same region the Linode exists in. It does this by typing the Frankfurt region's label into the autocomplete and asserting that there are no results, and the launch of Frankfurt 2 triggered the failure because the "No results" message no longer appears.

This fixes the issue by searching for the region by ID, circumventing the label conflicts altogether.

## Changes  🔄

- Rework region assertions to prevent region label conflicts from causing test failures
- Remove calls to deprecated helpers `fbtClick` and `getClick`

## Target release date 🗓️

N/A.

## How to test 🧪

### Prerequisites

Build and serve Cloud, then run the migrate tests:

```bash
yarn cy:run -s "cypress/e2e/core/linodes/migrate-linode.spec.ts"
```

- [x] Confirm that all 3 tests pass, particularly `shows DC-specific pricing information when migrating linodes to similarly priced DCs`

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support
