### PR TITLE
fix: [M3-9009] - Fix spacing for LKE cluster tags

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeEntityDetailFooter.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeEntityDetailFooter.tsx
@@ -107,7 +107,7 @@ export const KubeEntityDetailFooter = React.memo((props: FooterProps) => {
           },
         }}
         alignItems="flex-start"
-        lg={10}
+        lg="auto"
         xs={12}
       >
         <StyledBox>
@@ -165,7 +165,8 @@ export const KubeEntityDetailFooter = React.memo((props: FooterProps) => {
             justifyContent: 'flex-start',
           },
         }}
-        lg={2}
+        lg={3.5}
+        marginLeft="auto"
         xs={12}
       >
         <TagCell


### PR DESCRIPTION
## Description 📝

This PR fixes an existing LKE bug. On the LKE cluster details page, when the user has more than one tag, the tags get cut off on the left side in desktop view. Full tags are shown in tablet and mobile views. 

## Changes  🔄

- Adjusted the grid column layout at the large screen size
- Set the left margin on the tags grid item to retain correct alignment

## Target release date 🗓️

1/28/25

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-01-10 at 10 21 28 AM](https://github.com/user-attachments/assets/464237fa-f71a-49c5-ab4f-8a7d8381c44e) | ![Screenshot 2025-01-10 at 10 13 31 AM](https://github.com/user-attachments/assets/feb051ac-ca8a-4a4f-b974-1141b207d0ee) |
| <video src="https://github.com/user-attachments/assets/7226bd89-4d61-45d0-9dd2-15bca739cbd7" />` | <video src="https://github.com/user-attachments/assets/375a3451-b390-4663-987b-5cdc30760d26" />` |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have an LKE cluster on your account with 2+ cluster tags

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] On another branch (prod or develop), navigate to the LKE cluster details page and note that, at desktop screen sizes, only most of the first tag is displayed.

### Verification steps

(How to verify changes)

- [ ] On this branch, navigate to the LKE cluster details page and note that for 2+ cluster tags in desktop view, tags display as expected on the lefthand side and are styled as expected (gradient) on the right hand side.
- [ ] Resize the screen and confirm tags display as expected at other screen sizes.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
