### PR TITLE
change: [UIE-8268] dbaas summary add tooltip for ipv6 to read-only host for new db clusters

### DIFF
--- a/packages/manager/.changeset/pr-11291-changed-1732048644474.md
+++ b/packages/manager/.changeset/pr-11291-changed-1732048644474.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Tooltip for IPV6 should also be added to read-only host in dbaas summary ([#11291](https://github.com/linode/manager/pull/11291))

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -116,11 +116,11 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
   const readOnlyHost = () => {
     const defaultValue = isLegacy ? '-' : 'N/A';
     const value = readOnlyHostValue ? readOnlyHostValue : defaultValue;
-    const displayCopyTooltip = value !== '-' && value !== 'N/A';
+    const hasHost = value !== '-' && value !== 'N/A';
     return (
       <>
         {value}
-        {value && displayCopyTooltip && (
+        {value && hasHost && (
           <CopyTooltip className={classes.inlineCopyToolTip} text={value} />
         )}
         {isLegacy && (
@@ -128,6 +128,14 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
             status="help"
             sxTooltipIcon={sxTooltipIcon}
             text={privateHostCopy}
+          />
+        )}
+        {!isLegacy && hasHost && (
+          <TooltipIcon
+            componentsProps={hostTooltipComponentProps}
+            status="help"
+            sxTooltipIcon={sxTooltipIcon}
+            text={HOST_TOOLTIP_COPY}
           />
         )}
       </>


### PR DESCRIPTION
## Description 📝

Add tooltip for IPV6 to read-only host field on summary page for new db clusters. This tooltip will only appear if there is a host and it is not N/A.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Added tooltip for IPV6 to read-only host field on summary page for new db clusters.
- The tooltip will only appear if there is a host and it is not N/A.

## Target release date 🗓️

12/10/2024

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![readonly-before](https://github.com/user-attachments/assets/c0631d8a-1147-45b3-8efd-07dc31f4262f) | ![readonly-after-2](https://github.com/user-attachments/assets/874bb759-6336-4bff-953d-3b7e32f2f8b3) |

## How to test 🧪

### Prerequisites
- Have a new database so you can access it's summary page.
- The database must have a populated read-only host field, must not be N/A

### Verification steps

- Access the new database summary
- View that the populated read-only host field has a thumbnail with the ipv6 text

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
