### PR TITLE
fix: [M3-9086] – Revise description of "Add Node Pools" section on LKE Create page

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Object Storage `endpoint_type` sorting ([#11472](https://github.com/linode/manager/pull/11472))
 - Visibility of sensitive data in Managed and Longview with Mask Sensitive Data setting enabled ([#11476](https://github.com/linode/manager/pull/11476))
 - Display Kubernetes API endpoint for LKE-E cluster ([#11485](https://github.com/linode/manager/pull/11485))
+- Accuracy of "Add Node Pools" section on LKE Create page ([#11516](https://github.com/linode/manager/pull/11516))
 
 ### Removed:
 

--- a/packages/manager/src/features/Kubernetes/ClusterList/constants.ts
+++ b/packages/manager/src/features/Kubernetes/ClusterList/constants.ts
@@ -1,2 +1,5 @@
 export const ADD_NODE_POOLS_DESCRIPTION =
-  'Add groups of Linodes to your cluster. You can have a maximum of 250 Linodes per node pool. Node Pool data is encrypted at rest.';
+  'Add groups of Linodes to your cluster. You can have a maximum of 100 Linodes per node pool and a maximum of 250 Linodes per cluster.';
+
+export const ADD_NODE_POOLS_ENCRYPTION_DESCRIPTION =
+  'Node Pool data is encrypted at rest.';

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -9,7 +9,10 @@ import { useRegionsQuery } from 'src/queries/regions/regions';
 import { doesRegionSupportFeature } from 'src/utilities/doesRegionSupportFeature';
 import { extendType } from 'src/utilities/extendType';
 
-import { ADD_NODE_POOLS_DESCRIPTION } from '../ClusterList/constants';
+import {
+  ADD_NODE_POOLS_DESCRIPTION,
+  ADD_NODE_POOLS_ENCRYPTION_DESCRIPTION,
+} from '../ClusterList/constants';
 import { KubernetesPlansPanel } from '../KubernetesPlansPanel/KubernetesPlansPanel';
 
 import type {
@@ -106,8 +109,8 @@ const Panel = (props: NodePoolPanelProps) => {
         <KubernetesPlansPanel
           copy={
             isDiskEncryptionFeatureEnabled && regionSupportsDiskEncryption
-              ? ADD_NODE_POOLS_DESCRIPTION
-              : 'Add groups of Linodes to your cluster. You can have a maximum of 100 Linodes per node pool.'
+              ? `${ADD_NODE_POOLS_DESCRIPTION} ${ADD_NODE_POOLS_ENCRYPTION_DESCRIPTION}`
+              : ADD_NODE_POOLS_DESCRIPTION
           }
           getTypeCount={(planId) =>
             typeCountMap.get(planId) ?? DEFAULT_PLAN_COUNT


### PR DESCRIPTION
## Description 📝
https://github.com/linode/manager/pull/10578 updated the "Add Node Pools" section on the LKE Create page when LDE is enabled to state that the maximum number of linodes per node pool is 250. However, this is incorrect; the max per node pool is still 100, but the max per cluster is 250. This PR updates the copy to be clearer and more explicit. More details included in the ticket.

## Target release date 🗓️
1/14/25

## Preview 📷
| Linode Disk Encryption (LDE) disabled | Linode Disk Encryption (LDE) enabled |
| ------- | ------- |
| ![Screenshot 2025-01-13 at 6 08 25 PM](https://github.com/user-attachments/assets/4caef118-babf-4418-85cc-7aaaef6cfe93) | ![Screenshot 2025-01-13 at 6 08 09 PM](https://github.com/user-attachments/assets/3969b7f3-65f0-4eb8-a322-118da9ddebce) |

## How to test 🧪
### Verification steps
Toggling the `Linode Disk Encryption (LDE)` flag on and off in our DevTools should result in your view matching the preview. If the flag is on and you haven't yet selected a region, you will not see `Node Pool data is encrypted at rest.` at the end.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [X] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>