### PR TITLE
test: [M3-9072] - Fix test failures by using Debian 12 for test Linodes by default

### DIFF
--- a/packages/manager/.changeset/pr-11486-tests-1736284627318.md
+++ b/packages/manager/.changeset/pr-11486-tests-1736284627318.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix Cypress test failures stemming from Debian 10 Image deprecation ([#11486](https://github.com/linode/manager/pull/11486))

--- a/packages/manager/cypress/e2e/core/images/search-images.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/search-images.spec.ts
@@ -24,7 +24,7 @@ describe('Search Images', () => {
     cy.defer(
       () =>
         createTestLinode(
-          { image: 'linode/debian10', region: 'us-east' },
+          { image: 'linode/debian12', region: 'us-east' },
           { waitForDisks: true }
         ),
       'create linode'

--- a/packages/manager/cypress/e2e/core/images/smoke-create-image.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/smoke-create-image.spec.ts
@@ -10,7 +10,7 @@ import { randomLabel, randomNumber, randomPhrase } from 'support/util/random';
 describe('create image (using mocks)', () => {
   it('create image from a linode', () => {
     const mockDisks = [
-      linodeDiskFactory.build({ label: 'Debian 10 Disk', filesystem: 'ext4' }),
+      linodeDiskFactory.build({ label: 'Debian 12 Disk', filesystem: 'ext4' }),
       linodeDiskFactory.build({
         label: '512 MB Swap Image',
         filesystem: 'swap',

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-view-code-snippet.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-view-code-snippet.spec.ts
@@ -20,7 +20,7 @@ describe('Create Linode flow to validate code snippet modal', () => {
 
     // Set Linode label, distribution, plan type, password, etc.
     linodeCreatePage.setLabel(linodeLabel);
-    linodeCreatePage.selectImage('Debian 11');
+    linodeCreatePage.selectImage('Debian 12');
     linodeCreatePage.selectRegionById('us-east');
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(rootPass);

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-add-ons.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-add-ons.spec.ts
@@ -29,7 +29,7 @@ describe('Create Linode with Add-ons', () => {
     cy.visitWithLogin('/linodes/create');
 
     linodeCreatePage.setLabel(mockLinode.label);
-    linodeCreatePage.selectImage('Debian 11');
+    linodeCreatePage.selectImage('Debian 12');
     linodeCreatePage.selectRegionById(linodeRegion.id);
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));
@@ -83,7 +83,7 @@ describe('Create Linode with Add-ons', () => {
     cy.visitWithLogin('/linodes/create');
 
     linodeCreatePage.setLabel(mockLinode.label);
-    linodeCreatePage.selectImage('Debian 11');
+    linodeCreatePage.selectImage('Debian 12');
     linodeCreatePage.selectRegionById(linodeRegion.id);
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-firewall.spec.ts
@@ -45,7 +45,7 @@ describe('Create Linode with Firewall', () => {
     cy.visitWithLogin('/linodes/create');
 
     linodeCreatePage.setLabel(mockLinode.label);
-    linodeCreatePage.selectImage('Debian 11');
+    linodeCreatePage.selectImage('Debian 12');
     linodeCreatePage.selectRegionById(linodeRegion.id);
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));
@@ -111,7 +111,7 @@ describe('Create Linode with Firewall', () => {
     cy.visitWithLogin('/linodes/create');
 
     linodeCreatePage.setLabel(mockLinode.label);
-    linodeCreatePage.selectImage('Debian 11');
+    linodeCreatePage.selectImage('Debian 12');
     linodeCreatePage.selectRegionById(linodeRegion.id);
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));
@@ -218,7 +218,7 @@ describe('Create Linode with Firewall', () => {
     cy.visitWithLogin('/linodes/create');
 
     linodeCreatePage.setLabel(mockLinode.label);
-    linodeCreatePage.selectImage('Debian 11');
+    linodeCreatePage.selectImage('Debian 12');
     linodeCreatePage.selectRegionById(linodeRegion.id);
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-ssh-key.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-ssh-key.spec.ts
@@ -41,7 +41,7 @@ describe('Create Linode with SSH Key', () => {
     cy.visitWithLogin('/linodes/create');
 
     linodeCreatePage.setLabel(mockLinode.label);
-    linodeCreatePage.selectImage('Debian 11');
+    linodeCreatePage.selectImage('Debian 12');
     linodeCreatePage.selectRegionById(linodeRegion.id);
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));
@@ -107,7 +107,7 @@ describe('Create Linode with SSH Key', () => {
     cy.visitWithLogin('/linodes/create');
 
     linodeCreatePage.setLabel(mockLinode.label);
-    linodeCreatePage.selectImage('Debian 11');
+    linodeCreatePage.selectImage('Debian 12');
     linodeCreatePage.selectRegionById(linodeRegion.id);
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-user-data.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-user-data.spec.ts
@@ -34,7 +34,7 @@ describe('Create Linode with user data', () => {
     // Fill out create form, selecting a region and image that both have
     // cloud-init capabilities.
     linodeCreatePage.setLabel(mockLinode.label);
-    linodeCreatePage.selectImage('Debian 11');
+    linodeCreatePage.selectImage('Debian 12');
     linodeCreatePage.selectRegionById(linodeRegion.id);
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));
@@ -88,7 +88,7 @@ describe('Create Linode with user data', () => {
     cy.visitWithLogin('/linodes/create');
 
     linodeCreatePage.setLabel(mockLinode.label);
-    linodeCreatePage.selectImage('Debian 11');
+    linodeCreatePage.selectImage('Debian 12');
     linodeCreatePage.selectRegionById(mockLinodeRegion.id);
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
 

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-vlan.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-vlan.spec.ts
@@ -42,7 +42,7 @@ describe('Create Linode with VLANs', () => {
 
     // Fill out necessary Linode create fields.
     linodeCreatePage.selectRegionById(mockLinodeRegion.id);
-    linodeCreatePage.selectImage('Debian 11');
+    linodeCreatePage.selectImage('Debian 12');
     linodeCreatePage.setLabel(mockLinode.label);
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));
@@ -130,7 +130,7 @@ describe('Create Linode with VLANs', () => {
 
     // Fill out necessary Linode create fields.
     linodeCreatePage.selectRegionById(mockLinodeRegion.id);
-    linodeCreatePage.selectImage('Debian 11');
+    linodeCreatePage.selectImage('Debian 12');
     linodeCreatePage.setLabel(mockLinode.label);
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-vpc.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-vpc.spec.ts
@@ -90,7 +90,7 @@ describe('Create Linode with VPCs', () => {
     cy.visitWithLogin('/linodes/create');
 
     linodeCreatePage.setLabel(mockLinode.label);
-    linodeCreatePage.selectImage('Debian 11');
+    linodeCreatePage.selectImage('Debian 12');
     linodeCreatePage.selectRegionById(linodeRegion.id);
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));
@@ -214,7 +214,7 @@ describe('Create Linode with VPCs', () => {
     cy.visitWithLogin('/linodes/create');
 
     linodeCreatePage.setLabel(mockLinode.label);
-    linodeCreatePage.selectImage('Debian 11');
+    linodeCreatePage.selectImage('Debian 12');
     linodeCreatePage.selectRegionById(linodeRegion.id);
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));

--- a/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode.spec.ts
@@ -104,7 +104,7 @@ describe('Create Linode', () => {
 
           // Set Linode label, OS, plan type, password, etc.
           linodeCreatePage.setLabel(linodeLabel);
-          linodeCreatePage.selectImage('Debian 11');
+          linodeCreatePage.selectImage('Debian 12');
           linodeCreatePage.selectRegionById(linodeRegion.id);
           linodeCreatePage.selectPlan(
             planConfig.planType,
@@ -116,7 +116,7 @@ describe('Create Linode', () => {
           cy.get('[data-qa-linode-create-summary]')
             .scrollIntoView()
             .within(() => {
-              cy.findByText('Debian 11').should('be.visible');
+              cy.findByText('Debian 12').should('be.visible');
               cy.findByText(linodeRegion.label).should('be.visible');
               cy.findByText(planConfig.planLabel).should('be.visible');
             });
@@ -230,7 +230,7 @@ describe('Create Linode', () => {
 
     // Set Linode label, OS, plan type, password, etc.
     linodeCreatePage.setLabel(linodeLabel);
-    linodeCreatePage.selectImage('Debian 11');
+    linodeCreatePage.selectImage('Debian 12');
     linodeCreatePage.selectRegionById(linodeRegion.id);
     linodeCreatePage.selectPlan('Accelerated', mockAcceleratedType[0].label);
     linodeCreatePage.setRootPassword(randomString(32));
@@ -239,7 +239,7 @@ describe('Create Linode', () => {
     cy.get('[data-qa-linode-create-summary]')
       .scrollIntoView()
       .within(() => {
-        cy.findByText('Debian 11').should('be.visible');
+        cy.findByText('Debian 12').should('be.visible');
         cy.findByText(`US, ${linodeRegion.label}`).should('be.visible');
         cy.findByText(mockAcceleratedType[0].label).should('be.visible');
       });
@@ -462,7 +462,7 @@ describe('Create Linode', () => {
 
     // Set Linode label, OS, plan type, password, etc.
     linodeCreatePage.setLabel(linodeLabel);
-    linodeCreatePage.selectImage('Debian 11');
+    linodeCreatePage.selectImage('Debian 12');
     linodeCreatePage.selectRegionById(linodeRegion.id);
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));

--- a/packages/manager/cypress/e2e/core/linodes/linode-storage.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/linode-storage.spec.ts
@@ -208,7 +208,7 @@ describe('linode storage tab', () => {
    * - Confirms that Cloud Manager UI automatically updates to reflect resize.
    */
   it('resize disk', () => {
-    const diskName = 'Debian 10 Disk';
+    const diskName = 'Debian 12 Disk';
     cy.defer(() =>
       createTestLinode({ image: null }, { securityMethod: 'powered_off' })
     ).then((linode: Linode) => {

--- a/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/create-stackscripts.spec.ts
@@ -128,9 +128,9 @@ const fillOutLinodeForm = (label: string, regionName: string) => {
  * @returns Promise that resolves to the new Image.
  */
 const createLinodeAndImage = async () => {
-  // 1.5GB
-  // Shout out to Debian for fitting on a 1.5GB disk.
-  const resizedDiskSize = 1536;
+  // 2GB
+  // Shout out to Debian for fitting on a 2GB disk.
+  const resizedDiskSize = 2048;
   const linode = await createTestLinode(
     createLinodeRequestFactory.build({
       label: randomLabel(),

--- a/packages/manager/src/factories/linodes.ts
+++ b/packages/manager/src/factories/linodes.ts
@@ -287,7 +287,7 @@ export const linodeFactory = Factory.Sync.makeFactory<Linode>({
   group: '',
   hypervisor: 'kvm',
   id: Factory.each((i) => i),
-  image: 'linode/debian10',
+  image: 'linode/debian12',
   ipv4: ['50.116.6.212', '192.168.203.1'],
   ipv6: '2600:3c00::f03c:92ff:fee2:6c40/64',
   label: Factory.each((i) => `linode-${i}`),
@@ -309,7 +309,7 @@ export const linodeFactory = Factory.Sync.makeFactory<Linode>({
 export const createLinodeRequestFactory = Factory.Sync.makeFactory<CreateLinodeRequest>(
   {
     booted: true,
-    image: 'linode/debian10',
+    image: 'linode/debian12',
     label: Factory.each((i) => `linode-${i}`),
     region: 'us-southeast',
     root_pass: 'linode-root-password',


### PR DESCRIPTION
## Description 📝

This seeks to fix the Cypress test failures we're seeing on end-to-end tests which create Linodes. The failure was triggered by a backend change making the Debian 10 Image unavailable. This seeks to fix the test failures by updating our `linodeFactory` and `createLinodeRequestFactory` factories to use Debian 12 by default.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Use Debian 12 for Linode factories
- Replace various references to Debian 10 in the test suites

## Target release date 🗓️

ASAP since these failures are causing our E2E tests to be more or less unusable.

## How to test 🧪
We can rely on CI for this. I'm half expecting there to be some lingering failures that still need to be addressed after this first pass since this is a pretty broad change across a lot of tests.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.
