### PR TITLE
change: [M3-8928] - Switch from v4beta to v4 `account` endpoint for LKE-E

### DIFF
--- a/packages/api-v4/.changeset/pr-11413-removed-1734030444142.md
+++ b/packages/api-v4/.changeset/pr-11413-removed-1734030444142.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Removed
+---
+
+getAccountInfoBeta endpoint ([#11413](https://github.com/linode/manager/pull/11413))

--- a/packages/api-v4/src/account/account.ts
+++ b/packages/api-v4/src/account/account.ts
@@ -36,18 +36,6 @@ export const getAccountInfo = () => {
 };
 
 /**
- * getAccountInfoBeta
- *
- * Return beta endpoint account information,
- * including contact and billing info.
- *
- * @TODO LKE-E - M3-8838: Clean up after released to GA, if not otherwise in use
- */
-export const getAccountInfoBeta = () => {
-  return Request<Account>(setURL(`${BETA_API_ROOT}/account`), setMethod('GET'));
-};
-
-/**
  * getNetworkUtilization
  *
  * Return your current network transfer quota and usage.

--- a/packages/manager/.changeset/pr-11413-upcoming-features-1734030483336.md
+++ b/packages/manager/.changeset/pr-11413-upcoming-features-1734030483336.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Switch from v4beta to v4 account endpoint for LKE-E ([#11413](https://github.com/linode/manager/pull/11413))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -1158,7 +1158,13 @@ describe('LKE Cluster Creation with LKE-E', () => {
     });
 
     it('disables the Cluster Type selection without the LKE-E account capability', () => {
+      mockGetAccount(
+        accountFactory.build({
+          capabilities: [],
+        })
+      ).as('getAccount');
       cy.visitWithLogin('/kubernetes/clusters');
+      cy.wait(['@getAccount']);
 
       ui.button
         .findByTitle('Create Cluster')

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTypePanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTypePanel.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { DocsLink } from 'src/components/DocsLink/DocsLink';
 import { SelectionCard } from 'src/components/SelectionCard/SelectionCard';
-import { useAccountBeta } from 'src/queries/account/account';
+import { useAccount } from 'src/queries/account/account';
 
 import { StyledDocsLinkContainer } from './CreateCluster.styles';
 
@@ -19,7 +19,7 @@ interface Props {
 export const ClusterTypePanel = (props: Props) => {
   const { handleClusterTypeSelection, selectedTier } = props;
 
-  const { data: account } = useAccountBeta();
+  const { data: account } = useAccount();
 
   const mdDownBreakpoint = useMediaQuery((theme: Theme) =>
     theme.breakpoints.down('md')

--- a/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
@@ -16,7 +16,7 @@ import {
 } from './kubeUtils';
 
 const queryMocks = vi.hoisted(() => ({
-  useAccountBeta: vi.fn().mockReturnValue({}),
+  useAccount: vi.fn().mockReturnValue({}),
   useAccountBetaQuery: vi.fn().mockReturnValue({}),
   useFlags: vi.fn().mockReturnValue({}),
 }));
@@ -25,7 +25,7 @@ vi.mock('src/queries/account/account', () => {
   const actual = vi.importActual('src/queries/account/account');
   return {
     ...actual,
-    useAccountBeta: queryMocks.useAccountBeta,
+    useAccount: queryMocks.useAccount,
   };
 });
 
@@ -165,7 +165,7 @@ describe('helper functions', () => {
 
 describe('useIsLkeEnterpriseEnabled', () => {
   it('returns false for feature enablement if the account does not have the capability', () => {
-    queryMocks.useAccountBeta.mockReturnValue({
+    queryMocks.useAccount.mockReturnValue({
       data: {
         capabilities: [],
       },
@@ -188,7 +188,7 @@ describe('useIsLkeEnterpriseEnabled', () => {
   });
 
   it('returns true for LA feature enablement if the account has the capability + enabled LA feature flag values', () => {
-    queryMocks.useAccountBeta.mockReturnValue({
+    queryMocks.useAccount.mockReturnValue({
       data: {
         capabilities: ['Kubernetes Enterprise'],
       },
@@ -211,7 +211,7 @@ describe('useIsLkeEnterpriseEnabled', () => {
   });
 
   it('returns true for GA feature enablement if the account has the capability + enabled GA feature flag values', () => {
-    queryMocks.useAccountBeta.mockReturnValue({
+    queryMocks.useAccount.mockReturnValue({
       data: {
         capabilities: ['Kubernetes Enterprise'],
       },

--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -1,5 +1,5 @@
 import { useFlags } from 'src/hooks/useFlags';
-import { useAccountBeta } from 'src/queries/account/account';
+import { useAccount } from 'src/queries/account/account';
 import { useAccountBetaQuery } from 'src/queries/account/betas';
 import { isFeatureEnabledV2 } from 'src/utilities/accountCapabilities';
 import { getBetaStatus } from 'src/utilities/betaUtils';
@@ -195,7 +195,7 @@ export const getLatestVersion = (
  */
 export const useIsLkeEnterpriseEnabled = () => {
   const flags = useFlags();
-  const { data: account } = useAccountBeta();
+  const { data: account } = useAccount();
 
   const isLkeEnterpriseLAFlagEnabled = Boolean(
     flags?.lkeEnterprise?.enabled && flags.lkeEnterprise.la

--- a/packages/manager/src/queries/account/account.ts
+++ b/packages/manager/src/queries/account/account.ts
@@ -11,7 +11,6 @@ import {
 import { useSnackbar } from 'notistack';
 
 import { useIsTaxIdEnabled } from 'src/features/Account/utils';
-import { useFlags } from 'src/hooks/useFlags';
 import { useGrants, useProfile } from 'src/queries/profile/profile';
 
 import { queryPresets } from '../base';
@@ -34,21 +33,6 @@ export const useAccount = () => {
     ...queryPresets.oneTimeFetch,
     ...queryPresets.noRetry,
     enabled: !profile?.restricted,
-  });
-};
-
-/**
- * @TODO LKE-E - M3-8838: Clean up after released to GA, if not otherwise in use
- */
-export const useAccountBeta = () => {
-  const { data: profile } = useProfile();
-  const flags = useFlags();
-
-  return useQuery<Account, APIError[]>({
-    ...accountQueries.accountBeta,
-    ...queryPresets.oneTimeFetch,
-    ...queryPresets.noRetry,
-    enabled: !profile?.restricted && flags.lkeEnterprise?.enabled,
   });
 };
 

--- a/packages/manager/src/queries/account/queries.ts
+++ b/packages/manager/src/queries/account/queries.ts
@@ -3,7 +3,6 @@ import {
   getAccountBeta,
   getAccountBetas,
   getAccountInfo,
-  getAccountInfoBeta,
   getAccountLogins,
   getAccountMaintenance,
   getAccountSettings,
@@ -31,13 +30,6 @@ import type { Filter, Params, RequestOptions } from '@linode/api-v4';
 export const accountQueries = createQueryKeys('account', {
   account: {
     queryFn: getAccountInfo,
-    queryKey: null,
-  },
-  /**
-   * @TODO LKE-E - M3-8838: Clean up after released to GA, if not otherwise in use
-   */
-  accountBeta: {
-    queryFn: getAccountInfoBeta,
     queryKey: null,
   },
   agreements: {


### PR DESCRIPTION
## Description 📝

The LKE team has updated the /v4 endpoint to include the `Kubernetes Enterprise` capability, so we no longer have to use a seperate /v4beta account endpoint. This PR does the clean up to just use `/v4/account`.

## Changes  🔄

- Removed the request and query for /v4beta/account
- Fixed a test issue where running tests locally with the LKE-E customer tag on your account would fail for the test that is supposed to *not* have the account capability -- the account endpoint was not being mocked.

## Preview 📷
![Screenshot 2024-12-12 at 10 56 25 AM](https://github.com/user-attachments/assets/e107ca9d-0260-4621-bd3f-b5172a564b8f)
![Screenshot 2024-12-12 at 10 57 00 AM](https://github.com/user-attachments/assets/11a70b00-a6ac-496a-9e26-348eaec6d6c6)

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have the LKE-E customer tag on your account.
- Ensure the LKE-E feature flag is turned on in dev tools locally.

### Verification steps

(How to verify changes)

- [ ] Check out the PR.
- [ ] Check the `account` endpoint in the browser console or RQ dev tools. Observe that the `Kubernetes Enterprise` capability is returned from the /v4 endpoint.
- [ ] Go to the LKE Create Cluster page and confirm that the cluster type section renders for LKE-E.
- [ ] Confirm test passes locally:
```
yarn cy:run -s "cypress/e2e/core/kubernetes/lke-create.spec.ts"
```

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
