### PR TITLE
fix: CloudPulse metric definition types

### DIFF
--- a/packages/api-v4/.changeset/pr-11433-changed-1734483970019.md
+++ b/packages/api-v4/.changeset/pr-11433-changed-1734483970019.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Changed
+---
+
+Renamed `AvailableMetrics` type to `MetricDefinition` ([#11433](https://github.com/linode/manager/pull/11433))

--- a/packages/api-v4/.changeset/pr-11433-removed-1734484000708.md
+++ b/packages/api-v4/.changeset/pr-11433-removed-1734484000708.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Removed
+---
+
+`MetricDefinitions` type ([#11433](https://github.com/linode/manager/pull/11433))

--- a/packages/api-v4/src/cloudpulse/services.ts
+++ b/packages/api-v4/src/cloudpulse/services.ts
@@ -3,13 +3,13 @@ import Request, { setData, setMethod, setURL } from '../request';
 import {
   JWEToken,
   JWETokenPayLoad,
-  MetricDefinitions,
+  MetricDefinition,
   ServiceTypesList,
 } from './types';
-import { ResourcePage as Page } from 'src/types';
+import { ResourcePage } from 'src/types';
 
 export const getMetricDefinitionsByServiceType = (serviceType: string) => {
-  return Request<Page<MetricDefinitions>>(
+  return Request<ResourcePage<MetricDefinition>>(
     setURL(
       `${API_ROOT}/monitor/services/${encodeURIComponent(
         serviceType

--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -85,11 +85,7 @@ export interface AclpWidget {
   size: number;
 }
 
-export interface MetricDefinitions {
-  data: AvailableMetrics[];
-}
-
-export interface AvailableMetrics {
+export interface MetricDefinition {
   label: string;
   metric: string;
   metric_type: string;

--- a/packages/manager/.changeset/pr-11433-tech-stories-1734484023886.md
+++ b/packages/manager/.changeset/pr-11433-tech-stories-1734484023886.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Fixed CloudPulse metric definition types ([#11433](https://github.com/linode/manager/pull/11433))

--- a/packages/manager/cypress/e2e/core/cloudpulse/cloudpulse-dashboard-errors.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/cloudpulse-dashboard-errors.spec.ts
@@ -86,15 +86,13 @@ const dashboard = dashboardFactory.build({
   }),
 });
 
-const metricDefinitions = {
-  data: metrics.map(({ title, name, unit }) =>
-    dashboardMetricFactory.build({
-      label: title,
-      metric: name,
-      unit,
-    })
-  ),
-};
+const metricDefinitions = metrics.map(({ title, name, unit }) =>
+  dashboardMetricFactory.build({
+    label: title,
+    metric: name,
+    unit,
+  })
+);
 
 const mockRegion = regionFactory.build({
   capabilities: ['Managed Databases'],

--- a/packages/manager/cypress/e2e/core/cloudpulse/dbaas-widgets-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/dbaas-widgets-verification.spec.ts
@@ -89,15 +89,13 @@ const dashboard = dashboardFactory.build({
   }),
 });
 
-const metricDefinitions = {
-  data: metrics.map(({ title, name, unit }) =>
-    dashboardMetricFactory.build({
-      label: title,
-      metric: name,
-      unit,
-    })
-  ),
-};
+const metricDefinitions = metrics.map(({ title, name, unit }) =>
+  dashboardMetricFactory.build({
+    label: title,
+    metric: name,
+    unit,
+  })
+);
 
 const mockLinode = linodeFactory.build({
   label: clusterName,

--- a/packages/manager/cypress/e2e/core/cloudpulse/linode-widget-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/linode-widget-verification.spec.ts
@@ -62,8 +62,14 @@ const flags: Partial<Flags> = {
     },
   ],
 };
-const { metrics, id, serviceType, dashboardName, region, resource } =
-  widgetDetails.linode;
+const {
+  metrics,
+  id,
+  serviceType,
+  dashboardName,
+  region,
+  resource,
+} = widgetDetails.linode;
 
 const dashboard = dashboardFactory.build({
   label: dashboardName,
@@ -78,15 +84,13 @@ const dashboard = dashboardFactory.build({
   }),
 });
 
-const metricDefinitions = {
-  data: metrics.map(({ title, name, unit }) =>
-    dashboardMetricFactory.build({
-      label: title,
-      metric: name,
-      unit,
-    })
-  ),
-};
+const metricDefinitions = metrics.map(({ title, name, unit }) =>
+  dashboardMetricFactory.build({
+    label: title,
+    metric: name,
+    unit,
+  })
+);
 
 const mockLinode = linodeFactory.build({
   label: resource,

--- a/packages/manager/cypress/support/intercepts/cloudpulse.ts
+++ b/packages/manager/cypress/support/intercepts/cloudpulse.ts
@@ -6,7 +6,7 @@
 
 import { makeErrorResponse } from 'support/util/errors';
 import { apiMatcher } from 'support/util/intercepts';
-import { paginate, paginateResponse } from 'support/util/paginate';
+import { paginateResponse } from 'support/util/paginate';
 import { randomString } from 'support/util/random';
 import { makeResponse } from 'support/util/response';
 

--- a/packages/manager/cypress/support/intercepts/cloudpulse.ts
+++ b/packages/manager/cypress/support/intercepts/cloudpulse.ts
@@ -6,14 +6,14 @@
 
 import { makeErrorResponse } from 'support/util/errors';
 import { apiMatcher } from 'support/util/intercepts';
-import { paginateResponse } from 'support/util/paginate';
+import { paginate, paginateResponse } from 'support/util/paginate';
 import { randomString } from 'support/util/random';
 import { makeResponse } from 'support/util/response';
 
 import type {
   CloudPulseMetricsResponse,
   Dashboard,
-  MetricDefinitions,
+  MetricDefinition,
 } from '@linode/api-v4';
 
 /**
@@ -27,12 +27,12 @@ import type {
 
 export const mockGetCloudPulseMetricDefinitions = (
   serviceType: string,
-  metricDefinitions: MetricDefinitions
+  metricDefinitions: MetricDefinition[]
 ): Cypress.Chainable<null> => {
   return cy.intercept(
     'GET',
     apiMatcher(`/monitor/services/${serviceType}/metric-definitions`),
-    makeResponse(metricDefinitions)
+    makeResponse(paginate(metricDefinitions))
   );
 };
 

--- a/packages/manager/cypress/support/intercepts/cloudpulse.ts
+++ b/packages/manager/cypress/support/intercepts/cloudpulse.ts
@@ -32,7 +32,7 @@ export const mockGetCloudPulseMetricDefinitions = (
   return cy.intercept(
     'GET',
     apiMatcher(`/monitor/services/${serviceType}/metric-definitions`),
-    makeResponse(paginate(metricDefinitions))
+    paginateResponse(metricDefinitions)
   );
 };
 

--- a/packages/manager/src/factories/dashboards.ts
+++ b/packages/manager/src/factories/dashboards.ts
@@ -1,7 +1,7 @@
 import Factory from 'src/factories/factoryProxy';
 
 import type {
-  AvailableMetrics,
+  MetricDefinition,
   CloudPulseMetricsResponse,
   CloudPulseMetricsResponseData,
   Dashboard,
@@ -52,7 +52,7 @@ export const widgetFactory = Factory.Sync.makeFactory<Widgets>({
   y_label: Factory.each((i) => `y_label_${i}`),
 });
 
-export const dashboardMetricFactory = Factory.Sync.makeFactory<AvailableMetrics>(
+export const dashboardMetricFactory = Factory.Sync.makeFactory<MetricDefinition>(
   {
     available_aggregate_functions: ['min', 'max', 'avg', 'sum'],
     dimensions: [],

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/Metric.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/Metric.test.tsx
@@ -7,8 +7,8 @@ import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
 import { Metric } from './Metric';
 
 import type { CreateAlertDefinitionForm } from '../types';
-import type { AvailableMetrics } from '@linode/api-v4';
-const mockData: AvailableMetrics[] = [
+import type { MetricDefinition } from '@linode/api-v4';
+const mockData: MetricDefinition[] = [
   {
     available_aggregate_functions: ['min', 'max', 'avg'],
     dimensions: [

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/Metric.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/Metric.tsx
@@ -13,7 +13,7 @@ import { ClearIconButton } from './ClearIconButton';
 import type { Item } from '../../constants';
 import type { CreateAlertDefinitionForm, MetricCriteriaForm } from '../types';
 import type {
-  AvailableMetrics,
+  MetricDefinition,
   MetricAggregationType,
   MetricOperatorType,
 } from '@linode/api-v4';
@@ -23,7 +23,7 @@ interface MetricCriteriaProps {
   /**
    * metric data fetched by the metric definitions endpoint
    */
-  data: AvailableMetrics[];
+  data: MetricDefinition[];
   /**
    * variable to check for metric definitions api call error state
    */

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/MetricCriteria.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/MetricCriteria.test.tsx
@@ -8,7 +8,7 @@ import { convertToSeconds } from '../utilities';
 import { MetricCriteriaField } from './MetricCriteria';
 
 import type { CreateAlertDefinitionForm } from '../types';
-import type { MetricDefinitions } from '@linode/api-v4';
+import type { MetricDefinition, ResourcePage } from '@linode/api-v4';
 
 const queryMocks = vi.hoisted(() => ({
   useGetCloudPulseMetricDefinitionsByServiceType: vi.fn().mockReturnValue({}),
@@ -23,7 +23,7 @@ vi.mock('src/queries/cloudpulse/services', async () => {
   };
 });
 
-const mockData: MetricDefinitions = {
+const mockData: ResourcePage<MetricDefinition> = {
   data: [
     {
       available_aggregate_functions: ['min', 'max', 'avg'],
@@ -87,6 +87,9 @@ const mockData: MetricDefinitions = {
       unit: 'byte',
     },
   ],
+  page: 1,
+  pages: 1,
+  results: 2,
 };
 
 queryMocks.useGetCloudPulseMetricDefinitionsByServiceType.mockReturnValue({

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
@@ -25,7 +25,7 @@ import type { FilterValueType } from '../Dashboard/CloudPulseDashboardLanding';
 import type { CloudPulseResources } from '../shared/CloudPulseResourcesSelect';
 import type { Widgets } from '@linode/api-v4';
 import type {
-  AvailableMetrics,
+  MetricDefinition,
   TimeDuration,
   TimeGranularity,
 } from '@linode/api-v4';
@@ -56,7 +56,7 @@ export interface CloudPulseWidgetProperties {
   /**
    * metrics defined of this widget
    */
-  availableMetrics: AvailableMetrics | undefined;
+  availableMetrics: MetricDefinition | undefined;
 
   /**
    * time duration to fetch the metrics data in this widget

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidgetRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidgetRenderer.tsx
@@ -18,10 +18,10 @@ import type {
 } from './CloudPulseWidget';
 import type {
   AclpConfig,
-  AvailableMetrics,
   Dashboard,
   JWEToken,
-  MetricDefinitions,
+  MetricDefinition,
+  ResourcePage,
   TimeDuration,
   Widgets,
 } from '@linode/api-v4';
@@ -33,7 +33,7 @@ interface WidgetProps {
   isJweTokenFetching: boolean;
   jweToken?: JWEToken | undefined;
   manualRefreshTimeStamp?: number;
-  metricDefinitions: MetricDefinitions | undefined;
+  metricDefinitions: ResourcePage<MetricDefinition> | undefined;
   preferences?: AclpConfig;
   resourceList: CloudPulseResources[] | undefined;
   resources: string[];
@@ -143,7 +143,7 @@ export const RenderWidgets = React.memo(
           if (widget) {
             // find the metric defintion of the widget label
             const availMetrics = metricDefinitions?.data.find(
-              (availMetrics: AvailableMetrics) =>
+              (availMetrics: MetricDefinition) =>
                 widget.label === availMetrics.label
             );
             const cloudPulseWidgetProperties = getCloudPulseGraphProperties({

--- a/packages/manager/src/queries/cloudpulse/services.ts
+++ b/packages/manager/src/queries/cloudpulse/services.ts
@@ -6,7 +6,8 @@ import type {
   APIError,
   JWEToken,
   JWETokenPayLoad,
-  MetricDefinitions,
+  MetricDefinition,
+  ResourcePage,
   ServiceTypesList,
 } from '@linode/api-v4';
 
@@ -14,7 +15,7 @@ export const useGetCloudPulseMetricDefinitionsByServiceType = (
   serviceType: string | undefined,
   enabled: boolean
 ) => {
-  return useQuery<MetricDefinitions, APIError[]>({
+  return useQuery<ResourcePage<MetricDefinition>, APIError[]>({
     ...queryFactory.metricsDefinitons(serviceType),
     enabled,
   });


### PR DESCRIPTION
## Description 📝

This PR fixes some inconsistencies and inaccuracies with the types for the  `GET /monitor/services/{service_type}/metric-definitions` I discovered in my [upcoming work](https://github.com/linode/manager/compare/develop...bnussman-akamai:manager:M3-8955-update-react-vnc-to-v2?expand=1) 🔧 

## Changes  🔄

- Renames `AvailableMetrics` interface to `MetricDefinition` to be more inline with the API
- Removes the `MetricDefinitions` type because `ResourcePage<MetricDefinition>` should be used instead

## How to test 🧪

- Verify there are no regressions to CloudPulse 📈 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>