### PR TITLE
change: [M3-9041] - Remove `Images are not encrypted` warning

### DIFF
--- a/packages/manager/.changeset/pr-11443-removed-1734624899643.md
+++ b/packages/manager/.changeset/pr-11443-removed-1734624899643.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Removed
+---
+
+`Images are not encrypted warning` warning ([#11443](https://github.com/linode/manager/pull/11443))

--- a/packages/manager/cypress/e2e/core/images/create-image.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/create-image.spec.ts
@@ -1,46 +1,9 @@
-import type { Linode, Region } from '@linode/api-v4';
-import { accountFactory, linodeFactory, regionFactory } from 'src/factories';
+import type { Linode } from '@linode/api-v4';
 import { authenticate } from 'support/api/authentication';
-import { mockGetAccount } from 'support/intercepts/account';
-import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
 import { ui } from 'support/ui';
 import { cleanUp } from 'support/util/cleanup';
 import { createTestLinode } from 'support/util/linodes';
 import { randomLabel, randomPhrase } from 'support/util/random';
-import { mockGetRegions } from 'support/intercepts/regions';
-import {
-  mockGetLinodeDetails,
-  mockGetLinodes,
-} from 'support/intercepts/linodes';
-
-const mockRegions: Region[] = [
-  regionFactory.build({
-    capabilities: ['Linodes', 'Disk Encryption'],
-    id: 'us-east',
-    label: 'Newark, NJ',
-    site_type: 'core',
-  }),
-  regionFactory.build({
-    capabilities: ['Linodes', 'Disk Encryption'],
-    id: 'us-den-1',
-    label: 'Distributed - Denver, CO',
-    site_type: 'distributed',
-  }),
-];
-
-const mockLinodes: Linode[] = [
-  linodeFactory.build({
-    label: 'core-region-linode',
-    region: mockRegions[0].id,
-  }),
-  linodeFactory.build({
-    label: 'distributed-region-linode',
-    region: mockRegions[1].id,
-  }),
-];
-
-const DISK_ENCRYPTION_IMAGES_CAVEAT_COPY =
-  'Virtual Machine Images are not encrypted.';
 
 authenticate();
 describe('create image (e2e)', () => {
@@ -53,9 +16,9 @@ describe('create image (e2e)', () => {
     const label = randomLabel();
     const description = randomPhrase();
 
-    // When Alpine 3.19 becomes deprecated, we will have to update these values for the test to pass.
-    const image = 'linode/alpine3.19';
-    const disk = 'Alpine 3.19 Disk';
+    // When Alpine 3.20 becomes deprecated, we will have to update these values for the test to pass.
+    const image = 'linode/alpine3.20';
+    const disk = 'Alpine 3.20 Disk';
 
     cy.defer(
       () => createTestLinode({ image }, { waitForDisks: true }),
@@ -122,117 +85,5 @@ describe('create image (e2e)', () => {
           cy.findByText('Creating', { exact: false }).should('be.visible');
         });
     });
-  });
-
-  it('displays notice informing user that Images are not encrypted, provided the LDE feature is enabled and the selected linode is not in a distributed region', () => {
-    // Mock feature flag -- @TODO LDE: Remove feature flag once LDE is fully rolled out
-    mockAppendFeatureFlags({
-      linodeDiskEncryption: true,
-    }).as('getFeatureFlags');
-
-    // Mock responses
-    const mockAccount = accountFactory.build({
-      capabilities: ['Linodes', 'Disk Encryption'],
-    });
-
-    mockGetAccount(mockAccount).as('getAccount');
-    mockGetRegions(mockRegions).as('getRegions');
-    mockGetLinodes(mockLinodes).as('getLinodes');
-
-    // intercept request
-    cy.visitWithLogin('/images/create');
-    cy.wait(['@getFeatureFlags', '@getAccount', '@getLinodes', '@getRegions']);
-
-    // Find the Linode select and open it
-    cy.findByLabelText('Linode')
-      .should('be.visible')
-      .should('be.enabled')
-      .should('have.attr', 'placeholder', 'Select a Linode')
-      .click();
-
-    // Select the Linode
-    ui.autocompletePopper
-      .findByTitle(mockLinodes[0].label)
-      .should('be.visible')
-      .should('be.enabled')
-      .click();
-
-    // Check if notice is visible
-    cy.findByText(DISK_ENCRYPTION_IMAGES_CAVEAT_COPY).should('be.visible');
-  });
-
-  it('does not display a notice informing user that Images are not encrypted if the LDE feature is disabled', () => {
-    // Mock feature flag -- @TODO LDE: Remove feature flag once LDE is fully rolled out
-    mockAppendFeatureFlags({
-      linodeDiskEncryption: false,
-    }).as('getFeatureFlags');
-
-    // Mock responses
-    const mockAccount = accountFactory.build({
-      capabilities: ['Linodes', 'Disk Encryption'],
-    });
-
-    mockGetAccount(mockAccount).as('getAccount');
-    mockGetRegions(mockRegions).as('getRegions');
-    mockGetLinodes(mockLinodes).as('getLinodes');
-
-    // intercept request
-    cy.visitWithLogin('/images/create');
-    cy.wait(['@getFeatureFlags', '@getAccount', '@getLinodes', '@getRegions']);
-
-    // Find the Linode select and open it
-    cy.findByLabelText('Linode')
-      .should('be.visible')
-      .should('be.enabled')
-      .should('have.attr', 'placeholder', 'Select a Linode')
-      .click();
-
-    // Select the Linode
-    ui.autocompletePopper
-      .findByTitle(mockLinodes[0].label)
-      .should('be.visible')
-      .should('be.enabled')
-      .click();
-
-    // Check if notice is visible
-    cy.findByText(DISK_ENCRYPTION_IMAGES_CAVEAT_COPY).should('not.exist');
-  });
-
-  it('does not display a notice informing user that Images are not encrypted if the selected linode is in a distributed region', () => {
-    // Mock feature flag -- @TODO LDE: Remove feature flag once LDE is fully rolled out
-    mockAppendFeatureFlags({
-      linodeDiskEncryption: true,
-    }).as('getFeatureFlags');
-
-    // Mock responses
-    const mockAccount = accountFactory.build({
-      capabilities: ['Linodes', 'Disk Encryption'],
-    });
-
-    mockGetAccount(mockAccount).as('getAccount');
-    mockGetRegions(mockRegions).as('getRegions');
-    mockGetLinodes(mockLinodes).as('getLinodes');
-    mockGetLinodeDetails(mockLinodes[1].id, mockLinodes[1]);
-
-    // intercept request
-    cy.visitWithLogin('/images/create');
-    cy.wait(['@getFeatureFlags', '@getAccount', '@getRegions', '@getLinodes']);
-
-    // Find the Linode select and open it
-    cy.findByLabelText('Linode')
-      .should('be.visible')
-      .should('be.enabled')
-      .should('have.attr', 'placeholder', 'Select a Linode')
-      .click();
-
-    // Select the Linode
-    ui.autocompletePopper
-      .findByTitle(mockLinodes[1].label)
-      .should('be.visible')
-      .should('be.enabled')
-      .click();
-
-    // Check if notice is visible
-    cy.findByText(DISK_ENCRYPTION_IMAGES_CAVEAT_COPY).should('not.exist');
   });
 });

--- a/packages/manager/src/components/Encryption/constants.tsx
+++ b/packages/manager/src/components/Encryption/constants.tsx
@@ -49,9 +49,6 @@ export const DISK_ENCRYPTION_DESCRIPTION_NODE_POOL_REBUILD_CAVEAT =
 export const DISK_ENCRYPTION_BACKUPS_CAVEAT_COPY =
   'Virtual Machine Backups are not encrypted.';
 
-export const DISK_ENCRYPTION_IMAGES_CAVEAT_COPY =
-  'Virtual Machine Images are not encrypted.';
-
 export const ENCRYPT_DISK_DISABLED_REBUILD_LKE_REASON =
   'The Encrypt Disk setting cannot be changed for a Linode attached to a node pool.';
 

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.test.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.test.tsx
@@ -197,38 +197,6 @@ describe('CreateImageTab', () => {
     );
   });
 
-  it('should render an encryption notice if disk encryption is enabled and the Linode is not in a distributed compute region', async () => {
-    const region = regionFactory.build({ site_type: 'core' });
-    const linode = linodeFactory.build({ region: region.id });
-
-    server.use(
-      http.get('*/v4/linode/instances', () => {
-        return HttpResponse.json(makeResourcePage([linode]));
-      }),
-      http.get('*/v4/linode/instances/:id', () => {
-        return HttpResponse.json(linode);
-      }),
-      http.get('*/v4/regions', () => {
-        return HttpResponse.json(makeResourcePage([region]));
-      })
-    );
-
-    const { findByText, getByLabelText } = renderWithTheme(<CreateImageTab />, {
-      flags: { linodeDiskEncryption: true },
-    });
-
-    const linodeSelect = getByLabelText('Linode');
-
-    await userEvent.click(linodeSelect);
-
-    const linodeOption = await findByText(linode.label);
-
-    await userEvent.click(linodeOption);
-
-    // Verify encryption notice renders
-    await findByText('Virtual Machine Images are not encrypted.');
-  });
-
   it('should auto-populate image label based on linode and disk', async () => {
     const linode = linodeFactory.build();
     const disk1 = linodeDiskFactory.build();

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -13,12 +13,10 @@ import {
 } from '@linode/ui';
 import { createImageSchema } from '@linode/validation';
 import { useSnackbar } from 'notistack';
-import * as React from 'react';
+import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useHistory, useLocation } from 'react-router-dom';
 
-import { DISK_ENCRYPTION_IMAGES_CAVEAT_COPY } from 'src/components/Encryption/constants';
-import { useIsDiskEncryptionFeatureEnabled } from 'src/components/Encryption/utils';
 import { Link } from 'src/components/Link';
 import { TagsInput } from 'src/components/TagsInput/TagsInput';
 import { getRestrictedResourceText } from 'src/features/Account/utils';
@@ -77,10 +75,6 @@ export const CreateImageTab = () => {
   const isImageCreateRestricted = useRestrictedGlobalGrantCheck({
     globalGrantType: 'add_images',
   });
-
-  const {
-    isDiskEncryptionFeatureEnabled,
-  } = useIsDiskEncryptionFeatureEnabled();
 
   const onSubmit = handleSubmit(async (values) => {
     try {
@@ -156,17 +150,6 @@ export const CreateImageTab = () => {
   const linodeRegionSupportsImageStorage = selectedLinodeRegion?.capabilities.includes(
     'Object Storage'
   );
-
-  /*
-    We only want to display the notice about disk encryption if:
-    1. the Disk Encryption feature is enabled
-    2. a linode is selected
-    2. the selected linode is not in an Edge region
-  */
-  const showDiskEncryptionWarning =
-    isDiskEncryptionFeatureEnabled &&
-    selectedLinodeId !== null &&
-    !linodeIsInDistributedRegion;
 
   const linodeSelectHelperText = grants?.linode.some(
     (grant) => grant.permissions === 'read_only'
@@ -257,13 +240,6 @@ export const CreateImageTab = () => {
                 </Link>
                 . After it's stored, you can replicate it to other core compute
                 regions.
-              </Notice>
-            )}
-            {showDiskEncryptionWarning && (
-              <Notice variant="warning">
-                <Typography sx={(theme) => ({ fontFamily: theme.font.normal })}>
-                  {DISK_ENCRYPTION_IMAGES_CAVEAT_COPY}
-                </Typography>
               </Notice>
             )}
             <Controller


### PR DESCRIPTION
## Description 📝

- Removes the `Images are not encrypted` warning on the Image create flow
  - We are removing it because it is no longer true. Because _Image Service Gen2_ is GA, all newly created images **are encrypted** 🔒 

## Target release date 🗓️

1/14/2025

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2024-12-19 at 11 05 28 AM](https://github.com/user-attachments/assets/431e9f98-96d6-4be8-aa34-ff0d6aca0813) | ![Screenshot 2024-12-19 at 11 05 17 AM](https://github.com/user-attachments/assets/b0facf3d-3ee7-4ed7-9bb9-1eb958751f95) |

## How to test 🧪

- Check out this PR or use the internal preview link
- Create a Linode or use an existing Linode in a core region
- Select the Linode on the images create page (http://localhost:3000/images/create/disk)
- Verify there is no notice saying `Images are not encrypted`

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>