### PR TITLE
change: [M3-8343] - Change VPC expanded header background color

### DIFF
--- a/packages/manager/.changeset/pr-11366-changed-1733315498672.md
+++ b/packages/manager/.changeset/pr-11366-changed-1733315498672.md
@@ -2,4 +2,4 @@
 "@linode/manager": Changed
 ---
 
-Change VPC expanded header background color ([#11366](https://github.com/linode/manager/pull/11366))
+VPC expanded header background color ([#11366](https://github.com/linode/manager/pull/11366))

--- a/packages/manager/.changeset/pr-11366-changed-1733315498672.md
+++ b/packages/manager/.changeset/pr-11366-changed-1733315498672.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Change VPC expanded header background color ([#11366](https://github.com/linode/manager/pull/11366))

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
@@ -328,7 +328,14 @@ const getFirewallLinks = (data: Firewall[]): JSX.Element => {
 };
 
 export const SubnetLinodeTableRowHead = (
-  <TableRow>
+  <TableRow
+    sx={(theme) => ({
+      '& .MuiTableCell-root': {
+        backgroundColor:
+          theme.name == 'dark' ? theme.tokens.color.Neutrals[80] : undefined,
+      },
+    })}
+  >
     <StyledTableHeadCell>Linode Label</StyledTableHeadCell>
     <StyledTableHeadCell sx={{ width: '14%' }}>Status</StyledTableHeadCell>
     <Hidden smDown>

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
@@ -174,7 +174,15 @@ export const VPCSubnetsTable = (props: Props) => {
   }
 
   const SubnetTableRowHead = (
-    <TableRow>
+    <TableRow
+      sx={(theme) => ({
+        '& .MuiTableCell-root': {
+          backgroundColor:
+            theme.name == 'light' ? theme.color.black : undefined,
+          color: theme.name == 'light' ? `${theme.color.white}` : undefined,
+        },
+      })}
+    >
       <StyledTableSortCell
         sx={(theme) => ({
           [theme.breakpoints.down('sm')]: {
@@ -204,7 +212,7 @@ export const VPCSubnetsTable = (props: Props) => {
       <Hidden smDown>
         <StyledTableCell sx={{ width: '10%' }}>Linodes</StyledTableCell>
       </Hidden>
-      <StyledTableCell></StyledTableCell>
+      <StyledTableCell />
     </TableRow>
   );
 
@@ -364,6 +372,10 @@ const StyledTableCell = styled(TableCell, {
 const StyledTableSortCell = styled(TableSortCell, {
   label: 'StyledTableSortCell',
 })(({ theme }) => ({
+  '& .Mui-active': {
+    color: theme.name == 'light' ? `${theme.color.white}` : undefined,
+  },
   borderBottom: `1px solid ${theme.borderColors.borderTable} !important`,
+  color: theme.name == 'light' ? `${theme.color.white}` : undefined,
   whiteSpace: 'nowrap',
 }));


### PR DESCRIPTION
## Description 📝

This pull request updates the background color of the VPC expanded header for improved visual clarity and design consistency. The new color provides better contrast, ensuring the header is more distinguishable from surrounding elements.

## Changes  🔄

- Updated the background color of the VPC expanded header.
- Ensured compatibility with existing theme and design guidelines.

## Target release date 🗓️

N/A

## Preview 📷


| Before | After |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/c8e076c3-4fcc-4093-8486-d1f72dab6ad6) | ![After](https://github.com/user-attachments/assets/4a40578f-f8e3-4a49-b0da-05e657851eb7) |
| ![Before](https://github.com/user-attachments/assets/60058356-ef15-4941-ba03-294b1c135e6d) | ![After](https://github.com/user-attachments/assets/3e3df1e9-2c90-4f78-9281-53523d4f99b1) |

## How to test 🧪

### Prerequisites
- Ensure you have a Linode with a VPC.

### Reproduction steps

- Go to the VPC details page.
- Observe that the background color of the VPC expanded header has been updated.

### Verification steps

- Confirm that the new background color is applied as expected.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
