### PR TITLE
upcoming: [M3-8841] - Display LKE-E pricing in checkout bar

### DIFF
--- a/packages/api-v4/src/kubernetes/kubernetes.ts
+++ b/packages/api-v4/src/kubernetes/kubernetes.ts
@@ -276,6 +276,18 @@ export const getKubernetesTypes = (params?: Params) =>
   );
 
 /**
+ * getKubernetesTypesBeta
+ *
+ * Returns a paginated list of available Kubernetes types from beta API; used for dynamic pricing.
+ */
+export const getKubernetesTypesBeta = (params?: Params) =>
+  Request<Page<PriceType>>(
+    setURL(`${BETA_API_ROOT}/lke/types`),
+    setMethod('GET'),
+    setParams(params)
+  );
+
+/**
  * getKubernetesClusterControlPlaneACL
  *
  * Return control plane access list about a single Kubernetes cluster

--- a/packages/manager/src/factories/types.ts
+++ b/packages/manager/src/factories/types.ts
@@ -212,6 +212,17 @@ export const lkeHighAvailabilityTypeFactory = Factory.Sync.makeFactory<PriceType
   }
 );
 
+export const lkeEnterpriseTypeFactory = Factory.Sync.makeFactory<PriceType>({
+  id: 'lke-e',
+  label: 'LKE Enterprise',
+  price: {
+    hourly: 0.45,
+    monthly: 300,
+  },
+  region_prices: [],
+  transfer: 0,
+});
+
 export const objectStorageTypeFactory = Factory.Sync.makeFactory<PriceType>({
   id: 'objectstorage',
   label: 'Object Storage',

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTypePanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTypePanel.tsx
@@ -36,7 +36,7 @@ export const ClusterTypePanel = (props: Props) => {
     <Stack>
       <Stack flexDirection={mdDownBreakpoint ? 'column' : 'row'}>
         <Stack>
-          <Typography variant="h3">Cluster Type</Typography>
+          <Typography variant="h3">Cluster Tier</Typography>
           <Typography sx={{ marginTop: 1, maxWidth: 700 }}>
             Choose from a managed solution for smaller deployments or enterprise
             grade clusters with enhanced ingress, networking, and security.

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -103,7 +103,7 @@ export const CreateCluster = () => {
     data: kubernetesHighAvailabilityTypesData,
     isError: isErrorKubernetesTypes,
     isLoading: isLoadingKubernetesTypes,
-  } = useKubernetesTypesQuery();
+  } = useKubernetesTypesQuery(selectedTier === 'enterprise');
 
   const handleClusterTypeSelection = (tier: KubernetesTier) => {
     setSelectedTier(tier);

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -113,6 +113,10 @@ export const CreateCluster = () => {
     (type) => type.id === 'lke-ha'
   );
 
+  const lkeEnterpriseType = kubernetesHighAvailabilityTypesData?.find(
+    (type) => type.id === 'lke-e'
+  );
+
   const {
     data: allTypes,
     error: typesError,
@@ -498,6 +502,7 @@ export const CreateCluster = () => {
           region={selectedRegionId}
           regionsData={regionsData}
           removePool={removePool}
+          enterprisePrice={lkeEnterpriseType?.price.monthly ?? undefined}
           showHighAvailability={showHighAvailability}
           submitting={submitting}
           toggleHasAgreed={toggleHasAgreed}

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
@@ -128,4 +128,27 @@ describe('KubeCheckoutBar', () => {
     await findByText(/\$183\.00/);
     getByText(/\$--.--\/month/);
   });
+
+  it('should display the total price of the cluster with LKE Enterprise', async () => {
+    const { findByText } = renderWithTheme(
+      <KubeCheckoutBar {...props} enterprisePrice={300} />
+    );
+
+    // 5 node pools * 3 linodes per pool * 10 per linode + 300 per month for enterprise (HA included)
+    await findByText(/\$450\.00/);
+  });
+
+  it('should ignore standard HA pricing for LKE Enterprise', async () => {
+    const { findByText } = renderWithTheme(
+      <KubeCheckoutBar
+        {...props}
+        enterprisePrice={300}
+        highAvailability
+        highAvailabilityPrice="60"
+      />
+    );
+
+    // 5 node pools * 3 linodes per pool * 10 per linode + 300 per month for enterprise (HA included)
+    await findByText(/\$450\.00/);
+  });
 });

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -81,7 +81,7 @@ export const KubeCheckoutBar = (props: Props) => {
     highAvailabilityPrice !== undefined;
 
   const disableCheckout = Boolean(
-    needsAPool || gdprConditions || haConditions || !region
+    needsAPool || gdprConditions || haConditions && !enterprisePrice || !region
   );
 
   if (isLoading) {

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -117,6 +117,25 @@ export const KubeCheckoutBar = (props: Props) => {
       submitText="Create Cluster"
     >
       <>
+        {region && highAvailability && !enterprisePrice && (
+          <StyledBox>
+            <Divider dark spacingBottom={16} spacingTop={16} />
+            <StyledHeader>High Availability (HA) Control Plane</StyledHeader>
+            <Typography>{`$${highAvailabilityPrice}/month`}</Typography>
+          </StyledBox>
+        )}
+        {enterprisePrice && (
+          <StyledBox>
+            <Divider dark spacingBottom={16} spacingTop={16} />
+            <StyledHeader>LKE Enterprise</StyledHeader>
+            <Typography sx={{ width: '80%' }}>
+              HA control plane, Dedicated control plane
+            </Typography>
+            <Typography mt={1}>{`$${enterprisePrice?.toFixed(
+              2
+            )}/month`}</Typography>
+          </StyledBox>
+        )}
         {pools.map((thisPool, idx) => (
           <NodePoolSummary
             poolType={
@@ -148,25 +167,6 @@ export const KubeCheckoutBar = (props: Props) => {
             text={nodeWarning}
             variant="warning"
           />
-        )}
-        {region && highAvailability && !enterprisePrice && (
-          <StyledBox>
-            <StyledHeader>High Availability (HA) Control Plane</StyledHeader>
-            <Typography>{`$${highAvailabilityPrice}/month`}</Typography>
-            <Divider dark spacingBottom={0} spacingTop={16} />
-          </StyledBox>
-        )}
-        {enterprisePrice && (
-          <StyledBox>
-            <StyledHeader>LKE Enterprise</StyledHeader>
-            <Typography sx={{ width: '80%' }}>
-              HA control plane, Dedicated control plane
-            </Typography>
-            <Typography mt={1}>{`$${enterprisePrice?.toFixed(
-              2
-            )}/month`}</Typography>
-            <Divider dark spacingBottom={0} spacingTop={16} />
-          </StyledBox>
         )}
       </>
     </CheckoutBar>

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -1,5 +1,5 @@
-import { Box, CircleProgress, Divider, Notice } from '@linode/ui';
-import { Typography, styled } from '@mui/material';
+import { CircleProgress, Divider, Notice } from '@linode/ui';
+import { Typography } from '@mui/material';
 import * as React from 'react';
 
 import { CheckoutBar } from 'src/components/CheckoutBar/CheckoutBar';
@@ -17,7 +17,8 @@ import {
 } from 'src/utilities/pricing/kubernetes';
 
 import { nodeWarning } from '../kubeUtils';
-import { NodePoolSummary } from './NodePoolSummary';
+import { NodePoolSummaryItem } from './NodePoolSummaryItem';
+import { StyledHeader, StyledBox } from './KubeCheckoutSummary.styles';
 
 import type { KubeNodePoolResponse, Region } from '@linode/api-v4';
 
@@ -137,7 +138,7 @@ export const KubeCheckoutBar = (props: Props) => {
           </StyledBox>
         )}
         {pools.map((thisPool, idx) => (
-          <NodePoolSummary
+          <NodePoolSummaryItem
             poolType={
               types?.find((thisType) => thisType.id === thisPool.type) || null
             }
@@ -174,18 +175,3 @@ export const KubeCheckoutBar = (props: Props) => {
 };
 
 export default RenderGuard(KubeCheckoutBar);
-
-const StyledHeader = styled(Typography, {
-  label: 'StyledHeader',
-})(({ theme }) => ({
-  fontFamily: theme.font.bold,
-  fontSize: '16px',
-  paddingBottom: theme.spacing(0.5),
-  paddingTop: theme.spacing(0.5),
-}));
-
-const StyledBox = styled(Box, {
-  label: 'StyledBox',
-})(({ theme }) => ({
-  marginTop: theme.spacing(2),
-}));

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -10,7 +10,10 @@ import { useProfile } from 'src/queries/profile/profile';
 import { useSpecificTypes } from 'src/queries/types';
 import { extendTypesQueryResult } from 'src/utilities/extendType';
 import { getGDPRDetails } from 'src/utilities/formatRegion';
-import { LKE_CREATE_CLUSTER_CHECKOUT_MESSAGE } from 'src/utilities/pricing/constants';
+import {
+  LKE_CREATE_CLUSTER_CHECKOUT_MESSAGE,
+  LKE_ENTERPRISE_CREATE_CLUSTER_CHECKOUT_MESSAGE,
+} from 'src/utilities/pricing/constants';
 import {
   getKubernetesMonthlyPrice,
   getTotalClusterPrice,
@@ -81,7 +84,10 @@ export const KubeCheckoutBar = (props: Props) => {
     highAvailabilityPrice !== undefined;
 
   const disableCheckout = Boolean(
-    needsAPool || gdprConditions || haConditions && !enterprisePrice || !region
+    needsAPool ||
+      gdprConditions ||
+      (haConditions && !enterprisePrice) ||
+      !region
   );
 
   if (isLoading) {
@@ -114,7 +120,11 @@ export const KubeCheckoutBar = (props: Props) => {
       heading="Cluster Summary"
       isMakingRequest={submitting}
       onDeploy={createCluster}
-      priceSelectionText={LKE_CREATE_CLUSTER_CHECKOUT_MESSAGE}
+      priceSelectionText={
+        enterprisePrice
+          ? LKE_ENTERPRISE_CREATE_CLUSTER_CHECKOUT_MESSAGE
+          : LKE_CREATE_CLUSTER_CHECKOUT_MESSAGE
+      }
       submitText="Create Cluster"
     >
       <>

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -30,6 +30,7 @@ export interface Props {
   region: string | undefined;
   regionsData: Region[];
   removePool: (poolIdx: number) => void;
+  enterprisePrice?: number;
   showHighAvailability: boolean | undefined;
   submitting: boolean;
   toggleHasAgreed: () => void;
@@ -46,6 +47,7 @@ export const KubeCheckoutBar = (props: Props) => {
     region,
     regionsData,
     removePool,
+    enterprisePrice,
     showHighAvailability,
     submitting,
     toggleHasAgreed,
@@ -95,12 +97,14 @@ export const KubeCheckoutBar = (props: Props) => {
       calculatedPrice={
         region
           ? getTotalClusterPrice({
-              highAvailabilityPrice: highAvailability
-                ? Number(highAvailabilityPrice)
-                : undefined,
+              highAvailabilityPrice:
+                highAvailability && !enterprisePrice
+                  ? Number(highAvailabilityPrice)
+                  : undefined,
               pools,
               region,
               types: types ?? [],
+              enterprisePrice: enterprisePrice ?? undefined,
             })
           : undefined
       }
@@ -145,15 +149,25 @@ export const KubeCheckoutBar = (props: Props) => {
             variant="warning"
           />
         )}
-        {region && highAvailability ? (
-          <StyledHABox>
-            <StyledHAHeader>
-              High Availability (HA) Control Plane
-            </StyledHAHeader>
+        {region && highAvailability && !enterprisePrice && (
+          <StyledBox>
+            <StyledHeader>High Availability (HA) Control Plane</StyledHeader>
             <Typography>{`$${highAvailabilityPrice}/month`}</Typography>
             <Divider dark spacingBottom={0} spacingTop={16} />
-          </StyledHABox>
-        ) : undefined}
+          </StyledBox>
+        )}
+        {enterprisePrice && (
+          <StyledBox>
+            <StyledHeader>LKE Enterprise</StyledHeader>
+            <Typography sx={{ width: '80%' }}>
+              HA control plane, Dedicated control plane
+            </Typography>
+            <Typography mt={1}>{`$${enterprisePrice?.toFixed(
+              2
+            )}/month`}</Typography>
+            <Divider dark spacingBottom={0} spacingTop={16} />
+          </StyledBox>
+        )}
       </>
     </CheckoutBar>
   );
@@ -161,8 +175,8 @@ export const KubeCheckoutBar = (props: Props) => {
 
 export default RenderGuard(KubeCheckoutBar);
 
-const StyledHAHeader = styled(Typography, {
-  label: 'StyledHAHeader',
+const StyledHeader = styled(Typography, {
+  label: 'StyledHeader',
 })(({ theme }) => ({
   fontFamily: theme.font.bold,
   fontSize: '16px',
@@ -170,8 +184,8 @@ const StyledHAHeader = styled(Typography, {
   paddingTop: theme.spacing(0.5),
 }));
 
-const StyledHABox = styled(Box, {
-  label: 'StyledHABox',
+const StyledBox = styled(Box, {
+  label: 'StyledBox',
 })(({ theme }) => ({
   marginTop: theme.spacing(2),
 }));

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutSummary.styles.ts
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutSummary.styles.ts
@@ -1,0 +1,48 @@
+import { Box, IconButton, Typography } from '@linode/ui';
+import { styled } from '@mui/material/styles';
+
+export const StyledHeader = styled(Typography, {
+  label: 'StyledHeader',
+})(({ theme }) => ({
+  fontFamily: theme.font.bold,
+  fontSize: '16px',
+  paddingBottom: theme.spacing(0.5),
+  paddingTop: theme.spacing(0.5),
+}));
+
+export const StyledBox = styled(Box, {
+  label: 'StyledBox',
+})(({ theme }) => ({
+  marginTop: theme.spacing(2),
+}));
+
+export const StyledNodePoolSummaryBox = styled(Box, {
+  label: 'StyledNodePoolSummaryBox',
+})(() => ({
+  '& $textField': {
+    width: 53,
+  },
+  display: 'flex',
+  flexDirection: 'column',
+}));
+
+export const StyledIconButton = styled(IconButton, {
+  label: 'StyledIconButton',
+})(() => ({
+  '&:hover': {
+    color: '#6e6e6e',
+  },
+  alignItems: 'flex-start',
+  color: '#979797',
+  marginTop: -4,
+  padding: 0,
+}));
+
+export const StyledPriceBox = styled(Box, {
+  label: 'StyledPriceBox',
+})(({ theme }) => ({
+  '& h3': {
+    color: `${theme.palette.text.primary} !important`,
+    fontFamily: theme.font.normal,
+  },
+}));

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/NodePoolSummary.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/NodePoolSummary.test.tsx
@@ -4,7 +4,9 @@ import * as React from 'react';
 import { extendedTypes } from 'src/__data__/ExtendedType';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
-import { NodePoolSummary, Props } from './NodePoolSummary';
+import { NodePoolSummaryItem } from './NodePoolSummaryItem';
+
+import type { Props } from './NodePoolSummaryItem';
 
 const props: Props = {
   nodeCount: 3,
@@ -14,21 +16,21 @@ const props: Props = {
   updateNodeCount: vi.fn(),
 };
 
-describe('Node Pool Summary', () => {
+describe('Node Pool Summary Item', () => {
   it("should render the label of its pool's plan", () => {
-    const { getByText } = renderWithTheme(<NodePoolSummary {...props} />);
+    const { getByText } = renderWithTheme(<NodePoolSummaryItem {...props} />);
     getByText(/Linode 2 GB Plan/i);
     getByText(/1 CPU, 50 GB Storage/i);
   });
 
   it('should call its onRemove handler when the trash can is clicked', () => {
-    const { getByTestId } = renderWithTheme(<NodePoolSummary {...props} />);
+    const { getByTestId } = renderWithTheme(<NodePoolSummaryItem {...props} />);
     fireEvent.click(getByTestId('remove-pool-button'));
     expect(props.onRemove).toHaveBeenCalledTimes(1);
   });
 
   it("should display its pool's price", () => {
-    const { getByText } = renderWithTheme(<NodePoolSummary {...props} />);
+    const { getByText } = renderWithTheme(<NodePoolSummaryItem {...props} />);
     getByText('$1,000.00');
   });
 });

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/NodePoolSummaryItem.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/NodePoolSummaryItem.tsx
@@ -1,49 +1,19 @@
-import { Box, Divider, IconButton, Typography } from '@linode/ui';
+import { Box, Divider, Typography } from '@linode/ui';
 import Close from '@mui/icons-material/Close';
 import * as React from 'react';
-import { makeStyles } from 'tss-react/mui';
 
 import { DisplayPrice } from 'src/components/DisplayPrice';
 import { EnhancedNumberInput } from 'src/components/EnhancedNumberInput/EnhancedNumberInput';
 import { pluralize } from 'src/utilities/pluralize';
 
-import type { Theme } from '@mui/material/styles';
-import type { ExtendedType } from 'src/utilities/extendType';
+import {
+  StyledHeader,
+  StyledIconButton,
+  StyledNodePoolSummaryBox,
+  StyledPriceBox,
+} from './KubeCheckoutSummary.styles';
 
-const useStyles = makeStyles()((theme: Theme) => ({
-  button: {
-    '&:hover': {
-      color: '#6e6e6e',
-    },
-    alignItems: 'flex-start',
-    color: '#979797',
-    marginTop: -4,
-    padding: 0,
-  },
-  numberInput: {
-    marginBottom: theme.spacing(1.5),
-    marginTop: theme.spacing(2),
-  },
-  price: {
-    '& h3': {
-      color: `${theme.palette.text.primary} !important`,
-      fontFamily: theme.font.normal,
-    },
-  },
-  root: {
-    '& $textField': {
-      width: 53,
-    },
-  },
-  typeHeader: {
-    fontFamily: theme.font.bold,
-    fontSize: '16px',
-    paddingBottom: theme.spacing(0.5),
-  },
-  typeSubheader: {
-    fontSize: '14px',
-  },
-}));
+import type { ExtendedType } from 'src/utilities/extendType';
 
 export interface Props {
   nodeCount: number;
@@ -53,8 +23,7 @@ export interface Props {
   updateNodeCount: (count: number) => void;
 }
 
-export const NodePoolSummary = React.memo((props: Props) => {
-  const { classes } = useStyles();
+export const NodePoolSummaryItem = React.memo((props: Props) => {
   const { nodeCount, onRemove, poolType, price, updateNodeCount } = props;
 
   // This should never happen but TS wants us to account for the situation
@@ -66,45 +35,37 @@ export const NodePoolSummary = React.memo((props: Props) => {
   return (
     <>
       <Divider dark spacingBottom={12} spacingTop={24} />
-      <Box
-        className={classes.root}
-        data-testid="node-pool-summary"
-        display="flex"
-        flexDirection="column"
-      >
+      <StyledNodePoolSummaryBox data-testid="node-pool-summary">
         <Box display="flex" justifyContent="space-between">
           <div>
-            <Typography className={classes.typeHeader}>
-              {poolType.formattedLabel} Plan
-            </Typography>
-            <Typography className={classes.typeSubheader}>
+            <StyledHeader>{poolType.formattedLabel} Plan</StyledHeader>
+            <Typography>
               {pluralize('CPU', 'CPUs', poolType.vcpus)}, {poolType.disk / 1024}{' '}
               GB Storage
             </Typography>
           </div>
-          <IconButton
-            className={classes.button}
+          <StyledIconButton
             data-testid="remove-pool-button"
             onClick={onRemove}
             size="large"
             title={`Remove ${poolType.label} Node Pool`}
           >
             <Close />
-          </IconButton>
+          </StyledIconButton>
         </Box>
-        <div className={classes.numberInput}>
+        <Box mb={1.5} mt={2}>
           <EnhancedNumberInput
             min={1}
             setValue={updateNodeCount}
             value={nodeCount}
           />
-        </div>
-        <div className={classes.price}>
+        </Box>
+        <StyledPriceBox>
           {price ? (
             <DisplayPrice fontSize="14px" interval="month" price={price} />
           ) : undefined}
-        </div>
-      </Box>
+        </StyledPriceBox>
+      </StyledNodePoolSummaryBox>
     </>
   );
 });

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -51,6 +51,7 @@ import {
   linodeStatsFactory,
   linodeTransferFactory,
   linodeTypeFactory,
+  lkeEnterpriseTypeFactory,
   lkeHighAvailabilityTypeFactory,
   lkeStandardAvailabilityTypeFactory,
   longviewActivePlanFactory,
@@ -801,6 +802,7 @@ export const handlers = [
     const lkeTypes = [
       lkeStandardAvailabilityTypeFactory.build(),
       lkeHighAvailabilityTypeFactory.build(),
+      lkeEnterpriseTypeFactory.build(),
     ];
     return HttpResponse.json(makeResourcePage(lkeTypes));
   }),

--- a/packages/manager/src/queries/kubernetes.ts
+++ b/packages/manager/src/queries/kubernetes.ts
@@ -14,6 +14,7 @@ import {
   getKubernetesClustersBeta,
   getKubernetesTieredVersionsBeta,
   getKubernetesTypes,
+  getKubernetesTypesBeta,
   getKubernetesVersions,
   getNodePools,
   recycleAllNodes,
@@ -124,10 +125,12 @@ export const kubernetesQueries = createQueryKeys('kubernetes', {
     queryFn: () => getAllKubernetesTieredVersionsBeta(tier),
     queryKey: [tier],
   }),
-  types: {
-    queryFn: () => getAllKubernetesTypes(),
-    queryKey: null,
-  },
+  types: (useBetaEndpoint: boolean = false) => ({
+    queryFn: useBetaEndpoint
+      ? getAllKubernetesTypesBeta
+      : () => getAllKubernetesTypes(),
+    queryKey: [useBetaEndpoint ? 'v4beta' : 'v4'],
+  }),
   versions: {
     queryFn: () => getAllKubernetesVersions(),
     queryKey: null,
@@ -465,8 +468,13 @@ const getAllKubernetesTypes = () =>
     (results) => results.data
   );
 
-export const useKubernetesTypesQuery = () =>
+const getAllKubernetesTypesBeta = () =>
+  getAll<PriceType>((params) => getKubernetesTypesBeta(params))().then(
+    (results) => results.data
+  );
+
+export const useKubernetesTypesQuery = (useBetaEndpoint?: boolean) =>
   useQuery<PriceType[], APIError[]>({
     ...queryPresets.oneTimeFetch,
-    ...kubernetesQueries.types,
+    ...kubernetesQueries.types(useBetaEndpoint),
   });

--- a/packages/manager/src/utilities/pricing/constants.ts
+++ b/packages/manager/src/utilities/pricing/constants.ts
@@ -11,6 +11,8 @@ export const PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE =
   'Select a region to view plans and prices.';
 export const LKE_CREATE_CLUSTER_CHECKOUT_MESSAGE =
   'Select a region, HA choice, and add a Node Pool to view pricing and create a cluster.';
+export const LKE_ENTERPRISE_CREATE_CLUSTER_CHECKOUT_MESSAGE =
+  'Select a region and add a Node Pool to view pricing and create a cluster.';
 export const DIFFERENT_PRICE_STRUCTURE_WARNING =
   'The selected region has a different price structure.';
 export const MAGIC_DATE_THAT_DC_SPECIFIC_PRICING_WAS_IMPLEMENTED =

--- a/packages/manager/src/utilities/pricing/kubernetes.ts
+++ b/packages/manager/src/utilities/pricing/kubernetes.ts
@@ -11,6 +11,7 @@ interface MonthlyPriceOptions {
 }
 
 interface TotalClusterPriceOptions {
+  enterprisePrice?: number;
   highAvailabilityPrice?: number;
   pools: KubeNodePoolResponse[];
   region: Region['id'] | undefined;
@@ -42,6 +43,7 @@ export const getKubernetesMonthlyPrice = ({
  * @returns The total monthly cluster price
  */
 export const getTotalClusterPrice = ({
+  enterprisePrice,
   highAvailabilityPrice,
   pools,
   region,
@@ -57,5 +59,12 @@ export const getTotalClusterPrice = ({
     return accumulator + (kubernetesMonthlyPrice ?? 0);
   }, 0);
 
-  return highAvailabilityPrice ? price + highAvailabilityPrice : price;
+  if (enterprisePrice) {
+    return price + enterprisePrice;
+  }
+  if (highAvailabilityPrice) {
+    return price + highAvailabilityPrice;
+  }
+
+  return price;
 };


### PR DESCRIPTION
## Description 📝
When a user selects LKE-Enterprise as their cluster type, we want to display a line item in the Cluster Summary (CheckoutBar) to make users aware of the price of the feature.

## Changes  🔄
- LKE-Enterprise price line item is listed in the Cluster Summary section when the card is selected
  - "HA choice" wording removed in the checkout message as it's already included
- Moved the placement of HA and LKE-E line item to the top of the summary as node pools get added
- Renamed Cluster Type heading to Cluster Tier to best match the API (which returns 'tier')
- Styling & code clean up

## Preview 📷
https://github.com/user-attachments/assets/fa50de86-e562-4a3d-b9be-cabacf75e733

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have LKE-E customer tag on your account (see Project Tracker)

```
yarn test KubeCheckoutBar
```

### Verification steps

(How to verify changes)

- [ ] Go to http://localhost:3000/kubernetes/create
- [ ] Select the LKE Enterprise Tier. You should see a line item in the checkout summary of $300/mo
  - [ ] This item should stay at the top as node pool line items are added
- [ ] Select a region, version, and add Node Pools. Checkout summary should be updated to reflect the added Node Pools
- [ ] Ensure there has been no regressions in the standard LKE flow (it's expected that the HA summary item is at the top now)

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>