### PR TITLE
Release v1.136.1 - staging → master

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,8 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2025-02-18] - v1.136.1
-
+## [2025-02-19] - v1.136.1
 
 ### Fixed:
 

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2025-02-18] - v1.136.1
+
+
+### Fixed:
+
+- Uptime not displaying in Longview ([#11667](https://github.com/linode/manager/pull/11667))
+
 ## [2025-02-11] - v1.136.0
 
 

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -1291,16 +1291,16 @@ describe('LKE cluster updates', () => {
     });
 
     it('can add labels and taints', () => {
-      const mockNewSimpleLabel = 'my-label-key: my-label-value';
-      const mockNewDNSLabel = 'my-label-key.io/app: my-label-value';
+      const mockNewSimpleLabel = 'my_label.-key: my_label.-value';
+      const mockNewDNSLabel = 'my_label-key.io/app: my_label.-value';
       const mockNewTaint: Taint = {
-        key: 'my-taint-key',
-        value: 'my-taint-value',
+        key: 'my_taint.-key',
+        value: 'my_taint.-value',
         effect: 'NoSchedule',
       };
       const mockNewDNSTaint: Taint = {
-        key: 'my-taint-key.io/app',
-        value: 'my-taint-value',
+        key: 'my_taint-key.io/app',
+        value: 'my_taint.-value',
         effect: 'NoSchedule',
       };
       const mockNodePoolUpdated = nodePoolFactory.build({
@@ -1309,8 +1309,8 @@ describe('LKE cluster updates', () => {
         nodes: mockNodes,
         taints: [mockNewTaint, mockNewDNSTaint],
         labels: {
-          'my-label-key': 'my-label-value',
-          'my-label-key.io/app': 'my-label-value',
+          'my_label-key': 'my_label.-value',
+          'my_label-key.io/app': 'my_label.-value',
         },
       });
 

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.136.0",
+  "version": "1.136.1",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/manager/src/factories/longviewDisks.ts
+++ b/packages/manager/src/factories/longviewDisks.ts
@@ -1,16 +1,16 @@
 import Factory from 'src/factories/factoryProxy';
 
-import {
-  Disk,
-  LongviewDisk,
-  LongviewCPU,
+import type {
   CPU,
-  LongviewSystemInfo,
-  LongviewNetworkInterface,
+  Disk,
   InboundOutboundNetwork,
-  LongviewNetwork,
-  LongviewMemory,
+  LongviewCPU,
+  LongviewDisk,
   LongviewLoad,
+  LongviewMemory,
+  LongviewNetwork,
+  LongviewNetworkInterface,
+  LongviewSystemInfo,
   Uptime,
 } from 'src/features/Longview/request.types';
 
@@ -38,25 +38,25 @@ export const diskFactory = Factory.Sync.makeFactory<Disk>({
   childof: 0,
   children: 0,
   dm: 0,
-  isswap: 0,
-  mounted: 1,
-  reads: [mockStats[0]],
-  write_bytes: [mockStats[1]],
-  writes: [mockStats[2]],
   fs: {
-    total: [mockStats[3]],
+    free: [mockStats[6]],
     ifree: [mockStats[4]],
     itotal: [mockStats[5]],
     path: '/',
-    free: [mockStats[6]],
+    total: [mockStats[3]],
   },
+  isswap: 0,
+  mounted: 1,
   read_bytes: [mockStats[0]],
+  reads: [mockStats[0]],
+  write_bytes: [mockStats[1]],
+  writes: [mockStats[2]],
 });
 
 export const cpuFactory = Factory.Sync.makeFactory<CPU>({
   system: [mockStats[7]],
-  wait: [mockStats[8]],
   user: [mockStats[9]],
+  wait: [mockStats[8]],
 });
 
 export const longviewDiskFactory = Factory.Sync.makeFactory<LongviewDisk>({
@@ -117,15 +117,15 @@ export const longviewNetworkFactory = Factory.Sync.makeFactory<LongviewNetwork>(
 
 export const LongviewMemoryFactory = Factory.Sync.makeFactory<LongviewMemory>({
   Memory: {
+    real: {
+      buffers: [mockStats[15]],
+      cache: [mockStats[16]],
+      free: [mockStats[14]],
+      used: [mockStats[13]],
+    },
     swap: {
       free: [mockStats[12]],
       used: [mockStats[0]],
-    },
-    real: {
-      used: [mockStats[13]],
-      free: [mockStats[14]],
-      buffers: [mockStats[15]],
-      cache: [mockStats[16]],
     },
   },
 });
@@ -135,5 +135,5 @@ export const LongviewLoadFactory = Factory.Sync.makeFactory<LongviewLoad>({
 });
 
 export const UptimeFactory = Factory.Sync.makeFactory<Uptime>({
-  uptime: 84516.53,
+  Uptime: 84516.53,
 });

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/IconSection.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/IconSection.tsx
@@ -48,7 +48,7 @@ export const IconSection = React.memo((props: Props) => {
     props.longviewClientData?.SysInfo?.cpu?.type ??
     'CPU information not available';
 
-  const uptime = props.longviewClientData?.uptime ?? null;
+  const uptime = props.longviewClientData?.Uptime ?? null;
   const formattedUptime =
     uptime !== null ? `Up ${formatUptime(uptime)}` : 'Uptime not available';
 

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
@@ -74,7 +74,7 @@ export const LongviewClientHeader = enhanced(
 
     const hostname =
       longviewClientData.SysInfo?.hostname ?? 'Hostname not available';
-    const uptime = longviewClientData?.uptime ?? null;
+    const uptime = longviewClientData?.Uptime ?? null;
     const formattedUptime =
       uptime !== null ? `Up ${formatUptime(uptime)}` : 'Uptime not available';
     const packages = longviewClientData?.Packages ?? null;

--- a/packages/manager/src/features/Longview/request.types.ts
+++ b/packages/manager/src/features/Longview/request.types.ts
@@ -118,7 +118,7 @@ export interface LastUpdated {
 }
 
 export interface Uptime {
-  uptime: number;
+  Uptime: number;
 }
 
 export interface LongviewPackage {

--- a/packages/validation/CHANGELOG.md
+++ b/packages/validation/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2025-02-19] - v0.60.1
+
+### Fixed:
+
+- Inability to add LKE Node Pool Labels with underscore in key ([#11682](https://github.com/linode/manager/pull/11682))
+
+
 ## [2025-02-11] - v0.60.0
 
 

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/validation",
-  "version": "0.60.0",
+  "version": "0.60.1",
   "description": "Yup validation schemas for use with the Linode APIv4",
   "type": "module",
   "main": "lib/index.cjs",

--- a/packages/validation/src/kubernetes.schema.ts
+++ b/packages/validation/src/kubernetes.schema.ts
@@ -93,7 +93,7 @@ export const kubernetesControlPlaneACLPayloadSchema = object().shape({
 const alphaNumericValidCharactersRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-._]*[a-zA-Z0-9])?$/;
 
 // DNS subdomain key (example.com/my-app)
-const dnsKeyRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-./]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/;
+const dnsKeyRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-._/]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/;
 
 const MAX_DNS_KEY_TOTAL_LENGTH = 128;
 const MAX_DNS_KEY_SUFFIX_LENGTH = 62;


### PR DESCRIPTION
## Cloud Manager
### Fixed:

- Uptime not displaying in Longview ([#11667](https://github.com/linode/manager/pull/11667))

## Validation
### Fixed:

- Inability to add LKE Node Pool Labels with underscore in key ([#11682](https://github.com/linode/manager/pull/11682))