### PR TITLE
upcoming: [DI-23310] - Handle enable/disable action item for user created alerts

### DIFF
--- a/packages/api-v4/src/cloudpulse/alerts.ts
+++ b/packages/api-v4/src/cloudpulse/alerts.ts
@@ -11,6 +11,7 @@ import {
   AlertServiceType,
   CreateAlertDefinitionPayload,
   EditAlertDefinitionPayload,
+  EditAlertResourcesPayload,
   NotificationChannel,
 } from './types';
 import { BETA_API_ROOT as API_ROOT } from '../constants';
@@ -71,4 +72,19 @@ export const getNotificationChannels = (params?: Params, filters?: Filter) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filters)
+  );
+
+export const editAlertDefinitionEntities = (
+  data: EditAlertResourcesPayload,
+  serviceType: string,
+  alertId: number
+) =>
+  Request<Alert>(
+    setURL(
+      `http://blr-lhvl2d.bangalore.corp.akamai.com:9001/v4beta/monitor/services/${encodeURIComponent(
+        serviceType
+      )}/alert-definitions/${encodeURIComponent(alertId)}`
+    ),
+    setMethod('PUT'),
+    setData(data)
   );

--- a/packages/api-v4/src/cloudpulse/alerts.ts
+++ b/packages/api-v4/src/cloudpulse/alerts.ts
@@ -11,7 +11,6 @@ import {
   AlertServiceType,
   CreateAlertDefinitionPayload,
   EditAlertDefinitionPayload,
-  EditAlertResourcesPayload,
   NotificationChannel,
 } from './types';
 import { BETA_API_ROOT as API_ROOT } from '../constants';
@@ -72,19 +71,4 @@ export const getNotificationChannels = (params?: Params, filters?: Filter) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filters)
-  );
-
-export const editAlertDefinitionEntities = (
-  data: EditAlertResourcesPayload,
-  serviceType: string,
-  alertId: number
-) =>
-  Request<Alert>(
-    setURL(
-      `http://blr-lhvl2d.bangalore.corp.akamai.com:9001/v4beta/monitor/services/${encodeURIComponent(
-        serviceType
-      )}/alert-definitions/${encodeURIComponent(alertId)}`
-    ),
-    setMethod('PUT'),
-    setData(data)
   );

--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -180,6 +180,15 @@ export interface CreateAlertDefinitionPayload {
   trigger_conditions: TriggerCondition;
   channel_ids: number[];
 }
+export interface EditAlertResourcesPayload {
+  entity_ids?: string[];
+  status?: 'disabled' | 'enabled';
+}
+
+export interface AlertStatusUpdatePayload {
+  status: 'disabled' | 'enabled';
+}
+
 export interface MetricCriteria {
   metric: string;
   aggregate_function: MetricAggregationType;
@@ -307,5 +316,6 @@ export type NotificationChannel =
   | NotificationChannelPagerDuty;
 
 export interface EditAlertDefinitionPayload {
-  entity_ids: string[];
+  entity_ids?: string[];
+  status?: 'enabled' | 'disabled';
 }

--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -312,10 +312,10 @@ export interface EditAlertDefinitionPayload {
   status?: AlertStatusType;
 }
 
-export interface EditAlertDefinitionPayloadExtended
+export interface ExtendedEditAlertDefinitionPayload
   extends EditAlertDefinitionPayload {
   serviceType: string;
   alertId: string;
 }
 
-export type AlertStatusUpdateAction = 'Enable' | 'Disable';
+export type AlertStatusUpdateType = 'Enable' | 'Disable';

--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -312,7 +312,7 @@ export interface EditAlertDefinitionPayload {
   status?: AlertStatusType;
 }
 
-export interface ExtendedEditAlertDefinitionPayload
+export interface EditAlertDefinitionPayloadWithServiceTypeAndAlertId
   extends EditAlertDefinitionPayload {
   serviceType: string;
   alertId: string;

--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -180,14 +180,6 @@ export interface CreateAlertDefinitionPayload {
   trigger_conditions: TriggerCondition;
   channel_ids: number[];
 }
-export interface EditAlertResourcesPayload {
-  entity_ids?: string[];
-  status?: 'disabled' | 'enabled';
-}
-
-export interface AlertStatusUpdatePayload {
-  status: 'disabled' | 'enabled';
-}
 
 export interface MetricCriteria {
   metric: string;
@@ -317,5 +309,5 @@ export type NotificationChannel =
 
 export interface EditAlertDefinitionPayload {
   entity_ids?: string[];
-  status?: 'enabled' | 'disabled';
+  status?: AlertStatusType;
 }

--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -311,3 +311,11 @@ export interface EditAlertDefinitionPayload {
   entity_ids?: string[];
   status?: AlertStatusType;
 }
+
+export interface EditAlertDefinitionPayloadExtended
+  extends EditAlertDefinitionPayload {
+  serviceType: string;
+  alertId: string;
+}
+
+export type AlertStatusUpdateAction = 'Enable' | 'Disable';

--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -312,7 +312,7 @@ export interface EditAlertDefinitionPayload {
   status?: AlertStatusType;
 }
 
-export interface EditAlertDefinitionPayloadWithServiceTypeAndAlertId
+export interface EditAlertPayloadWithService
   extends EditAlertDefinitionPayload {
   serviceType: string;
   alertId: string;

--- a/packages/manager/.changeset/pr-11656-upcoming-features-1739419988145.md
+++ b/packages/manager/.changeset/pr-11656-upcoming-features-1739419988145.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Handle enable/disable action item for user created alerts in CloudPulse ([#11656](https://github.com/linode/manager/pull/11656))

--- a/packages/manager/src/factories/cloudpulse/alerts.ts
+++ b/packages/manager/src/factories/cloudpulse/alerts.ts
@@ -44,7 +44,7 @@ export const alertFactory = Factory.Sync.makeFactory<Alert>({
   ],
   class: 'dedicated',
   created: new Date().toISOString(),
-  created_by: 'user1',
+  created_by: 'system',
   description: 'Test description',
   entity_ids: ['1', '2', '3'],
   has_more_resources: true,
@@ -66,5 +66,5 @@ export const alertFactory = Factory.Sync.makeFactory<Alert>({
 
   type: 'system',
   updated: new Date().toISOString(),
-  updated_by: 'user1',
+  updated_by: 'system',
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertActionMenu.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertActionMenu.tsx
@@ -20,7 +20,7 @@ export interface ActionHandlers {
   /**
    * Callback for enable/disable toggle action
    */
-  handleEnableDisable?: () => void;
+  handleEnableDisable: () => void;
 }
 
 export interface AlertActionMenuProps {

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertActionMenu.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertActionMenu.tsx
@@ -4,7 +4,7 @@ import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
 
 import { getAlertTypeToActionsList } from '../Utils/AlertsActionMenu';
 
-import type { AlertDefinitionType } from '@linode/api-v4';
+import type { AlertDefinitionType, AlertStatusType } from '@linode/api-v4';
 
 export interface ActionHandlers {
   /**
@@ -16,6 +16,11 @@ export interface ActionHandlers {
    * Callback for edit alerts action
    */
   handleEdit: () => void;
+
+  /**
+   * Callback for enable/disable toggle action
+   */
+  handleEnableDisable: () => void;
 }
 
 export interface AlertActionMenuProps {
@@ -23,6 +28,10 @@ export interface AlertActionMenuProps {
    * The label of the alert
    */
   alertLabel: string;
+  /**
+   * Status of the alert
+   */
+  alertStatus: AlertStatusType;
   /**
    * Type of the alert
    */
@@ -34,10 +43,10 @@ export interface AlertActionMenuProps {
 }
 
 export const AlertActionMenu = (props: AlertActionMenuProps) => {
-  const { alertLabel, alertType, handlers } = props;
+  const { alertLabel, alertStatus, alertType, handlers } = props;
   return (
     <ActionMenu
-      actionsList={getAlertTypeToActionsList(handlers)[alertType]}
+      actionsList={getAlertTypeToActionsList(handlers, alertStatus)[alertType]}
       ariaLabel={`Action menu for Alert ${alertLabel}`}
     />
   );

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertActionMenu.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertActionMenu.tsx
@@ -20,7 +20,7 @@ export interface ActionHandlers {
   /**
    * Callback for enable/disable toggle action
    */
-  handleEnableDisable: () => void;
+  handleEnableDisable?: () => void;
 }
 
 export interface AlertActionMenuProps {

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.test.tsx
@@ -1,3 +1,4 @@
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { alertFactory } from 'src/factories';
@@ -5,6 +6,21 @@ import { formatDate } from 'src/utilities/formatDate';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { AlertsListTable } from './AlertListTable';
+
+const queryMocks = vi.hoisted(() => ({
+  useEditAlertDefinition: vi.fn(),
+}));
+
+vi.mock('src/queries/cloudpulse/alerts', () => ({
+  ...vi.importActual('src/queries/cloudpulse/alerts'),
+  useEditAlertDefinition: queryMocks.useEditAlertDefinition,
+}));
+
+queryMocks.useEditAlertDefinition.mockReturnValue({
+  isError: false,
+  mutateAsync: vi.fn().mockResolvedValue({}),
+  reset: vi.fn(),
+});
 
 describe('Alert List Table test', () => {
   it('should render the alert landing table ', async () => {
@@ -58,5 +74,79 @@ describe('Alert List Table test', () => {
         })
       )
     ).toBeVisible();
+  });
+
+  it('should show success snackbar when enabling alert succeeds', async () => {
+    const alert = alertFactory.build({ status: 'disabled', type: 'user' });
+    const { getByLabelText, getByText } = renderWithTheme(
+      <AlertsListTable
+        alerts={[alert]}
+        isLoading={false}
+        services={[{ label: 'Linode', value: 'linode' }]}
+      />
+    );
+
+    const actionMenu = getByLabelText(`Action menu for Alert ${alert.label}`);
+    await userEvent.click(actionMenu);
+    await userEvent.click(getByText('Enable')); // click the enable button to enable alert
+    expect(getByText('Alert enabled')).toBeInTheDocument(); // validate whether snackbar is displayed properly if alert is enabled successfully
+  });
+
+  it('should show success snackbar when disabling alert succeeds', async () => {
+    const alert = alertFactory.build({ status: 'enabled', type: 'user' });
+    const { getByLabelText, getByText } = renderWithTheme(
+      <AlertsListTable
+        alerts={[alert]}
+        isLoading={false}
+        services={[{ label: 'Linode', value: 'linode' }]}
+      />
+    );
+
+    const actionMenu = getByLabelText(`Action menu for Alert ${alert.label}`);
+    await userEvent.click(actionMenu);
+    await userEvent.click(getByText('Disable')); // click the enable button to enable alert
+    expect(getByText('Alert disabled')).toBeInTheDocument(); // validate whether snackbar is displayed properly if alert is disabled successfully
+  });
+
+  it('should show error snackbar when enabling alert fails', async () => {
+    queryMocks.useEditAlertDefinition.mockReturnValue({
+      mutateAsync: vi.fn().mockRejectedValue({}),
+    });
+
+    const alert = alertFactory.build({ status: 'disabled', type: 'user' });
+    const { getByLabelText, getByText } = renderWithTheme(
+      <AlertsListTable
+        alerts={[alert]}
+        isLoading={false}
+        services={[{ label: 'Linode', value: 'linode' }]}
+      />
+    );
+
+    const actionMenu = getByLabelText(`Action menu for Alert ${alert.label}`);
+    await userEvent.click(actionMenu);
+    await userEvent.click(getByText('Enable'));
+
+    expect(getByText('Enabling alert failed')).toBeInTheDocument(); // validate whether snackbar is displayed properly if an error is encountered while enabling an alert
+  });
+
+  it('should show error snackbar when disabling alert fails', async () => {
+    queryMocks.useEditAlertDefinition.mockReturnValue({
+      mutateAsync: vi.fn().mockRejectedValue({}),
+    });
+
+    const alert = alertFactory.build({ status: 'enabled', type: 'user' });
+    const { getByLabelText, getByText } = renderWithTheme(
+      <AlertsListTable
+        alerts={[alert]}
+        isLoading={false}
+        services={[{ label: 'Linode', value: 'linode' }]}
+      />
+    );
+
+    const actionMenu = getByLabelText(`Action menu for Alert ${alert.label}`);
+    await userEvent.click(actionMenu);
+    await userEvent.click(getByText('Disable'));
+
+    expect(getByText('Disabling alert failed')).toBeInTheDocument(); // validate whether snackbar is displayed properly if an error is encountered while disabling an alert
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.tsx
@@ -51,10 +51,6 @@ export const AlertsListTable = React.memo((props: AlertsListTableProps) => {
   const handleEdit = ({ id, service_type: serviceType }: Alert) => {
     history.push(`${location.pathname}/edit/${serviceType}/${id}`);
   };
-  const handleEnableDisable = (alert: Alert) => {
-    // This is just a pass-through function - actual implementation will be in AlertTableRow
-    // We keep this for consistency in how handlers are passed
-  };
 
   return (
     <OrderBy
@@ -107,7 +103,6 @@ export const AlertsListTable = React.memo((props: AlertsListTableProps) => {
                         handlers={{
                           handleDetails: () => handleDetails(alert),
                           handleEdit: () => handleEdit(alert),
-                          handleEnableDisable: () => handleEnableDisable(alert),
                         }}
                         alert={alert}
                         key={alert.id}

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.tsx
@@ -58,7 +58,8 @@ export const AlertsListTable = React.memo((props: AlertsListTableProps) => {
   const handleEnableDisable = React.useCallback(
     (alert: Alert) => {
       const toggleStatus = alert.status === 'enabled' ? 'disabled' : 'enabled';
-      const errorStatus = toggleStatus == 'disabled' ? 'Disabling' : 'Enabling';
+      const errorStatus =
+        toggleStatus === 'disabled' ? 'Disabling' : 'Enabling';
       editAlertDefinition({
         alertId: String(alert.id),
         serviceType: alert.service_type,

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.tsx
@@ -51,6 +51,10 @@ export const AlertsListTable = React.memo((props: AlertsListTableProps) => {
   const handleEdit = ({ id, service_type: serviceType }: Alert) => {
     history.push(`${location.pathname}/edit/${serviceType}/${id}`);
   };
+  const handleEnableDisable = (alert: Alert) => {
+    // This is just a pass-through function - actual implementation will be in AlertTableRow
+    // We keep this for consistency in how handlers are passed
+  };
 
   return (
     <OrderBy
@@ -103,6 +107,7 @@ export const AlertsListTable = React.memo((props: AlertsListTableProps) => {
                         handlers={{
                           handleDetails: () => handleDetails(alert),
                           handleEdit: () => handleEdit(alert),
+                          handleEnableDisable: () => handleEnableDisable(alert),
                         }}
                         alert={alert}
                         key={alert.id}

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.tsx
@@ -1,4 +1,5 @@
 import { Grid, TableBody, TableHead } from '@mui/material';
+import { enqueueSnackbar } from 'notistack';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -10,6 +11,7 @@ import { TableCell } from 'src/components/TableCell';
 import { TableContentWrapper } from 'src/components/TableContentWrapper/TableContentWrapper';
 import { TableRow } from 'src/components/TableRow';
 import { TableSortCell } from 'src/components/TableSortCell';
+import { useEditAlertDefinition } from 'src/queries/cloudpulse/alerts';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 import { AlertTableRow } from './AlertTableRow';
@@ -43,6 +45,7 @@ export const AlertsListTable = React.memo((props: AlertsListTableProps) => {
     ? getAPIErrorOrDefault(error, 'Error in fetching the alerts.')
     : undefined;
   const history = useHistory();
+  const { mutateAsync: editAlertDefinition } = useEditAlertDefinition(); // put call to update alert status
 
   const handleDetails = ({ id: _id, service_type: serviceType }: Alert) => {
     history.push(`${location.pathname}/detail/${serviceType}/${_id}`);
@@ -51,6 +54,31 @@ export const AlertsListTable = React.memo((props: AlertsListTableProps) => {
   const handleEdit = ({ id, service_type: serviceType }: Alert) => {
     history.push(`${location.pathname}/edit/${serviceType}/${id}`);
   };
+
+  const handleEnableDisable = React.useCallback(
+    (alert: Alert) => {
+      const toggleStatus = alert.status === 'enabled' ? 'disabled' : 'enabled';
+      const errorStatus = toggleStatus == 'disabled' ? 'Disabling' : 'Enabling';
+      editAlertDefinition({
+        alertId: String(alert.id),
+        serviceType: alert.service_type,
+        status: toggleStatus,
+      })
+        .then(() => {
+          // Handle success
+          enqueueSnackbar(`Alert ${toggleStatus}`, {
+            variant: 'success',
+          });
+        })
+        .catch(() => {
+          // Handle error
+          enqueueSnackbar(`${errorStatus} alert failed`, {
+            variant: 'error',
+          });
+        });
+    },
+    [editAlertDefinition]
+  );
 
   return (
     <OrderBy
@@ -103,6 +131,7 @@ export const AlertsListTable = React.memo((props: AlertsListTableProps) => {
                         handlers={{
                           handleDetails: () => handleDetails(alert),
                           handleEdit: () => handleEdit(alert),
+                          handleEnableDisable: () => handleEnableDisable(alert),
                         }}
                         alert={alert}
                         key={alert.id}

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.test.tsx
@@ -121,7 +121,7 @@ describe('Alert Row', () => {
 
   it('should have enable action item present inside action menu if the user created alert is disabled', async () => {
     const alert = alertFactory.build({ status: 'disabled', type: 'user' });
-    const { getAllByLabelText, getByText } = renderWithTheme(
+    const { getByLabelText, getByText } = renderWithTheme(
       <AlertTableRow
         handlers={{
           handleDetails: vi.fn(),
@@ -131,10 +131,8 @@ describe('Alert Row', () => {
         services={mockServices}
       />
     );
-    const firstActionMenu = getAllByLabelText(
-      `Action menu for Alert ${alert.label}`
-    )[0];
-    await userEvent.click(firstActionMenu);
+    const ActionMenu = getByLabelText(`Action menu for Alert ${alert.label}`);
+    await userEvent.click(ActionMenu);
     expect(getByText('Enable')).toBeInTheDocument(); // enable alert functionality is present in action items
     await userEvent.click(getByText('Enable')); // click the enable button to enable alert
     expect(

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.test.tsx
@@ -23,21 +23,6 @@ const mockServices: Item<string, AlertServiceType>[] = [
   },
 ];
 
-const queryMocks = vi.hoisted(() => ({
-  useEditAlertDefinition: vi.fn(),
-}));
-
-vi.mock('src/queries/cloudpulse/alerts', () => ({
-  ...vi.importActual('src/queries/cloudpulse/alerts'),
-  useEditAlertDefinition: queryMocks.useEditAlertDefinition,
-}));
-
-queryMocks.useEditAlertDefinition.mockReturnValue({
-  isError: false,
-  mutateAsync: vi.fn().mockResolvedValue({}),
-  reset: vi.fn(),
-});
-
 describe('Alert Row', () => {
   it('should render an alert row', async () => {
     const alert = alertFactory.build();
@@ -46,6 +31,7 @@ describe('Alert Row', () => {
         handlers={{
           handleDetails: vi.fn(),
           handleEdit: vi.fn(),
+          handleEnableDisable: vi.fn(),
         }}
         alert={alert}
         services={mockServices}
@@ -62,6 +48,7 @@ describe('Alert Row', () => {
         handlers={{
           handleDetails: vi.fn(),
           handleEdit: vi.fn(),
+          handleEnableDisable: vi.fn(),
         }}
         alert={alert}
         services={mockServices}
@@ -88,6 +75,7 @@ describe('Alert Row', () => {
           handlers={{
             handleDetails: vi.fn(),
             handleEdit: vi.fn(),
+            handleEnableDisable: vi.fn(),
           }}
           alert={alert}
           services={mockServices}
@@ -107,6 +95,7 @@ describe('Alert Row', () => {
         handlers={{
           handleDetails: vi.fn(),
           handleEdit: vi.fn(),
+          handleEnableDisable: vi.fn(),
         }}
         alert={alert}
         services={mockServices}
@@ -126,6 +115,7 @@ describe('Alert Row', () => {
         handlers={{
           handleDetails: vi.fn(),
           handleEdit: vi.fn(),
+          handleEnableDisable: vi.fn(),
         }}
         alert={alert}
         services={mockServices}
@@ -133,11 +123,7 @@ describe('Alert Row', () => {
     );
     const ActionMenu = getByLabelText(`Action menu for Alert ${alert.label}`);
     await userEvent.click(ActionMenu);
-    expect(getByText('Enable')).toBeInTheDocument(); // enable alert functionality is present in action items
-    await userEvent.click(getByText('Enable')); // click the enable button to enable alert
-    expect(
-      getByText('Alert enabled') // validate whether snackbar is displayed properly if alert is enabled successfully
-    ).toBeInTheDocument();
+    expect(getByText('Enable')).toBeInTheDocument();
   });
 
   it('should have disable action item present inside action menu if the user created alert is enabled', async () => {
@@ -156,34 +142,5 @@ describe('Alert Row', () => {
     const ActionMenu = getByLabelText(`Action menu for Alert ${alert.label}`);
     await userEvent.click(ActionMenu);
     expect(getByText('Disable')).toBeInTheDocument();
-    await userEvent.click(getByText('Disable'));
-    expect(getByText('Alert disabled')).toBeInTheDocument();
-  });
-
-  it('should show error message if enabling or disabling alert is failed', async () => {
-    queryMocks.useEditAlertDefinition.mockReturnValue({
-      isError: true,
-      mutateAsync: vi.fn().mockRejectedValue(Error('Disabling alert failed')),
-      reset: vi.fn(),
-    });
-    const alert = alertFactory.build({ type: 'user' });
-    const { getByLabelText, getByText } = renderWithTheme(
-      <AlertTableRow
-        handlers={{
-          handleDetails: vi.fn(),
-          handleEdit: vi.fn(),
-          handleEnableDisable: vi.fn(),
-        }}
-        alert={alert}
-        services={mockServices}
-      />
-    );
-    const ActionMenu = getByLabelText(`Action menu for Alert ${alert.label}`);
-    await userEvent.click(ActionMenu);
-    expect(getByText('Disable')).toBeInTheDocument();
-    await userEvent.click(getByText('Disable'));
-    expect(
-      getByText('Disabling alert failed') // validate whether snackbar is displayed properly if an error is encountered while disabling an alert
-    ).toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.test.tsx
@@ -30,6 +30,7 @@ describe('Alert Row', () => {
         handlers={{
           handleDetails: vi.fn(),
           handleEdit: vi.fn(),
+          handleEnableDisable: vi.fn(),
         }}
         alert={alert}
         services={mockServices}
@@ -46,6 +47,7 @@ describe('Alert Row', () => {
         handlers={{
           handleDetails: vi.fn(),
           handleEdit: vi.fn(),
+          handleEnableDisable: vi.fn(),
         }}
         alert={alert}
         services={mockServices}
@@ -72,6 +74,7 @@ describe('Alert Row', () => {
           handlers={{
             handleDetails: vi.fn(),
             handleEdit: vi.fn(),
+            handleEnableDisable: vi.fn(),
           }}
           alert={alert}
           services={mockServices}
@@ -91,6 +94,7 @@ describe('Alert Row', () => {
         handlers={{
           handleDetails: vi.fn(),
           handleEdit: vi.fn(),
+          handleEnableDisable: vi.fn(),
         }}
         alert={alert}
         services={mockServices}
@@ -101,5 +105,45 @@ describe('Alert Row', () => {
     )[0];
     await userEvent.click(firstActionMenu);
     expect(getByTestId('Show Details')).toBeInTheDocument();
+  });
+
+  it('should have enable action item present inside action menu if the user created alert is disabled', async () => {
+    const alert = alertFactory.build({ status: 'disabled' });
+    const { getAllByLabelText, getByText } = renderWithTheme(
+      <AlertTableRow
+        handlers={{
+          handleDetails: vi.fn(),
+          handleEdit: vi.fn(),
+          handleEnableDisable: vi.fn(),
+        }}
+        alert={alert}
+        services={mockServices}
+      />
+    );
+    const firstActionMenu = getAllByLabelText(
+      `Action menu for Alert ${alert.label}`
+    )[0];
+    await userEvent.click(firstActionMenu);
+    expect(getByText('Enable')).toBeInTheDocument();
+  });
+
+  it('should have disable action item present inside action menu if the user created alert is enabled', async () => {
+    const alert = alertFactory.build();
+    const { getAllByLabelText, getByText } = renderWithTheme(
+      <AlertTableRow
+        handlers={{
+          handleDetails: vi.fn(),
+          handleEdit: vi.fn(),
+          handleEnableDisable: vi.fn(),
+        }}
+        alert={alert}
+        services={mockServices}
+      />
+    );
+    const firstActionMenu = getAllByLabelText(
+      `Action menu for Alert ${alert.label}`
+    )[0];
+    await userEvent.click(firstActionMenu);
+    expect(getByText('Disable')).toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.test.tsx
@@ -22,6 +22,22 @@ const mockServices: Item<string, AlertServiceType>[] = [
     value: 'dbaas',
   },
 ];
+
+const queryMocks = vi.hoisted(() => ({
+  useEditAlertDefinition: vi.fn(),
+}));
+
+vi.mock('src/queries/cloudpulse/alerts', () => ({
+  ...vi.importActual('src/queries/cloudpulse/alerts'),
+  useEditAlertDefinition: queryMocks.useEditAlertDefinition,
+}));
+
+queryMocks.useEditAlertDefinition.mockReturnValue({
+  isError: false,
+  mutateAsync: vi.fn().mockResolvedValue({}),
+  reset: vi.fn(),
+});
+
 describe('Alert Row', () => {
   it('should render an alert row', async () => {
     const alert = alertFactory.build();
@@ -30,7 +46,6 @@ describe('Alert Row', () => {
         handlers={{
           handleDetails: vi.fn(),
           handleEdit: vi.fn(),
-          handleEnableDisable: vi.fn(),
         }}
         alert={alert}
         services={mockServices}
@@ -47,7 +62,6 @@ describe('Alert Row', () => {
         handlers={{
           handleDetails: vi.fn(),
           handleEdit: vi.fn(),
-          handleEnableDisable: vi.fn(),
         }}
         alert={alert}
         services={mockServices}
@@ -74,7 +88,6 @@ describe('Alert Row', () => {
           handlers={{
             handleDetails: vi.fn(),
             handleEdit: vi.fn(),
-            handleEnableDisable: vi.fn(),
           }}
           alert={alert}
           services={mockServices}
@@ -88,13 +101,12 @@ describe('Alert Row', () => {
   });
 
   it('should have the show details action item present inside action menu', async () => {
-    const alert = alertFactory.build({ status: 'enabled' });
+    const alert = alertFactory.build({ type: 'user' });
     const { getAllByLabelText, getByTestId } = renderWithTheme(
       <AlertTableRow
         handlers={{
           handleDetails: vi.fn(),
           handleEdit: vi.fn(),
-          handleEnableDisable: vi.fn(),
         }}
         alert={alert}
         services={mockServices}
@@ -108,13 +120,12 @@ describe('Alert Row', () => {
   });
 
   it('should have enable action item present inside action menu if the user created alert is disabled', async () => {
-    const alert = alertFactory.build({ status: 'disabled' });
+    const alert = alertFactory.build({ status: 'disabled', type: 'user' });
     const { getAllByLabelText, getByText } = renderWithTheme(
       <AlertTableRow
         handlers={{
           handleDetails: vi.fn(),
           handleEdit: vi.fn(),
-          handleEnableDisable: vi.fn(),
         }}
         alert={alert}
         services={mockServices}
@@ -124,12 +135,16 @@ describe('Alert Row', () => {
       `Action menu for Alert ${alert.label}`
     )[0];
     await userEvent.click(firstActionMenu);
-    expect(getByText('Enable')).toBeInTheDocument();
+    expect(getByText('Enable')).toBeInTheDocument(); // enable alert functionality is present in action items
+    await userEvent.click(getByText('Enable')); // click the enable button to enable alert
+    expect(
+      getByText('Alert enabled') // validate whether snackbar is displayed properly if alert is enabled successfully
+    ).toBeInTheDocument();
   });
 
   it('should have disable action item present inside action menu if the user created alert is enabled', async () => {
-    const alert = alertFactory.build();
-    const { getAllByLabelText, getByText } = renderWithTheme(
+    const alert = alertFactory.build({ type: 'user' });
+    const { getByLabelText, getByText } = renderWithTheme(
       <AlertTableRow
         handlers={{
           handleDetails: vi.fn(),
@@ -140,10 +155,37 @@ describe('Alert Row', () => {
         services={mockServices}
       />
     );
-    const firstActionMenu = getAllByLabelText(
-      `Action menu for Alert ${alert.label}`
-    )[0];
-    await userEvent.click(firstActionMenu);
+    const ActionMenu = getByLabelText(`Action menu for Alert ${alert.label}`);
+    await userEvent.click(ActionMenu);
     expect(getByText('Disable')).toBeInTheDocument();
+    await userEvent.click(getByText('Disable'));
+    expect(getByText('Alert disabled')).toBeInTheDocument();
+  });
+
+  it('should show error message if enabling or disabling alert is failed', async () => {
+    queryMocks.useEditAlertDefinition.mockReturnValue({
+      isError: true,
+      mutateAsync: vi.fn().mockRejectedValue(Error('Disabling alert failed')),
+      reset: vi.fn(),
+    });
+    const alert = alertFactory.build({ type: 'user' });
+    const { getByLabelText, getByText } = renderWithTheme(
+      <AlertTableRow
+        handlers={{
+          handleDetails: vi.fn(),
+          handleEdit: vi.fn(),
+          handleEnableDisable: vi.fn(),
+        }}
+        alert={alert}
+        services={mockServices}
+      />
+    );
+    const ActionMenu = getByLabelText(`Action menu for Alert ${alert.label}`);
+    await userEvent.click(ActionMenu);
+    expect(getByText('Disable')).toBeInTheDocument();
+    await userEvent.click(getByText('Disable'));
+    expect(
+      getByText('Disabling alert failed') // validate whether snackbar is displayed properly if an error is encountered while disabling an alert
+    ).toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.test.tsx
@@ -101,7 +101,7 @@ describe('Alert Row', () => {
   });
 
   it('should have the show details action item present inside action menu', async () => {
-    const alert = alertFactory.build({ type: 'user' });
+    const alert = alertFactory.build({ status: 'enabled' });
     const { getAllByLabelText, getByTestId } = renderWithTheme(
       <AlertTableRow
         handlers={{

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@linode/ui';
-import { useSnackbar } from 'notistack';
 import * as React from 'react';
 import { useLocation } from 'react-router-dom';
 
@@ -7,7 +6,6 @@ import { Link } from 'src/components/Link';
 import { StatusIcon } from 'src/components/StatusIcon/StatusIcon';
 import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
-import { useEditAlertDefinition } from 'src/queries/cloudpulse/alerts';
 import { capitalize } from 'src/utilities/capitalize';
 import { formatDate } from 'src/utilities/formatDate';
 
@@ -46,32 +44,6 @@ export const AlertTableRow = (props: Props) => {
   const location = useLocation();
   const { created_by, id, label, service_type, status, type, updated } = alert;
 
-  const { enqueueSnackbar } = useSnackbar();
-
-  const { mutateAsync: editAlertDefinition } = useEditAlertDefinition(
-    service_type,
-    String(id)
-  );
-
-  const toggleStatus = alert.status === 'enabled' ? 'disabled' : 'enabled';
-  const errorStatus = toggleStatus == 'disabled' ? 'Disabling' : 'Enabling';
-
-  const handleEnableDisable = () => {
-    editAlertDefinition({ status: toggleStatus })
-      .then(() => {
-        // Handle success
-        enqueueSnackbar(`Alert ${toggleStatus}`, {
-          variant: 'success',
-        });
-      })
-      .catch(() => {
-        // Handle error
-        enqueueSnackbar(`${errorStatus} alert failed`, {
-          variant: 'error',
-        });
-      });
-  };
-
   return (
     <TableRow data-qa-alert-cell={id} key={`alert-row-${id}`}>
       <TableCell>
@@ -99,7 +71,7 @@ export const AlertTableRow = (props: Props) => {
           alertLabel={label}
           alertStatus={status}
           alertType={type}
-          handlers={{ ...handlers, handleEnableDisable }}
+          handlers={handlers}
         />
       </TableCell>
     </TableRow>

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/constants.ts
@@ -1,3 +1,8 @@
+import type {
+  AlertStatusType,
+  AlertStatusUpdateAction,
+} from '../../../../../../api-v4/lib/cloudpulse/types';
+
 export const AlertListingTableLabelMap = [
   {
     colName: 'Alert Name',
@@ -20,3 +25,11 @@ export const AlertListingTableLabelMap = [
     label: 'updated',
   },
 ];
+
+export const statusToActionMap: Record<
+  AlertStatusType,
+  AlertStatusUpdateAction
+> = {
+  disabled: 'Enable',
+  enabled: 'Disable',
+};

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/constants.ts
@@ -1,7 +1,4 @@
-import type {
-  AlertStatusType,
-  AlertStatusUpdateAction,
-} from '../../../../../../api-v4/lib/cloudpulse/types';
+import type { AlertStatusType, AlertStatusUpdateType } from '@linode/api-v4';
 
 export const AlertListingTableLabelMap = [
   {
@@ -28,7 +25,7 @@ export const AlertListingTableLabelMap = [
 
 export const statusToActionMap: Record<
   AlertStatusType,
-  AlertStatusUpdateAction
+  AlertStatusUpdateType
 > = {
   disabled: 'Enable',
   enabled: 'Disable',

--- a/packages/manager/src/features/CloudPulse/Alerts/EditAlert/EditAlertResources.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/EditAlert/EditAlertResources.tsx
@@ -35,10 +35,7 @@ export const EditAlertResources = () => {
     serviceType
   );
 
-  const { mutateAsync: editAlert } = useEditAlertDefinition(
-    serviceType,
-    alertId
-  );
+  const { mutateAsync: editAlert } = useEditAlertDefinition();
   const [selectedResources, setSelectedResources] = React.useState<string[]>(
     []
   );
@@ -72,7 +69,9 @@ export const EditAlertResources = () => {
   const saveResources = () => {
     setShowConfirmation(false);
     editAlert({
+      alertId,
       entity_ids: selectedResources,
+      serviceType,
     })
       .then(() => {
         // on success land on the alert definition list page and show a success snackbar

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
@@ -1,15 +1,31 @@
 import type { ActionHandlers } from '../AlertsListing/AlertActionMenu';
-import type { AlertDefinitionType } from '@linode/api-v4';
+import type { AlertDefinitionType, AlertStatusType } from '@linode/api-v4';
 import type { Action } from 'src/components/ActionMenu/ActionMenu';
 
 /**
  * @param onClickHandlers The list of handlers required to be called on click of an action
  * @returns The actions based on the type of the alert
  */
-export const getAlertTypeToActionsList = ({
-  handleDetails,
-  handleEdit,
-}: ActionHandlers): Record<AlertDefinitionType, Action[]> => ({
+export const getAlertTypeToActionsList = (
+  { handleDetails, handleEdit, handleEnableDisable }: ActionHandlers,
+  alertStatus: AlertStatusType
+): Record<AlertDefinitionType, Action[]> => ({
+  custom: [
+    {
+      onClick: handleDetails,
+      title: 'Show Details',
+    },
+  ],
+  default: [
+    {
+      onClick: handleDetails,
+      title: 'Show Details',
+    },
+    {
+      onClick: handleEdit,
+      title: 'Edit',
+    },
+  ],
   // for now there is system and user alert types, in future more alert types can be added and action items will differ according to alert types
   system: [
     {
@@ -26,5 +42,13 @@ export const getAlertTypeToActionsList = ({
       onClick: handleDetails,
       title: 'Show Details',
     },
+    {
+      onClick: handleEnableDisable,
+      title: getTitleForEnableDisable(alertStatus),
+    },
   ],
 });
+
+export const getTitleForEnableDisable = (alertStatus: AlertStatusType) => {
+  return alertStatus == 'enabled' ? 'Disable' : 'Enable';
+};

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
@@ -43,7 +43,7 @@ export const getAlertTypeToActionsList = (
       title: 'Show Details',
     },
     {
-      onClick: handleEnableDisable,
+      onClick: handleEnableDisable ?? (() => {}),
       title: getTitleForEnableDisable(alertStatus),
     },
   ],

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
@@ -1,3 +1,5 @@
+import { statusToActionMap } from '../AlertsListing/constants';
+
 import type { ActionHandlers } from '../AlertsListing/AlertActionMenu';
 import type { AlertDefinitionType, AlertStatusType } from '@linode/api-v4';
 import type { Action } from 'src/components/ActionMenu/ActionMenu';
@@ -43,12 +45,12 @@ export const getAlertTypeToActionsList = (
       title: 'Show Details',
     },
     {
-      onClick: handleEnableDisable ?? (() => {}),
+      onClick: handleEnableDisable,
       title: getTitleForEnableDisable(alertStatus),
     },
   ],
 });
 
 export const getTitleForEnableDisable = (alertStatus: AlertStatusType) => {
-  return alertStatus == 'enabled' ? 'Disable' : 'Enable';
+  return statusToActionMap[alertStatus];
 };

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
@@ -12,22 +12,6 @@ export const getAlertTypeToActionsList = (
   { handleDetails, handleEdit, handleEnableDisable }: ActionHandlers,
   alertStatus: AlertStatusType
 ): Record<AlertDefinitionType, Action[]> => ({
-  custom: [
-    {
-      onClick: handleDetails,
-      title: 'Show Details',
-    },
-  ],
-  default: [
-    {
-      onClick: handleDetails,
-      title: 'Show Details',
-    },
-    {
-      onClick: handleEdit,
-      title: 'Edit',
-    },
-  ],
   // for now there is system and user alert types, in future more alert types can be added and action items will differ according to alert types
   system: [
     {

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -2478,13 +2478,26 @@ export const handlers = [
       return HttpResponse.json({}, { status: 404 });
     }
   ),
+  http.put(
+    '*/monitor/services/:serviceType/alert-definitions/:id',
+    ({ params, request }) => {
+      const body:any = request.json();
+      return HttpResponse.json(
+        alertFactory.build({
+          id: Number(params.id),
+          label: `Alert-${params.id}`,
+          status: body.status === 'enabled' ? 'disabled' : 'enabled',
+        }),
+        {
+          status: 200,
+        }
+      );
+    }
+  ),
   http.get('*/monitor/alert-channels', () => {
     return HttpResponse.json(
       makeResourcePage(notificationChannelFactory.buildList(3))
     );
-  }),
-  http.put('*/monitor/services/:serviceType/alert-definitions/:id', () => {
-    return HttpResponse.json(alertFactory.build());
   }),
   http.get('*/monitor/services', () => {
     const response: ServiceTypesList = {

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -2481,7 +2481,7 @@ export const handlers = [
   http.put(
     '*/monitor/services/:serviceType/alert-definitions/:id',
     ({ params, request }) => {
-      const body:any = request.json();
+      const body: any = request.json();
       return HttpResponse.json(
         alertFactory.build({
           id: Number(params.id),

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -2422,29 +2422,32 @@ export const handlers = [
   ),
   http.get('*/monitor/alert-definitions', async () => {
     const customAlerts = alertFactory.buildList(10, {
+      created_by: 'user1',
       severity: 0,
       type: 'user',
+      updated: '2021-10-16T04:00:00',
+      updated_by: 'user1',
     });
     const customAlertsWithServiceType = alertFactory.buildList(10, {
+      created_by: 'user1',
       service_type: 'dbaas',
       severity: 1,
       type: 'user',
+      updated_by: 'user1',
     });
-    const defaultAlerts = alertFactory.buildList(15, {
-      created_by: 'System',
-      type: 'system',
-    });
+    const defaultAlerts = alertFactory.buildList(15);
     const defaultAlertsWithServiceType = alertFactory.buildList(7, {
-      created_by: 'System',
       service_type: 'dbaas',
       severity: 3,
-      type: 'system',
     });
     const alerts = [
       ...defaultAlerts,
       ...alertFactory.buildList(8, {
+        created_by: 'user1',
         service_type: 'linode',
         status: 'disabled',
+        type: 'user',
+        updated_by: 'user1',
       }),
       ...customAlerts,
       ...defaultAlertsWithServiceType,

--- a/packages/manager/src/queries/cloudpulse/alerts.ts
+++ b/packages/manager/src/queries/cloudpulse/alerts.ts
@@ -16,7 +16,7 @@ import type {
   Alert,
   AlertServiceType,
   CreateAlertDefinitionPayload,
-  ExtendedEditAlertDefinitionPayload,
+  EditAlertDefinitionPayloadWithServiceTypeAndAlertId,
   NotificationChannel,
 } from '@linode/api-v4/lib/cloudpulse';
 import type { APIError, Filter, Params } from '@linode/api-v4/lib/types';
@@ -64,7 +64,11 @@ export const useAllAlertNotificationChannelsQuery = (
 
 export const useEditAlertDefinition = () => {
   const queryClient = useQueryClient();
-  return useMutation<Alert, APIError[], ExtendedEditAlertDefinitionPayload>({
+  return useMutation<
+    Alert,
+    APIError[],
+    EditAlertDefinitionPayloadWithServiceTypeAndAlertId
+  >({
     mutationFn: ({ alertId, serviceType, ...data }) =>
       editAlertDefinition(data, serviceType, alertId),
     onSuccess() {

--- a/packages/manager/src/queries/cloudpulse/alerts.ts
+++ b/packages/manager/src/queries/cloudpulse/alerts.ts
@@ -16,7 +16,7 @@ import type {
   Alert,
   AlertServiceType,
   CreateAlertDefinitionPayload,
-  EditAlertDefinitionPayload,
+  EditAlertDefinitionPayloadExtended,
   NotificationChannel,
 } from '@linode/api-v4/lib/cloudpulse';
 import type { APIError, Filter, Params } from '@linode/api-v4/lib/types';
@@ -62,13 +62,11 @@ export const useAllAlertNotificationChannelsQuery = (
   });
 };
 
-export const useEditAlertDefinition = (
-  serviceType: string,
-  alertId: string
-) => {
+export const useEditAlertDefinition = () => {
   const queryClient = useQueryClient();
-  return useMutation<Alert, APIError[], EditAlertDefinitionPayload>({
-    mutationFn: (data) => editAlertDefinition(data, serviceType, alertId),
+  return useMutation<Alert, APIError[], EditAlertDefinitionPayloadExtended>({
+    mutationFn: ({ alertId, serviceType, ...data }) =>
+      editAlertDefinition(data, serviceType, alertId),
     onSuccess() {
       queryClient.invalidateQueries(queryFactory.alerts);
     },

--- a/packages/manager/src/queries/cloudpulse/alerts.ts
+++ b/packages/manager/src/queries/cloudpulse/alerts.ts
@@ -16,7 +16,7 @@ import type {
   Alert,
   AlertServiceType,
   CreateAlertDefinitionPayload,
-  EditAlertDefinitionPayloadWithServiceTypeAndAlertId,
+  EditAlertPayloadWithService,
   NotificationChannel,
 } from '@linode/api-v4/lib/cloudpulse';
 import type { APIError, Filter, Params } from '@linode/api-v4/lib/types';
@@ -64,11 +64,7 @@ export const useAllAlertNotificationChannelsQuery = (
 
 export const useEditAlertDefinition = () => {
   const queryClient = useQueryClient();
-  return useMutation<
-    Alert,
-    APIError[],
-    EditAlertDefinitionPayloadWithServiceTypeAndAlertId
-  >({
+  return useMutation<Alert, APIError[], EditAlertPayloadWithService>({
     mutationFn: ({ alertId, serviceType, ...data }) =>
       editAlertDefinition(data, serviceType, alertId),
     onSuccess() {

--- a/packages/manager/src/queries/cloudpulse/alerts.ts
+++ b/packages/manager/src/queries/cloudpulse/alerts.ts
@@ -16,7 +16,7 @@ import type {
   Alert,
   AlertServiceType,
   CreateAlertDefinitionPayload,
-  EditAlertDefinitionPayloadExtended,
+  ExtendedEditAlertDefinitionPayload,
   NotificationChannel,
 } from '@linode/api-v4/lib/cloudpulse';
 import type { APIError, Filter, Params } from '@linode/api-v4/lib/types';
@@ -64,7 +64,7 @@ export const useAllAlertNotificationChannelsQuery = (
 
 export const useEditAlertDefinition = () => {
   const queryClient = useQueryClient();
-  return useMutation<Alert, APIError[], EditAlertDefinitionPayloadExtended>({
+  return useMutation<Alert, APIError[], ExtendedEditAlertDefinitionPayload>({
     mutationFn: ({ alertId, serviceType, ...data }) =>
       editAlertDefinition(data, serviceType, alertId),
     onSuccess() {


### PR DESCRIPTION
## Description 📝

Handle enable/disable functionality for user created alerts.

## Changes  🔄

- Any user created alert which is enabled will have action menu item listed as "Disable". Similarly, every user created alert which is disabled will have action menu item listed as "Enable".
- Clicking on enable/disable button will update the status of the alert accordingly with success and error representing snackbars being displayed in both the cases.

_Note: We are waiting for the edit api update from backend to test the status update. As of now, the status update of the alert will not show as the apis are not ready yet. The current changes are tested on mock data._

## Target release date 🗓️
25-02-25

## Preview 📷

| Before  | After   |
| ------- | ------- |
|![image](https://github.com/user-attachments/assets/d3ce623c-f58a-4ece-a20d-6fe7fe67bf47) | ![image](https://github.com/user-attachments/assets/c0b32567-2642-4dc6-908d-4da4a6759b22)|
|![image](https://github.com/user-attachments/assets/b5baa1e5-f673-4901-ba7c-4aac9a93b11a)| ![image](https://github.com/user-attachments/assets/e64c2d11-81c7-4932-b96a-70932e48d166)|
||![image](https://github.com/user-attachments/assets/b820f270-eb2d-4c9f-916b-757f9976d694)|
||![image](https://github.com/user-attachments/assets/1125a3d2-82f4-4ef7-bf6a-e4a3bab0e4d9)|

## How to test 🧪

### Verification steps

- Navigate to alerts tab in monitor.
- Click on the action item corresponding to any user created alert. If the alert's current status is enabled, action menu will show "Disable" button, and if the status is disabled, action menu will show "Enable" button.
- Click on the enable/disable button, the status will be updated for the respective alert and a success snackbar will be displayed at the bottom right of the page. In case of an error, a failure snackbar will be displayed as shown in preview.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

---