### PR TITLE
test: [M3-8996] - Add test for LKE cluster rename flow

### DIFF
--- a/packages/manager/.changeset/pr-11444-tests-1734632019649.md
+++ b/packages/manager/.changeset/pr-11444-tests-1734632019649.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add test for LKE cluster rename flow ([#11444](https://github.com/linode/manager/pull/11444))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -29,6 +29,7 @@ import {
   mockGetControlPlaneACL,
   mockUpdateControlPlaneACLError,
   mockGetControlPlaneACLError,
+  mockUpdateClusterError,
 } from 'support/intercepts/lke';
 import {
   mockGetLinodeType,
@@ -857,6 +858,74 @@ describe('LKE cluster updates', () => {
         .findByTitle('Delete Pool')
         .should('be.visible')
         .should('be.disabled');
+    });
+
+    /*
+     * - Confirms LKE summary page updates to reflect new cluster name.
+     */
+    it('can rename cluster', () => {
+      const mockCluster = kubernetesClusterFactory.build({
+        k8s_version: latestKubernetesVersion,
+      });
+      const mockNewCluster = kubernetesClusterFactory.build({
+        label: 'newClusterName',
+      });
+
+      mockGetCluster(mockCluster).as('getCluster');
+      mockGetKubernetesVersions().as('getVersions');
+      mockGetClusterPools(mockCluster.id, mockNodePools).as('getNodePools');
+      mockUpdateCluster(mockCluster.id, mockNewCluster).as('updateCluster');
+
+      cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}/summary`);
+      cy.wait(['@getCluster', '@getNodePools', '@getVersions']);
+
+      // LKE clusters can be renamed by clicking on the cluster's name in the breadcrumbs towards the top of the page.
+      cy.get('[data-testid="editable-text"] > [data-testid="button"]').click();
+      cy.findByTestId('textfield-input')
+        .should('be.visible')
+        .should('have.value', mockCluster.label)
+        .clear()
+        .type(`${mockNewCluster.label}{enter}`);
+
+      cy.wait('@updateCluster');
+
+      cy.findAllByText(mockNewCluster.label).should('be.visible');
+      cy.findAllByText(mockCluster.label).should('not.exist');
+    });
+
+    /*
+     * - Confirms error message shows when the API request fails.
+     */
+    it('can handle API errors when rename cluster', () => {
+      const mockCluster = kubernetesClusterFactory.build({
+        k8s_version: latestKubernetesVersion,
+      });
+      const mockErrorCluster = kubernetesClusterFactory.build({
+        label: 'errorClusterName',
+      });
+      const mockErrorMessage = 'API request fails';
+
+      mockGetCluster(mockCluster).as('getCluster');
+      mockGetKubernetesVersions().as('getVersions');
+      mockGetClusterPools(mockCluster.id, mockNodePools).as('getNodePools');
+      mockUpdateClusterError(mockCluster.id, mockErrorMessage).as(
+        'updateClusterError'
+      );
+
+      cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}/summary`);
+      cy.wait(['@getCluster', '@getNodePools', '@getVersions']);
+
+      // LKE cluster can be renamed by clicking on the cluster's name in the breadcrumbs towards the top of the page.
+      cy.get('[data-testid="editable-text"] > [data-testid="button"]').click();
+      cy.findByTestId('textfield-input')
+        .should('be.visible')
+        .should('have.value', mockCluster.label)
+        .clear()
+        .type(`${mockErrorCluster.label}{enter}`);
+
+      // Error message shows when API request fails.
+      cy.wait('@updateClusterError');
+      cy.findAllByText(mockErrorMessage).should('be.visible');
     });
   });
 

--- a/packages/manager/cypress/support/intercepts/lke.ts
+++ b/packages/manager/cypress/support/intercepts/lke.ts
@@ -508,3 +508,24 @@ export const mockGetLKEClusterTypes = (
 ): Cypress.Chainable<null> => {
   return cy.intercept('GET', apiMatcher('lke/types*'), paginateResponse(types));
 };
+
+/**
+ * Intercepts PUT request to update an LKE cluster and mocks an error response.
+ *
+ * @param clusterId - ID of cluster for which to intercept PUT request.
+ * @param errorMessage - Optional error message with which to mock response.
+ * @param statusCode - HTTP status code with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockUpdateClusterError = (
+  clusterId: number,
+  errorMessage: string = 'An unknown error occurred.',
+  statusCode: number = 500
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'PUT',
+    apiMatcher(`lke/clusters/${clusterId}`),
+    makeErrorResponse(errorMessage, statusCode)
+  );
+};


### PR DESCRIPTION
## Description 📝

Add a Cypress integration test using mock data to confirm that the LKE cluster rename flow works as expected.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Add tests in packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
- Add mockUpdateClusterError in packages/manager/cypress/support/intercepts/lke.ts

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/kubernetes/lke-update.spec.ts"
```

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>