### PR TITLE
upcoming: [M3-9104] - Implement Network Interfaces accordion in Account Settings

### DIFF
--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -99,7 +99,7 @@ export const linodeInterfaceAccountSettings = [
   'legacy_config_default_but_linode_allowed',
   'linode_default_but_legacy_config_allowed',
   'linode_only',
-];
+] as const;
 
 export type LinodeInterfaceAccountSetting = typeof linodeInterfaceAccountSettings[number];
 

--- a/packages/manager/.changeset/pr-11640-upcoming-features-1739304484421.md
+++ b/packages/manager/.changeset/pr-11640-upcoming-features-1739304484421.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add NetworkInterfaceType accordion to Account Settings ([#11640](https://github.com/linode/manager/pull/11640))

--- a/packages/manager/src/factories/accountSettings.ts
+++ b/packages/manager/src/factories/accountSettings.ts
@@ -5,7 +5,7 @@ import type { AccountSettings } from '@linode/api-v4/lib/account/types';
 export const accountSettingsFactory = Factory.Sync.makeFactory<AccountSettings>(
   {
     backups_enabled: false,
-    interfaces_for_new_linodes: 'legacy_config',
+    interfaces_for_new_linodes: 'legacy_config_only',
     longview_subscription: null,
     managed: false,
     network_helper: false,

--- a/packages/manager/src/features/Account/GlobalSettings.tsx
+++ b/packages/manager/src/features/Account/GlobalSettings.tsx
@@ -9,15 +9,17 @@ import {
 } from 'src/queries/account/settings';
 import { useAllLinodesQuery } from 'src/queries/linodes/linodes';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { useIsLinodeInterfacesEnabled } from 'src/utilities/linodes';
 
 import { BackupDrawer } from '../Backups';
 import AutoBackups from './AutoBackups';
 import CloseAccountSetting from './CloseAccountSetting';
 import { EnableManaged } from './EnableManaged';
 import NetworkHelper from './NetworkHelper';
+import { NetworkInterfaceType } from './NetworkInterfaceType';
 import { ObjectStorageSettings } from './ObjectStorageSettings';
 
-import type { APIError } from '@linode/api-v4';
+import type { APIError, LinodeInterfaceAccountSetting } from '@linode/api-v4';
 
 const GlobalSettings = () => {
   const [isBackupsDrawerOpen, setIsBackupsDrawerOpen] = React.useState(false);
@@ -28,6 +30,7 @@ const GlobalSettings = () => {
     isLoading: accountSettingsLoading,
   } = useAccountSettings();
 
+  const linodeInterfacesFlag = useIsLinodeInterfacesEnabled();
   const { data: linodes } = useAllLinodesQuery();
 
   const hasLinodesWithoutBackups =
@@ -67,7 +70,12 @@ const GlobalSettings = () => {
     return null;
   }
 
-  const { backups_enabled, managed, network_helper } = accountSettings;
+  const {
+    backups_enabled,
+    interfaces_for_new_linodes,
+    managed,
+    network_helper,
+  } = accountSettings;
 
   const toggleAutomaticBackups = () => {
     updateAccount({ backups_enabled: !backups_enabled }).catch(displayError);
@@ -77,8 +85,22 @@ const GlobalSettings = () => {
     updateAccount({ network_helper: !network_helper }).catch(displayError);
   };
 
+  const updateInterfaceSetting = (
+    newInterfaceSetting: LinodeInterfaceAccountSetting
+  ) => {
+    updateAccount({ interfaces_for_new_linodes: newInterfaceSetting }).catch(
+      displayError
+    );
+  };
+
   return (
     <div>
+      {linodeInterfacesFlag?.enabled && (
+        <NetworkInterfaceType
+          interfacesSetting={interfaces_for_new_linodes}
+          updateInterfaceSettings={updateInterfaceSetting}
+        />
+      )}
       <AutoBackups
         backups_enabled={backups_enabled}
         hasLinodesWithoutBackups={hasLinodesWithoutBackups}

--- a/packages/manager/src/features/Account/GlobalSettings.tsx
+++ b/packages/manager/src/features/Account/GlobalSettings.tsx
@@ -19,7 +19,7 @@ import NetworkHelper from './NetworkHelper';
 import { NetworkInterfaceType } from './NetworkInterfaceType';
 import { ObjectStorageSettings } from './ObjectStorageSettings';
 
-import type { APIError, LinodeInterfaceAccountSetting } from '@linode/api-v4';
+import type { APIError } from '@linode/api-v4';
 
 const GlobalSettings = () => {
   const [isBackupsDrawerOpen, setIsBackupsDrawerOpen] = React.useState(false);
@@ -70,12 +70,7 @@ const GlobalSettings = () => {
     return null;
   }
 
-  const {
-    backups_enabled,
-    interfaces_for_new_linodes,
-    managed,
-    network_helper,
-  } = accountSettings;
+  const { backups_enabled, managed, network_helper } = accountSettings;
 
   const toggleAutomaticBackups = () => {
     updateAccount({ backups_enabled: !backups_enabled }).catch(displayError);
@@ -85,22 +80,9 @@ const GlobalSettings = () => {
     updateAccount({ network_helper: !network_helper }).catch(displayError);
   };
 
-  const updateInterfaceSetting = (
-    newInterfaceSetting: LinodeInterfaceAccountSetting
-  ) => {
-    updateAccount({ interfaces_for_new_linodes: newInterfaceSetting }).catch(
-      displayError
-    );
-  };
-
   return (
     <div>
-      {linodeInterfacesFlag?.enabled && (
-        <NetworkInterfaceType
-          interfacesSetting={interfaces_for_new_linodes}
-          updateInterfaceSettings={updateInterfaceSetting}
-        />
-      )}
+      {linodeInterfacesFlag?.enabled && <NetworkInterfaceType />}
       <AutoBackups
         backups_enabled={backups_enabled}
         hasLinodesWithoutBackups={hasLinodesWithoutBackups}

--- a/packages/manager/src/features/Account/NetworkInterfaceType.test.tsx
+++ b/packages/manager/src/features/Account/NetworkInterfaceType.test.tsx
@@ -1,0 +1,31 @@
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { NetworkInterfaceType } from './NetworkInterfaceType';
+
+import type { LinodeInterfaceAccountSetting } from '@linode/api-v4';
+
+const props = {
+  interfacesSetting: 'legacy_config_only' as LinodeInterfaceAccountSetting,
+  updateInterfaceSettings: vi.fn(),
+};
+describe('NetworkInterfaces', () => {
+  it('renders the NetworkInterfaces accordion', () => {
+    const { getByText } = renderWithTheme(<NetworkInterfaceType {...props} />);
+
+    expect(getByText('Network Interface Type')).toBeVisible();
+    expect(getByText('Interfaces for new Linodes')).toBeVisible();
+    expect(getByText('Save')).toBeVisible();
+  });
+
+  it('confirms updateInterfaceSettings is called when clicking save', async () => {
+    const { getByText } = renderWithTheme(<NetworkInterfaceType {...props} />);
+
+    const saveButton = getByText('Save');
+    await userEvent.click(saveButton);
+
+    expect(props.updateInterfaceSettings).toHaveBeenCalled();
+  });
+});

--- a/packages/manager/src/features/Account/NetworkInterfaceType.tsx
+++ b/packages/manager/src/features/Account/NetworkInterfaceType.tsx
@@ -1,0 +1,95 @@
+import {
+  Accordion,
+  Autocomplete,
+  BetaChip,
+  Box,
+  Button,
+  Stack,
+  Typography,
+} from '@linode/ui';
+import * as React from 'react';
+
+import { Link } from 'src/components/Link';
+
+import type { LinodeInterfaceAccountSetting } from '@linode/api-v4';
+import type { SelectOption } from '@linode/ui';
+
+interface Props {
+  interfacesSetting: LinodeInterfaceAccountSetting;
+  updateInterfaceSettings: (
+    newInterfaceSettings: LinodeInterfaceAccountSetting
+  ) => void;
+}
+
+const accountSettingInterfaceOptions: SelectOption<LinodeInterfaceAccountSetting>[] = [
+  {
+    label: 'Configuration Profile Interfaces but allow Linode Interfaces',
+    value: 'legacy_config_default_but_linode_allowed',
+  },
+  {
+    label: 'Linode Interfaces but allow Configuration Profile Interfaces',
+    value: 'linode_default_but_legacy_config_allowed',
+  },
+  {
+    label: 'Configuration Profile Interfaces Only',
+    value: 'legacy_config_only',
+  },
+  {
+    label: 'Linode Interfaces Only',
+    value: 'linode_only',
+  },
+];
+
+export const NetworkInterfaceType = (props: Props) => {
+  const { interfacesSetting, updateInterfaceSettings } = props;
+  const [
+    selectedInterfaceSetting,
+    setSelectedInterfaceSetting,
+  ] = React.useState<LinodeInterfaceAccountSetting>(interfacesSetting);
+
+  return (
+    <Accordion
+      defaultExpanded
+      heading="Network Interface Type"
+      headingChip={<BetaChip color="primary" />}
+    >
+      <Stack>
+        <Typography variant="body1">
+          Set the network interface for your Linode instances to use during
+          creation. <Link to="/#">Learn more</Link>.
+        </Typography>
+        <Autocomplete
+          onChange={(_, item: SelectOption<LinodeInterfaceAccountSetting>) => {
+            setSelectedInterfaceSetting(item.value);
+          }}
+          sx={(theme) => ({
+            [theme.breakpoints.up('md')]: {
+              minWidth: '458px',
+            },
+          })}
+          textFieldProps={{
+            tooltipText: '@TODO Linode Interfaces - get copy for this tooltip',
+          }}
+          value={accountSettingInterfaceOptions.find(
+            (option) => option.value === selectedInterfaceSetting
+          )}
+          disableClearable
+          label="Interfaces for new Linodes"
+          options={accountSettingInterfaceOptions}
+        />
+        <Box
+          sx={(theme) => ({
+            marginTop: theme.spacing(2),
+          })}
+        >
+          <Button
+            buttonType="outlined"
+            onClick={() => updateInterfaceSettings(selectedInterfaceSetting)}
+          >
+            Save
+          </Button>
+        </Box>
+      </Stack>
+    </Accordion>
+  );
+};

--- a/packages/manager/src/features/Account/NetworkInterfaceType.tsx
+++ b/packages/manager/src/features/Account/NetworkInterfaceType.tsx
@@ -54,12 +54,12 @@ export const NetworkInterfaceType = () => {
   const values = {
     interfaces_for_new_linodes:
       accountSettings?.interfaces_for_new_linodes ??
-      'legacy_config_default_but_linode_allowed',
+      'linode_default_but_legacy_config_allowed',
   };
 
   const {
     control,
-    formState: { isDirty, isSubmitting },
+    formState: { isSubmitting }, // { isDirty, isSubmitting }
     handleSubmit,
     setError,
   } = useForm<InterfaceSettingValues>({
@@ -124,7 +124,7 @@ export const NetworkInterfaceType = () => {
           >
             <Button
               buttonType="outlined"
-              disabled={!isDirty}
+              // disabled={!isDirty}
               loading={isSubmitting}
               type="submit"
             >

--- a/packages/manager/src/features/Account/NetworkInterfaceType.tsx
+++ b/packages/manager/src/features/Account/NetworkInterfaceType.tsx
@@ -59,7 +59,7 @@ export const NetworkInterfaceType = () => {
 
   const {
     control,
-    formState: { isSubmitting }, // { isDirty, isSubmitting }
+    formState: { isDirty, isSubmitting },
     handleSubmit,
     setError,
   } = useForm<InterfaceSettingValues>({
@@ -98,10 +98,14 @@ export const NetworkInterfaceType = () => {
                 }}
                 sx={(theme) => ({
                   [theme.breakpoints.up('md')]: {
-                    minWidth: '458px',
+                    minWidth: '480px',
                   },
                 })}
                 textFieldProps={{
+                  expand: true,
+                  sx: {
+                    width: '468px',
+                  },
                   tooltipText:
                     '@TODO Linode Interfaces - get copy for this tooltip',
                 }}
@@ -124,7 +128,7 @@ export const NetworkInterfaceType = () => {
           >
             <Button
               buttonType="outlined"
-              // disabled={!isDirty}
+              disabled={!isDirty}
               loading={isSubmitting}
               type="submit"
             >

--- a/packages/manager/src/features/Account/NetworkInterfaceType.tsx
+++ b/packages/manager/src/features/Account/NetworkInterfaceType.tsx
@@ -1,9 +1,9 @@
 import {
   Accordion,
-  Autocomplete,
   BetaChip,
   Box,
   Button,
+  Select,
   Stack,
   Typography,
 } from '@linode/ui';
@@ -89,7 +89,7 @@ export const NetworkInterfaceType = () => {
           </Typography>
           <Controller
             render={({ field, fieldState }) => (
-              <Autocomplete
+              <Select
                 onChange={(
                   _,
                   item: SelectOption<LinodeInterfaceAccountSetting>
@@ -112,7 +112,6 @@ export const NetworkInterfaceType = () => {
                 value={accountSettingInterfaceOptions.find(
                   (option) => option.value === field.value
                 )}
-                disableClearable
                 errorText={fieldState.error?.message}
                 label="Interfaces for new Linodes"
                 options={accountSettingInterfaceOptions}

--- a/packages/ui/src/components/Accordion/Accordion.tsx
+++ b/packages/ui/src/components/Accordion/Accordion.tsx
@@ -56,6 +56,10 @@ export interface AccordionProps extends _AccordionProps {
    */
   heading: React.ReactNode | string;
   /**
+   * A chip to render in the heading
+   */
+  headingChip?: React.JSX.Element;
+  /**
    * A number to display in the Accordion's heading
    */
   headingNumberCount?: number;
@@ -100,6 +104,7 @@ export const Accordion = (props: AccordionProps) => {
     error,
     expandIconClassNames,
     heading,
+    headingChip,
     headingNumberCount,
     headingProps,
     success,
@@ -130,6 +135,7 @@ export const Accordion = (props: AccordionProps) => {
       >
         <Typography {...headingProps} data-qa-panel-subheading variant="h3">
           {heading}
+          {headingChip}
         </Typography>
         {headingNumberCount && headingNumberCount > 0 ? (
           <span className={classes.itemCount}>{headingNumberCount}</span>


### PR DESCRIPTION
## Description 📝
- Adds network Interface type accordion to account settings
- type cleanup in api package

## Preview 📷

![image](https://github.com/user-attachments/assets/ef9a1cbe-02f3-4bd9-bbc9-3a83d7e89a3c)

## How to test 🧪
- Confirm Network Interface Type paper is hidden when feature flag is disabled
- When flag is enabled, confirm clicking 'save' sends a request with the expected payload (note: the `interfaces_for_new_linodes` field isn't populated in the returned AccountSettings object yet...)
- NOTE: there may still be some tweaks to the accordion's final design 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
