### PR TITLE
refactor: [M3-8954] - Update `@hookform/resolvers` to latest

### DIFF
--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -148,14 +148,13 @@ export interface CreateAlertDefinitionPayload {
   rule_criteria: {
     rules: MetricCriteria[];
   };
-  triggerCondition: TriggerCondition;
+  trigger_condition: TriggerCondition;
   channel_ids: number[];
 }
 export interface MetricCriteria {
   metric: string;
   aggregation_type: MetricAggregationType;
   operator: MetricOperatorType;
-  value: number;
   dimension_filters: DimensionFilter[];
 }
 

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -19,7 +19,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@hookform/resolvers": "2.9.11",
+    "@hookform/resolvers": "3.9.1",
     "@linode/api-v4": "*",
     "@linode/design-language-system": "^2.6.1",
     "@linode/search": "*",

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
@@ -19,6 +19,7 @@ import { filterFormValues, filterMetricCriteriaFormValues } from './utilities';
 
 import type { CreateAlertDefinitionForm, MetricCriteriaForm } from './types';
 import type { TriggerCondition } from '@linode/api-v4/lib/cloudpulse/types';
+import type { ObjectSchema } from 'yup';
 
 const triggerConditionInitialValues: TriggerCondition = {
   evaluation_period_seconds: 0,
@@ -30,7 +31,6 @@ const criteriaInitialValues: MetricCriteriaForm = {
   dimension_filters: [],
   metric: '',
   operator: null,
-  value: 0,
 };
 const initialValues: CreateAlertDefinitionForm = {
   channel_ids: [],
@@ -43,7 +43,7 @@ const initialValues: CreateAlertDefinitionForm = {
   },
   serviceType: null,
   severity: null,
-  triggerCondition: triggerConditionInitialValues,
+  trigger_condition: triggerConditionInitialValues,
 };
 
 const overrides = [
@@ -65,7 +65,9 @@ export const CreateAlertDefinition = () => {
   const formMethods = useForm<CreateAlertDefinitionForm>({
     defaultValues: initialValues,
     mode: 'onBlur',
-    resolver: yupResolver(CreateAlertDefinitionFormSchema),
+    resolver: yupResolver(
+      CreateAlertDefinitionFormSchema as ObjectSchema<CreateAlertDefinitionForm>
+    ),
   });
 
   const {

--- a/packages/manager/src/features/Images/ImagesCreate/ImageUpload.utils.ts
+++ b/packages/manager/src/features/Images/ImagesCreate/ImageUpload.utils.ts
@@ -28,7 +28,9 @@ export interface ImageUploadFormData extends ImageUploadPayload {
  * form state at once.
  */
 export const ImageUploadSchema = uploadImageSchema.shape({
-  file: mixed().required('Image is required.'),
+  file: mixed((input): input is File => input instanceof File).required(
+    'Image is required.'
+  ),
 });
 
 /**

--- a/packages/manager/src/features/Linodes/LinodeCreate/resolvers.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreate/resolvers.ts
@@ -18,8 +18,10 @@ import type {
   LinodeCreateFormContext,
   LinodeCreateFormValues,
 } from './utilities';
+import type { CreateLinodeRequest } from '@linode/api-v4';
 import type { QueryClient } from '@tanstack/react-query';
 import type { FieldErrors, Resolver } from 'react-hook-form';
+import type { ObjectSchema } from 'yup';
 
 export const getLinodeCreateResolver = (
   tab: LinodeCreateType | undefined,
@@ -27,12 +29,12 @@ export const getLinodeCreateResolver = (
 ): Resolver<LinodeCreateFormValues, LinodeCreateFormContext> => {
   const schema = linodeCreateResolvers[tab ?? 'OS'];
   return async (values, context, options) => {
-    const transformedValues = getLinodeCreatePayload(structuredClone(values));
+    const transformedValues = getLinodeCreatePayload(values);
 
     const { errors } = await yupResolver(
-      schema,
-      {},
-      { mode: 'async', rawValues: true }
+      schema as ObjectSchema<CreateLinodeRequest>,
+      { strict: true },
+      { mode: 'async', raw: true }
     )(transformedValues, context, options);
 
     if (tab === 'Clone Linode' && !values.linode) {

--- a/packages/manager/src/features/Linodes/LinodeCreate/resolvers.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreate/resolvers.ts
@@ -29,11 +29,11 @@ export const getLinodeCreateResolver = (
 ): Resolver<LinodeCreateFormValues, LinodeCreateFormContext> => {
   const schema = linodeCreateResolvers[tab ?? 'OS'];
   return async (values, context, options) => {
-    const transformedValues = getLinodeCreatePayload(values);
+    const transformedValues = getLinodeCreatePayload(structuredClone(values));
 
     const { errors } = await yupResolver(
       schema as ObjectSchema<CreateLinodeRequest>,
-      { strict: true },
+      {},
       { mode: 'async', raw: true }
     )(transformedValues, context, options);
 

--- a/packages/validation/src/buckets.schema.ts
+++ b/packages/validation/src/buckets.schema.ts
@@ -47,8 +47,17 @@ export const CreateBucketSchema = object()
       }),
       endpoint_type: string()
         .oneOf([...ENDPOINT_TYPES])
-        .notRequired(),
-      cors_enabled: boolean().notRequired(),
+        .optional(),
+      cors_enabled: boolean().optional(),
+      acl: string()
+        .oneOf([
+          'private',
+          'public-read',
+          'authenticated-read',
+          'public-read-write',
+        ])
+        .optional(),
+      s3_endpoint: string().optional(),
     },
     [['cluster', 'region']]
   )

--- a/packages/validation/src/cloudpulse.schema.ts
+++ b/packages/validation/src/cloudpulse.schema.ts
@@ -1,4 +1,4 @@
-import { array, number, object, string } from 'yup';
+import { array, mixed, number, object, string } from 'yup';
 
 const dimensionFilters = object({
   dimension_label: string().required('Label is required for the filter.'),
@@ -16,10 +16,9 @@ const metricCriteria = object({
   dimension_filters: array().of(dimensionFilters).notRequired(),
 });
 
-const triggerCondition = object({
-  criteria_condition: string().required('Criteria condition is required.'),
-  polling_interval_seconds: string().required('Polling Interval is required.'),
-  evaluation_period_seconds: string().required(
+const trigger_condition = object({
+  polling_interval_seconds: number().required('Polling Interval is required.'),
+  evaluation_period_seconds: number().required(
     'Evaluation Period is required.'
   ),
   trigger_occurrences: number()
@@ -30,10 +29,15 @@ const triggerCondition = object({
 export const createAlertDefinitionSchema = object({
   label: string().required('Name is required.'),
   description: string().optional(),
-  severity: string().required('Severity is required.'),
-  entity_ids: array().of(string()).min(1, 'At least one resource is needed.'),
-  criteria: array()
-    .of(metricCriteria)
-    .min(1, 'At least one metric criteria is needed.'),
-  triggerCondition,
+  severity: number().oneOf([0, 1, 2, 3]).required('Severity is required.'),
+  entity_ids: array()
+    .of(string().required())
+    .min(1, 'At least one resource is needed.'),
+  rule_criteria: object({
+    rules: array()
+      .of(metricCriteria)
+      .min(1, 'At least one metric criteria is needed.'),
+  }),
+  trigger_condition,
+  channel_ids: array(number()),
 });

--- a/packages/validation/src/cloudpulse.schema.ts
+++ b/packages/validation/src/cloudpulse.schema.ts
@@ -1,4 +1,4 @@
-import { array, mixed, number, object, string } from 'yup';
+import { array, number, object, string } from 'yup';
 
 const dimensionFilters = object({
   dimension_label: string().required('Label is required for the filter.'),

--- a/packages/validation/src/images.schema.ts
+++ b/packages/validation/src/images.schema.ts
@@ -9,10 +9,10 @@ const labelSchema = string()
   );
 
 export const baseImageSchema = object({
-  label: labelSchema.notRequired(),
-  description: string().notRequired().min(1).max(65000),
-  cloud_init: boolean().notRequired(),
-  tags: array(string().min(3).max(50)).max(500).notRequired(),
+  label: labelSchema.optional(),
+  description: string().optional().min(1).max(65000),
+  cloud_init: boolean().optional(),
+  tags: array(string().min(3).max(50).required()).max(500).optional(),
 });
 
 export const createImageSchema = baseImageSchema.shape({
@@ -27,11 +27,11 @@ export const uploadImageSchema = baseImageSchema.shape({
 });
 
 export const updateImageSchema = object({
-  label: labelSchema.notRequired(),
+  label: labelSchema.optional(),
   description: string()
-    .notRequired()
+    .optional()
     .max(65000, 'Length must be 65000 characters or less.'),
-  tags: array(string()).notRequired(),
+  tags: array(string().required()).optional(),
 });
 
 export const updateImageRegionsSchema = object({

--- a/packages/validation/src/kubernetes.schema.ts
+++ b/packages/validation/src/kubernetes.schema.ts
@@ -62,13 +62,13 @@ export const createKubeClusterSchema = object().shape({
     .min(1, 'Please add at least one node pool.'),
 });
 
-export const ipv4Address = string().required().test({
+export const ipv4Address = string().defined().test({
   name: 'validateIP',
   message: 'Must be a valid IPv4 address.',
   test: validateIP,
 });
 
-export const ipv6Address = string().required().test({
+export const ipv6Address = string().defined().test({
   name: 'validateIP',
   message: 'Must be a valid IPv6 address.',
   test: validateIP,

--- a/packages/validation/src/kubernetes.schema.ts
+++ b/packages/validation/src/kubernetes.schema.ts
@@ -62,13 +62,13 @@ export const createKubeClusterSchema = object().shape({
     .min(1, 'Please add at least one node pool.'),
 });
 
-export const ipv4Address = string().test({
+export const ipv4Address = string().required().test({
   name: 'validateIP',
   message: 'Must be a valid IPv4 address.',
   test: validateIP,
 });
 
-export const ipv6Address = string().test({
+export const ipv6Address = string().required().test({
   name: 'validateIP',
   message: 'Must be a valid IPv6 address.',
   test: validateIP,
@@ -77,10 +77,12 @@ export const ipv6Address = string().test({
 const controlPlaneACLOptionsSchema = object().shape({
   enabled: boolean(),
   'revision-id': string(),
-  addresses: object().shape({
-    ipv4: array().of(ipv4Address).nullable(),
-    ipv6: array().of(ipv6Address).nullable(),
-  }),
+  addresses: object()
+    .shape({
+      ipv4: array().of(ipv4Address).nullable(),
+      ipv6: array().of(ipv6Address).nullable(),
+    })
+    .notRequired(),
 });
 
 export const kubernetesControlPlaneACLPayloadSchema = object().shape({

--- a/yarn.lock
+++ b/yarn.lock
@@ -949,10 +949,10 @@
   dependencies:
     levn "^0.4.1"
 
-"@hookform/resolvers@2.9.11":
-  version "2.9.11"
-  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-2.9.11.tgz#9ce96e7746625a89239f68ca57c4f654264c17ef"
-  integrity sha512-bA3aZ79UgcHj7tFV7RlgThzwSSHZgvfbt2wprldRkYBcMopdMvHyO17Wwp/twcJasNFischFfS7oz8Katz8DdQ==
+"@hookform/resolvers@3.9.1":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-3.9.1.tgz#a23883c40bfd449cb6c6ab5a0fa0729184c950ff"
+  integrity sha512-ud2HqmGBM0P0IABqoskKWI6PEf6ZDDBZkFqe2Vnl+mTHCEHzr3ISjjZyCwTjC/qpL25JC9aIDkloQejvMeq0ug==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
## Description 📝

- Updates  `@hookform/resolvers` to latest  📦 
- Brings enhanced type-safety and will unblock other efforts like M3-8956 ✨ 

## Changes  🔄

> [!note]
> These changes were necessary to satisfy TypeScript now that yup resolvers are more type safe

- Fixes incorrect CloudPulse alerting incorrect types / schemas
- Replaces some instances of  `notRequired()` with `optional()`
  - `notRequired()` means the value can be null, undefined, or not present
  - `optional()` means the value can be undefined or not present 
  - This change was needed to make our resolvers satisfy/match the types defined in `api-v4`
- Added missing fields on `CreateBucketSchema`
- Fixed deprecations and cleaned up the Linode Create resolver 

## Preview 📷

> [!note]
> There should be no UI changes

## How to test 🧪

- Check for schema regressions
  - Manually test affected forms
  - Verify cypress tests pass for affected forms

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>