### PR TITLE
refactor: Use Query Key Factor for Object ACL and Fix Incorrect api-v4 type

### DIFF
--- a/packages/api-v4/src/object-storage/objects.ts
+++ b/packages/api-v4/src/object-storage/objects.ts
@@ -64,7 +64,7 @@ export const updateObjectACL = (
   name: string,
   acl: Omit<ACLType, 'custom'>
 ) =>
-  Request<ObjectStorageObjectACL>(
+  Request<{}>(
     setMethod('PUT'),
     setURL(
       `${API_ROOT}/object-storage/buckets/${encodeURIComponent(

--- a/packages/manager/src/queries/object-storage/queries.ts
+++ b/packages/manager/src/queries/object-storage/queries.ts
@@ -17,6 +17,7 @@ import {
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 import {
   keepPreviousData,
+  queryOptions,
   useInfiniteQuery,
   useMutation,
   useQuery,
@@ -76,6 +77,17 @@ export const objectStorageQueries = createQueryKeys('object-storage', {
         queryKey: null,
       },
       objects: {
+        contextQueries: {
+          acl: (name: string) => ({
+            queryFn: () =>
+              getObjectACL({
+                bucket: bucketName,
+                clusterId: clusterOrRegion,
+                params: { name },
+              }),
+            queryKey: [name],
+          }),
+        },
         // This is a placeholder queryFn and QueryKey. View the `useObjectBucketObjectsInfiniteQuery` implementation for details.
         queryFn: null,
         queryKey: null,
@@ -209,8 +221,9 @@ export const useObjectAccess = (
 ) =>
   useQuery<ObjectStorageObjectACL, APIError[]>({
     enabled: queryEnabled,
-    queryFn: () => getObjectACL({ bucket, clusterId, params }),
-    queryKey: [bucket, clusterId, params.name],
+    ...objectStorageQueries
+      .bucket(clusterId, bucket)
+      ._ctx.objects._ctx.acl(params.name),
   });
 
 export const useUpdateBucketAccessMutation = (
@@ -241,16 +254,20 @@ export const useUpdateObjectAccessMutation = (
   name: string
 ) => {
   const queryClient = useQueryClient();
+
+  const options = queryOptions(
+    objectStorageQueries
+      .bucket(clusterId, bucketName)
+      ._ctx.objects._ctx.acl(name)
+  );
+
   return useMutation<{}, APIError[], ACLType>({
     mutationFn: (data) => updateObjectACL(clusterId, bucketName, name, data),
-    onSuccess: (_, acl) => {
-      queryClient.setQueryData<ObjectStorageObjectACL>(
-        [bucketName, clusterId, name],
-        (oldData) => ({
-          acl,
-          acl_xml: oldData?.acl_xml ?? null,
-        })
-      );
+    onSuccess(_, acl) {
+      queryClient.setQueryData(options.queryKey, (oldData) => ({
+        acl,
+        acl_xml: oldData?.acl_xml ?? null,
+      }));
     },
   });
 };


### PR DESCRIPTION
## Description 📝

- Updates Object Storage `useObjectAccess` query to use our query key factory for consistency 🏭 
- Fixes incorrect return type of `updateObjectACL`  api-v4 function 🔧

## Preview 📷

> [!note]
> No UI changes are expected.  This screenshot just shows where this query is used. 

![Screenshot 2024-12-04 at 1 07 17 PM](https://github.com/user-attachments/assets/9b162cd4-5a3e-4f4d-8903-5d943d8fe23d)

## How to test 🧪

- Create an Object Storage bucket (or use an existing bucket)
- Add a new object (or use an existing object)
- Verify you can change the ACL for an object
- Verify the React Query cache updates correctly and the UI works as expected

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>