### PR TITLE
feat: [M3-9020] - LKE UI updates for checkout bar & Nodebalancer Details summary

### DIFF
--- a/packages/api-v4/.changeset/pr-11653-changed-1739986135472.md
+++ b/packages/api-v4/.changeset/pr-11653-changed-1739986135472.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Changed
+---
+
+Added `type` and `lke_cluster` to Nodebalancer interface and `getNodeBalancerBeta` function ([#11653](https://github.com/linode/manager/pull/11653))

--- a/packages/api-v4/src/nodebalancers/nodebalancers.ts
+++ b/packages/api-v4/src/nodebalancers/nodebalancers.ts
@@ -2,7 +2,7 @@ import {
   NodeBalancerSchema,
   UpdateNodeBalancerSchema,
 } from '@linode/validation/lib/nodebalancers.schema';
-import { API_ROOT } from '../constants';
+import { API_ROOT, BETA_API_ROOT } from '../constants';
 import Request, {
   setData,
   setMethod,
@@ -42,6 +42,21 @@ export const getNodeBalancers = (params?: Params, filters?: Filter) =>
 export const getNodeBalancer = (nodeBalancerId: number) =>
   Request<NodeBalancer>(
     setURL(`${API_ROOT}/nodebalancers/${encodeURIComponent(nodeBalancerId)}`),
+    setMethod('GET')
+  );
+
+/**
+ * getNodeBalancerBeta
+ *
+ * Returns detailed information about a single NodeBalancer including type (only available for LKE-E).
+ *
+ * @param nodeBalancerId { number } The ID of the NodeBalancer to retrieve.
+ */
+export const getNodeBalancerBeta = (nodeBalancerId: number) =>
+  Request<NodeBalancer>(
+    setURL(
+      `${BETA_API_ROOT}/nodebalancers/${encodeURIComponent(nodeBalancerId)}`
+    ),
     setMethod('GET')
   );
 

--- a/packages/api-v4/src/nodebalancers/types.ts
+++ b/packages/api-v4/src/nodebalancers/types.ts
@@ -1,5 +1,3 @@
-import { KubernetesTier } from 'src/kubernetes/types';
-
 type TCPAlgorithm = 'roundrobin' | 'leastconn' | 'source';
 type UDPAlgorithm = 'roundrobin' | 'leastconn' | 'ring_hash';
 
@@ -14,10 +12,11 @@ export type Stickiness = TCPStickiness | UDPStickiness;
 
 type NodeBalancerType = 'common' | 'premium';
 
-interface ClusterInfo {
+export interface LKEClusterInfo {
   label: string;
-  id: number | null;
-  tier: KubernetesTier;
+  id: number;
+  url: string;
+  type: 'lkecluster';
 }
 
 export interface NodeBalancer {
@@ -39,7 +38,7 @@ export interface NodeBalancer {
   region: string;
   type?: NodeBalancerType;
   // Cluster info if the NB is associated with LKE/LKE-E
-  cluster?: ClusterInfo;
+  lke_cluster?: LKEClusterInfo | null;
   ipv4: string;
   ipv6: null | string;
   created: string;

--- a/packages/api-v4/src/nodebalancers/types.ts
+++ b/packages/api-v4/src/nodebalancers/types.ts
@@ -1,3 +1,5 @@
+import { KubernetesTier } from 'src/kubernetes/types';
+
 type TCPAlgorithm = 'roundrobin' | 'leastconn' | 'source';
 type UDPAlgorithm = 'roundrobin' | 'leastconn' | 'ring_hash';
 
@@ -11,6 +13,12 @@ type UDPStickiness = 'none' | 'session' | 'source_ip';
 export type Stickiness = TCPStickiness | UDPStickiness;
 
 type NodeBalancerType = 'common' | 'premium';
+
+interface ClusterInfo {
+  label: string;
+  id: number | null;
+  tier: KubernetesTier;
+}
 
 export interface NodeBalancer {
   id: number;
@@ -30,6 +38,8 @@ export interface NodeBalancer {
   client_udp_sess_throttle?: number;
   region: string;
   type?: NodeBalancerType;
+  // Cluster info if the NB is associated with LKE/LKE-E
+  cluster?: ClusterInfo;
   ipv4: string;
   ipv6: null | string;
   created: string;

--- a/packages/api-v4/src/nodebalancers/types.ts
+++ b/packages/api-v4/src/nodebalancers/types.ts
@@ -37,7 +37,10 @@ export interface NodeBalancer {
   client_udp_sess_throttle?: number;
   region: string;
   type?: NodeBalancerType;
-  // Cluster info if the NB is associated with LKE/LKE-E
+  /**
+   * If the NB is associated with a cluster (active or deleted), return its info
+   * If the NB is not associated with a cluster, return null
+   */
   lke_cluster?: LKEClusterInfo | null;
   ipv4: string;
   ipv6: null | string;

--- a/packages/api-v4/src/nodebalancers/types.ts
+++ b/packages/api-v4/src/nodebalancers/types.ts
@@ -10,6 +10,8 @@ type UDPStickiness = 'none' | 'session' | 'source_ip';
 
 export type Stickiness = TCPStickiness | UDPStickiness;
 
+type NodeBalancerType = 'common' | 'premium';
+
 export interface NodeBalancer {
   id: number;
   label: string;
@@ -27,6 +29,7 @@ export interface NodeBalancer {
    */
   client_udp_sess_throttle?: number;
   region: string;
+  type?: NodeBalancerType;
   ipv4: string;
   ipv6: null | string;
   created: string;

--- a/packages/manager/.changeset/pr-11653-added-1739985989958.md
+++ b/packages/manager/.changeset/pr-11653-added-1739985989958.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+LKE UI updates for checkout bar & Nodebalancer Details summary ([#11653](https://github.com/linode/manager/pull/11653))

--- a/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
@@ -1,9 +1,8 @@
-import { Divider, Typography } from '@linode/ui';
+import { Typography } from '@linode/ui';
 import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 
 import { DisplayPrice } from 'src/components/DisplayPrice';
-import { Link } from 'src/components/Link';
 
 import {
   StyledButton,
@@ -14,9 +13,9 @@ import {
 
 export interface CheckoutBarProps {
   /**
-   * Additional pricing text displayed after the calculated total
+   * Additional pricing to display after the calculated total
    */
-  additionalPriceText?: string;
+  additionalPricing?: JSX.Element;
   /**
    * JSX element to be displayed as an agreement section.
    */
@@ -66,7 +65,7 @@ export interface CheckoutBarProps {
 
 const CheckoutBar = (props: CheckoutBarProps) => {
   const {
-    additionalPriceText,
+    additionalPricing,
     agreement,
     calculatedPrice,
     children,
@@ -103,13 +102,7 @@ const CheckoutBar = (props: CheckoutBarProps) => {
           {(price >= 0 && !disabled) || price ? (
             <>
               <DisplayPrice interval="mo" price={price} />
-              {additionalPriceText && (
-                <>
-                  <Divider dark spacingBottom={16} spacingTop={16} />
-                  <Typography>{additionalPriceText}</Typography>
-                  <Link to="https://www.linode.com/pricing/">See pricing</Link>.
-                </>
-              )}
+              {additionalPricing}
             </>
           ) : (
             <Typography>{priceSelectionText}</Typography>

--- a/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
@@ -1,8 +1,9 @@
-import { Typography } from '@linode/ui';
+import { Divider, Typography } from '@linode/ui';
 import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 
 import { DisplayPrice } from 'src/components/DisplayPrice';
+import { Link } from 'src/components/Link';
 
 import {
   StyledButton,
@@ -12,6 +13,10 @@ import {
 } from './styles';
 
 export interface CheckoutBarProps {
+  /**
+   * Additional pricing text displayed after the calculated total
+   */
+  additionalPriceText?: string;
   /**
    * JSX element to be displayed as an agreement section.
    */
@@ -61,6 +66,7 @@ export interface CheckoutBarProps {
 
 const CheckoutBar = (props: CheckoutBarProps) => {
   const {
+    additionalPriceText,
     agreement,
     calculatedPrice,
     children,
@@ -95,7 +101,16 @@ const CheckoutBar = (props: CheckoutBarProps) => {
       {
         <StyledCheckoutSection data-qa-total-price>
           {(price >= 0 && !disabled) || price ? (
-            <DisplayPrice interval="mo" price={price} />
+            <>
+              <DisplayPrice interval="mo" price={price} />
+              {additionalPriceText && (
+                <>
+                  <Divider dark spacingBottom={16} spacingTop={16} />
+                  <Typography>{additionalPriceText}</Typography>
+                  <Link to="#">See pricing</Link>.
+                </>
+              )}
+            </>
           ) : (
             <Typography>{priceSelectionText}</Typography>
           )}

--- a/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
@@ -107,7 +107,7 @@ const CheckoutBar = (props: CheckoutBarProps) => {
                 <>
                   <Divider dark spacingBottom={16} spacingTop={16} />
                   <Typography>{additionalPriceText}</Typography>
-                  <Link to="#">See pricing</Link>.
+                  <Link to="https://www.linode.com/pricing/">See pricing</Link>.
                 </>
               )}
             </>

--- a/packages/manager/src/factories/account.ts
+++ b/packages/manager/src/factories/account.ts
@@ -54,6 +54,7 @@ export const accountFactory = Factory.Sync.makeFactory<Account>({
     'Object Storage',
     'Placement Group',
     'Vlans',
+    'Kubernetes Enterprise',
   ],
   city: 'Philadelphia',
   company: Factory.each((i) => `company-${i}`),

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
@@ -66,6 +66,15 @@ describe('KubeCheckoutBar', () => {
     expect(queryAllByText(/minimum of 3 nodes/i)).toHaveLength(0);
   });
 
+  it('should render additional pricing text', async () => {
+    const { findByText } = renderComponent(props);
+    expect(
+      await findByText(
+        /Additional services added to the cluster may incur charges./i
+      )
+    ).toBeVisible();
+  });
+
   it('should show a warning if any pool has fewer than 3 nodes', async () => {
     const poolsWithSmallNode = [...pools, nodePoolFactory.build({ count: 2 })];
     const { findByText } = renderComponent({

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
@@ -66,13 +66,20 @@ describe('KubeCheckoutBar', () => {
     expect(queryAllByText(/minimum of 3 nodes/i)).toHaveLength(0);
   });
 
-  it('should render additional pricing text', async () => {
-    const { findByText } = renderComponent(props);
+  it('should render additional pricing text and link', async () => {
+    const { findByText, getByRole } = renderComponent(props);
     expect(
       await findByText(
         /Additional services added to the cluster may incur charges./i
       )
     ).toBeVisible();
+
+    const additionalPricingLink = getByRole('link');
+    expect(additionalPricingLink).toHaveTextContent('See pricing');
+    expect(additionalPricingLink).toHaveAttribute(
+      'href',
+      'https://www.linode.com/pricing/'
+    );
   });
 
   it('should show a warning if any pool has fewer than 3 nodes', async () => {

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -9,6 +9,7 @@ import { useProfile } from 'src/queries/profile/profile';
 import { useSpecificTypes } from 'src/queries/types';
 import { extendTypesQueryResult } from 'src/utilities/extendType';
 import { getGDPRDetails } from 'src/utilities/formatRegion';
+import { LKE_ADDITIONAL_PRICING } from 'src/utilities/pricing/constants';
 import {
   LKE_CREATE_CLUSTER_CHECKOUT_MESSAGE,
   LKE_ENTERPRISE_CREATE_CLUSTER_CHECKOUT_MESSAGE,
@@ -119,6 +120,7 @@ export const KubeCheckoutBar = (props: Props) => {
           ? LKE_ENTERPRISE_CREATE_CLUSTER_CHECKOUT_MESSAGE
           : LKE_CREATE_CLUSTER_CHECKOUT_MESSAGE
       }
+      additionalPriceText={LKE_ADDITIONAL_PRICING}
       data-qa-checkout-bar
       disabled={disableCheckout}
       heading="Cluster Summary"

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -2,6 +2,7 @@ import { CircleProgress, Divider, Notice, Typography } from '@linode/ui';
 import * as React from 'react';
 
 import { CheckoutBar } from 'src/components/CheckoutBar/CheckoutBar';
+import { Link } from 'src/components/Link';
 import { RenderGuard } from 'src/components/RenderGuard';
 import { EUAgreementCheckbox } from 'src/features/Account/Agreements/EUAgreementCheckbox';
 import { useAccountAgreements } from 'src/queries/account/agreements';
@@ -9,11 +10,11 @@ import { useProfile } from 'src/queries/profile/profile';
 import { useSpecificTypes } from 'src/queries/types';
 import { extendTypesQueryResult } from 'src/utilities/extendType';
 import { getGDPRDetails } from 'src/utilities/formatRegion';
-import { LKE_ADDITIONAL_PRICING } from 'src/utilities/pricing/constants';
 import {
   LKE_CREATE_CLUSTER_CHECKOUT_MESSAGE,
   LKE_ENTERPRISE_CREATE_CLUSTER_CHECKOUT_MESSAGE,
 } from 'src/utilities/pricing/constants';
+import { LKE_ADDITIONAL_PRICING } from 'src/utilities/pricing/constants';
 import {
   getKubernetesMonthlyPrice,
   getTotalClusterPrice,
@@ -120,7 +121,7 @@ export const KubeCheckoutBar = (props: Props) => {
           ? LKE_ENTERPRISE_CREATE_CLUSTER_CHECKOUT_MESSAGE
           : LKE_CREATE_CLUSTER_CHECKOUT_MESSAGE
       }
-      additionalPriceText={LKE_ADDITIONAL_PRICING}
+      additionalPricing={AdditionalPricing}
       data-qa-checkout-bar
       disabled={disableCheckout}
       heading="Cluster Summary"
@@ -184,5 +185,19 @@ export const KubeCheckoutBar = (props: Props) => {
     </CheckoutBar>
   );
 };
+
+const AdditionalPricing = (
+  <>
+    <Divider dark spacingBottom={16} spacingTop={16} />
+    <Typography>{LKE_ADDITIONAL_PRICING}</Typography>
+    <Link
+      data-testid="additional-pricing-link"
+      to="https://www.linode.com/pricing/"
+    >
+      See pricing
+    </Link>
+    .
+  </>
+);
 
 export default RenderGuard(KubeCheckoutBar);

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.test.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react';
 import * as React from 'react';
 
 import {
@@ -5,6 +6,7 @@ import {
   nodeBalancerConfigFactory,
   nodeBalancerFactory,
 } from 'src/factories';
+import { HttpResponse, http, server } from 'src/mocks/testServer';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { SummaryPanel } from './SummaryPanel';
@@ -76,6 +78,10 @@ describe('SummaryPanel', () => {
     expect(getByText('Host Name:')).toBeVisible();
     expect(getByText('example.com')).toBeVisible();
     expect(getByText('Region:')).toBeVisible();
+    // Type should not display for non-premium NBs
+    expect(getByText('Type:')).not.toBeVisible();
+    // Cluster should not display for if the NB is not associated with LKE or LKE-E
+    expect(getByText('Cluster:')).not.toBeVisible();
 
     // Firewall panel
     expect(getByText('Firewall')).toBeVisible();
@@ -88,5 +94,70 @@ describe('SummaryPanel', () => {
     // Tags panel
     expect(getByText('Tags')).toBeVisible();
     expect(getByText('Add a tag')).toBeVisible();
+  });
+
+  it('displays type: premium if the nodebalancer is premium', () => {
+    queryMocks.useNodeBalancerQuery.mockReturnValue({
+      data: nodeBalancerFactory.build({ type: 'premium' }),
+    });
+
+    const { container } = renderWithTheme(<SummaryPanel />);
+
+    expect(container.querySelector('[data-qa-type]')).toHaveTextContent(
+      'Type: Premium'
+    );
+  });
+
+  it('displays link to cluster if it exists', () => {
+    queryMocks.useNodeBalancerQuery.mockReturnValue({
+      data: nodeBalancerFactory.build({
+        lke_cluster: {
+          id: 1,
+          label: 'lke-123',
+          type: 'lkecluster',
+          url: 'v4/lke/clusters/1',
+        },
+      }),
+    });
+
+    const { container, getByText } = renderWithTheme(<SummaryPanel />);
+
+    expect(getByText('Cluster:')).toBeVisible();
+    const clusterLink = container.querySelector('[data-qa-cluster] a');
+    expect(clusterLink).toHaveTextContent('lke-123');
+    expect(clusterLink).toHaveAttribute(
+      'href',
+      '/kubernetes/clusters/1/summary'
+    );
+  });
+
+  it('displays cluster name as deleted text if the cluster was deleted', async () => {
+    queryMocks.useNodeBalancerQuery.mockReturnValue({
+      data: nodeBalancerFactory.build({
+        lke_cluster: {
+          id: 1,
+          label: 'lke-123',
+          type: 'lkecluster',
+          url: 'v4/lke/clusters/1',
+        },
+      }),
+    });
+
+    server.use(
+      http.get('*/lke/clusters/:clusterId', () => {
+        return HttpResponse.json({}, { status: 404 });
+      })
+    );
+
+    const { container } = renderWithTheme(<SummaryPanel />);
+
+    await waitFor(() => {
+      const clusterLink = container.querySelector('[data-qa-cluster]');
+      expect(clusterLink).toHaveTextContent('Cluster: lke-123 (deleted)');
+      expect(clusterLink).not.toHaveAttribute(
+        'href',
+        '/kubernetes/clusters/1/summary'
+      );
+    });
   });
 });

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.test.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.test.tsx
@@ -66,7 +66,7 @@ describe('SummaryPanel', () => {
   });
 
   it('renders the panel if there is data to render', () => {
-    const { getByText } = renderWithTheme(<SummaryPanel />);
+    const { getByText, queryByText } = renderWithTheme(<SummaryPanel />);
 
     // Main summary panel
     expect(getByText(nodeBalancerDetails)).toBeVisible();
@@ -79,9 +79,9 @@ describe('SummaryPanel', () => {
     expect(getByText('example.com')).toBeVisible();
     expect(getByText('Region:')).toBeVisible();
     // Type should not display for non-premium NBs
-    expect(getByText('Type:')).not.toBeVisible();
+    expect(queryByText('Type:')).not.toBeInTheDocument();
     // Cluster should not display for if the NB is not associated with LKE or LKE-E
-    expect(getByText('Cluster:')).not.toBeVisible();
+    expect(queryByText('Cluster:')).not.toBeInTheDocument();
 
     // Firewall panel
     expect(getByText('Firewall')).toBeVisible();

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -69,11 +69,20 @@ export const SummaryPanel = () => {
             <StyledSection>
               <Typography data-qa-ports variant="body1">
                 <strong>Cluster: </strong>
-                <Link
-                  to={`/kubernetes/clusters/${nodebalancer.cluster.id}/summary`}
-                >
-                  {nodebalancer.cluster.label}
-                </Link>{' '}
+                {nodebalancer.cluster.id === null ? (
+                  <>
+                    <span style={{ textDecoration: 'line-through' }}>
+                      {nodebalancer.cluster.label}
+                    </span>
+                    <span style={{ fontStyle: 'italic' }}> (deleted)</span>
+                  </>
+                ) : (
+                  <Link
+                    to={`/kubernetes/clusters/${nodebalancer.cluster.id}/summary`}
+                  >
+                    {nodebalancer.cluster.label}
+                  </Link>
+                )}
               </Typography>
             </StyledSection>
           )}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -57,6 +57,14 @@ export const SummaryPanel = () => {
           <StyledTitle data-qa-title variant="h3">
             NodeBalancer Details
           </StyledTitle>
+          {nodebalancer.type === 'premium' && (
+            <StyledSection>
+              <Typography data-qa-ports variant="body1">
+                <strong>Type: </strong>
+                Premium
+              </Typography>
+            </StyledSection>
+          )}
           <StyledSection>
             <Typography data-qa-ports variant="body1">
               <strong>Ports: </strong>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -72,7 +72,7 @@ export const SummaryPanel = () => {
           </StyledTitle>
           {nodebalancer.type === 'premium' && (
             <StyledSection>
-              <Typography data-qa-ports variant="body1">
+              <Typography data-qa-type variant="body1">
                 <strong>Type: </strong>
                 Premium
               </Typography>
@@ -80,7 +80,7 @@ export const SummaryPanel = () => {
           )}
           {nodebalancer.lke_cluster && (
             <StyledSection>
-              <Typography data-qa-ports variant="body1">
+              <Typography data-qa-cluster variant="body1">
                 <strong>Cluster: </strong>
                 {clusterStatus === 'error' ? (
                   <>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -35,10 +35,10 @@ export const SummaryPanel = () => {
     id: nodebalancer?.id,
   });
 
-  // check if the cluster has been deleted
+  // If we can't get the cluster (status === 'error'), we can assume it's been deleted
   const { status: clusterStatus } = useKubernetesClusterQuery(
     nodebalancer?.lke_cluster?.id ?? -1,
-    nodebalancer && nodebalancer.lke_cluster !== null,
+    nodebalancer && Boolean(nodebalancer.lke_cluster),
     {
       refetchOnMount: false,
       refetchOnReconnect: false,

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -6,6 +6,7 @@ import { Link, useParams } from 'react-router-dom';
 import { TagCell } from 'src/components/TagCell/TagCell';
 import { IPAddress } from 'src/features/Linodes/LinodesLanding/IPAddress';
 import { useIsResourceRestricted } from 'src/hooks/useIsResourceRestricted';
+import { useKubernetesClusterQuery } from 'src/queries/kubernetes';
 import {
   useAllNodeBalancerConfigsQuery,
   useNodeBalancerQuery,
@@ -33,6 +34,18 @@ export const SummaryPanel = () => {
     grantType: 'nodebalancer',
     id: nodebalancer?.id,
   });
+
+  // check if the cluster has been deleted
+  const { status: clusterStatus } = useKubernetesClusterQuery(
+    nodebalancer?.lke_cluster?.id ?? -1,
+    nodebalancer && nodebalancer.lke_cluster !== null,
+    {
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+      retry: false,
+    }
+  );
 
   const configPorts = configs?.reduce((acc, config) => {
     return [...acc, { configId: config.id, port: config.port }];
@@ -65,22 +78,22 @@ export const SummaryPanel = () => {
               </Typography>
             </StyledSection>
           )}
-          {nodebalancer.cluster && (
+          {nodebalancer.lke_cluster && (
             <StyledSection>
               <Typography data-qa-ports variant="body1">
                 <strong>Cluster: </strong>
-                {nodebalancer.cluster.id === null ? (
+                {clusterStatus === 'error' ? (
                   <>
                     <span style={{ textDecoration: 'line-through' }}>
-                      {nodebalancer.cluster.label}
+                      {nodebalancer.lke_cluster.label}
                     </span>
                     <span style={{ fontStyle: 'italic' }}> (deleted)</span>
                   </>
                 ) : (
                   <Link
-                    to={`/kubernetes/clusters/${nodebalancer.cluster.id}/summary`}
+                    to={`/kubernetes/clusters/${nodebalancer.lke_cluster.id}/summary`}
                   >
-                    {nodebalancer.cluster.label}
+                    {nodebalancer.lke_cluster.label}
                   </Link>
                 )}
               </Typography>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -65,6 +65,18 @@ export const SummaryPanel = () => {
               </Typography>
             </StyledSection>
           )}
+          {nodebalancer.cluster && (
+            <StyledSection>
+              <Typography data-qa-ports variant="body1">
+                <strong>Cluster: </strong>
+                <Link
+                  to={`/kubernetes/clusters/${nodebalancer.cluster.id}/summary`}
+                >
+                  {nodebalancer.cluster.label}
+                </Link>{' '}
+              </Typography>
+            </StyledSection>
+          )}
           <StyledSection>
             <Typography data-qa-ports variant="body1">
               <strong>Ports: </strong>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -912,6 +912,13 @@ export const handlers = [
     });
     return HttpResponse.json(nodeBalancer);
   }),
+  http.get('*/v4beta/nodebalancers/:nodeBalancerID', ({ params }) => {
+    const nodeBalancer = nodeBalancerFactory.build({
+      id: Number(params.nodeBalancerID),
+      type: 'premium',
+    });
+    return HttpResponse.json(nodeBalancer);
+  }),
   http.get('*/nodebalancers/:nodeBalancerID/configs', ({ params }) => {
     const configs = nodeBalancerConfigFactory.buildList(2, {
       nodebalancer_id: Number(params.nodeBalancerID),

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -914,6 +914,11 @@ export const handlers = [
   }),
   http.get('*/v4beta/nodebalancers/:nodeBalancerID', ({ params }) => {
     const nodeBalancer = nodeBalancerFactory.build({
+      cluster: {
+        id: 1,
+        label: 'lke-e-123',
+        tier: 'enterprise',
+      },
       id: Number(params.nodeBalancerID),
       type: 'premium',
     });

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -835,6 +835,7 @@ export const handlers = [
     const id = Number(params.clusterId);
     const cluster = kubernetesAPIResponse.build({ id, k8s_version: '1.16' });
     return HttpResponse.json(cluster);
+    // return HttpResponse.json({}, { status: 404 });
   }),
   http.put('*/lke/clusters/:clusterId', async ({ params }) => {
     const id = Number(params.clusterId);
@@ -914,12 +915,13 @@ export const handlers = [
   }),
   http.get('*/v4beta/nodebalancers/:nodeBalancerID', ({ params }) => {
     const nodeBalancer = nodeBalancerFactory.build({
-      cluster: {
+      id: Number(params.nodeBalancerID),
+      lke_cluster: {
         id: 1,
         label: 'lke-e-123',
-        tier: 'enterprise',
+        type: 'lkecluster',
+        url: 'v4/lke/clusters/1',
       },
-      id: Number(params.nodeBalancerID),
       type: 'premium',
     });
     return HttpResponse.json(nodeBalancer);

--- a/packages/manager/src/queries/kubernetes.ts
+++ b/packages/manager/src/queries/kubernetes.ts
@@ -137,14 +137,19 @@ export const kubernetesQueries = createQueryKeys('kubernetes', {
   },
 });
 
-export const useKubernetesClusterQuery = (id: number) => {
+export const useKubernetesClusterQuery = (
+  id: number,
+  enabled = false,
+  options = {}
+) => {
   const { isLoading: isAPLAvailabilityLoading, showAPL } = useAPLAvailability();
   const { isLkeEnterpriseLAFeatureEnabled } = useIsLkeEnterpriseEnabled();
   const useBetaEndpoint = showAPL || isLkeEnterpriseLAFeatureEnabled;
 
   return useQuery<KubernetesCluster, APIError[]>({
     ...kubernetesQueries.cluster(id)._ctx.cluster(useBetaEndpoint),
-    enabled: !isAPLAvailabilityLoading,
+    enabled: enabled || !isAPLAvailabilityLoading,
+    ...options,
   });
 };
 

--- a/packages/manager/src/queries/kubernetes.ts
+++ b/packages/manager/src/queries/kubernetes.ts
@@ -139,7 +139,7 @@ export const kubernetesQueries = createQueryKeys('kubernetes', {
 
 export const useKubernetesClusterQuery = (
   id: number,
-  enabled = false,
+  enabled = true,
   options = {}
 ) => {
   const { isLoading: isAPLAvailabilityLoading, showAPL } = useAPLAvailability();
@@ -148,7 +148,7 @@ export const useKubernetesClusterQuery = (
 
   return useQuery<KubernetesCluster, APIError[]>({
     ...kubernetesQueries.cluster(id)._ctx.cluster(useBetaEndpoint),
-    enabled: enabled || !isAPLAvailabilityLoading,
+    enabled: enabled && !isAPLAvailabilityLoading,
     ...options,
   });
 };

--- a/packages/manager/src/utilities/pricing/constants.ts
+++ b/packages/manager/src/utilities/pricing/constants.ts
@@ -19,3 +19,5 @@ export const MAGIC_DATE_THAT_DC_SPECIFIC_PRICING_WAS_IMPLEMENTED =
   '2023-10-05 00:00:00Z';
 export const DOCS_LINK_LABEL_DC_PRICING = 'How Data Center Pricing Works';
 export const DOCS_LINK_LABEL_APL_APPLICATIONS = 'Available Applications';
+export const LKE_ADDITIONAL_PRICING =
+  'Additional services added to the cluster may incur charges.';


### PR DESCRIPTION
## Description 📝

- Added a `Premium` indicator on the NodeBalancer details pages for HCNBs.
- Added link to LKE/LKE-E cluster on the NodeBalancer details page if the NB is associated
- Added additional pricing text to the LKE/LKE-E checkout bar

## Preview 📷

<details>
<summary> Preview </summary>

| Nodebalancer  | LKE/LKE-E | Preview  |
| ------- | ------- | ------- |
| Premium | No | <img src="https://github.com/user-attachments/assets/2f8560da-8324-4fd9-a36c-3d436b3d39d9" width="300" /> |
| Premium | Yes | <img src="https://github.com/user-attachments/assets/98f0dba1-abdd-4be8-9a33-8d87f77e3eb5" width="300" /> |
| Premium | Yes (deleted) | <img src="https://github.com/user-attachments/assets/729b79d9-3437-4bf9-b368-9e1b07995e1a" width="300" /> |
| Common | No | <img src="https://github.com/user-attachments/assets/2673b368-af66-4c79-b107-916e82d22dd7" width="300" /> |
| Common | Yes | <img src="https://github.com/user-attachments/assets/d78c7703-11a6-47ce-8bfd-97d53d332296" width="300" /> |
| Common | Yes (deleted) | <img src="https://github.com/user-attachments/assets/04d85f05-92ec-4fe3-96c6-a29f79734a65" width="300" /> |

<img src="https://github.com/user-attachments/assets/b3ce6c62-dd8c-4763-baed-48c95d472c96" height="400" />

</details>

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Use the legacy MSW

### Verification steps

(How to verify changes)

- [ ] Go to `/kubernetes/create`, fill out the form, and confirm the additional pricing text is shown
- [ ] Turn on the MSW, go to a Nodebalancer's details page
  - [ ] Test out different values for the LKE cluster and nodebalancer type by updating the GET for `*/lke/clusters/:clusterId` on lines 834-838 and the GET for `*/v4beta/nodebalancers/:nodeBalancerID` on lines 916-927

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>