### PR TITLE
test: [M3-9040] - Unit tests to validate aria-labels of Action Menu for Linode IPs and ranges

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.test.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+
+import { ipAddressFactory } from 'src/factories/networking';
+import { renderWithTheme, resizeScreenSize } from 'src/utilities/testHelpers';
+
+import { LinodeNetworkingActionMenu } from './LinodeNetworkingActionMenu';
+
+import type { IPRange } from '@linode/api-v4';
+
+describe('LinodeNetworkingActionMenu', () => {
+  beforeAll(() => {
+    // Set width to 1279px (< 1280px) to ensure the Action menu is visible.
+    resizeScreenSize(1279);
+  });
+
+  const mockLinodeIPv4 = ipAddressFactory.buildList(1, {
+    public: true,
+    type: 'ipv4',
+  })[0];
+
+  const mockLinodeIPv6Range: IPRange = {
+    prefix: 64,
+    range: '2600:3c00:e000:0000::',
+    region: 'us-west',
+    route_target: '2a01:7e00::f03c:93ff:fe6e:1233',
+  };
+
+  const props = {
+    isOnlyPublicIP: true,
+    isVPCOnlyLinode: false,
+    onEdit: vi.fn(),
+    onRemove: vi.fn(),
+    readOnly: false,
+  };
+
+  it('should display the correct aria-label for the IP address action menu', () => {
+    const { getByRole } = renderWithTheme(
+      <LinodeNetworkingActionMenu
+        {...props}
+        ipAddress={mockLinodeIPv4}
+        ipType="IPv4 – Public"
+      />
+    );
+
+    const actionMenuButton = getByRole('button');
+    expect(actionMenuButton).toHaveAttribute(
+      'aria-label',
+      `Action menu for IP Address ${mockLinodeIPv4.address}`
+    );
+  });
+
+  it('should display the correct aria-label for the IP range action menu', () => {
+    const { getByRole } = renderWithTheme(
+      <LinodeNetworkingActionMenu
+        {...props}
+        ipAddress={mockLinodeIPv6Range}
+        ipType="IPv6 – Range"
+      />
+    );
+
+    const actionMenuButton = getByRole('button');
+    expect(actionMenuButton).toHaveAttribute(
+      'aria-label',
+      `Action menu for IP Address ${mockLinodeIPv6Range.range}`
+    );
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
@@ -122,6 +122,6 @@ export const LinodeNetworkingActionMenu = (props: Props) => {
       )}
     </>
   ) : (
-    <Box sx={{ height: 40 }}></Box>
+    <Box sx={{ height: 40 }} />
   );
 };


### PR DESCRIPTION
## Description 📝
Unit tests to validate aria-labels of Action Menus for Linode IP addresses/ranges

## Changes  🔄
- Add unit tests to validate ARIA labels of Action Menus for Linode IP addresses and ranges

## Target release date 🗓️
N/A

## How to test 🧪
- `yarn test LinodeNetworkingActionMenu`
- Ensure all tests pass

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules