### PR TITLE
fix: [M3-9398] - Improve clarity for OBJ validation message

### DIFF
--- a/packages/validation/.changeset/pr-11712-fixed-1740408470305.md
+++ b/packages/validation/.changeset/pr-11712-fixed-1740408470305.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Fixed
+---
+
+improve clarity for OBJ bucket creation validation message ([#11712](https://github.com/linode/manager/pull/11712))

--- a/packages/validation/src/buckets.schema.ts
+++ b/packages/validation/src/buckets.schema.ts
@@ -11,7 +11,7 @@ export const CreateBucketSchema = object()
         .matches(/^\S*$/, 'Label must not contain spaces.')
         .matches(
           /^[a-z0-9].*[a-z0-9]$/,
-          'Label must start and end with a letter or number.'
+          'Label must start and end with a lowercase letter or number.'
         )
         .matches(
           /^(?!.*[.-]{2})[a-z0-9.-]+$/,


### PR DESCRIPTION
## Description 📝
Cloud Manager only reports that "Label must start and end with a letter or number." without specifying they need to be lowercase.

## Changes  🔄
- Cloud Manager should report that labels must start with an lowercase letter or number

## Target release date 🗓️
3/11

## Preview 📷
<img width="465" alt="Screenshot 2025-02-24 at 9 44 36 AM" src="https://github.com/user-attachments/assets/b8caa703-f27f-4427-be3a-dd7378bae640" />

## How to test 🧪

### Prerequisites

### Verification steps
- Create an OBJ bucket with `Jjj`
- Observe `lowercase` has been added to validation message

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>