### PR TITLE
feat: [M3-8494] - Volume grouping by tag added.

### DIFF
--- a/packages/manager/.changeset/pr-11498-added-1736438563619.md
+++ b/packages/manager/.changeset/pr-11498-added-1736438563619.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Grouping by tags for the Volumes table ([#11498](https://github.com/linode/manager/pull/11498))

--- a/packages/manager/cypress/e2e/core/volumes/group-volumes-by-tag.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/group-volumes-by-tag.spec.ts
@@ -1,0 +1,54 @@
+import { ui } from 'support/ui';
+import { cleanUp } from 'support/util/cleanup';
+import { chooseRegion } from 'support/util/regions';
+import { randomLabel } from 'support/util/random';
+import { volumeRequestPayloadFactory } from 'src/factories';
+import { createVolume } from '@linode/api-v4';
+import { authenticate } from 'support/api/authentication';
+import { apiMatcher } from 'support/util/intercepts';
+
+const tags = new Array(2).fill(0).map(() => randomLabel(3));
+
+function createVolumesForTest() {
+  const mockVolumeRequests = new Array(5).fill(0).map((_, idx) => {
+    const volumeRequest = volumeRequestPayloadFactory.build({
+      label: randomLabel(),
+      region: chooseRegion().id,
+      tags: idx !== 4 ? [tags[idx % 2]] : [],
+    });
+
+    return createVolume(volumeRequest);
+  });
+
+  return Promise.all(mockVolumeRequests);
+}
+
+authenticate();
+describe('Group Volumes by tag', () => {
+  before(() => {
+    cleanUp(['volumes', 'linodes']);
+  });
+
+  it('should group volumes by tag', () => {
+    cy.defer(() => createVolumesForTest(), 'creating volumes').then(() => {
+      cy.visitWithLogin('/volumes');
+
+      ui.button.findByAttribute('data-testid', 'group-by-tag').click();
+
+      cy.intercept('PUT', apiMatcher('profile/preferences'), (req) => {
+        expect(req.body.volumes_group_by_tag).to.be.true;
+        req.continue((res) => res.body);
+      });
+
+      tags.forEach((tag) => {
+        cy.findByText(tag).should('be.visible');
+      });
+
+      cy.findByText('No Tags').should('be.visible');
+    });
+  });
+
+  after(() => {
+    cleanUp(['volumes', 'linodes']);
+  });
+});

--- a/packages/manager/src/components/GroupByTagToggle.tsx
+++ b/packages/manager/src/components/GroupByTagToggle.tsx
@@ -29,6 +29,7 @@ export const GroupByTagToggle = React.memo((props: GroupByTagToggleProps) => {
         <StyledToggleButton
           aria-describedby={groupByDescriptionId}
           aria-label={`Toggle group by tag`}
+          data-testid="group-by-tag"
           disableRipple
           // See https://github.com/linode/manager/pull/6653 for more details
           disabled={isLargeAccount}

--- a/packages/manager/src/features/Volumes/VolumesActionMenu.test.tsx
+++ b/packages/manager/src/features/Volumes/VolumesActionMenu.test.tsx
@@ -38,7 +38,7 @@ describe('Volume action menu', () => {
 
     await userEvent.click(actionMenuButton);
 
-    for (const action of ['Show Config', 'Edit']) {
+    for (const action of ['Show Config', 'Edit', 'Manage Tags', 'Resize']) {
       expect(getByText(action)).toBeVisible();
     }
   });

--- a/packages/manager/src/features/Volumes/VolumesHeader.tsx
+++ b/packages/manager/src/features/Volumes/VolumesHeader.tsx
@@ -1,0 +1,99 @@
+import {
+  CircleProgress,
+  IconButton,
+  InputAdornment,
+  TextField,
+} from '@linode/ui';
+import CloseIcon from '@mui/icons-material/Close';
+import { useNavigate } from '@tanstack/react-router';
+import * as React from 'react';
+import { debounce } from 'throttle-debounce';
+
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import { LandingHeader } from 'src/components/LandingHeader';
+import { getRestrictedResourceText } from 'src/features/Account/utils';
+import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
+
+interface Params {
+  isFetching: boolean;
+  searchQueryKey?: string;
+}
+
+export function VolumesHeader({ isFetching, searchQueryKey }: Params) {
+  const navigate = useNavigate();
+
+  const isRestricted = useRestrictedGlobalGrantCheck({
+    globalGrantType: 'add_volumes',
+  });
+
+  const resetSearch = () => {
+    navigate({
+      search: (prev) => ({
+        ...prev,
+        query: undefined,
+      }),
+      to: '/volumes',
+    });
+  };
+
+  const onSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+    navigate({
+      search: (prev) => ({
+        ...prev,
+        page: undefined,
+        query: e.target.value || undefined,
+      }),
+      to: '/volumes',
+    });
+  };
+
+  return (
+    <>
+      <DocumentTitleSegment segment="Volumes" />
+      <LandingHeader
+        breadcrumbProps={{
+          pathname: 'Volumes',
+          removeCrumbX: 1,
+        }}
+        buttonDataAttrs={{
+          tooltipText: getRestrictedResourceText({
+            action: 'create',
+            isSingular: false,
+            resourceType: 'Volumes',
+          }),
+        }}
+        disabledCreateButton={isRestricted}
+        docsLink="https://techdocs.akamai.com/cloud-computing/docs/block-storage"
+        entity="Volume"
+        onButtonClick={() => navigate({ to: '/volumes/create' })}
+        title="Volumes"
+      />
+      <TextField
+        InputProps={{
+          endAdornment: searchQueryKey && (
+            <InputAdornment position="end">
+              {isFetching && <CircleProgress size="sm" />}
+
+              <IconButton
+                aria-label="Clear"
+                data-testid="clear-volumes-search"
+                onClick={resetSearch}
+                size="small"
+              >
+                <CloseIcon />
+              </IconButton>
+            </InputAdornment>
+          ),
+        }}
+        onChange={debounce(400, (e) => {
+          onSearch(e);
+        })}
+        hideLabel
+        label="Search"
+        placeholder="Search Volumes"
+        sx={{ mb: 2 }}
+        value={searchQueryKey ?? ''}
+      />
+    </>
+  );
+}

--- a/packages/manager/src/features/Volumes/VolumesHeader.tsx
+++ b/packages/manager/src/features/Volumes/VolumesHeader.tsx
@@ -19,7 +19,7 @@ interface Params {
   searchQueryKey?: string;
 }
 
-export function VolumesHeader({ isFetching, searchQueryKey }: Params) {
+export const VolumesHeader = ({ isFetching, searchQueryKey }: Params) => {
   const navigate = useNavigate();
 
   const isRestricted = useRestrictedGlobalGrantCheck({
@@ -96,4 +96,4 @@ export function VolumesHeader({ isFetching, searchQueryKey }: Params) {
       />
     </>
   );
-}
+};

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -3,7 +3,6 @@ import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
 import * as React from 'react';
 
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
-import { PreferenceToggle } from 'src/components/PreferenceToggle/PreferenceToggle';
 import { useDialogData } from 'src/hooks/useDialogData';
 import { useOrderV2 } from 'src/hooks/useOrderV2';
 import { usePaginationV2 } from 'src/hooks/usePaginationV2';
@@ -13,7 +12,6 @@ import {
   VOLUME_TABLE_DEFAULT_ORDER,
   VOLUME_TABLE_DEFAULT_ORDER_BY,
 } from 'src/routes/volumes/constants';
-import { sendGroupByTagEnabledEvent } from 'src/utilities/analytics/customEventAnalytics';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 import { DeleteVolumeDialog } from './Dialogs/DeleteVolumeDialog';
@@ -112,28 +110,13 @@ export const VolumesLanding = () => {
     <>
       <VolumesHeader isFetching={isFetching} searchQueryKey={query} />
 
-      <PreferenceToggle
-        preferenceKey="volumes_group_by_tag"
-        preferenceOptions={[false, true]}
-        toggleCallbackFn={sendGroupByAnalytic}
-      >
-        {({
-          preference: volumesAreGrouped,
-          togglePreference: toggleGroupVolumes,
-        }) => {
-          return (
-            <VolumesTable
-              handleOrderChange={handleOrderChange}
-              order={order}
-              orderBy={orderBy}
-              pagination={pagination}
-              toggleGroupVolumes={toggleGroupVolumes}
-              volumes={volumes}
-              volumesAreGrouped={volumesAreGrouped}
-            />
-          );
-        }}
-      </PreferenceToggle>
+      <VolumesTable
+        handleOrderChange={handleOrderChange}
+        order={order}
+        orderBy={orderBy}
+        pagination={pagination}
+        volumes={volumes}
+      />
 
       <AttachVolumeDrawer
         isFetching={isFetchingVolume}
@@ -192,9 +175,3 @@ export const VolumesLanding = () => {
     </>
   );
 };
-
-const sendGroupByAnalytic = (value: boolean) => {
-  sendGroupByTagEnabledEvent('volumes landing', value);
-};
-
-export default VolumesLanding;

--- a/packages/manager/src/features/Volumes/VolumesTable.tsx
+++ b/packages/manager/src/features/Volumes/VolumesTable.tsx
@@ -1,0 +1,184 @@
+import { useNavigate } from '@tanstack/react-router';
+import * as React from 'react';
+
+import { useIsBlockStorageEncryptionFeatureEnabled } from 'src/components/Encryption/utils';
+import { GroupByTagToggle } from 'src/components/GroupByTagToggle';
+import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFooter';
+import { Table } from 'src/components/Table';
+import { TableBody } from 'src/components/TableBody';
+import { TableCell } from 'src/components/TableCell';
+import { TableHead } from 'src/components/TableHead';
+import { TableRow } from 'src/components/TableRow';
+import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
+import { TableSortCell } from 'src/components/TableSortCell';
+
+import {
+  StyledTagHeader,
+  StyledTagHeaderRow,
+} from '../Linodes/LinodesLanding/DisplayLinodes.styles';
+import { VolumeTableRow } from './VolumeTableRow';
+
+import type { ResourcePage, Volume } from '@linode/api-v4';
+import type { PaginationProps } from 'src/hooks/usePagination';
+import type { VolumeAction } from 'src/routes/volumes';
+
+interface Props {
+  handleOrderChange: any;
+  order: 'asc' | 'desc';
+  orderBy: string;
+  pagination: PaginationProps;
+  toggleGroupVolumes: () => boolean;
+  volumes: ResourcePage<Volume> | undefined;
+  volumesAreGrouped: boolean;
+}
+
+export function VolumesTable({
+  handleOrderChange,
+  order,
+  orderBy,
+  pagination,
+  toggleGroupVolumes,
+  volumes,
+  volumesAreGrouped,
+}: Props) {
+  const {
+    isBlockStorageEncryptionFeatureEnabled,
+  } = useIsBlockStorageEncryptionFeatureEnabled();
+
+  const navigate = useNavigate();
+
+  const handleAction = (volume: Volume, action: VolumeAction) => {
+    navigate({
+      params: { action, volumeId: volume.id },
+      search: (prev) => prev,
+      to: `/volumes/$volumeId/$action`,
+    });
+  };
+
+  const getVolumeTableRow = (volume: Volume) => {
+    return (
+      <VolumeTableRow
+        handlers={{
+          handleAttach: () => handleAction(volume, 'attach'),
+          handleClone: () => handleAction(volume, 'clone'),
+          handleDelete: () => handleAction(volume, 'delete'),
+          handleDetach: () => handleAction(volume, 'detach'),
+          handleDetails: () => handleAction(volume, 'details'),
+          handleEdit: () => handleAction(volume, 'edit'),
+          handleManageTags: () => handleAction(volume, 'manage-tags'),
+          handleResize: () => handleAction(volume, 'resize'),
+          handleUpgrade: () => handleAction(volume, 'upgrade'),
+        }}
+        isBlockStorageEncryptionFeatureEnabled={
+          isBlockStorageEncryptionFeatureEnabled
+        }
+        key={volume.id}
+        volume={volume}
+      />
+    );
+  };
+
+  const getUngroupedVolumes = () => {
+    return volumes?.data.map((volume) => getVolumeTableRow(volume));
+  };
+
+  const getGroupedVolumes = () => {
+    const tags = Array.from(
+      new Set(volumes?.data.flatMap((volume) => volume.tags))
+    );
+
+    const volumesWithNoTags = volumes?.data.filter(
+      (volume) => !volume.tags.length
+    );
+
+    return (
+      <>
+        {volumesWithNoTags?.length && getTagHeaderRow('No Tags')}
+        {volumesWithNoTags?.map((volume) => getVolumeTableRow(volume))}
+
+        {tags?.map((tag, index) => (
+          <React.Fragment key={index}>
+            {getTagHeaderRow(tag)}
+
+            {volumes?.data
+              .filter((volume) => volume.tags.includes(tag))
+              .map((volume) => getVolumeTableRow(volume))}
+          </React.Fragment>
+        ))}
+      </>
+    );
+  };
+
+  const getTagHeaderRow = (tag: string) => {
+    return (
+      <StyledTagHeaderRow data-qa-tag-header={tag}>
+        <TableCell colSpan={7}>
+          <StyledTagHeader variant="h2">{tag}</StyledTagHeader>
+        </TableCell>
+      </StyledTagHeaderRow>
+    );
+  };
+
+  return (
+    <>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableSortCell
+              active={orderBy === 'label'}
+              direction={order}
+              handleClick={handleOrderChange}
+              label="label"
+            >
+              Label
+            </TableSortCell>
+            <TableSortCell
+              active={orderBy === 'status'}
+              direction={order}
+              handleClick={handleOrderChange}
+              label="status"
+            >
+              Status
+            </TableSortCell>
+            <TableCell>Region</TableCell>
+            <TableSortCell
+              active={orderBy === 'size'}
+              direction={order}
+              handleClick={handleOrderChange}
+              label="size"
+            >
+              Size
+            </TableSortCell>
+            <TableCell>Attached To</TableCell>
+            {isBlockStorageEncryptionFeatureEnabled && (
+              <TableCell>Encryption</TableCell>
+            )}
+            <TableCell sx={{ padding: '0 !important', textAlign: 'right' }}>
+              <GroupByTagToggle
+                isGroupedByTag={volumesAreGrouped}
+                toggleGroupByTag={toggleGroupVolumes}
+              />
+            </TableCell>
+          </TableRow>
+        </TableHead>
+
+        <TableBody>
+          {volumes?.data.length === 0 && (
+            <TableRowEmpty colSpan={6} message="No volume found" />
+          )}
+
+          {volumesAreGrouped ? getGroupedVolumes() : getUngroupedVolumes()}
+        </TableBody>
+      </Table>
+
+      <PaginationFooter
+        count={volumes?.results ?? 0}
+        eventCategory="Volumes Table"
+        handlePageChange={pagination.handlePageChange}
+        handleSizeChange={pagination.handlePageSizeChange}
+        page={pagination.page}
+        pageSize={pagination.pageSize}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Description 📝

Added "Group by tag" functionality to the Volumes table.

## Changes  🔄

- Added "Group by tag" button
- Volumes header moved into a separate component.
- Volumes table moved into a separate component.
- Preferences toggle added for `volumes_group_by_tag` profile property.
- Created `group-volumes-by-tag.spec.ts`

## Preview 📷

![image](https://github.com/user-attachments/assets/b700f4b5-d718-44ce-9464-361da63439d2)

## How to test 🧪

- Create several volumes for testing.
- Go to Volume -> Action Menu -> Manage Tags.
- Add some tags to each testing volume.
- Press group by tag button.
- Observe "profile/preferences" PUT request.
- Observe the Volumes table.

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules