### PR TITLE
tech-story: [M3-6904] - Replace react-select instances in /Users with new Select

### DIFF
--- a/packages/manager/.changeset/pr-11430-tech-stories-1734463578200.md
+++ b/packages/manager/.changeset/pr-11430-tech-stories-1734463578200.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Replace react-select instances in /Users with new Select ([#11430](https://github.com/linode/manager/pull/11430))

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -10,6 +10,7 @@ import {
   FormControlLabel,
   Notice,
   Paper,
+  Select,
   Toggle,
   Typography,
 } from '@linode/ui';
@@ -41,7 +42,6 @@ import {
   StyledHeaderGrid,
   StyledPaper,
   StyledPermPaper,
-  StyledSelect,
   StyledUnrestrictedGrid,
 } from './UserPermissions.styles';
 import { UserPermissionsEntitySection } from './UserPermissionsEntitySection';
@@ -55,8 +55,8 @@ import type {
   User,
 } from '@linode/api-v4/lib/account';
 import type { APIError } from '@linode/api-v4/lib/types';
+import type { SelectOptionType } from '@linode/ui';
 import type { QueryClient } from '@tanstack/react-query';
-import type { Item } from 'src/components/EnhancedSelect/Select';
 import type { WithFeatureFlagProps } from 'src/containers/flags.container';
 import type { WithQueryClientProps } from 'src/containers/withQueryClient.container';
 interface Props {
@@ -598,17 +598,26 @@ class UserPermissions extends React.Component<CombinedProps, State> {
             </Typography>
           </Grid>
           <Grid style={{ marginTop: 5 }}>
-            <StyledSelect
-              defaultValue={defaultPerm}
+            <Select
+              sx={{
+                '& > .MuiBox-root': {
+                  '& label': {
+                    position: 'relative',
+                    right: 10,
+                    top: -4,
+                  },
+                  alignItems: 'center',
+                  display: 'flex',
+                },
+              }}
+              value={{
+                label: defaultPerm?.label ?? '',
+                value: defaultPerm?.value ?? '',
+              }}
               id="setall"
-              inline
-              isClearable={false}
               label="Set all permissions to:"
-              name="setall"
-              noMarginTop
-              onChange={this.setAllEntitiesTo}
+              onChange={(_, value) => this.setAllEntitiesTo(value)}
               options={permOptions}
-              small
             />
           </Grid>
         </Grid>
@@ -779,13 +788,13 @@ class UserPermissions extends React.Component<CombinedProps, State> {
       });
   };
 
-  setAllEntitiesTo = (e: Item<string>) => {
-    const value = e.value === 'null' ? null : e.value;
+  setAllEntitiesTo = (e: SelectOptionType | null | undefined) => {
+    const value = e?.value === 'null' ? null : e?.value;
     this.entityPerms.map((entity: GrantType) =>
       this.entitySetAllTo(entity, value as GrantLevel)()
     );
     this.setState({
-      setAllPerm: e.value as 'null' | 'read_only' | 'read_write',
+      setAllPerm: e?.value as 'null' | 'read_only' | 'read_write',
     });
   };
 

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -31,12 +31,14 @@ export interface SelectProps
     EnhancedAutocompleteProps<SelectOptionType>,
     | 'errorText'
     | 'helperText'
+    | 'id'
     | 'isOptionEqualToValue'
     | 'loading'
     | 'noOptionsText'
     | 'onBlur'
     | 'options'
     | 'placeholder'
+    | 'sx'
     | 'textFieldProps'
     | 'value'
   > {
@@ -103,6 +105,7 @@ export const Select = (props: SelectProps) => {
     onChange,
     options,
     searchable = false,
+    sx,
     textFieldProps,
     ...rest
   } = props;
@@ -201,8 +204,9 @@ export const Select = (props: SelectProps) => {
           </ListItem>
         );
       }}
-      sx={
-        !creatable && !searchable
+      sx={{
+        ...sx,
+        ...(!creatable && !searchable
           ? {
               '& .MuiInputBase-input': {
                 '&::selection': {
@@ -210,8 +214,8 @@ export const Select = (props: SelectProps) => {
                 },
               },
             }
-          : null
-      }
+          : null),
+      }}
       disableClearable={!clearable}
       forcePopupIcon
       freeSolo={creatable}


### PR DESCRIPTION
## Description 📝
Replace the only instance of react-select under the `/Users` namespace.

Bonus, the old select display was broken 🎉 

## Changes  🔄
- replace `react-select` instance
- added a couple props on the new Select (`sx` & `id`)

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-12-17 at 14 10 21](https://github.com/user-attachments/assets/099b4ef2-5836-41ad-8a80-bf356709579b) | ![Screenshot 2024-12-17 at 14 18 21](https://github.com/user-attachments/assets/68766448-5675-4c97-ba25-293c2e5ff716) |

## How to test 🧪

### Verification steps
- Navigate to  `/account/users/{user}/permissions` (for a "secondary" user)
- Disable "Full Access Account"
- Scroll down to the permission section and confirm the styling and behavior of the "Specific Permissions" select


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules


