### PR TITLE
refactor: [M3-8253] - Replace pathOr ramda function with custom utility - Part 2

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Graphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Graphs.tsx
@@ -1,6 +1,5 @@
 import { Typography } from '@linode/ui';
 import { useTheme } from '@mui/material/styles';
-import { pathOr } from 'ramda';
 import * as React from 'react';
 
 import { LongviewLineGraph } from 'src/components/LongviewLineGraph/LongviewLineGraph';
@@ -164,11 +163,7 @@ export const formatINodes = (
 ): StatWithDummyPoint[] => {
   return itotal.map((eachTotalStat, index) => {
     const { x: totalX, y: totalY } = eachTotalStat;
-    const { y: freeY } = pathOr(
-      { x: 0, y: null },
-      [index],
-      ifree
-    ) as StatWithDummyPoint;
+    const { y: freeY } = ifree?.[index] ?? { x: 0, y: null };
 
     const cleanedY =
       typeof totalY === 'number' && typeof freeY === 'number'

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
@@ -1,6 +1,5 @@
 import { Typography } from '@linode/ui';
 import Grid from '@mui/material/Unstable_Grid2/Grid2';
-import { pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
 
@@ -21,7 +20,6 @@ import {
 } from './LongviewClientHeader.styles';
 import { RestrictedUserLabel } from './RestrictedUserLabel';
 
-import type { LongviewPackage } from '../request.types';
 import type { APIError } from '@linode/api-v4/lib/types';
 import type { DispatchProps } from 'src/containers/longview.container';
 import type { Props as LVDataProps } from 'src/containers/longview.stats.container';
@@ -76,14 +74,10 @@ export const LongviewClientHeader = enhanced(
 
     const hostname =
       longviewClientData.SysInfo?.hostname ?? 'Hostname not available';
-    const uptime = pathOr<null | number>(null, ['Uptime'], longviewClientData);
+    const uptime = longviewClientData?.uptime ?? null;
     const formattedUptime =
       uptime !== null ? `Up ${formatUptime(uptime)}` : 'Uptime not available';
-    const packages = pathOr<LongviewPackage[] | null>(
-      null,
-      ['Packages'],
-      longviewClientData
-    );
+    const packages = longviewClientData?.Packages ?? null;
     const numPackagesToUpdate = packages ? packages.length : 0;
     const packagesToUpdate = getPackageNoticeText(packages);
 

--- a/packages/manager/src/features/Managed/Contacts/ContactsDrawer.tsx
+++ b/packages/manager/src/features/Managed/Contacts/ContactsDrawer.tsx
@@ -2,7 +2,7 @@ import { Notice, Select, TextField } from '@linode/ui';
 import { createContactSchema } from '@linode/validation/lib/managed.schema';
 import Grid from '@mui/material/Unstable_Grid2';
 import { Formik } from 'formik';
-import { pathOr, pick } from 'ramda';
+import { pick } from 'ramda';
 import * as React from 'react';
 
 import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
@@ -125,9 +125,10 @@ const ContactsDrawer = (props: ContactsDrawerProps) => {
             values,
           } = formikProps;
 
-          const primaryPhoneError = pathOr('', ['phone', 'primary'], errors);
+          // @todo: map the primary and secondary phone errors to the respective variables when using react-hook-form
+          const primaryPhoneError = errors?.phone ?? '';
           // prettier-ignore
-          const secondaryPhoneError = pathOr('', ['phone', 'secondary'], errors);
+          const secondaryPhoneError = errors?.phone ?? '';
 
           return (
             <>
@@ -172,7 +173,7 @@ const ContactsDrawer = (props: ContactsDrawerProps) => {
                       name="phone.primary"
                       onBlur={handleBlur}
                       onChange={handleChange}
-                      value={pathOr('', ['phone', 'primary'], values)}
+                      value={values?.phone?.primary ?? ''}
                     />
                   </Grid>
                   <Grid md={6} xs={12}>
@@ -183,7 +184,7 @@ const ContactsDrawer = (props: ContactsDrawerProps) => {
                       name="phone.secondary"
                       onBlur={handleBlur}
                       onChange={handleChange}
-                      value={pathOr('', ['phone', 'secondary'], values)}
+                      value={values?.phone?.secondary ?? ''}
                     />
                   </Grid>
                 </Grid>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -11,15 +11,7 @@ import {
 import { useTheme } from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { createLazyRoute } from '@tanstack/react-router';
-import {
-  append,
-  clone,
-  compose,
-  defaultTo,
-  lensPath,
-  over,
-  pathOr,
-} from 'ramda';
+import { append, clone, compose, defaultTo, lensPath, over } from 'ramda';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -630,6 +622,9 @@ const NodeBalancerCreate = () => {
                   onChange('protocol')(value);
                   afterProtocolUpdate(idx);
                 }}
+                onUdpCheckPortChange={(value) =>
+                  onChange('udp_check_port')(value)
+                }
                 addNode={addNodeBalancerConfigNode(idx)}
                 algorithm={nodeBalancerFields.configs[idx].algorithm!}
                 checkBody={nodeBalancerFields.configs[idx].check_body!}
@@ -654,9 +649,6 @@ const NodeBalancerCreate = () => {
                 onProxyProtocolChange={onChange('proxy_protocol')}
                 onSessionStickinessChange={onChange('stickiness')}
                 onSslCertificateChange={onChange('ssl_cert')}
-                onUdpCheckPortChange={(value) =>
-                  onChange('udp_check_port')(value)
-                }
                 port={nodeBalancerFields.configs[idx].port!}
                 privateKey={nodeBalancerFields.configs[idx].ssl_key!}
                 protocol={nodeBalancerFields.configs[idx].protocol!}
@@ -791,7 +783,7 @@ export const fieldErrorsToNodePathErrors = (errors: APIError[]) => {
       }
   */
   return errors.reduce((acc: any, error: APIError) => {
-    const errorFields = pathOr('', ['field'], error).split('|');
+    const errorFields = error?.field?.split('|') ?? [''];
     const pathErrors: FieldAndPath[] = errorFields.map((field: string) =>
       getPathAndFieldFromFieldString(field)
     );

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
@@ -17,7 +17,6 @@ import {
   defaultTo,
   lensPath,
   over,
-  pathOr,
   set,
   view,
 } from 'ramda';
@@ -1016,7 +1015,7 @@ class NodeBalancerConfigurations extends React.Component<
   state: State = {
     configErrors: [],
     configSubmitting: [],
-    configs: pathOr([], ['response'], this.props.configs),
+    configs: this.props.configs?.response?.data ?? [],
     deleteConfigConfirmDialog: clone(
       NodeBalancerConfigurations.defaultDeleteConfigConfirmDialogState
     ),

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
@@ -53,7 +53,6 @@ import type {
   Grants,
   NodeBalancerConfig,
   NodeBalancerConfigNode,
-  ResourcePage,
 } from '@linode/api-v4';
 import type { Lens } from 'ramda';
 import type { RouteComponentProps } from 'react-router-dom';
@@ -96,9 +95,7 @@ interface MatchProps {
 type RouteProps = RouteComponentProps<MatchProps>;
 
 interface PreloadedProps {
-  configs: PromiseLoaderResponse<
-    ResourcePage<NodeBalancerConfigFieldsWithStatus>
-  >;
+  configs: PromiseLoaderResponse<NodeBalancerConfigFieldsWithStatus[]>;
 }
 
 interface State {
@@ -1015,7 +1012,7 @@ class NodeBalancerConfigurations extends React.Component<
   state: State = {
     configErrors: [],
     configSubmitting: [],
-    configs: this.props.configs?.response?.data ?? [],
+    configs: this.props.configs?.response ?? [],
     deleteConfigConfirmDialog: clone(
       NodeBalancerConfigurations.defaultDeleteConfigConfirmDialogState
     ),

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -1,5 +1,4 @@
 import { Button, CircleProgress, Notice } from '@linode/ui';
-import { pathOr } from 'ramda';
 import * as React from 'react';
 import { withRouter } from 'react-router-dom';
 import { Waypoint } from 'react-waypoint';
@@ -446,17 +445,14 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
         !grants.data?.global.add_stackscripts;
 
       if (error) {
+        const apiError = handleUnauthorizedErrors(
+          error,
+          'You are not authorized to view StackScripts for this account.'
+        );
         return (
           <div style={{ overflow: 'hidden' }}>
             <ErrorState
-              errorText={pathOr(
-                'There was an error.',
-                [0, 'reason'],
-                handleUnauthorizedErrors(
-                  error,
-                  'You are not authorized to view StackScripts for this account.'
-                )
-              )}
+              errorText={apiError?.[0]?.reason ?? 'There was an error'}
             />
           </div>
         );
@@ -578,7 +574,7 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
                    * would never be scrolled into view no matter how much you scrolled on the
                    * trackpad. Especially finicky at zoomed in browser sizes
                    */}
-                  <div style={{ minHeight: '150px' }}></div>
+                  <div style={{ minHeight: '150px' }} />
                 </Waypoint>
               ) : (
                 <Button

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -452,7 +452,7 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
         return (
           <div style={{ overflow: 'hidden' }}>
             <ErrorState
-              errorText={apiError?.[0]?.reason ?? 'There was an error'}
+              errorText={apiError?.[0]?.reason ?? 'There was an error.'}
             />
           </div>
         );

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchSuggestion.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchSuggestion.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@linode/ui';
-import { pathOr } from 'ramda';
 import * as React from 'react';
 
 import { EntityIcon } from 'src/components/EntityIcon/EntityIcon';
@@ -17,6 +16,7 @@ import {
 
 import type { LinodeStatus } from '@linode/api-v4/lib/linodes';
 import type { OptionProps } from 'react-select';
+import type { EntityVariants } from 'src/components/EntityIcon/EntityIcon';
 
 export interface SearchSuggestionT {
   description: string;
@@ -40,7 +40,7 @@ export interface SearchSuggestionProps extends OptionProps<any, any> {
 export const SearchSuggestion = (props: SearchSuggestionProps) => {
   const { data, innerProps, innerRef, label, selectProps } = props;
   const { description, icon, searchText, status, tags } = data.data;
-  const searchResultIcon = pathOr<string>('default', [], icon);
+  const searchResultIcon = (icon ?? 'default') as EntityVariants;
 
   const handleClick = () => {
     const suggestion = data;

--- a/packages/manager/src/layouts/Logout.tsx
+++ b/packages/manager/src/layouts/Logout.tsx
@@ -1,14 +1,15 @@
-import { pathOr } from 'ramda';
 import { Component } from 'react';
-import { MapDispatchToProps, MapStateToProps, connect } from 'react-redux';
-import { AnyAction } from 'redux';
-import { ThunkDispatch } from 'redux-thunk';
+import { connect } from 'react-redux';
 
 import { CLIENT_ID } from 'src/constants';
-import { ApplicationState } from 'src/store';
 import { clearUserInput } from 'src/store/authentication/authentication.helpers';
 import { handleLogout } from 'src/store/authentication/authentication.requests';
 import { getEnvLocalStorageOverrides } from 'src/utilities/storage';
+
+import type { MapDispatchToProps, MapStateToProps } from 'react-redux';
+import type { AnyAction } from 'redux';
+import type { ThunkDispatch } from 'redux-thunk';
+import type { ApplicationState } from 'src/store';
 
 interface LogoutProps extends DispatchProps, StateProps {}
 
@@ -38,7 +39,7 @@ const mapStateToProps: MapStateToProps<StateProps, {}, ApplicationState> = (
   state,
   ownProps
 ) => ({
-  token: pathOr('', ['authentication', 'token'], state),
+  token: state?.authentication?.token ?? '',
 });
 
 interface DispatchProps {

--- a/packages/manager/src/utilities/errorUtils.ts
+++ b/packages/manager/src/utilities/errorUtils.ts
@@ -1,7 +1,6 @@
-import { APIError } from '@linode/api-v4/lib/types';
-import { pathOr } from 'ramda';
-
 import { DEFAULT_ERROR_MESSAGE } from 'src/constants';
+
+import type { APIError } from '@linode/api-v4/lib/types';
 
 /**
  *
@@ -55,8 +54,7 @@ export const getErrorStringOrDefault = (
   if (typeof errors === 'string') {
     return errors;
   }
-  const apiErrors = pathOr(errors, ['response', 'data', 'errors'], errors);
-  return pathOr<string>(defaultError, [0, 'reason'], apiErrors);
+  return errors?.[0]?.reason ?? defaultError;
 };
 
 /**


### PR DESCRIPTION
## Description 📝

Removed instances of `pathOr` from Ramda and replace them with a custom utility function.

Since the `pathOr` utility from Ramda is used in multiple places throughout the codebase + we aim to eliminate any dependency on Ramda, it is more efficient and maintainable to remove/replace it with a custom utility function.

> [!NOTE]
> There are a large number of files that have been using Ramda's `pathOr`. Hence, I've broken this into 2 parts. [Part 1 [here](https://github.com/linode/manager/pull/11512)]


## Changes  🔄
 
- Removed instances of Ramda's `pathOr` and replaced it with inbuilt functionality.

## How to test 🧪

### Verification steps

- [ ] Ensure no existing functionality is broken
- [ ] Make sure all the instances of pathOr has been replaced with optional chaining
- [ ] Ensure all tests pass

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
