### PR TITLE
fix: [M3-9269] - Switch LKE Node Pool footer order with pagination

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -241,6 +241,14 @@ export const NodeTable = React.memo((props: Props) => {
                   )}
                 </TableBody>
               </Table>
+              <PaginationFooter
+                count={count}
+                eventCategory="Node Table"
+                handlePageChange={handlePageChange}
+                handleSizeChange={handlePageSizeChange}
+                page={page}
+                pageSize={pageSize}
+              />
               <StyledTableFooter>
                 <StyledPoolInfoBox>
                   {isDiskEncryptionFeatureEnabled &&
@@ -265,14 +273,6 @@ export const NodeTable = React.memo((props: Props) => {
                 </StyledPoolInfoBox>
                 <TagCell tags={tags} updateTags={updateTags} view="inline" />
               </StyledTableFooter>
-              <PaginationFooter
-                count={count}
-                eventCategory="Node Table"
-                handlePageChange={handlePageChange}
-                handleSizeChange={handlePageSizeChange}
-                page={page}
-                pageSize={pageSize}
-              />
             </>
           )}
         </Paginate>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -45,6 +45,7 @@ import {
   invoiceFactory,
   invoiceItemFactory,
   kubeEndpointFactory,
+  kubeLinodeFactory,
   kubernetesAPIResponse,
   kubernetesVersionFactory,
   linodeConfigFactory,
@@ -849,9 +850,15 @@ export const handlers = [
     const unencryptedPools = nodePoolFactory.buildList(5, {
       disk_encryption: 'disabled',
     });
-    nodePoolFactory.resetSequenceNumber();
+    const paginatedPool = nodePoolFactory.buildList(1, {
+      nodes: kubeLinodeFactory.buildList(26),
+    });
     return HttpResponse.json(
-      makeResourcePage([...encryptedPools, ...unencryptedPools])
+      makeResourcePage([
+        ...encryptedPools,
+        ...unencryptedPools,
+        ...paginatedPool,
+      ])
     );
   }),
   http.get('*/lke/clusters/*/api-endpoints', async () => {


### PR DESCRIPTION
## Description 📝
In NodeTable.tsx, we have two footers: StyledTableFooter (which contains StyledPoolInfoBox, listing the pool id, encryption status, and [recently added] tags) and PaginationFooter. These footers are displaying in the incorrect order and makes the table look broken when there are >25 nodes in the pool, which is made even more apparent if a user were to add multiple tags.
 
This PR simply switches the order the PaginationFooter and StyledTableFooter are displayed.

## Changes  🔄
- Swaps the order of the Node Pool footers
- Updates the legacy mocks to include a pool with paginated nodes (we do have M3-9205 in the backlog to switch all of LKE over to the MSW 2.0, but in the meantime...)

## Target release date 🗓️

2/25

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-02-10 at 9 07 16 AM](https://github.com/user-attachments/assets/08c7244a-2219-4e57-b393-4de1fabdceb0) | ![Screenshot 2025-02-10 at 2 04 32 PM](https://github.com/user-attachments/assets/64657cde-7188-4ff2-b946-ce00193e9ad2) |

## How to test 🧪

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Check out `develop` and make the same edits to the `serverHandler.ts` GET /pools request that this PR does to mock a pool with >25 nodes for pagination purposes
- [ ] Turn on the MSW with the Legacy MSW Handler preset
- [ ] Go to the LKE cluster details page and observe the broken looking table for the node pool that is paginated

### Verification steps

(How to verify changes)
- [ ] Check out this branch
- [ ] Turn on the MSW with the Legacy MSW Handler preset
- [ ] Go to the LKE cluster details page and observe the no-longer-broken-looking table for the node pool that is paginated

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
