### PR TITLE
Release v1.134.0 - release → staging

### DIFF
--- a/packages/api-v4/.changeset/pr-11321-added-1733240671518.md
+++ b/packages/api-v4/.changeset/pr-11321-added-1733240671518.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Added
----
-
-Types for UDP NodeBalancer support ([#11321](https://github.com/linode/manager/pull/11321))

--- a/packages/api-v4/.changeset/pr-11346-changed-1733145182722.md
+++ b/packages/api-v4/.changeset/pr-11346-changed-1733145182722.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Changed
----
-
-Type of `AlertDefinitionType` to `'system'|'user'`   ([#11346](https://github.com/linode/manager/pull/11346))

--- a/packages/api-v4/.changeset/pr-11347-fixed-1733327446988.md
+++ b/packages/api-v4/.changeset/pr-11347-fixed-1733327446988.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Fixed
----
-
-Nullable AccountBeta ended & description properties ([#11347](https://github.com/linode/manager/pull/11347))

--- a/packages/api-v4/.changeset/pr-11368-added-1733420616390.md
+++ b/packages/api-v4/.changeset/pr-11368-added-1733420616390.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Added
----
-
-Tags to `KubeNodePoolResponse` and `CreateNodePoolData` ([#11368](https://github.com/linode/manager/pull/11368))

--- a/packages/api-v4/.changeset/pr-11369-fixed-1733335872885.md
+++ b/packages/api-v4/.changeset/pr-11369-fixed-1733335872885.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Fixed
----
-
-Incorrect return type of `updateObjectACL` ([#11369](https://github.com/linode/manager/pull/11369))

--- a/packages/api-v4/.changeset/pr-11392-changed-1733853811812.md
+++ b/packages/api-v4/.changeset/pr-11392-changed-1733853811812.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Changed
----
-
-Property names, and types of the CreateAlertDefinitionPayload and Alert interfaces ([#11392](https://github.com/linode/manager/pull/11392))

--- a/packages/api-v4/.changeset/pr-11397-upcoming-features-1734001143561.md
+++ b/packages/api-v4/.changeset/pr-11397-upcoming-features-1734001143561.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Upcoming Features
----
-
-fix types for iam api ([#11397](https://github.com/linode/manager/pull/11397))

--- a/packages/api-v4/.changeset/pr-11399-upcoming-features-1733923542682.md
+++ b/packages/api-v4/.changeset/pr-11399-upcoming-features-1733923542682.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Upcoming Features
----
-
-Add new `getAlertDefinitionByServiceTypeAndId` endpoint to fetch Cloud Pulse alert details by id and service type ([#11399](https://github.com/linode/manager/pull/11399))

--- a/packages/api-v4/.changeset/pr-11400-upcoming-features-1733998451458.md
+++ b/packages/api-v4/.changeset/pr-11400-upcoming-features-1733998451458.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Upcoming Features
----
-
-New `Block Storage Performance B1` linode capability ([#11400](https://github.com/linode/manager/pull/11400))

--- a/packages/api-v4/.changeset/pr-11413-removed-1734030444142.md
+++ b/packages/api-v4/.changeset/pr-11413-removed-1734030444142.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Removed
----
-
-getAccountInfoBeta endpoint ([#11413](https://github.com/linode/manager/pull/11413))

--- a/packages/api-v4/.changeset/pr-11419-upcoming-features-1734115734709.md
+++ b/packages/api-v4/.changeset/pr-11419-upcoming-features-1734115734709.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Upcoming Features
----
-
-Add `getKubernetesTypesBeta` function ([#11419](https://github.com/linode/manager/pull/11419))

--- a/packages/api-v4/.changeset/pr-11426-changed-1734381690407.md
+++ b/packages/api-v4/.changeset/pr-11426-changed-1734381690407.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Changed
----
-
-BaseDatabase total_disk_size_gb and used_disk_size_gb are always expected and used_disk_size_gb can be null  ([#11426](https://github.com/linode/manager/pull/11426))

--- a/packages/api-v4/.changeset/pr-11433-changed-1734483970019.md
+++ b/packages/api-v4/.changeset/pr-11433-changed-1734483970019.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Changed
----
-
-Renamed `AvailableMetrics` type to `MetricDefinition` ([#11433](https://github.com/linode/manager/pull/11433))

--- a/packages/api-v4/.changeset/pr-11433-removed-1734484000708.md
+++ b/packages/api-v4/.changeset/pr-11433-removed-1734484000708.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Removed
----
-
-`MetricDefinitions` type ([#11433](https://github.com/linode/manager/pull/11433))

--- a/packages/api-v4/.changeset/pr-11445-changed-1734706802321.md
+++ b/packages/api-v4/.changeset/pr-11445-changed-1734706802321.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Changed
----
-
-Changed MetricCritera, DimensionFilter and Alert Interfaces ([#11445](https://github.com/linode/manager/pull/11445))

--- a/packages/api-v4/CHANGELOG.md
+++ b/packages/api-v4/CHANGELOG.md
@@ -1,3 +1,35 @@
+## [2025-01-14] - v0.132.0
+
+### Added:
+
+- Types for UDP NodeBalancer support ([#11321](https://github.com/linode/manager/pull/11321))
+- Tags to `KubeNodePoolResponse` and `CreateNodePoolData` ([#11368](https://github.com/linode/manager/pull/11368))
+
+### Changed:
+
+- Type of `AlertDefinitionType` to `'system'|'user'`   ([#11346](https://github.com/linode/manager/pull/11346))
+- Property names, and types of the CreateAlertDefinitionPayload and Alert interfaces ([#11392](https://github.com/linode/manager/pull/11392))
+- BaseDatabase total_disk_size_gb and used_disk_size_gb are always expected and used_disk_size_gb can be null ([#11426](https://github.com/linode/manager/pull/11426))
+- Renamed `AvailableMetrics` type to `MetricDefinition` ([#11433](https://github.com/linode/manager/pull/11433))
+- Changed MetricCritera, DimensionFilter and Alert Interfaces ([#11445](https://github.com/linode/manager/pull/11445))
+
+### Fixed:
+
+- Nullable AccountBeta ended & description properties ([#11347](https://github.com/linode/manager/pull/11347))
+- Incorrect return type of `updateObjectACL` ([#11369](https://github.com/linode/manager/pull/11369))
+
+### Removed:
+
+- getAccountInfoBeta endpoint ([#11413](https://github.com/linode/manager/pull/11413))
+- `MetricDefinitions` type ([#11433](https://github.com/linode/manager/pull/11433))
+
+### Upcoming Features:
+
+- Fix types for IAM API ([#11397](https://github.com/linode/manager/pull/11397))
+- Add new `getAlertDefinitionByServiceTypeAndId` endpoint to fetch Cloud Pulse alert details by id and service type ([#11399](https://github.com/linode/manager/pull/11399))
+- New `Block Storage Performance B1` linode capability ([#11400](https://github.com/linode/manager/pull/11400))
+- Add `getKubernetesTypesBeta` function ([#11419](https://github.com/linode/manager/pull/11419))
+
 ## [2024-12-10] - v0.131.0
 
 ### Added:

--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/api-v4",
-  "version": "0.131.0",
+  "version": "0.132.0",
   "homepage": "https://github.com/linode/manager/tree/develop/packages/api-v4",
   "bugs": {
     "url": "https://github.com/linode/manager/issues"

--- a/packages/manager/.changeset/pr-10820-changed-1725610034084.md
+++ b/packages/manager/.changeset/pr-10820-changed-1725610034084.md
@@ -1,5 +1,0 @@
----
-'@linode/manager': Changed
----
-
-Volume drawers and action menu ([#10820](https://github.com/linode/manager/pull/10820))

--- a/packages/manager/.changeset/pr-11151-added-1731944151381.md
+++ b/packages/manager/.changeset/pr-11151-added-1731944151381.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-New DatePicker Component ([#11151](https://github.com/linode/manager/pull/11151))

--- a/packages/manager/.changeset/pr-11154-tech-stories-1730404184309.md
+++ b/packages/manager/.changeset/pr-11154-tech-stories-1730404184309.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Migrate `/volumes` to Tanstack router ([#11154](https://github.com/linode/manager/pull/11154))

--- a/packages/manager/.changeset/pr-11253-added-1731495888267.md
+++ b/packages/manager/.changeset/pr-11253-added-1731495888267.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-Notice for OS Distro Nearing EOL/EOS ([#11253](https://github.com/linode/manager/pull/11253))

--- a/packages/manager/.changeset/pr-11300-fixed-1732196456888.md
+++ b/packages/manager/.changeset/pr-11300-fixed-1732196456888.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Create support ticket for buckets created through legacy flow ([#11300](https://github.com/linode/manager/pull/11300))

--- a/packages/manager/.changeset/pr-11303-fixed-1733422977888.md
+++ b/packages/manager/.changeset/pr-11303-fixed-1733422977888.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Incorrect Cloning Commands in Linode CLI Modal ([#11303](https://github.com/linode/manager/pull/11303))

--- a/packages/manager/.changeset/pr-11321-tech-stories-1733243149867.md
+++ b/packages/manager/.changeset/pr-11321-tech-stories-1733243149867.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Clean up NodeBalancer related types ([#11321](https://github.com/linode/manager/pull/11321))

--- a/packages/manager/.changeset/pr-11328-tech-stories-1732650627657.md
+++ b/packages/manager/.changeset/pr-11328-tech-stories-1732650627657.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Dev Tools fixes and improvements ([#11328](https://github.com/linode/manager/pull/11328))

--- a/packages/manager/.changeset/pr-11335-added-1732792310960.md
+++ b/packages/manager/.changeset/pr-11335-added-1732792310960.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-Cypress test for restricted user Image non-Empty landing page ([#11335](https://github.com/linode/manager/pull/11335))

--- a/packages/manager/.changeset/pr-11339-fixed-1732776925827.md
+++ b/packages/manager/.changeset/pr-11339-fixed-1732776925827.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Events landing page lists events in wrong order ([#11339](https://github.com/linode/manager/pull/11339))

--- a/packages/manager/.changeset/pr-11341-tests-1732886601848.md
+++ b/packages/manager/.changeset/pr-11341-tests-1732886601848.md
@@ -1,5 +1,0 @@
----
-'@linode/manager': Tests
----
-
-Cypress component tests for firewall rules drag and drop keyboard interaction ([#11341](https://github.com/linode/manager/pull/11341))

--- a/packages/manager/.changeset/pr-11344-tests-1733127883345.md
+++ b/packages/manager/.changeset/pr-11344-tests-1733127883345.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Cypress component test for firewall inbound and outbound rules for mouse drag and drop ([#11344](https://github.com/linode/manager/pull/11344))

--- a/packages/manager/.changeset/pr-11345-tech-stories-1733225462381.md
+++ b/packages/manager/.changeset/pr-11345-tech-stories-1733225462381.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Replace one-off hardcoded color values with color tokens pt4 ([#11345](https://github.com/linode/manager/pull/11345))

--- a/packages/manager/.changeset/pr-11346-added-1733145106911.md
+++ b/packages/manager/.changeset/pr-11346-added-1733145106911.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-AlertListing component and AlertTableRow component with Unit Tests ([#11346](https://github.com/linode/manager/pull/11346))

--- a/packages/manager/.changeset/pr-11347-tests-1733170030162.md
+++ b/packages/manager/.changeset/pr-11347-tests-1733170030162.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Mock LKE creation flow + APL coverage ([#11347](https://github.com/linode/manager/pull/11347))

--- a/packages/manager/.changeset/pr-11350-tests-1733842479277.md
+++ b/packages/manager/.changeset/pr-11350-tests-1733842479277.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Improve Linode end-to-end test stability by increasing timeouts ([#11350](https://github.com/linode/manager/pull/11350))

--- a/packages/manager/.changeset/pr-11351-added-1733194164261.md
+++ b/packages/manager/.changeset/pr-11351-added-1733194164261.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-aria-describedby to TextField with helper text ([#11351](https://github.com/linode/manager/pull/11351))

--- a/packages/manager/.changeset/pr-11354-upcoming-features-1733237771685.md
+++ b/packages/manager/.changeset/pr-11354-upcoming-features-1733237771685.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add `CloudPulseAppliedFilter` and `CloudPulseAppliedFilterRenderer` components, update filter change handler function to add another parameter `label` ([#11354](https://github.com/linode/manager/pull/11354))

--- a/packages/manager/.changeset/pr-11357-tech-stories-1733778960338.md
+++ b/packages/manager/.changeset/pr-11357-tech-stories-1733778960338.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Refactor VPC Create to use `react-hook-form` instead of `formik` ([#11357](https://github.com/linode/manager/pull/11357))

--- a/packages/manager/.changeset/pr-11359-upcoming-features-1733244908637.md
+++ b/packages/manager/.changeset/pr-11359-upcoming-features-1733244908637.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Update Kubernetes Versions in Create Cluster flow to support tiers for LKE-E ([#11359](https://github.com/linode/manager/pull/11359))

--- a/packages/manager/.changeset/pr-11360-tech-stories-1733774598326.md
+++ b/packages/manager/.changeset/pr-11360-tech-stories-1733774598326.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Add `IMAGE_REGISTRY` Docker build argument ([#11360](https://github.com/linode/manager/pull/11360))

--- a/packages/manager/.changeset/pr-11364-tech-stories-1733273269749.md
+++ b/packages/manager/.changeset/pr-11364-tech-stories-1733273269749.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Remove `reselect` dependency ([#11364](https://github.com/linode/manager/pull/11364))

--- a/packages/manager/.changeset/pr-11365-tests-1733305182663.md
+++ b/packages/manager/.changeset/pr-11365-tests-1733305182663.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Fix `delete-volume.spec.ts` flaky test ([#11365](https://github.com/linode/manager/pull/11365))

--- a/packages/manager/.changeset/pr-11367-upcoming-features-1733488193445.md
+++ b/packages/manager/.changeset/pr-11367-upcoming-features-1733488193445.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add new users table component for IAM ([#11367](https://github.com/linode/manager/pull/11367))

--- a/packages/manager/.changeset/pr-11368-added-1733415278919.md
+++ b/packages/manager/.changeset/pr-11368-added-1733415278919.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-Node Pool Tags to LKE Cluster details page ([#11368](https://github.com/linode/manager/pull/11368))

--- a/packages/manager/.changeset/pr-11369-tech-stories-1733335919284.md
+++ b/packages/manager/.changeset/pr-11369-tech-stories-1733335919284.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Update `useObjectAccess` to use a query key factory ([#11369](https://github.com/linode/manager/pull/11369))

--- a/packages/manager/.changeset/pr-11379-fixed-1733476117431.md
+++ b/packages/manager/.changeset/pr-11379-fixed-1733476117431.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Disallow word-break in billing contact info ([#11379](https://github.com/linode/manager/pull/11379))

--- a/packages/manager/.changeset/pr-11382-upcoming-features-1733485035913.md
+++ b/packages/manager/.changeset/pr-11382-upcoming-features-1733485035913.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Show ACLP supported regions per service type in region select ([#11382](https://github.com/linode/manager/pull/11382))

--- a/packages/manager/.changeset/pr-11383-tests-1733523460107.md
+++ b/packages/manager/.changeset/pr-11383-tests-1733523460107.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Add cypress test for Credit Card Expired banner ([#11383](https://github.com/linode/manager/pull/11383))

--- a/packages/manager/.changeset/pr-11384-fixed-1733733978349.md
+++ b/packages/manager/.changeset/pr-11384-fixed-1733733978349.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Object Storage object uploader spinner spinning backwards ([#11384](https://github.com/linode/manager/pull/11384))

--- a/packages/manager/.changeset/pr-11385-fixed-1733735480951.md
+++ b/packages/manager/.changeset/pr-11385-fixed-1733735480951.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Document title from URL to appropriate keyword ([#11385](https://github.com/linode/manager/pull/11385))

--- a/packages/manager/.changeset/pr-11387-fixed-1733763957768.md
+++ b/packages/manager/.changeset/pr-11387-fixed-1733763957768.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-dbaas settings maintenance does not display review state and allows version upgrade when updates are available ([#11387](https://github.com/linode/manager/pull/11387))

--- a/packages/manager/.changeset/pr-11388-changed-1733815118971.md
+++ b/packages/manager/.changeset/pr-11388-changed-1733815118971.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Update layout in CloudPulseDashboardWithFilters component, add a `getFilters` util method in `FilterBuilder.ts` ([#11388](https://github.com/linode/manager/pull/11388))

--- a/packages/manager/.changeset/pr-11389-added-1733834884159.md
+++ b/packages/manager/.changeset/pr-11389-added-1733834884159.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-MultipleIPInput Story in Storybook ([#11389](https://github.com/linode/manager/pull/11389))

--- a/packages/manager/.changeset/pr-11390-tests-1733844253656.md
+++ b/packages/manager/.changeset/pr-11390-tests-1733844253656.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Cypress test flake: Rebuild Linode ([#11390](https://github.com/linode/manager/pull/11390))

--- a/packages/manager/.changeset/pr-11391-tech-stories-1733949258449.md
+++ b/packages/manager/.changeset/pr-11391-tech-stories-1733949258449.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Replace instances of `react-select` in Managed ([#11391](https://github.com/linode/manager/pull/11391))

--- a/packages/manager/.changeset/pr-11392-added-1733853776123.md
+++ b/packages/manager/.changeset/pr-11392-added-1733853776123.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-Metric, MetricCriteria, ClearIconButton components with Unit Tests ([#11392](https://github.com/linode/manager/pull/11392))

--- a/packages/manager/.changeset/pr-11393-tech-stories-1733855306252.md
+++ b/packages/manager/.changeset/pr-11393-tech-stories-1733855306252.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Refactor VPCEditDrawer and SubnetEditDrawer to use `react-hook-form` instead of `formik` ([#11393](https://github.com/linode/manager/pull/11393))

--- a/packages/manager/.changeset/pr-11394-tests-1733856095533.md
+++ b/packages/manager/.changeset/pr-11394-tests-1733856095533.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Improve assertions made in `smoke-billing-activity.spec.ts` ([#11394](https://github.com/linode/manager/pull/11394))

--- a/packages/manager/.changeset/pr-11394-tests-1733856145159.md
+++ b/packages/manager/.changeset/pr-11394-tests-1733856145159.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Clean up `DatabaseBackups.test.tsx` ([#11394](https://github.com/linode/manager/pull/11394))

--- a/packages/manager/.changeset/pr-11395-added-1734381247482.md
+++ b/packages/manager/.changeset/pr-11395-added-1734381247482.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-Add Date Presets Functionality to Date Picker component ([#11395](https://github.com/linode/manager/pull/11395))

--- a/packages/manager/.changeset/pr-11397-upcoming-features-1733916688951.md
+++ b/packages/manager/.changeset/pr-11397-upcoming-features-1733916688951.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add new user details components for iam ([#11397](https://github.com/linode/manager/pull/11397))

--- a/packages/manager/.changeset/pr-11398-fixed-1733917277527.md
+++ b/packages/manager/.changeset/pr-11398-fixed-1733917277527.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Misplaced `errorGroup` prop causing console error in NodeBalancerConfigPanel ([#11398](https://github.com/linode/manager/pull/11398))

--- a/packages/manager/.changeset/pr-11399-upcoming-features-1733923517331.md
+++ b/packages/manager/.changeset/pr-11399-upcoming-features-1733923517331.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add column for actions to Cloud Pulse alert definitions listing view and scaffolding for Definition Details page ([#11399](https://github.com/linode/manager/pull/11399))

--- a/packages/manager/.changeset/pr-11400-upcoming-features-1733927873131.md
+++ b/packages/manager/.changeset/pr-11400-upcoming-features-1733927873131.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-High performance volume indicator ([#11400](https://github.com/linode/manager/pull/11400))

--- a/packages/manager/.changeset/pr-11401-upcoming-features-1733923108694.md
+++ b/packages/manager/.changeset/pr-11401-upcoming-features-1733923108694.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add new no assigned roles component for iam ([#11401](https://github.com/linode/manager/pull/11401))

--- a/packages/manager/.changeset/pr-11405-upcoming-features-1733957273478.md
+++ b/packages/manager/.changeset/pr-11405-upcoming-features-1733957273478.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Initial support for NodeBalancer UDP protocol  ([#11405](https://github.com/linode/manager/pull/11405))

--- a/packages/manager/.changeset/pr-11406-changed-1734097478149.md
+++ b/packages/manager/.changeset/pr-11406-changed-1734097478149.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Database Resize: Updated tooltip text, plan selection descriptions, and summary text for new databases ([#11406](https://github.com/linode/manager/pull/11406))

--- a/packages/manager/.changeset/pr-11407-tests-1734013914322.md
+++ b/packages/manager/.changeset/pr-11407-tests-1734013914322.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Fix account login and logout tests when using non-Prod environment ([#11407](https://github.com/linode/manager/pull/11407))

--- a/packages/manager/.changeset/pr-11408-tests-1734042066746.md
+++ b/packages/manager/.changeset/pr-11408-tests-1734042066746.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Add cypress component tests for Autocomplete  ([#11408](https://github.com/linode/manager/pull/11408))

--- a/packages/manager/.changeset/pr-11410-tech-stories-1734037217982.md
+++ b/packages/manager/.changeset/pr-11410-tech-stories-1734037217982.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Update our docs regarding useEffect best practices ([#11410](https://github.com/linode/manager/pull/11410))

--- a/packages/manager/.changeset/pr-11411-tests-1734023093705.md
+++ b/packages/manager/.changeset/pr-11411-tests-1734023093705.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Update mock region for LKE cluster creation test ([#11411](https://github.com/linode/manager/pull/11411))

--- a/packages/manager/.changeset/pr-11412-fixed-1734107098320.md
+++ b/packages/manager/.changeset/pr-11412-fixed-1734107098320.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Account Cancellation Survey Button Color Issues ([#11412](https://github.com/linode/manager/pull/11412))

--- a/packages/manager/.changeset/pr-11413-upcoming-features-1734030483336.md
+++ b/packages/manager/.changeset/pr-11413-upcoming-features-1734030483336.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Switch from v4beta to v4 account endpoint for LKE-E ([#11413](https://github.com/linode/manager/pull/11413))

--- a/packages/manager/.changeset/pr-11414-fixed-1734041664478.md
+++ b/packages/manager/.changeset/pr-11414-fixed-1734041664478.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-DBaaS Manage Access IP fields are displaying an IPv4 validation error message when both IPv6 and IPv4 are available. ([#11414](https://github.com/linode/manager/pull/11414))

--- a/packages/manager/.changeset/pr-11415-upcoming-features-1734109279111.md
+++ b/packages/manager/.changeset/pr-11415-upcoming-features-1734109279111.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Update Kubernetes version upgrade components for LKE-E ([#11415](https://github.com/linode/manager/pull/11415))

--- a/packages/manager/.changeset/pr-11416-fixed-1734094290557.md
+++ b/packages/manager/.changeset/pr-11416-fixed-1734094290557.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-`RegionHelperText` causing console errors ([#11416](https://github.com/linode/manager/pull/11416))

--- a/packages/manager/.changeset/pr-11417-changed-1734111263221.md
+++ b/packages/manager/.changeset/pr-11417-changed-1734111263221.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-DBaaS Settings Maintenance field Upgrade Version pending updates tooltip should display accurate text ([#11417](https://github.com/linode/manager/pull/11417))

--- a/packages/manager/.changeset/pr-11418-tech-stories-1734276290091.md
+++ b/packages/manager/.changeset/pr-11418-tech-stories-1734276290091.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Refactor Domains Routing (Tanstack Router) ([#11418](https://github.com/linode/manager/pull/11418))

--- a/packages/manager/.changeset/pr-11419-upcoming-features-1734115680736.md
+++ b/packages/manager/.changeset/pr-11419-upcoming-features-1734115680736.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Display LKE-E pricing in checkout bar ([#11419](https://github.com/linode/manager/pull/11419))

--- a/packages/manager/.changeset/pr-11422-tests-1734356272451.md
+++ b/packages/manager/.changeset/pr-11422-tests-1734356272451.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Cypress tests to validate errors in Linode Create Backups tab ([#11422](https://github.com/linode/manager/pull/11422))

--- a/packages/manager/.changeset/pr-11424-fixed-1734375315983.md
+++ b/packages/manager/.changeset/pr-11424-fixed-1734375315983.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Linode Edit Config warning  message when initially selecting a VPC as the primary interface ([#11424](https://github.com/linode/manager/pull/11424))

--- a/packages/manager/.changeset/pr-11426-fixed-1734381380797.md
+++ b/packages/manager/.changeset/pr-11426-fixed-1734381380797.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-DBaaS Resize tab Used field is displaying just GB on provisioning database cluster ([#11426](https://github.com/linode/manager/pull/11426))

--- a/packages/manager/.changeset/pr-11427-tech-stories-1734383515695.md
+++ b/packages/manager/.changeset/pr-11427-tech-stories-1734383515695.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Update Pendo URL with CNAME and update Analytics developer docs ([#11427](https://github.com/linode/manager/pull/11427))

--- a/packages/manager/.changeset/pr-11428-tech-stories-1734382681885.md
+++ b/packages/manager/.changeset/pr-11428-tech-stories-1734382681885.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Add MSW crud domains ([#11428](https://github.com/linode/manager/pull/11428))

--- a/packages/manager/.changeset/pr-11430-tech-stories-1734463578200.md
+++ b/packages/manager/.changeset/pr-11430-tech-stories-1734463578200.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Replace react-select instances in /Users with new Select ([#11430](https://github.com/linode/manager/pull/11430))

--- a/packages/manager/.changeset/pr-11431-fixed-1734558226981.md
+++ b/packages/manager/.changeset/pr-11431-fixed-1734558226981.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Various bugs in Managed tables ([#11431](https://github.com/linode/manager/pull/11431))

--- a/packages/manager/.changeset/pr-11433-tech-stories-1734484023886.md
+++ b/packages/manager/.changeset/pr-11433-tech-stories-1734484023886.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Fixed CloudPulse metric definition types ([#11433](https://github.com/linode/manager/pull/11433))

--- a/packages/manager/.changeset/pr-11434-tech-stories-1734487085461.md
+++ b/packages/manager/.changeset/pr-11434-tech-stories-1734487085461.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Patch `cookie` version as resolution for dependabot  ([#11434](https://github.com/linode/manager/pull/11434))

--- a/packages/manager/.changeset/pr-11435-tests-1734516339389.md
+++ b/packages/manager/.changeset/pr-11435-tests-1734516339389.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Cypress test to validate aria label of Linode IP Addresses action menu ([#11435](https://github.com/linode/manager/pull/11435))

--- a/packages/manager/.changeset/pr-11436-upcoming-features-1734526137538.md
+++ b/packages/manager/.changeset/pr-11436-upcoming-features-1734526137538.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-fix invalid routes in the iam ([#11436](https://github.com/linode/manager/pull/11436))

--- a/packages/manager/.changeset/pr-11437-fixed-1734527875368.md
+++ b/packages/manager/.changeset/pr-11437-fixed-1734527875368.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-ARIA label of action menu in Domains Landing table row ([#11437](https://github.com/linode/manager/pull/11437))

--- a/packages/manager/.changeset/pr-11440-tests-1734593684793.md
+++ b/packages/manager/.changeset/pr-11440-tests-1734593684793.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Cypress test to validate CAA records are editable ([#11440](https://github.com/linode/manager/pull/11440))

--- a/packages/manager/.changeset/pr-11442-upcoming-features-1734651568762.md
+++ b/packages/manager/.changeset/pr-11442-upcoming-features-1734651568762.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Designate LKE-E clusters with 'Enterprise' chip ([#11442](https://github.com/linode/manager/pull/11442))

--- a/packages/manager/.changeset/pr-11443-removed-1734624899643.md
+++ b/packages/manager/.changeset/pr-11443-removed-1734624899643.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Removed
----
-
-`Images are not encrypted warning` warning ([#11443](https://github.com/linode/manager/pull/11443))

--- a/packages/manager/.changeset/pr-11444-tests-1734632019649.md
+++ b/packages/manager/.changeset/pr-11444-tests-1734632019649.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Add test for LKE cluster rename flow ([#11444](https://github.com/linode/manager/pull/11444))

--- a/packages/manager/.changeset/pr-11445-added-1734705630196.md
+++ b/packages/manager/.changeset/pr-11445-added-1734705630196.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-DimensionFilter, DimensionFilterField, TriggerCondition component along with Unit Tests ([#11445](https://github.com/linode/manager/pull/11445))

--- a/packages/manager/.changeset/pr-11448-tests-1734703218321.md
+++ b/packages/manager/.changeset/pr-11448-tests-1734703218321.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Add unit tests to validate aria-labels of Action Menu for Linode IPs & ranges ([#11448](https://github.com/linode/manager/pull/11448))

--- a/packages/manager/.changeset/pr-11450-fixed-1734717495561.md
+++ b/packages/manager/.changeset/pr-11450-fixed-1734717495561.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-VPC interface not being set as the primary interface when creating a Linode ([#11450](https://github.com/linode/manager/pull/11450))

--- a/packages/manager/.changeset/pr-11450-tests-1735836787604.md
+++ b/packages/manager/.changeset/pr-11450-tests-1735836787604.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Add cypress tests confirming Lionde Config Unrecommended status displays as expected in VPC Subnet table ([#11450](https://github.com/linode/manager/pull/11450))

--- a/packages/manager/.changeset/pr-11453-fixed-1734765509208.md
+++ b/packages/manager/.changeset/pr-11453-fixed-1734765509208.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-`Create Token` button becomes disabled when all permissions are selected individually (without using 'select all') and child-account is hidden ([#11453](https://github.com/linode/manager/pull/11453))

--- a/packages/manager/.changeset/pr-11456-tech-stories-1734933761673.md
+++ b/packages/manager/.changeset/pr-11456-tech-stories-1734933761673.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Replace Select with Autocomplete component in Object Storage ([#11456](https://github.com/linode/manager/pull/11456))

--- a/packages/manager/.changeset/pr-11457-upcoming-features-1734962589506.md
+++ b/packages/manager/.changeset/pr-11457-upcoming-features-1734962589506.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add support for new optional filter - 'Tags' in monitor ([#11457](https://github.com/linode/manager/pull/11457))

--- a/packages/manager/.changeset/pr-11458-tests-1734984299850.md
+++ b/packages/manager/.changeset/pr-11458-tests-1734984299850.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Add Cypress test for LKE node pool tagging ([#11368](https://github.com/linode/manager/pull/11368))

--- a/packages/manager/.changeset/pr-11460-fixed-1735030571347.md
+++ b/packages/manager/.changeset/pr-11460-fixed-1735030571347.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Discrepancy in Object Storage Bucket size in CM ([#11460](https://github.com/linode/manager/pull/11460))

--- a/packages/manager/.changeset/pr-11464-upcoming-features-1735566884863.md
+++ b/packages/manager/.changeset/pr-11464-upcoming-features-1735566884863.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Exhaustive unit tests for CloudPulse widgets ([#11464](https://github.com/linode/manager/pull/11464))

--- a/packages/manager/.changeset/pr-11466-upcoming-features-1735637634055.md
+++ b/packages/manager/.changeset/pr-11466-upcoming-features-1735637634055.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add Alert Details Overview section in Cloud Pulse Alert Details page ([#11466](https://github.com/linode/manager/pull/11466))

--- a/packages/manager/.changeset/pr-11467-tech-stories-1735836122260.md
+++ b/packages/manager/.changeset/pr-11467-tech-stories-1735836122260.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Update `react-vnc` to 2.0.2 ([#11467](https://github.com/linode/manager/pull/11467))

--- a/packages/manager/.changeset/pr-11469-upcoming-features-1735867251319.md
+++ b/packages/manager/.changeset/pr-11469-upcoming-features-1735867251319.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Improve Close Account Dialog UI ([#11469](https://github.com/linode/manager/pull/11469))

--- a/packages/manager/.changeset/pr-11472-fixed-1736174726210.md
+++ b/packages/manager/.changeset/pr-11472-fixed-1736174726210.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Object Storage `endpoint_type` sorting ([#11472](https://github.com/linode/manager/pull/11472))

--- a/packages/manager/.changeset/pr-11475-upcoming-features-1735939864502.md
+++ b/packages/manager/.changeset/pr-11475-upcoming-features-1735939864502.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Update LKE cluster details kube specs for LKE-E monthly pricing ([#11475](https://github.com/linode/manager/pull/11475))

--- a/packages/manager/.changeset/pr-11476-fixed-1736263048231.md
+++ b/packages/manager/.changeset/pr-11476-fixed-1736263048231.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Visibility of sensitive data in Managed and Longview with Mask Sensitive Data setting enabled ([#11476](https://github.com/linode/manager/pull/11476))

--- a/packages/manager/.changeset/pr-11478-tests-1736180178602.md
+++ b/packages/manager/.changeset/pr-11478-tests-1736180178602.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Add coverage for Kube version upgrades in landing page ([#11478](https://github.com/linode/manager/pull/11478))

--- a/packages/manager/.changeset/pr-11485-fixed-1736282505902.md
+++ b/packages/manager/.changeset/pr-11485-fixed-1736282505902.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Display Kubernetes API endpoint for LKE-E cluster ([#11485](https://github.com/linode/manager/pull/11485))

--- a/packages/manager/.changeset/pr-11486-tests-1736284627318.md
+++ b/packages/manager/.changeset/pr-11486-tests-1736284627318.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Fix Cypress test failures stemming from Debian 10 Image deprecation ([#11486](https://github.com/linode/manager/pull/11486))

--- a/packages/manager/.changeset/pr-11491-changed-1736357771250.md
+++ b/packages/manager/.changeset/pr-11491-changed-1736357771250.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Temporarily remove Properties tab from Gen2 buckets ([#11491](https://github.com/linode/manager/pull/11491))

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,125 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2025-01-14] - v1.134.0
+
+### Added:
+
+- New DatePicker Component ([#11151](https://github.com/linode/manager/pull/11151))
+- Date Presets Functionality to Date Picker component ([#11395](https://github.com/linode/manager/pull/11395))
+- Notice for OS Distro Nearing EOL/EOS ([#11253](https://github.com/linode/manager/pull/11253))
+- AlertListing component and AlertTableRow component with Unit Tests ([#11346](https://github.com/linode/manager/pull/11346))
+- aria-describedby to TextField with helper text ([#11351](https://github.com/linode/manager/pull/11351))
+- Node Pool Tags to LKE Cluster details page ([#11368](https://github.com/linode/manager/pull/11368))
+- MultipleIPInput Story in Storybook ([#11389](https://github.com/linode/manager/pull/11389))
+- Metric, MetricCriteria, ClearIconButton components with Unit Tests ([#11392](https://github.com/linode/manager/pull/11392))
+- DimensionFilter, DimensionFilterField, TriggerCondition component along with Unit Tests ([#11445](https://github.com/linode/manager/pull/11445))
+- Manage Tags to Volumes table action menu and moved actions inside menu ([#11421](https://github.com/linode/manager/pull/11421))
+
+### Changed:
+
+- Update layout in CloudPulseDashboardWithFilters component, add a `getFilters` util method in `FilterBuilder.ts` ([#11388](https://github.com/linode/manager/pull/11388))
+- Database Resize: Updated tooltip text, plan selection descriptions, and summary text for new databases ([#11406](https://github.com/linode/manager/pull/11406))
+- DBaaS Settings Maintenance field Upgrade Version pending updates tooltip should display accurate text ([#11417](https://github.com/linode/manager/pull/11417))
+
+### Fixed:
+
+- Create support ticket for buckets created through legacy flow ([#11300](https://github.com/linode/manager/pull/11300))
+- Incorrect Cloning Commands in Linode CLI Modal ([#11303](https://github.com/linode/manager/pull/11303))
+- Events landing page lists events in wrong order ([#11339](https://github.com/linode/manager/pull/11339))
+- Disallow word-break in billing contact info ([#11379](https://github.com/linode/manager/pull/11379))
+- Object Storage object uploader spinner spinning backwards ([#11384](https://github.com/linode/manager/pull/11384))
+- Document title from URL to appropriate keyword ([#11385](https://github.com/linode/manager/pull/11385))
+- DBaaS settings maintenance does not display review state and allows version upgrade when updates are available ([#11387](https://github.com/linode/manager/pull/11387))
+- Misplaced `errorGroup` prop causing console error in NodeBalancerConfigPanel ([#11398](https://github.com/linode/manager/pull/11398))
+- Account Cancellation Survey Button Color Issues ([#11412](https://github.com/linode/manager/pull/11412))
+- DBaaS Manage Access IP fields are displaying an IPv4 validation error message when both IPv6 and IPv4 are available. ([#11414](https://github.com/linode/manager/pull/11414))
+- `RegionHelperText` causing console errors ([#11416](https://github.com/linode/manager/pull/11416))
+- Linode Edit Config warning  message when initially selecting a VPC as the primary interface ([#11424](https://github.com/linode/manager/pull/11424))
+- DBaaS Resize tab Used field is displaying just GB on provisioning database cluster ([#11426](https://github.com/linode/manager/pull/11426))
+- Various bugs in Managed tables ([#11431](https://github.com/linode/manager/pull/11431))
+- ARIA label of action menu in Domains Landing table row ([#11437](https://github.com/linode/manager/pull/11437))
+- VPC interface not being set as the primary interface when creating a Linode ([#11450](https://github.com/linode/manager/pull/11450))
+- `Create Token` button becomes disabled when all permissions are selected individually (without using 'select all') and child-account is hidden ([#11453](https://github.com/linode/manager/pull/11453))
+- Discrepancy in Object Storage Bucket size in CM ([#11460](https://github.com/linode/manager/pull/11460))
+- Object Storage `endpoint_type` sorting ([#11472](https://github.com/linode/manager/pull/11472))
+- Visibility of sensitive data in Managed and Longview with Mask Sensitive Data setting enabled ([#11476](https://github.com/linode/manager/pull/11476))
+- Display Kubernetes API endpoint for LKE-E cluster ([#11485](https://github.com/linode/manager/pull/11485))
+
+### Removed:
+
+- `Images are not encrypted warning` warning ([#11443](https://github.com/linode/manager/pull/11443))
+- Temporarily remove Properties tab from Gen2 buckets ([#11491](https://github.com/linode/manager/pull/11491))
+
+### Tech Stories:
+
+- Migrate `/volumes` to Tanstack router ([#11154](https://github.com/linode/manager/pull/11154))
+- Clean up NodeBalancer related types ([#11321](https://github.com/linode/manager/pull/11321))
+- Dev Tools fixes and improvements ([#11328](https://github.com/linode/manager/pull/11328))
+- Replace one-off hardcoded color values with color tokens pt4 ([#11345](https://github.com/linode/manager/pull/11345))
+- Refactor VPC Create to use `react-hook-form` instead of `formik` ([#11357](https://github.com/linode/manager/pull/11357))
+- Refactor VPCEditDrawer and SubnetEditDrawer to use `react-hook-form` instead of `formik` ([#11393](https://github.com/linode/manager/pull/11393))
+- Add `IMAGE_REGISTRY` Docker build argument ([#11360](https://github.com/linode/manager/pull/11360))
+- Remove `reselect` dependency ([#11364](https://github.com/linode/manager/pull/11364))
+- Update `useObjectAccess` to use a query key factory ([#11369](https://github.com/linode/manager/pull/11369))
+- Replace instances of `react-select` in Managed ([#11391](https://github.com/linode/manager/pull/11391))
+- Update our docs regarding useEffect best practices ([#11410](https://github.com/linode/manager/pull/11410))
+- Refactor Domains Routing (Tanstack Router) ([#11418](https://github.com/linode/manager/pull/11418))
+- Update Pendo URL with CNAME and update Analytics developer docs ([#11427](https://github.com/linode/manager/pull/11427))
+- Add MSW crud domains ([#11428](https://github.com/linode/manager/pull/11428))
+- Replace react-select instances in /Users with new Select ([#11430](https://github.com/linode/manager/pull/11430))
+- Fixed CloudPulse metric definition types ([#11433](https://github.com/linode/manager/pull/11433))
+- Patch `cookie` version as resolution for dependabot  ([#11434](https://github.com/linode/manager/pull/11434))
+- Replace Select with Autocomplete component in Object Storage ([#11456](https://github.com/linode/manager/pull/11456))
+- Update `react-vnc` to 2.0.2 ([#11467](https://github.com/linode/manager/pull/11467))
+
+### Tests:
+
+- Cypress component test for firewall inbound and outbound rules for mouse drag and drop ([#11344](https://github.com/linode/manager/pull/11344))
+- Cypress component tests for firewall rules drag and drop keyboard interaction ([#11341](https://github.com/linode/manager/pull/11341))
+- Mock LKE creation flow + APL coverage ([#11347](https://github.com/linode/manager/pull/11347))
+- Improve Linode end-to-end test stability by increasing timeouts ([#11350](https://github.com/linode/manager/pull/11350))
+- Fix `delete-volume.spec.ts` flaky test ([#11365](https://github.com/linode/manager/pull/11365))
+- Add Cypress test for Credit Card Expired banner ([#11383](https://github.com/linode/manager/pull/11383))
+- Cypress test flake: Rebuild Linode ([#11390](https://github.com/linode/manager/pull/11390))
+- Improve assertions made in `smoke-billing-activity.spec.ts` ([#11394](https://github.com/linode/manager/pull/11394))
+- Clean up `DatabaseBackups.test.tsx` ([#11394](https://github.com/linode/manager/pull/11394))
+- Fix account login and logout tests when using non-Prod environment ([#11407](https://github.com/linode/manager/pull/11407))
+- Add Cypress component tests for Autocomplete  ([#11408](https://github.com/linode/manager/pull/11408))
+- Update mock region for LKE cluster creation test ([#11411](https://github.com/linode/manager/pull/11411))
+- Cypress tests to validate errors in Linode Create Backups tab ([#11422](https://github.com/linode/manager/pull/11422))
+- Cypress test to validate aria label of Linode IP Addresses action menu ([#11435](https://github.com/linode/manager/pull/11435))
+- Cypress test to validate CAA records are editable ([#11440](https://github.com/linode/manager/pull/11440))
+- Add test for LKE cluster rename flow ([#11444](https://github.com/linode/manager/pull/11444))
+- Add unit tests to validate aria-labels of Action Menu for Linode IPs & ranges ([#11448](https://github.com/linode/manager/pull/11448))
+- Add Cypress tests confirming Lionde Config Unrecommended status displays as expected in VPC Subnet table ([#11450](https://github.com/linode/manager/pull/11450))
+- Add Cypress test for LKE node pool tagging ([#11368](https://github.com/linode/manager/pull/11368))
+- Add coverage for Kube version upgrades in landing page ([#11478](https://github.com/linode/manager/pull/11478))
+- Fix Cypress test failures stemming from Debian 10 Image deprecation ([#11486](https://github.com/linode/manager/pull/11486))
+- Added Cypress test for restricted user Image non-Empty landing page ([#11335](https://github.com/linode/manager/pull/11335))
+
+### Upcoming Features:
+
+- Update Kubernetes Versions in Create Cluster flow to support tiers for LKE-E ([#11359](https://github.com/linode/manager/pull/11359))
+- Switch from v4beta to v4 account endpoint for LKE-E ([#11413](https://github.com/linode/manager/pull/11413))
+- Update Kubernetes version upgrade components for LKE-E ([#11415](https://github.com/linode/manager/pull/11415))
+- Display LKE-E pricing in checkout bar ([#11419](https://github.com/linode/manager/pull/11419))
+- Designate LKE-E clusters with 'Enterprise' chip ([#11442](https://github.com/linode/manager/pull/11442))
+- Update LKE cluster details kube specs for LKE-E monthly pricing ([#11475](https://github.com/linode/manager/pull/11475))
+- Add new users table component for IAM ([#11367](https://github.com/linode/manager/pull/11367))
+- Add new user details components for IAM ([#11397](https://github.com/linode/manager/pull/11397))
+- High performance volume indicator ([#11400](https://github.com/linode/manager/pull/11400))
+- Add new no assigned roles component for IAM ([#11401](https://github.com/linode/manager/pull/11401))
+- Fix invalid routes in the IAM ([#11436](https://github.com/linode/manager/pull/11436))
+- Initial support for NodeBalancer UDP protocol  ([#11405](https://github.com/linode/manager/pull/11405))
+- Add support for new optional filter - 'Tags' in monitor ([#11457](https://github.com/linode/manager/pull/11457))
+- Show ACLP supported regions per service type in region select ([#11382](https://github.com/linode/manager/pull/11382))
+- Add `CloudPulseAppliedFilter` and `CloudPulseAppliedFilterRenderer` components, update filter change handler function to add another parameter `label` ([#11354](https://github.com/linode/manager/pull/11354))
+- Add column for actions to Cloud Pulse alert definitions listing view and scaffolding for Definition Details page ([#11399](https://github.com/linode/manager/pull/11399))
+- Exhaustive unit tests for CloudPulse widgets ([#11464](https://github.com/linode/manager/pull/11464))
+- Add Alert Details Overview section in Cloud Pulse Alert Details page ([#11466](https://github.com/linode/manager/pull/11466))
+- Improve Close Account Dialog UI ([#11469](https://github.com/linode/manager/pull/11469))
+
 ## [2024-12-20] - v1.133.2
 
 ### Fixed:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.133.2",
+  "version": "1.134.0",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/ui/.changeset/pr-11333-changed-1733176201231.md
+++ b/packages/ui/.changeset/pr-11333-changed-1733176201231.md
@@ -1,5 +1,0 @@
----
-"@linode/ui": Changed
----
-
-Update `EditableText` to not use `react-router-dom` and accept a `LinkComponent` prop ([#11333](https://github.com/linode/manager/pull/11333))

--- a/packages/ui/.changeset/pr-11391-added-1733949199859.md
+++ b/packages/ui/.changeset/pr-11391-added-1733949199859.md
@@ -1,5 +1,0 @@
----
-"@linode/ui": Added
----
-
-New Select component ([#11391](https://github.com/linode/manager/pull/11391))

--- a/packages/ui/.changeset/pr-11469-added-1735867052403.md
+++ b/packages/ui/.changeset/pr-11469-added-1735867052403.md
@@ -1,5 +1,0 @@
----
-"@linode/ui": Added
----
-
-New `color="warning"` button style and improved type-safety ([#11469](https://github.com/linode/manager/pull/11469))

--- a/packages/ui/.changeset/pr-11469-added-1735867206808.md
+++ b/packages/ui/.changeset/pr-11469-added-1735867206808.md
@@ -1,5 +1,0 @@
----
-"@linode/ui": Added
----
-
-New `MuiButton` variant `loading` along with `color="warning"` styles" ([#11469](https://github.com/linode/manager/pull/11469))

--- a/packages/ui/.changeset/pr-11469-fixed-1735867161139.md
+++ b/packages/ui/.changeset/pr-11469-fixed-1735867161139.md
@@ -1,5 +1,0 @@
----
-"@linode/ui": Fixed
----
-
-`sx` prop now properly works being passed down to `Notice` component ([#11469](https://github.com/linode/manager/pull/11469))

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [2025-01-14] - v0.5.0
+
+### Added:
+
+- New Select component ([#11391](https://github.com/linode/manager/pull/11391))
+- New `color="warning"` button style and improved type-safety ([#11469](https://github.com/linode/manager/pull/11469))
+- New `MuiButton` variant `loading` along with `color="warning"` styles" ([#11469](https://github.com/linode/manager/pull/11469))
+
+### Changed:
+
+- Update `EditableText` to not use `react-router-dom` and accept a `LinkComponent` prop ([#11333](https://github.com/linode/manager/pull/11333))
+
+### Fixed:
+
+- `sx` prop now properly works being passed down to `Notice` component ([#11469](https://github.com/linode/manager/pull/11469))
+
 ## [2024-12-10] - v0.4.0
 
 ### Added:

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,7 +2,7 @@
   "name": "@linode/ui",
   "author": "Linode",
   "description": "Linode UI component library",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "main": "src/index.ts",
   "module": "src/index.ts",

--- a/packages/validation/.changeset/pr-11321-added-1733240871159.md
+++ b/packages/validation/.changeset/pr-11321-added-1733240871159.md
@@ -1,5 +1,0 @@
----
-"@linode/validation": Added
----
-
-Validation for UDP NodeBalancer support ([#11321](https://github.com/linode/manager/pull/11321))

--- a/packages/validation/.changeset/pr-11357-changed-1733929595429.md
+++ b/packages/validation/.changeset/pr-11357-changed-1733929595429.md
@@ -1,5 +1,0 @@
----
-"@linode/validation": Changed
----
-
-Update VPC validation to temporarily hide mention of IPv6 in UI, fix punctuation ([#11357](https://github.com/linode/manager/pull/11357))

--- a/packages/validation/.changeset/pr-11393-changed-1733855352751.md
+++ b/packages/validation/.changeset/pr-11393-changed-1733855352751.md
@@ -1,5 +1,0 @@
----
-"@linode/validation": Changed
----
-
-Update VPC label validation schema punctuation, fix label validation regex ([#11393](https://github.com/linode/manager/pull/11393))

--- a/packages/validation/.changeset/pr-11445-changed-1734706687923.md
+++ b/packages/validation/.changeset/pr-11445-changed-1734706687923.md
@@ -1,5 +1,0 @@
----
-"@linode/validation": Changed
----
-
-Error messages for few attributes ([#11445](https://github.com/linode/manager/pull/11445))

--- a/packages/validation/CHANGELOG.md
+++ b/packages/validation/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [2025-01-14] - v0.58.0
+
+### Added:
+
+- Validation for UDP NodeBalancer support ([#11321](https://github.com/linode/manager/pull/11321))
+
+### Changed:
+
+- Update VPC validation to temporarily hide mention of IPv6 in UI, fix punctuation ([#11357](https://github.com/linode/manager/pull/11357))
+- Update VPC label validation schema punctuation, fix label validation regex ([#11393](https://github.com/linode/manager/pull/11393))
+- Error messages for few attributes ([#11445](https://github.com/linode/manager/pull/11445))
+
 ## [2024-12-10] - v0.57.0
 
 ### Added:

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/validation",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "description": "Yup validation schemas for use with the Linode APIv4",
   "type": "module",
   "main": "lib/index.cjs",


### PR DESCRIPTION
### Added:

- New DatePicker Component ([#11151](https://github.com/linode/manager/pull/11151))
- Date Presets Functionality to Date Picker component ([#11395](https://github.com/linode/manager/pull/11395))
- Notice for OS Distro Nearing EOL/EOS ([#11253](https://github.com/linode/manager/pull/11253))
- AlertListing component and AlertTableRow component with Unit Tests ([#11346](https://github.com/linode/manager/pull/11346))
- aria-describedby to TextField with helper text ([#11351](https://github.com/linode/manager/pull/11351))
- Node Pool Tags to LKE Cluster details page ([#11368](https://github.com/linode/manager/pull/11368))
- MultipleIPInput Story in Storybook ([#11389](https://github.com/linode/manager/pull/11389))
- Metric, MetricCriteria, ClearIconButton components with Unit Tests ([#11392](https://github.com/linode/manager/pull/11392))
- DimensionFilter, DimensionFilterField, TriggerCondition component along with Unit Tests ([#11445](https://github.com/linode/manager/pull/11445))
- Manage Tags to Volumes table action menu and moved actions inside menu ([#11421](https://github.com/linode/manager/pull/11421))

### Changed:

- Update layout in CloudPulseDashboardWithFilters component, add a `getFilters` util method in `FilterBuilder.ts` ([#11388](https://github.com/linode/manager/pull/11388))
- Database Resize: Updated tooltip text, plan selection descriptions, and summary text for new databases ([#11406](https://github.com/linode/manager/pull/11406))
- DBaaS Settings Maintenance field Upgrade Version pending updates tooltip should display accurate text ([#11417](https://github.com/linode/manager/pull/11417))

### Fixed:

- Create support ticket for buckets created through legacy flow ([#11300](https://github.com/linode/manager/pull/11300))
- Incorrect Cloning Commands in Linode CLI Modal ([#11303](https://github.com/linode/manager/pull/11303))
- Events landing page lists events in wrong order ([#11339](https://github.com/linode/manager/pull/11339))
- Disallow word-break in billing contact info ([#11379](https://github.com/linode/manager/pull/11379))
- Object Storage object uploader spinner spinning backwards ([#11384](https://github.com/linode/manager/pull/11384))
- Document title from URL to appropriate keyword ([#11385](https://github.com/linode/manager/pull/11385))
- DBaaS settings maintenance does not display review state and allows version upgrade when updates are available ([#11387](https://github.com/linode/manager/pull/11387))
- Misplaced `errorGroup` prop causing console error in NodeBalancerConfigPanel ([#11398](https://github.com/linode/manager/pull/11398))
- Account Cancellation Survey Button Color Issues ([#11412](https://github.com/linode/manager/pull/11412))
- DBaaS Manage Access IP fields are displaying an IPv4 validation error message when both IPv6 and IPv4 are available. ([#11414](https://github.com/linode/manager/pull/11414))
- `RegionHelperText` causing console errors ([#11416](https://github.com/linode/manager/pull/11416))
- Linode Edit Config warning  message when initially selecting a VPC as the primary interface ([#11424](https://github.com/linode/manager/pull/11424))
- DBaaS Resize tab Used field is displaying just GB on provisioning database cluster ([#11426](https://github.com/linode/manager/pull/11426))
- Various bugs in Managed tables ([#11431](https://github.com/linode/manager/pull/11431))
- ARIA label of action menu in Domains Landing table row ([#11437](https://github.com/linode/manager/pull/11437))
- VPC interface not being set as the primary interface when creating a Linode ([#11450](https://github.com/linode/manager/pull/11450))
- `Create Token` button becomes disabled when all permissions are selected individually (without using 'select all') and child-account is hidden ([#11453](https://github.com/linode/manager/pull/11453))
- Discrepancy in Object Storage Bucket size in CM ([#11460](https://github.com/linode/manager/pull/11460))
- Object Storage `endpoint_type` sorting ([#11472](https://github.com/linode/manager/pull/11472))
- Visibility of sensitive data in Managed and Longview with Mask Sensitive Data setting enabled ([#11476](https://github.com/linode/manager/pull/11476))
- Display Kubernetes API endpoint for LKE-E cluster ([#11485](https://github.com/linode/manager/pull/11485))

### Removed:

- `Images are not encrypted warning` warning ([#11443](https://github.com/linode/manager/pull/11443))
- Temporarily remove Properties tab from Gen2 buckets ([#11491](https://github.com/linode/manager/pull/11491))

### Tech Stories:

- Migrate `/volumes` to Tanstack router ([#11154](https://github.com/linode/manager/pull/11154))
- Clean up NodeBalancer related types ([#11321](https://github.com/linode/manager/pull/11321))
- Dev Tools fixes and improvements ([#11328](https://github.com/linode/manager/pull/11328))
- Replace one-off hardcoded color values with color tokens pt4 ([#11345](https://github.com/linode/manager/pull/11345))
- Refactor VPC Create to use `react-hook-form` instead of `formik` ([#11357](https://github.com/linode/manager/pull/11357))
- Refactor VPCEditDrawer and SubnetEditDrawer to use `react-hook-form` instead of `formik` ([#11393](https://github.com/linode/manager/pull/11393))
- Add `IMAGE_REGISTRY` Docker build argument ([#11360](https://github.com/linode/manager/pull/11360))
- Remove `reselect` dependency ([#11364](https://github.com/linode/manager/pull/11364))
- Update `useObjectAccess` to use a query key factory ([#11369](https://github.com/linode/manager/pull/11369))
- Replace instances of `react-select` in Managed ([#11391](https://github.com/linode/manager/pull/11391))
- Update our docs regarding useEffect best practices ([#11410](https://github.com/linode/manager/pull/11410))
- Refactor Domains Routing (Tanstack Router) ([#11418](https://github.com/linode/manager/pull/11418))
- Update Pendo URL with CNAME and update Analytics developer docs ([#11427](https://github.com/linode/manager/pull/11427))
- Add MSW crud domains ([#11428](https://github.com/linode/manager/pull/11428))
- Replace react-select instances in /Users with new Select ([#11430](https://github.com/linode/manager/pull/11430))
- Fixed CloudPulse metric definition types ([#11433](https://github.com/linode/manager/pull/11433))
- Patch `cookie` version as resolution for dependabot  ([#11434](https://github.com/linode/manager/pull/11434))
- Replace Select with Autocomplete component in Object Storage ([#11456](https://github.com/linode/manager/pull/11456))
- Update `react-vnc` to 2.0.2 ([#11467](https://github.com/linode/manager/pull/11467))

### Tests:

- Cypress component test for firewall inbound and outbound rules for mouse drag and drop ([#11344](https://github.com/linode/manager/pull/11344))
- Cypress component tests for firewall rules drag and drop keyboard interaction ([#11341](https://github.com/linode/manager/pull/11341))
- Mock LKE creation flow + APL coverage ([#11347](https://github.com/linode/manager/pull/11347))
- Improve Linode end-to-end test stability by increasing timeouts ([#11350](https://github.com/linode/manager/pull/11350))
- Fix `delete-volume.spec.ts` flaky test ([#11365](https://github.com/linode/manager/pull/11365))
- Add Cypress test for Credit Card Expired banner ([#11383](https://github.com/linode/manager/pull/11383))
- Cypress test flake: Rebuild Linode ([#11390](https://github.com/linode/manager/pull/11390))
- Improve assertions made in `smoke-billing-activity.spec.ts` ([#11394](https://github.com/linode/manager/pull/11394))
- Clean up `DatabaseBackups.test.tsx` ([#11394](https://github.com/linode/manager/pull/11394))
- Fix account login and logout tests when using non-Prod environment ([#11407](https://github.com/linode/manager/pull/11407))
- Add Cypress component tests for Autocomplete  ([#11408](https://github.com/linode/manager/pull/11408))
- Update mock region for LKE cluster creation test ([#11411](https://github.com/linode/manager/pull/11411))
- Cypress tests to validate errors in Linode Create Backups tab ([#11422](https://github.com/linode/manager/pull/11422))
- Cypress test to validate aria label of Linode IP Addresses action menu ([#11435](https://github.com/linode/manager/pull/11435))
- Cypress test to validate CAA records are editable ([#11440](https://github.com/linode/manager/pull/11440))
- Add test for LKE cluster rename flow ([#11444](https://github.com/linode/manager/pull/11444))
- Add unit tests to validate aria-labels of Action Menu for Linode IPs & ranges ([#11448](https://github.com/linode/manager/pull/11448))
- Add Cypress tests confirming Lionde Config Unrecommended status displays as expected in VPC Subnet table ([#11450](https://github.com/linode/manager/pull/11450))
- Add Cypress test for LKE node pool tagging ([#11368](https://github.com/linode/manager/pull/11368))
- Add coverage for Kube version upgrades in landing page ([#11478](https://github.com/linode/manager/pull/11478))
- Fix Cypress test failures stemming from Debian 10 Image deprecation ([#11486](https://github.com/linode/manager/pull/11486))
- Added Cypress test for restricted user Image non-Empty landing page ([#11335](https://github.com/linode/manager/pull/11335))

### Upcoming Features:

- Update Kubernetes Versions in Create Cluster flow to support tiers for LKE-E ([#11359](https://github.com/linode/manager/pull/11359))
- Switch from v4beta to v4 account endpoint for LKE-E ([#11413](https://github.com/linode/manager/pull/11413))
- Update Kubernetes version upgrade components for LKE-E ([#11415](https://github.com/linode/manager/pull/11415))
- Display LKE-E pricing in checkout bar ([#11419](https://github.com/linode/manager/pull/11419))
- Designate LKE-E clusters with 'Enterprise' chip ([#11442](https://github.com/linode/manager/pull/11442))
- Update LKE cluster details kube specs for LKE-E monthly pricing ([#11475](https://github.com/linode/manager/pull/11475))
- Add new users table component for IAM ([#11367](https://github.com/linode/manager/pull/11367))
- Add new user details components for IAM ([#11397](https://github.com/linode/manager/pull/11397))
- High performance volume indicator ([#11400](https://github.com/linode/manager/pull/11400))
- Add new no assigned roles component for IAM ([#11401](https://github.com/linode/manager/pull/11401))
- Fix invalid routes in the IAM ([#11436](https://github.com/linode/manager/pull/11436))
- Initial support for NodeBalancer UDP protocol  ([#11405](https://github.com/linode/manager/pull/11405))
- Add support for new optional filter - 'Tags' in monitor ([#11457](https://github.com/linode/manager/pull/11457))
- Show ACLP supported regions per service type in region select ([#11382](https://github.com/linode/manager/pull/11382))
- Add `CloudPulseAppliedFilter` and `CloudPulseAppliedFilterRenderer` components, update filter change handler function to add another parameter `label` ([#11354](https://github.com/linode/manager/pull/11354))
- Add column for actions to Cloud Pulse alert definitions listing view and scaffolding for Definition Details page ([#11399](https://github.com/linode/manager/pull/11399))
- Exhaustive unit tests for CloudPulse widgets ([#11464](https://github.com/linode/manager/pull/11464))
- Add Alert Details Overview section in Cloud Pulse Alert Details page ([#11466](https://github.com/linode/manager/pull/11466))
- Improve Close Account Dialog UI ([#11469](https://github.com/linode/manager/pull/11469))