### PR TITLE
fix: [UIE-8259] dbaas landing paginator disappears when pageSize is less than the number of instances

### DIFF
--- a/packages/manager/.changeset/pr-11275-fixed-1731961142321.md
+++ b/packages/manager/.changeset/pr-11275-fixed-1731961142321.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+dbaas landing paginator disappears when pageSize is less than the number of instances ([#11275](https://github.com/linode/manager/pull/11275))

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -147,6 +147,7 @@ const DatabaseLanding = () => {
       <DatabaseLandingTable
         data={legacyDatabases?.data}
         handleOrderChange={legacyDatabaseHandleOrderChange}
+        results={legacyDatabases?.results}
         order={legacyDatabaseOrder}
         orderBy={legacyDatabaseOrderBy}
       />
@@ -156,6 +157,7 @@ const DatabaseLanding = () => {
   const defaultTable = () => {
     return (
       <DatabaseLandingTable
+        results={newDatabases?.results}
         data={newDatabases?.data}
         handleOrderChange={newDatabaseHandleOrderChange}
         isNewDatabase={true}

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLandingTable.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLandingTable.tsx
@@ -31,6 +31,7 @@ interface Props {
   order: 'asc' | 'desc';
   orderBy: string;
   showSuspend?: boolean;
+  results: number | undefined;
 }
 const DatabaseLandingTable = ({
   data,
@@ -38,6 +39,7 @@ const DatabaseLandingTable = ({
   isNewDatabase,
   order,
   orderBy,
+  results,
   showSuspend,
 }: Props) => {
   const { data: events } = useInProgressEvents();
@@ -190,7 +192,7 @@ const DatabaseLandingTable = ({
         </TableBody>
       </Table>
       <PaginationFooter
-        count={data?.length || 0}
+        count={results || 0}
         eventCategory="Databases Table"
         handlePageChange={pagination.handlePageChange}
         handleSizeChange={pagination.handlePageSizeChange}


### PR DESCRIPTION
## Description 📝

DbaaS landing page table paginator disappears when the pageSize is less than the number of instances retrieved from the backend. This prevents users from being able to view the additional instances that would be displayed on the following pages.

## Changes  🔄

- DBaaS Landing page now leverages the results property instead of the length of the number of database instances retrieved from a single page via the backend response. The results property provides the total number of instances.

## Target release date 🗓️

12/10/2024

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![before-fix](https://github.com/user-attachments/assets/e9c22a29-9871-4a61-b581-e9e7da0eb528) | ![after-fix](https://github.com/user-attachments/assets/8ac918cf-9740-465f-b2ab-b5dd9abaa854) |

## How to test 🧪

### Prerequisites
- Have the ability to access the database landing page and create new databases

### Reproduction steps

- Create a greater number of databases than the default or set pageSize determined by your preferences.
- ie. Create 29 databases if your pageSize is 25.
- Observe that the paginator is no longer visible

### Verification steps

- Access the databaseLanding page with the databases created in the reproduction steps
- Observe that the paginator is now visible and does not get hidden when you adjust the pageSize.

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
