### PR TITLE
fix: [DI-23469] - Fix low space between dashboard select & date time range picker

### DIFF
--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
@@ -133,27 +133,25 @@ export const CloudPulseDashboardWithFilters = React.memo(
           }}
         >
           <Grid container>
-            <Grid
-              container
-              display="flex"
-              flexWrap="wrap"
-              item
-              justifyContent="space-between"
-              m={3}
-              rowGap={2}
-              xs={12}
-            >
-              <Grid item md={4} xs={12}>
+            <Grid item xs={12}>
+              <Box
+                display="flex"
+                flexDirection={{ lg: 'row', xs: 'column' }}
+                flexWrap="wrap"
+                gap={2}
+                justifyContent="space-between"
+                m={3}
+              >
                 <CloudPulseDashboardSelect
                   defaultValue={dashboardId}
                   isServiceIntegration
                 />
-              </Grid>
 
-              <CloudPulseDateTimeRangePicker
-                handleStatsChange={handleTimeRangeChange}
-                savePreferences
-              />
+                <CloudPulseDateTimeRangePicker
+                  handleStatsChange={handleTimeRangeChange}
+                  savePreferences
+                />
+              </Box>
             </Grid>
 
             <Grid item xs={12}>

--- a/packages/manager/src/features/CloudPulse/Overview/GlobalFilters.tsx
+++ b/packages/manager/src/features/CloudPulse/Overview/GlobalFilters.tsx
@@ -95,49 +95,47 @@ export const GlobalFilters = React.memo((props: GlobalFilterProperties) => {
 
   return (
     <Grid container>
-      <Grid
-        container
-        display="flex"
-        flexWrap="wrap"
-        item
-        justifyContent="space-between"
-        m={3}
-        rowGap={2}
-        xs={12}
-      >
-        <Grid item lg={4} xs={12}>
+      <Grid item xs={12}>
+        <Box
+          display="flex"
+          flexDirection={{ lg: 'row', xs: 'column' }}
+          flexWrap="wrap"
+          gap={2}
+          justifyContent="space-between"
+          m={3}
+        >
           <CloudPulseDashboardSelect
             defaultValue={preferences?.dashboardId}
             handleDashboardChange={onDashboardChange}
             savePreferences
           />
-        </Grid>
-        <Box
-          display="flex"
-          flexDirection={{ md: 'row', xs: 'column' }}
-          flexWrap="wrap"
-          gap={2}
-        >
-          <CloudPulseDateTimeRangePicker
-            defaultValue={preferences?.timeRange}
-            handleStatsChange={handleTimeRangeChange}
-            savePreferences
-          />
-          <CloudPulseTooltip placement="bottom-end" title="Refresh">
-            <IconButton
-              sx={{
-                marginBlockEnd: 'auto',
-                marginTop: { md: theme.spacing(3.5) },
-              }}
-              aria-label="Refresh Dashboard Metrics"
-              data-testid="global-refresh"
-              disabled={!selectedDashboard}
-              onClick={handleGlobalRefresh}
-              size="small"
-            >
-              <StyledReload />
-            </IconButton>
-          </CloudPulseTooltip>
+          <Box
+            display="flex"
+            flexDirection={{ md: 'row', xs: 'column' }}
+            flexWrap="wrap"
+            gap={2}
+          >
+            <CloudPulseDateTimeRangePicker
+              defaultValue={preferences?.timeRange}
+              handleStatsChange={handleTimeRangeChange}
+              savePreferences
+            />
+            <CloudPulseTooltip placement="bottom-end" title="Refresh">
+              <IconButton
+                sx={{
+                  marginBlockEnd: 'auto',
+                  marginTop: { md: theme.spacing(3.5) },
+                }}
+                aria-label="Refresh Dashboard Metrics"
+                data-testid="global-refresh"
+                disabled={!selectedDashboard}
+                onClick={handleGlobalRefresh}
+                size="small"
+              >
+                <StyledReload />
+              </IconButton>
+            </CloudPulseTooltip>
+          </Box>
         </Box>
       </Grid>
       {selectedDashboard && (


### PR DESCRIPTION
## Description 📝

increased the gap between dashboard select & time range picker before the flex box wraps.

## Changes  🔄

List any change(s) relevant to the reviewer.

1. Updated global filters css
2. Updated CloudPulseDashboardWithFilters css.

## Target release date 🗓️

25th Feb

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
|![Screenshot 2025-02-12 at 5 26 12 PM](https://github.com/user-attachments/assets/0e7693a6-8d93-4440-8bdd-a838f2ffe384)|![Screenshot 2025-02-13 at 4 18 08 PM](https://github.com/user-attachments/assets/a5194e72-9b96-4ecf-833b-01043e8223e2)|

## How to test 🧪

### Prerequisites

(How to setup test environment)

- ...
- ...

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

