### PR TITLE
fix: [M3-9061] - Node Pools CTA Buttons on Small Screens

### DIFF
--- a/packages/manager/.changeset/pr-11701-fixed-1740128402516.md
+++ b/packages/manager/.changeset/pr-11701-fixed-1740128402516.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Node Pools CTA buttons on small screens ([#11701](https://github.com/linode/manager/pull/11701))

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -160,7 +160,7 @@ export const NodePoolsDisplay = (props: Props) => {
         flexWrap="wrap"
         justifyContent="space-between"
       >
-        <Stack alignItems="center" direction="row" spacing={2}>
+        <Stack alignItems="center" direction="row">
           <Typography variant="h2">Node Pools</Typography>
         </Stack>
         <Stack
@@ -172,9 +172,9 @@ export const NodePoolsDisplay = (props: Props) => {
           })}
           alignItems="center"
           direction="row"
-          spacing={1}
+          gap={1}
         >
-          <FormLabel htmlFor={ariaIdentifier}>
+          <FormLabel htmlFor={ariaIdentifier} sx={{ mb: 0 }}>
             <Typography ml={1} mr={1}>
               Status
             </Typography>
@@ -226,22 +226,20 @@ export const NodePoolsDisplay = (props: Props) => {
             </Button>
           )}
           <Hidden mdUp>
-            <Box sx={{ ml: 'auto !important' }}>
-              <Box sx={{ ml: 1 }}>
-                <ActionMenu
-                  actionsList={[
-                    {
-                      onClick: () => setIsRecycleClusterOpen(true),
-                      title: 'Recycle All Nodes',
-                    },
-                    {
-                      onClick: handleOpenAddDrawer,
-                      title: 'Add a Node Pool',
-                    },
-                  ]}
-                  ariaLabel={`Action menu for Node Pools header`}
-                />
-              </Box>
+            <Box sx={{ ml: 'auto' }}>
+              <ActionMenu
+                actionsList={[
+                  {
+                    onClick: () => setIsRecycleClusterOpen(true),
+                    title: 'Recycle All Nodes',
+                  },
+                  {
+                    onClick: handleOpenAddDrawer,
+                    title: 'Add a Node Pool',
+                  },
+                ]}
+                ariaLabel={`Action menu for Node Pools header`}
+              />
             </Box>
           </Hidden>
           <Hidden mdDown>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -164,9 +164,13 @@ export const NodePoolsDisplay = (props: Props) => {
           <Typography variant="h2">Node Pools</Typography>
         </Stack>
         <Stack
+          sx={(theme) => ({
+            [theme.breakpoints.down('md')]: {
+              width: '100%',
+            },
+          })}
           alignItems="center"
           direction="row"
-          marginLeft="auto"
           paddingTop="8px"
           spacing={1}
         >
@@ -222,20 +226,22 @@ export const NodePoolsDisplay = (props: Props) => {
             </Button>
           )}
           <Hidden mdUp>
-            <Box sx={{ ml: 0.5 }}>
-              <ActionMenu
-                actionsList={[
-                  {
-                    onClick: () => setIsRecycleClusterOpen(true),
-                    title: 'Recycle All Nodes',
-                  },
-                  {
-                    onClick: handleOpenAddDrawer,
-                    title: 'Add a Node Pool',
-                  },
-                ]}
-                ariaLabel={`Action menu for Node Pools header`}
-              />
+            <Box sx={{ ml: 'auto !important' }}>
+              <Box sx={{ ml: 1 }}>
+                <ActionMenu
+                  actionsList={[
+                    {
+                      onClick: () => setIsRecycleClusterOpen(true),
+                      title: 'Recycle All Nodes',
+                    },
+                    {
+                      onClick: handleOpenAddDrawer,
+                      title: 'Add a Node Pool',
+                    },
+                  ]}
+                  ariaLabel={`Action menu for Node Pools header`}
+                />
+              </Box>
             </Box>
           </Hidden>
           <Hidden mdDown>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -1,9 +1,18 @@
-import { Button, CircleProgress, Select, Stack, Typography } from '@linode/ui';
+import {
+  Box,
+  Button,
+  CircleProgress,
+  Select,
+  Stack,
+  Typography,
+} from '@linode/ui';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { Hidden } from '@mui/material';
 import React, { useState } from 'react';
 import { Waypoint } from 'react-waypoint';
 
+import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { FormLabel } from 'src/components/FormLabel';
 import { useDefaultExpandedNodePools } from 'src/hooks/useDefaultExpandedNodePools';
@@ -150,7 +159,7 @@ export const NodePoolsDisplay = (props: Props) => {
         direction="row"
         flexWrap="wrap"
         justifyContent="space-between"
-        spacing={2}
+        sx={{ paddingLeft: { md: 0, sm: 1, xs: 1 }, paddingTop: 3 }}
       >
         <Stack alignItems="center" direction="row" spacing={2}>
           <Typography variant="h2">Node Pools</Typography>
@@ -207,15 +216,34 @@ export const NodePoolsDisplay = (props: Props) => {
               Expand All Pools
             </Button>
           )}
-          <Button
-            buttonType="outlined"
-            onClick={() => setIsRecycleClusterOpen(true)}
-          >
-            Recycle All Nodes
-          </Button>
-          <Button buttonType="primary" onClick={handleOpenAddDrawer}>
-            Add a Node Pool
-          </Button>
+          <Hidden smUp>
+            <Box sx={{ ml: 0.5 }}>
+              <ActionMenu
+                actionsList={[
+                  {
+                    onClick: () => setIsRecycleClusterOpen(true),
+                    title: 'Recycle All Nodes',
+                  },
+                  {
+                    onClick: handleOpenAddDrawer,
+                    title: 'Add a Node Pool',
+                  },
+                ]}
+                ariaLabel={`Action menu for Node Pools header`}
+              />
+            </Box>
+          </Hidden>
+          <Hidden smDown>
+            <Button
+              buttonType="secondary"
+              onClick={() => setIsRecycleClusterOpen(true)}
+            >
+              Recycle All Nodes
+            </Button>
+            <Button buttonType="primary" onClick={handleOpenAddDrawer}>
+              Add a Node Pool
+            </Button>
+          </Hidden>
         </Stack>
       </Stack>
       {poolsError && <ErrorState errorText={poolsError[0].reason} />}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -159,12 +159,17 @@ export const NodePoolsDisplay = (props: Props) => {
         direction="row"
         flexWrap="wrap"
         justifyContent="space-between"
-        sx={{ paddingLeft: { md: 0, sm: 1, xs: 1 }, paddingTop: 3 }}
       >
         <Stack alignItems="center" direction="row" spacing={2}>
           <Typography variant="h2">Node Pools</Typography>
         </Stack>
-        <Stack alignItems="center" direction="row" spacing={1}>
+        <Stack
+          alignItems="center"
+          direction="row"
+          marginLeft="auto"
+          paddingTop="8px"
+          spacing={1}
+        >
           <FormLabel htmlFor={ariaIdentifier}>
             <Typography ml={1} mr={1}>
               Status
@@ -216,7 +221,7 @@ export const NodePoolsDisplay = (props: Props) => {
               Expand All Pools
             </Button>
           )}
-          <Hidden smUp>
+          <Hidden mdUp>
             <Box sx={{ ml: 0.5 }}>
               <ActionMenu
                 actionsList={[
@@ -233,7 +238,7 @@ export const NodePoolsDisplay = (props: Props) => {
               />
             </Box>
           </Hidden>
-          <Hidden smDown>
+          <Hidden mdDown>
             <Button
               buttonType="secondary"
               onClick={() => setIsRecycleClusterOpen(true)}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -165,13 +165,13 @@ export const NodePoolsDisplay = (props: Props) => {
         </Stack>
         <Stack
           sx={(theme) => ({
+            paddingTop: theme.spacing(1),
             [theme.breakpoints.down('md')]: {
               width: '100%',
             },
           })}
           alignItems="center"
           direction="row"
-          paddingTop="8px"
           spacing={1}
         >
           <FormLabel htmlFor={ariaIdentifier}>
@@ -246,7 +246,7 @@ export const NodePoolsDisplay = (props: Props) => {
           </Hidden>
           <Hidden mdDown>
             <Button
-              buttonType="secondary"
+              buttonType="outlined"
               onClick={() => setIsRecycleClusterOpen(true)}
             >
               Recycle All Nodes

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -165,8 +165,8 @@ export const NodePoolsDisplay = (props: Props) => {
         </Stack>
         <Stack
           sx={(theme) => ({
-            paddingTop: theme.spacing(1),
             [theme.breakpoints.down('md')]: {
+              paddingTop: theme.spacing(1),
               width: '100%',
             },
           })}


### PR DESCRIPTION
## Description 📝

When the LKE details page is viewed on mobile screens, there is an unexpected gap between the Node Pool CTAs and the right edge of the screen + *overflow issue*.

## Changes  🔄
- Add action menu for `Recycle All Nodes` and `Add A Node Pool` buttons for for screens < `md`
- Some style adjustments

## Target release date 🗓️
N/A



## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-02-21 at 2 08 27 PM](https://github.com/user-attachments/assets/9417b2a9-b0cf-4dec-b05e-376befe244cf) | ![Screenshot 2025-02-21 at 2 13 13 PM](https://github.com/user-attachments/assets/826778ea-e778-4594-b1a0-2950e67c6e4d) |
| ![Screenshot 2025-02-21 at 2 16 44 PM](https://github.com/user-attachments/assets/2d1f6a6f-ecc5-43a6-814c-d933181017a1) | ![Screenshot 2025-02-21 at 2 17 50 PM](https://github.com/user-attachments/assets/e2374552-9ebc-46fd-9034-e32784c6888b)| 
| None | ![Screenshot 2025-02-21 at 2 18 41 PM](https://github.com/user-attachments/assets/740c9deb-37f4-4f11-bb37-2f3ae2c33598) |



## How to test 🧪
- Ensure no styling/overflow issue for Node Pool CTA Buttons on Small Screens

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules