### PR TITLE
change: [M3-9074] - Remove properties tab from Gen2 buckets

### DIFF
--- a/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-details-gen2.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-details-gen2.spec.ts
@@ -5,8 +5,6 @@ import {
   mockGetObjectStorageEndpoints,
   mockGetBucketAccess,
 } from 'support/intercepts/object-storage';
-import { checkRateLimitsTable } from 'support/util/object-storage-gen2';
-import { ui } from 'support/ui';
 import {
   accountFactory,
   objectStorageBucketFactoryGen2,
@@ -140,98 +138,6 @@ describe('Object Storage Gen 2 bucket details tabs', () => {
 
         // confirms the SSL/TLS tab is not present
         cy.findByText('SSL/TLS').should('not.exist');
-      });
-    });
-  });
-
-  describe('Properties tab', () => {
-    ['E0', 'E1'].forEach((endpoint: ObjectStorageEndpointTypes) => {
-      /**
-       * Parameterized test for buckets with endpoint types of E0 and E1
-       * - Confirms the Properties tab is visible
-       * - Confirms there is no bucket rate limits table
-       */
-      it(`confirms the Properties tab does not have a rate limits table for buckets with endpoint type ${endpoint}`, () => {
-        const { mockBucket, mockEndpoint } = createMocksBasedOnEndpointType(
-          endpoint
-        );
-        const { cluster, label } = mockBucket;
-
-        mockGetBucketsForRegion(mockRegion.id, [mockBucket]).as(
-          'getBucketsForRegion'
-        );
-        mockGetObjectStorageEndpoints([mockEndpoint]).as(
-          'getObjectStorageEndpoints'
-        );
-
-        cy.visitWithLogin(
-          `/object-storage/buckets/${cluster}/${label}/properties`
-        );
-        cy.wait([
-          '@getFeatureFlags',
-          '@getAccount',
-          '@getObjectStorageEndpoints',
-          '@getBucketsForRegion',
-        ]);
-
-        cy.findByText('Bucket Rate Limits').should('be.visible');
-        // confirms helper text
-        cy.contains(
-          'This endpoint type supports up to 750 Requests Per Second (RPS). Understand bucket rate limits'
-        ).should('be.visible');
-
-        // confirm bucket rate limit table should not exist
-        cy.get('[data-testid="bucket-rate-limit-table"]').should('not.exist');
-
-        // confirm 'Save' button is disabled (for now)
-        ui.button
-          .findByAttribute('label', 'Save')
-          .should('be.visible')
-          .should('be.disabled');
-      });
-    });
-
-    ['E2', 'E3'].forEach((endpoint: ObjectStorageEndpointTypes) => {
-      /**
-       * Parameterized test for buckets with endpoint types of E2 and E3
-       * - Confirms the Properties tab is visible
-       * - Confirms bucket rates limit table exists
-       */
-      it(`confirms the Properties tab and rate limits table for buckets with endpoint type ${endpoint}`, () => {
-        const { mockBucket, mockEndpoint } = createMocksBasedOnEndpointType(
-          endpoint
-        );
-        const { cluster, label } = mockBucket;
-
-        mockGetBucketsForRegion(mockRegion.id, [mockBucket]).as(
-          'getBucketsForRegion'
-        );
-        mockGetObjectStorageEndpoints([mockEndpoint]).as(
-          'getObjectStorageEndpoints'
-        );
-
-        cy.visitWithLogin(
-          `/object-storage/buckets/${cluster}/${label}/properties`
-        );
-        cy.wait([
-          '@getFeatureFlags',
-          '@getAccount',
-          '@getObjectStorageEndpoints',
-          '@getBucketsForRegion',
-        ]);
-
-        cy.findByText('Bucket Rate Limits');
-        cy.contains(
-          'Specifies the maximum Requests Per Second (RPS) for a bucket. To increase it to High, open a support ticket. Understand bucket rate limits.'
-        ).should('be.visible');
-        // Confirm bucket rate limits table exists with correct values
-        checkRateLimitsTable(endpoint);
-
-        // confirm 'Save' button is disabled (for now)
-        ui.button
-          .findByAttribute('label', 'Save')
-          .should('be.visible')
-          .should('be.disabled');
       });
     });
   });

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
@@ -28,11 +28,6 @@ const BucketSSL = React.lazy(() =>
     default: module.BucketSSL,
   }))
 );
-const BucketProperties = React.lazy(() =>
-  import('./BucketProperties').then((module) => ({
-    default: module.BucketProperties,
-  }))
-);
 
 interface MatchProps {
   bucketName: string;
@@ -75,14 +70,6 @@ export const BucketDetailLanding = React.memo((props: Props) => {
       routeName: `${props.match.url}/access`,
       title: 'Access',
     },
-    ...(isObjectStorageGen2Enabled
-      ? [
-          {
-            routeName: `${props.match.url}/properties`,
-            title: 'Properties',
-          },
-        ]
-      : []),
     ...(!isGen2Endpoint
       ? [
           {
@@ -136,11 +123,6 @@ export const BucketDetailLanding = React.memo((props: Props) => {
                 endpointType={endpoint_type}
               />
             </SafeTabPanel>
-            {isObjectStorageGen2Enabled && bucket && (
-              <SafeTabPanel index={2}>
-                <BucketProperties bucket={bucket} />
-              </SafeTabPanel>
-            )}
             <SafeTabPanel index={tabs.length - 1}>
               <BucketSSL bucketName={bucketName} clusterId={clusterId} />
             </SafeTabPanel>


### PR DESCRIPTION
## Description 📝
The `Properties` tab is a little premature. Although it's correct mostly, it's not 100% for all customers so we need to entirely remove that control for pre-existing buckets until such time as we can expose the correct limit in the API.

>[!note]
I'll save this PR for future implementation

## Changes  🔄
- Removed `Properties` tab from Gen2 clusters

## Target release date 🗓️
1/14

## Preview 📷

| Before  | After   |
| ------- | ------- |
|![Screenshot 2025-01-08 at 12 21 30 PM](https://github.com/user-attachments/assets/2d080037-04d0-4d18-87bf-87afad9a1f71) | ![Screenshot 2025-01-08 at 12 20 56 PM](https://github.com/user-attachments/assets/805948a4-c959-41e4-8303-d7813dc76f78) |

## How to test 🧪

### Prerequisites
- Ensure you have the customer capabilities to create gen2 clusters
- Enable feature flag for OBJ gen2

### Reproduction steps
- Create or go to an existing buckets detail page
- Observe properties tab

### Verification steps
- Verify this tab no longer shows or is accessible.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>