### PR TITLE
test: [M3-8998] - LKE view/download Kubeconfig from summary page

### DIFF
--- a/packages/manager/.changeset/pr-11571-tests-1738095531248.md
+++ b/packages/manager/.changeset/pr-11571-tests-1738095531248.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+tests for kubeconfig download and viewing ([#11571](https://github.com/linode/manager/pull/11571))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-landing-page.spec.ts
@@ -1,6 +1,5 @@
 import type { KubernetesCluster } from '@linode/api-v4';
 import {
-  mockGetCluster,
   mockGetClusters,
   mockGetClusterPools,
   mockGetKubeconfig,
@@ -169,32 +168,6 @@ describe('LKE landing page', () => {
 
     cy.wait('@getKubeconfig');
     readDownload(mockKubeconfigFilename).should('eq', mockKubeconfigContents);
-  });
-
-  it('can view kubeconfig contents', () => {
-    const mockCluster = kubernetesClusterFactory.build();
-    const mockKubeconfigContents = '---'; // Valid YAML.
-    const mockKubeconfigResponse = {
-      kubeconfig: btoa(mockKubeconfigContents),
-    };
-    mockGetCluster(mockCluster).as('getCluster');
-    mockGetKubeconfig(mockCluster.id, mockKubeconfigResponse).as(
-      'getKubeconfig'
-    );
-    cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
-    cy.wait(['@getCluster']);
-    // open drawer
-    cy.get('p:contains("View")')
-      .should('be.visible')
-      .should('be.enabled')
-      .click();
-    cy.wait('@getKubeconfig');
-    cy.findByTestId('drawer-title').should('be.visible');
-    cy.get('code')
-      .should('be.visible')
-      .within(() => {
-        cy.get('span').contains(mockKubeconfigContents);
-      });
   });
 
   it('does not show an Upgrade chip when there is no new kubernetes standard version', () => {

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-landing-page.spec.ts
@@ -1,5 +1,6 @@
 import type { KubernetesCluster } from '@linode/api-v4';
 import {
+  mockGetCluster,
   mockGetClusters,
   mockGetClusterPools,
   mockGetKubeconfig,
@@ -168,6 +169,32 @@ describe('LKE landing page', () => {
 
     cy.wait('@getKubeconfig');
     readDownload(mockKubeconfigFilename).should('eq', mockKubeconfigContents);
+  });
+
+  it('can view kubeconfig contents', () => {
+    const mockCluster = kubernetesClusterFactory.build();
+    const mockKubeconfigContents = '---'; // Valid YAML.
+    const mockKubeconfigResponse = {
+      kubeconfig: btoa(mockKubeconfigContents),
+    };
+    mockGetCluster(mockCluster).as('getCluster');
+    mockGetKubeconfig(mockCluster.id, mockKubeconfigResponse).as(
+      'getKubeconfig'
+    );
+    cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
+    cy.wait(['@getCluster']);
+    // open drawer
+    cy.get('p:contains("View")')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+    cy.wait('@getKubeconfig');
+    cy.findByTestId('drawer-title').should('be.visible');
+    cy.get('code')
+      .should('be.visible')
+      .within(() => {
+        cy.get('span').contains(mockKubeconfigContents);
+      });
   });
 
   it('does not show an Upgrade chip when there is no new kubernetes standard version', () => {

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-summary-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-summary-page.spec.ts
@@ -1,6 +1,7 @@
 import { mockGetCluster, mockGetKubeconfig } from 'support/intercepts/lke';
 import { kubernetesClusterFactory } from 'src/factories';
 import { readDownload } from 'support/util/downloads';
+import { ui } from 'support/ui';
 
 const mockKubeconfigContents = '---'; // Valid YAML.
 const mockKubeconfigResponse = {
@@ -22,7 +23,7 @@ describe('LKE summary page', () => {
     const mockKubeconfigFilename = `${mockCluster.label}-kubeconfig.yaml`;
     cy.visitWithLogin(url);
     cy.wait(['@getCluster']);
-    cy.get(`p:contains(${mockKubeconfigFilename})`)
+    cy.findByText(mockKubeconfigFilename)
       .should('be.visible')
       .should('be.enabled')
       .click();
@@ -39,7 +40,7 @@ describe('LKE summary page', () => {
       .should('be.enabled')
       .click();
     cy.wait('@getKubeconfig');
-    cy.findByTestId('drawer-title').should('be.visible');
+    ui.drawer.findByTitle('View Kubeconfig').should('be.visible');
     cy.get('code')
       .should('be.visible')
       .within(() => {

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-summary-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-summary-page.spec.ts
@@ -1,0 +1,51 @@
+import { mockGetCluster, mockGetKubeconfig } from 'support/intercepts/lke';
+import { kubernetesClusterFactory } from 'src/factories';
+import { readDownload } from 'support/util/downloads';
+
+const mockKubeconfigContents = '---'; // Valid YAML.
+const mockKubeconfigResponse = {
+  kubeconfig: btoa(mockKubeconfigContents),
+};
+
+const mockCluster = kubernetesClusterFactory.build();
+const url = `/kubernetes/clusters/${mockCluster.id}`;
+
+describe('LKE summary page', () => {
+  beforeEach(() => {
+    mockGetCluster(mockCluster).as('getCluster');
+    mockGetKubeconfig(mockCluster.id, mockKubeconfigResponse).as(
+      'getKubeconfig'
+    );
+  });
+
+  it('can download kubeconfig', () => {
+    const mockKubeconfigFilename = `${mockCluster.label}-kubeconfig.yaml`;
+    cy.visitWithLogin(url);
+    cy.wait(['@getCluster']);
+    cy.get(`p:contains(${mockKubeconfigFilename})`)
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+    cy.wait('@getKubeconfig');
+    readDownload(mockKubeconfigFilename).should('eq', mockKubeconfigContents);
+  });
+
+  it('can view kubeconfig contents', () => {
+    cy.visitWithLogin(url);
+    cy.wait(['@getCluster']);
+    // open drawer
+    cy.get('p:contains("View")')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+    cy.wait('@getKubeconfig');
+    cy.findByTestId('drawer-title').should('be.visible');
+    cy.get('code')
+      .should('be.visible')
+      .within(() => {
+        cy.get('span').contains(mockKubeconfigContents);
+      });
+  });
+
+  // TODO: add test for failure to download yaml file
+});


### PR DESCRIPTION
## Description 📝

Add integration tests for viewing and downloading the kubeconfig file from the /kubernetes/clusters/<id>/summary page.

## Changes  🔄

List any change(s) relevant to the reviewer.

Added tests to packages/manager/cypress/e2e/core/kubernetes/lke-summary-page.spec.ts  

## How to test 🧪
-yarn cy:run -s "packages/manager/cypress/e2e/core/kubernetes/lke-summary-page.spec.ts" 

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

---

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

---
