### PR TITLE
fix: [UIE-8228] - Database Resize: text update

### DIFF
--- a/packages/manager/.changeset/pr-11406-changed-1734097478149.md
+++ b/packages/manager/.changeset/pr-11406-changed-1734097478149.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Database Resize: Updated tooltip text, plan selection descriptions, and summary text for new databases ([#11406](https://github.com/linode/manager/pull/11406))

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseSummarySection.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseSummarySection.test.tsx
@@ -4,18 +4,18 @@ import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import { Router } from 'react-router-dom';
 
-import { databaseTypeFactory } from 'src/factories';
+import { databaseFactory, databaseTypeFactory } from 'src/factories';
+import DatabaseCreate from 'src/features/Databases/DatabaseCreate/DatabaseCreate';
+import { DatabaseResize } from 'src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize';
 import { makeResourcePage } from 'src/mocks/serverHandlers';
 import { HttpResponse, http, server } from 'src/mocks/testServer';
 import { mockMatchMedia, renderWithTheme } from 'src/utilities/testHelpers';
-
-import DatabaseCreate from './DatabaseCreate';
 
 const loadingTestId = 'circle-progress';
 
 beforeAll(() => mockMatchMedia());
 
-describe('database node selector', () => {
+describe('database summary section', () => {
   const flags = {
     dbaasV2: {
       beta: false,
@@ -62,6 +62,54 @@ describe('database node selector', () => {
     const summary = getByTestId('currentSummary');
     const selectedPlanText = 'Dedicated 4 GB $60/month';
     expect(summary).toHaveTextContent(selectedPlanText);
+    const selectedNodesText = '3 Nodes - HA $140/month';
+    expect(summary).toHaveTextContent(selectedNodesText);
+  });
+
+  it('should render correct suffix for 1 Node', async () => {
+    const mockDatabase = databaseFactory.build({
+      cluster_size: 3,
+      engine: 'mysql',
+      platform: 'rdbms-default',
+      type: 'g6-nanode-1',
+    });
+    const { getByTestId } = renderWithTheme(
+      <DatabaseResize database={mockDatabase} />,
+      {
+        flags,
+      }
+    );
+    expect(getByTestId(loadingTestId)).toBeInTheDocument();
+    await waitForElementToBeRemoved(getByTestId(loadingTestId));
+
+    const node = getByTestId('database-node-1');
+    await userEvent.click(node);
+
+    const summary = getByTestId('resizeSummary');
+    const selectedNodesText = '1 Node $60/month';
+    expect(summary).toHaveTextContent(selectedNodesText);
+  });
+
+  it('should render correct suffix for 3 Nodes', async () => {
+    const mockDatabase = databaseFactory.build({
+      cluster_size: 1,
+      engine: 'mysql',
+      platform: 'rdbms-default',
+      type: 'g6-nanode-1',
+    });
+    const { getByTestId } = renderWithTheme(
+      <DatabaseResize database={mockDatabase} />,
+      {
+        flags,
+      }
+    );
+    expect(getByTestId(loadingTestId)).toBeInTheDocument();
+    await waitForElementToBeRemoved(getByTestId(loadingTestId));
+
+    const node = getByTestId('database-node-3');
+    await userEvent.click(node);
+
+    const summary = getByTestId('resizeSummary');
     const selectedNodesText = '3 Nodes - HA $140/month';
     expect(summary).toHaveTextContent(selectedNodesText);
   });

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseSummarySection.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseSummarySection.tsx
@@ -65,10 +65,7 @@ export const DatabaseSummarySection = (props: Props) => {
       ) : (
         <span>{currentPlanPrice}</span>
       )}
-      <Typography
-        component="span"
-        // sx={(theme) => ({ marginRight: theme.spacing(1) })}
-      >
+      <Typography component="span">
         {currentClusterSize} Node
         {currentClusterSize > 1 ? 's - HA ' : ' '}
       </Typography>
@@ -77,6 +74,15 @@ export const DatabaseSummarySection = (props: Props) => {
   ) : (
     'Please specify your cluster configuration'
   );
+  const getSuffix = (numberOfNodes: number) => {
+    let suffix = '';
+    if (numberOfNodes > 1) {
+      suffix = isNewDatabase ? 's - HA ' : 's: ';
+    } else {
+      suffix = isNewDatabase ? ' ' : ': ';
+    }
+    return suffix;
+  };
   const resizeSummary = (
     <Box
       sx={(theme: Theme) => ({
@@ -101,8 +107,7 @@ export const DatabaseSummarySection = (props: Props) => {
             component="span"
           >
             {resizeData.numberOfNodes} Node
-            {resizeData.numberOfNodes > 1 ? 's' : ''}
-            {!isNewDatabase ? ': ' : ' - HA '}
+            {getSuffix(resizeData.numberOfNodes)}
           </Typography>
           {resizeData.price}
         </>

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseSummarySection.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseSummarySection.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { StyledPlanSummarySpan } from '../DatabaseDetail/DatabaseResize/DatabaseResize.style';
 import { useIsDatabasesEnabled } from '../utilities';
 import { StyledSpan } from './DatabaseCreate.style';
+import { getSuffix } from './utilities';
 
 import type {
   ClusterSize,
@@ -67,22 +68,14 @@ export const DatabaseSummarySection = (props: Props) => {
       )}
       <Typography component="span">
         {currentClusterSize} Node
-        {currentClusterSize > 1 ? 's - HA ' : ' '}
+        {getSuffix(isNewDatabase, currentClusterSize)}
       </Typography>
       {currentNodePrice}
     </Box>
   ) : (
     'Please specify your cluster configuration'
   );
-  const getSuffix = (numberOfNodes: number) => {
-    let suffix = '';
-    if (numberOfNodes > 1) {
-      suffix = isNewDatabase ? 's - HA ' : 's: ';
-    } else {
-      suffix = isNewDatabase ? ' ' : ': ';
-    }
-    return suffix;
-  };
+
   const resizeSummary = (
     <Box
       sx={(theme: Theme) => ({
@@ -98,16 +91,9 @@ export const DatabaseSummarySection = (props: Props) => {
               : resizeData.plan}
           </StyledPlanSummarySpan>{' '}
           {isNewDatabase && <StyledSpan>{resizeData.basePrice}</StyledSpan>}
-          <Typography
-            sx={
-              isNewDatabase
-                ? (theme) => ({ marginRight: theme.spacing(1) })
-                : null
-            }
-            component="span"
-          >
+          <Typography component="span">
             {resizeData.numberOfNodes} Node
-            {getSuffix(resizeData.numberOfNodes)}
+            {getSuffix(isNewDatabase, resizeData.numberOfNodes)}
           </Typography>
           {resizeData.price}
         </>

--- a/packages/manager/src/features/Databases/DatabaseCreate/utilities.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/utilities.tsx
@@ -81,3 +81,22 @@ export const getEngineOptions = (engines: DatabaseEngine[]) => {
     };
   });
 };
+
+/**
+ * Determines the suffix string for a node based on whether
+ * the database is new and the number of nodes in the configuration.
+ *
+ * @param {boolean} isNewDatabase - Indicates if the database is a new instance.
+ * @param {number} numberOfNodes - The number of nodes.
+ * @returns {string} The suffix string to be appended to the node:
+ *  - If there are multiple nodes, appends 's - HA ' for new databases or 's: ' otherwise.
+ *  - If there is only one node, appends a space for new databases or ': ' otherwise.
+ *
+ */
+export const getSuffix = (isNewDatabase: boolean, numberOfNodes: number) => {
+  if (numberOfNodes > 1) {
+    return isNewDatabase ? 's - HA ' : 's: ';
+  } else {
+    return isNewDatabase ? ' ' : ': ';
+  }
+};

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.tsx
@@ -102,8 +102,9 @@ export const DatabaseResize = ({ database, disabled = false }: Props) => {
     <>
       <Typography variant="h2">Resize a Database Cluster</Typography>
       <Typography sx={{ marginTop: '4px' }}>
-        Adapt the cluster to your needs by resizing to a larger plan. Clusters
-        cannot be resized to smaller plans.
+        {isNewDatabaseGA
+          ? 'Adapt the cluster to your needs by resizing it to a smaller or larger plan.'
+          : 'Adapt the cluster to your needs by resizing to a larger plan. Clusters cannot be resized to smaller plans.'}
       </Typography>
     </>
   );
@@ -298,6 +299,7 @@ export const DatabaseResize = ({ database, disabled = false }: Props) => {
           disabledSmallerPlans={disabledPlans}
           handleTabChange={handleTabChange}
           header="Choose a Plan"
+          isLegacyDatabase={!isNewDatabaseGA}
           onSelect={(selected: string) => setSelectedPlanId(selected)}
           selectedId={selectedPlanId}
           tabDisabledMessage="Resizing a 2-node cluster is only allowed with Dedicated plans."

--- a/packages/manager/src/features/Databases/DatabaseEngineVersion.tsx
+++ b/packages/manager/src/features/Databases/DatabaseEngineVersion.tsx
@@ -45,10 +45,12 @@ export const DatabaseEngineVersion = (props: Props) => {
       {isDefaultGA && hasUpdates && (
         <StyledLink
           data-testid="maintenance-link"
+          sx={{ verticalAlign: 'bottom' }}
           to={`/databases/${engine}/${databaseID}/settings`}
         >
           <StatusIcon
             ariaLabel="Maintenance update"
+            component="span"
             pulse={false}
             status="other"
           />

--- a/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanSelection.tsx
@@ -59,6 +59,7 @@ export const PlanSelection = (props: PlanSelectionProps) => {
     planBelongsToDisabledClass,
     planHasLimitedAvailability,
     planIsDisabled512Gb,
+    planIsSmallerThanUsage,
     planIsTooSmall,
   } = plan;
 
@@ -83,6 +84,7 @@ export const PlanSelection = (props: PlanSelectionProps) => {
   const rowIsDisabled =
     (!isDatabaseFlow && isSamePlan) ||
     planIsTooSmall ||
+    planIsSmallerThanUsage ||
     planBelongsToDisabledClass ||
     planIsDisabled512Gb ||
     planHasLimitedAvailability ||
@@ -92,6 +94,7 @@ export const PlanSelection = (props: PlanSelectionProps) => {
     planBelongsToDisabledClass,
     planHasLimitedAvailability,
     planIsDisabled512Gb,
+    planIsSmallerThanUsage,
     planIsTooSmall,
     wholePanelIsDisabled,
   });
@@ -106,7 +109,8 @@ export const PlanSelection = (props: PlanSelectionProps) => {
     (planBelongsToDisabledClass ||
       planIsDisabled512Gb ||
       planHasLimitedAvailability ||
-      planIsTooSmall);
+      planIsTooSmall ||
+      planIsSmallerThanUsage);
 
   const isDistributedPlan =
     plan.id.includes('dedicated-edge') || plan.id.includes('nanode-edge');

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -40,6 +40,7 @@ export interface PlansPanelProps {
   handleTabChange?: (index: number) => void;
   header?: string;
   isCreate?: boolean;
+  isLegacyDatabase?: boolean;
   linodeID?: number | undefined;
   onSelect: (key: string) => void;
   regionsData?: Region[];
@@ -72,6 +73,7 @@ export const PlansPanel = (props: PlansPanelProps) => {
     handleTabChange,
     header,
     isCreate,
+    isLegacyDatabase,
     linodeID,
     onSelect,
     regionsData,
@@ -150,6 +152,7 @@ export const PlansPanel = (props: PlansPanelProps) => {
         disableLargestGbPlansFlag: flags.disableLargestGbPlans,
         disabledClasses,
         disabledSmallerPlans,
+        isLegacyDatabase,
         plans: plansMap,
         regionAvailabilities,
         selectedRegionId: selectedRegionID,

--- a/packages/manager/src/features/components/PlansPanel/constants.ts
+++ b/packages/manager/src/features/components/PlansPanel/constants.ts
@@ -4,6 +4,8 @@ export const LIMITED_AVAILABILITY_COPY =
   'This plan has limited deployment availability.';
 export const SMALLER_PLAN_DISABLED_COPY =
   'Resizing to smaller plans is not supported.';
+export const PLAN_IS_SMALLER_THAN_USAGE_COPY =
+  'The usage storage in this plan is smaller than your current usage.';
 export const PLAN_NOT_AVAILABLE_IN_REGION_COPY =
   "This plan isn't available for the selected region.";
 export const PLAN_IS_CURRENTLY_UNAVAILABLE_COPY =

--- a/packages/manager/src/features/components/PlansPanel/types.ts
+++ b/packages/manager/src/features/components/PlansPanel/types.ts
@@ -32,6 +32,7 @@ export interface PlanSelectionAvailabilityTypes {
   planBelongsToDisabledClass: boolean;
   planHasLimitedAvailability: boolean;
   planIsDisabled512Gb: boolean;
+  planIsSmallerThanUsage?: boolean;
   planIsTooSmall: boolean;
   planIsTooSmallForAPL?: boolean;
 }

--- a/packages/manager/src/features/components/PlansPanel/utils.test.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.test.ts
@@ -285,6 +285,8 @@ describe('extractPlansInformation', () => {
           planBelongsToDisabledClass: false,
           planHasLimitedAvailability: true,
           planIsDisabled512Gb: false,
+          planIsSmallerThanUsage: false,
+          planIsTooSmallForAPL: undefined,
         },
       },
     ]);
@@ -296,18 +298,24 @@ describe('extractPlansInformation', () => {
         planBelongsToDisabledClass: false,
         planHasLimitedAvailability: true,
         planIsDisabled512Gb: false,
+        planIsSmallerThanUsage: false,
+        planIsTooSmallForAPL: undefined,
       },
       {
         ...g7Standard1,
         planBelongsToDisabledClass: false,
         planHasLimitedAvailability: false,
         planIsDisabled512Gb: false,
+        planIsSmallerThanUsage: false,
+        planIsTooSmallForAPL: undefined,
       },
       {
         ...g6Nanode1,
         planBelongsToDisabledClass: false,
         planHasLimitedAvailability: false,
         planIsDisabled512Gb: false,
+        planIsSmallerThanUsage: false,
+        planIsTooSmallForAPL: undefined,
       },
     ]);
   });
@@ -316,6 +324,7 @@ describe('extractPlansInformation', () => {
     const result = extractPlansInformation({
       disableLargestGbPlansFlag: false,
       disabledSmallerPlans: [g7Standard1],
+      isLegacyDatabase: true,
       plans: [g6Standard1, g6Nanode1, g7Standard1],
       regionAvailabilities: [
         regionAvailabilityFactory.build({
@@ -344,7 +353,9 @@ describe('extractPlansInformation', () => {
           planBelongsToDisabledClass: false,
           planHasLimitedAvailability: true,
           planIsDisabled512Gb: false,
+          planIsSmallerThanUsage: false,
           planIsTooSmall: false,
+          planIsTooSmallForAPL: undefined,
         },
       },
       {
@@ -353,7 +364,9 @@ describe('extractPlansInformation', () => {
           planBelongsToDisabledClass: false,
           planHasLimitedAvailability: true,
           planIsDisabled512Gb: false,
+          planIsSmallerThanUsage: false,
           planIsTooSmall: false,
+          planIsTooSmallForAPL: undefined,
         },
       },
       {
@@ -362,7 +375,9 @@ describe('extractPlansInformation', () => {
           planBelongsToDisabledClass: false,
           planHasLimitedAvailability: false,
           planIsDisabled512Gb: false,
+          planIsSmallerThanUsage: false,
           planIsTooSmall: true,
+          planIsTooSmallForAPL: undefined,
         },
       },
     ]);
@@ -375,7 +390,9 @@ describe('extractPlansInformation', () => {
           planBelongsToDisabledClass: false,
           planHasLimitedAvailability: true,
           planIsDisabled512Gb: false,
+          planIsSmallerThanUsage: false,
           planIsTooSmall: false,
+          planIsTooSmallForAPL: undefined,
         },
       },
       {
@@ -384,7 +401,9 @@ describe('extractPlansInformation', () => {
           planBelongsToDisabledClass: false,
           planHasLimitedAvailability: true,
           planIsDisabled512Gb: false,
+          planIsSmallerThanUsage: false,
           planIsTooSmall: false,
+          planIsTooSmallForAPL: undefined,
         },
       },
       {
@@ -393,7 +412,9 @@ describe('extractPlansInformation', () => {
           planBelongsToDisabledClass: false,
           planHasLimitedAvailability: false,
           planIsDisabled512Gb: false,
+          planIsSmallerThanUsage: false,
           planIsTooSmall: true,
+          planIsTooSmallForAPL: undefined,
         },
       },
     ]);
@@ -428,14 +449,18 @@ describe('extractPlansInformation', () => {
         planBelongsToDisabledClass: false,
         planHasLimitedAvailability: false,
         planIsDisabled512Gb: false,
+        planIsSmallerThanUsage: false,
         planIsTooSmall: false,
+        planIsTooSmallForAPL: undefined,
       },
       {
         ...g6Nanode1,
         planBelongsToDisabledClass: false,
         planHasLimitedAvailability: false,
         planIsDisabled512Gb: false,
+        planIsSmallerThanUsage: false,
         planIsTooSmall: false,
+        planIsTooSmallForAPL: undefined,
       },
     ]);
   });

--- a/packages/manager/src/features/components/PlansPanel/utils.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.ts
@@ -7,6 +7,7 @@ import {
   DEDICATED_512_GB_PLAN,
   LIMITED_AVAILABILITY_COPY,
   PLAN_IS_CURRENTLY_UNAVAILABLE_COPY,
+  PLAN_IS_SMALLER_THAN_USAGE_COPY,
   PLAN_IS_TOO_SMALL_FOR_APL_COPY,
   PLAN_NOT_AVAILABLE_IN_REGION_COPY,
   PREMIUM_512_GB_PLAN,
@@ -290,6 +291,7 @@ interface ExtractPlansInformationProps {
   disabledClasses?: LinodeTypeClass[];
   disabledSmallerPlans?: PlanSelectionType[];
   isAPLEnabled?: boolean;
+  isLegacyDatabase?: boolean;
   plans: PlanSelectionType[];
   regionAvailabilities: RegionAvailability[] | undefined;
   selectedRegionId: Region['id'] | undefined;
@@ -312,6 +314,7 @@ export const extractPlansInformation = ({
   disabledClasses,
   disabledSmallerPlans,
   isAPLEnabled,
+  isLegacyDatabase,
   plans,
   regionAvailabilities,
   selectedRegionId,
@@ -331,11 +334,16 @@ export const extractPlansInformation = ({
       const planBelongsToDisabledClass = Boolean(
         disabledClasses?.includes(plan.class)
       );
-      const planIsTooSmall = Boolean(
+      const disabledPlans = Boolean(
         disabledSmallerPlans?.find(
           (disabledPlan) => disabledPlan.id === plan.id
         )
       );
+      const planIsTooSmall = Boolean(isLegacyDatabase && disabledPlans);
+      const planIsSmallerThanUsage = Boolean(
+        !isLegacyDatabase && disabledPlans
+      );
+
       const planIsTooSmallForAPL =
         isAPLEnabled && Boolean(plan.memory < 8000 || plan.vcpus < 4);
 
@@ -344,6 +352,7 @@ export const extractPlansInformation = ({
         planBelongsToDisabledClass,
         planHasLimitedAvailability,
         planIsDisabled512Gb,
+        planIsSmallerThanUsage,
         planIsTooSmall,
         planIsTooSmallForAPL,
       };
@@ -355,6 +364,7 @@ export const extractPlansInformation = ({
       planBelongsToDisabledClass,
       planHasLimitedAvailability,
       planIsDisabled512Gb,
+      planIsSmallerThanUsage,
       planIsTooSmall,
       planIsTooSmallForAPL,
     } = plan;
@@ -368,6 +378,7 @@ export const extractPlansInformation = ({
       planHasLimitedAvailability ||
       planIsDisabled512Gb ||
       planIsTooSmall ||
+      planIsSmallerThanUsage ||
       planIsTooSmallForAPL
     ) {
       return [...acc, plan];
@@ -395,6 +406,7 @@ export const getDisabledPlanReasonCopy = ({
   planBelongsToDisabledClass,
   planHasLimitedAvailability,
   planIsDisabled512Gb,
+  planIsSmallerThanUsage,
   planIsTooSmall,
   planIsTooSmallForAPL,
   wholePanelIsDisabled,
@@ -402,6 +414,7 @@ export const getDisabledPlanReasonCopy = ({
   planBelongsToDisabledClass: DisabledTooltipReasons['planBelongsToDisabledClass'];
   planHasLimitedAvailability: DisabledTooltipReasons['planHasLimitedAvailability'];
   planIsDisabled512Gb: DisabledTooltipReasons['planIsDisabled512Gb'];
+  planIsSmallerThanUsage?: DisabledTooltipReasons['planIsSmallerThanUsage'];
   planIsTooSmall: DisabledTooltipReasons['planIsTooSmall'];
   planIsTooSmallForAPL?: DisabledTooltipReasons['planIsTooSmallForAPL'];
   wholePanelIsDisabled?: DisabledTooltipReasons['wholePanelIsDisabled'];
@@ -416,6 +429,8 @@ export const getDisabledPlanReasonCopy = ({
 
   if (planIsTooSmall) {
     return SMALLER_PLAN_DISABLED_COPY;
+  } else if (planIsSmallerThanUsage) {
+    return PLAN_IS_SMALLER_THAN_USAGE_COPY;
   }
 
   if (planIsTooSmallForAPL) {


### PR DESCRIPTION
## Description 📝

Database Resize: Disabled plan tooltip updated for new databases, and updated plan selection descriptions.

## Changes  🔄

- Database Resize: Updated disabled plan tooltip for new database
- Database Resize: Updated plan selection descriptions for new database
- Database Resize > Summary Section : Updated text

## Target release date 🗓️

01/14/2025

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-12-12 at 3 03 27 PM](https://github.com/user-attachments/assets/33c35aa4-f385-4960-b288-253a40fc39d4) | ![Screenshot 2024-12-12 at 3 02 56 PM](https://github.com/user-attachments/assets/ab41b545-a550-49f3-8b2c-10084a990a77) |
| ![Screenshot 2024-12-12 at 3 04 03 PM](https://github.com/user-attachments/assets/5d2720f4-18a9-4d1a-9d0b-70b59c36106a) | ![Screenshot 2024-12-12 at 3 03 55 PM](https://github.com/user-attachments/assets/9931249a-660e-4cd4-a337-3085befb0f36) |
| ![Screenshot 2024-12-12 at 3 05 33 PM](https://github.com/user-attachments/assets/c794474e-aa28-485c-a34f-3516f76cafb8) | ![Screenshot 2024-12-12 at 3 05 39 PM](https://github.com/user-attachments/assets/cfe1e37a-b77c-4146-9fae-7a92ff56d887) |

## How to test 🧪

### Prerequisites

- dbaasV2 feature flag set to GA

### Verification steps

(How to verify changes)

- Choose a new database
- Navigate to the Database Resize tab
- Description in the Current Summary section is updated
- Scroll down to the Plan Selection table
- Hover over the tooltip for a disabled plan and confirm the text is updated
- Scroll down to the Summary section and check that the text for nodes is updated

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>