### PR TITLE
test: [M3-8835] - Add accelerated plans test case to `plan-selection.spec.ts`

### DIFF
--- a/packages/manager/.changeset/pr-11323-tests-1732563014945.md
+++ b/packages/manager/.changeset/pr-11323-tests-1732563014945.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add tests for accelerated plans in `plan-selection.spec.ts` ([#11323](https://github.com/linode/manager/pull/11323))

--- a/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
@@ -515,7 +515,7 @@ describe('Linode Accelerated plans', () => {
           '@getFeatureFlags',
         ]);
 
-        // Confirms Accelerated tab does not show up for LKE clusters
+        // Confirms Accelerated tab does not show up for linodes
         cy.findByText('Accelerated').should('not.exist');
       });
     });


### PR DESCRIPTION
## Description 📝
Adds test cases to ensure accelerated plans appear when expected

## Changes  🔄
- adds various tests to verify Accelerated plans in Linode and LKE plan panels

## Target release date 🗓️
12/10

## How to test 🧪

```
yarn cy:run -s "cypress/e2e/core/linodes/plan-selection.spec.ts"
```

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
