### PR TITLE
change: [UIE-8440] - Allow more symbols to be used in Search v2

### DIFF
--- a/packages/search/src/search.peggy
+++ b/packages/search/src/search.peggy
@@ -108,10 +108,10 @@ String "search value"
   / Word
 
 Word "word"
-  = [a-zA-Z0-9\-\.]+ { return text(); }
+  = [a-zA-Z0-9-_.@]+ { return text(); }
 
 StringWithSpaces "string with spaces"
-  = [a-zA-Z0-9\-|_\.\: ]+ { return text(); }
+  = [a-zA-Z0-9-_.:@ ]+ { return text(); }
 
 Number "numeric search value"
   = number:[0-9\.]+ { return parseFloat(number.join("")); }

--- a/packages/search/src/search.test.ts
+++ b/packages/search/src/search.test.ts
@@ -165,6 +165,39 @@ describe("getAPIFilterFromQuery", () => {
     });
   });
 
+  it("allows '@' symbol in search", () => {
+    const query = 'email: thisisafakeemail@linode.com';
+
+    expect(getAPIFilterFromQuery(query, { searchableFieldsWithoutOperator: [] })).toEqual({
+      filter: {
+        email: { '+contains': "thisisafakeemail@linode.com" }
+      },
+      error: null,
+    });
+  });
+
+  it("allows '-' symbol in search", () => {
+    const query = 'username: test-user-1';
+
+    expect(getAPIFilterFromQuery(query, { searchableFieldsWithoutOperator: [] })).toEqual({
+      filter: {
+        username: { '+contains': "test-user-1" }
+      },
+      error: null,
+    });
+  });
+
+  it("allows '_' symbol in search", () => {
+    const query = 'username: test_user_1';
+
+    expect(getAPIFilterFromQuery(query, { searchableFieldsWithoutOperator: [] })).toEqual({
+      filter: {
+        username: { '+contains': "test_user_1" }
+      },
+      error: null,
+    });
+  });
+
   it("allows a quoted string so you can use spaces in the query (single quotes)", () => {
     const query = "label: 'my stackscript' and username = linode";
 


### PR DESCRIPTION
## Description 📝

IAM uses Search v2 to power the users table. They noticed that it does not allow `@` and `_` in searches, which is important for usernames and emails

This PR allows more symbols to unblock the IAM team

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-02-05 at 10 13 53 AM](https://github.com/user-attachments/assets/1065d487-1d99-4bd8-9851-223c0520f6ae) | ![Screenshot 2025-02-05 at 10 08 39 AM](https://github.com/user-attachments/assets/ae73edc8-54dd-47d4-b5a3-3154b91855e0) |
| ![Screenshot 2025-02-05 at 10 13 41 AM](https://github.com/user-attachments/assets/cf5f72b2-8dd3-4c3a-8c8a-4d79ad8d7af1) | ![Screenshot 2025-02-05 at 10 08 16 AM](https://github.com/user-attachments/assets/27b44ac7-84da-4e49-b05e-557b6f6f5e99) |


## How to test 🧪

- Using dev
- Go to http://localhost:3000/iam/users
- Test searching on various fields like `username` and `email`
- Verify you can perform the searches you'd expect to be able to perform

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>