### PR TITLE
Refactor: [M3-9249] - Convert Logout and OAuth to functional components

### DIFF
--- a/packages/manager/.changeset/pr-11620-tech-stories-1738782536719.md
+++ b/packages/manager/.changeset/pr-11620-tech-stories-1738782536719.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Convert Logout and OAuth to functional components ([#11620](https://github.com/linode/manager/pull/11620))

--- a/packages/manager/src/layouts/Logout.tsx
+++ b/packages/manager/src/layouts/Logout.tsx
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import * as React from 'react';
 import { connect } from 'react-redux';
 
 import { CLIENT_ID } from 'src/constants';
@@ -13,8 +13,8 @@ import type { ApplicationState } from 'src/store';
 
 interface LogoutProps extends DispatchProps, StateProps {}
 
-export class Logout extends Component<LogoutProps> {
-  componentDidMount() {
+export const Logout = ({ dispatchLogout, token }: LogoutProps) => {
+  React.useEffect(() => {
     // Clear any user input (in the Support Drawer) since the user is manually logging out.
     clearUserInput();
 
@@ -23,13 +23,11 @@ export class Logout extends Component<LogoutProps> {
     const clientID = localStorageOverrides?.clientID ?? CLIENT_ID;
 
     // Split the token so we can get the token portion of the "<prefix> <token>" pair
-    this.props.dispatchLogout(clientID || '', this.props.token.split(' ')[1]);
-  }
+    dispatchLogout(clientID || '', token.split(' ')[1]);
+  }, [dispatchLogout, token]);
 
-  render() {
-    return null;
-  }
-}
+  return null;
+};
 
 interface StateProps {
   token: string;

--- a/packages/manager/src/layouts/OAuth.test.tsx
+++ b/packages/manager/src/layouts/OAuth.test.tsx
@@ -36,8 +36,20 @@ describe('layouts/OAuth', () => {
 
     const mockProps: CombinedProps = {
       dispatchStartSession: vi.fn(),
-      history,
-      location,
+      history: {
+        ...history,
+        location: {
+          ...location,
+          search:
+            '?code=test-code&returnTo=/&state=9f16ac6c-5518-4b96-b4a6-26a16f85b127',
+        },
+        push: vi.fn(),
+      },
+      location: {
+        ...location,
+        search:
+          '?code=test-code&returnTo=/&state=9f16ac6c-5518-4b96-b4a6-26a16f85b127',
+      },
       match,
     };
 

--- a/packages/manager/src/layouts/OAuth.tsx
+++ b/packages/manager/src/layouts/OAuth.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 
 import { SplashScreen } from 'src/components/SplashScreen';
 import { CLIENT_ID, LOGIN_ROOT } from 'src/constants';
@@ -42,7 +41,6 @@ export const OAuthCallbackPage = ({
   dispatchStartSession,
   history,
 }: CombinedProps) => {
-  const [isLoading, setIsLoading] = React.useState(false);
   const { location } = history;
 
   const checkNonce = (nonce: string) => {
@@ -95,14 +93,10 @@ export const OAuthCallbackPage = ({
           codeVerifier
         );
 
-        setIsLoading(true);
-
         const response = await fetch(`${loginURL}/oauth/token`, {
           body: formData,
           method: 'POST',
         });
-
-        setIsLoading(false);
 
         if (response.ok) {
           const tokenParams = await response.json();
@@ -155,9 +149,9 @@ export const OAuthCallbackPage = ({
 
     exchangeAuthorizationCodeForToken(code, returnTo, nonce);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location.search, dispatchStartSession, history]);
+  }, []);
 
-  return isLoading ? <SplashScreen /> : null;
+  return <SplashScreen />;
 };
 
 const clearStorageAndRedirectToLogout = () => {
@@ -185,4 +179,4 @@ const mapDispatchToProps = (dispatch: any): DispatchProps => ({
 
 const connected = connect(undefined, mapDispatchToProps);
 
-export default connected(withRouter(OAuthCallbackPage));
+export default connected(OAuthCallbackPage);


### PR DESCRIPTION
## Description 📝
In order to reroute Accounts, we should convert our old layouts (logout, oAuth) components to functional components. It's not 100% needed, but the more class component we can get rid of the better off we are for future refactors and/or framework updates. 
 
Since those are sensitive areas of the application it is not a bad idea to isolate changes.
It will also reduce the scope of any future refactors, including removing redux - CC @bnussman-akamai 

## Changes  🔄
- Convert `<Logout.tsx />` & OAuth.tsx to functional components
- Add missing props for test to succeed as it did previously

## Preview 📷
Nothin' here

## How to test 🧪

### Prerequisites

### Verification steps
- Ensure proper log out of user and clearing of local storage tokens
- Confirm tests are passing (units & e2e)

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
