### PR TITLE
change: [M3-9232] - Clean up `disallowImageUploadToNonObjRegions` flag and add `ignoreAccountAvailability` prop to `RegionMultiSelect`

### DIFF
--- a/packages/manager/.changeset/pr-11598-changed-1738606647435.md
+++ b/packages/manager/.changeset/pr-11598-changed-1738606647435.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Make the `RegionMultiSelect` in the "Manage Image Regions" drawer ignore account capabilities ([#11598](https://github.com/linode/manager/pull/11598))

--- a/packages/manager/.changeset/pr-11598-tech-stories-1738606544178.md
+++ b/packages/manager/.changeset/pr-11598-tech-stories-1738606544178.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Remove `disallowImageUploadToNonObjRegions` feature flag ([#11598](https://github.com/linode/manager/pull/11598))

--- a/packages/manager/.changeset/pr-11598-tech-stories-1738606600844.md
+++ b/packages/manager/.changeset/pr-11598-tech-stories-1738606600844.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Add `ignoreAccountAvailability` prop to `RegionMultiSelect` ([#11598](https://github.com/linode/manager/pull/11598))

--- a/packages/manager/src/components/RegionSelect/RegionMultiSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionMultiSelect.tsx
@@ -39,6 +39,7 @@ export const RegionMultiSelect = React.memo((props: RegionMultiSelectProps) => {
     errorText,
     forcefullyShownRegionIds,
     helperText,
+    ignoreAccountAvailability,
     isClearable,
     label,
     onChange,
@@ -54,7 +55,7 @@ export const RegionMultiSelect = React.memo((props: RegionMultiSelectProps) => {
   const {
     data: accountAvailability,
     isLoading: accountAvailabilityLoading,
-  } = useAllAccountAvailabilitiesQuery();
+  } = useAllAccountAvailabilitiesQuery(!ignoreAccountAvailability);
 
   const regionOptions = getRegionOptions({
     currentCapability,
@@ -77,6 +78,7 @@ export const RegionMultiSelect = React.memo((props: RegionMultiSelectProps) => {
       acc[region.id] = disabledRegionsFromProps[region.id];
     }
     if (
+      !ignoreAccountAvailability &&
       isRegionOptionUnavailable({
         accountAvailabilityData: accountAvailability,
         currentCapability,

--- a/packages/manager/src/components/RegionSelect/RegionSelect.types.ts
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.types.ts
@@ -78,6 +78,11 @@ export interface RegionMultiSelectProps
    */
   forcefullyShownRegionIds?: Set<string>;
   helperText?: string;
+  /**
+   * Ignores account availability information when rendering region options
+   * @default false
+   */
+  ignoreAccountAvailability?: boolean;
   isClearable?: boolean;
   label?: string;
   onChange: (ids: string[]) => void;

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -115,7 +115,6 @@ export interface Flags {
   dbaasV2: BetaFeatureFlag;
   dbaasV2MonitorMetrics: BetaFeatureFlag;
   disableLargestGbPlans: boolean;
-  disallowImageUploadToNonObjRegions: boolean;
   gecko2: GeckoFeatureFlag;
   gpuv2: gpuV2;
   iam: BetaFeatureFlag;

--- a/packages/manager/src/features/Images/ImagesCreate/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/ImageUpload.tsx
@@ -256,11 +256,6 @@ export const ImageUpload = () => {
             <Controller
               render={({ field, fieldState }) => (
                 <RegionSelect
-                  currentCapability={
-                    flags.disallowImageUploadToNonObjRegions
-                      ? 'Object Storage'
-                      : undefined
-                  }
                   disabled={
                     isImageCreateRestricted || form.formState.isSubmitting
                   }
@@ -268,6 +263,7 @@ export const ImageUpload = () => {
                     inputRef: field.ref,
                     onBlur: field.onBlur,
                   }}
+                  currentCapability="Object Storage" // Images use Object Storage as their storage backend
                   disableClearable
                   errorText={fieldState.error?.message}
                   ignoreAccountAvailability

--- a/packages/manager/src/features/Images/ImagesLanding/ImageRegions/ManageImageRegionsForm.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImageRegions/ManageImageRegionsForm.tsx
@@ -116,6 +116,7 @@ export const ManageImageReplicasForm = (props: Props) => {
         currentCapability="Object Storage" // Images use Object Storage as the storage backend
         disabledRegions={disabledRegions}
         errorText={errors.regions?.message}
+        ignoreAccountAvailability // Ignore the account capability because we are just using "Object Storage" for region compatibility
         label="Add Regions"
         placeholder="Select regions or type to search"
         regions={regions?.filter((r) => r.site_type === 'core') ?? []}


### PR DESCRIPTION
## Description 📝

- Cleans up references to the `disallowImageUploadToNonObjRegions` feature flag 🏴 
  - This was needed for Image Service Gen2
  - It has been **enabled** for a long time so we can now safely remove the flag 🧹 
- Adds `ignoreAccountAvailability` prop to the `RegionMultiSelect` component
  - This already exists on the `RegionSelect` component (done in https://github.com/linode/manager/pull/11038), but the multi-select needs it too
  - This ensures the use of the "Object Storage" capability doesn't interfere with the user's ability to replicate an image to other regions

## Preview 📷

> [!note]
> No UI changes expected

![Screenshot 2025-02-03 at 1 14 10 PM](https://github.com/user-attachments/assets/34ab8e07-3ecb-4d7f-866b-c59f77ab8e7f)

## How to test 🧪

- Verify users can still only upload images to regions with the "Object Storage" capability
- Verify the RegionMultiSelect in the "Manage Image Regions" drawer does not factor in account capabilities

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>