### PR TITLE
fix: [M3-9073] - Fix duplicate specs in Cypress Slack / GH notifications

### DIFF
--- a/packages/manager/.changeset/pr-11489-tests-1736348080190.md
+++ b/packages/manager/.changeset/pr-11489-tests-1736348080190.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix test notification formatting and output issues ([#11489](https://github.com/linode/manager/pull/11489))

--- a/scripts/junit-summary/formatters/slack-formatter.ts
+++ b/scripts/junit-summary/formatters/slack-formatter.ts
@@ -14,7 +14,7 @@ import { cypressRunCommand } from '../util/cypress';
  * The Slack notification has a maximum character limit, so we must truncate
  * the failure results to reduce the risk of hitting that limit.
  */
-const FAILURE_SUMMARY_LIMIT = 6;
+const FAILURE_SUMMARY_LIMIT = 4;
 
 /**
  * Outputs test result summary formatted as a Slack message.

--- a/scripts/junit-summary/util/cypress.ts
+++ b/scripts/junit-summary/util/cypress.ts
@@ -6,6 +6,7 @@
  * @returns Cypress run command to run `testFiles`.
  */
 export const cypressRunCommand = (testFiles: string[]): string => {
-  const testFilesList = testFiles.join(',');
+  const dedupedTestFiles = Array.from(new Set(testFiles));
+  const testFilesList = dedupedTestFiles.join(',');
   return `yarn cy:run -s "${testFilesList}"`;
 };


### PR DESCRIPTION
## Description 📝

This fixes an issue in our Slack and GitHub notifications for Cypress tests. When more than one failure occurs in the spec, the `yarn cy:run` command in the notification lists the spec multiple times.

Additionally, this reduces the number of failures listed in our Slack notification from 6 to 4. This should help reduce the risk of our notification messages getting truncated.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Only list a spec file once in command output when multiple tests in the spec fail
- Reduce the max number of specs listed in Slack notification from 6 to 4

## Target release date 🗓️

N/A

## Preview 📷

| Before  | After   |
------ | ------- |
| ![Screenshot 2025-01-08 at 9 40 01 AM](https://github.com/user-attachments/assets/2e384bf9-eb1b-4ae6-ba9e-bfc9623022b2) |  |
| ![Screenshot 2025-01-08 at 9 43 47 AM](https://github.com/user-attachments/assets/b43427f4-4278-4261-b496-00857706a944) | ![Screenshot 2025-01-08 at 9 44 14 AM](https://github.com/user-attachments/assets/bc8cb905-732f-4815-bbf6-6ab4519536b4) |

## How to test 🧪

1. Find some spec with multiple tests and cause them to fail (example: by throwing an error at the top of the test)
    -  For these steps, we'll use `cypress/e2e/core/billing/billing-contact.spec.ts` as an example
2. Generate JUnit files by running `CY_TEST_JUNIT_REPORT=1 yarn cy:run -s "cypress/e2e/core/billing/billing-contact.spec.ts"
3. Run JUnit summary script with `yarn junit:summary ./packages/manager/cypress/results --format github`
4. Confirm Markdown output
    - If you're reproducing the issue, observe that the spec is listed twice in the `yarn cy:run` command section
    - If you're confirming the fix, observe that the spec is listed only once in the `yarn cy:run` command section

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

