### PR TITLE
change: [UIE-8228] - DBaaS Resize GA: Enable Downsizing, update node presentation

### DIFF
--- a/packages/manager/.changeset/pr-11311-changed-1732288180106.md
+++ b/packages/manager/.changeset/pr-11311-changed-1732288180106.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+DBaaS Resize GA: Enable Downsizing (horizontal and vertical), enable 'Shared' tab, updated node presentation ([#11311](https://github.com/linode/manager/pull/11311))

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseNodeSelector.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseNodeSelector.tsx
@@ -14,7 +14,6 @@ import type {
   DatabasePriceObject,
   Engine,
 } from '@linode/api-v4/lib/databases/types';
-import type { Theme } from '@mui/material';
 import type {
   PlanSelectionType,
   PlanSelectionWithDatabaseType,
@@ -36,9 +35,6 @@ interface Props {
   selectedPlan: PlanSelectionWithDatabaseType | undefined;
   selectedTab: number;
 }
-const typographyBaseStyles = (theme: Theme) => ({
-  color: theme.palette.mode === 'dark' ? theme.color.grey6 : theme.color.grey1,
-});
 
 export const DatabaseNodeSelector = (props: Props) => {
   const {
@@ -87,17 +83,10 @@ export const DatabaseNodeSelector = (props: Props) => {
       />
     );
 
-    const isDisabled = (nodeSize: ClusterSize) => {
-      return currentClusterSize && nodeSize < currentClusterSize;
-    };
-
     const options = [
       {
         label: (
-          <Typography
-            component="div"
-            sx={isDisabled(1) ? typographyBaseStyles : undefined}
-          >
+          <Typography component="div">
             <span>1 Node {` `}</span>
             {currentClusterSize === 1 && currentChip}
             <br />
@@ -115,10 +104,7 @@ export const DatabaseNodeSelector = (props: Props) => {
     if (hasDedicated && selectedTab === 0 && isDatabasesV2Enabled) {
       options.push({
         label: (
-          <Typography
-            component="div"
-            sx={isDisabled(2) ? typographyBaseStyles : undefined}
-          >
+          <Typography component="div">
             <span>2 Nodes - High Availability</span>
             {currentClusterSize === 2 && currentChip}
             <br />
@@ -135,10 +121,7 @@ export const DatabaseNodeSelector = (props: Props) => {
 
     options.push({
       label: (
-        <Typography
-          component="div"
-          sx={isDisabled(3) ? typographyBaseStyles : undefined}
-        >
+        <Typography component="div">
           <span>3 Nodes - High Availability (recommended)</span>
           {currentClusterSize === 3 && currentChip}
           <br />
@@ -186,9 +169,6 @@ export const DatabaseNodeSelector = (props: Props) => {
         >
           {nodeOptions.map((nodeOption) => (
             <FormControlLabel
-              disabled={
-                currentClusterSize && nodeOption.value < currentClusterSize
-              }
               control={<Radio />}
               data-qa-radio={nodeOption.label}
               data-testid={`database-node-${nodeOption.value}`}

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.test.tsx
@@ -18,7 +18,11 @@ describe('Database Backups', () => {
       platform: 'rdbms-legacy',
     });
 
-    const backups = databaseBackupFactory.buildList(7);
+    const backups = [
+      databaseBackupFactory.build({ created: '2022-01-01T00:01:01' }),
+      databaseBackupFactory.build({ created: '2022-02-01T00:01:01' }),
+      databaseBackupFactory.build({ created: '2022-03-01T00:01:01' }),
+    ];
 
     server.use(
       http.get('*/profile', () => {
@@ -38,7 +42,7 @@ describe('Database Backups', () => {
       const expectedDate = formatDate(backup.created, { timezone: 'utc' });
 
       // eslint-disable-next-line no-await-in-loop
-      const backupItem = await findByText(expectedDate);
+      const backupItem = await findByText(expectedDate, {}, { timeout: 5_000 });
 
       expect(backupItem).toBeVisible();
     }

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.test.tsx
@@ -18,11 +18,7 @@ describe('Database Backups', () => {
       platform: 'rdbms-legacy',
     });
 
-    const backups = [
-      databaseBackupFactory.build({ created: '2022-01-01T00:01:01' }),
-      databaseBackupFactory.build({ created: '2022-02-01T00:01:01' }),
-      databaseBackupFactory.build({ created: '2022-03-01T00:01:01' }),
-    ];
+    const backups = databaseBackupFactory.buildList(7);
 
     server.use(
       http.get('*/profile', () => {
@@ -42,7 +38,7 @@ describe('Database Backups', () => {
       const expectedDate = formatDate(backup.created, { timezone: 'utc' });
 
       // eslint-disable-next-line no-await-in-loop
-      const backupItem = await findByText(expectedDate, {}, { timeout: 5_000 });
+      const backupItem = await findByText(expectedDate);
 
       expect(backupItem).toBeVisible();
     }

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.test.tsx
@@ -270,17 +270,6 @@ describe('database resize', () => {
       expect(selectedNodeRadioButton).toBeChecked();
     });
 
-    it('should disable visible lower node selections', async () => {
-      const { getByTestId } = renderWithTheme(
-        <DatabaseResize database={mockDatabase} />,
-        { flags }
-      );
-      await waitForElementToBeRemoved(getByTestId(loadingTestId));
-      const selectedNodeRadioButton = getByTestId('database-node-1').children[0]
-        .children[0] as HTMLInputElement;
-      expect(selectedNodeRadioButton).toBeDisabled();
-    });
-
     it('should set price, enable resize button, and update resize summary when a new number of nodes is selected', async () => {
       const mockDatabase = databaseFactory.build({
         cluster_size: 1,
@@ -395,52 +384,20 @@ describe('database resize', () => {
         },
       };
 
-      const { findByTestId } = renderWithTheme(
+      const { getAllByRole, getByTestId } = renderWithTheme(
         <DatabaseResize database={mockDatabase} />,
-        { flags }
-      );
-
-      expect(await findByTestId('database-nodes')).toBeDefined();
-      expect(await findByTestId('database-node-1')).toBeDefined();
-      expect(await findByTestId('database-node-2')).toBeDefined();
-      expect(await findByTestId('database-node-3')).toBeDefined();
-    });
-
-    it('should disable lower node selections', async () => {
-      const mockDatabase = databaseFactory.build({
-        cluster_size: 3,
-        platform: 'rdbms-default',
-        type: 'g6-dedicated-2',
-      });
-
-      const flags = {
-        dbaasV2: {
-          beta: false,
-          enabled: true,
-        },
-      };
-
-      // Mock route history so the Plan Selection table displays prices without requiring a region in the DB resize flow.
-      const history = createMemoryHistory();
-      history.push(`databases/${database.engine}/${database.id}/resize`);
-
-      const { getByTestId } = renderWithTheme(
-        <Router history={history}>
-          <DatabaseResize database={mockDatabase} />
-        </Router>,
         { flags }
       );
       expect(getByTestId(loadingTestId)).toBeInTheDocument();
       await waitForElementToBeRemoved(getByTestId(loadingTestId));
-      expect(
-        getByTestId('database-node-1').children[0].children[0]
-      ).toBeDisabled();
-      expect(
-        getByTestId('database-node-2').children[0].children[0]
-      ).toBeDisabled();
-      expect(
-        getByTestId('database-node-3').children[0].children[0]
-      ).toBeEnabled();
+
+      const dedicatedTab = getAllByRole('tab')[0];
+      await userEvent.click(dedicatedTab);
+
+      expect(getByTestId('database-nodes')).toBeDefined();
+      expect(getByTestId('database-node-1')).toBeDefined();
+      expect(getByTestId('database-node-2')).toBeDefined();
+      expect(getByTestId('database-node-3')).toBeDefined();
     });
   });
 

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.test.tsx
@@ -384,14 +384,15 @@ describe('database resize', () => {
         },
       };
 
-      const { getAllByRole, getByTestId } = renderWithTheme(
+      const { getByRole, getByTestId } = renderWithTheme(
         <DatabaseResize database={mockDatabase} />,
         { flags }
       );
       expect(getByTestId(loadingTestId)).toBeInTheDocument();
       await waitForElementToBeRemoved(getByTestId(loadingTestId));
 
-      const dedicatedTab = getAllByRole('tab')[0];
+      const dedicatedTab = getByRole('tab', { name: 'Dedicated CPU' });
+
       await userEvent.click(dedicatedTab);
 
       expect(getByTestId('database-nodes')).toBeDefined();

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResizeCurrentConfiguration.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResizeCurrentConfiguration.tsx
@@ -57,8 +57,10 @@ export const DatabaseResizeCurrentConfiguration = ({ database }: Props) => {
 
   const configuration =
     database.cluster_size === 1
-      ? 'Primary'
-      : `Primary +${database.cluster_size - 1} replicas`;
+      ? 'Primary (1 Node)'
+      : database.cluster_size > 2
+      ? `Primary (+${database.cluster_size - 1} Nodes)`
+      : `Primary (+${database.cluster_size - 1} Node)`;
 
   const sxTooltipIcon = {
     marginLeft: 0.5,

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummary.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummary.test.tsx
@@ -11,8 +11,8 @@ import { DatabaseSummary } from './DatabaseSummary';
 import type { Database } from '@linode/api-v4';
 
 const CLUSTER_CONFIGURATION = 'Cluster Configuration';
-const THREE_NODE = 'Primary +2 replicas';
-const TWO_NODE = 'Primary +1 replicas';
+const THREE_NODE = 'Primary (+2 Nodes)';
+const TWO_NODE = 'Primary (+1 Node)';
 const VERSION = 'Version';
 
 const CONNECTION_DETAILS = 'Connection Details';

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.test.tsx
@@ -11,7 +11,7 @@ import type { Database, DatabaseStatus } from '@linode/api-v4/lib/databases';
 
 const STATUS_VALUE = 'Active';
 const PLAN_VALUE = 'New DBaaS - Dedicated 8 GB';
-const NODES_VALUE = 'Primary +1 replicas';
+const NODES_VALUE = 'Primary (+1 Node)';
 const REGION_ID = 'us-east';
 const REGION_LABEL = 'Newark, NJ';
 
@@ -150,7 +150,7 @@ describe('DatabaseSummaryClusterConfiguration', () => {
       expect(queryAllByText('Nanode 1 GB')).toHaveLength(1);
 
       expect(queryAllByText('Nodes')).toHaveLength(1);
-      expect(queryAllByText('Primary')).toHaveLength(1);
+      expect(queryAllByText('Primary (1 Node)')).toHaveLength(1);
 
       expect(queryAllByText('CPUs')).toHaveLength(1);
       expect(queryAllByText(1)).toHaveLength(1);

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.tsx
@@ -55,8 +55,10 @@ export const DatabaseSummaryClusterConfiguration = (props: Props) => {
 
   const configuration =
     database.cluster_size === 1
-      ? 'Primary'
-      : `Primary +${database.cluster_size - 1} replicas`;
+      ? 'Primary (1 Node)'
+      : database.cluster_size > 2
+      ? `Primary (+${database.cluster_size - 1} Nodes)`
+      : `Primary (+${database.cluster_size - 1} Node)`;
 
   const sxTooltipIcon = {
     marginLeft: '4px',

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/legacy/DatabaseSummaryClusterConfigurationLegacy.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/legacy/DatabaseSummaryClusterConfigurationLegacy.tsx
@@ -67,8 +67,10 @@ export const DatabaseSummaryClusterConfigurationLegacy = (props: Props) => {
 
   const configuration =
     database.cluster_size === 1
-      ? 'Primary'
-      : `Primary +${database.cluster_size - 1} replicas`;
+      ? 'Primary (1 Node)'
+      : database.cluster_size > 2
+      ? `Primary (+${database.cluster_size - 1} Nodes)`
+      : `Primary (+${database.cluster_size - 1} Node)`;
 
   const sxTooltipIcon = {
     marginLeft: '4px',

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -82,7 +82,7 @@ export const PlanSelection = (props: PlanSelectionProps) => {
   )}/mo ($${price?.hourly ?? UNKNOWN_PRICE}/hr)`;
 
   const rowIsDisabled =
-    isSamePlan ||
+    (!isDatabaseFlow && isSamePlan) ||
     planIsTooSmall ||
     planBelongsToDisabledClass ||
     planIsDisabled512Gb ||
@@ -125,7 +125,7 @@ export const PlanSelection = (props: PlanSelectionProps) => {
           onClick={() => (!rowIsDisabled ? onSelect(plan.id) : undefined)}
         >
           <StyledRadioCell>
-            {!isSamePlan && (
+            {(!isSamePlan || (isDatabaseFlow && isSamePlan)) && (
               <FormControlLabel
                 aria-label={`${plan.heading} ${
                   rowIsDisabled ? `- ${disabledPlanReasonCopy}` : ''


### PR DESCRIPTION
## Description 📝

DBaaS Resize GA: Enable Downsizing (horizontal and vertical) and enable 'Shared' tab for resizing 2N cluster. Updated node presentation.

## Changes  🔄

Database Resize: 
- Enable Downsizing (horizontal and vertical)
- Enable the 'Shared' tab for resizing 2N cluster
- Enable 'Current Plan' for selection

Updated node presentation in the 'Database Summary' and 'Database Resize' tabs.

## Target release date 🗓️

12/10/24

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-11-22 at 4 00 42 PM](https://github.com/user-attachments/assets/c6b34d3b-9819-4255-8787-d9d99db1cd45) | ![Screenshot 2024-11-22 at 4 01 06 PM](https://github.com/user-attachments/assets/bdc506c6-c23b-4390-9cc0-4055399c2a1e) |
| ![Screenshot 2024-11-22 at 4 05 31 PM](https://github.com/user-attachments/assets/5470ae5a-9d10-49d0-8f7a-1ac77c768480) | ![Screenshot 2024-11-22 at 4 05 40 PM](https://github.com/user-attachments/assets/64cac79b-caec-48a0-bf92-9b76cc0b164f) |
| ![Screenshot 2024-11-22 at 4 06 04 PM](https://github.com/user-attachments/assets/ce1b174b-56be-4c25-9096-0debcab3a18e) | ![Screenshot 2024-11-22 at 4 06 13 PM](https://github.com/user-attachments/assets/e2a3cb5b-3c00-4086-ad5e-6f7572432198) |

## How to test 🧪

### Prerequisites

- dbaasV2 feature flag set to GA
- choose a new database

### Verification steps

- Select the new database.
- Navigate to the Database Resize tab.
- Database Cluster is available for downsizing (both horizontal and vertical)
- Shared Tab is enabled for 2 Nodes Cluster 
- Database Resize > Current configurations: the Nodes presentation is updated
- Summary tab: the Nodes presentation is updated


## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
