### PR TITLE
fix: [M3-8506] - `RegionHelperText` causing console errors

### DIFF
--- a/packages/manager/.changeset/pr-11416-fixed-1734094290557.md
+++ b/packages/manager/.changeset/pr-11416-fixed-1734094290557.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+`RegionHelperText` causing console errors ([#11416](https://github.com/linode/manager/pull/11416))

--- a/packages/manager/src/components/SelectRegionPanel/RegionHelperText.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/RegionHelperText.tsx
@@ -14,8 +14,12 @@ export const RegionHelperText = (props: RegionHelperTextProps) => {
   const { onClick, showCoreHelperText, ...rest } = props;
 
   return (
-    <Box {...rest}>
-      <Typography data-testid="region-select-helper-test" variant="body1">
+    <Box component="span" sx={{ display: 'block' }} {...rest}>
+      <Typography
+        component="span"
+        data-testid="region-select-helper-test"
+        variant="body1"
+      >
         {showCoreHelperText &&
           `Data centers in central locations support a robust set of cloud computing services. `}
         You can use

--- a/packages/manager/src/components/SelectRegionPanel/RegionHelperText.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/RegionHelperText.tsx
@@ -11,10 +11,10 @@ interface RegionHelperTextProps extends BoxProps {
 }
 
 export const RegionHelperText = (props: RegionHelperTextProps) => {
-  const { onClick, showCoreHelperText, ...rest } = props;
+  const { onClick, showCoreHelperText, sx, ...rest } = props;
 
   return (
-    <Box component="span" sx={{ display: 'block' }} {...rest}>
+    <Box {...rest} component="span" sx={{ ...sx, display: 'block' }}>
       <Typography
         component="span"
         data-testid="region-select-helper-test"


### PR DESCRIPTION
## Description 📝
This PR fixes console errors caused due to how `RegionHelperText` component is being used in some places (like in `textFieldProps`, etc) (main reason: block-level elements should not be descendants of inline-level elements)

## Changes  🔄
- Keeping in-line elements descendants of block-level elements 

## Target release date 🗓️
N/A

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-12-13 at 5 57 32 PM](https://github.com/user-attachments/assets/5dcd6a13-3feb-45b3-bf6a-339ee9b20fc5) |  No console errors  |

## How to test 🧪
- Go to Kubernetes/Create Cluster
   - Ensure no console errors
- Go to NodeBalancers/Create
   - Ensure no console errors
- Ensure everything works as expected wherever `RegionHelperText` is used

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>