### PR TITLE
fix: [M3-8796] - Disallow word-break in billing contact info

### DIFF
--- a/packages/manager/.changeset/pr-11379-fixed-1733476117431.md
+++ b/packages/manager/.changeset/pr-11379-fixed-1733476117431.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Disallow word-break in billing contact info ([#11379](https://github.com/linode/manager/pull/11379))

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
@@ -216,7 +216,7 @@ export const ContactInformation = React.memo((props: Props) => {
                 {(firstName || lastName) && (
                   <StyledTypography
                     data-qa-contact-name
-                    sx={{ wordBreak: 'break-all' }}
+                    sx={{ wordBreak: 'keep-all' }}
                   >
                     {firstName} {lastName}
                   </StyledTypography>
@@ -224,7 +224,7 @@ export const ContactInformation = React.memo((props: Props) => {
                 {company && (
                   <StyledTypography
                     data-qa-company
-                    sx={{ wordBreak: 'break-all' }}
+                    sx={{ wordBreak: 'keep-all' }}
                   >
                     {company}
                   </StyledTypography>


### PR DESCRIPTION
## Description 📝

We are preventing word breaks in the billing contact information to improve layout and readability.

## Changes  🔄

- Disabled word breaks in billing contact info.

## Target release date 🗓️

N/A

## Preview 📷


| Before | After |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/a5896216-3d90-4710-b130-c5686147b433) | ![After](https://github.com/user-attachments/assets/4d63283f-5197-4c3d-b634-ce1152626388) |

## How to test 🧪

### Prerequisites

- Ensure a billing contact info is saved in the account.

### Reproduction steps

- Log in and go to the Account Page.
- Check if the billing info is displayed without word breaks.

### Verification steps

- Ensure the billing info is shown without line breaks.

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support
