### PR TITLE
feat: [M3-9231] - Improve Node Pool Collapsing UX

### DIFF
--- a/packages/manager/.changeset/pr-11619-added-1739207937605.md
+++ b/packages/manager/.changeset/pr-11619-added-1739207937605.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Improve Node Pool Collapsing UX ([#11619](https://github.com/linode/manager/pull/11619))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -1697,14 +1697,14 @@ describe('LKE cluster updates', () => {
     });
     const mockNodePools = [
       nodePoolFactory.build({
-        nodes: kubeLinodeFactory.buildList(4),
-        count: 4,
+        nodes: kubeLinodeFactory.buildList(10),
+        count: 10,
       }),
       nodePoolFactory.build({
-        nodes: kubeLinodeFactory.buildList(3),
-        count: 3,
+        nodes: kubeLinodeFactory.buildList(5),
+        count: 5,
       }),
-      nodePoolFactory.build({ nodes: [kubeLinodeFactory.build()], count: 1 }),
+      nodePoolFactory.build({ nodes: [kubeLinodeFactory.build()] }),
     ];
     mockGetCluster(mockCluster).as('getCluster');
     mockGetClusterPools(mockCluster.id, mockNodePools).as('getNodePools');
@@ -1713,7 +1713,7 @@ describe('LKE cluster updates', () => {
     cy.wait(['@getCluster', '@getNodePools']);
 
     cy.get(`[data-qa-node-pool-id="${mockNodePools[0].id}"]`).within(() => {
-      // Accordion should be collapsed by default since there are more than 3 nodes
+      // Accordion should be collapsed by default since there are more than 9 nodes
       cy.get(`[data-qa-panel-summary]`).should(
         'have.attr',
         'aria-expanded',
@@ -1722,7 +1722,7 @@ describe('LKE cluster updates', () => {
     });
 
     cy.get(`[data-qa-node-pool-id="${mockNodePools[1].id}"]`).within(() => {
-      // Accordion should be expanded by default since there are not more than 3 nodes
+      // Accordion should be expanded by default since there are not more than 9 nodes
       cy.get(`[data-qa-panel-summary]`).should(
         'have.attr',
         'aria-expanded',
@@ -1731,7 +1731,7 @@ describe('LKE cluster updates', () => {
     });
 
     cy.get(`[data-qa-node-pool-id="${mockNodePools[2].id}"]`).within(() => {
-      // Accordion should be expanded by default since there are not more than 3 nodes
+      // Accordion should be expanded by default since there are not more than 9 nodes
       cy.get(`[data-qa-panel-summary]`).should(
         'have.attr',
         'aria-expanded',

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -1691,6 +1691,91 @@ describe('LKE cluster updates', () => {
     });
   });
 
+  it('sets default expanded node pools and has collapse/expand all functionality', () => {
+    const mockCluster = kubernetesClusterFactory.build({
+      k8s_version: latestKubernetesVersion,
+    });
+    const mockNodePools = [
+      nodePoolFactory.build({
+        nodes: kubeLinodeFactory.buildList(4),
+        count: 4,
+      }),
+      nodePoolFactory.build({
+        nodes: kubeLinodeFactory.buildList(3),
+        count: 3,
+      }),
+      nodePoolFactory.build({ nodes: [kubeLinodeFactory.build()], count: 1 }),
+    ];
+    mockGetCluster(mockCluster).as('getCluster');
+    mockGetClusterPools(mockCluster.id, mockNodePools).as('getNodePools');
+
+    cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
+    cy.wait(['@getCluster', '@getNodePools']);
+
+    cy.get(`[data-qa-node-pool-id="${mockNodePools[0].id}"]`).within(() => {
+      // Accordion should be collapsed by default since there are more than 3 nodes
+      cy.get(`[data-qa-panel-summary]`).should(
+        'have.attr',
+        'aria-expanded',
+        'false'
+      );
+    });
+
+    cy.get(`[data-qa-node-pool-id="${mockNodePools[1].id}"]`).within(() => {
+      // Accordion should be expanded by default since there are not more than 3 nodes
+      cy.get(`[data-qa-panel-summary]`).should(
+        'have.attr',
+        'aria-expanded',
+        'true'
+      );
+    });
+
+    cy.get(`[data-qa-node-pool-id="${mockNodePools[2].id}"]`).within(() => {
+      // Accordion should be expanded by default since there are not more than 3 nodes
+      cy.get(`[data-qa-panel-summary]`).should(
+        'have.attr',
+        'aria-expanded',
+        'true'
+      );
+    });
+
+    // Collapse all pools
+    ui.button
+      .findByTitle('Collapse All Pools')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.get(`[data-qa-node-pool-id]`).each(($pool) => {
+      // Accordion should be collapsed
+      cy.wrap($pool).within(() => {
+        cy.get(`[data-qa-panel-summary]`).should(
+          'have.attr',
+          'aria-expanded',
+          'false'
+        );
+      });
+    });
+
+    // Expand all pools
+    ui.button
+      .findByTitle('Expand All Pools')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.get(`[data-qa-node-pool-id]`).each(($pool) => {
+      // Accordion should be expanded
+      cy.wrap($pool).within(() => {
+        cy.get(`[data-qa-panel-summary]`).should(
+          'have.attr',
+          'aria-expanded',
+          'true'
+        );
+      });
+    });
+  });
+
   it('filters the node tables based on selected status filter', () => {
     const mockCluster = kubernetesClusterFactory.build({
       k8s_version: latestKubernetesVersion,

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -31,6 +31,7 @@ interface Props {
   clusterTier: KubernetesTier;
   count: number;
   encryptionStatus: EncryptionStatus | undefined;
+  handleAccordionClick: () => void;
   handleClickLabelsAndTaints: (poolId: number) => void;
   handleClickResize: (poolId: number) => void;
   isOnlyNodePool: boolean;
@@ -54,6 +55,7 @@ export const NodePool = (props: Props) => {
     clusterTier,
     count,
     encryptionStatus,
+    handleAccordionClick,
     handleClickLabelsAndTaints,
     handleClickResize,
     isOnlyNodePool,
@@ -212,7 +214,8 @@ export const NodePool = (props: Props) => {
       }
       data-qa-node-pool-id={poolId}
       data-qa-node-pool-section
-      defaultExpanded={accordionExpanded}
+      expanded={accordionExpanded}
+      onClick={handleAccordionClick}
     >
       <NodeTable
         clusterCreated={clusterCreated}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -24,6 +24,7 @@ import type {
 import type { EncryptionStatus } from '@linode/api-v4/lib/linodes/types';
 
 interface Props {
+  accordionExpanded: boolean;
   autoscaler: AutoscaleSettings;
   clusterCreated: string;
   clusterId: number;
@@ -46,6 +47,7 @@ interface Props {
 
 export const NodePool = (props: Props) => {
   const {
+    accordionExpanded,
     autoscaler,
     clusterCreated,
     clusterId,
@@ -210,7 +212,7 @@ export const NodePool = (props: Props) => {
       }
       data-qa-node-pool-id={poolId}
       data-qa-node-pool-section
-      defaultExpanded={true}
+      defaultExpanded={accordionExpanded}
     >
       <NodeTable
         clusterCreated={clusterCreated}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -215,7 +215,7 @@ export const NodePool = (props: Props) => {
       data-qa-node-pool-id={poolId}
       data-qa-node-pool-section
       expanded={accordionExpanded}
-      onClick={handleAccordionClick}
+      onChange={handleAccordionClick}
     >
       <NodeTable
         clusterCreated={clusterCreated}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -124,6 +124,27 @@ export const NodePoolsDisplay = (props: Props) => {
     setIsLabelsAndTaintsDrawerOpen(true);
   };
 
+  const defaultExpandedPools =
+    _pools
+      ?.filter((pool) => {
+        // If there's only one node pool, expand it no matter how many nodes there are
+        if (_pools.length === 1) {
+          return true;
+        }
+        // If there are more than 3 node pools, keep them all collapsed
+        if (_pools.length > 3) {
+          return false;
+        }
+        // Otherwise, if the user has between 1-3 node pools:
+        // If the node pool has 1-3 nodes, keep it expanded
+        if (pool.count <= 3) {
+          return true;
+        }
+        // Collapse everything else
+        return false;
+      })
+      .map(({ id }) => id) ?? [];
+
   if (isLoading || pools === undefined) {
     return <CircleProgress />;
   }
@@ -202,6 +223,7 @@ export const NodePoolsDisplay = (props: Props) => {
                 setSelectedNodeId(nodeId);
                 setIsRecycleNodeOpen(true);
               }}
+              accordionExpanded={defaultExpandedPools.includes(id)}
               autoscaler={thisPool.autoscaler}
               clusterCreated={clusterCreated}
               clusterId={clusterID}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -164,8 +164,9 @@ export const NodePoolsDisplay = (props: Props) => {
         storage.nodePoolsExpanded.set(clusterID, _expandedAccordions);
         return setExpandedAccordions(_expandedAccordions);
       } else {
-        storage.nodePoolsExpanded.set(clusterID, [id]);
-        return setExpandedAccordions([id]);
+        _expandedAccordions = [...defaultExpandedPools, id];
+        storage.nodePoolsExpanded.set(clusterID, _expandedAccordions);
+        return setExpandedAccordions(_expandedAccordions);
       }
     }
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -184,7 +184,7 @@ export const NodePoolsDisplay = (props: Props) => {
             />
           </Stack>
           <Button
-            buttonType="secondary"
+            buttonType="outlined"
             onClick={() => setIsRecycleClusterOpen(true)}
           >
             Recycle All Nodes

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -145,6 +145,30 @@ export const NodePoolsDisplay = (props: Props) => {
       })
       .map(({ id }) => id) ?? [];
 
+  const [expandedAccordions, setExpandedAccordions] = useState<
+    number[] | undefined
+  >(undefined);
+
+  const handleAccordionClick = (id: number) => {
+    if (expandedAccordions === undefined) {
+      if (defaultExpandedPools.includes(id)) {
+        return setExpandedAccordions(
+          defaultExpandedPools.filter((poolId) => poolId !== id)
+        );
+      } else {
+        return setExpandedAccordions([id]);
+      }
+    }
+
+    if (expandedAccordions.includes(id)) {
+      setExpandedAccordions(
+        expandedAccordions.filter((number) => number !== id)
+      );
+    } else {
+      setExpandedAccordions([...expandedAccordions, id]);
+    }
+  };
+
   if (isLoading || pools === undefined) {
     return <CircleProgress />;
   }
@@ -152,15 +176,19 @@ export const NodePoolsDisplay = (props: Props) => {
   return (
     <>
       <Stack
+        sx={{
+          paddingBottom: 1,
+          paddingLeft: { md: 0, sm: 1, xs: 1 },
+          paddingTop: 3,
+        }}
         alignItems="center"
         direction="row"
         flexWrap="wrap"
         justifyContent="space-between"
         spacing={2}
-        sx={{ paddingLeft: { md: 0, sm: 1, xs: 1 }, paddingTop: 3 }}
       >
-        <Typography variant="h2">Node Pools</Typography>
-        <Stack direction="row" spacing={1}>
+        <Stack alignItems="center" direction="row" spacing={2}>
+          <Typography variant="h2">Node Pools</Typography>
           <Stack alignItems="end" direction="row">
             <FormLabel htmlFor={ariaIdentifier}>
               <Typography ml={1} mr={1}>
@@ -183,6 +211,27 @@ export const NodePoolsDisplay = (props: Props) => {
               sx={{ width: 130 }}
             />
           </Stack>
+          {(expandedAccordions === undefined &&
+            defaultExpandedPools.length > 0) ||
+          (expandedAccordions && expandedAccordions.length > 0) ? (
+            <Button
+              buttonType="secondary"
+              compactX
+              onClick={() => setExpandedAccordions([])}
+            >
+              Collapse All
+            </Button>
+          ) : (
+            <Button
+              buttonType="secondary"
+              compactX
+              onClick={() => setExpandedAccordions(_pools?.map(({ id }) => id))}
+            >
+              Expand All
+            </Button>
+          )}
+        </Stack>
+        <Stack direction="row" spacing={1}>
           <Button
             buttonType="outlined"
             onClick={() => setIsRecycleClusterOpen(true)}
@@ -207,6 +256,11 @@ export const NodePoolsDisplay = (props: Props) => {
 
           return (
             <NodePool
+              accordionExpanded={
+                expandedAccordions === undefined
+                  ? defaultExpandedPools.includes(id)
+                  : expandedAccordions.includes(id)
+              }
               openAutoscalePoolDialog={(poolId) => {
                 setSelectedPoolId(poolId);
                 setIsAutoscaleDialogOpen(true);
@@ -223,13 +277,13 @@ export const NodePoolsDisplay = (props: Props) => {
                 setSelectedNodeId(nodeId);
                 setIsRecycleNodeOpen(true);
               }}
-              accordionExpanded={defaultExpandedPools.includes(id)}
               autoscaler={thisPool.autoscaler}
               clusterCreated={clusterCreated}
               clusterId={clusterID}
               clusterTier={clusterTier}
               count={count}
               encryptionStatus={disk_encryption}
+              handleAccordionClick={() => handleAccordionClick(id)}
               handleClickLabelsAndTaints={handleOpenLabelsAndTaintsDrawer}
               handleClickResize={handleOpenResizeDrawer}
               isOnlyNodePool={pools?.length === 1}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -156,32 +156,6 @@ export const NodePoolsDisplay = (props: Props) => {
           <Typography variant="h2">Node Pools</Typography>
         </Stack>
         <Stack alignItems="center" direction="row" spacing={1}>
-          {(expandedAccordions === undefined &&
-            defaultExpandedPools.length > 0) ||
-          (expandedAccordions && expandedAccordions.length > 0) ? (
-            <Button
-              buttonType="secondary"
-              compactX
-              endIcon={<ExpandLessIcon />}
-              onClick={() => setExpandedAccordions([])}
-              sx={{ '& span': { marginLeft: 0.5 } }}
-            >
-              Collapse All Pools
-            </Button>
-          ) : (
-            <Button
-              onClick={() => {
-                const expandedAccordions = _pools?.map(({ id }) => id) ?? [];
-                setExpandedAccordions(expandedAccordions);
-              }}
-              buttonType="secondary"
-              compactX
-              endIcon={<ExpandMoreIcon />}
-              sx={{ '& span': { marginLeft: 0.5 } }}
-            >
-              Expand All Pools
-            </Button>
-          )}
           <FormLabel htmlFor={ariaIdentifier}>
             <Typography ml={1} mr={1}>
               Status
@@ -201,6 +175,38 @@ export const NodePoolsDisplay = (props: Props) => {
             placeholder="Select a status"
             sx={{ width: 130 }}
           />
+          {(expandedAccordions === undefined &&
+            defaultExpandedPools.length > 0) ||
+          (expandedAccordions && expandedAccordions.length > 0) ? (
+            <Button
+              sx={{
+                '& span': { marginLeft: 0.5 },
+                paddingLeft: 0.5,
+                paddingRight: 0.5,
+              }}
+              buttonType="secondary"
+              endIcon={<ExpandLessIcon />}
+              onClick={() => setExpandedAccordions([])}
+            >
+              Collapse All Pools
+            </Button>
+          ) : (
+            <Button
+              onClick={() => {
+                const expandedAccordions = _pools?.map(({ id }) => id) ?? [];
+                setExpandedAccordions(expandedAccordions);
+              }}
+              sx={{
+                '& span': { marginLeft: 0.5 },
+                paddingLeft: 0.5,
+                paddingRight: 0.5,
+              }}
+              buttonType="secondary"
+              endIcon={<ExpandMoreIcon />}
+            >
+              Expand All Pools
+            </Button>
+          )}
           <Button
             buttonType="outlined"
             onClick={() => setIsRecycleClusterOpen(true)}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -1,4 +1,6 @@
 import { Button, CircleProgress, Select, Stack, Typography } from '@linode/ui';
+import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
+import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore';
 import React, { useState } from 'react';
 import { Waypoint } from 'react-waypoint';
 
@@ -189,28 +191,8 @@ export const NodePoolsDisplay = (props: Props) => {
       >
         <Stack alignItems="center" direction="row" spacing={2}>
           <Typography variant="h2">Node Pools</Typography>
-          <Stack alignItems="end" direction="row">
-            <FormLabel htmlFor={ariaIdentifier}>
-              <Typography ml={1} mr={1}>
-                Status
-              </Typography>
-            </FormLabel>
-            <Select
-              value={
-                statusOptions?.find(
-                  (option) => option.value === statusFilter
-                ) ?? null
-              }
-              data-qa-status-filter
-              hideLabel
-              id={ariaIdentifier}
-              label="Status"
-              onChange={(_, item) => setStatusFilter(item?.value)}
-              options={statusOptions ?? []}
-              placeholder="Select a status"
-              sx={{ width: 130 }}
-            />
-          </Stack>
+        </Stack>
+        <Stack alignItems="center" direction="row" spacing={1}>
           {(expandedAccordions === undefined &&
             defaultExpandedPools.length > 0) ||
           (expandedAccordions && expandedAccordions.length > 0) ? (
@@ -218,20 +200,41 @@ export const NodePoolsDisplay = (props: Props) => {
               buttonType="secondary"
               compactX
               onClick={() => setExpandedAccordions([])}
+              startIcon={<UnfoldLessIcon />}
+              sx={{ '& span': { marginRight: 0.5 } }}
             >
-              Collapse All
+              Collapse All Pools
             </Button>
           ) : (
             <Button
               buttonType="secondary"
               compactX
               onClick={() => setExpandedAccordions(_pools?.map(({ id }) => id))}
+              startIcon={<UnfoldMoreIcon />}
+              sx={{ '& span': { marginRight: 0.5 } }}
             >
-              Expand All
+              Expand All Pools
             </Button>
           )}
-        </Stack>
-        <Stack direction="row" spacing={1}>
+          <FormLabel htmlFor={ariaIdentifier}>
+            <Typography ml={1} mr={1}>
+              Status
+            </Typography>
+          </FormLabel>
+          <Select
+            value={
+              statusOptions?.find((option) => option.value === statusFilter) ??
+              null
+            }
+            data-qa-status-filter
+            hideLabel
+            id={ariaIdentifier}
+            label="Status"
+            onChange={(_, item) => setStatusFilter(item?.value)}
+            options={statusOptions ?? []}
+            placeholder="Select a status"
+            sx={{ width: 130 }}
+          />
           <Button
             buttonType="outlined"
             onClick={() => setIsRecycleClusterOpen(true)}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -161,26 +161,23 @@ export const NodePoolsDisplay = (props: Props) => {
         _expandedAccordions = defaultExpandedPools.filter(
           (poolId) => poolId !== id
         );
-        storage.nodePoolsExpanded.set(clusterID, _expandedAccordions);
-        return setExpandedAccordions(_expandedAccordions);
       } else {
         _expandedAccordions = [...defaultExpandedPools, id];
-        storage.nodePoolsExpanded.set(clusterID, _expandedAccordions);
-        return setExpandedAccordions(_expandedAccordions);
       }
+      storage.nodePoolsExpanded.set(clusterID, _expandedAccordions);
+      return setExpandedAccordions(_expandedAccordions);
     }
 
     if (expandedAccordions.includes(id)) {
       _expandedAccordions = expandedAccordions.filter(
         (number) => number !== id
       );
-      setExpandedAccordions(_expandedAccordions);
-      storage.nodePoolsExpanded.set(clusterID, _expandedAccordions);
     } else {
       _expandedAccordions = [...expandedAccordions, id];
-      setExpandedAccordions(_expandedAccordions);
-      storage.nodePoolsExpanded.set(clusterID, _expandedAccordions);
     }
+
+    setExpandedAccordions(_expandedAccordions);
+    storage.nodePoolsExpanded.set(clusterID, _expandedAccordions);
   };
 
   if (isLoading || pools === undefined) {

--- a/packages/manager/src/hooks/useDefaultExpandedNodePools.test.ts
+++ b/packages/manager/src/hooks/useDefaultExpandedNodePools.test.ts
@@ -26,7 +26,7 @@ describe('useDefaultExpandedNodePools', () => {
     expect(result.current.defaultExpandedPools).toStrictEqual([100]);
   });
 
-  it('returns node pools with less than 4 nodes as the default expanded pools if the user has between 1-3 node pools', () => {
+  it('returns node pools with less than 10 nodes as the default expanded pools if the user has between 1-3 node pools', () => {
     const nodePools = [
       nodePoolFactory.build({
         count: 1,
@@ -34,14 +34,14 @@ describe('useDefaultExpandedNodePools', () => {
         nodes: [kubeLinodeFactory.build()],
       }),
       nodePoolFactory.build({
-        count: 5,
+        count: 10,
         id: 101,
-        nodes: kubeLinodeFactory.buildList(5),
+        nodes: kubeLinodeFactory.buildList(10),
       }),
       nodePoolFactory.build({
-        count: 3,
+        count: 6,
         id: 102,
-        nodes: kubeLinodeFactory.buildList(3),
+        nodes: kubeLinodeFactory.buildList(6),
       }),
     ];
 

--- a/packages/manager/src/hooks/useDefaultExpandedNodePools.test.ts
+++ b/packages/manager/src/hooks/useDefaultExpandedNodePools.test.ts
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react';
+
+import {
+  kubeLinodeFactory,
+  nodePoolFactory,
+} from 'src/factories/kubernetesCluster';
+
+import { useDefaultExpandedNodePools } from './useDefaultExpandedNodePools';
+
+const clusterID = 1;
+
+describe('useDefaultExpandedNodePools', () => {
+  it('returns a single node pool as the default expanded pool', () => {
+    const singleNodePool = [
+      nodePoolFactory.build({
+        count: 50,
+        id: 100,
+        nodes: kubeLinodeFactory.buildList(50),
+      }),
+    ];
+
+    const { result } = renderHook(() =>
+      useDefaultExpandedNodePools(clusterID, singleNodePool)
+    );
+
+    expect(result.current.defaultExpandedPools).toStrictEqual([100]);
+  });
+
+  it('returns node pools with less than 4 nodes as the default expanded pools if the user has between 1-3 node pools', () => {
+    const nodePools = [
+      nodePoolFactory.build({
+        count: 1,
+        id: 100,
+        nodes: [kubeLinodeFactory.build()],
+      }),
+      nodePoolFactory.build({
+        count: 5,
+        id: 101,
+        nodes: kubeLinodeFactory.buildList(5),
+      }),
+      nodePoolFactory.build({
+        count: 3,
+        id: 102,
+        nodes: kubeLinodeFactory.buildList(3),
+      }),
+    ];
+
+    const { result } = renderHook(() =>
+      useDefaultExpandedNodePools(clusterID, nodePools)
+    );
+
+    expect(result.current.defaultExpandedPools).toStrictEqual([100, 102]);
+  });
+
+  it('returns no default expanded pools if the user has more than 3 node pools', () => {
+    const nodePools = nodePoolFactory.buildList(10);
+
+    const { result } = renderHook(() =>
+      useDefaultExpandedNodePools(clusterID, nodePools)
+    );
+
+    expect(result.current.defaultExpandedPools).toStrictEqual([]);
+  });
+});

--- a/packages/manager/src/hooks/useDefaultExpandedNodePools.ts
+++ b/packages/manager/src/hooks/useDefaultExpandedNodePools.ts
@@ -24,8 +24,8 @@ export const useDefaultExpandedNodePools = (
           return false;
         }
         // Otherwise, if the user has between 1-3 node pools:
-        // If the node pool has 1-3 nodes, keep it expanded
-        if (pool.count <= 3) {
+        // If the node pool has <10 nodes, keep it expanded
+        if (pool.count < 10) {
           return true;
         }
         // Collapse everything else

--- a/packages/manager/src/hooks/useDefaultExpandedNodePools.ts
+++ b/packages/manager/src/hooks/useDefaultExpandedNodePools.ts
@@ -1,0 +1,73 @@
+import * as React from 'react';
+
+import { storage } from 'src/utilities/storage';
+
+import type { KubeNodePoolResponse } from '@linode/api-v4';
+
+export const useDefaultExpandedNodePools = (
+  clusterID: number,
+  pools: KubeNodePoolResponse[] | undefined
+) => {
+  const [expandedAccordions, _setExpandedAccordions] = React.useState<
+    number[] | undefined
+  >(storage.nodePoolsExpanded.get(clusterID) ?? undefined);
+
+  const defaultExpandedPools =
+    pools
+      ?.filter((pool) => {
+        // If there's only one node pool, expand it no matter how many nodes there are
+        if (pools.length === 1) {
+          return true;
+        }
+        // If there are more than 3 node pools, keep them all collapsed
+        if (pools.length > 3) {
+          return false;
+        }
+        // Otherwise, if the user has between 1-3 node pools:
+        // If the node pool has 1-3 nodes, keep it expanded
+        if (pool.count <= 3) {
+          return true;
+        }
+        // Collapse everything else
+        return false;
+      })
+      .map(({ id }) => id) ?? [];
+
+  const setExpandedAccordions = (expandedAccordions: number[]) => {
+    storage.nodePoolsExpanded.set(clusterID, expandedAccordions);
+    _setExpandedAccordions(expandedAccordions);
+  };
+
+  const handleAccordionClick = (id: number) => {
+    let _expandedAccordions;
+
+    // Initial load with no saved local storage
+    if (expandedAccordions === undefined) {
+      if (defaultExpandedPools.includes(id)) {
+        _expandedAccordions = defaultExpandedPools.filter(
+          (poolId) => poolId !== id
+        );
+      } else {
+        _expandedAccordions = [...defaultExpandedPools, id];
+      }
+      return setExpandedAccordions(_expandedAccordions);
+    }
+
+    if (expandedAccordions.includes(id)) {
+      _expandedAccordions = expandedAccordions.filter(
+        (number) => number !== id
+      );
+    } else {
+      _expandedAccordions = [...expandedAccordions, id];
+    }
+
+    setExpandedAccordions(_expandedAccordions);
+  };
+
+  return {
+    defaultExpandedPools,
+    expandedAccordions,
+    handleAccordionClick,
+    setExpandedAccordions,
+  };
+};

--- a/packages/manager/src/utilities/storage.ts
+++ b/packages/manager/src/utilities/storage.ts
@@ -57,6 +57,7 @@ const TICKET = 'ticket';
 const STACKSCRIPT = 'stackscript';
 const DEV_TOOLS_ENV = 'devTools/env';
 const REGION_FILTER = 'regionFilter';
+const NODE_POOLS_EXPANDED = 'nodePoolsExpanded';
 
 export type PageSize = number;
 export type RegionFilter = 'all' | RegionSite;
@@ -113,6 +114,10 @@ export interface Storage {
   infinitePageSize: {
     get: () => PageSize;
     set: (perPage: PageSize) => void;
+  };
+  nodePoolsExpanded: {
+    get: (clusterId: number) => number[];
+    set: (clusterId: number, v: number[]) => void;
   };
   pageSize: {
     get: () => PageSize;
@@ -187,6 +192,11 @@ export const storage: Storage = {
       return Number(getStorage(INFINITE_PAGE_SIZE, fallback));
     },
     set: (v) => setStorage(INFINITE_PAGE_SIZE, `${v}`),
+  },
+  nodePoolsExpanded: {
+    get: (clusterId) => getStorage(`${NODE_POOLS_EXPANDED}-${clusterId}`),
+    set: (clusterId, v) =>
+      setStorage(`${NODE_POOLS_EXPANDED}-${clusterId}`, JSON.stringify(v)),
   },
   pageSize: {
     get: () => {


### PR DESCRIPTION
## Description 📝
Improve UX of collapsible Node Pools

## Changes  🔄

- Add default logic for expanded/collapsed node pools
- Added a Collapse/Expand all pools button
- Preserve user state to local storage

## Preview 📷
<details>
<summary> Preview </summary>

| Nodes Pools  | Cluster view   |
| ------- | ------- |
| 1 | <video src="https://github.com/user-attachments/assets/93b18092-21d7-41a1-9911-d813bc6b4e81" /> |
| 3 | <video src="https://github.com/user-attachments/assets/5bfd8277-b5c8-4735-8945-b23043eb79db" /> |
| 4 | <video src="https://github.com/user-attachments/assets/a449a163-a0e2-496b-91d8-40e185d3804e" /> |

Expand/Collapse
<video src="https://github.com/user-attachments/assets/e1f3e2ad-0e45-4ae2-8b7a-92b17c05898b" />

</details>

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have a LKE or LKE-E cluster with multiple node pools with varying amount of nodes in each node pool

### Verification steps

(How to verify changes)

- [ ] Test various node pool sizes and nodes in each pool
  - [ ] If there's only one node pool, the pool is expanded by default regardless of how many nodes there are
  - [ ] if the user has between 1-3 node pools, if the node pool has <10 nodes, keep that pool expanded by default
  - [ ] If there are more than 3 node pools, keep them all collapsed by default
- [ ] State should be saved to local storage if the user expands/collapse the node pool and this should override default behavior
- [ ] Test expand/collapse all button

```
yarn cy:run -s "cypress/e2e/core/kubernetes/lke-update.spec.ts"
```

You can use the legacy MSW and update the get function in line 836 of `serverHandlers.ts` to something like:
```
return HttpResponse.json(
  makeResourcePage([
    nodePoolFactory.build({
      nodes: kubeLinodeFactory.buildList(50),
      count: 50,
    }),
  ])
);
```

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>