### PR TITLE
test: [M3-9023] - Add coverage for Kube version upgrades in landing page

### DIFF
--- a/packages/manager/.changeset/pr-11478-tests-1736180178602.md
+++ b/packages/manager/.changeset/pr-11478-tests-1736180178602.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add coverage for Kube version upgrades in landing page ([#11478](https://github.com/linode/manager/pull/11478))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-landing-page.spec.ts
@@ -170,7 +170,7 @@ describe('LKE landing page', () => {
     readDownload(mockKubeconfigFilename).should('eq', mockKubeconfigContents);
   });
 
-  it('does not show an Upgrade chip when there is no new kubernetes version', () => {
+  it('does not show an Upgrade chip when there is no new kubernetes standard version', () => {
     const oldVersion = '1.25';
     const newVersion = '1.26';
 

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -25,7 +25,6 @@ import {
   mockRecycleAllNodes,
   mockGetDashboardUrl,
   mockGetApiEndpoints,
-  mockGetClusters,
   mockUpdateControlPlaneACL,
   mockGetControlPlaneACL,
   mockUpdateControlPlaneACLError,
@@ -238,65 +237,6 @@ describe('LKE cluster updates', () => {
       ui.toast.findByMessage('Recycle started successfully.');
     });
 
-    it('can upgrade the standard kubernetes version from the landing page', () => {
-      const oldVersion = '1.25';
-      const newVersion = '1.26';
-
-      const cluster = kubernetesClusterFactory.build({
-        k8s_version: oldVersion,
-      });
-
-      const updatedCluster = { ...cluster, k8s_version: newVersion };
-
-      mockGetClusters([cluster]).as('getClusters');
-      mockGetKubernetesVersions([newVersion, oldVersion]).as('getVersions');
-      mockUpdateCluster(cluster.id, updatedCluster).as('updateCluster');
-      mockRecycleAllNodes(cluster.id).as('recycleAllNodes');
-
-      cy.visitWithLogin(`/kubernetes/clusters`);
-
-      cy.wait(['@getClusters', '@getVersions']);
-
-      cy.findByText(oldVersion).should('be.visible');
-
-      cy.findByText('UPGRADE')
-        .should('be.visible')
-        .should('be.enabled')
-        .click();
-
-      ui.dialog
-        .findByTitle(
-          `Step 1: Upgrade ${cluster.label} to Kubernetes ${newVersion}`
-        )
-        .should('be.visible');
-
-      mockGetClusters([updatedCluster]).as('getClusters');
-
-      ui.button
-        .findByTitle('Upgrade Version')
-        .should('be.visible')
-        .should('be.enabled')
-        .click();
-
-      cy.wait(['@updateCluster', '@getClusters']);
-
-      ui.dialog
-        .findByTitle('Step 2: Recycle All Cluster Nodes')
-        .should('be.visible');
-
-      ui.button
-        .findByTitle('Recycle All Nodes')
-        .should('be.visible')
-        .should('be.enabled')
-        .click();
-
-      cy.wait('@recycleAllNodes');
-
-      ui.toast.assertMessage('Recycle started successfully.');
-
-      cy.findByText(newVersion).should('be.visible');
-    });
-
     /*
      * - Confirms UI flow of upgrading Kubernetes enterprise version using mocked API requests.
      * - Confirms that Kubernetes upgrade prompt is shown when not up-to-date.
@@ -423,80 +363,6 @@ describe('LKE cluster updates', () => {
       cy.findByText(`Version ${newVersion}`);
 
       ui.toast.findByMessage('Recycle started successfully.');
-    });
-
-    it('can upgrade the enterprise kubernetes version from the landing page', () => {
-      const oldVersion = '1.31.1+lke1';
-      const newVersion = '1.32.1+lke2';
-
-      mockGetAccount(
-        accountFactory.build({
-          capabilities: ['Kubernetes Enterprise'],
-        })
-      ).as('getAccount');
-
-      // TODO LKE-E: Remove once feature is in GA
-      mockAppendFeatureFlags({
-        lkeEnterprise: { enabled: true, la: true },
-      });
-
-      const cluster = kubernetesClusterFactory.build({
-        k8s_version: oldVersion,
-        tier: 'enterprise',
-      });
-
-      const updatedCluster = { ...cluster, k8s_version: newVersion };
-
-      mockGetClusters([cluster]).as('getClusters');
-      mockGetTieredKubernetesVersions('enterprise', [
-        { id: newVersion, tier: 'enterprise' },
-        { id: oldVersion, tier: 'enterprise' },
-      ]).as('getTieredVersions');
-      mockUpdateCluster(cluster.id, updatedCluster).as('updateCluster');
-      mockRecycleAllNodes(cluster.id).as('recycleAllNodes');
-
-      cy.visitWithLogin(`/kubernetes/clusters`);
-
-      cy.wait(['@getAccount', '@getClusters', '@getTieredVersions']);
-
-      cy.findByText(oldVersion).should('be.visible');
-
-      cy.findByText('UPGRADE')
-        .should('be.visible')
-        .should('be.enabled')
-        .click();
-
-      ui.dialog
-        .findByTitle(
-          `Step 1: Upgrade ${cluster.label} to Kubernetes ${newVersion}`
-        )
-        .should('be.visible');
-
-      mockGetClusters([updatedCluster]).as('getClusters');
-
-      ui.button
-        .findByTitle('Upgrade Version')
-        .should('be.visible')
-        .should('be.enabled')
-        .click();
-
-      cy.wait(['@updateCluster', '@getClusters']);
-
-      ui.dialog
-        .findByTitle('Step 2: Recycle All Cluster Nodes')
-        .should('be.visible');
-
-      ui.button
-        .findByTitle('Recycle All Nodes')
-        .should('be.visible')
-        .should('be.enabled')
-        .click();
-
-      cy.wait('@recycleAllNodes');
-
-      ui.toast.assertMessage('Recycle started successfully.');
-
-      cy.findByText(newVersion).should('be.visible');
     });
 
     /*


### PR DESCRIPTION
## Description 📝
Add coverage for checking that there is no upgrade chip when there is no new kube version available and move kube version landing page e2e tests from `lke-update.spec.ts` to `lke-landing-page.spec.ts`

## How to test 🧪

```
yarn cy:run -s "cypress/e2e/core/kubernetes/lke-landing-page.spec.ts"
```

### Verification steps

(How to verify changes)

- [ ] Confirm e2e tests are passing

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>