### PR TITLE
fix: Region Availablity Plans Panel API Request

### DIFF
--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -94,7 +94,7 @@ export const PlansPanel = (props: PlansPanelProps) => {
 
   const { data: regionAvailabilities } = useRegionAvailabilityQuery(
     selectedRegionID || '',
-    Boolean(flags.soldOutChips) && selectedRegionID !== undefined
+    Boolean(flags.soldOutChips) && Boolean(selectedRegionID)
   );
 
   const _types = types.filter((type) => {


### PR DESCRIPTION
## Description 📝

- Fixes erroneous API requests made by Cloud Manager to the `/v4/regions/{id}/availability` endpoint
- In devenv, this was causing Traeifk to respond with an unexpected response ❌ 
- In production, this was causing the API to respond with a paginated response because `/v4/regions//availability` is interpreted as `/v4/regions/availability`. We are lucky this didn't cause any crashes 🍀 
- This is happening because the new Linode Create flow stores an empty string when no region is selected because of how things are typed

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-02-21 at 7 34 22 PM](https://github.com/user-attachments/assets/db1877b7-885c-41fa-b439-616fab3b8a9f)  | ![Screenshot 2025-02-21 at 7 34 40 PM](https://github.com/user-attachments/assets/51de0be5-8abb-4003-9d2f-954160e058d1) |

## How to test 🧪

- Ensure a fetch to `/v4/regions/{id}/availability` **does not occour** when the page is loaded
- Ensure a fetch to `/v4/regions/{id}/availability` happens **once a region is selected**

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
