### PR TITLE
upcoming: [DI-22130] - Alert listing action menu and Alert Detail landing

### DIFF
--- a/packages/api-v4/.changeset/pr-11399-upcoming-features-1733923542682.md
+++ b/packages/api-v4/.changeset/pr-11399-upcoming-features-1733923542682.md
@@ -2,4 +2,4 @@
 "@linode/api-v4": Upcoming Features
 ---
 
-Add new endpoint to fetch alert details by id ([#11399](https://github.com/linode/manager/pull/11399))
+Add new endpoint to fetch alert details by id and service type ([#11399](https://github.com/linode/manager/pull/11399))

--- a/packages/api-v4/.changeset/pr-11399-upcoming-features-1733923542682.md
+++ b/packages/api-v4/.changeset/pr-11399-upcoming-features-1733923542682.md
@@ -2,4 +2,4 @@
 "@linode/api-v4": Upcoming Features
 ---
 
-Add new endpoint to fetch alert details by id and service type ([#11399](https://github.com/linode/manager/pull/11399))
+Add new `getAlertDefinitionByIdAndServiceType` endpoint to fetch Cloud Pulse alert details by id and service type ([#11399](https://github.com/linode/manager/pull/11399))

--- a/packages/api-v4/.changeset/pr-11399-upcoming-features-1733923542682.md
+++ b/packages/api-v4/.changeset/pr-11399-upcoming-features-1733923542682.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Upcoming Features
+---
+
+Add new endpoint to fetch alert details by id ([#11399](https://github.com/linode/manager/pull/11399))

--- a/packages/api-v4/.changeset/pr-11399-upcoming-features-1733923542682.md
+++ b/packages/api-v4/.changeset/pr-11399-upcoming-features-1733923542682.md
@@ -2,4 +2,4 @@
 "@linode/api-v4": Upcoming Features
 ---
 
-Add new `getAlertDefinitionByIdAndServiceType` endpoint to fetch Cloud Pulse alert details by id and service type ([#11399](https://github.com/linode/manager/pull/11399))
+Add new `getAlertDefinitionByServiceTypeAndId` endpoint to fetch Cloud Pulse alert details by id and service type ([#11399](https://github.com/linode/manager/pull/11399))

--- a/packages/api-v4/src/cloudpulse/alerts.ts
+++ b/packages/api-v4/src/cloudpulse/alerts.ts
@@ -32,7 +32,10 @@ export const getAlertDefinitions = (params?: Params, filters?: Filter) =>
     setXFilter(filters)
   );
 
-export const getAlertDefinitionById = (alertId: number, serviceType: string) =>
+export const getAlertDefinitionByIdAndServiceType = (
+  alertId: number,
+  serviceType: string
+) =>
   Request<Alert>(
     setURL(
       `${API_ROOT}/monitor/services/${encodeURIComponent(

--- a/packages/api-v4/src/cloudpulse/alerts.ts
+++ b/packages/api-v4/src/cloudpulse/alerts.ts
@@ -31,3 +31,13 @@ export const getAlertDefinitions = (params?: Params, filters?: Filter) =>
     setParams(params),
     setXFilter(filters)
   );
+
+export const getAlertDefinitionById = (alertId: number, serviceType: string) =>
+  Request<Alert>(
+    setURL(
+      `${API_ROOT}/monitor/services/${encodeURIComponent(
+        serviceType
+      )}/alert-definitions/${encodeURIComponent(alertId)}`
+    ),
+    setMethod('GET')
+  );

--- a/packages/api-v4/src/cloudpulse/alerts.ts
+++ b/packages/api-v4/src/cloudpulse/alerts.ts
@@ -32,9 +32,9 @@ export const getAlertDefinitions = (params?: Params, filters?: Filter) =>
     setXFilter(filters)
   );
 
-export const getAlertDefinitionByIdAndServiceType = (
-  alertId: number,
-  serviceType: string
+export const getAlertDefinitionByServiceTypeAndId = (
+  serviceType: string,
+  alertId: number
 ) =>
   Request<Alert>(
     setURL(

--- a/packages/manager/.changeset/pr-11399-upcoming-features-1733923517331.md
+++ b/packages/manager/.changeset/pr-11399-upcoming-features-1733923517331.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add new action item row in the alert listing view and an empty details page with breadcrumbs ([#11399](https://github.com/linode/manager/pull/11399))

--- a/packages/manager/.changeset/pr-11399-upcoming-features-1733923517331.md
+++ b/packages/manager/.changeset/pr-11399-upcoming-features-1733923517331.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-Add new action item column in the alert listing view and an empty details page with breadcrumbs ([#11399](https://github.com/linode/manager/pull/11399))
+Add column for actions to Cloud Pulse alert definitions listing view and scaffolding for Definition Details page ([#11399](https://github.com/linode/manager/pull/11399))

--- a/packages/manager/.changeset/pr-11399-upcoming-features-1733923517331.md
+++ b/packages/manager/.changeset/pr-11399-upcoming-features-1733923517331.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-Add new action item row in the alert listing view and an empty details page with breadcrumbs ([#11399](https://github.com/linode/manager/pull/11399))
+Add new action item column in the alert listing view and an empty details page with breadcrumbs ([#11399](https://github.com/linode/manager/pull/11399))

--- a/packages/manager/src/factories/index.ts
+++ b/packages/manager/src/factories/index.ts
@@ -53,6 +53,7 @@ export * from './volume';
 export * from './vpcs';
 export * from './dashboards';
 export * from './cloudpulse/services';
+export * from './cloudpulse/alerts';
 
 // Convert factory output to our itemsById pattern
 export const normalizeEntities = (entities: any[]) => {

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { alertFactory } from 'src/factories/cloudpulse/alerts';
+import { alertFactory } from 'src/factories/';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { AlertDetail } from './AlertDetail';

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.test.tsx
@@ -29,7 +29,7 @@ beforeEach(() => {
 
 describe('AlertDetail component tests', () => {
   it('should render the error state on details API call failure', () => {
-    // Override only the failing query
+    // return isError true
     queryMocks.useAlertDefinitionQuery.mockReturnValueOnce({
       data: null,
       isError: true,
@@ -56,7 +56,7 @@ describe('AlertDetail component tests', () => {
   });
 
   it('should render the loading state when API call is fetching', () => {
-    // Override only the failing query
+    // return isFetching true
     queryMocks.useAlertDefinitionQuery.mockReturnValueOnce({
       data: null,
       isError: false,

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.test.tsx
@@ -36,7 +36,7 @@ describe('AlertDetail component tests', () => {
       isFetching: false,
     });
 
-    const { getByText } = renderWithTheme(<AlertDetail />);
+    const { getByTestId, getByText } = renderWithTheme(<AlertDetail />);
 
     // Assert error message is displayed
     expect(
@@ -44,6 +44,15 @@ describe('AlertDetail component tests', () => {
         'An error occurred while loading the definitions. Please try again later.'
       )
     ).toBeInTheDocument();
+
+    // validate breadcrumbs on error state
+    const link = getByTestId('link-text');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveTextContent('Definitions');
+    expect(link.closest('a')).toHaveAttribute(
+      'href',
+      '/monitor/alerts/definitions'
+    );
   });
 
   it('should render the loading state when API call is fetching', () => {
@@ -54,8 +63,17 @@ describe('AlertDetail component tests', () => {
       isFetching: true,
     });
 
-    const screen = renderWithTheme(<AlertDetail />);
+    const { getByTestId } = renderWithTheme(<AlertDetail />);
 
-    expect(screen.getByTestId('circle-progress')).toBeInTheDocument();
+    expect(getByTestId('circle-progress')).toBeInTheDocument();
+
+    // validate breadcrumbs on loading state
+    const link = getByTestId('link-text');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveTextContent('Definitions');
+    expect(link.closest('a')).toHaveAttribute(
+      'href',
+      '/monitor/alerts/definitions'
+    );
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.test.tsx
@@ -46,13 +46,7 @@ describe('AlertDetail component tests', () => {
     ).toBeInTheDocument();
 
     // validate breadcrumbs on error state
-    const link = getByTestId('link-text');
-    expect(link).toBeInTheDocument();
-    expect(link).toHaveTextContent('Definitions');
-    expect(link.closest('a')).toHaveAttribute(
-      'href',
-      '/monitor/alerts/definitions'
-    );
+    validateBreadcrumbs(getByTestId('link-text'));
   });
 
   it('should render the loading state when API call is fetching', () => {
@@ -68,12 +62,15 @@ describe('AlertDetail component tests', () => {
     expect(getByTestId('circle-progress')).toBeInTheDocument();
 
     // validate breadcrumbs on loading state
-    const link = getByTestId('link-text');
-    expect(link).toBeInTheDocument();
-    expect(link).toHaveTextContent('Definitions');
-    expect(link.closest('a')).toHaveAttribute(
-      'href',
-      '/monitor/alerts/definitions'
-    );
+    validateBreadcrumbs(getByTestId('link-text'));
   });
 });
+
+const validateBreadcrumbs = (link: HTMLElement) => {
+  expect(link).toBeInTheDocument();
+  expect(link).toHaveTextContent('Definitions');
+  expect(link.closest('a')).toHaveAttribute(
+    'href',
+    '/monitor/alerts/definitions'
+  );
+};

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import { alertFactory } from 'src/factories/cloudpulse/alerts';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { AlertDetail } from './AlertDetail';
+
+// Mock Data
+const alertDetails = alertFactory.build({ service_type: 'linode' });
+
+// Mock Queries
+const queryMocks = vi.hoisted(() => ({
+  useAlertDefinitionQuery: vi.fn(),
+}));
+
+vi.mock('src/queries/cloudpulse/alerts', () => ({
+  ...vi.importActual('src/queries/cloudpulse/alerts'),
+  useAlertDefinitionQuery: queryMocks.useAlertDefinitionQuery,
+}));
+
+// Shared Setup
+beforeEach(() => {
+  queryMocks.useAlertDefinitionQuery.mockReturnValue({
+    data: alertDetails,
+    isError: false,
+    isFetching: false,
+  });
+});
+
+describe('AlertDetail component tests', () => {
+  it('should render the error state on details API call failure', () => {
+    // Override only the failing query
+    queryMocks.useAlertDefinitionQuery.mockReturnValueOnce({
+      data: null,
+      isError: true,
+      isFetching: false,
+    });
+
+    const { getByText } = renderWithTheme(<AlertDetail />);
+
+    // Assert error message is displayed
+    expect(
+      getByText(
+        'An error occurred while loading the definitions. Please try again later.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('should render the loading state when API call is fetching', () => {
+    // Override only the failing query
+    queryMocks.useAlertDefinitionQuery.mockReturnValueOnce({
+      data: null,
+      isError: false,
+      isFetching: true,
+    });
+
+    const screen = renderWithTheme(<AlertDetail />);
+
+    expect(screen.getByTestId('circle-progress')).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
@@ -60,11 +60,7 @@ export const AlertDetail = () => {
       <>
         <Breadcrumb crumbOverrides={crumbOverrides} pathname={pathname} />
         <Box alignContent="center" height={theme.spacing(75)}>
-          <ErrorState
-            errorText={
-              'An error occurred while loading the definitions. Please try again later.'
-            }
-          />
+          <ErrorState errorText="An error occurred while loading the definitions. Please try again later." />
         </Box>
       </>
     );

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
@@ -69,6 +69,6 @@ export const AlertDetail = () => {
       </>
     );
   }
-  // TODO: The overview, criteria, resources details for alerts will be added by consuming the results of useAlertDefinitionQuery call
+  // TODO: The overview, criteria, resources details for alerts will be added by consuming the results of useAlertDefinitionQuery call in the coming PR's
   return <Breadcrumb crumbOverrides={crumbOverrides} pathname={pathname} />;
 };

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
@@ -1,4 +1,5 @@
 import { CircleProgress } from '@linode/ui';
+import { Grid, useTheme } from '@mui/material';
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -43,25 +44,31 @@ export const AlertDetail = () => {
     return { crumbOverrides: overrides, pathname: '/Definitions/Details' };
   }, [alertId, serviceType]);
 
+  const theme = useTheme();
+
   if (isFetching) {
-    return <CircleProgress />;
+    return (
+      <Grid alignItems="center" container height={theme.spacing(75)}>
+        <Grid item xs={12}>
+          <CircleProgress />
+        </Grid>
+      </Grid>
+    );
   }
 
   if (isError) {
     return (
-      <>
-        <Breadcrumb crumbOverrides={crumbOverrides} pathname={pathname} />
-        <ErrorState errorText={'Error loading alert details.'} />
-      </>
+      <Grid alignItems="center" container height={theme.spacing(75)}>
+        <Grid item xs={12}>
+          <ErrorState
+            errorText={
+              'An error occurred while loading the definitions. Please try again later.'
+            }
+          />
+        </Grid>
+      </Grid>
     );
   }
-
-  return (
-    <React.Fragment>
-      <Breadcrumb crumbOverrides={crumbOverrides} pathname={pathname} />
-      {/**
-       * TODO,  The implementations of show details page by use of data from useAlertDefinitionQuery will be added in upcoming PR's to keep this PR small
-       */}
-    </React.Fragment>
-  );
+  // TODO: The overview, criteria, resources details for alerts will be added in upcoming PR's by consuming the results of useAlertDefinitionQuery call
+  return <Breadcrumb crumbOverrides={crumbOverrides} pathname={pathname} />;
 };

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
@@ -48,21 +48,27 @@ export const AlertDetail = () => {
 
   if (isFetching) {
     return (
-      <Box alignContent="center" height={theme.spacing(75)}>
-        <CircleProgress />
-      </Box>
+      <>
+        <Breadcrumb crumbOverrides={crumbOverrides} pathname={pathname} />
+        <Box alignContent="center" height={theme.spacing(75)}>
+          <CircleProgress />
+        </Box>
+      </>
     );
   }
 
   if (isError) {
     return (
-      <Box alignContent="center" height={theme.spacing(75)}>
-        <ErrorState
-          errorText={
-            'An error occurred while loading the definitions. Please try again later.'
-          }
-        />
-      </Box>
+      <>
+        <Breadcrumb crumbOverrides={crumbOverrides} pathname={pathname} />
+        <Box alignContent="center" height={theme.spacing(75)}>
+          <ErrorState
+            errorText={
+              'An error occurred while loading the definitions. Please try again later.'
+            }
+          />
+        </Box>
+      </>
     );
   }
   // TODO: The overview, criteria, resources details for alerts will be added by consuming the results of useAlertDefinitionQuery call

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
@@ -1,5 +1,5 @@
-import { CircleProgress } from '@linode/ui';
-import { Grid, useTheme } from '@mui/material';
+import { Box, CircleProgress } from '@linode/ui';
+import { useTheme } from '@mui/material';
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -48,25 +48,21 @@ export const AlertDetail = () => {
 
   if (isFetching) {
     return (
-      <Grid alignItems="center" container height={theme.spacing(75)}>
-        <Grid item xs={12}>
-          <CircleProgress />
-        </Grid>
-      </Grid>
+      <Box alignContent="center" height={theme.spacing(75)}>
+        <CircleProgress />
+      </Box>
     );
   }
 
   if (isError) {
     return (
-      <Grid alignItems="center" container height={theme.spacing(75)}>
-        <Grid item xs={12}>
-          <ErrorState
-            errorText={
-              'An error occurred while loading the definitions. Please try again later.'
-            }
-          />
-        </Grid>
-      </Grid>
+      <Box alignContent="center" height={theme.spacing(75)}>
+        <ErrorState
+          errorText={
+            'An error occurred while loading the definitions. Please try again later.'
+          }
+        />
+      </Box>
     );
   }
   // TODO: The overview, criteria, resources details for alerts will be added in upcoming PR's by consuming the results of useAlertDefinitionQuery call

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
@@ -65,6 +65,6 @@ export const AlertDetail = () => {
       </Box>
     );
   }
-  // TODO: The overview, criteria, resources details for alerts will be added in upcoming PR's by consuming the results of useAlertDefinitionQuery call
+  // TODO: The overview, criteria, resources details for alerts will be added by consuming the results of useAlertDefinitionQuery call
   return <Breadcrumb crumbOverrides={crumbOverrides} pathname={pathname} />;
 };

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
@@ -1,7 +1,12 @@
-import { Breadcrumb } from 'src/components/Breadcrumb/Breadcrumb';
+import { CircleProgress } from '@linode/ui';
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { BreadcrumbProps } from 'src/components/Breadcrumb/Breadcrumb';
+
+import { Breadcrumb } from 'src/components/Breadcrumb/Breadcrumb';
+import { ErrorState } from 'src/components/ErrorState/ErrorState';
+import { useAlertDefinitionQuery } from 'src/queries/cloudpulse/alerts';
+
+import type { BreadcrumbProps } from 'src/components/Breadcrumb/Breadcrumb';
 
 interface RouteParams {
   /*
@@ -14,9 +19,13 @@ interface RouteParams {
   serviceType: string;
 }
 
-export const AlertDetail = () => { 
-
+export const AlertDetail = () => {
   const { alertId, serviceType } = useParams<RouteParams>();
+
+  const { isError, isFetching } = useAlertDefinitionQuery(
+    Number(alertId),
+    serviceType
+  );
 
   const { crumbOverrides, pathname } = React.useMemo((): BreadcrumbProps => {
     const overrides = [
@@ -34,14 +43,25 @@ export const AlertDetail = () => {
     return { crumbOverrides: overrides, pathname: '/Definitions/Details' };
   }, [alertId, serviceType]);
 
+  if (isFetching) {
+    return <CircleProgress />;
+  }
+
+  if (isError) {
+    return (
+      <>
+        <Breadcrumb crumbOverrides={crumbOverrides} pathname={pathname} />
+        <ErrorState errorText={'Error loading alert details.'} />
+      </>
+    );
+  }
 
   return (
     <React.Fragment>
       <Breadcrumb crumbOverrides={crumbOverrides} pathname={pathname} />
       {/**
-       * TODO,  The implementations of show details page will be added in upcoming PR's to keep this PR small
+       * TODO,  The implementations of show details page by use of data from useAlertDefinitionQuery will be added in upcoming PR's to keep this PR small
        */}
     </React.Fragment>
   );
-
-}
+};

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
@@ -10,11 +10,11 @@ import { useAlertDefinitionQuery } from 'src/queries/cloudpulse/alerts';
 import type { BreadcrumbProps } from 'src/components/Breadcrumb/Breadcrumb';
 
 interface RouteParams {
-  /*
+  /**
    * The id of the alert for which the data needs to be shown
    */
   alertId: string;
-  /*
+  /**
    * The service type like linode, dbaas etc., of the the alert for which the data needs to be shown
    */
   serviceType: string;

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
@@ -1,0 +1,47 @@
+import { Breadcrumb } from 'src/components/Breadcrumb/Breadcrumb';
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { BreadcrumbProps } from 'src/components/Breadcrumb/Breadcrumb';
+
+interface RouteParams {
+  /*
+   * The id of the alert for which the data needs to be shown
+   */
+  alertId: string;
+  /*
+   * The service type like linode, dbaas etc., of the the alert for which the data needs to be shown
+   */
+  serviceType: string;
+}
+
+export const AlertDetail = () => { 
+
+  const { alertId, serviceType } = useParams<RouteParams>();
+
+  const { crumbOverrides, pathname } = React.useMemo((): BreadcrumbProps => {
+    const overrides = [
+      {
+        label: 'Definitions',
+        linkTo: '/monitor/alerts/definitions',
+        position: 1,
+      },
+      {
+        label: 'Details',
+        linkTo: `/monitor/alerts/definitions/details/${serviceType}/${alertId}`,
+        position: 2,
+      },
+    ];
+    return { crumbOverrides: overrides, pathname: '/Definitions/Details' };
+  }, [alertId, serviceType]);
+
+
+  return (
+    <React.Fragment>
+      <Breadcrumb crumbOverrides={crumbOverrides} pathname={pathname} />
+      {/**
+       * TODO,  The implementations of show details page will be added in upcoming PR's to keep this PR small
+       */}
+    </React.Fragment>
+  );
+
+}

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
@@ -7,8 +7,6 @@ import { Breadcrumb } from 'src/components/Breadcrumb/Breadcrumb';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { useAlertDefinitionQuery } from 'src/queries/cloudpulse/alerts';
 
-import type { BreadcrumbProps } from 'src/components/Breadcrumb/Breadcrumb';
-
 interface RouteParams {
   /**
    * The id of the alert for which the data needs to be shown
@@ -28,7 +26,7 @@ export const AlertDetail = () => {
     serviceType
   );
 
-  const { crumbOverrides, pathname } = React.useMemo((): BreadcrumbProps => {
+  const { crumbOverrides, pathname } = React.useMemo(() => {
     const overrides = [
       {
         label: 'Definitions',

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsLanding/AlertsDefinitionLanding.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsLanding/AlertsDefinitionLanding.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Route, Switch } from 'react-router-dom';
 
+import { AlertDetail } from '../AlertsDetail/AlertDetail';
 import { AlertListing } from '../AlertsListing/AlertListing';
 import { CreateAlertDefinition } from '../CreateAlert/CreateAlertDefinition';
 
@@ -12,6 +13,12 @@ export const AlertDefinitionLanding = () => {
         exact
         path="/monitor/alerts/definitions"
       />
+      <Route
+        exact
+        path="/monitor/alerts/definitions/detail/:serviceType/:alertId"
+      >
+        <AlertDetail />
+      </Route>
       <Route
         component={CreateAlertDefinition}
         path="/monitor/alerts/definitions/create"

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertActionMenu.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertActionMenu.tsx
@@ -29,7 +29,7 @@ export const AlertActionMenu = (props: AlertActionMenuProps) => {
   return (
     <ActionMenu
       actionsList={getAlertTypeToActionsList(handlers)[alertType]}
-      ariaLabel={'Action menu for Alert'}
+      ariaLabel="Action menu for Alert"
     />
   );
 };

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertActionMenu.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertActionMenu.tsx
@@ -24,18 +24,11 @@ export interface AlertActionMenuProps {
   handlers: ActionHandlers;
 }
 
-/**
- * The handlers and alertType are made optional only temporarily, they will be enabled but they are dependent on another feature which will be part of next PR
- */
 export const AlertActionMenu = (props: AlertActionMenuProps) => {
   const { alertType, handlers } = props;
   return (
     <ActionMenu
-      actionsList={
-        handlers && alertType
-          ? getAlertTypeToActionsList(handlers)[alertType]
-          : []
-      }
+      actionsList={getAlertTypeToActionsList(handlers)[alertType]}
       ariaLabel={'Action menu for Alert'}
     />
   );

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertActionMenu.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertActionMenu.tsx
@@ -7,7 +7,7 @@ import { getAlertTypeToActionsList } from '../Utils/AlertsActionMenu';
 import type { AlertDefinitionType } from '@linode/api-v4';
 
 export interface ActionHandlers {
-  /*
+  /**
    * Callback for show details action
    */
   handleDetails: () => void;

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertActionMenu.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertActionMenu.tsx
@@ -2,16 +2,12 @@ import * as React from 'react';
 
 import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
 
+import { getAlertTypeToActionsList } from '../Utils/AlertsActionMenu';
+
 import type { AlertDefinitionType } from '@linode/api-v4';
 
 export interface ActionHandlers {
-  // These handlers will be enhanced based on the alert type and actions required
-  /**
-   * Callback for delete action
-   */
-  handleDelete: () => void;
-
-  /**
+  /*
    * Callback for show details action
    */
   handleDetails: () => void;
@@ -21,16 +17,26 @@ export interface AlertActionMenuProps {
   /**
    * Type of the alert
    */
-  alertType?: AlertDefinitionType;
+  alertType: AlertDefinitionType;
   /**
    * Handlers for alert actions like delete, show details etc.,
    */
-  handlers?: ActionHandlers;
+  handlers: ActionHandlers;
 }
 
 /**
  * The handlers and alertType are made optional only temporarily, they will be enabled but they are dependent on another feature which will be part of next PR
  */
-export const AlertActionMenu = () => {
-  return <ActionMenu actionsList={[]} ariaLabel={'Action menu for Alert'} />;
+export const AlertActionMenu = (props: AlertActionMenuProps) => {
+  const { alertType, handlers } = props;
+  return (
+    <ActionMenu
+      actionsList={
+        handlers && alertType
+          ? getAlertTypeToActionsList(handlers)[alertType]
+          : []
+      }
+      ariaLabel={'Action menu for Alert'}
+    />
+  );
 };

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.test.tsx
@@ -1,7 +1,7 @@
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
-import { alertFactory } from 'src/factories/cloudpulse/alerts';
+import { alertFactory } from 'src/factories';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { AlertListing } from './AlertListing';

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.test.tsx
@@ -1,3 +1,4 @@
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
 import { alertFactory } from 'src/factories/cloudpulse/alerts';
@@ -20,7 +21,7 @@ vi.mock('src/queries/cloudpulse/alerts', async () => {
 const mockResponse = alertFactory.buildList(3);
 
 describe('Alert Listing', () => {
-  it('should render the error message', async () => {
+  it('should render the error message', () => {
     queryMocks.useAllAlertDefinitionsQuery.mockReturnValue({
       data: undefined,
       error: 'an error happened',
@@ -31,22 +32,23 @@ describe('Alert Listing', () => {
     getAllByText('Error in fetching the alerts.');
   });
 
-  it('should render the alert landing table with items', async () => {
+  it('should render the alert landing table with items', () => {
     queryMocks.useAllAlertDefinitionsQuery.mockReturnValue({
       data: mockResponse,
       isError: false,
       isLoading: false,
       status: 'success',
     });
-    const { getByText } = renderWithTheme(<AlertListing />);
+    const { getAllByLabelText, getByText } = renderWithTheme(<AlertListing />);
     expect(getByText('Alert Name')).toBeInTheDocument();
     expect(getByText('Service')).toBeInTheDocument();
     expect(getByText('Status')).toBeInTheDocument();
     expect(getByText('Last Modified')).toBeInTheDocument();
     expect(getByText('Created By')).toBeInTheDocument();
+    expect(getAllByLabelText('Action menu for Alert').length).toBe(3);
   });
 
-  it('should render the alert row', async () => {
+  it('should render the alert row', () => {
     queryMocks.useAllAlertDefinitionsQuery.mockReturnValue({
       data: mockResponse,
       isError: false,
@@ -58,5 +60,20 @@ describe('Alert Listing', () => {
     expect(getByText(mockResponse[0].label)).toBeInTheDocument();
     expect(getByText(mockResponse[1].label)).toBeInTheDocument();
     expect(getByText(mockResponse[2].label)).toBeInTheDocument();
+  });
+
+  it('should have the show details action item present inside action menu', async () => {
+    queryMocks.useAllAlertDefinitionsQuery.mockReturnValue({
+      data: mockResponse,
+      isError: false,
+      isLoading: false,
+      status: 'success',
+    });
+    const { getAllByLabelText, getByTestId } = renderWithTheme(
+      <AlertListing />
+    );
+    const firstActionMenu = getAllByLabelText('Action menu for Alert')[0];
+    await userEvent.click(firstActionMenu);
+    expect(getByTestId('Show Details')).toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
@@ -29,10 +29,8 @@ export const AlertListing = () => {
 
   const history = useHistory();
 
-  const handleDetails = (alert: Alert) => {
-    history.push(
-      `${location.pathname}/detail/${alert.service_type}/${alert.id}`
-    );
+  const handleDetails = ({ id, service_type: serviceType }: Alert) => {
+    history.push(`${location.pathname}/detail/${serviceType}/${id}`);
   };
 
   if (alerts?.length === 0) {

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
@@ -1,6 +1,7 @@
 import { Paper } from '@linode/ui';
 import { Grid } from '@mui/material';
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 
 import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
@@ -16,6 +17,8 @@ import { useAllAlertDefinitionsQuery } from 'src/queries/cloudpulse/alerts';
 import { AlertTableRow } from './AlertTableRow';
 import { AlertListingTableLabelMap } from './constants';
 
+import type { Alert } from '@linode/api-v4';
+
 export const AlertListing = () => {
   // These are dummy order value and handleOrder methods, will replace them in the next PR
   const order = 'asc';
@@ -23,6 +26,15 @@ export const AlertListing = () => {
     return 'asc';
   };
   const { data: alerts, isError, isLoading } = useAllAlertDefinitionsQuery();
+
+  const history = useHistory();
+
+  const handleDetails = (alert: Alert) => {
+    history.push(
+      `${location.pathname}/detail/${alert.service_type}/${alert.id}`
+    );
+  };
+
   if (alerts?.length === 0) {
     return (
       <Grid item xs={12}>
@@ -63,7 +75,13 @@ export const AlertListing = () => {
           )}
           {isLoading && <TableRowLoading columns={7} />}
           {alerts?.map((alert) => (
-            <AlertTableRow alert={alert} key={alert.id} />
+            <AlertTableRow
+              handlers={{
+                handleDetails: () => handleDetails(alert),
+              }}
+              alert={alert}
+              key={alert.id}
+            />
           ))}
         </TableBody>
       </Table>

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { alertFactory } from 'src/factories/cloudpulse/alerts';
+import { alertFactory } from 'src/factories';
 import { capitalize } from 'src/utilities/capitalize';
 import { renderWithTheme, wrapWithTableBody } from 'src/utilities/testHelpers';
 

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.test.tsx
@@ -9,7 +9,14 @@ import { AlertTableRow } from './AlertTableRow';
 describe('Alert Row', () => {
   it('should render an alert row', async () => {
     const alert = alertFactory.build();
-    const renderedAlert = <AlertTableRow alert={alert} />;
+    const renderedAlert = (
+      <AlertTableRow
+        handlers={{
+          handleDetails: vi.fn(),
+        }}
+        alert={alert}
+      />
+    );
     const { getByText } = renderWithTheme(wrapWithTableBody(renderedAlert));
     expect(getByText(alert.label)).toBeVisible();
   });
@@ -21,7 +28,14 @@ describe('Alert Row', () => {
   it('should render the status field in green color if status is enabled', () => {
     const statusValue = 'enabled';
     const alert = alertFactory.build({ status: statusValue });
-    const renderedAlert = <AlertTableRow alert={alert} />;
+    const renderedAlert = (
+      <AlertTableRow
+        handlers={{
+          handleDetails: vi.fn(),
+        }}
+        alert={alert}
+      />
+    );
     const { getByText } = renderWithTheme(wrapWithTableBody(renderedAlert));
     const statusElement = getByText(capitalize(statusValue));
     expect(getComputedStyle(statusElement).color).toBe('rgb(0, 176, 80)');

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.tsx
@@ -9,6 +9,7 @@ import { capitalize } from 'src/utilities/capitalize';
 
 import { AlertActionMenu } from './AlertActionMenu';
 
+import type { ActionHandlers } from './AlertActionMenu';
 import type { Alert } from '@linode/api-v4';
 
 interface Props {
@@ -16,11 +17,13 @@ interface Props {
    * alert details used by the component to fill the row details
    */
   alert: Alert;
+
+  handlers: ActionHandlers;
 }
 
 export const AlertTableRow = (props: Props) => {
-  const { alert } = props;
-  const { created_by, id, label, service_type, status, updated } = alert;
+  const { alert, handlers } = props;
+  const { created_by, id, label, service_type, status, type, updated } = alert;
   const theme = useTheme();
   return (
     <TableRow data-qa-alert-cell={id} key={`alert-row-${id}`}>
@@ -45,7 +48,7 @@ export const AlertTableRow = (props: Props) => {
         {/* handlers are supposed to be passed to this AlertActionMenu,
         it is dependent on other feature and will added as that feature in the next PR
         */}
-        <AlertActionMenu />
+        <AlertActionMenu alertType={type} handlers={handlers} />
       </TableCell>
     </TableRow>
   );

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.tsx
@@ -18,7 +18,7 @@ interface Props {
    */
   alert: Alert;
   /**
-   * The callback handlers for clicking an action menu item like show details, delete etc.,
+   * The callback handlers for clicking an action menu item like Show Details, Delete, etc.
    */
   handlers: ActionHandlers;
 }

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.tsx
@@ -47,9 +47,6 @@ export const AlertTableRow = (props: Props) => {
       </TableCell>
       <TableCell>{created_by}</TableCell>
       <TableCell actionCell>
-        {/* handlers are supposed to be passed to this AlertActionMenu,
-        it is dependent on other feature and will added as that feature in the next PR
-        */}
         <AlertActionMenu alertType={type} handlers={handlers} />
       </TableCell>
     </TableRow>

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.tsx
@@ -17,7 +17,9 @@ interface Props {
    * alert details used by the component to fill the row details
    */
   alert: Alert;
-
+  /**
+   * The callback handlers for clicking an action menu item like show details, delete etc.,
+   */
   handlers: ActionHandlers;
 }
 

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
@@ -9,7 +9,7 @@ import type { Action } from 'src/components/ActionMenu/ActionMenu';
 export const getAlertTypeToActionsList = ({
   handleDetails,
 }: ActionHandlers): Record<AlertDefinitionType, Action[]> => ({
-  // for now there is system and user alert types, may be in future more alert types can be added and action items will differ according to alert types
+  // for now there is system and user alert types, in future more alert types can be added and action items will differ according to alert types
   system: [
     {
       disabled: false,

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
@@ -3,7 +3,7 @@ import type { AlertDefinitionType } from '@linode/api-v4';
 import type { Action } from 'src/components/ActionMenu/ActionMenu';
 
 /**
- * @param onClickHandlers The list of handlers required to be called, on click of an action
+ * @param onClickHandlers The list of handlers required to be called on click of an action
  * @returns The actions based on the type of the alert
  */
 export const getAlertTypeToActionsList = ({

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
@@ -12,14 +12,12 @@ export const getAlertTypeToActionsList = ({
   // for now there is system and user alert types, in future more alert types can be added and action items will differ according to alert types
   system: [
     {
-      disabled: false,
       onClick: handleDetails,
       title: 'Show Details',
     },
   ],
   user: [
     {
-      disabled: false,
       onClick: handleDetails,
       title: 'Show Details',
     },

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
@@ -1,0 +1,28 @@
+import type { ActionHandlers } from '../AlertsListing/AlertActionMenu';
+import type { AlertDefinitionType } from '@linode/api-v4';
+import type { Action } from 'src/components/ActionMenu/ActionMenu';
+
+/**
+ *
+ * @param onClickHandlers The list of handlers required to be called, on click of an action
+ * @returns The actions based on the type of the alert
+ */
+export const getAlertTypeToActionsList = (
+  onClickHandlers: ActionHandlers
+): Record<AlertDefinitionType, Action[]> => ({
+  // for now there is custom and default alert types, may be in future more alert types can be added
+  system: [
+    {
+      disabled: false,
+      onClick: onClickHandlers.handleDetails,
+      title: 'Show Details',
+    },
+  ],
+  user: [
+    {
+      disabled: false,
+      onClick: onClickHandlers.handleDetails,
+      title: 'Show Details',
+    },
+  ],
+});

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
@@ -3,25 +3,24 @@ import type { AlertDefinitionType } from '@linode/api-v4';
 import type { Action } from 'src/components/ActionMenu/ActionMenu';
 
 /**
- *
  * @param onClickHandlers The list of handlers required to be called, on click of an action
  * @returns The actions based on the type of the alert
  */
-export const getAlertTypeToActionsList = (
-  onClickHandlers: ActionHandlers
-): Record<AlertDefinitionType, Action[]> => ({
-  // for now there is custom and default alert types, may be in future more alert types can be added
+export const getAlertTypeToActionsList = ({
+  handleDetails,
+}: ActionHandlers): Record<AlertDefinitionType, Action[]> => ({
+  // for now there is system and user alert types, may be in future more alert types can be added and action items will differ according to alert types
   system: [
     {
       disabled: false,
-      onClick: onClickHandlers.handleDetails,
+      onClick: handleDetails,
       title: 'Show Details',
     },
   ],
   user: [
     {
       disabled: false,
-      onClick: onClickHandlers.handleDetails,
+      onClick: handleDetails,
       title: 'Show Details',
     },
   ],

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -2391,6 +2391,20 @@ export const handlers = [
     ];
     return HttpResponse.json(makeResourcePage(alerts));
   }),
+  http.get(
+    '*/monitor/services/:serviceType/alert-definitions/:id',
+    ({ params }) => {
+      if (params.id !== undefined) {
+        return HttpResponse.json(
+          alertFactory.build({
+            id: Number(params.id),
+            service_type: params.serviceType === 'linode' ? 'linode' : 'dbaas',
+          })
+        );
+      }
+      return HttpResponse.json({}, { status: 404 });
+    }
+  ),
   http.get('*/monitor/services', () => {
     const response: ServiceTypesList = {
       data: [

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -19,6 +19,7 @@ import {
   accountFactory,
   accountMaintenanceFactory,
   accountTransferFactory,
+  alertFactory,
   appTokenFactory,
   betaFactory,
   contactFactory,
@@ -105,8 +106,6 @@ import { getStorage } from 'src/utilities/storage';
 
 const getRandomWholeNumber = (min: number, max: number) =>
   Math.floor(Math.random() * (max - min + 1) + min);
-
-import { alertFactory } from 'src/factories/cloudpulse/alerts';
 import { pickRandom } from 'src/utilities/random';
 
 import type {

--- a/packages/manager/src/queries/cloudpulse/alerts.ts
+++ b/packages/manager/src/queries/cloudpulse/alerts.ts
@@ -44,6 +44,6 @@ export const useAlertDefinitionQuery = (
   serviceType: string
 ) => {
   return useQuery<Alert, APIError[]>({
-    ...queryFactory.alerts._ctx.alertByIdAndServiceType(alertId, serviceType),
+    ...queryFactory.alerts._ctx.alertByServiceTypeAndId(serviceType, alertId),
   });
 };

--- a/packages/manager/src/queries/cloudpulse/alerts.ts
+++ b/packages/manager/src/queries/cloudpulse/alerts.ts
@@ -38,3 +38,13 @@ export const useAllAlertDefinitionsQuery = (
     placeholderData: keepPreviousData,
   });
 };
+
+export const useAlertDefinitionQuery = (
+  alertId: number,
+  serviceType: string
+) => {
+  return useQuery<Alert, APIError[]>({
+    ...queryFactory.alertById(alertId, serviceType),
+    enabled: alertId !== undefined,
+  });
+};

--- a/packages/manager/src/queries/cloudpulse/alerts.ts
+++ b/packages/manager/src/queries/cloudpulse/alerts.ts
@@ -44,6 +44,6 @@ export const useAlertDefinitionQuery = (
   serviceType: string
 ) => {
   return useQuery<Alert, APIError[]>({
-    ...queryFactory.alerts._ctx.alertById(alertId, serviceType),
+    ...queryFactory.alerts._ctx.alertByIdAndServiceType(alertId, serviceType),
   });
 };

--- a/packages/manager/src/queries/cloudpulse/alerts.ts
+++ b/packages/manager/src/queries/cloudpulse/alerts.ts
@@ -45,6 +45,5 @@ export const useAlertDefinitionQuery = (
 ) => {
   return useQuery<Alert, APIError[]>({
     ...queryFactory.alerts._ctx.alertById(alertId, serviceType),
-    enabled: alertId !== undefined,
   });
 };

--- a/packages/manager/src/queries/cloudpulse/alerts.ts
+++ b/packages/manager/src/queries/cloudpulse/alerts.ts
@@ -44,7 +44,7 @@ export const useAlertDefinitionQuery = (
   serviceType: string
 ) => {
   return useQuery<Alert, APIError[]>({
-    ...queryFactory.alertById(alertId, serviceType),
+    ...queryFactory.alerts._ctx.alertById(alertId, serviceType),
     enabled: alertId !== undefined,
   });
 };

--- a/packages/manager/src/queries/cloudpulse/queries.ts
+++ b/packages/manager/src/queries/cloudpulse/queries.ts
@@ -1,5 +1,5 @@
 import {
-  getAlertDefinitionById,
+  getAlertDefinitionByIdAndServiceType,
   getCloudPulseServiceTypes,
   getDashboardById,
   getDashboards,
@@ -30,8 +30,9 @@ export const queryFactory = createQueryKeys(key, {
         // This query key is a placeholder , it will be updated once the relevant queries are added
         queryKey: null,
       },
-      alertById: (alertId: number, serviceType: string) => ({
-        queryFn: () => getAlertDefinitionById(alertId, serviceType),
+      alertByIdAndServiceType: (alertId: number, serviceType: string) => ({
+        queryFn: () =>
+          getAlertDefinitionByIdAndServiceType(alertId, serviceType),
         queryKey: [alertId, serviceType],
       }),
       all: (params: Params = {}, filter: Filter = {}) => ({

--- a/packages/manager/src/queries/cloudpulse/queries.ts
+++ b/packages/manager/src/queries/cloudpulse/queries.ts
@@ -1,5 +1,5 @@
 import {
-  getAlertDefinitionByIdAndServiceType,
+  getAlertDefinitionByServiceTypeAndId,
   getCloudPulseServiceTypes,
   getDashboardById,
   getDashboards,
@@ -30,9 +30,9 @@ export const queryFactory = createQueryKeys(key, {
         // This query key is a placeholder , it will be updated once the relevant queries are added
         queryKey: null,
       },
-      alertByIdAndServiceType: (alertId: number, serviceType: string) => ({
+      alertByServiceTypeAndId: (serviceType: string, alertId: number) => ({
         queryFn: () =>
-          getAlertDefinitionByIdAndServiceType(alertId, serviceType),
+          getAlertDefinitionByServiceTypeAndId(serviceType, alertId),
         queryKey: [alertId, serviceType],
       }),
       all: (params: Params = {}, filter: Filter = {}) => ({

--- a/packages/manager/src/queries/cloudpulse/queries.ts
+++ b/packages/manager/src/queries/cloudpulse/queries.ts
@@ -1,4 +1,5 @@
 import {
+  getAlertDefinitionById,
   getCloudPulseServiceTypes,
   getDashboardById,
   getDashboards,
@@ -23,6 +24,10 @@ import type {
 const key = 'Clousepulse';
 
 export const queryFactory = createQueryKeys(key, {
+  alertById: (alertId: number, serviceType: string) => ({
+    queryFn: () => getAlertDefinitionById(alertId, serviceType),
+    queryKey: [alertId, serviceType],
+  }),
   alerts: {
     contextQueries: {
       alert: {

--- a/packages/manager/src/queries/cloudpulse/queries.ts
+++ b/packages/manager/src/queries/cloudpulse/queries.ts
@@ -24,16 +24,16 @@ import type {
 const key = 'Clousepulse';
 
 export const queryFactory = createQueryKeys(key, {
-  alertById: (alertId: number, serviceType: string) => ({
-    queryFn: () => getAlertDefinitionById(alertId, serviceType),
-    queryKey: [alertId, serviceType],
-  }),
   alerts: {
     contextQueries: {
       alert: {
         // This query key is a placeholder , it will be updated once the relevant queries are added
         queryKey: null,
       },
+      alertById: (alertId: number, serviceType: string) => ({
+        queryFn: () => getAlertDefinitionById(alertId, serviceType),
+        queryKey: [alertId, serviceType],
+      }),
       all: (params: Params = {}, filter: Filter = {}) => ({
         queryFn: () => getAllAlertsRequest(params, filter),
         queryKey: [params, filter],


### PR DESCRIPTION
## Description 📝
Added a action menu for the AlertListing component table rows and Added a empty Alert detail landing page with loading and error case handling alone

## Changes  🔄

1. Added action menu for different alert types that will be displayed in each row of alert listing page.
2. Added an empty Alert detail component with changes for loading and error state handling for API call alone.
3. Added a new useAlertDefinitionQuery hook, which fetches the alert details API by id and service type.

## Target release date 🗓️
19-12-2024

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-12-11 at 9 53 57 AM](https://github.com/user-attachments/assets/c7899962-1dc2-4c59-8575-b07ad600c4a6)|![Screenshot 2024-12-11 at 9 54 06 AM](https://github.com/user-attachments/assets/dc3d492c-cfc1-4476-8c81-5f52ac859156)|
|![Screenshot 2024-12-12 at 2 53 29 PM](https://github.com/user-attachments/assets/d18eecb5-bc20-489e-831f-7857bdc11ef7)|![Screenshot 2024-12-12 at 2 53 38 PM](https://github.com/user-attachments/assets/23afad6b-94bc-4bc6-a723-8a9322a4cb89)|
## How to test 🧪

1. Login as mock as the API endpoints are not available.
2. Navigate to monitor tab and select alerts section.
3. In the list view select action menu and select show details
4. You will redirected to a empty details page, with breadcrumbs on it.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules
