### PR TITLE
fix: [UIE-8342] DBaaS resize used field should show N/A when property is null

### DIFF
--- a/packages/api-v4/.changeset/pr-11426-changed-1734381690407.md
+++ b/packages/api-v4/.changeset/pr-11426-changed-1734381690407.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Changed
+---
+
+BaseDatabase total_disk_size_gb and used_disk_size_gb are always expected and used_disk_size_gb can be null  ([#11426](https://github.com/linode/manager/pull/11426))

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -165,16 +165,8 @@ interface BaseDatabase extends DatabaseInstance {
   port: number;
   /** @Deprecated used by rdbms-legacy only, rdbms-default always uses TLS */
   ssl_connection: boolean;
-  /**
-   * total_disk_size_gb is feature flagged by the API.
-   * It may not be defined.
-   */
-  total_disk_size_gb?: number;
-  /**
-   * used_disk_size_gb is feature flagged by the API.
-   * It may not be defined.
-   */
-  used_disk_size_gb?: number;
+  total_disk_size_gb: number;
+  used_disk_size_gb: number | null;
 }
 
 /** @deprecated TODO (UIE-8214) remove POST GA */

--- a/packages/manager/.changeset/pr-11426-fixed-1734381380797.md
+++ b/packages/manager/.changeset/pr-11426-fixed-1734381380797.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+DBaaS Resize tab Used field is displaying just GB on provisioning database cluster ([#11426](https://github.com/linode/manager/pull/11426))

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResizeCurrentConfiguration.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResizeCurrentConfiguration.tsx
@@ -139,7 +139,9 @@ export const DatabaseResizeCurrentConfiguration = ({ database }: Props) => {
               </StyledSummaryTextTypography>
               <StyledSummaryTextTypography>
                 <span style={{ fontFamily: theme.font.bold }}>Used</span>{' '}
-                {database.used_disk_size_gb} GB
+                {database.used_disk_size_gb !== null
+                  ? `${database.used_disk_size_gb} GB`
+                  : 'N/A'}
               </StyledSummaryTextTypography>
             </>
           ) : (


### PR DESCRIPTION
## Description 📝
When DB is provisioning, the DBaaS resize tab "Used" field under Current Configuration shows just "GB". This field is mapped to used_disk_size_gb property which is null because the value is not available yet. The "Used" field should display "N/A" when no value is available.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Resize tab Used field will now display N/A when used_disk_size_gb is null.

## Target release date 🗓️
1/14/25

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![resize-null-before](https://github.com/user-attachments/assets/7a4a61d4-a950-437e-809c-c97a6bc2cec3) | ![resize-null-after](https://github.com/user-attachments/assets/45cb99e6-a8c5-4adb-970d-aefa44786cd9) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have access to databases tab and the DatabaseResize tab

### Reproduction steps

- [ ] Create a new database cluster
- [ ] Access database cluster details while the DB is provisioning
- [ ] Navigate to the Resize tab and, under Current Configuration, see that the value in the "Used" field is "GB"

### Verification steps

- [ ] Using the reproduction steps listed above, access the Resize tab for a provisioning database cluster. 
- [ ] View the "Used" field under Current Configuration and verify that N/A is displayed

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
