### PR TITLE
refactor: [M3-8910] - Move `H1Header` to `at linode/ui` package

### DIFF
--- a/packages/manager/.changeset/pr-11283-removed-1732021380915.md
+++ b/packages/manager/.changeset/pr-11283-removed-1732021380915.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Removed
+---
+
+Move `H1Header` from `manager` to `ui` package ([#11283](https://github.com/linode/manager/pull/11283))

--- a/packages/manager/src/components/Breadcrumb/FinalCrumb.styles.tsx
+++ b/packages/manager/src/components/Breadcrumb/FinalCrumb.styles.tsx
@@ -1,7 +1,7 @@
+import { H1Header } from '@linode/ui';
 import { styled } from '@mui/material';
 
 import { EditableText } from 'src/components/EditableText/EditableText';
-import { H1Header } from 'src/components/H1Header/H1Header';
 
 export const StyledDiv = styled('div', { label: 'StyledDiv' })({
   display: 'flex',

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -1,12 +1,10 @@
-import { Button, ClickAwayListener } from '@linode/ui';
+import { Button, ClickAwayListener, H1Header } from '@linode/ui';
 import Check from '@mui/icons-material/Check';
 import Close from '@mui/icons-material/Close';
 import Edit from '@mui/icons-material/Edit';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { makeStyles } from 'tss-react/mui';
-
-import { H1Header } from 'src/components/H1Header/H1Header';
 
 import { TextField } from '../TextField';
 

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -1,9 +1,8 @@
-import { Button, fadeIn } from '@linode/ui';
+import { Button, H1Header, fadeIn } from '@linode/ui';
 import { styled, useTheme } from '@mui/material/styles';
 import * as React from 'react';
 
 import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
-import { H1Header } from 'src/components/H1Header/H1Header';
 import { Typography } from 'src/components/Typography';
 
 import { TransferDisplay } from '../TransferDisplay/TransferDisplay';

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Chip, Divider, TooltipIcon } from '@linode/ui';
+import { Box, Button, Chip, Divider, H1Header, TooltipIcon } from '@linode/ui';
 import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 import { Link, useHistory } from 'react-router-dom';
@@ -6,7 +6,6 @@ import { makeStyles } from 'tss-react/mui';
 
 import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
 import { DateTimeDisplay } from 'src/components/DateTimeDisplay';
-import { H1Header } from 'src/components/H1Header/H1Header';
 import { ScriptCode } from 'src/components/ScriptCode/ScriptCode';
 import { Typography } from 'src/components/Typography';
 import { useAccountManagement } from 'src/hooks/useAccountManagement';

--- a/packages/manager/src/features/CancelLanding/CancelLanding.tsx
+++ b/packages/manager/src/features/CancelLanding/CancelLanding.tsx
@@ -1,11 +1,10 @@
-import { Button } from '@linode/ui';
+import { Button, H1Header } from '@linode/ui';
 import { path } from 'ramda';
 import * as React from 'react';
 import { Redirect, useLocation } from 'react-router-dom';
 import { makeStyles } from 'tss-react/mui';
 
 import AkamaiLogo from 'src/assets/logo/akamai-logo.svg';
-import { H1Header } from 'src/components/H1Header/H1Header';
 import { Typography } from 'src/components/Typography';
 
 import type { Theme } from '@mui/material/styles';

--- a/packages/manager/src/features/Events/EventsLanding.styles.ts
+++ b/packages/manager/src/features/Events/EventsLanding.styles.ts
@@ -1,6 +1,6 @@
+import { H1Header } from '@linode/ui';
 import { styled } from '@mui/material/styles';
 
-import { H1Header } from 'src/components/H1Header/H1Header';
 import { TableCell } from 'src/components/TableCell';
 import { Typography } from 'src/components/Typography';
 

--- a/packages/manager/src/features/Help/Panels/SearchPanel.tsx
+++ b/packages/manager/src/features/Help/Panels/SearchPanel.tsx
@@ -1,8 +1,6 @@
-import { Paper } from '@linode/ui';
+import { H1Header, Paper } from '@linode/ui';
 import { styled } from '@mui/material/styles';
 import * as React from 'react';
-
-import { H1Header } from 'src/components/H1Header/H1Header';
 
 import AlgoliaSearchBar from './AlgoliaSearchBar';
 

--- a/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.test.tsx
+++ b/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.test.tsx
@@ -1,9 +1,9 @@
+import { H1Header } from '@linode/ui';
 import { screen } from '@testing-library/react';
 import { assocPath } from 'ramda';
 import * as React from 'react';
 
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
-import { H1Header } from 'src/components/H1Header/H1Header';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import SupportSearchLanding from './SupportSearchLanding';

--- a/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
+++ b/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
@@ -1,4 +1,4 @@
-import { Box, InputAdornment, Notice } from '@linode/ui';
+import { Box, H1Header, InputAdornment, Notice } from '@linode/ui';
 import Search from '@mui/icons-material/Search';
 import Grid from '@mui/material/Unstable_Grid2';
 import { createLazyRoute } from '@tanstack/react-router';
@@ -6,7 +6,6 @@ import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import { makeStyles } from 'tss-react/mui';
 
-import { H1Header } from 'src/components/H1Header/H1Header';
 import { TextField } from 'src/components/TextField';
 import { COMMUNITY_SEARCH_URL, DOCS_SEARCH_URL } from 'src/constants';
 import { getQueryParamFromQueryString } from 'src/utilities/queryParams';

--- a/packages/manager/src/features/Search/SearchLanding.styles.ts
+++ b/packages/manager/src/features/Search/SearchLanding.styles.ts
@@ -1,10 +1,9 @@
 import { keyframes } from '@emotion/react';
-import { Stack } from '@linode/ui';
+import { H1Header, Stack } from '@linode/ui';
 import { styled } from '@mui/material/styles';
 import Grid from '@mui/material/Unstable_Grid2';
 
 import Error from 'src/assets/icons/error.svg';
-import { H1Header } from 'src/components/H1Header/H1Header';
 
 export const StyledStack = styled(Stack, {
   label: 'StyledStack',

--- a/packages/ui/.changeset/pr-11283-added-1732021489065.md
+++ b/packages/ui/.changeset/pr-11283-added-1732021489065.md
@@ -1,0 +1,5 @@
+---
+"@linode/ui": Added
+---
+
+Move `H1Header` from `manager` to `ui` package ([#11283](https://github.com/linode/manager/pull/11283))

--- a/packages/ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 
 import { CheckboxIcon, CheckboxCheckedIcon } from '../../assets/icons';
 
-// @TODO: Import from 'ui' package once FormControlLabel is migrated.
+// @todo: modularization - Import from 'ui' package once FormControlLabel is migrated.
 import { FormControlLabel } from '@mui/material';
 
 import type { CheckboxProps } from '@mui/material/Checkbox';

--- a/packages/ui/src/components/H1Header/H1Header.tsx
+++ b/packages/ui/src/components/H1Header/H1Header.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 
-import { Typography } from 'src/components/Typography';
-
 import type { SxProps, Theme } from '@mui/material/styles';
+
+// @TODO: Import from 'ui' package once Typography is migrated.
+import { Typography } from '@mui/material';
 
 interface H1HeaderProps {
   className?: string;

--- a/packages/ui/src/components/H1Header/H1Header.tsx
+++ b/packages/ui/src/components/H1Header/H1Header.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import type { SxProps, Theme } from '@mui/material/styles';
 
-// @TODO: Import from 'ui' package once Typography is migrated.
+// @todo: modularization - Import from 'ui' package once Typography is migrated.
 import { Typography } from '@mui/material';
 
 interface H1HeaderProps {

--- a/packages/ui/src/components/H1Header/H1Header.tsx
+++ b/packages/ui/src/components/H1Header/H1Header.tsx
@@ -1,9 +1,8 @@
+// @todo: modularization - Import from 'ui' package once Typography is migrated.
+import { Typography } from '@mui/material';
 import * as React from 'react';
 
 import type { SxProps, Theme } from '@mui/material/styles';
-
-// @todo: modularization - Import from 'ui' package once Typography is migrated.
-import { Typography } from '@mui/material';
 
 interface H1HeaderProps {
   className?: string;

--- a/packages/ui/src/components/H1Header/index.ts
+++ b/packages/ui/src/components/H1Header/index.ts
@@ -1,0 +1,1 @@
+export * from './H1Header';

--- a/packages/ui/src/components/Notice/Notice.tsx
+++ b/packages/ui/src/components/Notice/Notice.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import { WarningIcon, AlertIcon as Error, CheckIcon } from '../../assets/icons';
 
+// @todo: modularization - Import from 'ui' package once Typography is migrated.
 import { Typography } from '@mui/material';
 
 import { useStyles } from './Notice.styles';

--- a/packages/ui/src/components/Radio/Radio.stories.tsx
+++ b/packages/ui/src/components/Radio/Radio.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-// @TODO: Import from 'ui' package once FormControlLabel is migrated.
+// @todo: modularization - Import from 'ui' package once FormControlLabel is migrated.
 import { FormControlLabel } from '@mui/material';
 
 import { Box } from '../Box';

--- a/packages/ui/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.stories.tsx
@@ -2,6 +2,8 @@ import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
 import { Tooltip } from './Tooltip';
+
+// @todo: modularization - Import from 'ui' package once Typography is migrated.
 import { Typography } from '@mui/material';
 
 const meta: Meta<typeof Tooltip> = {

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -8,6 +8,7 @@ export * from './ClickAwayListener';
 export * from './Divider';
 export * from './FormControl';
 export * from './FormHelperText';
+export * from './H1Header';
 export * from './IconButton';
 export * from './Input';
 export * from './InputAdornment';


### PR DESCRIPTION
## Description 📝
Moves the `H1Header` component to the `@linode/ui` package and updates existing imports.
- This PR needs to be merged before we move `EditableText` & `Breadcrumb` components

## Changes  🔄
- Move `H1Header` component to `@linode/ui` package
- Update existing imports

## Target release date 🗓️
N/A

## How to test 🧪
- Confirm all checks pass
- Confirm nothing on CM breaks
   - Ensure everything works as expected wherever `H1Header` is used

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules