### PR TITLE
test: [M3-8979] - Fix lke-create test by using a different mock region

### DIFF
--- a/packages/manager/.changeset/pr-11411-tests-1734023093705.md
+++ b/packages/manager/.changeset/pr-11411-tests-1734023093705.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Update mock region for LKE cluster creation test ([#11411](https://github.com/linode/manager/pull/11411))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -484,7 +484,8 @@ describe('LKE Cluster Creation with DC-specific pricing', () => {
    * - Confirms that HA helper text updates dynamically to display pricing when a region is selected.
    */
   it('can dynamically update prices when creating an LKE cluster based on region', () => {
-    const dcSpecificPricingRegion = getRegionById('us-east');
+    // In staging API, only the Dallas region is available for LKE creation
+    const dcSpecificPricingRegion = getRegionById('us-central');
     const clusterLabel = randomLabel();
     const clusterPlans = new Array(2)
       .fill(null)


### PR DESCRIPTION
## Description 📝
The "can dynamically update prices when creating an LKE cluster based on region" test in lke-create.spec.ts fails when running against the staging API because only the Dallas region is available for LKE creation but the test assumes Newark is present. Fix the test by using a different mock region.

## Changes  🔄
List any change(s) relevant to the reviewer.

- Update mock region to Dallas

## How to test 🧪
To reproduce the issue locally you’ll want to set your REACT_APP_API_ROOT var in .env to the staging URL. You might also have to set REACT_APP_LOGIN_ROOT to the login staging URL, then run the following command
```
yarn cy:run -s "cypress/e2e/core/kubernetes/lke-create.spec.ts"
```

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules
