### PR TITLE
fix: [M3-9344, M3-9336] - Fix LKE-E cluster filtering bug and non-LKE linode failed request bug

### DIFF
--- a/packages/manager/.changeset/pr-11714-fixed-1740421546666.md
+++ b/packages/manager/.changeset/pr-11714-fixed-1740421546666.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+404 cluster endpoint errors on Linode details page for non-LKE Linodes ([#11714](https://github.com/linode/manager/pull/11714))

--- a/packages/manager/.changeset/pr-11714-upcoming-features-1740421599114.md
+++ b/packages/manager/.changeset/pr-11714-upcoming-features-1740421599114.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Fix LKE cluster table sorting when LKE-E beta endpoint is used ([#11714](https://github.com/linode/manager/pull/11714))

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
@@ -131,7 +131,10 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
   const secondAddress = ipv6 ? ipv6 : ipv4.length > 1 ? ipv4[1] : null;
   const matchesLgUp = useMediaQuery(theme.breakpoints.up('lg'));
 
-  const { data: cluster } = useKubernetesClusterQuery(linodeLkeClusterId ?? -1);
+  const { data: cluster } = useKubernetesClusterQuery(
+    linodeLkeClusterId ?? -1,
+    Boolean(linodeLkeClusterId)
+  );
 
   return (
     <>

--- a/packages/manager/src/queries/kubernetes.ts
+++ b/packages/manager/src/queries/kubernetes.ts
@@ -114,7 +114,7 @@ export const kubernetesQueries = createQueryKeys('kubernetes', {
       ) => ({
         queryFn: () =>
           useBetaEndpoint
-            ? getKubernetesClustersBeta()
+            ? getKubernetesClustersBeta(params, filter)
             : getKubernetesClusters(params, filter),
         queryKey: [params, filter, useBetaEndpoint ? 'v4beta' : 'v4'],
       }),


### PR DESCRIPTION
## Description 📝

This PR fixes two minor bugs that were both related to LKE requests. They are *unrelated*, but were such small changes  that I bundled them in one PR.

## Changes  🔄

- **Fix 1**: Passes the missing `params` and `filter` arguments to `getKubernetesClustersBeta` queryFn, which allows us to sort the clusters table on the LKE landing page when the LKE-E feature is enabled (aka: when we use the beta endpoint)
- **Fix 2**: Enables the `useKubernetesClusterQuery` only if the Linode has a `linodeLkeClusterId` so that we don't get any 404 errors from that endpoint for non LKE-associated Linodes

## Target release date 🗓️

3/11

## Preview 📷

| Before  | After   |
| ------- | ------- |
|<video src="https://github.com/user-attachments/assets/138e4d73-09b3-44ab-9b2c-568c67ff9286" /> | <video src="https://github.com/user-attachments/assets/c5b1a3bf-5fe8-4c66-a479-6f8e0a93b735" /> |
| <video src="https://github.com/user-attachments/assets/bccc1840-e940-4d12-8458-f0a0f09ba5e5" /> | <video src="https://github.com/user-attachments/assets/ed020f86-37cd-428b-8db7-d1030fe469be" /> |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Bug 1: Have the LKE-E feature flag on and the LKE-E customer tag on your account (see project tracker). Have at least two LKE clusters on your account so you can attempt to sort them.
- Bug 2: Have a normal Linode on your account that is not part of an LKE cluster

### Reproduction steps

(How to reproduce the issue, if applicable)

Bug 1:
- [ ] Go to the LKE landing page and try to sort the columns in the table. Observe that nothing happens and the network request passes no filters.


Bug 2:
- [ ] Open the network tab in the browser dev tools. Go to the normal Linode's details page. Observe the failed 404 request to `https://cloud.linode.com/api/v4/lke/clusters/-1` that ran, even though this isn't a Linode that is part of an LKE cluster.

### Verification steps

(How to verify changes)

Bug 1:
- [ ] Check out this PR and go to the LKE landing page and try to sort the columns in the table. Observe that they correctly sort now because the network request passes the correct filters.

Bug 2:
- [ ] Open the network tab in the browser dev tools. Go to the normal Linode's details page. Observe there is NO failed 404 request to `https://cloud.linode.com/api/v4/lke/clusters/-1` because the query is only enabled if an `linodeLkeClusterId` is provided.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
