### PR TITLE
fix: [M3-9252] - Kill `MuiAccordionSummary-root` transition in primary nav

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
@@ -115,6 +115,9 @@ export const StyledAccordion = styled(Accordion, {
       height: 16,
       width: 16,
     },
+    '.MuiAccordionSummary-root': {
+      transition: 'none',
+    },
     '.MuiButtonBase-root, MuiAccordionSummary-root': {
       '&:hover': {
         backgroundColor: theme.tokens.color.Neutrals[100],


### PR DESCRIPTION
## Description 📝
Fixes an annoying transition when collapsing a section of the `PrimaryNav`.

🎗️ No need for a changeset, just patching the unreleased CDS updates

## Changes  🔄
- Remove accordion summary transition (in Primary nav only) to prevent unwanted pixel shifts on collapse

## Target release date 🗓️
⚠️ **2/25/2025**

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/d131fc19-ad50-4078-a743-b5e32a24e12c" /> | <video src="https://github.com/user-attachments/assets/eae32f79-4229-4137-a5f7-e9b0937713c7" /> |

## How to test 🧪

### Prerequisites

### Verification steps
- Verify change by comparing develop branch VS this branch:
  - confirm no pixel shift while collapsing PrimaryNav section
  - confirm no regression to PrimaryNav

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
