### PR TITLE
refactor: [M3-6675] - Remove span from button component

### DIFF
--- a/packages/manager/.changeset/pr-11627-removed-1738841591644.md
+++ b/packages/manager/.changeset/pr-11627-removed-1738841591644.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Removed
+---
+
+Span from Button Component ([#11627](https://github.com/linode/manager/pull/11627))

--- a/packages/manager/cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
@@ -502,9 +502,7 @@ describe('linode landing checks for empty state', () => {
     cy.get(linodeLocators.nonEmptyLinodePage.docsLink).should('not.exist');
 
     // Assert that Download CSV button does not exist
-    cy.get(linodeLocators.nonEmptyLinodePage.downloadCsvButton)
-      .contains('Download CSV')
-      .should('not.exist');
+    cy.get('button').contains('Download CSV').should('not.exist');
   });
 
   it('checks restricted user has no access to create linode on linode landing page', () => {
@@ -612,6 +610,9 @@ describe('linode landing checks for non-empty state with restricted user', () =>
       .should('be.visible')
       .and('be.disabled')
       .trigger('mouseover');
+
+    // Assert that Download CSV button does exist
+    cy.get('button').contains('Download CSV').should('exist');
 
     // Assert that tooltip is visible with message
     ui.tooltip

--- a/packages/manager/cypress/support/ui/locators/linode-locators.ts
+++ b/packages/manager/cypress/support/ui/locators/linode-locators.ts
@@ -12,8 +12,6 @@ export const emptyLinodePage = {
 export const nonEmptyLinodePage = {
   /** Non-Empty Linode landing page Docs link. */
   docsLink: 'a[aria-label="Docs - link opens in a new tab"]',
-  /** Non-Empty Linode landing page Download CSV button. */
-  downloadCsvButton: 'span[data-testid="loadingIcon"]',
   /** Non-Empty Linode landing page Linodes label header. */
   linodesLabel: 'h1[data-qa-header="Linodes"]',
   /** Non-Empty Linode landing page Linodes table. */

--- a/packages/manager/src/features/Account/CloseAccountSetting.test.tsx
+++ b/packages/manager/src/features/Account/CloseAccountSetting.test.tsx
@@ -41,10 +41,9 @@ describe('Close Account Settings', () => {
 
     const { getByTestId } = renderWithTheme(<CloseAccountSetting />);
     const button = getByTestId('close-account-button');
-    const span = button.querySelector('span');
     expect(button).toBeInTheDocument();
     expect(button).toBeEnabled();
-    expect(span).toHaveTextContent('Close Account');
+    expect(button).toHaveTextContent('Close Account');
   });
 
   it('should render a disabled Close Account button with tooltip for a parent account user', async () => {

--- a/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.test.tsx
+++ b/packages/manager/src/features/Profile/APITokens/CreateAPITokenDrawer.test.tsx
@@ -79,7 +79,7 @@ describe('Create API Token Drawer', () => {
       );
       const submitBtn = getByText('Create Token');
 
-      expect(submitBtn).not.toHaveAttribute('aria-disabled', 'true');
+      expect(submitBtn).toHaveAttribute('aria-disabled', 'true');
       await userEvent.click(selectAllNoAccessPermRadioButton);
       await userEvent.click(submitBtn);
 

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -90,15 +90,6 @@ const StyledButton = styled(_Button, {
   }),
 }));
 
-const Span = styled('span')({
-  '@supports (-moz-appearance: none)': {
-    /* Fix text alignment for Firefox */
-    marginTop: 2,
-  },
-  alignItems: 'center',
-  display: 'flex',
-});
-
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
@@ -164,9 +155,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         sx={sx}
         variant={buttonTypeToVariant[buttonType] || 'text'}
       >
-        <Span data-testid="loadingIcon">
-          {loading ? <ReloadIcon /> : children}
-        </Span>
+        {loading ? <ReloadIcon data-testid="loadingIcon" /> : children}
       </StyledButton>
     );
 


### PR DESCRIPTION
## Description 📝

This PR removes the `<span>` component from the children of the Button component. This change will make it easier for test selectors to locate button elements without having to first find the `<span>` and then locate the closest button.

## Changes 🔄

- Remove `<span>` from Button component children to simplify test selector targeting.

## Target release date 🗓️  
N/A

### Verification steps

- [ ] Verify that button elements can now be found directly by test selectors without needing to reference the `<span>`.
- [ ] Ensure no existing functionality is broken and no regressions are introduced.
- [ ] Confirm all tests pass successfully.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>