### PR TITLE
refactor: [M3-8964] - Remove `reselect` dependency

### DIFF
--- a/packages/manager/.changeset/pr-11364-tech-stories-1733273269749.md
+++ b/packages/manager/.changeset/pr-11364-tech-stories-1733273269749.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Remove \`reselect\` dependency ([#11364](https://github.com/linode/manager/pull/11364))

--- a/packages/manager/.changeset/pr-11364-tech-stories-1733273269749.md
+++ b/packages/manager/.changeset/pr-11364-tech-stories-1733273269749.md
@@ -2,4 +2,4 @@
 "@linode/manager": Tech Stories
 ---
 
-Remove \`reselect\` dependency ([#11364](https://github.com/linode/manager/pull/11364))
+Remove `reselect` dependency ([#11364](https://github.com/linode/manager/pull/11364))

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -79,7 +79,6 @@
     "recompose": "^0.30.0",
     "redux": "^4.0.4",
     "redux-thunk": "^2.3.0",
-    "reselect": "^4.0.0",
     "search-string": "^3.1.0",
     "throttle-debounce": "^2.0.0",
     "tss-react": "^4.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8732,11 +8732,6 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
-reselect@^4.0.0:
-  version "4.1.8"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.8.tgz#3f5dc671ea168dccdeb3e141236f69f02eaec524"
-  integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==
-
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"


### PR DESCRIPTION
## Description 📝

- Removes the `reselect` dependency 📦 
- I think this is some kind of Redux tool. We probably used it at some point but don't anymore now that we've removed more redux related code.

## How to test 🧪

- Verify `yarn.lock` changes look correct
- Verify `reselect` isn't used anywhere
- Verify automated checks pass 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>