### PR TITLE
change: [UIE-8253] - DBaaS GA: UI update, bug fix

### DIFF
--- a/packages/manager/.changeset/pr-11282-changed-1732019056361.md
+++ b/packages/manager/.changeset/pr-11282-changed-1732019056361.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+DBaaS: Updated button styles in Settings Tab, improved UI for Maintenance and Summary tabs, added 'Database name' in Connection Details, fix text in Version Upgrade popup, disabled actions for suspended/suspending clusters ([#11282](https://github.com/linode/manager/pull/11282))

--- a/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
@@ -179,7 +179,7 @@ export const AccessControls = (props: Props) => {
           <div className={classes.sectionText}>{description ?? null}</div>
         </div>
         <Button
-          buttonType="primary"
+          buttonType="outlined"
           className={classes.addAccessControlBtn}
           data-testid="button-access-control"
           disabled={disabled}

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.tsx
@@ -1,4 +1,4 @@
-import { Divider, Paper } from '@linode/ui';
+import { Divider, Paper, Stack } from '@linode/ui';
 import * as React from 'react';
 
 import { Typography } from 'src/components/Typography';
@@ -111,8 +111,11 @@ export const DatabaseSettings: React.FC<Props> = (props) => {
   return (
     <>
       <Paper>
-        {isDatabasesV2GA && isDefaultDB && (
-          <>
+        <Stack
+          divider={<Divider spacingBottom={0} spacingTop={0} />}
+          spacing={3}
+        >
+          {isDatabasesV2GA && isDefaultDB && (
             <DatabaseSettingsMenuItem
               buttonText={'Suspend Cluster'}
               descriptiveText={suspendClusterCopy}
@@ -120,33 +123,27 @@ export const DatabaseSettings: React.FC<Props> = (props) => {
               onClick={onSuspendCluster}
               sectionTitle={'Suspend Cluster'}
             />
-            <Divider spacingBottom={22} spacingTop={28} />
-          </>
-        )}
-        <AccessControls
-          database={database}
-          description={accessControlCopy}
-          disabled={disabled}
-        />
-        <Divider spacingBottom={22} spacingTop={28} />
-        <DatabaseSettingsMenuItem
-          buttonText="Reset Root Password"
-          descriptiveText={resetRootPasswordCopy}
-          disabled={disabled}
-          onClick={onResetRootPassword}
-          sectionTitle="Reset the Root Password"
-        />
-        <Divider spacingBottom={22} spacingTop={28} />
-        <DatabaseSettingsMenuItem
-          buttonText="Delete Cluster"
-          descriptiveText={deleteClusterCopy}
-          disabled={Boolean(profile?.restricted)}
-          onClick={onDeleteCluster}
-          sectionTitle="Delete the Cluster"
-        />
-        {isDatabasesV2GA && isDefaultDB && (
-          <>
-            <Divider spacingBottom={22} spacingTop={28} />
+          )}
+          <AccessControls
+            database={database}
+            description={accessControlCopy}
+            disabled={disabled}
+          />
+          <DatabaseSettingsMenuItem
+            buttonText="Reset Root Password"
+            descriptiveText={resetRootPasswordCopy}
+            disabled={disabled}
+            onClick={onResetRootPassword}
+            sectionTitle="Reset the Root Password"
+          />
+          <DatabaseSettingsMenuItem
+            buttonText="Delete Cluster"
+            descriptiveText={deleteClusterCopy}
+            disabled={Boolean(profile?.restricted)}
+            onClick={onDeleteCluster}
+            sectionTitle="Delete the Cluster"
+          />
+          {isDatabasesV2GA && isDefaultDB && (
             <DatabaseSettingsMaintenance
               databaseEngine={database.engine}
               databasePendingUpdates={database.updates.pending}
@@ -154,14 +151,13 @@ export const DatabaseSettings: React.FC<Props> = (props) => {
               onReviewUpdates={onReviewUpdates}
               onUpgradeVersion={onUpgradeVersion}
             />
-          </>
-        )}
-        <Divider spacingBottom={22} spacingTop={28} />
-        <MaintenanceWindow
-          database={database}
-          disabled={disabled}
-          timezone={profile?.timezone}
-        />
+          )}
+          <MaintenanceWindow
+            database={database}
+            disabled={disabled}
+            timezone={profile?.timezone}
+          />
+        </Stack>
       </Paper>
       <DatabaseSettingsDeleteClusterDialog
         databaseEngine={database.engine}

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsMaintenance.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsMaintenance.tsx
@@ -35,7 +35,7 @@ export const DatabaseSettingsMaintenance = (props: Props) => {
 
   return (
     <Grid container data-qa-settings-section="Maintenance">
-      <Grid item xs={4}>
+      <Grid item xs={6}>
         <StyledTypography variant="h3">Maintenance</StyledTypography>
         <BoldTypography>Version</BoldTypography>
         <StyledTypography>{engineVersion}</StyledTypography>
@@ -47,14 +47,14 @@ export const DatabaseSettingsMaintenance = (props: Props) => {
           Upgrade Version
         </StyledLinkButton>
       </Grid>
-      <Grid item xs={4}>
-        {/*
+      {/*
         TODO Uncomment and provide value when the EOL is returned by the API.
         Currently, it is not supported, however they are working on returning it since it has value to the end user
-        <StyledTypography variant="h3">End of life</StyledTypography>
-        */}
-      </Grid>
-      <Grid item xs={4}>
+        <Grid item xs={4}>
+          <StyledTypography variant="h3">End of life</StyledTypography>
+        </Grid>
+      */}
+      <Grid item xs={6}>
         <StyledTypography variant="h3">Maintenance updates</StyledTypography>
         {hasUpdates ? (
           <BoldTypography>

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsMenuItem.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsMenuItem.tsx
@@ -68,7 +68,7 @@ export const DatabaseSettingsMenuItem = (props: Props) => {
         </Typography>
       </div>
       <Button
-        buttonType="primary"
+        buttonType="outlined"
         className={classes.sectionButton}
         data-qa-settings-button={buttonText}
         disabled={disabled}

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsUpgradeVersionDialog.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsUpgradeVersionDialog.tsx
@@ -119,9 +119,9 @@ export const DatabaseSettingsUpgradeVersionDialog = (props: Props) => {
         Current Version: v{databaseVersion}
       </Typography>
       <Typography>
-        Please select the new MySQL version. Once you select the new version we
+        {`Please select the new ${DATABASE_ENGINE_MAP[databaseEngine]} version. Once you select the new version we
         will check it for compatibility with your current version. If it is
-        compatible you can proceed with the upgrade.
+        compatible you can proceed with the upgrade.`}
       </Typography>
 
       <FormControl sx={{ mb: theme.spacing(2) }}>

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.tsx
@@ -72,26 +72,26 @@ export const DatabaseSummaryClusterConfiguration = (props: Props) => {
       <Typography className={classes.header} variant="h3">
         Cluster Configuration
       </Typography>
-      <StyledGridContainer container md={10} spacing={0}>
+      <StyledGridContainer container md={11} spacing={0}>
         <Grid lg={1} md={2} xs={4}>
           <StyledLabelTypography>Status</StyledLabelTypography>
         </Grid>
-        <StyledValueGrid lg={1.5} md={4} xs={8}>
+        <StyledValueGrid lg={2} md={4} xs={8}>
           <DatabaseStatusDisplay database={database} events={events} />
         </StyledValueGrid>
-        <Grid lg={1} md={2} xs={4}>
+        <Grid lg={0.9} md={2} xs={4}>
           <StyledLabelTypography>Plan</StyledLabelTypography>
         </Grid>
-        <StyledValueGrid lg={2.5} md={4} xs={8}>
+        <StyledValueGrid lg={2.2} md={4} xs={8}>
           {formatStorageUnits(type.label)}
         </StyledValueGrid>
         <Grid lg={1} md={2} xs={4}>
           <StyledLabelTypography>Nodes</StyledLabelTypography>
         </Grid>
-        <StyledValueGrid lg={2} md={4} xs={8}>
+        <StyledValueGrid lg={1.7} md={4} xs={8}>
           {configuration}
         </StyledValueGrid>
-        <Grid lg={1.5} md={2} xs={4}>
+        <Grid lg={1.7} md={2} xs={4}>
           <StyledLabelTypography>CPUs</StyledLabelTypography>
         </Grid>
         <StyledValueGrid lg={1.5} md={4} xs={8}>
@@ -100,7 +100,7 @@ export const DatabaseSummaryClusterConfiguration = (props: Props) => {
         <Grid lg={1} md={2} xs={4}>
           <StyledLabelTypography>Engine</StyledLabelTypography>
         </Grid>
-        <StyledValueGrid lg={1.5} md={4} xs={8}>
+        <StyledValueGrid lg={2} md={4} xs={8}>
           <DatabaseEngineVersion
             databaseEngine={database.engine}
             databaseID={database.id}
@@ -109,19 +109,19 @@ export const DatabaseSummaryClusterConfiguration = (props: Props) => {
             databaseVersion={database.version}
           />
         </StyledValueGrid>
-        <Grid lg={1} md={2} xs={4}>
+        <Grid lg={0.9} md={2} xs={4}>
           <StyledLabelTypography>Region</StyledLabelTypography>
         </Grid>
-        <StyledValueGrid lg={2.5} md={4} xs={8}>
+        <StyledValueGrid lg={2.2} md={4} xs={8}>
           {region?.label ?? database.region}
         </StyledValueGrid>
         <Grid lg={1} md={2} xs={4}>
           <StyledLabelTypography>RAM</StyledLabelTypography>
         </Grid>
-        <StyledValueGrid lg={2} md={4} xs={8}>
+        <StyledValueGrid lg={1.7} md={4} xs={8}>
           {type.memory / 1024} GB
         </StyledValueGrid>
-        <Grid lg={1.5} md={2} xs={4}>
+        <Grid lg={1.7} md={2} xs={4}>
           <StyledLabelTypography>
             {database.total_disk_size_gb ? 'Total Disk Size' : 'Storage'}
           </StyledLabelTypography>

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -223,6 +223,12 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
           )}
         </StyledValueGrid>
         <Grid md={4} xs={3}>
+          <StyledLabelTypography>Database name</StyledLabelTypography>
+        </Grid>
+        <StyledValueGrid md={8} xs={9}>
+          defaultdb
+        </StyledValueGrid>
+        <Grid md={4} xs={3}>
           <StyledLabelTypography>Host</StyledLabelTypography>
         </Grid>
         <StyledValueGrid md={8} xs={9}>

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseActionMenu.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseActionMenu.tsx
@@ -1,21 +1,22 @@
+import { enqueueSnackbar } from 'notistack';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
+import { useResumeDatabaseMutation } from 'src/queries/databases/databases';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+
+import { useIsDatabasesEnabled } from '../utilities';
 
 import type { DatabaseStatus, Engine } from '@linode/api-v4';
 import type { Action } from 'src/components/ActionMenu/ActionMenu';
-import { useIsDatabasesEnabled } from '../utilities';
-import { useResumeDatabaseMutation } from 'src/queries/databases/databases';
-import { enqueueSnackbar } from 'notistack';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 interface Props {
   databaseEngine: Engine;
   databaseId: number;
   databaseLabel: string;
-  handlers: ActionHandlers;
   databaseStatus: DatabaseStatus;
+  handlers: ActionHandlers;
 }
 
 export interface ActionHandlers {
@@ -30,8 +31,8 @@ export const DatabaseActionMenu = (props: Props) => {
     databaseEngine,
     databaseId,
     databaseLabel,
-    handlers,
     databaseStatus,
+    handlers,
   } = props;
 
   const { isDatabasesV2GA } = useIsDatabasesEnabled();
@@ -64,17 +65,17 @@ export const DatabaseActionMenu = (props: Props) => {
 
   const actions: Action[] = [
     {
-      disabled: isDatabaseNotRunning,
+      disabled: isDatabaseNotRunning || isDatabaseSuspended,
       onClick: handlers.handleManageAccessControls,
       title: 'Manage Access Controls',
     },
     {
-      disabled: isDatabaseNotRunning,
+      disabled: isDatabaseNotRunning || isDatabaseSuspended,
       onClick: handlers.handleResetPassword,
       title: 'Reset Root Password',
     },
     {
-      disabled: isDatabaseNotRunning,
+      disabled: isDatabaseNotRunning || isDatabaseSuspended,
       onClick: () => {
         history.push({
           pathname: `/databases/${databaseEngine}/${databaseId}/resize`,


### PR DESCRIPTION
## Description 📝

DBaaS GA: UI update, bug fix.

## Changes  🔄

- Database Settings: Changed the button style from primary to outlined for Suspend Cluster, Manage Access Controls, Reset Root Password, and Delete Cluster
- Database Settings > Maintenance: Updated UI
- Version Upgrade > Popup dialog: Updated the text to display the correct instance name
- Database Summary: Updated the UI to prevent text wrapping for the "Engine" value
- Database Summary > Connection Details: Added 'Database name' field
- Database Landing Page:  Disabled all features except resume and delete when database is either in suspended or in suspending (state)
- Database Settings refactoring

## Target release date 🗓️

12/10/24

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-11-19 at 1 03 49 PM](https://github.com/user-attachments/assets/3be61f66-47e2-4e9b-bb5e-4fe952b19aef) | ![Screenshot 2024-11-19 at 1 03 57 PM](https://github.com/user-attachments/assets/03f88e2a-eeb8-475f-b64b-cdafb7f844d4) |
| ![Screenshot 2024-11-19 at 1 04 33 PM](https://github.com/user-attachments/assets/eb04fa12-0f41-499b-aa51-ef5f03c2c14b) | ![Screenshot 2024-11-19 at 1 05 01 PM](https://github.com/user-attachments/assets/a6f55939-0618-49be-9cd0-57e87578fe35) |
| ![Screenshot 2024-11-19 at 1 05 26 PM](https://github.com/user-attachments/assets/316fd567-a489-4f83-a029-a9ca428a95ee) | ![Screenshot 2024-11-19 at 1 05 35 PM](https://github.com/user-attachments/assets/0b916429-fa82-4bbf-887d-d55348a21127) |
| ![Screenshot 2024-11-19 at 1 08 44 PM](https://github.com/user-attachments/assets/4c49a6a6-81ea-4985-813f-50feffeaf84f) | ![Screenshot 2024-11-19 at 1 08 55 PM](https://github.com/user-attachments/assets/32636adb-6743-4ba4-9ab1-d5258e875b6a) |

## How to test 🧪

### Prerequisites

### Verification steps

- Database Landing Page : choose the database cluster and click 'Suspend' in action menu. Verify that when the cluster is suspended, only the 'Resume' and 'Delete' actions are available for this cluster.
- Navigate to the Database Settings tab to see updated UI
- Navigate to the Database Summary tab to see updated UI and new field in Connection Details section
- Navigate to the Database Setting > Version Upgrade > Popup dialog: Confirm that the text displays the correct instance name.


## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
