### PR TITLE
fix: [M3-9400] - Selection Card UI regression caused by MUI v6

### DIFF
--- a/packages/manager/src/components/SelectionCard/CardBase.styles.ts
+++ b/packages/manager/src/components/SelectionCard/CardBase.styles.ts
@@ -40,7 +40,7 @@ export const CardBaseGrid = styled(Grid, {
   height: '100%',
   margin: 0,
   minHeight: 60,
-  padding: `0 ${theme.spacing(1)} !important`,
+  padding: theme.spacing(1.5),
   position: 'relative',
   transition:
     'background-color 225ms ease-in-out, border-color 225ms ease-in-out',


### PR DESCRIPTION
## Description 📝

- Fixes Selection Card UI regression caused by MUI v6 (https://github.com/linode/manager/pull/11688)

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-02-24 at 1 25 18 PM](https://github.com/user-attachments/assets/3737eb2c-3af6-4909-8384-0c6bb1cb3463) | ![Screenshot 2025-02-24 at 1 25 01 PM](https://github.com/user-attachments/assets/6d3c0b76-a6d3-426c-bf20-ca350739d0e7) |

## How to test 🧪

- Check instances of the Selection Card UI component throughout the codebase
  - For example, LKE Enterprise / Linode Plan on Small Screen Sizes, etc...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>