### PR TITLE
poc: Use MUI's Button Loading State

### DIFF
--- a/packages/manager/src/components/CheckoutBar/CheckoutBar.test.tsx
+++ b/packages/manager/src/components/CheckoutBar/CheckoutBar.test.tsx
@@ -50,12 +50,12 @@ describe('CheckoutBar', () => {
   });
 
   it('should disable submit button and show loading icon if isMakingRequest is true', () => {
-    const { getByTestId } = renderWithTheme(
+    const { getByTestId, getByRole } = renderWithTheme(
       <CheckoutBar {...defaultArgs} isMakingRequest={true} />
     );
 
     expect(getByTestId('button')).toBeDisabled();
-    expect(getByTestId('loadingIcon')).toBeInTheDocument();
+    expect(getByRole('progressbar')).toBeInTheDocument();
   });
 
   it("should disable submit button and show 'Submit' text if disabled prop is set", () => {

--- a/packages/manager/src/components/DeletionDialog/DeletionDialog.test.tsx
+++ b/packages/manager/src/components/DeletionDialog/DeletionDialog.test.tsx
@@ -132,9 +132,7 @@ describe('DeletionDialog', () => {
     expect(deleteButton).toBeInTheDocument();
     expect(deleteButton).toBeDisabled();
 
-    const loadingSvgIcon = deleteButton.querySelector(
-      '[data-testid="loadingIcon"]'
-    );
+    const loadingSvgIcon = deleteButton.querySelector('[role="progressbar"]');
 
     expect(loadingSvgIcon).toBeInTheDocument();
   });

--- a/packages/manager/src/features/TopMenu/CreateMenu/CreateMenu.tsx
+++ b/packages/manager/src/features/TopMenu/CreateMenu/CreateMenu.tsx
@@ -158,6 +158,7 @@ export const CreateMenu = () => {
         buttonType="primary"
         data-qa-add-new-menu-button
         disableRipple
+        loading
         id="create-menu"
         onClick={handleClick}
         startIcon={<StyledAddIcon />}

--- a/packages/manager/src/features/TopMenu/CreateMenu/CreateMenu.tsx
+++ b/packages/manager/src/features/TopMenu/CreateMenu/CreateMenu.tsx
@@ -158,7 +158,6 @@ export const CreateMenu = () => {
         buttonType="primary"
         data-qa-add-new-menu-button
         disableRipple
-        loading
         id="create-menu"
         onClick={handleClick}
         startIcon={<StyledAddIcon />}

--- a/packages/ui/src/components/Button/Button.test.tsx
+++ b/packages/ui/src/components/Button/Button.test.tsx
@@ -12,9 +12,9 @@ describe('Button', () => {
   });
 
   it('should render the loading state', () => {
-    const { getByTestId } = renderWithTheme(<Button loading>Test</Button>);
+    const { getByRole } = renderWithTheme(<Button loading>Test</Button>);
 
-    const loadingIcon = getByTestId('loadingIcon');
+    const loadingIcon = getByRole('progressbar');
     expect(loadingIcon).toBeInTheDocument();
   });
 

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -3,8 +3,6 @@ import _Button from '@mui/material/Button';
 import { styled } from '@mui/material/styles';
 import * as React from 'react';
 
-import { ReloadIcon } from '../../assets';
-import { rotate360 } from '../../foundations';
 import { omittedProps } from '../../utilities';
 import { Tooltip } from '../Tooltip';
 
@@ -63,13 +61,8 @@ export interface ButtonProps extends _ButtonProps {
 }
 
 const StyledButton = styled(_Button, {
-  shouldForwardProp: omittedProps([
-    'compactX',
-    'compactY',
-    'loading',
-    'buttonType',
-  ]),
-})<ButtonProps>(({ theme, ...props }) => ({
+  shouldForwardProp: omittedProps(['compactX', 'compactY', 'buttonType']),
+})<ButtonProps>(({ ...props }) => ({
   ...(props.compactX && {
     minWidth: 50,
     paddingLeft: 0,
@@ -79,14 +72,6 @@ const StyledButton = styled(_Button, {
     minHeight: 20,
     paddingBottom: 0,
     paddingTop: 0,
-  }),
-  ...(props.loading && {
-    '& svg': {
-      animation: `${rotate360} 2s linear infinite`,
-      height: `${theme.spacing(2)}`,
-      margin: '0 auto',
-      width: `${theme.spacing(2)}`,
-    },
   }),
 }));
 
@@ -103,7 +88,6 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       compactX,
       compactY,
       disabled,
-      loading,
       sx,
       sxEndIcon,
       tooltipAnalyticsEvent,
@@ -147,15 +131,13 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         compactY={compactY}
         data-testid={rest['data-testid'] || 'button'}
         disableRipple={disabled || rest.disableRipple}
-        disabled={loading}
-        loading={loading}
         onClick={disabled ? (e) => e.preventDefault() : rest.onClick}
         onKeyDown={disabled ? handleDisabledKeyDown : rest.onKeyDown}
         ref={ref}
         sx={sx}
         variant={buttonTypeToVariant[buttonType] || 'text'}
       >
-        {loading ? <ReloadIcon data-testid="loadingIcon" /> : children}
+        {children}
       </StyledButton>
     );
 

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -29,8 +29,6 @@ export interface ButtonProps extends _ButtonProps {
    * * @default 'secondary'
    * */
   buttonType?: ButtonType;
-  /** Additional css class to pass to the component */
-  className?: string;
   /**
    * Reduce the padding on the x-axis
    * @default false
@@ -45,13 +43,6 @@ export interface ButtonProps extends _ButtonProps {
    * Optional test ID
    */
   'data-testid'?: string;
-  /**
-   * Show a loading indicator
-   * @default false
-   */
-  loading?: boolean;
-  /** The `sx` prop can be either object or function */
-  sx?: SxProps<Theme>;
   /** Pass specific CSS styling for the SVG icon. */
   sxEndIcon?: SxProps<Theme>;
   /** Tooltip analytics event */
@@ -62,13 +53,13 @@ export interface ButtonProps extends _ButtonProps {
 
 const StyledButton = styled(_Button, {
   shouldForwardProp: omittedProps(['compactX', 'compactY', 'buttonType']),
-})<ButtonProps>(({ ...props }) => ({
-  ...(props.compactX && {
+})<ButtonProps>(({ compactX, compactY }) => ({
+  ...(compactX && {
     minWidth: 50,
     paddingLeft: 0,
     paddingRight: 0,
   }),
-  ...(props.compactY && {
+  ...(compactY && {
     minHeight: 20,
     paddingBottom: 0,
     paddingTop: 0,
@@ -82,13 +73,8 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       // and we end up with the wrong styles (purple color, see #6455)
       // It would be nice to remove this default and require the prop but this fixes the issue for now.
       buttonType = 'secondary',
-      children,
-      className,
       color,
-      compactX,
-      compactY,
       disabled,
-      sx,
       sxEndIcon,
       tooltipAnalyticsEvent,
       tooltipText,
@@ -114,7 +100,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       }
     };
 
-    const renderButton = (
+    const button = (
       <StyledButton
         {...rest}
         aria-describedby={
@@ -125,34 +111,30 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         }
         aria-disabled={disabled}
         buttonType={buttonType}
-        className={className}
         color={(color === 'error' && color) || buttonTypeToColor[buttonType]}
-        compactX={compactX}
-        compactY={compactY}
         data-testid={rest['data-testid'] || 'button'}
         disableRipple={disabled || rest.disableRipple}
         onClick={disabled ? (e) => e.preventDefault() : rest.onClick}
         onKeyDown={disabled ? handleDisabledKeyDown : rest.onKeyDown}
         ref={ref}
-        sx={sx}
         variant={buttonTypeToVariant[buttonType] || 'text'}
-      >
-        {children}
-      </StyledButton>
+      />
     );
 
-    return showTooltip ? (
-      <Tooltip
-        aria-label={rest['aria-label']}
-        data-testid="Tooltip"
-        id="button-tooltip"
-        onClick={handleTooltipAnalytics}
-        title={tooltipText}
-      >
-        {renderButton}
-      </Tooltip>
-    ) : (
-      renderButton
-    );
+    if (showTooltip) {
+      return (
+        <Tooltip
+          aria-label={rest['aria-label']}
+          data-testid="Tooltip"
+          id="button-tooltip"
+          onClick={handleTooltipAnalytics}
+          title={tooltipText}
+        >
+          {button}
+        </Tooltip>
+      );
+    }
+
+    return button;
   }
 );

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -519,6 +519,9 @@ export const lightTheme: ThemeOptions = {
           backgroundColor: 'transparent',
           color: Button.Secondary.Default.Text,
         },
+        loading: {
+          color: 'transparent !important',
+        },
         outlined: {
           '&:hover, &:focus': {
             backgroundColor: Color.Neutrals[5],


### PR DESCRIPTION
## Description 📝

- Uses MUI's (newly) built-in button loading state!

## Benefits
- Less code and maintenance required by us
- Button no longer changes size when loading 🎉 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-02-23 at 10 25 28 PM](https://github.com/user-attachments/assets/0695b0a5-c52d-4cd1-a64c-220daf714961) | ![Screenshot 2025-02-23 at 10 24 44 PM](https://github.com/user-attachments/assets/6796972a-6711-40b1-bba9-b2fbd703e1cc) |

## How to test 🧪

- Check our `<Button />` throughout the application
- Check button in Storybook 📖 
- Verify is looks and works better than the current implementation
- Verify new style aligns with Akamai's Core Design System

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>