### PR TITLE
fix: [M3-9360] - Collapsible Node Pool overflow bug

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Document titles with incorrect keywords ([#11635](https://github.com/linode/manager/pull/11635))
 - Order of footers for paginated LKE Node Pools ([#11639](https://github.com/linode/manager/pull/11639))
 - TabIndex reset issue and incorrect enhanced number input minus sign SVG color ([#11651](https://github.com/linode/manager/pull/11654))
+- Collapsible Node Pool overflow bug ([#11699](https://github.com/linode/manager/pull/11699))
 
 ### Removed:
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -216,8 +216,8 @@ export const NodePool = (props: Props) => {
       data-qa-node-pool-section
       expanded={accordionExpanded}
       onChange={handleAccordionClick}
-      // This improves performance for large components and also addresses table in accordion overflow-y issue
-      slotProps={{ transition: { unmountOnExit: true } }}
+      // Improve performance by unmounting large content from the DOM when collapsed
+      slotProps={{ transition: { unmountOnExit: nodes.length > 25 } }}
     >
       <NodeTable
         clusterCreated={clusterCreated}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -216,6 +216,8 @@ export const NodePool = (props: Props) => {
       data-qa-node-pool-section
       expanded={accordionExpanded}
       onChange={handleAccordionClick}
+      // This improves performance for large components and also addresses table in accordion overflow-y issue
+      slotProps={{ transition: { unmountOnExit: true } }}
     >
       <NodeTable
         clusterCreated={clusterCreated}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -248,6 +248,10 @@ export const NodeTable = React.memo((props: Props) => {
                 handleSizeChange={handlePageSizeChange}
                 page={page}
                 pageSize={pageSize}
+                /**
+                 * M3-9360: Since this table is in an accordion, the position needs to be relative
+                 * to prevent an overflow-y issue with the absolutely positioned visually-hidden footer label
+                 **/
                 sx={{ position: 'relative' }}
               />
               <StyledTableFooter>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -248,6 +248,7 @@ export const NodeTable = React.memo((props: Props) => {
                 handleSizeChange={handlePageSizeChange}
                 page={page}
                 pageSize={pageSize}
+                sx={{ position: 'relative' }}
               />
               <StyledTableFooter>
                 <StyledPoolInfoBox>


### PR DESCRIPTION
## Description 📝

1. Fix y-axis overflow when a Node Pool with a table is collapsed by setting the `PaginationFooter` position to be relative
   - This was caused due to the `visually-hidden` style we're applying to the footer label which has `position: absolute`, so it didn't follow the outer div's `overflow: hidden` rule
   - https://stackoverflow.com/questions/4605715/position-absolute-and-overflow-hidden

2. Unmount accordion content if there are more than 25 nodes for [performance](https://mui.com/material-ui/react-accordion/#performance)

## Target release date 🗓️

2/25

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/d576a234-7e26-4bb9-aee3-637f27a33914" /> | <video src="https://github.com/user-attachments/assets/ca72a8af-c442-4255-9849-c78fe7ce978b" /> |


## How to test 🧪

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] On a different branch, go to a cluster's details page with the MSW on
- [ ] Observe the y-axis overflow when the node pool with a table is collapsed

### Verification steps

(How to verify changes)

- [ ] Checkout this branch or preview link, go to a cluster's details page with the MSW on
- [ ] Observe that there is **no** y-axis overflow when the node pool with a table is collapsed
- [ ] Collapsed Accordion content should not exist in the DOM if the pool has more than 25 nodes

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>