### PR TITLE
fix: [M3-7706, 9005] - Set VPC interface as primary when creating a Linode

### DIFF
--- a/packages/manager/.changeset/pr-11450-fixed-1734717495561.md
+++ b/packages/manager/.changeset/pr-11450-fixed-1734717495561.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+VPC interface not being set as the primary interface when creating a Linode ([#11450](https://github.com/linode/manager/pull/11450))

--- a/packages/manager/.changeset/pr-11450-tests-1735836787604.md
+++ b/packages/manager/.changeset/pr-11450-tests-1735836787604.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add cypress tests confirming Lionde Config Unrecommended status displays as expected in VPC Subnet table ([#11450](https://github.com/linode/manager/pull/11450))

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-vpc.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-vpc.spec.ts
@@ -3,7 +3,10 @@ import {
   regionFactory,
   subnetFactory,
   vpcFactory,
+  linodeConfigFactory,
+  LinodeConfigInterfaceFactoryWithVPC,
 } from 'src/factories';
+import { mockGetLinodeConfigs } from 'support/intercepts/configs';
 import {
   mockCreateLinode,
   mockGetLinodeDetails,
@@ -12,6 +15,7 @@ import { mockGetRegions } from 'support/intercepts/regions';
 import {
   mockCreateVPC,
   mockCreateVPCError,
+  mockGetSubnets,
   mockGetVPC,
   mockGetVPCs,
 } from 'support/intercepts/vpc';
@@ -25,12 +29,14 @@ import {
   randomString,
 } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
+import { WARNING_ICON_UNRECOMMENDED_CONFIG } from 'src/features/VPCs/constants';
 
 describe('Create Linode with VPCs', () => {
   /*
    * - Confirms UI flow to create a Linode with an existing VPC assigned using mock API data.
    * - Confirms that VPC assignment is reflected in create summary section.
    * - Confirms that outgoing API request contains expected VPC interface data.
+   * - Confirms newly assigned Linode does not have an unrecommended config notice inside VPC
    */
   it('can assign existing VPCs during Linode Create flow', () => {
     const linodeRegion = chooseRegion({ capabilities: ['VPCs'] });
@@ -54,6 +60,27 @@ describe('Create Linode with VPCs', () => {
       label: randomLabel(),
       region: linodeRegion.id,
     });
+
+    const mockInterface = LinodeConfigInterfaceFactoryWithVPC.build({
+      vpc_id: mockVPC.id,
+      subnet_id: mockSubnet.id,
+      primary: true,
+      active: true,
+    });
+
+    const mockLinodeConfig = linodeConfigFactory.build({
+      interfaces: [mockInterface],
+    });
+
+    const mockUpdatedSubnet = {
+      ...mockSubnet,
+      linodes: [
+        {
+          id: mockLinode.id,
+          interfaces: [{ id: mockInterface.id, active: true }],
+        },
+      ],
+    };
 
     mockGetVPCs([mockVPC]).as('getVPCs');
     mockGetVPC(mockVPC).as('getVPC');
@@ -105,12 +132,27 @@ describe('Create Linode with VPCs', () => {
       expect(expectedVpcInterface['ipv4']).to.be.an('object').that.is.empty;
       expect(expectedVpcInterface['subnet_id']).to.equal(mockSubnet.id);
       expect(expectedVpcInterface['purpose']).to.equal('vpc');
+      // Confirm that VPC interfaces are always marked as the primary interface
+      expect(expectedVpcInterface['primary']).to.equal(true);
     });
 
     // Confirm redirect to new Linode.
     cy.url().should('endWith', `/linodes/${mockLinode.id}`);
     // Confirm toast notification should appear on Linode create.
     ui.toast.assertMessage(`Your Linode ${mockLinode.label} is being created.`);
+
+    // Confirm newly created Linode does not have unrecommended configuration notice
+    mockGetVPC(mockVPC).as('getVPC');
+    mockGetSubnets(mockVPC.id, [mockUpdatedSubnet]).as('getSubnets');
+    mockGetLinodeDetails(mockLinode.id, mockLinode).as('getLinode');
+    mockGetLinodeConfigs(mockLinode.id, [mockLinodeConfig]).as(
+      'getLinodeConfigs'
+    );
+
+    cy.visit(`/vpcs/${mockVPC.id}`);
+    cy.findByLabelText(`expand ${mockSubnet.label} row`).click();
+    cy.wait('@getLinodeConfigs');
+    cy.findByTestId(WARNING_ICON_UNRECOMMENDED_CONFIG).should('not.exist');
   });
 
   /*
@@ -118,6 +160,7 @@ describe('Create Linode with VPCs', () => {
    * - Creates a VPC and a subnet from within the Linode Create flow.
    * - Confirms that Cloud responds gracefully when VPC create API request fails.
    * - Confirms that outgoing API request contains correct VPC interface data.
+   * - Confirms newly assigned Linode does not have an unrecommended config notice inside VPC
    */
   it('can assign new VPCs during Linode Create flow', () => {
     const linodeRegion = chooseRegion({ capabilities: ['VPCs'] });
@@ -144,6 +187,27 @@ describe('Create Linode with VPCs', () => {
       label: randomLabel(),
       region: linodeRegion.id,
     });
+
+    const mockInterface = LinodeConfigInterfaceFactoryWithVPC.build({
+      vpc_id: mockVPC.id,
+      subnet_id: mockSubnet.id,
+      primary: true,
+      active: true,
+    });
+
+    const mockLinodeConfig = linodeConfigFactory.build({
+      interfaces: [mockInterface],
+    });
+
+    const mockUpdatedSubnet = {
+      ...mockSubnet,
+      linodes: [
+        {
+          id: mockLinode.id,
+          interfaces: [{ id: mockInterface.id, active: true }],
+        },
+      ],
+    };
 
     mockGetVPCs([]);
     mockCreateLinode(mockLinode).as('createLinode');
@@ -232,11 +296,26 @@ describe('Create Linode with VPCs', () => {
       expect(expectedVpcInterface['ipv4']).to.deep.equal({ nat_1_1: 'any' });
       expect(expectedVpcInterface['subnet_id']).to.equal(mockSubnet.id);
       expect(expectedVpcInterface['purpose']).to.equal('vpc');
+      // Confirm that VPC interfaces are always marked as the primary interface
+      expect(expectedVpcInterface['primary']).to.equal(true);
     });
 
     cy.url().should('endWith', `/linodes/${mockLinode.id}`);
     // Confirm toast notification should appear on Linode create.
     ui.toast.assertMessage(`Your Linode ${mockLinode.label} is being created.`);
+
+    // Confirm newly created Linode does not have unrecommended configuration notice
+    mockGetVPC(mockVPC).as('getVPC');
+    mockGetSubnets(mockVPC.id, [mockUpdatedSubnet]).as('getSubnets');
+    mockGetLinodeDetails(mockLinode.id, mockLinode).as('getLinode');
+    mockGetLinodeConfigs(mockLinode.id, [mockLinodeConfig]).as(
+      'getLinodeConfigs'
+    );
+
+    cy.visit(`/vpcs/${mockVPC.id}`);
+    cy.findByLabelText(`expand ${mockSubnet.label} row`).click();
+    cy.wait('@getLinodeConfigs');
+    cy.findByTestId(WARNING_ICON_UNRECOMMENDED_CONFIG).should('not.exist');
   });
 
   /*

--- a/packages/manager/cypress/e2e/core/vpc/vpc-details-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/vpc/vpc-details-page.spec.ts
@@ -8,11 +8,21 @@ import {
   mockEditSubnet,
   mockGetSubnets,
 } from 'support/intercepts/vpc';
-import { subnetFactory, vpcFactory } from '@src/factories';
+import { mockGetLinodeConfigs } from 'support/intercepts/configs';
+import { mockGetLinodeDetails } from 'support/intercepts/linodes';
+import {
+  linodeFactory,
+  linodeConfigFactory,
+  LinodeConfigInterfaceFactoryWithVPC,
+  subnetFactory,
+  vpcFactory,
+} from '@src/factories';
 import { randomLabel, randomNumber, randomPhrase } from 'support/util/random';
+import { chooseRegion } from 'support/util/regions';
 import type { VPC } from '@linode/api-v4';
 import { getRegionById } from 'support/util/regions';
 import { ui } from 'support/ui';
+import { WARNING_ICON_UNRECOMMENDED_CONFIG } from 'src/features/VPCs/constants';
 
 describe('VPC details page', () => {
   /**
@@ -265,5 +275,118 @@ describe('VPC details page', () => {
     cy.findByText('Subnets (0)');
     cy.findByText('No Subnets are assigned.');
     cy.findByText(mockEditedSubnet.label).should('not.exist');
+  });
+
+  /**
+   * - Confirms UI for Linode with a recommended config (no notice displayed)
+   */
+  it('does not display an unrecommended config notice for a Linode', () => {
+    const linodeRegion = chooseRegion({ capabilities: ['VPCs'] });
+
+    const mockInterfaceId = randomNumber();
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+    });
+
+    const mockSubnet = subnetFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      linodes: [
+        {
+          id: mockLinode.id,
+          interfaces: [{ id: mockInterfaceId, active: true }],
+        },
+      ],
+      ipv4: '10.0.0.0/24',
+    });
+
+    const mockVPC = vpcFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+      subnets: [mockSubnet],
+    });
+
+    const mockInterface = LinodeConfigInterfaceFactoryWithVPC.build({
+      vpc_id: mockVPC.id,
+      subnet_id: mockSubnet.id,
+      primary: true,
+      active: true,
+    });
+
+    const mockLinodeConfig = linodeConfigFactory.build({
+      interfaces: [mockInterface],
+    });
+
+    mockGetVPC(mockVPC).as('getVPC');
+    mockGetSubnets(mockVPC.id, [mockSubnet]).as('getSubnets');
+    mockGetLinodeDetails(mockLinode.id, mockLinode).as('getLinode');
+    mockGetLinodeConfigs(mockLinode.id, [mockLinodeConfig]).as(
+      'getLinodeConfigs'
+    );
+
+    cy.visitWithLogin(`/vpcs/${mockVPC.id}`);
+    cy.findByLabelText(`expand ${mockSubnet.label} row`).click();
+    cy.wait('@getLinodeConfigs');
+    cy.findByTestId(WARNING_ICON_UNRECOMMENDED_CONFIG).should('not.exist');
+  });
+
+  /**
+   * - Confirms UI for Linode with an unrecommended config (notice displayed)
+   */
+  it('displays an unrecommended config notice for a Linode', () => {
+    const linodeRegion = chooseRegion({ capabilities: ['VPCs'] });
+
+    const mockInterfaceId = randomNumber();
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+    });
+
+    const mockSubnet = subnetFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      linodes: [
+        {
+          id: mockLinode.id,
+          interfaces: [{ id: mockInterfaceId, active: true }],
+        },
+      ],
+      ipv4: '10.0.0.0/24',
+    });
+
+    const mockVPC = vpcFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+      subnets: [mockSubnet],
+    });
+
+    const mockInterface = LinodeConfigInterfaceFactoryWithVPC.build({
+      id: mockInterfaceId,
+      vpc_id: mockVPC.id,
+      subnet_id: mockSubnet.id,
+      primary: false,
+      active: true,
+    });
+
+    const mockLinodeConfig = linodeConfigFactory.build({
+      interfaces: [mockInterface],
+    });
+
+    mockGetVPC(mockVPC).as('getVPC');
+    mockGetSubnets(mockVPC.id, [mockSubnet]).as('getSubnets');
+    mockGetLinodeDetails(mockLinode.id, mockLinode).as('getLinode');
+    mockGetLinodeConfigs(mockLinode.id, [mockLinodeConfig]).as(
+      'getLinodeConfigs'
+    );
+
+    cy.visitWithLogin(`/vpcs/${mockVPC.id}`);
+    cy.findByLabelText(`expand ${mockSubnet.label} row`).click();
+    cy.wait('@getLinodeConfigs');
+    cy.findByTestId(WARNING_ICON_UNRECOMMENDED_CONFIG).should('exist');
   });
 });

--- a/packages/manager/src/factories/subnets.ts
+++ b/packages/manager/src/factories/subnets.ts
@@ -1,8 +1,9 @@
-import {
+import Factory from 'src/factories/factoryProxy';
+
+import type {
   Subnet,
   SubnetAssignedLinodeData,
 } from '@linode/api-v4/lib/vpcs/types';
-import Factory from 'src/factories/factoryProxy';
 
 // NOTE: Changing to fixed array length for the interfaces and linodes fields of the
 // subnetAssignedLinodeDataFactory and subnetFactory respectively -- see [M3-7227] for more details

--- a/packages/manager/src/features/Linodes/LinodeCreate/utilities.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/utilities.test.tsx
@@ -177,6 +177,7 @@ describe('getInterfacesPayload', () => {
       {
         ipam_address: '',
         label: '',
+        primary: true,
         purpose: 'vpc',
         vpc_id: 5,
       },
@@ -210,6 +211,7 @@ describe('getInterfacesPayload', () => {
       {
         ipam_address: '',
         label: '',
+        primary: true,
         purpose: 'vpc',
         vpc_id: 5,
       },
@@ -248,6 +250,7 @@ describe('getInterfacesPayload', () => {
       {
         ipam_address: '',
         label: '',
+        primary: true,
         purpose: 'vpc',
         vpc_id: 5,
       },
@@ -286,6 +289,7 @@ describe('getInterfacesPayload', () => {
       {
         ipam_address: '',
         label: '',
+        primary: true,
         purpose: 'vpc',
         vpc_id: 5,
       },

--- a/packages/manager/src/features/Linodes/LinodeCreate/utilities.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/utilities.test.tsx
@@ -157,6 +157,8 @@ describe('getInterfacesPayload', () => {
           {
             ipam_address: '',
             label: '',
+            // Confirms VPC interface passed in is returned as expected - VPC interfaces should be marked as primary if they exist
+            primary: true,
             purpose: 'vpc',
             vpc_id: 5,
           },
@@ -191,6 +193,7 @@ describe('getInterfacesPayload', () => {
           {
             ipam_address: '',
             label: '',
+            primary: true,
             purpose: 'vpc',
             vpc_id: 5,
           },
@@ -230,6 +233,7 @@ describe('getInterfacesPayload', () => {
           {
             ipam_address: '',
             label: '',
+            primary: true,
             purpose: 'vpc',
             vpc_id: 5,
           },
@@ -269,6 +273,7 @@ describe('getInterfacesPayload', () => {
           {
             ipam_address: '',
             label: '',
+            primary: true,
             purpose: 'vpc',
             vpc_id: 5,
           },

--- a/packages/manager/src/features/Linodes/LinodeCreate/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreate/utilities.ts
@@ -226,6 +226,7 @@ const defaultInterfaces: InterfacePayload[] = [
   {
     ipam_address: '',
     label: '',
+    primary: true,
     purpose: 'vpc',
   },
   {


### PR DESCRIPTION
## Description 📝
Sets VPC interfaces as the primary interface when creating a Linode - [this had been lost in the refactor](https://github.com/linode/manager/blob/988469ddde3fd9464be4bb61fc22822034f4c0c1/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx#L898). 

See internal ticket 7706 for details of investigation. This does not resolve the unrecommended config notice for already existing Linodes, just for newly created ones. Customers with this notice on their Linode will need to manually edit their configs to resolve it. 

The bug with the Linode Config Dialog should be resolved in #11424 

## Target release date 🗓️
1/14

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/92eaa631-341e-4ee1-a665-faff1cbf839b) | ![image](https://github.com/user-attachments/assets/4baba400-abad-4200-8bde-949c59da1ca0) |

## How to test 🧪

### Reproduction steps
- Create a Linode (assign it to a VPC in the creation flow)
- Note how inside the VPC, the Linode has an 'unrecommended config' notice

### Verification steps
- Following the same steps above, confirm that a newly created Linode will not have unrecommended config notice
- Confirm that any time a Linode is created with a VPC interface, the VPC interface will be marked as primary (test with/without Vlans and private IPs)

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

