### PR TITLE
test: [M3-9417] - Fix CloudPulse test failures involving notice text assertions

### DIFF
--- a/packages/manager/.changeset/pr-11728-tests-1740514341603.md
+++ b/packages/manager/.changeset/pr-11728-tests-1740514341603.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fixed CloudPulse test failures triggered by new notice ([#11728](https://github.com/linode/manager/pull/11728))

--- a/packages/manager/cypress/e2e/core/cloudpulse/create-user-alert.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/create-user-alert.spec.ts
@@ -221,11 +221,7 @@ describe('Create Alert', () => {
       .check();
 
     // Assert resource selection notice
-    cy.get('[data-qa-notice="true"]')
-      .find('p')
-      .should('have.text', '1 of 10 resources are selected.');
-
-    cy.get('[data-qa-notice="true"]').should('be.visible').should('be.enabled');
+    cy.findByText('1 of 10 resources are selected.');
 
     // Fill metric details for the first rule
     const cpuUsageMetricDetails = {

--- a/packages/manager/cypress/e2e/core/cloudpulse/edit-system-alert.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/edit-system-alert.spec.ts
@@ -121,26 +121,21 @@ describe('Integration Tests for Edit Alert', () => {
     // Verify that the heading with text 'region' is visible
     ui.heading.findByText('region').should('be.visible');
 
-    // Verify the initial selection of resources
-    cy.get('[data-qa-notice="true"]').should(
-      'contain.text',
-      '3 of 50 resources are selected'
-    );
-    // Select all resources
-    cy.get('[data-qa-notice="true"]').within(() => {
-      ui.button.findByTitle('Select All').should('be.visible').click();
+    // Verify the initial selection of resources, then select all resources.
+    cy.findByText('3 of 50 resources are selected.')
+      .should('be.visible')
+      .closest('[data-qa-notice]')
+      .within(() => {
+        ui.button.findByTitle('Select All').should('be.visible').click();
 
-      // Unselect button should be visible after clicking on Select All button
-      ui.button
-        .findByTitle('Unselect All')
-        .should('be.visible')
-        .should('be.enabled');
-    });
+        ui.button
+          .findByTitle('Unselect All')
+          .should('be.visible')
+          .should('be.enabled');
+      });
 
-    cy.get('[data-qa-notice="true"]').should(
-      'contain.text',
-      '50 of 50 resources are selected'
-    );
+    // Confirm notice text updates to reflect selection.
+    cy.findByText('50 of 50 resources are selected.').should('be.visible');
 
     // Verify the initial state of the page size
     ui.pagination.findPageSizeSelect().click();


### PR DESCRIPTION
## Description 📝

This fixes a pair of CloudPulse E2E test failures that were triggered by the addition of the new CDS notice. This fixes the failures by asserting the contents of the notice text.

## Changes  🔄

- Fix test failures by asserting notice text directly

## Target release date 🗓️

N/A

## How to test 🧪

We can rely on CI for this, but you can also confirm that the tests pass by running them locally:

```bash
yarn cy:run -s "cypress/e2e/core/cloudpulse/create-user-alert.spec.ts,cypress/e2e/core/cloudpulse/edit-system-alert.spec.ts"
```

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.
