### PR TITLE
upcoming: [M3-9042] - Update LKE cluster details kube specs for LKE-E monthly pricing

### DIFF
--- a/packages/manager/.changeset/pr-11475-upcoming-features-1735939864502.md
+++ b/packages/manager/.changeset/pr-11475-upcoming-features-1735939864502.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update LKE cluster details kube specs for LKE-E monthly pricing ([#11475](https://github.com/linode/manager/pull/11475))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -11,6 +11,7 @@ import {
   regionFactory,
   nodePoolFactory,
   kubeLinodeFactory,
+  lkeHighAvailabilityTypeFactory,
 } from 'src/factories';
 import {
   mockCreateCluster,
@@ -126,7 +127,10 @@ const mockedLKEHAClusterPrices: PriceType[] = [
     transfer: 0,
   },
 ];
-const mockedLKEEnterprisePrices = [lkeEnterpriseTypeFactory.build()];
+const mockedLKEEnterprisePrices = [
+  lkeHighAvailabilityTypeFactory.build(),
+  lkeEnterpriseTypeFactory.build(),
+];
 const clusterPlans: LkePlanDescription[] = [
   {
     nodeCount: dedicatedNodeCount,
@@ -1068,16 +1072,18 @@ describe('LKE Cluster Creation with LKE-E', () => {
      * - Confirms an LKE-E supported region can be selected
      * - Confirms an LKE-E supported k8 version can be selected
      * - Confirms the checkout bar displays the correct LKE-E info
-     * - Confirms an enterprise cluster can be created
+     * - Confirms an enterprise cluster can be created with the correct chip, version, and price
      */
     it('creates an LKE-E cluster with the account capability', () => {
       const clusterLabel = randomLabel();
       const mockedEnterpriseCluster = kubernetesClusterFactory.build({
         label: clusterLabel,
-        region: clusterRegion.id,
+        region: 'us-iad',
         tier: 'enterprise',
         k8s_version: latestEnterpriseTierKubernetesVersion.id,
       });
+      const mockedEnterpriseClusterPools = [nanodeMemoryPool, dedicatedCpuPool];
+      const mockedLKEClusterTypes = [dedicatedType, nanodeType];
 
       mockGetAccount(
         accountFactory.build({
@@ -1090,6 +1096,7 @@ describe('LKE Cluster Creation with LKE-E', () => {
       mockGetKubernetesVersions([latestKubernetesVersion]).as(
         'getKubernetesVersions'
       );
+      mockGetLinodeTypes(mockedLKEClusterTypes).as('getLinodeTypes');
       mockGetLKEClusterTypes(mockedLKEEnterprisePrices).as(
         'getLKEEnterpriseClusterTypes'
       );
@@ -1108,6 +1115,12 @@ describe('LKE Cluster Creation with LKE-E', () => {
       mockGetCluster(mockedEnterpriseCluster).as('getCluster');
       mockCreateCluster(mockedEnterpriseCluster).as('createCluster');
       mockGetClusters([mockedEnterpriseCluster]).as('getClusters');
+      mockGetClusterPools(
+        mockedEnterpriseCluster.id,
+        mockedEnterpriseClusterPools
+      ).as('getClusterPools');
+      mockGetDashboardUrl(mockedEnterpriseCluster.id).as('getDashboardUrl');
+      mockGetApiEndpoints(mockedEnterpriseCluster.id).as('getApiEndpoints');
 
       cy.visitWithLogin('/kubernetes/clusters');
       cy.wait(['@getAccount']);
@@ -1222,8 +1235,8 @@ describe('LKE Cluster Creation with LKE-E', () => {
           cy.findByText(`Dedicated 4 GB Plan`).should('be.visible');
           cy.findByText('$144.00').should('be.visible');
           cy.findByText(`Linode 2 GB Plan`).should('be.visible');
-          cy.findByText('$36.00').should('be.visible');
-          cy.findByText('$480.00').should('be.visible');
+          cy.findByText('$15.00').should('be.visible');
+          cy.findByText('$459.00').should('be.visible');
 
           ui.button
             .findByTitle('Create Cluster')
@@ -1233,16 +1246,28 @@ describe('LKE Cluster Creation with LKE-E', () => {
         });
 
       // Wait for LKE cluster to be created and confirm that we are redirected
-      // to the cluster summary page, where the cluster has an LKE-E version.
-      cy.wait(['@getCluster', '@createCluster']);
+      // to the cluster summary page.
+      cy.wait([
+        '@getCluster',
+        '@getClusterPools',
+        '@createCluster',
+        '@getLKEEnterpriseClusterTypes',
+        '@getLinodeTypes',
+        '@getDashboardUrl',
+        '@getApiEndpoints',
+      ]);
+
       cy.url().should(
         'endWith',
         `/kubernetes/clusters/${mockedEnterpriseCluster.id}/summary`
       );
 
+      // Confirm the LKE-E cluster has the correct enterprise chip, version, and pricing.
+      cy.findByText('ENTERPRISE').should('be.visible');
       cy.findByText(
         `Version ${latestEnterpriseTierKubernetesVersion.id}`
       ).should('be.visible');
+      cy.findByText('$459.00/month').should('be.visible');
     });
 
     it('disables the Cluster Type selection without the LKE-E account capability', () => {

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeClusterSpecs.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeClusterSpecs.tsx
@@ -68,7 +68,7 @@ export const KubeClusterSpecs = React.memo((props: Props) => {
     data: kubernetesHighAvailabilityTypesData,
     isError: isErrorKubernetesTypes,
     isLoading: isLoadingKubernetesTypes,
-  } = useKubernetesTypesQuery();
+  } = useKubernetesTypesQuery(cluster.tier === 'enterprise');
 
   const matchesColGapBreakpointDown = useMediaQuery(
     theme.breakpoints.down(theme.breakpoints.values.lg)
@@ -78,12 +78,17 @@ export const KubeClusterSpecs = React.memo((props: Props) => {
     (type) => type.id === 'lke-ha'
   );
 
+  const lkeEnterpriseType = kubernetesHighAvailabilityTypesData?.find(
+    (type) => type.id === 'lke-e'
+  );
+
   const region = regions?.find((r) => r.id === cluster.region);
   const displayRegion = region?.label ?? cluster.region;
 
   const highAvailabilityPrice = cluster.control_plane.high_availability
     ? getDCSpecificPriceByType({ regionId: region?.id, type: lkeHAType })
     : undefined;
+  const enterprisePrice = lkeEnterpriseType?.price.monthly ?? undefined;
 
   const kubeSpecsLeft = [
     `Version ${cluster.k8s_version}`,
@@ -107,6 +112,7 @@ export const KubeClusterSpecs = React.memo((props: Props) => {
       </>
     ) : (
       `$${getTotalClusterPrice({
+        enterprisePrice: enterprisePrice,
         highAvailabilityPrice: highAvailabilityPrice
           ? Number(highAvailabilityPrice)
           : undefined,


### PR DESCRIPTION
## Description 📝

The cluster pricing in the Kube Specs on the LKE details page for an enterprise cluster does not currently match the price that was given when creating a cluster because the LKE-E HA price ($300/month) is not factored in. We need to update this to provide consistent and accurate pricing information for LKE-E clusters.

## Changes  🔄

- Updated the kube specs to correctly calculate LKE-E HA pricing ($300/month)
- Updated `lke-create.spec.ts` with test coverage for this

## Target release date 🗓️

1/14/25

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-01-03 at 1 26 08 PM](https://github.com/user-attachments/assets/3c46e675-47af-4285-b96b-42a29ee3cd56) | ![Screenshot 2025-01-03 at 1 25 58 PM](https://github.com/user-attachments/assets/1fbf5dde-e920-4b79-8e44-552fe5820f3d) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have the LKE-E enterprise tag on your account (see project tracker)
- Ensure the LKE-E feature is on in dev tools (enabled + la)
- Have an LKE-E cluster created on your account

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] In prod/develop, go to the cluster details page for your LKE-E cluster and observe that the pricing is incorrect (it's using the regular HA pricing of $60/month + node pool cost)

### Verification steps

(How to verify changes)

- [ ] On this branch, go to the cluster details page for your LKE-E cluster and observe that the pricing is correct (uses the enterprise HA pricing of $300/month + node pool cost); it will be $240 higher
- [ ] Confirm that standard LKE clusters are priced with the standard HA cost

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

