### PR TITLE
change: [M3-9132] – Revise description for "Disk Encryption" section in Linode Create flow

### DIFF
--- a/packages/manager/.changeset/pr-11536-changed-1737152603420.md
+++ b/packages/manager/.changeset/pr-11536-changed-1737152603420.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Revise Disk Encryption description copy in Linode Create flow ([#11536](https://github.com/linode/manager/pull/11536))

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-disk-encryption.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-disk-encryption.spec.ts
@@ -7,7 +7,7 @@ import { makeFeatureFlagData } from 'support/util/feature-flags';
 import {
   checkboxTestId,
   headerTestId,
-} from 'src/components/Encryption/Encryption';
+} from 'src/components/Encryption/constants';
 
 describe('Create Linode with Disk Encryption', () => {
   it('should not have a "Disk Encryption" section visible if the feature flag is off and user does not have capability', () => {

--- a/packages/manager/src/components/Encryption/Encryption.test.tsx
+++ b/packages/manager/src/components/Encryption/Encryption.test.tsx
@@ -2,12 +2,8 @@ import * as React from 'react';
 
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
-import {
-  Encryption,
-  checkboxTestId,
-  descriptionTestId,
-  headerTestId,
-} from './Encryption';
+import { checkboxTestId, descriptionTestId, headerTestId } from './constants';
+import { Encryption } from './Encryption';
 
 describe('DiskEncryption', () => {
   it('should render a header', () => {

--- a/packages/manager/src/components/Encryption/Encryption.tsx
+++ b/packages/manager/src/components/Encryption/Encryption.tsx
@@ -2,6 +2,8 @@ import { Box, Checkbox, Notice, Typography } from '@linode/ui';
 import { List, ListItem } from '@mui/material';
 import * as React from 'react';
 
+import { checkboxTestId, descriptionTestId, headerTestId } from './constants';
+
 export interface EncryptionProps {
   descriptionCopy: JSX.Element | string;
   disabled?: boolean;
@@ -12,10 +14,6 @@ export interface EncryptionProps {
   notices?: string[];
   onChange: (checked: boolean) => void;
 }
-
-export const headerTestId = 'encryption-header';
-export const descriptionTestId = 'encryption-description';
-export const checkboxTestId = 'encrypt-entity-checkbox';
 
 export const Encryption = (props: EncryptionProps) => {
   const {

--- a/packages/manager/src/components/Encryption/constants.tsx
+++ b/packages/manager/src/components/Encryption/constants.tsx
@@ -2,15 +2,20 @@ import React from 'react';
 
 import { Link } from 'src/components/Link';
 
+/* Test IDs */
+export const headerTestId = 'encryption-header';
+export const descriptionTestId = 'encryption-description';
+export const checkboxTestId = 'encrypt-entity-checkbox';
+
 /* Disk Encryption constants */
 const DISK_ENCRYPTION_GUIDE_LINK =
   'https://techdocs.akamai.com/cloud-computing/docs/local-disk-encryption';
 
 export const DISK_ENCRYPTION_GENERAL_DESCRIPTION = (
   <>
-    Secure this Linode using data at rest encryption. Data center systems take
-    care of encrypting and decrypting for you. After the Linode is created, use
-    Rebuild to enable or disable this feature.{' '}
+    Secure this Linode with data-at-rest encryption. Data center systems handle
+    encryption automatically for you. After the Linode is created, use Rebuild
+    to enable or disable encryption.{' '}
     <Link to={DISK_ENCRYPTION_GUIDE_LINK}>Learn more</Link>.
   </>
 );


### PR DESCRIPTION
## Description 📝
In prod at maximum viewport widths, the "Disk Encryption" section's description in the Linode Create flow has a single word that hangs on the second line. This PR revises the copy to be more concise to prevent this.

## Target release date 🗓️
1/28/25

## Preview 📷
| Prod  | This Branch   |
| ------- | ------- |
| ![Screenshot 2025-01-17 at 4 43 52 PM](https://github.com/user-attachments/assets/6385085f-e8d9-422d-9e07-d88dbf2c1cce) | ![Screenshot 2025-01-17 at 4 44 03 PM](https://github.com/user-attachments/assets/1ea9ad62-b566-4f11-8e5e-d92e8d5ac701) |

### Verification steps
Confirm what you see at the maximum viewport width matches the preview above

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [X] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [X] All unit tests are passing
- [X] TypeScript compilation succeeded without errors
- [X] Code passes all linting rules
</details>