### PR TITLE
test: [M3-8692] - Component tests for PasswordInput

### DIFF
--- a/packages/manager/.changeset/pr-11508-tests-1736539546177.md
+++ b/packages/manager/.changeset/pr-11508-tests-1736539546177.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add component tests for PasswordInput ([#11508](https://github.com/linode/manager/pull/11508))

--- a/packages/manager/cypress/component/components/password-input.spec.tsx
+++ b/packages/manager/cypress/component/components/password-input.spec.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { ui } from 'support/ui';
+import { checkComponentA11y } from 'support/util/accessibility';
+import { createSpy } from 'support/util/components';
+import { componentTests, visualTests } from 'support/util/components';
+
+import PasswordInput from 'src/components/PasswordInput/PasswordInput';
+
+componentTests('PasswordInput', (mount) => {
+  describe('PasswordInput interactions', () => {});
+
+  visualTests((mount) => {
+    describe('Accessibility checks', () => {
+      it('passes aXe check when password input is visible', () => {});
+
+      it('passes aXe check when password input is not visible', () => {});
+    });
+  });
+});

--- a/packages/manager/cypress/component/components/password-input.spec.tsx
+++ b/packages/manager/cypress/component/components/password-input.spec.tsx
@@ -1,19 +1,172 @@
 import * as React from 'react';
-import { ui } from 'support/ui';
 import { checkComponentA11y } from 'support/util/accessibility';
-import { createSpy } from 'support/util/components';
 import { componentTests, visualTests } from 'support/util/components';
 
 import PasswordInput from 'src/components/PasswordInput/PasswordInput';
 
+const fakePassword = 'this is a password';
+const props = {
+  label: 'Password Input',
+  value: fakePassword,
+};
+
 componentTests('PasswordInput', (mount) => {
-  describe('PasswordInput interactions', () => {});
+  describe('PasswordInput interactions', () => {
+    /**
+     * - Confirms password text starts hidden
+     * - Confirms password text can be shown after clicking eye button
+     */
+    it('can show password text', () => {
+      mount(<PasswordInput {...props} />);
+
+      // Password textfield starts off as 'password' type
+      cy.get('[type="password"]').should('be.visible');
+      cy.findByTestId('VisibilityIcon').should('be.visible').click();
+      cy.findByTestId('VisibilityIcon').should('not.exist');
+
+      // After clicking the visibility icon, textfield becomes a normal textfield
+      cy.get('[type="password"]').should('not.exist');
+      cy.get('[type="text"]').should('be.visible');
+    });
+
+    /**
+     * - Confirms password text can be hidden again after being revealed
+     */
+    it('can hide password text', () => {
+      mount(<PasswordInput {...props} />);
+
+      // Password textfield starts off as 'password' type
+      cy.get('[type="password"]').should('be.visible');
+      cy.findByTestId('VisibilityIcon').should('be.visible').click();
+      cy.findByTestId('VisibilityIcon').should('not.exist');
+
+      // After clicking the visibility icon, textfield becomes a normal textfield
+      cy.get('[type="password"]').should('not.exist');
+      cy.get('[type="text"]').should('be.visible');
+
+      // Clicking VisibilityOffIcon changes input type to password again
+      cy.findByTestId('VisibilityOffIcon').should('be.visible').click();
+      cy.findByTestId('VisibilityOffIcon').should('not.exist');
+      cy.findByTestId('VisibilityIcon').should('be.visible');
+      cy.get('[type="password"]').should('be.visible');
+      cy.get('[type="text"]').should('not.exist');
+    });
+
+    /**
+     * - Confirms password input displays when a weak password is entered
+     */
+    it('displays an indicator for a weak password', () => {
+      const TestWeakStrength = () => {
+        const [password, setPassword] = React.useState('');
+        return (
+          <PasswordInput
+            {...props}
+            onChange={(e) => setPassword(e.target.value)}
+            value={password}
+          />
+        );
+      };
+
+      mount(<TestWeakStrength />);
+
+      // Starts off as 'Weak' if no password entered
+      cy.findByText('Weak').should('be.visible');
+
+      cy.findByTestId('textfield-input').should('be.visible').type('weak');
+      cy.findByText('Weak').should('be.visible');
+    });
+
+    /**
+     * - Confirms password input displays when a fair password is entered
+     */
+    it('displays an indicator for a fair password', () => {
+      const TestMediumStrength = () => {
+        const [password, setPassword] = React.useState('');
+        return (
+          <PasswordInput
+            {...props}
+            onChange={(e) => setPassword(e.target.value)}
+            value={password}
+          />
+        );
+      };
+
+      mount(<TestMediumStrength />);
+
+      // Starts off as 'Weak' if no password entered
+      cy.findByText('Weak').should('be.visible');
+
+      cy.findByTestId('textfield-input')
+        .should('be.visible')
+        .type('fair-pass1');
+      cy.findByText('Fair').should('be.visible');
+    });
+
+    /**
+     * - Confirms password input displays when a good password is entered
+     */
+    it('displays an indicator for a "good" password', () => {
+      const TestGoodStrength = () => {
+        const [password, setPassword] = React.useState('');
+        return (
+          <PasswordInput
+            {...props}
+            onChange={(e) => setPassword(e.target.value)}
+            value={password}
+          />
+        );
+      };
+
+      mount(<TestGoodStrength />);
+
+      // Starts off as 'Weak' if no password entered
+      cy.findByText('Weak').should('be.visible');
+
+      cy.findByTestId('textfield-input')
+        .should('be.visible')
+        .type('st0ng!!-password1!!');
+      cy.findByText('Good').should('be.visible');
+    });
+  });
 
   visualTests((mount) => {
     describe('Accessibility checks', () => {
-      it('passes aXe check when password input is visible', () => {});
+      it('passes aXe check when password input is visible', () => {
+        mount(<PasswordInput {...props} />);
+        cy.findByTestId('VisibilityIcon').should('be.visible').click();
 
-      it('passes aXe check when password input is not visible', () => {});
+        checkComponentA11y();
+      });
+
+      it('passes aXe check when password input is not visible', () => {
+        mount(<PasswordInput {...props} />);
+
+        checkComponentA11y();
+      });
+
+      it('passes aXe check for a weak password', () => {
+        mount(<PasswordInput {...props} value="" />);
+
+        checkComponentA11y();
+      });
+
+      it('passes aXe check for a fair password', () => {
+        mount(<PasswordInput {...props} value="fair-pass1" />);
+
+        checkComponentA11y();
+      });
+
+      it('passes aXe check for a "good" password', () => {
+        mount(<PasswordInput {...props} value="st0ng!!-password1!!" />);
+
+        checkComponentA11y();
+      });
+
+      it('passes aXe check when strength is hidden', () => {
+        mount(<PasswordInput {...props} hideValidation />);
+
+        checkComponentA11y();
+      });
     });
   });
 });

--- a/packages/manager/cypress/component/components/password-input.spec.tsx
+++ b/packages/manager/cypress/component/components/password-input.spec.tsx
@@ -162,8 +162,20 @@ componentTests('PasswordInput', (mount) => {
         checkComponentA11y();
       });
 
-      it('passes aXe check when strength is hidden', () => {
+      it('passes aXe check when password input is designated as required', () => {
+        mount(<PasswordInput {...props} required />);
+
+        checkComponentA11y();
+      });
+
+      it('passes aXe check when strength value is hidden', () => {
         mount(<PasswordInput {...props} hideValidation />);
+
+        checkComponentA11y();
+      });
+
+      it('passes aXe check when strength label is shown', () => {
+        mount(<PasswordInput {...props} hideStrengthLabel={false} />);
 
         checkComponentA11y();
       });

--- a/packages/manager/cypress/component/components/password-input.spec.tsx
+++ b/packages/manager/cypress/component/components/password-input.spec.tsx
@@ -14,25 +14,9 @@ componentTests('PasswordInput', (mount) => {
   describe('PasswordInput interactions', () => {
     /**
      * - Confirms password text starts hidden
-     * - Confirms password text can be shown after clicking eye button
+     * - Confirms password text can be revealed or hidden when toggling visibility icon
      */
-    it('can show password text', () => {
-      mount(<PasswordInput {...props} />);
-
-      // Password textfield starts off as 'password' type
-      cy.get('[type="password"]').should('be.visible');
-      cy.findByTestId('VisibilityIcon').should('be.visible').click();
-      cy.findByTestId('VisibilityIcon').should('not.exist');
-
-      // After clicking the visibility icon, textfield becomes a normal textfield
-      cy.get('[type="password"]').should('not.exist');
-      cy.get('[type="text"]').should('be.visible');
-    });
-
-    /**
-     * - Confirms password text can be hidden again after being revealed
-     */
-    it('can hide password text', () => {
+    it('can show and hide password text', () => {
       mount(<PasswordInput {...props} />);
 
       // Password textfield starts off as 'password' type
@@ -77,7 +61,8 @@ componentTests('PasswordInput', (mount) => {
     });
 
     /**
-     * - Confirms password input displays when a fair password is entered
+     * - Confirm password indicator can update when a password is entered
+     * - Confirms password input can display indicator for a fair password
      */
     it('displays an indicator for a fair password', () => {
       const TestMediumStrength = () => {
@@ -93,17 +78,21 @@ componentTests('PasswordInput', (mount) => {
 
       mount(<TestMediumStrength />);
 
-      // Starts off as 'Weak' if no password entered
+      // Starts off as 'Weak' when no password entered
       cy.findByText('Weak').should('be.visible');
 
       cy.findByTestId('textfield-input')
         .should('be.visible')
         .type('fair-pass1');
+
+      // After typing in a fair password, the strength indicator updates
       cy.findByText('Fair').should('be.visible');
+      cy.findByText('Weak').should('not.exist');
     });
 
     /**
-     * - Confirms password input displays when a good password is entered
+     * - Confirm password indicator can update when a password is entered
+     * - Confirms password input can display indicator for a good password
      */
     it('displays an indicator for a "good" password', () => {
       const TestGoodStrength = () => {
@@ -119,13 +108,16 @@ componentTests('PasswordInput', (mount) => {
 
       mount(<TestGoodStrength />);
 
-      // Starts off as 'Weak' if no password entered
+      // Starts off as 'Weak' when no password entered
       cy.findByText('Weak').should('be.visible');
 
       cy.findByTestId('textfield-input')
         .should('be.visible')
-        .type('st0ng!!-password1!!');
+        .type('str0ng!!-password1!!');
+
+      // After typing in a strong password, the strength indicator updates
       cy.findByText('Good').should('be.visible');
+      cy.findByText('Weak').should('not.exist');
     });
   });
 

--- a/packages/manager/src/components/PasswordInput/HideShowText.stories.tsx
+++ b/packages/manager/src/components/PasswordInput/HideShowText.stories.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import { Meta, StoryObj } from '@storybook/react';
 import React, { useState } from 'react';
 
 import { HideShowText } from './HideShowText';
+
+import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof HideShowText> = {
   component: HideShowText,

--- a/packages/manager/src/components/PasswordInput/PasswordInput.stories.tsx
+++ b/packages/manager/src/components/PasswordInput/PasswordInput.stories.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import { Meta, StoryObj } from '@storybook/react';
 import React, { useState } from 'react';
 
 import PasswordInput from './PasswordInput';
+
+import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof PasswordInput> = {
   component: PasswordInput,

--- a/packages/manager/src/components/PasswordInput/StrengthIndicator.stories.tsx
+++ b/packages/manager/src/components/PasswordInput/StrengthIndicator.stories.tsx
@@ -1,7 +1,8 @@
-import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
 import { StrengthIndicator } from './StrengthIndicator';
+
+import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof StrengthIndicator> = {
   component: StrengthIndicator,


### PR DESCRIPTION
## Description 📝
- Adds component tests for the PasswordInput component to tests its interactions

## How to test 🧪
- mainly been using yarn cy:debug and selecting component tests to check these tests

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
