### PR TITLE
fix: [M3-9401] - Account Billing page regression due to MUI v6

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Divider, TooltipIcon, Typography } from '@linode/ui';
-import { useTheme } from '@mui/material/styles';
 import Grid from '@mui/material/Grid2';
+import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 
@@ -17,8 +17,6 @@ import { PromoDisplay } from './PromoDisplay';
 
 import type { PaymentMethod } from '@linode/api-v4';
 import type { ActivePromotion } from '@linode/api-v4/lib/account/types';
-import type { GridSize } from '@mui/material';
-import type { Breakpoint } from '@mui/material/styles';
 
 interface BillingSummaryProps {
   balance: number;
@@ -124,7 +122,7 @@ export const BillingSummary = (props: BillingSummaryProps) => {
   };
 
   // The layout changes if there are promotions.
-  const gridDimensions: Partial<Record<Breakpoint, GridSize>> =
+  const gridDimensions =
     promotions && promotions.length > 0 ? { md: 4, xs: 12 } : { sm: 6, xs: 12 };
 
   const balanceJSX =
@@ -157,17 +155,17 @@ export const BillingSummary = (props: BillingSummaryProps) => {
   return (
     <>
       <Grid
-        container
-        spacing={2}
-        size={12}
         sx={{
           margin: 0,
         }}
+        container
+        size={12}
+        spacing={2}
       >
         <Grid
-          {...gridDimensions}
           size={{
             sm: 6,
+            ...gridDimensions,
           }}
         >
           <BillingPaper variant="outlined">
@@ -236,7 +234,7 @@ export const BillingSummary = (props: BillingSummaryProps) => {
             </BillingPaper>
           </Grid>
         ) : null}
-        <Grid {...gridDimensions}>
+        <Grid size={gridDimensions}>
           <BillingPaper variant="outlined">
             <Box alignItems="center" display="flex">
               <Typography variant="h3">Accrued Charges</Typography>


### PR DESCRIPTION
## Description 📝

- Fixes a UI regression on the account billing page caused by the MUI v6 upgrade (https://github.com/linode/manager/pull/11688)

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-02-24 at 1 11 07 PM](https://github.com/user-attachments/assets/3afd7f27-a72f-4341-868d-6562fafddfb2) | ![Screenshot 2025-02-24 at 1 10 40 PM](https://github.com/user-attachments/assets/84903ebc-0c3f-4c82-b9ac-52728f084168) |

## How to test 🧪

- Test the UI on http://localhost:3000/account/billing
- Turn on the MSW and verify there are no regressions when the user has a promo code in use 🎟️ 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>