### PR TITLE
fix: [PDI-3099] - Enable `Create Token` button if all visible permissions selected

### DIFF
--- a/packages/manager/.changeset/pr-11453-fixed-1734765509208.md
+++ b/packages/manager/.changeset/pr-11453-fixed-1734765509208.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+`Create Token` button becomes disabled when all permissions are selected individually (without using 'select all') and child-account is hidden ([#11453](https://github.com/linode/manager/pull/11453))

--- a/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.tsx
@@ -35,6 +35,7 @@ import {
   allScopesAreTheSame,
   basePermNameMap,
   hasAccessBeenSelectedForAllScopes,
+  levelMap,
   permTuplesToScopeString,
   scopeStringToPermTuples,
 } from './utils';
@@ -178,8 +179,8 @@ export const CreateAPITokenDrawer = (props: Props) => {
   // Permission scopes with a different default when Selecting All for the specified access level.
   const excludedScopesFromSelectAll: ExcludedScope[] = [
     {
-      defaultAccessLevel: 0,
-      invalidAccessLevels: [1],
+      defaultAccessLevel: levelMap.none,
+      invalidAccessLevels: [levelMap.read_only],
       name: 'vpc',
     },
   ];
@@ -383,7 +384,10 @@ export const CreateAPITokenDrawer = (props: Props) => {
       <ActionsPanel
         primaryButtonProps={{
           'data-testid': 'create-button',
-          disabled: !hasAccessBeenSelectedForAllScopes(form.values.scopes),
+          disabled: !hasAccessBeenSelectedForAllScopes(
+            form.values.scopes,
+            hideChildAccountAccessScope ? ['child_account'] : []
+          ),
           label: 'Create Token',
           loading: isPending,
           onClick: () => form.handleSubmit(),

--- a/packages/manager/src/features/Profile/APITokens/utils.test.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.test.ts
@@ -436,6 +436,11 @@ describe('hasAccessBeenSelectedForAllScopes', () => {
     ['vpc', 0],
   ];
 
+  const allExceptChildAccountSelectedScopes: Permission[] = [
+    ...allSelectedScopes,
+    ['child_account', -1],
+  ];
+
   it('should return false if scopes are all set to a default of no selection', () => {
     expect(hasAccessBeenSelectedForAllScopes(defaultScopes)).toBe(false);
   });
@@ -446,5 +451,12 @@ describe('hasAccessBeenSelectedForAllScopes', () => {
   });
   it('should return true if all scopes have a valid selection', () => {
     expect(hasAccessBeenSelectedForAllScopes(allSelectedScopes)).toBe(true);
+  });
+  it('should return true if all scopes except those excluded have a valid selection', () => {
+    expect(
+      hasAccessBeenSelectedForAllScopes(allExceptChildAccountSelectedScopes, [
+        'child_account',
+      ])
+    ).toBe(true);
   });
 });

--- a/packages/manager/src/features/Profile/APITokens/utils.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.ts
@@ -259,6 +259,7 @@ Omit<typeof basePermNameMap, T[number]['name']> => {
  * Determines whether a selection has been made for every scope, since by default, the scope permissions are set to null.
  *
  * @param scopeTuples - The array of scope tuples.
+ * @param excludedPerms - The permission keys to be excluded from this check.
  * @returns {boolean} True if all scopes have permissions set to none/read_only/read_write, false otherwise.
  */
 export const hasAccessBeenSelectedForAllScopes = (

--- a/packages/manager/src/features/Profile/APITokens/utils.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.ts
@@ -2,9 +2,7 @@ import { DateTime } from 'luxon';
 
 import { isPast } from 'src/utilities/isPast';
 
-import { ExcludedScope } from './CreateAPITokenDrawer';
-
-export type Permission = [keyof typeof basePermNameMap, number];
+import type { ExcludedScope } from './CreateAPITokenDrawer';
 
 export const basePerms = [
   'account',
@@ -45,6 +43,10 @@ export const basePermNameMap = {
   volumes: 'Volumes',
   vpc: 'VPCs',
 } as const;
+
+type PermissionKey = keyof typeof basePermNameMap;
+
+export type Permission = [PermissionKey, number];
 
 export const inverseLevelMap = ['none', 'read_only', 'read_write'];
 
@@ -177,7 +179,7 @@ export const permTuplesToScopeString = (scopeTups: Permission[]): string => {
   }
   const joinedTups = scopeTups.reduce((acc, [key, value]) => {
     const level = inverseLevelMap[value];
-    if (level !== 'none') {
+    if (level && level !== 'none') {
       return [...acc, [key, level].join(':')];
     }
     return [...acc];
@@ -260,14 +262,17 @@ Omit<typeof basePermNameMap, T[number]['name']> => {
  * @returns {boolean} True if all scopes have permissions set to none/read_only/read_write, false otherwise.
  */
 export const hasAccessBeenSelectedForAllScopes = (
-  scopeTuples: Permission[]
+  scopeTuples: Permission[],
+  excludedPerms?: PermissionKey[]
 ): boolean => {
   const validAccessLevels = [
     levelMap['none'],
     levelMap['read_only'],
     levelMap['read_write'],
   ];
-  return scopeTuples.every((scopeTuple) =>
-    validAccessLevels.includes(scopeTuple[1])
+  return scopeTuples.every(
+    (scopeTuple) =>
+      validAccessLevels.includes(scopeTuple[1]) ||
+      excludedPerms?.includes(scopeTuple[0])
   );
 };


### PR DESCRIPTION
## Description 📝

This is to fix the issue where the `Create Token` button becomes disabled when the child-account is hidden and all permissions are individually selected, without using select all options.

Feel free to add a Jira ticket to my PR title if you would like to.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Fix the issue described above.
- Slightly refactor the initialization of `excludedScopesFromSelectAll` with constant values from the map.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/2c89820e-e1d0-4936-acfd-5888098323df) | ![image](https://github.com/user-attachments/assets/4af5b343-1c98-45a9-a34a-98ad2f8d08c2) |

## How to test 🧪

### Reproduction and verification steps

- [ ] Select all permissions individually without using select all on an account without child account enabled.
- [ ] The `Create Token` button is still disabled (prod version).
- [ ] The `Create Token` button is enabled (the version in this branch).

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>