### PR TITLE
test: [M3-8864] - Cypress tests to validate errors in Linode Create Backups tab

### DIFF
--- a/packages/manager/.changeset/pr-11422-tests-1734356272451.md
+++ b/packages/manager/.changeset/pr-11422-tests-1734356272451.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Cypress tests to validate errors in Linode Create Backups tab ([#11422](https://github.com/linode/manager/pull/11422))

--- a/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
@@ -488,7 +488,7 @@ describe('Create Linode', () => {
     cy.findByText(`${createLinodeErrorMessage}`).should('not.exist');
   });
 
-  it('shows correct validation errors when a backup or plan is not selected', () => {
+  it('shows correct validation errors if no backup or plan is selected', () => {
     cy.visitWithLogin('/linodes/create');
 
     // Navigate to Linode Create page "Backups" tab

--- a/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
@@ -487,4 +487,25 @@ describe('Create Linode', () => {
     // Confirm the createLinodeErrorMessage disappears.
     cy.findByText(`${createLinodeErrorMessage}`).should('not.exist');
   });
+
+  it('shows correct validation errors when a backup or plan is not selected', () => {
+    cy.visitWithLogin('/linodes/create');
+
+    // Navigate to Linode Create page "Backups" tab
+    cy.get('[role="tablist"]')
+      .should('be.visible')
+      .findByText('Backups')
+      .click();
+
+    // Submit without selecting any options
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    // Confirm the correct validation errors show up on the page.
+    cy.findByText('You must select a Backup.').should('be.visible');
+    cy.findByText('Plan is required.').should('be.visible');
+  });
 });


### PR DESCRIPTION
## Description 📝
Add Cypress test to validate error messages if required options are not selected in the Linode Create Backups tab.

- Related to: https://github.com/linode/manager/pull/11147

## Changes  🔄

List any change(s) relevant to the reviewer.
- Add a Cypress test to validate error messages if required options are not selected in the Linode Create Backups tab.

## Target release date 🗓️
N/A

## How to test 🧪
- `yarn cy:run -s "cypress/e2e/core/linodes/create-linode.spec.ts"`
- Ensure all tests pass

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>