### PR TITLE
test: [M3-8768] - Cypress test flake: Rebuild Linode

### DIFF
--- a/packages/manager/.changeset/pr-11390-tests-1733844253656.md
+++ b/packages/manager/.changeset/pr-11390-tests-1733844253656.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Cypress test flake: Rebuild Linode ([#11390](https://github.com/linode/manager/pull/11390))

--- a/packages/manager/cypress/e2e/core/linodes/rebuild-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/rebuild-linode.spec.ts
@@ -194,6 +194,7 @@ describe('rebuild linode', () => {
 
         cy.wait('@getStackScripts');
         cy.findByLabelText('Search by Label, Username, or Description')
+          .scrollIntoView()
           .should('be.visible')
           .type(`${stackScriptName}`);
 
@@ -266,6 +267,7 @@ describe('rebuild linode', () => {
           .click();
 
         cy.findByLabelText('Search by Label, Username, or Description')
+          .scrollIntoView()
           .should('be.visible')
           .type(`${stackScript.label}`);
 


### PR DESCRIPTION
## Description 📝

The list of StackScripts loads before Cypress selects the search field, causing the search field to go out of view which triggers a failure in a should('be.visible') assertion. This can be fixed by adding .scrollIntoView before asserting the element's visibility.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Add .scrollIntoView before asserting the element's visibility in packages/manager/cypress/e2e/core/linodes/rebuild-linode.spec.ts

## How to test 🧪

```
yarn cy:run -s "cypress/e2e/core/linodes/rebuild-linode.spec.ts"
```

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
