### PR TITLE
test: [M3-8487] - Improve Cypress test VLAN handling

### DIFF
--- a/packages/manager/.changeset/pr-11362-tests-1740410848045.md
+++ b/packages/manager/.changeset/pr-11362-tests-1740410848045.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Improve Cypress test VLAN handling ([#11362](https://github.com/linode/manager/pull/11362))

--- a/packages/manager/cypress/support/api/vlans.ts
+++ b/packages/manager/cypress/support/api/vlans.ts
@@ -1,0 +1,27 @@
+import { VLAN, getVlans } from '@linode/api-v4';
+import { pageSize } from 'support/constants/api';
+import { depaginate } from 'support/util/paginate';
+
+import { isTestLabel } from './common';
+
+/**
+ * Returns a VLAN to use for a test resource, creating it if one does not already exist.
+ *
+ * @returns Promise that resolves to existing or new VLAN.
+ */
+export const findOrCreateDependencyVlan = async (linodeRegion: string) => {
+  const vlans = await depaginate<VLAN>((page: number) =>
+    getVlans({ page, page_size: pageSize })
+  );
+
+  const suitableVlans = vlans.filter(({ label, region }: VLAN) => {
+    return isTestLabel(label) && region === linodeRegion;
+  });
+
+  if (suitableVlans.length > 0) {
+    return suitableVlans[0];
+  }
+
+  // No suitable VLANs exist, so we'll return null value and create a new one later.
+  return null;
+};

--- a/packages/manager/cypress/support/api/vlans.ts
+++ b/packages/manager/cypress/support/api/vlans.ts
@@ -3,6 +3,7 @@ import { pageSize } from 'support/constants/api';
 import { depaginate } from 'support/util/paginate';
 
 import { isTestLabel } from './common';
+import { randomLabel } from 'support/util/random';
 
 /**
  * Returns a VLAN to use for a test resource, creating it if one does not already exist.
@@ -14,14 +15,14 @@ export const findOrCreateDependencyVlan = async (linodeRegion: string) => {
     getVlans({ page, page_size: pageSize })
   );
 
-  const suitableVlans = vlans.filter(({ label, region }: VLAN) => {
+  const suitableVlan = vlans.find(({ label, region }: VLAN) => {
     return isTestLabel(label) && region === linodeRegion;
   });
 
-  if (suitableVlans.length > 0) {
-    return suitableVlans[0];
+  if (suitableVlan) {
+    return suitableVlan.label;
   }
 
   // No suitable VLANs exist, so we'll return null value and create a new one later.
-  return null;
+  return randomLabel();
 };

--- a/packages/manager/cypress/support/api/vlans.ts
+++ b/packages/manager/cypress/support/api/vlans.ts
@@ -6,9 +6,9 @@ import { isTestLabel } from './common';
 import { randomLabel } from 'support/util/random';
 
 /**
- * Returns a VLAN to use for a test resource, creating it if one does not already exist.
+ * Returns a VLAN label to use for a test resource, creating it if one does not already exist.
  *
- * @returns Promise that resolves to existing or new VLAN.
+ * @returns Promise that resolves to existing or new VLAN label.
  */
 export const findOrCreateDependencyVlan = async (linodeRegion: string) => {
   const vlans = await depaginate<VLAN>((page: number) =>
@@ -23,6 +23,6 @@ export const findOrCreateDependencyVlan = async (linodeRegion: string) => {
     return suitableVlan.label;
   }
 
-  // No suitable VLANs exist, so we'll return null value and create a new one later.
+  // No suitable VLANs exist, so we'll return random label and create a new one later.
   return randomLabel();
 };

--- a/packages/manager/cypress/support/util/linodes.ts
+++ b/packages/manager/cypress/support/util/linodes.ts
@@ -15,6 +15,7 @@ import type {
   InterfacePayload,
   Linode,
 } from '@linode/api-v4';
+import { findOrCreateDependencyVlan } from 'support/api/vlans';
 
 /**
  * Linode create interface to configure a Linode with no public internet access.
@@ -84,6 +85,11 @@ export const createTestLinode = async (
     ...(options || {}),
   };
 
+  let regionId = createRequestPayload?.region;
+  if (!regionId) {
+    regionId = chooseRegion().id;
+  }
+
   const securityMethodPayload: Partial<CreateLinodeRequest> = await (async () => {
     switch (resolvedOptions.securityMethod) {
       case 'firewall':
@@ -94,8 +100,13 @@ export const createTestLinode = async (
         };
 
       case 'vlan_no_internet':
+        const vlanConfig = linodeVlanNoInternetConfig;
+        const vlan = await findOrCreateDependencyVlan(regionId);
+        if (vlan && vlan.label) {
+          vlanConfig[0].label = vlan.label;
+        }
         return {
-          interfaces: linodeVlanNoInternetConfig,
+          interfaces: vlanConfig,
         };
 
       case 'powered_off':
@@ -110,7 +121,8 @@ export const createTestLinode = async (
       booted: false,
       image: 'linode/ubuntu24.04',
       label: randomLabel(),
-      region: chooseRegion().id,
+      region: regionId,
+      booted: false,
     }),
     ...(createRequestPayload || {}),
     ...securityMethodPayload,


### PR DESCRIPTION
## Description 📝
Improve Cypress test to handle VLAN assignment.

## Major Changes 🔄
- Improve Cypress test that checks if a test VLAN exists for the desired region before creating a new one. If one exists, use it instead.

## How to test 🧪
Run `Boots a config` test case in
```
yarn cy:run -s "cypress/e2e/core/linodes/linode-config.spec.ts"
```
No new VLAN is created when there exists one for the desired region.