### PR TITLE
change: [M3-9162] - Bugs in Plans table for LKE

### DIFF
--- a/packages/manager/.changeset/pr-11651-changed-1739400469975.md
+++ b/packages/manager/.changeset/pr-11651-changed-1739400469975.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Fix tabIndex reset issue and update minus sign SVG for currentColor support ([#11651](https://github.com/linode/manager/pull/11651))

--- a/packages/manager/src/assets/icons/LKEminusSign.svg
+++ b/packages/manager/src/assets/icons/LKEminusSign.svg
@@ -1,11 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="11px" height="3px" viewBox="0 0 11 3" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <title>Group 3</title>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="LKE-Create" transform="translate(-1030.000000, -227.000000)" stroke="#3682DB" stroke-width="1.8">
-            <g id="Group-3" transform="translate(1030.000000, 228.000000)">
-                <line x1="0" y1="0.5" x2="11" y2="0.5" id="Line-8"></line>
-            </g>
-        </g>
-    </g>
+<svg width="11px" height="3px" viewBox="0 0 11 3" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+    <path d="M0 1.5 H11" stroke="currentColor" stroke-width="1.8" />
 </svg>

--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -67,7 +67,7 @@ const TabbedPanel = React.memo((props: TabbedPanelProps) => {
   };
 
   useEffect(() => {
-    if (tabIndex !== initTab) {
+    if (tabIndex === undefined && initTab !== undefined) {
       setTabIndex(initTab);
     }
   }, [initTab]);


### PR DESCRIPTION
## Description 📝

This PR addresses two issues with the LKE plans table in the Add Node Pool flow. It ensures the `-` (minus) button appears properly disabled and gray for disabled rows, and prevents the tab from switching unexpectedly when interacting with node pool actions.

## Changes  🔄

- Updated button styles to ensure the `-` button is gray and disabled when a row is disabled.
- Fixed an issue where the tab would unexpectedly switch back to the first tab after interacting with the node pool.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/346ca99c-c81a-4bdd-ac7c-a2542c8711bf" /> | <video src="https://github.com/user-attachments/assets/d6631542-d8bb-4903-bc4a-758954fc5ee9" /> |


### Reproduction steps

- [ ] Go to the LKE plans table via the cluster create flow or the Add Node Pool drawer from the cluster details page.
- [ ] **Bug 1**: Observe that the `-` (minus) button is blue when a row is disabled, rather than grey.
- [ ] **Bug 2**: Remove all nodes by reaching 0 in the enhanced number select, and notice that the tab unexpectedly switches back to the first tab, creating a confusing user experience.

### Verification steps

- [ ] Open the "Add a Node Pool" drawer from the Kubernetes Node Pools section.
- [ ] Click either the "Shared CPU" or "High Memory" plan tab.
- [ ] Confirm the minus (`-`) buttons are disabled and gray.
- [ ] On any active row, click a plus (`+`) button and confirm the minus (`-`) button becomes active/enabled (blue).
- [ ] Click the minus (`-`) button on the same row and confirm that the active tab does not change.


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>