### PR TITLE
fix: Preferences type_to_confirm being undefined no longer causes button to be disabled

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -7,7 +7,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [2025-01-14] - v1.134.0
 
 ### Added:
-
 - New DatePicker Component ([#11151](https://github.com/linode/manager/pull/11151))
 - Date Presets Functionality to Date Picker component ([#11395](https://github.com/linode/manager/pull/11395))
 - Notice for OS Distro Nearing EOL/EOS ([#11253](https://github.com/linode/manager/pull/11253))
@@ -27,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed:
 
+- Preferences type_to_confirm being undefined no longer causes button to be disabled
 - Create support ticket for buckets created through legacy flow ([#11300](https://github.com/linode/manager/pull/11300))
 - Incorrect Cloning Commands in Linode CLI Modal ([#11303](https://github.com/linode/manager/pull/11303))
 - Events landing page lists events in wrong order ([#11339](https://github.com/linode/manager/pull/11339))

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [2025-01-14] - v1.134.0
 
 ### Added:
+
 - New DatePicker Component ([#11151](https://github.com/linode/manager/pull/11151))
 - Date Presets Functionality to Date Picker component ([#11395](https://github.com/linode/manager/pull/11395))
 - Notice for OS Distro Nearing EOL/EOS ([#11253](https://github.com/linode/manager/pull/11253))
@@ -26,7 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed:
 
-- Preferences type_to_confirm being undefined no longer causes button to be disabled
+- Preferences type_to_confirm being undefined no longer causes button to be disabled ([#11499](https://github.com/linode/manager/pull/11499))
 - Create support ticket for buckets created through legacy flow ([#11300](https://github.com/linode/manager/pull/11300))
 - Incorrect Cloning Commands in Linode CLI Modal ([#11303](https://github.com/linode/manager/pull/11303))
 - Events landing page lists events in wrong order ([#11339](https://github.com/linode/manager/pull/11339))

--- a/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
+++ b/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
@@ -43,13 +43,13 @@ export const DeletionDialog = React.memo((props: DeletionDialogProps) => {
   } = props;
 
   const { data: typeToConfirmPreference } = usePreferences(
-    (preferences) => preferences?.type_to_confirm
+    (preferences) => preferences?.type_to_confirm ?? true
   );
 
   const [confirmationText, setConfirmationText] = React.useState('');
 
   const typeToConfirmRequired =
-    typeToConfirm && typeToConfirmPreference !== false;
+    typeToConfirm && Boolean(typeToConfirmPreference);
 
   const renderActions = () => (
     <ActionsPanel

--- a/packages/manager/src/components/TypeToConfirm/TypeToConfirm.tsx
+++ b/packages/manager/src/components/TypeToConfirm/TypeToConfirm.tsx
@@ -3,10 +3,11 @@ import * as React from 'react';
 
 import { FormGroup } from 'src/components/FormGroup';
 import { Link } from 'src/components/Link';
+import { usePreferences } from 'src/queries/profile/preferences';
 
 import type { TextFieldProps } from '@linode/ui';
-import type { Theme } from '@mui/material';
 import type { SxProps } from '@mui/material';
+import type { Theme } from '@mui/material';
 
 export interface TypeToConfirmProps extends Omit<TextFieldProps, 'onChange'> {
   confirmationText?: JSX.Element | string;
@@ -36,18 +37,25 @@ export const TypeToConfirm = (props: TypeToConfirmProps) => {
     title,
     typographyStyle,
     typographyStyleSx,
-    visible,
+    visible = false,
     ...rest
   } = props;
 
+  const { data: typeToConfirmPreference } = usePreferences(
+    (preferences) => preferences?.type_to_confirm ?? true
+  );
+
   /*
-    There was an edge case bug where, when preferences?.type_to_confirm was undefined,
-    the type-to-confirm input did not appear and the language in the instruction text
-    did not match. If 'visible' is not explicitly false, we treat it as true.
+    There is an edge case where preferences?.type_to_confirm is undefined
+    when the user has not yet set a preference as seen in /profile/settings?preferenceEditor=true.
+    Therefore, the 'visible' prop defaults to true unless explicitly set to false, ensuring this feature is enabled by default.
   */
 
-  const showTypeToConfirmInput = visible !== false;
-  const disableOrEnable = showTypeToConfirmInput ? 'disable' : 'enable';
+  const showTypeToConfirmInput = Boolean(visible);
+  const disableOrEnable =
+    showTypeToConfirmInput || Boolean(typeToConfirmPreference)
+      ? 'disable'
+      : 'enable';
 
   return (
     <>

--- a/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
+++ b/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
@@ -128,12 +128,12 @@ export const TypeToConfirmDialog = (props: CombinedProps) => {
   };
 
   const { data: typeToConfirmPreference } = usePreferences(
-    (preferences) => preferences?.type_to_confirm
+    (preferences) => preferences?.type_to_confirm ?? true
   );
 
   const isCloseAccount = entity.subType === 'CloseAccount';
   const isTypeToConfirmEnabled =
-    typeToConfirmPreference !== false || isCloseAccount;
+    Boolean(typeToConfirmPreference) || isCloseAccount;
   const isTextConfirmationValid =
     confirmationValues.confirmText === entity.name;
   const isCloseAccountValid =

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -84,7 +84,7 @@ export const RebuildFromImage = (props: Props) => {
   const {
     data: typeToConfirmPreference,
     isLoading: isLoadingPreferences,
-  } = usePreferences((preferences) => preferences?.type_to_confirm);
+  } = usePreferences((preferences) => preferences?.type_to_confirm ?? true);
 
   const { checkForNewEvents } = useEventsPollingActions();
 
@@ -126,7 +126,7 @@ export const RebuildFromImage = (props: Props) => {
   }, [shouldReuseUserData]);
 
   const submitButtonDisabled =
-    typeToConfirmPreference !== false && confirmationText !== linodeLabel;
+    Boolean(typeToConfirmPreference) && confirmationText !== linodeLabel;
 
   const handleFormSubmit = (
     { authorized_users, image, root_pass }: RebuildFromImageForm,

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
@@ -86,7 +86,7 @@ export const RebuildFromStackScript = (props: Props) => {
   const {
     data: typeToConfirmPreference,
     isLoading: isLoadingPreferences,
-  } = usePreferences((preferences) => preferences?.type_to_confirm);
+  } = usePreferences((preferences) => preferences?.type_to_confirm ?? true);
 
   const { checkForNewEvents } = useEventsPollingActions();
 
@@ -107,7 +107,7 @@ export const RebuildFromStackScript = (props: Props) => {
 
   const [confirmationText, setConfirmationText] = React.useState<string>('');
   const submitButtonDisabled =
-    typeToConfirmPreference !== false && confirmationText !== linodeLabel;
+    Boolean(typeToConfirmPreference) && confirmationText !== linodeLabel;
 
   const [
     ss,

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -74,7 +74,7 @@ export const LinodeResize = (props: Props) => {
   const { data: types } = useAllTypes(open);
 
   const { data: typeToConfirmPreference } = usePreferences(
-    (preferences) => preferences?.type_to_confirm,
+    (preferences) => preferences?.type_to_confirm ?? true,
     open
   );
 
@@ -167,7 +167,7 @@ export const LinodeResize = (props: Props) => {
   const tableDisabled = hostMaintenance || isLinodesGrantReadOnly;
 
   const submitButtonDisabled =
-    typeToConfirmPreference !== false && confirmationText !== linode?.label;
+    Boolean(typeToConfirmPreference) && confirmationText !== linode?.label;
 
   const type = types?.find((t) => t.id === linode?.type);
 

--- a/packages/manager/src/features/Profile/Settings/TypeToConfirm.tsx
+++ b/packages/manager/src/features/Profile/Settings/TypeToConfirm.tsx
@@ -7,16 +7,12 @@ import {
 } from 'src/queries/profile/preferences';
 
 export const TypeToConfirm = () => {
+  // Type-to-confirm is enabled by default when no preference is set.
   const { data: typeToConfirmPreference, isLoading } = usePreferences(
-    (preferences) => preferences?.type_to_confirm
+    (preferences) => preferences?.type_to_confirm ?? true
   );
 
   const { mutateAsync: updatePreferences } = useMutatePreferences();
-
-  // Type-to-confirm is enabled by default (no preference is set)
-  // or if the user explicitly enables it.
-  const isTypeToConfirmEnabled =
-    typeToConfirmPreference === undefined || typeToConfirmPreference === true;
 
   return (
     <Paper>
@@ -33,11 +29,11 @@ export const TypeToConfirm = () => {
             onChange={(_, checked) =>
               updatePreferences({ type_to_confirm: checked })
             }
-            checked={isTypeToConfirmEnabled}
+            checked={typeToConfirmPreference}
           />
         }
         label={`Type-to-confirm is ${
-          isTypeToConfirmEnabled ? 'enabled' : 'disabled'
+          typeToConfirmPreference ? 'enabled' : 'disabled'
         }`}
         disabled={isLoading}
       />


### PR DESCRIPTION
## Description 📝
There is an edge case where `preferences?.type_to_confirm` is `undefined` when the user has not yet set a preference as seen in `/profile/settings?preferenceEditor=true`. 

## Changes  🔄
- Ensure that `preferences?.type_to_confirm` resolves to a boolean value (default true)

## Target release date 🗓️
01/14

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![localhost_3000_linodes (1)](https://github.com/user-attachments/assets/d8523b48-ce45-45cf-a033-fc943742d0e2) | ![localhost_3000_linodes (2)](https://github.com/user-attachments/assets/0dbec815-3cdd-4e03-9dc3-5a65e1b3b182) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- ...
- ...

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

---

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

---
