### PR TITLE
test: [M3-8758]- Fixed `delete-volume.spec.ts` flaky test

### DIFF
--- a/packages/manager/.changeset/pr-11365-tests-1733305182663.md
+++ b/packages/manager/.changeset/pr-11365-tests-1733305182663.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix `delete-volume.spec.ts` flaky test ([#11365](https://github.com/linode/manager/pull/11365))

--- a/packages/manager/cypress/e2e/core/volumes/delete-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/delete-volume.spec.ts
@@ -1,4 +1,4 @@
-import { createVolume } from '@linode/api-v4/lib/volumes';
+import { createVolume, VolumeRequestPayload } from '@linode/api-v4/lib/volumes';
 import { Volume } from '@linode/api-v4';
 import { volumeRequestPayloadFactory } from 'src/factories/volume';
 import { authenticate } from 'support/api/authentication';
@@ -7,12 +7,27 @@ import { randomLabel } from 'support/util/random';
 import { ui } from 'support/ui';
 import { chooseRegion } from 'support/util/regions';
 import { cleanUp } from 'support/util/cleanup';
+import { SimpleBackoffMethod } from 'support/util/backoff';
+import { pollVolumeStatus } from 'support/util/polling';
 
 // Local storage override to force volume table to list up to 100 items.
 // This is a workaround while we wait to get stuck volumes removed.
 // @TODO Remove local storage override when stuck volumes are removed from test accounts.
 const pageSizeOverride = {
   PAGE_SIZE: 100,
+};
+
+/**
+ * Creates a Volume and waits for it to become active.
+ *
+ * @param volumeRequest - Volume create request payload.
+ *
+ * @returns Promise that resolves to created Volume.
+ */
+const createActiveVolume = async (volumeRequest: VolumeRequestPayload) => {
+  const volume = await createVolume(volumeRequest);
+  await pollVolumeStatus(volume.id, 'active', new SimpleBackoffMethod(10000));
+  return volume;
 };
 
 authenticate();
@@ -37,7 +52,7 @@ describe('volume delete flow', () => {
       region: chooseRegion().id,
     });
 
-    cy.defer(() => createVolume(volumeRequest), 'creating volume').then(
+    cy.defer(() => createActiveVolume(volumeRequest), 'creating volume').then(
       (volume: Volume) => {
         interceptDeleteVolume(volume.id).as('deleteVolume');
         cy.visitWithLogin('/volumes', {


### PR DESCRIPTION
## Description 📝
The test doesn't wait for the Volume to finish being created before attempting to delete.

## Changes  🔄
- Added polling to the Volumes endpoint to wait for the Volume to be ready before proceeding with the rest of the test.

## Target release date 🗓️
12/12


## How to test 🧪

- [ ] Run `delete-volume.spec.ts` test using `yarn cy:debug`

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
