### PR TITLE
test: Fix unit tests depending on `formatPercentage` to reflect latest changes

### DIFF
--- a/packages/manager/src/components/LineGraph/MetricsDisplay.test.tsx
+++ b/packages/manager/src/components/LineGraph/MetricsDisplay.test.tsx
@@ -86,7 +86,7 @@ describe('CPUMetrics', () => {
       />
     );
 
-    for (const value of ['10.00%', '5.50%', '7.75%']) {
+    for (const value of ['10.00 %', '5.50 %', '7.75 %']) {
       expect(getByText(value)).toBeVisible();
     }
   });

--- a/packages/manager/src/utilities/statMetrics.test.ts
+++ b/packages/manager/src/utilities/statMetrics.test.ts
@@ -131,8 +131,8 @@ describe('format number', () => {
 
 describe('formatting', () => {
   it('formatPercent adds percent sign', () => {
-    expect(formatPercentage(12)).toBe('12.00%');
-    expect(formatPercentage(0)).toBe('0.00%');
-    expect(formatPercentage(123456789)).toBe('123456789.00%');
+    expect(formatPercentage(12)).toBe('12.00 %');
+    expect(formatPercentage(0)).toBe('0.00 %');
+    expect(formatPercentage(123456789)).toBe('123456789.00 %');
   });
 });


### PR DESCRIPTION
## Description 📝
Quick fix to address unit test failures - in  #11294, formatPercent now adds an extra space

## How to test 🧪
```
yarn test MetricsDisplay.test.tsx && yarn test statMetrics.test.ts
```
+ checks should pass (minus potential flaky tests)

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
