### PR TITLE
added: [M3-6989] - `aria-describedby` to TextField with helper text

### DIFF
--- a/packages/manager/.changeset/pr-11351-added-1733194164261.md
+++ b/packages/manager/.changeset/pr-11351-added-1733194164261.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+aria-describedby to TextField with helper text ([#11351](https://github.com/linode/manager/pull/11351))

--- a/packages/ui/src/components/TextField/TextField.test.tsx
+++ b/packages/ui/src/components/TextField/TextField.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, getDefaultNormalizer } from '@testing-library/react';
 import * as React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { renderWithTheme } from '../../utilities/testHelpers';
 import { InputAdornment } from '../InputAdornment';

--- a/packages/ui/src/components/TextField/TextField.test.tsx
+++ b/packages/ui/src/components/TextField/TextField.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, getDefaultNormalizer } from '@testing-library/react';
 import * as React from 'react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { renderWithTheme } from '../../utilities/testHelpers';
 import { InputAdornment } from '../InputAdornment';
@@ -90,5 +90,37 @@ describe('TextField', () => {
     expect(input?.getAttribute('value')).toBe('10');
     fireEvent.change(input, { target: { value: '1' } });
     expect(input?.getAttribute('value')).toBe('2');
+  });
+
+  it('renders a helper text with an input id', () => {
+    const { getByText } = renderWithTheme(
+      <TextField helperText="Helper text" inputId="input-id" label="" />
+    );
+
+    expect(getByText('Helper text')).toBeInTheDocument();
+    const helperText = getByText('Helper text');
+    expect(helperText.getAttribute('id')).toBe('input-id-helper-text');
+  });
+
+  it('renders a helper text with a label', () => {
+    const { getByText } = renderWithTheme(
+      <TextField helperText="Helper text" label="Label" />
+    );
+
+    const helperText = getByText('Helper text');
+
+    expect(helperText).toBeInTheDocument();
+    expect(helperText.getAttribute('id')).toBe('label-helper-text');
+  });
+
+  it('renders a helper text with a fallback id', () => {
+    const { getByText } = renderWithTheme(
+      <TextField helperText="Helper text" label="" />
+    );
+
+    const helperText = getByText('Helper text');
+
+    // ':rg:' being the default react generated id
+    expect(helperText.getAttribute('id')).toBe(':rg:-helper-text');
   });
 });

--- a/packages/ui/src/components/TextField/TextField.tsx
+++ b/packages/ui/src/components/TextField/TextField.tsx
@@ -113,7 +113,8 @@ interface InputToolTipProps {
   tooltipWidth?: number;
 }
 
-interface TextFieldPropsOverrides extends StandardTextFieldProps {
+interface TextFieldPropsOverrides
+  extends Omit<StandardTextFieldProps, 'label'> {
   // We override this prop to make it required
   label: string;
 }
@@ -248,8 +249,7 @@ export const TextField = (props: TextFieldProps) => {
       : `error-for-scroll`;
   }
 
-  const validInputId =
-    inputId || (label ? convertToKebabCase(`${label}`) : undefined);
+  const validInputId = inputId || convertToKebabCase(label);
 
   const labelSuffixText = required
     ? '(required)'
@@ -364,6 +364,9 @@ export const TextField = (props: TextFieldProps) => {
             ...SelectProps,
           }}
           inputProps={{
+            'aria-describedby': helperText
+              ? `${validInputId}-helper-text`
+              : undefined,
             'data-testid': 'textfield-input',
             id: validInputId,
             ...inputProps,
@@ -437,7 +440,10 @@ export const TextField = (props: TextFieldProps) => {
         </FormHelperText>
       )}
       {helperText && helperTextPosition === 'bottom' && (
-        <FormHelperText data-qa-textfield-helper-text>
+        <FormHelperText
+          data-qa-textfield-helper-text
+          id={`${validInputId}-helper-text`}
+        >
           {helperText}
         </FormHelperText>
       )}

--- a/packages/ui/src/components/TextField/TextField.tsx
+++ b/packages/ui/src/components/TextField/TextField.tsx
@@ -257,6 +257,8 @@ export const TextField = (props: TextFieldProps) => {
       : // label could still be an empty string
         fallbackId);
 
+  const helperTextId = `${validInputId}-helper-text`;
+
   const labelSuffixText = required
     ? '(required)'
     : optional
@@ -370,9 +372,7 @@ export const TextField = (props: TextFieldProps) => {
             ...SelectProps,
           }}
           inputProps={{
-            'aria-describedby': helperText
-              ? `${validInputId}-helper-text`
-              : undefined,
+            'aria-describedby': helperText ? helperTextId : undefined,
             'data-testid': 'textfield-input',
             id: validInputId,
             ...inputProps,
@@ -446,10 +446,7 @@ export const TextField = (props: TextFieldProps) => {
         </FormHelperText>
       )}
       {helperText && helperTextPosition === 'bottom' && (
-        <FormHelperText
-          data-qa-textfield-helper-text
-          id={`${validInputId}-helper-text`}
-        >
+        <FormHelperText data-qa-textfield-helper-text id={helperTextId}>
           {helperText}
         </FormHelperText>
       )}

--- a/packages/ui/src/components/TextField/TextField.tsx
+++ b/packages/ui/src/components/TextField/TextField.tsx
@@ -167,6 +167,7 @@ export const TextField = (props: TextFieldProps) => {
 
   const [_value, setValue] = React.useState<Value>(value);
   const theme = useTheme();
+  const fallbackId = React.useId();
 
   React.useEffect(() => {
     setValue(value);
@@ -249,7 +250,12 @@ export const TextField = (props: TextFieldProps) => {
       : `error-for-scroll`;
   }
 
-  const validInputId = inputId || convertToKebabCase(label);
+  const validInputId =
+    inputId ||
+    (label
+      ? convertToKebabCase(label)
+      : // label could still be an empty string
+        fallbackId);
 
   const labelSuffixText = required
     ? '(required)'

--- a/packages/ui/src/components/TextField/TextField.tsx
+++ b/packages/ui/src/components/TextField/TextField.tsx
@@ -258,6 +258,7 @@ export const TextField = (props: TextFieldProps) => {
         fallbackId);
 
   const helperTextId = `${validInputId}-helper-text`;
+  const errorTextId = `${validInputId}-error-text`;
 
   const labelSuffixText = required
     ? '(required)'
@@ -325,6 +326,7 @@ export const TextField = (props: TextFieldProps) => {
             marginTop: theme.spacing(),
           }}
           data-qa-textfield-helper-text
+          id={helperTextId}
         >
           {helperText}
         </FormHelperText>
@@ -373,6 +375,8 @@ export const TextField = (props: TextFieldProps) => {
           }}
           inputProps={{
             'aria-describedby': helperText ? helperTextId : undefined,
+            'aria-errormessage': errorText ? errorTextId : undefined,
+            'aria-invalid': !!error || !!errorText,
             'data-testid': 'textfield-input',
             id: validInputId,
             ...inputProps,


### PR DESCRIPTION
## Description 📝
Tiny PR to add better accessibility to the `Textfield` via its `helperText` prop.

On screen, it is trivial for a user to see a helper test associated with a field, but this is not necessarily true for someone using a screen reader, since the helper text is a plain paragraph floating under the input, and isn't associated with its relevant interactive element.

## Changes  🔄
- Describe the textfield by its helper text when disabled
- Cleanup textfield input ID logic (see self review)

## Preview 📷
![Screenshot 2024-12-02 at 16 39 25](https://github.com/user-attachments/assets/df8e72c2-e581-43db-bc2e-2c52c6519100)

## How to test 🧪

### Prerequisites

### Verification steps
- [ ] Check markup to confirm `Textfield` & `HelperText` relationship
- [ ] Optional: confirm behavior with VoiceOver util

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
