### PR TITLE
feat: [M3-9173] - Surface LKE cluster label and id on an associated Linode's details page

### DIFF
--- a/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
@@ -136,6 +136,7 @@ export const LinodeEntityDetail = (props: Props) => {
             linodePlan={linodePlan}
             linodeRegionDisplay={linodeRegionDisplay}
             linodeTags={linode.tags}
+            linodeLkeClusterId={linode.lke_cluster_id}
           />
         }
         header={

--- a/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
@@ -121,6 +121,7 @@ export const LinodeEntityDetail = (props: Props) => {
             linodeId={linode.id}
             linodeIsInDistributedRegion={linodeIsInDistributedRegion}
             linodeLabel={linode.label}
+            linodeLkeClusterId={linode.lke_cluster_id}
             numCPUs={linode.specs.vcpus}
             numVolumes={numberOfVolumes}
             region={linode.region}
@@ -136,7 +137,6 @@ export const LinodeEntityDetail = (props: Props) => {
             linodePlan={linodePlan}
             linodeRegionDisplay={linodeRegionDisplay}
             linodeTags={linode.tags}
-            linodeLkeClusterId={linode.lke_cluster_id}
           />
         }
         header={

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
@@ -46,6 +46,7 @@ import type {
 } from '@linode/api-v4/lib/linodes/types';
 import type { Subnet } from '@linode/api-v4/lib/vpcs';
 import type { TypographyProps } from '@linode/ui';
+import { useKubernetesClusterQuery } from 'src/queries/kubernetes';
 
 interface LinodeEntityDetailProps {
   id: number;
@@ -72,6 +73,7 @@ export interface BodyProps {
   linodeId: number;
   linodeIsInDistributedRegion: boolean;
   linodeLabel: string;
+  linodeLkeClusterId: null | number;
   numCPUs: number;
   numVolumes: number;
   region: string;
@@ -92,6 +94,7 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
     linodeId,
     linodeIsInDistributedRegion,
     linodeLabel,
+    linodeLkeClusterId,
     numCPUs,
     numVolumes,
     region,
@@ -127,6 +130,8 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
   // the second IPv4 address if it exists.
   const secondAddress = ipv6 ? ipv6 : ipv4.length > 1 ? ipv4[1] : null;
   const matchesLgUp = useMediaQuery(theme.breakpoints.up('lg'));
+
+  const { data: cluster } = useKubernetesClusterQuery(linodeLkeClusterId ?? -1);
 
   return (
     <>
@@ -321,6 +326,29 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
               </StyledIPv4Box>
             )}
           </Grid>
+        </Grid>
+      )}
+      {linodeLkeClusterId && (
+        <Grid
+          sx={{
+            borderTop: `1px solid ${theme.borderColors.borderTable}`,
+            padding: `${theme.spacing(2)} ${theme.spacing(2)}`,
+            [theme.breakpoints.down('md')]: {
+              paddingLeft: 3,
+            },
+          }}
+          container
+          direction="column"
+          spacing={2}
+        >
+          <StyledListItem sx={{ borderRight: 'unset' }}>
+            <StyledLabelBox component="span">LKE Cluster:</StyledLabelBox>{' '}
+            <Link to={`/kubernetes/clusters/${linodeLkeClusterId}`}>
+              {cluster?.label ?? linodeLkeClusterId}
+            </Link>
+            &nbsp;
+            {cluster ? `(ID: ${linodeLkeClusterId})` : undefined}
+          </StyledListItem>
         </Grid>
       )}
     </>

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailFooter.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailFooter.tsx
@@ -3,7 +3,6 @@ import Grid from '@mui/material/Unstable_Grid2';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
 
-import { Link } from 'src/components/Link';
 import { TagCell } from 'src/components/TagCell/TagCell';
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 import { useLinodeUpdateMutation } from 'src/queries/linodes/linodes';
@@ -24,7 +23,6 @@ interface FooterProps {
   linodeCreated: string;
   linodeId: number;
   linodeLabel: string;
-  linodeLkeClusterId: null | number;
   linodePlan: null | string;
   linodeRegionDisplay: null | string;
   linodeTags: string[];
@@ -40,7 +38,6 @@ export const LinodeEntityDetailFooter = React.memo((props: FooterProps) => {
     linodeCreated,
     linodeId,
     linodeLabel,
-    linodeLkeClusterId,
     linodePlan,
     linodeRegionDisplay,
     linodeTags,
@@ -73,7 +70,8 @@ export const LinodeEntityDetailFooter = React.memo((props: FooterProps) => {
     <Grid
       sx={{
         flex: 1,
-        padding: 0,
+        paddingX: 1,
+        paddingY: 0,
       }}
       alignItems="center"
       container
@@ -123,14 +121,6 @@ export const LinodeEntityDetailFooter = React.memo((props: FooterProps) => {
             <StyledLabelBox component="span">Linode ID:</StyledLabelBox>{' '}
             {linodeId}
           </StyledListItem>
-          {linodeLkeClusterId && (
-            <StyledListItem>
-              <StyledLabelBox component="span">LKE Cluster ID:</StyledLabelBox>{' '}
-              <Link to={`/kubernetes/clusters/${linodeLkeClusterId}`}>
-                {linodeLkeClusterId}
-              </Link>
-            </StyledListItem>
-          )}
           <StyledListItem
             sx={{
               ...sxLastListItem,

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailFooter.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailFooter.tsx
@@ -3,6 +3,7 @@ import Grid from '@mui/material/Unstable_Grid2';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
 
+import { Link } from 'src/components/Link';
 import { TagCell } from 'src/components/TagCell/TagCell';
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 import { useLinodeUpdateMutation } from 'src/queries/linodes/linodes';
@@ -23,6 +24,7 @@ interface FooterProps {
   linodeCreated: string;
   linodeId: number;
   linodeLabel: string;
+  linodeLkeClusterId: null | number;
   linodePlan: null | string;
   linodeRegionDisplay: null | string;
   linodeTags: string[];
@@ -38,6 +40,7 @@ export const LinodeEntityDetailFooter = React.memo((props: FooterProps) => {
     linodeCreated,
     linodeId,
     linodeLabel,
+    linodeLkeClusterId,
     linodePlan,
     linodeRegionDisplay,
     linodeTags,
@@ -120,6 +123,14 @@ export const LinodeEntityDetailFooter = React.memo((props: FooterProps) => {
             <StyledLabelBox component="span">Linode ID:</StyledLabelBox>{' '}
             {linodeId}
           </StyledListItem>
+          {linodeLkeClusterId && (
+            <StyledListItem>
+              <StyledLabelBox component="span">LKE Cluster ID:</StyledLabelBox>{' '}
+              <Link to={`/kubernetes/clusters/${linodeLkeClusterId}`}>
+                {linodeLkeClusterId}
+              </Link>
+            </StyledListItem>
+          )}
           <StyledListItem
             sx={{
               ...sxLastListItem,


### PR DESCRIPTION
## Description 📝

The [Linode instances endpoint](https://techdocs.akamai.com/linode-api/reference/get-linode-instance) returns an `lke_cluster_id` for a given Linode if it is part of an LKE cluster. We can surface this value for easier conceptual and functional linking of the two entities. 

This PR adds an LKE section to the Linode details summary. Clicking on the LKE cluster label will navigate the user to the linked cluster's details page.

## Changes  🔄
- Surface the `lke_cluster_id` in the LinodeEntityDetailBody
- Adjust spacing so that the LinodeEntityDetailFooter content is aligned with the rest of the sections

## Target release date 🗓️

2/11/25

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-01-24 at 3 39 34 PM](https://github.com/user-attachments/assets/5a83c752-e7fc-408d-baa8-82332a29b102) | ![Screenshot 2025-01-24 at 3 38 34 PM](https://github.com/user-attachments/assets/35a013fb-9426-43f8-b9e8-726734a7f838) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have an LKE cluster on your account with at least 1 node (or create one)
- Navigate to the LKE node's Linode details page

### Verification steps

(How to verify changes)

- [ ] Observe the new section that displays the LKE cluster label and id
- [ ] Click the link and confirm it redirects to the LKE cluster details page

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [X] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>