### PR TITLE
hotfix: Incorrect Region Options

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2024-12-20] - v1.133.2
+
+### Fixed:
+
+- Incorrectly displayed region options ([#11449](https://github.com/linode/manager/pull/11449))
+
+
 ## [2024-12-19] - v1.133.1
 
 ### Fixed:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.133.1",
+  "version": "1.133.2",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/manager/src/components/RegionSelect/RegionMultiSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionMultiSelect.tsx
@@ -38,6 +38,7 @@ export const RegionMultiSelect = React.memo((props: RegionMultiSelectProps) => {
     disabled,
     disabledRegions: disabledRegionsFromProps,
     errorText,
+    forcefullyShownRegionIds,
     helperText,
     isClearable,
     label,
@@ -51,8 +52,6 @@ export const RegionMultiSelect = React.memo((props: RegionMultiSelectProps) => {
     ...rest
   } = props;
 
-  const { isObjectStorageGen2Enabled } = useIsObjectStorageGen2Enabled();
-
   const {
     data: accountAvailability,
     isLoading: accountAvailabilityLoading,
@@ -60,7 +59,7 @@ export const RegionMultiSelect = React.memo((props: RegionMultiSelectProps) => {
 
   const regionOptions = getRegionOptions({
     currentCapability,
-    isObjectStorageGen2Enabled,
+    forcefullyShownRegionIds,
     regions,
   });
 

--- a/packages/manager/src/components/RegionSelect/RegionMultiSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionMultiSelect.tsx
@@ -3,7 +3,6 @@ import CloseIcon from '@mui/icons-material/Close';
 import React from 'react';
 
 import { Flag } from 'src/components/Flag';
-import { useIsObjectStorageGen2Enabled } from 'src/features/ObjectStorage/hooks/useIsObjectStorageGen2Enabled';
 import { useAllAccountAvailabilitiesQuery } from 'src/queries/account/availability';
 import { getRegionCountryGroup } from 'src/utilities/formatRegion';
 

--- a/packages/manager/src/components/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.tsx
@@ -54,7 +54,6 @@ export const RegionSelect = <
   } = props;
 
   const { isGeckoLAEnabled } = useIsGeckoEnabled();
-  const { isObjectStorageGen2Enabled } = useIsObjectStorageGen2Enabled();
 
   const {
     data: accountAvailability,
@@ -63,7 +62,6 @@ export const RegionSelect = <
 
   const regionOptions = getRegionOptions({
     currentCapability,
-    isObjectStorageGen2Enabled,
     regionFilter,
     regions,
   });

--- a/packages/manager/src/components/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 
 import { Flag } from 'src/components/Flag';
 import { useIsGeckoEnabled } from 'src/components/RegionSelect/RegionSelect.utils';
-import { useIsObjectStorageGen2Enabled } from 'src/features/ObjectStorage/hooks/useIsObjectStorageGen2Enabled';
 import { useAllAccountAvailabilitiesQuery } from 'src/queries/account/availability';
 import { getRegionCountryGroup } from 'src/utilities/formatRegion';
 
@@ -39,6 +38,7 @@ export const RegionSelect = <
     disabled,
     disabledRegions: disabledRegionsFromProps,
     errorText,
+    forcefullyShownRegionIds,
     helperText,
     ignoreAccountAvailability,
     label,
@@ -62,6 +62,7 @@ export const RegionSelect = <
 
   const regionOptions = getRegionOptions({
     currentCapability,
+    forcefullyShownRegionIds,
     regionFilter,
     regions,
   });

--- a/packages/manager/src/components/RegionSelect/RegionSelect.types.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.types.ts
@@ -38,6 +38,11 @@ export interface RegionSelectProps<
    * A key/value object for disabling regions by their ID.
    */
   disabledRegions?: Record<string, DisableItemOption>;
+  /**
+   * Used to override filtering done by the `currentCapability` prop
+   * @todo Remove this after Object Storage Gen2.
+   */
+  forcefullyShownRegionIds?: Set<string>;
   helperText?: string;
   /**
    * Ignores account availability information when rendering region options
@@ -67,6 +72,11 @@ export interface RegionMultiSelectProps
   }>;
   currentCapability: Capabilities | undefined;
   disabledRegions?: Record<string, DisableItemOption>;
+  /**
+   * Used to override filtering done by the `currentCapability` prop
+   * @todo Remove this after Object Storage Gen2.
+   */
+  forcefullyShownRegionIds?: Set<string>;
   helperText?: string;
   isClearable?: boolean;
   label?: string;

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.tsx
@@ -15,41 +15,17 @@ const NORTH_AMERICA = CONTINENT_CODE_TO_CONTINENT.NA;
 
 interface RegionSelectOptionsOptions {
   currentCapability: Capabilities | undefined;
-  /**
-   * @TODO: This is a temporary property to gate the whitelisted regions to Gen2 users
-   */
-  isObjectStorageGen2Enabled?: boolean;
   regionFilter?: RegionFilterValue;
   regions: Region[];
 }
 
-// @TODO: OBJ Gen2: This should be removed once these regions obtain the `Object Storage` capability.
-const WHITELISTED_REGIONS = new Set([
-  'gb-lon',
-  'au-mel',
-  'in-bom-2',
-  'de-fra-2',
-  'sg-sin-2',
-]);
-
 export const getRegionOptions = ({
   currentCapability,
-  isObjectStorageGen2Enabled,
   regionFilter,
   regions,
 }: RegionSelectOptionsOptions) => {
   return regions
     .filter((region) => {
-      // @TODO: OBJ Gen2: Remove this one-off logic once these regions (WHITELISTED_REGIONS)
-      // have the `Object Storage` capability.
-      if (
-        currentCapability === 'Object Storage' &&
-        isObjectStorageGen2Enabled &&
-        WHITELISTED_REGIONS.has(region.id)
-      ) {
-        return true;
-      }
-
       if (
         currentCapability &&
         !region.capabilities.includes(currentCapability)

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.tsx
@@ -15,17 +15,23 @@ const NORTH_AMERICA = CONTINENT_CODE_TO_CONTINENT.NA;
 
 interface RegionSelectOptionsOptions {
   currentCapability: Capabilities | undefined;
+  forcefullyShownRegionIds?: Set<string>;
   regionFilter?: RegionFilterValue;
   regions: Region[];
 }
 
 export const getRegionOptions = ({
   currentCapability,
+  forcefullyShownRegionIds,
   regionFilter,
   regions,
 }: RegionSelectOptionsOptions) => {
   return regions
     .filter((region) => {
+      if (forcefullyShownRegionIds?.has(region.id)) {
+        return true;
+      }
+
       if (
         currentCapability &&
         !region.capabilities.includes(currentCapability)

--- a/packages/manager/src/components/RegionSelect/RegionSelect.utils.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.utils.tsx
@@ -40,7 +40,13 @@ export const getRegionOptions = ({
 }: RegionSelectOptionsOptions) => {
   return regions
     .filter((region) => {
-      if (isObjectStorageGen2Enabled && WHITELISTED_REGIONS.has(region.id)) {
+      // @TODO: OBJ Gen2: Remove this one-off logic once these regions (WHITELISTED_REGIONS)
+      // have the `Object Storage` capability.
+      if (
+        currentCapability === 'Object Storage' &&
+        isObjectStorageGen2Enabled &&
+        WHITELISTED_REGIONS.has(region.id)
+      ) {
         return true;
       }
 

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyRegions/AccessKeyRegions.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyRegions/AccessKeyRegions.tsx
@@ -35,7 +35,7 @@ export const AccessKeyRegions = (props: Props) => {
       placeholder={
         selectedRegion.length > 0 ? '' : 'Select regions or type to search'
       }
-      currentCapability="Object Storage"
+      currentCapability={undefined} // filtering is handled by the `useObjectStorageRegions` hook
       disabled={disabled}
       errorText={errorText}
       isClearable={false}

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyRegions/AccessKeyRegions.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyRegions/AccessKeyRegions.tsx
@@ -5,6 +5,8 @@ import { useObjectStorageRegions } from 'src/features/ObjectStorage/hooks/useObj
 import { sortByString } from 'src/utilities/sort-by';
 
 import type { Region } from '@linode/api-v4';
+import { useIsObjectStorageGen2Enabled } from '../../hooks/useIsObjectStorageGen2Enabled';
+import { WHITELISTED_REGIONS } from '../../utilities';
 
 interface Props {
   disabled?: boolean;
@@ -27,15 +29,20 @@ export const AccessKeyRegions = (props: Props) => {
     availableStorageRegions,
   } = useObjectStorageRegions();
 
+  const { isObjectStorageGen2Enabled } = useIsObjectStorageGen2Enabled();
+
   // Error could be: 1. General Regions error, 2. Field error, 3. Nothing
   const errorText = error || allRegionsError?.[0]?.reason;
 
   return (
     <RegionMultiSelect
+      forcefullyShownRegionIds={
+        isObjectStorageGen2Enabled ? WHITELISTED_REGIONS : undefined
+      }
       placeholder={
         selectedRegion.length > 0 ? '' : 'Select regions or type to search'
       }
-      currentCapability={undefined} // filtering is handled by the `useObjectStorageRegions` hook
+      currentCapability="Object Storage"
       disabled={disabled}
       errorText={errorText}
       isClearable={false}

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRegions.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRegions.tsx
@@ -25,7 +25,7 @@ export const BucketRegions = (props: Props) => {
 
   return (
     <RegionSelect
-      currentCapability="Object Storage"
+      currentCapability={undefined} // filtering is handled by the `useObjectStorageRegions` hook
       disableClearable
       disabled={disabled}
       errorText={errorText}

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRegions.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRegions.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 
 import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
 import { useObjectStorageRegions } from 'src/features/ObjectStorage/hooks/useObjectStorageRegions';
+import { useIsObjectStorageGen2Enabled } from '../hooks/useIsObjectStorageGen2Enabled';
+import { WHITELISTED_REGIONS } from '../utilities';
 
 interface Props {
   disabled?: boolean;
@@ -20,12 +22,17 @@ export const BucketRegions = (props: Props) => {
     availableStorageRegions,
   } = useObjectStorageRegions();
 
+  const { isObjectStorageGen2Enabled}  = useIsObjectStorageGen2Enabled();
+
   // Error could be: 1. General Regions error, 2. Field error, 3. Nothing
   const errorText = error || allRegionsError?.[0]?.reason;
 
   return (
     <RegionSelect
-      currentCapability={undefined} // filtering is handled by the `useObjectStorageRegions` hook
+      forcefullyShownRegionIds={
+        isObjectStorageGen2Enabled ? WHITELISTED_REGIONS : undefined
+      }
+      currentCapability="Object Storage"
       disableClearable
       disabled={disabled}
       errorText={errorText}

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRegions.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketRegions.tsx
@@ -22,7 +22,7 @@ export const BucketRegions = (props: Props) => {
     availableStorageRegions,
   } = useObjectStorageRegions();
 
-  const { isObjectStorageGen2Enabled}  = useIsObjectStorageGen2Enabled();
+  const { isObjectStorageGen2Enabled } = useIsObjectStorageGen2Enabled();
 
   // Error could be: 1. General Regions error, 2. Field error, 3. Nothing
   const errorText = error || allRegionsError?.[0]?.reason;

--- a/packages/manager/src/features/ObjectStorage/hooks/useObjectStorageRegions.tsx
+++ b/packages/manager/src/features/ObjectStorage/hooks/useObjectStorageRegions.tsx
@@ -5,8 +5,6 @@ import { useObjectStorageEndpoints } from 'src/queries/object-storage/queries';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { getRegionsByRegionId } from 'src/utilities/regions';
 
-import { useIsObjectStorageGen2Enabled } from './useIsObjectStorageGen2Enabled';
-
 export const useObjectStorageRegions = () => {
   const { data: allRegions, error: allRegionsError } = useRegionsQuery();
   const {
@@ -15,16 +13,9 @@ export const useObjectStorageRegions = () => {
     isFetching: isStorageEndpointsLoading,
   } = useObjectStorageEndpoints();
 
-  const { isObjectStorageGen2Enabled } = useIsObjectStorageGen2Enabled();
-
   const availableStorageRegions = React.useMemo(
-    () =>
-      filterRegionsByEndpoints(
-        allRegions,
-        storageEndpoints,
-        isObjectStorageGen2Enabled
-      ),
-    [allRegions, storageEndpoints, isObjectStorageGen2Enabled]
+    () => filterRegionsByEndpoints(allRegions, storageEndpoints),
+    [allRegions, storageEndpoints]
   );
 
   const regionsByIdMap =

--- a/packages/manager/src/features/ObjectStorage/hooks/useObjectStorageRegions.tsx
+++ b/packages/manager/src/features/ObjectStorage/hooks/useObjectStorageRegions.tsx
@@ -5,6 +5,8 @@ import { useObjectStorageEndpoints } from 'src/queries/object-storage/queries';
 import { useRegionsQuery } from 'src/queries/regions/regions';
 import { getRegionsByRegionId } from 'src/utilities/regions';
 
+import { useIsObjectStorageGen2Enabled } from './useIsObjectStorageGen2Enabled';
+
 export const useObjectStorageRegions = () => {
   const { data: allRegions, error: allRegionsError } = useRegionsQuery();
   const {
@@ -13,9 +15,16 @@ export const useObjectStorageRegions = () => {
     isFetching: isStorageEndpointsLoading,
   } = useObjectStorageEndpoints();
 
+  const { isObjectStorageGen2Enabled } = useIsObjectStorageGen2Enabled();
+
   const availableStorageRegions = React.useMemo(
-    () => filterRegionsByEndpoints(allRegions, storageEndpoints),
-    [allRegions, storageEndpoints]
+    () =>
+      filterRegionsByEndpoints(
+        allRegions,
+        storageEndpoints,
+        isObjectStorageGen2Enabled
+      ),
+    [allRegions, storageEndpoints, isObjectStorageGen2Enabled]
   );
 
   const regionsByIdMap =

--- a/packages/manager/src/features/ObjectStorage/utilities.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.ts
@@ -1,6 +1,5 @@
 import { OBJECT_STORAGE_DELIMITER } from 'src/constants';
 
-import type { Region } from '@linode/api-v4';
 import type { AccountSettings } from '@linode/api-v4/lib/account';
 import type {
   ACLType,

--- a/packages/manager/src/features/ObjectStorage/utilities.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.ts
@@ -174,7 +174,7 @@ export const objectACLHelperText: Record<ACLType, string> = {
 };
 
 // @TODO: OBJ Gen2: This should be removed once these regions obtain the `Object Storage` capability.
-const WHITELISTED_REGIONS = new Set([
+export const WHITELISTED_REGIONS = new Set([
   'gb-lon',
   'au-mel',
   'in-bom-2',
@@ -186,35 +186,21 @@ const WHITELISTED_REGIONS = new Set([
  * For OBJ Gen2 users, filter regions based on available Object Storage endpoints.
  * Otherwise, we return the regions as is.
  */
-export const filterRegionsByEndpoints = (
-  regions: Region[] | undefined,
-  objecStorageEndpoints: ObjectStorageEndpoint[] | undefined,
-  isObjectStorageGen2Enabled: boolean
-): Region[] => {
+export const filterRegionsByEndpoints = <T extends { id: string }>(
+  regions: T[] | undefined,
+  objecStorageEndpoints: ObjectStorageEndpoint[] | undefined
+): T[] => {
   if (!regions) {
     return [];
   }
 
-  const regionsWithObjectStorage = regions.filter((r) => {
-    if (isObjectStorageGen2Enabled) {
-      // If Object Storage Gen2 is enabled, we need to include WHITELISTED_REGIONS
-      return (
-        r.capabilities.includes('Object Storage') ||
-        WHITELISTED_REGIONS.has(r.id)
-      );
-    }
-    return r.capabilities.includes('Object Storage');
-  });
-
   if (!objecStorageEndpoints) {
-    return regionsWithObjectStorage;
+    return regions;
   }
 
   const endpointRegions = new Set(
     objecStorageEndpoints.map((endpoint) => endpoint.region)
   );
 
-  return regionsWithObjectStorage.filter((region) =>
-    endpointRegions.has(region.id)
-  );
+  return regions.filter((region) => endpointRegions.has(region.id));
 };


### PR DESCRIPTION
## Description 📝

- Fixes bug introduced in https://github.com/linode/manager/pull/11432

## Bug Summary 🐛 

- One-off logic was added for Object Storage Gen2, but that logic was applied to all region selects throughout Cloud Manager resulting in users seeing incorrect region options outside of Object Storage 🌎 

https://github.com/linode/manager/blob/0b0fa666fff8a4252bb48591d6235eb2198abb04/packages/manager/src/components/RegionSelect/RegionSelect.utils.tsx#L43-L45

## The Fix 🔧 

- Add a condition to check that `currentCapability === 'Object Storage'` to the new one-off logic so that it only applies to Object Storage region selects


## Preview 📷

### Before

`sg-sin-2` is shown as both a core region and a distributed region 😳

<img src="https://github.com/user-attachments/assets/20dbcdfa-fb65-46f1-9871-178f97c67a27" height="400px"  />
<img src="https://github.com/user-attachments/assets/4096d42b-569b-435a-b1a4-4ac77805fd0a" height="400px" /> 


### After

`sg-sin-2` only shows up as a core region

<img src="https://github.com/user-attachments/assets/1a020223-10d1-4c6f-bf4a-d717151689b7" height="400px"  />
<img src="https://github.com/user-attachments/assets/9e395898-5611-4e15-9fd3-6a14f7f9349a" height="400px"  />

## How to test 🧪

- Check Region Selects throughout Cloud Manager
  - Verify correct regions are shown
  - Verify that on Linode Create, regions are not duplicated under "Core" and "Distributed"

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>