### PR TITLE
change: [UIE-8194] DBaaS Settings maintenance pending updates tooltip should have accurate tooltip text

### DIFF
--- a/packages/manager/.changeset/pr-11417-changed-1734111263221.md
+++ b/packages/manager/.changeset/pr-11417-changed-1734111263221.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+DBaaS Settings Maintenance field Upgrade Version pending updates tooltip should display accurate text ([#11417](https://github.com/linode/manager/pull/11417))

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsMaintenance.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsMaintenance.tsx
@@ -52,7 +52,9 @@ export const DatabaseSettingsMaintenance = (props: Props) => {
             }}
             text={
               <Typography>
-                Upgrades are disabled while maintenance updates are in progress.
+                Upgrades are disabled due to pending maintenance updates. To
+                enable the upgrade, apply available updates now or wait until
+                the next maintenance window.
               </Typography>
             }
             status="help"


### PR DESCRIPTION
## Description 📝

This pull request is for a small change in the DBaaS Settings maintenance field. It updates the text used for the tooltip that gets displayed next to the Upgrade Version button when the button is disabled due to pending maintenance updates.

## Changes  🔄

- Text is changed to "Upgrades are disabled due to pending maintenance updates. To enable the upgrade, apply available updates now or wait until the next maintenance window."

## Target release date 🗓️

1/14/25

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![maintenance-tooltip-before](https://github.com/user-attachments/assets/12e0970f-98e3-48ed-9e58-8c58fef1984d) | ![maintenance-tooltip-after-2](https://github.com/user-attachments/assets/332a0b31-c01d-4055-a9dd-7354e16ca060) |

## How to test 🧪

### Prerequisites

- Managed Databases
- dbaasV2 feature flag set for GA
- Use mock data so you can view the pending updates state reliably, or have a Default DB created e.g. postgresql 13 with pending updates available

### Verification steps
- [ ] For a new database cluster that has pending updates available. Access that Database Cluster Details and navigate to Settings.
- [ ] View the Maintenance field in Settings and there will be a tooltip visible next to the disabled Upgrade Version button.
- [ ] Hover over this field to view the updated text.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
