### PR TITLE
test: [M3-8918] - Cypress test for restricted user Image empty landing page

### DIFF
--- a/packages/manager/.changeset/pr-11281-tests-1732015326269.md
+++ b/packages/manager/.changeset/pr-11281-tests-1732015326269.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Cypress test for restricted user Image Empty landing page ([#11281](https://github.com/linode/manager/pull/11281))

--- a/packages/manager/cypress/e2e/core/images/images-empty-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/images-empty-landing-page.spec.ts
@@ -65,9 +65,6 @@ describe('Images empty landing page', () => {
    * - Confirms that hovering "Create Image" button shows a Warning for restricted user.
    */
   it('checks restricted user has no access to create Image on Image landing page', () => {
-    // Assert that List of Images table not exist
-    cy.get('table[aria-label="List of Images"]').should('not.exist');
-
     // object to create a mockProfile for non-restricted user
     const mockProfile = profileFactory.build({
       username: randomLabel(),
@@ -97,6 +94,9 @@ describe('Images empty landing page', () => {
     cy.wait('@getImages');
     cy.url().should('endWith', '/images');
 
+    // Assert that List of Images table not exist
+    cy.get('table[aria-label="List of Images"]').should('not.exist');
+
     // confirms 'Create Image' button is disabled
     ui.button
       .findByTitle('Create Image')
@@ -110,4 +110,8 @@ describe('Images empty landing page', () => {
       )
       .should('be.visible');
   });
+
+  // checks for reference section on empty page
+  cy.findByText('Getting Started Guides').should('be.visible');
+  cy.findByText('Video Playlist').should('be.visible');
 });

--- a/packages/manager/cypress/e2e/core/images/images-empty-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/images-empty-landing-page.spec.ts
@@ -1,15 +1,27 @@
 import { ui } from 'support/ui';
 import { mockGetAllImages } from 'support/intercepts/images';
+import { profileFactory } from '@src/factories';
+import { accountUserFactory } from '@src/factories/accountUsers';
+import { grantsFactory } from '@src/factories/grants';
+import { mockGetUser } from 'support/intercepts/account';
+import {
+  mockGetProfile,
+  mockGetProfileGrants,
+} from 'support/intercepts/profile';
+import { randomLabel } from 'support/util/random';
 
 describe('Images empty landing page', () => {
-  /**
+  beforeEach(() => {
+    // Mock setup to display the Image landing page in an empty state
+    mockGetAllImages([]).as('getImages');
+  });
+
+  /*
    * - Confirms Images landing page empty state is shown when no Images are present:
    * - Confirms that "Getting Started Guides" and "Video Playlist" are listed on landing page.
    * - Confirms that clicking "Create Image" navigates user to image create page.
    */
   it('shows the empty state when there are no images', () => {
-    mockGetAllImages([]).as('getImages');
-
     cy.visitWithLogin('/images');
     cy.wait(['@getImages']);
 
@@ -45,5 +57,57 @@ describe('Images empty landing page', () => {
       .click();
 
     cy.url().should('endWith', '/images/create/disk');
+  });
+
+  /*
+   * - Confirms Images table not exist.
+   * - Confirms that "Create Image" button is disabled for restricted user.
+   * - Confirms that hovering "Create Image" button shows a Warning for restricted user.
+   */
+  it('checks restricted user has no access to create Image on Image landing page', () => {
+    // Assert that List of Images table not exist
+    cy.get('table[aria-label="List of Images"]').should('not.exist');
+
+    // object to create a mockProfile for non-restricted user
+    const mockProfile = profileFactory.build({
+      username: randomLabel(),
+      restricted: true,
+    });
+
+    // object to create a mockUser for non-restricted user
+    const mockUser = accountUserFactory.build({
+      username: mockProfile.username,
+      restricted: true,
+      user_type: 'default',
+    });
+
+    // object to create a mockGrants for non-restricted user
+    const mockGrants = grantsFactory.build({
+      global: {
+        add_images: false,
+      },
+    });
+
+    mockGetProfile(mockProfile);
+    mockGetProfileGrants(mockGrants);
+    mockGetUser(mockUser);
+
+    // Login and wait for application to load
+    cy.visitWithLogin('/images');
+    cy.wait('@getImages');
+    cy.url().should('endWith', '/images');
+
+    // confirms 'Create Image' button is disabled
+    ui.button
+      .findByTitle('Create Image')
+      .should('be.visible')
+      .and('be.disabled')
+      .trigger('mouseover');
+
+    ui.tooltip
+      .findByText(
+        "You don't have permissions to create Images. Please contact your account administrator to request the necessary permissions."
+      )
+      .should('be.visible');
   });
 });

--- a/packages/manager/cypress/e2e/core/images/images-empty-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/images-empty-landing-page.spec.ts
@@ -109,9 +109,9 @@ describe('Images empty landing page', () => {
         "You don't have permissions to create Images. Please contact your account administrator to request the necessary permissions."
       )
       .should('be.visible');
-  });
 
-  // checks for reference section on empty page
-  cy.findByText('Getting Started Guides').should('be.visible');
-  cy.findByText('Video Playlist').should('be.visible');
+    // checks for reference section on empty page
+    cy.findByText('Getting Started Guides').should('be.visible');
+    cy.findByText('Video Playlist').should('be.visible');
+  });
 });


### PR DESCRIPTION
## Description 📝

Added cypress test for restricted user Image Empty landing page

## Changes  🔄

Added below cypress tests under in spec file - `cypress/e2e/core/images/images-empty-landing-page.spec.ts`

- checks restricted user has no access to create Image on Image Empty landing page

## How to test 🧪

`yarn cy:run -s cypress/e2e/core/images/images-empty-landing-page.spec.ts`

### Verification steps

When test executed using this command `yarn cy:run -s cypress/e2e/core/images/images-empty-landing-page.spec.ts` all tests should pass successfully.

![Tests](https://github.com/user-attachments/assets/b9b40683-6bdc-4568-816b-45c31f5d3022)

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support