### PR TITLE
[M3-8991 + M3-6911] - New Select Component + Managed Replacement

### DIFF
--- a/packages/manager/.changeset/pr-11391-tech-stories-1733949258449.md
+++ b/packages/manager/.changeset/pr-11391-tech-stories-1733949258449.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Replace instances of `react-select` in Managed ([#11391](https://github.com/linode/manager/pull/11391))

--- a/packages/manager/cypress/component/poc/select.spec.tsx
+++ b/packages/manager/cypress/component/poc/select.spec.tsx
@@ -1,0 +1,336 @@
+import { Box, Select, Typography } from '@linode/ui';
+import * as React from 'react';
+import { ui } from 'support/ui';
+import { createSpy } from 'support/util/components';
+import { componentTests } from 'support/util/components';
+
+import type { SelectOptionType, SelectProps } from '@linode/ui';
+
+const options = [
+  { label: 'Option 1', value: 'option-1' },
+  { label: 'Option 2', value: 'option-2' },
+  { label: 'Option 3', value: 'option-3' },
+];
+
+const openAutocompletePopper = () => {
+  ui.button
+    .findByAttribute('title', 'Open')
+    .should('be.visible')
+    .should('be.enabled')
+    .click();
+};
+
+componentTests('Select', (mount) => {
+  describe('Basics', () => {
+    describe('Open menu', () => {
+      it('can open drop-down menu by clicking drop-down arrow', () => {
+        mount(<Select {...defaultProps} />);
+
+        openAutocompletePopper();
+
+        ui.autocompletePopper
+          .find()
+          .should('be.visible')
+          .within(() => {
+            cy.get('li').should('have.length', options.length);
+          });
+
+        options.forEach((option) => {
+          ui.autocompletePopper
+            .findByTitle(`${option.label}`)
+            .should('be.visible');
+        });
+      });
+
+      it('should show a "No options found" message when no options are found', () => {
+        mount(<Select {...defaultProps} options={[]} />);
+
+        openAutocompletePopper();
+
+        ui.autocompletePopper
+          .find()
+          .should('be.visible')
+          .within(() => {
+            cy.contains('No options available').should('be.visible');
+          });
+      });
+
+      it('can close menu with ESC key', () => {
+        mount(<Select {...defaultProps} />);
+
+        openAutocompletePopper();
+
+        ui.autocompletePopper
+          .findByTitle(`${options[0].label}`)
+          .should('be.visible');
+
+        cy.get('body').type('{esc}');
+        cy.get('[data-qa-autocomplete-popper]').should('not.exist');
+      });
+
+      it('can close autocomplete popper by clicking away', () => {
+        mount(
+          <>
+            <span id="other-element">Other Element</span>
+            <Select {...defaultProps} />
+          </>
+        );
+
+        openAutocompletePopper();
+
+        ui.autocompletePopper
+          .findByTitle(`${options[0].label}`)
+          .should('be.visible');
+
+        cy.get('#other-element').click();
+        cy.get('[data-qa-autocomplete-popper]').should('not.exist');
+      });
+    });
+
+    describe('Selection', () => {
+      it('can select an option initially', () => {
+        mount(<Select {...defaultProps} />);
+
+        openAutocompletePopper();
+
+        ui.autocompletePopper
+          .findByTitle(`${options[0].label}`)
+          .should('be.visible')
+          .click();
+
+        cy.get('input').should('have.attr', 'value', `${options[0].label}`);
+        cy.get('[data-qa-autocomplete-popper]').should('not.exist');
+      });
+
+      it('can select an option by typing', () => {
+        mount(<Select {...defaultProps} searchable />);
+
+        cy.get('input').should('have.attr', 'placeholder', 'Select an option');
+        cy.findByText('My Select').should('be.visible').click();
+        cy.focused().type(options[0].label[0]);
+
+        ui.autocompletePopper
+          .findByTitle(`${options[0].label}`)
+          .should('be.visible')
+          .click();
+
+        cy.get('input').should('have.attr', 'value', `${options[0].label}`);
+        cy.get('[data-qa-autocomplete-popper]').should('not.exist');
+      });
+
+      it('can change region selection', () => {
+        mount(
+          <Select
+            {...defaultProps}
+            value={{
+              label: options[0].label,
+              value: options[0].value,
+            }}
+          />
+        );
+
+        openAutocompletePopper();
+
+        ui.autocompletePopper
+          .findByTitle(`${options[1].label}`)
+          .scrollIntoView()
+          .should('be.visible')
+          .click();
+
+        cy.get('input').should('have.attr', 'value', `${options[1].label}`);
+
+        cy.get('[data-qa-autocomplete-popper]').should('not.exist');
+      });
+
+      it('can clear region selection', () => {
+        mount(
+          <Select
+            {...defaultProps}
+            value={{
+              label: options[1].label,
+              value: options[1].value,
+            }}
+            clearable
+          />
+        );
+
+        cy.get('input').should('have.attr', 'value', `${options[1].label}`);
+
+        cy.findByLabelText('Clear')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+
+        cy.get('input').should('have.attr', 'value', '');
+        cy.get('input').should('have.attr', 'placeholder', 'Select an option');
+      });
+
+      it('cannot clear region selection when clearable is disabled', () => {
+        mount(
+          <Select
+            {...defaultProps}
+            value={{
+              label: options[1].label,
+              value: options[1].value,
+            }}
+            clearable={false}
+          />
+        );
+
+        cy.get('input').should('have.attr', 'value', `${options[1].label}`);
+        cy.findByLabelText('Clear').should('not.exist');
+      });
+
+      it('cannot clear region selection when no region is selected', () => {
+        mount(<Select {...defaultProps} />);
+
+        cy.get('input').should('have.attr', 'value', '');
+        cy.get('input').should('have.attr', 'placeholder', 'Select an option');
+
+        cy.findByLabelText('Clear').should('not.exist');
+      });
+
+      it('calls `onChange` callback when region is initially selected', () => {
+        const spyFn = createSpy(() => {}, 'changeSpy');
+        mount(<Select {...defaultProps} onChange={spyFn} value={undefined} />);
+
+        openAutocompletePopper();
+
+        ui.autocompletePopper
+          .findByTitle(`${options[1].label}`)
+          .should('be.visible')
+          .click();
+
+        cy.get('@changeSpy').should('have.been.calledOnce');
+      });
+
+      it('calls `onChange` callback when region is cleared (if clearable is true)', () => {
+        const spyFn = createSpy(() => {}, 'changeSpy');
+        mount(
+          <Select
+            {...defaultProps}
+            value={{
+              label: options[1].label,
+              value: options[1].value,
+            }}
+            clearable
+            onChange={spyFn}
+          />
+        );
+
+        cy.findByLabelText('Clear')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+
+        cy.get('@changeSpy').should('have.been.calledOnce');
+      });
+    });
+  });
+
+  describe('Creatable', () => {
+    it('can create a new option', () => {
+      mount(<Select {...defaultProps} creatable />);
+      const newOption = 'New Option';
+
+      cy.get('input').should('have.attr', 'placeholder', 'Select an option');
+      cy.findByText('My Select').should('be.visible').click();
+      cy.focused().type(newOption);
+
+      ui.autocompletePopper
+        .find()
+        .within(() => {
+          cy.contains(`Create "${newOption}"`).should('be.visible');
+        })
+        .click();
+
+      cy.get('input').should('have.attr', 'value', newOption);
+    });
+  });
+
+  const defaultProps: SelectProps = {
+    label: 'My Select',
+    onChange: () => {},
+    options,
+    placeholder: 'Select an option',
+  };
+
+  describe('Logic', () => {
+    const WrappedSelect = (props: Partial<SelectProps>) => {
+      const [value, setValue] = React.useState<
+        SelectOptionType | null | undefined
+      >(null);
+
+      return (
+        <>
+          <Select
+            {...defaultProps}
+            onChange={(_, newValue) =>
+              setValue({
+                label: newValue?.label ?? '',
+                value: newValue?.value.replace(' ', '-').toLowerCase() ?? '',
+              })
+            }
+            textFieldProps={{
+              onChange: (e) =>
+                setValue({
+                  label: e.target.value,
+                  value: e.target.value.replace(' ', '-').toLowerCase(),
+                }),
+            }}
+            value={value ?? null}
+            {...props}
+          />
+          <Box sx={{ mt: 2 }}>
+            <Typography data-qa-selected-value>
+              {JSON.stringify(value)}
+            </Typography>
+          </Box>
+        </>
+      );
+    };
+
+    it('renders the value for an existing option', () => {
+      mount(<WrappedSelect />);
+
+      cy.get('[data-qa-selected-value]').should('have.text', 'null');
+
+      options.forEach((option) => {
+        openAutocompletePopper();
+        ui.autocompletePopper
+          .findByTitle(`${option.label}`)
+          .should('be.visible')
+          .click();
+
+        cy.get('[data-qa-selected-value]').should(
+          'have.text',
+          `{"label":"${option.label}","value":"${option.value}"}`
+        );
+      });
+    });
+
+    it('renders the value for a new option', () => {
+      mount(<WrappedSelect creatable />);
+      const newOption = 'New Option';
+
+      cy.get('[data-qa-selected-value]').should('have.text', 'null');
+
+      openAutocompletePopper();
+      cy.focused().type(newOption);
+
+      ui.autocompletePopper
+        .find()
+        .within(() => {
+          cy.contains(`Create "${newOption}"`).should('be.visible');
+        })
+        .click();
+
+      cy.get('[data-qa-selected-value]').should(
+        'have.text',
+        `{"label":"${newOption}","value":"${newOption
+          .replace(' ', '-')
+          .toLowerCase()}"}`
+      );
+    });
+  });
+});

--- a/packages/manager/cypress/component/poc/select.spec.tsx
+++ b/packages/manager/cypress/component/poc/select.spec.tsx
@@ -192,7 +192,7 @@ componentTests('Select', (mount) => {
 
       it('calls `onChange` callback when region is initially selected', () => {
         const spyFn = createSpy(() => {}, 'changeSpy');
-        mount(<Select {...defaultProps} onChange={spyFn} value={undefined} />);
+        mount(<Select {...defaultProps} onChange={spyFn} value={null} />);
 
         openAutocompletePopper();
 
@@ -253,6 +253,7 @@ componentTests('Select', (mount) => {
     onChange: () => {},
     options,
     placeholder: 'Select an option',
+    value: null,
   };
 
   describe('Logic', () => {

--- a/packages/manager/cypress/component/poc/select.spec.tsx
+++ b/packages/manager/cypress/component/poc/select.spec.tsx
@@ -100,6 +100,18 @@ componentTests('Select', (mount) => {
 
         cy.get('input').should('have.attr', 'value', `${options[0].label}`);
         cy.get('[data-qa-autocomplete-popper]').should('not.exist');
+
+        openAutocompletePopper();
+
+        ui.autocompletePopper
+          .find()
+          .should('be.visible')
+          .within(() => {
+            cy.get('li').should('have.length', options.length);
+            cy.contains(`${options[0].label}`)
+              .should('be.visible')
+              .should('have.attr', 'aria-selected', 'true');
+          });
       });
 
       it('can select an option by typing', () => {
@@ -253,7 +265,6 @@ componentTests('Select', (mount) => {
     onChange: () => {},
     options,
     placeholder: 'Select an option',
-    value: null,
   };
 
   describe('Logic', () => {

--- a/packages/manager/cypress/component/poc/select.spec.tsx
+++ b/packages/manager/cypress/component/poc/select.spec.tsx
@@ -192,7 +192,7 @@ componentTests('Select', (mount) => {
 
       it('calls `onChange` callback when region is initially selected', () => {
         const spyFn = createSpy(() => {}, 'changeSpy');
-        mount(<Select {...defaultProps} onChange={spyFn} value={null} />);
+        mount(<Select {...defaultProps} onChange={spyFn} />);
 
         openAutocompletePopper();
 
@@ -279,7 +279,7 @@ componentTests('Select', (mount) => {
                   value: e.target.value.replace(' ', '-').toLowerCase(),
                 }),
             }}
-            value={value ?? null}
+            value={value}
             {...props}
           />
           <Box sx={{ mt: 2 }}>

--- a/packages/manager/src/features/Managed/Contacts/ContactsDrawer.tsx
+++ b/packages/manager/src/features/Managed/Contacts/ContactsDrawer.tsx
@@ -188,7 +188,6 @@ const ContactsDrawer = (props: ContactsDrawerProps) => {
                   </Grid>
                 </Grid>
 
-                {/* @todo: This <Select /> should be clearable eventually, but isn't currently allowed by the API. */}
                 <Select
                   onChange={(_, selectedGroup) =>
                     setFieldValue('group', selectedGroup?.value)
@@ -205,7 +204,6 @@ const ContactsDrawer = (props: ContactsDrawerProps) => {
                         }
                       : null
                   }
-                  clearable
                   creatable
                   errorText={errors.group}
                   label="Group"

--- a/packages/manager/src/features/Managed/Contacts/ContactsDrawer.tsx
+++ b/packages/manager/src/features/Managed/Contacts/ContactsDrawer.tsx
@@ -1,4 +1,4 @@
-import { Notice, TextField } from '@linode/ui';
+import { Notice, Select, TextField } from '@linode/ui';
 import { createContactSchema } from '@linode/validation/lib/managed.schema';
 import Grid from '@mui/material/Unstable_Grid2';
 import { Formik } from 'formik';
@@ -7,7 +7,6 @@ import * as React from 'react';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Drawer } from 'src/components/Drawer';
-import Select from 'src/components/EnhancedSelect/Select';
 import {
   useCreateContactMutation,
   useUpdateContactMutation,
@@ -191,7 +190,7 @@ const ContactsDrawer = (props: ContactsDrawerProps) => {
 
                 {/* @todo: This <Select /> should be clearable eventually, but isn't currently allowed by the API. */}
                 <Select
-                  onChange={(selectedGroup) =>
+                  onChange={(_, selectedGroup) =>
                     setFieldValue('group', selectedGroup?.value)
                   }
                   options={groups.map((group) => ({
@@ -208,7 +207,6 @@ const ContactsDrawer = (props: ContactsDrawerProps) => {
                   }
                   creatable
                   errorText={errors.group}
-                  isClearable={false}
                   label="Group"
                   placeholder="Create or Select a Group"
                 />

--- a/packages/manager/src/features/Managed/Contacts/ContactsDrawer.tsx
+++ b/packages/manager/src/features/Managed/Contacts/ContactsDrawer.tsx
@@ -205,6 +205,7 @@ const ContactsDrawer = (props: ContactsDrawerProps) => {
                         }
                       : null
                   }
+                  clearable
                   creatable
                   errorText={errors.group}
                   label="Group"

--- a/packages/manager/src/features/Managed/MonitorDrawer.tsx
+++ b/packages/manager/src/features/Managed/MonitorDrawer.tsx
@@ -1,4 +1,10 @@
-import { InputAdornment, Notice, TextField } from '@linode/ui';
+import {
+  Autocomplete,
+  InputAdornment,
+  Notice,
+  Select,
+  TextField,
+} from '@linode/ui';
 import { createServiceMonitorSchema } from '@linode/validation/lib/managed.schema';
 import Grid from '@mui/material/Unstable_Grid2';
 import { Formik } from 'formik';
@@ -7,7 +13,6 @@ import * as React from 'react';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Drawer } from 'src/components/Drawer';
-import Select from 'src/components/EnhancedSelect/Select';
 
 import type {
   ManagedCredential,
@@ -157,7 +162,7 @@ const MonitorDrawer = (props: MonitorDrawerProps) => {
               />
 
               <Select
-                onChange={(item: Item<ServiceType>) =>
+                onChange={(_, item: Item<ServiceType>) =>
                   setFieldValue(
                     'consultation_group',
                     item === null ? '' : item.value
@@ -170,11 +175,11 @@ const MonitorDrawer = (props: MonitorDrawerProps) => {
                   values.consultation_group || '',
                   groupOptions
                 )}
+                clearable
                 data-qa-add-consultation-group
                 errorText={errors.consultation_group}
-                isClearable
                 label="Contact Group"
-                name="consultation_group"
+                // name="consultation_group"
                 onBlur={handleBlur}
                 options={groupOptions}
                 placeholder="Select a group..."
@@ -183,17 +188,17 @@ const MonitorDrawer = (props: MonitorDrawerProps) => {
               <Grid container spacing={2}>
                 <Grid sm={6} xs={12}>
                   <Select
-                    onChange={(item: Item<ServiceType>) =>
+                    onChange={(_, item: Item<ServiceType>) =>
                       setFieldValue('service_type', item.value)
                     }
                     textFieldProps={{
                       required: mode === modes.CREATING,
                     }}
+                    clearable={false}
                     data-qa-add-service-type
                     errorText={errors.service_type}
-                    isClearable={false}
                     label="Monitor Type"
-                    name="service_type"
+                    // name="service_type"
                     onBlur={handleBlur}
                     options={typeOptions}
                     value={getValueFromItem(values.service_type, typeOptions)}
@@ -254,13 +259,16 @@ const MonitorDrawer = (props: MonitorDrawerProps) => {
                 onChange={handleChange}
                 value={values.notes}
               />
-              <Select
-                onChange={(items: Item<number>[]) => {
+              <Autocomplete
+                onChange={(_, items: Item<number>[] | null) => {
                   setFieldValue(
                     'credentials',
-                    items.map((thisItem) => thisItem.value)
+                    items?.map((thisItem) => thisItem.value) || []
                   );
                 }}
+                placeholder={
+                  values?.credentials?.length === 0 ? 'None Required' : ''
+                }
                 textFieldProps={{
                   tooltipText: helperText.credentials,
                 }}
@@ -270,13 +278,11 @@ const MonitorDrawer = (props: MonitorDrawerProps) => {
                 )}
                 data-qa-add-credentials
                 errorText={errors.credentials}
-                isClearable={false}
-                isMulti
                 label="Credentials"
-                name="credentials"
+                multiple
+                // name="credentials"
                 onBlur={handleBlur}
                 options={credentialOptions}
-                placeholder="None Required"
               />
               <ActionsPanel
                 primaryButtonProps={{

--- a/packages/manager/src/features/Managed/MonitorDrawer.tsx
+++ b/packages/manager/src/features/Managed/MonitorDrawer.tsx
@@ -182,6 +182,7 @@ const MonitorDrawer = (props: MonitorDrawerProps) => {
                 onBlur={handleBlur}
                 options={groupOptions}
                 placeholder="Select a group..."
+                searchable
               />
 
               <Grid container spacing={2}>
@@ -193,7 +194,6 @@ const MonitorDrawer = (props: MonitorDrawerProps) => {
                     textFieldProps={{
                       required: mode === modes.CREATING,
                     }}
-                    clearable={false}
                     data-qa-add-service-type
                     errorText={errors.service_type}
                     label="Monitor Type"

--- a/packages/manager/src/features/Managed/MonitorDrawer.tsx
+++ b/packages/manager/src/features/Managed/MonitorDrawer.tsx
@@ -179,7 +179,6 @@ const MonitorDrawer = (props: MonitorDrawerProps) => {
                 data-qa-add-consultation-group
                 errorText={errors.consultation_group}
                 label="Contact Group"
-                // name="consultation_group"
                 onBlur={handleBlur}
                 options={groupOptions}
                 placeholder="Select a group..."
@@ -198,7 +197,6 @@ const MonitorDrawer = (props: MonitorDrawerProps) => {
                     data-qa-add-service-type
                     errorText={errors.service_type}
                     label="Monitor Type"
-                    // name="service_type"
                     onBlur={handleBlur}
                     options={typeOptions}
                     value={getValueFromItem(values.service_type, typeOptions)}
@@ -280,7 +278,6 @@ const MonitorDrawer = (props: MonitorDrawerProps) => {
                 errorText={errors.credentials}
                 label="Credentials"
                 multiple
-                // name="credentials"
                 onBlur={handleBlur}
                 options={credentialOptions}
               />

--- a/packages/manager/src/features/Managed/MonitorDrawer.tsx
+++ b/packages/manager/src/features/Managed/MonitorDrawer.tsx
@@ -83,7 +83,7 @@ const helperText = {
 };
 
 const getValueFromItem = (value: string, options: Item<any>[]) => {
-  return options.find((thisOption) => thisOption.value === value);
+  return options.find((thisOption) => thisOption.value === value) || null;
 };
 
 const getMultiValuesFromItems = (values: number[], options: Item<any>[]) => {

--- a/packages/ui/.changeset/pr-11391-added-1733949199859.md
+++ b/packages/ui/.changeset/pr-11391-added-1733949199859.md
@@ -1,0 +1,5 @@
+---
+"@linode/ui": Added
+---
+
+New Select component ([#11391](https://github.com/linode/manager/pull/11391))

--- a/packages/ui/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/ui/src/components/Autocomplete/Autocomplete.tsx
@@ -136,6 +136,10 @@ export const Autocomplete = <
               </>
             ),
           }}
+          inputProps={{
+            ...params.inputProps,
+            ...textFieldProps?.inputProps,
+          }}
         />
       )}
       renderOption={(props, option, state, ownerState) => {

--- a/packages/ui/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/ui/src/components/Autocomplete/Autocomplete.tsx
@@ -14,7 +14,10 @@ import {
 } from './Autocomplete.styles';
 
 import type { TextFieldProps } from '../TextField';
-import type { AutocompleteProps } from '@mui/material/Autocomplete';
+import type {
+  AutocompleteProps,
+  AutocompleteRenderInputParams,
+} from '@mui/material/Autocomplete';
 
 export interface EnhancedAutocompleteProps<
   T extends { label: string },
@@ -38,6 +41,7 @@ export interface EnhancedAutocompleteProps<
   /** Element to show when the Autocomplete search yields no results. */
   noOptionsText?: JSX.Element | string;
   placeholder?: string;
+  renderInput?: (_params: AutocompleteRenderInputParams) => React.ReactNode;
   /** Label for the "select all" option. */
   selectAllLabel?: string;
   textFieldProps?: Partial<TextFieldProps>;
@@ -85,6 +89,7 @@ export const Autocomplete = <
     onChange,
     options,
     placeholder,
+    renderInput,
     renderOption,
     selectAllLabel = '',
     textFieldProps,
@@ -108,40 +113,44 @@ export const Autocomplete = <
           ? optionsWithSelectAll
           : options
       }
-      renderInput={(params) => (
-        <TextField
-          errorText={errorText}
-          helperText={helperText}
-          inputId={params.id}
-          label={label}
-          loading={loading}
-          noMarginTop={noMarginTop}
-          placeholder={placeholder ?? 'Select an option'}
-          required={textFieldProps?.InputProps?.required}
-          tooltipText={textFieldProps?.tooltipText}
-          {...params}
-          {...textFieldProps}
-          InputProps={{
-            ...params.InputProps,
-            ...textFieldProps?.InputProps,
-            endAdornment: (
-              <>
-                {loading && (
-                  <InputAdornment position="end">
-                    <CircleProgress size="sm" />
-                  </InputAdornment>
-                )}
-                {textFieldProps?.InputProps?.endAdornment}
-                {params.InputProps.endAdornment}
-              </>
-            ),
-          }}
-          inputProps={{
-            ...params.inputProps,
-            ...textFieldProps?.inputProps,
-          }}
-        />
-      )}
+      renderInput={
+        renderInput
+          ? renderInput
+          : (params) => (
+              <TextField
+                errorText={errorText}
+                helperText={helperText}
+                inputId={params.id}
+                label={label}
+                loading={loading}
+                noMarginTop={noMarginTop}
+                placeholder={placeholder ?? 'Select an option'}
+                required={textFieldProps?.InputProps?.required}
+                tooltipText={textFieldProps?.tooltipText}
+                {...params}
+                {...textFieldProps}
+                InputProps={{
+                  ...params.InputProps,
+                  ...textFieldProps?.InputProps,
+                  endAdornment: (
+                    <>
+                      {loading && (
+                        <InputAdornment position="end">
+                          <CircleProgress size="sm" />
+                        </InputAdornment>
+                      )}
+                      {textFieldProps?.InputProps?.endAdornment}
+                      {params.InputProps.endAdornment}
+                    </>
+                  ),
+                }}
+                inputProps={{
+                  ...params.inputProps,
+                  ...textFieldProps?.inputProps,
+                }}
+              />
+            )
+      }
       renderOption={(props, option, state, ownerState) => {
         const isSelectAllOption = option === selectAllOption;
         const ListItem = isSelectAllOption ? StyledListItem : 'li';

--- a/packages/ui/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/ui/src/components/Autocomplete/Autocomplete.tsx
@@ -144,10 +144,6 @@ export const Autocomplete = <
                     </>
                   ),
                 }}
-                inputProps={{
-                  ...params.inputProps,
-                  ...textFieldProps?.inputProps,
-                }}
               />
             )
       }

--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -16,12 +16,17 @@ const meta: Meta<SelectProps> = {
 type Story = StoryObj<SelectProps>;
 
 const defaultArgs: SelectProps = {
+  clearable: false,
+  creatable: false,
+  hideLabel: false,
   label: 'A Select with a couple options',
   options: [
     { label: 'Option 1', value: 'option-1' },
     { label: 'Option 2', value: 'option-2' },
   ],
   placeholder: 'Select an option',
+  required: false,
+  searchable: false,
 };
 
 export const Default: Story = {
@@ -81,6 +86,8 @@ export const Creatable: Story = {
   args: {
     ...defaultArgs,
     creatable: true,
+    label: 'A select where one can create an option',
+    placeholder: 'Select or create an option',
   },
   render: (args) => {
     const Wrapper = () => {

--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -27,7 +27,6 @@ const defaultArgs: SelectProps = {
   placeholder: 'Select an option',
   required: false,
   searchable: false,
-  value: null,
 };
 
 export const Default: Story = {

--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { Select } from './Select';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof Select> = {
+  component: Select,
+  title: 'Components/Selects/Select',
+};
+
+type Story = StoryObj<typeof Select>;
+
+export const Default: Story = {
+  args: {
+    label: 'A Select with a couple options',
+    options: [
+      { label: 'Option 1', value: 'option-1' },
+      { label: 'Option 2', value: 'option-2' },
+    ],
+  },
+  render: (args) => <Select {...args} />,
+};
+
+export default meta;

--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -27,6 +27,7 @@ const defaultArgs: SelectProps = {
   placeholder: 'Select an option',
   required: false,
   searchable: false,
+  value: null,
 };
 
 export const Default: Story = {

--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -34,6 +34,44 @@ export const Default: Story = {
   render: (args) => <Select {...args} />,
 };
 
+export const Creatable: Story = {
+  args: {
+    ...defaultArgs,
+    creatable: true,
+    label: 'A select where one can create an option',
+    placeholder: 'Select or create an option',
+  },
+  render: (args) => {
+    const Wrapper = () => {
+      const [value, setValue] = React.useState(args.value);
+
+      return (
+        <>
+          <Select
+            {...args}
+            textFieldProps={{
+              onChange: (e) =>
+                setValue({
+                  label: e.target.value,
+                  value: e.target.value.replace(' ', '-').toLowerCase(),
+                }),
+            }}
+            onChange={(_, newValue) => setValue(newValue)}
+            value={value}
+          />
+          <Box sx={{ mt: 2 }}>
+            <Typography>
+              <strong>Selected Value: </strong> {JSON.stringify(value)}
+            </Typography>
+          </Box>
+        </>
+      );
+    };
+
+    return <Wrapper />;
+  },
+};
+
 export const Searchable: Story = {
   args: {
     ...defaultArgs,
@@ -82,42 +120,13 @@ export const WithErrorText: Story = {
   render: (args) => <Select {...args} />,
 };
 
-export const Creatable: Story = {
+export const NoOptionsText: Story = {
   args: {
     ...defaultArgs,
-    creatable: true,
-    label: 'A select where one can create an option',
-    placeholder: 'Select or create an option',
+    noOptionsText: "Nothin' here",
+    options: [],
   },
-  render: (args) => {
-    const Wrapper = () => {
-      const [value, setValue] = React.useState(args.value);
-
-      return (
-        <>
-          <Select
-            {...args}
-            textFieldProps={{
-              onChange: (e) =>
-                setValue({
-                  label: e.target.value,
-                  value: e.target.value.replace(' ', '-').toLowerCase(),
-                }),
-            }}
-            onChange={(_, newValue) => setValue(newValue)}
-            value={value}
-          />
-          <Box sx={{ mt: 2 }}>
-            <Typography>
-              <strong>Selected Value: </strong> {JSON.stringify(value)}
-            </Typography>
-          </Box>
-        </>
-      );
-    };
-
-    return <Wrapper />;
-  },
+  render: (args) => <Select {...args} />,
 };
 
 export default meta;

--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -18,6 +18,7 @@ export const Default: Story = {
       { label: 'Option 1', value: 'option-1' },
       { label: 'Option 2', value: 'option-2' },
     ],
+    placeholder: 'Select an option',
   },
   render: (args) => <Select {...args} />,
 };

--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -49,6 +49,12 @@ export const Creatable: Story = {
         <>
           <Select
             {...args}
+            onChange={(_, newValue) =>
+              setValue({
+                label: newValue?.label ?? '',
+                value: newValue?.value.replace(' ', '-').toLowerCase() ?? '',
+              })
+            }
             textFieldProps={{
               onChange: (e) =>
                 setValue({
@@ -56,7 +62,6 @@ export const Creatable: Story = {
                   value: e.target.value.replace(' ', '-').toLowerCase(),
                 }),
             }}
-            onChange={(_, newValue) => setValue(newValue)}
             value={value ?? null}
           />
           <Box sx={{ mt: 2 }}>

--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -1,26 +1,116 @@
 import React from 'react';
 
+import { Box } from '../Box';
+import { Typography } from '../Typography';
 import { Select } from './Select';
 
+import type { SelectProps } from './Select';
 import type { Meta, StoryObj } from '@storybook/react';
 
-const meta: Meta<typeof Select> = {
+const meta: Meta<SelectProps> = {
   component: Select,
+  decorators: [(Story) => <Box sx={{ height: 300 }}>{Story()}</Box>],
   title: 'Components/Selects/Select',
 };
 
-type Story = StoryObj<typeof Select>;
+type Story = StoryObj<SelectProps>;
+
+const defaultArgs: SelectProps = {
+  label: 'A Select with a couple options',
+  options: [
+    { label: 'Option 1', value: 'option-1' },
+    { label: 'Option 2', value: 'option-2' },
+  ],
+  placeholder: 'Select an option',
+};
 
 export const Default: Story = {
+  args: defaultArgs,
+  render: (args) => <Select {...args} />,
+};
+
+export const Searchable: Story = {
   args: {
-    label: 'A Select with a couple options',
-    options: [
-      { label: 'Option 1', value: 'option-1' },
-      { label: 'Option 2', value: 'option-2' },
-    ],
-    placeholder: 'Select an option',
+    ...defaultArgs,
+    searchable: true,
   },
   render: (args) => <Select {...args} />,
+};
+
+export const Required: Story = {
+  args: {
+    ...defaultArgs,
+    required: true,
+  },
+  render: (args) => <Select {...args} />,
+};
+
+export const Clearable: Story = {
+  args: {
+    ...defaultArgs,
+    clearable: true,
+  },
+  render: (args) => <Select {...args} />,
+};
+
+export const Loading: Story = {
+  args: {
+    ...defaultArgs,
+    loading: true,
+  },
+  render: (args) => <Select {...args} />,
+};
+
+export const WithHelperText: Story = {
+  args: {
+    ...defaultArgs,
+    helperText: 'This is some helper text',
+  },
+  render: (args) => <Select {...args} />,
+};
+
+export const WithErrorText: Story = {
+  args: {
+    ...defaultArgs,
+    errorText: 'This is some error text',
+  },
+  render: (args) => <Select {...args} />,
+};
+
+export const Creatable: Story = {
+  args: {
+    ...defaultArgs,
+    creatable: true,
+  },
+  render: (args) => {
+    const Wrapper = () => {
+      const [value, setValue] = React.useState(args.value);
+
+      return (
+        <>
+          <Select
+            {...args}
+            textFieldProps={{
+              onChange: (e) =>
+                setValue({
+                  label: e.target.value,
+                  value: e.target.value.replace(' ', '-').toLowerCase(),
+                }),
+            }}
+            onChange={(_, newValue) => setValue(newValue)}
+            value={value}
+          />
+          <Box sx={{ mt: 2 }}>
+            <Typography>
+              <strong>Selected Value: </strong> {JSON.stringify(value)}
+            </Typography>
+          </Box>
+        </>
+      );
+    };
+
+    return <Wrapper />;
+  },
 };
 
 export default meta;

--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -57,7 +57,7 @@ export const Creatable: Story = {
                 }),
             }}
             onChange={(_, newValue) => setValue(newValue)}
-            value={value}
+            value={value ?? null}
           />
           <Box sx={{ mt: 2 }}>
             <Typography>

--- a/packages/ui/src/components/Select/Select.test.tsx
+++ b/packages/ui/src/components/Select/Select.test.tsx
@@ -1,0 +1,68 @@
+import { screen, waitFor, within } from '@testing-library/dom';
+import { fireEvent } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { renderWithTheme } from '../../utilities/testHelpers';
+import { Select } from './Select';
+
+const options = [
+  { label: 'Option 1', value: 'option-1' },
+  { label: 'Option 2', value: 'option-2' },
+  { label: 'Option 3', value: 'option-3' },
+];
+
+describe('Select', () => {
+  it('It renders a Select with a label and options', async () => {
+    const onChange = vi.fn();
+    const { getByRole, getByText } = renderWithTheme(
+      <Select label="My Select" onChange={onChange} options={options} />
+    );
+
+    expect(getByText('My Select')).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Open' })).toBeInTheDocument();
+
+    const selectInput = getByRole('combobox');
+
+    options.forEach((option) => {
+      fireEvent.focus(selectInput);
+      fireEvent.change(selectInput, { target: { value: option.label } });
+      expect(getByText(option.label)).toBeInTheDocument();
+
+      const listbox = document.querySelector('[role="listbox"]');
+      const optionElement = within(listbox as HTMLElement).getByText(
+        option.label
+      );
+      fireEvent.click(optionElement);
+
+      expect(onChange).toHaveBeenCalledWith(expect.any(Object), option);
+      expect(selectInput).toHaveValue(option.label);
+    });
+  });
+
+  it('can be clearable', async () => {
+    const onChange = vi.fn();
+    const { getByRole } = renderWithTheme(
+      <Select
+        clearable
+        label="My Select"
+        onChange={onChange}
+        options={options}
+      />
+    );
+
+    const selectInput = getByRole('combobox');
+    fireEvent.mouseDown(selectInput);
+
+    const listbox = screen.getByRole('listbox');
+    const optionElement = within(listbox).getByText(options[0].label);
+    fireEvent.click(optionElement);
+
+    await waitFor(() => {
+      const clearButton = screen.getByRole('button', { name: 'Clear' });
+      expect(clearButton).toBeInTheDocument();
+      fireEvent.click(clearButton);
+      expect(onChange).toHaveBeenCalledWith(expect.any(Object), null);
+    });
+  });
+});

--- a/packages/ui/src/components/Select/Select.test.tsx
+++ b/packages/ui/src/components/Select/Select.test.tsx
@@ -19,14 +19,14 @@ describe('Select', () => {
         label="My Select"
         onChange={onChange}
         options={options}
-        placeholder="Select an option"
+        placeholder="Select something!"
       />
     );
 
     const select = getByRole('combobox');
     expect(select).toHaveAttribute('aria-autocomplete', 'list');
     expect(select).toHaveAttribute('aria-expanded', 'false');
-    expect(select).toHaveAttribute('placeholder', 'Select an option');
+    expect(select).toHaveAttribute('placeholder', 'Select something!');
     expect(select).toHaveAttribute('readOnly');
 
     expect(getByText('My Select')).toBeInTheDocument();

--- a/packages/ui/src/components/Select/Select.test.tsx
+++ b/packages/ui/src/components/Select/Select.test.tsx
@@ -20,7 +20,6 @@ describe('Select', () => {
         onChange={onChange}
         options={options}
         placeholder="Select something!"
-        value={null}
       />
     );
 
@@ -46,7 +45,7 @@ describe('Select', () => {
 
   it('can have its label visually hidden', async () => {
     const { container } = renderWithTheme(
-      <Select hideLabel label="My Select" options={options} value={null} />
+      <Select hideLabel label="My Select" options={options} />
     );
 
     const label = container.querySelector(
@@ -85,31 +84,21 @@ describe('Select', () => {
 
   it('features helper text', () => {
     const { getByText } = renderWithTheme(
-      <Select
-        helperText="Helper text"
-        label="My Select"
-        options={options}
-        value={null}
-      />
+      <Select helperText="Helper text" label="My Select" options={options} />
     );
     expect(getByText('Helper text')).toBeInTheDocument();
   });
 
   it('features error text', () => {
     const { getByText } = renderWithTheme(
-      <Select
-        errorText="Error text"
-        label="My Select"
-        options={options}
-        value={null}
-      />
+      <Select errorText="Error text" label="My Select" options={options} />
     );
     expect(getByText('Error text')).toBeInTheDocument();
   });
 
   it('features loading state', () => {
     const { getByRole } = renderWithTheme(
-      <Select label="My Select" loading options={options} value={null} />
+      <Select label="My Select" loading options={options} />
     );
     expect(
       getByRole('progressbar', { name: 'Content is loading' })
@@ -118,14 +107,14 @@ describe('Select', () => {
 
   it('features a required state', () => {
     const { getByText } = renderWithTheme(
-      <Select label="My Select" options={options} required value={null} />
+      <Select label="My Select" options={options} required />
     );
     expect(getByText('(required)')).toBeInTheDocument();
   });
 
   it('features a searchable state', () => {
     const { getByRole } = renderWithTheme(
-      <Select label="My Select" options={options} searchable value={null} />
+      <Select label="My Select" options={options} searchable />
     );
     const select = getByRole('combobox');
     expect(select).not.toHaveAttribute('readOnly');

--- a/packages/ui/src/components/Select/Select.test.tsx
+++ b/packages/ui/src/components/Select/Select.test.tsx
@@ -20,6 +20,7 @@ describe('Select', () => {
         onChange={onChange}
         options={options}
         placeholder="Select something!"
+        value={null}
       />
     );
 
@@ -45,7 +46,7 @@ describe('Select', () => {
 
   it('can have its label visually hidden', async () => {
     const { container } = renderWithTheme(
-      <Select hideLabel label="My Select" options={options} />
+      <Select hideLabel label="My Select" options={options} value={null} />
     );
 
     const label = container.querySelector(
@@ -84,21 +85,31 @@ describe('Select', () => {
 
   it('features helper text', () => {
     const { getByText } = renderWithTheme(
-      <Select helperText="Helper text" label="My Select" options={options} />
+      <Select
+        helperText="Helper text"
+        label="My Select"
+        options={options}
+        value={null}
+      />
     );
     expect(getByText('Helper text')).toBeInTheDocument();
   });
 
   it('features error text', () => {
     const { getByText } = renderWithTheme(
-      <Select errorText="Error text" label="My Select" options={options} />
+      <Select
+        errorText="Error text"
+        label="My Select"
+        options={options}
+        value={null}
+      />
     );
     expect(getByText('Error text')).toBeInTheDocument();
   });
 
   it('features loading state', () => {
     const { getByRole } = renderWithTheme(
-      <Select label="My Select" loading options={options} />
+      <Select label="My Select" loading options={options} value={null} />
     );
     expect(
       getByRole('progressbar', { name: 'Content is loading' })
@@ -107,14 +118,14 @@ describe('Select', () => {
 
   it('features a required state', () => {
     const { getByText } = renderWithTheme(
-      <Select label="My Select" options={options} required />
+      <Select label="My Select" options={options} required value={null} />
     );
     expect(getByText('(required)')).toBeInTheDocument();
   });
 
   it('features a searchable state', () => {
     const { getByRole } = renderWithTheme(
-      <Select label="My Select" options={options} searchable />
+      <Select label="My Select" options={options} searchable value={null} />
     );
     const select = getByRole('combobox');
     expect(select).not.toHaveAttribute('readOnly');

--- a/packages/ui/src/components/Select/Select.test.tsx
+++ b/packages/ui/src/components/Select/Select.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -34,9 +34,9 @@ describe('Select', () => {
 
     const selectInput = getByRole('combobox');
 
-    options.forEach((option) => {
-      fireEvent.focus(selectInput);
-      fireEvent.change(selectInput, { target: { value: option.label } });
+    options.forEach(async (option) => {
+      await userEvent.click(selectInput);
+      await userEvent.type(selectInput, option.label);
 
       expect(getByText(option.label)).toBeInTheDocument();
       expect(selectInput).toHaveValue(option.label);
@@ -78,7 +78,7 @@ describe('Select', () => {
       '.MuiAutocomplete-clearIndicator'
     );
     expect(clearButton).toBeInTheDocument();
-    fireEvent.click(clearButton!);
+    await userEvent.click(clearButton!);
     expect(onChange).toHaveBeenCalledWith(expect.any(Object), null);
   });
 

--- a/packages/ui/src/components/Select/Select.test.tsx
+++ b/packages/ui/src/components/Select/Select.test.tsx
@@ -15,8 +15,19 @@ describe('Select', () => {
   it('renders a Select with a label and options', async () => {
     const onChange = vi.fn();
     const { getByRole, getByText } = renderWithTheme(
-      <Select label="My Select" onChange={onChange} options={options} />
+      <Select
+        label="My Select"
+        onChange={onChange}
+        options={options}
+        placeholder="Select an option"
+      />
     );
+
+    const select = getByRole('combobox');
+    expect(select).toHaveAttribute('aria-autocomplete', 'list');
+    expect(select).toHaveAttribute('aria-expanded', 'false');
+    expect(select).toHaveAttribute('placeholder', 'Select an option');
+    expect(select).toHaveAttribute('readOnly');
 
     expect(getByText('My Select')).toBeInTheDocument();
     expect(getByRole('button', { name: 'Open' })).toBeInTheDocument();
@@ -45,7 +56,7 @@ describe('Select', () => {
 
   it('can be clearable', async () => {
     const onChange = vi.fn();
-    const { container } = renderWithTheme(
+    const { container, getByRole } = renderWithTheme(
       <Select
         isOptionEqualToValue={(option, value) =>
           option.value === value.value && option.label === value.label
@@ -61,11 +72,51 @@ describe('Select', () => {
       />
     );
 
+    const select = getByRole('combobox');
+    expect(select).toHaveValue(options[0].label);
     const clearButton = container.querySelector(
       '.MuiAutocomplete-clearIndicator'
     );
     expect(clearButton).toBeInTheDocument();
     fireEvent.click(clearButton!);
     expect(onChange).toHaveBeenCalledWith(expect.any(Object), null);
+  });
+
+  it('features helper text', () => {
+    const { getByText } = renderWithTheme(
+      <Select helperText="Helper text" label="My Select" options={options} />
+    );
+    expect(getByText('Helper text')).toBeInTheDocument();
+  });
+
+  it('features error text', () => {
+    const { getByText } = renderWithTheme(
+      <Select errorText="Error text" label="My Select" options={options} />
+    );
+    expect(getByText('Error text')).toBeInTheDocument();
+  });
+
+  it('features loading state', () => {
+    const { getByRole } = renderWithTheme(
+      <Select label="My Select" loading options={options} />
+    );
+    expect(
+      getByRole('progressbar', { name: 'Content is loading' })
+    ).toBeInTheDocument();
+  });
+
+  it('features a required state', () => {
+    const { getByText } = renderWithTheme(
+      <Select label="My Select" options={options} required />
+    );
+    expect(getByText('(required)')).toBeInTheDocument();
+  });
+
+  it('features a searchable state', () => {
+    const { getByRole } = renderWithTheme(
+      <Select label="My Select" options={options} searchable />
+    );
+    const select = getByRole('combobox');
+    expect(select).not.toHaveAttribute('readOnly');
   });
 });

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -21,12 +21,44 @@ export interface SelectProps
     | 'textFieldProps'
     | 'value'
   > {
+  /**
+   * Whether the select can be cleared once a value is selected.
+   *
+   * @default false
+   */
   clearable?: boolean;
+  /**
+   * Whether the select can create a new option.
+   * This will enable the freeSolo prop on the Autocomplete component.
+   *
+   * @default false
+   */
   creatable?: boolean;
+  /**
+   * Whether to visually hide the label, which is still required for accessibility.
+   *
+   * @default false
+   */
   hideLabel?: boolean;
+  /**
+   * The label for the select.
+   */
   label: string;
+  /**
+   * The callback function that is invoked when the value changes.
+   */
   onChange?: (_event: React.SyntheticEvent, _value: OptionType | null) => void;
+  /**
+   * Whether the select is required.
+   *
+   * @default false
+   */
   required?: boolean;
+  /**
+   * Whether the select is searchable.
+   *
+   * @default false
+   */
   searchable?: boolean;
 }
 

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -3,50 +3,124 @@ import React from 'react';
 
 import { Autocomplete } from '../Autocomplete';
 import { Box } from '../Box';
+import { TextField } from '../TextField';
 
 import type { EnhancedAutocompleteProps } from '../Autocomplete';
+import type { BoxProps } from '../Box';
 
 type OptionType = { label: string; value: string };
 
-type SelectProps = Pick<
-  EnhancedAutocompleteProps<OptionType>,
-  | 'errorText'
-  | 'helperText'
-  | 'label'
-  | 'onChange'
-  | 'options'
-  | 'placeholder'
-  | 'textFieldProps'
-  | 'value'
->;
+export interface SelectProps
+  extends Pick<
+    EnhancedAutocompleteProps<OptionType>,
+    | 'errorText'
+    | 'helperText'
+    | 'loading'
+    | 'options'
+    | 'placeholder'
+    | 'textFieldProps'
+    | 'value'
+  > {
+  clearable?: boolean;
+  creatable?: boolean;
+  hideLabel?: boolean;
+  label: string;
+  onChange?: (event: React.SyntheticEvent, value: OptionType | null) => void;
+  required?: boolean;
+  searchable?: boolean;
+}
 
 /**
- * An abstracted Autocomplete component with some props overridden for convenience and consistency.
+ * An abstracted Autocomplete component with a limited set of props.
+ * This component is meant to be used when wanting:
+ * - A simple select without search ability
+ * - A create-able select
+ *
+ * For any other use-cases, use the Autocomplete component directly.
  */
 export const Select = (props: SelectProps) => {
-  const { textFieldProps, ...rest } = props;
+  const {
+    clearable = false,
+    creatable = false,
+    hideLabel = false,
+    label,
+    onChange,
+    searchable = false,
+    textFieldProps,
+    ...rest
+  } = props;
+
+  const handleChange = (
+    event: React.SyntheticEvent,
+    value: OptionType | null | string
+  ) => {
+    if (creatable && typeof value === 'string') {
+      onChange?.(event, {
+        label: value,
+        value: value.toLowerCase().replace(/\s+/g, '-'),
+      });
+    } else {
+      onChange?.(event, value as OptionType | null);
+    }
+  };
 
   return (
-    <SelectContainer>
+    <SelectContainer creatable={creatable}>
       <Autocomplete
         {...rest}
-        textFieldProps={{
-          ...textFieldProps,
-          inputProps: {
-            ...textFieldProps?.inputProps,
-            readOnly: true,
-          },
-        }}
+        renderInput={
+          creatable
+            ? (params) => (
+                <TextField
+                  {...params}
+                  {...textFieldProps}
+                  errorText={props.errorText}
+                  helperText={props.helperText}
+                  hideLabel={hideLabel}
+                  inputId={params.id}
+                  label={label}
+                  placeholder={props.placeholder}
+                  required={props.required}
+                />
+              )
+            : undefined
+        }
+        textFieldProps={
+          !creatable
+            ? {
+                ...textFieldProps,
+                InputProps: {
+                  ...textFieldProps?.InputProps,
+                  required: props.required,
+                },
+                hideLabel,
+                inputProps: {
+                  ...textFieldProps?.inputProps,
+                  readOnly: !searchable,
+                },
+              }
+            : undefined
+        }
+        disableClearable={!clearable}
+        freeSolo={creatable}
+        label={label}
+        onChange={handleChange}
       />
     </SelectContainer>
   );
 };
 
-const SelectContainer = styled(Box)(({}) => ({
+interface SelectContainerProps extends BoxProps {
+  creatable?: boolean;
+}
+
+const SelectContainer = styled(Box)<SelectContainerProps>(({ creatable }) => ({
   '& .MuiInputBase-root, & .MuiInputBase-input': {
-    '&::selection': {
-      backgroundColor: 'transparent',
-    },
+    ...(!creatable && {
+      '&::selection': {
+        backgroundColor: 'transparent !important',
+      },
+    }),
     cursor: 'pointer',
   },
 }));

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -1,0 +1,58 @@
+import { KeyboardArrowDown } from '@mui/icons-material';
+import {
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select as MuiSelect,
+} from '@mui/material';
+import React from 'react';
+import { styled } from '@mui/material';
+
+import type { SelectProps as MuiSelectProps } from '@mui/material';
+
+interface SelectProps
+  extends Omit<
+    MuiSelectProps,
+    'IconComponent' | 'children' | 'label' | 'multiple' | 'native' | 'variant'
+  > {
+  label: string;
+  options: { label: string; value: string }[];
+}
+
+/**
+ * A simple select component with a list of options.
+ * A wrapper around MuiSelect with some props overridden for convenience and consistency.
+ */
+export const Select = (props: SelectProps) => {
+  const { label, options, ...rest } = props;
+  return (
+    <FormControl fullWidth>
+      <InputLabel shrink>{label}</InputLabel>
+      <StyledSelect
+        {...rest}
+        IconComponent={KeyboardArrowDown}
+        color="primary"
+        variant="standard"
+        MenuProps={{
+          PaperProps: {
+            sx: {
+              left: '0px !important',
+            },
+          },
+        }}
+      >
+        {options.map((option) => (
+          <MenuItem key={option.value} value={option.value}>
+            {option.label}
+          </MenuItem>
+        ))}
+      </StyledSelect>
+    </FormControl>
+  );
+};
+
+const StyledSelect = styled(MuiSelect, {
+  label: 'StyledSelect',
+})({
+  border: 'none',
+});

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -25,7 +25,7 @@ export interface SelectProps
   creatable?: boolean;
   hideLabel?: boolean;
   label: string;
-  onChange?: (event: React.SyntheticEvent, value: OptionType | null) => void;
+  onChange?: (_event: React.SyntheticEvent, _value: OptionType | null) => void;
   required?: boolean;
   searchable?: boolean;
 }

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -22,6 +22,7 @@ export interface SelectProps
     EnhancedAutocompleteProps<OptionType>,
     | 'errorText'
     | 'helperText'
+    | 'isOptionEqualToValue'
     | 'loading'
     | 'noOptionsText'
     | 'options'

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -106,7 +106,7 @@ export const Select = (props: SelectProps) => {
         {...rest}
         options={
           creatable
-            ? options.length === 0
+            ? options.length === 0 && !inputValue
               ? [{ label: 'No options available', value: '' }] // No options at all
               : inputValue && !options.some((opt) => opt.value === inputValue)
               ? [

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -146,6 +146,7 @@ export const Select = (props: SelectProps) => {
           </li>
         )}
         disableClearable={!clearable}
+        forcePopupIcon
         freeSolo={creatable}
         getOptionDisabled={(option: OptionType) => option.value === ''}
         label={label}

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -25,6 +25,7 @@ export interface SelectProps
     | 'isOptionEqualToValue'
     | 'loading'
     | 'noOptionsText'
+    | 'onBlur'
     | 'options'
     | 'placeholder'
     | 'textFieldProps'

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -29,7 +29,6 @@ export interface SelectProps
     | 'options'
     | 'placeholder'
     | 'textFieldProps'
-    | 'value'
   > {
   /**
    * Whether the select can be cleared once a value is selected.
@@ -73,6 +72,11 @@ export interface SelectProps
    * @default false
    */
   searchable?: boolean;
+  /**
+   * The value of the select.
+   * We ensure that when passing in a value, it is never undefined. (to prevent controlled/uncontrolled input issues)
+   */
+  value: SelectOptionType | null;
 }
 
 /**
@@ -101,7 +105,7 @@ export const Select = (props: SelectProps) => {
 
   const handleChange = (
     event: React.SyntheticEvent,
-    value: SelectOptionType | null | string
+    value: SelectProps['value'] | string
   ) => {
     if (creatable && typeof value === 'string') {
       onChange?.(event, {

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -38,6 +38,7 @@ export interface SelectProps
     | 'options'
     | 'placeholder'
     | 'textFieldProps'
+    | 'value'
   > {
   /**
    * Whether the select can be cleared once a value is selected.
@@ -81,10 +82,6 @@ export interface SelectProps
    * @default false
    */
   searchable?: boolean;
-  /**
-   * The value of the select.
-   */
-  value?: SelectOptionType | null;
 }
 
 /**
@@ -163,11 +160,13 @@ export const Select = (props: SelectProps) => {
                 {params.InputProps.endAdornment}
               </>
             ),
+            sx: { cursor: creatable || searchable ? 'text' : 'pointer' },
           }}
           inputProps={{
             ...params.inputProps,
             ...textFieldProps?.inputProps,
             readOnly: !creatable && !searchable,
+            sx: { cursor: creatable || searchable ? 'text' : 'pointer' },
           }}
           errorText={props.errorText}
           helperText={props.helperText}
@@ -202,6 +201,17 @@ export const Select = (props: SelectProps) => {
           </ListItem>
         );
       }}
+      sx={
+        !creatable && !searchable
+          ? {
+              '& .MuiInputBase-input': {
+                '&::selection': {
+                  background: 'transparent',
+                },
+              },
+            }
+          : null
+      }
       disableClearable={!clearable}
       forcePopupIcon
       freeSolo={creatable}
@@ -212,7 +222,6 @@ export const Select = (props: SelectProps) => {
       onInputChange={(_, value) => setInputValue(value)}
       options={_options}
       selectOnFocus={false}
-      value={valueOrNull(props.value)}
     />
   );
 };
@@ -231,13 +240,6 @@ interface GetOptionsProps {
    */
   options: readonly InternalOptionType[];
 }
-
-/**
- * Ensure that when passing in a value, it is never undefined.
- * (to prevent controlled/uncontrolled input issues)
- */
-const valueOrNull = (value: SelectOptionType | null | undefined) =>
-  value ?? null;
 
 /**
  * Get the options for the Select component.

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -213,13 +213,20 @@ const getOptions = ({ creatable, inputValue, options }: GetOptionsProps) => {
     return [{ label: 'No options available', noOptions: true, value: '' }];
   }
 
-  if (
-    inputValue &&
-    !options.some((opt) => opt.value === inputValue || opt.label === inputValue)
-  ) {
+  if (inputValue) {
+    const matchingOptions = options.filter(
+      (opt) =>
+        opt.label.toLowerCase().includes(inputValue.toLowerCase()) ||
+        opt.value.toLowerCase().includes(inputValue.toLowerCase())
+    );
+
+    if (!matchingOptions.length) {
+      return [{ create: true, label: inputValue, value: inputValue }];
+    }
+
     return [
       { create: true, label: inputValue, value: inputValue },
-      ...options,
+      ...matchingOptions,
     ].sort((a, b) => {
       if (a.create) {
         return -1;

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -1,4 +1,5 @@
 import { KeyboardArrowDown } from '@mui/icons-material';
+import { styled } from '@mui/material';
 import {
   FormControl,
   InputLabel,
@@ -6,7 +7,6 @@ import {
   Select as MuiSelect,
 } from '@mui/material';
 import React from 'react';
-import { styled } from '@mui/material';
 
 import type { SelectProps as MuiSelectProps } from '@mui/material';
 
@@ -33,13 +33,6 @@ export const Select = (props: SelectProps) => {
         IconComponent={KeyboardArrowDown}
         color="primary"
         variant="standard"
-        MenuProps={{
-          PaperProps: {
-            sx: {
-              left: '0px !important',
-            },
-          },
-        }}
       >
         {options.map((option) => (
           <MenuItem key={option.value} value={option.value}>
@@ -51,8 +44,26 @@ export const Select = (props: SelectProps) => {
   );
 };
 
-const StyledSelect = styled(MuiSelect, {
+const BaseSelect = styled(MuiSelect, {
   label: 'StyledSelect',
-})({
-  border: 'none',
-});
+})(() => ({
+  '& .MuiSvgIcon-root': {
+    top: 4,
+  },
+}));
+
+const StyledSelect = styled(({ className, ...props }: MuiSelectProps) => (
+  <BaseSelect
+    {...props}
+    MenuProps={{ PaperProps: { className }, marginThreshold: 0 }}
+  />
+))(({ theme }) => ({
+  '& .MuiList-root': {
+    border: `1px solid ${theme.palette.primary.main}`,
+    overflow: 'hidden',
+    width: 'calc(100% + 2px)',
+  },
+  marginLeft: -1,
+  marginTop: -1,
+  overflow: 'visible',
+}));

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -8,18 +8,18 @@ import { TextField } from '../TextField';
 
 import type { EnhancedAutocompleteProps } from '../Autocomplete';
 
-type OptionType = {
+export type SelectOptionType = {
   label: string;
   value: string;
 };
 
-interface InternalOptionType extends OptionType {
+interface InternalOptionType extends SelectOptionType {
   create?: boolean;
   noOptions?: boolean;
 }
 export interface SelectProps
   extends Pick<
-    EnhancedAutocompleteProps<OptionType>,
+    EnhancedAutocompleteProps<SelectOptionType>,
     | 'errorText'
     | 'helperText'
     | 'isOptionEqualToValue'
@@ -100,7 +100,7 @@ export const Select = (props: SelectProps) => {
 
   const handleChange = (
     event: React.SyntheticEvent,
-    value: OptionType | null | string
+    value: SelectOptionType | null | string
   ) => {
     if (creatable && typeof value === 'string') {
       onChange?.(event, {
@@ -186,7 +186,7 @@ export const Select = (props: SelectProps) => {
       disableClearable={!clearable}
       forcePopupIcon
       freeSolo={creatable}
-      getOptionDisabled={(option: OptionType) => option.value === ''}
+      getOptionDisabled={(option: SelectOptionType) => option.value === ''}
       label={label}
       noOptionsText={noOptionsText}
       onChange={handleChange}

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -1,69 +1,52 @@
-import { KeyboardArrowDown } from '@mui/icons-material';
 import { styled } from '@mui/material';
-import {
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select as MuiSelect,
-} from '@mui/material';
 import React from 'react';
 
-import type { SelectProps as MuiSelectProps } from '@mui/material';
+import { Autocomplete } from '../Autocomplete';
+import { Box } from '../Box';
 
-interface SelectProps
-  extends Omit<
-    MuiSelectProps,
-    'IconComponent' | 'children' | 'label' | 'multiple' | 'native' | 'variant'
-  > {
-  label: string;
-  options: { label: string; value: string }[];
-}
+import type { EnhancedAutocompleteProps } from '../Autocomplete';
+
+type OptionType = { label: string; value: string };
+
+type SelectProps = Pick<
+  EnhancedAutocompleteProps<OptionType>,
+  | 'errorText'
+  | 'helperText'
+  | 'label'
+  | 'onChange'
+  | 'options'
+  | 'placeholder'
+  | 'textFieldProps'
+  | 'value'
+>;
 
 /**
- * A simple select component with a list of options.
- * A wrapper around MuiSelect with some props overridden for convenience and consistency.
+ * An abstracted Autocomplete component with some props overridden for convenience and consistency.
  */
 export const Select = (props: SelectProps) => {
-  const { label, options, ...rest } = props;
+  const { textFieldProps, ...rest } = props;
+
   return (
-    <FormControl fullWidth>
-      <InputLabel shrink>{label}</InputLabel>
-      <StyledSelect
+    <SelectContainer>
+      <Autocomplete
         {...rest}
-        IconComponent={KeyboardArrowDown}
-        color="primary"
-        variant="standard"
-      >
-        {options.map((option) => (
-          <MenuItem key={option.value} value={option.value}>
-            {option.label}
-          </MenuItem>
-        ))}
-      </StyledSelect>
-    </FormControl>
+        textFieldProps={{
+          ...textFieldProps,
+          inputProps: {
+            ...textFieldProps?.inputProps,
+            readOnly: true,
+          },
+        }}
+      />
+    </SelectContainer>
   );
 };
 
-const BaseSelect = styled(MuiSelect, {
-  label: 'StyledSelect',
-})(() => ({
-  '& .MuiSvgIcon-root': {
-    top: 4,
+const SelectContainer = styled(Box)(({}) => ({
+  '& .MuiInputBase-root, & .MuiInputBase-input': {
+    '&::selection': {
+      backgroundColor: 'transparent',
+    },
+    cursor: 'pointer',
   },
-}));
-
-const StyledSelect = styled(({ className, ...props }: MuiSelectProps) => (
-  <BaseSelect
-    {...props}
-    MenuProps={{ PaperProps: { className }, marginThreshold: 0 }}
-  />
-))(({ theme }) => ({
-  '& .MuiList-root': {
-    border: `1px solid ${theme.palette.primary.main}`,
-    overflow: 'hidden',
-    width: 'calc(100% + 2px)',
-  },
-  marginLeft: -1,
-  marginTop: -1,
-  overflow: 'visible',
 }));

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -23,6 +23,7 @@ export * from './Notice';
 export * from './Paper';
 export * from './Radio';
 export * from './RadioGroup';
+export * from './Select/Select';
 export * from './Stack';
 export * from './TextField';
 export * from './Toggle';


### PR DESCRIPTION
## Description 📝
This PR introduces a new Select component aimed to facilitate the full deprecation of `react-select`.

This new component wraps Autocomplete to make a "simple" Select for the following reasons:
- Our new Select needs more capabilities than a simple select (easily disabling search, being clearable, being "creatable") in order to fulfill some of the UX requirements of `react-select`
- Wrapping `Autocomplete` allows us to 
  - only pick the options we are interested in
  - facilitates the developer experience for simple Select cases
  - Customize this instance only without adding further complexity to `Autocomplete` (for instance, adding the "creatable" logic to our existing `Autocomplete` would further complicate its maintenance)
  - Keep styling and common props consistency (helper text, error text, loading state, required state etc) without having to redefine them all over

In addition of adding a Story and relevant test, this PR replaces `react-select` in the Managed feature so we can see it in action in Cloud Manager.

> [!NOTE]
> This Select will also replace existing instances of `<Textfield select />`

## Changes  🔄

List any change(s) relevant to the reviewer.
- Add new Select component in `@linode/ui`
- Add new story
- Add unit test
- Add component test
- Replace instances in Managed

## Preview 📷
![Screenshot 2024-12-12 at 11 41 52](https://github.com/user-attachments/assets/38faee86-13a0-4087-9cdd-6aee7859c9fc)

## How to test 🧪

### Verification steps
- Verify component behavior in Storybook: http://localhost:6006/?path=/docs/components-selects-select--documentation
- Verify component implementation and behavior in Managed:
  - /managed/monitors 👉 "Add Monitor" then "Edit Monitor" once created (**don't forget** to delete your bogus Monitor in order to avoid a failing one that's going to send warnings to the Managed team)
  - /managed/contacts 👉 "Add Contact" then "Edit Contact" once created

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules


