### PR TITLE
upcoming: [DI-21842] - Fixed recharts issues in Cloudpulse

### DIFF
--- a/packages/manager/src/components/AreaChart/utils.ts
+++ b/packages/manager/src/components/AreaChart/utils.ts
@@ -57,6 +57,10 @@ export const generate12HourTicks = (
   const startTime = data[0].timestamp;
   const endTime = data[data.length - 1].timestamp;
 
+  if (tickCount === 1) {
+    return [(startTime + endTime) / 2];
+  }
+
   // Calculate duration in hours
   const duration = DateTime.fromMillis(endTime, { zone: timezone }).diff(
     DateTime.fromMillis(startTime, { zone: timezone }),

--- a/packages/manager/src/components/LineGraph/MetricsDisplay.tsx
+++ b/packages/manager/src/components/LineGraph/MetricsDisplay.tsx
@@ -116,10 +116,8 @@ export const MetricsDisplay = ({
       '.MuiTable-root': {
         border: 0,
       },
+      height: legendHeight,
       overflowY: 'auto',
-      [theme.breakpoints.up(1100)]: {
-        height: legendHeight,
-      },
     })}
     aria-label="Stats and metrics"
     stickyHeader

--- a/packages/manager/src/features/CloudPulse/Widget/components/CloudPulseLineGraph.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/components/CloudPulseLineGraph.tsx
@@ -38,9 +38,11 @@ export const CloudPulseLineGraph = React.memo((props: CloudPulseLineGraph) => {
       ) : (
         <AreaChart
           {...rest}
+          xAxisTickCount={
+            isSmallScreen ? undefined : Math.min(rest.data.length, 7)
+          }
           fillOpacity={0.5}
           legendHeight={theme.spacing(16)}
-          xAxisTickCount={isSmallScreen ? undefined : 7}
         />
       )}
       {rest.data.length === 0 && (

--- a/packages/manager/src/features/CloudPulse/Widget/components/CloudPulseLineGraph.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/components/CloudPulseLineGraph.tsx
@@ -42,7 +42,7 @@ export const CloudPulseLineGraph = React.memo((props: CloudPulseLineGraph) => {
             isSmallScreen ? undefined : Math.min(rest.data.length, 7)
           }
           fillOpacity={0.5}
-          legendHeight={theme.spacing(16)}
+          legendHeight={theme.spacing(18)}
         />
       )}
       {rest.data.length === 0 && (


### PR DESCRIPTION
## Description 📝

Fixed some recharts related issues found post migration from Chart JS to Recharts in Cloudpulse

## Changes  🔄

List any change(s) relevant to the reviewer.

1. Updated ticks generation logic for 1 tick point
2. Increased legend height in CloudPulseLineGraph
3. Removed breakpoint condition for LegendsHeight in MetricsDisplay

## Target release date 🗓️
10 Dec 2024

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
|![Screenshot 2024-11-25 at 3 50 23 PM](https://github.com/user-attachments/assets/3e440407-fbd1-4f70-bc2d-5e60977accf1)|![Screenshot 2024-11-25 at 3 51 05 PM](https://github.com/user-attachments/assets/37815916-277c-4889-a006-c895f7c85ef3)|
|![Screenshot 2024-11-25 at 3 47 59 PM](https://github.com/user-attachments/assets/472851b2-65a2-41bb-8b47-9f8b5a133710)|![Screenshot 2024-11-25 at 3 47 03 PM](https://github.com/user-attachments/assets/e6d1f403-8b7e-4f21-95fb-99dec9879a94)|
| <video src="https://github.com/user-attachments/assets/031ac803-d78d-4c79-a158-bfb1f6d88ad6"/> | <video src="https://github.com/user-attachments/assets/8af7317e-c34a-44f8-8bb7-da53919e7bd1"/> |


## How to test 🧪
Go to monitor tab & switch to mock user
1. Reduce the page size to mobile screen & you'll see legend rows are still scrollable ( when legends rows are more than 2).
2. Generate one data point by modifying the mock response of `monitor/services/:serviceType/metrics` and you'll notice with full & half size widget, you'll see only one tick while in the current alpha version it is generating 2 ticks while moving from half size to full size widget

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules
