### PR TITLE
fix: [M3-9032] - ARIA label of action menu in Domains Landing table row

### DIFF
--- a/packages/manager/.changeset/pr-11437-fixed-1734527875368.md
+++ b/packages/manager/.changeset/pr-11437-fixed-1734527875368.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+ARIA label of action menu in Domains Landing table row ([#11437](https://github.com/linode/manager/pull/11437))

--- a/packages/manager/cypress/e2e/core/domains/smoke-clone-domain.spec.ts
+++ b/packages/manager/cypress/e2e/core/domains/smoke-clone-domain.spec.ts
@@ -60,7 +60,7 @@ describe('Clone a Domain', () => {
           .closest('tr')
           .within(() => {
             ui.actionMenu
-              .findByTitle(`Action menu for Domain ${domain}`)
+              .findByTitle(`Action menu for Domain ${domain.domain}`)
               .should('be.visible')
               .click();
           });
@@ -84,7 +84,7 @@ describe('Clone a Domain', () => {
           .closest('tr')
           .within(() => {
             ui.actionMenu
-              .findByTitle(`Action menu for Domain ${domain}`)
+              .findByTitle(`Action menu for Domain ${domain.domain}`)
               .should('be.visible')
               .click();
           });

--- a/packages/manager/cypress/e2e/core/domains/smoke-delete-domain.spec.ts
+++ b/packages/manager/cypress/e2e/core/domains/smoke-delete-domain.spec.ts
@@ -33,7 +33,7 @@ describe('Delete a Domain', () => {
           .closest('tr')
           .within(() => {
             ui.actionMenu
-              .findByTitle(`Action menu for Domain ${domain}`)
+              .findByTitle(`Action menu for Domain ${domain.domain}`)
               .should('be.visible')
               .click();
           });
@@ -57,7 +57,7 @@ describe('Delete a Domain', () => {
           .closest('tr')
           .within(() => {
             ui.actionMenu
-              .findByTitle(`Action menu for Domain ${domain}`)
+              .findByTitle(`Action menu for Domain ${domain.domain}`)
               .should('be.visible')
               .click();
           });

--- a/packages/manager/src/features/Domains/DomainActionMenu.tsx
+++ b/packages/manager/src/features/Domains/DomainActionMenu.tsx
@@ -91,7 +91,7 @@ export const DomainActionMenu = React.memo((props: DomainActionMenuProps) => {
         })}
       <ActionMenu
         actionsList={menuActions}
-        ariaLabel={`Action menu for Domain ${domain}`}
+        ariaLabel={`Action menu for Domain ${domain.domain}`}
       />
     </>
   );


### PR DESCRIPTION
## Description 📝
A small, quick PR to fix ARIA label of action menu in Domains Landing table row.

## Changes  🔄
- Updated the aria-label of the Action Menu in the Domains Landing page table row from `[object Object]` to a human-readable label
- Updated e2e tests

## Target release date 🗓️
N/A

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-12-18 at 6 24 38 PM](https://github.com/user-attachments/assets/e014f534-ed29-422c-92a4-6adc2e4c0eb7) | ![Screenshot 2024-12-18 at 6 40 17 PM](https://github.com/user-attachments/assets/c08527d9-6dff-4936-abae-58aab68e9c96) |

## How to test 🧪
- Go to the Domains Landing Page
- Inspect the Table Row Action Menu
- Check that the `aria-label` is in a human-readable format
- Ensure all tests pass


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules