### PR TITLE
fix: [M3-9063] - Display Kubernetes API endpoint for LKE-E cluster

### DIFF
--- a/packages/manager/.changeset/pr-11485-fixed-1736282505902.md
+++ b/packages/manager/.changeset/pr-11485-fixed-1736282505902.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Display Kubernetes API endpoint for LKE-E cluster ([#11485](https://github.com/linode/manager/pull/11485))

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.test.tsx
@@ -17,7 +17,7 @@ const props = {
 };
 
 describe('KubeConfigDisplay', () => {
-  it('should display the 443 endpoint if it exists', async () => {
+  it('should display the endpoint with port 443 if it exists', async () => {
     const endpoints = [
       kubeEndpointFactory.build({
         endpoint: `https://test.linodelke.net:6443`,
@@ -40,7 +40,7 @@ describe('KubeConfigDisplay', () => {
     });
   });
 
-  it('should display first endpoint if the 443 port does not exist', async () => {
+  it('should display first endpoint if the endpoint with port 443 does not exist', async () => {
     const endpoints = [
       kubeEndpointFactory.build({
         endpoint: `https://test.linodelke.net:6443`,

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.test.tsx
@@ -1,0 +1,65 @@
+import { waitFor } from '@testing-library/react';
+import * as React from 'react';
+
+import { kubeEndpointFactory } from 'src/factories/kubernetesCluster';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { KubeConfigDisplay } from './KubeConfigDisplay';
+
+const props = {
+  clusterId: 1,
+  clusterLabel: 'cluster-test',
+  handleOpenDrawer: vi.fn(),
+  isResettingKubeConfig: false,
+  setResetKubeConfigDialogOpen: vi.fn(),
+};
+
+describe('KubeConfigDisplay', () => {
+  it('should display the 443 endpoint if it exists', async () => {
+    const endpoints = [
+      kubeEndpointFactory.build({
+        endpoint: `https://test.linodelke.net:6443`,
+      }),
+      kubeEndpointFactory.build({
+        endpoint: `https://test.linodelke.net:443`,
+      }),
+    ];
+
+    server.use(
+      http.get('*/lke/clusters/*/api-endpoints', () => {
+        return HttpResponse.json(makeResourcePage(endpoints));
+      })
+    );
+
+    const { getByText } = renderWithTheme(<KubeConfigDisplay {...props} />);
+
+    await waitFor(() => {
+      expect(getByText('https://test.linodelke.net:443')).toBeVisible();
+    });
+  });
+
+  it('should display first endpoint if the 443 port does not exist', async () => {
+    const endpoints = [
+      kubeEndpointFactory.build({
+        endpoint: `https://test.linodelke.net:6443`,
+      }),
+      kubeEndpointFactory.build({
+        endpoint: `https://test.linodelke.net:123`,
+      }),
+    ];
+
+    server.use(
+      http.get('*/lke/clusters/*/api-endpoints', () => {
+        return HttpResponse.json(makeResourcePage(endpoints));
+      })
+    );
+
+    const { getByText } = renderWithTheme(<KubeConfigDisplay {...props} />);
+
+    await waitFor(() => {
+      expect(getByText('https://test.linodelke.net:6443')).toBeVisible();
+    });
+  });
+});

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     pointerEvents: 'none',
   },
   kubeconfigElement: {
-    '&:first-child': {
+    '&:first-of-type': {
       borderLeft: 'none',
     },
     '&:hover': {

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.tsx
@@ -154,7 +154,7 @@ export const KubeConfigDisplay = (props: Props) => {
   };
 
   const getEndpointToDisplay = (endpoints: string[]) => {
-    // We are returning the 443 endpoint to be the most user-friendly but if it doesn't exist, return the first endpoint available
+    // We are returning the endpoint with port 443 to be the most user-friendly, but if it doesn't exist, return the first endpoint available
     return (
       endpoints.find((thisResponse) =>
         thisResponse.match(/linodelke\.net:443$/i)

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.tsx
@@ -154,9 +154,11 @@ export const KubeConfigDisplay = (props: Props) => {
   };
 
   const getEndpointToDisplay = (endpoints: string[]) => {
-    // Per discussions with the API team and UX, we should display only the endpoint with port 443, so we are matching on that.
-    return endpoints.find((thisResponse) =>
-      thisResponse.match(/linodelke\.net:443$/i)
+    // We are returning the 443 endpoint to be the most user-friendly but if it doesn't exist, return the first endpoint available
+    return (
+      endpoints.find((thisResponse) =>
+        thisResponse.match(/linodelke\.net:443$/i)
+      ) ?? endpoints[0]
     );
   };
 


### PR DESCRIPTION
## Description 📝
Due to the way that existing code was written, we were only returning Kubernetes API endpoints for clusters if the endpoint matched port 443 (e.g. `/linodelke\.net:443`). However, LKE-E endpoints use the `6443` port so nothing was returning

This PR adds a check to render the first available endpoint if port 443 is not available

## Changes  🔄

List any change(s) relevant to the reviewer.

- Render the first available endpoint if endpoint with port 443 is not available
- Added some unit tests

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/f8c680b3-c095-4386-93f3-1fa406243db2) | ![image](https://github.com/user-attachments/assets/5fc57cfa-3a09-42e7-af50-559e24008ca6) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Ensure you have LKE-E customer tags (check project tracker)
- Have an LKE-E cluster created

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] On another branch (e.g. `develop`), go to the details page of an LKE-E cluster
- [ ] The Kubernetes API endpoint displays `Your endpoint will be displayed here once it is available.`

### Verification steps

(How to verify changes)

- [ ] Checkout this PR or use the preview link, go to the details page of an LKE-E cluster
- [ ] The Kubernetes API endpoint displays the first endpoint available (should be something like `https://lke287706.us-ord.enterprise.linodelke.net:6443`)

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>