### PR TITLE
feat: [M3-8855] - Surface Node Pool Tags

### DIFF
--- a/packages/api-v4/.changeset/pr-11368-added-1733420616390.md
+++ b/packages/api-v4/.changeset/pr-11368-added-1733420616390.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Added
+---
+
+tags to KubeNodePoolResponse and CreateNodePoolData ([#11368](https://github.com/linode/manager/pull/11368))

--- a/packages/api-v4/.changeset/pr-11368-added-1733420616390.md
+++ b/packages/api-v4/.changeset/pr-11368-added-1733420616390.md
@@ -2,4 +2,4 @@
 "@linode/api-v4": Added
 ---
 
-tags to KubeNodePoolResponse and CreateNodePoolData ([#11368](https://github.com/linode/manager/pull/11368))
+Tags to `KubeNodePoolResponse` and `CreateNodePoolData` ([#11368](https://github.com/linode/manager/pull/11368))

--- a/packages/api-v4/src/kubernetes/types.ts
+++ b/packages/api-v4/src/kubernetes/types.ts
@@ -23,6 +23,7 @@ export interface KubeNodePoolResponse {
   count: number;
   id: number;
   nodes: PoolNodeResponse[];
+  tags: string[];
   type: string;
   autoscaler: AutoscaleSettings;
   disk_encryption?: EncryptionStatus; // @TODO LDE: remove optionality once LDE is fully rolled out
@@ -42,6 +43,7 @@ export interface CreateNodePoolData {
 export interface UpdateNodePoolData {
   autoscaler: AutoscaleSettings;
   count: number;
+  tags: string[];
 }
 
 export interface AutoscaleSettings {

--- a/packages/manager/.changeset/pr-11368-added-1733415278919.md
+++ b/packages/manager/.changeset/pr-11368-added-1733415278919.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Surface Node Pool Tags ([#11368](https://github.com/linode/manager/pull/11368))

--- a/packages/manager/.changeset/pr-11368-added-1733415278919.md
+++ b/packages/manager/.changeset/pr-11368-added-1733415278919.md
@@ -2,4 +2,4 @@
 "@linode/manager": Added
 ---
 
-Surface Node Pool Tags ([#11368](https://github.com/linode/manager/pull/11368))
+Node Pool Tags to LKE Cluster details page ([#11368](https://github.com/linode/manager/pull/11368))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -860,7 +860,7 @@ describe('LKE cluster updates', () => {
     });
   });
 
-  it.only('can add and delete node pool tags', () => {
+  it('can add and delete node pool tags', () => {
     const mockCluster = kubernetesClusterFactory.build({
       k8s_version: latestKubernetesVersion,
     });
@@ -887,7 +887,7 @@ describe('LKE cluster updates', () => {
     cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
     cy.wait(['@getCluster', '@getNodePoolsNoTags', '@getVersions']);
 
-    cy.get('[data-qa-node-pool-id="1"]').within(() => {
+    cy.get(`[data-qa-node-pool-id="${mockNodePoolNoTags.id}"]`).within(() => {
       ui.button.findByTitle('Add a tag').should('be.visible').click();
 
       cy.findByLabelText('Create or Select a Tag')

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -881,7 +881,6 @@ describe('LKE cluster updates', () => {
     );
     mockGetKubernetesVersions().as('getVersions');
     mockUpdateNodePool(mockCluster.id, mockNodePoolWithTags).as('addTag');
-    mockUpdateNodePool(mockCluster.id, mockNodePoolNoTags).as('deleteTag');
     mockGetDashboardUrl(mockCluster.id);
     mockGetApiEndpoints(mockCluster.id);
 
@@ -908,20 +907,23 @@ describe('LKE cluster updates', () => {
 
     cy.wait(['@addTag', '@getNodePoolsWithTags']);
 
-    // // Delete the newly added node pool tag.
-    // cy.get(`[data-qa-tag="${mockNodePoolWithTags.tags[0]}"]`)
-    //   .should('be.visible')
-    //   .within(() => {
-    //     ui.button
-    //       .findByTitle('Delete tag')
-    //       .should('be.visible')
-    //       .should('be.enabled')
-    //       .click();
-    //   });
+    mockUpdateNodePool(mockCluster.id, mockNodePoolNoTags).as('deleteTag');
+    mockGetClusterPools(mockCluster.id, [mockNodePoolNoTags]).as(
+      'getNodePoolsNoTags'
+    );
 
-    // cy.wait(['@deleteTag', '@getNodePoolsNoTags']);
-    // cy.get(`[data-qa-tag="${mockNodePoolWithTags.tags[0]}"]`)
-    // .should('not.exist')
+    // Delete the newly added node pool tag.
+    cy.get(`[data-qa-tag="${mockNodePoolWithTags.tags[0]}"]`)
+      .should('be.visible')
+      .within(() => {
+        cy.get('[data-qa-delete-tag="true"]').should('be.visible').click();
+      });
+
+    cy.wait(['@deleteTag', '@getNodePoolsNoTags']);
+
+    cy.get(`[data-qa-tag="${mockNodePoolWithTags.tags[0]}"]`).should(
+      'not.exist'
+    );
   });
 
   describe('LKE cluster updates for DC-specific prices', () => {

--- a/packages/manager/src/factories/kubernetesCluster.ts
+++ b/packages/manager/src/factories/kubernetesCluster.ts
@@ -29,6 +29,7 @@ export const nodePoolFactory = Factory.Sync.makeFactory<KubeNodePoolResponse>({
   disk_encryption: 'enabled',
   id: Factory.each((id) => id),
   nodes: kubeLinodeFactory.buildList(3),
+  tags: [],
   type: 'g6-standard-1',
 });
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -21,6 +21,7 @@ import type { EncryptionStatus } from '@linode/api-v4/lib/linodes/types';
 
 interface Props {
   autoscaler: AutoscaleSettings;
+  clusterId: number;
   encryptionStatus: EncryptionStatus | undefined;
   handleClickResize: (poolId: number) => void;
   isOnlyNodePool: boolean;
@@ -30,12 +31,14 @@ interface Props {
   openRecycleAllNodesDialog: (poolId: number) => void;
   openRecycleNodeDialog: (nodeID: string, linodeLabel: string) => void;
   poolId: number;
+  tags: string[];
   typeLabel: string;
 }
 
 export const NodePool = (props: Props) => {
   const {
     autoscaler,
+    clusterId,
     encryptionStatus,
     handleClickResize,
     isOnlyNodePool,
@@ -45,6 +48,7 @@ export const NodePool = (props: Props) => {
     openRecycleAllNodesDialog,
     openRecycleNodeDialog,
     poolId,
+    tags,
     typeLabel,
   } = props;
 
@@ -134,10 +138,12 @@ export const NodePool = (props: Props) => {
         </Hidden>
       </Paper>
       <NodeTable
+        clusterId={clusterId}
         encryptionStatus={encryptionStatus}
         nodes={nodes}
         openRecycleNodeDialog={openRecycleNodeDialog}
         poolId={poolId}
+        tags={tags}
         typeLabel={typeLabel}
       />
     </Box>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -104,7 +104,7 @@ export const NodePoolsDisplay = (props: Props) => {
       {poolsError && <ErrorState errorText={poolsError[0].reason} />}
       <Stack spacing={2}>
         {_pools?.map((thisPool) => {
-          const { disk_encryption, id, nodes } = thisPool;
+          const { disk_encryption, id, nodes, tags } = thisPool;
 
           const thisPoolType = types?.find(
             (thisType) => thisType.id === thisPool.type
@@ -131,12 +131,14 @@ export const NodePoolsDisplay = (props: Props) => {
                 setIsRecycleNodeOpen(true);
               }}
               autoscaler={thisPool.autoscaler}
+              clusterId={clusterID}
               encryptionStatus={disk_encryption}
               handleClickResize={handleOpenResizeDrawer}
               isOnlyNodePool={pools?.length === 1}
               key={id}
               nodes={nodes ?? []}
               poolId={thisPool.id}
+              tags={tags}
               typeLabel={typeLabel}
             />
           );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.styles.ts
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.styles.ts
@@ -1,8 +1,9 @@
-import { Typography } from '@linode/ui';
+import { Box, Typography } from '@linode/ui';
 import { styled } from '@mui/material/styles';
 
 import VerticalDivider from 'src/assets/icons/divider-vertical.svg';
 import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
+import { TagCell } from 'src/components/TagCell/TagCell';
 
 export const StyledCopyTooltip = styled(CopyTooltip, {
   label: 'CopyTooltip',
@@ -26,4 +27,26 @@ export const StyledTypography = styled(Typography, {
   label: 'StyledTypography',
 })(({ theme }) => ({
   margin: `0 0 0 ${theme.spacing()}`,
+}));
+
+export const StyledTagCell = styled(TagCell, {
+  label: 'StyledTagCell',
+})(({ theme }) => ({
+  [theme.breakpoints.down('sm')]: {
+    marginTop: 1,
+  },
+  width: '100%',
+}));
+
+export const StyledTableFooter = styled(Box, {
+  label: 'StyledTableFooter',
+})(({ theme }) => ({
+  alignItems: 'center',
+  background: theme.bg.bgPaper,
+  display: 'flex',
+  justifyContent: 'space-between',
+  padding: `0 ${theme.spacing(2)}`,
+  [theme.breakpoints.down('sm')]: {
+    flexDirection: 'column',
+  },
 }));

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.styles.ts
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.styles.ts
@@ -29,12 +29,19 @@ export const StyledTypography = styled(Typography, {
   margin: `0 0 0 ${theme.spacing()}`,
 }));
 
+export const StyledPoolInfoBox = styled(Box, {
+  label: 'StyledPoolInfoBox',
+})(({ theme }) => ({
+  display: 'flex',
+  [theme.breakpoints.down('sm')]: {
+    padding: `${theme.spacing()} 0`,
+  },
+  width: '100%',
+}));
+
 export const StyledTagCell = styled(TagCell, {
   label: 'StyledTagCell',
-})(({ theme }) => ({
-  [theme.breakpoints.down('sm')]: {
-    marginTop: 1,
-  },
+})(() => ({
   width: '100%',
 }));
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.styles.ts
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.styles.ts
@@ -47,6 +47,7 @@ export const StyledTableFooter = styled(Box, {
   justifyContent: 'space-between',
   padding: `0 ${theme.spacing(2)}`,
   [theme.breakpoints.down('sm')]: {
+    display: 'block',
     flexDirection: 'column',
   },
 }));

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.styles.ts
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.styles.ts
@@ -33,7 +33,7 @@ export const StyledPoolInfoBox = styled(Box, {
   label: 'StyledPoolInfoBox',
 })(({ theme }) => ({
   display: 'flex',
-  [theme.breakpoints.down('sm')]: {
+  [theme.breakpoints.down('md')]: {
     padding: `${theme.spacing()} 0`,
   },
   width: '100%',
@@ -53,7 +53,7 @@ export const StyledTableFooter = styled(Box, {
   display: 'flex',
   justifyContent: 'space-between',
   padding: `0 ${theme.spacing(2)}`,
-  [theme.breakpoints.down('sm')]: {
+  [theme.breakpoints.down('md')]: {
     display: 'block',
     flexDirection: 'column',
   },

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.styles.ts
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.styles.ts
@@ -3,7 +3,6 @@ import { styled } from '@mui/material/styles';
 
 import VerticalDivider from 'src/assets/icons/divider-vertical.svg';
 import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
-import { TagCell } from 'src/components/TagCell/TagCell';
 
 export const StyledCopyTooltip = styled(CopyTooltip, {
   label: 'CopyTooltip',
@@ -26,23 +25,25 @@ export const StyledVerticalDivider = styled(VerticalDivider, {
 export const StyledTypography = styled(Typography, {
   label: 'StyledTypography',
 })(({ theme }) => ({
-  margin: `0 0 0 ${theme.spacing()}`,
+  margin: `0 ${theme.spacing(2)} 0 ${theme.spacing()}`,
+  [theme.breakpoints.down('md')]: {
+    padding: theme.spacing(),
+  },
+}));
+
+export const StyledNotEncryptedBox = styled(Box, {
+  label: 'StyledNotEncryptedBox',
+})(({ theme }) => ({
+  alignItems: 'center',
+  display: 'flex',
+  margin: `0 ${theme.spacing(2)} 0 ${theme.spacing()}`,
 }));
 
 export const StyledPoolInfoBox = styled(Box, {
   label: 'StyledPoolInfoBox',
-})(({ theme }) => ({
-  display: 'flex',
-  [theme.breakpoints.down('md')]: {
-    padding: `${theme.spacing()} 0`,
-  },
-  width: '100%',
-}));
-
-export const StyledTagCell = styled(TagCell, {
-  label: 'StyledTagCell',
 })(() => ({
-  width: '100%',
+  display: 'flex',
+  width: '50%',
 }));
 
 export const StyledTableFooter = styled(Box, {
@@ -56,5 +57,6 @@ export const StyledTableFooter = styled(Box, {
   [theme.breakpoints.down('md')]: {
     display: 'block',
     flexDirection: 'column',
+    paddingBottom: theme.spacing(),
   },
 }));

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.test.tsx
@@ -4,17 +4,21 @@ import { kubeLinodeFactory } from 'src/factories/kubernetesCluster';
 import { linodeFactory } from 'src/factories/linodes';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
-import { NodeTable, Props, encryptionStatusTestId } from './NodeTable';
+import { NodeTable, encryptionStatusTestId } from './NodeTable';
+
+import type { Props } from './NodeTable';
 
 const mockLinodes = linodeFactory.buildList(3);
 
 const mockKubeNodes = kubeLinodeFactory.buildList(3);
 
 const props: Props = {
+  clusterId: 1,
   encryptionStatus: 'enabled',
   nodes: mockKubeNodes,
   openRecycleNodeDialog: vi.fn(),
   poolId: 1,
+  tags: [],
   typeLabel: 'Linode 2G',
 };
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -16,15 +16,16 @@ import { TableContentWrapper } from 'src/components/TableContentWrapper/TableCon
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
 import { TableSortCell } from 'src/components/TableSortCell';
+import { TagCell } from 'src/components/TagCell/TagCell';
 import { useUpdateNodePoolMutation } from 'src/queries/kubernetes';
 import { useAllLinodesQuery } from 'src/queries/linodes/linodes';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 import { NodeRow as _NodeRow } from './NodeRow';
 import {
+  StyledNotEncryptedBox,
   StyledPoolInfoBox,
   StyledTableFooter,
-  StyledTagCell,
   StyledTypography,
   StyledVerticalDivider,
 } from './NodeTable.styles';
@@ -172,7 +173,9 @@ export const NodeTable = React.memo((props: Props) => {
                       data-testid={encryptionStatusTestId}
                       display="flex"
                     >
-                      <Typography>Pool ID {poolId}</Typography>
+                      <Typography sx={{ textWrap: 'nowrap' }}>
+                        Pool ID {poolId}
+                      </Typography>
                       <StyledVerticalDivider />
                       <EncryptedStatus
                         encryptionStatus={encryptionStatus}
@@ -183,11 +186,7 @@ export const NodeTable = React.memo((props: Props) => {
                     <Typography>Pool ID {poolId}</Typography>
                   )}
                 </StyledPoolInfoBox>
-                <StyledTagCell
-                  tags={tags}
-                  updateTags={updateTags}
-                  view="inline"
-                />
+                <TagCell tags={tags} updateTags={updateTags} view="inline" />
               </StyledTableFooter>
               <PaginationFooter
                 count={count}
@@ -241,10 +240,10 @@ export const EncryptedStatus = ({
   ) : encryptionStatus === 'disabled' ? (
     <>
       <Unlock />
-      <StyledTypography sx={{ whiteSpace: 'nowrap' }}>
-        Not Encrypted
-      </StyledTypography>
-      {tooltipText ? <TooltipIcon status="help" text={tooltipText} /> : null}
+      <StyledNotEncryptedBox>
+        <Typography sx={{ whiteSpace: 'nowrap' }}>Not Encrypted</Typography>
+        {tooltipText ? <TooltipIcon status="help" text={tooltipText} /> : null}
+      </StyledNotEncryptedBox>
     </>
   ) : null;
 };

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -16,13 +16,17 @@ import { TableContentWrapper } from 'src/components/TableContentWrapper/TableCon
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
 import { TableSortCell } from 'src/components/TableSortCell';
-import { TagCell } from 'src/components/TagCell/TagCell';
 import { useUpdateNodePoolMutation } from 'src/queries/kubernetes';
 import { useAllLinodesQuery } from 'src/queries/linodes/linodes';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 import { NodeRow as _NodeRow } from './NodeRow';
-import { StyledTypography, StyledVerticalDivider } from './NodeTable.styles';
+import {
+  StyledTableFooter,
+  StyledTagCell,
+  StyledTypography,
+  StyledVerticalDivider,
+} from './NodeTable.styles';
 
 import type { NodeRow } from './NodeRow';
 import type { PoolNodeResponse } from '@linode/api-v4/lib/kubernetes';
@@ -158,18 +162,7 @@ export const NodeTable = React.memo((props: Props) => {
                   </TableContentWrapper>
                 </TableBody>
               </Table>
-              <Box
-                sx={(theme) => ({
-                  background: theme.bg.bgPaper,
-                  [theme.breakpoints.down('sm')]: {
-                    flexDirection: 'column',
-                  },
-                })}
-                alignItems="center"
-                display="flex"
-                justifyContent="space-between"
-                px={2}
-              >
+              <StyledTableFooter>
                 <Box display="flex" width="100%">
                   {isDiskEncryptionFeatureEnabled &&
                   encryptionStatus !== undefined ? (
@@ -189,18 +182,12 @@ export const NodeTable = React.memo((props: Props) => {
                     <Typography>Pool ID {poolId}</Typography>
                   )}
                 </Box>
-                <TagCell
-                  sx={(theme) => ({
-                    [theme.breakpoints.down('sm')]: {
-                      marginTop: 1,
-                    },
-                    width: '100%',
-                  })}
+                <StyledTagCell
                   tags={tags}
                   updateTags={updateTags}
                   view="inline"
                 />
-              </Box>
+              </StyledTableFooter>
               <PaginationFooter
                 count={count}
                 eventCategory="Node Table"

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -167,23 +167,21 @@ export const NodeTable = React.memo((props: Props) => {
                 justifyContent="space-between"
                 px={2}
               >
-                <Box
-                  alignItems="center"
-                  data-testid={encryptionStatusTestId}
-                  display="flex"
-                  flexDirection="row"
-                  width="100%"
-                >
+                <Box display="flex" width="100%">
                   {isDiskEncryptionFeatureEnabled &&
                   encryptionStatus !== undefined ? (
-                    <>
+                    <Box
+                      alignItems="center"
+                      data-testid={encryptionStatusTestId}
+                      display="flex"
+                    >
                       <Typography>Pool ID {poolId}</Typography>
                       <StyledVerticalDivider />
                       <EncryptedStatus
                         encryptionStatus={encryptionStatus}
                         tooltipText={DISK_ENCRYPTION_NODE_POOL_GUIDANCE_COPY}
                       />
-                    </>
+                    </Box>
                   ) : (
                     <Typography>Pool ID {poolId}</Typography>
                   )}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -161,6 +161,9 @@ export const NodeTable = React.memo((props: Props) => {
               <Box
                 sx={(theme) => ({
                   background: theme.bg.bgPaper,
+                  [theme.breakpoints.down('sm')]: {
+                    flexDirection: 'column',
+                  },
                 })}
                 alignItems="center"
                 display="flex"
@@ -187,9 +190,12 @@ export const NodeTable = React.memo((props: Props) => {
                   )}
                 </Box>
                 <TagCell
-                  sx={{
+                  sx={(theme) => ({
+                    [theme.breakpoints.down('sm')]: {
+                      marginTop: 1,
+                    },
                     width: '100%',
-                  }}
+                  })}
                   tags={tags}
                   updateTags={updateTags}
                   view="inline"
@@ -246,7 +252,7 @@ export const EncryptedStatus = ({
     </>
   ) : encryptionStatus === 'disabled' ? (
     <>
-      <Unlock style={{ minWidth: 16 }} />
+      <Unlock />
       <StyledTypography sx={{ whiteSpace: 'nowrap' }}>
         Not Encrypted
       </StyledTypography>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -22,6 +22,7 @@ import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 import { NodeRow as _NodeRow } from './NodeRow';
 import {
+  StyledPoolInfoBox,
   StyledTableFooter,
   StyledTagCell,
   StyledTypography,
@@ -163,7 +164,7 @@ export const NodeTable = React.memo((props: Props) => {
                 </TableBody>
               </Table>
               <StyledTableFooter>
-                <Box display="flex" width="100%">
+                <StyledPoolInfoBox>
                   {isDiskEncryptionFeatureEnabled &&
                   encryptionStatus !== undefined ? (
                     <Box
@@ -181,7 +182,7 @@ export const NodeTable = React.memo((props: Props) => {
                   ) : (
                     <Typography>Pool ID {poolId}</Typography>
                   )}
-                </Box>
+                </StyledPoolInfoBox>
                 <StyledTagCell
                   tags={tags}
                   updateTags={updateTags}


### PR DESCRIPTION
## Description 📝
The /pools endpoint returns Tags for node pools, but we don't currently surface them in the UI: https://techdocs.akamai.com/linode-api/reference/get-lke-node-pool 

At the bottom of each node pool section, we will now display the list of tags associated with a node pool and the option to add a new tag. 

## Changes  🔄
- Added Tags to Kubernetes Node Pool table

## Preview 📷
https://github.com/user-attachments/assets/0dd7612d-5c78-4eae-841f-a309dd60798a

## How to test 🧪

### Verification steps

(How to verify changes)

- [ ] Go to a Kubernetes cluster's details page
- [ ] Test the `Add a Tag` button at the bottom of a Node Pool table

```
yarn cy:run -s "cypress/e2e/core/kubernetes/lke-update.spec.ts"
```

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>