### PR TITLE
fix: [DI-23411] - Updated preference key for date time range picker

### DIFF
--- a/packages/manager/.changeset/pr-11631-added-1738936959631.md
+++ b/packages/manager/.changeset/pr-11631-added-1738936959631.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Update `TIME_DURATION` constant from `timeDuration` to `timeRange` ([#11631](https://github.com/linode/manager/pull/11631))

--- a/packages/manager/src/features/CloudPulse/Overview/GlobalFilters.tsx
+++ b/packages/manager/src/features/CloudPulse/Overview/GlobalFilters.tsx
@@ -119,7 +119,7 @@ export const GlobalFilters = React.memo((props: GlobalFilterProperties) => {
           gap={2}
         >
           <CloudPulseDateTimeRangePicker
-            defaultValue={preferences?.timeDuration}
+            defaultValue={preferences?.timeRange}
             handleStatsChange={handleTimeRangeChange}
             savePreferences
           />

--- a/packages/manager/src/features/CloudPulse/Utils/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/constants.ts
@@ -6,7 +6,7 @@ export const RESOURCES = 'resources';
 
 export const INTERVAL = 'interval';
 
-export const TIME_DURATION = 'timeDuration';
+export const TIME_DURATION = 'dateTimeDuration';
 
 export const AGGREGATE_FUNCTION = 'aggregateFunction';
 


### PR DESCRIPTION
## Description 📝

Changed preference key for date time range picker because preference saved with previous time range select has different structure to save preference and it may impact user experience who are first time using date time range picker with preferences have data from older time range select.

## Changes  🔄

List any change(s) relevant to the reviewer.

1. Updated constants to change values of TIME_DURATION

## Target release date 🗓️

10 Feb

## Preview 📷

Error because of bug
![Screenshot 2025-02-06 at 10 55 23 PM](https://github.com/user-attachments/assets/1c2ee47c-7f23-4079-8edc-566de3e116c9)

## How to test 🧪

### Prerequisites

(How to setup test environment)

- ...
- ...

### Reproduction steps

(How to reproduce the issue, if applicable)

1. Go to cloud.linode.com/monitor/dashboards.
2. Change value in time range dropdown and see the request data in network tab for preferences api
3. You'll see its value for timeDuration key is a string value based on previous time range select but with new date time range picker it should be an object of {end: string, start: string, preset: string}.

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>


