### PR TITLE
test: [M3-9150] - Cypress test for Image create page for restricted users

### DIFF
--- a/packages/manager/.changeset/pr-11705-tests-1740407261971.md
+++ b/packages/manager/.changeset/pr-11705-tests-1740407261971.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Cypress test for Image create page for restricted users ([#11705](https://github.com/linode/manager/pull/11705))


### PR DESCRIPTION
## Description 📝
Add test to check the warning message and disabled fields in image create page for restricted users

## Major Changes 🔄
- Add test to check `/images/create` page
- Add test to check `images/create/upload` page

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/images/smoke-create-image.spec.ts"
```