### PR TITLE
upcoming: [M3-8840] - Add Cluster Type selection to LKE Create Cluster flow

### DIFF
--- a/packages/manager/.changeset/pr-11322-upcoming-features-1732570083227.md
+++ b/packages/manager/.changeset/pr-11322-upcoming-features-1732570083227.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add Cluster Type section to Create Cluster flow for LKE-E ([#11322](https://github.com/linode/manager/pull/11322))

--- a/packages/manager/src/components/SelectionCard/SelectionCard.tsx
+++ b/packages/manager/src/components/SelectionCard/SelectionCard.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 
 import { CardBase } from './CardBase';
 
+import type { TooltipProps } from '@linode/ui';
 import type { SxProps, Theme } from '@mui/material/styles';
 
 export interface SelectionCardProps {
@@ -87,6 +88,11 @@ export interface SelectionCardProps {
    * Optional text to set in a tooltip when hovering over the card.
    */
   tooltip?: JSX.Element | string;
+  /**
+   * The placement of the tooltip
+   * @default top
+   */
+  tooltipPlacement?: TooltipProps['placement'];
 }
 
 /**
@@ -114,6 +120,7 @@ export const SelectionCard = React.memo((props: SelectionCardProps) => {
     sxGrid,
     sxTooltip,
     tooltip,
+    tooltipPlacement = 'top',
   } = props;
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLElement>) => {
@@ -171,7 +178,7 @@ export const SelectionCard = React.memo((props: SelectionCardProps) => {
         componentsProps={{
           tooltip: { sx: sxTooltip },
         }}
-        placement="top"
+        placement={tooltipPlacement}
         title={tooltip}
       >
         {cardGrid}

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTypePanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTypePanel.tsx
@@ -66,6 +66,7 @@ export const ClusterTypePanel = (props: Props) => {
               ? 'LKE Enterprise is not currently enabled on this contract. To inquire, fill out the Cloud Computing Sales form or email sales@linode.com.'
               : undefined
           }
+          tooltipPlacement="bottom"
         />
       </Stack>
     </Stack>

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTypePanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTypePanel.tsx
@@ -1,5 +1,5 @@
 import { Stack } from '@linode/ui';
-import { Typography } from '@mui/material';
+import { Typography, useMediaQuery } from '@mui/material';
 import React from 'react';
 
 import { DocsLink } from 'src/components/DocsLink/DocsLink';
@@ -9,6 +9,7 @@ import { StyledDocsLinkContainer } from './CreateCluster.styles';
 
 import type { KubernetesTier } from '@linode/api-v4';
 import { useAccount } from 'src/queries/account/account';
+import { useTheme } from '@mui/material/styles';
 
 interface Props {
   handleClusterTypeSelection: (tier: KubernetesTier) => void;
@@ -20,13 +21,17 @@ export const ClusterTypePanel = (props: Props) => {
 
   const { data: account } = useAccount();
 
+  const theme = useTheme();
+  const mdDownBreakpoint = useMediaQuery(theme.breakpoints.down('md'));
+  const smDownBreakpoint = useMediaQuery(theme.breakpoints.down('sm'));
+
   const isLkeEnterpriseSelectionDisabled = !account?.capabilities?.includes(
     'Kubernetes Enterprise'
   );
 
   return (
     <Stack>
-      <Stack flexDirection="row">
+      <Stack flexDirection={mdDownBreakpoint ? 'column' : 'row'}>
         <Stack>
           <Typography variant="h3">Cluster Type</Typography>
           <Typography sx={{ marginTop: 1, maxWidth: 700 }}>
@@ -39,7 +44,11 @@ export const ClusterTypePanel = (props: Props) => {
         </StyledDocsLinkContainer>
       </Stack>
 
-      <Stack flexDirection="row" gap={2} marginTop={2}>
+      <Stack
+        flexDirection={smDownBreakpoint ? 'column' : 'row'}
+        gap={2}
+        marginTop={2}
+      >
         <SelectionCard
           subheadings={[
             'Up to 250 nodes, 1000 pods',
@@ -47,7 +56,7 @@ export const ClusterTypePanel = (props: Props) => {
             'HA control plane (optional)',
           ]}
           checked={selectedTier === 'standard'}
-          heading={'LKE'}
+          heading="LKE"
           onClick={() => handleClusterTypeSelection('standard')}
         />
         <SelectionCard
@@ -57,16 +66,15 @@ export const ClusterTypePanel = (props: Props) => {
             'HA control plane (included)',
           ]}
           checked={selectedTier === 'enterprise'}
-          heading={'LKE Enterprise'}
+          heading="LKE Enterprise"
           onClick={() => handleClusterTypeSelection('enterprise')}
           disabled={isLkeEnterpriseSelectionDisabled}
-          sxTooltip={{ width: 700 }}
           tooltip={
             isLkeEnterpriseSelectionDisabled
               ? 'LKE Enterprise is not currently enabled on this contract. To inquire, fill out the Cloud Computing Sales form or email sales@linode.com.'
               : undefined
           }
-          tooltipPlacement="bottom"
+          tooltipPlacement={smDownBreakpoint ? 'bottom' : 'right'}
         />
       </Stack>
     </Stack>

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTypePanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTypePanel.tsx
@@ -8,8 +8,8 @@ import { SelectionCard } from 'src/components/SelectionCard/SelectionCard';
 import { StyledDocsLinkContainer } from './CreateCluster.styles';
 
 import type { KubernetesTier } from '@linode/api-v4';
-import { useAccount } from 'src/queries/account/account';
 import { useTheme } from '@mui/material/styles';
+import { useAccountBeta } from 'src/queries/account/account';
 
 interface Props {
   handleClusterTypeSelection: (tier: KubernetesTier) => void;
@@ -19,7 +19,7 @@ interface Props {
 export const ClusterTypePanel = (props: Props) => {
   const { handleClusterTypeSelection, selectedTier } = props;
 
-  const { data: account } = useAccount();
+  const { data: account } = useAccountBeta();
 
   const theme = useTheme();
   const mdDownBreakpoint = useMediaQuery(theme.breakpoints.down('md'));

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTypePanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTypePanel.tsx
@@ -1,0 +1,58 @@
+import { Stack } from '@linode/ui';
+import { Typography } from '@mui/material';
+import React from 'react';
+
+import { DocsLink } from 'src/components/DocsLink/DocsLink';
+import { SelectionCard } from 'src/components/SelectionCard/SelectionCard';
+
+import { StyledDocsLinkContainer } from './CreateCluster.styles';
+
+import type { KubernetesTier } from '@linode/api-v4';
+
+interface Props {
+  handleClusterTypeSelection: (tier: KubernetesTier) => void;
+  selectedTier: KubernetesTier;
+}
+
+export const ClusterTypePanel = (props: Props) => {
+  const { handleClusterTypeSelection, selectedTier } = props;
+  return (
+    <Stack>
+      <Stack flexDirection="row">
+        <Stack>
+          <Typography variant="h3">Cluster Type</Typography>
+          <Typography sx={{ marginTop: 1, maxWidth: 700 }}>
+            Choose from a managed solution for smaller deployments or enterprise
+            grade clusters with enhanced ingress, networking, and security.
+          </Typography>
+        </Stack>
+        <StyledDocsLinkContainer>
+          <DocsLink href="/" label="Full Cluster Features" />
+        </StyledDocsLinkContainer>
+      </Stack>
+
+      <Stack flexDirection="row" gap={2} marginTop={2}>
+        <SelectionCard
+          subheadings={[
+            'Up to 250 nodes, 1000 pods',
+            'Shared control plane',
+            'HA control plane (optional)',
+          ]}
+          checked={selectedTier === 'standard'}
+          heading={'LKE'}
+          onClick={() => handleClusterTypeSelection('standard')}
+        />
+        <SelectionCard
+          subheadings={[
+            'Up to 500 nodes, 5000 pods',
+            'Dedicated control plane',
+            'HA control plane (included)',
+          ]}
+          checked={selectedTier === 'enterprise'}
+          heading={'LKE Enterprise'}
+          onClick={() => handleClusterTypeSelection('enterprise')}
+        />
+      </Stack>
+    </Stack>
+  );
+};

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTypePanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTypePanel.tsx
@@ -8,6 +8,7 @@ import { SelectionCard } from 'src/components/SelectionCard/SelectionCard';
 import { StyledDocsLinkContainer } from './CreateCluster.styles';
 
 import type { KubernetesTier } from '@linode/api-v4';
+import { useAccount } from 'src/queries/account/account';
 
 interface Props {
   handleClusterTypeSelection: (tier: KubernetesTier) => void;
@@ -16,6 +17,13 @@ interface Props {
 
 export const ClusterTypePanel = (props: Props) => {
   const { handleClusterTypeSelection, selectedTier } = props;
+
+  const { data: account } = useAccount();
+
+  const isLkeEnterpriseSelectionDisabled = !account?.capabilities?.includes(
+    'Kubernetes Enterprise'
+  );
+
   return (
     <Stack>
       <Stack flexDirection="row">
@@ -51,6 +59,13 @@ export const ClusterTypePanel = (props: Props) => {
           checked={selectedTier === 'enterprise'}
           heading={'LKE Enterprise'}
           onClick={() => handleClusterTypeSelection('enterprise')}
+          disabled={isLkeEnterpriseSelectionDisabled}
+          sxTooltip={{ width: 700 }}
+          tooltip={
+            isLkeEnterpriseSelectionDisabled
+              ? 'LKE Enterprise is not currently enabled on this contract. To inquire, fill out the Cloud Computing Sales form or email sales@linode.com.'
+              : undefined
+          }
         />
       </Stack>
     </Stack>

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTypePanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTypePanel.tsx
@@ -4,12 +4,12 @@ import React from 'react';
 
 import { DocsLink } from 'src/components/DocsLink/DocsLink';
 import { SelectionCard } from 'src/components/SelectionCard/SelectionCard';
+import { useAccountBeta } from 'src/queries/account/account';
 
 import { StyledDocsLinkContainer } from './CreateCluster.styles';
 
 import type { KubernetesTier } from '@linode/api-v4';
-import { useTheme } from '@mui/material/styles';
-import { useAccountBeta } from 'src/queries/account/account';
+import type { Theme } from '@mui/material/styles';
 
 interface Props {
   handleClusterTypeSelection: (tier: KubernetesTier) => void;
@@ -21,9 +21,12 @@ export const ClusterTypePanel = (props: Props) => {
 
   const { data: account } = useAccountBeta();
 
-  const theme = useTheme();
-  const mdDownBreakpoint = useMediaQuery(theme.breakpoints.down('md'));
-  const smDownBreakpoint = useMediaQuery(theme.breakpoints.down('sm'));
+  const mdDownBreakpoint = useMediaQuery((theme: Theme) =>
+    theme.breakpoints.down('md')
+  );
+  const smDownBreakpoint = useMediaQuery((theme: Theme) =>
+    theme.breakpoints.down('sm')
+  );
 
   const isLkeEnterpriseSelectionDisabled = !account?.capabilities?.includes(
     'Kubernetes Enterprise'
@@ -65,15 +68,15 @@ export const ClusterTypePanel = (props: Props) => {
             'Dedicated control plane',
             'HA control plane (included)',
           ]}
-          checked={selectedTier === 'enterprise'}
-          heading="LKE Enterprise"
-          onClick={() => handleClusterTypeSelection('enterprise')}
-          disabled={isLkeEnterpriseSelectionDisabled}
           tooltip={
             isLkeEnterpriseSelectionDisabled
               ? 'LKE Enterprise is not currently enabled on this contract. To inquire, fill out the Cloud Computing Sales form or email sales@linode.com.'
               : undefined
           }
+          checked={selectedTier === 'enterprise'}
+          disabled={isLkeEnterpriseSelectionDisabled}
+          heading="LKE Enterprise"
+          onClick={() => handleClusterTypeSelection('enterprise')}
           tooltipPlacement={smDownBreakpoint ? 'bottom' : 'right'}
         />
       </Stack>

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.styles.ts
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.styles.ts
@@ -51,11 +51,10 @@ export const StyledFieldWithDocsStack = styled(Stack, {
 }));
 
 export const StyledDocsLinkContainer = styled(Box, {
-  label: 'StyledRegionSelectStack',
+  label: 'StyledDocsLinkContainer',
 })(({ theme }) => ({
   alignSelf: 'flex-start',
   marginLeft: 'auto',
-  marginTop: theme.spacing(2),
   [theme.breakpoints.down('md')]: {
     marginLeft: 'unset',
     marginTop: theme.spacing(2),

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -131,7 +131,7 @@ export const CreateCluster = () => {
     isError: versionLoadError,
   } = useKubernetesVersionQuery();
 
-  const { isLkeEnterpriseLAEnabled } = useIsLkeEnterpriseEnabled();
+  const { isLkeEnterpriseLAFlagEnabled } = useIsLkeEnterpriseEnabled();
 
   const versions = (versionData ?? []).map((thisVersion) => ({
     label: thisVersion.id,
@@ -204,7 +204,7 @@ export const CreateCluster = () => {
     }
 
     const createClusterFn =
-      showAPL || isLkeEnterpriseLAEnabled
+      showAPL || isLkeEnterpriseLAFlagEnabled
         ? createKubernetesClusterBeta
         : createKubernetesCluster;
 
@@ -309,7 +309,7 @@ export const CreateCluster = () => {
             label="Cluster Label"
             value={label || ''}
           />
-          {isLkeEnterpriseLAEnabled && (
+          {isLkeEnterpriseLAFlagEnabled && (
             <>
               <Divider sx={{ marginBottom: 4, marginTop: 4 }} />
               <ClusterTypePanel

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -105,6 +105,13 @@ export const CreateCluster = () => {
     isLoading: isLoadingKubernetesTypes,
   } = useKubernetesTypesQuery();
 
+  const handleClusterTypeSelection = (tier: KubernetesTier) => {
+    if (tier === 'enterprise') {
+      setHighAvailability(false);
+    }
+    setSelectedTier(tier);
+  };
+
   const lkeHAType = kubernetesHighAvailabilityTypesData?.find(
     (type) => type.id === 'lke-ha'
   );
@@ -132,8 +139,8 @@ export const CreateCluster = () => {
   } = useKubernetesVersionQuery();
 
   const {
-    isLkeEnterpriseLAFlagEnabled,
     isLkeEnterpriseLAFeatureEnabled,
+    isLkeEnterpriseLAFlagEnabled,
   } = useIsLkeEnterpriseEnabled();
 
   const versions = (versionData ?? []).map((thisVersion) => ({
@@ -316,7 +323,7 @@ export const CreateCluster = () => {
             <>
               <Divider sx={{ marginBottom: 2, marginTop: 4 }} />
               <ClusterTypePanel
-                handleClusterTypeSelection={setSelectedTier}
+                handleClusterTypeSelection={handleClusterTypeSelection}
                 selectedTier={selectedTier}
               />
             </>

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -337,7 +337,9 @@ export const CreateCluster = () => {
                 value={selectedRegionId}
               />
             </Stack>
-            <StyledDocsLinkContainer>
+            <StyledDocsLinkContainer
+              sx={(theme) => ({ marginTop: theme.spacing(2) })}
+            >
               <DocsLink
                 href="https://www.linode.com/pricing"
                 label={DOCS_LINK_LABEL_DC_PRICING}

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -131,7 +131,10 @@ export const CreateCluster = () => {
     isError: versionLoadError,
   } = useKubernetesVersionQuery();
 
-  const { isLkeEnterpriseLAFlagEnabled } = useIsLkeEnterpriseEnabled();
+  const {
+    isLkeEnterpriseLAFlagEnabled,
+    isLkeEnterpriseLAFeatureEnabled,
+  } = useIsLkeEnterpriseEnabled();
 
   const versions = (versionData ?? []).map((thisVersion) => ({
     label: thisVersion.id,
@@ -204,7 +207,7 @@ export const CreateCluster = () => {
     }
 
     const createClusterFn =
-      showAPL || isLkeEnterpriseLAFlagEnabled
+      showAPL || isLkeEnterpriseLAFeatureEnabled
         ? createKubernetesClusterBeta
         : createKubernetesCluster;
 

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -314,7 +314,7 @@ export const CreateCluster = () => {
           />
           {isLkeEnterpriseLAFlagEnabled && (
             <>
-              <Divider sx={{ marginBottom: 4, marginTop: 4 }} />
+              <Divider sx={{ marginBottom: 2, marginTop: 4 }} />
               <ClusterTypePanel
                 handleClusterTypeSelection={setSelectedTier}
                 selectedTier={selectedTier}

--- a/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
@@ -164,7 +164,7 @@ describe('helper functions', () => {
 });
 
 describe('useIsLkeEnterpriseEnabled', () => {
-  it('returns false if the account does not have the capability', () => {
+  it('returns false for feature enablement if the account does not have the capability', () => {
     queryMocks.useAccountBeta.mockReturnValue({
       data: {
         capabilities: [],
@@ -180,12 +180,14 @@ describe('useIsLkeEnterpriseEnabled', () => {
 
     const { result } = renderHook(() => useIsLkeEnterpriseEnabled());
     expect(result.current).toStrictEqual({
-      isLkeEnterpriseGAEnabled: false,
-      isLkeEnterpriseLAEnabled: false,
+      isLkeEnterpriseGAFeatureEnabled: false,
+      isLkeEnterpriseGAFlagEnabled: true,
+      isLkeEnterpriseLAFeatureEnabled: false,
+      isLkeEnterpriseLAFlagEnabled: true,
     });
   });
 
-  it('returns true for LA if the account has the capability + enabled LA feature flag values', () => {
+  it('returns true for LA feature enablement if the account has the capability + enabled LA feature flag values', () => {
     queryMocks.useAccountBeta.mockReturnValue({
       data: {
         capabilities: ['Kubernetes Enterprise'],
@@ -201,12 +203,14 @@ describe('useIsLkeEnterpriseEnabled', () => {
 
     const { result } = renderHook(() => useIsLkeEnterpriseEnabled());
     expect(result.current).toStrictEqual({
-      isLkeEnterpriseGAEnabled: false,
-      isLkeEnterpriseLAEnabled: true,
+      isLkeEnterpriseGAFeatureEnabled: false,
+      isLkeEnterpriseGAFlagEnabled: false,
+      isLkeEnterpriseLAFeatureEnabled: true,
+      isLkeEnterpriseLAFlagEnabled: true,
     });
   });
 
-  it('returns true for GA if the account has the capability + enabled GA feature flag values', () => {
+  it('returns true for GA feature enablement if the account has the capability + enabled GA feature flag values', () => {
     queryMocks.useAccountBeta.mockReturnValue({
       data: {
         capabilities: ['Kubernetes Enterprise'],
@@ -222,8 +226,10 @@ describe('useIsLkeEnterpriseEnabled', () => {
 
     const { result } = renderHook(() => useIsLkeEnterpriseEnabled());
     expect(result.current).toStrictEqual({
-      isLkeEnterpriseGAEnabled: true,
-      isLkeEnterpriseLAEnabled: true,
+      isLkeEnterpriseGAFeatureEnabled: true,
+      isLkeEnterpriseGAFlagEnabled: true,
+      isLkeEnterpriseLAFeatureEnabled: true,
+      isLkeEnterpriseLAFlagEnabled: true,
     });
   });
 });

--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -191,7 +191,7 @@ export const getLatestVersion = (
  * Hook to determine if the LKE-Enterprise feature should be visible to the user.
  * Based on the user's account capability and the feature flag.
  *
- * @returns {boolean, boolean, boolean, boolean} - Whether the LKE-Enterprise feature is enabled for the current user in LA and GA, respectively.
+ * @returns {boolean, boolean, boolean, boolean} - Whether the LKE-Enterprise flags are enabled for LA/GA and whether feature is enabled for LA/GA (flags + account capability).
  */
 export const useIsLkeEnterpriseEnabled = () => {
   const flags = useFlags();

--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -1,6 +1,7 @@
 import { useFlags } from 'src/hooks/useFlags';
 import { useAccountBeta } from 'src/queries/account/account';
 import { useAccountBetaQuery } from 'src/queries/account/betas';
+import { isFeatureEnabledV2 } from 'src/utilities/accountCapabilities';
 import { getBetaStatus } from 'src/utilities/betaUtils';
 import { sortByVersion } from 'src/utilities/sort-by';
 
@@ -12,7 +13,6 @@ import type {
 } from '@linode/api-v4/lib/kubernetes';
 import type { Region } from '@linode/api-v4/lib/regions';
 import type { ExtendedType } from 'src/utilities/extendType';
-import { isFeatureEnabledV2 } from 'src/utilities/accountCapabilities';
 export const nodeWarning = `We recommend a minimum of 3 nodes in each Node Pool to avoid downtime during upgrades and maintenance.`;
 export const nodesDeletionWarning = `All nodes will be deleted and new nodes will be created to replace them.`;
 export const localStorageWarning = `Any local storage (such as \u{2019}hostPath\u{2019} volumes) will be erased.`;
@@ -191,29 +191,34 @@ export const getLatestVersion = (
  * Hook to determine if the LKE-Enterprise feature should be visible to the user.
  * Based on the user's account capability and the feature flag.
  *
- * @returns {boolean, boolean} - Whether the LKE-Enterprise feature is enabled for the current user in LA and GA, respectively.
+ * @returns {boolean, boolean, boolean, boolean} - Whether the LKE-Enterprise feature is enabled for the current user in LA and GA, respectively.
  */
 export const useIsLkeEnterpriseEnabled = () => {
   const flags = useFlags();
   const { data: account } = useAccountBeta();
 
-  const isLkeEnterpriseLA = Boolean(
+  const isLkeEnterpriseLAFlagEnabled = Boolean(
     flags?.lkeEnterprise?.enabled && flags.lkeEnterprise.la
   );
-  const isLkeEnterpriseGA = Boolean(
+  const isLkeEnterpriseGAFlagEnabled = Boolean(
     flags.lkeEnterprise?.enabled && flags.lkeEnterprise.ga
   );
 
-  const isLkeEnterpriseLAEnabled = isFeatureEnabledV2(
+  const isLkeEnterpriseLAFeatureEnabled = isFeatureEnabledV2(
     'Kubernetes Enterprise',
-    isLkeEnterpriseLA,
+    isLkeEnterpriseLAFlagEnabled,
     account?.capabilities ?? []
   );
-  const isLkeEnterpriseGAEnabled = isFeatureEnabledV2(
+  const isLkeEnterpriseGAFeatureEnabled = isFeatureEnabledV2(
     'Kubernetes Enterprise',
-    isLkeEnterpriseGA,
+    isLkeEnterpriseGAFlagEnabled,
     account?.capabilities ?? []
   );
 
-  return { isLkeEnterpriseLAEnabled, isLkeEnterpriseGAEnabled };
+  return {
+    isLkeEnterpriseGAFeatureEnabled,
+    isLkeEnterpriseGAFlagEnabled,
+    isLkeEnterpriseLAFeatureEnabled,
+    isLkeEnterpriseLAFlagEnabled,
+  };
 };

--- a/packages/manager/src/queries/kubernetes.ts
+++ b/packages/manager/src/queries/kubernetes.ts
@@ -136,8 +136,8 @@ export const kubernetesQueries = createQueryKeys('kubernetes', {
 
 export const useKubernetesClusterQuery = (id: number) => {
   const { isLoading: isAPLAvailabilityLoading, showAPL } = useAPLAvailability();
-  const { isLkeEnterpriseLAEnabled } = useIsLkeEnterpriseEnabled();
-  const useBetaEndpoint = showAPL || isLkeEnterpriseLAEnabled;
+  const { isLkeEnterpriseLAFeatureEnabled } = useIsLkeEnterpriseEnabled();
+  const useBetaEndpoint = showAPL || isLkeEnterpriseLAFeatureEnabled;
 
   return useQuery<KubernetesCluster, APIError[]>({
     ...kubernetesQueries.cluster(id)._ctx.cluster(useBetaEndpoint),
@@ -150,8 +150,8 @@ export const useKubernetesClustersQuery = (
   filter: Filter,
   enabled = true
 ) => {
-  const { isLkeEnterpriseLAEnabled } = useIsLkeEnterpriseEnabled();
-  const useBetaEndpoint = isLkeEnterpriseLAEnabled;
+  const { isLkeEnterpriseLAFeatureEnabled } = useIsLkeEnterpriseEnabled();
+  const useBetaEndpoint = isLkeEnterpriseLAFeatureEnabled;
 
   return useQuery<ResourcePage<KubernetesCluster>, APIError[]>({
     ...kubernetesQueries.lists._ctx.paginated(params, filter, useBetaEndpoint),
@@ -391,8 +391,8 @@ export const useKubernetesTieredVersionQuery = (tier: string) => {
  * Before you use this, consider implementing infinite scroll instead.
  */
 export const useAllKubernetesClustersQuery = (enabled = false) => {
-  const { isLkeEnterpriseLAEnabled } = useIsLkeEnterpriseEnabled();
-  const useBetaEndpoint = isLkeEnterpriseLAEnabled;
+  const { isLkeEnterpriseLAFeatureEnabled } = useIsLkeEnterpriseEnabled();
+  const useBetaEndpoint = isLkeEnterpriseLAFeatureEnabled;
 
   return useQuery<KubernetesCluster[], APIError[]>({
     ...kubernetesQueries.lists._ctx.all(useBetaEndpoint),


### PR DESCRIPTION
## Description 📝

We want to allow users the ability to create an LKE-Enterprise cluster in the create flow. 

## Changes  🔄

- A new Cluster Type section exists in the Create Cluster form.
- Copy describes the section and a docs link with placeholder content.
- The cards handle enabled/disabled state as follows:
   - When the feature flag is disabled, do not display the Cluster Type Panel.
   - When the feature flag is enabled but the user lacks the LKE-Enterprise account capability, the Enterprise panel is disabled and displays a tooltip.
   - When the feature flag is enabled and the user has the LKE-Enterprise account capability, the Enterprise panel is enabled and LKE (standard) is selected by default. 
- When the Enterprise cluster type is enabled, the HA Control Plane section is not visible.
- Test coverage confirms the above.

## Preview 📷

| Flag ON with Capability  | Flag ON without Capability  |
| ------- | ------- |
| ![Screenshot 2024-11-25 at 1 52 27 PM](https://github.com/user-attachments/assets/d2d44cb0-4296-42b4-970e-f7b1f3284d97) ![Screenshot 2024-11-25 at 1 52 34 PM](https://github.com/user-attachments/assets/79282022-e6af-4359-95cb-069383d70a00) | ![Screenshot 2024-11-25 at 1 34 28 PM](https://github.com/user-attachments/assets/0c9adf59-a4d8-4926-a48a-ea29ad0b1e12) ![Screenshot 2024-11-25 at 1 34 44 PM](https://github.com/user-attachments/assets/bb89f7f9-0604-40ac-9507-4ec388ad5d6a) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have LKE-E customer tag on your account (see Project Tracker)

### Verification steps

(How to verify changes)
**Note: an actual LKE-E cluster is not creatable yet. An LKE-E version will need to be set, which is an upcoming ticket (M3-8848).**

- [ ] Go to http://localhost:3000/kubernetes/create
- [ ] Confirm the Cluster Type section shows as expected:
  - [ ] Feature flag in dev tools ON, customer tag ON: Cluster Type is visible; HA section is not visible when Enterprise is selected
   - [ ] Feature flag in dev tools OFF, customer tag ON: Cluster Type is not visible; HA section is always visible
   - [ ] Feature flag in dev tools ON, customer tag OFF: Cluster Type is visible; Enterprise selection is disabled; HA section is always visible
- [ ] Confirm test coverage passes:
```
yarn cy:run -s "cypress/e2e/core/kubernetes/lke-create.spec.ts"
```

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
