### PR TITLE
fix: [M3-8506] - Misplaced `errorGroup` prop causing console error

### DIFF
--- a/packages/manager/.changeset/pr-11398-fixed-1733917277527.md
+++ b/packages/manager/.changeset/pr-11398-fixed-1733917277527.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Misplaced `errorGroup` prop causing console error in NodeBalancerConfigPanel ([#11398](https://github.com/linode/manager/pull/11398))

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -275,8 +275,8 @@ export const NodeBalancerConfigPanel = (
               textFieldProps={{
                 dataAttrs: {
                   'data-qa-proxy-protocol-select': true,
-                  errorGroup: forEdit ? `${configIdx}` : undefined,
                 },
+                errorGroup: forEdit ? `${configIdx}` : undefined,
               }}
               autoHighlight
               disableClearable


### PR DESCRIPTION
## Description 📝
A small, quick PR to fix the misplaced `errorGroup` prop that was causing a console error.

Note: We will fix the other unrelated console errors in a follow-up PR

## Changes  🔄
- Correctly placed `errorGroup` in textFieldProps

## Target release date 🗓️
N/A

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-12-11 at 4 57 32 PM](https://github.com/user-attachments/assets/9d2a562d-200a-4b7e-83d9-182f36363aa4) | No console error due to the `errorGroup` prop|

## How to test 🧪
- Go to `Create NodeBalancers`
- Ensure no console error when selecting TCP protocol in Configuration panel 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>