### PR TITLE
test: [M3 8035] - Refactor Marketplace App (OCA) Cypress test

### DIFF
--- a/packages/manager/.changeset/pr-11591-tests-1738598203085.md
+++ b/packages/manager/.changeset/pr-11591-tests-1738598203085.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Refactor OCA tests ([#11591](https://github.com/linode/manager/pull/11591))

--- a/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
+++ b/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
@@ -5,10 +5,7 @@ import {
   mockGetStackScripts,
 } from 'support/intercepts/stackscripts';
 import { mockCreateLinode } from 'support/intercepts/linodes';
-import {
-  getRandomOCAId,
-  replaceHTMLEntities,
-} from 'support/util/one-click-apps';
+import { getRandomOCAId } from 'support/util/one-click-apps';
 import { randomLabel, randomString } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
 import { stackScriptFactory } from 'src/factories/stackscripts';
@@ -99,9 +96,7 @@ describe('OneClick Apps (OCA)', () => {
         .findByTitle(getMarketplaceAppLabel(candidateStackScript.label))
         .should('be.visible')
         .within(() => {
-          cy.findByText(replaceHTMLEntities(candidateApp.description)).should(
-            'be.visible'
-          );
+          // compare summary instead of description bc latter contains too many special characters and line breaks
           cy.findByText(candidateApp.summary).should('be.visible');
           cy.findByText(candidateApp.website!).should('be.visible');
         });
@@ -256,5 +251,54 @@ describe('OneClick Apps (OCA)', () => {
     cy.wait('@createLinode');
 
     ui.toast.assertMessage(`Your Linode ${linode.label} is being created.`);
+  });
+
+  // leave test disabled by default
+  xit('Validate the summaries of all the OneClick Apps', () => {
+    cy.tag('method:e2e');
+
+    interceptGetStackScripts().as('getStackScripts');
+    cy.visitWithLogin(`/linodes/create?type=One-Click`);
+
+    cy.wait('@getStackScripts').then((xhr) => {
+      // Check the content of the app list
+      cy.findByTestId('one-click-apps-container').within(() => {
+        const stackScripts: StackScript[] = xhr.response?.body.data ?? [];
+        for (const stackscriptId in oneClickApps) {
+          // expected data of the app in the selected tile
+          const candidateApp = oneClickApps[stackscriptId];
+          const candidateStackScript = stackScripts.find(
+            (s) => s.id === +stackscriptId
+          );
+
+          if (!candidateStackScript) {
+            console.log(
+              'missing stackscript from UI ',
+              stackscriptId,
+              candidateApp.description
+            );
+            throw new Error(
+              'No StackScript returned by the API for the candidate app.'
+            );
+          } else {
+            cy.findAllByLabelText(
+              `Info for "${getMarketplaceAppLabel(candidateStackScript.label)}"`
+            )
+              .first()
+              .scrollIntoView()
+              .should('be.visible')
+              .should('be.enabled')
+              .click();
+
+            ui.drawer.find().within(() => {
+              // compare summary instead of description bc latter contains too many special characters and line breaks
+              cy.findByText(candidateApp.summary).should('be.visible');
+            });
+
+            ui.drawerCloseButton.find().click();
+          }
+        }
+      });
+    });
   });
 });

--- a/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
+++ b/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
@@ -10,6 +10,7 @@ import { chooseRegion } from 'support/util/regions';
 import { stackScriptFactory } from 'src/factories/stackscripts';
 import { oneClickApps } from 'src/features/OneClickApps/oneClickApps';
 import { getMarketplaceAppLabel } from 'src/features/Linodes/LinodeCreate/Tabs/Marketplace/utilities';
+import { decode } from 'he';
 
 import type { StackScript } from '@linode/api-v4';
 import { imageFactory, linodeFactory } from 'src/factories';
@@ -271,22 +272,11 @@ function getRandomApp(): number {
 /**
  * Replaces the HTML entities such as &amp; and &reg; with the html character
  * This fn is the corollary to scripts/junit-summary/util/escape.ts which converts the html character to the html entity
- * Taken from https://stackoverflow.com/questions/76821044/how-to-replace-html-entity-by-the-string-character
  * *
  * @param str - string containing html entities
  *
  * @returns string
  */
 const replaceHTMLEntities = (str: string) => {
-  const htmlEntities: { [key: string]: string } = {
-    '&amp;': '&',
-    '&reg;': '®',
-  };
-
-  const strDecoded = str.replace(/&[\w#]+;/g, (entity) => {
-    return htmlEntities[entity] || entity;
-  });
-  // replace any tab characters. some descriptions (ie, OCA id 595742) have double spaces that get converted to tabs
-  // also need to replace line breaks, either <br/> or <br> (see OCA id 1132204)
-  return strDecoded.replace('\t', '').replace(/<br ?\/?>/g, '');
+  return decode(str.replace('  ', ' '));
 };

--- a/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
+++ b/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
@@ -117,10 +117,8 @@ describe('OneClick Apps (OCA)', () => {
         label: 'Debian 11',
       }),
     ];
-    // get a randomly selected app
-    const candidateStackScriptId = getRandomOCAId();
     const stackscript = stackScriptFactory.build({
-      id: candidateStackScriptId,
+      id: getRandomOCAId(),
       username: 'linode',
       user_gravatar_id: '9d4d301385af69ceb7ad658aad09c142',
       label: 'E2E Test App',

--- a/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
+++ b/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
@@ -5,12 +5,15 @@ import {
   mockGetStackScripts,
 } from 'support/intercepts/stackscripts';
 import { mockCreateLinode } from 'support/intercepts/linodes';
+import {
+  getRandomOCAId,
+  replaceHTMLEntities,
+} from 'support/util/one-click-apps';
 import { randomLabel, randomString } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
 import { stackScriptFactory } from 'src/factories/stackscripts';
 import { oneClickApps } from 'src/features/OneClickApps/oneClickApps';
 import { getMarketplaceAppLabel } from 'src/features/Linodes/LinodeCreate/Tabs/Marketplace/utilities';
-import { decode } from 'he';
 
 import type { StackScript } from '@linode/api-v4';
 import { imageFactory, linodeFactory } from 'src/factories';
@@ -62,7 +65,7 @@ describe('OneClick Apps (OCA)', () => {
 
     cy.wait('@getStackScripts').then((xhr) => {
       const stackScripts: StackScript[] = xhr.response?.body.data ?? [];
-      const candidateStackScriptId = getRandomApp();
+      const candidateStackScriptId = getRandomOCAId();
       const candidateApp = oneClickApps[candidateStackScriptId];
 
       if (!candidateApp) {
@@ -120,7 +123,7 @@ describe('OneClick Apps (OCA)', () => {
       }),
     ];
     // get a randomly selected app
-    const candidateStackScriptId = getRandomApp();
+    const candidateStackScriptId = getRandomOCAId();
     const stackscript = stackScriptFactory.build({
       id: candidateStackScriptId,
       username: 'linode',
@@ -255,28 +258,3 @@ describe('OneClick Apps (OCA)', () => {
     ui.toast.assertMessage(`Your Linode ${linode.label} is being created.`);
   });
 });
-
-/**
- * Returns the id of a randomly selected oneClickApp
- * @returns number
- */
-function getRandomApp(): number {
-  // pick a random app
-  const appKeys = Object.keys(oneClickApps);
-  const index = Math.floor(Math.random() * appKeys.length);
-  // id should be number, so "+" useful to coerce from string
-  const id = +appKeys[index];
-  return id;
-}
-
-/**
- * Replaces the HTML entities such as &amp; and &reg; with the html character
- * This fn is the corollary to scripts/junit-summary/util/escape.ts which converts the html character to the html entity
- * *
- * @param str - string containing html entities
- *
- * @returns string
- */
-const replaceHTMLEntities = (str: string) => {
-  return decode(str.replace('  ', ' '));
-};

--- a/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
+++ b/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
@@ -61,10 +61,7 @@ describe('OneClick Apps (OCA)', () => {
 
     cy.wait('@getStackScripts').then((xhr) => {
       const stackScripts: StackScript[] = xhr.response?.body.data ?? [];
-
-      // For the sake of this test, use the first marketplace app defined in Cloud Manager
-      const candidateStackScriptId = +Object.keys(oneClickApps)[0];
-
+      const candidateStackScriptId = getRandomApp();
       const candidateApp = oneClickApps[candidateStackScriptId];
 
       if (!candidateApp) {
@@ -119,10 +116,8 @@ describe('OneClick Apps (OCA)', () => {
         label: 'Debian 11',
       }),
     ];
-
-    // For the sake of this test, use the first marketplace app defined in Cloud Manager
-    const candidateStackScriptId = +Object.keys(oneClickApps)[0];
-
+    // get a randomly selected app
+    const candidateStackScriptId = getRandomApp();
     const stackscript = stackScriptFactory.build({
       id: candidateStackScriptId,
       username: 'linode',
@@ -257,3 +252,16 @@ describe('OneClick Apps (OCA)', () => {
     ui.toast.assertMessage(`Your Linode ${linode.label} is being created.`);
   });
 });
+
+/**
+ * Returns the id of a randomly selected oneClickApp
+ * @returns number
+ */
+function getRandomApp(): number {
+  // pick a random app
+  const appKeys = Object.keys(oneClickApps);
+  const index = Math.floor(Math.random() * appKeys.length);
+  // id should be number, so "+" useful to coerce from string
+  const id = +appKeys[index];
+  return id;
+}

--- a/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
+++ b/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
@@ -95,7 +95,9 @@ describe('OneClick Apps (OCA)', () => {
         .findByTitle(getMarketplaceAppLabel(candidateStackScript.label))
         .should('be.visible')
         .within(() => {
-          cy.findByText(candidateApp.description).should('be.visible');
+          cy.findByText(replaceHTMLEntities(candidateApp.description)).should(
+            'be.visible'
+          );
           cy.findByText(candidateApp.summary).should('be.visible');
           cy.findByText(candidateApp.website!).should('be.visible');
         });
@@ -265,3 +267,26 @@ function getRandomApp(): number {
   const id = +appKeys[index];
   return id;
 }
+
+/**
+ * Replaces the HTML entities such as &amp; and &reg; with the html character
+ * This fn is the corollary to scripts/junit-summary/util/escape.ts which converts the html character to the html entity
+ * Taken from https://stackoverflow.com/questions/76821044/how-to-replace-html-entity-by-the-string-character
+ * *
+ * @param str - string containing html entities
+ *
+ * @returns string
+ */
+const replaceHTMLEntities = (str: string) => {
+  const htmlEntities: { [key: string]: string } = {
+    '&amp;': '&',
+    '&reg;': '®',
+  };
+
+  const strDecoded = str.replace(/&[\w#]+;/g, (entity) => {
+    return htmlEntities[entity] || entity;
+  });
+  // replace any tab characters. some descriptions (ie, OCA id 595742) have double spaces that get converted to tabs
+  // also need to replace line breaks, either <br/> or <br> (see OCA id 1132204)
+  return strDecoded.replace('\t', '').replace(/<br ?\/?>/g, '');
+};

--- a/packages/manager/cypress/support/util/one-click-apps.ts
+++ b/packages/manager/cypress/support/util/one-click-apps.ts
@@ -1,0 +1,27 @@
+import { oneClickApps } from 'src/features/OneClickApps/oneClickApps';
+import { decode } from 'he';
+
+/**
+ * Returns the id of a randomly selected oneClickApp
+ * @returns number
+ */
+export function getRandomOCAId(): number {
+  // pick a random app
+  const appKeys = Object.keys(oneClickApps);
+  const index = Math.floor(Math.random() * appKeys.length);
+  // id should be number, so "+" useful to coerce from string
+  const id = +appKeys[index];
+  return id;
+}
+
+/**
+ * Replaces the HTML entities such as &amp; and &reg; with the html character
+ * This fn is the corollary to scripts/junit-summary/util/escape.ts which converts the html character to the html entity
+ * *
+ * @param str - string containing html entities
+ *
+ * @returns string
+ */
+export const replaceHTMLEntities = (str: string) => {
+  return decode(str.replace('  ', ' '));
+};

--- a/packages/manager/cypress/support/util/one-click-apps.ts
+++ b/packages/manager/cypress/support/util/one-click-apps.ts
@@ -1,5 +1,5 @@
 import { oneClickApps } from 'src/features/OneClickApps/oneClickApps';
-
+import { randomItem } from 'support/util/random';
 /**
  * Returns the id of a randomly selected oneClickApp
  * @returns number
@@ -7,8 +7,8 @@ import { oneClickApps } from 'src/features/OneClickApps/oneClickApps';
 export function getRandomOCAId(): number {
   // pick a random app
   const appKeys = Object.keys(oneClickApps);
-  const index = Math.floor(Math.random() * appKeys.length);
+  const index = randomItem(appKeys);
   // id should be number, so "+" useful to coerce from string
-  const id = +appKeys[index];
+  const id = +index;
   return id;
 }

--- a/packages/manager/cypress/support/util/one-click-apps.ts
+++ b/packages/manager/cypress/support/util/one-click-apps.ts
@@ -1,5 +1,4 @@
 import { oneClickApps } from 'src/features/OneClickApps/oneClickApps';
-import { decode } from 'he';
 
 /**
  * Returns the id of a randomly selected oneClickApp
@@ -13,15 +12,3 @@ export function getRandomOCAId(): number {
   const id = +appKeys[index];
   return id;
 }
-
-/**
- * Replaces the HTML entities such as &amp; and &reg; with the html character
- * This fn is the corollary to scripts/junit-summary/util/escape.ts which converts the html character to the html entity
- * *
- * @param str - string containing html entities
- *
- * @returns string
- */
-export const replaceHTMLEntities = (str: string) => {
-  return decode(str.replace('  ', ' '));
-};


### PR DESCRIPTION
## Description 📝

Refactor tests for one-click-apps to improve reliability. 

## Changes  🔄

List any change(s) relevant to the reviewer.

- Use random app from list of OCAs, instead of always using the first one
-"Fix" string input from OCA descriptions by replacing HTML special entities (such as "&amp;") with the html character ("&" in this case). Replacing only the ampersand and registered trademark entities for now, bc those are the only entities used in the descriptions in src/features/OneClickApps/oneClickApps.ts. 
 

## How to test 🧪
-yarn cy:run -s "packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts"

 

### Reproduction steps

Tests sporadically fail. The tests in the current develop branch will certainly fail if you hardcode the 2nd and 3rd tests in packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts to use a OCA description that has html entities (such as 595742 or 1132204 for an ID).  

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

