### PR TITLE
change: [M3-8961] - Change Pendo sanitized url path string to match UXR request

### DIFF
--- a/packages/manager/.changeset/pr-11361-tech-stories-1733330515390.md
+++ b/packages/manager/.changeset/pr-11361-tech-stories-1733330515390.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Change Pendo sanitized URL path string ([#11361](https://github.com/linode/manager/pull/11361))

--- a/packages/manager/src/hooks/usePendo.test.ts
+++ b/packages/manager/src/hooks/usePendo.test.ts
@@ -2,19 +2,19 @@ import { transformUrl } from './usePendo';
 
 const ID_URLS = [
   {
-    expectedTransform: 'https://cloud.linode.com/nodebalancers/XXXX',
+    expectedTransform: 'https://cloud.linode.com/nodebalancers/*',
     position: 'end',
     url: 'https://cloud.linode.com/nodebalancers/123',
   },
   {
     expectedTransform:
-      'https://cloud.linode.com/nodebalancers/XXXX/configurations',
+      'https://cloud.linode.com/nodebalancers/*/configurations',
     position: 'middle',
     url: 'https://cloud.linode.com/nodebalancers/123/configurations',
   },
   {
     expectedTransform:
-      'https://cloud.linode.com/nodebalancers/XXXX/configurations/XXXX',
+      'https://cloud.linode.com/nodebalancers/*/configurations/*',
     position: 'multiple',
     url: 'https://cloud.linode.com/nodebalancers/123/configurations/456',
   },
@@ -37,23 +37,20 @@ const USERNAME_URLS = [
 
 const OBJ_URLS = [
   {
-    expectedTransform:
-      'http://cloud.linode.com/object-storage/buckets/XXXX/XXXX',
+    expectedTransform: 'http://cloud.linode.com/object-storage/buckets/*/*',
     path: 'us-west/abc123',
   },
   {
-    expectedTransform:
-      'http://cloud.linode.com/object-storage/buckets/XXXX/XXXX/ssl',
+    expectedTransform: 'http://cloud.linode.com/object-storage/buckets/*/*/ssl',
     path: 'us-west/abc123/ssl',
   },
   {
-    expectedTransform:
-      'http://cloud.linode.com/object-storage/buckets/XXXX/XXXX',
+    expectedTransform: 'http://cloud.linode.com/object-storage/buckets/*/*',
     path: 'us-west/123abc',
   },
   {
     expectedTransform:
-      'http://cloud.linode.com/object-storage/buckets/XXXX/XXXX/access',
+      'http://cloud.linode.com/object-storage/buckets/*/*/access',
     path: 'us-west/123abc/access',
   },
 ];

--- a/packages/manager/src/hooks/usePendo.ts
+++ b/packages/manager/src/hooks/usePendo.ts
@@ -41,14 +41,14 @@ export const transformUrl = (url: string) => {
   const oauthPathMatchingRegex = /(#access_token).*/;
   let transformedUrl = url;
 
-  // Replace any ids with XXXX and keep the rest of the URL intact
-  transformedUrl = url.replace(idMatchingRegex, '/XXXX');
+  // Replace any ids with * and keep the rest of the URL intact
+  transformedUrl = url.replace(idMatchingRegex, `/*`);
 
-  // Replace the region and bucket names with XXXX and keep the rest of the URL intact.
+  // Replace the region and bucket names with * and keep the rest of the URL intact.
   // Object storage file navigation is truncated via the 'clear search' transform.
   transformedUrl = transformedUrl.replace(
     bucketPathMatchingRegex,
-    'buckets/XXXX/XXXX'
+    'buckets/*/*'
   );
 
   // Remove everything after access_token


### PR DESCRIPTION
## Description 📝

UXR has reported:

"On our end, to ensure we are tracking accurately, we have to replace the `XXXX` with an `<ignore>` or `*` rule in the Pendo Tagging tool. Is there a way to replace it with a `*`? It will save manual steps in Pendo.. . once most pages have those bits replaced while retrotagging, we can make sure to look out for `XXXX` and replaced it in the Rule Builder with the attached screenshots."

Even with rules configured, changing the `XXXX` to `*` now will save time and speed up the tagging process in the future because new URLs will not have to have the same rules configured to transform the `XXXX`s.

**Note: We confirmed via Pendo that the unicode %2A wouldn't be an issue - the * in a rule will match the unicode in the normalized pattern.**

## Changes  🔄

- Replaced the `XXXX` string with `*` in URL transformation and unit test 

## Target release date 🗓️

12/10

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-12-03 at 10 20 29 AM](https://github.com/user-attachments/assets/9b303439-ca42-49f6-9626-aa7e8212a524) | ![image (9)](https://github.com/user-attachments/assets/cb44b839-f8d4-4873-b8ff-2237085ace8c) |
| ![Screenshot 2024-12-03 at 10 21 28 AM](https://github.com/user-attachments/assets/41289925-1dcb-4eff-9a6f-49056d85acb8) | ![Screenshot 2024-12-03 at 10 38 00 AM](https://github.com/user-attachments/assets/de7355d2-42f5-4d0e-aece-878c6c16d187) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Follow the instructions here: https://github.com/linode/manager/pull/10982

### Verification steps

(How to verify changes)

- [ ] Confirm the change looking at the normalizedUrl in requests in the browser console filtering on "pendo".
- [ ] Confirm unit test passes:
```
yarn test usePendo
```

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
