### PR TITLE
feat: [M3-8931] - Add doc link and region availability banner for Accelerated plans

### DIFF
--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
@@ -7,6 +7,7 @@ import { useFlags } from 'src/hooks/useFlags';
 
 import { APLNotice } from './APLNotice';
 import {
+  ACCELERATED_COMPUTE_INSTANCES_LINK,
   DEDICATED_COMPUTE_INSTANCES_LINK,
   GPU_COMPUTE_INSTANCES_LINK,
   HIGH_MEMORY_COMPUTE_INSTANCES_LINK,
@@ -60,12 +61,7 @@ export const PlanInformation = (props: PlanInformationProps) => {
     hasMajorityOfPlansDisabled;
 
   const transferBanner = (
-    <Notice
-      spacingBottom={
-        planType === 'accelerated' && !showLimitedAvailabilityBanner ? 24 : 8
-      }
-      variant="warning"
-    >
+    <Notice spacingBottom={8} variant="warning">
       <Typography
         fontFamily={(theme: Theme) => theme.font.bold}
         fontSize="1rem"
@@ -109,7 +105,17 @@ export const PlanInformation = (props: PlanInformationProps) => {
           />
         </>
       ) : null}
-      {planType === 'accelerated' && transferBanner}
+      {planType === 'accelerated' && (
+        <>
+          {transferBanner}
+          <PlansAvailabilityNotice
+            hasSelectedRegion={hasSelectedRegion}
+            isSelectedRegionEligibleForPlan={isSelectedRegionEligibleForPlan}
+            planType={planType}
+            regionsData={regionsData || []}
+          />
+        </>
+      )}
       {planType === 'metal' ? (
         <MetalNotice
           dataTestId="metal-notice"
@@ -177,9 +183,8 @@ export const ClassDescriptionCopy = (props: ExtendedPlanType) => {
       docLink = GPU_COMPUTE_INSTANCES_LINK;
       break;
     case 'accelerated':
-      // TODO: accelerated plans - acquire doc link
       planTypeLabel = 'Accelerated';
-      docLink = '#';
+      docLink = ACCELERATED_COMPUTE_INSTANCES_LINK;
       break;
     default:
       planTypeLabel = null;

--- a/packages/manager/src/features/components/PlansPanel/constants.ts
+++ b/packages/manager/src/features/components/PlansPanel/constants.ts
@@ -27,6 +27,9 @@ export const GPU_COMPUTE_INSTANCES_LINK =
   'https://techdocs.akamai.com/cloud-computing/docs/gpu-compute-instances';
 export const TRANSFER_COSTS_LINK =
   'https://techdocs.akamai.com/cloud-computing/docs/network-transfer-usage-and-costs';
+// TODO: accelerated plans - update to GA link (when GA launches)
+export const ACCELERATED_COMPUTE_INSTANCES_LINK =
+  'https://techdocs.akamai.com/cloud-computing/docs/accelerated-compute-instances-beta';
 
 export const DEDICATED_512_GB_PLAN: ExtendedType = {
   accelerated_devices: 0,


### PR DESCRIPTION
## Description 📝
- add doc link and region availability banner

## Target release date 🗓️
12/10 - in develop before release cut

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/cfe4dd24-b160-4b86-8e15-398451a764fc) | ![image](https://github.com/user-attachments/assets/de12ddc0-8faa-4ce8-806d-c3067ca031fd) |

## How to test 🧪
- confirm Region availability banner shows up as expected (for all regions except the 5 accel is available in)
- confirm doc link

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
