### PR TITLE
feat: [M3-9092] - Add Feature Flag for Linode Interfaces

### DIFF
--- a/packages/api-v4/.changeset/pr-11584-added-1738172957966.md
+++ b/packages/api-v4/.changeset/pr-11584-added-1738172957966.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Added
+---
+
+Add `Enhanced Interfaces` to a Region's `Capabilities` ([#11584](https://github.com/linode/manager/pull/11584))

--- a/packages/api-v4/src/regions/types.ts
+++ b/packages/api-v4/src/regions/types.ts
@@ -9,6 +9,7 @@ export type Capabilities =
   | 'Cloud Firewall'
   | 'Disk Encryption'
   | 'Distributed Plans'
+  | 'Enhanced Interfaces'
   | 'GPU Linodes'
   | 'Kubernetes'
   | 'Kubernetes Enterprise'

--- a/packages/manager/.changeset/pr-11584-tech-stories-1738170829685.md
+++ b/packages/manager/.changeset/pr-11584-tech-stories-1738170829685.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Add Feature Flag for Linode Interfaces project ([#11584](https://github.com/linode/manager/pull/11584))

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -28,6 +28,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'imageServiceGen2Ga', label: 'Image Service Gen2 GA' },
   { flag: 'limitsEvolution', label: 'Limits Evolution' },
   { flag: 'linodeDiskEncryption', label: 'Linode Disk Encryption (LDE)' },
+  { flag: 'linodeInterfaces', label: 'Linode Interfaces' },
   { flag: 'lkeEnterprise', label: 'LKE-Enterprise' },
   { flag: 'objMultiCluster', label: 'OBJ Multi-Cluster' },
   { flag: 'objectStorageGen2', label: 'OBJ Gen2' },

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -97,6 +97,7 @@ interface AclpAlerting {
   notificationChannels: boolean;
   recentActivity: boolean;
 }
+
 export interface Flags {
   acceleratedPlans: AcceleratedPlansFlag;
   aclp: AclpFlag;
@@ -123,6 +124,7 @@ export interface Flags {
   ipv6Sharing: boolean;
   limitsEvolution: BaseFeatureFlag;
   linodeDiskEncryption: boolean;
+  linodeInterfaces: BaseFeatureFlag;
   lkeEnterprise: LkeEnterpriseFlag;
   mainContentBanner: MainContentBanner;
   marketplaceAppOverrides: MarketplaceAppOverride[];

--- a/packages/manager/src/utilities/linodes.test.ts
+++ b/packages/manager/src/utilities/linodes.test.ts
@@ -22,7 +22,7 @@ describe('addMaintenanceToLinodes', () => {
 });
 
 describe('useIsLinodeInterfacesEnabled', () => {
-  it('returns true if the feature is enabled', () => {
+  it('returns enabled: true if the feature is enabled', () => {
     const options = { flags: { linodeInterfaces: { enabled: true } } };
 
     const { result } = renderHook(() => useIsLinodeInterfacesEnabled(), {
@@ -32,7 +32,7 @@ describe('useIsLinodeInterfacesEnabled', () => {
     expect(result.current?.enabled).toBe(true);
   });
 
-  it('returns false if the feature is NOT enabled', () => {
+  it('returns enabled: false if the feature is NOT enabled', () => {
     const options = { flags: { linodeInterfaces: { enabled: false } } };
 
     const { result } = renderHook(() => useIsLinodeInterfacesEnabled(), {

--- a/packages/manager/src/utilities/linodes.test.ts
+++ b/packages/manager/src/utilities/linodes.test.ts
@@ -1,6 +1,12 @@
+import { renderHook } from '@testing-library/react';
+
 import { accountMaintenanceFactory, linodeFactory } from 'src/factories';
 
-import { addMaintenanceToLinodes } from './linodes';
+import {
+  addMaintenanceToLinodes,
+  useIsLinodeInterfacesEnabled,
+} from './linodes';
+import { wrapWithTheme } from './testHelpers';
 
 describe('addMaintenanceToLinodes', () => {
   it('adds relevant maintenance items to Linodes', () => {
@@ -12,5 +18,27 @@ describe('addMaintenanceToLinodes', () => {
     expect(result[0].maintenance).not.toBeNull();
     expect(result[1].maintenance).toBeNull();
     expect(result[0].maintenance?.when).toBe(accountMaintenance[0].when);
+  });
+});
+
+describe('useIsLinodeInterfacesEnabled', () => {
+  it('returns true if the feature is enabled', () => {
+    const options = { flags: { linodeInterfaces: { enabled: true } } };
+
+    const { result } = renderHook(() => useIsLinodeInterfacesEnabled(), {
+      wrapper: (ui) => wrapWithTheme(ui, options),
+    });
+
+    expect(result.current?.enabled).toBe(true);
+  });
+
+  it('returns false if the feature is NOT enabled', () => {
+    const options = { flags: { linodeInterfaces: { enabled: false } } };
+
+    const { result } = renderHook(() => useIsLinodeInterfacesEnabled(), {
+      wrapper: (ui) => wrapWithTheme(ui, options),
+    });
+
+    expect(result.current?.enabled).toBe(false);
   });
 });

--- a/packages/manager/src/utilities/linodes.ts
+++ b/packages/manager/src/utilities/linodes.ts
@@ -1,4 +1,6 @@
-import { AccountMaintenance, Linode } from '@linode/api-v4';
+import { useFlags } from 'src/hooks/useFlags';
+
+import type { AccountMaintenance, Linode } from '@linode/api-v4';
 
 export interface Maintenance {
   when: null | string;
@@ -29,4 +31,19 @@ export const addMaintenanceToLinodes = (
         }
       : { ...thisLinode, maintenance: null };
   });
+};
+
+/**
+ * Returns whether or not features related to the *Linode Interfaces* project
+ * should be enabled.
+ *
+ * Currently, this just uses the `linodeInterfaces` feature flag as a source of truth,
+ * but will eventually also look at account capabilities.
+ */
+export const useIsLinodeInterfacesEnabled = () => {
+  const flags = useFlags();
+
+  // @TODO Linode Interfaces - check for customer tag when it exists
+
+  return flags.linodeInterfaces;
 };


### PR DESCRIPTION
## Description 📝

- Adds a feature flag for the Linode Interfaces project 🔌 🏴 
  - The flag is just a `BaseFeatureFlag` for now, but we will likely extend `BaseFeatureFlag` with more properties as this project evolves
- Adds initial `useIsLinodeInterfacesEnabled` hook 🎣 
  - This is just acts as a useful abstraction over the flag and customer tags
- Opening this PR now so that we can begin building out the UI behind a flag 

## Preview 📷

![Screenshot 2025-01-29 at 12 06 18 PM](https://github.com/user-attachments/assets/f25fddfe-47da-46b5-adbb-df2d20b7237e)

## How to test 🧪

- Nothing to test in the UI! Just verify the code looks correct and doesn't make any crazy errors
- Verify the unit test brings value
  - It is basic for now, but it will be nice to have once this project gets a bit more complex


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
