### PR TITLE
fix: [M3-9049] - Resolve bucket size discrepancy in CM

### DIFF
--- a/packages/manager/.changeset/pr-11460-fixed-1735030571347.md
+++ b/packages/manager/.changeset/pr-11460-fixed-1735030571347.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Discrepancy in Object Storage Bucket size in CM ([#11460](https://github.com/linode/manager/pull/11460))

--- a/packages/manager/src/store/selectors/getSearchEntities.ts
+++ b/packages/manager/src/store/selectors/getSearchEntities.ts
@@ -157,7 +157,7 @@ export const bucketToSearchableItem = (
   data: {
     cluster: bucket.cluster,
     created: bucket.created,
-    description: readableBytes(bucket.size).formatted,
+    description: readableBytes(bucket.size, { base10: true }).formatted,
     icon: 'storage',
     label: bucket.label,
     path: `/object-storage/buckets/${bucket.cluster}/${bucket.label}`,


### PR DESCRIPTION
## Description 📝

This PR resolves the bucket size discrepancy in CM by converting the frontend display of Object Storage bucket sizes to the **correct decimal size** unit, ensuring consistency and avoiding confusion.
 
## Changes 🔄

- Fixed bucket size unit discrepancy in CM (converted to **Decimal Unit**).

## Target release date 🗓️

N/A

## Preview 📷

| Before | After |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/8add11b7-6f3a-4ef3-89d7-6f5c90a844c6) | ![After](https://github.com/user-attachments/assets/7a6e3436-18fb-4b36-bf1b-7f8d4e4ea984) |
| ![Before](https://github.com/user-attachments/assets/6356f930-0f72-4b93-a4e5-592c1618f778) | ![After](https://github.com/user-attachments/assets/fefbd8e9-e575-4864-89a1-0b3a2fe3ef52) |

## How to test 🧪

### Prerequisites

- Ensure necessary permissions for managing Object Storage Buckets.
- Create a bucket and add an object.

### Steps

- Check that the bucket size is displayed in correct decimal size on the frontend in CM.

### Verification

- After Changes, confirm the bucket size displays correctly in **Decimal Unit** in CM.

## As an Author, I have considered 🤔

- [x] 👀 Doing a self review
- [x] ❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
- [ ] 🤏 Splitting feature into small PRs
- [x] ➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] 🧪 Providing/Improving test coverage
- [ ] 🔐 Removing all sensitive information from the code and PR description
- [ ] 🚩 Using a feature flag to protect the release
- [x] 👣 Providing comprehensive reproduction steps
- [ ] 📑 Providing or updating our documentation
- [ ] 🕛 Scheduling a pair reviewing session
- [ ] 📱 Providing mobile support
- [ ] ♿  Providing accessibility support