### PR TITLE
fix: [M3-9060] - Object Storage `endpoint_type`  sorting

### DIFF
--- a/packages/manager/.changeset/pr-11472-fixed-1736174726210.md
+++ b/packages/manager/.changeset/pr-11472-fixed-1736174726210.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Object Storage `endpoint_type` sorting ([#11472](https://github.com/linode/manager/pull/11472))

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable.tsx
@@ -72,11 +72,11 @@ export const BucketTable = (props: Props) => {
                 {isEndpointTypeAvailable && (
                   <Hidden lgDown>
                     <TableSortCell
-                      active={orderBy === 'endpointType'}
+                      active={orderBy === 'endpoint_type'}
                       data-qa-created
                       direction={order}
                       handleClick={handleOrderChange}
-                      label="endpointType"
+                      label="endpoint_type"
                     >
                       Endpoint Type
                     </TableSortCell>


### PR DESCRIPTION
## Description 📝
The property name for `endpoint_type` was misspelled causing the sorting for that column not to work.

## Target release date 🗓️
01/14/2025

## How to test 🧪
### Verification steps
- Go to `/object-storage/buckets`
- Ensure feature flag is enabled
- Ensure you have the customer tags 
   - `obj_use_regions_mode`
   - `obj_enable_use_endpoint_types`
- Observe that Endpoint Type sorting now works 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>