### PR TITLE
upcoming: [DI-21694] - Added Resource Select component to the Create-alert form

### DIFF
--- a/packages/api-v4/src/cloudpulse/alerts.ts
+++ b/packages/api-v4/src/cloudpulse/alerts.ts
@@ -5,12 +5,12 @@ import { BETA_API_ROOT as API_ROOT } from 'src/constants';
 
 export const createAlertDefinition = (
   data: CreateAlertDefinitionPayload,
-  service_type: AlertServiceType
+  serviceType: AlertServiceType
 ) =>
   Request<Alert>(
     setURL(
       `${API_ROOT}/monitor/services/${encodeURIComponent(
-        service_type!
+        serviceType!
       )}/alert-definitions`
     ),
     setMethod('POST'),

--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -143,7 +143,7 @@ export interface ServiceTypesList {
 export interface CreateAlertDefinitionPayload {
   label: string;
   description?: string;
-  resource_ids?: string[];
+  entity_ids?: string[];
   severity: AlertSeverityType;
   rule_criteria: {
     rules: MetricCriteria[];
@@ -174,11 +174,12 @@ export interface Alert {
   id: number;
   label: string;
   description: string;
+  has_more_resources: boolean;
   status: AlertStatusType;
   type: AlertDefinitionType;
   severity: AlertSeverityType;
   service_type: AlertServiceType;
-  resource_ids: string[];
+  entity_ids: string[];
   rule_criteria: {
     rules: MetricCriteria[];
   };

--- a/packages/manager/.changeset/pr-11331-added-1732627930598.md
+++ b/packages/manager/.changeset/pr-11331-added-1732627930598.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+ResourceMultiSelect component, along with UT. Changed case for few variables and properties ([#11331](https://github.com/linode/manager/pull/11331))

--- a/packages/manager/src/factories/cloudpulse/alerts.ts
+++ b/packages/manager/src/factories/cloudpulse/alerts.ts
@@ -7,9 +7,10 @@ export const alertFactory = Factory.Sync.makeFactory<Alert>({
   created: new Date().toISOString(),
   created_by: 'user1',
   description: '',
+  entity_ids: ['0', '1', '2', '3'],
+  has_more_resources: true,
   id: Factory.each((i) => i),
   label: Factory.each((id) => `Alert-${id}`),
-  resource_ids: ['0', '1', '2', '3'],
   rule_criteria: {
     rules: [],
   },

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsLanding/AlertsDefinitionLanding.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsLanding/AlertsDefinitionLanding.tsx
@@ -14,7 +14,7 @@ export const AlertDefinitionLanding = () => {
       />
       <Route
         component={() => <CreateAlertDefinition />}
-        path="/monitor/cloudpulse/alerts/definitions/create"
+        path="/monitor/alerts/definitions/create"
       />
     </Switch>
   );

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsLanding/AlertsLanding.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsLanding/AlertsLanding.tsx
@@ -84,7 +84,6 @@ export const AlertsLanding = React.memo(() => {
         <Switch>
           <Route
             component={AlertDefinitionLanding}
-            exact
             path={'/monitor/alerts/definitions'}
           />
           <Redirect from="*" to="/monitor/alerts/definitions" />

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.test.tsx
@@ -34,5 +34,6 @@ describe('AlertDefinition Create', () => {
     expect(getByText('Severity is required.')).toBeVisible();
     expect(getByText('Service is required.')).toBeVisible();
     expect(getByText('Region is required.')).toBeVisible();
+    expect(getByText('At least one resource is needed.')).toBeVisible();
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
@@ -143,13 +143,13 @@ export const CreateAlertDefinition = () => {
           <CloudPulseServiceSelect name="serviceType" />
           {serviceWatcher === 'dbaas' && <EngineOption name="engineType" />}
           <CloudPulseRegionSelect name="region" />
-          <CloudPulseAlertSeveritySelect name="severity" />
           <CloudPulseMultiResourceSelect
             engine={watch('engineType')}
             name="resource_ids"
             region={watch('region')}
             serviceType={serviceWatcher}
           />
+          <CloudPulseAlertSeveritySelect name="severity" />
           <ActionsPanel
             primaryButtonProps={{
               label: 'Submit',

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
@@ -81,7 +81,7 @@ export const CreateAlertDefinition = () => {
     getValues('serviceType')!
   );
 
-  const serviceWatcher = watch('serviceType');
+  const serviceTypeWatcher = watch('serviceType');
   const onSubmit = handleSubmit(async (values) => {
     try {
       await createAlert(filterFormValues(values));
@@ -141,13 +141,13 @@ export const CreateAlertDefinition = () => {
             name="description"
           />
           <CloudPulseServiceSelect name="serviceType" />
-          {serviceWatcher === 'dbaas' && <EngineOption name="engineType" />}
+          {serviceTypeWatcher === 'dbaas' && <EngineOption name="engineType" />}
           <CloudPulseRegionSelect name="region" />
           <CloudPulseMultiResourceSelect
             engine={watch('engineType')}
             name="entity_ids"
             region={watch('region')}
-            serviceType={serviceWatcher}
+            serviceType={serviceTypeWatcher}
           />
           <CloudPulseAlertSeveritySelect name="severity" />
           <ActionsPanel

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
@@ -12,6 +12,7 @@ import { useCreateAlertDefinition } from 'src/queries/cloudpulse/alerts';
 import { CloudPulseAlertSeveritySelect } from './GeneralInformation/AlertSeveritySelect';
 import { EngineOption } from './GeneralInformation/EngineOption';
 import { CloudPulseRegionSelect } from './GeneralInformation/RegionSelect';
+import { CloudPulseMultiResourceSelect } from './GeneralInformation/ResourceMultiSelect';
 import { CloudPulseServiceSelect } from './GeneralInformation/ServiceTypeSelect';
 import { CreateAlertDefinitionFormSchema } from './schemas';
 import { filterFormValues, filterMetricCriteriaFormValues } from './utilities';
@@ -33,14 +34,14 @@ const criteriaInitialValues: MetricCriteriaForm = {
 };
 const initialValues: CreateAlertDefinitionForm = {
   channel_ids: [],
-  engine_type: null,
+  engineType: null,
   label: '',
   region: '',
   resource_ids: [],
   rule_criteria: {
     rules: filterMetricCriteriaFormValues(criteriaInitialValues),
   },
-  service_type: null,
+  serviceType: null,
   severity: null,
   triggerCondition: triggerConditionInitialValues,
 };
@@ -48,19 +49,18 @@ const initialValues: CreateAlertDefinitionForm = {
 const overrides = [
   {
     label: 'Definitions',
-    linkTo: '/monitor/cloudpulse/alerts/definitions',
+    linkTo: '/monitor/alerts/definitions',
     position: 1,
   },
   {
     label: 'Details',
-    linkTo: `/monitor/cloudpulse/alerts/definitions/create`,
+    linkTo: `/monitor/alerts/definitions/create`,
     position: 2,
   },
 ];
 export const CreateAlertDefinition = () => {
   const history = useHistory();
-  const alertCreateExit = () =>
-    history.push('/monitor/cloudpulse/alerts/definitions');
+  const alertCreateExit = () => history.push('/monitor/alerts/definitions');
 
   const formMethods = useForm<CreateAlertDefinitionForm>({
     defaultValues: initialValues,
@@ -78,10 +78,10 @@ export const CreateAlertDefinition = () => {
   } = formMethods;
   const { enqueueSnackbar } = useSnackbar();
   const { mutateAsync: createAlert } = useCreateAlertDefinition(
-    getValues('service_type')!
+    getValues('serviceType')!
   );
 
-  const serviceWatcher = watch('service_type');
+  const serviceWatcher = watch('serviceType');
   const onSubmit = handleSubmit(async (values) => {
     try {
       await createAlert(filterFormValues(values));
@@ -140,10 +140,16 @@ export const CreateAlertDefinition = () => {
             control={control}
             name="description"
           />
-          <CloudPulseServiceSelect name="service_type" />
-          {serviceWatcher === 'dbaas' && <EngineOption name="engine_type" />}
+          <CloudPulseServiceSelect name="serviceType" />
+          {serviceWatcher === 'dbaas' && <EngineOption name="engineType" />}
           <CloudPulseRegionSelect name="region" />
           <CloudPulseAlertSeveritySelect name="severity" />
+          <CloudPulseMultiResourceSelect
+            engine={watch('engineType')}
+            name="resource_ids"
+            region={watch('region')}
+            serviceType={serviceWatcher}
+          />
           <ActionsPanel
             primaryButtonProps={{
               label: 'Submit',

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
@@ -35,9 +35,9 @@ const criteriaInitialValues: MetricCriteriaForm = {
 const initialValues: CreateAlertDefinitionForm = {
   channel_ids: [],
   engineType: null,
+  entity_ids: [],
   label: '',
   region: '',
-  resource_ids: [],
   rule_criteria: {
     rules: filterMetricCriteriaFormValues(criteriaInitialValues),
   },
@@ -145,7 +145,7 @@ export const CreateAlertDefinition = () => {
           <CloudPulseRegionSelect name="region" />
           <CloudPulseMultiResourceSelect
             engine={watch('engineType')}
-            name="resource_ids"
+            name="entity_ids"
             region={watch('region')}
             serviceType={serviceWatcher}
           />

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/EngineOption.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/EngineOption.test.tsx
@@ -9,7 +9,7 @@ import { EngineOption } from './EngineOption';
 describe('EngineOption component tests', () => {
   it('should render the component when resource type is dbaas', () => {
     const { getByLabelText, getByTestId } = renderWithThemeAndHookFormContext({
-      component: <EngineOption name={'engine_type'} />,
+      component: <EngineOption name={'engineType'} />,
     });
     expect(getByLabelText('Engine Option')).toBeInTheDocument();
     expect(getByTestId('engine-option')).toBeInTheDocument();
@@ -17,7 +17,7 @@ describe('EngineOption component tests', () => {
   it('should render the options happy path', async () => {
     const user = userEvent.setup();
     renderWithThemeAndHookFormContext({
-      component: <EngineOption name={'engine_type'} />,
+      component: <EngineOption name={'engineType'} />,
     });
     user.click(screen.getByRole('button', { name: 'Open' }));
     expect(await screen.findByRole('option', { name: 'MySQL' }));
@@ -26,7 +26,7 @@ describe('EngineOption component tests', () => {
   it('should be able to select an option', async () => {
     const user = userEvent.setup();
     renderWithThemeAndHookFormContext({
-      component: <EngineOption name={'engine_type'} />,
+      component: <EngineOption name={'engineType'} />,
     });
     user.click(screen.getByRole('button', { name: 'Open' }));
     await user.click(await screen.findByRole('option', { name: 'MySQL' }));

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ResourceMultiSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ResourceMultiSelect.test.tsx
@@ -35,7 +35,7 @@ describe('ResourceMultiSelect component tests', () => {
       component: (
         <CloudPulseMultiResourceSelect
           engine="mysql"
-          name="resource_ids"
+          name="entity_ids"
           region={undefined}
           serviceType={null}
         />
@@ -56,7 +56,7 @@ describe('ResourceMultiSelect component tests', () => {
       component: (
         <CloudPulseMultiResourceSelect
           engine="mysql"
-          name="resource_ids"
+          name="entity_ids"
           region="us-east"
           serviceType="linode"
         />
@@ -86,7 +86,7 @@ describe('ResourceMultiSelect component tests', () => {
       component: (
         <CloudPulseMultiResourceSelect
           engine="mysql"
-          name="resource_ids"
+          name="entity_ids"
           region="us-east"
           serviceType="linode"
         />
@@ -117,7 +117,7 @@ describe('ResourceMultiSelect component tests', () => {
       component: (
         <CloudPulseMultiResourceSelect
           engine="mysql"
-          name="resource_ids"
+          name="entity_ids"
           region="us-east"
           serviceType="linode"
         />
@@ -152,7 +152,7 @@ describe('ResourceMultiSelect component tests', () => {
       component: (
         <CloudPulseMultiResourceSelect
           engine="mysql"
-          name="resource_ids"
+          name="entity_ids"
           region="us-east"
           serviceType="linode"
         />
@@ -188,7 +188,7 @@ describe('ResourceMultiSelect component tests', () => {
       component: (
         <CloudPulseMultiResourceSelect
           engine="mysql"
-          name="resource_ids"
+          name="entity_ids"
           region="us-east"
           serviceType="dbaas"
         />
@@ -207,7 +207,7 @@ describe('ResourceMultiSelect component tests', () => {
       component: (
         <CloudPulseMultiResourceSelect
           engine="mysql"
-          name="resource_ids"
+          name="entity_ids"
           region="us-east"
           serviceType="linode"
         />

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ResourceMultiSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ResourceMultiSelect.test.tsx
@@ -1,0 +1,220 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+
+import { linodeFactory } from 'src/factories';
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
+
+import { CloudPulseMultiResourceSelect } from './ResourceMultiSelect';
+
+const queryMocks = vi.hoisted(() => ({
+  useResourcesQuery: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('src/queries/cloudpulse/resources', async () => {
+  const actual = await vi.importActual('src/queries/cloudpulse/resources');
+  return {
+    ...actual,
+    useResourcesQuery: queryMocks.useResourcesQuery,
+  };
+});
+const SELECT_ALL = 'Select All';
+const ARIA_SELECTED = 'aria-selected';
+describe('ResourceMultiSelect component tests', () => {
+  it('should render disabled component if the props are undefined or regions and service type does not have any values', () => {
+    queryMocks.useResourcesQuery.mockReturnValue({
+      data: linodeFactory.buildList(2),
+      isError: false,
+      isLoading: false,
+      status: 'success',
+    });
+    const {
+      getByPlaceholderText,
+      getByTestId,
+    } = renderWithThemeAndHookFormContext({
+      component: (
+        <CloudPulseMultiResourceSelect
+          engine="mysql"
+          name="resource_ids"
+          region={undefined}
+          serviceType={null}
+        />
+      ),
+    });
+    expect(getByTestId('resource-select')).toBeInTheDocument();
+    expect(getByPlaceholderText('Select Resources')).toBeInTheDocument();
+  });
+  it('should render resources happy path', async () => {
+    const user = userEvent.setup();
+    queryMocks.useResourcesQuery.mockReturnValue({
+      data: linodeFactory.buildList(2),
+      isError: false,
+      isLoading: false,
+      status: 'success',
+    });
+    renderWithThemeAndHookFormContext({
+      component: (
+        <CloudPulseMultiResourceSelect
+          engine="mysql"
+          name="resource_ids"
+          region="us-east"
+          serviceType="linode"
+        />
+      ),
+    });
+    user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(
+      await screen.findByRole('option', {
+        name: 'linode-3',
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', {
+        name: 'linode-4',
+      })
+    ).toBeInTheDocument();
+  });
+  it('should be able to select all resources', async () => {
+    const user = userEvent.setup();
+    queryMocks.useResourcesQuery.mockReturnValue({
+      data: linodeFactory.buildList(2),
+      isError: false,
+      isLoading: false,
+      status: 'success',
+    });
+    renderWithThemeAndHookFormContext({
+      component: (
+        <CloudPulseMultiResourceSelect
+          engine="mysql"
+          name="resource_ids"
+          region="us-east"
+          serviceType="linode"
+        />
+      ),
+    });
+    user.click(await screen.findByRole('button', { name: 'Open' }));
+    await user.click(await screen.findByRole('option', { name: SELECT_ALL }));
+    expect(
+      await screen.findByRole('option', {
+        name: 'linode-5',
+      })
+    ).toHaveAttribute(ARIA_SELECTED, 'true');
+    expect(
+      screen.getByRole('option', {
+        name: 'linode-6',
+      })
+    ).toHaveAttribute(ARIA_SELECTED, 'true');
+  });
+  it('should be able to deselect the selected resources', async () => {
+    const user = userEvent.setup();
+    queryMocks.useResourcesQuery.mockReturnValue({
+      data: linodeFactory.buildList(2),
+      isError: false,
+      isLoading: false,
+      status: 'success',
+    });
+    renderWithThemeAndHookFormContext({
+      component: (
+        <CloudPulseMultiResourceSelect
+          engine="mysql"
+          name="resource_ids"
+          region="us-east"
+          serviceType="linode"
+        />
+      ),
+    });
+    user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(await screen.findByRole('option', { name: SELECT_ALL }));
+    await user.click(
+      await screen.findByRole('option', { name: 'Deselect All' })
+    );
+    expect(
+      await screen.findByRole('option', {
+        name: 'linode-7',
+      })
+    ).toHaveAttribute(ARIA_SELECTED, 'false');
+    expect(
+      screen.getByRole('option', {
+        name: 'linode-8',
+      })
+    ).toHaveAttribute(ARIA_SELECTED, 'false');
+  });
+
+  it('should select multiple resources', async () => {
+    const user = userEvent.setup();
+    queryMocks.useResourcesQuery.mockReturnValue({
+      data: linodeFactory.buildList(3),
+      isError: false,
+      isLoading: false,
+      status: 'success',
+    });
+    renderWithThemeAndHookFormContext({
+      component: (
+        <CloudPulseMultiResourceSelect
+          engine="mysql"
+          name="resource_ids"
+          region="us-east"
+          serviceType="linode"
+        />
+      ),
+    });
+    user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(await screen.findByRole('option', { name: 'linode-9' }));
+    await user.click(await screen.findByRole('option', { name: 'linode-10' }));
+
+    expect(
+      await screen.findByRole('option', {
+        name: 'linode-9',
+      })
+    ).toHaveAttribute(ARIA_SELECTED, 'true');
+    expect(
+      screen.getByRole('option', {
+        name: 'linode-10',
+      })
+    ).toHaveAttribute(ARIA_SELECTED, 'true');
+    expect(
+      screen.getByRole('option', {
+        name: 'linode-11',
+      })
+    ).toHaveAttribute(ARIA_SELECTED, 'false');
+    expect(
+      screen.getByRole('option', {
+        name: 'Select All',
+      })
+    ).toHaveAttribute(ARIA_SELECTED, 'false');
+  });
+  it('should render the label as cluster when resource is of dbaas type', () => {
+    const { getByLabelText } = renderWithThemeAndHookFormContext({
+      component: (
+        <CloudPulseMultiResourceSelect
+          engine="mysql"
+          name="resource_ids"
+          region="us-east"
+          serviceType="dbaas"
+        />
+      ),
+    });
+    expect(getByLabelText('Cluster'));
+  });
+  it('should render error messages when there is an API call failure', () => {
+    queryMocks.useResourcesQuery.mockReturnValue({
+      data: undefined,
+      isError: true,
+      isLoading: false,
+      status: 'error',
+    });
+    renderWithThemeAndHookFormContext({
+      component: (
+        <CloudPulseMultiResourceSelect
+          engine="mysql"
+          name="resource_ids"
+          region="us-east"
+          serviceType="linode"
+        />
+      ),
+    });
+    expect(
+      screen.getByText('Failed to fetch the resources.')
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ResourceMultiSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ResourceMultiSelect.test.tsx
@@ -22,8 +22,9 @@ const SELECT_ALL = 'Select All';
 const ARIA_SELECTED = 'aria-selected';
 describe('ResourceMultiSelect component tests', () => {
   it('should render disabled component if the props are undefined or regions and service type does not have any values', () => {
+    const mockLinodes = linodeFactory.buildList(2);
     queryMocks.useResourcesQuery.mockReturnValue({
-      data: linodeFactory.buildList(2),
+      data: mockLinodes,
       isError: false,
       isLoading: false,
       status: 'success',
@@ -46,8 +47,9 @@ describe('ResourceMultiSelect component tests', () => {
   });
   it('should render resources happy path', async () => {
     const user = userEvent.setup();
+    const mockLinodes = linodeFactory.buildList(2);
     queryMocks.useResourcesQuery.mockReturnValue({
-      data: linodeFactory.buildList(2),
+      data: mockLinodes,
       isError: false,
       isLoading: false,
       status: 'success',
@@ -65,19 +67,20 @@ describe('ResourceMultiSelect component tests', () => {
     user.click(screen.getByRole('button', { name: 'Open' }));
     expect(
       await screen.findByRole('option', {
-        name: 'linode-3',
+        name: mockLinodes[0].label,
       })
     ).toBeInTheDocument();
     expect(
       screen.getByRole('option', {
-        name: 'linode-4',
+        name: mockLinodes[1].label,
       })
     ).toBeInTheDocument();
   });
   it('should be able to select all resources', async () => {
     const user = userEvent.setup();
+    const mockLinodes = linodeFactory.buildList(2);
     queryMocks.useResourcesQuery.mockReturnValue({
-      data: linodeFactory.buildList(2),
+      data: mockLinodes,
       isError: false,
       isLoading: false,
       status: 'success',
@@ -96,19 +99,20 @@ describe('ResourceMultiSelect component tests', () => {
     await user.click(await screen.findByRole('option', { name: SELECT_ALL }));
     expect(
       await screen.findByRole('option', {
-        name: 'linode-5',
+        name: mockLinodes[0].label,
       })
     ).toHaveAttribute(ARIA_SELECTED, 'true');
     expect(
       screen.getByRole('option', {
-        name: 'linode-6',
+        name: mockLinodes[0].label,
       })
     ).toHaveAttribute(ARIA_SELECTED, 'true');
   });
   it('should be able to deselect the selected resources', async () => {
     const user = userEvent.setup();
+    const mockLinodes = linodeFactory.buildList(2);
     queryMocks.useResourcesQuery.mockReturnValue({
-      data: linodeFactory.buildList(2),
+      data: mockLinodes,
       isError: false,
       isLoading: false,
       status: 'success',
@@ -130,20 +134,21 @@ describe('ResourceMultiSelect component tests', () => {
     );
     expect(
       await screen.findByRole('option', {
-        name: 'linode-7',
+        name: mockLinodes[0].label,
       })
     ).toHaveAttribute(ARIA_SELECTED, 'false');
     expect(
       screen.getByRole('option', {
-        name: 'linode-8',
+        name: mockLinodes[1].label,
       })
     ).toHaveAttribute(ARIA_SELECTED, 'false');
   });
 
   it('should select multiple resources', async () => {
     const user = userEvent.setup();
+    const mockLinodes = linodeFactory.buildList(3);
     queryMocks.useResourcesQuery.mockReturnValue({
-      data: linodeFactory.buildList(3),
+      data: mockLinodes,
       isError: false,
       isLoading: false,
       status: 'success',
@@ -159,22 +164,26 @@ describe('ResourceMultiSelect component tests', () => {
       ),
     });
     user.click(screen.getByRole('button', { name: 'Open' }));
-    await user.click(await screen.findByRole('option', { name: 'linode-9' }));
-    await user.click(await screen.findByRole('option', { name: 'linode-10' }));
+    await user.click(
+      await screen.findByRole('option', { name: mockLinodes[0].label })
+    );
+    await user.click(
+      await screen.findByRole('option', { name: mockLinodes[1].label })
+    );
 
     expect(
       await screen.findByRole('option', {
-        name: 'linode-9',
+        name: mockLinodes[0].label,
       })
     ).toHaveAttribute(ARIA_SELECTED, 'true');
     expect(
       screen.getByRole('option', {
-        name: 'linode-10',
+        name: mockLinodes[1].label,
       })
     ).toHaveAttribute(ARIA_SELECTED, 'true');
     expect(
       screen.getByRole('option', {
-        name: 'linode-11',
+        name: mockLinodes[2].label,
       })
     ).toHaveAttribute(ARIA_SELECTED, 'false');
     expect(

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ResourceMultiSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ResourceMultiSelect.test.tsx
@@ -45,6 +45,7 @@ describe('ResourceMultiSelect component tests', () => {
     expect(getByTestId('resource-select')).toBeInTheDocument();
     expect(getByPlaceholderText('Select Resources')).toBeInTheDocument();
   });
+
   it('should render resources happy path', async () => {
     const user = userEvent.setup();
     const mockLinodes = linodeFactory.buildList(2);
@@ -76,6 +77,7 @@ describe('ResourceMultiSelect component tests', () => {
       })
     ).toBeInTheDocument();
   });
+
   it('should be able to select all resources', async () => {
     const user = userEvent.setup();
     const mockLinodes = linodeFactory.buildList(2);
@@ -108,6 +110,7 @@ describe('ResourceMultiSelect component tests', () => {
       })
     ).toHaveAttribute(ARIA_SELECTED, 'true');
   });
+
   it('should be able to deselect the selected resources', async () => {
     const user = userEvent.setup();
     const mockLinodes = linodeFactory.buildList(2);
@@ -192,6 +195,7 @@ describe('ResourceMultiSelect component tests', () => {
       })
     ).toHaveAttribute(ARIA_SELECTED, 'false');
   });
+
   it('should render the label as cluster when resource is of dbaas type', () => {
     const { getByLabelText } = renderWithThemeAndHookFormContext({
       component: (
@@ -203,8 +207,9 @@ describe('ResourceMultiSelect component tests', () => {
         />
       ),
     });
-    expect(getByLabelText('Cluster'));
+    expect(getByLabelText('Clusters'));
   });
+
   it('should render error messages when there is an API call failure', () => {
     queryMocks.useResourcesQuery.mockReturnValue({
       data: undefined,

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ResourceMultiSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ResourceMultiSelect.tsx
@@ -41,14 +41,14 @@ export const CloudPulseMultiResourceSelect = (
     engine !== null ? { engine, region } : { region }
   );
 
-  const getResourcesList = (): Item<string, string>[] => {
+  const getResourcesList = React.useMemo((): Item<string, string>[] => {
     return resources && resources.length > 0
       ? resources.map((resource) => ({
           label: resource.label,
           value: resource.id,
         }))
       : [];
-  };
+  }, [resources]);
 
   React.useEffect(() => {
     setValue('resource_ids', []);
@@ -69,29 +69,29 @@ export const CloudPulseMultiResourceSelect = (
           textFieldProps={{
             InputProps: {
               sx: {
-                maxHeight: '55px',
+                maxHeight: '60px',
                 overflow: 'auto',
               },
             },
           }}
           value={
             field.value
-              ? getResourcesList().filter((resource) =>
+              ? getResourcesList.filter((resource) =>
                   field.value.includes(resource.value)
                 )
               : []
           }
-          isOptionEqualToValue={(option, value) => option.value === value.value}
           autoHighlight
           clearOnBlur
           data-testid="resource-select"
           disabled={!Boolean(region && serviceType)}
+          isOptionEqualToValue={(option, value) => option.value === value.value}
           label={serviceType === 'dbaas' ? 'Cluster' : 'Resources'}
           limitTags={2}
           loading={isLoading && Boolean(region && serviceType)}
           multiple
           onBlur={field.onBlur}
-          options={getResourcesList()}
+          options={getResourcesList}
           placeholder="Select Resources"
         />
       )}

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ResourceMultiSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ResourceMultiSelect.tsx
@@ -50,6 +50,10 @@ export const CloudPulseMultiResourceSelect = (
       : [];
   }, [resources]);
 
+  /* useEffect is used here to reset the value of entity_ids back to [] when the region, engine, serviceType props are changed ,
+      as the options to the Autocomplete component are dependent on those props , the values of the Autocomplete won't match with the given options that are passed
+      and this may raise a warning or error with the isOptionEqualToValue prop in the Autocomplete.
+  */
   React.useEffect(() => {
     setValue(name, []);
   }, [region, serviceType, engine, setValue, name]);

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ResourceMultiSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ResourceMultiSelect.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+
+import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
+import { useResourcesQuery } from 'src/queries/cloudpulse/resources';
+
+import type { Item } from '../../constants';
+import type { CreateAlertDefinitionForm } from '../types';
+import type { AlertServiceType } from '@linode/api-v4';
+import type { FieldPathByValue } from 'react-hook-form';
+
+interface CloudPulseResourceSelectProps {
+  /**
+   * engine option type selected by the user
+   */
+  engine: null | string;
+  /**
+   * name used for the component to set in the form
+   */
+  name: FieldPathByValue<CreateAlertDefinitionForm, string[]>;
+  /**
+   * region selected by the user
+   */
+  region: string | undefined;
+  /**
+   * service type selected by the user
+   */
+  serviceType: AlertServiceType | null;
+}
+
+export const CloudPulseMultiResourceSelect = (
+  props: CloudPulseResourceSelectProps
+) => {
+  const { engine, name, region, serviceType } = { ...props };
+  const { control, setValue } = useFormContext<CreateAlertDefinitionForm>();
+
+  const { data: resources, isError, isLoading } = useResourcesQuery(
+    Boolean(region && serviceType),
+    serviceType?.toString(),
+    {},
+    engine !== null ? { engine, region } : { region }
+  );
+
+  const getResourcesList = (): Item<string, string>[] => {
+    return resources && resources.length > 0
+      ? resources.map((resource) => ({
+          label: resource.label,
+          value: resource.id,
+        }))
+      : [];
+  };
+
+  React.useEffect(() => {
+    setValue('resource_ids', []);
+  }, [region, serviceType, engine, setValue]);
+
+  return (
+    <Controller
+      render={({ field, fieldState }) => (
+        <Autocomplete
+          errorText={
+            fieldState.error?.message ??
+            (isError ? 'Failed to fetch the resources.' : '')
+          }
+          onChange={(_, resources: { label: string; value: string }[]) => {
+            const resourceIds = resources.map((resource) => resource.value);
+            field.onChange(resourceIds);
+          }}
+          textFieldProps={{
+            InputProps: {
+              sx: {
+                maxHeight: '55px',
+                overflow: 'auto',
+              },
+            },
+          }}
+          value={
+            field.value
+              ? getResourcesList().filter((resource) =>
+                  field.value.includes(resource.value)
+                )
+              : []
+          }
+          isOptionEqualToValue={(option, value) => option.value === value.value}
+          autoHighlight
+          clearOnBlur
+          data-testid="resource-select"
+          disabled={!Boolean(region && serviceType)}
+          label={serviceType === 'dbaas' ? 'Cluster' : 'Resources'}
+          limitTags={2}
+          loading={isLoading && Boolean(region && serviceType)}
+          multiple
+          onBlur={field.onBlur}
+          options={getResourcesList()}
+          placeholder="Select Resources"
+        />
+      )}
+      control={control}
+      name={name}
+    />
+  );
+};

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ResourceMultiSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ResourceMultiSelect.tsx
@@ -51,8 +51,8 @@ export const CloudPulseMultiResourceSelect = (
   }, [resources]);
 
   React.useEffect(() => {
-    setValue('resource_ids', []);
-  }, [region, serviceType, engine, setValue]);
+    setValue(name, []);
+  }, [region, serviceType, engine, setValue, name]);
 
   return (
     <Controller
@@ -65,14 +65,6 @@ export const CloudPulseMultiResourceSelect = (
           onChange={(_, resources: { label: string; value: string }[]) => {
             const resourceIds = resources.map((resource) => resource.value);
             field.onChange(resourceIds);
-          }}
-          textFieldProps={{
-            InputProps: {
-              sx: {
-                maxHeight: '60px',
-                overflow: 'auto',
-              },
-            },
           }}
           value={
             field.value

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ResourceMultiSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ResourceMultiSelect.tsx
@@ -82,7 +82,7 @@ export const CloudPulseMultiResourceSelect = (
           data-testid="resource-select"
           disabled={!Boolean(region && serviceType)}
           isOptionEqualToValue={(option, value) => option.value === value.value}
-          label={serviceType === 'dbaas' ? 'Cluster' : 'Resources'}
+          label={serviceType === 'dbaas' ? 'Clusters' : 'Resources'}
           limitTags={2}
           loading={isLoading && Boolean(region && serviceType)}
           multiple

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ServiceTypeSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ServiceTypeSelect.test.tsx
@@ -41,7 +41,7 @@ queryMocks.useCloudPulseServiceTypes.mockReturnValue({
 describe('ServiceTypeSelect component tests', () => {
   it('should render the Autocomplete component', () => {
     const { getAllByText, getByTestId } = renderWithThemeAndHookFormContext({
-      component: <CloudPulseServiceSelect name="service_type" />,
+      component: <CloudPulseServiceSelect name="serviceType" />,
     });
     expect(getByTestId('servicetype-select')).toBeInTheDocument();
     getAllByText('Service');
@@ -49,7 +49,7 @@ describe('ServiceTypeSelect component tests', () => {
 
   it('should render service types happy path', async () => {
     renderWithThemeAndHookFormContext({
-      component: <CloudPulseServiceSelect name="service_type" />,
+      component: <CloudPulseServiceSelect name="serviceType" />,
     });
     userEvent.click(screen.getByRole('button', { name: 'Open' }));
     expect(
@@ -66,7 +66,7 @@ describe('ServiceTypeSelect component tests', () => {
 
   it('should be able to select a service type', async () => {
     renderWithThemeAndHookFormContext({
-      component: <CloudPulseServiceSelect name="service_type" />,
+      component: <CloudPulseServiceSelect name="serviceType" />,
     });
     userEvent.click(screen.getByRole('button', { name: 'Open' }));
     await userEvent.click(
@@ -81,7 +81,7 @@ describe('ServiceTypeSelect component tests', () => {
       isLoading: false,
     });
     renderWithThemeAndHookFormContext({
-      component: <CloudPulseServiceSelect name="service_type" />,
+      component: <CloudPulseServiceSelect name="serviceType" />,
     });
     expect(
       screen.getByText('Failed to fetch the service types.')

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/schemas.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/schemas.ts
@@ -8,8 +8,8 @@ const engineOptionValidation = string().when('service_type', {
 });
 export const CreateAlertDefinitionFormSchema = createAlertDefinitionSchema.concat(
   object({
-    engine_type: engineOptionValidation,
+    engineType: engineOptionValidation,
     region: string().required('Region is required.'),
-    service_type: string().required('Service is required.').nullable(),
+    serviceType: string().required('Service is required.').nullable(),
   })
 );

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/types.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/types.ts
@@ -10,8 +10,8 @@ import type {
 export interface CreateAlertDefinitionForm
   extends Omit<CreateAlertDefinitionPayload, 'severity'> {
   engineType: null | string;
+  entity_ids: string[];
   region: string;
-  resource_ids: string[];
   serviceType: AlertServiceType | null;
   severity: AlertSeverityType | null;
 }

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/types.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/types.ts
@@ -9,9 +9,10 @@ import type {
 
 export interface CreateAlertDefinitionForm
   extends Omit<CreateAlertDefinitionPayload, 'severity'> {
-  engine_type: null | string;
+  engineType: null | string;
   region: string;
-  service_type: AlertServiceType | null;
+  resource_ids: string[];
+  serviceType: AlertServiceType | null;
   severity: AlertSeverityType | null;
 }
 

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/utilities.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/utilities.ts
@@ -18,8 +18,8 @@ export const filterFormValues = (
   ]);
   // severity has a need for null in the form for edge-cases, so null-checking and returning it as an appropriate type
   const severity = formValues.severity!;
-  const resourceIds = formValues.resource_ids!;
-  return { ...values, resource_ids: resourceIds, severity };
+  const entityIds = formValues.entity_ids;
+  return { ...values, entity_ids: entityIds, severity };
 };
 
 export const filterMetricCriteriaFormValues = (

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/utilities.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/utilities.ts
@@ -11,21 +11,22 @@ export const filterFormValues = (
   formValues: CreateAlertDefinitionForm
 ): CreateAlertDefinitionPayload => {
   const values = omitProps(formValues, [
-    'service_type',
+    'serviceType',
     'region',
-    'engine_type',
+    'engineType',
     'severity',
   ]);
   // severity has a need for null in the form for edge-cases, so null-checking and returning it as an appropriate type
   const severity = formValues.severity!;
-  return { ...values, severity };
+  const resourceIds = formValues.resource_ids!;
+  return { ...values, resource_ids: resourceIds, severity };
 };
 
 export const filterMetricCriteriaFormValues = (
   formValues: MetricCriteriaForm
 ): MetricCriteria[] => {
-  const aggregation_type = formValues.aggregation_type!;
+  const aggregationType = formValues.aggregation_type!;
   const operator = formValues.operator!;
   const values = omitProps(formValues, ['aggregation_type', 'operator']);
-  return [{ ...values, aggregation_type, operator }];
+  return [{ ...values, aggregation_type: aggregationType, operator }];
 };

--- a/packages/manager/src/queries/cloudpulse/alerts.ts
+++ b/packages/manager/src/queries/cloudpulse/alerts.ts
@@ -10,10 +10,10 @@ import type {
 } from '@linode/api-v4/lib/cloudpulse';
 import type { APIError } from '@linode/api-v4/lib/types';
 
-export const useCreateAlertDefinition = (service_type: AlertServiceType) => {
+export const useCreateAlertDefinition = (serviceType: AlertServiceType) => {
   const queryClient = useQueryClient();
   return useMutation<Alert, APIError[], CreateAlertDefinitionPayload>({
-    mutationFn: (data) => createAlertDefinition(data, service_type),
+    mutationFn: (data) => createAlertDefinition(data, serviceType),
     onSuccess() {
       queryClient.invalidateQueries(queryFactory.alerts);
     },

--- a/packages/validation/src/cloudpulse.schema.ts
+++ b/packages/validation/src/cloudpulse.schema.ts
@@ -30,7 +30,7 @@ const triggerCondition = object({
 export const createAlertDefinitionSchema = object({
   label: string().required('Name is required.'),
   description: string().optional(),
-  resource_ids: array().of(string()).min(1, 'At least one resource is needed.'),
+  entity_ids: array().of(string()).min(1, 'At least one resource is needed.'),
   severity: string().required('Severity is required.').nullable(),
   criteria: array()
     .of(metricCriteria)


### PR DESCRIPTION
## Description 📝

- Added the Resource Multi Select component under General Information section to the Create alert form.

## Changes  🔄
- Added a MultiSelect Autocomplete component for selecting Resources
- Added Unit Test for the Resource Multi Select component
- Changed few variables and properties to camelCase

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-11-19 at 21 38 14](https://github.com/user-attachments/assets/5c482b69-527e-4848-8cf9-fbcc2c5531ec) | ![Screenshot 2024-11-26 at 18 43 55](https://github.com/user-attachments/assets/fda80b26-7823-409c-ac37-48ca3cab8f4e) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- The tabs are controlled by a featureFlag called aclpAlerting, the flag has been currently disabled. For testing enable the definitions part of the aclpAlerting flag to be true.
- The API endpoints are not live yet, so use Legacy MSW Handlers for the mock responses.

### Verification steps

(How to verify changes)

- In Monitor (once the prerequisites are followed) , Alerts tab should be visible next to Dashboards.
- Under that,  Definition tab and a Create button should be visible.
- On clicking Create, the Form Page should be visible.
- The label of Resources component should change to Clusters if Service is `Database `

## As an Author, I have considered 🤔

- 👀 Doing a self review
- ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- 🤏 Splitting feature into small PRs
- ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- 🧪 Providing/improving test coverage
- 🔐 Removing all sensitive information from the code and PR description
- 🚩 Using a feature flag to protect the release
- 👣 Providing comprehensive reproduction steps
- 📑 Providing or updating our documentation
- 🕛 Scheduling a pair reviewing session
- 📱 Providing mobile support
- ♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules
