### PR TITLE
feat: [M3-9158] - Add GPU plans support for LKE in Cloud Manager

### DIFF
--- a/packages/manager/.changeset/pr-11544-added-1737522840655.md
+++ b/packages/manager/.changeset/pr-11544-added-1737522840655.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+GPU plans in Kubernetes create flow ([#11544](https://github.com/linode/manager/pull/11544))

--- a/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
@@ -437,21 +437,25 @@ describe.only('displays specific kubernetes plans for GPU', () => {
     cy.get(k8PlansPanel).within(() => {
       cy.findAllByRole('alert').should('have.length', 2);
       cy.get(notices.unavailable).should('be.visible');
-      cy.findAllByRole('row').should('have.length', 3);
-      cy.get('[data-qa-plan-row="gpu-2 Ada"]').should('have.attr', 'disabled');
-      cy.get('[data-qa-plan-row="gpu-1"]').should('have.attr', 'disabled');
 
-      cy.get('[data-qa="NVIDIA RTX 4000 Ada table-header"]')
-        .parent()
-        .within(() => {
-          cy.findByText('NVIDIA RTX 4000 Ada').should('be.visible');
-        });
+      cy.findByRole('table', {
+        name: 'List of NVIDIA RTX 4000 Ada Plans',
+      }).within(() => {
+        cy.findByText('NVIDIA RTX 4000 Ada').should('be.visible');
+        cy.findAllByRole('row').should('have.length', 2);
+        cy.get('[data-qa-plan-row="gpu-2 Ada"]').should(
+          'have.attr',
+          'disabled'
+        );
+      });
 
-      cy.get('[data-qa="NVIDIA Quadro RTX 6000 table-header"]')
-        .parent()
-        .within(() => {
-          cy.findByText('NVIDIA Quadro RTX 6000').should('be.visible');
-        });
+      cy.findByRole('table', {
+        name: 'List of NVIDIA Quadro RTX 6000 Plans',
+      }).within(() => {
+        cy.findByText('NVIDIA Quadro RTX 6000').should('be.visible');
+        cy.findAllByRole('row').should('have.length', 2);
+        cy.get('[data-qa-plan-row="gpu-1"]').should('have.attr', 'disabled');
+      });
     });
   });
 });

--- a/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
@@ -409,6 +409,53 @@ describe('displays specific linode plans for GPU', () => {
   });
 });
 
+describe.only('displays specific kubernetes plans for GPU', () => {
+  beforeEach(() => {
+    mockGetRegions(mockRegions).as('getRegions');
+    mockGetLinodeTypes(mockLinodeTypes).as('getLinodeTypes');
+    mockGetRegionAvailability(mockRegions[0].id, mockRegionAvailability).as(
+      'getRegionAvailability'
+    );
+    mockAppendFeatureFlags({
+      gpuv2: {
+        transferBanner: true,
+        planDivider: true,
+        egressBanner: true,
+      },
+    }).as('getFeatureFlags');
+  });
+
+  it('Should render divided tables when GPU divider enabled', () => {
+    cy.visitWithLogin('/kubernetes/create');
+    cy.wait(['@getRegions', '@getLinodeTypes', '@getFeatureFlags']);
+    ui.regionSelect.find().click();
+    ui.regionSelect.findItemByRegionLabel(mockRegions[0].label).click();
+
+    // GPU tab
+    // Should display two separate tables
+    cy.findByText('GPU').click();
+    cy.get(k8PlansPanel).within(() => {
+      cy.findAllByRole('alert').should('have.length', 2);
+      cy.get(notices.unavailable).should('be.visible');
+      cy.findAllByRole('row').should('have.length', 3);
+      cy.get('[data-qa-plan-row="gpu-2 Ada"]').should('have.attr', 'disabled');
+      cy.get('[data-qa-plan-row="gpu-1"]').should('have.attr', 'disabled');
+
+      cy.get('[data-qa="NVIDIA RTX 4000 Ada table-header"]')
+        .parent()
+        .within(() => {
+          cy.findByText('NVIDIA RTX 4000 Ada').should('be.visible');
+        });
+
+      cy.get('[data-qa="NVIDIA Quadro RTX 6000 table-header"]')
+        .parent()
+        .within(() => {
+          cy.findByText('NVIDIA Quadro RTX 6000').should('be.visible');
+        });
+    });
+  });
+});
+
 describe('Linode Accelerated plans', () => {
   beforeEach(() => {
     mockGetRegions(mockRegions).as('getRegions');

--- a/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
@@ -409,7 +409,7 @@ describe('displays specific linode plans for GPU', () => {
   });
 });
 
-describe.only('displays specific kubernetes plans for GPU', () => {
+describe('displays specific kubernetes plans for GPU', () => {
   beforeEach(() => {
     mockGetRegions(mockRegions).as('getRegions');
     mockGetLinodeTypes(mockLinodeTypes).as('getLinodeTypes');

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -121,8 +121,8 @@ const Panel = (props: NodePoolPanelProps) => {
               return false;
             }
 
-            // No Nanodes or GPUs in Kubernetes clusters
-            return t.class !== 'nanode' && t.class !== 'gpu';
+            // No Nanodes in Kubernetes clusters
+            return t.class !== 'nanode';
           })}
           error={apiError}
           hasSelectedRegion={hasSelectedRegion}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
@@ -180,10 +180,6 @@ export const AddNodePoolDrawer = (props: Props) => {
               setSelectedTypeInfo({ count: 1, planId: newType });
             }
           }}
-          // No nanodes or GPUs in clusters
-          types={extendedTypes.filter(
-            (t) => t.class !== 'nanode' && t.class !== 'gpu'
-          )}
           addPool={handleAdd}
           getTypeCount={getTypeCount}
           hasSelectedRegion={hasSelectedRegion}
@@ -194,6 +190,8 @@ export const AddNodePoolDrawer = (props: Props) => {
           resetValues={resetDrawer}
           selectedId={selectedTypeInfo?.planId}
           selectedRegionId={clusterRegionId}
+          // No nanodes in clusters
+          types={extendedTypes.filter((t) => t.class !== 'nanode')}
           updatePlanCount={updatePlanCount}
         />
         {selectedTypeInfo &&

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
@@ -159,64 +159,104 @@ export const KubernetesPlanContainer = (
       </Hidden>
       <Hidden mdDown>
         <Grid lg={12} xs={12}>
-          <Table aria-label="List of Linode Plans" spacingBottom={16}>
-            <TableHead>
-              <TableRow>
-                {tableCells.map(({ cellName, center, noWrap, testId }) => {
-                  const attributeValue = `${testId}-header`;
-                  return (
-                    <TableCell
-                      center={center}
-                      data-qa={attributeValue}
-                      key={testId}
-                      noWrap={noWrap}
+          {planSelectionDividers.map((planSelectionDivider) =>
+            planType === planSelectionDivider.planType &&
+            planSelectionDivider.flag ? (
+              planSelectionDivider.tables.map((table) => {
+                const filteredPlans = table.planFilter
+                  ? plans.filter(table.planFilter)
+                  : plans;
+                return (
+                  filteredPlans.length > 0 && (
+                    <Table
+                      aria-label={`List of ${table.header} Plans`}
+                      key={table.header}
+                      spacingBottom={16}
                     >
-                      {cellName === 'Quantity' ? (
-                        <p className="visually-hidden">{cellName}</p>
-                      ) : (
-                        cellName
-                      )}
-                    </TableCell>
-                  );
-                })}
-              </TableRow>
-            </TableHead>
-            <TableBody role="grid">
-              {shouldDisplayNoRegionSelectedMessage ? (
-                <TableRowEmpty
-                  colSpan={9}
-                  message={PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE}
-                />
-              ) : (
-                planSelectionDividers.map((planSelectionDivider) =>
-                  planType === planSelectionDivider.planType &&
-                  planSelectionDivider.flag
-                    ? planSelectionDivider.tables.map((table) => {
-                        const filteredPlans = table.planFilter
-                          ? plans.filter(table.planFilter)
-                          : plans;
-                        return [
-                          filteredPlans.length > 0 && (
-                            <Grid key={table.header} xs={12}>
-                              <Typography
-                                data-qa={`${table.header} table-header`}
-                                variant="h3"
-                              >
-                                {table.header}
-                              </Typography>
-                            </Grid>
-                          ),
+                      <TableHead>
+                        <TableRow>
+                          {tableCells.map(
+                            ({ cellName, center, noWrap, testId }) => {
+                              const attributeValue = `${testId}-header`;
+                              return (
+                                <TableCell
+                                  center={center}
+                                  data-qa={attributeValue}
+                                  key={testId}
+                                  noWrap={noWrap}
+                                >
+                                  {cellName === 'Quantity' ? (
+                                    <p className="visually-hidden">
+                                      {cellName}
+                                    </p>
+                                  ) : cellName === 'Plan' ? (
+                                    table.header
+                                  ) : (
+                                    cellName
+                                  )}
+                                </TableCell>
+                              );
+                            }
+                          )}
+                        </TableRow>
+                      </TableHead>
+                      <TableBody role="grid">
+                        {shouldDisplayNoRegionSelectedMessage ? (
+                          <TableRowEmpty
+                            colSpan={9}
+                            message={PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE}
+                          />
+                        ) : (
                           renderPlanSelection({
                             header: table.header,
                             planFilter: table.planFilter,
-                          }),
-                        ];
-                      })
-                    : renderPlanSelection()
-                )
-              )}
-            </TableBody>
-          </Table>
+                          })
+                        )}
+                      </TableBody>
+                    </Table>
+                  )
+                );
+              })
+            ) : (
+              <Table
+                aria-label="List of Linode Plans"
+                key={planType}
+                spacingBottom={16}
+              >
+                <TableHead>
+                  <TableRow>
+                    {tableCells.map(({ cellName, center, noWrap, testId }) => {
+                      const attributeValue = `${testId}-header`;
+                      return (
+                        <TableCell
+                          center={center}
+                          data-qa={attributeValue}
+                          key={testId}
+                          noWrap={noWrap}
+                        >
+                          {cellName === 'Quantity' ? (
+                            <p className="visually-hidden">{cellName}</p>
+                          ) : (
+                            cellName
+                          )}
+                        </TableCell>
+                      );
+                    })}
+                  </TableRow>
+                </TableHead>
+                <TableBody role="grid">
+                  {shouldDisplayNoRegionSelectedMessage ? (
+                    <TableRowEmpty
+                      colSpan={9}
+                      message={PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE}
+                    />
+                  ) : (
+                    renderPlanSelection()
+                  )}
+                </TableBody>
+              </Table>
+            )
+          )}
         </Grid>
       </Hidden>
     </Grid>

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
@@ -3,16 +3,11 @@ import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 
 import { Hidden } from 'src/components/Hidden';
-import { Table } from 'src/components/Table';
-import { TableBody } from 'src/components/TableBody';
-import { TableCell } from 'src/components/TableCell';
-import { TableHead } from 'src/components/TableHead';
-import { TableRow } from 'src/components/TableRow';
-import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
 import { useFlags } from 'src/hooks/useFlags';
 import { PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE } from 'src/utilities/pricing/constants';
 
 import { KubernetesPlanSelection } from './KubernetesPlanSelection';
+import { KubernetesPlanSelectionTable } from './KubernetesPlanSelectionTable';
 
 import type { LinodeTypeClass } from '@linode/api-v4';
 import type {
@@ -20,16 +15,6 @@ import type {
   PlanSelectionFilterOptionsTable,
 } from 'src/features/components/PlansPanel/PlanContainer';
 import type { PlanWithAvailability } from 'src/features/components/PlansPanel/types';
-
-const tableCells = [
-  { cellName: 'Plan', center: false, noWrap: false, testId: 'plan' },
-  { cellName: 'Monthly', center: false, noWrap: false, testId: 'monthly' },
-  { cellName: 'Hourly', center: false, noWrap: false, testId: 'hourly' },
-  { cellName: 'RAM', center: true, noWrap: false, testId: 'ram' },
-  { cellName: 'CPUs', center: true, noWrap: false, testId: 'cpu' },
-  { cellName: 'Storage', center: true, noWrap: false, testId: 'storage' },
-  { cellName: 'Quantity', center: false, noWrap: false, testId: 'quantity' },
-];
 
 export interface KubernetesPlanContainerProps {
   allDisabledPlans: PlanWithAvailability[];
@@ -162,99 +147,36 @@ export const KubernetesPlanContainer = (
           {planSelectionDividers.map((planSelectionDivider) =>
             planType === planSelectionDivider.planType &&
             planSelectionDivider.flag ? (
-              planSelectionDivider.tables.map((table) => {
+              planSelectionDivider.tables.map((table, idx) => {
                 const filteredPlans = table.planFilter
                   ? plans.filter(table.planFilter)
                   : plans;
                 return (
                   filteredPlans.length > 0 && (
-                    <Table
-                      aria-label={`List of ${table.header} Plans`}
-                      key={table.header}
-                      spacingBottom={16}
-                    >
-                      <TableHead>
-                        <TableRow>
-                          {tableCells.map(
-                            ({ cellName, center, noWrap, testId }) => {
-                              const attributeValue = `${testId}-header`;
-                              return (
-                                <TableCell
-                                  center={center}
-                                  data-qa={attributeValue}
-                                  key={testId}
-                                  noWrap={noWrap}
-                                >
-                                  {cellName === 'Quantity' ? (
-                                    <p className="visually-hidden">
-                                      {cellName}
-                                    </p>
-                                  ) : cellName === 'Plan' ? (
-                                    table.header
-                                  ) : (
-                                    cellName
-                                  )}
-                                </TableCell>
-                              );
-                            }
-                          )}
-                        </TableRow>
-                      </TableHead>
-                      <TableBody role="grid">
-                        {shouldDisplayNoRegionSelectedMessage ? (
-                          <TableRowEmpty
-                            colSpan={9}
-                            message={PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE}
-                          />
-                        ) : (
-                          renderPlanSelection({
-                            header: table.header,
-                            planFilter: table.planFilter,
-                          })
-                        )}
-                      </TableBody>
-                    </Table>
+                    <KubernetesPlanSelectionTable
+                      renderPlanSelection={() =>
+                        renderPlanSelection({
+                          header: table.header,
+                          planFilter: table.planFilter,
+                        })
+                      }
+                      shouldDisplayNoRegionSelectedMessage={
+                        shouldDisplayNoRegionSelectedMessage
+                      }
+                      filterOptions={table}
+                      key={`k8-plan-filter-${idx}`}
+                    />
                   )
                 );
               })
             ) : (
-              <Table
-                aria-label="List of Linode Plans"
+              <KubernetesPlanSelectionTable
+                shouldDisplayNoRegionSelectedMessage={
+                  shouldDisplayNoRegionSelectedMessage
+                }
                 key={planType}
-                spacingBottom={16}
-              >
-                <TableHead>
-                  <TableRow>
-                    {tableCells.map(({ cellName, center, noWrap, testId }) => {
-                      const attributeValue = `${testId}-header`;
-                      return (
-                        <TableCell
-                          center={center}
-                          data-qa={attributeValue}
-                          key={testId}
-                          noWrap={noWrap}
-                        >
-                          {cellName === 'Quantity' ? (
-                            <p className="visually-hidden">{cellName}</p>
-                          ) : (
-                            cellName
-                          )}
-                        </TableCell>
-                      );
-                    })}
-                  </TableRow>
-                </TableHead>
-                <TableBody role="grid">
-                  {shouldDisplayNoRegionSelectedMessage ? (
-                    <TableRowEmpty
-                      colSpan={9}
-                      message={PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE}
-                    />
-                  ) : (
-                    renderPlanSelection()
-                  )}
-                </TableBody>
-              </Table>
+                renderPlanSelection={renderPlanSelection}
+              />
             )
           )}
         </Grid>

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
@@ -1,4 +1,4 @@
-import { Notice } from '@linode/ui';
+import { Notice, Typography } from '@linode/ui';
 import Grid from '@mui/material/Unstable_Grid2';
 import * as React from 'react';
 
@@ -9,10 +9,16 @@ import { TableCell } from 'src/components/TableCell';
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
 import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
+import { useFlags } from 'src/hooks/useFlags';
 import { PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE } from 'src/utilities/pricing/constants';
 
 import { KubernetesPlanSelection } from './KubernetesPlanSelection';
 
+import type { LinodeTypeClass } from '@linode/api-v4';
+import type {
+  PlanSelectionDividers,
+  PlanSelectionFilterOptionsTable,
+} from 'src/features/components/PlansPanel/PlanContainer';
 import type { PlanWithAvailability } from 'src/features/components/PlansPanel/types';
 
 const tableCells = [
@@ -31,6 +37,7 @@ export interface KubernetesPlanContainerProps {
   hasMajorityOfPlansDisabled: boolean;
   onAdd?: (key: string, value: number) => void;
   onSelect: (key: string) => void;
+  planType?: LinodeTypeClass;
   plans: PlanWithAvailability[];
   selectedId?: string;
   selectedRegionId?: string;
@@ -46,44 +53,75 @@ export const KubernetesPlanContainer = (
     hasMajorityOfPlansDisabled,
     onAdd,
     onSelect,
+    planType,
     plans,
     selectedId,
     selectedRegionId,
     updatePlanCount,
     wholePanelIsDisabled,
   } = props;
-
+  const flags = useFlags();
   const shouldDisplayNoRegionSelectedMessage = !selectedRegionId;
 
-  const renderPlanSelection = React.useCallback(() => {
-    return plans.map((plan, id) => {
-      return (
-        <KubernetesPlanSelection
-          getTypeCount={getTypeCount}
-          hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
-          idx={id}
-          key={id}
-          onAdd={onAdd}
-          onSelect={onSelect}
-          plan={plan}
-          selectedId={selectedId}
-          selectedRegionId={selectedRegionId}
-          updatePlanCount={updatePlanCount}
-          wholePanelIsDisabled={wholePanelIsDisabled}
-        />
-      );
-    });
-  }, [
-    wholePanelIsDisabled,
-    hasMajorityOfPlansDisabled,
-    getTypeCount,
-    onAdd,
-    onSelect,
-    plans,
-    selectedId,
-    selectedRegionId,
-    updatePlanCount,
-  ]);
+  /**
+   * This features allows us to divide the GPU plans into two separate tables.
+   * This can be re-used for other plan types in the future.
+   */
+  const planSelectionDividers: PlanSelectionDividers[] = [
+    {
+      flag: Boolean(flags.gpuv2?.planDivider),
+      planType: 'gpu',
+      tables: [
+        {
+          header: 'NVIDIA RTX 4000 Ada',
+          planFilter: (plan: PlanWithAvailability) =>
+            plan.label.includes('Ada'),
+        },
+        {
+          header: 'NVIDIA Quadro RTX 6000',
+          planFilter: (plan: PlanWithAvailability) =>
+            !plan.label.includes('Ada'),
+        },
+      ],
+    },
+  ];
+
+  const renderPlanSelection = React.useCallback(
+    (filterOptions?: PlanSelectionFilterOptionsTable) => {
+      const _plans = filterOptions?.planFilter
+        ? plans.filter(filterOptions.planFilter)
+        : plans;
+
+      return _plans.map((plan, id) => {
+        return (
+          <KubernetesPlanSelection
+            getTypeCount={getTypeCount}
+            hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
+            idx={id}
+            key={id}
+            onAdd={onAdd}
+            onSelect={onSelect}
+            plan={plan}
+            selectedId={selectedId}
+            selectedRegionId={selectedRegionId}
+            updatePlanCount={updatePlanCount}
+            wholePanelIsDisabled={wholePanelIsDisabled}
+          />
+        );
+      });
+    },
+    [
+      wholePanelIsDisabled,
+      hasMajorityOfPlansDisabled,
+      getTypeCount,
+      onAdd,
+      onSelect,
+      plans,
+      selectedId,
+      selectedRegionId,
+      updatePlanCount,
+    ]
+  );
 
   return (
     <Grid container spacing={2}>
@@ -97,7 +135,26 @@ export const KubernetesPlanContainer = (
             variant="info"
           />
         ) : (
-          renderPlanSelection()
+          planSelectionDividers.map((planSelectionDivider) =>
+            planType === planSelectionDivider.planType &&
+            planSelectionDivider.flag
+              ? planSelectionDivider.tables.map((table) => {
+                  const filteredPlans = table.planFilter
+                    ? plans.filter(table.planFilter)
+                    : plans;
+                  return [
+                    filteredPlans.length > 0 && (
+                      <Grid key={table.header} xs={12}>
+                        <Typography variant="h3">{table.header}</Typography>
+                      </Grid>
+                    ),
+                    renderPlanSelection({
+                      planFilter: table.planFilter,
+                    }),
+                  ];
+                })
+              : renderPlanSelection()
+          )
         )}
       </Hidden>
       <Hidden mdDown>
@@ -131,7 +188,28 @@ export const KubernetesPlanContainer = (
                   message={PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE}
                 />
               ) : (
-                renderPlanSelection()
+                planSelectionDividers.map((planSelectionDivider) =>
+                  planType === planSelectionDivider.planType &&
+                  planSelectionDivider.flag
+                    ? planSelectionDivider.tables.map((table) => {
+                        const filteredPlans = table.planFilter
+                          ? plans.filter(table.planFilter)
+                          : plans;
+                        return [
+                          filteredPlans.length > 0 && (
+                            <Grid key={table.header} xs={12}>
+                              <Typography variant="h3">
+                                {table.header}
+                              </Typography>
+                            </Grid>
+                          ),
+                          renderPlanSelection({
+                            planFilter: table.planFilter,
+                          }),
+                        ];
+                      })
+                    : renderPlanSelection()
+                )
               )}
             </TableBody>
           </Table>

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanContainer.tsx
@@ -198,12 +198,16 @@ export const KubernetesPlanContainer = (
                         return [
                           filteredPlans.length > 0 && (
                             <Grid key={table.header} xs={12}>
-                              <Typography variant="h3">
+                              <Typography
+                                data-qa={`${table.header} table-header`}
+                                variant="h3"
+                              >
                                 {table.header}
                               </Typography>
                             </Grid>
                           ),
                           renderPlanSelection({
+                            header: table.header,
                             planFilter: table.planFilter,
                           }),
                         ];

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelectionTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelectionTable.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+
+import { Table } from 'src/components/Table';
+import { TableBody } from 'src/components/TableBody';
+import { TableCell } from 'src/components/TableCell';
+import { TableHead } from 'src/components/TableHead';
+import { TableRow } from 'src/components/TableRow';
+import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
+import { PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE } from 'src/utilities/pricing/constants';
+
+import type { PlanSelectionFilterOptionsTable } from 'src/features/components/PlansPanel/PlanContainer';
+
+interface KubernetesPlanSelectionTableProps {
+  filterOptions?: PlanSelectionFilterOptionsTable;
+  renderPlanSelection: (
+    filterOptions?: PlanSelectionFilterOptionsTable | undefined
+  ) => React.JSX.Element[];
+  shouldDisplayNoRegionSelectedMessage: boolean;
+}
+
+const tableCells = [
+  { cellName: 'Plan', center: false, noWrap: false, testId: 'plan' },
+  { cellName: 'Monthly', center: false, noWrap: false, testId: 'monthly' },
+  { cellName: 'Hourly', center: false, noWrap: false, testId: 'hourly' },
+  { cellName: 'RAM', center: true, noWrap: false, testId: 'ram' },
+  { cellName: 'CPUs', center: true, noWrap: false, testId: 'cpu' },
+  { cellName: 'Storage', center: true, noWrap: false, testId: 'storage' },
+  { cellName: 'Quantity', center: false, noWrap: false, testId: 'quantity' },
+];
+
+export const KubernetesPlanSelectionTable = (
+  props: KubernetesPlanSelectionTableProps
+) => {
+  const {
+    filterOptions,
+    renderPlanSelection,
+    shouldDisplayNoRegionSelectedMessage,
+  } = props;
+
+  return (
+    <Table
+      aria-label={`List of ${filterOptions?.header ?? 'Linode'} Plans`}
+      spacingBottom={16}
+    >
+      <TableHead>
+        <TableRow>
+          {tableCells.map(({ cellName, center, noWrap, testId }) => {
+            const attributeValue = `${testId}-header`;
+            return (
+              <TableCell
+                center={center}
+                data-qa={attributeValue}
+                key={testId}
+                noWrap={noWrap}
+              >
+                {cellName === 'Quantity' ? (
+                  <p className="visually-hidden">{cellName}</p>
+                ) : cellName === 'Plan' && filterOptions?.header ? (
+                  filterOptions.header
+                ) : (
+                  cellName
+                )}
+              </TableCell>
+            );
+          })}
+        </TableRow>
+      </TableHead>
+      <TableBody role="grid">
+        {shouldDisplayNoRegionSelectedMessage ? (
+          <TableRowEmpty
+            colSpan={9}
+            message={PLAN_SELECTION_NO_REGION_SELECTED_MESSAGE}
+          />
+        ) : (
+          renderPlanSelection()
+        )}
+      </TableBody>
+    </Table>
+  );
+};

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
@@ -121,6 +121,7 @@ export const KubernetesPlansPanel = (props: Props) => {
                 hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
                 onAdd={onAdd}
                 onSelect={onSelect}
+                planType={plan}
                 plans={plansForThisLinodeTypeClass}
                 selectedId={selectedId}
                 selectedRegionId={selectedRegionId}

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
@@ -106,6 +106,7 @@ export const KubernetesPlansPanel = (props: Props) => {
                 isSelectedRegionEligibleForPlan={isSelectedRegionEligibleForPlan(
                   plan
                 )}
+                flow="kubernetes"
                 hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
                 hasSelectedRegion={hasSelectedRegion}
                 isAPLEnabled={isAPLEnabled}

--- a/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanContainer.tsx
@@ -20,7 +20,7 @@ export interface PlanSelectionFilterOptionsTable {
   planFilter?: (plan: PlanWithAvailability) => boolean;
 }
 
-interface PlanSelectionDividers {
+export interface PlanSelectionDividers {
   flag: boolean;
   planType: LinodeTypeClass;
   tables: PlanSelectionFilterOptionsTable[];

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.test.tsx
@@ -11,6 +11,7 @@ import {
 import type { PlanInformationProps } from './PlanInformation';
 
 const mockProps: PlanInformationProps = {
+  flow: 'linode',
   hasMajorityOfPlansDisabled: false,
   hasSelectedRegion: true,
   isAPLEnabled: true,

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
@@ -29,6 +29,7 @@ interface ExtendedPlanType {
 
 export interface PlanInformationProps extends ExtendedPlanType {
   disabledClasses?: LinodeTypeClass[];
+  flow: 'kubernetes' | 'linode';
   hasMajorityOfPlansDisabled: boolean;
   hasSelectedRegion: boolean;
   hideLimitedAvailabilityBanner?: boolean;
@@ -40,6 +41,7 @@ export interface PlanInformationProps extends ExtendedPlanType {
 export const PlanInformation = (props: PlanInformationProps) => {
   const {
     disabledClasses,
+    flow,
     hasMajorityOfPlansDisabled,
     hasSelectedRegion,
     hideLimitedAvailabilityBanner,
@@ -96,7 +98,7 @@ export const PlanInformation = (props: PlanInformationProps) => {
               </Typography>
             </Notice>
           )}
-          {showTransferBanner && transferBanner}
+          {showTransferBanner && flow === 'linode' && transferBanner}
           <PlansAvailabilityNotice
             hasSelectedRegion={hasSelectedRegion}
             isSelectedRegionEligibleForPlan={isSelectedRegionEligibleForPlan}

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -175,6 +175,7 @@ export const PlansPanel = (props: PlansPanelProps) => {
                   plan
                 )}
                 disabledClasses={disabledClasses}
+                flow="linode"
                 hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}
                 hasSelectedRegion={hasSelectedRegion}
                 planType={plan}


### PR DESCRIPTION
## Description 📝
This PR brings GPU plans to the LKE create flow.

GPU plans for LKE have already been made available through the API, but not in Cloud Manger which has broken service parity between the API consumers.

This task implements a new GPU tab within the LKE create flow to provide the ability to create clusters with the GPU class. It mirrors the existing look and functionality (UI + UX) of the linode create flow plan selection, inclufing the split table (new ADA plans VS legacy RTX plans).

## Changes  🔄
- Add new GPU tabs in the kubernetes create flow and cluster details 'Add Node Pool' flow
- Implement associated display logic
  - disabled plans
  - notices
  - split table (ADA vs RTX)
- Provide/consolidate e2e tests with new plans

## Target release date 🗓️
⚠️   **01/28/2025**

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-01-21 at 16 10 09](https://github.com/user-attachments/assets/fe7b89f2-dd7a-44e5-996b-bf07c002328e) | ![Screenshot 2025-01-21 at 23 21 23](https://github.com/user-attachments/assets/e09579a6-e30e-453e-9aff-79daace415f1) |
| ![Screenshot 2025-01-22 at 9 22 45 AM](https://github.com/user-attachments/assets/d746ecc3-e0c9-4df1-a1b8-db962e24d1e2) | ![Screenshot 2025-01-22 at 9 19 08 AM](https://github.com/user-attachments/assets/0063b985-b253-4b0c-9b31-c0a2fa057543) |


## How to test 🧪

### Verification steps
- Navigate to the LKE create flow: `/kubernetes/create`
- Confirm the following:
  - new GPU tab
  - split table (ADA vs RTX plans)
  - ability to create a cluster with a GPU node pool
  - mobile handling
  - no transfer banner as opposed to the linode create flow
  - Navigate to the cluster details page and confirm that nodes can be added with the GPU tab when the 'Add Node Pool' button is clicked in a cluster with a valid region

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
