### PR TITLE
fix: [9144] - Remove duplicate options in support search

### DIFF
--- a/packages/manager/.changeset/pr-11604-fixed-1738652958345.md
+++ b/packages/manager/.changeset/pr-11604-fixed-1738652958345.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Remove duplicate options from help and support search ([#11604](https://github.com/linode/manager/pull/11604))
+Duplicate options from help and support search ([#11604](https://github.com/linode/manager/pull/11604))

--- a/packages/manager/.changeset/pr-11604-fixed-1738652958345.md
+++ b/packages/manager/.changeset/pr-11604-fixed-1738652958345.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Remove duplicate options from help and support search ([#11604](https://github.com/linode/manager/pull/11604))

--- a/packages/manager/src/features/Help/Panels/AlgoliaSearchBar.tsx
+++ b/packages/manager/src/features/Help/Panels/AlgoliaSearchBar.tsx
@@ -94,13 +94,7 @@ const AlgoliaSearchBar = (props: AlgoliaSearchBarProps) => {
       )}
       <Autocomplete
         renderOption={(props, option) => {
-          return (
-            <SearchItem
-              data={option}
-              {...props}
-              key={`${props.key}-${option.value}`}
-            />
-          );
+          return <SearchItem data={option} {...props} key={`${props.key}`} />;
         }}
         slotProps={{
           paper: {

--- a/packages/manager/src/features/Help/Panels/AlgoliaSearchBar.tsx
+++ b/packages/manager/src/features/Help/Panels/AlgoliaSearchBar.tsx
@@ -94,7 +94,13 @@ const AlgoliaSearchBar = (props: AlgoliaSearchBarProps) => {
       )}
       <Autocomplete
         renderOption={(props, option) => {
-          return <SearchItem data={option} {...props} key={`${props.key}`} />;
+          return (
+            <SearchItem
+              data={option}
+              {...props}
+              key={`${props.key}-${option.value}`}
+            />
+          );
         }}
         slotProps={{
           paper: {

--- a/packages/manager/src/features/Help/SearchHOC.tsx
+++ b/packages/manager/src/features/Help/SearchHOC.tsx
@@ -48,32 +48,42 @@ export const convertDocsToItems = (
   highlight: boolean,
   hits: SearchHit[] = []
 ): ConvertedItems[] => {
-  return hits.map((hit: SearchHit, idx: number) => {
-    return {
-      data: {
-        href: DOCS_BASE_URL + hit.href,
-        source: 'Linode documentation',
-      },
-      label: getDocsResultLabel(hit, highlight),
-      value: idx,
-    };
+  const uniqueHits = new Map<string, ConvertedItems>();
+  hits.forEach((hit: SearchHit, idx: number) => {
+    const href = DOCS_BASE_URL + hit.href;
+    if (!uniqueHits.has(href)) {
+      uniqueHits.set(href, {
+        data: {
+          href,
+          source: 'Linode documentation',
+        },
+        label: getDocsResultLabel(hit, highlight),
+        value: idx,
+      });
+    }
   });
+  return Array.from(uniqueHits.values());
 };
 
 export const convertCommunityToItems = (
   highlight: boolean,
   hits: SearchHit[] = []
 ): ConvertedItems[] => {
-  return hits.map((hit: SearchHit, idx: number) => {
-    return {
-      data: {
-        href: getCommunityUrl(hit.objectID),
-        source: 'Linode Community Site',
-      },
-      label: getCommunityResultLabel(hit, highlight),
-      value: idx,
-    };
+  const uniqueItems = new Map<string, ConvertedItems>();
+  hits.forEach((hit: SearchHit, idx: number) => {
+    const href = getCommunityUrl(hit.objectID);
+    if (!uniqueItems.has(href)) {
+      uniqueItems.set(href, {
+        data: {
+          href,
+          source: 'Linode Community Site',
+        },
+        label: getCommunityResultLabel(hit, highlight),
+        value: idx,
+      });
+    }
   });
+  return Array.from(uniqueItems.values());
 };
 
 export const getCommunityUrl = (id: string) => {


### PR DESCRIPTION
## Description 📝

This PR resolves the issue of duplicate options appearing in the Help & Support search Autocomplete. Previously, duplicate results (e.g., "fedora") were displayed in the dropdown, but now they are filtered out before reaching the Autocomplete.

## Changes 🔄

- Update Search filtering to remove duplicates before they reach the Autocomplete.

## Target release date 🗓️
N/A

## Preview 📷
| Before | After |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/407093f5-1327-434c-8c83-d0783dcbcf04) | ![After](https://github.com/user-attachments/assets/aba898ad-3c3d-41d4-b74f-710497665cff) |


### Verification steps

- [ ] Verify that duplicate options no longer appear in the Autocomplete dropdown for any search term (e.g., "fedora").
- [ ] Confirm that no existing functionality is broken and no regressions are introduced.
- [ ] Ensure that all tests pass successfully.


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>