### PR TITLE
fix: [M3-8958] - LinodeCreate OS Panel fetches region with -1 on page load

### DIFF
--- a/packages/manager/.changeset/pr-11356-fixed-1733237715392.md
+++ b/packages/manager/.changeset/pr-11356-fixed-1733237715392.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+LinodeCreate OS Panel fetches region with -1 on page load ([#11356](https://github.com/linode/manager/pull/11356))

--- a/packages/manager/src/features/Linodes/LinodeCreate/Tabs/OperatingSystems.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Tabs/OperatingSystems.tsx
@@ -32,7 +32,7 @@ export const OperatingSystems = () => {
     name: 'region',
   });
 
-  const { data: region } = useRegionQuery(regionId ?? -1);
+  const { data: region } = useRegionQuery(regionId);
 
   const isCreateLinodeRestricted = useRestrictedGlobalGrantCheck({
     globalGrantType: 'add_linodes',


### PR DESCRIPTION
## Description 📝
Super small fix to avoid having OS panel fetching a -1 region by default. 

bug introduced in https://github.com/linode/manager/pull/11206/files

The query is disabled if if there's no region ID so passing a default `-1` breaks that pattern
https://github.com/linode/manager/blob/develop/packages/manager/src/queries/regions/regions.ts#L43

## Changes  🔄
- fix `-1` default fetch to regions/{id} query 

## Target release date 🗓️
**12/12/2024**

## Preview 📷
![Screenshot 2024-12-03 at 09 56 03](https://github.com/user-attachments/assets/fe631424-2785-4d45-bb38-6da511a5d31d)

## How to test 🧪

### Prerequisites

### Verification steps
- [ ] Verify no `-1` is ran when /linodes/create?type=OS loads
