### PR TITLE
change: [M3-8742] - Update Pendo URL with CNAME

### DIFF
--- a/docs/tooling/analytics.md
+++ b/docs/tooling/analytics.md
@@ -2,7 +2,7 @@
 
 ## Pendo
 
-Cloud Manager uses [Pendo](https://www.pendo.io/pendo-for-your-customers/) to capture analytics, guide users, and improve the user experience.  Pendo is the **preferred** method for collecting analytics, including user events, since it requires no development effort and can be accomplished via the Pendo UI.
+Cloud Manager uses [Pendo](https://www.pendo.io/pendo-for-your-customers/) to capture analytics, guide users, and improve the user experience. Pendo is the **preferred** method for collecting analytics, including user events, since it requires no development effort and can be accomplished via the Pendo UI.
 
 To view Pendo dashboards, Cloud Manager developers must follow internal processes to request access.
 

--- a/docs/tooling/analytics.md
+++ b/docs/tooling/analytics.md
@@ -1,8 +1,35 @@
 # Analytics
 
+## Pendo
+
+Cloud Manager uses [Pendo](https://www.pendo.io/pendo-for-your-customers/) to capture analytics, guide users, and improve the user experience.  Pendo is the **preferred** method for collecting analytics, including user events, since it requires no development effort and can be accomplished via the Pendo UI.
+
+To view Pendo dashboards, Cloud Manager developers must follow internal processes to request access.
+
+### Set Up and Initialization
+
+Pendo is configured in [`usePendo.js`](https://github.com/linode/manager/blob/develop/packages/manager/src/hooks/usePendo.ts). This custom hook allows us to initialize the Pendo analytics script when the [App](https://github.com/linode/manager/blob/develop/packages/manager/src/App.tsx#L56) is mounted.
+
+Important notes:
+
+- Pendo is only loaded if a valid `PENDO_API_KEY` is configured as an environment variable. In our development, staging, and production environments, `PENDO_API_KEY` is available at build time. See **Locally Testing Page Views & Custom Events and/or Troubleshooting Pendo** for set up with local environments.
+- We load the Pendo agent from the CDN, rather than [self-hosting](https://support.pendo.io/hc/en-us/articles/360038969692-Self-hosting-the-Pendo-agent), and we have configured a [CNAME](https://support.pendo.io/hc/en-us/articles/360043539891-CNAME-for-Pendo).
+- We are hashing account and visitor IDs in a way that is consistent with Akamai's standards.
+- At initialization, we do string transformation on select URL patterns to **remove  sensitive data**. When new URL patterns are added to Cloud Manager, verify that existing transforms remove sensitive data; if not, update the transforms.
+- Pendo is currently not using any client-side (cookies or local) storage.
+- Pendo makes use of the existing `data-testid` properties, used in our automated testing, for tagging elements. They are more persistent and reliable than CSS properties, which are liable to change.
+
+### Locally Testing Page Views & Custom Events and/or Troubleshooting Pendo
+
+1. Set the `REACT_APP_PENDO_API_KEY` environment variable in `.env`.
+2. Use the browser tools Network tab, filter requests by "psp.cloud", and check that successful network requests have been made to load Pendo scripts. (Also visible in browser tools Sources tab.)
+3. In the browser console, type `pendo.validateEnvironment()`.
+4. You should see command output in the console, and it should include a hashed `accountId` and hashed `visitorId`. Each page view change or custom event that fires should be visible as a request in the Network tab.
+5. If the console does not output the expected ids and instead outputs something like `Cookies are disabled in Pendo config. Is this expected?` in response to the above command, clear app storage with the browser tools. Once redirected back to Login, update the OneTrust cookie settings to enable cookies via "Manage Preferences" in the banner at the bottom of the screen. Log back into Cloud Manager and Pendo should load.
+
 ## Adobe Analytics
 
-Cloud Manager uses Adobe Analytics to capture page view and custom event statistics. To view analytics, Cloud Manager developers must follow internal processes to request access to Adobe Analytics dashboards.
+Cloud Manager uses Adobe Analytics to capture page view and custom event statistics, although Pendo is the preferred method for collecting this data where possible, as of Q4 2024. To view analytics, Cloud Manager developers must follow internal processes to request access to Adobe Analytics dashboards.
 
 ### Writing a Custom Event
 
@@ -63,27 +90,3 @@ See the `LinodeCreateForm` form events as an example.
 3. In the browser console, type `_satellite.setDebug(true)`.
 4. Refresh the page. You should see Adobe debug log output in the console. Each page view change or custom event that fires should be visible in the logs.
 5. When viewing dashboards in Adobe Analytics, it may take ~1 hour for analytics data to update. Once this happens, locally fired events will be visible in the dev dashboard.
-
-## Pendo
-
-Cloud Manager uses [Pendo](https://www.pendo.io/pendo-for-your-customers/) to capture analytics, guide users, and improve the user experience. To view Pendo dashboards, Cloud Manager developers must follow internal processes to request access.
-
-### Set Up and Initialization
-
-Pendo is configured in [`usePendo.js`](https://github.com/linode/manager/blob/develop/packages/manager/src/hooks/usePendo.ts). This custom hook allows us to initialize the Pendo analytics script when the [App](https://github.com/linode/manager/blob/develop/packages/manager/src/App.tsx#L56) is mounted.
-
-Important notes:
-
-- Pendo is only loaded if a valid `PENDO_API_KEY` is configured as an environment variable. In our development, staging, and production environments, `PENDO_API_KEY` is available at build time. See **Locally Testing Page Views & Custom Events and/or Troubleshooting Pendo** for set up with local environments.
-- We load the Pendo agent from the CDN, rather than [self-hosting](https://support.pendo.io/hc/en-us/articles/360038969692-Self-hosting-the-Pendo-agent).
-- We are hashing account and visitor IDs in a way that is consistent with Akamai's standards.
-- At initialization, we do string transformation on select URL patterns to **remove  sensitive data**. When new URL patterns are added to Cloud Manager, verify that existing transforms remove sensitive data; if not, update the transforms.
-- Pendo is currently not using any client-side (cookies or local) storage.
-- Pendo makes use of the existing `data-testid` properties, used in our automated testing, for tagging elements. They are more persistent and reliable than CSS properties, which are liable to change.
-
-### Locally Testing Page Views & Custom Events and/or Troubleshooting Pendo
-
-1. Set the `REACT_APP_PENDO_API_KEY` environment variable in `.env`.
-2. Use the browser tools Network tab, filter requests by "pendo", and check that successful network requests have been made to load Pendo scripts. (Also visible in browser tools Sources tab.)
-3. In the browser console, type `pendo.validateEnvironment()`.
-4. You should see command output in the console, and it should include a hashed `accountId` and hashed `visitorId`. Each page view change or custom event that fires should be visible as a request in the Network tab.

--- a/docs/tooling/analytics.md
+++ b/docs/tooling/analytics.md
@@ -22,7 +22,7 @@ Important notes:
 ### Locally Testing Page Views & Custom Events and/or Troubleshooting Pendo
 
 1. Set the `REACT_APP_PENDO_API_KEY` environment variable in `.env`.
-2. Use the browser tools Network tab, filter requests by "psp.cloud", and check that successful network requests have been made to load Pendo scripts. (Also visible in browser tools Sources tab.)
+2. Use the browser tools Network tab, filter requests by "psp.cloud", and check that successful network requests have been made to load Pendo scripts (also visible in the browser tools Sources tab).
 3. In the browser console, type `pendo.validateEnvironment()`.
 4. You should see command output in the console, and it should include a hashed `accountId` and hashed `visitorId`. Each page view change or custom event that fires should be visible as a request in the Network tab.
 5. If the console does not output the expected ids and instead outputs something like `Cookies are disabled in Pendo config. Is this expected?` in response to the above command, clear app storage with the browser tools. Once redirected back to Login, update the OneTrust cookie settings to enable cookies via "Manage Preferences" in the banner at the bottom of the screen. Log back into Cloud Manager and Pendo should load.

--- a/packages/manager/.changeset/pr-11427-tech-stories-1734383515695.md
+++ b/packages/manager/.changeset/pr-11427-tech-stories-1734383515695.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Update Pendo URL with CNAME and update Analytics developer docs ([#11427](https://github.com/linode/manager/pull/11427))

--- a/packages/manager/src/hooks/usePendo.ts
+++ b/packages/manager/src/hooks/usePendo.ts
@@ -69,7 +69,8 @@ export const usePendo = () => {
   const accountId = hashUniquePendoId(account?.euuid);
   const visitorId = hashUniquePendoId(profile?.uid.toString());
 
-  const PENDO_URL = `https://cdn.pendo.io/agent/static/${PENDO_API_KEY}/pendo.js`;
+  // This URL uses a Pendo-configured CNAME (M3-8742).
+  const PENDO_URL = `https://content.psp.cloud.linode.com/agent/static/${PENDO_API_KEY}/pendo.js`;
 
   React.useEffect(() => {
     if (PENDO_API_KEY) {


### PR DESCRIPTION
## Description 📝

ACC's Pendo implementation uses a CNAME; we want to provide the same set up with Cloud Manager and ensure Pendo is working for as many users as possible.

From Pendo docs:

> A Canonical Name record (abbreviated as CNAME record) is a type of resource record in the Domain Name System (DNS) used to specify that a domain name is an alias for another domain, which is the "canonical" domain.

> Our CNAME feature allows you to create hostnames under your own vanity domain (subdomain), used in place of Pendo hostnames for both sending events and downloading guide content. This helps ensure that events are collected and guides are served to end users who even if they're subject to ad-blocking software, firewalls, VPNs, web filters, and so on.

## Changes  🔄

- Lots of coordination for this PR with Pendo, the Akamai DNS folks, and the Linode Linux SRE folks, but _our_ Cloud Manager changes are very minor:
   - Update the Pendo URL to use a CNAME
- Update the Analytics developer docs with a few assorted changes
   - Swap the order of Pendo and Adobe Analytics on the page
   - Call out that Pendo is preferred for capturing analytics
   - Update the testing and troubleshooting steps to specify use of `psp.cloud` as a search term, not `pendo` (this _is_ an update related to the CNAME change in this PR)

## Target release date 🗓️

1/14

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-12-16 at 12 48 47 PM](https://github.com/user-attachments/assets/d01f1274-0b48-4c26-9267-3740544d3899) ![Screenshot 2024-12-16 at 12 49 20 PM](https://github.com/user-attachments/assets/a42779b8-4dbe-4a21-935f-9496f5a55f74) ![Screenshot 2024-12-16 at 12 49 26 PM](https://github.com/user-attachments/assets/917766d3-3998-41c3-876f-12e1c1638b3b) | ![Screenshot 2024-12-16 at 12 47 53 PM](https://github.com/user-attachments/assets/96f7dd22-036f-42e7-8f78-f344b08e9061) ![Screenshot 2024-12-16 at 12 48 11 PM](https://github.com/user-attachments/assets/f1c34362-1518-40aa-ad53-bc02de002e9c) ![Screenshot 2024-12-16 at 12 48 18 PM](https://github.com/user-attachments/assets/e6f85088-84a5-4959-bb26-23f00cb15b66) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Follow the instructions here: https://github.com/linode/manager/pull/10982

### Verification steps

(How to verify changes)

- [ ] Confirm the change looking at the normalizedUrl in requests in the browser console filtering on "**psp.cloud**".
   - [ ] The `pendo.js` agent loads with `content.psp.cloud.linode.com` in its Request URL
   - [ ] User events (e.g. page views or clicks) are sent with `data.psp.cloud.linode.com` in their Request URL
- [ ] Confirm docs updates are clear, no typos by reading the diff

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>