### PR TITLE
test: [M3-7511, M3-9147] restricted user has disabled inputs on object storage creation

### DIFF
--- a/packages/manager/.changeset/pr-11560-tests-1737658018185.md
+++ b/packages/manager/.changeset/pr-11560-tests-1737658018185.md
@@ -2,4 +2,4 @@
 "@linode/manager": Tests
 ---
 
-tests of object storage creation form for restricted user ([#11560](https://github.com/linode/manager/pull/11560))
+Add Cypress tests for object storage creation form for restricted user ([#11560](https://github.com/linode/manager/pull/11560))

--- a/packages/manager/.changeset/pr-11560-tests-1737658018185.md
+++ b/packages/manager/.changeset/pr-11560-tests-1737658018185.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+tests of object storage creation form for restricted user ([#11560](https://github.com/linode/manager/pull/11560))

--- a/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-access-keys-gen2.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-access-keys-gen2.spec.ts
@@ -121,14 +121,21 @@ describe('Object Storage Gen2 create access key modal has disabled fields for re
 
     cy.wait(['@getFeatureFlags', '@getAccount', '@getProfile']);
     // error message
-    cy.findByTestId('notice-error-important').should('be.visible');
-    // label
-    cy.findByLabelText(/Label.*/)
+    ui.drawer
+      .findByTitle('Create Access Key')
       .should('be.visible')
-      .should('be.disabled');
-    // region
-    ui.regionSelect.find().should('be.visible').should('be.disabled');
-    // submit button is disabled
-    cy.findByTestId('submit').should('be.visible').should('be.disabled');
+      .within(() => {
+        cy.findByText(
+          /You don't have bucket_access to create an Access Key./
+        ).should('be.visible');
+        // label
+        cy.findByLabelText(/Label.*/)
+          .should('be.visible')
+          .should('be.disabled');
+        // region
+        ui.regionSelect.find().should('be.visible').should('be.disabled');
+        // submit button is disabled
+        cy.findByTestId('submit').should('be.visible').should('be.disabled');
+      });
   });
 });

--- a/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-access-keys-gen2.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-access-keys-gen2.spec.ts
@@ -1,7 +1,9 @@
 import { mockGetAccount } from 'support/intercepts/account';
 import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
+import { mockGetProfile } from 'support/intercepts/profile';
 import { mockGetAccessKeys } from 'support/intercepts/object-storage';
 import { accountFactory, objectStorageKeyFactory } from 'src/factories';
+import { profileFactory } from 'src/factories/profile';
 import { ui } from 'support/ui';
 
 describe('Object Storage gen2 access keys tests', () => {
@@ -83,5 +85,50 @@ describe('Object Storage gen2 access keys tests', () => {
           'be.visible'
         );
       });
+  });
+});
+
+/**
+ * When a restricted user navigates to object-storage/access-keys/create, an error is shown in the "Create Access Key" drawer noting that the user does not have access key creation permissions
+ */
+describe('Object Storage Gen2 create access key modal has disabled fields for restricted user', () => {
+  beforeEach(() => {
+    mockAppendFeatureFlags({
+      objMultiCluster: true,
+      objectStorageGen2: { enabled: true },
+    }).as('getFeatureFlags');
+    mockGetAccount(
+      accountFactory.build({
+        capabilities: [
+          'Object Storage',
+          'Object Storage Endpoint Types',
+          'Object Storage Access Key Regions',
+        ],
+      })
+    ).as('getAccount');
+    // restricted user
+    mockGetProfile(
+      profileFactory.build({
+        email: 'mock-user@linode.com',
+        restricted: true,
+      })
+    ).as('getProfile');
+  });
+
+  // access keys creation
+  it('create access keys form', () => {
+    cy.visitWithLogin('/object-storage/access-keys/create');
+
+    cy.wait(['@getFeatureFlags', '@getAccount', '@getProfile']);
+    // error message
+    cy.findByTestId('notice-error-important').should('be.visible');
+    // label
+    cy.findByLabelText(/Label.*/)
+      .should('be.visible')
+      .should('be.disabled');
+    // region
+    ui.regionSelect.find().should('be.visible').should('be.disabled');
+    // submit button is disabled
+    cy.findByTestId('submit').should('be.visible').should('be.disabled');
   });
 });

--- a/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-create-gen2.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-create-gen2.spec.ts
@@ -720,9 +720,9 @@ describe('Object Storage Gen2 create bucket tests', () => {
 });
 
 /**
- * When a restricted user navigates to object-storage/create, an error is shown in the "Create Bucket" drawer noting that the user does not have bucket creation permissions
+ * When a restricted user navigates to object-storage/buckets/create, an error is shown in the "Create Bucket" drawer noting that the user does not have bucket creation permissions
  */
-describe('Object Storage Gen2 create bucket modal has disabled fields', () => {
+describe('Object Storage Gen2 create bucket modal has disabled fields for restricted user', () => {
   beforeEach(() => {
     mockAppendFeatureFlags({
       objMultiCluster: true,
@@ -746,13 +746,6 @@ describe('Object Storage Gen2 create bucket modal has disabled fields', () => {
     ).as('getProfile');
   });
 
-  //TODO: this test fails rn. why should create button be enabled on landing page but not modal?
-  xit('bucket landing page should have Create button disabled', () => {
-    cy.visitWithLogin('/object-storage/buckets');
-    cy.wait(['@getFeatureFlags', '@getAccount', '@getProfile']);
-    cy.findByTestId('button').should('be.visible').should('be.disabled');
-  });
-
   // bucket creation
   it('create bucket form', () => {
     cy.visitWithLogin('/object-storage/buckets/create');
@@ -760,31 +753,13 @@ describe('Object Storage Gen2 create bucket modal has disabled fields', () => {
 
     // error message
     cy.findByTestId('notice-error').should('be.visible');
-    cy.get('#label').should('be.visible').should('be.disabled');
-    cy.findByTestId('region-select').within(() => {
-      cy.get('input').should('be.visible').should('be.disabled');
-    });
+    cy.findByLabelText(/Label.*/)
+      .should('be.visible')
+      .should('be.disabled');
+    ui.regionSelect.find().should('be.visible').should('be.disabled');
     // submit button should be enabled
     cy.findByTestId('create-bucket-button')
       .should('be.visible')
       .should('be.enabled');
-  });
-
-  // access keys creation
-  it('create access keys form', () => {
-    cy.visitWithLogin('/object-storage/access-keys/create');
-
-    cy.wait(['@getFeatureFlags', '@getAccount', '@getProfile']);
-    // error message
-    cy.findByTestId('notice-error-important').should('be.visible');
-    // label
-    cy.get('#label').should('be.visible').should('be.disabled');
-    // region
-    cy.findByTestId('region-select').within(() => {
-      cy.get('input').should('be.visible').should('be.disabled');
-    });
-    // submit button
-    // TODO: create button is disabled?
-    cy.findByTestId('submit').should('be.visible').should('be.disabled');
   });
 });

--- a/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-create-gen2.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-create-gen2.spec.ts
@@ -752,14 +752,21 @@ describe('Object Storage Gen2 create bucket modal has disabled fields for restri
     cy.wait(['@getFeatureFlags', '@getAccount', '@getProfile']);
 
     // error message
-    cy.findByTestId('notice-error').should('be.visible');
-    cy.findByLabelText(/Label.*/)
+    ui.drawer
+      .findByTitle('Create Bucket')
       .should('be.visible')
-      .should('be.disabled');
-    ui.regionSelect.find().should('be.visible').should('be.disabled');
-    // submit button should be enabled
-    cy.findByTestId('create-bucket-button')
-      .should('be.visible')
-      .should('be.enabled');
+      .within(() => {
+        cy.findByText(/You don't have permissions to create a Bucket./).should(
+          'be.visible'
+        );
+        cy.findByLabelText(/Label.*/)
+          .should('be.visible')
+          .should('be.disabled');
+        ui.regionSelect.find().should('be.visible').should('be.disabled');
+        // submit button should be enabled
+        cy.findByTestId('create-bucket-button')
+          .should('be.visible')
+          .should('be.enabled');
+      });
   });
 });

--- a/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-create-gen2.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-create-gen2.spec.ts
@@ -746,16 +746,9 @@ describe('Object Storage Gen2 create bucket modal has disabled fields', () => {
     ).as('getProfile');
   });
 
-  //TODO: this test fails rn but this is the desired behavior
-  it('bucket landing page should have Create button disabled', () => {
+  //TODO: this test fails rn. why should create button be enabled on landing page but not modal?
+  xit('bucket landing page should have Create button disabled', () => {
     cy.visitWithLogin('/object-storage/buckets');
-    cy.wait(['@getFeatureFlags', '@getAccount', '@getProfile']);
-    cy.findByTestId('button').should('be.visible').should('be.disabled');
-  });
-
-  //TODO: this test fails rn but this is the desired behavior
-  it('access keys landing page should have Create button disabled', () => {
-    cy.visitWithLogin('/object-storage/access-keys');
     cy.wait(['@getFeatureFlags', '@getAccount', '@getProfile']);
     cy.findByTestId('button').should('be.visible').should('be.disabled');
   });
@@ -771,8 +764,7 @@ describe('Object Storage Gen2 create bucket modal has disabled fields', () => {
     cy.findByTestId('region-select').within(() => {
       cy.get('input').should('be.visible').should('be.disabled');
     });
-    // submit button
-    // TODO: label/region inputs disabled but create button is ENabled?
+    // submit button should be enabled
     cy.findByTestId('create-bucket-button')
       .should('be.visible')
       .should('be.enabled');

--- a/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-create-gen2.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-create-gen2.spec.ts
@@ -23,7 +23,7 @@ import { profileFactory } from 'src/factories/profile';
 import { chooseRegion } from 'support/util/regions';
 import type { ACLType, ObjectStorageEndpoint } from '@linode/api-v4';
 
-xdescribe('Object Storage Gen2 create bucket tests', () => {
+describe('Object Storage Gen2 create bucket tests', () => {
   beforeEach(() => {
     mockAppendFeatureFlags({
       objMultiCluster: true,


### PR DESCRIPTION
## Description 📝

Integration tests for M3-7511 and M3-9147 (avoiding internal linkage on the public repo as a security best practice). When user navigates to object-storage/buckets/create, the label and region inputs are disabled. When user navigates to object-storage/access-keys/create, the label and region inputs as well as the Create button are disabled. 

## Changes  🔄

- Added integration tests to packages/manager/cypress/support/intercepts/object-storage.ts. 

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/objectStorageGen2/bucket-access-keys-gen2.spec.ts,cypress/e2e/core/objectStorageGen2/bucket-create-gen2.spec.ts"
```
   
## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
