### PR TITLE
fix: [UIE-8386] - IAM RBAC: fix redirects to old route

### DIFF
--- a/packages/manager/.changeset/pr-11539-upcoming-features-1737537564184.md
+++ b/packages/manager/.changeset/pr-11539-upcoming-features-1737537564184.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+fix redirects from /account to /iam ([#11539](https://github.com/linode/manager/pull/11539))

--- a/packages/manager/src/features/IAM/Users/UserDetails/DeleteUserPanel.tsx
+++ b/packages/manager/src/features/IAM/Users/UserDetails/DeleteUserPanel.tsx
@@ -47,7 +47,7 @@ export const DeleteUserPanel = ({ user }: Props) => {
         </Typography>
         <UserDeleteConfirmation
           onClose={() => setIsDeleteDialogOpen(false)}
-          onSuccess={() => history.push(`/account/users`)}
+          onSuccess={() => history.push(`/iam/users`)}
           open={isDeleteDialogOpen}
           username={user.username}
         />

--- a/packages/manager/src/features/IAM/Users/UserDetails/UsernamePanel.tsx
+++ b/packages/manager/src/features/IAM/Users/UserDetails/UsernamePanel.tsx
@@ -36,7 +36,7 @@ export const UsernamePanel = ({ user }: Props) => {
       const user = await mutateAsync(values);
 
       // Because the username changed, we need to update the username in the URL
-      history.replace(`/account/users/${user.username}`);
+      history.replace(`/iam/users/${user.username}/details`);
 
       enqueueSnackbar('Username updated successfully', { variant: 'success' });
     } catch (error) {

--- a/packages/manager/src/features/IAM/Users/UsersTable/CreateUserDrawer.tsx
+++ b/packages/manager/src/features/IAM/Users/UsersTable/CreateUserDrawer.tsx
@@ -104,19 +104,15 @@ export const CreateUserDrawer = (props: Props) => {
         <Controller
           render={({ field }) => (
             <FormControlLabel
-              control={
-                <Toggle
-                  onChange={(e) => {
-                    field.onChange(!e.target.checked);
-                  }}
-                  checked={!field.value}
-                  data-qa-create-restricted
-                />
-              }
               label={`This user will have ${
                 field.value ? 'limited' : 'full'
               } access to account features.
                     This can be changed later.`}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                field.onChange(!e.target.checked);
+              }}
+              checked={!field.value}
+              control={<Toggle data-qa-create-restricted />}
               sx={{ marginTop: 1 }}
             />
           )}


### PR DESCRIPTION
## Description 📝

Fix redirects from `/account/` to `/iam/` when editing the username or deleting the user.
## Changes  🔄

List any change(s) relevant to the reviewer.

- small adjustment in the `CreateUserDrawer`
- fix redirects from `/account` to `/iam`

## Target release date 🗓️

1/28/25 (dev)

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Ensure the Identity and Access Beta flag is enabled in dev tools
- Click on the any username in the users table and go to the tab Assigned Roles or click on the user's menu View User Roles
- Edit username or delete the user

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Edit username or delete the user


### Verification steps

(How to verify changes)

- [x] redirect to `/iam/...`

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

