### PR TITLE
fix: [M3-9343] - Fix validation with LKE Node Pool Labels creation

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,13 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2025-02-18] - v1.136.1
-
+## [2025-02-19] - v1.136.1
 
 ### Fixed:
 
 - Uptime not displaying in Longview ([#11667](https://github.com/linode/manager/pull/11667))
-- Inability to add LKE Node Pool Labels with underscore in key ([#11682](https://github.com/linode/manager/pull/11682))
 
 ## [2025-02-11] - v1.136.0
 

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed:
 
 - Uptime not displaying in Longview ([#11667](https://github.com/linode/manager/pull/11667))
+- Inability to add LKE Node Pool Labels with underscore in key ([#11682](https://github.com/linode/manager/pull/11682))
 
 ## [2025-02-11] - v1.136.0
 

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -1291,16 +1291,16 @@ describe('LKE cluster updates', () => {
     });
 
     it('can add labels and taints', () => {
-      const mockNewSimpleLabel = 'my-label-key: my-label-value';
-      const mockNewDNSLabel = 'my-label-key.io/app: my-label-value';
+      const mockNewSimpleLabel = 'my_label.-key: my_label.-value';
+      const mockNewDNSLabel = 'my_label-key.io/app: my_label.-value';
       const mockNewTaint: Taint = {
-        key: 'my-taint-key',
-        value: 'my-taint-value',
+        key: 'my_taint.-key',
+        value: 'my_taint.-value',
         effect: 'NoSchedule',
       };
       const mockNewDNSTaint: Taint = {
-        key: 'my-taint-key.io/app',
-        value: 'my-taint-value',
+        key: 'my_taint-key.io/app',
+        value: 'my_taint.-value',
         effect: 'NoSchedule',
       };
       const mockNodePoolUpdated = nodePoolFactory.build({
@@ -1309,8 +1309,8 @@ describe('LKE cluster updates', () => {
         nodes: mockNodes,
         taints: [mockNewTaint, mockNewDNSTaint],
         labels: {
-          'my-label-key': 'my-label-value',
-          'my-label-key.io/app': 'my-label-value',
+          'my_label-key': 'my_label.-value',
+          'my_label-key.io/app': 'my_label.-value',
         },
       });
 

--- a/packages/validation/CHANGELOG.md
+++ b/packages/validation/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2025-02-19] - v0.60.1
+
+### Fixed:
+
+- Inability to add LKE Node Pool Labels with underscore in key ([#11682](https://github.com/linode/manager/pull/11682))
+
+
 ## [2025-02-11] - v0.60.0
 
 

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/validation",
-  "version": "0.60.0",
+  "version": "0.60.1",
   "description": "Yup validation schemas for use with the Linode APIv4",
   "type": "module",
   "main": "lib/index.cjs",

--- a/packages/validation/src/kubernetes.schema.ts
+++ b/packages/validation/src/kubernetes.schema.ts
@@ -93,7 +93,7 @@ export const kubernetesControlPlaneACLPayloadSchema = object().shape({
 const alphaNumericValidCharactersRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-._]*[a-zA-Z0-9])?$/;
 
 // DNS subdomain key (example.com/my-app)
-const dnsKeyRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-./]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/;
+const dnsKeyRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-._/]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/;
 
 const MAX_DNS_KEY_TOTAL_LENGTH = 128;
 const MAX_DNS_KEY_SUFFIX_LENGTH = 62;

--- a/packages/validation/src/kubernetes.schema.ts
+++ b/packages/validation/src/kubernetes.schema.ts
@@ -93,7 +93,7 @@ export const kubernetesControlPlaneACLPayloadSchema = object().shape({
 const alphaNumericValidCharactersRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-._]*[a-zA-Z0-9])?$/;
 
 // DNS subdomain key (example.com/my-app)
-const dnsKeyRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-._/]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/;
+const dnsKeyRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-./]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/;
 
 const MAX_DNS_KEY_TOTAL_LENGTH = 128;
 const MAX_DNS_KEY_SUFFIX_LENGTH = 62;


### PR DESCRIPTION
## Description 📝

We have a client-side validation error impacting the creation of valid labels. The validation was not accepting an underscore as a valid character for DNS subdomain keys.

When applying a node pool label in Cloud Manager, the attempt is rejected with the error "Labels must be valid key-value pairs". When using the same label via API the node pool is created and the label is applied correctly. 

**Note**: If unfamiliar with labels and taints, you may be asking: can we rely on the API for validation and not worry about all the complexities client-side? See [context](https://github.com/linode/manager/pull/11553#discussion_r1932990692).

## Changes  🔄
- Updated the regex
- Updated test coverage to include all valid keys to ensure naming doesn't throw validation errors

## Target release date 🗓️

2/19

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/1f73707e-079f-4a2a-b6fb-df93844c57d9" />  | <video src="https://github.com/user-attachments/assets/860ca4a7-c843-4fbb-bc56-05b401bf801b" />  |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- See the internal ticket
- Have an LKE cluster on your account

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Go to the LKE cluster's details page and attempt to add a new label to a node pool using the label name in the ticket
- [ ] Observe the validation error

### Verification steps

(How to verify changes)

- [ ] Go to the LKE cluster's details page and attempt to add a new label to a node pool using the label name in the ticket
- [ ] Observe no validation error; the label submits successfully
- [ ] Ensure there aren't any other invalid characters missing from the regexes (try to break it, see [here](https://techdocs.akamai.com/cloud-computing/docs/deploy-and-manage-a-kubernetes-cluster-with-the-api#add-labels-and-taints-to-your-lke-node-pools) for valid characters)
- [ ] Ensure test coverage passes:
```
yarn cy:run -s "cypress/e2e/core/kubernetes/lke-update.spec.ts"
```

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
