### PR TITLE
test: [M3-6611] - Add new assertions for linode backup tests

### DIFF
--- a/packages/manager/.changeset/pr-11326-tests-1732566960471.md
+++ b/packages/manager/.changeset/pr-11326-tests-1732566960471.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add new assertions for linode backup tests ([#11326](https://github.com/linode/manager/pull/11326))

--- a/packages/manager/.changeset/pr-11326-tests-1732566960471.md
+++ b/packages/manager/.changeset/pr-11326-tests-1732566960471.md
@@ -2,4 +2,4 @@
 "@linode/manager": Tests
 ---
 
-Add new assertions for linode backup tests ([#11326](https://github.com/linode/manager/pull/11326))
+Add new assertions for linode backup Cypress tests ([#11326](https://github.com/linode/manager/pull/11326))

--- a/packages/manager/cypress/e2e/core/linodes/backup-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/backup-linode.spec.ts
@@ -45,6 +45,8 @@ describe('linode backups', () => {
    * - Confirms that enable backup prompt is shown when backups are not enabled.
    * - Confirms that user is warned of additional backups charges before enabling.
    * - Confirms that Linode details page updates to reflect that backups are enabled.
+   * - Confirms that user can cancel Linode backups.
+   * - Confirms that user cannot re-enable Linode backups after canceling.
    */
   it('can enable backups', () => {
     cy.tag('method:e2e');
@@ -130,6 +132,7 @@ describe('linode backups', () => {
       cy.wait('@cancelBackups');
       ui.toast.assertMessage('Backups are being canceled for this Linode');
 
+      // Confirm that user is warned when attempting to re-enable Linode backups after canceling.
       ui.button
         .findByTitle('Enable Backups')
         .should('be.visible')
@@ -146,7 +149,7 @@ describe('linode backups', () => {
             .should('be.enabled')
             .click();
 
-          // Confirm that user is warned of additional backup charges.
+          // Confirm that users cannot re-enable backups without first waiting 24 hrs.
           cy.contains(ReenableBackupsFailureNote).should('be.visible');
         });
     });

--- a/packages/manager/cypress/e2e/core/linodes/backup-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/backup-linode.spec.ts
@@ -19,6 +19,7 @@ import {
   interceptEnableLinodeBackups,
   interceptGetLinode,
   interceptCreateLinodeSnapshot,
+  interceptCancelLinodeBackups,
 } from 'support/intercepts/linodes';
 import { ui } from 'support/ui';
 import { cleanUp } from 'support/util/cleanup';
@@ -27,6 +28,11 @@ import { dcPricingMockLinodeTypesForBackups } from 'support/constants/dc-specifi
 import { chooseRegion } from 'support/util/regions';
 import { expectManagedDisabled } from 'support/api/managed';
 import { createTestLinode } from 'support/util/linodes';
+
+const BackupsCancellationNote =
+  'Once backups for this Linode have been canceled, you cannot re-enable them for 24 hours.';
+const ReenableBackupsFailureNote =
+  'Please wait 24 hours before reactivating backups for this Linode.';
 
 authenticate();
 describe('linode backups', () => {
@@ -60,9 +66,11 @@ describe('linode backups', () => {
     ).then((linode: Linode) => {
       interceptGetLinode(linode.id).as('getLinode');
       interceptEnableLinodeBackups(linode.id).as('enableBackups');
+      interceptCancelLinodeBackups(linode.id).as('cancelBackups');
 
       // Navigate to Linode details page "Backups" tab.
-      cy.visitWithLogin(`linodes/${linode.id}/backup`);
+      cy.visitWithLogin(`linodes/${linode.id}`);
+      cy.findAllByText('Backups').should('be.visible').click();
       cy.wait('@getLinode');
 
       // Wait for Linode to finish provisioning.
@@ -100,6 +108,47 @@ describe('linode backups', () => {
       cy.findByText('Automatic and manual backups will be listed here').should(
         'be.visible'
       );
+
+      // Confirm Backups Cancellation Note is visible when cancel Linode backups.
+      ui.button
+        .findByTitle('Cancel Backups')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+      ui.dialog
+        .findByTitle('Confirm Cancellation')
+        .should('be.visible')
+        .within(() => {
+          cy.contains(BackupsCancellationNote).should('be.visible');
+          ui.button
+            .findByTitle('Cancel Backups')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+      // Confirm toast notification appears and UI updates to reflect cancel backups.
+      cy.wait('@cancelBackups');
+      ui.toast.assertMessage('Backups are being canceled for this Linode');
+
+      ui.button
+        .findByTitle('Enable Backups')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+
+      ui.dialog
+        .findByTitle('Enable backups?')
+        .should('be.visible')
+        .within(() => {
+          ui.button
+            .findByTitle('Enable Backups')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+
+          // Confirm that user is warned of additional backup charges.
+          cy.contains(ReenableBackupsFailureNote).should('be.visible');
+        });
     });
   });
 
@@ -127,7 +176,8 @@ describe('linode backups', () => {
       interceptCreateLinodeSnapshot(linode.id).as('createSnapshot');
 
       // Navigate to Linode details page "Backups" tab.
-      cy.visitWithLogin(`/linodes/${linode.id}/backup`);
+      cy.visitWithLogin(`linodes/${linode.id}`);
+      cy.findAllByText('Backups').should('be.visible').click();
       cy.wait('@getLinode');
 
       // Wait for the Linode to finish provisioning.

--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -588,3 +588,19 @@ export const mockGetLinodeIPAddresses = (
     makeResponse(ipAddresses)
   );
 };
+
+/**
+ * Intercepts POST request to cancel backups for a Linode.
+ *
+ * @param linodeId - ID of Linode for which to enable backups.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptCancelLinodeBackups = (
+  linodeId: number
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`linode/instances/${linodeId}/backups/cancel`)
+  );
+};


### PR DESCRIPTION
## Description 📝

The cypress/e2e/core/linodes/backup-linode.spec.ts have a few shortcomings that should be addressed:

- Navigate to the "Backups" tab of a Linode details page using the UI rather than navigating directly to "/linodes/:id/backups"
- Add test/assertions for canceling Linode backups
- Add test/assertions for error flow when attempting to re-enable Linode backups after canceling (users cannot re-enable backups without first waiting 24 hrs)

## Changes  🔄

List any change(s) relevant to the reviewer.

- Add new assertions for linode backup tests

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/linodes/backup-linode.spec.ts"
```

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support
