### PR TITLE
refactor: [M3-9238] - Remove `@types/react-beautiful-dnd` dependency

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -118,6 +118,7 @@
     ]
   },
   "devDependencies": {
+    "@4tw/cypress-drag-drop": "^2.2.5",
     "@linode/eslint-plugin-cloud-manager": "^0.0.5",
     "@storybook/addon-a11y": "^8.4.7",
     "@storybook/addon-actions": "^8.4.7",
@@ -155,7 +156,6 @@
     "@types/qrcode.react": "^0.8.0",
     "@types/ramda": "0.25.16",
     "@types/react": "^18.2.55",
-    "@types/react-beautiful-dnd": "^13.0.0",
     "@types/react-csv": "^1.1.3",
     "@types/react-dom": "^18.2.18",
     "@types/react-redux": "~7.1.7",
@@ -169,7 +169,6 @@
     "@types/zxcvbn": "^4.4.0",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
-    "@4tw/cypress-drag-drop": "^2.2.5",
     "@vitejs/plugin-react-swc": "^3.7.2",
     "@vitest/coverage-v8": "^3.0.3",
     "@vitest/ui": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2587,13 +2587,6 @@
   resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.25.16.tgz#1d4eeb78d3247d1ceef971b458dd8469646cd1b4"
   integrity sha512-jNxaEg+kSJ58iaM9bBawJugDxexXVPnLU245yEI1p2BTcfR5pcgM6mpsyBhRRo2ozyfJUvTmasL2Ft+C6BNkVQ==
 
-"@types/react-beautiful-dnd@^13.0.0":
-  version "13.1.8"
-  resolved "https://registry.yarnpkg.com/@types/react-beautiful-dnd/-/react-beautiful-dnd-13.1.8.tgz#f52d3ea07e1e19159d6c3c4a48c8da3d855e60b4"
-  integrity sha512-E3TyFsro9pQuK4r8S/OL6G99eq7p8v29sX0PM7oT8Z+PJfZvSQTx4zTQbUJ+QZXioAF0e7TGBEcA1XhYhCweyQ==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-csv@^1.1.3":
   version "1.1.10"
   resolved "https://registry.yarnpkg.com/@types/react-csv/-/react-csv-1.1.10.tgz#b4e292d7330d2fa12062c579c752f254f559bf56"


### PR DESCRIPTION
## Description 📝
Since we've replaced the deprecated `react-beautiful-dnd` library with `dnd-kit` in https://github.com/linode/manager/pull/11127, the `@types/react-beautiful-dnd` dependency is no longer needed and should be removed.


## Changes  🔄
- Removes `@types/react-beautiful-dnd` dependency 🧹


## Target release date 🗓️
N/A


## How to test 🧪
- Verify yarn.lock changes look correct
- Verify `react-beautiful-dnd` isn't used anywhere
- Verify all checks pass

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
