### PR TITLE
upcoming: [DI-20595] - ACLP Supported regions per service type

### DIFF
--- a/packages/manager/.changeset/pr-11381-upcoming-features-1733479690692.md
+++ b/packages/manager/.changeset/pr-11381-upcoming-features-1733479690692.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Show ACLP supported regions per service type in region select ([#11381](https://github.com/linode/manager/pull/11381))

--- a/packages/manager/.changeset/pr-11381-upcoming-features-1733479690692.md
+++ b/packages/manager/.changeset/pr-11381-upcoming-features-1733479690692.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Show ACLP supported regions per service type in region select ([#11381](https://github.com/linode/manager/pull/11381))

--- a/packages/manager/.changeset/pr-11382-upcoming-features-1733485035913.md
+++ b/packages/manager/.changeset/pr-11382-upcoming-features-1733485035913.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Show ACLP supported regions per service type in region select ([#11382](https://github.com/linode/manager/pull/11382))

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -69,10 +69,11 @@ interface LkeEnterpriseFlag extends BaseFeatureFlag {
   la: boolean;
 }
 
-export interface CloudPulseResourceTypeMapFlag {
+export interface CloudPulseServiceTypeMapFlag {
   dimensionKey: string;
   maxResourceSelections?: number;
   serviceType: string;
+  supportedRegionIds?: string;
 }
 
 interface gpuV2 {
@@ -101,7 +102,7 @@ export interface Flags {
   aclp: AclpFlag;
   aclpAlerting: AclpAlerting;
   aclpReadEndpoint: string;
-  aclpResourceTypeMap: CloudPulseResourceTypeMapFlag[];
+  aclpServiceTypeMap: CloudPulseServiceTypeMapFlag[];
   apiMaintenance: APIMaintenance;
   apicliButtonCopy: string;
   apl: boolean;

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -69,7 +69,7 @@ interface LkeEnterpriseFlag extends BaseFeatureFlag {
   la: boolean;
 }
 
-export interface CloudPulseServiceTypeMapFlag {
+export interface CloudPulseResourceTypeMapFlag {
   dimensionKey: string;
   maxResourceSelections?: number;
   serviceType: string;
@@ -102,7 +102,7 @@ export interface Flags {
   aclp: AclpFlag;
   aclpAlerting: AclpAlerting;
   aclpReadEndpoint: string;
-  aclpServiceTypeMap: CloudPulseServiceTypeMapFlag[];
+  aclpResourceTypeMap: CloudPulseResourceTypeMapFlag[];
   apiMaintenance: APIMaintenance;
   apicliButtonCopy: string;
   apl: boolean;

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -25,7 +25,7 @@ import type { Theme } from '@mui/material';
 import type { DataSet } from 'src/components/AreaChart/AreaChart';
 import type { AreaProps } from 'src/components/AreaChart/AreaChart';
 import type { MetricsDisplayRow } from 'src/components/LineGraph/MetricsDisplay';
-import type { CloudPulseResourceTypeMapFlag, FlagSet } from 'src/featureFlags';
+import type { CloudPulseServiceTypeMapFlag, FlagSet } from 'src/featureFlags';
 
 interface LabelNameOptionsProps {
   /**
@@ -122,7 +122,7 @@ interface DimensionNameProperties {
   /**
    * flag dimension key mapping for service type
    */
-  flag: CloudPulseResourceTypeMapFlag | undefined;
+  flag: CloudPulseServiceTypeMapFlag | undefined;
 
   /**
    * metric key-value to generate dimension name
@@ -315,8 +315,8 @@ const getLabelName = (props: LabelNameOptionsProps): string => {
     return `${label} (${unit})`;
   }
 
-  const flag = flags?.aclpResourceTypeMap?.find(
-    (obj: CloudPulseResourceTypeMapFlag) => obj.serviceType === serviceType
+  const flag = flags?.aclpServiceTypeMap?.find(
+    (obj: CloudPulseServiceTypeMapFlag) => obj.serviceType === serviceType
   );
 
   return getDimensionName({ flag, metric, resources });

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -25,7 +25,7 @@ import type { Theme } from '@mui/material';
 import type { DataSet } from 'src/components/AreaChart/AreaChart';
 import type { AreaProps } from 'src/components/AreaChart/AreaChart';
 import type { MetricsDisplayRow } from 'src/components/LineGraph/MetricsDisplay';
-import type { CloudPulseServiceTypeMapFlag, FlagSet } from 'src/featureFlags';
+import type { CloudPulseResourceTypeMapFlag, FlagSet } from 'src/featureFlags';
 
 interface LabelNameOptionsProps {
   /**
@@ -122,7 +122,7 @@ interface DimensionNameProperties {
   /**
    * flag dimension key mapping for service type
    */
-  flag: CloudPulseServiceTypeMapFlag | undefined;
+  flag: CloudPulseResourceTypeMapFlag | undefined;
 
   /**
    * metric key-value to generate dimension name
@@ -315,8 +315,8 @@ const getLabelName = (props: LabelNameOptionsProps): string => {
     return `${label} (${unit})`;
   }
 
-  const flag = flags?.aclpServiceTypeMap?.find(
-    (obj: CloudPulseServiceTypeMapFlag) => obj.serviceType === serviceType
+  const flag = flags?.aclpResourceTypeMap?.find(
+    (obj: CloudPulseResourceTypeMapFlag) => obj.serviceType === serviceType
   );
 
   return getDimensionName({ flag, metric, resources });

--- a/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
@@ -3,11 +3,14 @@ import { CloudPulseSelectTypes } from './models';
 import type { CloudPulseServiceTypeFilterMap } from './models';
 
 const TIME_DURATION = 'Time Range';
+const DBAAS_CAPABILITY = 'Managed Databases';
+const LINODE_CAPABILITY = 'Linodes';
 
 export const LINODE_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
   filters: [
     {
       configuration: {
+        capability: LINODE_CAPABILITY,
         filterKey: 'region',
         filterType: 'string',
         isFilterable: false,
@@ -20,6 +23,7 @@ export const LINODE_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
     },
     {
       configuration: {
+        capability: LINODE_CAPABILITY,
         dependency: ['region'],
         filterKey: 'resource_id',
         filterType: 'string',
@@ -35,6 +39,7 @@ export const LINODE_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
     },
     {
       configuration: {
+        capability: LINODE_CAPABILITY,
         filterKey: 'relative_time_duration',
         filterType: 'string',
         isFilterable: true,
@@ -55,6 +60,7 @@ export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
   filters: [
     {
       configuration: {
+        capability: DBAAS_CAPABILITY,
         filterKey: 'engine',
         filterType: 'string',
         isFilterable: false, // isFilterable -- this determines whethere you need to pass it metrics api
@@ -80,6 +86,7 @@ export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
     },
     {
       configuration: {
+        capability: DBAAS_CAPABILITY,
         filterKey: 'region',
         filterType: 'string',
         isFilterable: false,
@@ -92,6 +99,7 @@ export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
     },
     {
       configuration: {
+        capability: DBAAS_CAPABILITY,
         dependency: ['region', 'engine'],
         filterKey: 'resource_id',
         filterType: 'string',
@@ -107,6 +115,7 @@ export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
     },
     {
       configuration: {
+        capability: DBAAS_CAPABILITY,
         filterKey: 'relative_time_duration',
         filterType: 'string',
         isFilterable: true,
@@ -121,6 +130,7 @@ export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
     },
     {
       configuration: {
+        capability: DBAAS_CAPABILITY,
         filterKey: 'node_type',
         filterType: 'string',
         isFilterable: true, // isFilterable -- this determines whether you need to pass it metrics api
@@ -149,7 +159,7 @@ export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
 };
 
 export const FILTER_CONFIG: Readonly<
-  Map<string, CloudPulseServiceTypeFilterMap>
+  Map<string | undefined, CloudPulseServiceTypeFilterMap>
 > = new Map([
   ['dbaas', DBAAS_CONFIG],
   ['linode', LINODE_CONFIG],

--- a/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
@@ -7,10 +7,10 @@ const DBAAS_CAPABILITY = 'Managed Databases';
 const LINODE_CAPABILITY = 'Linodes';
 
 export const LINODE_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
+  capability: LINODE_CAPABILITY,
   filters: [
     {
       configuration: {
-        capability: LINODE_CAPABILITY,
         filterKey: 'region',
         filterType: 'string',
         isFilterable: false,
@@ -23,7 +23,6 @@ export const LINODE_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
     },
     {
       configuration: {
-        capability: LINODE_CAPABILITY,
         dependency: ['region'],
         filterKey: 'resource_id',
         filterType: 'string',
@@ -39,7 +38,6 @@ export const LINODE_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
     },
     {
       configuration: {
-        capability: LINODE_CAPABILITY,
         filterKey: 'relative_time_duration',
         filterType: 'string',
         isFilterable: true,
@@ -57,10 +55,10 @@ export const LINODE_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
 };
 
 export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
+  capability: DBAAS_CAPABILITY,
   filters: [
     {
       configuration: {
-        capability: DBAAS_CAPABILITY,
         filterKey: 'engine',
         filterType: 'string',
         isFilterable: false, // isFilterable -- this determines whethere you need to pass it metrics api
@@ -86,7 +84,6 @@ export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
     },
     {
       configuration: {
-        capability: DBAAS_CAPABILITY,
         filterKey: 'region',
         filterType: 'string',
         isFilterable: false,
@@ -99,7 +96,6 @@ export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
     },
     {
       configuration: {
-        capability: DBAAS_CAPABILITY,
         dependency: ['region', 'engine'],
         filterKey: 'resource_id',
         filterType: 'string',
@@ -115,7 +111,6 @@ export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
     },
     {
       configuration: {
-        capability: DBAAS_CAPABILITY,
         filterKey: 'relative_time_duration',
         filterType: 'string',
         isFilterable: true,
@@ -130,7 +125,6 @@ export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
     },
     {
       configuration: {
-        capability: DBAAS_CAPABILITY,
         filterKey: 'node_type',
         filterType: 'string',
         isFilterable: true, // isFilterable -- this determines whether you need to pass it metrics api
@@ -159,7 +153,7 @@ export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
 };
 
 export const FILTER_CONFIG: Readonly<
-  Map<string | undefined, CloudPulseServiceTypeFilterMap>
+  Map<string, CloudPulseServiceTypeFilterMap>
 > = new Map([
   ['dbaas', DBAAS_CONFIG],
   ['linode', LINODE_CONFIG],

--- a/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
@@ -3,8 +3,8 @@ import { CloudPulseSelectTypes } from './models';
 import type { CloudPulseServiceTypeFilterMap } from './models';
 
 const TIME_DURATION = 'Time Range';
-const DBAAS_CAPABILITY = 'Managed Databases';
-const LINODE_CAPABILITY = 'Linodes';
+export const DBAAS_CAPABILITY = 'Managed Databases';
+export const LINODE_CAPABILITY = 'Linodes';
 
 export const LINODE_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
   capability: LINODE_CAPABILITY,

--- a/packages/manager/src/features/CloudPulse/Utils/models.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/models.ts
@@ -1,4 +1,8 @@
-import type { DatabaseEngine, DatabaseType } from '@linode/api-v4';
+import type {
+  Capabilities,
+  DatabaseEngine,
+  DatabaseType,
+} from '@linode/api-v4';
 import type { QueryFunction, QueryKey } from '@tanstack/react-query';
 
 /**
@@ -82,6 +86,11 @@ export interface CloudPulseServiceTypeFiltersConfiguration {
    * example, databaseQueries.types, databaseQueries.engines etc., makes use of existing query key and optimises cache
    */
   apiV4QueryKey?: QueryFunctionAndKey;
+
+  /**
+   * This is the current capability corresponding to the service type
+   */
+  capability: Capabilities;
 
   /**
    * This is an optional field, it is used to disable a certain filter, untill of the dependent filters are selected

--- a/packages/manager/src/features/CloudPulse/Utils/models.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/models.ts
@@ -10,6 +10,10 @@ import type { QueryFunction, QueryKey } from '@tanstack/react-query';
  */
 export interface CloudPulseServiceTypeFilterMap {
   /**
+   * Current capability corresponding to a service type
+   */
+  readonly capability: Capabilities;
+  /**
    * The list of filters for a service type
    */
 
@@ -86,11 +90,6 @@ export interface CloudPulseServiceTypeFiltersConfiguration {
    * example, databaseQueries.types, databaseQueries.engines etc., makes use of existing query key and optimises cache
    */
   apiV4QueryKey?: QueryFunctionAndKey;
-
-  /**
-   * This is the current capability corresponding to the service type
-   */
-  capability: Capabilities;
 
   /**
    * This is an optional field, it is used to disable a certain filter, untill of the dependent filters are selected

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
@@ -1,12 +1,15 @@
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
-import * as regions from 'src/queries/regions/regions';
+import { dashboardFactory, regionFactory } from 'src/factories';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { CloudPulseRegionSelect } from './CloudPulseRegionSelect';
 
 import type { CloudPulseRegionSelectProps } from './CloudPulseRegionSelect';
 import type { Region } from '@linode/api-v4';
+import type { CloudPulseServiceTypeMapFlag, Flags } from 'src/featureFlags';
+import type * as regions from 'src/queries/regions/regions';
 
 const props: CloudPulseRegionSelectProps = {
   handleRegionChange: vi.fn(),
@@ -14,11 +17,32 @@ const props: CloudPulseRegionSelectProps = {
   selectedDashboard: undefined,
 };
 
-describe('CloudPulseRegionSelect', () => {
-  vi.spyOn(regions, 'useRegionsQuery').mockReturnValue({
-    data: Array<Region>(),
-  } as ReturnType<typeof regions.useRegionsQuery>);
+const queryMocks = vi.hoisted(() => ({
+  useRegionsQuery: vi.fn().mockReturnValue({}),
+}));
 
+const flags: Partial<Flags> = {
+  aclpServiceTypeMap: [
+    {
+      serviceType: 'dbaas',
+      supportedRegionIds: 'us-west',
+    },
+    {
+      serviceType: 'linode',
+      supportedRegionIds: 'us-east',
+    },
+  ] as CloudPulseServiceTypeMapFlag[],
+};
+
+vi.mock('src/queries/regions/regions', async () => {
+  const actual = await vi.importActual('src/queries/regions/regions');
+  return {
+    ...actual,
+    useRegionsQuery: queryMocks.useRegionsQuery,
+  };
+});
+
+describe('CloudPulseRegionSelect', () => {
   it('should render a Region Select component', () => {
     const { getByLabelText, getByTestId } = renderWithTheme(
       <CloudPulseRegionSelect {...props} />
@@ -29,7 +53,7 @@ describe('CloudPulseRegionSelect', () => {
   });
 
   it('should render a Region Select component with proper error message on api call failure', () => {
-    vi.spyOn(regions, 'useRegionsQuery').mockReturnValue({
+    queryMocks.useRegionsQuery.mockReturnValue({
       data: undefined,
       isError: true,
       isLoading: false,
@@ -40,4 +64,40 @@ describe('CloudPulseRegionSelect', () => {
 
     expect(getByText('Failed to fetch Region.'));
   });
+
+  it('should render a Region Select component with capability specific and launchDarkly based supported regions', async () => {
+    const user = userEvent.setup();
+
+    const allRegions: Region[] = [
+      regionFactory.build({ capabilities: ['Linodes'], id: 'us-east' }),
+      regionFactory.build({
+        capabilities: ['Managed Databases'],
+        id: 'us-west',
+        label: 'US, Fremont, CA',
+      }),
+    ];
+
+    queryMocks.useRegionsQuery.mockReturnValue({
+      data: allRegions,
+      isError: false,
+      isLoading: false,
+    });
+
+    const { getByRole } = renderWithTheme(
+      <CloudPulseRegionSelect
+        {...props}
+        // eslint-disable-next-line camelcase
+        selectedDashboard={dashboardFactory.build({ service_type: 'dbaas' })}
+      />,
+      { flags }
+    );
+
+    await user.click(getByRole('button', { name: 'Open' }));
+    // example: region id => 'us-west' belongs to service type - 'dbass', capability -'Managed Databases', and is supported via launchDarkly
+    expect(
+      getByRole('option', {
+        name: 'US, Fremont, CA (us-west)',
+      })
+    ).toBeInTheDocument();
+});
 });

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
@@ -8,7 +8,7 @@ import { CloudPulseRegionSelect } from './CloudPulseRegionSelect';
 
 import type { CloudPulseRegionSelectProps } from './CloudPulseRegionSelect';
 import type { Region } from '@linode/api-v4';
-import type { CloudPulseServiceTypeMapFlag, Flags } from 'src/featureFlags';
+import type { CloudPulseResourceTypeMapFlag, Flags } from 'src/featureFlags';
 import type * as regions from 'src/queries/regions/regions';
 
 const props: CloudPulseRegionSelectProps = {
@@ -22,16 +22,16 @@ const queryMocks = vi.hoisted(() => ({
 }));
 
 const flags: Partial<Flags> = {
-  aclpServiceTypeMap: [
+  aclpResourceTypeMap: [
     {
       serviceType: 'dbaas',
-      supportedRegionIds: 'us-west',
+      supportedRegionIds: 'us-west, us-east',
     },
     {
       serviceType: 'linode',
-      supportedRegionIds: 'us-lax',
+      supportedRegionIds: 'us-lax, us-mia',
     },
-  ] as CloudPulseServiceTypeMapFlag[],
+  ] as CloudPulseResourceTypeMapFlag[],
 };
 
 vi.mock('src/queries/regions/regions', async () => {
@@ -75,9 +75,19 @@ describe('CloudPulseRegionSelect', () => {
         label: 'US, Los Angeles, CA',
       }),
       regionFactory.build({
+        capabilities: ['Linodes'],
+        id: 'us-mia',
+        label: 'US, Miami, FL',
+      }),
+      regionFactory.build({
         capabilities: ['Managed Databases'],
         id: 'us-west',
         label: 'US, Fremont, CA',
+      }),
+      regionFactory.build({
+        capabilities: ['Managed Databases'],
+        id: 'us-east',
+        label: 'US, Newark, NJ',
       }),
     ];
 
@@ -104,8 +114,18 @@ describe('CloudPulseRegionSelect', () => {
       })
     ).toBeInTheDocument();
     expect(
+      getByRole('option', {
+        name: 'US, Newark, NJ (us-east)',
+      })
+    ).toBeInTheDocument();
+    expect(
       queryByRole('option', {
         name: 'US, Los Angeles, CA (us-lax)',
+      })
+    ).toBeNull();
+    expect(
+      queryByRole('option', {
+        name: 'US, Miami, FL (us-mia)',
       })
     ).toBeNull();
   });

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
@@ -29,7 +29,7 @@ const flags: Partial<Flags> = {
     },
     {
       serviceType: 'linode',
-      supportedRegionIds: 'us-east',
+      supportedRegionIds: 'us-lax',
     },
   ] as CloudPulseServiceTypeMapFlag[],
 };
@@ -69,7 +69,11 @@ describe('CloudPulseRegionSelect', () => {
     const user = userEvent.setup();
 
     const allRegions: Region[] = [
-      regionFactory.build({ capabilities: ['Linodes'], id: 'us-east' }),
+      regionFactory.build({
+        capabilities: ['Linodes'],
+        id: 'us-lax',
+        label: 'US, Los Angeles, CA',
+      }),
       regionFactory.build({
         capabilities: ['Managed Databases'],
         id: 'us-west',
@@ -83,7 +87,7 @@ describe('CloudPulseRegionSelect', () => {
       isLoading: false,
     });
 
-    const { getByRole } = renderWithTheme(
+    const { getByRole, queryByRole } = renderWithTheme(
       <CloudPulseRegionSelect
         {...props}
         // eslint-disable-next-line camelcase
@@ -99,5 +103,10 @@ describe('CloudPulseRegionSelect', () => {
         name: 'US, Fremont, CA (us-west)',
       })
     ).toBeInTheDocument();
-});
+    expect(
+      queryByRole('option', {
+        name: 'US, Los Angeles, CA (us-lax)',
+      })
+    ).toBeNull();
+  });
 });

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
@@ -113,7 +113,7 @@ describe('CloudPulseRegionSelect', () => {
     );
 
     await user.click(getByRole('button', { name: 'Open' }));
-    // example: region id => 'us-west' belongs to service type - 'dbass', capability -'Managed Databases', and is supported via launchDarkly
+    // example: region id => 'us-west' belongs to service type - 'dbaas', capability -'Managed Databases', and is supported via launchDarkly
     expect(
       getByRole('option', {
         name: 'US, Fremont, CA (us-west)',

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { dashboardFactory, regionFactory } from 'src/factories';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
+import { DBAAS_CAPABILITY, LINODE_CAPABILITY } from '../Utils/FilterConfig';
 import { CloudPulseRegionSelect } from './CloudPulseRegionSelect';
 
 import type { CloudPulseRegionSelectProps } from './CloudPulseRegionSelect';
@@ -70,24 +71,29 @@ describe('CloudPulseRegionSelect', () => {
 
     const allRegions: Region[] = [
       regionFactory.build({
-        capabilities: ['Linodes'],
+        capabilities: [LINODE_CAPABILITY],
         id: 'us-lax',
         label: 'US, Los Angeles, CA',
       }),
       regionFactory.build({
-        capabilities: ['Linodes'],
+        capabilities: [LINODE_CAPABILITY],
         id: 'us-mia',
         label: 'US, Miami, FL',
       }),
       regionFactory.build({
-        capabilities: ['Managed Databases'],
+        capabilities: [DBAAS_CAPABILITY],
         id: 'us-west',
         label: 'US, Fremont, CA',
       }),
       regionFactory.build({
-        capabilities: ['Managed Databases'],
+        capabilities: [DBAAS_CAPABILITY],
         id: 'us-east',
         label: 'US, Newark, NJ',
+      }),
+      regionFactory.build({
+        capabilities: [DBAAS_CAPABILITY],
+        id: 'us-central',
+        label: 'US, Dallas, TX',
       }),
     ];
 

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
@@ -26,7 +26,7 @@ const flags: Partial<Flags> = {
   aclpResourceTypeMap: [
     {
       serviceType: 'dbaas',
-      supportedRegionIds: 'us-west, us-east, ,',
+      supportedRegionIds: 'us-west, us-east',
     },
     {
       serviceType: 'linode',

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
@@ -126,6 +126,11 @@ describe('CloudPulseRegionSelect', () => {
     ).toBeInTheDocument();
     expect(
       queryByRole('option', {
+        name: 'US, Dallas, TX (us-central)',
+      })
+    ).toBeNull();
+    expect(
+      queryByRole('option', {
         name: 'US, Los Angeles, CA (us-lax)',
       })
     ).toBeNull();

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
@@ -26,7 +26,7 @@ const flags: Partial<Flags> = {
   aclpResourceTypeMap: [
     {
       serviceType: 'dbaas',
-      supportedRegionIds: 'us-west, us-east',
+      supportedRegionIds: 'us-west, us-east, ,',
     },
     {
       serviceType: 'linode',

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
 
 import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
+import { useFlags } from 'src/hooks/useFlags';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 
-import type { Dashboard, FilterValue } from '@linode/api-v4';
+import { FILTER_CONFIG } from '../Utils/FilterConfig';
+
+import type { CloudPulseServiceTypeFilters } from '../Utils/models';
+import type { Dashboard, FilterValue, Region } from '@linode/api-v4';
 
 export interface CloudPulseRegionSelectProps {
   defaultValue?: FilterValue;
@@ -18,6 +22,8 @@ export const CloudPulseRegionSelect = React.memo(
   (props: CloudPulseRegionSelectProps) => {
     const { data: regions, isError, isLoading } = useRegionsQuery();
 
+    const flags = useFlags();
+
     const {
       defaultValue,
       handleRegionChange,
@@ -26,6 +32,16 @@ export const CloudPulseRegionSelect = React.memo(
       savePreferences,
       selectedDashboard,
     } = props;
+
+    const currentFilterConfig:
+      | CloudPulseServiceTypeFilters
+      | undefined = FILTER_CONFIG.get(
+      selectedDashboard?.service_type
+    )?.filters.filter(
+      (config) => config.configuration.filterKey === 'region'
+    )[0];
+    // Capture the current capability from corresponding filter config
+    const capability = currentFilterConfig?.configuration.capability;
 
     const [selectedRegion, setSelectedRegion] = React.useState<string>();
     // Once the data is loaded, set the state variable with value stored in preferences
@@ -40,13 +56,35 @@ export const CloudPulseRegionSelect = React.memo(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [regions]);
 
+    // validate launchDrakly region_ids with the ids from the fetched 'all-regions'
+    const supportedRegions = React.useMemo<Region[] | undefined>(() => {
+      const serviceTypeFlag = flags.aclpServiceTypeMap?.find(
+        (item) => item.serviceType === selectedDashboard?.service_type
+      );
+
+      const supportedRegionsIdList = serviceTypeFlag?.supportedRegionIds
+        ?.split(',')
+        .map((regionId) => regionId.trim());
+
+      if (!supportedRegionsIdList?.length) {
+        return regions;
+      }
+
+      const validatedRegions = regions?.filter((region) =>
+        supportedRegionsIdList?.includes(region.id)
+      );
+
+      return validatedRegions ? validatedRegions : regions;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [flags.aclpServiceTypeMap, regions, selectedDashboard?.service_type]);
+
     return (
       <RegionSelect
         onChange={(_, region) => {
           setSelectedRegion(region?.id);
           handleRegionChange(region?.id, savePreferences);
         }}
-        currentCapability={undefined}
+        currentCapability={capability}
         data-testid="region-select"
         disableClearable={false}
         disabled={!selectedDashboard || !regions}
@@ -56,7 +94,7 @@ export const CloudPulseRegionSelect = React.memo(
         loading={isLoading}
         noMarginTop
         placeholder={placeholder ?? 'Select a Region'}
-        regions={regions ? regions : []}
+        regions={supportedRegions ? supportedRegions : []}
         value={selectedRegion}
       />
     );

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
@@ -70,11 +70,9 @@ export const CloudPulseRegionSelect = React.memo(
         return regions;
       }
 
-      const validatedRegions = regions?.filter((region) =>
+      return regions?.filter((region) =>
         supportedRegionsIdList?.includes(region.id)
       );
-
-      return validatedRegions ? validatedRegions : regions;
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [flags.aclpServiceTypeMap, regions, selectedDashboard?.service_type]);
 
@@ -94,7 +92,7 @@ export const CloudPulseRegionSelect = React.memo(
         loading={isLoading}
         noMarginTop
         placeholder={placeholder ?? 'Select a Region'}
-        regions={supportedRegions ? supportedRegions : []}
+        regions={supportedRegions ? supportedRegions : regions ? regions : []}
         value={selectedRegion}
       />
     );

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
@@ -1,4 +1,3 @@
-import { isNil } from 'ramda';
 import * as React from 'react';
 
 import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
@@ -8,6 +8,7 @@ import { FILTER_CONFIG } from '../Utils/FilterConfig';
 
 import type { Dashboard, FilterValue, Region } from '@linode/api-v4';
 import type { CloudPulseResourceTypeMapFlag } from 'src/featureFlags';
+import { isNil } from 'ramda';
 
 export interface CloudPulseRegionSelectProps {
   defaultValue?: FilterValue;
@@ -57,17 +58,17 @@ export const CloudPulseRegionSelect = React.memo(
         (item: CloudPulseResourceTypeMapFlag) =>
           item.serviceType === serviceType
       );
-      const supportedRegionsIdList =
-        resourceTypeFlag?.supportedRegionIds
-          ?.split(',')
-          .map((regionId: string) => regionId.trim())
-          .filter((regionId: string) => regionId.length > 0) || [];
 
-      if (!supportedRegionsIdList.length) {
+      if (isNil(resourceTypeFlag?.supportedRegionIds)) {
         return regions;
       }
+
+      const supportedRegionsIdList = resourceTypeFlag.supportedRegionIds
+        .split(',')
+        .map((regionId: string) => regionId.trim());
+
       return regions?.filter((region) =>
-        supportedRegionsIdList?.includes(region.id)
+        supportedRegionsIdList.includes(region.id)
       );
     }, [flags.aclpResourceTypeMap, regions, serviceType]);
 

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
@@ -59,7 +59,10 @@ export const CloudPulseRegionSelect = React.memo(
           item.serviceType === serviceType
       );
 
-      if (isNil(resourceTypeFlag?.supportedRegionIds)) {
+      if (
+        resourceTypeFlag?.supportedRegionIds === null ||
+        resourceTypeFlag?.supportedRegionIds === undefined
+      ) {
         return regions;
       }
 
@@ -88,7 +91,7 @@ export const CloudPulseRegionSelect = React.memo(
         loading={isLoading}
         noMarginTop
         placeholder={placeholder ?? 'Select a Region'}
-        regions={supportedRegions ? supportedRegions : []}
+        regions={supportedRegions ?? []}
         value={selectedRegion}
       />
     );

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
@@ -51,7 +51,7 @@ export const CloudPulseRegionSelect = React.memo(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [regions]);
 
-    // validate launchDrakly region_ids with the ids from the fetched 'all-regions'
+    // validate launchDarkly region_ids with the ids from the fetched 'all-regions'
     const supportedRegions = React.useMemo<Region[] | undefined>(() => {
       const resourceTypeFlag = flags.aclpResourceTypeMap?.find(
         (item: CloudPulseResourceTypeMapFlag) =>

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
@@ -60,7 +60,7 @@ export const CloudPulseRegionSelect = React.memo(
 
     // validate launchDrakly region_ids with the ids from the fetched 'all-regions'
     const supportedRegions = React.useMemo<Region[] | undefined>(() => {
-      const serviceTypeFlag:
+      const resourceTypeFlag:
         | CloudPulseResourceTypeMapFlag
         | undefined = flags.aclpResourceTypeMap?.find(
         (item: CloudPulseResourceTypeMapFlag) =>
@@ -68,7 +68,7 @@ export const CloudPulseRegionSelect = React.memo(
       );
 
       const supportedRegionsIdList: string[] =
-        serviceTypeFlag?.supportedRegionIds
+        resourceTypeFlag?.supportedRegionIds
           ?.split(',')
           .map((regionId: string) => regionId.trim()) || [];
 

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
@@ -6,12 +6,7 @@ import { useRegionsQuery } from 'src/queries/regions/regions';
 
 import { FILTER_CONFIG } from '../Utils/FilterConfig';
 
-import type {
-  Capabilities,
-  Dashboard,
-  FilterValue,
-  Region,
-} from '@linode/api-v4';
+import type { Dashboard, FilterValue, Region } from '@linode/api-v4';
 import type { CloudPulseResourceTypeMapFlag } from 'src/featureFlags';
 
 export interface CloudPulseRegionSelectProps {

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
@@ -1,3 +1,4 @@
+import { isNil } from 'ramda';
 import * as React from 'react';
 
 import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
@@ -8,7 +9,6 @@ import { FILTER_CONFIG } from '../Utils/FilterConfig';
 
 import type { Dashboard, FilterValue, Region } from '@linode/api-v4';
 import type { CloudPulseResourceTypeMapFlag } from 'src/featureFlags';
-import { isNil } from 'ramda';
 
 export interface CloudPulseRegionSelectProps {
   defaultValue?: FilterValue;

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
@@ -57,16 +57,15 @@ export const CloudPulseRegionSelect = React.memo(
         (item: CloudPulseResourceTypeMapFlag) =>
           item.serviceType === serviceType
       );
-
       const supportedRegionsIdList =
         resourceTypeFlag?.supportedRegionIds
           ?.split(',')
-          .map((regionId: string) => regionId.trim()) || [];
+          .map((regionId: string) => regionId.trim())
+          .filter((regionId: string) => regionId.length > 0) || [];
 
       if (!supportedRegionsIdList.length) {
         return regions;
       }
-
       return regions?.filter((region) =>
         supportedRegionsIdList?.includes(region.id)
       );

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
@@ -39,11 +39,9 @@ export const CloudPulseRegionSelect = React.memo(
     } = props;
 
     const serviceType: string | undefined = selectedDashboard?.service_type;
-    const capability = React.useMemo<Capabilities | undefined>(() => {
-      return serviceType
-        ? FILTER_CONFIG.get(serviceType)?.capability
-        : undefined;
-    }, [serviceType]);
+    const capability = serviceType
+      ? FILTER_CONFIG.get(serviceType)?.capability
+      : undefined;
 
     const [selectedRegion, setSelectedRegion] = React.useState<string>();
     // Once the data is loaded, set the state variable with value stored in preferences
@@ -60,14 +58,12 @@ export const CloudPulseRegionSelect = React.memo(
 
     // validate launchDrakly region_ids with the ids from the fetched 'all-regions'
     const supportedRegions = React.useMemo<Region[] | undefined>(() => {
-      const resourceTypeFlag:
-        | CloudPulseResourceTypeMapFlag
-        | undefined = flags.aclpResourceTypeMap?.find(
+      const resourceTypeFlag = flags.aclpResourceTypeMap?.find(
         (item: CloudPulseResourceTypeMapFlag) =>
           item.serviceType === serviceType
       );
 
-      const supportedRegionsIdList: string[] =
+      const supportedRegionsIdList =
         resourceTypeFlag?.supportedRegionIds
           ?.split(',')
           .map((regionId: string) => regionId.trim()) || [];

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
@@ -87,11 +87,11 @@ export const CloudPulseResourcesSelect = React.memo(
 
     // Maximum resource selection limit is fetched from launchdarkly
     const maxResourceSelectionLimit = React.useMemo(() => {
-      const obj = flags.aclpResourceTypeMap?.find(
+      const obj = flags.aclpServiceTypeMap?.find(
         (item) => item.serviceType === resourceType
       );
       return obj?.maxResourceSelections || 10;
-    }, [resourceType, flags.aclpResourceTypeMap]);
+    }, [resourceType, flags.aclpServiceTypeMap]);
 
     const resourcesLimitReached = React.useMemo(() => {
       return getResourcesList.length > maxResourceSelectionLimit;

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
@@ -87,11 +87,11 @@ export const CloudPulseResourcesSelect = React.memo(
 
     // Maximum resource selection limit is fetched from launchdarkly
     const maxResourceSelectionLimit = React.useMemo(() => {
-      const obj = flags.aclpServiceTypeMap?.find(
+      const obj = flags.aclpResourceTypeMap?.find(
         (item) => item.serviceType === resourceType
       );
       return obj?.maxResourceSelections || 10;
-    }, [resourceType, flags.aclpServiceTypeMap]);
+    }, [resourceType, flags.aclpResourceTypeMap]);
 
     const resourcesLimitReached = React.useMemo(() => {
       return getResourcesList.length > maxResourceSelectionLimit;


### PR DESCRIPTION
## Description 📝

ACLP supports a limited set of regions per service type and capability based on LaunchDarkly config. Regions are now correctly filtered according to the capability they belong to and the supported regions fetched from launchDarkly.

## Changes  🔄

1. Added new key for supported regions in aclpResourceType Flag.
2. Validated the region ids from flag with all the regions fetched from api.
3. Filtered the service type specific regions using corresponding capabilities.
4. Added relevant unit test to verify.

## Target release date 🗓️

12 December 2024

## Preview 📷

<img src="https://github.com/user-attachments/assets/bdc5bccf-47c8-4cb8-8d9b-e02b328b4747" width = "300" height = "200">


## How to test 🧪

1. Navigate to monitor tab.
2. Select a dashboard.
3. Open networks tab, find the launchDarkly config, see supported region ids in aclpResourceTypeMap, verify that these are same as the region ids listed in 'regions' autocomplete popper list. In case supportedRegionIds is null/undefined, all regions per capability will be shown.
Note: ids are listed at the end of region option label in autocomplete list.


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

---
