### PR TITLE
fix: [M3-9410] - Unable to save non-US billing contact info without tax id

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [2025-02-25] - v1.137.1
 ### Fixed:
 
-- Unable to save non-US billing contact information without tax id
+- Unable to save non-US billing contact information without tax id ([#11725](https://github.com/linode/manager/pull/11725))
 
 
 ## [2025-02-25] - v1.137.0

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2025-02-25] - v1.137.1
+### Fixed:
+
+- Unable to save non-US billing contact information without tax id
+
+
 ## [2025-02-25] - v1.137.0
 
 
@@ -15,7 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed:
 
-- Introduce 2025 CDS redesign ([#11465](https://github.com/linode/manager/pull/11465)) 
+- Introduce 2025 CDS redesign ([#11465](https://github.com/linode/manager/pull/11465))
 - Improve Syntax Highlighting ([#11611](https://github.com/linode/manager/pull/11611))
 - Clarify OAuth setup instructions in Getting Started README ([#11622](https://github.com/linode/manager/pull/11622))
 - Replace `Box` elements with `<StyledLinkButton>` for better accessibility and add `aria-label`s in the KubeConfigDisplay ([#11648](https://github.com/linode/manager/pull/11648))

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2025-02-25] - v1.137.1
+
 ### Fixed:
 
 - Unable to save non-US billing contact information without tax id ([#11725](https://github.com/linode/manager/pull/11725))

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.137.0",
+  "version": "1.137.1",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
@@ -449,10 +449,7 @@ const UpdateContactInformationForm = ({ focusEmail, onClose }: Props) => {
       <ActionsPanel
         primaryButtonProps={{
           'data-testid': 'save-contact-info',
-          disabled:
-            isReadOnly ||
-            (nonUSCountry &&
-              (!billingAgreementChecked || !formik.values.tax_id)),
+          disabled: isReadOnly || (nonUSCountry && !billingAgreementChecked),
           label: 'Save Changes',
           loading: isPending,
           type: 'submit',


### PR DESCRIPTION
## Description 📝
Customers report that they are unable to update their Billing address without entering a Tax ID which they do not have as an individual/non-business entity. This should be an optional field.

## Changes  🔄
- Removed the condition that makes this required

## Target release date 🗓️
2/25

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-02-25 at 1 09 16 PM](https://github.com/user-attachments/assets/f5d01cd1-b239-42a8-abd9-a95916d70ba5) | ![Screenshot 2025-02-25 at 1 08 58 PM](https://github.com/user-attachments/assets/44a435d5-a4db-45bb-97ff-0c19ddba25cb) |

## How to test 🧪

### Verification steps
- Ensure non-US users can update their contact information without a tax id
- Ensure US users can update their contact information properly 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x ] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
