### PR TITLE
test: [M3-8547] - Add unit tests for `DocsLink` component

### DIFF
--- a/packages/manager/.changeset/pr-11336-added-1732711112187.md
+++ b/packages/manager/.changeset/pr-11336-added-1732711112187.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+unit test cases for `DocsLink` component ([#11336](https://github.com/linode/manager/pull/11336))

--- a/packages/manager/src/components/DocsLink/DocsLink.test.tsx
+++ b/packages/manager/src/components/DocsLink/DocsLink.test.tsx
@@ -1,0 +1,45 @@
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { sendHelpButtonClickEvent } from 'src/utilities/analytics/customEventAnalytics';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { DocsLink } from './DocsLink';
+
+import type { DocsLinkProps } from './DocsLink';
+
+vi.mock('src/utilities/analytics/customEventAnalytics', () => ({
+  sendHelpButtonClickEvent: vi.fn(),
+}));
+
+const mockLabel = 'Custom Doc Link Label';
+const mockHref =
+  'https://techdocs.akamai.com/cloud-computing/docs/faqs-for-compute-instances';
+const mockAnalyticsLabel = 'Label';
+
+const defaultProps: DocsLinkProps = {
+  analyticsLabel: mockAnalyticsLabel,
+  href: mockHref,
+  label: mockLabel,
+};
+
+describe('DocsLink', () => {
+  it('should render the label', () => {
+    const { getByText } = renderWithTheme(<DocsLink {...defaultProps} />);
+    expect(getByText(mockLabel)).toBeVisible();
+  });
+
+  it('should allow user to click the label and redirect to the url', async () => {
+    const { getByRole } = renderWithTheme(<DocsLink {...defaultProps} />);
+    const link = getByRole('link', {
+      name: 'Custom Doc Link Label - link opens in a new tab',
+    });
+    expect(link).toBeInTheDocument();
+    await userEvent.click(link);
+    expect(sendHelpButtonClickEvent).toHaveBeenCalledTimes(1);
+    expect(sendHelpButtonClickEvent).toHaveBeenCalledWith(
+      mockHref,
+      mockAnalyticsLabel
+    );
+  });
+});


### PR DESCRIPTION
## Description 📝
Added Unit test cases for `DocsLink` components.

## Changes  🔄

- Add unit test cases for `DocsLink` components.

## Target release date 🗓️
N/A

## How to test 🧪

### Verification steps
(How to verify changes)
- Run `yarn test src/components/DocsLink --reporter verbose`
- Verify that all the test cases pass.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support

