### PR TITLE
upcoming: [DI-22941] - Update dependency and order for tags

### DIFF
--- a/packages/manager/.changeset/pr-11615-upcoming-features-1738754714037.md
+++ b/packages/manager/.changeset/pr-11615-upcoming-features-1738754714037.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update Tags dependency and filtering based on Region in CloudPulse ([#11615](https://github.com/linode/manager/pull/11615))

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
@@ -1,7 +1,7 @@
 import { dashboardFactory } from 'src/factories';
 import { databaseQueries } from 'src/queries/databases/databases';
 
-import { REGION, RESOURCES, TAGS } from './constants';
+import { RESOURCES } from './constants';
 import {
   buildXFilter,
   checkIfAllMandatoryFiltersAreSelected,

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
@@ -2,6 +2,7 @@ import { dashboardFactory } from 'src/factories';
 import { databaseQueries } from 'src/queries/databases/databases';
 
 import { RESOURCES } from './constants';
+import { deepEqual, getFilters } from './FilterBuilder';
 import {
   buildXFilter,
   checkIfAllMandatoryFiltersAreSelected,

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
@@ -12,6 +12,7 @@ import {
   getMetricsCallCustomFilters,
   getRegionProperties,
   getResourcesProperties,
+  getTagsProperties,
   getTimeDurationProperties,
 } from './FilterBuilder';
 import { FILTER_CONFIG } from './FilterConfig';
@@ -47,6 +48,38 @@ it('test getRegionProperties method', () => {
     expect(handleRegionChange).toBeDefined();
     expect(selectedDashboard).toEqual(mockDashboard);
     expect(label).toEqual(name);
+  }
+});
+
+it('test getTagsProperties', () => {
+  const tagsConfig = linodeConfig?.filters.find(
+    (filterObj) => filterObj.name === 'Tags'
+  );
+
+  expect(tagsConfig).toBeDefined();
+
+  if (tagsConfig) {
+    const {
+      disabled,
+      handleTagsChange,
+      label,
+      region,
+      resourceType,
+    } = getTagsProperties(
+      {
+        config: tagsConfig,
+        dashboard: mockDashboard,
+        dependentFilters: { region: 'us-east' },
+        isServiceAnalyticsIntegration: true,
+      },
+      vi.fn()
+    );
+    const { name } = tagsConfig.configuration;
+    expect(handleTagsChange).toBeDefined();
+    expect(disabled).toEqual(false);
+    expect(label).toEqual(name);
+    expect(region).toEqual('us-east');
+    expect(resourceType).toEqual('linode');
   }
 });
 

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
@@ -176,6 +176,46 @@ it('test getResourceSelectionProperties method with disabled true', () => {
   }
 });
 
+describe('checkIfWeNeedToDisableFilterByFilterKey', () => {
+  // resources filter has region as mandatory and tags as an optional filter, this should reflect in the dependent filters
+  it('should enable filter when dependent filter region is provided', () => {
+    const result = checkIfWeNeedToDisableFilterByFilterKey(
+      'resource_id',
+      { region: 'us-east' },
+      mockDashboard
+    );
+    expect(result).toEqual(false);
+  });
+
+  it('should disable filter when dependent filter region is undefined', () => {
+    const result = checkIfWeNeedToDisableFilterByFilterKey(
+      'resource_id',
+      { region: undefined },
+      mockDashboard
+    );
+    expect(result).toEqual(true);
+  });
+
+  it('should disable filter when no dependent filters are provided', () => {
+    const result = checkIfWeNeedToDisableFilterByFilterKey(
+      'resource_id',
+      {},
+      mockDashboard
+    );
+    expect(result).toEqual(true);
+  });
+
+  it('should disable filter when required dependent filter is undefined in dependent filters but defined in preferences', () => {
+    const result = checkIfWeNeedToDisableFilterByFilterKey(
+      'resource_id',
+      { region: 'us-east', tags: undefined },
+      mockDashboard,
+      { region: 'us-east', tags: ['tag-1'] } // tags are defined in preferences which confirms that this optional filter was selected
+    );
+    expect(result).toEqual(true);
+  });
+});
+
 it('test checkIfWeNeedToDisableFilterByFilterKey method all cases', () => {
   let result = checkIfWeNeedToDisableFilterByFilterKey(
     'resource_id',

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
@@ -1,8 +1,7 @@
 import { dashboardFactory } from 'src/factories';
 import { databaseQueries } from 'src/queries/databases/databases';
 
-import { RESOURCES } from './constants';
-import { deepEqual, getFilters } from './FilterBuilder';
+import { REGION, RESOURCES, TAGS } from './constants';
 import {
   buildXFilter,
   checkIfAllMandatoryFiltersAreSelected,
@@ -196,6 +195,23 @@ it('test checkIfWeNeedToDisableFilterByFilterKey method all cases', () => {
   result = checkIfWeNeedToDisableFilterByFilterKey(
     'resource_id',
     {},
+    mockDashboard
+  );
+
+  expect(result).toEqual(true);
+
+  result = checkIfWeNeedToDisableFilterByFilterKey(
+    'resource_id',
+    { region: 'us-east', tags: undefined },
+    mockDashboard,
+    { ['region']: 'us-east', ['tags']: ['tag-1'] }
+  );
+
+  expect(result).toEqual(true); // disabled is true as tags are not updated in dependent filters
+
+  result = checkIfWeNeedToDisableFilterByFilterKey(
+    'tags',
+    { region: undefined },
     mockDashboard
   );
 

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -73,7 +73,8 @@ export const getTagsProperties = (
     disabled: checkIfWeNeedToDisableFilterByFilterKey(
       filterKey,
       dependentFilters ?? {},
-      dashboard
+      dashboard,
+      preferences
     ),
     handleTagsChange,
     optional: props.config.configuration.isOptional,
@@ -144,7 +145,8 @@ export const getResourcesProperties = (
     disabled: checkIfWeNeedToDisableFilterByFilterKey(
       filterKey,
       dependentFilters ?? {},
-      dashboard
+      dashboard,
+      preferences
     ),
     handleResourcesSelection: handleResourceChange,
     label,
@@ -293,8 +295,11 @@ export const checkIfWeNeedToDisableFilterByFilterKey = (
   dependentFilters: {
     [key: string]: FilterValueType | TimeDuration;
   },
-  dashboard: Dashboard
+  dashboard: Dashboard,
+  preferences?: AclpConfig
 ): boolean | undefined => {
+  console.log(preferences);
+  console.log(filterKey);
   if (dashboard?.service_type) {
     const serviceTypeConfig = FILTER_CONFIG.get(dashboard.service_type);
     const filters = serviceTypeConfig?.filters ?? [];
@@ -314,6 +319,15 @@ export const checkIfWeNeedToDisableFilterByFilterKey = (
     if (filter) {
       return filter.configuration.dependency?.some((dependent) => {
         const dependentFilter = dependentFilters[dependent];
+
+        if (
+          preferences &&
+          preferences[dependent] &&
+          (!dependentFilter ||
+            (Array.isArray(dependentFilter) && dependentFilter.length === 0))
+        ) {
+          return true; // here we are having in preferences but we are not having it in dependent filter
+        }
 
         return (
           !optionalFilters.has(dependent) &&

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -298,8 +298,6 @@ export const checkIfWeNeedToDisableFilterByFilterKey = (
   dashboard: Dashboard,
   preferences?: AclpConfig
 ): boolean | undefined => {
-  console.log(preferences);
-  console.log(filterKey);
   if (dashboard?.service_type) {
     const serviceTypeConfig = FILTER_CONFIG.get(dashboard.service_type);
     const filters = serviceTypeConfig?.filters ?? [];
@@ -326,7 +324,7 @@ export const checkIfWeNeedToDisableFilterByFilterKey = (
           (!dependentFilter ||
             (Array.isArray(dependentFilter) && dependentFilter.length === 0))
         ) {
-          return true; // here we are having in preferences but we are not having it in dependent filter
+          return true; // dependent filters should be updated as par with preferences updates
         }
 
         return (

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -63,6 +63,7 @@ export const getTagsProperties = (
 ): CloudPulseTagsSelectProps => {
   const { filterKey, name: label, placeholder } = props.config.configuration;
   const {
+    config,
     dashboard,
     dependentFilters,
     isServiceAnalyticsIntegration,
@@ -82,6 +83,7 @@ export const getTagsProperties = (
     region: dependentFilters?.[REGION],
     resourceType: dashboard.service_type,
     savePreferences: !isServiceAnalyticsIntegration,
+    xFilter: buildXFilter(config, dependentFilters ?? {}),
   };
 };
 

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -324,7 +324,7 @@ export const checkIfWeNeedToDisableFilterByFilterKey = (
           (!dependentFilter ||
             (Array.isArray(dependentFilter) && dependentFilter.length === 0))
         ) {
-          return true; // Since filters are set one by one, disabled will be true until the values present inside the dependent filter don't match with the values stored in the preference key
+          return true; // Since filters are set one by one, disabled will be true until the values present inside the dependent filter don't exactly match with the values stored in the preference key
         }
 
         return (

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -63,7 +63,6 @@ export const getTagsProperties = (
 ): CloudPulseTagsSelectProps => {
   const { filterKey, name: label, placeholder } = props.config.configuration;
   const {
-    config,
     dashboard,
     dependentFilters,
     isServiceAnalyticsIntegration,
@@ -83,7 +82,6 @@ export const getTagsProperties = (
     region: dependentFilters?.[REGION],
     resourceType: dashboard.service_type,
     savePreferences: !isServiceAnalyticsIntegration,
-    xFilter: buildXFilter(config, dependentFilters ?? {}),
   };
 };
 

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -53,6 +53,7 @@ interface CloudPulseMandatoryFilterCheckProps {
  * @param config - accepts a CloudPulseServiceTypeFilters of tag key
  * @param handleTagsChange - the callback when we select new tag
  * @param dashboard - the selected dashboard's service type
+ * @param dependentFilters - tags are dependent on region filter, we need this for disabling the tags selection component
  * @param isServiceAnalyticsIntegration - only if this is false, we need to save preferences , else no need
  * @returns CloudPulseTagSelectProps
  */
@@ -60,14 +61,25 @@ export const getTagsProperties = (
   props: CloudPulseFilterProperties,
   handleTagsChange: (tags: CloudPulseTags[], savePref?: boolean) => void
 ): CloudPulseTagsSelectProps => {
-  const { name: label, placeholder } = props.config.configuration;
-  const { dashboard, isServiceAnalyticsIntegration, preferences } = props;
+  const { filterKey, name: label, placeholder } = props.config.configuration;
+  const {
+    dashboard,
+    dependentFilters,
+    isServiceAnalyticsIntegration,
+    preferences,
+  } = props;
   return {
     defaultValue: preferences?.[TAGS],
+    disabled: checkIfWeNeedToDisableFilterByFilterKey(
+      filterKey,
+      dependentFilters ?? {},
+      dashboard
+    ),
     handleTagsChange,
     optional: props.config.configuration.isOptional,
     label,
     placeholder,
+    region: dependentFilters?.[REGION],
     resourceType: dashboard.service_type,
     savePreferences: !isServiceAnalyticsIntegration,
   };

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -324,7 +324,7 @@ export const checkIfWeNeedToDisableFilterByFilterKey = (
           (!dependentFilter ||
             (Array.isArray(dependentFilter) && dependentFilter.length === 0))
         ) {
-          return true; // Since filters are set one by one, disabled will be true until the values present inside the dependent filter don't exactly match with the values stored in the preference key
+          return true; // Since filters are set one by one, disabled will be true until the values that are defined inside the preferences are populated in the dependent filters as well
         }
 
         return (

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -324,7 +324,7 @@ export const checkIfWeNeedToDisableFilterByFilterKey = (
           (!dependentFilter ||
             (Array.isArray(dependentFilter) && dependentFilter.length === 0))
         ) {
-          return true; // dependent filters should be updated as par with preferences updates
+          return true; // The values present inside the dependent filter should always match the values stored in the preference key
         }
 
         return (

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -324,7 +324,7 @@ export const checkIfWeNeedToDisableFilterByFilterKey = (
           (!dependentFilter ||
             (Array.isArray(dependentFilter) && dependentFilter.length === 0))
         ) {
-          return true; // The values present inside the dependent filter should always match the values stored in the preference key
+          return true; // Since filters are set one by one, disabled will be true until the values present inside the dependent filter don't match with the values stored in the preference key
         }
 
         return (

--- a/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
@@ -75,6 +75,22 @@ export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
   filters: [
     {
       configuration: {
+        dependency: ['region'],
+        filterKey: 'tags',
+        filterType: 'string',
+        isFilterable: false,
+        isMetricsFilter: false,
+        isMultiSelect: true,
+        isOptional: true,
+        name: 'Tags',
+        neededInServicePage: false,
+        placeholder: 'Select Tags',
+        priority: 4,
+      },
+      name: 'Tags',
+    },
+    {
+      configuration: {
         filterKey: 'engine',
         filterType: 'string',
         isFilterable: false, // isFilterable -- this determines whethere you need to pass it metrics api

--- a/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
@@ -75,22 +75,6 @@ export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
   filters: [
     {
       configuration: {
-        dependency: ['region'],
-        filterKey: 'tags',
-        filterType: 'string',
-        isFilterable: false,
-        isMetricsFilter: false,
-        isMultiSelect: true,
-        isOptional: true,
-        name: 'Tags',
-        neededInServicePage: false,
-        placeholder: 'Select Tags',
-        priority: 4,
-      },
-      name: 'Tags',
-    },
-    {
-      configuration: {
         filterKey: 'engine',
         filterType: 'string',
         isFilterable: false, // isFilterable -- this determines whethere you need to pass it metrics api

--- a/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
@@ -11,6 +11,19 @@ export const LINODE_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
   filters: [
     {
       configuration: {
+        filterKey: 'region',
+        filterType: 'string',
+        isFilterable: false,
+        isMetricsFilter: false,
+        name: 'Region',
+        neededInServicePage: false,
+        priority: 1,
+      },
+      name: 'Region',
+    },
+    {
+      configuration: {
+        dependency: ['region'],
         filterKey: 'tags',
         filterType: 'string',
         isFilterable: false,
@@ -23,18 +36,6 @@ export const LINODE_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
         priority: 4,
       },
       name: 'Tags',
-    },
-    {
-      configuration: {
-        filterKey: 'region',
-        filterType: 'string',
-        isFilterable: false,
-        isMetricsFilter: false,
-        name: 'Region',
-        neededInServicePage: false,
-        priority: 1,
-      },
-      name: 'Region',
     },
     {
       configuration: {

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
@@ -138,6 +138,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
           selectedTags,
           savePref,
           {
+            [RESOURCE_ID]: undefined,
             [TAGS]: selectedTags,
           }
         );
@@ -171,6 +172,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
         const updatedPreferenceData = {
           [REGION]: region,
           [RESOURCES]: undefined,
+          [TAGS]: undefined,
         };
         emitFilterChangeByFilterKey(
           REGION,

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
@@ -209,6 +209,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
             {
               config,
               dashboard,
+              dependentFilters: dependentFilterReference.current,
               isServiceAnalyticsIntegration,
               preferences,
             },

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
@@ -102,6 +102,10 @@ export const CloudPulseResourcesSelect = React.memo(
 
     // Once the data is loaded, set the state variable with value stored in preferences
     React.useEffect(() => {
+      if (disabled && !selectedResources) {
+        return;
+      }
+
       if (resources && savePreferences && !selectedResources) {
         const defaultResources =
           defaultValue && Array.isArray(defaultValue)

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
@@ -105,7 +105,7 @@ export const CloudPulseResourcesSelect = React.memo(
       if (disabled && !selectedResources) {
         return;
       }
-
+      // To save default values, go through side effects if disabled is false
       if (resources && savePreferences && !selectedResources) {
         const defaultResources =
           defaultValue && Array.isArray(defaultValue)

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.test.tsx
@@ -16,6 +16,7 @@ const props: CloudPulseTagsSelectProps = {
   optional: true,
   region: 'us-east',
   resourceType: 'linode',
+  xFilter: { region: 'us-east' },
 };
 
 const queryMocks = vi.hoisted(() => ({
@@ -85,13 +86,13 @@ describe('CloudPulseTagsSelect component tests', () => {
     const user = userEvent.setup();
 
     queryMocks.useAllLinodesQuery.mockReturnValue({
-      data: linodeFactory.buildList(2, { tags: ['tag-2', 'tag-3'] }),
+      data: [],
       isError: false,
       isLoading: false,
       status: 'success',
     });
     const { getByRole, queryAllByRole } = renderWithTheme(
-      <CloudPulseTagsSelect {...props} region={'us-central'} />
+      <CloudPulseTagsSelect {...props} xFilter={{ region: 'us-central' }} />
     );
     await user.click(getByRole('button', { name: 'Open' }));
     const options = queryAllByRole('option');

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.test.tsx
@@ -16,7 +16,6 @@ const props: CloudPulseTagsSelectProps = {
   optional: true,
   region: 'us-east',
   resourceType: 'linode',
-  xFilter: { region: 'us-east' },
 };
 
 const queryMocks = vi.hoisted(() => ({
@@ -92,7 +91,7 @@ describe('CloudPulseTagsSelect component tests', () => {
       status: 'success',
     });
     const { getByRole, queryAllByRole } = renderWithTheme(
-      <CloudPulseTagsSelect {...props} xFilter={{ region: 'us-central' }} />
+      <CloudPulseTagsSelect {...props} region={'us-central'} />
     );
     await user.click(getByRole('button', { name: 'Open' }));
     const options = queryAllByRole('option');

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.test.tsx
@@ -6,7 +6,17 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { CloudPulseTagsSelect } from './CloudPulseTagsFilter';
 
+import type { CloudPulseTagsSelectProps } from './CloudPulseTagsFilter';
 import type { useAllLinodesQuery } from 'src/queries/linodes/linodes';
+
+const props: CloudPulseTagsSelectProps = {
+  disabled: false,
+  handleTagsChange: vi.fn(),
+  label: 'Tags',
+  optional: true,
+  region: 'us-east',
+  resourceType: 'linode',
+};
 
 const queryMocks = vi.hoisted(() => ({
   useAllLinodesQuery: vi.fn().mockReturnValue({}),
@@ -20,7 +30,6 @@ vi.mock('src/queries/linodes/linodes', async () => {
   };
 });
 
-const mockTagsHandler = vi.fn();
 const SELECT_ALL = 'Select All';
 const ARIA_SELECTED = 'aria-selected';
 const LABEL_SUBTITLE = 'Tags (optional)';
@@ -41,17 +50,24 @@ describe('CloudPulseTagsSelect component tests', () => {
       getByLabelText,
       getByPlaceholderText,
       getByTestId,
-    } = renderWithTheme(
-      <CloudPulseTagsSelect
-        handleTagsChange={mockTagsHandler}
-        label="Tags"
-        optional
-        resourceType="linode"
-      />
-    );
+    } = renderWithTheme(<CloudPulseTagsSelect {...props} />);
     expect(getByTestId('tags-select')).toBeInTheDocument();
     expect(getByLabelText(LABEL_SUBTITLE)).toBeInTheDocument();
     expect(getByPlaceholderText('Select Tags')).toBeInTheDocument();
+  });
+
+  it('should render a disabled Tags Select component when disabled is true or region is undefined', () => {
+    queryMocks.useAllLinodesQuery.mockReturnValue({
+      data: linodeFactory.buildList(2),
+      isError: false,
+      isLoading: false,
+      status: 'success',
+    });
+    const { getByRole } = renderWithTheme(
+      <CloudPulseTagsSelect {...props} disabled={true} />
+    );
+
+    expect(getByRole('button', { name: 'Open' })).toBeDisabled();
   });
 
   it('should render a Tags Select component with error message on api call failure', () => {
@@ -60,18 +76,29 @@ describe('CloudPulseTagsSelect component tests', () => {
       isError: true,
       isLoading: false,
     } as ReturnType<typeof useAllLinodesQuery>);
-    const { getByText } = renderWithTheme(
-      <CloudPulseTagsSelect
-        handleTagsChange={mockTagsHandler}
-        label="Tags"
-        resourceType="linode"
-      />
-    );
+    const { getByText } = renderWithTheme(<CloudPulseTagsSelect {...props} />);
 
     expect(getByText('Failed to fetch Tags.'));
   });
 
-  it('should select multiple tags', async () => {
+  it('should render a Tags Select component with tags filtered based on the selected region', async () => {
+    const user = userEvent.setup();
+
+    queryMocks.useAllLinodesQuery.mockReturnValue({
+      data: linodeFactory.buildList(2, { tags: ['tag-2', 'tag-3'] }),
+      isError: false,
+      isLoading: false,
+      status: 'success',
+    });
+    const { getByRole, queryAllByRole } = renderWithTheme(
+      <CloudPulseTagsSelect {...props} region={'us-central'} />
+    );
+    await user.click(getByRole('button', { name: 'Open' }));
+    const options = queryAllByRole('option');
+    expect(options).toHaveLength(0); // no tags for the selected region
+  });
+
+  it('should select multiple tags from the tags filtered based on the selected region', async () => {
     const user = userEvent.setup();
 
     queryMocks.useAllLinodesQuery.mockReturnValue({
@@ -83,12 +110,7 @@ describe('CloudPulseTagsSelect component tests', () => {
       status: 'success',
     });
     const { getByLabelText, getByRole } = renderWithTheme(
-      <CloudPulseTagsSelect
-        handleTagsChange={mockTagsHandler}
-        label="Tags"
-        optional
-        resourceType={'linode'}
-      />
+      <CloudPulseTagsSelect {...props} />
     );
     await user.click(getByRole('button', { name: 'Open' }));
     await user.click(getByRole('option', { name: 'tag-2' }));
@@ -122,12 +144,7 @@ describe('CloudPulseTagsSelect component tests', () => {
       status: 'success',
     });
     const { getByLabelText, getByRole } = renderWithTheme(
-      <CloudPulseTagsSelect
-        handleTagsChange={mockTagsHandler}
-        label="Tags"
-        optional
-        resourceType={'linode'}
-      />
+      <CloudPulseTagsSelect {...props} />
     );
     await user.click(getByRole('button', { name: 'Open' }));
     await user.click(getByRole('option', { name: SELECT_ALL }));
@@ -156,10 +173,8 @@ describe('CloudPulseTagsSelect component tests', () => {
 
     const { getByRole } = renderWithTheme(
       <CloudPulseTagsSelect
+        {...props}
         defaultValue={['tag-2']}
-        handleTagsChange={mockTagsHandler}
-        label="Tags"
-        resourceType={'linode'}
         savePreferences
       />
     );

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
@@ -4,10 +4,8 @@ import React from 'react';
 import { useAllLinodesQuery } from 'src/queries/linodes/linodes';
 import { themes } from 'src/utilities/theme';
 
-import { deepEqual } from '../Utils/FilterBuilder';
-
 import type { FilterValueType } from '../Dashboard/CloudPulseDashboardLanding';
-import type { Filter, FilterValue, Linode } from '@linode/api-v4';
+import type { FilterValue, Linode } from '@linode/api-v4';
 
 export interface CloudPulseTags {
   label: string;
@@ -23,7 +21,6 @@ export interface CloudPulseTagsSelectProps {
   region: FilterValueType;
   resourceType: string | undefined;
   savePreferences?: boolean;
-  xFilter?: Filter;
 }
 
 export const CloudPulseTagsSelect = React.memo(
@@ -38,12 +35,12 @@ export const CloudPulseTagsSelect = React.memo(
       region,
       resourceType,
       savePreferences,
-      xFilter,
     } = props;
 
+    const regionFilter = region ? (region as string) : undefined;
     const { data: linodesByRegion, isError, isLoading } = useAllLinodesQuery(
       {},
-      xFilter ? xFilter : { region: region as string },
+      { region: regionFilter },
       !disabled && Boolean(region && resourceType)
     );
 
@@ -82,7 +79,7 @@ export const CloudPulseTagsSelect = React.memo(
         setSelectedTags(filteredTags);
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [tags, resourceType, region, xFilter]);
+    }, [tags, resourceType, region]);
 
     return (
       <Autocomplete
@@ -132,30 +129,5 @@ export const CloudPulseTagsSelect = React.memo(
         value={selectedTags ?? []}
       />
     );
-  },
-  compareProps
+  }
 );
-
-function compareProps(
-  prevProps: CloudPulseTagsSelectProps,
-  nextProps: CloudPulseTagsSelectProps
-): boolean {
-  // these properties can be extended going forward
-  const keysToCompare: (keyof CloudPulseTagsSelectProps)[] = [
-    'region',
-    'resourceType',
-  ];
-
-  for (const key of keysToCompare) {
-    if (prevProps[key] !== nextProps[key]) {
-      return false;
-    }
-  }
-
-  if (!deepEqual(prevProps.xFilter, nextProps.xFilter)) {
-    return false;
-  }
-
-  // Ignore function props in comparison
-  return true;
-}

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
@@ -63,9 +63,9 @@ export const CloudPulseTagsSelect = React.memo(
 
     React.useEffect(() => {
       if (disabled && !selectedTags) {
-        return; // To save default values, go through side effects if disabled is false
+        return;
       }
-
+      // To save default values, go through side effects if disabled is false
       if (!tags || !savePreferences || selectedTags) {
         if (selectedTags) {
           setSelectedTags([]);

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
@@ -18,7 +18,7 @@ export interface CloudPulseTagsSelectProps {
   label: string;
   optional?: boolean;
   placeholder?: string;
-  region?: FilterValueType;
+  region: FilterValueType;
   resourceType: string | undefined;
   savePreferences?: boolean;
 }
@@ -40,7 +40,7 @@ export const CloudPulseTagsSelect = React.memo(
     const { data: linodes, isError, isLoading } = useAllLinodesQuery();
     // fetch all linode instances, consume the associated tags
     const tags = React.useMemo(() => {
-      if (!linodes) {
+      if (!linodes || !region) {
         return [];
       }
 

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
@@ -63,7 +63,7 @@ export const CloudPulseTagsSelect = React.memo(
 
     React.useEffect(() => {
       if (disabled && !selectedTags) {
-        return;
+        return; // To save default values, go through side effects if disabled is false
       }
 
       if (!tags || !savePreferences || selectedTags) {

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
@@ -50,7 +50,7 @@ export const CloudPulseTagsSelect = React.memo(
     // fetch all linode instances, consume the associated tags
     const tags = React.useMemo(() => {
       if (!linodesByRegion) {
-        return [];
+        return undefined;
       }
 
       return Array.from(
@@ -65,20 +65,22 @@ export const CloudPulseTagsSelect = React.memo(
     const isAutocompleteOpen = React.useRef(false); // Ref to track the open state of Autocomplete
 
     React.useEffect(() => {
-      if (!tags || !savePreferences || !region) {
-        setSelectedTags([]);
-        handleTagsChange([]);
-        return;
+      if (!tags || !savePreferences || selectedTags) {
+        if (selectedTags) {
+          setSelectedTags([]);
+          handleTagsChange([]);
+        }
+      } else {
+        const defaultTags =
+          defaultValue && Array.isArray(defaultValue)
+            ? defaultValue.map((tag) => String(tag))
+            : [];
+        const filteredTags = tags.filter((tag) =>
+          defaultTags.includes(String(tag.label))
+        );
+        handleTagsChange(filteredTags);
+        setSelectedTags(filteredTags);
       }
-      const defaultTags =
-        defaultValue && Array.isArray(defaultValue)
-          ? defaultValue.map((tag) => String(tag))
-          : [];
-      const filteredTags = tags.filter((tag) =>
-        defaultTags.includes(String(tag.label))
-      );
-      handleTagsChange(filteredTags);
-      setSelectedTags(filteredTags);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [tags, resourceType, region, xFilter]);
 
@@ -125,7 +127,7 @@ export const CloudPulseTagsSelect = React.memo(
         loading={isLoading}
         multiple
         noMarginTop
-        options={tags}
+        options={tags ?? []}
         placeholder={selectedTags?.length ? '' : placeholder || 'Select Tags'}
         value={selectedTags ?? []}
       />

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useAllLinodesQuery } from 'src/queries/linodes/linodes';
 import { themes } from 'src/utilities/theme';
 
+import type { FilterValueType } from '../Dashboard/CloudPulseDashboardLanding';
 import type { FilterValue, Linode } from '@linode/api-v4';
 
 export interface CloudPulseTags {
@@ -17,6 +18,7 @@ export interface CloudPulseTagsSelectProps {
   label: string;
   optional?: boolean;
   placeholder?: string;
+  region?: FilterValueType;
   resourceType: string | undefined;
   savePreferences?: boolean;
 }
@@ -25,10 +27,12 @@ export const CloudPulseTagsSelect = React.memo(
   (props: CloudPulseTagsSelectProps) => {
     const {
       defaultValue,
+      disabled,
       handleTagsChange,
       label,
       optional,
       placeholder,
+      region,
       resourceType,
       savePreferences,
     } = props;
@@ -39,12 +43,17 @@ export const CloudPulseTagsSelect = React.memo(
       if (!linodes) {
         return [];
       }
+
+      const linodesByRegion = linodes.filter(
+        (linode: Linode) => linode.region === region
+      ); // filter linodes by region to achieve tags by region
+
       return Array.from(
-        new Set(linodes.flatMap((linode: Linode) => linode.tags))
+        new Set(linodesByRegion.flatMap((linode: Linode) => linode.tags))
       )
         .sort()
         .map((tag) => ({ label: tag })) as CloudPulseTags[];
-    }, [linodes]);
+    }, [linodes, region]);
 
     const [selectedTags, setSelectedTags] = React.useState<CloudPulseTags[]>();
 
@@ -104,7 +113,7 @@ export const CloudPulseTagsSelect = React.memo(
         autoHighlight
         clearOnBlur
         data-testid="tags-select"
-        disabled={!resourceType}
+        disabled={disabled}
         errorText={isError ? `Failed to fetch ${label || 'Tags'}.` : ''}
         label={label || 'Tags'}
         limitTags={1}

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
@@ -62,6 +62,10 @@ export const CloudPulseTagsSelect = React.memo(
     const isAutocompleteOpen = React.useRef(false); // Ref to track the open state of Autocomplete
 
     React.useEffect(() => {
+      if (disabled && !selectedTags) {
+        return;
+      }
+
       if (!tags || !savePreferences || selectedTags) {
         if (selectedTags) {
           setSelectedTags([]);
@@ -79,7 +83,7 @@ export const CloudPulseTagsSelect = React.memo(
         setSelectedTags(filteredTags);
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [tags, resourceType, region]);
+    }, [tags, resourceType, region, disabled]);
 
     return (
       <Autocomplete

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -688,6 +688,11 @@ export const handlers = [
         region: 'us-central',
       }),
       linodeFactory.build({
+        label: 'linode_with_tag_test4',
+        region: 'us-east',
+        tags: ['test4'],
+      }),
+      linodeFactory.build({
         label: 'eu-linode',
         region: 'eu-west',
       }),
@@ -704,6 +709,7 @@ export const handlers = [
       const headers = JSON.parse(request.headers.get('x-filter') || '{}');
       const orFilters = headers['+or'];
       const andFilters = headers['+and'];
+      const regionFilter = headers.region;
 
       let filteredLinodes = linodes; // Default to the original linodes in case no filters are applied
 
@@ -727,6 +733,12 @@ export const handlers = [
           return orFilters.some((filter: { tags: string }) =>
             linode.tags.includes(filter.tags)
           );
+        });
+      }
+
+      if (regionFilter) {
+        filteredLinodes = filteredLinodes.filter((linode) => {
+          return linode.region === regionFilter;
         });
       }
 


### PR DESCRIPTION
## Description 📝

Updated the tags dependency and filtering based on region.

## Changes  🔄

- Tags will be placed after region selection component.
- Tags will be in disabled state in case no region is selected. When a region is selected, tags will be filtered based on the region and listed in tags selection component.

## Target release date 🗓️
11-02-2025

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/31e28816-38ee-4308-9497-1c72c583e390)|![image](https://github.com/user-attachments/assets/208d16f5-77b2-4930-85bc-535f356da5df)|

**Latest Flow** 👇

https://github.com/user-attachments/assets/b7429137-7956-48b0-9ae5-ca66e395346b

## How to test 🧪

### Verification steps

(How to verify changes)

- Navigate to monitor tab.
- Select a dashboard.
- Tags are in disabled state if no region is selected. Select any region, tags will be enabled and listed after being filtered based on the selected region.
- To verify if tags are filtered based on region, go to the /instances api call in network tab and see the tags associated with the selected region and see if all associated tags are listed in the dropdown.
- Finally, select tag/tags, resources to visualize the metrics.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

---
