### PR TITLE
fix: [M3-8196] - Fix Linode Edit Config warning message when initially selecting a VPC as the primary interface

### DIFF
--- a/packages/manager/.changeset/pr-11424-fixed-1734375315983.md
+++ b/packages/manager/.changeset/pr-11424-fixed-1734375315983.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Linode Edit Config warning  message when initially selecting a VPC as the primary interface ([#11424](https://github.com/linode/manager/pull/11424))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
@@ -1273,7 +1273,6 @@ export const unrecommendedConfigNoticeSelector = ({
 
    If not one of the above scenarios, do not display a warning notice re: configuration
   */
-
   if (
     vpcInterface &&
     primaryInterfaceIndex !== thisIndex &&

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
@@ -1004,7 +1004,7 @@ export const LinodeConfigDialog = (props: Props) => {
                   disabled={isReadOnly}
                   label="Primary Interface (Default Route)"
                   options={getPrimaryInterfaceOptions(values.interfaces)}
-                  value={primaryInterfaceOptions[primaryInterfaceIndex ?? 0]}
+                  value={primaryInterfaceOptions[primaryInterfaceIndex]}
                 />
                 <Divider
                   sx={{
@@ -1242,7 +1242,7 @@ export const unrecommendedConfigNoticeSelector = ({
   values,
 }: {
   _interface: ExtendedInterface;
-  primaryInterfaceIndex: number | undefined;
+  primaryInterfaceIndex: number;
   thisIndex: number;
   values: EditableFields;
 }): JSX.Element | null => {
@@ -1255,9 +1255,7 @@ export const unrecommendedConfigNoticeSelector = ({
 
   // Edge case: users w/ ability to have multiple VPC interfaces. Scenario 1 & 2 notices not helpful if that's done
   const primaryInterfaceIsVPC =
-    primaryInterfaceIndex !== undefined
-      ? values.interfaces[primaryInterfaceIndex].purpose === 'vpc'
-      : false;
+    values.interfaces[primaryInterfaceIndex].purpose === 'vpc';
 
   /*
    Scenario 1:

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
@@ -290,7 +290,7 @@ export const LinodeConfigDialog = (props: Props) => {
   const [
     primaryInterfaceIndex,
     setPrimaryInterfaceIndex,
-  ] = React.useState<number>();
+  ] = React.useState<number>(0);
 
   const regionHasVLANS = regions.some(
     (thisRegion) =>
@@ -1273,6 +1273,7 @@ export const unrecommendedConfigNoticeSelector = ({
 
    If not one of the above scenarios, do not display a warning notice re: configuration
   */
+
   if (
     vpcInterface &&
     primaryInterfaceIndex !== thisIndex &&


### PR DESCRIPTION
## Description 📝
- Fixes error messaging when initially selecting a VPC as the primary interface (for eth0)

## Changes  🔄
- Change initial primaryInterfaceIndex to 0 (matches autocomplete's previous initial value)

## Target release date 🗓️
next release - 1/14?

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/480544e7-1101-4824-a10f-155f08109d7f) | ![image](https://github.com/user-attachments/assets/b76ac1c2-a26d-42d5-95e4-55989d4671dd) |

## How to test 🧪

With a Linode not assigned to a VPC,

### Reproduction steps
- Go to linode's configurations and edit/add a new config
- set eth0 to VPC and notice how warning message doesn't align

### Verification steps
- Confirm above bug fixed
- Confirm behavior still matches this PR: https://github.com/linode/manager/pull/9916
- Confirm no regressions in behavior of config panel for editing existing configs/adding new configs

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
