### PR TITLE
refactor: [M3-9130] - Replace `data-test-id` attributes with `data-testid` and add eslint rules

### DIFF
--- a/packages/manager/.changeset/pr-11634-tech-stories-1739173865935.md
+++ b/packages/manager/.changeset/pr-11634-tech-stories-1739173865935.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Replace `data-test-id` attributes with `data-testid` and add eslint rules ([#11634](https://github.com/linode/manager/pull/11634))

--- a/packages/manager/.eslintrc.cjs
+++ b/packages/manager/.eslintrc.cjs
@@ -256,6 +256,14 @@ module.exports = {
         name: '@mui/material',
       },
     ],
+    'no-restricted-syntax': [
+      'warn', // @todo: change it to 'error'
+      {
+        message:
+          "The 'data-test-id' attribute is not allowed; use 'data-testid' instead.",
+        selector: "JSXAttribute[name.name='data-test-id']",
+      },
+    ],
     'no-throw-literal': 'warn',
     'no-trailing-spaces': 'warn',
     // allowing to init vars to undefined

--- a/packages/manager/.eslintrc.cjs
+++ b/packages/manager/.eslintrc.cjs
@@ -218,6 +218,7 @@ module.exports = {
     'comma-dangle': 'off', // Prettier and TS both handle and check for this one
     // radix: Codacy considers it as an error, i put it here to fix it before push
     curly: 'warn',
+    eqeqeq: 'warn',
     // See: https://www.w3.org/TR/graphics-aria-1.0/
     'jsx-a11y/aria-role': [
       'error',
@@ -257,7 +258,7 @@ module.exports = {
       },
     ],
     'no-restricted-syntax': [
-      'warn', // @todo: change it to 'error'
+      'error',
       {
         message:
           "The 'data-test-id' attribute is not allowed; use 'data-testid' instead.",

--- a/packages/manager/cypress/e2e/core/notificationsAndEvents/events.spec.ts
+++ b/packages/manager/cypress/e2e/core/notificationsAndEvents/events.spec.ts
@@ -28,7 +28,7 @@ describe('verify notification types and icons', () => {
         }
         const text = [`${events[i].message}`, `${events[i].entity?.label}`];
         const regex = new RegExp(`${text.join('|')}`, 'g');
-        cy.get(`[data-test-id="${events[i].action}"]`).within(() => {
+        cy.get(`[data-testid="${events[i].action}"]`).within(() => {
           cy.contains(regex);
         });
       }
@@ -38,7 +38,7 @@ describe('verify notification types and icons', () => {
       events.forEach((event) => {
         const text = [`${event.message}`, `${event.entity?.label}`];
         const regex = new RegExp(`${text.join('|')}`, 'g');
-        cy.get(`[data-test-id="${event.action}"]`).within(() => {
+        cy.get(`[data-testid="${event.action}"]`).within(() => {
           cy.contains(regex);
         });
       });

--- a/packages/manager/cypress/e2e/core/notificationsAndEvents/notifications.spec.ts
+++ b/packages/manager/cypress/e2e/core/notificationsAndEvents/notifications.spec.ts
@@ -23,11 +23,11 @@ describe('verify notification types and icons', () => {
     cy.visitWithLogin('/linodes');
     cy.wait('@mockNotifications');
     cy.get('button[aria-label="Notifications"]').click();
-    cy.get('[data-test-id="showMoreButton"').click();
+    cy.get('[data-testid="showMoreButton"').click();
     notifications.forEach((notification) => {
-      cy.get(`[data-test-id="${notification.type}"]`).within(() => {
+      cy.get(`[data-testid="${notification.type}"]`).within(() => {
         if (notification.severity != 'minor') {
-          cy.get(`[data-test-id="${notification.severity + 'Icon'}"]`);
+          cy.get(`[data-testid="${notification.severity + 'Icon'}"]`);
         }
       });
     });

--- a/packages/manager/src/components/DeletionDialog/DeletionDialog.test.tsx
+++ b/packages/manager/src/components/DeletionDialog/DeletionDialog.test.tsx
@@ -133,7 +133,7 @@ describe('DeletionDialog', () => {
     expect(deleteButton).toBeDisabled();
 
     const loadingSvgIcon = deleteButton.querySelector(
-      '[data-test-id="ReloadIcon"]'
+      '[data-testid="loadingIcon"]'
     );
 
     expect(loadingSvgIcon).toBeInTheDocument();

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -45,7 +45,7 @@ export const EventRow = (props: EventRowProps) => {
   } = formatProgressEvent(event);
 
   return (
-    <TableRow data-qa-event-row data-test-id={action}>
+    <TableRow data-qa-event-row data-testid={action}>
       <TableCell data-qa-event-message-cell>
         <Box sx={{ mt: showProgress ? 0.5 : 0 }}>{message}</Box>
         {showProgress && (

--- a/packages/manager/src/features/NotificationCenter/Notifications/NotificationCenterNotificationMessage.tsx
+++ b/packages/manager/src/features/NotificationCenter/Notifications/NotificationCenterNotificationMessage.tsx
@@ -49,7 +49,7 @@ export const NotificationCenterNotificationMessage = (
           alignItem: 'flex-start',
           display: 'flex',
         }}
-        data-test-id={notification.type}
+        data-testid={notification.type}
       >
         <Box
           sx={{
@@ -71,7 +71,7 @@ export const NotificationCenterNotificationMessage = (
                 sx={{
                   fill: theme.color.red,
                 }}
-                data-test-id={`${severity}Icon`}
+                data-testid={`${severity}Icon`}
               />
             ) : null}
             {severity === 'major' ? (
@@ -79,7 +79,7 @@ export const NotificationCenterNotificationMessage = (
                 sx={{
                   fill: theme.palette.warning.dark,
                 }}
-                data-test-id={severity + 'Icon'}
+                data-testid={severity + 'Icon'}
               />
             ) : null}
           </Box>

--- a/packages/manager/src/features/NotificationCenter/Notifications/NotificationCenterNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/Notifications/NotificationCenterNotifications.tsx
@@ -70,7 +70,7 @@ export const NotificationCenterNotifications = React.memo(
                 textDecoration: 'none !important',
               })}
               aria-label={`Display all ${content.length} items`}
-              data-test-id="showMoreButton"
+              data-testid="showMoreButton"
               onClick={() => setShowAll(!showAll)}
             >
               {showAll ? 'Collapse' : `${content.length - count} more`}

--- a/packages/ui/.changeset/pr-11634-tech-stories-1739192088418.md
+++ b/packages/ui/.changeset/pr-11634-tech-stories-1739192088418.md
@@ -1,5 +1,5 @@
 ---
-'@linode/ui': Tech Stories
+'@linode/ui': Added
 ---
 
-Add eslint rules to disallow `data-test-id` attributes and enforce type-safe equality operators ([#11634](https://github.com/linode/manager/pull/11634))
+ESLint rules to disallow `data-test-id` attributes and enforce type-safe equality operators ([#11634](https://github.com/linode/manager/pull/11634))

--- a/packages/ui/.changeset/pr-11634-tech-stories-1739192088418.md
+++ b/packages/ui/.changeset/pr-11634-tech-stories-1739192088418.md
@@ -1,0 +1,5 @@
+---
+'@linode/ui': Tech Stories
+---
+
+Add eslint rules to disallow `data-test-id` attributes and enforce type-safe equality operators ([#11634](https://github.com/linode/manager/pull/11634))

--- a/packages/ui/.eslintrc.json
+++ b/packages/ui/.eslintrc.json
@@ -35,6 +35,14 @@
     "camelcase": ["warn", { "properties": "always" }],
     "comma-dangle": "off",
     "curly": "warn",
+    "eqeqeq": "warn",
+    "no-restricted-syntax": [
+      "error",
+      {
+        "message": "The 'data-test-id' attribute is not allowed; use 'data-testid' instead.",
+        "selector": "JSXAttribute[name.name='data-test-id']"
+      }
+    ],
     "no-unused-vars": [
       "warn",
       {


### PR DESCRIPTION
## Description 📝

Replace `data-test-id` attributes with `data-testid` and add eslint rules

We have a lot of erroneous `data-test-id` attributes defined throughout the codebase. These don't offer the same compatibility with Testing Library's functions and should be replaced with `data-testid` to avoid confusion.

## Changes  🔄
- Replace `data-test-id` attributes with `data-testid`
- Add eslint rules (in `manager` and `ui` package) for:
  - Disallow the use of `data-test-id` attribute
  - To use the type-safe equality operators 

## Target release date 🗓️
N/A

## Preview 📷
![Screenshot 2025-02-10 at 1 12 02 PM](https://github.com/user-attachments/assets/4a29bd8b-73b5-4987-8438-3a870e3dcb2c)
![Screenshot 2025-02-10 at 1 16 24 PM](https://github.com/user-attachments/assets/6166ba6a-918c-4656-a7d4-afc5a872023f)

## How to test 🧪
- Ensure everything builds properly
- Ensure any violations of the new rules trigger warnings/errors in your IDE
- To confirm if unit tests pass:
Run `yarn test`
- To confirm if E2E tests pass:
Rebuild and serve Cloud Manager by running `yarn && yarn build && yarn start:manager:ci`, then in another console session run `yarn cy:run`. Alternatively, we can rely on our automated PR tests.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules