### PR TITLE
fix: Broken `TooltipIcon` import

### DIFF
--- a/packages/manager/src/features/Images/ImagesLanding/ImageStatus.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImageStatus.tsx
@@ -1,8 +1,7 @@
-import { Stack } from '@linode/ui';
+import { Stack, TooltipIcon } from '@linode/ui';
 import React from 'react';
 
 import { StatusIcon } from 'src/components/StatusIcon/StatusIcon';
-import { TooltipIcon } from 'src/components/TooltipIcon';
 import { capitalizeAllWords } from 'src/utilities/capitalize';
 
 import { imageStatusIconMap } from './ImageRegions/ImageRegionRow';


### PR DESCRIPTION
## Description 📝

- Updates `TooltipIcon` to import from `@linode/ui`
- I caused this by merging  https://github.com/linode/manager/pull/11257 - it was a bit outdated 🤦‍♂️ 