### PR TITLE
test: [M3-8863, M3-9040] - Cypress test to validate aria label of Linode IP Addresses/Ranges action menu

### DIFF
--- a/packages/manager/.changeset/pr-11435-tests-1734516339389.md
+++ b/packages/manager/.changeset/pr-11435-tests-1734516339389.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Cypress test to validate aria label of Linode IP Addresses action menu ([#11435](https://github.com/linode/manager/pull/11435))

--- a/packages/manager/cypress/e2e/core/linodes/linode-network.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/linode-network.spec.ts
@@ -83,10 +83,11 @@ describe('linode networking', () => {
     ui.toast.assertMessage(`Successfully updated RDNS for ${linodeIPv4}`);
   });
 
-  it('validates content of IP Address table row action menu aria Label', () => {
-    // Setting the viewport to 1279px x 800px (width < 1280px) to make Action menu visible
+  it('validates the action menu title (aria-label) for the IP address in the table row', () => {
+    // Set the viewport to 1279px x 800px (width < 1280px) to ensure the Action menu is visible.
     cy.viewport(1279, 800);
 
+    // Ensure the action menu has the correct aria-label for the IP address.
     cy.get(`[data-qa-ip="${linodeIPv4}"]`)
       .should('be.visible')
       .closest('tr')

--- a/packages/manager/cypress/e2e/core/linodes/linode-network.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/linode-network.spec.ts
@@ -9,19 +9,16 @@ import { mockUpdateIPAddress } from 'support/intercepts/networking';
 import { ui } from 'support/ui';
 
 describe('linode networking', () => {
-  /**
-   * - Confirms the success toast message after editing RDNS
-   */
-  it('checks for the toast message upon editing an RDNS', () => {
-    const mockLinode = linodeFactory.build();
-    const linodeIPv4 = mockLinode.ipv4[0];
-    const mockRDNS = `${linodeIPv4}.ip.linodeusercontent.com`;
-    const ipAddress = ipAddressFactory.build({
-      address: linodeIPv4,
-      linode_id: mockLinode.id,
-      rdns: mockRDNS,
-    });
+  const mockLinode = linodeFactory.build();
+  const linodeIPv4 = mockLinode.ipv4[0];
+  const mockRDNS = `${linodeIPv4}.ip.linodeusercontent.com`;
+  const ipAddress = ipAddressFactory.build({
+    address: linodeIPv4,
+    linode_id: mockLinode.id,
+    rdns: mockRDNS,
+  });
 
+  beforeEach(() => {
     mockGetLinodeDetails(mockLinode.id, mockLinode).as('getLinode');
     mockGetLinodeFirewalls(mockLinode.id, []).as('getLinodeFirewalls');
     mockGetLinodeIPAddresses(mockLinode.id, {
@@ -36,7 +33,12 @@ describe('linode networking', () => {
 
     cy.visitWithLogin(`linodes/${mockLinode.id}/networking`);
     cy.wait(['@getLinode', '@getLinodeFirewalls', '@getLinodeIPAddresses']);
+  });
 
+  /**
+   * - Confirms the success toast message after editing RDNS
+   */
+  it('checks for the toast message upon editing an RDNS', () => {
     cy.findByLabelText('IPv4 Addresses')
       .should('be.visible')
       .within(() => {
@@ -79,5 +81,19 @@ describe('linode networking', () => {
 
     // confirm RDNS toast message
     ui.toast.assertMessage(`Successfully updated RDNS for ${linodeIPv4}`);
+  });
+
+  it('validates content of IP Address table row action menu aria Label', () => {
+    // Setting the viewport to 1279px x 800px (width < 1280px) to make Action menu visible
+    cy.viewport(1279, 800);
+
+    cy.get(`[data-qa-ip="${linodeIPv4}"]`)
+      .should('be.visible')
+      .closest('tr')
+      .within(() => {
+        ui.actionMenu
+          .findByTitle(`Action menu for IP Address ${linodeIPv4}`)
+          .should('be.visible');
+      });
   });
 });


### PR DESCRIPTION
## Description 📝
Cypress test to validate ARIA label of Linode IP Addresses action menu
- Related to: https://github.com/linode/manager/pull/11167

## Changes  🔄
- Add Cypress test to validate ARIA label of Linode IP Addresses table row action menu
- Refactor the code

## Target release date 🗓️
N/A

## How to test 🧪
- `yarn cy:run -s "cypress/e2e/core/linodes/linode-network.spec.ts"`
- Ensure all tests pass

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules