### PR TITLE
refactor: [M3-8986] - Refactor VPCEditDrawer and SubnetEditDrawer to use `react-hook-form`

### DIFF
--- a/packages/manager/.changeset/pr-11393-tech-stories-1733855306252.md
+++ b/packages/manager/.changeset/pr-11393-tech-stories-1733855306252.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Refactor VPCEditDrawer and SubnetEditDrawer to use `react-hook-form` instead of `formik` ([#11393](https://github.com/linode/manager/pull/11393))

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetEditDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetEditDrawer.tsx
@@ -1,12 +1,13 @@
+import { yupResolver } from '@hookform/resolvers/yup';
 import { Notice, TextField } from '@linode/ui';
-import { useFormik } from 'formik';
+import { modifySubnetSchema } from '@linode/validation';
 import * as React from 'react';
+import { Controller, useForm } from 'react-hook-form';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Drawer } from 'src/components/Drawer';
 import { useGrants, useProfile } from 'src/queries/profile/profile';
 import { useUpdateSubnetMutation } from 'src/queries/vpcs/vpcs';
-import { getErrorMap } from 'src/utilities/errorUtils';
 
 import type { ModifySubnetPayload, Subnet } from '@linode/api-v4';
 
@@ -24,29 +25,41 @@ export const SubnetEditDrawer = (props: Props) => {
   const { onClose, open, subnet, vpcId } = props;
 
   const {
-    error,
     isPending,
     mutateAsync: updateSubnet,
-    reset,
+    reset: resetMutation,
   } = useUpdateSubnetMutation(vpcId, subnet?.id ?? -1);
 
-  const form = useFormik<ModifySubnetPayload>({
-    enableReinitialize: true,
-    initialValues: {
+  const {
+    control,
+    formState: { errors, isDirty, isSubmitting },
+    handleSubmit,
+    reset: resetForm,
+    setError,
+  } = useForm<ModifySubnetPayload>({
+    mode: 'onBlur',
+    resolver: yupResolver(modifySubnetSchema),
+    values: {
       label: subnet?.label ?? '',
-    },
-    async onSubmit(values) {
-      await updateSubnet(values);
-      onClose();
     },
   });
 
-  React.useEffect(() => {
-    if (open) {
-      form.resetForm();
-      reset();
+  const handleDrawerClose = () => {
+    onClose();
+    resetForm();
+    resetMutation();
+  };
+
+  const onSubmit = async (values: ModifySubnetPayload) => {
+    try {
+      await updateSubnet(values);
+      handleDrawerClose();
+    } catch (errors) {
+      for (const error of errors) {
+        setError(error?.field ?? 'root', { message: error.reason });
+      }
     }
-  }, [open]);
+  };
 
   const { data: profile } = useProfile();
   const { data: grants } = useGrants();
@@ -59,11 +72,11 @@ export const SubnetEditDrawer = (props: Props) => {
     Boolean(profile?.restricted) &&
     (vpcPermissions?.permissions === 'read_only' || grants?.vpc.length === 0);
 
-  const errorMap = getErrorMap(['label'], error);
-
   return (
-    <Drawer onClose={onClose} open={open} title="Edit Subnet">
-      {errorMap.none && <Notice text={errorMap.none} variant="error" />}
+    <Drawer onClose={handleDrawerClose} open={open} title="Edit Subnet">
+      {errors.root?.message && (
+        <Notice text={errors.root.message} variant="error" />
+      )}
       {readOnly && (
         <Notice
           important
@@ -71,14 +84,21 @@ export const SubnetEditDrawer = (props: Props) => {
           variant="error"
         />
       )}
-      <form onSubmit={form.handleSubmit}>
-        <TextField
-          disabled={readOnly}
-          errorText={errorMap.label}
-          label="Label"
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Controller
+          render={({ field, fieldState }) => (
+            <TextField
+              disabled={readOnly}
+              errorText={fieldState.error?.message}
+              label="Label"
+              name="label"
+              onBlur={field.onBlur}
+              onChange={field.onChange}
+              value={field.value}
+            />
+          )}
+          control={control}
           name="label"
-          onChange={form.handleChange}
-          value={form.values.label}
         />
         <TextField
           disabled
@@ -89,12 +109,12 @@ export const SubnetEditDrawer = (props: Props) => {
         <ActionsPanel
           primaryButtonProps={{
             'data-testid': 'save-button',
-            disabled: !form.dirty,
+            disabled: !isDirty || readOnly,
             label: 'Save',
-            loading: isPending,
+            loading: isPending || isSubmitting,
             type: 'submit',
           }}
-          secondaryButtonProps={{ label: 'Cancel', onClick: onClose }}
+          secondaryButtonProps={{ label: 'Cancel', onClick: handleDrawerClose }}
         />
       </form>
     </Drawer>

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCEditDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCEditDrawer.tsx
@@ -1,7 +1,8 @@
+import { yupResolver } from '@hookform/resolvers/yup';
 import { Notice, TextField } from '@linode/ui';
 import { updateVPCSchema } from '@linode/validation/lib/vpcs.schema';
-import { useFormik } from 'formik';
 import * as React from 'react';
+import { Controller, useForm } from 'react-hook-form';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Drawer } from 'src/components/Drawer';
@@ -9,7 +10,6 @@ import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
 import { useGrants, useProfile } from 'src/queries/profile/profile';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { useUpdateVPCMutation } from 'src/queries/vpcs/vpcs';
-import { getErrorMap } from 'src/utilities/errorUtils';
 
 import type { UpdateVPCPayload, VPC } from '@linode/api-v4/lib/vpcs/types';
 
@@ -36,60 +36,53 @@ export const VPCEditDrawer = (props: Props) => {
     (vpcPermissions?.permissions === 'read_only' || grants?.vpc.length === 0);
 
   const {
-    error,
     isPending,
     mutateAsync: updateVPC,
-    reset,
+    reset: resetMutation,
   } = useUpdateVPCMutation(vpc?.id ?? -1);
 
-  interface UpdateVPCPayloadWithNone extends UpdateVPCPayload {
-    none?: string;
-  }
-
-  const form = useFormik<UpdateVPCPayloadWithNone>({
-    enableReinitialize: true,
-    initialValues: {
+  const {
+    control,
+    formState: { errors, isDirty, isSubmitting },
+    handleSubmit,
+    reset: resetForm,
+    setError,
+    watch,
+  } = useForm<UpdateVPCPayload>({
+    mode: 'onBlur',
+    resolver: yupResolver(updateVPCSchema),
+    values: {
       description: vpc?.description,
       label: vpc?.label,
     },
-    async onSubmit(values) {
-      await updateVPC(values);
-      onClose();
-    },
-    validateOnChange: false,
-    validationSchema: updateVPCSchema,
   });
 
-  const handleFieldChange = (field: string, value: string) => {
-    form.setFieldValue(field, value);
-    if (form.errors[field as keyof UpdateVPCPayloadWithNone]) {
-      form.setFieldError(field, undefined);
-    }
+  const values = watch();
+
+  const handleDrawerClose = () => {
+    onClose();
+    resetForm();
+    resetMutation();
   };
 
-  React.useEffect(() => {
-    if (open) {
-      form.resetForm();
-      reset();
-    }
-  }, [open]);
-
-  // If there's an error, sync it with formik
-  React.useEffect(() => {
-    if (error) {
-      const errorMap = getErrorMap(['label', 'description'], error);
-      for (const [field, reason] of Object.entries(errorMap)) {
-        form.setFieldError(field, reason);
+  const onSubmit = async () => {
+    try {
+      await updateVPC(values);
+      handleDrawerClose();
+    } catch (errors) {
+      for (const error of errors) {
+        setError(error?.field ?? 'root', { message: error.reason });
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [error]);
+  };
 
   const { data: regionsData, error: regionsError } = useRegionsQuery();
 
   return (
-    <Drawer onClose={onClose} open={open} title="Edit VPC">
-      {form.errors.none && <Notice text={form.errors.none} variant="error" />}
+    <Drawer onClose={handleDrawerClose} open={open} title="Edit VPC">
+      {errors.root?.message && (
+        <Notice text={errors.root.message} variant="error" />
+      )}
       {readOnly && (
         <Notice
           important
@@ -97,23 +90,37 @@ export const VPCEditDrawer = (props: Props) => {
           variant="error"
         />
       )}
-      <form onSubmit={form.handleSubmit}>
-        <TextField
-          disabled={readOnly}
-          errorText={form.errors.label}
-          label="Label"
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Controller
+          render={({ field, fieldState }) => (
+            <TextField
+              disabled={readOnly}
+              errorText={fieldState.error?.message}
+              label="Label"
+              name="label"
+              onBlur={field.onBlur}
+              onChange={field.onChange}
+              value={field.value}
+            />
+          )}
+          control={control}
           name="label"
-          onChange={(e) => handleFieldChange('label', e.target.value)}
-          value={form.values.label}
         />
-        <TextField
-          disabled={readOnly}
-          errorText={form.errors.description}
-          label="Description"
-          multiline
-          onChange={(e) => handleFieldChange('description', e.target.value)}
-          rows={1}
-          value={form.values.description}
+        <Controller
+          render={({ field, fieldState }) => (
+            <TextField
+              disabled={readOnly}
+              errorText={fieldState.error?.message}
+              label="Description"
+              multiline
+              onBlur={field.onBlur}
+              onChange={field.onChange}
+              rows={1}
+              value={field.value}
+            />
+          )}
+          control={control}
+          name="description"
         />
         {regionsData && (
           <RegionSelect
@@ -129,12 +136,12 @@ export const VPCEditDrawer = (props: Props) => {
         <ActionsPanel
           primaryButtonProps={{
             'data-testid': 'save-button',
-            disabled: !form.dirty || readOnly,
+            disabled: !isDirty || readOnly,
             label: 'Save',
-            loading: isPending,
+            loading: isPending || isSubmitting,
             type: 'submit',
           }}
-          secondaryButtonProps={{ label: 'Cancel', onClick: onClose }}
+          secondaryButtonProps={{ label: 'Cancel', onClick: handleDrawerClose }}
         />
       </form>
     </Drawer>

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCEditDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCEditDrawer.tsx
@@ -1,6 +1,6 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Notice, TextField } from '@linode/ui';
-import { updateVPCSchema } from '@linode/validation/lib/vpcs.schema';
+import { updateVPCSchema } from '@linode/validation';
 import * as React from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
@@ -11,7 +11,7 @@ import { useGrants, useProfile } from 'src/queries/profile/profile';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { useUpdateVPCMutation } from 'src/queries/vpcs/vpcs';
 
-import type { UpdateVPCPayload, VPC } from '@linode/api-v4/lib/vpcs/types';
+import type { UpdateVPCPayload, VPC } from '@linode/api-v4';
 
 interface Props {
   onClose: () => void;
@@ -47,7 +47,6 @@ export const VPCEditDrawer = (props: Props) => {
     handleSubmit,
     reset: resetForm,
     setError,
-    watch,
   } = useForm<UpdateVPCPayload>({
     mode: 'onBlur',
     resolver: yupResolver(updateVPCSchema),
@@ -57,15 +56,13 @@ export const VPCEditDrawer = (props: Props) => {
     },
   });
 
-  const values = watch();
-
   const handleDrawerClose = () => {
     onClose();
     resetForm();
     resetMutation();
   };
 
-  const onSubmit = async () => {
+  const onSubmit = async (values: UpdateVPCPayload) => {
     try {
       await updateVPC(values);
       handleDrawerClose();

--- a/packages/validation/.changeset/pr-11393-changed-1733855352751.md
+++ b/packages/validation/.changeset/pr-11393-changed-1733855352751.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Changed
+---
+
+Update VPC label validation schema punctuation, fix label validation regex ([#11393](https://github.com/linode/manager/pull/11393))

--- a/packages/validation/src/vpcs.schema.ts
+++ b/packages/validation/src/vpcs.schema.ts
@@ -2,13 +2,13 @@ import ipaddr from 'ipaddr.js';
 import { array, lazy, object, string } from 'yup';
 
 const LABEL_MESSAGE = 'Label must be between 1 and 64 characters.';
-const LABEL_REQUIRED = 'Label is required';
+const LABEL_REQUIRED = 'Label is required.';
 const LABEL_REQUIREMENTS =
-  'Must include only ASCII letters, numbers, and dashes';
+  'Label must include only ASCII letters, numbers, and dashes.';
 
 const labelTestDetails = {
   testName: 'no two dashes in a row',
-  testMessage: 'Must not contain two dashes in a row',
+  testMessage: 'Label must not contain two dashes in a row.',
 };
 
 const IP_EITHER_BOTH_NOT_NEITHER =
@@ -116,11 +116,11 @@ const labelValidation = string()
   )
   .min(1, LABEL_MESSAGE)
   .max(64, LABEL_MESSAGE)
-  .matches(/[a-zA-Z0-9-]+/, LABEL_REQUIREMENTS);
+  .matches(/^[a-zA-Z0-9-]*$/, LABEL_REQUIREMENTS);
 
 export const updateVPCSchema = object({
-  label: labelValidation.notRequired(),
-  description: string().notRequired(),
+  label: labelValidation,
+  description: string(),
 });
 
 export const createSubnetSchema = object().shape(


### PR DESCRIPTION
## Description 📝
- refactors VPCEditDrawer and SubnetEditDrawer to use react-hook-form instead of formik

## Changes  🔄
- update drawers + introduces dynamic validation
- update validation schema regex to be more accurate for non number/letter characters
- update validation schema error messages slightly

## How to test 🧪
- Confirm behavior matches prod for editing a VPC and editing a subnet*
  - *there will now be some dynamic error validation tho
- Confirm tests pass
```
yarn test SubnetEditDrawer
```
```
yarn test VPCEditDrawer
```
```
yarn cy:run -s "cypress/e2e/core/vpc/vpc-landing-page.spec.ts"
```
```
yarn cy:run -s "cypress/e2e/core/vpc/vpc-details-page.spec.ts"
```

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
