### PR TITLE
refactor: [M3-8252] - Remove ramda from `DomainRecords` (Part 2)

### DIFF
--- a/packages/manager/.changeset/pr-11587-tech-stories-1738221754635.md
+++ b/packages/manager/.changeset/pr-11587-tech-stories-1738221754635.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Remove ramda from `DomainRecords` pt2 ([#11587](https://github.com/linode/manager/pull/11587))

--- a/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecordDrawer.tsx
@@ -77,7 +77,6 @@ export interface EditableDomainFields extends EditableSharedFields {
   refresh_sec?: number;
   retry_sec?: number;
   soa_email?: string;
-  ttl_sec?: number;
 }
 
 type ErrorFields =

--- a/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecordDrawer.tsx
@@ -3,7 +3,6 @@ import {
   updateDomainRecord,
 } from '@linode/api-v4/lib/domains';
 import { Notice } from '@linode/ui';
-import { path } from 'ramda';
 import * as React from 'react';
 import { useForm } from 'react-hook-form';
 
@@ -262,7 +261,7 @@ export const DomainRecordDrawer = (props: DomainRecordDrawerProps) => {
     <Drawer
       onClose={handleClose}
       open={open}
-      title={`${path([mode], modeMap)} ${path([type], typeMap)} Record`}
+      title={`${modeMap[mode]} ${typeMap[type]} Record`}
     >
       <form onSubmit={onSubmit} ref={formContainerRef}>
         {otherErrors.map((error, idx) =>

--- a/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecordDrawerUtils.test.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecordDrawerUtils.test.tsx
@@ -179,11 +179,14 @@ describe('Domain record helper methods', () => {
       });
     });
 
-    it('should return an empty object for PTR, slave types', () => {
+    it('should return an empty object for PTR, slave types (default cases)', () => {
       const types: (DomainType | RecordType)[] = ['slave', 'PTR'];
 
       types.forEach((type) => {
-        const result = filterDataByType(mockRecordFields, type);
+        const mockFields =
+          type === 'slave' ? mockDomainFields : mockRecordFields;
+
+        const result = filterDataByType(mockFields, type);
 
         expect(result).toEqual({});
       });

--- a/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecordDrawerUtils.test.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecordDrawerUtils.test.tsx
@@ -1,9 +1,16 @@
 import {
   castFormValuesToNumeric,
+  filterDataByType,
   resolve,
   resolveAlias,
   shouldResolve,
 } from './DomainRecordDrawerUtils';
+
+import type {
+  EditableDomainFields,
+  EditableRecordFields,
+} from './DomainRecordDrawer';
+import type { DomainType, RecordType } from '@linode/api-v4/lib/domains';
 
 const exampleDomain = 'example.com';
 
@@ -81,6 +88,104 @@ describe('Domain record helper methods', () => {
       const result = castFormValuesToNumeric(formValues, ['apple']);
       expect(result).toEqual({
         apple: undefined,
+      });
+    });
+  });
+
+  describe('filterDataByType', () => {
+    const mockDomainFields: EditableDomainFields = {
+      axfr_ips: ['192.168.0.1'],
+      domain: exampleDomain,
+      expire_sec: 3600,
+      refresh_sec: 7200,
+      retry_sec: 300,
+      soa_email: 'soa@example.com',
+      ttl_sec: 86400,
+    };
+
+    const mockRecordFields: EditableRecordFields = {
+      name: 'www',
+      port: '80',
+      priority: '10',
+      protocol: 'tcp',
+      service: '_http',
+      tag: 'tag-example',
+      target: exampleDomain,
+      ttl_sec: 3600,
+      weight: '5',
+    };
+
+    it('should return correct master data for domain type "master"', () => {
+      const result = filterDataByType(mockDomainFields, 'master');
+
+      expect(result).toEqual({
+        axfr_ips: ['192.168.0.1'],
+        domain: exampleDomain,
+        expire_sec: 3600,
+        refresh_sec: 7200,
+        retry_sec: 300,
+        soa_email: 'soa@example.com',
+        ttl_sec: 86400,
+      });
+    });
+
+    it('should return correct record data for "A", "AAAA", "CNAME", "NS", "TXT" types', () => {
+      const recordTypes: RecordType[] = ['A', 'AAAA', 'CNAME', 'NS', 'TXT'];
+
+      recordTypes.forEach((type) => {
+        const result = filterDataByType(mockRecordFields, type);
+
+        expect(result).toEqual({
+          name: 'www',
+          target: exampleDomain,
+          ttl_sec: 3600,
+        });
+      });
+    });
+
+    it('should return correct CAA record data for type "CAA"', () => {
+      const result = filterDataByType(mockRecordFields, 'CAA');
+
+      expect(result).toEqual({
+        name: 'www',
+        tag: 'tag-example',
+        target: exampleDomain,
+        ttl_sec: 3600,
+      });
+    });
+
+    it('should return correct MX record data for type "MX"', () => {
+      const result = filterDataByType(mockRecordFields, 'MX');
+
+      expect(result).toEqual({
+        name: 'www',
+        priority: '10',
+        target: exampleDomain,
+        ttl_sec: 3600,
+      });
+    });
+
+    it('should return correct SRV record data for type "SRV"', () => {
+      const result = filterDataByType(mockRecordFields, 'SRV');
+
+      expect(result).toEqual({
+        port: '80',
+        priority: '10',
+        protocol: 'tcp',
+        service: '_http',
+        target: exampleDomain,
+        ttl_sec: 3600,
+        weight: '5',
+      });
+    });
+
+    it('should return an empty object for PTR, slave types', () => {
+      const types: (DomainType | RecordType)[] = ['slave', 'PTR'];
+
+      types.forEach((type) => {
+        const result = filterDataByType(mockRecordFields, type);
+
+        expect(result).toEqual({});
       });
     });
   });

--- a/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecordDrawerUtils.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecordDrawerUtils.tsx
@@ -1,5 +1,4 @@
 import produce from 'immer';
-import { cond, equals, pick } from 'ramda';
 
 import { maybeCastToNumber } from 'src/utilities/maybeCastToNumber';
 
@@ -83,68 +82,6 @@ export const castFormValuesToNumeric = (
   });
 };
 
-export const filterDataByType = (
-  fields: EditableDomainFields | EditableRecordFields,
-  t: DomainType | RecordType
-): Partial<EditableDomainFields | EditableRecordFields> =>
-  cond([
-    [
-      () => equals('master', t),
-      () =>
-        pick(
-          [
-            'domain',
-            'soa_email',
-            'refresh_sec',
-            'retry_sec',
-            'expire_sec',
-            'ttl_sec',
-            'axfr_ips',
-          ],
-          fields
-        ),
-    ],
-    // [
-    //   () => equals('slave', t),
-    //   () => pick([], fields),
-    // ],
-    [() => equals('A', t), () => pick(['name', 'target', 'ttl_sec'], fields)],
-    [
-      () => equals('AAAA', t),
-      () => pick(['name', 'target', 'ttl_sec'], fields),
-    ],
-    [
-      () => equals('CAA', t),
-      () => pick(['name', 'tag', 'target', 'ttl_sec'], fields),
-    ],
-    [
-      () => equals('CNAME', t),
-      () => pick(['name', 'target', 'ttl_sec'], fields),
-    ],
-    [
-      () => equals('MX', t),
-      () => pick(['target', 'priority', 'ttl_sec', 'name'], fields),
-    ],
-    [() => equals('NS', t), () => pick(['target', 'name', 'ttl_sec'], fields)],
-    [
-      () => equals('SRV', t),
-      () =>
-        pick(
-          [
-            'service',
-            'protocol',
-            'priority',
-            'port',
-            'weight',
-            'target',
-            'ttl_sec',
-          ],
-          fields
-        ),
-    ],
-    [() => equals('TXT', t), () => pick(['name', 'target', 'ttl_sec'], fields)],
-  ])();
-
 /**
  * the defaultFieldState is used to pre-populate the drawer with either
  * editable data or defaults.
@@ -170,3 +107,108 @@ export const defaultFieldsState = (
   ttl_sec: props.ttl_sec ?? 0,
   weight: props.weight ?? '5',
 });
+
+const getMasterPayload = (
+  fields: EditableDomainFields
+): Pick<
+  EditableDomainFields,
+  | 'axfr_ips'
+  | 'domain'
+  | 'expire_sec'
+  | 'refresh_sec'
+  | 'retry_sec'
+  | 'soa_email'
+  | 'ttl_sec'
+> => {
+  return {
+    axfr_ips: fields.axfr_ips,
+    domain: fields.domain,
+    expire_sec: fields.expire_sec,
+    refresh_sec: fields.refresh_sec,
+    retry_sec: fields.retry_sec,
+    soa_email: fields.soa_email,
+    ttl_sec: fields.ttl_sec,
+  };
+};
+
+/**
+ * Get payload for `A`, `AAAA`, `CNAME`, `NS`, `TXT` records
+ * @param fields - (unfiltered) Domain Record form data fields
+ */
+const getSharedRecordPayload = (
+  fields: EditableRecordFields
+): Pick<EditableRecordFields, 'name' | 'target' | 'ttl_sec'> => {
+  return {
+    name: fields.name,
+    target: fields.target,
+    ttl_sec: fields.ttl_sec,
+  };
+};
+
+const getCAARecordPayload = (
+  fields: EditableRecordFields
+): Pick<EditableRecordFields, 'name' | 'tag' | 'target' | 'ttl_sec'> => {
+  return {
+    name: fields.name,
+    tag: fields.tag,
+    target: fields.target,
+    ttl_sec: fields.ttl_sec,
+  };
+};
+
+const getMXRecordPayload = (
+  fields: EditableRecordFields
+): Pick<EditableRecordFields, 'name' | 'priority' | 'target' | 'ttl_sec'> => {
+  return {
+    name: fields.name,
+    priority: fields.priority,
+    target: fields.target,
+    ttl_sec: fields.ttl_sec,
+  };
+};
+
+const getSRVRecordPayload = (
+  fields: EditableRecordFields
+): Pick<
+  EditableRecordFields,
+  'port' | 'priority' | 'protocol' | 'service' | 'target' | 'ttl_sec' | 'weight'
+> => {
+  return {
+    port: fields.port,
+    priority: fields.priority,
+    protocol: fields.protocol,
+    service: fields.service,
+    target: fields.target,
+    ttl_sec: fields.ttl_sec,
+    weight: fields.weight,
+  };
+};
+
+export const filterDataByType = (
+  fields: EditableDomainFields | EditableRecordFields,
+  type: DomainType | RecordType
+): Partial<EditableDomainFields | EditableRecordFields> => {
+  switch (type) {
+    case 'master':
+      return getMasterPayload(fields);
+
+    case 'A':
+    case 'AAAA':
+    case 'CNAME':
+    case 'NS':
+    case 'TXT':
+      return getSharedRecordPayload(fields);
+
+    case 'CAA':
+      return getCAARecordPayload(fields);
+
+    case 'MX':
+      return getMXRecordPayload(fields);
+
+    case 'SRV':
+      return getSRVRecordPayload(fields);
+
+    default:
+      return {};
+  }
+};

--- a/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecordDrawerUtils.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecordDrawerUtils.tsx
@@ -108,7 +108,7 @@ export const defaultFieldsState = (
   weight: props.weight ?? '5',
 });
 
-const getMasterPayload = (
+const getMasterData = (
   fields: EditableDomainFields
 ): Pick<
   EditableDomainFields,
@@ -132,10 +132,10 @@ const getMasterPayload = (
 };
 
 /**
- * Get payload for `A`, `AAAA`, `CNAME`, `NS`, `TXT` records
+ * Get data for `A`, `AAAA`, `CNAME`, `NS`, `TXT` records
  * @param fields - (unfiltered) Domain Record form data fields
  */
-const getSharedRecordPayload = (
+const getSharedRecordData = (
   fields: EditableRecordFields
 ): Pick<EditableRecordFields, 'name' | 'target' | 'ttl_sec'> => {
   return {
@@ -145,7 +145,7 @@ const getSharedRecordPayload = (
   };
 };
 
-const getCAARecordPayload = (
+const getCAARecordData = (
   fields: EditableRecordFields
 ): Pick<EditableRecordFields, 'name' | 'tag' | 'target' | 'ttl_sec'> => {
   return {
@@ -156,7 +156,7 @@ const getCAARecordPayload = (
   };
 };
 
-const getMXRecordPayload = (
+const getMXRecordData = (
   fields: EditableRecordFields
 ): Pick<EditableRecordFields, 'name' | 'priority' | 'target' | 'ttl_sec'> => {
   return {
@@ -167,7 +167,7 @@ const getMXRecordPayload = (
   };
 };
 
-const getSRVRecordPayload = (
+const getSRVRecordData = (
   fields: EditableRecordFields
 ): Pick<
   EditableRecordFields,
@@ -190,23 +190,23 @@ export const filterDataByType = (
 ): Partial<EditableDomainFields | EditableRecordFields> => {
   switch (type) {
     case 'master':
-      return getMasterPayload(fields);
+      return getMasterData(fields);
 
     case 'A':
     case 'AAAA':
     case 'CNAME':
     case 'NS':
     case 'TXT':
-      return getSharedRecordPayload(fields);
+      return getSharedRecordData(fields);
 
     case 'CAA':
-      return getCAARecordPayload(fields);
+      return getCAARecordData(fields);
 
     case 'MX':
-      return getMXRecordPayload(fields);
+      return getMXRecordData(fields);
 
     case 'SRV':
-      return getSRVRecordPayload(fields);
+      return getSRVRecordData(fields);
 
     default:
       return {};


### PR DESCRIPTION
## Description 📝
Ramda should be completely removed/replaced with native JS equivalent

- Remove ramda from `DomainRecords` - Part 2
- Follow-up to:
  - https://github.com/linode/manager/pull/11514
  - https://github.com/linode/manager/pull/11538

## Changes  🔄
- Remove 🧹 ramda from:
   - `/DomainRecords/DomainRecordDrawer.tsx`
   - `/DomainRecords/DomainRecordDrawerUtils.tsx`
- Remove duplicate `ttl_sec?: number;` from `EditableDomainFields` type
- Add unit tests for `filterDataByType` 🧪

## Target release date 🗓️
N/A

## Preview 📷
No visual changes

## How to test 🧪
- Ensure no existing functionality is broken
- Verify all `Create/Edit` Domain Record Drawer flows work as expected
    - Ensure the Domain Record Drawer title is displaying correctly for each record type as expected
    - Test `Create/Edit` for `SOA`, `NS`, `MX`, `A/AAAA`, `CNAME`, `TXT`, `SRV`, `CAA` records and `Tags`
    - Open both `cloud.linode.com` and this branch (locally or in the preview PR) side by side in two tabs
       - In Network tab, verify the fields in the payloads for `Create/Edit` of each record in this branch (or preview PR branch) match exactly with what you would see on `cloud.linode.com`

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules