### PR TITLE
fix: [M3-9124] - Link styles in `KubernetesClusterRow` and clean up one-off styles

### DIFF
--- a/packages/manager/src/features/Kubernetes/ClusterList/KubernetesClusterRow.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/KubernetesClusterRow.tsx
@@ -1,11 +1,9 @@
-import { Chip } from '@linode/ui';
-import Grid from '@mui/material/Unstable_Grid2';
-import * as React from 'react';
-import { Link } from 'react-router-dom';
-import { makeStyles } from 'tss-react/mui';
+import { Chip, Stack } from '@linode/ui';
+import React from 'react';
 
 import { DateTimeDisplay } from 'src/components/DateTimeDisplay';
 import { Hidden } from 'src/components/Hidden';
+import { Link } from 'src/components/Link';
 import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
 import { useAllKubernetesNodePoolQuery } from 'src/queries/kubernetes';
@@ -23,33 +21,6 @@ import { ClusterChips } from './ClusterChips';
 
 import type { KubeNodePoolResponse, KubernetesCluster } from '@linode/api-v4';
 
-const useStyles = makeStyles()(() => ({
-  clusterRow: {
-    '&:before': {
-      display: 'none',
-    },
-  },
-  labelStatusWrapper: {
-    alignItems: 'center',
-    display: 'flex',
-    flexFlow: 'row nowrap',
-    whiteSpace: 'nowrap',
-  },
-  link: {
-    '&:hover, &:focus': {
-      textDecoration: 'underline',
-    },
-    display: 'block',
-    fontSize: '.875rem',
-    lineHeight: '1.125rem',
-  },
-  version: {
-    alignItems: 'center',
-    display: 'flex',
-    justifyContent: 'flex-start',
-  },
-}));
-
 export interface Props {
   cluster: KubernetesCluster;
   openDeleteDialog: (
@@ -62,7 +33,6 @@ export interface Props {
 
 export const KubernetesClusterRow = (props: Props) => {
   const { cluster, openDeleteDialog, openUpgradeDialog } = props;
-  const { classes } = useStyles();
 
   const { data: pools } = useAllKubernetesNodePoolQuery(cluster.id);
   const typesQuery = useSpecificTypes(pools?.map((pool) => pool.type) ?? []);
@@ -86,46 +56,35 @@ export const KubernetesClusterRow = (props: Props) => {
 
   return (
     <TableRow
-      className={classes.clusterRow}
       data-qa-cluster-cell={cluster.id}
       data-testid={'cluster-row'}
       key={cluster.id}
     >
       <TableCell data-qa-cluster-label>
-        <Grid
-          alignItems="center"
-          container
+        <Stack
+          direction="row"
           justifyContent="space-between"
-          wrap="nowrap"
+          spacing={1}
+          alignItems="center"
         >
-          <Grid className="py0">
-            <div className={classes.labelStatusWrapper}>
-              <Link
-                className={classes.link}
-                tabIndex={0}
-                to={`/kubernetes/clusters/${cluster.id}/summary`}
-              >
-                {cluster.label}
-              </Link>
-            </div>
-          </Grid>
-          <ClusterChips cluster={cluster} sx={{ marginLeft: 1 }} />
-        </Grid>
+          <Link tabIndex={0} to={`/kubernetes/clusters/${cluster.id}/summary`}>
+            {cluster.label}
+          </Link>
+          <ClusterChips cluster={cluster} />
+        </Stack>
       </TableCell>
       <Hidden mdDown>
         <TableCell data-qa-cluster-version>
-          <div className={classes.version}>
-            {cluster.k8s_version}
-            {hasUpgrade && (
-              <Chip
-                clickable
-                label="UPGRADE"
-                onClick={openUpgradeDialog}
-                size="small"
-                sx={{ mx: 2 }}
-              />
-            )}
-          </div>
+          {cluster.k8s_version}
+          {hasUpgrade && (
+            <Chip
+              clickable
+              label="UPGRADE"
+              onClick={openUpgradeDialog}
+              size="small"
+              sx={{ mx: 2 }}
+            />
+          )}
         </TableCell>
         <TableCell data-qa-cluster-date>
           <DateTimeDisplay value={cluster.created} />


### PR DESCRIPTION
## Description 📝

- Cleans up one-off styles in `KubernetesClusterRow` 
- Uses `Link` from `src/components/Link` rather than `react-router-dom` directly so that colors are correct
  - In dark mode, the raw `react-router-dom` link is too dark

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-01-15 at 6 19 35 PM](https://github.com/user-attachments/assets/984e01aa-8f6f-4de3-8b0b-6c62e231794e) | ![Screenshot 2025-01-15 at 6 19 40 PM](https://github.com/user-attachments/assets/ca137e61-5e1c-4c35-a8d7-a99ae373b89c) |

## How to test 🧪

- Turn on the MSW or have some LKE clusters on your account
- Verify there are no regressions to `KubernetesClusterRow` 
  - Verify the chips have no regressions 🏷️ 
    - Enterprise chip
    - HA chip
    - Version upgrade chip

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>