### PR TITLE
upcoming: [DI-21118] - Monitor scope as part of PAT token

### DIFF
--- a/packages/manager/.changeset/pr-11318-upcoming-features-1732533180876.md
+++ b/packages/manager/.changeset/pr-11318-upcoming-features-1732533180876.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+As part of creating the PAT token, Enabled a new scope - 'Monitor' within Cloud Manager UI ([#11318](https://github.com/linode/manager/pull/11318))

--- a/packages/manager/src/features/Profile/APITokens/ViewAPITokenDrawer.test.tsx
+++ b/packages/manager/src/features/Profile/APITokens/ViewAPITokenDrawer.test.tsx
@@ -111,14 +111,13 @@ describe('View API Token Drawer', () => {
         {...props}
         token={appTokenFactory.build({
           scopes:
-            'aclp:read_write databases:read_only domains:read_write child_account:read_write events:read_write firewall:read_write images:read_write ips:read_write linodes:read_only lke:read_only longview:read_write nodebalancers:read_write object_storage:read_only stackscripts:read_write volumes:read_only vpc:read_write',
+            'databases:read_only domains:read_write child_account:read_write events:read_write firewall:read_write images:read_write ips:read_write linodes:read_only lke:read_only longview:read_write monitor:read_only nodebalancers:read_write object_storage:read_only stackscripts:read_write volumes:read_only vpc:read_write',
         })}
       />
     );
 
     const expectedScopeLevels = {
       account: 0,
-      aclp: 2,
       child_account: 2,
       databases: 1,
       domains: 2,
@@ -129,6 +128,7 @@ describe('View API Token Drawer', () => {
       linodes: 1,
       lke: 1,
       longview: 2,
+      monitor: 1,
       nodebalancers: 2,
       object_storage: 1,
       stackscripts: 2,

--- a/packages/manager/src/features/Profile/APITokens/ViewAPITokenDrawer.test.tsx
+++ b/packages/manager/src/features/Profile/APITokens/ViewAPITokenDrawer.test.tsx
@@ -111,13 +111,14 @@ describe('View API Token Drawer', () => {
         {...props}
         token={appTokenFactory.build({
           scopes:
-            'databases:read_only domains:read_write child_account:read_write events:read_write firewall:read_write images:read_write ips:read_write linodes:read_only lke:read_only longview:read_write nodebalancers:read_write object_storage:read_only stackscripts:read_write volumes:read_only vpc:read_write',
+            'aclp:read_write databases:read_only domains:read_write child_account:read_write events:read_write firewall:read_write images:read_write ips:read_write linodes:read_only lke:read_only longview:read_write nodebalancers:read_write object_storage:read_only stackscripts:read_write volumes:read_only vpc:read_write',
         })}
       />
     );
 
     const expectedScopeLevels = {
       account: 0,
+      aclp: 2,
       child_account: 2,
       databases: 1,
       domains: 2,

--- a/packages/manager/src/features/Profile/APITokens/utils.test.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.test.ts
@@ -315,7 +315,7 @@ describe('APIToken utils', () => {
         ];
         expect(allScopesAreTheSame(scopes)).toBe(2);
       });
-      it('should return null if all scopes are not same', () => {
+      it('should return null if all scopes are different', () => {
         const scopes: Permission[] = [
           ['account', 1],
           ['child_account', 0],

--- a/packages/manager/src/features/Profile/APITokens/utils.test.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.test.ts
@@ -28,7 +28,6 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('*');
       const expected = [
         ['account', 2],
-        ['aclp', 2],
         ['child_account', 2],
         ['databases', 2],
         ['domains', 2],
@@ -39,6 +38,7 @@ describe('APIToken utils', () => {
         ['linodes', 2],
         ['lke', 2],
         ['longview', 2],
+        ['monitor', 2],
         ['nodebalancers', 2],
         ['object_storage', 2],
         ['stackscripts', 2],
@@ -54,7 +54,6 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('');
       const expected = [
         ['account', 0],
-        ['aclp', 0],
         ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
@@ -65,6 +64,7 @@ describe('APIToken utils', () => {
         ['linodes', 0],
         ['lke', 0],
         ['longview', 0],
+        ['monitor', 0],
         ['nodebalancers', 0],
         ['object_storage', 0],
         ['stackscripts', 0],
@@ -81,7 +81,6 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:none');
       const expected = [
         ['account', 0],
-        ['aclp', 0],
         ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
@@ -92,6 +91,7 @@ describe('APIToken utils', () => {
         ['linodes', 0],
         ['lke', 0],
         ['longview', 0],
+        ['monitor', 0],
         ['nodebalancers', 0],
         ['object_storage', 0],
         ['stackscripts', 0],
@@ -108,7 +108,6 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:read_only');
       const expected = [
         ['account', 1],
-        ['aclp', 0],
         ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
@@ -119,6 +118,7 @@ describe('APIToken utils', () => {
         ['linodes', 0],
         ['lke', 0],
         ['longview', 0],
+        ['monitor', 0],
         ['nodebalancers', 0],
         ['object_storage', 0],
         ['stackscripts', 0],
@@ -135,7 +135,6 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:read_write');
       const expected = [
         ['account', 2],
-        ['aclp', 0],
         ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
@@ -146,6 +145,7 @@ describe('APIToken utils', () => {
         ['linodes', 0],
         ['lke', 0],
         ['longview', 0],
+        ['monitor', 0],
         ['nodebalancers', 0],
         ['object_storage', 0],
         ['stackscripts', 0],
@@ -164,7 +164,6 @@ describe('APIToken utils', () => {
       );
       const expected = [
         ['account', 0],
-        ['aclp', 0],
         ['child_account', 0],
         ['databases', 0],
         ['domains', 1],
@@ -175,6 +174,7 @@ describe('APIToken utils', () => {
         ['linodes', 0],
         ['lke', 0],
         ['longview', 2],
+        ['monitor', 0],
         ['nodebalancers', 0],
         ['object_storage', 0],
         ['stackscripts', 0],
@@ -195,7 +195,6 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:none,tokens:read_write');
       const expected = [
         ['account', 2],
-        ['aclp', 0],
         ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
@@ -206,6 +205,7 @@ describe('APIToken utils', () => {
         ['linodes', 0],
         ['lke', 0],
         ['longview', 0],
+        ['monitor', 0],
         ['nodebalancers', 0],
         ['object_storage', 0],
         ['stackscripts', 0],
@@ -226,7 +226,6 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:read_only,tokens:none');
       const expected = [
         ['account', 1],
-        ['aclp', 0],
         ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
@@ -237,6 +236,7 @@ describe('APIToken utils', () => {
         ['linodes', 0],
         ['lke', 0],
         ['longview', 0],
+        ['monitor', 0],
         ['nodebalancers', 0],
         ['object_storage', 0],
         ['stackscripts', 0],
@@ -253,7 +253,6 @@ describe('APIToken utils', () => {
       it('should return 0 if all scopes are 0', () => {
         const scopes: Permission[] = [
           ['account', 0],
-          ['aclp', 0],
           ['child_account', 0],
           ['databases', 0],
           ['domains', 0],
@@ -264,6 +263,7 @@ describe('APIToken utils', () => {
           ['linodes', 0],
           ['lke', 0],
           ['longview', 0],
+          ['monitor', 0],
           ['nodebalancers', 0],
           ['object_storage', 0],
           ['stackscripts', 0],
@@ -275,7 +275,6 @@ describe('APIToken utils', () => {
       it('should return 1 if all scopes are 1', () => {
         const scopes: Permission[] = [
           ['account', 1],
-          ['aclp', 1],
           ['child_account', 1],
           ['databases', 1],
           ['domains', 1],
@@ -286,6 +285,7 @@ describe('APIToken utils', () => {
           ['linodes', 1],
           ['lke', 1],
           ['longview', 1],
+          ['monitor', 1],
           ['nodebalancers', 1],
           ['object_storage', 1],
           ['stackscripts', 1],
@@ -296,7 +296,6 @@ describe('APIToken utils', () => {
       it('should return 2 if all scopes are 2', () => {
         const scopes: Permission[] = [
           ['account', 2],
-          ['aclp', 2],
           ['child_account', 2],
           ['databases', 2],
           ['domains', 2],
@@ -307,6 +306,7 @@ describe('APIToken utils', () => {
           ['linodes', 2],
           ['lke', 2],
           ['longview', 2],
+          ['monitor', 2],
           ['nodebalancers', 2],
           ['object_storage', 2],
           ['stackscripts', 2],
@@ -318,7 +318,6 @@ describe('APIToken utils', () => {
       it('should return null if all scopes are not same', () => {
         const scopes: Permission[] = [
           ['account', 1],
-          ['aclp', 2],
           ['child_account', 0],
           ['databases', 0],
           ['domains', 2],
@@ -329,6 +328,7 @@ describe('APIToken utils', () => {
           ['linodes', 1],
           ['lke', 2],
           ['longview', 2],
+          ['monitor', 2],
           ['nodebalancers', 0],
           ['object_storage', 2],
           ['stackscripts', 2],
@@ -341,7 +341,6 @@ describe('APIToken utils', () => {
     it('should return 1 if all scopes, except any exclusions, are 1', () => {
       const scopes: Permission[] = [
         ['account', 1],
-        ['aclp', 1],
         ['child_account', 1],
         ['databases', 1],
         ['domains', 1],
@@ -352,6 +351,7 @@ describe('APIToken utils', () => {
         ['linodes', 1],
         ['lke', 1],
         ['longview', 2],
+        ['monitor', 1],
         ['nodebalancers', 1],
         ['object_storage', 1],
         ['stackscripts', 1],
@@ -378,7 +378,6 @@ describe('APIToken utils', () => {
 describe('hasAccessBeenSelectedForAllScopes', () => {
   const defaultScopes: Permission[] = [
     ['account', -1],
-    ['aclp', -1],
     ['child_account', -1],
     ['databases', -1],
     ['domains', -1],
@@ -389,6 +388,7 @@ describe('hasAccessBeenSelectedForAllScopes', () => {
     ['linodes', -1],
     ['lke', -1],
     ['longview', -1],
+    ['monitor', -1],
     ['nodebalancers', -1],
     ['object_storage', -1],
     ['stackscripts', -1],
@@ -398,7 +398,6 @@ describe('hasAccessBeenSelectedForAllScopes', () => {
 
   const missingSelectionScopes: Permission[] = [
     ['account', -1],
-    ['aclp', -1],
     ['child_account', -1],
     ['databases', -1],
     ['domains', -1],
@@ -409,6 +408,7 @@ describe('hasAccessBeenSelectedForAllScopes', () => {
     ['linodes', -1],
     ['lke', -1],
     ['longview', -1],
+    ['monitor', -1],
     ['nodebalancers', -1],
     ['object_storage', -1],
     ['stackscripts', -1],
@@ -418,7 +418,6 @@ describe('hasAccessBeenSelectedForAllScopes', () => {
 
   const allSelectedScopes: Permission[] = [
     ['account', 1],
-    ['aclp', 0],
     ['child_account', 0],
     ['databases', 0],
     ['domains', 0],
@@ -429,6 +428,7 @@ describe('hasAccessBeenSelectedForAllScopes', () => {
     ['linodes', 2],
     ['lke', 0],
     ['longview', 0],
+    ['monitor', 0],
     ['nodebalancers', 0],
     ['object_storage', 0],
     ['stackscripts', 0],

--- a/packages/manager/src/features/Profile/APITokens/utils.test.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.test.ts
@@ -28,6 +28,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('*');
       const expected = [
         ['account', 2],
+        ['aclp', 2],
         ['child_account', 2],
         ['databases', 2],
         ['domains', 2],
@@ -53,6 +54,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('');
       const expected = [
         ['account', 0],
+        ['aclp', 0],
         ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
@@ -79,6 +81,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:none');
       const expected = [
         ['account', 0],
+        ['aclp', 0],
         ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
@@ -105,6 +108,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:read_only');
       const expected = [
         ['account', 1],
+        ['aclp', 0],
         ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
@@ -131,6 +135,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:read_write');
       const expected = [
         ['account', 2],
+        ['aclp', 0],
         ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
@@ -159,6 +164,7 @@ describe('APIToken utils', () => {
       );
       const expected = [
         ['account', 0],
+        ['aclp', 0],
         ['child_account', 0],
         ['databases', 0],
         ['domains', 1],
@@ -189,6 +195,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:none,tokens:read_write');
       const expected = [
         ['account', 2],
+        ['aclp', 0],
         ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
@@ -219,6 +226,7 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:read_only,tokens:none');
       const expected = [
         ['account', 1],
+        ['aclp', 0],
         ['child_account', 0],
         ['databases', 0],
         ['domains', 0],
@@ -245,6 +253,7 @@ describe('APIToken utils', () => {
       it('should return 0 if all scopes are 0', () => {
         const scopes: Permission[] = [
           ['account', 0],
+          ['aclp', 0],
           ['child_account', 0],
           ['databases', 0],
           ['domains', 0],
@@ -266,6 +275,7 @@ describe('APIToken utils', () => {
       it('should return 1 if all scopes are 1', () => {
         const scopes: Permission[] = [
           ['account', 1],
+          ['aclp', 1],
           ['child_account', 1],
           ['databases', 1],
           ['domains', 1],
@@ -286,6 +296,7 @@ describe('APIToken utils', () => {
       it('should return 2 if all scopes are 2', () => {
         const scopes: Permission[] = [
           ['account', 2],
+          ['aclp', 2],
           ['child_account', 2],
           ['databases', 2],
           ['domains', 2],
@@ -304,9 +315,10 @@ describe('APIToken utils', () => {
         ];
         expect(allScopesAreTheSame(scopes)).toBe(2);
       });
-      it('should return null if all scopes are different', () => {
+      it('should return null if all scopes are not same', () => {
         const scopes: Permission[] = [
           ['account', 1],
+          ['aclp', 2],
           ['child_account', 0],
           ['databases', 0],
           ['domains', 2],
@@ -329,6 +341,7 @@ describe('APIToken utils', () => {
     it('should return 1 if all scopes, except any exclusions, are 1', () => {
       const scopes: Permission[] = [
         ['account', 1],
+        ['aclp', 1],
         ['child_account', 1],
         ['databases', 1],
         ['domains', 1],
@@ -365,6 +378,7 @@ describe('APIToken utils', () => {
 describe('hasAccessBeenSelectedForAllScopes', () => {
   const defaultScopes: Permission[] = [
     ['account', -1],
+    ['aclp', -1],
     ['child_account', -1],
     ['databases', -1],
     ['domains', -1],
@@ -384,6 +398,7 @@ describe('hasAccessBeenSelectedForAllScopes', () => {
 
   const missingSelectionScopes: Permission[] = [
     ['account', -1],
+    ['aclp', -1],
     ['child_account', -1],
     ['databases', -1],
     ['domains', -1],
@@ -403,6 +418,7 @@ describe('hasAccessBeenSelectedForAllScopes', () => {
 
   const allSelectedScopes: Permission[] = [
     ['account', 1],
+    ['aclp', 0],
     ['child_account', 0],
     ['databases', 0],
     ['domains', 0],

--- a/packages/manager/src/features/Profile/APITokens/utils.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.ts
@@ -8,6 +8,7 @@ export type Permission = [keyof typeof basePermNameMap, number];
 
 export const basePerms = [
   'account',
+  'aclp',
   'child_account',
   'databases',
   'domains',
@@ -27,6 +28,7 @@ export const basePerms = [
 
 export const basePermNameMap = {
   account: 'Account',
+  aclp: 'ACLP',
   child_account: 'Child Account Access',
   databases: 'Databases',
   domains: 'Domains',

--- a/packages/manager/src/features/Profile/APITokens/utils.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.ts
@@ -8,7 +8,6 @@ export type Permission = [keyof typeof basePermNameMap, number];
 
 export const basePerms = [
   'account',
-  'aclp',
   'child_account',
   'databases',
   'domains',
@@ -19,6 +18,7 @@ export const basePerms = [
   'linodes',
   'lke',
   'longview',
+  'monitor',
   'nodebalancers',
   'object_storage',
   'stackscripts',
@@ -28,7 +28,6 @@ export const basePerms = [
 
 export const basePermNameMap = {
   account: 'Account',
-  aclp: 'ACLP',
   child_account: 'Child Account Access',
   databases: 'Databases',
   domains: 'Domains',
@@ -39,6 +38,7 @@ export const basePermNameMap = {
   linodes: 'Linodes',
   lke: 'Kubernetes',
   longview: 'Longview',
+  monitor: 'Monitor',
   nodebalancers: 'NodeBalancers',
   object_storage: 'Object Storage',
   stackscripts: 'StackScripts',


### PR DESCRIPTION
## Description 📝

A new 'Monitor' scope is enabled within Cloud Manager UI for PAT token creation.

## Changes  🔄
- Added new scope 'Monitor' for PAT token creation.

## Target release date 🗓️
2-Dec-2024

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Before](https://github.com/user-attachments/assets/458e73f4-bd18-4ad1-980f-c4e97c138e56) | ![After](https://github.com/user-attachments/assets/721bdc67-7e4b-4eb2-8acf-9d0d98dd3959) |

## How to test 🧪

### Verification steps
1. Login as mock user.
2. Click on "mock-user" profile tab at the right top.
3. Go to api-tokens, click on "create a personal access token", you should see "Monitor" listed as one of the scopes with freedom of selecting any/all three types of access.


## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
