### PR TITLE
fix: [M3-9024] - Mask sensitive data in Managed and Longview

### DIFF
--- a/packages/manager/.changeset/pr-11476-fixed-1736263048231.md
+++ b/packages/manager/.changeset/pr-11476-fixed-1736263048231.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Visibility of sensitive data in Managed and Longview with Mask Sensitive Data setting enabled ([#11476](https://github.com/linode/manager/pull/11476))

--- a/packages/manager/src/components/MaskableText/MaskableText.tsx
+++ b/packages/manager/src/components/MaskableText/MaskableText.tsx
@@ -29,6 +29,10 @@ export interface MaskableTextProps {
    */
   length?: MaskableTextLength;
   /**
+   * Optional styling for the masked and unmasked Typography
+   */
+  sxTypography?: SxProps<Theme>;
+  /**
    * Optional styling for VisibilityTooltip icon
    */
   sxVisibilityTooltip?: SxProps<Theme>;
@@ -44,6 +48,7 @@ export const MaskableText = (props: MaskableTextProps) => {
     iconPosition = 'end',
     isToggleable = false,
     length,
+    sxTypography,
     sxVisibilityTooltip,
     text,
   } = props;
@@ -54,7 +59,11 @@ export const MaskableText = (props: MaskableTextProps) => {
 
   const [isMasked, setIsMasked] = React.useState(maskedPreferenceSetting);
 
-  const unmaskedText = children ? children : <Typography>{text}</Typography>;
+  const unmaskedText = children ? (
+    children
+  ) : (
+    <Typography sx={sxTypography}>{text}</Typography>
+  );
 
   // Return early based on the preference setting and the original text.
 
@@ -85,7 +94,7 @@ export const MaskableText = (props: MaskableTextProps) => {
         />
       )}
       {isMasked ? (
-        <Typography sx={{ overflowWrap: 'anywhere' }}>
+        <Typography sx={{ overflowWrap: 'anywhere', ...sxTypography }}>
           {createMaskedText(text, length)}
         </Typography>
       ) : (

--- a/packages/manager/src/components/MaskableText/MaskableText.tsx
+++ b/packages/manager/src/components/MaskableText/MaskableText.tsx
@@ -85,7 +85,7 @@ export const MaskableText = (props: MaskableTextProps) => {
       {iconPosition === 'start' && isToggleable && (
         <VisibilityTooltip
           sx={{
-            marginLeft: 'unset',
+            marginLeft: 0,
             marginRight: '8px',
             ...sxVisibilityTooltip,
           }}

--- a/packages/manager/src/components/MaskableText/MaskableText.tsx
+++ b/packages/manager/src/components/MaskableText/MaskableText.tsx
@@ -5,6 +5,8 @@ import * as React from 'react';
 import { usePreferences } from 'src/queries/profile/preferences';
 import { createMaskedText } from 'src/utilities/createMaskedText';
 
+import type { SxProps, Theme } from '@mui/material';
+
 export type MaskableTextLength = 'ipv4' | 'ipv6' | 'plaintext';
 
 export interface MaskableTextProps {
@@ -13,7 +15,13 @@ export interface MaskableTextProps {
    */
   children?: JSX.Element | JSX.Element[];
   /**
+   * Optionally specifies the position of the VisibilityTooltip icon either before or after the text.
+   * @default end
+   */
+  iconPosition?: 'end' | 'start';
+  /**
    * If true, displays a VisibilityTooltip icon to toggle the masked and unmasked text.
+   * @default false
    */
   isToggleable?: boolean;
   /**
@@ -21,13 +29,24 @@ export interface MaskableTextProps {
    */
   length?: MaskableTextLength;
   /**
+   * Optional styling for VisibilityTooltip icon
+   */
+  sxVisibilityTooltip?: SxProps<Theme>;
+  /**
    * The original, maskable text; if the text is not masked, render this text or the styled text via children.
    */
   text: string | undefined;
 }
 
 export const MaskableText = (props: MaskableTextProps) => {
-  const { children, isToggleable = false, length, text } = props;
+  const {
+    children,
+    iconPosition = 'end',
+    isToggleable = false,
+    length,
+    sxVisibilityTooltip,
+    text,
+  } = props;
 
   const { data: maskedPreferenceSetting } = usePreferences(
     (preferences) => preferences?.maskSensitiveData
@@ -54,6 +73,17 @@ export const MaskableText = (props: MaskableTextProps) => {
       flexDirection="row"
       justifyContent="flex-start"
     >
+      {iconPosition === 'start' && isToggleable && (
+        <VisibilityTooltip
+          sx={{
+            marginLeft: 'unset',
+            marginRight: '8px',
+            ...sxVisibilityTooltip,
+          }}
+          handleClick={() => setIsMasked(!isMasked)}
+          isVisible={!isMasked}
+        />
+      )}
       {isMasked ? (
         <Typography sx={{ overflowWrap: 'anywhere' }}>
           {createMaskedText(text, length)}
@@ -61,7 +91,7 @@ export const MaskableText = (props: MaskableTextProps) => {
       ) : (
         unmaskedText
       )}
-      {isToggleable && (
+      {iconPosition === 'end' && isToggleable && (
         <VisibilityTooltip
           handleClick={() => setIsMasked(!isMasked)}
           isVisible={!isMasked}

--- a/packages/manager/src/components/MaskableText/MaskableTextArea.tsx
+++ b/packages/manager/src/components/MaskableText/MaskableTextArea.tsx
@@ -1,0 +1,18 @@
+import { Typography } from '@linode/ui';
+import React from 'react';
+
+import { Link } from '../Link';
+
+/**
+ * This copy is intended to display where a larger area of data is masked.
+ * Example: Billing Contact info, rather than masking many individual fields
+ */
+export const MaskableTextAreaCopy = () => {
+  return (
+    <Typography>
+      This data is sensitive and hidden for privacy. To unmask all sensitive
+      data by default, go to{' '}
+      <Link to="/profile/settings">profile settings</Link>.
+    </Typography>
+  );
+};

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { useState } from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 
-import { Link } from 'src/components/Link';
+import { MaskableTextAreaCopy } from 'src/components/MaskableText/MaskableTextArea';
 import { getRestrictedResourceText } from 'src/features/Account/utils';
 import { EDIT_BILLING_CONTACT } from 'src/features/Billing/constants';
 import { StyledAutorenewIcon } from 'src/features/TopMenu/NotificationMenu/NotificationMenu';
@@ -198,11 +198,7 @@ export const ContactInformation = React.memo((props: Props) => {
           </Box>
         </BillingBox>
         {maskSensitiveDataPreference && isContactInfoMasked ? (
-          <Typography>
-            This data is sensitive and hidden for privacy. To unmask all
-            sensitive data by default, go to{' '}
-            <Link to="/profile/settings">profile settings</Link>.
-          </Typography>
+          <MaskableTextAreaCopy />
         ) : (
           <Grid container spacing={2}>
             {(firstName ||

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ConnectionRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ConnectionRow.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 
+import { MaskableText } from 'src/components/MaskableText/MaskableText';
 import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
-import { LongviewPort } from 'src/features/Longview/request.types';
+
+import type { LongviewPort } from 'src/features/Longview/request.types';
 
 interface Props {
   connection: LongviewPort;
@@ -17,7 +19,7 @@ export const ConnectionRow = (props: Props) => {
         {connection.name}
       </TableCell>
       <TableCell data-qa-active-connection-user parentColumn="User">
-        {connection.user}
+        <MaskableText isToggleable text={connection.user} />
       </TableCell>
       <TableCell data-qa-active-connection-count parentColumn="Count">
         {connection.count}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/LongviewServiceRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/LongviewServiceRow.tsx
@@ -19,7 +19,7 @@ export const LongviewServiceRow = (props: Props) => {
         {service.name}
       </TableCell>
       <TableCell data-qa-service-user parentColumn="User">
-        {service.user}
+        <MaskableText isToggleable text={service.user} />
       </TableCell>
       <TableCell data-qa-service-protocol parentColumn="Protocol">
         {service.type}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/LongviewServiceRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/LongviewServiceRow.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 
+import { MaskableText } from 'src/components/MaskableText/MaskableText';
 import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
-import { LongviewService } from 'src/features/Longview/request.types';
+
+import type { LongviewService } from 'src/features/Longview/request.types';
 
 interface Props {
   service: LongviewService;
@@ -26,7 +28,7 @@ export const LongviewServiceRow = (props: Props) => {
         {service.port}
       </TableCell>
       <TableCell data-qa-service-ip parentColumn="IP">
-        {service.ip}
+        <MaskableText isToggleable text={service.ip} />
       </TableCell>
     </TableRow>
   );

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesTable.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesTable.tsx
@@ -1,6 +1,6 @@
-import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 
+import { MaskableText } from 'src/components/MaskableText/MaskableText';
 import OrderBy from 'src/components/OrderBy';
 import { TableBody } from 'src/components/TableBody';
 import { TableCell } from 'src/components/TableCell';
@@ -15,7 +15,9 @@ import { useWindowDimensions } from 'src/hooks/useWindowDimensions';
 import { readableBytes } from 'src/utilities/unitConversions';
 
 import { StyledDiv, StyledTable } from './ProcessesTable.styles';
-import { Process } from './types';
+
+import type { Process } from './types';
+import type { APIError } from '@linode/api-v4/lib/types';
 
 export interface ProcessesTableProps {
   error?: string;
@@ -184,7 +186,9 @@ export const ProcessesTableRow = React.memo((props: ProcessTableRowProps) => {
       <TableCell data-testid={`name-${name}`}>
         <StyledDiv>{name}</StyledDiv>
       </TableCell>
-      <TableCell data-testid={`user-${user}`}>{user}</TableCell>
+      <TableCell data-testid={`user-${user}`}>
+        <MaskableText isToggleable text={user} />
+      </TableCell>
       <TableCell data-testid={`max-count-${Math.round(maxCount)}`}>
         {Math.round(maxCount)}
       </TableCell>

--- a/packages/manager/src/features/Longview/shared/InstallationInstructions.styles.ts
+++ b/packages/manager/src/features/Longview/shared/InstallationInstructions.styles.ts
@@ -4,6 +4,12 @@ import Grid from '@mui/material/Unstable_Grid2';
 export const StyledInstructionGrid = styled(Grid, {
   label: 'StyledInstructionGrid',
 })(({ theme }) => ({
+  boxSizing: 'border-box',
+  columnGap: 1,
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'center',
+  margin: '0',
   [theme.breakpoints.up('sm')]: {
     '&:not(:first-of-type)': {
       '&:before': {
@@ -19,8 +25,6 @@ export const StyledInstructionGrid = styled(Grid, {
     width: 'auto',
   },
   width: '100%',
-  boxSizing: 'border-box',
-  margin: '0',
 }));
 
 export const StyledContainerGrid = styled(Grid, {

--- a/packages/manager/src/features/Longview/shared/InstallationInstructions.tsx
+++ b/packages/manager/src/features/Longview/shared/InstallationInstructions.tsx
@@ -93,6 +93,7 @@ export const InstallationInstructions = React.memo((props: Props) => {
               isToggleable
               sxTypography={{ color: theme.color.grey1 }}
               text={props.APIKey}
+              sxVisibilityTooltip={{ marginLeft: 1 }}
             />
           </StyledInstructionGrid>
         </Grid>

--- a/packages/manager/src/features/Longview/shared/InstallationInstructions.tsx
+++ b/packages/manager/src/features/Longview/shared/InstallationInstructions.tsx
@@ -1,4 +1,5 @@
-import { Box, Typography } from '@linode/ui';
+import { Typography } from '@linode/ui';
+import { useTheme } from '@mui/material/styles';
 import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 
@@ -18,6 +19,7 @@ interface Props {
 
 export const InstallationInstructions = React.memo((props: Props) => {
   const command = `curl -s https://lv.linode.com/${props.installationKey} | sudo bash`;
+  const theme = useTheme();
 
   return (
     <Grid container spacing={2}>
@@ -84,16 +86,19 @@ export const InstallationInstructions = React.memo((props: Props) => {
               </Link>
             </Typography>
           </StyledInstructionGrid>
-          <StyledInstructionGrid>
-            <Typography data-testid="api-key">
-              API Key:{' '}
-              <Box
-                component="span"
-                sx={(theme) => ({ color: theme.color.grey1 })}
-              >
-                {props.APIKey}
-              </Box>
-            </Typography>
+          <StyledInstructionGrid
+            columnGap={1}
+            display="flex"
+            flexDirection="row"
+            justifyContent="center"
+          >
+            <Typography data-testid="api-key">API Key:</Typography>
+            <MaskableText
+              iconPosition="start"
+              isToggleable
+              sxTypography={{ color: theme.color.grey1 }}
+              text={props.APIKey}
+            />
           </StyledInstructionGrid>
         </Grid>
       </Grid>

--- a/packages/manager/src/features/Longview/shared/InstallationInstructions.tsx
+++ b/packages/manager/src/features/Longview/shared/InstallationInstructions.tsx
@@ -86,12 +86,7 @@ export const InstallationInstructions = React.memo((props: Props) => {
               </Link>
             </Typography>
           </StyledInstructionGrid>
-          <StyledInstructionGrid
-            columnGap={1}
-            display="flex"
-            flexDirection="row"
-            justifyContent="center"
-          >
+          <StyledInstructionGrid>
             <Typography data-testid="api-key">API Key:</Typography>
             <MaskableText
               iconPosition="start"

--- a/packages/manager/src/features/Longview/shared/InstallationInstructions.tsx
+++ b/packages/manager/src/features/Longview/shared/InstallationInstructions.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
 import { Link } from 'src/components/Link';
+import { MaskableText } from 'src/components/MaskableText/MaskableText';
 
 import {
   StyledContainerGrid,
@@ -41,9 +42,22 @@ export const InstallationInstructions = React.memo((props: Props) => {
               paddingTop: 0,
             }}
           >
-            <pre>
-              <code>{command}</code>
-            </pre>
+            <MaskableText
+              sxVisibilityTooltip={{
+                '& svg': {
+                  height: 'auto',
+                  width: '20px',
+                },
+                marginRight: '24px',
+              }}
+              iconPosition="start"
+              isToggleable
+              text={command}
+            >
+              <pre>
+                <code>{command}</code>
+              </pre>
+            </MaskableText>
           </Grid>
         </StyledContainerGrid>
       </Grid>

--- a/packages/manager/src/features/Longview/shared/InstallationInstructions.tsx
+++ b/packages/manager/src/features/Longview/shared/InstallationInstructions.tsx
@@ -87,13 +87,15 @@ export const InstallationInstructions = React.memo((props: Props) => {
             </Typography>
           </StyledInstructionGrid>
           <StyledInstructionGrid>
-            <Typography data-testid="api-key">API Key:</Typography>
+            <Typography data-testid="api-key" sx={{ marginRight: 0.5 }}>
+              API Key:
+            </Typography>
             <MaskableText
               iconPosition="start"
               isToggleable
               sxTypography={{ color: theme.color.grey1 }}
-              text={props.APIKey}
               sxVisibilityTooltip={{ marginLeft: 1 }}
+              text={props.APIKey}
             />
           </StyledInstructionGrid>
         </Grid>

--- a/packages/manager/src/features/Managed/Contacts/ContactsRow.tsx
+++ b/packages/manager/src/features/Managed/Contacts/ContactsRow.tsx
@@ -5,6 +5,7 @@ import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
 
 import ActionMenu from './ContactsActionMenu';
+import { MaskableText } from 'src/components/MaskableText/MaskableText';
 
 import type { ManagedContact } from '@linode/api-v4/lib/managed';
 
@@ -19,14 +20,24 @@ export const ContactsRow = (props: ContactsRowProps) => {
 
   return (
     <TableRow key={contact.id}>
-      <TableCell>{contact.name}</TableCell>
+      <TableCell>
+        <MaskableText text={contact.name} isToggleable />
+      </TableCell>
       <Hidden mdDown>
-        <TableCell>{contact.group}</TableCell>
+        <TableCell>
+          <MaskableText text={contact.group ?? ''} isToggleable />
+        </TableCell>
       </Hidden>
-      <TableCell>{contact.email}</TableCell>
+      <TableCell>
+        <MaskableText text={contact.email} isToggleable />
+      </TableCell>
       <Hidden xsDown>
-        <TableCell>{contact.phone.primary}</TableCell>
-        <TableCell>{contact.phone.secondary}</TableCell>
+        <TableCell>
+          <MaskableText text={contact.phone.primary ?? ''} isToggleable />
+        </TableCell>
+        <TableCell>
+          <MaskableText text={contact.phone.secondary ?? ''} isToggleable />
+        </TableCell>
       </Hidden>
       <TableCell actionCell>
         <ActionMenu

--- a/packages/manager/src/features/Managed/SSHAccess/LinodePubKey.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/LinodePubKey.tsx
@@ -1,11 +1,18 @@
-import { Box, Button, Typography } from '@linode/ui';
+import { Button, Stack, Typography } from '@linode/ui';
+import { useMediaQuery } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
 import copy from 'copy-to-clipboard';
 import * as React from 'react';
 
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { Link } from 'src/components/Link';
+import { MaskableTextAreaCopy } from 'src/components/MaskableText/MaskableTextArea';
+import {
+  StyledVisibilityHideIcon,
+  StyledVisibilityShowIcon,
+} from 'src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.styles';
 import { useManagedSSHKey } from 'src/queries/managed/managed';
+import { usePreferences } from 'src/queries/profile/preferences';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
 import {
@@ -19,14 +26,23 @@ import {
   StyledTypography,
 } from './LinodePubKey.styles';
 
+import type { Theme } from '@storybook/core/theming';
+
 const DOC_URL =
   'https://techdocs.akamai.com/cloud-computing/docs/configure-ssh-access-for-managed-services';
 
 const LinodePubKey = () => {
   const { data, error, isLoading } = useManagedSSHKey();
+  const { data: preferences } = usePreferences();
 
   const [copied, setCopied] = React.useState<boolean>(false);
+  const [isSSHKeyMasked, setIsSSHKeyMasked] = React.useState(
+    preferences?.maskSensitiveData
+  );
   const timeout = React.useRef<NodeJS.Timeout>();
+  const matchesSmDownBreakpoint = useMediaQuery((theme: Theme) =>
+    theme.breakpoints.down('sm')
+  );
 
   React.useEffect(() => {
     if (copied) {
@@ -70,27 +86,45 @@ const LinodePubKey = () => {
     <StyledRootPaper>
       <Grid container justifyContent="space-between" spacing={2}>
         <Grid lg={4} md={3} xs={12}>
-          <Box display="flex" flexDirection="row">
+          <Stack flexDirection="row">
             <StyledSSHKeyIcon />
             <Typography variant="h3">Linode Public Key</Typography>
-          </Box>
+          </Stack>
           <Typography>
             You must <Link to={DOC_URL}>install our public SSH key</Link> on all
             managed Linodes so we can access them and diagnose issues.
           </Typography>
         </Grid>
-        {/* Hide the SSH key on x-small viewports */}
-        <StyledSSHKeyContainerGrid md={6} sm={5} xs={12}>
+        <StyledSSHKeyContainerGrid md={6} sm={7} xs={12}>
           <StyledTypography variant="subtitle1">
-            {data?.ssh_key || ''}
+            {preferences?.maskSensitiveData && isSSHKeyMasked ? (
+              <MaskableTextAreaCopy />
+            ) : (
+              data?.ssh_key || ''
+            )}
             {/* See NOTE A. If that CSS is removed, we can use the following instead: */}
             {/* pubKey.slice(0, 160)} . . . */}
           </StyledTypography>
         </StyledSSHKeyContainerGrid>
         <StyledCopyToClipboardGrid lg={2} md={3} sm={4} xs={12}>
-          <Button buttonType="secondary" onClick={handleCopy}>
-            {!copied ? 'Copy to clipboard' : 'Copied!'}
-          </Button>
+          <Stack
+            flexDirection={matchesSmDownBreakpoint ? 'row' : 'column'}
+            marginLeft={matchesSmDownBreakpoint ? 'auto' : undefined}
+          >
+            <Button buttonType="secondary" onClick={handleCopy}>
+              {!copied ? 'Copy to clipboard' : 'Copied!'}
+            </Button>
+            {preferences?.maskSensitiveData && (
+              <Button onClick={() => setIsSSHKeyMasked(!isSSHKeyMasked)}>
+                {isSSHKeyMasked ? (
+                  <StyledVisibilityShowIcon />
+                ) : (
+                  <StyledVisibilityHideIcon />
+                )}
+                {isSSHKeyMasked ? 'Show Key' : 'Hide Key'}
+              </Button>
+            )}
+          </Stack>
         </StyledCopyToClipboardGrid>
       </Grid>
     </StyledRootPaper>

--- a/packages/manager/src/features/Managed/SSHAccess/LinodePubKey.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/LinodePubKey.tsx
@@ -19,9 +19,8 @@ import {
   StyledTypography,
 } from './LinodePubKey.styles';
 
-// @todo: is this URL correct? Are there new docs being written?
 const DOC_URL =
-  'https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-the-linode-managed-service#adding-the-public-key';
+  'https://techdocs.akamai.com/cloud-computing/docs/configure-ssh-access-for-managed-services';
 
 const LinodePubKey = () => {
   const { data, error, isLoading } = useManagedSSHKey();

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
@@ -30,7 +30,9 @@ export const SSHAccessRow = (props: SSHAccessRowProps) => {
         {isAccessEnabled ? 'Enabled' : 'Disabled'}
       </TableCell>
       <Hidden smDown>
-        <TableCell data-qa-managed-user>{linodeSetting.ssh.user}</TableCell>
+        <TableCell data-qa-managed-user>
+          <MaskableText isToggleable text={linodeSetting.ssh.user} />
+        </TableCell>
         <TableCell data-qa-managed-ip>
           {linodeSetting.ssh.ip === 'any' ? (
             'Any'

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
@@ -1,11 +1,13 @@
-import { ManagedLinodeSetting } from '@linode/api-v4/lib/managed';
 import * as React from 'react';
 
 import { Hidden } from 'src/components/Hidden';
+import { MaskableText } from 'src/components/MaskableText/MaskableText';
 import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
 
 import ActionMenu from './SSHAccessActionMenu';
+
+import type { ManagedLinodeSetting } from '@linode/api-v4/lib/managed';
 
 interface SSHAccessRowProps {
   linodeSetting: ManagedLinodeSetting;
@@ -30,7 +32,15 @@ export const SSHAccessRow = (props: SSHAccessRowProps) => {
       <Hidden smDown>
         <TableCell data-qa-managed-user>{linodeSetting.ssh.user}</TableCell>
         <TableCell data-qa-managed-ip>
-          {linodeSetting.ssh.ip === 'any' ? 'Any' : linodeSetting.ssh.ip}
+          {linodeSetting.ssh.ip === 'any' ? (
+            'Any'
+          ) : (
+            <MaskableText
+              isToggleable
+              length="ipv4"
+              text={linodeSetting.ssh.ip}
+            />
+          )}
         </TableCell>
         <TableCell data-qa-managed-port>{linodeSetting.ssh.port}</TableCell>
       </Hidden>


### PR DESCRIPTION
## Description 📝

We overlooked a couple of older, more niche sections of Cloud Manager with the Mask Sensitive Data feature. This PR masks data in Managed and Longview.

## Changes  🔄

- Name, email, primary phone, and secondary phone are maskable and toggleable on the Managed > Contacts tab
- User, IP addresses, and SSH keys are maskable and toggleable on the Managed > SSH Access tab
- API keys, contact information, user, and IP addresses are masked and toggleable on the Longview landing and the Longview client details page

## Target release date 🗓️

1/14/25

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-01-06 at 11 06 27 PM](https://github.com/user-attachments/assets/a633fa4c-d02e-4856-9595-101472e385ee) | ![Screenshot 2025-01-06 at 11 05 23 PM](https://github.com/user-attachments/assets/0a873626-33fb-4783-9b11-b10f56bbb39c) |
| ![Screenshot 2025-01-06 at 11 07 15 PM](https://github.com/user-attachments/assets/d1b48a67-0ac7-4773-aa4a-1c7eb05b3e42) | ![Screenshot 2025-01-06 at 11 05 50 PM](https://github.com/user-attachments/assets/ccf7afa0-b676-481f-8264-8feadaf01523) |
| ![Screenshot 2025-01-06 at 11 43 14 PM](https://github.com/user-attachments/assets/57993b70-cd13-45cd-a7c6-a60f861d1c3f) | ![Screenshot 2025-01-06 at 11 30 57 PM](https://github.com/user-attachments/assets/c3507a35-f2ad-4a93-93fb-0d3ed0307f23) ![Screenshot 2025-01-06 at 11 37 09 PM](https://github.com/user-attachments/assets/e85d980e-a520-45d8-b344-c07208715d83) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Go to http://localhost:3000/profile/settings and enable the Mask Sensitive Data setting
- Have at least one Linode on your account
- Install the Longview agent on that Linode ([docs](https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-longview))

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Enable Managed in admin (or use the MSW, Legacy Handlers) and in prod, go to:
   - [ ] https://cloud.linode.com/managed/ssh-access -  Observe unmasked public key, User, and IP ('Edit' the row and change the IP from 'Any' to see this)
   - [ ] https://cloud.linode.com/managed/contacts - Add a contact and observe the unmasked sensitive fields
- [ ] Go to Longview landing and observe the API key and cURL command is visible; on the details pages, observe the same, and note the User and IP fields in the tables (which may not have data)

### Verification steps

(How to verify changes)

- [ ] On this branch, repeat the steps above and observe:
   - [ ] Managed SSH Access public key, user, and IP are toggleable masked data. The public key notice resizes gracefully on smaller screens.
   - [ ] Managed Contacts cells have toggleable masked data.
- [ ] Longview API key and cURL command are toggleable masked data. If you do not have data in the table for User and IP fields in the Longview client details tabs, look at the diff and confirm the right columns are wrapped in the MaskableText component.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
