### PR TITLE
docs: [M3-8932] - Add Form Validation Best Practices

### DIFF
--- a/docs/development-guide/15-composition.md
+++ b/docs/development-guide/15-composition.md
@@ -96,12 +96,12 @@ export const linodeCreateResolvers = {
 
 ```typescript
 export const getFormResolver = (
-  formType: string | undefined,
+  type: string | undefined,
   queryClient: QueryClient
 ): Resolver<FormValues, FormContext> => {
 
   // Get the appropriate schema based on form type
-  const schema = formResolvers[formType ?? 'basic'];
+  const schema = linodeCreateResolvers[type ?? 'Backups'];
 
   return async (values, context, options) => {
     // Validate against the schema
@@ -132,7 +132,7 @@ export const getFormResolver = (
 3. Usage/Implementation (see: [LinodeCreate/index](https://github.com/linode/manager/blob/develop/packages/manager/src/features/Linodes/LinodeCreate/index.tsx#L78))
 ```typescript
 const form = useForm({
-  resolver: getFormResolver(formType, queryClient),
+  resolver: getFormResolver(type, queryClient),
   defaultValues,
   context: { /* form context */ },
 });

--- a/packages/manager/.changeset/pr-11298-tech-stories-1732224052945.md
+++ b/packages/manager/.changeset/pr-11298-tech-stories-1732224052945.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Add Documentation for Form Validation Best Practices ([#11298](https://github.com/linode/manager/pull/11298))


### PR DESCRIPTION
## Description 📝

Currently, form validation implementations vary across the application. We need to establish a pattern for extending API validation schemas that maintains a clear separation between API contract validation and UI-specific validation requirements.

## Changes  🔄
Create documentation explaining:
- When to use simple schema extension vs. full resolver pattern
- How to extend API validation schemas
- Best practices for async validation using QueryClient
- Examples of common validation patterns
- Establish pattern for simple validation extensions

## Target release date 🗓️
12/10