### PR TITLE
test: Fix `DateTimeRangePicker` unit test failure

### DIFF
--- a/packages/manager/src/components/DatePicker/DateTimeRangePicker.test.tsx
+++ b/packages/manager/src/components/DatePicker/DateTimeRangePicker.test.tsx
@@ -27,14 +27,12 @@ const Props: DateTimeRangePickerProps = {
 };
 
 describe('DateTimeRangePicker Component', () => {
-  let fixedNow: DateTime;
-
   beforeEach(() => {
     // Mock DateTime.now to return a fixed datetime
-    fixedNow = DateTime.fromISO(
+    const fixedNow = DateTime.fromISO(
       '2024-12-18T00:28:27.071-06:00'
-    ) as DateTime<true>;
-    vi.spyOn(DateTime, 'now').mockImplementation(() => fixedNow);
+    ).toUTC() as DateTime<true>;
+    vi.setSystemTime(fixedNow.toJSDate());
   });
 
   afterEach(() => {
@@ -51,8 +49,7 @@ describe('DateTimeRangePicker Component', () => {
   });
 
   it('should call onChange when start date is changed', async () => {
-    const currentYear = new Date().getFullYear(); // Dynamically get the current year
-    const currentMonth = String(new Date().getMonth() + 1).padStart(2, '0'); // Get current month (1-based)
+    vi.setSystemTime(vi.getRealSystemTime());
 
     renderWithTheme(<DateTimeRangePicker onChange={onChangeMock} />);
 
@@ -62,11 +59,17 @@ describe('DateTimeRangePicker Component', () => {
     await userEvent.click(screen.getByRole('gridcell', { name: '10' }));
     await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
 
+    const expectedStartTime = DateTime.fromObject({
+      day: 10,
+      month: DateTime.now().month,
+      year: DateTime.now().year,
+    }).toISO();
+
     // Check if the onChange function is called with the expected  value
     expect(onChangeMock).toHaveBeenCalledWith({
       end: null,
       preset: 'custom_range',
-      start: `${currentYear}-${currentMonth}-10T00:00:00.000-06:00`,
+      start: expectedStartTime,
       timeZone: null,
     });
   });
@@ -164,8 +167,8 @@ describe('DateTimeRangePicker Component', () => {
     await userEvent.click(last24HoursOption);
 
     // Expected start and end dates in ISO format
-    const expectedStartDateISO = fixedNow.minus({ hours: 24 }).toISO(); // 2024-12-17T00:28:27.071-06:00
-    const expectedEndDateISO = fixedNow.toISO(); // 2024-12-18T00:28:27.071-06:00
+    const expectedStartDateISO = DateTime.now().minus({ hours: 24 }).toISO(); // 2024-12-17T00:28:27.071-06:00
+    const expectedEndDateISO = DateTime.now().toISO(); // 2024-12-18T00:28:27.071-06:00
 
     // Verify onChangeMock was called with correct ISO strings
     expect(onChangeMock).toHaveBeenCalledWith({
@@ -191,8 +194,8 @@ describe('DateTimeRangePicker Component', () => {
     await userEvent.click(last7DaysOption);
 
     // Expected start and end dates in ISO format
-    const expectedStartDateISO = fixedNow.minus({ days: 7 }).toISO();
-    const expectedEndDateISO = fixedNow.toISO();
+    const expectedStartDateISO = DateTime.now().minus({ days: 7 }).toISO();
+    const expectedEndDateISO = DateTime.now().toISO();
 
     // Verify that onChange is called with the correct date range
     expect(onChangeMock).toHaveBeenCalledWith({
@@ -218,8 +221,8 @@ describe('DateTimeRangePicker Component', () => {
     await userEvent.click(last30DaysOption);
 
     // Expected start and end dates in ISO format
-    const expectedStartDateISO = fixedNow.minus({ days: 30 }).toISO();
-    const expectedEndDateISO = fixedNow.toISO();
+    const expectedStartDateISO = DateTime.now().minus({ days: 30 }).toISO();
+    const expectedEndDateISO = DateTime.now().toISO();
 
     // Verify that onChange is called with the correct date range
     expect(onChangeMock).toHaveBeenCalledWith({
@@ -245,8 +248,8 @@ describe('DateTimeRangePicker Component', () => {
     await userEvent.click(thisMonthOption);
 
     // Expected start and end dates in ISO format
-    const expectedStartDateISO = fixedNow.startOf('month').toISO();
-    const expectedEndDateISO = fixedNow.endOf('month').toISO();
+    const expectedStartDateISO = DateTime.now().startOf('month').toISO();
+    const expectedEndDateISO = DateTime.now().endOf('month').toISO();
 
     // Verify that onChange is called with the correct date range
     expect(onChangeMock).toHaveBeenCalledWith({
@@ -271,7 +274,7 @@ describe('DateTimeRangePicker Component', () => {
     const lastMonthOption = screen.getByText('Last Month');
     await userEvent.click(lastMonthOption);
 
-    const lastMonth = fixedNow.minus({ months: 1 });
+    const lastMonth = DateTime.now().minus({ months: 1 });
 
     // Expected start and end dates in ISO format
     const expectedStartDateISO = lastMonth.startOf('month').toISO();


### PR DESCRIPTION
## Description 📝

This attempts to fix a unit test failure in `DateTimeRangePicker.test.ts` when the test is run in an environment whose system locale is not set to central time (UTC-06:00). Also does some clean up related to the way that the system time is mocked.

Opening this so it's ready in case the unit test failure blocks our release and can point this to the release in that case (cc @hana-akamai), but otherwise no rush to review/merge this.

## Changes  🔄

- Fix test failure in DateTimeRangePicker unit tests
- Clean up

## Target release date 🗓️

Possibly 1/14, otherwise N/A


## How to test 🧪

```bash
yarn test DateTimeRangePicker.test
```

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
