### PR TITLE
feat: [UIE-8372] - database migration event notification

### DIFF
--- a/packages/api-v4/.changeset/pr-11590-added-1738256458071.md
+++ b/packages/api-v4/.changeset/pr-11590-added-1738256458071.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Added
+---
+
+new Database status for migration event ([#11590](https://github.com/linode/manager/pull/11590))

--- a/packages/api-v4/.changeset/pr-11590-added-1738256458071.md
+++ b/packages/api-v4/.changeset/pr-11590-added-1738256458071.md
@@ -2,4 +2,4 @@
 "@linode/api-v4": Added
 ---
 
-new Database status for migration event ([#11590](https://github.com/linode/manager/pull/11590))
+New database statuses for database_migration event ([#11590](https://github.com/linode/manager/pull/11590))

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -330,6 +330,7 @@ export const EventActionKeys = [
   'database_scale',
   'database_update_failed',
   'database_update',
+  'database_migrate',
   'database_upgrade',
   'disk_create',
   'disk_delete',

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -33,6 +33,8 @@ export type DatabaseStatus =
   | 'active'
   | 'degraded'
   | 'failed'
+  | 'migrating'
+  | 'migrated'
   | 'provisioning'
   | 'resizing'
   | 'restoring'

--- a/packages/manager/.changeset/pr-11590-added-1738256866553.md
+++ b/packages/manager/.changeset/pr-11590-added-1738256866553.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Database status display and event notifications for database migration  ([#11590](https://github.com/linode/manager/pull/11590))

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -20,6 +20,8 @@ export const possibleStatuses: DatabaseStatus[] = [
   'active',
   'degraded',
   'failed',
+  'migrating',
+  'migrated',
   'provisioning',
   'resizing',
   'restoring',

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseStatusDisplay.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseStatusDisplay.tsx
@@ -16,6 +16,8 @@ export const databaseStatusMap: Record<DatabaseStatus, Status> = {
   active: 'active',
   degraded: 'inactive',
   failed: 'error',
+  migrated: 'inactive',
+  migrating: 'other',
   provisioning: 'other',
   resizing: 'other',
   restoring: 'other',

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
@@ -63,7 +63,10 @@ export const DatabaseRow = ({
   const formattedPlan = plan && formatStorageUnits(plan.label);
   const actualRegion = regions?.find((r) => r.id === region);
   const isLinkInactive =
-    status === 'suspended' || status === 'suspending' || status === 'resuming';
+    status === 'suspended' ||
+    status === 'suspending' ||
+    status === 'resuming' ||
+    status === 'migrated';
   const { isDatabasesV2GA } = useIsDatabasesEnabled();
 
   const configuration =

--- a/packages/manager/src/features/Events/factories/database.tsx
+++ b/packages/manager/src/features/Events/factories/database.tsx
@@ -106,6 +106,20 @@ export const database: PartialEventMap<'database'> = {
       </>
     ),
   },
+  database_migrate: {
+    finished: (e) => (
+      <>
+        Database <EventLink event={e} to="entity" /> migration{' '}
+        <strong>completed</strong>
+      </>
+    ),
+    started: (e) => (
+      <>
+        Database <EventLink event={e} to="entity" /> migration{' '}
+        <strong>in progress</strong>
+      </>
+    ),
+  },
   database_resize: {
     failed: (e) => (
       <>

--- a/packages/manager/src/features/Events/factories/database.tsx
+++ b/packages/manager/src/features/Events/factories/database.tsx
@@ -110,13 +110,13 @@ export const database: PartialEventMap<'database'> = {
     finished: (e) => (
       <>
         Database <EventLink event={e} to="entity" /> migration{' '}
-        <strong>completed</strong>
+        <strong>completed</strong>.
       </>
     ),
     started: (e) => (
       <>
         Database <EventLink event={e} to="entity" /> migration{' '}
-        <strong>in progress</strong>
+        <strong>in progress</strong>.
       </>
     ),
   },

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1705,6 +1705,18 @@ export const handlers = [
         message: 'Low disk space.',
         status: 'notification',
       });
+      const dbMigrationEvents = eventFactory.buildList(1, {
+        action: 'database_migrate',
+        entity: { id: 11, label: 'database-11', type: 'database' },
+        message: 'Database migration started.',
+        status: 'started',
+      });
+      const dbMigrationFinishedEvents = eventFactory.buildList(1, {
+        action: 'database_migrate',
+        entity: { id: 11, label: 'database-11', type: 'database' },
+        message: 'Database migration finished.',
+        status: 'finished',
+      });
       const oldEvents = eventFactory.buildList(20, {
         action: 'account_update',
         percent_complete: 100,
@@ -1745,6 +1757,8 @@ export const handlers = [
       return HttpResponse.json(
         makeResourcePage([
           ...events,
+          ...dbMigrationEvents,
+          ...dbMigrationFinishedEvents,
           ...dbEvents,
           ...placementGroupAssignedEvent,
           ...placementGroupCreateEvent,


### PR DESCRIPTION
## Description 📝

DBaaS migrate event notification

## Changes  🔄

List any change(s) relevant to the reviewer.

- added a new states: 'Migrating', 'Migrated', that are displayed for the cluster
- added an event notification under the bell icon with a message about the migration status 

## Target release date 🗓️

2/11/25

## Preview 📷

| Before  | After   |
| ------- | ------- |
|  | ![Screenshot 2025-01-30 at 5 54 13 PM](https://github.com/user-attachments/assets/381a88cd-3407-4564-a239-97c97aea7eb8) |
|  | ![Screenshot 2025-01-30 at 5 46 57 PM](https://github.com/user-attachments/assets/a68dfadf-1458-4c0f-82f3-876dbb1f8c64) |

## How to test 🧪

### Verification steps

(How to verify changes)

- When the migration process starts, the database status will change to "Migrating", and a new event notification will appear under the bell icon indicating that the migration is in progress.

- Once the migration is complete, the database status will change to "Migrated", and a new event notification will appear under the bell icon confirming that the migration is completed. 


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
