### PR TITLE
fix: Preferences type_to_confirm being undefined no longer causes button to be disabled

### DIFF
--- a/packages/manager/.changeset/pr-11500-fixed-1736439852730.md
+++ b/packages/manager/.changeset/pr-11500-fixed-1736439852730.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Preferences type_to_confirm being undefined no longer causes button to be disabled ([#11500](https://github.com/linode/manager/pull/11500))

--- a/packages/manager/.changeset/pr-11500-fixed-1736439852730.md
+++ b/packages/manager/.changeset/pr-11500-fixed-1736439852730.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Preferences type_to_confirm being undefined no longer causes button to be disabled ([#11500](https://github.com/linode/manager/pull/11500))

--- a/packages/manager/src/components/DeletionDialog/DeletionDialog.stories.tsx
+++ b/packages/manager/src/components/DeletionDialog/DeletionDialog.stories.tsx
@@ -33,9 +33,6 @@ const meta: Meta<typeof DeletionDialog> = {
     open: {
       description: 'Is the modal open?',
     },
-    typeToConfirm: {
-      description: `Whether or not a user is required to type the enity's label to delete.`,
-    },
   },
   args: {
     disableAutoFocus: true,
@@ -52,7 +49,6 @@ const meta: Meta<typeof DeletionDialog> = {
     onDelete: action('onDelete'),
     open: true,
     style: { position: 'unset' },
-    typeToConfirm: true,
   },
   component: DeletionDialog,
   title: 'Components/Dialog/DeletionDialog',

--- a/packages/manager/src/components/DeletionDialog/DeletionDialog.test.tsx
+++ b/packages/manager/src/components/DeletionDialog/DeletionDialog.test.tsx
@@ -6,6 +6,25 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 import { DeletionDialog } from './DeletionDialog';
 
 import type { DeletionDialogProps } from './DeletionDialog';
+import type { ManagerPreferences } from 'src/types/ManagerPreferences';
+
+const preference: ManagerPreferences['type_to_confirm'] = true;
+
+const queryMocks = vi.hoisted(() => ({
+  usePreferences: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('src/queries/profile/preferences', async () => {
+  const actual = await vi.importActual('src/queries/profile/preferences');
+  return {
+    ...actual,
+    usePreferences: queryMocks.usePreferences,
+  };
+});
+
+queryMocks.usePreferences.mockReturnValue({
+  data: preference,
+});
 
 describe('DeletionDialog', () => {
   const defaultArgs: DeletionDialogProps = {
@@ -128,6 +147,10 @@ describe('DeletionDialog', () => {
   ])(
     'should %s input field with label when typeToConfirm is %s',
     (_, typeToConfirm) => {
+      queryMocks.usePreferences.mockReturnValue({
+        data: preference,
+      });
+
       const { queryByTestId } = renderWithTheme(
         <DeletionDialog
           {...defaultArgs}

--- a/packages/manager/src/components/DeletionDialog/DeletionDialog.test.tsx
+++ b/packages/manager/src/components/DeletionDialog/DeletionDialog.test.tsx
@@ -91,12 +91,21 @@ describe('DeletionDialog', () => {
   });
 
   it('should call onDelete when the DeletionDialog delete button is clicked', () => {
+    queryMocks.usePreferences.mockReturnValue({
+      data: preference,
+    });
     const { getByTestId } = renderWithTheme(
       <DeletionDialog {...defaultArgs} open={true} />
     );
 
     const deleteButton = getByTestId('confirm');
-    expect(deleteButton).not.toBeDisabled();
+    expect(deleteButton).toBeDisabled();
+
+    const input = getByTestId('textfield-input');
+    fireEvent.change(input, { target: { value: defaultArgs.label } });
+
+    expect(deleteButton).toBeEnabled();
+
     fireEvent.click(deleteButton);
 
     expect(defaultArgs.onDelete).toHaveBeenCalled();
@@ -148,15 +157,11 @@ describe('DeletionDialog', () => {
     'should %s input field with label when typeToConfirm is %s',
     (_, typeToConfirm) => {
       queryMocks.usePreferences.mockReturnValue({
-        data: preference,
+        data: typeToConfirm,
       });
 
       const { queryByTestId } = renderWithTheme(
-        <DeletionDialog
-          {...defaultArgs}
-          open={true}
-          typeToConfirm={typeToConfirm}
-        />
+        <DeletionDialog {...defaultArgs} open={true} />
       );
 
       if (typeToConfirm) {

--- a/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
+++ b/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
@@ -49,7 +49,7 @@ export const DeletionDialog = React.memo((props: DeletionDialogProps) => {
   const [confirmationText, setConfirmationText] = React.useState('');
 
   const typeToConfirmRequired =
-    typeToConfirm && Boolean(typeToConfirmPreference);
+    typeToConfirm || Boolean(typeToConfirmPreference);
 
   const renderActions = () => (
     <ActionsPanel

--- a/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
+++ b/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
@@ -43,13 +43,13 @@ export const DeletionDialog = React.memo((props: DeletionDialogProps) => {
   } = props;
 
   const { data: typeToConfirmPreference } = usePreferences(
-    (preferences) => preferences?.type_to_confirm
+    (preferences) => preferences?.type_to_confirm ?? true
   );
 
   const [confirmationText, setConfirmationText] = React.useState('');
 
   const typeToConfirmRequired =
-    typeToConfirm && typeToConfirmPreference !== false;
+    typeToConfirm && Boolean(typeToConfirmPreference);
 
   const renderActions = () => (
     <ActionsPanel

--- a/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
+++ b/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
@@ -19,15 +19,8 @@ export interface DeletionDialogProps extends Omit<DialogProps, 'title'> {
   onClose: () => void;
   onDelete: () => void;
   open: boolean;
-  typeToConfirm?: boolean;
 }
 
-/**
- * A Deletion Dialog is used for deleting entities such as Linodes, NodeBalancers, Volumes, or other entities.
- *
- * Require `typeToConfirm` when an action would have a significant negative impact if done in error, consider requiring the user to enter a unique identifier such as entity label before activating the action button.
- * If a user has opted out of type-to-confirm this will be ignored
- */
 export const DeletionDialog = React.memo((props: DeletionDialogProps) => {
   const theme = useTheme();
   const {
@@ -38,7 +31,6 @@ export const DeletionDialog = React.memo((props: DeletionDialogProps) => {
     onClose,
     onDelete,
     open,
-    typeToConfirm,
     ...rest
   } = props;
 
@@ -48,14 +40,12 @@ export const DeletionDialog = React.memo((props: DeletionDialogProps) => {
 
   const [confirmationText, setConfirmationText] = React.useState('');
 
-  const typeToConfirmRequired =
-    typeToConfirm || Boolean(typeToConfirmPreference);
-
   const renderActions = () => (
     <ActionsPanel
       primaryButtonProps={{
         'data-testid': 'confirm',
-        disabled: typeToConfirmRequired && confirmationText !== label,
+        disabled:
+          Boolean(typeToConfirmPreference) && confirmationText !== label,
         label: ` Delete ${titlecase(entity)}`,
         loading,
         onClick: onDelete,
@@ -111,7 +101,7 @@ export const DeletionDialog = React.memo((props: DeletionDialogProps) => {
         label={`${capitalize(entity)} Name:`}
         placeholder={label}
         value={confirmationText}
-        visible={typeToConfirmRequired}
+        visible={Boolean(typeToConfirmPreference)}
       />
     </ConfirmationDialog>
   );

--- a/packages/manager/src/components/TypeToConfirm/TypeToConfirm.test.tsx
+++ b/packages/manager/src/components/TypeToConfirm/TypeToConfirm.test.tsx
@@ -4,22 +4,62 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { TypeToConfirm } from './TypeToConfirm';
 
+import type { ManagerPreferences } from 'src/types/ManagerPreferences';
+
 const props = { onClick: vi.fn() };
+
+const preference: ManagerPreferences['type_to_confirm'] = true;
+
+const queryMocks = vi.hoisted(() => ({
+  usePreferences: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('src/queries/profile/preferences', async () => {
+  const actual = await vi.importActual('src/queries/profile/preferences');
+  return {
+    ...actual,
+    usePreferences: queryMocks.usePreferences,
+  };
+});
+
+queryMocks.usePreferences.mockReturnValue({
+  data: preference,
+});
 
 describe('TypeToConfirm Component', () => {
   const labelText = 'Label';
 
-  it('Should have a label', () => {
-    const { getByText } = renderWithTheme(
+  it('Should not show label when visible prop not provided', () => {
+    const { queryByText } = renderWithTheme(
       <TypeToConfirm label={labelText} onChange={vi.fn()} {...props} />
+    );
+    expect(queryByText(labelText)).not.toBeInTheDocument();
+  });
+
+  it('Should not show input when visible prop not provided', () => {
+    const { queryByLabelText } = renderWithTheme(
+      <TypeToConfirm label={labelText} onChange={vi.fn()} {...props} />
+    );
+    expect(queryByLabelText(labelText)).not.toBeInTheDocument();
+  });
+
+  it('Should display label when visible is true', () => {
+    queryMocks.usePreferences.mockReturnValue({
+      data: preference,
+    });
+    const { getByText } = renderWithTheme(
+      <TypeToConfirm label={labelText} onChange={vi.fn()} {...props} visible />
     );
     const label = getByText(labelText);
     expect(label).toHaveTextContent(labelText);
   });
 
-  it('Should have a text input field associated with label', () => {
+  it('Should display input when visible is true', () => {
+    queryMocks.usePreferences.mockReturnValue({
+      data: preference,
+    });
     const { getByLabelText } = renderWithTheme(
-      <TypeToConfirm label={labelText} onChange={vi.fn()} {...props} />
+      <TypeToConfirm label={labelText} onChange={vi.fn()} {...props} visible />
     );
     const input = getByLabelText(labelText, { selector: 'input' });
     expect(input).toBeInTheDocument();

--- a/packages/manager/src/components/TypeToConfirm/TypeToConfirm.tsx
+++ b/packages/manager/src/components/TypeToConfirm/TypeToConfirm.tsx
@@ -3,10 +3,11 @@ import * as React from 'react';
 
 import { FormGroup } from 'src/components/FormGroup';
 import { Link } from 'src/components/Link';
+import { usePreferences } from 'src/queries/profile/preferences';
 
 import type { TextFieldProps } from '@linode/ui';
-import type { Theme } from '@mui/material';
 import type { SxProps } from '@mui/material';
+import type { Theme } from '@mui/material';
 
 export interface TypeToConfirmProps extends Omit<TextFieldProps, 'onChange'> {
   confirmationText?: JSX.Element | string;
@@ -36,18 +37,25 @@ export const TypeToConfirm = (props: TypeToConfirmProps) => {
     title,
     typographyStyle,
     typographyStyleSx,
-    visible,
+    visible = false,
     ...rest
   } = props;
 
+  const { data: typeToConfirmPreference } = usePreferences(
+    (preferences) => preferences?.type_to_confirm ?? true
+  );
+
   /*
-    There was an edge case bug where, when preferences?.type_to_confirm was undefined,
-    the type-to-confirm input did not appear and the language in the instruction text
-    did not match. If 'visible' is not explicitly false, we treat it as true.
+    There is an edge case where preferences?.type_to_confirm is undefined
+    when the user has not yet set a preference as seen in /profile/settings?preferenceEditor=true.
+    Therefore, the 'visible' prop defaults to true unless explicitly set to false, ensuring this feature is enabled by default.
   */
 
-  const showTypeToConfirmInput = visible !== false;
-  const disableOrEnable = showTypeToConfirmInput ? 'disable' : 'enable';
+  const showTypeToConfirmInput = Boolean(visible);
+  const disableOrEnable =
+    showTypeToConfirmInput || Boolean(typeToConfirmPreference)
+      ? 'disable'
+      : 'enable';
 
   return (
     <>

--- a/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
+++ b/packages/manager/src/components/TypeToConfirmDialog/TypeToConfirmDialog.tsx
@@ -128,12 +128,12 @@ export const TypeToConfirmDialog = (props: CombinedProps) => {
   };
 
   const { data: typeToConfirmPreference } = usePreferences(
-    (preferences) => preferences?.type_to_confirm
+    (preferences) => preferences?.type_to_confirm ?? true
   );
 
   const isCloseAccount = entity.subType === 'CloseAccount';
   const isTypeToConfirmEnabled =
-    typeToConfirmPreference !== false || isCloseAccount;
+    Boolean(typeToConfirmPreference) || isCloseAccount;
   const isTextConfirmationValid =
     confirmationValues.confirmText === entity.name;
   const isCloseAccountValid =

--- a/packages/manager/src/features/Domains/DeleteDomain.tsx
+++ b/packages/manager/src/features/Domains/DeleteDomain.tsx
@@ -54,7 +54,6 @@ export const DeleteDomain = (props: DeleteDomainProps) => {
         onClose={() => setOpen(false)}
         onDelete={onDelete}
         open={open}
-        typeToConfirm
       />
     </>
   );

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -360,7 +360,6 @@ export const DomainsLanding = (props: DomainsLandingProps) => {
         onClose={navigateToDomains}
         onDelete={removeDomain}
         open={params.action === 'delete'}
-        typeToConfirm
       />
     </>
   );

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -84,7 +84,7 @@ export const RebuildFromImage = (props: Props) => {
   const {
     data: typeToConfirmPreference,
     isLoading: isLoadingPreferences,
-  } = usePreferences((preferences) => preferences?.type_to_confirm);
+  } = usePreferences((preferences) => preferences?.type_to_confirm ?? true);
 
   const { checkForNewEvents } = useEventsPollingActions();
 
@@ -126,7 +126,7 @@ export const RebuildFromImage = (props: Props) => {
   }, [shouldReuseUserData]);
 
   const submitButtonDisabled =
-    typeToConfirmPreference !== false && confirmationText !== linodeLabel;
+    Boolean(typeToConfirmPreference) && confirmationText !== linodeLabel;
 
   const handleFormSubmit = (
     { authorized_users, image, root_pass }: RebuildFromImageForm,

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
@@ -86,7 +86,7 @@ export const RebuildFromStackScript = (props: Props) => {
   const {
     data: typeToConfirmPreference,
     isLoading: isLoadingPreferences,
-  } = usePreferences((preferences) => preferences?.type_to_confirm);
+  } = usePreferences((preferences) => preferences?.type_to_confirm ?? true);
 
   const { checkForNewEvents } = useEventsPollingActions();
 
@@ -107,7 +107,7 @@ export const RebuildFromStackScript = (props: Props) => {
 
   const [confirmationText, setConfirmationText] = React.useState<string>('');
   const submitButtonDisabled =
-    typeToConfirmPreference !== false && confirmationText !== linodeLabel;
+    Boolean(typeToConfirmPreference) && confirmationText !== linodeLabel;
 
   const [
     ss,

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -74,7 +74,7 @@ export const LinodeResize = (props: Props) => {
   const { data: types } = useAllTypes(open);
 
   const { data: typeToConfirmPreference } = usePreferences(
-    (preferences) => preferences?.type_to_confirm,
+    (preferences) => preferences?.type_to_confirm ?? true,
     open
   );
 
@@ -167,7 +167,7 @@ export const LinodeResize = (props: Props) => {
   const tableDisabled = hostMaintenance || isLinodesGrantReadOnly;
 
   const submitButtonDisabled =
-    typeToConfirmPreference !== false && confirmationText !== linode?.label;
+    Boolean(typeToConfirmPreference) && confirmationText !== linode?.label;
 
   const type = types?.find((t) => t.id === linode?.type);
 

--- a/packages/manager/src/features/Profile/Settings/TypeToConfirm.tsx
+++ b/packages/manager/src/features/Profile/Settings/TypeToConfirm.tsx
@@ -7,16 +7,12 @@ import {
 } from 'src/queries/profile/preferences';
 
 export const TypeToConfirm = () => {
+  // Type-to-confirm is enabled by default when no preference is set.
   const { data: typeToConfirmPreference, isLoading } = usePreferences(
-    (preferences) => preferences?.type_to_confirm
+    (preferences) => preferences?.type_to_confirm ?? true
   );
 
   const { mutateAsync: updatePreferences } = useMutatePreferences();
-
-  // Type-to-confirm is enabled by default (no preference is set)
-  // or if the user explicitly enables it.
-  const isTypeToConfirmEnabled =
-    typeToConfirmPreference === undefined || typeToConfirmPreference === true;
 
   return (
     <Paper>
@@ -33,11 +29,11 @@ export const TypeToConfirm = () => {
             onChange={(_, checked) =>
               updatePreferences({ type_to_confirm: checked })
             }
-            checked={isTypeToConfirmEnabled}
+            checked={typeToConfirmPreference}
           />
         }
         label={`Type-to-confirm is ${
-          isTypeToConfirmEnabled ? 'enabled' : 'disabled'
+          typeToConfirmPreference ? 'enabled' : 'disabled'
         }`}
         disabled={isLoading}
       />


### PR DESCRIPTION
## Description 📝
There is an edge case where `preferences?.type_to_confirm` is `undefined` when the user has not yet set a preference as seen in `/profile/settings?preferenceEditor=true`. 

## Changes  🔄
- Ensure that `preferences?.type_to_confirm` resolves to a boolean value (default true)

## Target release date 🗓️
01/14

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![localhost_3000_linodes (1)](https://github.com/user-attachments/assets/d8523b48-ce45-45cf-a033-fc943742d0e2) | ![localhost_3000_linodes (2)](https://github.com/user-attachments/assets/0dbec815-3cdd-4e03-9dc3-5a65e1b3b182) |

## How to test 🧪

### Prerequisites
- Removed `type_to_confirm` preference from /profile/settings?preferenceEditor=true

### Reproduction steps
- Observe the disabled button for linode deletion dialogs and others

### Verification steps
#### Step 1
- Removed `type_to_confirm` preference from /profile/settings?preferenceEditor=true
- Ensure type-to-confirm is enabled by default
- Check linode: delete, resize, rebuild
- Check domain: delete
- Check close account still works as intended
#### Step 2
- Disable type-to-confirm
- Check linode: delete, resize, rebuild
- Check domain: delete
- Check close account still works as intended

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>