### PR TITLE
fix: Disabled button in Collapsible Node Pool Accordion

### DIFF
--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -1614,14 +1614,35 @@ describe('LKE cluster updates', () => {
     const mockCluster = kubernetesClusterFactory.build({
       k8s_version: latestKubernetesVersion,
     });
+    const mockSingleNodePool = mockNodePools[0];
     mockGetCluster(mockCluster).as('getCluster');
-    mockGetClusterPools(mockCluster.id, mockNodePools).as('getNodePools');
+    mockGetClusterPools(mockCluster.id, [mockSingleNodePool]).as(
+      'getNodePools'
+    );
 
     cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
     cy.wait(['@getCluster', '@getNodePools']);
 
-    cy.get(`[data-qa-node-pool-id="${mockNodePools[0].id}"]`).within(() => {
+    cy.get(`[data-qa-node-pool-id="${mockSingleNodePool.id}"]`).within(() => {
       // Accordion should be expanded by default
+      cy.get(`[data-qa-panel-summary]`).should(
+        'have.attr',
+        'aria-expanded',
+        'true'
+      );
+
+      // Click on a disabled button
+      cy.get('[data-testid="node-pool-actions"]')
+        .should('be.visible')
+        .within(() => {
+          ui.button
+            .findByTitle('Delete Pool')
+            .should('be.visible')
+            .should('be.disabled')
+            .click();
+        });
+
+      // Check that the accordion is still expanded
       cy.get(`[data-qa-panel-summary]`).should(
         'have.attr',
         'aria-expanded',
@@ -1652,7 +1673,7 @@ describe('LKE cluster updates', () => {
           .click();
       });
 
-    cy.get(`[data-qa-node-pool-id="${mockNodePools[0].id}"]`).within(() => {
+    cy.get(`[data-qa-node-pool-id="${mockSingleNodePool.id}"]`).within(() => {
       // Check that the accordion is still expanded
       cy.get(`[data-qa-panel-summary]`).should(
         'have.attr',

--- a/packages/manager/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.tsx
@@ -147,6 +147,9 @@ export const ActionMenu = React.memo((props: ActionMenuProps) => {
                 handleClose(e);
                 a.onClick();
               }
+              if (stopClickPropagation) {
+                e.stopPropagation();
+              }
             }}
             data-qa-action-menu-item={a.title}
             data-testid={a.title}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -188,6 +188,7 @@ export const NodePool = (props: Props) => {
                 disableFocusListener={!isOnlyNodePool}
                 disableHoverListener={!isOnlyNodePool}
                 disableTouchListener={!isOnlyNodePool}
+                onClick={(e) => e.stopPropagation()}
                 title="Clusters must contain at least one node pool."
               >
                 <div>


### PR DESCRIPTION
## Description 📝
Fix clicking disabled delete button also collapsing/expanding the accordion. No changeset needed as this hasn't been released yet

## Target release date 🗓️
2/11/15

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/96d45cd9-2c90-4eae-943d-8e8f8f659658" /> | <video src="https://github.com/user-attachments/assets/9012a7aa-b38d-4442-a613-d860610ac547" /> |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have a LKE or LKE-E cluster set up with 1 node pool

### Verification steps

(How to verify changes)

- [ ] Go to a LKE or LKE-E cluster with only 1 node pool
- [ ] Click on the disabled delete pool button. The accordion should stay as is and not expand or collapse from the click

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
