### PR TITLE
upcoming: [DI-22558] - Added Trigger condition and Dimension Filter components

### DIFF
--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -2,7 +2,11 @@ export type AlertSeverityType = 0 | 1 | 2 | 3;
 export type MetricAggregationType = 'avg' | 'sum' | 'min' | 'max' | 'count';
 export type MetricOperatorType = 'eq' | 'gt' | 'lt' | 'gte' | 'lte';
 export type AlertServiceType = 'linode' | 'dbaas';
-type DimensionFilterOperatorType = 'eq' | 'neq' | 'startswith' | 'endswith';
+export type DimensionFilterOperatorType =
+  | 'eq'
+  | 'neq'
+  | 'startswith'
+  | 'endswith';
 export type AlertDefinitionType = 'system' | 'user';
 export type AlertStatusType = 'enabled' | 'disabled';
 export type CriteriaConditionType = 'ALL';
@@ -168,20 +172,24 @@ export interface MetricCriteria {
   aggregation_type: MetricAggregationType;
   operator: MetricOperatorType;
   threshold: number;
-  dimension_filters: DimensionFilter[];
+  dimension_filters?: DimensionFilter[];
 }
 
-export interface AlertDefinitionMetricCriteria extends MetricCriteria {
+export interface AlertDefinitionMetricCriteria
+  extends Omit<MetricCriteria, 'dimension_filters'> {
   unit: string;
   label: string;
+  dimension_filters?: AlertDefinitionDimensionFilter[];
 }
 export interface DimensionFilter {
-  label: string;
   dimension_label: string;
   operator: DimensionFilterOperatorType;
   value: string;
 }
 
+export interface AlertDefinitionDimensionFilter extends DimensionFilter {
+  label: string;
+}
 export interface TriggerCondition {
   polling_interval_seconds: number;
   evaluation_period_seconds: number;

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
@@ -10,6 +10,7 @@ import { Breadcrumb } from 'src/components/Breadcrumb/Breadcrumb';
 import { useCreateAlertDefinition } from 'src/queries/cloudpulse/alerts';
 
 import { MetricCriteriaField } from './Criteria/MetricCriteria';
+import { TriggerConditions } from './Criteria/TriggerConditions';
 import { CloudPulseAlertSeveritySelect } from './GeneralInformation/AlertSeveritySelect';
 import { EngineOption } from './GeneralInformation/EngineOption';
 import { CloudPulseRegionSelect } from './GeneralInformation/RegionSelect';
@@ -164,8 +165,10 @@ export const CreateAlertDefinition = () => {
             name="rule_criteria.rules"
             serviceType={serviceTypeWatcher!}
           />
-          {/* This is just being displayed to pass the typecheck-manager test. In the next PR maxScrapeInterval will be used by another component */}
-          {maxScrapeInterval}
+          <TriggerConditions
+            maxScrapingInterval={maxScrapeInterval}
+            name={'trigger_conditions'}
+          />
           <ActionsPanel
             primaryButtonProps={{
               label: 'Submit',

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilter.tsx
@@ -1,0 +1,74 @@
+import { Box } from '@linode/ui';
+import { Button, Stack, Typography } from '@linode/ui';
+import React from 'react';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+
+import { DimensionFilterField } from './DimensionFilterField';
+
+import type { CreateAlertDefinitionForm, DimensionFilterForm } from '../types';
+import type { Dimension } from '@linode/api-v4';
+import type { FieldPathByValue } from 'react-hook-form';
+
+interface DimensionFilterProps {
+  /**
+   * dimension filter data for the selected metric
+   */
+  dimensionOptions: Dimension[];
+  /**
+   * name used for the component to set in the form
+   */
+  name: FieldPathByValue<CreateAlertDefinitionForm, DimensionFilterForm[]>;
+}
+export const DimensionFilters = (props: DimensionFilterProps) => {
+  const { dimensionOptions, name } = props;
+  const { control } = useFormContext<CreateAlertDefinitionForm>();
+
+  const { append, fields, remove } = useFieldArray({
+    control,
+    name,
+  });
+  return (
+    <Box sx={(theme) => ({ marginTop: theme.spacing(2) })}>
+      <>
+        <Box
+          alignItems={'center'}
+          display={'flex'}
+          justifyContent={'space-between'}
+        >
+          <Typography variant={'h3'}>
+            Dimension Filter
+            <Typography component="span"> (optional)</Typography>
+          </Typography>
+        </Box>
+
+        <Stack>
+          {fields !== null &&
+            fields.length !== 0 &&
+            fields.map((field, index) => (
+              <DimensionFilterField
+                dimensionOptions={dimensionOptions}
+                key={field.id}
+                name={`${name}.${index}`}
+                onFilterDelete={() => remove(index)}
+              />
+            ))}
+        </Stack>
+        <Button
+          onClick={() =>
+            append({
+              dimension_label: null,
+              operator: null,
+              value: null,
+            })
+          }
+          buttonType="secondary"
+          compactX={true}
+          size="small"
+          sx={(theme) => ({ marginTop: theme.spacing(1) })}
+        >
+          Add dimension filter
+        </Button>
+      </>
+    </Box>
+  );
+};

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterField.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterField.tsx
@@ -1,0 +1,184 @@
+import { Autocomplete } from '@linode/ui';
+import { Grid } from '@mui/material';
+import React from 'react';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
+
+import { DimensionOperatorOptions } from '../../constants';
+import { ClearIconButton } from './ClearIconButton';
+
+import type { CreateAlertDefinitionForm, DimensionFilterForm } from '../types';
+import type { Dimension, DimensionFilterOperatorType } from '@linode/api-v4';
+import type { FieldPathByValue } from 'react-hook-form';
+
+interface DimensionFilterFieldProps {
+  /**
+   * dimension filter data options to list in the Autocomplete component
+   */
+  dimensionOptions: Dimension[];
+  /**
+   * name (with the index) used for the component to set in form
+   */
+  name: FieldPathByValue<CreateAlertDefinitionForm, DimensionFilterForm>;
+  /**
+   * function to delete the DimensionFilter component
+   * @returns void
+   */
+  onFilterDelete: () => void;
+}
+
+export const DimensionFilterField = (props: DimensionFilterFieldProps) => {
+  const { dimensionOptions, name, onFilterDelete } = props;
+
+  const { control, setValue } = useFormContext<CreateAlertDefinitionForm>();
+
+  const dataFieldOptions =
+    dimensionOptions.map((dimension) => ({
+      label: dimension.label,
+      value: dimension.dimension_label,
+    })) ?? [];
+
+  const handleDataFieldChange = (
+    selected: { label: string; value: string },
+    operation: string
+  ) => {
+    const fieldValue = {
+      dimension_label: null,
+      operator: null,
+      value: null,
+    };
+    if (operation === 'selectOption') {
+      setValue(name, { ...fieldValue, dimension_label: selected.value });
+    }
+    if (operation === 'clear') {
+      setValue(name, fieldValue);
+    }
+  };
+
+  const dimensionFieldWatcher = useWatch({
+    control,
+    name: `${name}.dimension_label`,
+  });
+
+  const selectedDimension = React.useMemo(() => {
+    return dimensionOptions && dimensionFieldWatcher
+      ? dimensionOptions.find(
+          (dim) => dim.dimension_label === dimensionFieldWatcher
+        )
+      : null;
+  }, [dimensionFieldWatcher, dimensionOptions]);
+
+  const valueOptions = React.useMemo(() => {
+    return selectedDimension && selectedDimension.values
+      ? selectedDimension.values.map((val) => ({ label: val, value: val }))
+      : [];
+  }, [selectedDimension]);
+
+  // eslint-disable-next-line no-console
+  console.log(dimensionFieldWatcher, selectedDimension, dataFieldOptions);
+  return (
+    <Grid alignItems="flex-start" container spacing={2}>
+      <Grid item md={3} sm={6} xs={12}>
+        <Controller
+          render={({ field, fieldState }) => (
+            <Autocomplete
+              onChange={(
+                _,
+                newValue: { label: string; value: string },
+                operation
+              ) => {
+                handleDataFieldChange(newValue, operation);
+              }}
+              value={
+                field.value !== null
+                  ? dataFieldOptions.find(
+                      (option) => option.value === field.value
+                    ) ?? null
+                  : null
+              }
+              data-testid="Data-field"
+              errorText={fieldState.error?.message}
+              label="Data Field"
+              onBlur={field.onBlur}
+              options={dataFieldOptions}
+              placeholder="Select a Data field"
+            />
+          )}
+          control={control}
+          name={`${name}.dimension_label`}
+        />
+      </Grid>
+      <Grid item md={2} sm={3} xs={12}>
+        <Controller
+          render={({ field, fieldState }) => (
+            <Autocomplete
+              onChange={(
+                _,
+                newValue: { label: string; value: DimensionFilterOperatorType },
+                operation
+              ) => {
+                if (operation === 'selectOption') {
+                  field.onChange(newValue.value);
+                }
+                if (operation === 'clear') {
+                  field.onChange(null);
+                }
+              }}
+              value={
+                field.value !== null
+                  ? DimensionOperatorOptions.find(
+                      (option) => option.value === field.value
+                    ) ?? null
+                  : null
+              }
+              data-testid="Operator"
+              errorText={fieldState.error?.message}
+              label={'Operator'}
+              onBlur={field.onBlur}
+              options={DimensionOperatorOptions}
+            />
+          )}
+          control={control}
+          name={`${name}.operator`}
+        />
+      </Grid>
+      <Grid item md={3} sm={4} xs={12}>
+        <Controller
+          render={({ field, fieldState }) => (
+            <Autocomplete
+              onChange={(
+                _,
+                selected: { label: string; value: string },
+                operation
+              ) => {
+                if (operation === 'selectOption') {
+                  field.onChange(selected.value);
+                }
+                if (operation === 'clear') {
+                  field.onChange(null);
+                }
+              }}
+              value={
+                field.value !== null
+                  ? valueOptions.find(
+                      (option) => option.value === field.value
+                    ) ?? null
+                  : null
+              }
+              data-testid="Value"
+              errorText={fieldState.error?.message}
+              label="Value"
+              onBlur={field.onBlur}
+              options={valueOptions}
+              placeholder="Select a Value"
+            />
+          )}
+          control={control}
+          name={`${name}.value`}
+        />
+      </Grid>
+      <Grid item marginTop={6} paddingLeft={1}>
+        <ClearIconButton handleClick={onFilterDelete} />
+      </Grid>
+    </Grid>
+  );
+};

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/Metric.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/Metric.tsx
@@ -9,6 +9,7 @@ import {
   MetricOperatorOptions,
 } from '../../constants';
 import { ClearIconButton } from './ClearIconButton';
+import { DimensionFilters } from './DimensionFilter';
 
 import type { Item } from '../../constants';
 import type { CreateAlertDefinitionForm, MetricCriteriaForm } from '../types';
@@ -291,6 +292,11 @@ export const Metric = (props: MetricCriteriaProps) => {
             </Grid>
           </Grid>
         </Grid>
+        <DimensionFilters
+          dimensionOptions={selectedMetric?.dimensions ?? []}
+          key={metricWatcher}
+          name={`${name}.dimension_filters`}
+        />
       </Stack>
     </Box>
   );

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/TriggerConditions.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/TriggerConditions.tsx
@@ -1,0 +1,208 @@
+import { Autocomplete, Box, TextField, Typography } from '@linode/ui';
+import { Grid } from '@mui/material';
+import * as React from 'react';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
+
+import {
+  EvaluationPeriodOptions,
+  PollingIntervalOptions,
+} from '../../constants';
+
+import type { CreateAlertDefinitionForm } from '../types';
+import type {
+  CreateAlertDefinitionPayload,
+  TriggerCondition,
+} from '@linode/api-v4';
+import type { FieldPathByValue } from 'react-hook-form';
+interface TriggerConditionProps {
+  /**
+   * maximum scraping interval value for a metric to filter the evaluation period and polling interval options
+   */
+  maxScrapingInterval: number;
+  /**
+   * name used for the component to set in form
+   */
+  name: FieldPathByValue<CreateAlertDefinitionPayload, TriggerCondition>;
+}
+export const TriggerConditions = (props: TriggerConditionProps) => {
+  const { maxScrapingInterval, name } = props;
+
+  const { control } = useFormContext<CreateAlertDefinitionForm>();
+  const serviceTypeWatcher = useWatch({
+    control,
+    name: 'serviceType',
+  });
+  const getPollingIntervalOptions = () => {
+    const options = serviceTypeWatcher
+      ? PollingIntervalOptions[serviceTypeWatcher]
+      : [];
+    return options.filter((item) => item.value >= maxScrapingInterval);
+  };
+
+  const getEvaluationPeriodOptions = () => {
+    const options = serviceTypeWatcher
+      ? EvaluationPeriodOptions[serviceTypeWatcher]
+      : [];
+    return options.filter((item) => item.value >= maxScrapingInterval);
+  };
+
+  return (
+    <Box
+      sx={(theme) => ({
+        backgroundColor:
+          theme.name === 'light' ? theme.color.grey5 : theme.color.grey9,
+        borderRadius: 1,
+        marginTop: theme.spacing(2),
+        p: 2,
+      })}
+    >
+      <Typography variant="h3"> Trigger Conditions</Typography>
+      <Grid alignItems="flex-start" container spacing={2}>
+        <Grid item md={3} sm={6} xs={12}>
+          <Controller
+            render={({ field, fieldState }) => (
+              <Autocomplete
+                onChange={(
+                  _,
+                  selected: { label: string; value: number },
+                  operation
+                ) => {
+                  if (operation === 'selectOption') {
+                    field.onChange(selected.value);
+                  }
+                  if (operation === 'clear') {
+                    field.onChange(null);
+                  }
+                }}
+                textFieldProps={{
+                  labelTooltipText:
+                    'Defines the timeframe for collecting data in polling intervals to understand the service performance. Choose the data lookback period where the thresholds are applied to gather the information impactful for your business.',
+                }}
+                value={
+                  field.value !== null
+                    ? getEvaluationPeriodOptions().find(
+                        (option) => option.value === field.value
+                      ) ?? null
+                    : null
+                }
+                data-testid="Evaluation-period"
+                disabled={!serviceTypeWatcher}
+                errorText={fieldState.error?.message}
+                label={'Evaluation Period'}
+                onBlur={field.onBlur}
+                options={getEvaluationPeriodOptions()}
+                placeholder="Select an Evaluation period"
+              />
+            )}
+            control={control}
+            name={`${name}.evaluation_period_seconds`}
+          />
+        </Grid>
+        <Grid item md={2.5} sm={6} xs={12}>
+          <Controller
+            render={({ field, fieldState }) => (
+              <Autocomplete
+                onChange={(
+                  _,
+                  newValue: { label: string; value: number },
+                  operation
+                ) => {
+                  if (operation === 'selectOption') {
+                    field.onChange(newValue.value);
+                  }
+                  if (operation === 'clear') {
+                    field.onChange(null);
+                  }
+                }}
+                textFieldProps={{
+                  labelTooltipText:
+                    'Choose how often you intend to evaulate the alert condition.',
+                }}
+                value={
+                  field.value !== null
+                    ? getPollingIntervalOptions().find(
+                        (option) => option.value === field.value
+                      ) ?? null
+                    : null
+                }
+                data-testid="Polling-interval"
+                disabled={!serviceTypeWatcher}
+                errorText={fieldState.error?.message}
+                label={'Polling Interval'}
+                onBlur={field.onBlur}
+                options={getPollingIntervalOptions()}
+                placeholder="Select a Polling"
+              />
+            )}
+            control={control}
+            name={`${name}.polling_interval_seconds`}
+          />
+        </Grid>
+        <Grid item marginTop={{ sm: 1, xs: 0 }} md={'auto'} sm={12} xs={12}>
+          <Grid alignItems="flex-start" container>
+            <Grid item md={'auto'} sm={6} xs={12}>
+              <Box marginTop={{ md: 4 }}>
+                <Typography
+                  sx={{
+                    alignItems: 'center',
+                    display: 'flex',
+                    height: { sm: '56px', xs: '50px' },
+                  }}
+                  variant="body1"
+                >
+                  criteria are met for at least
+                </Typography>
+              </Box>
+            </Grid>
+            <Grid
+              item
+              md={3}
+              sm={'auto'}
+              sx={{ marginTop: { md: 2.5 }, paddingLeft: { md: 1 } }}
+              xs={'auto'}
+            >
+              <Controller
+                render={({ field, fieldState }) => (
+                  <TextField
+                    onWheel={(event) =>
+                      event.target instanceof HTMLElement && event.target.blur()
+                    }
+                    sx={{
+                      height: '30px',
+                      width: '30px',
+                    }}
+                    data-testid={'Trigger-occurences'}
+                    errorText={fieldState.error?.message}
+                    label={''}
+                    min={0}
+                    name={`${name}.trigger_occurrences`}
+                    onBlur={field.onBlur}
+                    onChange={(e) => field.onChange(e.target.value)}
+                    type="number"
+                    value={field.value ?? 0}
+                  />
+                )}
+                control={control}
+                name={`${name}.trigger_occurrences`}
+              />
+            </Grid>
+            <Grid item md={'auto'} paddingLeft={{ md: 2.5 }} sm={12} xs={12}>
+              <Box sx={{ marginTop: { md: 4, sx: 2 } }}>
+                <Typography
+                  sx={{
+                    alignItems: 'center',
+                    display: 'flex',
+                    height: { sm: '56px', xs: '50px' },
+                  }}
+                  variant="body1"
+                >
+                  consecutive occurences.
+                </Typography>
+              </Box>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/types.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/types.ts
@@ -3,13 +3,18 @@ import type {
   AlertSeverityType,
   CreateAlertDefinitionPayload,
   DimensionFilter,
+  DimensionFilterOperatorType,
   MetricAggregationType,
   MetricCriteria,
   MetricOperatorType,
+  TriggerCondition,
 } from '@linode/api-v4';
 
 export interface CreateAlertDefinitionForm
-  extends Omit<CreateAlertDefinitionPayload, 'rule_criteria' | 'severity'> {
+  extends Omit<
+    CreateAlertDefinitionPayload,
+    'rule_criteria' | 'severity' | 'trigger_conditions'
+  > {
   engineType: null | string;
   entity_ids: string[];
   region: string;
@@ -18,12 +23,32 @@ export interface CreateAlertDefinitionForm
   };
   serviceType: AlertServiceType | null;
   severity: AlertSeverityType | null;
+  trigger_conditions: TriggerConditionForm;
 }
 
 export interface MetricCriteriaForm
-  extends Omit<MetricCriteria, 'aggregation_type' | 'metric' | 'operator'> {
+  extends Omit<
+    MetricCriteria,
+    'aggregation_type' | 'dimension_filters' | 'metric' | 'operator'
+  > {
   aggregation_type: MetricAggregationType | null;
-  dimension_filters: DimensionFilter[];
+  dimension_filters: DimensionFilterForm[];
   metric: null | string;
   operator: MetricOperatorType | null;
+}
+
+export interface DimensionFilterForm
+  extends Omit<DimensionFilter, 'dimension_label' | 'operator' | 'value'> {
+  dimension_label: null | string;
+  operator: DimensionFilterOperatorType | null;
+  value: null | string;
+}
+
+export interface TriggerConditionForm
+  extends Omit<
+    TriggerCondition,
+    'evaluation_period_seconds' | 'polling_interval_seconds'
+  > {
+  evaluation_period_seconds: null | number;
+  polling_interval_seconds: null | number;
 }

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/utilities.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/utilities.ts
@@ -1,9 +1,16 @@
 import { omitProps } from '@linode/ui';
 
-import type { CreateAlertDefinitionForm, MetricCriteriaForm } from './types';
+import type {
+  CreateAlertDefinitionForm,
+  DimensionFilterForm,
+  MetricCriteriaForm,
+  TriggerConditionForm,
+} from './types';
 import type {
   CreateAlertDefinitionPayload,
+  DimensionFilter,
   MetricCriteria,
+  TriggerCondition,
 } from '@linode/api-v4';
 
 // filtering out the form properties which are not part of the payload
@@ -16,16 +23,18 @@ export const filterFormValues = (
     'engineType',
     'severity',
     'rule_criteria',
+    'trigger_conditions',
   ]);
-  // severity has a need for null in the form for edge-cases, so null-checking and returning it as an appropriate type
   const severity = formValues.severity ?? 1;
   const entityIds = formValues.entity_ids;
   const rules = formValues.rule_criteria.rules;
+  const triggerConditions = formValues.trigger_conditions;
   return {
     ...values,
     entity_ids: entityIds,
     rule_criteria: { rules: filterMetricCriteriaFormValues(rules) },
     severity,
+    trigger_conditions: filterTriggerConditionFormValues(triggerConditions),
   };
 };
 
@@ -37,11 +46,35 @@ export const filterMetricCriteriaFormValues = (
     return {
       ...values,
       aggregation_type: rule.aggregation_type ?? 'avg',
-      dimension_filters: rule.dimension_filters,
+      dimension_filters: filterDimensionFilterFormValues(
+        rule.dimension_filters
+      ),
       metric: rule.metric ?? '',
       operator: rule.operator ?? 'eq',
     };
   });
+};
+
+const filterDimensionFilterFormValues = (
+  formValues: DimensionFilterForm[]
+): DimensionFilter[] => {
+  return formValues.map((dimensionFilter) => {
+    return {
+      dimension_label: dimensionFilter.dimension_label ?? '',
+      operator: dimensionFilter.operator ?? 'eq',
+      value: dimensionFilter.value ?? '',
+    };
+  });
+};
+
+const filterTriggerConditionFormValues = (
+  formValues: TriggerConditionForm
+): TriggerCondition => {
+  return {
+    ...formValues,
+    evaluation_period_seconds: formValues.evaluation_period_seconds ?? 0,
+    polling_interval_seconds: formValues.polling_interval_seconds ?? 0,
+  };
 };
 
 export const convertToSeconds = (secondsList: string[]) => {

--- a/packages/manager/src/features/CloudPulse/Alerts/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/constants.ts
@@ -1,5 +1,6 @@
 import type {
   AlertSeverityType,
+  DimensionFilterOperatorType,
   MetricAggregationType,
   MetricOperatorType,
 } from '@linode/api-v4';
@@ -71,3 +72,45 @@ export const MetricAggregationOptions: Item<string, MetricAggregationType>[] = [
     value: 'sum',
   },
 ];
+
+export const DimensionOperatorOptions: Item<
+  string,
+  DimensionFilterOperatorType
+>[] = [
+  {
+    label: 'Equal',
+    value: 'eq',
+  },
+  {
+    label: 'Ends with',
+    value: 'endswith',
+  },
+  {
+    label: 'Not Equal',
+    value: 'neq',
+  },
+  {
+    label: 'Starts with',
+    value: 'startswith',
+  },
+];
+
+export const EvaluationPeriodOptions = {
+  dbaas: [{ label: '5m', value: 300 }],
+  linode: [
+    { label: '1m', value: 60 },
+    { label: '5m', value: 300 },
+    { label: '15m', value: 900 },
+    { label: '30m', value: 1800 },
+    { label: '1hr', value: 3600 },
+  ],
+};
+
+export const PollingIntervalOptions = {
+  dbaas: [{ label: '5m', value: 300 }],
+  linode: [
+    { label: '1m', value: 60 },
+    { label: '5m', value: 300 },
+    { label: '10m', value: 600 },
+  ],
+};

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -2458,12 +2458,12 @@ export const handlers = [
           available_aggregate_functions: ['min', 'max', 'avg'],
           dimensions: [
             {
-              dim_label: 'cpu',
+              dimension_label: 'cpu',
               label: 'CPU name',
               values: null,
             },
             {
-              dim_label: 'state',
+              dimension_label: 'state',
               label: 'State of CPU',
               values: [
                 'user',
@@ -2477,7 +2477,7 @@ export const handlers = [
               ],
             },
             {
-              dim_label: 'LINODE_ID',
+              dimension_label: 'LINODE_ID',
               label: 'Linode ID',
               values: null,
             },
@@ -2492,7 +2492,7 @@ export const handlers = [
           available_aggregate_functions: ['min', 'max', 'avg', 'sum'],
           dimensions: [
             {
-              dim_label: 'state',
+              dimension_label: 'state',
               label: 'State of memory',
               values: [
                 'used',
@@ -2504,7 +2504,7 @@ export const handlers = [
               ],
             },
             {
-              dim_label: 'LINODE_ID',
+              dimension_label: 'LINODE_ID',
               label: 'Linode ID',
               values: null,
             },
@@ -2519,17 +2519,17 @@ export const handlers = [
           available_aggregate_functions: ['min', 'max', 'avg', 'sum'],
           dimensions: [
             {
-              dim_label: 'device',
+              dimension_label: 'device',
               label: 'Device name',
               values: ['lo', 'eth0'],
             },
             {
-              dim_label: 'direction',
+              dimension_label: 'direction',
               label: 'Direction of network transfer',
               values: ['transmit', 'receive'],
             },
             {
-              dim_label: 'LINODE_ID',
+              dimension_label: 'LINODE_ID',
               label: 'Linode ID',
               values: null,
             },
@@ -2544,17 +2544,17 @@ export const handlers = [
           available_aggregate_functions: ['min', 'max', 'avg', 'sum'],
           dimensions: [
             {
-              dim_label: 'device',
+              dimension_label: 'device',
               label: 'Device name',
               values: ['loop0', 'sda', 'sdb'],
             },
             {
-              dim_label: 'direction',
+              dimension_label: 'direction',
               label: 'Operation direction',
               values: ['read', 'write'],
             },
             {
-              dim_label: 'LINODE_ID',
+              dimension_label: 'LINODE_ID',
               label: 'Linode ID',
               values: null,
             },


### PR DESCRIPTION


## Description 📝
- Added  Dimension Filters feature to the Metric Criteria component 
- Added Trigger condition component to the Create Alert Form under Criteria section

## Changes  🔄

- Added DimensionFilter component which has a FieldArray to add the DimensionFilterField components dynamically
- Added the Autocomplete components for Data Field, Operator and Value in DimensionFilterField
- Added the Autocomplete and TextField components for Evaluation Period, Polling Interval and Trigger Occurrences in DimensionFilterField
- Added and changed some types of CreateAlertDefinitionPayload, Alert interfaces
- Changed some types for MetricCriteriaForm,CreateAlertPayloadForm and added DimensionFiltersForm, TriggerConditionForm
- Changed the filterFormValues utility methods for MetricCriteriaForm interfaces and added DimensionFilterForm and TriggerConditionForm interfaces

TBD:
- Unit Tests for the Added components.

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/a5520d70-226d-45e0-ac97-5d8dd5933ce5) | ![image](https://github.com/user-attachments/assets/a88eee08-5283-4bae-bfec-f0966f151dc8) |

## How to test 🧪

### Prerequisites

(How to setup test environment)
- The tabs are controlled by a featureFlag called aclpAlerting, the flag has been currently disabled. For testing enable the definitions part of the aclpAlerting flag to be true.
- The API endpoints are not live yet, so use Legacy MSW Handlers for the mock responses

- In Monitor (once the prerequisites are followed) , Alerts tab should be visible next to Dashboards.
- Under that, Definition tab and a Create button should be visible.
- On clicking Create, the Form Page should be visible
- To choose from the Data Field drop down, selecting a Service is required
### Verification steps

(How to verify changes)

- [ ] The DimensionFilters component should be visible when clicked on the AddDimensionFilter Button
- [ ] Once a Metric Data Field is selected, Dimension Filter Data Field can be selected 
- [ ] For the Value field in DimensionFilter component, Dimension Filter Data Field is required
- [ ] For Trigger Conditions the Polling Interval and Evaluation Period components the options are dependent on the Service selected. Should be able to select and choose a value 
- [ ] The displayed options in Polling Interval and Evaluation Period components must be greater than or equal to the scrape interval of the selected Metric Data Field

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
