### PR TITLE
fix: [M3-9025] - Region validation when switching to LKE-E

### DIFF
--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -111,6 +111,11 @@ export const CreateCluster = () => {
     // HA is enabled by default for enterprise clusters
     if (tier === 'enterprise') {
       setHighAvailability(true);
+
+      // When changing the tier to enterprise, we want to check if the pre-selected region has the capability
+      if (!selectedRegion?.capabilities.includes('Kubernetes Enterprise')) {
+        setSelectedRegion(undefined);
+      }
     } else {
       setHighAvailability(undefined);
     }
@@ -162,17 +167,6 @@ export const CreateCluster = () => {
       setVersion(getLatestVersion(versions).value);
     }
   }, [versionData]);
-
-  // When changing the tier to Enterprise, we want to check if the pre-selected region has the capability
-  React.useEffect(() => {
-    if (
-      isLkeEnterpriseLAFeatureEnabled &&
-      selectedTier === 'enterprise' &&
-      !selectedRegion?.capabilities.includes('Kubernetes Enterprise')
-    ) {
-      setSelectedRegion(undefined);
-    }
-  }, [isLkeEnterpriseLAFeatureEnabled, selectedRegion, selectedTier]);
 
   const createCluster = () => {
     if (ipV4Addr.some((ip) => ip.error) || ipV6Addr.some((ip) => ip.error)) {


### PR DESCRIPTION
## Description 📝
Fix region validation when a user is switching from LKE to LKE-E tier in the Kubernetes create flow

## Preview 📷
| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/139a7bac-17a1-4d21-bdb7-f7042944bd5a" /> | <video src="https://github.com/user-attachments/assets/57715543-9bd7-4802-94bd-0a88f2b304a9" /> |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Ensure you have the customer tags for LKE-E (check project tracker)

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Go to another branch or dev environment and navigate to the Kubernetes create page
- [ ] Enter a cluster label, select LKE as the tier, select a non LKE-E supported region (i.e. Atlanta, GA), select a HA control plane option, add a plan
- [ ] Change the selected tier to LKE-E. Notice the region select is cleared but the Create Cluster button is enabled. Clicking Create Cluster shows an error text in the Region field

### Verification steps

(How to verify changes)

- [ ] Checkout this branch or PR preview link and navigate to the Kubernetes create page
- [ ] Enter a cluster label, select LKE as the tier, select a non LKE-E supported region (i.e. Atlanta, GA), select a HA control plane option, add a plan
- [ ] Change the selected tier to LKE-E. The region select should be cleared and the Create Cluster button is disabled

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>