### PR TITLE
DI-23234 : CloudPulse Alerting API type issue fix

### DIFF
--- a/packages/api-v4/.changeset/pr-11582-fixed-1738159169460.md
+++ b/packages/api-v4/.changeset/pr-11582-fixed-1738159169460.md
@@ -2,4 +2,4 @@
 "@linode/api-v4": Fixed
 ---
 
-Types for CloudPulse Alerting create and details schemas ([#11582](https://github.com/linode/manager/pull/11582))
+Types for CloudPulse Alerting create and detail schemas ([#11582](https://github.com/linode/manager/pull/11582))

--- a/packages/api-v4/.changeset/pr-11582-fixed-1738159169460.md
+++ b/packages/api-v4/.changeset/pr-11582-fixed-1738159169460.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Fixed
+---
+
+Types for CloudPulse Alerting create and details schemas ([#11582](https://github.com/linode/manager/pull/11582))

--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -172,7 +172,7 @@ export interface CreateAlertDefinitionPayload {
 }
 export interface MetricCriteria {
   metric: string;
-  aggregation_type: MetricAggregationType;
+  aggregation_function: MetricAggregationType;
   operator: MetricOperatorType;
   threshold: number;
   dimension_filters?: DimensionFilter[];
@@ -214,7 +214,7 @@ export interface Alert {
     rules: AlertDefinitionMetricCriteria[];
   };
   trigger_conditions: TriggerCondition;
-  channels: {
+  alert_channels: {
     id: string;
     label: string;
     url: string;

--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -172,7 +172,7 @@ export interface CreateAlertDefinitionPayload {
 }
 export interface MetricCriteria {
   metric: string;
-  aggregation_function: MetricAggregationType;
+  aggregate_function: MetricAggregationType;
   operator: MetricOperatorType;
   threshold: number;
   dimension_filters?: DimensionFilter[];
@@ -215,10 +215,10 @@ export interface Alert {
   };
   trigger_conditions: TriggerCondition;
   alert_channels: {
-    id: string;
+    id: number;
     label: string;
     url: string;
-    type: 'channel';
+    type: 'alert-channel';
   }[];
   created_by: string;
   updated_by: string;

--- a/packages/manager/cypress/e2e/core/cloudpulse/alert-show-details.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alert-show-details.spec.ts
@@ -153,10 +153,10 @@ describe('Integration Tests for Dbaas Alert Show Detail Page', () => {
           .eq(index)
           .within(() => {
             cy.get(
-              `[data-qa-chip="${aggregationTypeMap[rule.aggregation_type]}"]`
+              `[data-qa-chip="${aggregationTypeMap[rule.aggregate_function]}"]`
             )
               .should('be.visible')
-              .should('have.text', aggregationTypeMap[rule.aggregation_type]);
+              .should('have.text', aggregationTypeMap[rule.aggregate_function]);
 
             cy.get(`[data-qa-chip="${rule.label}"]`)
               .should('be.visible')

--- a/packages/manager/src/factories/cloudpulse/alerts.ts
+++ b/packages/manager/src/factories/cloudpulse/alerts.ts
@@ -17,7 +17,7 @@ export const alertDimensionsFactory = Factory.Sync.makeFactory<AlertDefinitionDi
 
 export const alertRulesFactory = Factory.Sync.makeFactory<AlertDefinitionMetricCriteria>(
   {
-    aggregation_type: 'avg',
+    aggregation_function: 'avg',
     dimension_filters: alertDimensionsFactory.buildList(1),
     label: 'CPU Usage',
     metric: 'cpu_usage',
@@ -28,7 +28,7 @@ export const alertRulesFactory = Factory.Sync.makeFactory<AlertDefinitionMetricC
 );
 
 export const alertFactory = Factory.Sync.makeFactory<Alert>({
-  channels: [
+  alert_channels: [
     {
       id: '1',
       label: 'sample1',

--- a/packages/manager/src/factories/cloudpulse/alerts.ts
+++ b/packages/manager/src/factories/cloudpulse/alerts.ts
@@ -17,7 +17,7 @@ export const alertDimensionsFactory = Factory.Sync.makeFactory<AlertDefinitionDi
 
 export const alertRulesFactory = Factory.Sync.makeFactory<AlertDefinitionMetricCriteria>(
   {
-    aggregation_function: 'avg',
+    aggregate_function: 'avg',
     dimension_filters: alertDimensionsFactory.buildList(1),
     label: 'CPU Usage',
     metric: 'cpu_usage',
@@ -30,15 +30,15 @@ export const alertRulesFactory = Factory.Sync.makeFactory<AlertDefinitionMetricC
 export const alertFactory = Factory.Sync.makeFactory<Alert>({
   alert_channels: [
     {
-      id: '1',
+      id: 1,
       label: 'sample1',
-      type: 'channel',
+      type: 'alert-channel',
       url: '',
     },
     {
-      id: '2',
+      id: 2,
       label: 'sample2',
-      type: 'channel',
+      type: 'alert-channel',
       url: '',
     },
   ],

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
@@ -134,7 +134,7 @@ export const AlertDetail = () => {
           }}
         >
           <AlertDetailNotification
-            channelIds={alertDetails.channels.map(({ id }) => id)}
+            channelIds={alertDetails.alert_channels.map(({ id }) => id)}
           />
         </Box>
       </Box>

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetailCriteria.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetailCriteria.test.tsx
@@ -16,7 +16,7 @@ describe('AlertDetailCriteria component tests', () => {
     const alertDetails = alertFactory.build({
       rule_criteria: {
         rules: alertRulesFactory.buildList(2, {
-          aggregation_type: 'avg',
+          aggregation_function: 'avg',
           dimension_filters: alertDimensionsFactory.buildList(2),
           label: 'CPU Usage',
           metric: 'cpu_usage',

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetailCriteria.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetailCriteria.test.tsx
@@ -16,7 +16,7 @@ describe('AlertDetailCriteria component tests', () => {
     const alertDetails = alertFactory.build({
       rule_criteria: {
         rules: alertRulesFactory.buildList(2, {
-          aggregation_function: 'avg',
+          aggregate_function: 'avg',
           dimension_filters: alertDimensionsFactory.buildList(2),
           label: 'CPU Usage',
           metric: 'cpu_usage',

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetailNotification.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetailNotification.test.tsx
@@ -39,7 +39,7 @@ beforeEach(() => {
 describe('AlertDetailNotification component tests', () => {
   it('should render the alert detail notification channels successfully', () => {
     const { getAllByText, getByText } = renderWithTheme(
-      <AlertDetailNotification channelIds={['1', '2', '3']} />
+      <AlertDetailNotification channelIds={[1, 2, 3]} />
     );
 
     expect(getByText(notificationChannel)).toBeInTheDocument();
@@ -59,7 +59,7 @@ describe('AlertDetailNotification component tests', () => {
       isFetching: false,
     });
     const { getByText } = renderWithTheme(
-      <AlertDetailNotification channelIds={['1', '2', '3']} />
+      <AlertDetailNotification channelIds={[1, 2, 3]} />
     );
 
     expect(getByText(notificationChannel)).toBeInTheDocument();
@@ -73,7 +73,7 @@ describe('AlertDetailNotification component tests', () => {
       isFetching: false,
     });
     const { getByText } = renderWithTheme(
-      <AlertDetailNotification channelIds={['1', '2', '3']} />
+      <AlertDetailNotification channelIds={[1, 2, 3]} />
     );
 
     expect(getByText(notificationChannel)).toBeInTheDocument();

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetailNotification.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetailNotification.tsx
@@ -19,7 +19,7 @@ interface NotificationChannelProps {
    * List of channel IDs associated with the alert.
    * These IDs are used to fetch and display notification channels.
    */
-  channelIds: string[];
+  channelIds: number[];
 }
 export const AlertDetailNotification = React.memo(
   (props: NotificationChannelProps) => {

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/RenderAlertsMetricsAndDimensions.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/RenderAlertsMetricsAndDimensions.tsx
@@ -33,7 +33,7 @@ export const RenderAlertMetricsAndDimensions = React.memo(
     return ruleCriteria.rules.map(
       (
         {
-          aggregation_type: aggregationType,
+          aggregation_function: aggregationType,
           dimension_filters: dimensionFilters,
           label,
           operator,

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/RenderAlertsMetricsAndDimensions.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/RenderAlertsMetricsAndDimensions.tsx
@@ -33,7 +33,7 @@ export const RenderAlertMetricsAndDimensions = React.memo(
     return ruleCriteria.rules.map(
       (
         {
-          aggregation_function: aggregationType,
+          aggregate_function: aggregationType,
           dimension_filters: dimensionFilters,
           label,
           operator,

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
@@ -34,7 +34,7 @@ const triggerConditionInitialValues: TriggerConditionForm = {
   trigger_occurrences: 0,
 };
 const criteriaInitialValues: MetricCriteriaForm = {
-  aggregation_type: null,
+  aggregate_function: null,
   dimension_filters: [],
   metric: null,
   operator: null,

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/Metric.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/Metric.tsx
@@ -64,7 +64,7 @@ export const Metric = (props: MetricCriteriaProps) => {
     operation: string
   ) => {
     const fieldValue: MetricCriteriaForm = {
-      aggregation_type: null,
+      aggregate_function: null,
       dimension_filters: [],
       metric: null,
       operator: null,
@@ -202,7 +202,7 @@ export const Metric = (props: MetricCriteriaProps) => {
                 />
               )}
               control={control}
-              name={`${name}.aggregation_type`}
+              name={`${name}.aggregate_function`}
             />
           </Grid>
           <Grid item lg={2} md={3} sm={6} xs={12}>

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/MetricCriteria.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/MetricCriteria.tsx
@@ -92,7 +92,7 @@ export const MetricCriteriaField = (props: MetricCriteriaProps) => {
       <Button
         onClick={() =>
           append({
-            aggregation_type: null,
+            aggregate_function: null,
             dimension_filters: [],
             metric: null,
             operator: null,

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/types.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/types.ts
@@ -30,9 +30,9 @@ export interface CreateAlertDefinitionForm
 export interface MetricCriteriaForm
   extends Omit<
     MetricCriteria,
-    'aggregation_type' | 'dimension_filters' | 'metric' | 'operator'
+    'aggregate_function' | 'dimension_filters' | 'metric' | 'operator'
   > {
-  aggregation_type: MetricAggregationType | null;
+  aggregate_function: MetricAggregationType | null;
   dimension_filters: DimensionFilterForm[];
   metric: null | string;
   operator: MetricOperatorType | null;

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/utilities.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/utilities.ts
@@ -42,10 +42,14 @@ export const filterMetricCriteriaFormValues = (
   formValues: MetricCriteriaForm[]
 ): MetricCriteria[] => {
   return formValues.map((rule) => {
-    const values = omitProps(rule, ['aggregation_type', 'operator', 'metric']);
+    const values = omitProps(rule, [
+      'aggregate_function',
+      'operator',
+      'metric',
+    ]);
     return {
       ...values,
-      aggregation_type: rule.aggregation_type ?? 'avg',
+      aggregate_function: rule.aggregate_function ?? 'avg',
       dimension_filters: filterDimensionFilterFormValues(
         rule.dimension_filters
       ),

--- a/packages/validation/src/cloudpulse.schema.ts
+++ b/packages/validation/src/cloudpulse.schema.ts
@@ -10,7 +10,7 @@ const dimensionFilters = object({
 
 const metricCriteria = object({
   metric: string().required(fieldErrorMessage),
-  aggregation_type: string().required(fieldErrorMessage),
+  aggregate_function: string().required(fieldErrorMessage),
   operator: string().required(fieldErrorMessage),
   threshold: number()
     .required(fieldErrorMessage)


### PR DESCRIPTION
## Description 📝

Fixed types in the apiV4 type setup of CloudPulse alerts according to latest API spec.

## Changes  🔄

1. Changed types for alert details / create alert path according to latest API spec.

## Target release date 🗓️
05-01-2025 (alpha)

## How to test 🧪

1. Login as mock user as some endpoints are not available.
2. Navigate to Monitor tab and then to alerts section.
3. Pages like list, create and details should work accordingly.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
