### PR TITLE
fix: [M3-8847] RegionSelect width

### DIFF
--- a/packages/manager/src/components/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.tsx
@@ -121,7 +121,7 @@ export const RegionSelect = <
         }}
         sx={(theme) => ({
           [theme.breakpoints.up('md')]: {
-            maxWidth: tooltipText ? '458px' : '416px',
+            width: tooltipText ? '458px' : '416px',
           },
         })}
         textFieldProps={{


### PR DESCRIPTION
## Description 📝
fix to a regression introduced in https://github.com/linode/manager/pull/11348/files#diff-53966653a902407c449c1ebecc270efaa4bb9b0f8f1eac2c925cbf5bc2eb4268R124

no need for changeset since it was just merged to develop

## Changes  🔄
- restore RegionSelect width

## How to test 🧪

### Prerequisites

### Verification steps
- [ ] check wherever RegionSelect is implemented (linode create etc) 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>
</details>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

