### PR TITLE
refactor: [M3-8246, M3-8252] - Replace Ramda's `splitAt` with custom utility

### DIFF
--- a/packages/manager/.changeset/pr-11483-tech-stories-1736333190430.md
+++ b/packages/manager/.changeset/pr-11483-tech-stories-1736333190430.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Replace ramda's `splitAt` with custom utility ([#11483](https://github.com/linode/manager/pull/11483))

--- a/packages/manager/src/components/OrderBy.tsx
+++ b/packages/manager/src/components/OrderBy.tsx
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import { equals, pathOr, sort, splitAt } from 'ramda';
+import { equals, pathOr, sort } from 'ramda';
 import * as React from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { debounce } from 'throttle-debounce';
@@ -16,6 +16,7 @@ import {
   sortByString,
   sortByUTFDate,
 } from 'src/utilities/sort-by';
+import { splitStringAt } from 'src/utilities/splitAt';
 
 import type { Order } from 'src/hooks/useOrder';
 import type { ManagerPreferences } from 'src/types/ManagerPreferences';
@@ -113,7 +114,7 @@ export const sortData = <T,>(orderBy: string, order: Order) => {
      */
     let orderByProp;
     if (orderBy.includes('[')) {
-      orderByProp = splitAt(orderBy.indexOf('['), orderBy) // will end up like ['ipv4', '[0]']
+      orderByProp = splitStringAt(orderBy.indexOf('['), orderBy) // will end up like ['ipv4', '[0]']
         .map((eachValue) =>
           eachValue.includes('[')
             ? /** if the element has square brackets, remove them and convert to a number */

--- a/packages/manager/src/components/OrderBy.tsx
+++ b/packages/manager/src/components/OrderBy.tsx
@@ -16,7 +16,7 @@ import {
   sortByString,
   sortByUTFDate,
 } from 'src/utilities/sort-by';
-import { splitStringAt } from 'src/utilities/splitAt';
+import { splitAt } from 'src/utilities/splitAt';
 
 import type { Order } from 'src/hooks/useOrder';
 import type { ManagerPreferences } from 'src/types/ManagerPreferences';
@@ -114,7 +114,7 @@ export const sortData = <T,>(orderBy: string, order: Order) => {
      */
     let orderByProp;
     if (orderBy.includes('[')) {
-      orderByProp = splitStringAt(orderBy.indexOf('['), orderBy) // will end up like ['ipv4', '[0]']
+      orderByProp = splitAt(orderBy.indexOf('['), orderBy) // will end up like ['ipv4', '[0]']
         .map((eachValue) =>
           eachValue.includes('[')
             ? /** if the element has square brackets, remove them and convert to a number */

--- a/packages/manager/src/components/Tags/Tags.tsx
+++ b/packages/manager/src/components/Tags/Tags.tsx
@@ -1,8 +1,8 @@
-import { splitAt } from 'ramda';
 import * as React from 'react';
 
 import { ShowMore } from 'src/components/ShowMore/ShowMore';
 import { Tag } from 'src/components/Tag/Tag';
+import { splitArrayAt } from 'src/utilities/splitAt';
 
 export interface TagsProps {
   /**
@@ -35,7 +35,7 @@ export const Tags = (props: TagsProps) => {
     return null;
   }
 
-  const [visibleTags, additionalTags] = splitAt(3, tags);
+  const [visibleTags, additionalTags] = splitArrayAt(3, tags);
   return (
     <>
       {renderTags(visibleTags)}

--- a/packages/manager/src/components/Tags/Tags.tsx
+++ b/packages/manager/src/components/Tags/Tags.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { ShowMore } from 'src/components/ShowMore/ShowMore';
 import { Tag } from 'src/components/Tag/Tag';
-import { splitArrayAt } from 'src/utilities/splitAt';
+import { splitAt } from 'src/utilities/splitAt';
 
 export interface TagsProps {
   /**
@@ -35,7 +35,7 @@ export const Tags = (props: TagsProps) => {
     return null;
   }
 
-  const [visibleTags, additionalTags] = splitArrayAt(3, tags);
+  const [visibleTags, additionalTags] = splitAt(3, tags);
   return (
     <>
       {renderTags(visibleTags)}

--- a/packages/manager/src/features/Domains/DomainActionMenu.tsx
+++ b/packages/manager/src/features/Domains/DomainActionMenu.tsx
@@ -1,12 +1,15 @@
-import { Domain } from '@linode/api-v4/lib/domains';
-import { Theme, useTheme } from '@mui/material/styles';
+import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import { splitAt } from 'ramda';
 import * as React from 'react';
 import { makeStyles } from 'tss-react/mui';
 
-import { Action, ActionMenu } from 'src/components/ActionMenu/ActionMenu';
+import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
 import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
+import { splitArrayAt } from 'src/utilities/splitAt';
+
+import type { Domain } from '@linode/api-v4/lib/domains';
+import type { Theme } from '@mui/material/styles';
+import type { Action } from 'src/components/ActionMenu/ActionMenu';
 
 const useStyles = makeStyles()(() => ({
   button: {
@@ -74,7 +77,10 @@ export const DomainActionMenu = React.memo((props: DomainActionMenuProps) => {
   // Index at which non-inline actions begin. Our convention: place actions that are inline (at non-mobile/non-tablet viewports) at start of the array.
   const splitActionsArrayIndex = matchesSmDown ? 0 : 2;
 
-  const [inlineActions, menuActions] = splitAt(splitActionsArrayIndex, actions);
+  const [inlineActions, menuActions] = splitArrayAt(
+    splitActionsArrayIndex,
+    actions
+  );
 
   return (
     <>

--- a/packages/manager/src/features/Domains/DomainActionMenu.tsx
+++ b/packages/manager/src/features/Domains/DomainActionMenu.tsx
@@ -5,7 +5,7 @@ import { makeStyles } from 'tss-react/mui';
 
 import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
 import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
-import { splitArrayAt } from 'src/utilities/splitAt';
+import { splitAt } from 'src/utilities/splitAt';
 
 import type { Domain } from '@linode/api-v4/lib/domains';
 import type { Theme } from '@mui/material/styles';
@@ -77,10 +77,7 @@ export const DomainActionMenu = React.memo((props: DomainActionMenuProps) => {
   // Index at which non-inline actions begin. Our convention: place actions that are inline (at non-mobile/non-tablet viewports) at start of the array.
   const splitActionsArrayIndex = matchesSmDown ? 0 : 2;
 
-  const [inlineActions, menuActions] = splitArrayAt(
-    splitActionsArrayIndex,
-    actions
-  );
+  const [inlineActions, menuActions] = splitAt(splitActionsArrayIndex, actions);
 
   return (
     <>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigActionMenu.tsx
@@ -6,7 +6,7 @@ import { useHistory } from 'react-router-dom';
 
 import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
 import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
-import { splitArrayAt } from 'src/utilities/splitAt';
+import { splitAt } from 'src/utilities/splitAt';
 
 import type { Config } from '@linode/api-v4/lib/linodes';
 import type { Theme } from '@mui/material/styles';
@@ -61,10 +61,7 @@ export const ConfigActionMenu = (props: Props) => {
   ];
 
   const splitActionsArrayIndex = matchesSmDown ? 0 : 2;
-  const [inlineActions, menuActions] = splitArrayAt(
-    splitActionsArrayIndex,
-    actions
-  );
+  const [inlineActions, menuActions] = splitAt(splitActionsArrayIndex, actions);
 
   return (
     <Box alignItems="center" display="flex" justifyContent="flex-end">

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigActionMenu.tsx
@@ -1,12 +1,12 @@
 import { Box } from '@linode/ui';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import { splitAt } from 'ramda';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
 import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
+import { splitArrayAt } from 'src/utilities/splitAt';
 
 import type { Config } from '@linode/api-v4/lib/linodes';
 import type { Theme } from '@mui/material/styles';
@@ -61,7 +61,10 @@ export const ConfigActionMenu = (props: Props) => {
   ];
 
   const splitActionsArrayIndex = matchesSmDown ? 0 : 2;
-  const [inlineActions, menuActions] = splitAt(splitActionsArrayIndex, actions);
+  const [inlineActions, menuActions] = splitArrayAt(
+    splitActionsArrayIndex,
+    actions
+  );
 
   return (
     <Box alignItems="center" display="flex" justifyContent="flex-end">

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeDiskActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeDiskActionMenu.tsx
@@ -1,7 +1,6 @@
 import { Box } from '@linode/ui';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import { splitAt } from 'ramda';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -12,6 +11,7 @@ import { sendEvent } from 'src/utilities/analytics/utils';
 import type { Disk, Linode } from '@linode/api-v4';
 import type { Theme } from '@mui/material/styles';
 import type { Action } from 'src/components/ActionMenu/ActionMenu';
+import { splitArrayAt } from 'src/utilities/splitAt';
 
 interface Props {
   disk: Disk;
@@ -87,7 +87,10 @@ export const LinodeDiskActionMenu = (props: Props) => {
   ];
 
   const splitActionsArrayIndex = matchesSmDown ? 0 : 2;
-  const [inlineActions, menuActions] = splitAt(splitActionsArrayIndex, actions);
+  const [inlineActions, menuActions] = splitArrayAt(
+    splitActionsArrayIndex,
+    actions
+  );
 
   return (
     <Box alignItems="center" display="flex" justifyContent="flex-end">

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeDiskActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeDiskActionMenu.tsx
@@ -7,11 +7,11 @@ import { useHistory } from 'react-router-dom';
 import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
 import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
 import { sendEvent } from 'src/utilities/analytics/utils';
+import { splitAt } from 'src/utilities/splitAt';
 
 import type { Disk, Linode } from '@linode/api-v4';
 import type { Theme } from '@mui/material/styles';
 import type { Action } from 'src/components/ActionMenu/ActionMenu';
-import { splitArrayAt } from 'src/utilities/splitAt';
 
 interface Props {
   disk: Disk;
@@ -87,10 +87,7 @@ export const LinodeDiskActionMenu = (props: Props) => {
   ];
 
   const splitActionsArrayIndex = matchesSmDown ? 0 : 2;
-  const [inlineActions, menuActions] = splitArrayAt(
-    splitActionsArrayIndex,
-    actions
-  );
+  const [inlineActions, menuActions] = splitAt(splitActionsArrayIndex, actions);
 
   return (
     <Box alignItems="center" display="flex" justifyContent="flex-end">

--- a/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.tsx
@@ -10,7 +10,7 @@ import {
   useEnableMonitorMutation,
 } from 'src/queries/managed/managed';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import { splitArrayAt } from 'src/utilities/splitAt';
+import { splitAt } from 'src/utilities/splitAt';
 
 import type { MonitorStatus } from '@linode/api-v4/lib/managed';
 import type { APIError } from '@linode/api-v4/lib/types';
@@ -102,10 +102,7 @@ export const MonitorActionMenu = (props: MonitorActionMenuProps) => {
   ];
 
   const splitActionsArrayIndex = matchesSmDown ? 0 : 2;
-  const [inlineActions, menuActions] = splitArrayAt(
-    splitActionsArrayIndex,
-    actions
-  );
+  const [inlineActions, menuActions] = splitAt(splitActionsArrayIndex, actions);
 
   return (
     <>

--- a/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.tsx
@@ -1,18 +1,20 @@
-import { MonitorStatus } from '@linode/api-v4/lib/managed';
-import { APIError } from '@linode/api-v4/lib/types';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useSnackbar } from 'notistack';
-import { splitAt } from 'ramda';
 import * as React from 'react';
 
-import { Action, ActionMenu } from 'src/components/ActionMenu/ActionMenu';
+import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
 import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
 import {
   useDisableMonitorMutation,
   useEnableMonitorMutation,
 } from 'src/queries/managed/managed';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { splitArrayAt } from 'src/utilities/splitAt';
+
+import type { MonitorStatus } from '@linode/api-v4/lib/managed';
+import type { APIError } from '@linode/api-v4/lib/types';
+import type { Action } from 'src/components/ActionMenu/ActionMenu';
 
 export interface MonitorActionMenuProps {
   label: string;
@@ -100,7 +102,10 @@ export const MonitorActionMenu = (props: MonitorActionMenuProps) => {
   ];
 
   const splitActionsArrayIndex = matchesSmDown ? 0 : 2;
-  const [inlineActions, menuActions] = splitAt(splitActionsArrayIndex, actions);
+  const [inlineActions, menuActions] = splitArrayAt(
+    splitActionsArrayIndex,
+    actions
+  );
 
   return (
     <>

--- a/packages/manager/src/features/Search/ResultGroup.tsx
+++ b/packages/manager/src/features/Search/ResultGroup.tsx
@@ -9,7 +9,7 @@ import { TableCell } from 'src/components/TableCell';
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
 import { capitalize } from 'src/utilities/capitalize';
-import { splitArrayAt } from 'src/utilities/splitAt';
+import { splitAt } from 'src/utilities/splitAt';
 
 import { StyledButton, StyledTypography } from './ResultGroup.styles';
 import { ResultRow } from './ResultRow';
@@ -36,9 +36,7 @@ export const ResultGroup = (props: ResultGroupProps) => {
   }
 
   const [initial, hidden] =
-    results.length > groupSize
-      ? splitArrayAt(groupSize, results)
-      : [results, []];
+    results.length > groupSize ? splitAt(groupSize, results) : [results, []];
 
   return (
     <Grid>

--- a/packages/manager/src/features/Search/ResultGroup.tsx
+++ b/packages/manager/src/features/Search/ResultGroup.tsx
@@ -1,8 +1,7 @@
 import Grid from '@mui/material/Unstable_Grid2';
-import { isEmpty, splitAt } from 'ramda';
+import { isEmpty } from 'ramda';
 import * as React from 'react';
 
-import { Item } from 'src/components/EnhancedSelect/Select';
 import { Hidden } from 'src/components/Hidden';
 import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
@@ -10,9 +9,12 @@ import { TableCell } from 'src/components/TableCell';
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
 import { capitalize } from 'src/utilities/capitalize';
+import { splitArrayAt } from 'src/utilities/splitAt';
 
 import { StyledButton, StyledTypography } from './ResultGroup.styles';
 import { ResultRow } from './ResultRow';
+
+import type { Item } from 'src/components/EnhancedSelect/Select';
 
 interface ResultGroupProps {
   entity: string;
@@ -34,7 +36,9 @@ export const ResultGroup = (props: ResultGroupProps) => {
   }
 
   const [initial, hidden] =
-    results.length > groupSize ? splitAt(groupSize, results) : [results, []];
+    results.length > groupSize
+      ? splitArrayAt(groupSize, results)
+      : [results, []];
 
   return (
     <Grid>

--- a/packages/manager/src/utilities/splitAt.test.ts
+++ b/packages/manager/src/utilities/splitAt.test.ts
@@ -1,0 +1,78 @@
+import { splitArrayAt, splitStringAt } from './splitAt';
+
+describe('splitArrayAt', () => {
+  it('splits an array at the given index', () => {
+    const result = splitArrayAt(3, [1, 2, 3, 4, 5]);
+    expect(result).toEqual([
+      [1, 2, 3],
+      [4, 5],
+    ]);
+  });
+
+  it('splits an array when index is 0', () => {
+    const result = splitArrayAt(0, [1, 2, 3, 4, 5]);
+    expect(result).toEqual([[], [1, 2, 3, 4, 5]]);
+  });
+
+  it('splits an array when index is the length of the array', () => {
+    const result = splitArrayAt(5, [1, 2, 3, 4, 5]);
+    expect(result).toEqual([[1, 2, 3, 4, 5], []]);
+  });
+
+  it('splits an array when index is the (length - 1) of the array', () => {
+    const result = splitArrayAt(4, [1, 2, 3, 4, 5]);
+    expect(result).toEqual([[1, 2, 3, 4], [5]]);
+  });
+
+  it('splits an empty array', () => {
+    const result = splitArrayAt(0, []);
+    expect(result).toEqual([[], []]);
+  });
+
+  it('splits an array of one element', () => {
+    const result = splitArrayAt(1, [1]);
+    expect(result).toEqual([[1], []]);
+  });
+
+  it('splits an array at the given negative index', () => {
+    const result = splitArrayAt(-1, [1, 2, 3, 4, 5]);
+    expect(result).toEqual([[1, 2, 3, 4], [5]]);
+  });
+});
+
+describe('splitStringAt', () => {
+  it('splits a string at the given index', () => {
+    const result = splitStringAt(3, 'abcdefgh');
+    expect(result).toEqual(['abc', 'defgh']);
+  });
+
+  it('splits a string when index is 0', () => {
+    const result = splitStringAt(0, 'abcdefgh');
+    expect(result).toEqual(['', 'abcdefgh']);
+  });
+
+  it('splits a string when index is the length of the string', () => {
+    const result = splitStringAt(8, 'abcdefgh');
+    expect(result).toEqual(['abcdefgh', '']);
+  });
+
+  it('splits a string when index is the (length - 1) of the string', () => {
+    const result = splitStringAt(7, 'abcdefgh');
+    expect(result).toEqual(['abcdefg', 'h']);
+  });
+
+  it('splits an empty string', () => {
+    const result = splitStringAt(0, '');
+    expect(result).toEqual(['', '']);
+  });
+
+  it('splits a string with one character', () => {
+    const result = splitStringAt(1, 'a');
+    expect(result).toEqual(['a', '']);
+  });
+
+  it('splits a string at the given negative index', () => {
+    const result = splitStringAt(-1, 'abcdefgh');
+    expect(result).toEqual(['abcdefg', 'h']);
+  });
+});

--- a/packages/manager/src/utilities/splitAt.test.ts
+++ b/packages/manager/src/utilities/splitAt.test.ts
@@ -1,8 +1,9 @@
-import { splitArrayAt, splitStringAt } from './splitAt';
+import { splitAt } from './splitAt';
 
-describe('splitArrayAt', () => {
+describe('splitAt', () => {
+  // For arrays
   it('splits an array at the given index', () => {
-    const result = splitArrayAt(3, [1, 2, 3, 4, 5]);
+    const result = splitAt(3, [1, 2, 3, 4, 5]);
     expect(result).toEqual([
       [1, 2, 3],
       [4, 5],
@@ -10,69 +11,68 @@ describe('splitArrayAt', () => {
   });
 
   it('splits an array when index is 0', () => {
-    const result = splitArrayAt(0, [1, 2, 3, 4, 5]);
+    const result = splitAt(0, [1, 2, 3, 4, 5]);
     expect(result).toEqual([[], [1, 2, 3, 4, 5]]);
   });
 
   it('splits an array when index is the length of the array', () => {
-    const result = splitArrayAt(5, [1, 2, 3, 4, 5]);
+    const result = splitAt(5, [1, 2, 3, 4, 5]);
     expect(result).toEqual([[1, 2, 3, 4, 5], []]);
   });
 
   it('splits an array when index is the (length - 1) of the array', () => {
-    const result = splitArrayAt(4, [1, 2, 3, 4, 5]);
+    const result = splitAt(4, [1, 2, 3, 4, 5]);
     expect(result).toEqual([[1, 2, 3, 4], [5]]);
   });
 
   it('splits an empty array', () => {
-    const result = splitArrayAt(0, []);
+    const result = splitAt(0, []);
     expect(result).toEqual([[], []]);
   });
 
   it('splits an array of one element', () => {
-    const result = splitArrayAt(1, [1]);
+    const result = splitAt(1, [1]);
     expect(result).toEqual([[1], []]);
   });
 
   it('splits an array at the given negative index', () => {
-    const result = splitArrayAt(-1, [1, 2, 3, 4, 5]);
+    const result = splitAt(-1, [1, 2, 3, 4, 5]);
     expect(result).toEqual([[1, 2, 3, 4], [5]]);
   });
-});
 
-describe('splitStringAt', () => {
   it('splits a string at the given index', () => {
-    const result = splitStringAt(3, 'abcdefgh');
+    const result = splitAt(3, 'abcdefgh');
     expect(result).toEqual(['abc', 'defgh']);
   });
 
+  // For strings
   it('splits a string when index is 0', () => {
-    const result = splitStringAt(0, 'abcdefgh');
+    const result = splitAt(0, 'abcdefgh');
     expect(result).toEqual(['', 'abcdefgh']);
   });
 
   it('splits a string when index is the length of the string', () => {
-    const result = splitStringAt(8, 'abcdefgh');
+    const result = splitAt(8, 'abcdefgh');
     expect(result).toEqual(['abcdefgh', '']);
   });
 
   it('splits a string when index is the (length - 1) of the string', () => {
-    const result = splitStringAt(7, 'abcdefgh');
+    const result = splitAt(7, 'abcdefgh');
     expect(result).toEqual(['abcdefg', 'h']);
   });
 
   it('splits an empty string', () => {
-    const result = splitStringAt(0, '');
+    const result = splitAt(0, '');
     expect(result).toEqual(['', '']);
   });
 
   it('splits a string with one character', () => {
-    const result = splitStringAt(1, 'a');
+    const result = splitAt(1, 'a');
     expect(result).toEqual(['a', '']);
   });
 
   it('splits a string at the given negative index', () => {
-    const result = splitStringAt(-1, 'abcdefgh');
+    const result = splitAt(-1, 'abcdefgh');
     expect(result).toEqual(['abcdefg', 'h']);
   });
 });

--- a/packages/manager/src/utilities/splitAt.test.ts
+++ b/packages/manager/src/utilities/splitAt.test.ts
@@ -40,12 +40,12 @@ describe('splitAt', () => {
     expect(result).toEqual([[1, 2, 3, 4], [5]]);
   });
 
+  // For strings
   it('splits a string at the given index', () => {
     const result = splitAt(3, 'abcdefgh');
     expect(result).toEqual(['abc', 'defgh']);
   });
 
-  // For strings
   it('splits a string when index is 0', () => {
     const result = splitAt(0, 'abcdefgh');
     expect(result).toEqual(['', 'abcdefgh']);

--- a/packages/manager/src/utilities/splitAt.ts
+++ b/packages/manager/src/utilities/splitAt.ts
@@ -1,27 +1,18 @@
+export function splitAt<T>(index: number, input: T[]): [T[], T[]];
+
+export function splitAt(index: number, input: string): [string, string];
+
 /**
- * Splits an array into two parts at the given index.
+ * Splits a given list or string at a given index.
  *
  * @param index - The index to split at.
- * @param input - The list (array) to split.
- * @returns An array containing two subarrays: the first part (0 to index), the second part (index to end).
+ * @param input - The list (array) or string to split.
+ * @returns An array containing two parts: the first part (0 to index), the second part (index to end).
  *
  * @example
  * splitAt(3, [1, 2, 3, 4, 5]); // [[1, 2, 3], [4, 5]]
- */
-export function splitAt<T>(index: number, input: T[]): [T[], T[]];
-
-/**
- * Splits a string into two parts at the given index.
- *
- * @param index - The index to split at.
- * @param input - The string to split.
- * @returns An array containing two strings: the first part (0 to index), the second part (index to end).
- *
- * @example
  * splitAt(3, "hello"); // ["hel", "lo"]
  */
-export function splitAt(index: number, input: string): [string, string];
-
 export function splitAt<T>(index: number, input: T[] | string) {
   return [input.slice(0, index), input.slice(index)];
 }

--- a/packages/manager/src/utilities/splitAt.ts
+++ b/packages/manager/src/utilities/splitAt.ts
@@ -2,26 +2,26 @@
  * Splits an array into two parts at the given index.
  *
  * @param index - The index to split at.
- * @param array - The list (array) to split.
+ * @param input - The list (array) to split.
  * @returns An array containing two subarrays: the first part (0 to index), the second part (index to end).
  *
  * @example
- * splitArrayAt(3, [1, 2, 3, 4, 5]); // [[1, 2, 3], [4, 5]]
+ * splitAt(3, [1, 2, 3, 4, 5]); // [[1, 2, 3], [4, 5]]
  */
-export const splitArrayAt = <T>(index: number, array: T[]) => {
-  return [array.slice(0, index), array.slice(index)] as [T[], T[]];
-};
+export function splitAt<T>(index: number, input: T[]): [T[], T[]];
 
 /**
  * Splits a string into two parts at the given index.
  *
  * @param index - The index to split at.
- * @param string - string to split.
+ * @param input - The string to split.
  * @returns An array containing two strings: the first part (0 to index), the second part (index to end).
  *
  * @example
- * splitStringAt(3, "hello"); // ["hel", "lo"]
+ * splitAt(3, "hello"); // ["hel", "lo"]
  */
-export const splitStringAt = (index: number, string: string) => {
-  return [string.slice(0, index), string.slice(index)] as [string, string];
-};
+export function splitAt(index: number, input: string): [string, string];
+
+export function splitAt<T>(index: number, input: T[] | string) {
+  return [input.slice(0, index), input.slice(index)];
+}

--- a/packages/manager/src/utilities/splitAt.ts
+++ b/packages/manager/src/utilities/splitAt.ts
@@ -1,0 +1,27 @@
+/**
+ * Splits an array into two parts at the given index.
+ *
+ * @param index - The index to split at.
+ * @param array - The list (array) to split.
+ * @returns An array containing two subarrays: the first part (0 to index), the second part (index to end).
+ *
+ * @example
+ * splitArrayAt(3, [1, 2, 3, 4, 5]); // [[1, 2, 3], [4, 5]]
+ */
+export const splitArrayAt = <T>(index: number, array: T[]) => {
+  return [array.slice(0, index), array.slice(index)] as [T[], T[]];
+};
+
+/**
+ * Splits a string into two parts at the given index.
+ *
+ * @param index - The index to split at.
+ * @param string - string to split.
+ * @returns An array containing two strings: the first part (0 to index), the second part (index to end).
+ *
+ * @example
+ * splitStringAt(3, "hello"); // ["hel", "lo"]
+ */
+export const splitStringAt = (index: number, string: string) => {
+  return [string.slice(0, index), string.slice(index)] as [string, string];
+};


### PR DESCRIPTION
## Description 📝
Remove instances of splitAt from Ramda and replace them with a custom utility function.

Since the `splitAt` utility from Ramda is used in multiple places throughout the codebase + we aim to eliminate any dependency on Ramda, it is more efficient and maintainable to replace it with a custom utility function.

## Changes  🔄
- Created a custom `splitAt` utility function
- Added unit tests for the new utility function
- Replaced all instances of Ramda's `splitAt` with the custom utility.

## Target release date 🗓️
N/A

## Preview 📷
No visual changes

## How to test 🧪
- Ensure no existing functionality is broken
- Make sure all the instances of `splitAt` ramda has been replaced with the custom utility
- Ensure all tests pass

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>


- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
