### PR TITLE
fix: [UIE-8446] - restore backup date and time fix

### DIFF
--- a/packages/manager/.changeset/pr-11628-fixed-1738858900211.md
+++ b/packages/manager/.changeset/pr-11628-fixed-1738858900211.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Database restore backup timezone inconsistency ([#11628](https://github.com/linode/manager/pull/11628))

--- a/packages/manager/.changeset/pr-11628-fixed-1738858900211.md
+++ b/packages/manager/.changeset/pr-11628-fixed-1738858900211.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Database restore backup timezone inconsistency ([#11628](https://github.com/linode/manager/pull/11628))

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Buggy Copy Token behavior on LKE details page ([#11592](https://github.com/linode/manager/pull/11592))
 - Longview Detail id param not found (local only) ([#11599](https://github.com/linode/manager/pull/11599))
+- Database restore backup timezone inconsistency ([#11628](https://github.com/linode/manager/pull/11628))
 
 ### Tech Stories:
 
@@ -104,7 +105,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Spacing for LKE cluster tags at desktop screen sizes ([#11507](https://github.com/linode/manager/pull/11507))
 - Zoom-in icon hover effect in CloudPulse ([#11526](https://github.com/linode/manager/pull/11526))
 - Linode Config Dialog misrepresenting primary interface ([#11542](https://github.com/linode/manager/pull/11542))
-- Database restore backup timezone inconsistency ([#11628](https://github.com/linode/manager/pull/11628))
 
 ### Tech Stories:
 

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -104,6 +104,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Spacing for LKE cluster tags at desktop screen sizes ([#11507](https://github.com/linode/manager/pull/11507))
 - Zoom-in icon hover effect in CloudPulse ([#11526](https://github.com/linode/manager/pull/11526))
 - Linode Config Dialog misrepresenting primary interface ([#11542](https://github.com/linode/manager/pull/11542))
+- Database restore backup timezone inconsistency ([#11628](https://github.com/linode/manager/pull/11628))
 
 ### Tech Stories:
 

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -102,7 +102,7 @@ export const DatabaseBackups = (props: Props) => {
   const isDefaultDatabase = database?.platform === 'rdbms-default';
 
   const oldestBackup = database?.oldest_restore_time
-    ? DateTime.fromISO(database.oldest_restore_time)
+    ? DateTime.fromISO(`${database.oldest_restore_time}Z`)
     : null;
 
   const unableToRestoreCopy = !oldestBackup
@@ -206,6 +206,9 @@ export const DatabaseBackups = (props: Props) => {
             <FormControl style={{ marginTop: 0 }}>
               {/* TODO: Replace Time Select to the own custom date-time picker component when it's ready */}
               <Autocomplete
+                disabled={
+                  disabled || !selectedDate || versionOption === 'newest'
+                }
                 getOptionDisabled={(option) =>
                   isTimeOutsideBackup(
                     option.value,
@@ -231,9 +234,6 @@ export const DatabaseBackups = (props: Props) => {
                 }}
                 autoComplete={false}
                 className={classes.timeAutocomplete}
-                disabled={
-                  disabled || !selectedDate || versionOption === 'newest'
-                }
                 label=""
                 onChange={(_, newTime) => setSelectedTime(newTime)}
                 options={TIME_OPTIONS}

--- a/packages/manager/src/features/Databases/utilities.test.ts
+++ b/packages/manager/src/features/Databases/utilities.test.ts
@@ -387,7 +387,7 @@ describe('toFormatedDate', () => {
     const result = toFormatedDate(selectedDate, selectedTime.value);
     expect(result).toContain('2025-01-15 14:00');
   });
-  it('should convert a date and time to the format YYYY-MM-DD HH:mm for the dialog', () => {
+  it('should handle newest full backup plus incremental option correctly in UTC', () => {
     const selectedDate = null;
     const today = DateTime.utc();
     const mockTodayWithHours = `${today.toISODate()} ${today.hour}:00`;

--- a/packages/manager/src/features/Databases/utilities.test.ts
+++ b/packages/manager/src/features/Databases/utilities.test.ts
@@ -13,6 +13,7 @@ import {
   isDefaultDatabase,
   isLegacyDatabase,
   isTimeOutsideBackup,
+  toFormatedDate,
   toISOString,
   upgradableVersions,
   useIsDatabasesEnabled,
@@ -359,30 +360,46 @@ describe('isDateOutsideBackup', () => {
 describe('isTimeOutsideBackup', () => {
   it('should return true when hour + selected date is before oldest backup', () => {
     const selectedDate = DateTime.fromISO('2024-10-02');
-    const oldestBackup = DateTime.fromISO('2024-10-02T09:00:00');
+    const oldestBackup = DateTime.fromISO('2024-10-02T09:00:00Z');
     const result = isTimeOutsideBackup(8, selectedDate, oldestBackup);
     expect(result).toEqual(true);
   });
 
   it('should return false when hour + selected date is equal to the oldest backup', () => {
     const selectedDate = DateTime.fromISO('2024-10-02');
-    const oldestBackup = DateTime.fromISO('2024-10-02T09:00:00');
+    const oldestBackup = DateTime.fromISO('2024-10-02T09:00:00Z');
     const result = isTimeOutsideBackup(9, selectedDate, oldestBackup);
     expect(result).toEqual(false);
   });
 
   it('should return false when hour + selected date is after the oldest backup', () => {
     const selectedDate = DateTime.fromISO('2024-10-03');
-    const oldestBackup = DateTime.fromISO('2024-10-02T09:00:00');
+    const oldestBackup = DateTime.fromISO('2024-10-02T09:00:00Z');
     const result = isTimeOutsideBackup(1, selectedDate, oldestBackup);
     expect(result).toEqual(false);
+  });
+});
+
+describe('toFormatedDate', () => {
+  it('should convert a date and time to the format YYYY-MM-DD HH:mm for the dialog', () => {
+    const selectedDate = DateTime.fromObject({ day: 15, month: 1, year: 2025 });
+    const selectedTime: TimeOption = { label: '14:00', value: 14 };
+    const result = toFormatedDate(selectedDate, selectedTime.value);
+    expect(result).toContain('2025-01-15 14:00');
+  });
+  it('should convert a date and time to the format YYYY-MM-DD HH:mm for the dialog', () => {
+    const selectedDate = null;
+    const today = DateTime.utc();
+    const mockTodayWithHours = `${today.toISODate()} ${today.hour}:00`;
+    const result = toFormatedDate(selectedDate, undefined);
+    expect(result).toContain(mockTodayWithHours);
   });
 });
 
 describe('toISOString', () => {
   it('should convert a date and time to ISO string format', () => {
     const selectedDate = DateTime.fromObject({ day: 15, month: 5, year: 2023 });
-    const selectedTime: TimeOption = { label: '02:00', value: 14 };
+    const selectedTime: TimeOption = { label: '14:00', value: 14 };
     const result = toISOString(selectedDate, selectedTime.value);
     expect(result).toContain('2023-05-15T14:00');
   });

--- a/packages/manager/src/features/Databases/utilities.ts
+++ b/packages/manager/src/features/Databases/utilities.ts
@@ -128,7 +128,7 @@ export const isDateOutsideBackup = (
   if (!oldestBackup) {
     return true;
   }
-  const today = DateTime.now();
+  const today = DateTime.utc();
   return date < oldestBackup || date > today;
 };
 
@@ -169,10 +169,10 @@ export const toSelectedDateTime = (
   time: number = 0
 ) => {
   const isoDate = selectedDate?.toISODate();
-  const isoTime = DateTime.now()
+  const isoTime = DateTime.utc()
     .set({ hour: time, minute: 0 })
     ?.toISOTime({ includeOffset: false });
-  return DateTime.fromISO(`${isoDate}T${isoTime}`);
+  return DateTime.fromISO(`${isoDate}T${isoTime}`, { zone: 'UTC' });
 };
 
 /**
@@ -187,7 +187,7 @@ export const toFormatedDate = (
   selectedDate?: DateTime | null,
   selectedTime?: number
 ) => {
-  const today = DateTime.now();
+  const today = DateTime.utc();
   const isoDate =
     selectedDate && selectedTime
       ? toISOString(selectedDate!, selectedTime)

--- a/packages/manager/src/features/GlobalNotifications/DatabaseMigrationInfoBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/DatabaseMigrationInfoBanner.tsx
@@ -10,8 +10,8 @@ export const DatabaseMigrationInfoBanner = () => {
         Legacy clusters decommission
       </Typography>
       <Typography lineHeight="20px">
-        Legacy database clusters will only be available until the end of 2025.
-        At that time, we’ll migrate your clusters to the new solution. For
+        Legacy database clusters will only be available until the end of June
+        2025. At that time, we’ll migrate your clusters to the new solution. For
         questions regarding the new database clusters or the migration,{' '}
         <SupportLink entity={{ type: 'database_id' }} text="contact support" />.
       </Typography>


### PR DESCRIPTION
## Description 📝

Fix for Timezone Display Inconsistency During Restore Backup

## Changes  🔄

- Updated the date-time picker to consistently show times in UTC
- Prevented restoring from a timestamp in the future
- Ensured the time selected for restoration will always be in UTC

## Target release date 🗓️

2/11/25

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-02-06 at 5 01 24 PM](https://github.com/user-attachments/assets/d340e22f-ee13-4818-84cb-3acbbc911a6f) | ![Screenshot 2025-02-06 at 5 01 05 PM](https://github.com/user-attachments/assets/c892095e-ad7a-496b-9403-2cff9582dcaf) |
| ![Screenshot 2025-02-06 at 5 02 08 PM](https://github.com/user-attachments/assets/8c4f3f6e-dd80-4597-a6c2-19e3086061a8) | ![Screenshot 2025-02-06 at 5 02 19 PM](https://github.com/user-attachments/assets/cdfc3d32-8460-4b63-95ac-64103add6f5d) |

## How to test 🧪

### Verification steps

#### Newest full backup:
- Navigate to the Backups tab in your database cluster
- Select “Restore a Backup” using the “Newest full backup plus incremental” option
- Check that the time displayed in the modal shows UTC time
- After selecting "Restore," a new database will be created with a UTC timestamp appended

#### Specific Date & Time:
- Navigate to the Backups tab in your database cluster
- Select “Restore a Backup” using the “Specific date & time” option 
- Choose today’s date
- Verify the dropdown displays UTC hourly times to select, with future times after the current UTC time being disabled
- The selected time will restore in UTC as chosen

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
