### PR TITLE
fix: Cypress tests failing in Github Actions, fix `resize-linode.spec.ts` failure, address `DatabaseBackups.test.tsx` flake

### DIFF
--- a/packages/manager/.changeset/pr-11561-tests-1737675052334.md
+++ b/packages/manager/.changeset/pr-11561-tests-1737675052334.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Stop using `--headless=old` Chrome flag to run headless Cypress tests ([#11561](https://github.com/linode/manager/pull/11561))

--- a/packages/manager/.changeset/pr-11561-tests-1737675335132.md
+++ b/packages/manager/.changeset/pr-11561-tests-1737675335132.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix `resize-linode.spec.ts` test failure caused by updated API notification message ([#11561](https://github.com/linode/manager/pull/11561))

--- a/packages/manager/cypress/e2e/core/linodes/resize-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/resize-linode.spec.ts
@@ -51,7 +51,7 @@ describe('resize linode', () => {
 
       cy.wait('@linodeResize');
       cy.contains(
-        "Your linode will be warm resized and will automatically attempt to power off and restore to it's previous state."
+        "Your linode will be warm resized and will automatically attempt to power off and restore to its previous state."
       ).should('be.visible');
     });
   });

--- a/packages/manager/cypress/support/plugins/configure-browser.ts
+++ b/packages/manager/cypress/support/plugins/configure-browser.ts
@@ -53,21 +53,8 @@ export const configureBrowser: CypressPlugin = (on, _config) => {
       },
     };
 
-    // Disable Chrome's new headless implementation.
-    // This attempts to resolve indefinite test hanging.
-    //
-    // See also: https://github.com/cypress-io/cypress/issues/27264
-    if (browser.name === 'chrome' && browser.isHeadless) {
-      // If present, remove the `--headless=new` command line argument.
-      launchOptions.args = launchOptions.args.filter((arg: string) => {
-        return arg !== '--headless=new';
-      });
-      // Append `--headless=old` and `--disable-dev-shm-usage` args.
-      launchOptions.args.push('--headless=old');
-      launchOptions.args.push('--disable-dev-shm-usage');
-    }
-
     displayBrowserInfo(browser, launchOptions);
+
     return launchOptions;
   });
 };

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.test.tsx
@@ -9,7 +9,10 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 import DatabaseBackups from './DatabaseBackups';
 
 describe('Database Backups (Legacy)', () => {
-  it('should render a list of backups after loading', async () => {
+  /**
+   * Skipped due to repeated flake issues
+   */
+  it.skip('should render a list of backups after loading', async () => {
     const mockDatabase = databaseFactory.build({
       platform: 'rdbms-legacy',
     });

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.test.tsx
@@ -8,11 +8,13 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import DatabaseBackups from './DatabaseBackups';
 
-describe('Database Backups (Legacy)', () => {
-  /**
-   * Skipped due to repeated flake issues
-   */
-  it.skip('should render a list of backups after loading', async () => {
+/**
+ * Skipped due to repeated flake issues that we've been unable to fix after a few attempts
+ * 1. https://github.com/linode/manager/pull/11130
+ * 2. https://github.com/linode/manager/pull/11394
+ */
+describe.skip('Database Backups (Legacy)', () => {
+  it('should render a list of backups after loading', async () => {
     const mockDatabase = databaseFactory.build({
       platform: 'rdbms-legacy',
     });


### PR DESCRIPTION
## Description 📝

- An attempt to fix our failing Cypress test that run in Github Actions
  - I believe the issue was caused by a chrome update. It seems the issue started happening on runs that use Chrome 132 ([example](https://github.com/linode/manager/actions/runs/12937051157/job/36084103538)). Things worked on Chrome 131 ([example](https://github.com/linode/manager/actions/runs/12894576526/job/35953896429)).
  - Chrome 132 no longer supports the old headless mode according to [this post](https://developer.chrome.com/blog/removing-headless-old-from-chrome#:~:text=We're%20happy%20to%20announce,runs%20the%20new%20Headless%20mode.) so this PR removes the old headless mode flag we were using
  - This issue is not happening in our Jenkins cypress pipeline because that uses an older Chrome version that I believe is included in the cypress docker image
- Skips the flakey tests in `DatabaseBackups.test.tsx`
  - It has gotten [out of hand](https://github.com/linode/manager/actions/workflows/coverage.yml?query=is%3Afailure)
  - I can't take it anymore 😖  In my opinion it is hurting us more than it is helping us
- Fixes `resize-linode.spec.ts` failure caused by an API change

## Preview 📷

![Screenshot 2025-01-23 at 4 16 11 PM](https://github.com/user-attachments/assets/a9d967c3-f431-470c-8fee-51c35c5c6876)


## How to test 🧪

- I **am** able to reproduce with `yarn cy:run` locally and this change fixes the issue
  - We should just confirm that this doesn't cause any regressions like "indefinite test hanging".  This is why this extra config was added in the first place
- Because the e2e Github Actions only runs on `develop`, `staging`, and `master` I can't easily test this
  - I think we just have to merge and hope, but let me know if you have ideas on how to test this


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>