### PR TITLE
upcoming: [M3-9210] - Update Linode Interface types as specified

### DIFF
--- a/packages/api-v4/.changeset/pr-11621-upcoming-features-1738790605953.md
+++ b/packages/api-v4/.changeset/pr-11621-upcoming-features-1738790605953.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Upcoming Features
+---
+
+Update region capability and Public Interface object for Linode Interfaces ([#11621](https://github.com/linode/manager/pull/11621))

--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -287,17 +287,23 @@ export interface PublicInterfaceData {
       address: string;
       primary: boolean;
     }[];
-    // shared: string[];
+    shared: {
+      address: string;
+      linode_id: number;
+    }[];
   };
   ipv6: {
-    addresses: {
+    slaac: {
       address: string;
       prefix: string;
     }[];
-    // shared: string[];
+    shared: {
+      range: string;
+      route_target: string | null;
+    }[];
     ranges: {
       range: string;
-      route_target: string;
+      route_target: string | null;
     }[];
   };
 }

--- a/packages/api-v4/src/regions/types.ts
+++ b/packages/api-v4/src/regions/types.ts
@@ -9,7 +9,7 @@ export type Capabilities =
   | 'Cloud Firewall'
   | 'Disk Encryption'
   | 'Distributed Plans'
-  | 'Enhanced Interfaces'
+  | 'Linode Interfaces'
   | 'GPU Linodes'
   | 'Kubernetes'
   | 'Kubernetes Enterprise'

--- a/packages/manager/src/factories/linodeInterface.ts
+++ b/packages/manager/src/factories/linodeInterface.ts
@@ -67,10 +67,12 @@ export const linodeInterfaceFactoryPublic = Factory.Sync.makeFactory<LinodeInter
             primary: true,
           },
         ],
+        shared: [],
       },
       ipv6: {
-        addresses: [],
         ranges: [],
+        shared: [],
+        slaac: [],
       },
     },
     updated: '2020-01-01 00:00:00',


### PR DESCRIPTION
## Description 📝
- Update region capability to 'Linode Interfaces'
- add shared field for public interface get object ipv4/ipv6
- update `addresses` field in public interface object to `slaac`
  - this field has not been updated in the API yet - it will be updated soon. adding a `wait to merge` label on this PR

## How to test 🧪
- confirm changes match API spec / comments in API spec
- see linked API prs in ticket

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
