### PR TITLE
upcoming: [M3-9402] - Hide GPU plans tab for LKE-E

### DIFF
--- a/packages/manager/.changeset/pr-11726-upcoming-features-1740510652938.md
+++ b/packages/manager/.changeset/pr-11726-upcoming-features-1740510652938.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Hide GPU plans tab for LKE-E ([#11726](https://github.com/linode/manager/pull/11726))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -104,6 +104,18 @@ const nanodeType = linodeTypeFactory.build({
   )?.region_prices,
   vcpus: 1,
 }) as ExtendedType;
+const gpuType = linodeTypeFactory.build({
+  class: 'gpu',
+  id: 'g2-gpu-1',
+}) as ExtendedType;
+const highMemType = linodeTypeFactory.build({
+  class: 'highmem',
+  id: 'g7-highmem-1',
+}) as ExtendedType;
+const premiumType = linodeTypeFactory.build({
+  class: 'premium',
+  id: 'g7-premium-1',
+}) as ExtendedType;
 const mockedLKEClusterPrices: PriceType[] = [
   {
     id: 'lke-sa',
@@ -148,7 +160,20 @@ const clusterPlans: LkePlanDescription[] = [
     type: 'nanode',
   },
 ];
-const mockedLKEClusterTypes = [dedicatedType, nanodeType];
+const mockedLKEClusterTypes = [
+  dedicatedType,
+  nanodeType,
+  gpuType,
+  highMemType,
+  premiumType,
+];
+const validEnterprisePlanTabs = [
+  'Dedicated CPU',
+  'Shared CPU',
+  'High Memory',
+  'Premium CPU',
+];
+const validStandardPlanTabs = [...validEnterprisePlanTabs, 'GPU'];
 
 describe('LKE Cluster Creation', () => {
   /*
@@ -219,6 +244,11 @@ describe('LKE Cluster Creation', () => {
     cy.get('[data-testid="ha-radio-button-no"]').should('be.visible').click();
 
     let monthPrice = 0;
+
+    // Confirm the expected available plans display.
+    validStandardPlanTabs.forEach((tab) => {
+      ui.tabList.findTabByTitle(tab).should('be.visible');
+    });
 
     // Add a node pool for each selected plan, and confirm that the
     // selected node pool plan is added to the checkout bar.
@@ -371,7 +401,8 @@ describe('LKE Cluster Creation with APL enabled', () => {
       )?.region_prices,
       vcpus: 8,
     });
-    const mockedLKEClusterTypes = [
+
+    const mockedAPLLKEClusterTypes = [
       dedicatedType,
       dedicated4Type,
       dedicated8Type,
@@ -401,7 +432,7 @@ describe('LKE Cluster Creation with APL enabled', () => {
       mockedLKECluster.id,
       mockedLKEClusterControlPlane
     ).as('getControlPlaneACL');
-    mockGetLinodeTypes(mockedLKEClusterTypes).as('getLinodeTypes');
+    mockGetLinodeTypes(mockedAPLLKEClusterTypes).as('getLinodeTypes');
     mockGetLKEClusterTypes(mockedLKEHAClusterPrices).as('getLKEClusterTypes');
     mockGetApiEndpoints(mockedLKECluster.id).as('getApiEndpoints');
 
@@ -1090,7 +1121,6 @@ describe('LKE Cluster Creation with LKE-E', () => {
         k8s_version: latestEnterpriseTierKubernetesVersion.id,
       });
       const mockedEnterpriseClusterPools = [nanodeMemoryPool, dedicatedCpuPool];
-      const mockedLKEClusterTypes = [dedicatedType, nanodeType];
 
       mockGetAccount(
         accountFactory.build({
@@ -1195,6 +1225,13 @@ describe('LKE Cluster Creation with LKE-E', () => {
         .should('be.visible')
         .should('be.enabled')
         .click();
+
+      // Confirm the expected available plans display.
+      validEnterprisePlanTabs.forEach((tab) => {
+        ui.tabList.findTabByTitle(tab).should('be.visible');
+      });
+      // Confirm the GPU tab is not visible in the plans panel for LKE-E.
+      ui.tabList.findTabByTitle('GPU').should('not.exist');
 
       // Add a node pool for each selected plan, and confirm that the
       // selected node pool plan is added to the checkout bar.

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -487,6 +487,7 @@ export const CreateCluster = () => {
             isSelectedRegionEligibleForPlan={isSelectedRegionEligibleForPlan}
             regionsData={regionsData}
             selectedRegionId={selectedRegion?.id}
+            selectedTier={selectedTier}
             types={typesData || []}
             typesLoading={typesLoading}
           />

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.test.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.test.tsx
@@ -14,6 +14,7 @@ const props: NodePoolPanelProps = {
   isSelectedRegionEligibleForPlan: () => false,
   regionsData: [],
   selectedRegionId: 'us-east',
+  selectedTier: 'standard',
   types: extendedTypes,
   typesLoading: false,
 };

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -17,6 +17,7 @@ import { KubernetesPlansPanel } from '../KubernetesPlansPanel/KubernetesPlansPan
 
 import type {
   KubeNodePoolResponse,
+  KubernetesTier,
   LinodeTypeClass,
   Region,
 } from '@linode/api-v4';
@@ -33,6 +34,7 @@ export interface NodePoolPanelProps {
   isSelectedRegionEligibleForPlan: (planType?: LinodeTypeClass) => boolean;
   regionsData: Region[];
   selectedRegionId: Region['id'] | undefined;
+  selectedTier: KubernetesTier;
   types: ExtendedType[];
   typesError?: string;
   typesLoading: boolean;
@@ -66,6 +68,7 @@ const Panel = (props: NodePoolPanelProps) => {
     isSelectedRegionEligibleForPlan,
     regionsData,
     selectedRegionId,
+    selectedTier,
     types,
   } = props;
 
@@ -136,6 +139,7 @@ const Panel = (props: NodePoolPanelProps) => {
           resetValues={() => null} // In this flow we don't want to clear things on tab changes
           selectedId={selectedType}
           selectedRegionId={selectedRegionId}
+          selectedTier={selectedTier}
           updatePlanCount={updatePlanCount}
         />
       </Grid>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.test.tsx
@@ -2,12 +2,15 @@ import * as React from 'react';
 
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
-import { AddNodePoolDrawer, Props } from './AddNodePoolDrawer';
+import { AddNodePoolDrawer } from './AddNodePoolDrawer';
+
+import type { Props } from './AddNodePoolDrawer';
 
 const props: Props = {
   clusterId: 0,
   clusterLabel: 'test',
   clusterRegionId: 'us-east',
+  clusterTier: 'standard',
   onClose: vi.fn(),
   open: true,
   regionsData: [],

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.test.tsx
@@ -22,4 +22,18 @@ describe('AddNodePoolDrawer', () => {
 
     await findByText('Dedicated CPU');
   });
+
+  it('should display the GPU tab for standard clusters', async () => {
+    const { findByText } = renderWithTheme(<AddNodePoolDrawer {...props} />);
+
+    expect(await findByText('GPU')).toBeInTheDocument();
+  });
+
+  it('should not display the GPU tab for enterprise clusters', async () => {
+    const { queryByText } = renderWithTheme(
+      <AddNodePoolDrawer {...props} clusterTier="enterprise" />
+    );
+
+    await expect(queryByText('GPU')).toBeNull();
+  });
 });

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
@@ -21,7 +21,7 @@ import { KubernetesPlansPanel } from '../../KubernetesPlansPanel/KubernetesPlans
 import { nodeWarning } from '../../kubeUtils';
 import { hasInvalidNodePoolPrice } from './utils';
 
-import type { Region } from '@linode/api-v4';
+import type { KubernetesTier, Region } from '@linode/api-v4';
 import type { Theme } from '@mui/material/styles';
 
 const useStyles = makeStyles()((theme: Theme) => ({
@@ -60,6 +60,7 @@ export interface Props {
   clusterId: number;
   clusterLabel: string;
   clusterRegionId: Region['id'];
+  clusterTier: KubernetesTier;
   onClose: () => void;
   open: boolean;
   regionsData: Region[];
@@ -70,6 +71,7 @@ export const AddNodePoolDrawer = (props: Props) => {
     clusterId,
     clusterLabel,
     clusterRegionId,
+    clusterTier,
     onClose,
     open,
     regionsData,
@@ -190,6 +192,7 @@ export const AddNodePoolDrawer = (props: Props) => {
           resetValues={resetDrawer}
           selectedId={selectedTypeInfo?.planId}
           selectedRegionId={clusterRegionId}
+          selectedTier={clusterTier}
           // No nanodes in clusters
           types={extendedTypes.filter((t) => t.class !== 'nanode')}
           updatePlanCount={updatePlanCount}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -318,6 +318,7 @@ export const NodePoolsDisplay = (props: Props) => {
         clusterId={clusterID}
         clusterLabel={clusterLabel}
         clusterRegionId={clusterRegionId}
+        clusterTier={clusterTier}
         onClose={() => setAddDrawerOpen(false)}
         open={addDrawerOpen}
         regionsData={regionsData}

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
@@ -14,7 +14,11 @@ import { useRegionAvailabilityQuery } from 'src/queries/regions/regions';
 
 import { KubernetesPlanContainer } from './KubernetesPlanContainer';
 
-import type { CreateNodePoolData, Region } from '@linode/api-v4';
+import type {
+  CreateNodePoolData,
+  KubernetesTier,
+  Region,
+} from '@linode/api-v4';
 import type { LinodeTypeClass } from '@linode/api-v4/lib/linodes/types';
 import type { PlanSelectionType } from 'src/features/components/PlansPanel/types';
 import type { ExtendedType } from 'src/utilities/extendType';
@@ -37,6 +41,7 @@ interface Props {
   resetValues: () => void;
   selectedId?: string;
   selectedRegionId?: Region['id'] | string;
+  selectedTier: KubernetesTier;
   types: ExtendedType[];
   updatePlanCount: (planId: string, newCount: number) => void;
 }
@@ -58,6 +63,7 @@ export const KubernetesPlansPanel = (props: Props) => {
     resetValues,
     selectedId,
     selectedRegionId,
+    selectedTier,
     types,
     updatePlanCount,
   } = props;
@@ -74,7 +80,11 @@ export const KubernetesPlansPanel = (props: Props) => {
 
   const _types = types.filter(
     (type) =>
-      !type.id.includes('dedicated-edge') && !type.id.includes('nanode-edge')
+      !type.id.includes('dedicated-edge') &&
+      !type.id.includes('nanode-edge') &&
+      // Filter out GPU types for enterprise; otherwise, return the rest of the types.
+      // TODO: remove this once GPU plans are supported in LKE-E (Q3 2025)
+      (selectedTier === 'enterprise' ? !type.id.includes('gpu') : true)
   );
 
   const plans = getPlanSelectionsByPlanType(


### PR DESCRIPTION
## Description 📝

We need to hide the GPU plans tab for LKE-E because these plans will not be available for this tier until Q3 2025.

These changes apply to both the Create Cluster flow and the 'Add a Node Pool' flow on an LKE-E cluster details page.

Currently, we can see regions where GPUs are supposedly available listed under ‘global availability’ with an enterprise tier selected (which is misleading), and if we actually select that region, we can submit the form with a GPU plan, even though it’s not supported. Product's preference was to hide the GPU tab for enterprise clusters until Q3, rather than disable the panel with messaging.

## Changes  🔄
- Filtered out types whose `id` included GPU if the selectedTier is `enterprise` so that these types won't be converted into plans to display under a GPU tab
- Updated test coverage (Cypress for create cluster flow; unit test for cluster details Add Node Pool flow)

## Target release date 🗓️

3/11

## Preview 📷

| Before  | After   |
| ------- | ------- |
| GPU tab for LKE-E tier: ![Screenshot 2025-02-25 at 11 04 23 AM](https://github.com/user-attachments/assets/ef0715c5-5eda-4654-be39-2009ed8dc92b) | GPU tab for LKE tier: ![Screenshot 2025-02-25 at 10 15 43 AM](https://github.com/user-attachments/assets/c54f417c-ffdb-4c93-ab3a-62eb4b69c824) No GPU tab for LKE-E tier: ![Screenshot 2025-02-25 at 10 15 52 AM](https://github.com/user-attachments/assets/a1c0b932-1c8f-41d5-927c-b350bca381c6)|
| GPU tab for LKE-E cluster: ![Screenshot 2025-02-25 at 10 17 51 AM](https://github.com/user-attachments/assets/968b6d20-f3fe-472d-bfb5-451a4ed1ea65) | GPU tab for LKE cluster: ![Screenshot 2025-02-25 at 10 17 07 AM](https://github.com/user-attachments/assets/5519d78a-d0f0-49e3-a172-3a20f4d7284b) No GPU tab for LKE-E cluster: ![Screenshot 2025-02-25 at 10 16 19 AM](https://github.com/user-attachments/assets/2e452d8e-de04-492f-8bee-6f3a92aaaba0) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have LKE-E feature flag on and customer tag

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Check out develop locally, go to http://localhost:3000/kubernetes/create, and observe that when selecting an LKE-E tier, the GPU tab displays in the plans table.
- [ ] Create an LKE-E cluster in any region, of any type, and go to the cluster details page. Add a new node pool and observe the GPU tab in the plans table.

### Verification steps

(How to verify changes)

- [ ] Check out this PR, go to http://localhost:3000/kubernetes/create, and observe that when selecting an LKE-E tier, the GPU tab does not display in the plans table. The GPU tab will *remain* visible for the standard LKE tier.
- [ ] Create an LKE-E cluster in any region, of any type, and go to the cluster details page. Add a new node pool and observe the GPU tab does not display in the plans table.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
