### PR TITLE
feat: [UIE-8137] - IAM RBAC: add new user details component

### DIFF
--- a/packages/api-v4/.changeset/pr-11397-upcoming-features-1734001143561.md
+++ b/packages/api-v4/.changeset/pr-11397-upcoming-features-1734001143561.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Upcoming Features
+---
+
+fix types for iam api ([#11397](https://github.com/linode/manager/pull/11397))

--- a/packages/api-v4/src/iam/types.ts
+++ b/packages/api-v4/src/iam/types.ts
@@ -1,9 +1,4 @@
-export interface IamUserPermissions {
-  account_access: AccountAccessType[];
-  resource_access: ResourceAccess[];
-}
-
-type ResourceType =
+export type ResourceTypePermissions =
   | 'linode'
   | 'firewall'
   | 'nodebalancer'
@@ -16,22 +11,26 @@ type ResourceType =
   | 'account'
   | 'vpc';
 
-type AccountAccessType =
+export type AccountAccessType =
   | 'account_linode_admin'
+  | 'linode_creator'
+  | 'linode_contributor'
+  | 'firewall_creator';
+
+export type RoleType =
+  | 'linode_contributor'
+  | 'firewall_admin'
   | 'linode_creator'
   | 'firewall_creator';
 
-type RoleType = 'linode_contributor' | 'firewall_admin';
-
+export interface IamUserPermissions {
+  account_access: AccountAccessType[];
+  resource_access: ResourceAccess[];
+}
 export interface ResourceAccess {
   resource_id: number;
-  resource_type: ResourceType;
+  resource_type: ResourceTypePermissions;
   roles: RoleType[];
-}
-
-export interface IamAccountPermissions {
-  account_access: Access[];
-  resource_access: Access[];
 }
 
 type PermissionType =
@@ -41,13 +40,20 @@ type PermissionType =
   | 'delete_linode'
   | 'view_linode';
 
-interface Access {
-  resource_type: ResourceType;
+export interface IamAccountPermissions {
+  account_access: IamAccess[];
+  resource_access: IamAccess[];
+}
+
+export interface IamAccess {
+  resource_type: ResourceTypePermissions;
   roles: Roles[];
 }
 
 export interface Roles {
   name: string;
   description: string;
-  permissions?: PermissionType[];
+  permissions: PermissionType[];
 }
+
+export type IamAccessType = keyof IamAccountPermissions;

--- a/packages/manager/.changeset/pr-11397-upcoming-features-1733916688951.md
+++ b/packages/manager/.changeset/pr-11397-upcoming-features-1733916688951.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add new user details components for iam ([#11397](https://github.com/linode/manager/pull/11397))

--- a/packages/manager/src/factories/accountPermissions.ts
+++ b/packages/manager/src/factories/accountPermissions.ts
@@ -1,5 +1,6 @@
-import { IamAccountPermissions } from '@linode/api-v4';
 import Factory from 'src/factories/factoryProxy';
+
+import type { IamAccountPermissions } from '@linode/api-v4';
 
 export const accountPermissionsFactory = Factory.Sync.makeFactory<IamAccountPermissions>(
   {
@@ -8,9 +9,9 @@ export const accountPermissionsFactory = Factory.Sync.makeFactory<IamAccountPerm
         resource_type: 'account',
         roles: [
           {
-            name: 'account_admin',
             description:
               'Access to perform any supported action on all resources in the account',
+            name: 'account_admin',
             permissions: ['create_linode', 'update_linode', 'update_firewall'],
           },
         ],
@@ -19,9 +20,9 @@ export const accountPermissionsFactory = Factory.Sync.makeFactory<IamAccountPerm
         resource_type: 'linode',
         roles: [
           {
-            name: 'account_linode_admin',
             description:
               'Access to perform any supported action on all linode instances in the account',
+            name: 'account_linode_admin',
             permissions: ['create_linode', 'update_linode', 'delete_linode'],
           },
         ],
@@ -30,8 +31,9 @@ export const accountPermissionsFactory = Factory.Sync.makeFactory<IamAccountPerm
         resource_type: 'firewall',
         roles: [
           {
-            name: 'firewall_creator',
             description: 'Access to create a firewall instance',
+            name: 'firewall_creator',
+            permissions: ['update_firewall'],
           },
         ],
       },
@@ -41,8 +43,8 @@ export const accountPermissionsFactory = Factory.Sync.makeFactory<IamAccountPerm
         resource_type: 'linode',
         roles: [
           {
-            name: 'linode_contributor',
             description: 'Access to update a linode instance',
+            name: 'linode_contributor',
             permissions: ['update_linode', 'view_linode'],
           },
         ],
@@ -51,13 +53,15 @@ export const accountPermissionsFactory = Factory.Sync.makeFactory<IamAccountPerm
         resource_type: 'firewall',
         roles: [
           {
-            name: 'firewall_viewer',
             description: 'Access to view a firewall instance',
+            name: 'firewall_viewer',
+            permissions: ['update_firewall'],
           },
           {
-            name: 'firewall_admin',
             description:
               'Access to perform any supported action on a firewall instance',
+            name: 'firewall_admin',
+            permissions: ['update_firewall'],
           },
         ],
       },

--- a/packages/manager/src/features/IAM/Users/UserDetails/DeleteUserPanel.test.tsx
+++ b/packages/manager/src/features/IAM/Users/UserDetails/DeleteUserPanel.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { accountUserFactory, profileFactory } from 'src/factories';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { DeleteUserPanel } from './DeleteUserPanel';
+
+const queryMocks = vi.hoisted(() => ({
+  useProfile: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('src/queries/profile/profile', async () => {
+  const actual = await vi.importActual('src/queries/profile/profile');
+  return {
+    ...actual,
+    useProfile: queryMocks.useProfile,
+  };
+});
+
+describe('DeleteUserPanel', () => {
+  it('should disable the delete button for proxy user', () => {
+    const user = accountUserFactory.build({
+      user_type: 'proxy',
+      username: 'current_user',
+    });
+
+    const { getByTestId } = renderWithTheme(<DeleteUserPanel user={user} />);
+
+    const deleteButton = getByTestId('button');
+    expect(deleteButton).toBeDisabled();
+  });
+
+  it('should disable the delete button for the current user', () => {
+    queryMocks.useProfile.mockReturnValue({
+      data: profileFactory.build({ username: 'current_user' }),
+    });
+
+    const user = accountUserFactory.build({
+      user_type: 'default',
+      username: 'current_user',
+    });
+
+    const { getByTestId } = renderWithTheme(<DeleteUserPanel user={user} />);
+
+    const deleteButton = getByTestId('button');
+    expect(deleteButton).toBeDisabled();
+  });
+
+  it('should enable the delete button for deletable users', () => {
+    queryMocks.useProfile.mockReturnValue({
+      data: profileFactory.build({ username: 'current_user' }),
+    });
+
+    const user = accountUserFactory.build({
+      user_type: 'default',
+      username: 'user',
+    });
+
+    const { getByTestId } = renderWithTheme(<DeleteUserPanel user={user} />);
+
+    const deleteButton = getByTestId('button');
+    expect(deleteButton).toBeEnabled();
+  });
+
+  it('should open the delete confirmation dialog when the delete button is clicked', () => {
+    queryMocks.useProfile.mockReturnValue({
+      data: profileFactory.build({ username: 'current_user' }),
+    });
+
+    const user = accountUserFactory.build({
+      user_type: 'default',
+      username: 'user',
+    });
+
+    const { getByTestId, getByText } = renderWithTheme(
+      <DeleteUserPanel user={user} />
+    );
+
+    const deleteButton = getByTestId('button');
+    fireEvent.click(deleteButton);
+
+    expect(
+      getByText('The user will be deleted permanently.')
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/IAM/Users/UserDetails/DeleteUserPanel.tsx
+++ b/packages/manager/src/features/IAM/Users/UserDetails/DeleteUserPanel.tsx
@@ -1,0 +1,57 @@
+import { Box, Button, Paper, Stack, Typography } from '@linode/ui';
+import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+
+import { PARENT_USER } from 'src/features/Account/constants';
+import { useProfile } from 'src/queries/profile/profile';
+
+import { UserDeleteConfirmation } from './UserDeleteConfirmation';
+
+import type { User } from '@linode/api-v4';
+
+interface Props {
+  user: User;
+}
+
+export const DeleteUserPanel = ({ user }: Props) => {
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+  const history = useHistory();
+  const { data: profile } = useProfile();
+
+  const isProxyUserProfile = user.user_type === 'proxy';
+
+  const tooltipText =
+    profile?.username === user.username
+      ? 'You can\u{2019}t delete the currently active user.'
+      : isProxyUserProfile
+      ? `You can\u{2019}t delete a ${PARENT_USER}.`
+      : undefined;
+
+  return (
+    <Paper>
+      <Stack spacing={1}>
+        <Typography variant="h2">Delete User</Typography>
+        <Box>
+          <Button
+            buttonType="outlined"
+            disabled={profile?.username === user.username || isProxyUserProfile}
+            onClick={() => setIsDeleteDialogOpen(true)}
+            tooltipText={tooltipText}
+          >
+            Delete
+          </Button>
+        </Box>
+        <Typography variant="body1">
+          The user will be deleted permanently.
+        </Typography>
+        <UserDeleteConfirmation
+          onClose={() => setIsDeleteDialogOpen(false)}
+          onSuccess={() => history.push(`/account/users`)}
+          open={isDeleteDialogOpen}
+          username={user.username}
+        />
+      </Stack>
+    </Paper>
+  );
+};

--- a/packages/manager/src/features/IAM/Users/UserDetails/UserDeleteConfirmation.tsx
+++ b/packages/manager/src/features/IAM/Users/UserDetails/UserDeleteConfirmation.tsx
@@ -1,0 +1,73 @@
+import { Notice, Typography } from '@linode/ui';
+import { useSnackbar } from 'notistack';
+import * as React from 'react';
+
+import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
+import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
+import { useAccountUserDeleteMutation } from 'src/queries/account/users';
+
+interface Props {
+  onClose: () => void;
+  onSuccess?: () => void;
+  open: boolean;
+  username: string;
+}
+
+export const UserDeleteConfirmation = (props: Props) => {
+  const { onClose: _onClose, onSuccess, open, username } = props;
+
+  const { enqueueSnackbar } = useSnackbar();
+
+  const {
+    error,
+    isPending,
+    mutateAsync: deleteUser,
+    reset,
+  } = useAccountUserDeleteMutation(username);
+
+  const onClose = () => {
+    reset(); // resets the error state of the useMutation
+    _onClose();
+  };
+
+  const onDelete = async () => {
+    await deleteUser();
+    enqueueSnackbar(`User ${username} has been deleted successfully.`, {
+      variant: 'success',
+    });
+    if (onSuccess) {
+      onSuccess();
+    }
+    onClose();
+  };
+
+  return (
+    <ConfirmationDialog
+      actions={
+        <ActionsPanel
+          primaryButtonProps={{
+            label: 'Delete User',
+            loading: isPending,
+            onClick: onDelete,
+          }}
+          secondaryButtonProps={{
+            label: 'Cancel',
+            onClick: onClose,
+          }}
+          style={{ padding: 0 }}
+        />
+      }
+      error={error?.[0].reason}
+      onClose={onClose}
+      open={open}
+      title={`Delete user ${username}?`}
+    >
+      <Notice variant="warning">
+        <Typography sx={{ fontSize: '0.875rem' }}>
+          <strong>Warning:</strong> Deleting this User is permanent and can’t be
+          undone.
+        </Typography>
+      </Notice>
+    </ConfirmationDialog>
+  );
+};

--- a/packages/manager/src/features/IAM/Users/UserDetails/UserDetailsPanel.test.tsx
+++ b/packages/manager/src/features/IAM/Users/UserDetails/UserDetailsPanel.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+
+import { accountUserFactory } from 'src/factories';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { UserDetailsPanel } from './UserDetailsPanel';
+
+import type { IamUserPermissions } from '@linode/api-v4';
+
+describe('UserDetailsPanel', () => {
+  it("renders the user's username and email", async () => {
+    const user = accountUserFactory.build();
+    const assignedRoles = { account_access: [], resource_access: [] };
+
+    const { getByText } = renderWithTheme(
+      <UserDetailsPanel assignedRoles={assignedRoles} user={user} />
+    );
+
+    expect(getByText('Username')).toBeVisible();
+    expect(getByText(user.username)).toBeVisible();
+
+    expect(getByText('Email')).toBeVisible();
+    expect(getByText(user.email)).toBeVisible();
+  });
+
+  it("renders 'no roles assigned' if the user doesn't have the assigned roles", async () => {
+    const user = accountUserFactory.build({ restricted: true });
+    const assignedRoles = { account_access: [], resource_access: [] };
+
+    const { getByText } = renderWithTheme(
+      <UserDetailsPanel assignedRoles={assignedRoles} user={user} />
+    );
+
+    expect(getByText('Access')).toBeVisible();
+    expect(getByText('no roles assigned')).toBeVisible();
+  });
+
+  it("renders '5 roles assigned' if the user has 5 different roles", async () => {
+    const user = accountUserFactory.build({ restricted: false });
+    const assignedRoles: IamUserPermissions = {
+      account_access: [
+        'account_linode_admin',
+        'linode_creator',
+        'firewall_creator',
+      ],
+      resource_access: [
+        {
+          resource_id: 12345678,
+          resource_type: 'linode',
+          roles: ['linode_contributor', 'linode_creator'],
+        },
+        {
+          resource_id: 45678901,
+          resource_type: 'firewall',
+          roles: ['firewall_admin', 'firewall_creator'],
+        },
+      ],
+    };
+
+    const { getByText } = renderWithTheme(
+      <UserDetailsPanel assignedRoles={assignedRoles} user={user} />
+    );
+
+    expect(getByText('Access')).toBeVisible();
+    expect(getByText('5 roles assigned')).toBeVisible();
+  });
+
+  it("renders '3 roles assigned' if the user has 3 different roles", async () => {
+    const user = accountUserFactory.build({ restricted: false });
+    const assignedRoles: IamUserPermissions = {
+      account_access: [
+        'account_linode_admin',
+        'linode_creator',
+        'linode_contributor',
+      ],
+      resource_access: [
+        {
+          resource_id: 12345678,
+          resource_type: 'linode',
+          roles: ['linode_contributor', 'linode_creator'],
+        },
+      ],
+    };
+
+    const { getByText } = renderWithTheme(
+      <UserDetailsPanel assignedRoles={assignedRoles} user={user} />
+    );
+
+    expect(getByText('Access')).toBeVisible();
+    expect(getByText('3 roles assigned')).toBeVisible();
+  });
+
+  it("renders the user's phone number", async () => {
+    const user = accountUserFactory.build({
+      verified_phone_number: '+17040000000',
+    });
+    const assignedRoles = { account_access: [], resource_access: [] };
+
+    const { getByText } = renderWithTheme(
+      <UserDetailsPanel assignedRoles={assignedRoles} user={user} />
+    );
+
+    expect(getByText('Verified Phone Number')).toBeVisible();
+    expect(getByText(user.verified_phone_number!)).toBeVisible();
+  });
+
+  it("renders the user's 2FA status", async () => {
+    const user = accountUserFactory.build({ tfa_enabled: true });
+    const assignedRoles = { account_access: [], resource_access: [] };
+
+    const { getByText } = renderWithTheme(
+      <UserDetailsPanel assignedRoles={assignedRoles} user={user} />
+    );
+
+    expect(getByText('2FA')).toBeVisible();
+    expect(getByText('Enabled')).toBeVisible();
+  });
+});

--- a/packages/manager/src/features/IAM/Users/UserDetails/UserDetailsPanel.tsx
+++ b/packages/manager/src/features/IAM/Users/UserDetails/UserDetailsPanel.tsx
@@ -1,0 +1,140 @@
+import { Paper, Stack, Typography } from '@linode/ui';
+import Grid from '@mui/material/Unstable_Grid2';
+import React from 'react';
+
+import { DateTimeDisplay } from 'src/components/DateTimeDisplay';
+import { Link } from 'src/components/Link';
+import { StatusIcon } from 'src/components/StatusIcon/StatusIcon';
+import { TextTooltip } from 'src/components/TextTooltip';
+
+import type {
+  AccountAccessType,
+  IamUserPermissions,
+  ResourceAccess,
+  RoleType,
+  User,
+} from '@linode/api-v4';
+
+interface Props {
+  assignedRoles?: IamUserPermissions;
+  user: User;
+}
+
+export const UserDetailsPanel = ({ assignedRoles, user }: Props) => {
+  const assignRolesCount = assignedRoles ? getAssignRoles(assignedRoles) : 0;
+
+  const items = [
+    {
+      label: 'Username',
+      value: <Typography>{user.username}</Typography>,
+    },
+    {
+      label: 'Email',
+      value: <Typography>{user.email}</Typography>,
+    },
+    {
+      label: 'Access',
+      value:
+        assignRolesCount > 0 ? (
+          <Typography>
+            <Link to={`/iam/users/${user.username}/roles`}>
+              {`${assignRolesCount} role${
+                assignRolesCount !== 1 ? 's' : ''
+              } assigned`}
+            </Link>
+          </Typography>
+        ) : (
+          <span>no roles assigned</span>
+        ),
+    },
+    {
+      label: 'Last Login Status',
+      value: (
+        <Stack direction="row" spacing={1}>
+          <Typography textTransform="capitalize">
+            {user.last_login?.status ?? 'N/A'}
+          </Typography>
+          {user.last_login && (
+            <StatusIcon
+              status={
+                user.last_login?.status === 'successful' ? 'active' : 'error'
+              }
+            />
+          )}
+        </Stack>
+      ),
+    },
+    {
+      label: 'Last Login',
+      value: user.last_login ? (
+        <DateTimeDisplay value={user.last_login.login_datetime} />
+      ) : (
+        <Typography>N/A</Typography>
+      ),
+    },
+    {
+      label: 'Password Created',
+      value: user.password_created ? (
+        <DateTimeDisplay value={user.password_created} />
+      ) : (
+        <Typography>N/A</Typography>
+      ),
+    },
+    {
+      label: '2FA',
+      value: (
+        <Typography>{user.tfa_enabled ? 'Enabled' : 'Disabled'}</Typography>
+      ),
+    },
+    {
+      label: 'Verified Phone Number',
+      value: <Typography>{user.verified_phone_number ?? 'None'}</Typography>,
+    },
+    {
+      label: 'SSH Keys',
+      value:
+        user.ssh_keys.length > 0 ? (
+          <TextTooltip
+            displayText={String(user.ssh_keys.length)}
+            minWidth={1}
+            tooltipText={user.ssh_keys.join(', ')}
+          />
+        ) : (
+          <Typography>0</Typography>
+        ),
+    },
+  ];
+
+  return (
+    <Paper>
+      <Grid columns={{ md: 6, sm: 4, xs: 2 }} container spacing={2}>
+        {items.map((item) => (
+          <Grid key={item.label} md={2} sm={2} xs={2}>
+            <Stack direction="row" spacing={1}>
+              <Typography fontFamily={(theme) => theme.font.bold}>
+                {item.label}
+              </Typography>
+              {item.value}
+            </Stack>
+          </Grid>
+        ))}
+      </Grid>
+    </Paper>
+  );
+};
+
+const getAssignRoles = (assignedRoles: IamUserPermissions): number => {
+  const accountAccessRoles = assignedRoles.account_access || [];
+
+  const resourceAccessRoles = assignedRoles.resource_access
+    ? assignedRoles.resource_access
+        .map((resource: ResourceAccess) => resource.roles)
+        .flat()
+    : [];
+
+  const combinedRoles: (AccountAccessType | RoleType)[] = Array.from(
+    new Set([...accountAccessRoles, ...resourceAccessRoles])
+  );
+
+  return combinedRoles.length;
+};

--- a/packages/manager/src/features/IAM/Users/UserDetails/UserEmailPanel.test.tsx
+++ b/packages/manager/src/features/IAM/Users/UserDetails/UserEmailPanel.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import { accountUserFactory, profileFactory } from 'src/factories';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { UserEmailPanel } from './UserEmailPanel';
+
+describe('UserEmailPanel', () => {
+  it("initializes the form with the user's email", async () => {
+    const user = accountUserFactory.build();
+
+    const { getByLabelText } = renderWithTheme(<UserEmailPanel user={user} />);
+
+    const emailTextField = getByLabelText('Email');
+
+    expect(emailTextField).toHaveDisplayValue(user.email);
+  });
+
+  it("does not allow the user to update another user's email", async () => {
+    const profile = profileFactory.build({ username: 'my-linode-user-1' });
+    const user = accountUserFactory.build({ username: 'my-linode-user-2' });
+
+    server.use(
+      http.get('*/v4/profile', () => {
+        return HttpResponse.json(profile);
+      })
+    );
+
+    const { findByLabelText, getByLabelText, getByText } = renderWithTheme(
+      <UserEmailPanel user={user} />
+    );
+
+    const warning = await findByLabelText(
+      'You can’t change another user’s email address.'
+    );
+
+    // Verify there is a tooltip explaining that the user can't change
+    // another user's email.
+    expect(warning).toBeInTheDocument();
+
+    // Verify the input is disabled
+    expect(getByLabelText('Email')).toBeDisabled();
+
+    // Verify save button is disabled
+    expect(getByText('Save').closest('button')).toBeDisabled();
+  });
+
+  it("does not allow the user to update a proxy user's email", async () => {
+    const user = accountUserFactory.build({
+      user_type: 'proxy',
+      username: 'proxy-user-1',
+    });
+
+    const { getByLabelText, getByText } = renderWithTheme(
+      <UserEmailPanel user={user} />
+    );
+
+    const warning = getByLabelText('This field can’t be modified.');
+
+    // Verify there is a tooltip explaining that the user can't change
+    // a proxy user's email.
+    expect(warning).toBeInTheDocument();
+
+    // Verify the input is disabled
+    expect(getByLabelText('Email')).toBeDisabled();
+
+    // Verify save button is disabled
+    expect(getByText('Save').closest('button')).toBeDisabled();
+  });
+});

--- a/packages/manager/src/features/IAM/Users/UserDetails/UserEmailPanel.tsx
+++ b/packages/manager/src/features/IAM/Users/UserDetails/UserEmailPanel.tsx
@@ -1,0 +1,86 @@
+import { Button, Paper, TextField } from '@linode/ui';
+import { useSnackbar } from 'notistack';
+import React from 'react';
+import { Controller, useForm } from 'react-hook-form';
+
+import { RESTRICTED_FIELD_TOOLTIP } from 'src/features/Account/constants';
+import { useMutateProfile, useProfile } from 'src/queries/profile/profile';
+
+import type { User } from '@linode/api-v4';
+
+interface Props {
+  user: User;
+}
+
+export const UserEmailPanel = ({ user }: Props) => {
+  const { enqueueSnackbar } = useSnackbar();
+  const { data: profile } = useProfile();
+
+  const isProxyUserProfile = user?.user_type === 'proxy';
+
+  const { mutateAsync: updateProfile } = useMutateProfile();
+
+  const {
+    control,
+    formState: { isDirty, isSubmitting },
+    handleSubmit,
+    setError,
+  } = useForm({
+    defaultValues: { email: user.email },
+    values: { email: user.email },
+  });
+
+  const onSubmit = async (values: { email: string }) => {
+    try {
+      await updateProfile(values);
+
+      enqueueSnackbar('Email updated successfully', { variant: 'success' });
+    } catch (error) {
+      setError('email', { message: error[0].reason });
+    }
+  };
+
+  const disabledReason = isProxyUserProfile
+    ? RESTRICTED_FIELD_TOOLTIP
+    : profile?.username !== user.username
+    ? 'You can\u{2019}t change another user\u{2019}s email address.'
+    : undefined;
+
+  // This should be disabled if this is NOT the current user or if the proxy user is viewing their own profile.
+  const disableEmailField =
+    profile?.username !== user.username || isProxyUserProfile;
+
+  return (
+    <Paper>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Controller
+          render={({ field, fieldState }) => (
+            <TextField
+              disabled={disableEmailField}
+              errorText={fieldState.error?.message}
+              label="Email"
+              noMarginTop
+              onBlur={field.onBlur}
+              onChange={field.onChange}
+              tooltipText={disabledReason}
+              trimmed
+              type="email"
+              value={field.value}
+            />
+          )}
+          control={control}
+          name="email"
+        />
+        <Button
+          buttonType="primary"
+          disabled={!isDirty}
+          loading={isSubmitting}
+          sx={{ mt: 2 }}
+          type="submit"
+        >
+          Save
+        </Button>
+      </form>
+    </Paper>
+  );
+};

--- a/packages/manager/src/features/IAM/Users/UserDetails/UserProfile.tsx
+++ b/packages/manager/src/features/IAM/Users/UserDetails/UserProfile.tsx
@@ -1,0 +1,45 @@
+import { CircleProgress, Stack } from '@linode/ui';
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import { ErrorState } from 'src/components/ErrorState/ErrorState';
+import { NotFound } from 'src/components/NotFound';
+import { useAccountUser } from 'src/queries/account/users';
+import { useAccountUserPermissions } from 'src/queries/iam/iam';
+
+import { DeleteUserPanel } from './DeleteUserPanel';
+import { UserDetailsPanel } from './UserDetailsPanel';
+import { UserEmailPanel } from './UserEmailPanel';
+import { UsernamePanel } from './UsernamePanel';
+
+export const UserProfile = () => {
+  const { username } = useParams<{ username: string }>();
+
+  const { data: user, error, isLoading } = useAccountUser(username ?? '');
+  const { data: assignedRoles } = useAccountUserPermissions(username ?? '');
+
+  if (isLoading) {
+    return <CircleProgress />;
+  }
+
+  if (error) {
+    return <ErrorState errorText={error[0].reason} />;
+  }
+
+  if (!user) {
+    return <NotFound />;
+  }
+
+  return (
+    <>
+      <DocumentTitleSegment segment={`${username} - Profile`} />
+      <Stack spacing={2}>
+        <UserDetailsPanel assignedRoles={assignedRoles} user={user} />
+        <UsernamePanel user={user} />
+        <UserEmailPanel user={user} />
+        <DeleteUserPanel user={user} />
+      </Stack>
+    </>
+  );
+};

--- a/packages/manager/src/features/IAM/Users/UserDetails/UsernamePanel.test.tsx
+++ b/packages/manager/src/features/IAM/Users/UserDetails/UsernamePanel.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { accountUserFactory } from 'src/factories';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { UsernamePanel } from './UsernamePanel';
+
+describe('UsernamePanel', () => {
+  it("initializes the form with the user's username", async () => {
+    const user = accountUserFactory.build();
+
+    const { getByLabelText } = renderWithTheme(<UsernamePanel user={user} />);
+
+    const usernameTextField = getByLabelText('Username');
+
+    expect(usernameTextField).toHaveDisplayValue(user.username);
+  });
+
+  it("does not allow the user to update a proxy user's username", async () => {
+    const user = accountUserFactory.build({
+      user_type: 'proxy',
+      username: 'proxy-user-1',
+    });
+
+    const { getByLabelText, getByText } = renderWithTheme(
+      <UsernamePanel user={user} />
+    );
+
+    const warning = getByLabelText('This field can’t be modified.');
+
+    // Verify there is a tooltip explaining that the user can't change
+    // a proxy user's username.
+    expect(warning).toBeInTheDocument();
+
+    // Verify the input is disabled
+    expect(getByLabelText('Username')).toBeDisabled();
+
+    // Verify save button is disabled
+    expect(getByText('Save').closest('button')).toBeDisabled();
+  });
+});

--- a/packages/manager/src/features/IAM/Users/UserDetails/UsernamePanel.tsx
+++ b/packages/manager/src/features/IAM/Users/UserDetails/UsernamePanel.tsx
@@ -1,0 +1,83 @@
+import { Button, Paper, TextField } from '@linode/ui';
+import { useSnackbar } from 'notistack';
+import React from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { useHistory } from 'react-router-dom';
+
+import { RESTRICTED_FIELD_TOOLTIP } from 'src/features/Account/constants';
+import { useUpdateUserMutation } from 'src/queries/account/users';
+
+import type { User } from '@linode/api-v4';
+
+interface Props {
+  user: User;
+}
+
+export const UsernamePanel = ({ user }: Props) => {
+  const history = useHistory();
+  const { enqueueSnackbar } = useSnackbar();
+
+  const isProxyUserProfile = user?.user_type === 'proxy';
+
+  const { mutateAsync } = useUpdateUserMutation(user.username);
+
+  const {
+    control,
+    formState: { isDirty, isSubmitting },
+    handleSubmit,
+    setError,
+  } = useForm({
+    defaultValues: { username: user.username },
+    values: { username: user.username },
+  });
+
+  const onSubmit = async (values: Partial<User>) => {
+    try {
+      const user = await mutateAsync(values);
+
+      // Because the username changed, we need to update the username in the URL
+      history.replace(`/account/users/${user.username}`);
+
+      enqueueSnackbar('Username updated successfully', { variant: 'success' });
+    } catch (error) {
+      setError('username', { message: error[0].reason });
+    }
+  };
+
+  const tooltipForDisabledUsernameField = isProxyUserProfile
+    ? RESTRICTED_FIELD_TOOLTIP
+    : undefined;
+
+  return (
+    <Paper>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Controller
+          render={({ field, fieldState }) => (
+            <TextField
+              disabled={isProxyUserProfile}
+              errorText={fieldState.error?.message}
+              label="Username"
+              noMarginTop
+              onBlur={field.onBlur}
+              onChange={field.onChange}
+              tooltipText={tooltipForDisabledUsernameField}
+              trimmed
+              value={field.value}
+            />
+          )}
+          control={control}
+          name="username"
+        />
+        <Button
+          buttonType="primary"
+          disabled={!isDirty}
+          loading={isSubmitting}
+          sx={{ mt: 2 }}
+          type="submit"
+        >
+          Save
+        </Button>
+      </form>
+    </Paper>
+  );
+};

--- a/packages/manager/src/features/IAM/Users/UserDetailsLanding.tsx
+++ b/packages/manager/src/features/IAM/Users/UserDetailsLanding.tsx
@@ -14,6 +14,7 @@ import { Tabs } from 'src/components/Tabs/Tabs';
 import { useAccountUserPermissions } from 'src/queries/iam/iam';
 
 import { IAM_LABEL } from '../Shared/constants';
+import { UserProfile } from './UserDetails/UserProfile';
 import { UserResources } from './UserResources/UserResources';
 import { UserRoles } from './UserRoles/UserRoles';
 
@@ -73,7 +74,7 @@ export const UserDetailsLanding = () => {
         <TabLinkList tabs={tabs} />
         <TabPanels>
           <SafeTabPanel index={idx}>
-            <p>user details - UIE-8137</p>
+            <UserProfile />
           </SafeTabPanel>
           <SafeTabPanel index={++idx}>
             <UserRoles assignedRoles={assignedRoles} />


### PR DESCRIPTION
## Description 📝

IAM RBAC - user details component.
This component is almost identical to an existing one in the `Account`, with some adjustments.
One difference is the addition of a new field showing the number of assigned roles.

## Changes  🔄

List any change(s) relevant to the reviewer.

- new user details component

## Target release date 🗓️

1/14/25 (dev)

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| 📷 |![image](https://github.com/user-attachments/assets/c20e6321-56bf-4832-9feb-cdc4a80ce1fc)|
| 📷 |![image](https://github.com/user-attachments/assets/8f918892-208f-4aa3-b07e-214a589f7b47)|

## How to test 🧪

### Prerequisites

- Ensure the Identity and Access Beta flag is enabled in dev tools
- Click on the username in the users table or click on the user's menu `View User Details`


### Verification steps

(How to verify changes)

- [ ] Confirm user details renders.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>


