### PR TITLE
test: [M3-9131] - Increase Linode clone timeout to 5 minutes

### DIFF
--- a/packages/manager/.changeset/pr-11529-tests-1737049089021.md
+++ b/packages/manager/.changeset/pr-11529-tests-1737049089021.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Increase timeouts when performing Linode clone operations ([#11529](https://github.com/linode/manager/pull/11529))

--- a/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
@@ -18,6 +18,10 @@ import { randomLabel } from 'support/util/random';
 import { authenticate } from 'support/api/authentication';
 import { cleanUp } from 'support/util/cleanup';
 import { createTestLinode } from 'support/util/linodes';
+import {
+  LINODE_CLONE_TIMEOUT,
+  LINODE_CREATE_TIMEOUT,
+} from 'support/constants/linodes';
 import type { Linode } from '@linode/api-v4';
 
 /**
@@ -32,9 +36,6 @@ const getLinodeCloneUrl = (linode: Linode): string => {
   const typeQuery = `&typeID=${linode.type}`;
   return `/linodes/create?linodeID=${linode.id}${regionQuery}&type=Clone+Linode${typeQuery}`;
 };
-
-/* Timeout after 4 minutes while waiting for clone. */
-const CLONE_TIMEOUT = 240_000;
 
 authenticate();
 describe('clone linode', () => {
@@ -69,7 +70,9 @@ describe('clone linode', () => {
       cy.visitWithLogin(`/linodes/${linode.id}`);
 
       // Wait for Linode to boot, then initiate clone flow.
-      cy.findByText('OFFLINE').should('be.visible');
+      cy.findByText('OFFLINE', { timeout: LINODE_CREATE_TIMEOUT }).should(
+        'be.visible'
+      );
 
       ui.actionMenu
         .findByTitle(`Action menu for Linode ${linode.label}`)
@@ -108,7 +111,7 @@ describe('clone linode', () => {
       ui.toast.assertMessage(`Your Linode ${newLinodeLabel} is being created.`);
       ui.toast.assertMessage(
         `Linode ${linode.label} has been cloned to ${newLinodeLabel}.`,
-        { timeout: CLONE_TIMEOUT }
+        { timeout: LINODE_CLONE_TIMEOUT }
       );
     });
   });

--- a/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
@@ -4,6 +4,7 @@ import { authenticate } from 'support/api/authentication';
 import { cleanUp } from 'support/util/cleanup';
 import { mockGetVPC, mockGetVPCs } from 'support/intercepts/vpc';
 import { dcPricingMockLinodeTypes } from 'support/constants/dc-specific-pricing';
+import { LINODE_CLONE_TIMEOUT } from 'support/constants/linodes';
 import { chooseRegion, getRegionById } from 'support/util/regions';
 import { mockGetVLANs } from 'support/intercepts/vlans';
 import {
@@ -225,7 +226,8 @@ describe('Linode Config management', () => {
           .its('response.statusCode')
           .should('eq', 200);
         ui.toast.assertMessage(
-          `Configuration ${config.label} successfully updated`
+          `Configuration ${config.label} successfully updated`,
+          { timeout: LINODE_CLONE_TIMEOUT }
         );
 
         // Confirm that updated IPAM is automatically listed in config table.

--- a/packages/manager/cypress/support/constants/linodes.ts
+++ b/packages/manager/cypress/support/constants/linodes.ts
@@ -8,3 +8,10 @@
  * Equals 5 minutes.
  */
 export const LINODE_CREATE_TIMEOUT = 300_000;
+
+/**
+ * Length of time to wait for a Linode to be cloned.
+ *
+ * Equals 5 minutes.
+ */
+export const LINODE_CLONE_TIMEOUT = 300_000;


### PR DESCRIPTION
## Description 📝

This increases the clone timeout in our `linode-config.spec.ts` and `clone-linode.spec.ts` tests to 5 minutes in hopes of reducing the flakiness of these tests a bit.

We have a dedicated ticket (M3-8804) to continue investigating this test in case other actions are needed to completely resolve the stability issues, but hoping to get a quick win out of this in the meantime.

## Changes  🔄

- Linode clone timeout increased to 5 minutes
- Linode create timeout in clone test increased to 5 minutes

## Target release date 🗓️

N/A


## How to test 🧪

`yarn && yarn build && yarn start:manager:ci`, and then `yarn cy:run -s "cypress/e2e/core/linodes/clone-linode.spec.ts,cypress/e2e/core/linodes/linode-config.spec.ts"`

I'll probably run this in CI a few times to see how effective the changes are. If they aren't effective at all, I'll close the ticket.

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
