### PR TITLE
fix: [M3-8923] - Fix Account Maintenance Account X-Filter

### DIFF
--- a/packages/manager/.changeset/pr-11277-fixed-1732027147462.md
+++ b/packages/manager/.changeset/pr-11277-fixed-1732027147462.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Incorrect Account Maintenance X-Filter ([#11277](https://github.com/linode/manager/pull/11277))

--- a/packages/manager/src/components/MaintenanceBanner/MaintenanceBanner.tsx
+++ b/packages/manager/src/components/MaintenanceBanner/MaintenanceBanner.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 
 import { Typography } from 'src/components/Typography';
+import { PENDING_MAINTENANCE_FILTER } from 'src/features/Account/Maintenance/utilities';
 import { useAllAccountMaintenanceQuery } from 'src/queries/account/maintenance';
 import { useProfile } from 'src/queries/profile/profile';
 import { formatDate } from 'src/utilities/formatDate';
@@ -22,7 +23,7 @@ export const MaintenanceBanner = React.memo((props: Props) => {
 
   const { data: accountMaintenanceData } = useAllAccountMaintenanceQuery(
     {},
-    { status: { '+or': ['pending, started'] } }
+    PENDING_MAINTENANCE_FILTER
   );
 
   const {

--- a/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
+++ b/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
@@ -25,6 +25,7 @@ import {
 } from 'src/queries/account/maintenance';
 
 import { MaintenanceTableRow } from './MaintenanceTableRow';
+import { PENDING_MAINTENANCE_FILTER } from './utilities';
 
 import type { AccountMaintenance, Filter } from '@linode/api-v4';
 
@@ -70,7 +71,7 @@ export const MaintenanceTable = ({ type }: Props) => {
    */
   const filters: Record<Props['type'], Filter> = {
     completed: { status: 'completed' },
-    pending: { status: { '+or': ['pending', 'started'] } },
+    pending: PENDING_MAINTENANCE_FILTER,
   };
 
   const filter: Filter = {

--- a/packages/manager/src/features/Account/Maintenance/utilities.ts
+++ b/packages/manager/src/features/Account/Maintenance/utilities.ts
@@ -1,0 +1,3 @@
+export const PENDING_MAINTENANCE_FILTER = Object.freeze({
+  status: { '+or': ['pending', 'started'] },
+});

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
@@ -1,14 +1,16 @@
-import { Notification } from '@linode/api-v4/lib/account';
-import * as React from 'react';
+import React from 'react';
 import { useParams } from 'react-router-dom';
 
 import { MaintenanceBanner } from 'src/components/MaintenanceBanner/MaintenanceBanner';
 import { ProductNotification } from 'src/components/ProductNotification/ProductNotification';
+import { PENDING_MAINTENANCE_FILTER } from 'src/features/Account/Maintenance/utilities';
 import { useAllAccountMaintenanceQuery } from 'src/queries/account/maintenance';
 import { useNotificationsQuery } from 'src/queries/account/notifications';
 import { useLinodeQuery } from 'src/queries/linodes/linodes';
 
 import { MigrationNotification } from './MigrationNotification';
+
+import type { Notification } from '@linode/api-v4';
 
 const Notifications = () => {
   const { linodeId } = useParams<{ linodeId: string }>();
@@ -24,7 +26,7 @@ const Notifications = () => {
 
   const { data: accountMaintenanceData } = useAllAccountMaintenanceQuery(
     {},
-    { status: { '+or': ['pending, started'] } }
+    PENDING_MAINTENANCE_FILTER
   );
 
   const maintenanceForThisLinode = accountMaintenanceData?.find(

--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodesLandingCSVDownload.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodesLandingCSVDownload.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 
 import { DownloadCSV } from 'src/components/DownloadCSV/DownloadCSV';
+import { PENDING_MAINTENANCE_FILTER } from 'src/features/Account/Maintenance/utilities';
 import { useFormattedDate } from 'src/hooks/useFormattedDate';
 import { useAllAccountMaintenanceQuery } from 'src/queries/account/maintenance';
 import { useAllLinodesQuery } from 'src/queries/linodes/linodes';
@@ -18,7 +19,7 @@ export const LinodesLandingCSVDownload = () => {
 
   const { data: accountMaintenance } = useAllAccountMaintenanceQuery(
     {},
-    { status: { '+or': ['pending, started'] } }
+    PENDING_MAINTENANCE_FILTER
   );
 
   const downloadCSV = async () => {

--- a/packages/manager/src/features/Linodes/index.tsx
+++ b/packages/manager/src/features/Linodes/index.tsx
@@ -10,6 +10,7 @@ import { useAllLinodesQuery } from 'src/queries/linodes/linodes';
 import { addMaintenanceToLinodes } from 'src/utilities/linodes';
 import { storage } from 'src/utilities/storage';
 
+import { PENDING_MAINTENANCE_FILTER } from '../Account/Maintenance/utilities';
 import { linodesInTransition } from './transitions';
 
 import type { RegionFilter } from 'src/utilities/storage';
@@ -49,7 +50,7 @@ export const LinodesRoutes = () => {
 export const LinodesLandingWrapper = React.memo(() => {
   const { data: accountMaintenanceData } = useAllAccountMaintenanceQuery(
     {},
-    { status: { '+or': ['pending, started'] } }
+    PENDING_MAINTENANCE_FILTER
   );
 
   const { isGeckoLAEnabled } = useIsGeckoEnabled();


### PR DESCRIPTION
## Description 📝

- Fixes a faulty X-Filter causing features using the `GET /v4/account/maintenance`  to not yield any results
- I will add some tests in a follow up to this PR 🧪 

## Preview 📷

> [!note]
> Without this change, none of the following maintenance banners / tooltips would show 😢 

![Screenshot 2024-11-18 at 2 44 41 PM](https://github.com/user-attachments/assets/2c6dbf64-37a1-4629-9560-9d8a7b856b46)
![Screenshot 2024-11-18 at 11 29 54 AM](https://github.com/user-attachments/assets/069ad0a0-c13e-423d-ba11-3720a8c252d4)

## How to test 🧪

- Refer to my internal guide I posted in Slack on how to test 📖 
  - If you don't have the time to fully test, you can just check this PR for spelling / syntax, the changes are relatively safe and minimal

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules