### PR TITLE
fix: [UIE-8338] dbaas IP validation should display updated error message that includes IPV6

### DIFF
--- a/packages/manager/.changeset/pr-11414-fixed-1734041664478.md
+++ b/packages/manager/.changeset/pr-11414-fixed-1734041664478.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+DBaaS Manage Access IP fields are displaying an IPv4 validation error message when both IPv6 and IPv4 are available. ([#11414](https://github.com/linode/manager/pull/11414))

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -51,6 +51,10 @@ import type { APIError } from '@linode/api-v4/lib/types';
 import type { PlanSelectionWithDatabaseType } from 'src/features/components/PlansPanel/types';
 import type { DatabaseCreateValues } from 'src/features/Databases/DatabaseCreate/DatabaseClusterData';
 import type { ExtendedIP } from 'src/utilities/ipUtils';
+import {
+  ACCESS_CONTROLS_IP_VALIDATION_ERROR_TEXT,
+  ACCESS_CONTROLS_IP_VALIDATION_ERROR_TEXT_LEGACY,
+} from '../constants';
 
 const DatabaseCreate = () => {
   const history = useHistory();
@@ -97,7 +101,9 @@ const DatabaseCreate = () => {
   const handleIPValidation = () => {
     const validatedIps = validateIPs(values.allow_list, {
       allowEmptyAddress: true,
-      errorMessage: 'Must be a valid IPv4 address',
+      errorMessage: isDatabasesV2GA
+        ? ACCESS_CONTROLS_IP_VALIDATION_ERROR_TEXT
+        : ACCESS_CONTROLS_IP_VALIDATION_ERROR_TEXT_LEGACY,
     });
 
     if (validatedIps.some((ip) => ip.error)) {

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -10,6 +10,8 @@ import { MultipleIPInput } from 'src/components/MultipleIPInput/MultipleIPInput'
 import {
   ACCESS_CONTROLS_DRAWER_TEXT,
   ACCESS_CONTROLS_DRAWER_TEXT_LEGACY,
+  ACCESS_CONTROLS_IP_VALIDATION_ERROR_TEXT,
+  ACCESS_CONTROLS_IP_VALIDATION_ERROR_TEXT_LEGACY,
   LEARN_MORE_LINK,
   LEARN_MORE_LINK_LEGACY,
 } from 'src/features/Databases/constants';
@@ -123,7 +125,9 @@ const AddAccessControlDrawer = (props: CombinedProps) => {
   const onValidate = ({ _allowList }: Values) => {
     const validatedIPs = validateIPs(_allowList, {
       allowEmptyAddress: false,
-      errorMessage: 'Must be a valid IPv4 address.',
+      errorMessage: isDefaultDB
+        ? ACCESS_CONTROLS_IP_VALIDATION_ERROR_TEXT
+        : ACCESS_CONTROLS_IP_VALIDATION_ERROR_TEXT_LEGACY,
     });
 
     setValues({ _allowList: validatedIPs });

--- a/packages/manager/src/features/Databases/constants.ts
+++ b/packages/manager/src/features/Databases/constants.ts
@@ -11,6 +11,12 @@ export const ACCESS_CONTROLS_IN_SETTINGS_TEXT =
 export const ACCESS_CONTROLS_IN_SETTINGS_TEXT_LEGACY =
   'Add or remove IPv4 addresses or ranges that should be authorized to access your cluster.';
 
+export const ACCESS_CONTROLS_IP_VALIDATION_ERROR_TEXT =
+  'Must be a valid IPv6 or IPv4 address.';
+
+export const ACCESS_CONTROLS_IP_VALIDATION_ERROR_TEXT_LEGACY =
+  'Must be a valid IPv4 address.';
+
 export const SUSPEND_CLUSTER_TEXT = `Suspend the cluster if you don't use it temporarily to prevent being billed for it.`;
 
 export const RESET_ROOT_PASSWORD_TEXT =


### PR DESCRIPTION
## Description 📝

In DBaaS Create and Settings, Manage Access IP fields should display an updated validation error message that includes IPv6 when both IPv6 and IPv4 are available.

## Changes  🔄

-  DBaaS Create and Setting Manage Access IP field validation error messages have been updated to include IPv6 when available.

## Target release date 🗓️
1/14/25

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![db-settings-manage-access-before](https://github.com/user-attachments/assets/1a17115a-a75d-40a5-969e-9d8d3937b9ba) | ![db-settings-manage-access-after](https://github.com/user-attachments/assets/4a667fba-df38-41d3-8adc-4c803049a4a1) |
| ![db-create-before](https://github.com/user-attachments/assets/2ce177b3-7236-4ae3-9cdd-dedb42744ec8) | ![db-create-after](https://github.com/user-attachments/assets/a43efe1f-937e-40a8-863b-349036be304f) |

## How to test 🧪

### Prerequisites

- Have access to Databases tab
- To view changes in DBaaS Create, have dbaasV2 feature flag set to GA
- To view changes in DBaaS Settings Managed access drawer, have a new database cluster available.

### Reproduction steps

- [ ] For DBaaS Create, enter an invalid value into the Manage Access Allowed IP field and see that the error message only mentions requiring a valid IPv4 address even though IPv6 is also accepted.
- [ ] For DBaaS Settings, access Settings for a new database cluster. Then click the Manage Access button to open the drawer. Then enter invalid data and see that the error message only mentions requiring a valid IPv4 address even though IPv6 is also accepted.

### Verification steps

- [ ] Using the reproduction steps above, confirm that when IPv6 is available, the new validation error message is displayed for DBaaS Create and Settings Managed Access fields. "Must be a valid IPv6 or IPv4 address."

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
