### PR TITLE
upcoming: [DI-23317] - Filter regions by supported region ids

### DIFF
--- a/packages/manager/.changeset/pr-11692-upcoming-features-1740111658194.md
+++ b/packages/manager/.changeset/pr-11692-upcoming-features-1740111658194.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Filter regions by supported region ids - `getSupportedRegionIds` in CloudPulse alerts ([#11692](https://github.com/linode/manager/pull/11692))

--- a/packages/manager/src/factories/cloudpulse/alerts.ts
+++ b/packages/manager/src/factories/cloudpulse/alerts.ts
@@ -46,7 +46,7 @@ export const alertFactory = Factory.Sync.makeFactory<Alert>({
   created: new Date().toISOString(),
   created_by: 'system',
   description: 'Test description',
-  entity_ids: ['1', '2', '3'],
+  entity_ids: ['1', '2', '3', '51'],
   has_more_resources: true,
   id: Factory.each((i) => i),
   label: Factory.each((id) => `Alert-${id}`),

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/AlertsResources.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/AlertsResources.tsx
@@ -150,7 +150,7 @@ export const AlertResources = React.memo((props: AlertResourcesProp) => {
     };
 
     // Combine all the filters
-    return { ...platformFilter, ...typeFilter, ...regionFilter };
+    return { ...platformFilter, '+and': [typeFilter, regionFilter] };
   }, [alertClass, alertType, serviceType, supportedRegionIds]);
 
   const {

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertResourceUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertResourceUtils.test.ts
@@ -4,6 +4,7 @@ import {
   getFilteredResources,
   getRegionOptions,
   getRegionsIdRegionMap,
+  getSupportedRegionIds,
 } from './AlertResourceUtils';
 
 import type { CloudPulseResources } from '../../shared/CloudPulseResourcesSelect';
@@ -176,5 +177,34 @@ describe('getFilteredResources', () => {
         selectedResources: ['1'],
       });
     expect(result.length).toBe(data.length);
+  });
+});
+
+describe('getSupportedRegionIds', () => {
+  const mockResourceTypeMap = [
+    {
+      dimensionKey: 'LINODE_ID',
+      serviceType: 'linode',
+      supportedRegionIds: 'us-east,us-west,us-central,us-southeast',
+    },
+  ];
+
+  it('should return supported region ids', () => {
+    const result = getSupportedRegionIds(
+      mockResourceTypeMap,
+      'linode'
+    ) as string[];
+    expect(result.length).toBe(3);
+  });
+  it('should return undefined if no supported region ids are defined in resource type map for the given service type', () => {
+    const mockResourceTypeMap = [
+      {
+        dimensionKey: 'LINODE_ID',
+        serviceType: 'linode',
+      },
+    ];
+
+    const result = getSupportedRegionIds(mockResourceTypeMap, 'linode');
+    expect(result).toBeUndefined();
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertResourceUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertResourceUtils.test.ts
@@ -194,7 +194,7 @@ describe('getSupportedRegionIds', () => {
       mockResourceTypeMap,
       'linode'
     ) as string[];
-    expect(result.length).toBe(3);
+    expect(result.length).toBe(4);
   });
   it('should return undefined if no supported region ids are defined in resource type map for the given service type', () => {
     const mockResourceTypeMap = [

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertResourceUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertResourceUtils.ts
@@ -12,7 +12,8 @@ import type {
   AlertFilterKey,
   AlertFilterType,
 } from '../AlertsResources/types';
-import type { Region } from '@linode/api-v4';
+import type { AlertServiceType, Region } from '@linode/api-v4';
+import type { CloudPulseResourceTypeMapFlag } from 'src/featureFlags';
 
 interface FilterResourceProps {
   /**
@@ -130,6 +131,31 @@ export const getRegionOptions = (
     }
   });
   return Array.from(uniqueRegions);
+};
+
+/**
+ * @param aclpResourceTypeMap The launch darkly flag where supported region ids are listed
+ * @param serviceType The service type associated with the alerts
+ * @returns Array of supported regions associated with the resource ids of the alert
+ */
+export const getSupportedRegionIds = (
+  aclpResourceTypeMap: CloudPulseResourceTypeMapFlag[] | undefined,
+  serviceType: AlertServiceType | undefined
+): string[] | undefined => {
+  const resourceTypeFlag = aclpResourceTypeMap?.find(
+    (item: CloudPulseResourceTypeMapFlag) => item.serviceType === serviceType
+  );
+
+  if (
+    resourceTypeFlag?.supportedRegionIds === null ||
+    resourceTypeFlag?.supportedRegionIds === undefined
+  ) {
+    return undefined;
+  }
+
+  return resourceTypeFlag.supportedRegionIds
+    .split(',')
+    .map((regionId: string) => regionId.trim());
 };
 
 /**

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -763,6 +763,15 @@ export const handlers = [
         });
       }
 
+      // filter the linodes based on supported regions
+      if (orFilters?.length) {
+        filteredLinodes = linodes.filter((linode) => {
+          return orFilters.some(
+            (filter: { region: string }) => linode.region === filter.region
+          );
+        });
+      }
+
       if (regionFilter) {
         filteredLinodes = filteredLinodes.filter((linode) => {
           return linode.region === regionFilter;


### PR DESCRIPTION
## Description 📝

Filter regions by supported region ids by passing supported regions as an xfilter.

## Changes  🔄

- Region select autocomplete of alerts will have regions listed according to the supported region ids from launch darkly.
- Displayed resources will be the ones with region ids included in supported region ids.

## Target release date 🗓️
25-02-25

## Preview 📷
**LD flag:** 

![image](https://github.com/user-attachments/assets/e108de0d-d450-47e0-958f-bdd3560c4bdf)
--------------------
**servicetype: 'linode' =>** 
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/bb59f317-0ae0-4e52-a62d-e840cd4c49c7) | ![image](https://github.com/user-attachments/assets/63f02519-786e-4dad-af7a-99a95a073aec)|
| ![image](https://github.com/user-attachments/assets/a5f690fc-e352-4fd6-afe4-6d9c464fb088)|![image](https://github.com/user-attachments/assets/5d826490-e7e5-4d5c-bb86-553fe599d807)|

In case supported regions is an empty string: 
![image](https://github.com/user-attachments/assets/54a7f6a2-84fe-43ba-8cc1-d24fb61a5bf1)

## How to test 🧪

### Verification steps

(How to verify changes)

- Navigate to alerts in monitor tab.
- Open networks tab, locate `aclpResourceTypeMap` flag in launch darkly, note the supported region ids provided according to the service type.
- Now, go to alerts, select any alert, open region select autocomplete, verify that the region options available have region ids same as supported region ids from launch Darkly. Verify the filtered resources.
- If no region is selected, verify that the displayed filtered resources are the ones with region ids included in supported regions.


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>