### PR TITLE
change: [UIE-8228] - Database Resize: disable same size plan

### DIFF
--- a/packages/manager/.changeset/pr-11481-changed-1736250933443.md
+++ b/packages/manager/.changeset/pr-11481-changed-1736250933443.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Database Resize: Disable plans when the usable storage equals the used storage of the database cluster ([#11481](https://github.com/linode/manager/pull/11481))

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.utils.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.utils.tsx
@@ -1,0 +1,39 @@
+import { convertMegabytesTo } from 'src/utilities/unitConversions';
+
+import type { PlanSelectionWithDatabaseType } from 'src/features/components/PlansPanel/types';
+
+/**
+ * Filters a list of plans based on the current plan's disk size or the current used disk size.
+ *
+ * @param {string | undefined} currentPlanID - The ID of the current plan.
+ * @param {null | number} currentUsedDiskSize - The current used disk size.
+ * @param {PlanSelectionWithDatabaseType[]} types - The list of available plans to filter.
+ * @param {boolean} [isNewDatabase] - Optional flag indicating whether the database is new. If true, the filtering logic based on disk usage is applied.
+ *
+ * @returns {PlanSelectionWithDatabaseType[]} A filtered list of plans based on the conditions:
+ *   - If `isNewDatabase` is false and `currentPlanID` is provided, plans with disk sizes smaller or equal to the current plan are included.
+ *   - If `isNewDatabase` is true, plans are filtered based on their disk size compared to the current used disk size.
+ */
+export const isSmallerOrEqualCurrentPlan = (
+  currentPlanID: string | undefined,
+  currentUsedDiskSize: null | number,
+  types: PlanSelectionWithDatabaseType[],
+  isNewDatabase?: boolean
+) => {
+  const currentType = types.find((thisType) => thisType.id === currentPlanID);
+
+  return !isNewDatabase && currentType
+    ? types?.filter((type) =>
+        type.class === 'dedicated'
+          ? type.disk < currentType?.disk
+          : type.disk <= currentType?.disk
+      )
+    : types?.filter(
+        (type) =>
+          currentUsedDiskSize &&
+          currentUsedDiskSize >=
+            +convertMegabytesTo(type.disk, true)
+              .split(/(GB|MB|KB)/i)[0]
+              .trim()
+      );
+};


### PR DESCRIPTION
## Description 📝
Disable plans when the usable storage equals the used storage of the database cluster

## Changes  🔄
- Disable plans when storage equals usage
- Refactoring

## Target release date 🗓️
01/14/2025

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-01-03 at 2 44 14 PM](https://github.com/user-attachments/assets/e128ab60-3c20-4554-9a64-11335b49d6e5) | ![Screenshot 2025-01-03 at 2 43 56 PM](https://github.com/user-attachments/assets/7a9f080c-5b0d-4314-b054-30587c01017c) |

## How to test 🧪

### Verification steps

- select a database cluster
- navigate to the Resize tab
- plans with usable storage equal to the used storage of the database cluster are disabled

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
