### PR TITLE
fix: [M3-9235] - Longview Detail id param not found locally

### DIFF
--- a/packages/manager/.changeset/pr-11599-fixed-1738615199594.md
+++ b/packages/manager/.changeset/pr-11599-fixed-1738615199594.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Longview Detail id param not found (local only) ([#11599](https://github.com/linode/manager/pull/11599))

--- a/packages/manager/src/routes/longview/longviewLazyRoutes.tsx
+++ b/packages/manager/src/routes/longview/longviewLazyRoutes.tsx
@@ -13,15 +13,23 @@ export const longviewLandingLazyRoute = createLazyRoute('/longview')({
 // we'll just match the legacy routing behavior
 const LongviewDetailWrapper = () => {
   const { id } = useParams({ from: '/longview/clients/$id' });
-  const matchProps = {
+
+  if (!id) {
+    return null;
+  }
+
+  const props = {
     match: {
       params: {
         id,
       },
     },
+    params: {
+      id,
+    },
   };
 
-  return <EnhancedLongviewDetail {...matchProps} />;
+  return <EnhancedLongviewDetail {...props} />;
 };
 
 export const longviewDetailLazyRoute = createLazyRoute('/longview/clients/$id')(

--- a/packages/manager/src/routes/longview/longviewLazyRoutes.tsx
+++ b/packages/manager/src/routes/longview/longviewLazyRoutes.tsx
@@ -18,6 +18,8 @@ const LongviewDetailWrapper = () => {
     return null;
   }
 
+  // Leaving this old `match` prop in case it's somehow needed somewhere
+  // see https://github.com/linode/manager/pull/11599
   const props = {
     match: {
       params: {


### PR DESCRIPTION
## Description 📝
when going to a longview client detail (and only locally) we get a 

```
Cannot read properties of undefined (reading 'id') 
```
error. 

Interestingly, Production is unaffected and this was not an error when rerouting the features in https://github.com/linode/manager/pull/11490

## Changes  🔄
- Ensure `params.id` is passed to both the base & params `EnhancedLongviewDetail` props to satisfy redux

## Target release date 🗓️
**2/11/2025**

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-02-03 at 15 13 46](https://github.com/user-attachments/assets/097b3e40-fe0f-40f5-a046-48cd068143b4) | ![Screenshot 2025-02-03 at 15 14 07](https://github.com/user-attachments/assets/358c92f2-2f75-4f69-8a08-fc8250b1b12e) |

## How to test 🧪

### Prerequisites
- Have a working Longview client. ex
- Create a new Linode (use Debian)
- Create a new Longview client
- Copy the installation curl command
- SSH into your Linode and paste the installation command

Note: You can start the longview service with systemctl: `sudo systemctl start longview` if nothing is happening after a while

👉 following [https://www.linode.com/docs/products/tools/longview/guides/troubleshooting/](https://www.linode.com/docs/products/tools/longview/guides/troubleshooting/)

### Verification steps

- Verify the Longview Detail client (once available) can be navigated to
- run `yarn && yarn build && yarn start:manager:ci` to serve a build and ensure no regression
- All existing tests should pass

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
