### PR TITLE
hotfix: Uptime interface for LongView API response

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2025-02-18] - v1.136.1
+
+
+### Fixed:
+
+- Uptime not displaying in Longview ([#11667](https://github.com/linode/manager/pull/11667))
+
 ## [2025-02-11] - v1.136.0
 
 

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.136.0",
+  "version": "1.136.1",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/manager/src/factories/longviewDisks.ts
+++ b/packages/manager/src/factories/longviewDisks.ts
@@ -1,16 +1,16 @@
 import Factory from 'src/factories/factoryProxy';
 
-import {
-  Disk,
-  LongviewDisk,
-  LongviewCPU,
+import type {
   CPU,
-  LongviewSystemInfo,
-  LongviewNetworkInterface,
+  Disk,
   InboundOutboundNetwork,
-  LongviewNetwork,
-  LongviewMemory,
+  LongviewCPU,
+  LongviewDisk,
   LongviewLoad,
+  LongviewMemory,
+  LongviewNetwork,
+  LongviewNetworkInterface,
+  LongviewSystemInfo,
   Uptime,
 } from 'src/features/Longview/request.types';
 
@@ -38,25 +38,25 @@ export const diskFactory = Factory.Sync.makeFactory<Disk>({
   childof: 0,
   children: 0,
   dm: 0,
-  isswap: 0,
-  mounted: 1,
-  reads: [mockStats[0]],
-  write_bytes: [mockStats[1]],
-  writes: [mockStats[2]],
   fs: {
-    total: [mockStats[3]],
+    free: [mockStats[6]],
     ifree: [mockStats[4]],
     itotal: [mockStats[5]],
     path: '/',
-    free: [mockStats[6]],
+    total: [mockStats[3]],
   },
+  isswap: 0,
+  mounted: 1,
   read_bytes: [mockStats[0]],
+  reads: [mockStats[0]],
+  write_bytes: [mockStats[1]],
+  writes: [mockStats[2]],
 });
 
 export const cpuFactory = Factory.Sync.makeFactory<CPU>({
   system: [mockStats[7]],
-  wait: [mockStats[8]],
   user: [mockStats[9]],
+  wait: [mockStats[8]],
 });
 
 export const longviewDiskFactory = Factory.Sync.makeFactory<LongviewDisk>({
@@ -117,15 +117,15 @@ export const longviewNetworkFactory = Factory.Sync.makeFactory<LongviewNetwork>(
 
 export const LongviewMemoryFactory = Factory.Sync.makeFactory<LongviewMemory>({
   Memory: {
+    real: {
+      buffers: [mockStats[15]],
+      cache: [mockStats[16]],
+      free: [mockStats[14]],
+      used: [mockStats[13]],
+    },
     swap: {
       free: [mockStats[12]],
       used: [mockStats[0]],
-    },
-    real: {
-      used: [mockStats[13]],
-      free: [mockStats[14]],
-      buffers: [mockStats[15]],
-      cache: [mockStats[16]],
     },
   },
 });
@@ -135,5 +135,5 @@ export const LongviewLoadFactory = Factory.Sync.makeFactory<LongviewLoad>({
 });
 
 export const UptimeFactory = Factory.Sync.makeFactory<Uptime>({
-  uptime: 84516.53,
+  Uptime: 84516.53,
 });

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/IconSection.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/IconSection.tsx
@@ -48,7 +48,7 @@ export const IconSection = React.memo((props: Props) => {
     props.longviewClientData?.SysInfo?.cpu?.type ??
     'CPU information not available';
 
-  const uptime = props.longviewClientData?.uptime ?? null;
+  const uptime = props.longviewClientData?.Uptime ?? null;
   const formattedUptime =
     uptime !== null ? `Up ${formatUptime(uptime)}` : 'Uptime not available';
 

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
@@ -74,7 +74,7 @@ export const LongviewClientHeader = enhanced(
 
     const hostname =
       longviewClientData.SysInfo?.hostname ?? 'Hostname not available';
-    const uptime = longviewClientData?.uptime ?? null;
+    const uptime = longviewClientData?.Uptime ?? null;
     const formattedUptime =
       uptime !== null ? `Up ${formatUptime(uptime)}` : 'Uptime not available';
     const packages = longviewClientData?.Packages ?? null;

--- a/packages/manager/src/features/Longview/request.types.ts
+++ b/packages/manager/src/features/Longview/request.types.ts
@@ -118,7 +118,7 @@ export interface LastUpdated {
 }
 
 export interface Uptime {
-  uptime: number;
+  Uptime: number;
 }
 
 export interface LongviewPackage {


### PR DESCRIPTION
## Description 📝

- Fixes bug introduced in https://github.com/linode/manager/pull/11512/files#diff-668e84515a6d0c13ebc3e9be8ef065489c8c3d46c3ed2fa65c5bfed1a4b6967cR51

## Bug Summary 🐛 

- A request made to the LongView API for client metrics returns a key `Uptime` which has been incorrectly mapped in CM as `uptime`. This in turn displays 'Uptime not available'. 

https://github.com/linode/manager/blob/develop/packages/manager/src/features/Longview/request.types.ts#L120-L121

## The Fix 🔧 

- Changed the interface `Uptime` to rightly have a key `Uptime` instead of `uptime`


## Preview 📷

| Before | After |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/b6e116c6-a5d0-4de3-bdf3-f7e74c3d7eb4) | ![image](https://github.com/user-attachments/assets/7b3e7a93-c5f4-41db-83b4-5421c7092529)
| ![image](https://github.com/user-attachments/assets/a38cf7e8-def7-4a64-a17d-988b0ec7a17b) | ![image](https://github.com/user-attachments/assets/aa723031-ffea-4cb5-9a62-07fa7628c3cc) |




## How to test 🧪

- Create a LongView Client for a Linode
  - Verify that the uptime is shown in the LongView Detail page
  - Verify that the uptime is shown in the LongView Landing page, within the LongView Client row

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>