### PR TITLE
feat: [UIE-8136] - IAM RBAC: add new users table component (part 2)

### DIFF
--- a/packages/manager/.changeset/pr-11402-added-1736419050008.md
+++ b/packages/manager/.changeset/pr-11402-added-1736419050008.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+useCreateUserMutation for adding new users ([#11402](https://github.com/linode/manager/pull/11402))

--- a/packages/manager/.changeset/pr-11402-upcoming-features-1733927050433.md
+++ b/packages/manager/.changeset/pr-11402-upcoming-features-1733927050433.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+proxy users table, removing users, adding users ([#11402](https://github.com/linode/manager/pull/11402))

--- a/packages/manager/src/features/IAM/Shared/UserDeleteConfirmation.tsx
+++ b/packages/manager/src/features/IAM/Shared/UserDeleteConfirmation.tsx
@@ -1,0 +1,73 @@
+import { Notice, Typography } from '@linode/ui';
+import { useSnackbar } from 'notistack';
+import * as React from 'react';
+
+import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
+import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
+import { useAccountUserDeleteMutation } from 'src/queries/account/users';
+
+interface Props {
+  onClose: () => void;
+  onSuccess?: () => void;
+  open: boolean;
+  username: string;
+}
+
+export const UserDeleteConfirmation = (props: Props) => {
+  const { onClose: _onClose, onSuccess, open, username } = props;
+
+  const { enqueueSnackbar } = useSnackbar();
+
+  const {
+    error,
+    isPending,
+    mutateAsync: deleteUser,
+    reset,
+  } = useAccountUserDeleteMutation(username);
+
+  const onClose = () => {
+    reset(); // resets the error state of the useMutation
+    _onClose();
+  };
+
+  const onDelete = async () => {
+    await deleteUser();
+    enqueueSnackbar(`User ${username} has been deleted successfully.`, {
+      variant: 'success',
+    });
+    if (onSuccess) {
+      onSuccess();
+    }
+    onClose();
+  };
+
+  return (
+    <ConfirmationDialog
+      actions={
+        <ActionsPanel
+          primaryButtonProps={{
+            label: 'Delete User',
+            loading: isPending,
+            onClick: onDelete,
+          }}
+          secondaryButtonProps={{
+            label: 'Cancel',
+            onClick: onClose,
+          }}
+          style={{ padding: 0 }}
+        />
+      }
+      error={error?.[0].reason}
+      onClose={onClose}
+      open={open}
+      title={`Delete user ${username}?`}
+    >
+      <Notice variant="warning">
+        <Typography>
+          <strong>Warning:</strong> Deleting this User is permanent and can’t be
+          undone.
+        </Typography>
+      </Notice>
+    </ConfirmationDialog>
+  );
+};

--- a/packages/manager/src/features/IAM/Users/UsersTable/CreateUserDrawer.test.tsx
+++ b/packages/manager/src/features/IAM/Users/UsersTable/CreateUserDrawer.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { HttpResponse, http, server } from 'src/mocks/testServer';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { CreateUserDrawer } from './CreateUserDrawer';
+
+const props = {
+  onClose: vi.fn(),
+  open: true,
+};
+
+const testEmail = 'testuser@example.com';
+
+describe('CreateUserDrawer', () => {
+  it('should render the drawer when open is true', () => {
+    const { getByRole } = renderWithTheme(<CreateUserDrawer {...props} />);
+
+    const dialog = getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+  });
+
+  it('should allow the user to fill out the form', () => {
+    const { getByLabelText, getByRole } = renderWithTheme(
+      <CreateUserDrawer {...props} />
+    );
+
+    const dialog = getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+
+    fireEvent.change(getByLabelText(/username/i), {
+      target: { value: 'testuser' },
+    });
+    fireEvent.change(getByLabelText(/email/i), {
+      target: { value: testEmail },
+    });
+
+    expect(getByLabelText(/username/i)).toHaveValue('testuser');
+    expect(getByLabelText(/email/i)).toHaveValue(testEmail);
+  });
+
+  it('should display an error message when submission fails', async () => {
+    server.use(
+      http.post('*/account/users', () => {
+        return HttpResponse.json(
+          { error: [{ reason: 'An unexpected error occurred.' }] },
+          { status: 500 }
+        );
+      })
+    );
+
+    const {
+      findByText,
+      getByLabelText,
+      getByRole,
+      getByTestId,
+    } = renderWithTheme(<CreateUserDrawer {...props} />);
+
+    const dialog = getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+
+    fireEvent.change(getByLabelText(/username/i), {
+      target: { value: 'testuser' },
+    });
+    fireEvent.change(getByLabelText(/email/i), {
+      target: { value: testEmail },
+    });
+    fireEvent.click(getByTestId('submit'));
+
+    const errorMessage = await findByText('An unexpected error occurred.');
+    expect(errorMessage).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/IAM/Users/UsersTable/CreateUserDrawer.tsx
+++ b/packages/manager/src/features/IAM/Users/UsersTable/CreateUserDrawer.tsx
@@ -1,0 +1,149 @@
+import { Box, FormControlLabel, Notice, TextField, Toggle } from '@linode/ui';
+import * as React from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { useHistory } from 'react-router-dom';
+
+import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
+import { Drawer } from 'src/components/Drawer';
+import { useCreateUserMutation } from 'src/queries/account/users';
+
+import type { User } from '@linode/api-v4/lib/account';
+
+interface Props {
+  onClose: () => void;
+  open: boolean;
+}
+
+export const CreateUserDrawer = (props: Props) => {
+  const { onClose, open } = props;
+  const history = useHistory();
+  const { mutateAsync: createUserMutation } = useCreateUserMutation();
+
+  const {
+    control,
+    formState: { errors, isSubmitting },
+    handleSubmit,
+    reset,
+    setError,
+  } = useForm({
+    defaultValues: {
+      email: '',
+      restricted: false,
+      username: '',
+    },
+  });
+
+  const onSubmit = async (data: {
+    email: string;
+    restricted: boolean;
+    username: string;
+  }) => {
+    try {
+      const user: User = await createUserMutation(data);
+      handleClose();
+
+      if (user.restricted) {
+        history.push(`/account/users/${data.username}/permissions`, {
+          newUsername: user.username,
+        });
+      }
+    } catch (errors) {
+      for (const error of errors) {
+        setError(error?.field ?? 'root', { message: error.reason });
+      }
+    }
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  return (
+    <Drawer onClose={handleClose} open={open} title="Add a User">
+      {errors.root?.message && (
+        <Notice text={errors.root?.message} variant="error" />
+      )}
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Controller
+          render={({ field, fieldState }) => (
+            <TextField
+              data-qa-create-username
+              errorText={fieldState.error?.message}
+              label="Username"
+              onBlur={field.onBlur}
+              onChange={field.onChange}
+              required
+              trimmed
+              value={field.value}
+            />
+          )}
+          control={control}
+          name="username"
+          rules={{ required: 'Username is required' }}
+        />
+
+        <Controller
+          render={({ field, fieldState }) => (
+            <TextField
+              data-qa-create-email
+              errorText={fieldState.error?.message}
+              label="Email"
+              onChange={field.onChange}
+              required
+              trimmed
+              type="email"
+              value={field.value}
+            />
+          )}
+          control={control}
+          name="email"
+          rules={{ required: 'Email is required' }}
+        />
+
+        <Controller
+          render={({ field }) => (
+            <FormControlLabel
+              control={
+                <Toggle
+                  onChange={(e) => {
+                    field.onChange(!e.target.checked);
+                  }}
+                  checked={!field.value}
+                  data-qa-create-restricted
+                />
+              }
+              label={`This user will have ${
+                field.value ? 'limited' : 'full'
+              } access to account features.
+                    This can be changed later.`}
+              sx={{ marginTop: 1 }}
+            />
+          )}
+          control={control}
+          name="restricted"
+        />
+
+        <Box sx={{ marginTop: 1 }}>
+          <Notice
+            text="The user will be sent an email to set their password"
+            variant="warning"
+          />
+        </Box>
+        <ActionsPanel
+          primaryButtonProps={{
+            'data-testid': 'submit',
+            label: 'Add User',
+            loading: isSubmitting,
+            type: 'submit',
+          }}
+          secondaryButtonProps={{
+            'data-testid': 'cancel',
+            label: 'Cancel',
+            onClick: handleClose,
+          }}
+        />
+      </form>
+    </Drawer>
+  );
+};

--- a/packages/manager/src/features/IAM/Users/UsersTable/ProxyUserTable.tsx
+++ b/packages/manager/src/features/IAM/Users/UsersTable/ProxyUserTable.tsx
@@ -1,0 +1,68 @@
+import { Typography } from '@linode/ui';
+import React from 'react';
+
+import { Table } from 'src/components/Table';
+import { TableBody } from 'src/components/TableBody';
+import { PARENT_USER } from 'src/features/Account/constants';
+import { useAccountUsers } from 'src/queries/account/users';
+
+import { UsersLandingProxyTableHead } from './UsersLandingProxyTableHead';
+import { UsersLandingTableBody } from './UsersLandingTableBody';
+
+import type { Order } from './UsersLandingTableHead';
+
+interface Props {
+  handleDelete: (username: string) => void;
+  isProxyUser: boolean;
+  isRestrictedUser: boolean | undefined;
+  order: Order;
+}
+
+export const ProxyUserTable = ({
+  handleDelete,
+  isProxyUser,
+  isRestrictedUser,
+  order,
+}: Props) => {
+  const {
+    data: proxyUser,
+    error: proxyUserError,
+    isLoading: isLoadingProxyUser,
+  } = useAccountUsers({
+    enabled: isProxyUser && !isRestrictedUser,
+    filters: { user_type: 'proxy' },
+  });
+
+  const proxyNumCols = 3;
+
+  return (
+    <>
+      <Typography
+        sx={(theme) => ({
+          marginBottom: theme.spacing(2),
+          marginTop: theme.spacing(3),
+          textTransform: 'capitalize',
+          [theme.breakpoints.down('md')]: {
+            marginLeft: theme.spacing(1),
+          },
+        })}
+        variant="h3"
+      >
+        {PARENT_USER} Settings
+      </Typography>
+
+      <Table aria-label="List of Parent Users">
+        <UsersLandingProxyTableHead order={order} />
+        <TableBody>
+          <UsersLandingTableBody
+            error={proxyUserError}
+            isLoading={isLoadingProxyUser}
+            numCols={proxyNumCols}
+            onDelete={handleDelete}
+            users={proxyUser?.data}
+          />
+        </TableBody>
+      </Table>
+    </>
+  );
+};

--- a/packages/manager/src/features/IAM/Users/UsersTable/Users.tsx
+++ b/packages/manager/src/features/IAM/Users/UsersTable/Users.tsx
@@ -1,7 +1,8 @@
-import { Box, Button, Paper } from '@linode/ui';
+import { getAPIFilterFromQuery } from '@linode/search';
+import { Box, Button, Paper, Typography } from '@linode/ui';
 import { useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { DebouncedSearchTextField } from 'src/components/DebouncedSearchTextField';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
@@ -11,30 +12,53 @@ import { TableBody } from 'src/components/TableBody';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
 import { useAccountUsers } from 'src/queries/account/users';
+import { useProfile } from 'src/queries/profile/profile';
 
+import { UserDeleteConfirmation } from '../../Shared/UserDeleteConfirmation';
+import { CreateUserDrawer } from './CreateUserDrawer';
+import { ProxyUserTable } from './ProxyUserTable';
 import { UsersLandingTableBody } from './UsersLandingTableBody';
 import { UsersLandingTableHead } from './UsersLandingTableHead';
 
 import type { Filter } from '@linode/api-v4';
 
 export const UsersLanding = () => {
+  const [isCreateDrawerOpen, setIsCreateDrawerOpen] = React.useState<boolean>(
+    false
+  );
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
+  const [selectedUsername, setSelectedUsername] = React.useState('');
+
+  const [query, setQuery] = useState<string>();
+
+  const { data: profile } = useProfile();
   const theme = useTheme();
   const pagination = usePagination(1, 'account-users');
   const order = useOrder();
 
+  const isProxyUser =
+    profile?.user_type === 'child' || profile?.user_type === 'proxy';
+
+  const { error: searchError, filter } = getAPIFilterFromQuery(query, {
+    searchableFieldsWithoutOperator: ['username', 'email'],
+  });
+
   const usersFilter: Filter = {
     ['+order']: order.order,
     ['+order_by']: order.orderBy,
+    ...filter,
   };
 
   // Since this query is disabled for restricted users, use isLoading.
-  const { data: users, error, isLoading } = useAccountUsers({
+  const { data: users, error, isFetching, isLoading } = useAccountUsers({
     filters: usersFilter,
     params: {
       page: pagination.page,
       page_size: pagination.pageSize,
     },
   });
+
+  const isRestrictedUser = profile?.restricted;
 
   const isSmDown = useMediaQuery(theme.breakpoints.down('sm'));
   const isLgDown = useMediaQuery(theme.breakpoints.up('lg'));
@@ -44,16 +68,21 @@ export const UsersLanding = () => {
   const numCols = isSmDown ? 2 : numColsLg;
 
   const handleDelete = (username: string) => {
-    // mock
-  };
-
-  const handleSearch = async (value: string) => {
-    // mock
+    setIsDeleteDialogOpen(true);
+    setSelectedUsername(username);
   };
 
   return (
     <React.Fragment>
       <DocumentTitleSegment segment="Users & Grants" />
+      {isProxyUser && (
+        <ProxyUserTable
+          handleDelete={handleDelete}
+          isProxyUser={isProxyUser}
+          isRestrictedUser={isRestrictedUser}
+          order={order}
+        />
+      )}
       <Paper sx={(theme) => ({ marginTop: theme.spacing(2) })}>
         <Box
           sx={(theme) => ({
@@ -63,17 +92,43 @@ export const UsersLanding = () => {
             marginBottom: theme.spacing(2),
           })}
         >
-          <DebouncedSearchTextField
-            clearable
-            debounceTime={250}
-            hideLabel
-            label="Filter"
-            onSearch={handleSearch}
-            placeholder="Filter"
-            sx={{ width: 320 }}
-            value=""
-          />
-          <Button buttonType="primary">Add a User</Button>
+          {isProxyUser ? (
+            <Typography
+              sx={(theme) => ({
+                [theme.breakpoints.down('md')]: {
+                  marginLeft: theme.spacing(1),
+                },
+              })}
+              variant="h3"
+            >
+              User Settings
+            </Typography>
+          ) : (
+            <DebouncedSearchTextField
+              clearable
+              debounceTime={250}
+              errorText={searchError?.message}
+              hideLabel
+              isSearching={isFetching}
+              label="Filter"
+              onSearch={setQuery}
+              placeholder="Filter"
+              sx={{ width: 320 }}
+              value=""
+            />
+          )}
+          <Button
+            tooltipText={
+              isRestrictedUser
+                ? 'You cannot create other users as a restricted user.'
+                : undefined
+            }
+            buttonType="primary"
+            disabled={isRestrictedUser}
+            onClick={() => setIsCreateDrawerOpen(true)}
+          >
+            Add a User
+          </Button>
         </Box>
         <Table aria-label="List of Users">
           <UsersLandingTableHead order={order} />
@@ -83,7 +138,7 @@ export const UsersLanding = () => {
               isLoading={isLoading}
               numCols={numCols}
               onDelete={handleDelete}
-              users={users?.data}
+              users={users?.data ?? []}
             />
           </TableBody>
         </Table>
@@ -96,6 +151,15 @@ export const UsersLanding = () => {
           pageSize={pagination.pageSize}
         />
       </Paper>
+      <CreateUserDrawer
+        onClose={() => setIsCreateDrawerOpen(false)}
+        open={isCreateDrawerOpen}
+      />
+      <UserDeleteConfirmation
+        onClose={() => setIsDeleteDialogOpen(false)}
+        open={isDeleteDialogOpen}
+        username={selectedUsername}
+      />
     </React.Fragment>
   );
 };

--- a/packages/manager/src/features/IAM/Users/UsersTable/UsersLandingProxyTableHead.test.tsx
+++ b/packages/manager/src/features/IAM/Users/UsersTable/UsersLandingProxyTableHead.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { UsersLandingProxyTableHead } from './UsersLandingProxyTableHead';
+
+import type { SortOrder } from './UsersLandingTableHead';
+
+const mockOrder = {
+  handleOrderChange: vi.fn(),
+  order: 'asc' as SortOrder,
+  orderBy: 'username',
+};
+
+describe('UsersLandingProxyTableHead', () => {
+  it('should render Username cell', () => {
+    const { getByText } = renderWithTheme(
+      <UsersLandingProxyTableHead order={mockOrder} />
+    );
+
+    const username = getByText('Username');
+    expect(username).toBeInTheDocument();
+  });
+
+  it('should call handleOrderChange when Username sort cell is clicked', () => {
+    const { getByText } = renderWithTheme(
+      <UsersLandingProxyTableHead order={mockOrder} />
+    );
+
+    const usernameCell = getByText('Username');
+    expect(usernameCell).toBeInTheDocument();
+    fireEvent.click(usernameCell);
+
+    // Expect the handleOrderChange to have been called
+    expect(mockOrder.handleOrderChange).toHaveBeenCalled();
+  });
+
+  it('should render correctly with order props', () => {
+    const { getByText } = renderWithTheme(
+      <UsersLandingProxyTableHead order={mockOrder} />
+    );
+
+    const usernameCell = getByText('Username');
+    expect(usernameCell).toBeInTheDocument();
+
+    expect(usernameCell.closest('span')).toHaveAttribute(
+      'aria-label',
+      'Sort by username'
+    );
+  });
+});

--- a/packages/manager/src/features/IAM/Users/UsersTable/UsersLandingProxyTableHead.tsx
+++ b/packages/manager/src/features/IAM/Users/UsersTable/UsersLandingProxyTableHead.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { Hidden } from 'src/components/Hidden';
+import { TableCell } from 'src/components/TableCell';
+import { TableHead } from 'src/components/TableHead';
+import { TableRow } from 'src/components/TableRow/TableRow';
+import { TableSortCell } from 'src/components/TableSortCell';
+
+import type { Order } from './UsersLandingTableHead';
+
+interface Props {
+  order: Order;
+}
+
+export const UsersLandingProxyTableHead = ({ order }: Props) => {
+  return (
+    <TableHead
+      sx={{
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <TableRow>
+        <TableSortCell
+          active={order.orderBy === 'username'}
+          direction={order.order}
+          handleClick={order.handleOrderChange}
+          label="username"
+        >
+          Username
+        </TableSortCell>
+        <Hidden smDown>
+          <TableSortCell
+            active={order.orderBy === 'email'}
+            direction={order.order}
+            handleClick={order.handleOrderChange}
+            label="email"
+          >
+            Email Address
+          </TableSortCell>
+        </Hidden>
+        <TableCell />
+      </TableRow>
+    </TableHead>
+  );
+};

--- a/packages/manager/src/queries/account/users.ts
+++ b/packages/manager/src/queries/account/users.ts
@@ -1,4 +1,4 @@
-import { deleteUser, updateUser } from '@linode/api-v4';
+import { createUser, deleteUser, updateUser } from '@linode/api-v4';
 import {
   keepPreviousData,
   useMutation,
@@ -119,3 +119,21 @@ function getIsBlocklistedUser(username: string) {
   }
   return false;
 }
+
+export const useCreateUserMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<User, APIError[], Partial<User>>({
+    mutationFn: (data) => createUser(data),
+    onSuccess: (user) => {
+      queryClient.invalidateQueries({
+        queryKey: accountQueries.users._ctx.paginated._def,
+      });
+
+      queryClient.setQueryData(
+        accountQueries.users._ctx.user(user.username).queryKey,
+        user
+      );
+    },
+  });
+};


### PR DESCRIPTION
## Description 📝

IAM RBAC - users table component.
Includes the table for proxy users and the logic for deleting and filtering them, and an adding a new user.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Table for proxy users
- Deleting users
- Adding user

## Target release date 🗓️

1/14/25 (dev)


## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Ensure the Identity and Access Beta flag is enabled in dev tools

### Verification steps

(How to verify changes)

- [ ] Confirm table renders.
- [ ] Confirm adding a new user
- [ ] Confirm deleting an user

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>


