### PR TITLE
test: [M3-8070] Lint Cypress tests

### DIFF
--- a/packages/manager/.eslintrc.cjs
+++ b/packages/manager/.eslintrc.cjs
@@ -22,7 +22,7 @@ module.exports = {
     'build',
     'storybook-static',
     '.storybook',
-    'e2e',
+    'e2e/core',
     'public',
     '!.eslintrc.js',
   ],

--- a/packages/manager/cypress/e2e/region/images/create-machine-image-from-linode.spec.ts
+++ b/packages/manager/cypress/e2e/region/images/create-machine-image-from-linode.spec.ts
@@ -42,16 +42,16 @@ describe('Capture Machine Images', () => {
       ui.autocompletePopper.findByTitle(linode.label).click();
 
       // Select the Linode's disk.
-      cy.contains('Select a Disk').click().type(disk.label);
+      cy.contains('Select a Disk').click();
+      cy.focused().type(disk.label);
       ui.autocompletePopper.findByTitle(disk.label).click();
 
       // Specify a label and description for the captured image, click submit.
-      cy.findByLabelText('Label').should('be.visible').click().type(imageLabel);
+      cy.findByLabelText('Label').should('be.visible').click();
+      cy.focused().type(imageLabel);
 
-      cy.findByLabelText('Description')
-        .should('be.visible')
-        .click()
-        .type(imageDescription);
+      cy.findByLabelText('Description').should('be.visible').click();
+      cy.focused().type(imageDescription);
 
       ui.button
         .findByTitle('Create Image')

--- a/packages/manager/cypress/e2e/region/images/update-delete-machine-image.spec.ts
+++ b/packages/manager/cypress/e2e/region/images/update-delete-machine-image.spec.ts
@@ -97,17 +97,13 @@ describe('Delete Machine Images', () => {
             .findByTitle('Edit Image')
             .should('be.visible')
             .within(() => {
-              cy.findByLabelText('Label')
-                .should('be.visible')
-                .click()
-                .clear()
-                .type(newLabel);
+              cy.findByLabelText('Label').should('be.visible').click();
+              cy.focused().clear();
+              cy.focused().type(newLabel);
 
-              cy.findByLabelText('Description')
-                .should('be.visible')
-                .click()
-                .clear()
-                .type(newDescription);
+              cy.findByLabelText('Description').should('be.visible').click();
+              cy.focused().clear();
+              cy.focused().type(newDescription);
 
               ui.button
                 .findByTitle('Save Changes')

--- a/packages/manager/cypress/e2e/region/images/upload-machine-image.spec.ts
+++ b/packages/manager/cypress/e2e/region/images/upload-machine-image.spec.ts
@@ -27,12 +27,11 @@ describe('Upload Machine Images', () => {
     interceptUploadImage().as('uploadImage');
     // Navigate to Image upload page, enter label, select region, and upload Image file.
     cy.visitWithLogin('/images/create/upload');
-    cy.findByText('Label').should('be.visible').click().type(imageLabel);
+    cy.findByText('Label').should('be.visible').click();
+    cy.focused().type(imageLabel);
 
-    cy.findByText('Description')
-      .should('be.visible')
-      .click()
-      .type(imageDescription);
+    cy.findByText('Description').should('be.visible').click();
+    cy.focused().type(imageDescription);
 
     ui.regionSelect.find().click();
     ui.regionSelect.findItemByRegionId(region.id).should('be.visible').click();

--- a/packages/manager/cypress/e2e/region/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/region/linodes/create-linode.spec.ts
@@ -28,8 +28,11 @@ describe('Create Linodes', () => {
       });
 
     // Enter label and password.
-    cy.findByLabelText('Linode Label').click().clear().type(label);
-    cy.findByLabelText('Root Password').click().type(randomString(32));
+    cy.findByLabelText('Linode Label').click();
+    cy.focused().clear();
+    cy.focused().type(label);
+    cy.findByLabelText('Root Password').click();
+    cy.focused().type(randomString(32));
 
     // Submit.
     ui.button.findByTitle('Create Linode').click();

--- a/packages/manager/cypress/e2e/region/linodes/delete-linode.spec.ts
+++ b/packages/manager/cypress/e2e/region/linodes/delete-linode.spec.ts
@@ -53,10 +53,8 @@ describeRegions('Delete Linodes', (region: Region) => {
         .findByTitle(`Delete ${linode.label}?`)
         .should('be.visible')
         .within(() => {
-          cy.findByLabelText('Linode Label')
-            .should('be.visible')
-            .click()
-            .type(linode.label);
+          cy.findByLabelText('Linode Label').should('be.visible').click();
+          cy.focused().type(linode.label);
 
           ui.buttonGroup
             .findButtonByTitle('Delete')

--- a/packages/manager/cypress/e2e/region/linodes/update-linode.spec.ts
+++ b/packages/manager/cypress/e2e/region/linodes/update-linode.spec.ts
@@ -53,11 +53,9 @@ describeRegions('Can update Linodes', (region) => {
       cy.get('[data-qa-panel="Linode Label"]')
         .should('be.visible')
         .within(() => {
-          cy.findByLabelText('Label')
-            .should('be.visible')
-            .click()
-            .clear()
-            .type(newLabel);
+          cy.findByLabelText('Label').should('be.visible').click();
+          cy.focused().clear();
+          cy.focused().type(newLabel);
 
           ui.button
             .findByTitle('Save')
@@ -121,7 +119,8 @@ describeRegions('Can update Linodes', (region) => {
         cy.get('[data-qa-panel="Reset Root Password"]')
           .should('be.visible')
           .within(() => {
-            cy.findByText('Disk').should('be.visible').click().type(disk.label);
+            cy.findByText('Disk').should('be.visible').clear();
+            cy.focused().type(disk.label);
 
             ui.autocompletePopper
               .findByTitle(disk.label)
@@ -130,9 +129,9 @@ describeRegions('Can update Linodes', (region) => {
 
             cy.findByLabelText('New Root Password')
               .should('be.visible')
-              .click()
-              .clear()
-              .type(newPassword);
+              .clear();
+            cy.focused().clear();
+            cy.focused().type(newPassword);
 
             ui.button
               .findByTitle('Save')


### PR DESCRIPTION
## Description 📝

Add cypress tests to scope of files that are linted on precommit. The eventual goal is to allow linting on the entire packages/manager/cypress directory, but doing so right now results in 100+ files being changed. To simplify merging and review, excluding the packages/manager/cypress/e2e/core for now bc this path contains 90+ modified files.

## Changes  🔄

Some of the linting changes were simply formatting. The more difficult changes are the ones forced by the enforcement of the cypress/unsafe-to-chain-command. This rule prohibits chaining cypress statements after cypress methods that to chain further commands where it is unsafe "to chain further commands that rely on the subject after", which requires statements such as:

`cy.findByLabelText('Label').click().type('xyz');`

to be broken up into multiple statements such as:

```
cy.findByLabelText('Label').click();
cy.findByLabelText('Label').focused().type('xyz');
```

The cypress methods that I've had to un-chain are:

- click
- clear
- scrollIntoView

The scrollIntoView method does not set the scrolled element as the currentElement, so it requires getting/finding the element again. The following snippet:

```
ui.autocompletePopper
          .findByTitle('My Title')
          .scrollIntoView()
          .click();
```
 needs to be changed to:
```
ui.autocompletePopper
          .findByTitle('My Title')
          .scrollIntoView();
ui.autocompletePopper
          .findByTitle('My Title')
          .click(); 
```
Note that i haven't used aliases here to keep the snippets simple.

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- ...
- ...

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

---

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

---
