### PR TITLE
fix: [M3-8929] - Unexpected gradient on Linode Detail with VPC interface

### DIFF
--- a/packages/manager/.changeset/pr-11289-fixed-1732045131625.md
+++ b/packages/manager/.changeset/pr-11289-fixed-1732045131625.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Unexpected gradient on Linode Detail with VPC interface ([#11289](https://github.com/linode/manager/pull/11289))

--- a/packages/manager/.changeset/pr-11289-fixed-1732045131625.md
+++ b/packages/manager/.changeset/pr-11289-fixed-1732045131625.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Unexpected gradient on Linode Detail with VPC interface ([#11289](https://github.com/linode/manager/pull/11289))

--- a/packages/manager/src/features/Linodes/LinodeEntityDetail.styles.ts
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetail.styles.ts
@@ -1,4 +1,4 @@
-// This component was built asuming an unmodified MUI <Table />
+// This component was built assuming an unmodified MUI <Table />
 import { Box } from '@linode/ui';
 import { styled } from '@mui/material/styles';
 import Table from '@mui/material/Table';
@@ -97,30 +97,29 @@ export const StyledIPv4Box = styled(Box, { label: 'StyledIPv4Box' })(
     '&:hover .copy-tooltip > svg, & .copy-tooltip:focus > svg': {
       opacity: 1,
     },
+    border: 0,
     display: 'flex',
+    marginLeft: theme.spacing(2),
     [theme.breakpoints.down('md')]: {
       margin: theme.spacing(0),
     },
-    marginLeft: theme.spacing(2),
-    border: 0,
   })
 );
 
 export const StyledIPv4Label = styled(Box, { label: 'StyledIPv4Label' })(
   ({ theme }) => ({
+    alignContent: 'center',
+    backgroundColor: theme.name === 'light' ? theme.color.grey10 : theme.bg.app,
     color: theme.textColors.textAccessTable,
     fontFamily: theme.font.bold,
-    backgroundColor: theme.name === 'light' ? theme.color.grey10 : theme.bg.app,
-    padding: '10px 24px 10px 10px',
-    alignContent: 'center',
+    padding: `${theme.spacing(1)} ${theme.spacing(3)} ${theme.spacing(
+      1
+    )} ${theme.spacing(1.5)}`,
   })
 );
 
 export const StyledIPv4Item = styled(Box, { label: 'StyledIPv4Item' })(
   ({ theme }) => ({
-    '& div': {
-      fontSize: 15,
-    },
     alignItems: 'center',
     backgroundColor: theme.tokens.interaction.Background.Secondary,
     display: 'flex',

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
@@ -22,16 +22,15 @@ import { EncryptedStatus } from '../Kubernetes/KubernetesClusterDetail/NodePools
 import {
   StyledBodyGrid,
   StyledColumnLabelGrid,
+  StyledCopyTooltip,
+  StyledIPv4Box,
+  StyledIPv4Item,
+  StyledIPv4Label,
   StyledLabelBox,
   StyledListItem,
-  StyledIPv4Label,
-  StyledIPv4Item,
   StyledSummaryGrid,
   StyledVPCBox,
-  StyledCopyTooltip,
-  StyledGradientDiv,
   sxLastListItem,
-  StyledIPv4Box,
 } from './LinodeEntityDetail.styles';
 import { ipv4TableID } from './LinodesDetail/LinodeNetworking/LinodeIPAddresses';
 import { lishLink, sshLink } from './LinodesDetail/utilities';
@@ -45,7 +44,6 @@ import type {
 } from '@linode/api-v4/lib/linodes/types';
 import type { Subnet } from '@linode/api-v4/lib/vpcs';
 import type { TypographyProps } from 'src/components/Typography';
-import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
 
 interface LinodeEntityDetailProps {
   id: number;
@@ -256,10 +254,10 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
               margin: 0,
               padding: '0 0 8px 0',
               [theme.breakpoints.down('md')]: {
+                alignItems: 'start',
                 display: 'flex',
                 flexDirection: 'column',
                 paddingLeft: '8px',
-                alignItems: 'start',
               },
             }}
             alignItems="center"
@@ -292,13 +290,10 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
                   VPC IPv4
                 </StyledIPv4Label>
                 <StyledIPv4Item component="span" data-testid="vpc-ipv4">
-                  <StyledGradientDiv>
-                    <CopyTooltip
-                      copyableText
-                      text={configInterfaceWithVPC.ipv4.vpc}
-                    />
-                  </StyledGradientDiv>
-                  <StyledCopyTooltip text={configInterfaceWithVPC.ipv4.vpc} />
+                  {configInterfaceWithVPC.ipv4.vpc}
+                  <Box sx={{ ml: 1, position: 'relative', top: 1 }}>
+                    <StyledCopyTooltip text={configInterfaceWithVPC.ipv4.vpc} />
+                  </Box>
                 </StyledIPv4Item>
               </StyledIPv4Box>
             )}

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
@@ -5,6 +5,7 @@ import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 import { HashLink } from 'react-router-hash-link';
 
+import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
 import {
   DISK_ENCRYPTION_NODE_POOL_GUIDANCE_COPY as UNENCRYPTED_LKE_LINODE_GUIDANCE_COPY,
   UNENCRYPTED_STANDARD_LINODE_GUIDANCE_COPY,
@@ -290,7 +291,10 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
                   VPC IPv4
                 </StyledIPv4Label>
                 <StyledIPv4Item component="span" data-testid="vpc-ipv4">
-                  {configInterfaceWithVPC.ipv4.vpc}
+                  <CopyTooltip
+                    copyableText
+                    text={configInterfaceWithVPC.ipv4.vpc}
+                  />
                   <Box sx={{ ml: 1, position: 'relative', top: 1 }}>
                     <StyledCopyTooltip text={configInterfaceWithVPC.ipv4.vpc} />
                   </Box>

--- a/packages/manager/src/features/components/PlansPanel/APLNotice.tsx
+++ b/packages/manager/src/features/components/PlansPanel/APLNotice.tsx
@@ -1,6 +1,5 @@
+import { Notice } from '@linode/ui';
 import * as React from 'react';
-
-import { Notice } from 'src/components/Notice/Notice';
 
 import { APL_NOTICE_COPY } from './constants';
 


### PR DESCRIPTION
## Description 📝

This PR fixes a wrong implementation of the Linode Detail VPC IP copy UI, introduced by https://github.com/linode/manager/pull/11172

It is not only a bad visual defect, but also prevents the ability to click on the action menu

## Changes  🔄
- remove `<StyledGradientDiv>`
- improve implementation of copy tooltip
- improve/cleanup styling

## Preview 📷
![Screenshot 2024-11-19 at 13 16 13](https://github.com/user-attachments/assets/bfdb5ae0-7d43-460a-a628-f1daed05758e)

---

![Screenshot 2024-11-19 at 14 37 30](https://github.com/user-attachments/assets/ec92e438-6b5e-4c4c-a9f1-795e94aa2ac1)


## How to test 🧪

### Prerequisites
- Have a Linode with a VPC interface

### Reproduction steps
- Navigate to the linode's detail
- see issue with gradient

### Verification steps
- Navigate to the linode's detail
- Confirm gradient fix
- Confirm copy tooltip behavior

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules


