### PR TITLE
refactor: [M3-6910] - Replace instances in : Object Storage

### DIFF
--- a/packages/manager/.changeset/pr-11456-tech-stories-1734933761673.md
+++ b/packages/manager/.changeset/pr-11456-tech-stories-1734933761673.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Replace Select with Autocomplete component in Object Storage ([#11456](https://github.com/linode/manager/pull/11456))

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.test.tsx
@@ -15,7 +15,7 @@ const AUTHENTICATED_READ_TEXT = 'Authenticated Read';
 const BUCKET_ACCESS_URL = '*object-storage/buckets/*/*/access';
 const OBJECT_ACCESS_URL = '*object-storage/buckets/*/*/object-acl';
 
-vi.mock('src/components/EnhancedSelect/Select');
+vi.mock('src/components/Autocomplete/Autocomplete');
 
 const defaultProps: Props = {
   clusterOrRegion: 'in-maa',

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.test.tsx
@@ -15,8 +15,6 @@ const AUTHENTICATED_READ_TEXT = 'Authenticated Read';
 const BUCKET_ACCESS_URL = '*object-storage/buckets/*/*/access';
 const OBJECT_ACCESS_URL = '*object-storage/buckets/*/*/object-acl';
 
-vi.mock('src/components/Autocomplete/Autocomplete');
-
 const defaultProps: Props = {
   clusterOrRegion: 'in-maa',
   endpointType: 'E1',
@@ -30,9 +28,6 @@ describe('AccessSelect', () => {
       flags: { objectStorageGen2: { enabled: true } },
     });
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
   it.each([
     ['bucket', 'E0', true],
     ['bucket', 'E1', true],

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.test.tsx
@@ -23,7 +23,7 @@ vi.mock('@linode/api-v4/lib/object-storage/objects', async () => {
   };
 });
 
-vi.mock('src/components/EnhancedSelect/Select');
+vi.mock('src/components/Autocomplete/Autocomplete');
 
 const props: ObjectDetailsDrawerProps = {
   bucketName: 'my-bucket',

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.test.tsx
@@ -23,8 +23,6 @@ vi.mock('@linode/api-v4/lib/object-storage/objects', async () => {
   };
 });
 
-vi.mock('src/components/Autocomplete/Autocomplete');
-
 const props: ObjectDetailsDrawerProps = {
   bucketName: 'my-bucket',
   clusterId: 'cluster-id',

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.test.tsx
@@ -4,8 +4,6 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import ClusterSelect from './ClusterSelect';
 
-vi.mock('src/components/Autocomplete/Autocomplete');
-
 describe('ClusterSelect', () => {
   it('Renders a select with object storage clusters', () => {
     const { getByText } = renderWithTheme(

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.test.tsx
@@ -4,7 +4,7 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import ClusterSelect from './ClusterSelect';
 
-vi.mock('src/components/EnhancedSelect/Select');
+vi.mock('src/components/Autocomplete/Autocomplete');
 
 describe('ClusterSelect', () => {
   it('Renders a select with object storage clusters', () => {

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.test.tsx
@@ -18,7 +18,7 @@ const props = {
   onClose: vi.fn(),
 };
 
-vi.mock('src/components/EnhancedSelect/Select');
+vi.mock('src/components/Autocomplete/Autocomplete');
 
 describe('CreateBucketDrawer', () => {
   it.skip('Should show a general error notice if the API returns one', async () => {

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketDrawer.test.tsx
@@ -18,8 +18,6 @@ const props = {
   onClose: vi.fn(),
 };
 
-vi.mock('src/components/Autocomplete/Autocomplete');
-
 describe('CreateBucketDrawer', () => {
   it.skip('Should show a general error notice if the API returns one', async () => {
     server.use(

--- a/packages/manager/src/features/ObjectStorage/utilities.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.ts
@@ -1,13 +1,9 @@
 import { OBJECT_STORAGE_DELIMITER } from 'src/constants';
 
 import type { AccountSettings } from '@linode/api-v4/lib/account';
-import type {
-  ACLType,
-  ObjectStorageObject,
-} from '@linode/api-v4/lib/object-storage';
+import type { ObjectStorageObject } from '@linode/api-v4/lib/object-storage';
 import type { ObjectStorageEndpoint } from '@linode/api-v4/lib/object-storage';
 import type { FormikProps } from 'formik';
-import type { Item } from 'src/components/EnhancedSelect/Select';
 
 export const generateObjectUrl = (hostname: string, objectName: string) => {
   return `https://${hostname}/${objectName}`;
@@ -42,6 +38,11 @@ export const basename = (
 
   return path.substr(idx + 1);
 };
+
+export interface ACLType {
+  label: string;
+  value: string;
+}
 
 export interface ExtendedObject extends ObjectStorageObject {
   _displayName: string;
@@ -153,18 +154,18 @@ export const confirmObjectStorage = async <T extends {}>(
   }
 };
 
-export const objectACLOptions: Item<ACLType>[] = [
+export const objectACLOptions: ACLType[] = [
   { label: 'Private', value: 'private' },
   { label: 'Authenticated Read', value: 'authenticated-read' },
   { label: 'Public Read', value: 'public-read' },
 ];
 
-export const bucketACLOptions: Item<ACLType>[] = [
+export const bucketACLOptions: ACLType[] = [
   ...objectACLOptions,
   { label: 'Public Read/Write', value: 'public-read-write' },
 ];
 
-export const objectACLHelperText: Record<ACLType, string> = {
+export const objectACLHelperText: Record<string, string> = {
   'authenticated-read': 'Authenticated Read ACL',
   custom: 'Custom ACL',
   private: 'Private ACL',


### PR DESCRIPTION
## Description 📝
We want to get rid of our dependency on react-select for accessibility reasons and to consolidate our usage of third-party libraries.

## Changes  🔄
- Replaced `Select` with Autocomplete in `Object Storage` component. 

## Target release date 🗓️
N/A

## How to test 🧪

### Verification steps
(How to verify changes)
- Navigate to http://localhost:3000/object-storage/buckets and open details drawer
- Verify 'Access Control List (ACL)' dropdown functionality remains unchanged when using `Autocomplete`. 

## As an Author I have considered 🤔

*Check all that apply*

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a changeset
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [ ] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support