### PR TITLE
fix: [M3-8924] - Storybook `optimizeDeps` config to improve cold start

### DIFF
--- a/packages/manager/.changeset/pr-11278-fixed-1731985440482.md
+++ b/packages/manager/.changeset/pr-11278-fixed-1731985440482.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Storybook optimizeDeps config to improve cold start ([#11278](https://github.com/linode/manager/pull/11278))

--- a/packages/manager/.storybook/main.ts
+++ b/packages/manager/.storybook/main.ts
@@ -54,6 +54,17 @@ const config: StorybookConfig = {
       define: {
         'process.env': {},
       },
+      optimizeDeps: {
+        include: [
+          '@storybook/react',
+          '@storybook/react-vite',
+          'react',
+          'react-dom',
+        ],
+        esbuildOptions: {
+          target: 'esnext',
+        },
+      },
     });
   },
 };


### PR DESCRIPTION
## Description 📝
This PR attempts to config Storybook's `optimizeDeps` to stabilize the developer experience during the `@linode/ui` migration. Often time devs are getting dev build errors with cache validation when using storybook locally after components have been migrated, and especially while switching branches.. Clearing cache manually does not always achieve a clean slate, but I have found this config to help and not add friction or performance degradation. 

## Changes  🔄
- Add `optimizeDeps` config to storybook

## How to test 🧪

### Verification steps
- Check out this PR and run `yarn storybook`
  - Confirm no error when storybook opens
  - Confirm no performance degradation

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
