### PR TITLE
upcoming: [DI-21796] - Make node type filter dynamic based on cluster size

### DIFF
--- a/packages/manager/.changeset/pr-11643-upcoming-features-1739246456461.md
+++ b/packages/manager/.changeset/pr-11643-upcoming-features-1739246456461.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update Node-Type filter from static to dynamic in CloudPulse ([#11643](https://github.com/linode/manager/pull/11643))

--- a/packages/manager/cypress/e2e/core/cloudpulse/cloudpulse-dashboard-errors.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/cloudpulse-dashboard-errors.spec.ts
@@ -172,9 +172,9 @@ describe('Tests for API error handling', () => {
     ui.autocompletePopper.findByTitle(clusterName).should('be.visible').click();
 
     ui.button
-    .findByAttribute('aria-label', 'Close')
-    .should('be.visible')
-    .click();
+      .findByAttribute('aria-label', 'Close')
+      .should('be.visible')
+      .click();
 
     // Select a Node from the autocomplete input.
     ui.autocomplete
@@ -249,9 +249,9 @@ describe('Tests for API error handling', () => {
     ui.autocompletePopper.findByTitle(clusterName).should('be.visible').click();
 
     ui.button
-    .findByAttribute('aria-label', 'Close')
-    .should('be.visible')
-    .click();
+      .findByAttribute('aria-label', 'Close')
+      .should('be.visible')
+      .click();
 
     // Select a Node from the autocomplete input.
     ui.autocomplete
@@ -332,9 +332,9 @@ describe('Tests for API error handling', () => {
     ui.autocompletePopper.findByTitle(clusterName).should('be.visible').click();
 
     ui.button
-    .findByAttribute('aria-label', 'Close')
-    .should('be.visible')
-    .click();
+      .findByAttribute('aria-label', 'Close')
+      .should('be.visible')
+      .click();
     
     //  Select a node type from the autocomplete input.
     ui.autocomplete

--- a/packages/manager/cypress/e2e/core/cloudpulse/cloudpulse-dashboard-errors.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/cloudpulse-dashboard-errors.spec.ts
@@ -171,7 +171,10 @@ describe('Tests for API error handling', () => {
 
     ui.autocompletePopper.findByTitle(clusterName).should('be.visible').click();
 
-    cy.get('body').click('topRight');
+    ui.button
+    .findByAttribute('aria-label', 'Close')
+    .should('be.visible')
+    .click();
 
     // Select a Node from the autocomplete input.
     ui.autocomplete
@@ -245,7 +248,10 @@ describe('Tests for API error handling', () => {
 
     ui.autocompletePopper.findByTitle(clusterName).should('be.visible').click();
 
-    cy.get('body').click('topRight');
+    ui.button
+    .findByAttribute('aria-label', 'Close')
+    .should('be.visible')
+    .click();
 
     // Select a Node from the autocomplete input.
     ui.autocomplete
@@ -310,8 +316,6 @@ describe('Tests for API error handling', () => {
 
     ui.autocompletePopper.findByTitle(engine).should('be.visible').click();
 
-    cy.get('body').click('topRight');
-
     //  Select a region from the dropdown.
     ui.regionSelect.find().click();
     ui.regionSelect
@@ -327,7 +331,10 @@ describe('Tests for API error handling', () => {
 
     ui.autocompletePopper.findByTitle(clusterName).should('be.visible').click();
 
-    cy.get('body').click('topRight');
+    ui.button
+    .findByAttribute('aria-label', 'Close')
+    .should('be.visible')
+    .click();
     
     //  Select a node type from the autocomplete input.
     ui.autocomplete

--- a/packages/manager/cypress/e2e/core/cloudpulse/cloudpulse-dashboard-errors.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/cloudpulse-dashboard-errors.spec.ts
@@ -106,7 +106,7 @@ const databaseMock: Database = databaseFactory.build({
   region: mockRegion.id,
   version: '1',
   status: 'provisioning',
-  cluster_size: 1,
+  cluster_size: 3,
   engine: 'mysql',
 });
 const mockAccount = accountFactory.build();
@@ -170,6 +170,8 @@ describe('Tests for API error handling', () => {
       .type(clusterName);
 
     ui.autocompletePopper.findByTitle(clusterName).should('be.visible').click();
+
+    cy.get('body').click('topRight');
 
     // Select a Node from the autocomplete input.
     ui.autocomplete
@@ -243,6 +245,8 @@ describe('Tests for API error handling', () => {
 
     ui.autocompletePopper.findByTitle(clusterName).should('be.visible').click();
 
+    cy.get('body').click('topRight');
+
     // Select a Node from the autocomplete input.
     ui.autocomplete
       .findByLabel('Node Type')
@@ -306,6 +310,8 @@ describe('Tests for API error handling', () => {
 
     ui.autocompletePopper.findByTitle(engine).should('be.visible').click();
 
+    cy.get('body').click('topRight');
+
     //  Select a region from the dropdown.
     ui.regionSelect.find().click();
     ui.regionSelect
@@ -321,6 +327,8 @@ describe('Tests for API error handling', () => {
 
     ui.autocompletePopper.findByTitle(clusterName).should('be.visible').click();
 
+    cy.get('body').click('topRight');
+    
     //  Select a node type from the autocomplete input.
     ui.autocomplete
       .findByLabel('Node Type')

--- a/packages/manager/cypress/e2e/core/cloudpulse/dbaas-widgets-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/dbaas-widgets-verification.spec.ts
@@ -260,7 +260,10 @@ describe('Integration Tests for DBaaS Dashboard ', () => {
 
     ui.autocompletePopper.findByTitle(clusterName).should('be.visible').click();
 
-    cy.get('body').click('topRight'); // close the autocompletePopper of Database Clusters
+    ui.button
+    .findByAttribute('aria-label', 'Close')
+    .should('be.visible')
+    .click();
     
     // Select a Node from the autocomplete input.
     ui.autocomplete

--- a/packages/manager/cypress/e2e/core/cloudpulse/dbaas-widgets-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/dbaas-widgets-verification.spec.ts
@@ -261,9 +261,9 @@ describe('Integration Tests for DBaaS Dashboard ', () => {
     ui.autocompletePopper.findByTitle(clusterName).should('be.visible').click();
 
     ui.button
-    .findByAttribute('aria-label', 'Close')
-    .should('be.visible')
-    .click();
+      .findByAttribute('aria-label', 'Close')
+      .should('be.visible')
+      .click();
     
     // Select a Node from the autocomplete input.
     ui.autocomplete

--- a/packages/manager/cypress/e2e/core/cloudpulse/dbaas-widgets-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/dbaas-widgets-verification.spec.ts
@@ -172,7 +172,7 @@ const databaseMock: Database = databaseFactory.build({
   region: mockRegion.label,
   version: '1',
   status: 'provisioning',
-  cluster_size: 1,
+  cluster_size: 2,
   engine: 'mysql',
   hosts: {
     primary: undefined,
@@ -260,6 +260,8 @@ describe('Integration Tests for DBaaS Dashboard ', () => {
 
     ui.autocompletePopper.findByTitle(clusterName).should('be.visible').click();
 
+    cy.get('body').click('topRight'); // close the autocompletePopper of Database Clusters
+    
     // Select a Node from the autocomplete input.
     ui.autocomplete
       .findByLabel('Node Type')

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.test.tsx
@@ -112,7 +112,7 @@ describe('CloudPulseDashboardWithFilters component tests', () => {
       <CloudPulseDashboardWithFilters dashboardId={1} resource={1} />
     );
 
-    expect(screen.getByTestId(circleProgress)).toBeDefined(); // the dashboards started to render
+    expect(screen.getAllByTestId(circleProgress)).toBeDefined(); // the dashboards started to render
   });
 
   it('renders a CloudPulseDashboardWithFilters component with mandatory filter error for dbaas', () => {

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.test.tsx
@@ -113,6 +113,8 @@ describe('CloudPulseDashboardWithFilters component tests', () => {
     );
 
     expect(screen.getAllByTestId(circleProgress)).toBeDefined(); // the dashboards started to render
+    expect(screen.getByTestId('preset-select')).toBeInTheDocument();
+    expect(screen.getByTestId('node-type-select')).toBeInTheDocument();
   });
 
   it('renders a CloudPulseDashboardWithFilters component with mandatory filter error for dbaas', () => {

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
@@ -168,10 +168,10 @@ export const CloudPulseDashboardWithFilters = React.memo(
             {isFilterBuilderNeeded && (
               <CloudPulseDashboardFilterBuilder
                 dashboard={dashboard}
-                database_ids={[resource]}
                 emitFilterChange={onFilterChange}
                 handleToggleAppliedFilter={toggleAppliedFilter}
                 isServiceAnalyticsIntegration
+                resource_ids={[resource]}
               />
             )}
             <Grid item mb={3} mt={-3} xs={12}>

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
@@ -168,6 +168,7 @@ export const CloudPulseDashboardWithFilters = React.memo(
             {isFilterBuilderNeeded && (
               <CloudPulseDashboardFilterBuilder
                 dashboard={dashboard}
+                database_ids={[resource]}
                 emitFilterChange={onFilterChange}
                 handleToggleAppliedFilter={toggleAppliedFilter}
                 isServiceAnalyticsIntegration

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
@@ -284,49 +284,6 @@ it('test getNodeTypeProperties with disabled true', () => {
   }
 });
 
-it('test checkIfWeNeedToDisableFilterByFilterKey method all cases', () => {
-  let result = checkIfWeNeedToDisableFilterByFilterKey(
-    'resource_id',
-    { region: 'us-east' },
-    mockDashboard
-  );
-
-  expect(result).toEqual(false);
-
-  result = checkIfWeNeedToDisableFilterByFilterKey(
-    'resource_id',
-    { region: undefined },
-    mockDashboard
-  );
-
-  expect(result).toEqual(true);
-
-  result = checkIfWeNeedToDisableFilterByFilterKey(
-    'resource_id',
-    {},
-    mockDashboard
-  );
-
-  expect(result).toEqual(true);
-
-  result = checkIfWeNeedToDisableFilterByFilterKey(
-    'resource_id',
-    { region: 'us-east', tags: undefined },
-    mockDashboard,
-    { ['region']: 'us-east', ['tags']: ['tag-1'] }
-  );
-
-  expect(result).toEqual(true); // disabled is true as tags are not updated in dependent filters
-
-  result = checkIfWeNeedToDisableFilterByFilterKey(
-    'node_type',
-    { resource_id: undefined },
-    dbaasDashboard
-  );
-
-  expect(result).toEqual(true); // disabled is true as dependent filter is undefined
-});
-
 it('test buildXfilter method', () => {
   const resourceSelectionConfig = linodeConfig?.filters.find(
     (filterObj) => filterObj.name === 'Resources'

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
@@ -3,7 +3,7 @@ import { DateTime } from 'luxon';
 import { dashboardFactory } from 'src/factories';
 import { databaseQueries } from 'src/queries/databases/databases';
 
-import { RESOURCES } from './constants';
+import { RESOURCE_ID, RESOURCES } from './constants';
 import {
   buildXFilter,
   checkIfAllMandatoryFiltersAreSelected,
@@ -222,6 +222,39 @@ describe('checkIfWeNeedToDisableFilterByFilterKey', () => {
 });
 
 it('test getNodeTypeProperties', () => {
+  const nodeTypeSelectionConfig = dbaasConfig?.filters.find(
+    (filterObj) => filterObj.name === 'Node Type'
+  );
+
+  expect(nodeTypeSelectionConfig).toBeDefined();
+
+  if (nodeTypeSelectionConfig) {
+    const {
+      database_ids,
+      disabled,
+      handleNodeTypeChange,
+      label,
+      savePreferences,
+    } = getNodeTypeProperties(
+      {
+        config: nodeTypeSelectionConfig,
+        dashboard: dbaasDashboard,
+        dependentFilters: { [RESOURCE_ID]: [1] },
+        isServiceAnalyticsIntegration: false,
+        resource_ids: [1],
+      },
+      vi.fn()
+    );
+    const { name } = nodeTypeSelectionConfig.configuration;
+    expect(database_ids).toEqual([1]);
+    expect(handleNodeTypeChange).toBeDefined();
+    expect(savePreferences).toEqual(true);
+    expect(disabled).toEqual(false);
+    expect(label).toEqual(name);
+  }
+});
+
+it('test getNodeTypeProperties with disabled true', () => {
   const nodeTypeSelectionConfig = dbaasConfig?.filters.find(
     (filterObj) => filterObj.name === 'Node Type'
   );

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
@@ -7,7 +7,6 @@ import { RESOURCE_ID, RESOURCES } from './constants';
 import {
   buildXFilter,
   checkIfAllMandatoryFiltersAreSelected,
-  checkIfWeNeedToDisableFilterByFilterKey,
   constructAdditionalRequestFilters,
   getCustomSelectProperties,
   getMetricsCallCustomFilters,
@@ -16,6 +15,7 @@ import {
   getResourcesProperties,
   getTagsProperties,
   getTimeDurationProperties,
+  shouldDisableFilterByFilterKey,
 } from './FilterBuilder';
 import { deepEqual, getFilters } from './FilterBuilder';
 import { FILTER_CONFIG } from './FilterConfig';
@@ -181,10 +181,10 @@ it('test getResourceSelectionProperties method with disabled true', () => {
   }
 });
 
-describe('checkIfWeNeedToDisableFilterByFilterKey', () => {
+describe('shouldDisableFilterByFilterKey', () => {
   // resources filter has region as mandatory and tags as an optional filter, this should reflect in the dependent filters
   it('should enable filter when dependent filter region is provided', () => {
-    const result = checkIfWeNeedToDisableFilterByFilterKey(
+    const result = shouldDisableFilterByFilterKey(
       'resource_id',
       { region: 'us-east' },
       mockDashboard
@@ -193,7 +193,7 @@ describe('checkIfWeNeedToDisableFilterByFilterKey', () => {
   });
 
   it('should disable filter when dependent filter region is undefined', () => {
-    const result = checkIfWeNeedToDisableFilterByFilterKey(
+    const result = shouldDisableFilterByFilterKey(
       'resource_id',
       { region: undefined },
       mockDashboard
@@ -202,7 +202,7 @@ describe('checkIfWeNeedToDisableFilterByFilterKey', () => {
   });
 
   it('should disable filter when no dependent filters are provided', () => {
-    const result = checkIfWeNeedToDisableFilterByFilterKey(
+    const result = shouldDisableFilterByFilterKey(
       'resource_id',
       {},
       mockDashboard
@@ -211,7 +211,7 @@ describe('checkIfWeNeedToDisableFilterByFilterKey', () => {
   });
 
   it('should disable filter when required dependent filter is undefined in dependent filters but defined in preferences', () => {
-    const result = checkIfWeNeedToDisableFilterByFilterKey(
+    const result = shouldDisableFilterByFilterKey(
       'resource_id',
       { region: 'us-east', tags: undefined },
       mockDashboard,

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
@@ -11,6 +11,7 @@ import {
   constructAdditionalRequestFilters,
   getCustomSelectProperties,
   getMetricsCallCustomFilters,
+  getNodeTypeProperties,
   getRegionProperties,
   getResourcesProperties,
   getTagsProperties,
@@ -25,6 +26,8 @@ const mockDashboard = dashboardFactory.build();
 const linodeConfig = FILTER_CONFIG.get('linode');
 
 const dbaasConfig = FILTER_CONFIG.get('dbaas');
+
+const dbaasDashboard = dashboardFactory.build({ service_type: 'dbaas' });
 
 it('test getRegionProperties method', () => {
   const regionConfig = linodeConfig?.filters.find(
@@ -218,6 +221,36 @@ describe('checkIfWeNeedToDisableFilterByFilterKey', () => {
   });
 });
 
+it('test getNodeTypeProperties', () => {
+  const nodeTypeSelectionConfig = dbaasConfig?.filters.find(
+    (filterObj) => filterObj.name === 'Node Type'
+  );
+
+  expect(nodeTypeSelectionConfig).toBeDefined();
+
+  if (nodeTypeSelectionConfig) {
+    const {
+      disabled,
+      handleNodeTypeChange,
+      label,
+      savePreferences,
+    } = getNodeTypeProperties(
+      {
+        config: nodeTypeSelectionConfig,
+        dashboard: dbaasDashboard,
+        dependentFilters: {},
+        isServiceAnalyticsIntegration: false,
+      },
+      vi.fn()
+    );
+    const { name } = nodeTypeSelectionConfig.configuration;
+    expect(handleNodeTypeChange).toBeDefined();
+    expect(savePreferences).toEqual(true);
+    expect(disabled).toEqual(true);
+    expect(label).toEqual(name);
+  }
+});
+
 it('test checkIfWeNeedToDisableFilterByFilterKey method all cases', () => {
   let result = checkIfWeNeedToDisableFilterByFilterKey(
     'resource_id',
@@ -253,12 +286,12 @@ it('test checkIfWeNeedToDisableFilterByFilterKey method all cases', () => {
   expect(result).toEqual(true); // disabled is true as tags are not updated in dependent filters
 
   result = checkIfWeNeedToDisableFilterByFilterKey(
-    'tags',
-    { region: undefined },
-    mockDashboard
+    'node_type',
+    { resource_id: undefined },
+    dbaasDashboard
   );
 
-  expect(result).toEqual(true);
+  expect(result).toEqual(true); // disabled is true as dependent filter is undefined
 });
 
 it('test buildXfilter method', () => {

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -39,12 +39,12 @@ import type {
 interface CloudPulseFilterProperties {
   config: CloudPulseServiceTypeFilters;
   dashboard: Dashboard;
-  database_ids?: number[] | undefined;
   dependentFilters?: {
     [key: string]: FilterValueType;
   };
   isServiceAnalyticsIntegration: boolean;
   preferences?: AclpConfig;
+  resource_ids?: number[] | undefined;
 }
 
 interface CloudPulseMandatoryFilterCheckProps {
@@ -172,9 +172,9 @@ export const getNodeTypeProperties = (
   ) => void
 ): CloudPulseNodeTypeFilterProps => {
   const { filterKey, name: label, placeholder } = props.config.configuration;
-  const { dashboard, database_ids, dependentFilters, preferences } = props;
+  const { dashboard, dependentFilters, preferences, resource_ids } = props;
   return {
-    database_ids,
+    database_ids: resource_ids,
     defaultValue: preferences?.[NODE_TYPE],
     disabled: checkIfWeNeedToDisableFilterByFilterKey(
       filterKey,

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -11,10 +11,7 @@ import { CloudPulseSelectTypes } from './models';
 
 import type { FilterValueType } from '../Dashboard/CloudPulseDashboardLanding';
 import type { CloudPulseCustomSelectProps } from '../shared/CloudPulseCustomSelect';
-import type {
-  CloudPulseNodeTypeFilterProps,
-  CloudPulseNodeTypes,
-} from '../shared/CloudPulseNodeTypeFilter';
+import type { CloudPulseNodeTypeFilterProps } from '../shared/CloudPulseNodeTypeFilter';
 import type { CloudPulseRegionSelectProps } from '../shared/CloudPulseRegionSelect';
 import type {
   CloudPulseResources,
@@ -167,12 +164,19 @@ export const getResourcesProperties = (
 export const getNodeTypeProperties = (
   props: CloudPulseFilterProperties,
   handleNodeTypeChange: (
-    nodeType: CloudPulseNodeTypes | null,
+    nodeType: null | string | undefined,
+    label: string[],
     savePref?: boolean
   ) => void
 ): CloudPulseNodeTypeFilterProps => {
   const { filterKey, name: label, placeholder } = props.config.configuration;
-  const { dashboard, dependentFilters, preferences, resource_ids } = props;
+  const {
+    dashboard,
+    dependentFilters,
+    isServiceAnalyticsIntegration,
+    preferences,
+    resource_ids,
+  } = props;
   return {
     database_ids: resource_ids,
     defaultValue: preferences?.[NODE_TYPE],
@@ -184,7 +188,7 @@ export const getNodeTypeProperties = (
     handleNodeTypeChange,
     label,
     placeholder,
-    savePreferences: true,
+    savePreferences: !isServiceAnalyticsIntegration,
   };
 };
 

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -164,7 +164,7 @@ export const getResourcesProperties = (
 export const getNodeTypeProperties = (
   props: CloudPulseFilterProperties,
   handleNodeTypeChange: (
-    nodeType: null | string | undefined,
+    nodeType: string | undefined,
     label: string[],
     savePref?: boolean
   ) => void

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -74,7 +74,7 @@ export const getTagsProperties = (
   } = props;
   return {
     defaultValue: preferences?.[TAGS],
-    disabled: checkIfWeNeedToDisableFilterByFilterKey(
+    disabled: shouldDisableFilterByFilterKey(
       filterKey,
       dependentFilters ?? {},
       dashboard,
@@ -146,7 +146,7 @@ export const getResourcesProperties = (
   } = props;
   return {
     defaultValue: preferences?.[RESOURCES],
-    disabled: checkIfWeNeedToDisableFilterByFilterKey(
+    disabled: shouldDisableFilterByFilterKey(
       filterKey,
       dependentFilters ?? {},
       dashboard,
@@ -180,7 +180,7 @@ export const getNodeTypeProperties = (
   return {
     database_ids: resource_ids,
     defaultValue: preferences?.[NODE_TYPE],
-    disabled: checkIfWeNeedToDisableFilterByFilterKey(
+    disabled: shouldDisableFilterByFilterKey(
       filterKey,
       dependentFilters ?? {},
       dashboard
@@ -234,7 +234,7 @@ export const getCustomSelectProperties = (
       dashboard
     ),
     defaultValue: preferences?.[filterKey],
-    disabled: checkIfWeNeedToDisableFilterByFilterKey(
+    disabled: shouldDisableFilterByFilterKey(
       filterKey,
       dependentFilters ?? {},
       dashboard
@@ -325,7 +325,7 @@ export const buildXFilter = (
  * @param dashboard - the actual selected dashboard
  * @returns boolean | undefined
  */
-export const checkIfWeNeedToDisableFilterByFilterKey = (
+export const shouldDisableFilterByFilterKey = (
   filterKey: string,
   dependentFilters: {
     [key: string]: FilterValueType | TimeDuration;

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -1,4 +1,5 @@
 import {
+  NODE_TYPE,
   REGION,
   RELATIVE_TIME_DURATION,
   RESOURCE_ID,
@@ -10,6 +11,10 @@ import { CloudPulseSelectTypes } from './models';
 
 import type { FilterValueType } from '../Dashboard/CloudPulseDashboardLanding';
 import type { CloudPulseCustomSelectProps } from '../shared/CloudPulseCustomSelect';
+import type {
+  CloudPulseNodeTypeFilterProps,
+  CloudPulseNodeTypes,
+} from '../shared/CloudPulseNodeTypeFilter';
 import type { CloudPulseRegionSelectProps } from '../shared/CloudPulseRegionSelect';
 import type {
   CloudPulseResources,
@@ -34,6 +39,7 @@ import type {
 interface CloudPulseFilterProperties {
   config: CloudPulseServiceTypeFilters;
   dashboard: Dashboard;
+  database_ids?: number[] | undefined;
   dependentFilters?: {
     [key: string]: FilterValueType;
   };
@@ -155,6 +161,30 @@ export const getResourcesProperties = (
     resourceType: dashboard.service_type,
     savePreferences: !isServiceAnalyticsIntegration,
     xFilter: buildXFilter(config, dependentFilters ?? {}),
+  };
+};
+
+export const getNodeTypeProperties = (
+  props: CloudPulseFilterProperties,
+  handleNodeTypeChange: (
+    nodeType: CloudPulseNodeTypes | null,
+    savePref?: boolean
+  ) => void
+): CloudPulseNodeTypeFilterProps => {
+  const { filterKey, name: label, placeholder } = props.config.configuration;
+  const { dashboard, database_ids, dependentFilters, preferences } = props;
+  return {
+    database_ids,
+    defaultValue: preferences?.[NODE_TYPE],
+    disabled: checkIfWeNeedToDisableFilterByFilterKey(
+      filterKey,
+      dependentFilters ?? {},
+      dashboard
+    ),
+    handleNodeTypeChange,
+    label,
+    placeholder,
+    savePreferences: true,
   };
 };
 
@@ -419,7 +449,8 @@ export const constructAdditionalRequestFilters = (
         operator: Array.isArray(filter.filterValue) ? 'in' : 'eq',
         value: Array.isArray(filter.filterValue)
           ? Array.of(filter.filterValue).join(',')
-          : String(filter.filterValue),
+          : String(filter.filterValue).charAt(0).toLowerCase() +
+            String(filter.filterValue).slice(1),
       });
     }
   }

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -453,8 +453,7 @@ export const constructAdditionalRequestFilters = (
         operator: Array.isArray(filter.filterValue) ? 'in' : 'eq',
         value: Array.isArray(filter.filterValue)
           ? Array.of(filter.filterValue).join(',')
-          : String(filter.filterValue).charAt(0).toLowerCase() +
-            String(filter.filterValue).slice(1),
+          : String(filter.filterValue),
       });
     }
   }

--- a/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
@@ -1,3 +1,4 @@
+import { RESOURCE_ID } from './constants';
 import { CloudPulseSelectTypes } from './models';
 
 import type { CloudPulseServiceTypeFilterMap } from './models';
@@ -141,7 +142,7 @@ export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
     },
     {
       configuration: {
-        dependency: ['resource_id'],
+        dependency: [RESOURCE_ID],
         filterKey: 'node_type',
         filterType: 'string',
         isFilterable: true, // isFilterable -- this determines whether you need to pass it metrics api

--- a/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
@@ -141,6 +141,7 @@ export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
     },
     {
       configuration: {
+        dependency: ['resource_id'],
         filterKey: 'node_type',
         filterType: 'string',
         isFilterable: true, // isFilterable -- this determines whether you need to pass it metrics api
@@ -148,19 +149,8 @@ export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
         isMultiSelect: false,
         name: 'Node Type',
         neededInServicePage: true,
-        options: [
-          {
-            id: 'primary',
-            label: 'Primary',
-          },
-          {
-            id: 'secondary',
-            label: 'Secondary',
-          },
-        ],
         placeholder: 'Select a Node Type',
         priority: 5,
-        type: CloudPulseSelectTypes.static,
       },
       name: 'Node Type',
     },

--- a/packages/manager/src/features/CloudPulse/Utils/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/constants.ts
@@ -1,5 +1,9 @@
 export const DASHBOARD_ID = 'dashboardId';
 
+export const PRIMARY_NODE = 'primary';
+
+export const SECONDARY_NODE = 'secondary';
+
 export const REGION = 'region';
 
 export const RESOURCES = 'resources';

--- a/packages/manager/src/features/CloudPulse/Utils/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/constants.ts
@@ -14,6 +14,8 @@ export const SIZE = 'size';
 
 export const LABEL = 'label';
 
+export const NODE_TYPE = 'node_type';
+
 export const REFRESH = 'refresh';
 
 export const TIME_GRANULARITY = 'timeGranularity';

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseComponentRenderer.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseComponentRenderer.test.tsx
@@ -5,31 +5,35 @@ import { dashboardFactory } from 'src/factories';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import RenderComponent from '../shared/CloudPulseComponentRenderer';
+import { RESOURCE_ID } from '../Utils/constants';
 import {
   getNodeTypeProperties,
   getRegionProperties,
   getResourcesProperties,
   getTagsProperties,
 } from '../Utils/FilterBuilder';
-import { FILTER_CONFIG } from '../Utils/FilterConfig';
-
-const linodeFilterConfig = FILTER_CONFIG.get('linode');
-const dbaasFilterConfig = FILTER_CONFIG.get('dbaas');
 
 describe('ComponentRenderer component tests', () => {
   it('it should render provided tag filter in props', () => {
-    const tagProps = linodeFilterConfig?.filters.find(
-      (filter) => filter.configuration.filterKey === 'tags'
-    );
-
+    const tagProps = {
+      configuration: {
+        dependency: ['region'],
+        filterKey: 'tags',
+        filterType: 'string',
+        isFilterable: false,
+        isMetricsFilter: false,
+        isMultiSelect: true,
+        isOptional: true,
+        name: 'Tags',
+        neededInServicePage: false,
+        placeholder: 'Select Tags',
+        priority: 4,
+      },
+      name: 'Tags',
+    };
     const mockDashboard = dashboardFactory.build({
       service_type: 'linode',
     });
-
-    if (tagProps === undefined) {
-      expect(true).toEqual(false); // fail test
-      return;
-    }
 
     const { getByPlaceholderText } = renderWithTheme(
       <Grid item sx={{ marginLeft: 2 }} xs>
@@ -54,18 +58,21 @@ describe('ComponentRenderer component tests', () => {
   });
 
   it('it should render provided region filter in props', () => {
-    const regionProps = linodeFilterConfig?.filters.find(
-      (filter) => filter.configuration.filterKey === 'region'
-    );
-
+    const regionProps = {
+      configuration: {
+        filterKey: 'region',
+        filterType: 'string',
+        isFilterable: false,
+        isMetricsFilter: false,
+        name: 'Region',
+        neededInServicePage: false,
+        priority: 1,
+      },
+      name: 'Region',
+    };
     const mockDashboard = dashboardFactory.build({
       service_type: 'linode',
     });
-
-    if (regionProps === undefined) {
-      expect(true).toEqual(false); // fail test
-      return;
-    }
 
     const { getByPlaceholderText } = renderWithTheme(
       <Grid item sx={{ marginLeft: 2 }} xs>
@@ -89,17 +96,24 @@ describe('ComponentRenderer component tests', () => {
     expect(getByPlaceholderText('Select a Region')).toBeDefined();
   }),
     it('it should render provided resource filter in props', () => {
-      const resourceProps = linodeFilterConfig?.filters.find(
-        (filter) => filter.configuration.filterKey === 'resource_id'
-      );
+      const resourceProps = {
+        configuration: {
+          dependency: ['region', 'tags'],
+          filterKey: 'resource_id',
+          filterType: 'string',
+          isFilterable: true,
+          isMetricsFilter: true,
+          isMultiSelect: true,
+          name: 'Resources',
+          neededInServicePage: false,
+          placeholder: 'Select Resources',
+          priority: 2,
+        },
+        name: 'Resources',
+      };
       const mockDashboard = dashboardFactory.build({
         service_type: 'linode',
       });
-
-      if (resourceProps === undefined) {
-        expect(true, 'resourceProps to be defined').toEqual(false); // fail test
-        return;
-      }
 
       const { getByPlaceholderText } = renderWithTheme(
         <Grid item key={'resources'} sx={{ marginLeft: 2 }} xs>
@@ -124,17 +138,24 @@ describe('ComponentRenderer component tests', () => {
     });
 
   it('it should render provided node type filter in props', () => {
-    const nodeTypeProps = dbaasFilterConfig?.filters.find(
-      (filter) => filter.configuration.filterKey === 'node_type'
-    );
+    const nodeTypeProps = {
+      configuration: {
+        dependency: [RESOURCE_ID],
+        filterKey: 'node_type',
+        filterType: 'string',
+        isFilterable: true,
+        isMetricsFilter: false,
+        isMultiSelect: false,
+        name: 'Node Type',
+        neededInServicePage: true,
+        placeholder: 'Select a Node Type',
+        priority: 5,
+      },
+      name: 'Node Type',
+    };
     const mockDashboard = dashboardFactory.build({
       service_type: 'dbaas',
     });
-
-    if (nodeTypeProps === undefined) {
-      expect(true, 'resourceProps to be defined').toEqual(false); // fail test
-      return;
-    }
 
     const { getByPlaceholderText } = renderWithTheme(
       <Grid item sx={{ marginLeft: 2 }} xs>

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseComponentRenderer.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseComponentRenderer.test.tsx
@@ -6,6 +6,7 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import RenderComponent from '../shared/CloudPulseComponentRenderer';
 import {
+  getNodeTypeProperties,
   getRegionProperties,
   getResourcesProperties,
   getTagsProperties,
@@ -13,6 +14,7 @@ import {
 import { FILTER_CONFIG } from '../Utils/FilterConfig';
 
 const linodeFilterConfig = FILTER_CONFIG.get('linode');
+const dbaasFilterConfig = FILTER_CONFIG.get('dbaas');
 
 describe('ComponentRenderer component tests', () => {
   it('it should render provided tag filter in props', () => {
@@ -120,4 +122,39 @@ describe('ComponentRenderer component tests', () => {
       );
       expect(getByPlaceholderText('Select Resources')).toBeDefined();
     });
+
+  it('it should render provided node type filter in props', () => {
+    const resourceProps = dbaasFilterConfig?.filters.find(
+      (filter) => filter.configuration.filterKey === 'node_type'
+    );
+    const mockDashboard = dashboardFactory.build({
+      service_type: 'dbaas',
+    });
+
+    if (resourceProps === undefined) {
+      expect(true, 'resourceProps to be defined').toEqual(false); // fail test
+      return;
+    }
+
+    const { getByPlaceholderText } = renderWithTheme(
+      <Grid item sx={{ marginLeft: 2 }} xs>
+        {RenderComponent({
+          componentKey: 'node_type',
+          componentProps: {
+            ...getNodeTypeProperties(
+              {
+                config: resourceProps,
+                dashboard: mockDashboard,
+                dependentFilters: { resource_id: '1' },
+                isServiceAnalyticsIntegration: false,
+              },
+              vi.fn()
+            ),
+          },
+          key: 'node_type',
+        })}
+      </Grid>
+    );
+    expect(getByPlaceholderText('Select a Node Type')).toBeDefined();
+  });
 });

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseComponentRenderer.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseComponentRenderer.test.tsx
@@ -124,14 +124,14 @@ describe('ComponentRenderer component tests', () => {
     });
 
   it('it should render provided node type filter in props', () => {
-    const resourceProps = dbaasFilterConfig?.filters.find(
+    const nodeTypeProps = dbaasFilterConfig?.filters.find(
       (filter) => filter.configuration.filterKey === 'node_type'
     );
     const mockDashboard = dashboardFactory.build({
       service_type: 'dbaas',
     });
 
-    if (resourceProps === undefined) {
+    if (nodeTypeProps === undefined) {
       expect(true, 'resourceProps to be defined').toEqual(false); // fail test
       return;
     }
@@ -143,7 +143,7 @@ describe('ComponentRenderer component tests', () => {
           componentProps: {
             ...getNodeTypeProperties(
               {
-                config: resourceProps,
+                config: nodeTypeProps,
                 dashboard: mockDashboard,
                 dependentFilters: { resource_id: '1' },
                 isServiceAnalyticsIntegration: false,

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseComponentRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseComponentRenderer.tsx
@@ -3,12 +3,14 @@ import React from 'react';
 import NullComponent from 'src/components/NullComponent';
 
 import { CloudPulseCustomSelect } from './CloudPulseCustomSelect';
+import { CloudPulseNodeTypeFilter } from './CloudPulseNodeTypeFilter';
 import { CloudPulseRegionSelect } from './CloudPulseRegionSelect';
 import { CloudPulseResourcesSelect } from './CloudPulseResourcesSelect';
 import { CloudPulseTagsSelect } from './CloudPulseTagsFilter';
 import { CloudPulseTimeRangeSelect } from './CloudPulseTimeRangeSelect';
 
 import type { CloudPulseCustomSelectProps } from './CloudPulseCustomSelect';
+import type { CloudPulseNodeTypeFilterProps } from './CloudPulseNodeTypeFilter';
 import type { CloudPulseRegionSelectProps } from './CloudPulseRegionSelect';
 import type { CloudPulseResourcesSelectProps } from './CloudPulseResourcesSelect';
 import type { CloudPulseTagsSelectProps } from './CloudPulseTagsFilter';
@@ -19,6 +21,7 @@ export interface CloudPulseComponentRendererProps {
   componentKey: string;
   componentProps:
     | CloudPulseCustomSelectProps
+    | CloudPulseNodeTypeFilterProps
     | CloudPulseRegionSelectProps
     | CloudPulseResourcesSelectProps
     | CloudPulseTagsSelectProps
@@ -30,6 +33,7 @@ const Components: {
   [key: string]: MemoExoticComponent<
     React.ComponentType<
       | CloudPulseCustomSelectProps
+      | CloudPulseNodeTypeFilterProps
       | CloudPulseRegionSelectProps
       | CloudPulseResourcesSelectProps
       | CloudPulseTagsSelectProps
@@ -38,6 +42,7 @@ const Components: {
   >;
 } = {
   customSelect: CloudPulseCustomSelect,
+  node_type: CloudPulseNodeTypeFilter,
   region: CloudPulseRegionSelect,
   relative_time_duration: CloudPulseTimeRangeSelect,
   resource_id: CloudPulseResourcesSelect,

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.test.tsx
@@ -28,10 +28,10 @@ describe('CloudPulseDashboardFilterBuilder component tests', () => {
         dashboard={dashboardFactory.build({
           service_type: 'dbaas',
         })}
-        database_ids={[1, 2]}
         emitFilterChange={vi.fn()}
         handleToggleAppliedFilter={vi.fn()}
         isServiceAnalyticsIntegration={false}
+        resource_ids={[1, 2]}
       />
     );
 

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.test.tsx
@@ -28,6 +28,7 @@ describe('CloudPulseDashboardFilterBuilder component tests', () => {
         dashboard={dashboardFactory.build({
           service_type: 'dbaas',
         })}
+        database_ids={[1, 2]}
         emitFilterChange={vi.fn()}
         handleToggleAppliedFilter={vi.fn()}
         isServiceAnalyticsIntegration={false}
@@ -36,5 +37,7 @@ describe('CloudPulseDashboardFilterBuilder component tests', () => {
 
     expect(getByPlaceholderText('Select a Database Engine')).toBeDefined();
     expect(getByPlaceholderText('Select a Region')).toBeDefined();
+    expect(getByPlaceholderText('Select Database Clusters')).toBeDefined();
+    expect(getByPlaceholderText('Select a Node Type')).toBeDefined();
   });
 });

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
@@ -43,11 +43,6 @@ export interface CloudPulseDashboardFilterBuilderProps {
   dashboard: Dashboard;
 
   /**
-   * selected database ids
-   */
-  database_ids?: number[];
-
-  /**
    * all the selection changes in the filter goes through this method
    */
   emitFilterChange: (
@@ -69,17 +64,22 @@ export interface CloudPulseDashboardFilterBuilderProps {
    * Last selected values from user preferences
    */
   preferences?: AclpConfig;
+
+  /**
+   * selected resource ids
+   */
+  resource_ids?: number[];
 }
 
 export const CloudPulseDashboardFilterBuilder = React.memo(
   (props: CloudPulseDashboardFilterBuilderProps) => {
     const {
       dashboard,
-      database_ids,
       emitFilterChange,
       handleToggleAppliedFilter,
       isServiceAnalyticsIntegration,
       preferences,
+      resource_ids,
     } = props;
 
     const [, setDependentFilters] = React.useState<{
@@ -268,14 +268,14 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
             {
               config,
               dashboard,
-              database_ids: database_ids?.length
-                ? database_ids
-                : (dependentFilterReference.current[RESOURCE_ID] as number[]),
-              dependentFilters: database_ids?.length
-                ? { resource_id: database_ids }
+              dependentFilters: resource_ids?.length
+                ? { [RESOURCE_ID]: resource_ids }
                 : dependentFilterReference.current,
               isServiceAnalyticsIntegration,
               preferences,
+              resource_ids: resource_ids?.length
+                ? resource_ids
+                : (dependentFilterReference.current[RESOURCE_ID] as number[]),
             },
             handleNodeTypeChange
           );

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
@@ -30,7 +30,6 @@ import { FILTER_CONFIG } from '../Utils/FilterConfig';
 
 import type { FilterValueType } from '../Dashboard/CloudPulseDashboardLanding';
 import type { CloudPulseServiceTypeFilters } from '../Utils/models';
-import type { CloudPulseNodeTypes } from './CloudPulseNodeTypeFilter';
 import type { CloudPulseResources } from './CloudPulseResourcesSelect';
 import type { CloudPulseTags } from './CloudPulseTagsFilter';
 import type { AclpConfig, Dashboard } from '@linode/api-v4';
@@ -139,17 +138,14 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
     );
 
     const handleNodeTypeChange = React.useCallback(
-      (nodeType: CloudPulseNodeTypes | null, savePref: boolean = false) => {
-        const selectedNodeType = nodeType?.label;
-        emitFilterChangeByFilterKey(
-          NODE_TYPE,
-          selectedNodeType,
-          selectedNodeType ? [selectedNodeType] : [],
-          savePref,
-          {
-            [NODE_TYPE]: selectedNodeType,
-          }
-        );
+      (
+        nodeTypeId: string | undefined,
+        label: string[],
+        savePref: boolean = false
+      ) => {
+        emitFilterChangeByFilterKey(NODE_TYPE, nodeTypeId, label, savePref, {
+          [NODE_TYPE]: nodeTypeId,
+        });
       },
       [emitFilterChangeByFilterKey]
     );
@@ -179,6 +175,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
           resourceId.map((resource) => resource.label),
           savePref,
           {
+            [NODE_TYPE]: undefined,
             [RESOURCES]: resourceId.map((resource: { id: string }) =>
               String(resource.id)
             ),

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
@@ -272,7 +272,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
               preferences,
               resource_ids: resource_ids?.length
                 ? resource_ids
-                : (dependentFilterReference.current[RESOURCE_ID] as number[]),
+                : (dependentFilterReference.current[RESOURCE_ID] as string[])?.map((id: string) => Number(id)),
             },
             handleNodeTypeChange
           );

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.test.tsx
@@ -50,6 +50,11 @@ describe('CloudPulseNodeTypeFilter', () => {
   });
 
   it('initializes with Primary as default value when no preferences are saved', async () => {
+    queryMocks.useAllDatabasesQuery.mockReturnValue({
+      data: databaseInstanceFactory.buildList(2),
+      isError: false,
+      isLoading: false,
+    });
     const { getByLabelText, getByText } = renderWithTheme(
       <CloudPulseNodeTypeFilter
         {...props}
@@ -120,24 +125,11 @@ describe('CloudPulseNodeTypeFilter', () => {
       isLoading: false,
     });
 
-    const { getByLabelText, getByText } = renderWithTheme(
-      <CloudPulseNodeTypeFilter {...props} />
+    const { getByRole } = renderWithTheme(
+      <CloudPulseNodeTypeFilter {...props} defaultValue="secondary" />
     );
-
-    await userEvent.click(getByLabelText('Node Type'));
-
-    await userEvent.click(getByText('Secondary'));
-
-    const { container } = renderWithTheme(
-      <CloudPulseNodeTypeFilter {...props} defaultValue={'Secondary'} />
-    );
-    expect(within(container).getByRole('combobox')).toHaveValue('Secondary');
-    await userEvent.click(within(container).getByLabelText('Node Type'));
-    expect(
-      within(container).getByRole('option', { name: 'Primary' })
-    ).toHaveAttribute('aria-selected', 'false');
-    expect(
-      within(container).getByRole('option', { name: 'Secondary' })
-    ).toHaveAttribute('aria-selected', 'true');
+    const combobox = getByRole('combobox', { name: 'Node Type' });
+    expect(combobox).toBeInTheDocument();
+    expect(combobox).toHaveValue('Secondary');
   });
 });

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.test.tsx
@@ -92,7 +92,7 @@ describe('CloudPulseNodeTypeFilter', () => {
     });
 
     const { getByLabelText, getByText } = renderWithTheme(
-      <CloudPulseNodeTypeFilter {...props}/>
+      <CloudPulseNodeTypeFilter {...props} />
     );
 
     await userEvent.click(getByLabelText('Node Type'));

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.test.tsx
@@ -1,0 +1,143 @@
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+
+import { databaseInstanceFactory } from 'src/factories';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { CloudPulseNodeTypeFilter } from './CloudPulseNodeTypeFilter';
+
+import type { CloudPulseNodeTypeFilterProps } from './CloudPulseNodeTypeFilter';
+
+const props: CloudPulseNodeTypeFilterProps = {
+  database_ids: [1, 2],
+  defaultValue: undefined,
+  disabled: false,
+  handleNodeTypeChange: vi.fn(),
+  label: 'Node Type',
+  placeholder: 'Select a Node Type',
+  savePreferences: true,
+};
+
+const queryMocks = vi.hoisted(() => ({
+  useAllDatabasesQuery: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('src/queries/databases/databases', async () => {
+  const actual = await vi.importActual('src/queries/databases/databases');
+  return {
+    ...actual,
+    useAllDatabasesQuery: queryMocks.useAllDatabasesQuery,
+  };
+});
+
+describe('CloudPulseNodeTypeFilter', () => {
+  it('renders the component with correct props', () => {
+    const { getByLabelText, getByPlaceholderText } = renderWithTheme(
+      <CloudPulseNodeTypeFilter {...props} />
+    );
+    expect(getByLabelText('Node Type')).toBeInTheDocument();
+    expect(getByPlaceholderText('Select a Node Type')).toBeInTheDocument();
+  });
+
+  it('handles disabled state correctly', () => {
+    const { getByLabelText } = renderWithTheme(
+      <CloudPulseNodeTypeFilter {...props} disabled={true} />
+    );
+
+    const select = getByLabelText('Node Type');
+    expect(select).toBeDisabled();
+  });
+
+  it('initializes with Primary as default value when no preferences are saved', async () => {
+    const { getByLabelText, getByText } = renderWithTheme(
+      <CloudPulseNodeTypeFilter
+        {...props}
+        defaultValue={undefined}
+        savePreferences={false}
+      />
+    );
+    await userEvent.click(getByLabelText('Node Type'));
+    expect(getByText('Primary')).toBeInTheDocument();
+  });
+
+  it('displays correct options in dropdown in case of maximum cluster size one', async () => {
+    queryMocks.useAllDatabasesQuery.mockReturnValue({
+      data: [
+        databaseInstanceFactory.build({ cluster_size: 1, id: 1 }),
+        databaseInstanceFactory.build({ cluster_size: 1, id: 2 }),
+      ],
+      isError: false,
+      isLoading: false,
+    });
+
+    const { getByLabelText } = renderWithTheme(
+      <CloudPulseNodeTypeFilter {...props} />
+    );
+
+    await userEvent.click(getByLabelText('Node Type'));
+
+    expect(screen.getByText('Primary')).toBeInTheDocument();
+    expect(screen.queryByText('Secondary')).not.toBeInTheDocument();
+  });
+
+  it('displays correct options in dropdown if maximum cluster size is greater than one', async () => {
+    queryMocks.useAllDatabasesQuery.mockReturnValue({
+      data: [
+        databaseInstanceFactory.build({ cluster_size: 2, id: 1 }),
+        databaseInstanceFactory.build({ cluster_size: 3, id: 2 }),
+      ],
+      isError: false,
+      isLoading: false,
+    });
+
+    const { getByLabelText, getByText } = renderWithTheme(
+      <CloudPulseNodeTypeFilter {...props}/>
+    );
+
+    await userEvent.click(getByLabelText('Node Type'));
+
+    expect(getByText('Primary')).toBeInTheDocument();
+    expect(getByText('Secondary')).toBeInTheDocument();
+  });
+
+  it('handles empty database_ids', () => {
+    const { queryByText } = renderWithTheme(
+      <CloudPulseNodeTypeFilter {...props} database_ids={[]} />
+    );
+
+    expect(queryByText('Primary')).not.toBeInTheDocument();
+    expect(queryByText('Secondary')).not.toBeInTheDocument();
+  });
+
+  it('maintains selected value in preferences after re-render', async () => {
+    queryMocks.useAllDatabasesQuery.mockReturnValue({
+      data: [
+        databaseInstanceFactory.build({ cluster_size: 1, id: 1 }),
+        databaseInstanceFactory.build({ cluster_size: 3, id: 2 }),
+      ],
+      isError: false,
+      isLoading: false,
+    });
+
+    const { getByLabelText, getByText } = renderWithTheme(
+      <CloudPulseNodeTypeFilter {...props} />
+    );
+
+    await userEvent.click(getByLabelText('Node Type'));
+
+    await userEvent.click(getByText('Secondary'));
+
+    const { container } = renderWithTheme(
+      <CloudPulseNodeTypeFilter {...props} defaultValue={'Secondary'} />
+    );
+    expect(within(container).getByRole('combobox')).toHaveValue('Secondary');
+    await userEvent.click(within(container).getByLabelText('Node Type'));
+    expect(
+      within(container).getByRole('option', { name: 'Primary' })
+    ).toHaveAttribute('aria-selected', 'false');
+    expect(
+      within(container).getByRole('option', { name: 'Secondary' })
+    ).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
@@ -27,6 +27,8 @@ const nodeTypeMap = new Map<string, CloudPulseNodeType>(
   nodeTypeOptionsList.map((type) => [type.id, type])
 );
 
+const primaryNode = nodeTypeMap.get(PRIMARY_NODE);
+
 export interface CloudPulseNodeTypeFilterProps {
   /**
    * Selected database cluster ids
@@ -115,17 +117,7 @@ export const CloudPulseNodeTypeFilter = React.memo(
       setSelectedNodeType(selectedNode ?? null);
     };
 
-    const primaryNode = nodeTypeMap.get(PRIMARY_NODE);
-
-    // calculate available options based on cluster size, keep only primary as option if max cluster size is 1 for chosen clusters, else secondary
-    const availableOptions =
-      isClusterSizeGreaterThanOne === undefined
-        ? []
-        : isClusterSizeGreaterThanOne
-        ? nodeTypeOptionsList
-        : primaryNode
-        ? [primaryNode]
-        : [];
+    const availableOptions = getNodeTypeOptions(isClusterSizeGreaterThanOne);
 
     React.useEffect(() => {
       // when savePreferences is false, we retain the primary selection as default selected value
@@ -184,3 +176,23 @@ export const CloudPulseNodeTypeFilter = React.memo(
     );
   }
 );
+
+/**
+ * Calculates available node type options based on cluster size.
+ * Returns only primary as an option if max cluster size is 1 for chosen clusters,
+ * otherwise returns both primary and secondary options.
+ *
+ * @param isClusterSizeGreaterThanOne - Boolean indicating if any selected cluster has size > 1
+ * @returns Array of available node type options
+ */
+const getNodeTypeOptions = (
+  isClusterSizeGreaterThanOne: boolean | undefined
+): CloudPulseNodeType[] => {
+  return isClusterSizeGreaterThanOne === undefined
+    ? []
+    : isClusterSizeGreaterThanOne
+    ? nodeTypeOptionsList
+    : primaryNode
+    ? [primaryNode]
+    : [];
+};

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
@@ -53,7 +53,7 @@ export interface CloudPulseNodeTypeFilterProps {
   ) => void;
 
   /**
-   * A required label for the Autocomplete to ensure accessibility.
+   * A required label for the Autocomplete to ensure accessibility
    **/
   label: string;
 

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
@@ -128,7 +128,7 @@ export const CloudPulseNodeTypeFilter = React.memo(
         handleNodeTypeChange(undefined, []);
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [savePreferences, database_ids]);
+    }, [savePreferences, database_ids?.join(',')]);
 
     return (
       <Autocomplete

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
@@ -89,7 +89,7 @@ export const CloudPulseNodeTypeFilter = React.memo(
 
     return (
       <Autocomplete
-        onChange={(e, selectedNode) => {
+        onChange={(_e, selectedNode) => {
           handleNodeTypeChange(selectedNode, savePreferences);
           setSelectedNodeType(selectedNode);
         }}
@@ -102,7 +102,7 @@ export const CloudPulseNodeTypeFilter = React.memo(
         clearOnBlur
         data-testid="node-type-select"
         disabled={disabled}
-        errorText={isError ? 'Error loading node types' : ''}
+        errorText={isError ? 'Error loading node types.' : ''}
         fullWidth
         label={label || 'Node Type'}
         loading={isLoading}

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
@@ -1,0 +1,116 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { Autocomplete } from '@linode/ui';
+import * as React from 'react';
+
+import { useAllDatabasesQuery } from 'src/queries/databases/databases';
+
+import type { FilterValue } from '@linode/api-v4';
+
+export interface CloudPulseNodeTypes {
+  label: string;
+}
+
+export interface CloudPulseNodeTypeFilterProps {
+  database_ids?: number[];
+  defaultValue?: FilterValue;
+  disabled?: boolean;
+  handleNodeTypeChange: (
+    nodeType: CloudPulseNodeTypes | null,
+    savePref?: boolean
+  ) => void;
+  label: string;
+  placeholder?: string;
+  savePreferences?: boolean;
+}
+
+export const CloudPulseNodeTypeFilter = React.memo(
+  (props: CloudPulseNodeTypeFilterProps) => {
+    const {
+      database_ids,
+      defaultValue,
+      disabled,
+      handleNodeTypeChange,
+      label,
+      placeholder,
+      savePreferences,
+    } = props;
+
+    const [
+      selectedNodeType,
+      setSelectedNodeType,
+    ] = React.useState<CloudPulseNodeTypes | null>(null);
+
+    const {
+      data: databaseClusters,
+      isError,
+      isLoading,
+    } = useAllDatabasesQuery(); // fetch all databases
+
+    const maxClusterSize = React.useMemo<number>(() => {
+      return !databaseClusters || !database_ids?.length
+        ? 1
+        : Math.max(
+            ...databaseClusters
+              .filter((cluster) => database_ids.includes(cluster.id))
+              .map((cluster) => cluster.cluster_size)
+          );
+    }, [databaseClusters, database_ids]);
+
+    // node type options are based on maximum cluster size of the selected databases
+    const nodeTypeOptions = React.useMemo<CloudPulseNodeTypes[]>(() => {
+      return maxClusterSize > 1
+        ? [{ label: 'Primary' }, { label: 'Secondary' }]
+        : [{ label: 'Primary' }];
+    }, [maxClusterSize]);
+
+    const initialRenderRef = React.useRef(true); // used to check if the component is being rendered for the first time
+
+    // set the default node type based on preferences
+    React.useEffect(() => {
+      if (
+        initialRenderRef.current &&
+        database_ids?.length &&
+        savePreferences &&
+        defaultValue
+      ) {
+        const nodeType = nodeTypeOptions.find(
+          (type) => type.label === defaultValue
+        ) ?? {
+          label: 'Primary',
+        };
+        setSelectedNodeType(nodeType);
+        handleNodeTypeChange(nodeType);
+        initialRenderRef.current = false;
+      } else {
+        setSelectedNodeType({ label: 'Primary' });
+        handleNodeTypeChange({ label: 'Primary' });
+      }
+    }, [database_ids?.length, savePreferences, defaultValue, nodeTypeOptions]);
+
+    return (
+      <Autocomplete
+        onChange={(e, selectedNode) => {
+          handleNodeTypeChange(selectedNode, savePreferences);
+          setSelectedNodeType(selectedNode);
+        }}
+        slotProps={{
+          popper: {
+            placement: 'bottom',
+          },
+        }}
+        autoHighlight
+        clearOnBlur
+        data-testid="node-type-select"
+        disabled={disabled}
+        errorText={isError ? 'Error loading node types' : ''}
+        fullWidth
+        label={label || 'Node Type'}
+        loading={isLoading}
+        noMarginTop
+        options={nodeTypeOptions}
+        placeholder={placeholder ?? 'Select a Node Type'}
+        value={selectedNodeType}
+      />
+    );
+  }
+);

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
@@ -23,6 +23,10 @@ const nodeTypeOptionsList: CloudPulseNodeType[] = [
   },
 ];
 
+const nodeTypeMap = new Map<string, CloudPulseNodeType>(
+  nodeTypeOptionsList.map((type) => [type.id, type])
+);
+
 export interface CloudPulseNodeTypeFilterProps {
   /**
    * Selected database cluster ids
@@ -80,10 +84,6 @@ export const CloudPulseNodeTypeFilter = React.memo(
       isError,
       isLoading,
     } = useAllDatabasesQuery(); // fetch all databases
-
-    const nodeTypeMap = new Map<string, CloudPulseNodeType>(
-      nodeTypeOptionsList.map((type) => [type.id, type])
-    );
 
     const isClusterSizeGreaterThanOne = React.useMemo<
       boolean | undefined

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
@@ -13,16 +13,37 @@ export interface CloudPulseNodeType {
 }
 
 export interface CloudPulseNodeTypeFilterProps {
+  /**
+   * Selected database cluster ids
+   */
   database_ids?: number[];
+
+  /**
+   * Last selected node type value from user preferences
+   */
   defaultValue?: FilterValue;
+
+  /**
+   * Boolean to check if the filter selection is to be disabled
+   */
   disabled?: boolean;
+
+  /**
+   * This will handle the change in node type filter selection
+   */
   handleNodeTypeChange: (
     nodeTypeId: string | undefined,
     labels: string[],
     savePref?: boolean
   ) => void;
+
   label: string;
+
   placeholder?: string;
+
+  /**
+   * Boolean to check if preferences need to be saved and applied
+   */
   savePreferences?: boolean;
 }
 

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 
 import { useAllDatabasesQuery } from 'src/queries/databases/databases';
 
+import { PRIMARY_NODE } from '../Utils/constants';
+
 import type { DatabaseInstance, FilterValue } from '@linode/api-v4';
 
 export interface CloudPulseNodeType {
@@ -47,7 +49,7 @@ export const CloudPulseNodeTypeFilter = React.memo(
       isLoading,
     } = useAllDatabasesQuery(); // fetch all databases
 
-    const nodeTypeOptionslist = [
+    const nodeTypeOptionsList = [
       {
         id: 'primary',
         label: 'Primary',
@@ -57,6 +59,10 @@ export const CloudPulseNodeTypeFilter = React.memo(
         label: 'Secondary',
       },
     ];
+
+    const nodeTypeMap = new Map<string, CloudPulseNodeType>(
+      nodeTypeOptionsList.map((type) => [type.id, type])
+    );
 
     const isClusterSizeGreaterThanOne = React.useMemo<
       boolean | undefined
@@ -71,28 +77,51 @@ export const CloudPulseNodeTypeFilter = React.memo(
       );
     }, [databaseClusters, database_ids]);
 
+    const handleNodeTypeSelection = (
+      selectedNode: CloudPulseNodeType | null
+    ) => {
+      handleNodeTypeChange(
+        selectedNode?.id,
+        selectedNode ? [selectedNode.label] : [],
+        savePreferences
+      );
+      setSelectedNodeType(selectedNode ?? null);
+    };
+
+    const primaryNode = nodeTypeMap.get(PRIMARY_NODE);
+
+    const availableOptions =
+      isClusterSizeGreaterThanOne === undefined
+        ? []
+        : isClusterSizeGreaterThanOne
+        ? nodeTypeOptionsList
+        : primaryNode
+        ? [primaryNode]
+        : [];
+
     React.useEffect(() => {
       // when savePreferences is false, we retain the primary selection as default selected value
       if (!savePreferences) {
-        setSelectedNodeType(nodeTypeOptionslist[0]);
-        handleNodeTypeChange(nodeTypeOptionslist[0].id, [
-          nodeTypeOptionslist[0].label,
+        setSelectedNodeType(primaryNode ?? nodeTypeOptionsList[0]);
+        handleNodeTypeChange(primaryNode?.id ?? 'primary', [
+          primaryNode?.label ?? 'primary',
         ]);
         return;
       }
-      // when savePreferences is true and selected node is undefined
+      // when savePreferences is true and selected node is undefined, default value from preferences is shown on initial render
       if (
         isClusterSizeGreaterThanOne !== undefined &&
         savePreferences &&
         selectedNodeType === undefined
       ) {
-        const nodeType =
-          nodeTypeOptionslist.find((type) => type.id === defaultValue) ??
-          undefined;
+        const nodeType = defaultValue
+          ? nodeTypeMap.get(defaultValue as string)
+          : undefined;
         setSelectedNodeType(nodeType);
         handleNodeTypeChange(nodeType?.id, nodeType ? [nodeType?.label] : []);
         return;
       }
+      // set the selected node type as null to differentiate between initial and subsequent renders
       if (selectedNodeType) {
         setSelectedNodeType(null);
         handleNodeTypeChange(undefined, []);
@@ -104,21 +133,6 @@ export const CloudPulseNodeTypeFilter = React.memo(
       <Autocomplete
         isOptionEqualToValue={(option, value) =>
           option.id === value.id && option.label === value.label
-        }
-        onChange={(_e, selectedNode) => {
-          handleNodeTypeChange(
-            selectedNode?.id,
-            selectedNode ? [selectedNode.label] : [],
-            savePreferences
-          );
-          setSelectedNodeType(selectedNode);
-        }}
-        options={
-          isClusterSizeGreaterThanOne !== undefined
-            ? isClusterSizeGreaterThanOne
-              ? nodeTypeOptionslist
-              : [nodeTypeOptionslist[0]]
-            : []
         }
         slotProps={{
           popper: {
@@ -134,6 +148,8 @@ export const CloudPulseNodeTypeFilter = React.memo(
         label={label || 'Node Type'}
         loading={isLoading}
         noMarginTop
+        onChange={(_e, selectedNode) => handleNodeTypeSelection(selectedNode)}
+        options={availableOptions}
         placeholder={placeholder ?? 'Select a Node Type'}
         value={selectedNodeType ?? null}
       />

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
@@ -128,7 +128,7 @@ export const CloudPulseNodeTypeFilter = React.memo(
         handleNodeTypeChange(undefined, []);
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [savePreferences, database_ids?.join(',')]);
+    }, [savePreferences, database_ids?.sort().join(',')]);
 
     return (
       <Autocomplete

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
@@ -90,6 +90,7 @@ export const CloudPulseNodeTypeFilter = React.memo(
 
     const primaryNode = nodeTypeMap.get(PRIMARY_NODE);
 
+    // calculate available options based on cluster size, keep only primary as option if max cluster size is 1 for chosen clusters, else secondary
     const availableOptions =
       isClusterSizeGreaterThanOne === undefined
         ? []

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
@@ -52,8 +52,14 @@ export interface CloudPulseNodeTypeFilterProps {
     savePref?: boolean
   ) => void;
 
+  /**
+   * A required label for the Autocomplete to ensure accessibility.
+   **/
   label: string;
 
+  /**
+   * Placeholder text for Node Type selection input
+   **/
   placeholder?: string;
 
   /**

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
@@ -111,7 +111,7 @@ export const CloudPulseNodeTypeFilter = React.memo(
             selectedNode ? [selectedNode.label] : [],
             savePreferences
           );
-          setSelectedNodeType(selectedNode ?? null);
+          setSelectedNodeType(selectedNode);
         }}
         options={
           isClusterSizeGreaterThanOne !== undefined

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
@@ -1,12 +1,12 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import { Autocomplete } from '@linode/ui';
 import * as React from 'react';
 
 import { useAllDatabasesQuery } from 'src/queries/databases/databases';
 
-import type { FilterValue } from '@linode/api-v4';
+import type { DatabaseInstance, FilterValue } from '@linode/api-v4';
 
-export interface CloudPulseNodeTypes {
+export interface CloudPulseNodeType {
+  id: string;
   label: string;
 }
 
@@ -15,7 +15,8 @@ export interface CloudPulseNodeTypeFilterProps {
   defaultValue?: FilterValue;
   disabled?: boolean;
   handleNodeTypeChange: (
-    nodeType: CloudPulseNodeTypes | null,
+    nodeTypeId: string | undefined,
+    labels: string[],
     savePref?: boolean
   ) => void;
   label: string;
@@ -38,7 +39,7 @@ export const CloudPulseNodeTypeFilter = React.memo(
     const [
       selectedNodeType,
       setSelectedNodeType,
-    ] = React.useState<CloudPulseNodeTypes | null>(null);
+    ] = React.useState<CloudPulseNodeType | null>();
 
     const {
       data: databaseClusters,
@@ -46,53 +47,106 @@ export const CloudPulseNodeTypeFilter = React.memo(
       isLoading,
     } = useAllDatabasesQuery(); // fetch all databases
 
-    const maxClusterSize = React.useMemo<number>(() => {
-      return !databaseClusters || !database_ids?.length
-        ? 1
-        : Math.max(
-            ...databaseClusters
-              .filter((cluster) => database_ids.includes(cluster.id))
-              .map((cluster) => cluster.cluster_size)
-          );
+    const nodeTypeOptionslist = [
+      {
+        id: 'primary',
+        label: 'Primary',
+      },
+      {
+        id: 'secondary',
+        label: 'Secondary',
+      },
+    ];
+
+    const isClusterSizeGreaterThanOne = React.useMemo<
+      boolean | undefined
+    >(() => {
+      if (!databaseClusters || !database_ids?.length) {
+        return undefined;
+      }
+      // check if any cluster has a size greater than 1 for selected database ids
+      return databaseClusters.some(
+        (cluster: DatabaseInstance) =>
+          database_ids.includes(cluster.id) && cluster.cluster_size > 1
+      );
     }, [databaseClusters, database_ids]);
 
-    // node type options are based on maximum cluster size of the selected databases
-    const nodeTypeOptions = React.useMemo<CloudPulseNodeTypes[]>(() => {
-      return maxClusterSize > 1
-        ? [{ label: 'Primary' }, { label: 'Secondary' }]
-        : [{ label: 'Primary' }];
-    }, [maxClusterSize]);
-
-    const initialRenderRef = React.useRef(true); // used to check if the component is being rendered for the first time
-
-    // set the default node type based on preferences
     React.useEffect(() => {
-      if (
-        initialRenderRef.current &&
-        database_ids?.length &&
-        savePreferences &&
-        defaultValue
-      ) {
-        const nodeType = nodeTypeOptions.find(
-          (type) => type.label === defaultValue
-        ) ?? {
-          label: 'Primary',
-        };
-        setSelectedNodeType(nodeType);
-        handleNodeTypeChange(nodeType);
-        initialRenderRef.current = false;
-      } else {
-        setSelectedNodeType({ label: 'Primary' });
-        handleNodeTypeChange({ label: 'Primary' });
+      // when savePreferences is false, we retain the primary selection as default selected value
+      if (!savePreferences) {
+        setSelectedNodeType(nodeTypeOptionslist[0]);
+        handleNodeTypeChange(nodeTypeOptionslist[0].id, [
+          nodeTypeOptionslist[0].label,
+        ]);
+        return;
       }
-    }, [database_ids?.length, savePreferences, defaultValue, nodeTypeOptions]);
+
+      // when savePreferences is true and selected node is undefined
+      if (
+        isClusterSizeGreaterThanOne !== undefined &&
+        savePreferences &&
+        selectedNodeType === undefined
+      ) {
+        const nodeType =
+          nodeTypeOptionslist.find((type) => type.id === defaultValue) ??
+          nodeTypeOptionslist[0]; // set default value if available else set primary as default
+        setSelectedNodeType(nodeType);
+        handleNodeTypeChange(nodeType?.id, nodeType ? [nodeType?.label] : []);
+        return;
+      }
+      // when selected node type is null and clustersize is defined
+      if (
+        selectedNodeType == null &&
+        isClusterSizeGreaterThanOne !== undefined
+      ) {
+        setSelectedNodeType(nodeTypeOptionslist[0]);
+        handleNodeTypeChange(nodeTypeOptionslist[0].id, [
+          nodeTypeOptionslist[0].label,
+        ]);
+        return;
+      }
+      // if node type is already selected, check validity for current clusters
+      if (selectedNodeType) {
+        if (isClusterSizeGreaterThanOne === undefined) {
+          setSelectedNodeType(null);
+          handleNodeTypeChange(undefined, []);
+          return;
+        }
+
+        const isNodeTypeValid = isClusterSizeGreaterThanOne
+          ? nodeTypeOptionslist.find((type) => type.id === selectedNodeType.id)
+          : false;
+
+        if (!isNodeTypeValid) {
+          setSelectedNodeType(nodeTypeOptionslist[0]);
+          handleNodeTypeChange(nodeTypeOptionslist[0].id, [
+            nodeTypeOptionslist[0].label,
+          ]);
+        }
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [savePreferences, defaultValue, isClusterSizeGreaterThanOne]);
 
     return (
       <Autocomplete
+        isOptionEqualToValue={(option, value) =>
+          option.id === value.id && option.label === value.label
+        }
         onChange={(_e, selectedNode) => {
-          handleNodeTypeChange(selectedNode, savePreferences);
-          setSelectedNodeType(selectedNode);
+          handleNodeTypeChange(
+            selectedNode?.id,
+            selectedNode ? [selectedNode.label] : [],
+            savePreferences
+          );
+          setSelectedNodeType(selectedNode ?? null);
         }}
+        options={
+          isClusterSizeGreaterThanOne !== undefined
+            ? isClusterSizeGreaterThanOne
+              ? nodeTypeOptionslist
+              : [nodeTypeOptionslist[0]]
+            : []
+        }
         slotProps={{
           popper: {
             placement: 'bottom',
@@ -107,9 +161,8 @@ export const CloudPulseNodeTypeFilter = React.memo(
         label={label || 'Node Type'}
         loading={isLoading}
         noMarginTop
-        options={nodeTypeOptions}
         placeholder={placeholder ?? 'Select a Node Type'}
-        value={selectedNodeType}
+        value={selectedNodeType ?? null}
       />
     );
   }

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
@@ -12,6 +12,17 @@ export interface CloudPulseNodeType {
   label: string;
 }
 
+const nodeTypeOptionsList: CloudPulseNodeType[] = [
+  {
+    id: 'primary',
+    label: 'Primary',
+  },
+  {
+    id: 'secondary',
+    label: 'Secondary',
+  },
+];
+
 export interface CloudPulseNodeTypeFilterProps {
   /**
    * Selected database cluster ids
@@ -69,17 +80,6 @@ export const CloudPulseNodeTypeFilter = React.memo(
       isError,
       isLoading,
     } = useAllDatabasesQuery(); // fetch all databases
-
-    const nodeTypeOptionsList = [
-      {
-        id: 'primary',
-        label: 'Primary',
-      },
-      {
-        id: 'secondary',
-        label: 'Secondary',
-      },
-    ];
 
     const nodeTypeMap = new Map<string, CloudPulseNodeType>(
       nodeTypeOptionsList.map((type) => [type.id, type])

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
@@ -80,7 +80,6 @@ export const CloudPulseNodeTypeFilter = React.memo(
         ]);
         return;
       }
-
       // when savePreferences is true and selected node is undefined
       if (
         isClusterSizeGreaterThanOne !== undefined &&
@@ -89,43 +88,17 @@ export const CloudPulseNodeTypeFilter = React.memo(
       ) {
         const nodeType =
           nodeTypeOptionslist.find((type) => type.id === defaultValue) ??
-          nodeTypeOptionslist[0]; // set default value if available else set primary as default
+          undefined;
         setSelectedNodeType(nodeType);
         handleNodeTypeChange(nodeType?.id, nodeType ? [nodeType?.label] : []);
         return;
       }
-      // when selected node type is null and clustersize is defined
-      if (
-        selectedNodeType == null &&
-        isClusterSizeGreaterThanOne !== undefined
-      ) {
-        setSelectedNodeType(nodeTypeOptionslist[0]);
-        handleNodeTypeChange(nodeTypeOptionslist[0].id, [
-          nodeTypeOptionslist[0].label,
-        ]);
-        return;
-      }
-      // if node type is already selected, check validity for current clusters
       if (selectedNodeType) {
-        if (isClusterSizeGreaterThanOne === undefined) {
-          setSelectedNodeType(null);
-          handleNodeTypeChange(undefined, []);
-          return;
-        }
-
-        const isNodeTypeValid = isClusterSizeGreaterThanOne
-          ? nodeTypeOptionslist.find((type) => type.id === selectedNodeType.id)
-          : false;
-
-        if (!isNodeTypeValid) {
-          setSelectedNodeType(nodeTypeOptionslist[0]);
-          handleNodeTypeChange(nodeTypeOptionslist[0].id, [
-            nodeTypeOptionslist[0].label,
-          ]);
-        }
+        setSelectedNodeType(null);
+        handleNodeTypeChange(undefined, []);
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [savePreferences, defaultValue, isClusterSizeGreaterThanOne]);
+    }, [savePreferences, database_ids]);
 
     return (
       <Autocomplete

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -230,8 +230,18 @@ const databases = [
       id: 3,
       label: 'database-instance-3',
     });
+    const database4 = databaseInstanceFactory.build({
+      cluster_size: 1,
+      id: 4,
+      label: 'database-instance-4',
+    });
+    const database5 = databaseInstanceFactory.build({
+      cluster_size: 1,
+      id: 5,
+      label: 'database-instance-5',
+    });
 
-    const databases = [database1, database2, database3];
+    const databases = [database1, database2, database3, database4, database5];
     return HttpResponse.json(makeResourcePage(databases));
   }),
 

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -122,9 +122,11 @@ import type {
   AlertServiceType,
   AlertSeverityType,
   AlertStatusType,
+  ClusterSize,
   CreateAlertDefinitionPayload,
   CreateObjectStorageKeyPayload,
   Dashboard,
+  DatabaseInstance,
   FirewallStatus,
   NotificationType,
   ObjectStorageEndpointTypes,
@@ -215,7 +217,16 @@ const entityTransfers = [
 
 const databases = [
   http.get('*/databases/instances', () => {
-    const databases = databaseInstanceFactory.buildList(9);
+    const databases: DatabaseInstance[] = [];
+    for (let i = 1; i <= 3; i++) {
+      databases.push(
+        databaseInstanceFactory.build({
+          cluster_size: i as ClusterSize,
+          id: i,
+          label: `database-instance-${i}`,
+        })
+      );
+    }
     return HttpResponse.json(makeResourcePage(databases));
   }),
 

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -122,11 +122,9 @@ import type {
   AlertServiceType,
   AlertSeverityType,
   AlertStatusType,
-  ClusterSize,
   CreateAlertDefinitionPayload,
   CreateObjectStorageKeyPayload,
   Dashboard,
-  DatabaseInstance,
   FirewallStatus,
   NotificationType,
   ObjectStorageEndpointTypes,
@@ -217,16 +215,23 @@ const entityTransfers = [
 
 const databases = [
   http.get('*/databases/instances', () => {
-    const databases: DatabaseInstance[] = [];
-    for (let i = 1; i <= 3; i++) {
-      databases.push(
-        databaseInstanceFactory.build({
-          cluster_size: i as ClusterSize,
-          id: i,
-          label: `database-instance-${i}`,
-        })
-      );
-    }
+    const database1 = databaseInstanceFactory.build({
+      cluster_size: 1,
+      id: 1,
+      label: 'database-instance-1',
+    });
+    const database2 = databaseInstanceFactory.build({
+      cluster_size: 2,
+      id: 2,
+      label: 'database-instance-2',
+    });
+    const database3 = databaseInstanceFactory.build({
+      cluster_size: 3,
+      id: 3,
+      label: 'database-instance-3',
+    });
+
+    const databases = [database1, database2, database3];
     return HttpResponse.json(makeResourcePage(databases));
   }),
 


### PR DESCRIPTION
## Description 📝

Updated the node type filter selection from static to dynamic.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Node type filter selection is made dependent on database cluster selection, if the maximum cluster size of selected clusters is one, we will have primary as the only option listed and if cluster size > 1, we will have both primary and secondary listed in our options.
- Preferences will be saved and retained after node type selection
- In contextual view, default node type selection is primary as before, but the options are now limited based on the cluster size as same as centralized view.

_**Note**: After selecting a cluster, if another cluster is added or any existing selection is removed, the node type will clear. There is no change in this functionality._

## Target release date 🗓️
25-02-25

## Preview 📷

=>Node type is disabled in the 'After' screenshot if no cluster is selected as it is dependent on the cluster size of the cluster
| Before  | After   |
| ------- | ------- |
|![image](https://github.com/user-attachments/assets/418f6a03-c644-4fa2-91a5-2aee1d6e19ab)| ![image](https://github.com/user-attachments/assets/c07cb526-0e19-49ab-912e-3f3f1c752229)|
|![image](https://github.com/user-attachments/assets/7c4cc881-5d27-4dc5-82f9-ccff8ec41889)| ![image](https://github.com/user-attachments/assets/c00f290b-1876-429f-b1ca-b3770e9ed657)

**After: contextual view** 👇  

https://github.com/user-attachments/assets/1b2236dd-847a-4c1b-93e8-cc532a09ff37

**After: centralized view** 👇 

https://github.com/user-attachments/assets/ef51a06e-0c1f-4fd3-a69b-10829f43ac66


**After: Preferences** 👇 

https://github.com/user-attachments/assets/c959f226-d11a-4ea5-95d6-e9cb303e5e44


## How to test 🧪

### Verification steps
- Navigate to monitor tab.
- Select dashboard, engine, and region. Node type selection filter will be disabled state if no cluster is selected.
- Now, select any one or more database clusters. If any of the selected clusters have cluster size > 1, both primary and secondary will be listed in options of node type filter, else only primary.
_Note: cluster size can be obtained from the /instances api call which fetches the clusters._

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

---
