### PR TITLE
test: `machine-image-upload.spec.ts` test failures

### DIFF
--- a/packages/manager/cypress/e2e/core/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/machine-image-upload.spec.ts
@@ -5,7 +5,6 @@ import 'cypress-file-upload';
 import { RecPartial } from 'factory.ts';
 import { DateTime } from 'luxon';
 import { authenticate } from 'support/api/authentication';
-import { fbtVisible, getClick } from 'support/helpers';
 import {
   mockDeleteImage,
   mockGetCustomImages,
@@ -84,9 +83,9 @@ const assertFailed = (label: string, id: string, message: string) => {
   ui.toast.assertMessage(`Image ${label} could not be uploaded: ${message}`);
 
   cy.get(`[data-qa-image-cell="${id}"]`).within(() => {
-    fbtVisible(label);
-    fbtVisible('Upload Failed');
-    fbtVisible('N/A');
+    cy.findByText(label).should('be.visible');
+    cy.findByText('Upload Failed').should('be.visible'); // The status should be "Upload Failed"
+    cy.findAllByText('N/A').should('be.visible'); // The size should be "N/A"
   });
 };
 
@@ -98,9 +97,9 @@ const assertFailed = (label: string, id: string, message: string) => {
  */
 const assertProcessing = (label: string, id: string) => {
   cy.get(`[data-qa-image-cell="${id}"]`).within(() => {
-    fbtVisible(label);
-    fbtVisible('Pending Upload');
-    fbtVisible('Pending');
+    cy.findByText(label).should('be.visible');
+    cy.findByText('Pending Upload').should('be.visible'); // The status should be "Pending Upload"
+    cy.findAllByText('Pending').should('be.visible'); // The size should be "Pending"
   });
 };
 
@@ -115,8 +114,12 @@ const uploadImage = (label: string) => {
   const region = chooseRegion({ capabilities: ['Object Storage'] });
   const upload = 'machine-images/test-image.gz';
   cy.visitWithLogin('/images/create/upload');
-  getClick('[id="label"][data-testid="textfield-input"]').type(label);
-  getClick('[id="description"]').type('This is a machine image upload test');
+
+  cy.findByLabelText('Label').click().type(label);
+
+  cy.findByLabelText('Description')
+    .click()
+    .type('This is a machine image upload test');
 
   ui.regionSelect.find().click();
   ui.regionSelect.findItemByRegionId(region.id).click();
@@ -261,8 +264,8 @@ describe('machine image', () => {
       cy.wait('@getImages');
       ui.toast.assertMessage(availableMessage);
       cy.get(`[data-qa-image-cell="${imageId}"]`).within(() => {
-        fbtVisible(label);
-        fbtVisible('Available');
+        cy.findByText(label).should('be.visible');
+        cy.findByText('Available').should('be.visible');
       });
     });
   });


### PR DESCRIPTION
## Description 📝

- Fixes failures on `machine-image-upload.spec.ts` 
- I guess I caused this on https://github.com/linode/manager/pull/11257, but I'm not 100% sure because the tests were passing on that PR

## Preview 📷

| Before  | After   |
| ------- | ------- |
| 📷 | ![Screenshot 2024-11-25 at 8 59 04 AM](https://github.com/user-attachments/assets/44056e89-f061-4d22-a8e0-44f3ec502553) |


## How to test 🧪

- Run the `machine-image-upload.spec.ts` test using `yarn cy:debug`

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules