### PR TITLE
fix: [M3-9069] - Copy Token behavior on LKE details page

### DIFF
--- a/packages/manager/.changeset/pr-11592-fixed-1738326763592.md
+++ b/packages/manager/.changeset/pr-11592-fixed-1738326763592.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Buggy Copy Token behavior on K8s details page ([#11592](https://github.com/linode/manager/pull/11592))
+Buggy Copy Token behavior on LKE details page ([#11592](https://github.com/linode/manager/pull/11592))

--- a/packages/manager/.changeset/pr-11592-fixed-1738326763592.md
+++ b/packages/manager/.changeset/pr-11592-fixed-1738326763592.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Buggy Copy Token behavior on K8s details page ([#11592](https://github.com/linode/manager/pull/11592))

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.tsx
@@ -49,7 +49,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     cursor: 'pointer',
     display: 'flex',
     marginBottom: theme.spacing(1),
-    padding: `0 ${theme.spacing(0.5)}`,
+    padding: `0 ${theme.spacing(0.6)}`,
   },
   kubeconfigElements: {
     alignItems: 'center',
@@ -63,10 +63,10 @@ const useStyles = makeStyles()((theme: Theme) => ({
     whiteSpace: 'nowrap',
   },
   kubeconfigIcons: {
-    height: 16,
+    height: 14,
     margin: `0 ${theme.spacing(1)}`,
     objectFit: 'contain',
-    width: 16,
+    width: 14,
   },
   label: {
     fontFamily: theme.font.bold,

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.tsx
@@ -39,6 +39,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
   kubeconfigElement: {
     '&:first-of-type': {
       borderLeft: 'none',
+      paddingLeft: 0,
     },
     '&:hover': {
       opacity: 0.7,
@@ -47,13 +48,14 @@ const useStyles = makeStyles()((theme: Theme) => ({
     borderLeft: `1px solid ${theme.tokens.color.Neutrals[40]}`,
     cursor: 'pointer',
     display: 'flex',
+    marginBottom: theme.spacing(1),
+    padding: `0 ${theme.spacing(0.5)}`,
   },
   kubeconfigElements: {
     alignItems: 'center',
     color: theme.palette.primary.main,
     display: 'flex',
     flexWrap: 'wrap',
-    gap: theme.spacing(1),
   },
   kubeconfigFileText: {
     color: theme.textColors.linkActiveLight,
@@ -105,13 +107,17 @@ export const KubeConfigDisplay = (props: Props) => {
   const { enqueueSnackbar } = useSnackbar();
   const { classes, cx } = useStyles();
 
-  const { isFetching, refetch: getKubeConfig } = useKubernetesKubeConfigQuery(
+  const { refetch: getKubeConfig } = useKubernetesKubeConfigQuery(
     clusterId,
+    false
+  );
+  const [isCopyTokenLoading, setIsCopyTokenLoading] = React.useState<boolean>(
     false
   );
 
   const onCopyToken = async () => {
     try {
+      setIsCopyTokenLoading(true);
       const { data } = await getKubeConfig();
       const token = data && data.match(/token:\s*(\S+)/);
       if (token && token[1]) {
@@ -122,11 +128,13 @@ export const KubeConfigDisplay = (props: Props) => {
           variant: 'error',
         });
       }
+      setIsCopyTokenLoading(false);
     } catch (error) {
       enqueueSnackbar({
         message: (error as APIError[])[0].reason,
         variant: 'error',
       });
+      setIsCopyTokenLoading(false);
     }
   };
 
@@ -197,22 +205,17 @@ export const KubeConfigDisplay = (props: Props) => {
             <DetailsIcon className={classes.kubeconfigIcons} />
             <Typography className={classes.kubeconfigFileText}>View</Typography>
           </Box>
-          <Box
-            className={classes.kubeconfigElement}
-            onClick={onCopyToken}
-            sx={{ marginLeft: isFetching ? 1.25 : 0 }}
-          >
-            {isFetching ? (
-              <CircleProgress noPadding={true} size="xs" />
+          <Box className={classes.kubeconfigElement} onClick={onCopyToken}>
+            {isCopyTokenLoading ? (
+              <CircleProgress
+                className={classes.kubeconfigIcons}
+                noPadding
+                size="xs"
+              />
             ) : (
               <CopyIcon className={classes.kubeconfigIcons} />
             )}
-            <Box
-              className={classes.kubeconfigFileText}
-              sx={{ marginLeft: isFetching ? 1 : 0 }}
-            >
-              Copy Token
-            </Box>
+            <Box className={classes.kubeconfigFileText}>Copy Token</Box>
           </Box>
           <Box
             className={classes.kubeconfigElement}

--- a/packages/ui/src/components/CircleProgress/CircleProgress.tsx
+++ b/packages/ui/src/components/CircleProgress/CircleProgress.tsx
@@ -55,6 +55,7 @@ const CircleProgress = (props: CircleProgressProps) => {
   if (size) {
     return (
       <StyledCustomCircularProgress
+        {...rest}
         aria-label="Content is loading"
         data-qa-circle-progress
         data-testid="circle-progress"


### PR DESCRIPTION
## Description 📝

This PR addresses issues with the `Copy Token` behavior on k8s Details Page

## Changes  🔄
- Fixed the behavior of the `Copy Token` feature
- Ensured consistent spacing for KubeConfig items
- Removed unnecessary inline styles
- Added missing `{...rest}` additional props to the CircleProgress component when the `size` prop is provided

## Target release date 🗓️
N/A

## Preview 📷

| Before  | After  |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/d4f8fe00-a9e4-4eb3-b075-e582cbdf1385" />  | <video src="https://github.com/user-attachments/assets/c4a245d4-a072-44d0-8300-07cdff488d71" /> |
| ![Screenshot 2025-01-31 at 6 30 57 PM](https://github.com/user-attachments/assets/f61ef01c-935d-4d86-ba26-35ccfbc54307) | ![Screenshot 2025-01-31 at 6 29 06 PM](https://github.com/user-attachments/assets/07ecdd68-e16a-4e2c-8a8a-713fc3292167) |
| ![Screenshot 2025-01-31 at 6 21 21 PM](https://github.com/user-attachments/assets/722f10c8-521e-4cb8-8475-e9f579034f43) | ![Screenshot 2025-01-31 at 6 22 53 PM](https://github.com/user-attachments/assets/3015ff38-de9c-49a6-b006-c1447465578a) |

## How to test 🧪
- Verify that there are no regressions with the `CircleProgress` component when the `size` prop is provided, and ensure it behaves correctly wherever used in CM
- Ensure there are no styling issues when clicking the `Copy Token`
- Verify that clicking the KubeConfig "Download" icon does not display the `CircleProgress` component

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules