### PR TITLE
M3-8974: Fix account login tests when using non-Prod login environment

### DIFF
--- a/packages/manager/.changeset/pr-11407-tests-1734013914322.md
+++ b/packages/manager/.changeset/pr-11407-tests-1734013914322.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix account login and logout tests when using non-Prod environment ([#11407](https://github.com/linode/manager/pull/11407))

--- a/packages/manager/cypress/e2e/core/account/account-logout.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/account-logout.spec.ts
@@ -1,4 +1,4 @@
-import { LOGIN_ROOT } from 'src/constants';
+import { loginBaseUrl } from 'support/constants/login';
 import { interceptGetAccount } from 'support/intercepts/account';
 import { ui } from 'support/ui';
 
@@ -26,9 +26,9 @@ describe('Logout Test', () => {
         cy.findByText('Log Out').should('be.visible').click();
       });
     // Upon clicking "Log Out", the user is redirected to the login endpoint at <REACT_APP_LOGIN_ROOT>/login
-    cy.url().should('equal', `${LOGIN_ROOT}/login`);
+    cy.url().should('equal', `${loginBaseUrl}/login`);
     // Using cy.visit to navigate back to Cloud results in another redirect to the login page
     cy.visit('/');
-    cy.url().should('startWith', `${LOGIN_ROOT}/login`);
+    cy.url().should('startWith', `${loginBaseUrl}/login`);
   });
 });

--- a/packages/manager/cypress/e2e/core/general/account-login-redirect.spec.ts
+++ b/packages/manager/cypress/e2e/core/general/account-login-redirect.spec.ts
@@ -1,5 +1,5 @@
 import { mockApiRequestWithError } from 'support/intercepts/general';
-import { LOGIN_ROOT } from 'src/constants';
+import { loginBaseUrl } from 'support/constants/login';
 
 describe('account login redirect', () => {
   /**
@@ -14,7 +14,7 @@ describe('account login redirect', () => {
 
     cy.visitWithLogin('/linodes/create');
 
-    cy.url().should('contain', `${LOGIN_ROOT}/login?`, { exact: false });
+    cy.url().should('contain', `${loginBaseUrl}/login?`, { exact: false });
     cy.findByText('Please log in to continue.').should('be.visible');
   });
 

--- a/packages/manager/cypress/support/constants/login.ts
+++ b/packages/manager/cypress/support/constants/login.ts
@@ -1,0 +1,8 @@
+/**
+ * Constants related to Cloud Manager login/logout flows.
+ */
+
+/**
+ * Login base URL for Cloud Manager.
+ */
+export const loginBaseUrl = Cypress.env('REACT_APP_LOGIN_ROOT');


### PR DESCRIPTION
## Description 📝

This fixes test failures in two of our login related Cypress tests when the tests are run against a non-Prod environment. The issue is caused by importing the `LOGIN_ROOT` constant from `src`. Because that value gets set using the Vite-specific `meta.env` object, when imported from Cypress it always falls back to the default value.

This is necessary for running the Cloud Manager tests during the API release.

## Changes  🔄

- Get login environment using `REACT_APP_LOGIN_ROOT` environment variable directly

## Target release date 🗓️

1/14/2025

## How to test 🧪


Update your `.env` file so that `REACT_APP_API_ROOT` and `REACT_APP_LOGIN_ROOT` are pointing to the staging environment. Then run the tests using this command:

```bash
CYPRESS_BASE_URL="<staging env URL here>" yarn cy:run -s "cypress/e2e/core/account/account-logout.spec.ts,cypress/e2e/core/general/account-login-redirect.spec.ts"
```

Confirm that the tests pass. You can refer to the comment on M3-8974 for the staging URLs if needed.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
