### PR TITLE
feat: [M3-8947] - Improve linter rules for naming convention

### DIFF
--- a/packages/api-v4/.changeset/pr-11337-added-1732714186488.md
+++ b/packages/api-v4/.changeset/pr-11337-added-1732714186488.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Added
+---
+
+Linter rules for naming convention ([#11337](https://github.com/linode/manager/pull/11337))

--- a/packages/api-v4/.eslintrc.json
+++ b/packages/api-v4/.eslintrc.json
@@ -22,6 +22,11 @@
         "trailingUnderscore": "allow"
       },
       {
+        "format": null,
+        "modifiers": ["destructured"],
+        "selector": "variable"
+      },
+      {
         "format": ["camelCase", "PascalCase"],
         "selector": "function"
       },

--- a/packages/api-v4/.eslintrc.json
+++ b/packages/api-v4/.eslintrc.json
@@ -29,6 +29,10 @@
         "format": ["camelCase"],
         "leadingUnderscore": "allow",
         "selector": "parameter"
+      },
+      {
+        "format": ["PascalCase"],
+        "selector": "typeLike"
       }
     ],
     "@typescript-eslint/no-unused-vars": "off",

--- a/packages/api-v4/.eslintrc.json
+++ b/packages/api-v4/.eslintrc.json
@@ -13,6 +13,33 @@
     "plugin:prettier/recommended"
   ],
   "rules": {
+    "@typescript-eslint/naming-convention": [
+      "warn",
+      {
+        "format": ["camelCase", "UPPER_CASE", "PascalCase"],
+        "leadingUnderscore": "allow",
+        "selector": "variable",
+        "trailingUnderscore": "allow"
+      },
+      {
+        "format": ["camelCase", "PascalCase"],
+        "selector": "function"
+      },
+      {
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow",
+        "selector": "parameter"
+      }
+    ],
+    "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-inferrable-types": "off",
+    "@typescript-eslint/no-namespace": "warn",
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-empty-interface": "warn",
+    "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-use-before-define": "off",
+    "@typescript-eslint/interface-name-prefix": "off",
     "no-unused-vars": [
       "warn",
       {
@@ -33,15 +60,6 @@
     "no-console": "error",
     "no-undef-init": "off",
     "radix": "error",
-    "@typescript-eslint/no-unused-vars": "off",
-    "@typescript-eslint/no-inferrable-types": "off",
-    "@typescript-eslint/no-namespace": "warn",
-    "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/no-empty-interface": "warn",
-    "@typescript-eslint/no-non-null-assertion": "off",
-    "@typescript-eslint/no-explicit-any": "warn",
-    "@typescript-eslint/no-use-before-define": "off",
-    "@typescript-eslint/interface-name-prefix": "off",
     "sonarjs/cognitive-complexity": "warn",
     "sonarjs/no-duplicate-string": "warn",
     "sonarjs/prefer-immediate-return": "warn",

--- a/packages/manager/.changeset/pr-11337-added-1732714227095.md
+++ b/packages/manager/.changeset/pr-11337-added-1732714227095.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Linter rules for naming convention ([#11337](https://github.com/linode/manager/pull/11337))

--- a/packages/manager/.eslintrc.cjs
+++ b/packages/manager/.eslintrc.cjs
@@ -164,6 +164,24 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/interface-name-prefix': 'off',
+    '@typescript-eslint/naming-convention': [
+      'warn',
+      {
+        format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
+        leadingUnderscore: 'allow',
+        selector: 'variable',
+        trailingUnderscore: 'allow',
+      },
+      {
+        format: ['camelCase', 'PascalCase'],
+        selector: 'function',
+      },
+      {
+        format: ['camelCase'],
+        leadingUnderscore: 'allow',
+        selector: 'parameter',
+      },
+    ],
     '@typescript-eslint/no-empty-interface': 'warn',
     '@typescript-eslint/no-explicit-any': 'warn',
     '@typescript-eslint/no-inferrable-types': 'off',

--- a/packages/manager/.eslintrc.cjs
+++ b/packages/manager/.eslintrc.cjs
@@ -181,6 +181,10 @@ module.exports = {
         leadingUnderscore: 'allow',
         selector: 'parameter',
       },
+      {
+        format: ['PascalCase'],
+        selector: 'typeLike',
+      },
     ],
     '@typescript-eslint/no-empty-interface': 'warn',
     '@typescript-eslint/no-explicit-any': 'warn',

--- a/packages/manager/.eslintrc.cjs
+++ b/packages/manager/.eslintrc.cjs
@@ -173,6 +173,11 @@ module.exports = {
         trailingUnderscore: 'allow',
       },
       {
+        format: null,
+        modifiers: ['destructured'],
+        selector: 'variable',
+      },
+      {
         format: ['camelCase', 'PascalCase'],
         selector: 'function',
       },


### PR DESCRIPTION
## Description 📝

Follow up to the PR: #11330 

Previously added camelcase rule in `api-v4` and `manager` was causing thousands of warnings due to APIv4 property names in our codebase.

This PR Improves linter rules for naming convention - enforces rules for variables, functions, typeLike (`class`, `enum`, `interface`, `typeAlias`, `typeParameter`), and parameters, without the need to create any custom rules.

## Changes  🔄
- Enforce new linter rules (in `api-v4` and `manager` package) for:
   - variable
   - function
   - parameter
   - typeLike

## Target release date 🗓️
N/A

## How to test 🧪
- Ensure everything builds properly
- Test rule against APIv4 package, factories, and mock data to ensure no false positives
- Ensure any violations of the new rules trigger warnings/errors in your IDE
- Ensure no related warnings due to APIv4 property names in our codebase

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>