### PR TITLE
test: [M3-8693] - Cypress tests for Credit Card Expired banner

### DIFF
--- a/packages/manager/.changeset/pr-11383-tests-1733523460107.md
+++ b/packages/manager/.changeset/pr-11383-tests-1733523460107.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add cypress test for Credit Card Expired banner ([#11383](https://github.com/linode/manager/pull/11383))

--- a/packages/manager/cypress/e2e/core/billing/credit-card-expired-banner.spec.ts
+++ b/packages/manager/cypress/e2e/core/billing/credit-card-expired-banner.spec.ts
@@ -1,0 +1,36 @@
+import { accountFactory } from 'src/factories';
+import { mockGetAccount } from 'support/intercepts/account';
+import { mockGetUserPreferences } from 'support/intercepts/profile';
+import { ui } from 'support/ui';
+
+const creditCardExpiredBannerNotice =
+  'Your credit card has expired! Please update your payment details.';
+
+describe('Credit Card Expired Banner', () => {
+  beforeEach(() => {
+    mockGetUserPreferences({ dismissed_notifications: {} });
+  });
+
+  it('appears when the expiration date is in the past', () => {
+    mockGetAccount(
+      accountFactory.build({ credit_card: { expiry: '01/2000' } })
+    ).as('getAccount');
+    cy.visitWithLogin('/');
+    cy.wait('@getAccount');
+    cy.findByText(creditCardExpiredBannerNotice).should('be.visible');
+    ui.button.findByTitle('Update Card').should('be.visible').click();
+
+    // clicking on the link navigates to /account/billing
+    cy.url().should('endWith', '/account/billing');
+  });
+
+  it('does not appear when the expiration date is in the future', () => {
+    mockGetAccount(
+      accountFactory.build({ credit_card: { expiry: '01/2999' } })
+    ).as('getAccount');
+    cy.visitWithLogin('/account/billing');
+    cy.wait('@getAccount');
+    cy.findByText('Payment Methods').should('be.visible');
+    cy.findByText(creditCardExpiredBannerNotice).should('not.exist');
+  });
+});


### PR DESCRIPTION
## Changes 🔄

- Adds Cypress tests for the Credit Card Expired banner.
- Mocks the account endpoint with an expired and non-expired credit card.
- Verifies clicking the "Update Card" button navigates to `account/billing`.

## How to test 🧪
1. `yarn cy:run -s "cypress/e2e/core/billing/credit-card-expired-banner.spec.ts"`


2. Verify CI passes