### PR TITLE
change: [M3-9159] - Enable Pendo based on OneTrust cookie consent

### DIFF
--- a/docs/tooling/analytics.md
+++ b/docs/tooling/analytics.md
@@ -12,11 +12,11 @@ Pendo is configured in [`usePendo.js`](https://github.com/linode/manager/blob/de
 
 Important notes:
 
-- Pendo is only loaded if a valid `PENDO_API_KEY` is configured as an environment variable. In our development, staging, and production environments, `PENDO_API_KEY` is available at build time. See **Locally Testing Page Views & Custom Events and/or Troubleshooting Pendo** for set up with local environments.
+- Pendo is only loaded if the user has enabled Performance Cookies via OneTrust *and* if a valid `PENDO_API_KEY` is configured as an environment variable. In our development, staging, and production environments, `PENDO_API_KEY` is available at build time. See **Locally Testing Page Views & Custom Events and/or Troubleshooting Pendo** for set up with local environments.
 - We load the Pendo agent from the CDN, rather than [self-hosting](https://support.pendo.io/hc/en-us/articles/360038969692-Self-hosting-the-Pendo-agent), and we have configured a [CNAME](https://support.pendo.io/hc/en-us/articles/360043539891-CNAME-for-Pendo).
 - We are hashing account and visitor IDs in a way that is consistent with Akamai's standards.
 - At initialization, we do string transformation on select URL patterns to **remove  sensitive data**. When new URL patterns are added to Cloud Manager, verify that existing transforms remove sensitive data; if not, update the transforms.
-- Pendo is currently not using any client-side (cookies or local) storage.
+- Pendo will respect OneTrust cookie preferences in development, staging, and production environments and does not check cookie preferences in the local environment.
 - Pendo makes use of the existing `data-testid` properties, used in our automated testing, for tagging elements. They are more persistent and reliable than CSS properties, which are liable to change.
 
 ### Locally Testing Page Views & Custom Events and/or Troubleshooting Pendo

--- a/packages/manager/.changeset/pr-11564-tech-stories-1737743829459.md
+++ b/packages/manager/.changeset/pr-11564-tech-stories-1737743829459.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Enable Pendo based on OneTrust cookie consent ([#11564](https://github.com/linode/manager/pull/11564))

--- a/packages/manager/src/hooks/usePendo.ts
+++ b/packages/manager/src/hooks/usePendo.ts
@@ -4,13 +4,13 @@ import React from 'react';
 import { APP_ROOT, PENDO_API_KEY } from 'src/constants';
 import { useAccount } from 'src/queries/account/account.js';
 import { useProfile } from 'src/queries/profile/profile';
-
-import { loadScript } from './useScript';
 import {
+  ONE_TRUST_COOKIE_CATEGORIES,
   checkOptanonConsent,
   getCookie,
-  ONE_TRUST_COOKIE_CATEGORIES,
 } from 'src/utilities/analytics/utils';
+
+import { loadScript } from './useScript';
 
 declare global {
   interface Window {
@@ -165,5 +165,5 @@ export const usePendo = () => {
         });
       });
     }
-  }, [PENDO_URL, accountId, visitorId]);
+  }, [PENDO_URL, accountId, hasFunctionalCookieConsent, visitorId]);
 };

--- a/packages/manager/src/hooks/usePendo.ts
+++ b/packages/manager/src/hooks/usePendo.ts
@@ -75,16 +75,20 @@ export const usePendo = () => {
   const visitorId = hashUniquePendoId(profile?.uid.toString());
 
   const optanonCookie = getCookie('OptanonConsent');
-  const hasCookieConsent = checkOptanonConsent(
-    optanonCookie,
-    ONE_TRUST_COOKIE_CATEGORIES['Performance Cookies']
-  );
+  // Since OptanonConsent cookie always has a .linode.com domain, only check for consent in dev/staging/prod envs.
+  // When running the app locally, do not try to check for OneTrust cookie consent, just enable Pendo.
+  const hasConsentEnabled = !APP_ROOT.includes('localhost')
+    ? checkOptanonConsent(
+        optanonCookie,
+        ONE_TRUST_COOKIE_CATEGORIES['Performance Cookies']
+      )
+    : true;
 
   // This URL uses a Pendo-configured CNAME (M3-8742).
   const PENDO_URL = `https://content.psp.cloud.linode.com/agent/static/${PENDO_API_KEY}/pendo.js`;
 
   React.useEffect(() => {
-    if (PENDO_API_KEY && hasCookieConsent) {
+    if (PENDO_API_KEY && hasConsentEnabled) {
       // Adapted Pendo install script for readability
       // Refer to: https://support.pendo.io/hc/en-us/articles/21362607464987-Components-of-the-install-script#01H6S2EXET8C9FGSHP08XZAE4F
 
@@ -164,5 +168,5 @@ export const usePendo = () => {
         });
       });
     }
-  }, [PENDO_URL, accountId, hasCookieConsent, visitorId]);
+  }, [PENDO_URL, accountId, hasConsentEnabled, visitorId]);
 };

--- a/packages/manager/src/hooks/usePendo.ts
+++ b/packages/manager/src/hooks/usePendo.ts
@@ -78,7 +78,7 @@ export const usePendo = () => {
   // Since OptanonConsent cookie always has a .linode.com domain, only check for consent in dev/staging/prod envs.
   // When running the app locally, do not try to check for OneTrust cookie consent, just enable Pendo.
   const hasConsentEnabled =
-    !APP_ROOT.includes('localhost') ||
+    APP_ROOT.includes('localhost') ||
     checkOptanonConsent(
       optanonCookie,
       ONE_TRUST_COOKIE_CATEGORIES['Performance Cookies']

--- a/packages/manager/src/hooks/usePendo.ts
+++ b/packages/manager/src/hooks/usePendo.ts
@@ -77,12 +77,12 @@ export const usePendo = () => {
   const optanonCookie = getCookie('OptanonConsent');
   // Since OptanonConsent cookie always has a .linode.com domain, only check for consent in dev/staging/prod envs.
   // When running the app locally, do not try to check for OneTrust cookie consent, just enable Pendo.
-  const hasConsentEnabled = !APP_ROOT.includes('localhost')
-    ? checkOptanonConsent(
-        optanonCookie,
-        ONE_TRUST_COOKIE_CATEGORIES['Performance Cookies']
-      )
-    : true;
+  const hasConsentEnabled =
+    !APP_ROOT.includes('localhost') ||
+    checkOptanonConsent(
+      optanonCookie,
+      ONE_TRUST_COOKIE_CATEGORIES['Performance Cookies']
+    );
 
   // This URL uses a Pendo-configured CNAME (M3-8742).
   const PENDO_URL = `https://content.psp.cloud.linode.com/agent/static/${PENDO_API_KEY}/pendo.js`;

--- a/packages/manager/src/hooks/usePendo.ts
+++ b/packages/manager/src/hooks/usePendo.ts
@@ -75,17 +75,16 @@ export const usePendo = () => {
   const visitorId = hashUniquePendoId(profile?.uid.toString());
 
   const optanonCookie = getCookie('OptanonConsent');
-
-  const hasFunctionalCookieConsent = checkOptanonConsent(
+  const hasCookieConsent = checkOptanonConsent(
     optanonCookie,
-    ONE_TRUST_COOKIE_CATEGORIES['Functional Cookies']
+    ONE_TRUST_COOKIE_CATEGORIES['Performance Cookies']
   );
 
   // This URL uses a Pendo-configured CNAME (M3-8742).
   const PENDO_URL = `https://content.psp.cloud.linode.com/agent/static/${PENDO_API_KEY}/pendo.js`;
 
   React.useEffect(() => {
-    if (PENDO_API_KEY && hasFunctionalCookieConsent) {
+    if (PENDO_API_KEY && hasCookieConsent) {
       // Adapted Pendo install script for readability
       // Refer to: https://support.pendo.io/hc/en-us/articles/21362607464987-Components-of-the-install-script#01H6S2EXET8C9FGSHP08XZAE4F
 
@@ -165,5 +164,5 @@ export const usePendo = () => {
         });
       });
     }
-  }, [PENDO_URL, accountId, hasFunctionalCookieConsent, visitorId]);
+  }, [PENDO_URL, accountId, hasCookieConsent, visitorId]);
 };

--- a/packages/manager/src/utilities/analytics/utils.test.ts
+++ b/packages/manager/src/utilities/analytics/utils.test.ts
@@ -41,31 +41,31 @@ describe('checkOptanonConsent', () => {
     expect(
       checkOptanonConsent(
         mockFunctionalCookieConsentEnabled,
-        ONE_TRUST_COOKIE_CATEGORIES['Functional Cookies']
+        ONE_TRUST_COOKIE_CATEGORIES['Performance Cookies']
       )
     ).toEqual(true);
   });
 
   it('should return false if consent is disabled for the given Optanon cookie category', () => {
     const mockFunctionalCookieConsentDisabled =
-      'somestuffhere&groups=C0001%3A1%2CC0002%3A1%2CC0003%3A0%2CC0004%3A1%2CC0005%3A1&intType=6';
+      'somestuffhere&groups=C0001%3A1%2CC0002%3A0%2CC0003%3A1%2CC0004%3A1%2CC0005%3A1&intType=6';
 
     expect(
       checkOptanonConsent(
         mockFunctionalCookieConsentDisabled,
-        ONE_TRUST_COOKIE_CATEGORIES['Functional Cookies']
+        ONE_TRUST_COOKIE_CATEGORIES['Performance Cookies']
       )
     ).toEqual(false);
   });
 
   it('should return false if the consent category does not exist in the cookie', () => {
-    const mockNoFunctionalCookieCategory =
-      'somestuffhere&groups=C0001%3A1%2CC0002%3A1%2CC0004%3A1%2CC0005%3A1&intType=6';
+    const mockNoPerformanceCookieCategory =
+      'somestuffhere&groups=C0001%3A1%2CC0003%3A1%2CC0004%3A1%2CC0005%3A1&intType=6';
 
     expect(
       checkOptanonConsent(
-        mockNoFunctionalCookieCategory,
-        ONE_TRUST_COOKIE_CATEGORIES['Functional Cookies']
+        mockNoPerformanceCookieCategory,
+        ONE_TRUST_COOKIE_CATEGORIES['Performance Cookies']
       )
     ).toEqual(false);
   });
@@ -74,7 +74,7 @@ describe('checkOptanonConsent', () => {
     expect(
       checkOptanonConsent(
         undefined,
-        ONE_TRUST_COOKIE_CATEGORIES['Functional Cookies']
+        ONE_TRUST_COOKIE_CATEGORIES['Performance Cookies']
       )
     ).toEqual(false);
   });

--- a/packages/manager/src/utilities/analytics/utils.test.ts
+++ b/packages/manager/src/utilities/analytics/utils.test.ts
@@ -11,9 +11,9 @@ import type { FormEventOptions } from './types';
 
 describe('getCookie', () => {
   beforeAll(() => {
-    const cookies =
+    const mockCookies =
       'mycookie=my-cookie-value; OptanonConsent=cookie-consent-here; mythirdcookie=my-third-cookie;';
-    vi.spyOn(document, 'cookie', 'get').mockReturnValue(cookies);
+    vi.spyOn(document, 'cookie', 'get').mockReturnValue(mockCookies);
   });
 
   it('should return the value of a cookie from document.cookie given its name, given cookie in middle position', () => {
@@ -35,24 +35,24 @@ describe('getCookie', () => {
 
 describe('checkOptanonConsent', () => {
   it('should return true if consent is enabled for the given Optanon cookie category', () => {
-    const mockFunctionalCookieConsentEnabled =
+    const mockPerformanceCookieConsentEnabled =
       'somestuffhere&groups=C0001%3A1%2CC0002%3A1%2CC0003%3A1%2CC0004%3A1%2CC0005%3A1&intType=6';
 
     expect(
       checkOptanonConsent(
-        mockFunctionalCookieConsentEnabled,
+        mockPerformanceCookieConsentEnabled,
         ONE_TRUST_COOKIE_CATEGORIES['Performance Cookies']
       )
     ).toEqual(true);
   });
 
   it('should return false if consent is disabled for the given Optanon cookie category', () => {
-    const mockFunctionalCookieConsentDisabled =
+    const mockPerformanceCookieConsentDisabled =
       'somestuffhere&groups=C0001%3A1%2CC0002%3A0%2CC0003%3A1%2CC0004%3A1%2CC0005%3A1&intType=6';
 
     expect(
       checkOptanonConsent(
-        mockFunctionalCookieConsentDisabled,
+        mockPerformanceCookieConsentDisabled,
         ONE_TRUST_COOKIE_CATEGORIES['Performance Cookies']
       )
     ).toEqual(false);

--- a/packages/manager/src/utilities/analytics/utils.test.ts
+++ b/packages/manager/src/utilities/analytics/utils.test.ts
@@ -1,10 +1,84 @@
 import { generateTimeOfDay } from './customEventAnalytics';
 import {
+  ONE_TRUST_COOKIE_CATEGORIES,
+  checkOptanonConsent,
+  getCookie,
   getFormattedStringFromFormEventOptions,
   waitForAdobeAnalyticsToBeLoaded,
 } from './utils';
 
 import type { FormEventOptions } from './types';
+
+describe('getCookie', () => {
+  beforeAll(() => {
+    const cookies =
+      'mycookie=my-cookie-value; OptanonConsent=cookie-consent-here; mythirdcookie=my-third-cookie;';
+    vi.spyOn(document, 'cookie', 'get').mockReturnValue(cookies);
+  });
+
+  it('should return the value of a cookie from document.cookie given its name, given cookie in middle position', () => {
+    expect(getCookie('OptanonConsent')).toEqual('cookie-consent-here');
+  });
+
+  it('should return the value of a cookie from document.cookie given its name, given cookie in first position', () => {
+    expect(getCookie('mycookie')).toEqual('my-cookie-value');
+  });
+
+  it('should return the value of a cookie from document.cookie given its name, given cookie in last position', () => {
+    expect(getCookie('mythirdcookie')).toEqual('my-third-cookie');
+  });
+
+  it('should return undefined if the cookie does not exist in document.cookie', () => {
+    expect(getCookie('mysecondcookie')).toEqual(undefined);
+  });
+});
+
+describe('checkOptanonConsent', () => {
+  it('should return true if consent is enabled for the given Optanon cookie category', () => {
+    const mockFunctionalCookieConsentEnabled =
+      'somestuffhere&groups=C0001%3A1%2CC0002%3A1%2CC0003%3A1%2CC0004%3A1%2CC0005%3A1&intType=6';
+
+    expect(
+      checkOptanonConsent(
+        mockFunctionalCookieConsentEnabled,
+        ONE_TRUST_COOKIE_CATEGORIES['Functional Cookies']
+      )
+    ).toEqual(true);
+  });
+
+  it('should return false if consent is disabled for the given Optanon cookie category', () => {
+    const mockFunctionalCookieConsentDisabled =
+      'somestuffhere&groups=C0001%3A1%2CC0002%3A1%2CC0003%3A0%2CC0004%3A1%2CC0005%3A1&intType=6';
+
+    expect(
+      checkOptanonConsent(
+        mockFunctionalCookieConsentDisabled,
+        ONE_TRUST_COOKIE_CATEGORIES['Functional Cookies']
+      )
+    ).toEqual(false);
+  });
+
+  it('should return false if the consent category does not exist in the cookie', () => {
+    const mockNoFunctionalCookieCategory =
+      'somestuffhere&groups=C0001%3A1%2CC0002%3A1%2CC0004%3A1%2CC0005%3A1&intType=6';
+
+    expect(
+      checkOptanonConsent(
+        mockNoFunctionalCookieCategory,
+        ONE_TRUST_COOKIE_CATEGORIES['Functional Cookies']
+      )
+    ).toEqual(false);
+  });
+
+  it('should return false if the cookie is undefined', () => {
+    expect(
+      checkOptanonConsent(
+        undefined,
+        ONE_TRUST_COOKIE_CATEGORIES['Functional Cookies']
+      )
+    ).toEqual(false);
+  });
+});
 
 describe('generateTimeOfDay', () => {
   it('should generate human-readable time of day', () => {

--- a/packages/manager/src/utilities/analytics/utils.ts
+++ b/packages/manager/src/utilities/analytics/utils.ts
@@ -34,9 +34,7 @@ export const getCookie = (name: string) => {
     (cookie) => cookie.trim().startsWith(name + '=') // Trim whitespace so position in cookie string doesn't matter
   );
 
-  return selectedCookie
-    ? selectedCookie.trim().substring(name.length + 1)
-    : undefined;
+  return selectedCookie?.trim().substring(name.length + 1);
 };
 
 /**

--- a/packages/manager/src/utilities/analytics/utils.ts
+++ b/packages/manager/src/utilities/analytics/utils.ts
@@ -32,8 +32,9 @@ export const getCookie = (name: string): string | undefined => {
   let selectedCookie: string | undefined = undefined;
 
   cookies.forEach((cookie) => {
-    if (cookie.trim().startsWith(name + '=')) {
-      selectedCookie = cookie.substring(name.length + 1);
+    const trimmedCookie = cookie.trim(); // Remove whitespace so position in cookie string doesn't matter
+    if (trimmedCookie.startsWith(name + '=')) {
+      selectedCookie = trimmedCookie.substring(name.length + 1);
     }
   });
   return selectedCookie;


### PR DESCRIPTION
## Description 📝

This PR enables the Pendo analytics script based on the OneTrust cookie consent granted by the user in their cookie preferences. If users disable performance cookies, the Pendo script will not load.

Once we release this change to production, we _should_ be able to change a setting in our Pendo app subscription that has disabled cookies and client side storage use. The Login team needs cookies enabled on our subscription to allow for journey tracking between the anonymous users on Login and Cloud Manager's users. 

> [!NOTE]
> Confirming one thing with MADS about OneTrust and default opt-ins vs. opt-outs by geolocation (to make sure I don't have to handle anything else here) before I merge.
> ✅  **Confirmed:** For non GDPR countries, the user is opted in via OneTrust unless they choose to opt out. For GDPR, they get the option to choose in OneTrust and have to opt in as first time visitor.

## Changes  🔄

- Updates the `usePendo.js` hook to check for consent enablement before loading the script
- Creates new utility functions (`getCookie`, `checkOptanonConsent`) to handle this in `analytics/utils.ts` 
- Adds unit test coverage for new utils in `analytics/utils.test.ts`

## Target release date 🗓️

2/11/25

## How to test 🧪

### Verification steps

(How to verify changes)
- [ ] Check out this PR and go to http://localhost:3000
- [ ] Log out of whatever account you're in. At login.linode.com, select Cookie Preferences at the bottom of the screen
- [ ] **Disable** the **Performance Cookie**s setting by toggling it off
- [ ] In your code editor, go to L80 of `usePendo.js` and change the condition for  `const hasConsentEnabled = APP_ROOT.includes('localhost')` to add a `!`. In this PR, we want to *confirm* that the OneTrust cookie works locally, but normally we don't want to have to do these steps to enable Pendo for local development.
- [ ] Open the browser dev tools and go to Application > Cookies and view the table of cookies
- [ ] Find the `OptanonConsent` cookie and copy its value to your clipboard. Be sure to **uncheck** the `Show URL decoded` option
![Screenshot 2025-01-24 at 10 45 57 AM](https://github.com/user-attachments/assets/e2bc7cba-644d-447f-80fc-41f3e3aa44cc)
- [ ] Add a _new_ OptanonConsent cookie for _localhost_ for testing purposes. We can't read cookies with a different domain with `document.cookie`. To add a new cookie, click an empty cell at the bottom of the table. Name it `OptanonConsent` and copy the value from the linode.com cookie into the localhost `OptanonConsent` cookie. 
- [ ] If you want to confirm that OptanonConsent is now being returned in `document.cookie`, use the browser console to log the value for `document.cookie`.
- [ ] Refresh the page and confirm that Pendo has respected your cookie setting and NOT loaded, which you can do via any of the following:
   - [ ] Check the page HTML to confirm there is no Pendo script in the `<head>` tag (it's the script with `content.psp.cloud.linode.com`)
   - [ ] Filter network requests on `psp.` and confirm there are no requests
![Screenshot 2025-01-24 at 10 49 33 AM](https://github.com/user-attachments/assets/5f0a773c-242d-4eb2-a67a-e7882b7a356a)
   - [ ] In the browser console, log `pendo.validateEnvironment()` and confirm the command fails
![Screenshot 2025-01-24 at 10 49 16 AM](https://github.com/user-attachments/assets/e7b4958b-03dd-4577-ba5b-17104aeb0667)
- [ ] Repeat the steps above, but with an **Enabled** Performance Cookie setting to confirm Pendo is loaded and sending data
   - [ ] We can test this by editing the localhost `OptanonConsent` cookie value so that `C0002%3A0` is `C0002%3A1`. C0002 is the 'Performance Cookie' group; 0 is disabled, 1 is enabled
![Screenshot 2025-01-24 at 10 50 15 AM](https://github.com/user-attachments/assets/4afa6382-6cae-4717-b730-64fb1b461994)
![Screenshot 2025-01-24 at 10 50 03 AM](https://github.com/user-attachments/assets/6f8bea42-5a64-432d-8bc2-d69be1bde517)

- Ensure tests pass:
```
yarn test analytics/utils
```

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
