### PR TITLE
refactor: [M3-8252] - Remove ramda from `DomainRecords` (Part 1)

### DIFF
--- a/packages/manager/.changeset/pr-11514-tech-stories-1736784891293.md
+++ b/packages/manager/.changeset/pr-11514-tech-stories-1736784891293.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Remove ramda from `DomainRecords` pt1 ([#11514](https://github.com/linode/manager/pull/11514))

--- a/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecordActionMenu.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecordActionMenu.tsx
@@ -1,4 +1,3 @@
-import { has } from 'ramda';
 import * as React from 'react';
 
 import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
@@ -49,7 +48,7 @@ export const DomainRecordActionMenu = (props: DomainRecordActionMenuProps) => {
       },
       title: 'Edit',
     },
-    has('deleteData', props)
+    Boolean(props.deleteData)
       ? {
           onClick: () => {
             handleDelete();

--- a/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecords.tsx
@@ -1,7 +1,6 @@
 import { deleteDomainRecord as _deleteDomainRecord } from '@linode/api-v4/lib/domains';
 import { Typography } from '@linode/ui';
 import Grid from '@mui/material/Unstable_Grid2';
-import { lensPath, over } from 'ramda';
 import * as React from 'react';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
@@ -196,7 +195,10 @@ export const DomainRecords = (props: Props) => {
     fn: (confirmDialog: ConfirmationState) => ConfirmationState
   ) => {
     setState((prevState) => {
-      const newState = over(lensPath(['confirmDialog']), fn, prevState);
+      const newState = {
+        ...prevState,
+        confirmDialog: fn(prevState.confirmDialog),
+      };
       scrollErrorIntoViewV2(confirmDialogRef);
 
       return newState;
@@ -205,7 +207,10 @@ export const DomainRecords = (props: Props) => {
 
   const updateDrawer = (fn: (drawer: DrawerState) => DrawerState) => {
     setState((prevState) => {
-      return over(lensPath(['drawer']), fn, prevState);
+      return {
+        ...prevState,
+        drawer: fn(prevState.drawer),
+      };
     });
   };
 

--- a/packages/manager/src/features/Domains/DomainDetail/DomainRecords/generateTypes.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/DomainRecords/generateTypes.tsx
@@ -1,16 +1,10 @@
 import { Button } from '@linode/ui';
-import { compose, isEmpty, pathOr } from 'ramda';
 import React from 'react';
 
 import { truncateEnd } from 'src/utilities/truncate';
 
 import { DomainRecordActionMenu } from './DomainRecordActionMenu';
-import {
-  getNSRecords,
-  getTTL,
-  msToReadableTime,
-  typeEq,
-} from './DomainRecordsUtils';
+import { getNSRecords, getTimeColumn, typeEq } from './DomainRecordsUtils';
 
 import type { Props as DomainRecordsProps } from './DomainRecords';
 import type { Domain, DomainRecord } from '@linode/api-v4/lib/domains';
@@ -88,19 +82,19 @@ export const generateTypes = (
         title: 'Email',
       },
       {
-        render: getTTL,
+        render: (domain: Domain) => getTimeColumn(domain, 'ttl_sec'),
         title: 'Default TTL',
       },
       {
-        render: compose(msToReadableTime, pathOr(0, ['refresh_sec'])),
+        render: (domain: Domain) => getTimeColumn(domain, 'refresh_sec'),
         title: 'Refresh Rate',
       },
       {
-        render: compose(msToReadableTime, pathOr(0, ['retry_sec'])),
+        render: (domain: Domain) => getTimeColumn(domain, 'retry_sec'),
         title: 'Retry Rate',
       },
       {
-        render: compose(msToReadableTime, pathOr(0, ['expire_sec'])),
+        render: (domain: Domain) => getTimeColumn(domain, 'expire_sec'),
         title: 'Expire Time',
       },
       {
@@ -132,14 +126,14 @@ export const generateTypes = (
       {
         render: (record: DomainRecord) => {
           const subdomain = record.name;
-          return isEmpty(subdomain)
-            ? props.domain.domain
-            : `${subdomain}.${props.domain.domain}`;
+          return Boolean(subdomain)
+            ? `${subdomain}.${props.domain.domain}`
+            : props.domain.domain;
         },
         title: 'Subdomain',
       },
       {
-        render: getTTL,
+        render: (record: DomainRecord) => getTimeColumn(record, 'ttl_sec'),
         title: 'TTL',
       },
       {
@@ -197,7 +191,7 @@ export const generateTypes = (
         title: 'Subdomain',
       },
       {
-        render: getTTL,
+        render: (record: DomainRecord) => getTimeColumn(record, 'ttl_sec'),
         title: 'TTL',
       },
       {
@@ -239,7 +233,10 @@ export const generateTypes = (
         title: 'Hostname',
       },
       { render: (record: DomainRecord) => record.target, title: 'IP Address' },
-      { render: getTTL, title: 'TTL' },
+      {
+        render: (record: DomainRecord) => getTimeColumn(record, 'ttl_sec'),
+        title: 'TTL',
+      },
       {
         render: (domainRecordParams: DomainRecord) => {
           const { id, name, target, ttl_sec } = domainRecordParams;
@@ -278,7 +275,10 @@ export const generateTypes = (
     columns: [
       { render: (record: DomainRecord) => record.name, title: 'Hostname' },
       { render: (record: DomainRecord) => record.target, title: 'Aliases to' },
-      { render: getTTL, title: 'TTL' },
+      {
+        render: (record: DomainRecord) => getTimeColumn(record, 'ttl_sec'),
+        title: 'TTL',
+      },
       {
         render: (domainRecordParams: DomainRecord) => {
           const { id, name, target, ttl_sec } = domainRecordParams;
@@ -321,7 +321,10 @@ export const generateTypes = (
         render: (record: DomainRecord) => truncateEnd(record.target, 100),
         title: 'Value',
       },
-      { render: getTTL, title: 'TTL' },
+      {
+        render: (record: DomainRecord) => getTimeColumn(record, 'ttl_sec'),
+        title: 'TTL',
+      },
       {
         render: (domainRecordParams: DomainRecord) => {
           const { id, name, target, ttl_sec } = domainRecordParams;
@@ -372,7 +375,10 @@ export const generateTypes = (
       },
       { render: (record: DomainRecord) => String(record.port), title: 'Port' },
       { render: (record: DomainRecord) => record.target, title: 'Target' },
-      { render: getTTL, title: 'TTL' },
+      {
+        render: (record: DomainRecord) => getTimeColumn(record, 'ttl_sec'),
+        title: 'TTL',
+      },
       {
         render: ({
           id,
@@ -421,7 +427,10 @@ export const generateTypes = (
         render: (record: DomainRecord) => record.target,
         title: 'Value',
       },
-      { render: getTTL, title: 'TTL' },
+      {
+        render: (record: DomainRecord) => getTimeColumn(record, 'ttl_sec'),
+        title: 'TTL',
+      },
       {
         render: (domainRecordParams: DomainRecord) => {
           const { id, name, tag, target, ttl_sec } = domainRecordParams;


### PR DESCRIPTION
## Description 📝

Ramda should be completely removed/replaced with native JS equivalent

- Remove ramda from `DomainRecords` - Part 1

> [!Note]
> We will remove ramda from `/DomainRecords/DomainRecordDrawer.tsx` in Part 2, after refactoring `DomainRecordDrawer.tsx` to a functional component

## Changes  🔄
- Remove ramda from:
  - `/DomainRecords/DomainRecords.tsx`
  - `/DomainRecords/DomainRecordActionMenu.tsx`
  - `/DomainRecords/DomainRecordsUtils.ts`
  - `/DomainRecords/generateTypes.tsx`

## Target release date 🗓️
N/A

## Preview 📷
No visual changes

## How to test 🧪
- Ensure no existing functionality is broken
- Ensure all tests pass

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
