### PR TITLE
fix: [M3-8972] - Overflow issue in Kubernetes Summary section on smaller screens (→ `staging`)

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.tsx
@@ -37,14 +37,14 @@ const useStyles = makeStyles()((theme: Theme) => ({
     pointerEvents: 'none',
   },
   kubeconfigElement: {
+    '&:first-child': {
+      borderLeft: 'none',
+    },
     '&:hover': {
       opacity: 0.7,
     },
-    '&:last-child': {
-      borderRight: 'none',
-    },
     alignItems: 'center',
-    borderRight: '1px solid #c4c4c4',
+    borderLeft: '1px solid #c4c4c4',
     cursor: 'pointer',
     display: 'flex',
   },
@@ -52,6 +52,8 @@ const useStyles = makeStyles()((theme: Theme) => ({
     alignItems: 'center',
     color: theme.palette.primary.main,
     display: 'flex',
+    flexWrap: 'wrap',
+    gap: theme.spacing(1),
   },
   kubeconfigFileText: {
     color: theme.textColors.linkActiveLight,

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -1,6 +1,5 @@
 import { Box, Chip, Stack, StyledActionButton, Typography } from '@linode/ui';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import { useTheme } from '@mui/material/styles';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
 
@@ -38,8 +37,6 @@ export const KubeSummaryPanel = React.memo((props: Props) => {
 
   const { data: account } = useAccount();
   const { showControlPlaneACL } = getKubeControlPlaneACL(account);
-
-  const theme = useTheme();
 
   const { enqueueSnackbar } = useSnackbar();
 
@@ -95,7 +92,17 @@ export const KubeSummaryPanel = React.memo((props: Props) => {
     <Box>
       <EntityDetail
         body={
-          <Stack direction="row" flexWrap="wrap" gap={2} px={3} py={2}>
+          <Stack
+            sx={(theme) => ({
+              padding: theme.spacing(2),
+              [theme.breakpoints.down('sm')]: {
+                padding: theme.spacing(1),
+              },
+            })}
+            direction="row"
+            flexWrap="wrap"
+            gap={2}
+          >
             <KubeClusterSpecs cluster={cluster} />
             <KubeConfigDisplay
               clusterId={cluster.id}
@@ -135,12 +142,15 @@ export const KubeSummaryPanel = React.memo((props: Props) => {
         header={
           <EntityHeader>
             <Box
-              sx={{
+              sx={(theme) => ({
                 paddingBottom: theme.spacing(),
                 paddingLeft: theme.spacing(3),
                 paddingRight: theme.spacing(1),
                 paddingTop: theme.spacing(),
-              }}
+                [theme.breakpoints.down('sm')]: {
+                  paddingLeft: theme.spacing(2),
+                },
+              })}
             >
               <Typography variant="h2">Summary</Typography>
             </Box>


### PR DESCRIPTION
## Description 📝

This PR fixes a minor regression in CM (mobile view/smaller screens only) caused by https://github.com/linode/manager/pull/11179

> [!Note]
> Pointing this PR to staging

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-12-06 at 4 18 32 PM](https://github.com/user-attachments/assets/70566ae3-25d7-4edc-a24e-c20f9a228148) | ![Screenshot 2024-12-06 at 5 18 07 PM](https://github.com/user-attachments/assets/74fabdeb-4eac-48e0-8ba6-8e418cad86ec) |

## Changes  🔄
- Fixed Summary section Overflow issue 
- Fixed "Summary" header alignment (made responsive)
- Fixed text alignments and made some other improvements

## How to test 🧪
- Ensure no overflow issue in the "Summary" section on smaller devices


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>