### PR TITLE
refactor: [M3-8252] - Remove ramda from `CreateDomain.tsx`

### DIFF
--- a/packages/manager/.changeset/pr-11505-tech-stories-1736510197103.md
+++ b/packages/manager/.changeset/pr-11505-tech-stories-1736510197103.md
@@ -1,0 +1,5 @@
+---
+'@linode/manager': Tech Stories
+---
+
+Remove ramda from `CreateDomain.tsx` ([#11505](https://github.com/linode/manager/pull/11505))

--- a/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
+++ b/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
@@ -13,7 +13,6 @@ import { styled } from '@mui/material/styles';
 import Grid from '@mui/material/Unstable_Grid2';
 import { useNavigate } from '@tanstack/react-router';
 import { useFormik } from 'formik';
-import { path } from 'ramda';
 import * as React from 'react';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
@@ -201,8 +200,8 @@ export const CreateDomain = () => {
             return generateDefaultDomainRecords(
               domainData.domain,
               domainData.id,
-              path(['ipv4', 0], selectedDefaultLinode),
-              path(['ipv6'], selectedDefaultLinode)
+              selectedDefaultLinode?.ipv4?.[0],
+              selectedDefaultLinode?.ipv6
             )
               .then(() => {
                 return redirectToLandingOrDetail(type, domainData.id);
@@ -212,8 +211,8 @@ export const CreateDomain = () => {
                   `Default DNS Records couldn't be created from Linode: ${e[0].reason}`,
                   {
                     domainID: domainData.id,
-                    ipv4: path(['ipv4', 0], selectedDefaultLinode),
-                    ipv6: path(['ipv6'], selectedDefaultLinode),
+                    ipv4: selectedDefaultLinode?.ipv4?.[0],
+                    ipv6: selectedDefaultLinode?.ipv6,
                     selectedLinode: selectedDefaultLinode!.id,
                   }
                 );
@@ -228,8 +227,8 @@ export const CreateDomain = () => {
             return generateDefaultDomainRecords(
               domainData.domain,
               domainData.id,
-              path(['ipv4'], selectedDefaultNodeBalancer),
-              path(['ipv6'], selectedDefaultNodeBalancer)
+              selectedDefaultNodeBalancer?.ipv4,
+              selectedDefaultNodeBalancer?.ipv6
             )
               .then(() => {
                 return redirectToLandingOrDetail(type, domainData.id);
@@ -239,8 +238,8 @@ export const CreateDomain = () => {
                   `Default DNS Records couldn't be created from NodeBalancer: ${e[0].reason}`,
                   {
                     domainID: domainData.id,
-                    ipv4: path(['ipv4'], selectedDefaultNodeBalancer),
-                    ipv6: path(['ipv6'], selectedDefaultNodeBalancer),
+                    ipv4: selectedDefaultNodeBalancer?.ipv4,
+                    ipv6: selectedDefaultNodeBalancer?.ipv6,
                     selectedNodeBalancer: selectedDefaultNodeBalancer!.id,
                   }
                 );
@@ -279,10 +278,9 @@ export const CreateDomain = () => {
   };
 
   const updatePrimaryIPAddress = (newIPs: ExtendedIP[]) => {
-    const master_ips =
-      newIPs.length > 0 ? newIPs.map(extendedIPToString) : [''];
+    const masterIps = newIPs.length > 0 ? newIPs.map(extendedIPToString) : [''];
     if (mounted) {
-      formik.setFieldValue('master_ips', master_ips);
+      formik.setFieldValue('master_ips', masterIps);
     }
   };
 


### PR DESCRIPTION
## Description 📝

Ramda should be completely removed/replaced with native JS equivalent

## Changes  🔄
- Removed ramda from `CreateDomain.tsx` and replaced them with native JS equivalent

## Target release date 🗓️
N/A

## Preview 📷
No visual changes

## How to test 🧪
- Ensure no existing functionality is broken

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules