### PR TITLE
test: [M3-9251] - Add payment generation tests for PdfGenerator.ts

### DIFF
--- a/packages/manager/.changeset/pr-11644-tests-1739256775104.md
+++ b/packages/manager/.changeset/pr-11644-tests-1739256775104.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add unit tests for `payment` PDF generator ([#11644](https://github.com/linode/manager/pull/11644))


### PR DESCRIPTION
## Description 📝
Add `Payment` generation tests for PdfGenerator.ts
- Follow-up to #11625 

## Changes  🔄
- Add `payment` generation unit tests

## Target release date 🗓️
N/A

## How to test 🧪
- Run `yarn test PdfGenerator.test.ts`
- Ensure all tests pass

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules