### PR TITLE
change: [M3-8874] - Adjust network_in values for distributed plans

### DIFF
--- a/packages/manager/.changeset/pr-11313-changed-1732296370575.md
+++ b/packages/manager/.changeset/pr-11313-changed-1732296370575.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Adjust network_in values for distributed plans ([#11313](https://github.com/linode/manager/pull/11313))

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.test.tsx
@@ -123,6 +123,28 @@ describe('PlanSelection (table, desktop)', () => {
     );
   });
 
+  it('shows the same network_in and network_out values for distributed regions', () => {
+    const { container } = renderWithTheme(
+      wrapWithTableBody(
+        <PlanSelection
+          {...defaultProps}
+          plan={{
+            ...mockPlan,
+            class: 'dedicated',
+            id: 'g6-dedicated-edge-2',
+            // eslint-disable-next-line camelcase
+            network_out: 4000,
+          }}
+          selectedRegionId={'us-den-1'}
+          showNetwork
+        />
+      )
+    );
+    expect(container.querySelector('[data-qa-network]')).toHaveTextContent(
+      '4 Gbps / 4 Gbps'
+    );
+  });
+
   it('should not display an error message for $0 regions', () => {
     const propsWithRegionZeroPrice = {
       ...defaultProps,

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -109,6 +109,11 @@ export const PlanSelection = (props: PlanSelectionProps) => {
       planHasLimitedAvailability ||
       planIsTooSmall);
 
+  const isDistributedPlan =
+    plan.id.includes('dedicated-edge') || plan.id.includes('nanode-edge');
+
+  const networkOutGbps = plan.network_out && plan.network_out / 1000;
+
   return (
     <React.Fragment key={`tabbed-panel-${idx}`}>
       {/* Displays Table Row for larger screens */}
@@ -205,9 +210,9 @@ export const PlanSelection = (props: PlanSelectionProps) => {
             <TableCell center data-qa-network noWrap>
               {plan.network_out ? (
                 <>
-                  {LINODE_NETWORK_IN} Gbps{' '}
-                  <span style={{ color: '#9DA4A6' }}>/</span>{' '}
-                  {plan.network_out / 1000} Gbps
+                  {isDistributedPlan ? networkOutGbps : LINODE_NETWORK_IN} Gbps{' '}
+                  <span style={{ color: '#9DA4A6' }}>/</span> {networkOutGbps}{' '}
+                  Gbps
                 </>
               ) : (
                 ''


### PR DESCRIPTION
## Description 📝
Matt Hacket requested us to adjust the `Network In` values to match `Network out` for distributed regions so we are in parity with https://techdocs.akamai.com/cloud-computing/docs/plans-distributed

## Changes  🔄
- Adjust `Network In` value to match `Network Out` for distributed regions in the Linode Plan table

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/a5be8a3c-19bf-44e2-be55-edf6a47ffab1) | ![image](https://github.com/user-attachments/assets/ca538ad5-aa25-41d0-be3e-191ac325d26a) | 

## How to test 🧪

### Prerequisites
(How to setup test environment)
- Ensure your account has the `new-dc-testing`, `new-dc-testing-gecko`, `edge_testing` and `edge_compute` customer tags

### Verification steps

(How to verify changes)
- [ ] Go to the Linode Create flow and select a distributed region
- [ ] Confirm the Linode Plan table Network In / Out values are the same
- [ ] Core region Network In values should still be 40 Gbps

```
yarn test PlanSelection
```

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules