### PR TITLE
fix: [M3-9345] - RTX 6000 showing up in UI

### DIFF
--- a/packages/manager/.changeset/pr-11731-fixed-1740521257689.md
+++ b/packages/manager/.changeset/pr-11731-fixed-1740521257689.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fixed RTX 6000 plans showing up in LKE UI ([#11731](https://github.com/linode/manager/pull/11731))

--- a/packages/manager/.changeset/pr-11731-fixed-1740521257689.md
+++ b/packages/manager/.changeset/pr-11731-fixed-1740521257689.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Fixed RTX 6000 plans showing up in LKE UI ([#11731](https://github.com/linode/manager/pull/11731))
+RTX 6000 plans showing up in LKE UI ([#11731](https://github.com/linode/manager/pull/11731))

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
@@ -66,7 +66,7 @@ export const KubernetesPlansPanel = (props: Props) => {
 
   const { data: regionAvailabilities } = useRegionAvailabilityQuery(
     selectedRegionId || '',
-    Boolean(flags.soldOutChips) && Boolean(selectedRegionId)
+    Boolean(flags.soldOutChips) && selectedRegionId !== undefined
   );
 
   const isPlanDisabledByAPL = (plan: 'shared' | LinodeTypeClass) =>
@@ -80,7 +80,8 @@ export const KubernetesPlansPanel = (props: Props) => {
   const plans = getPlanSelectionsByPlanType(
     flags.disableLargestGbPlans
       ? replaceOrAppendPlaceholder512GbPlans(_types)
-      : _types
+      : _types,
+    { isLKE: true }
   );
 
   const tabs = Object.keys(plans).map(

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
@@ -66,7 +66,7 @@ export const KubernetesPlansPanel = (props: Props) => {
 
   const { data: regionAvailabilities } = useRegionAvailabilityQuery(
     selectedRegionId || '',
-    Boolean(flags.soldOutChips) && selectedRegionId !== undefined
+    Boolean(flags.soldOutChips) && Boolean(selectedRegionId)
   );
 
   const isPlanDisabledByAPL = (plan: 'shared' | LinodeTypeClass) =>

--- a/packages/manager/src/features/components/PlansPanel/utils.test.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.test.ts
@@ -135,6 +135,41 @@ describe('getPlanSelectionsByPlanType', () => {
 
     expect(actualKeys).toEqual(expectedOrder);
   });
+
+  it('should filter out RTX6000 plans when isLKE is true', () => {
+    const rtx6000Plan = typeFactory.build({
+      class: 'gpu',
+      id: 'g1-gpu-rtx6000-1',
+    });
+    const rtx4000Plan = typeFactory.build({
+      class: 'gpu',
+      id: 'g1-gpu-rtx4000-1',
+    });
+
+    // With isLKE: true, RTX6000 should be filtered out
+    const actualWithLKE = getPlanSelectionsByPlanType(
+      [rtx6000Plan, rtx4000Plan],
+      { isLKE: true }
+    );
+
+    // With isLKE: false or default, RTX6000 should remain
+    const actualWithoutLKE = getPlanSelectionsByPlanType(
+      [rtx6000Plan, rtx4000Plan],
+      { isLKE: false }
+    );
+
+    const actualWithDefault = getPlanSelectionsByPlanType([
+      rtx6000Plan,
+      rtx4000Plan,
+    ]);
+
+    // RTX6000 should be filtered out in LKE context
+    expect(actualWithLKE.gpu).toEqual([rtx4000Plan]);
+
+    // RTX6000 should remain in non-LKE context
+    expect(actualWithoutLKE.gpu).toEqual([rtx6000Plan, rtx4000Plan]);
+    expect(actualWithDefault.gpu).toEqual([rtx6000Plan, rtx4000Plan]);
+  });
 });
 
 describe('determineInitialPlanCategoryTab', () => {

--- a/packages/manager/src/features/components/PlansPanel/utils.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.ts
@@ -1,5 +1,4 @@
 import { arrayToList } from '@linode/utilities';
-
 import { useFlags } from 'src/hooks/useFlags';
 import { useAccount } from 'src/queries/account/account';
 import { isFeatureEnabledV2 } from 'src/utilities/accountCapabilities';
@@ -22,6 +21,7 @@ import type {
 } from './types';
 import type {
   Capabilities,
+  BaseType,
   LinodeTypeClass,
   Region,
   RegionAvailability,
@@ -74,6 +74,16 @@ export const useIsAcceleratedPlansEnabled = () => {
   return { isAcceleratedLKEPlansEnabled, isAcceleratedLinodePlansEnabled };
 };
 
+const shouldExcludePlan = (
+  type: { id: string },
+  options: { isLKE?: boolean } = {}
+): boolean => {
+  const { isLKE = false } = options;
+  const excludedPlanIdSubstring = 'rtx6000';
+  // Filter out RTX6000 plans when in LKE context
+  return isLKE && type.id.includes(excludedPlanIdSubstring);
+};
+
 /**
  * getPlanSelectionsByPlanType function takes an array of types, groups
  * them based on their class property into different plan types, filters out empty
@@ -85,17 +95,22 @@ export const useIsAcceleratedPlansEnabled = () => {
  */
 
 export const getPlanSelectionsByPlanType = <
-  T extends { class: LinodeTypeClass }
+  T extends BaseType & { class: LinodeTypeClass }
 >(
-  types: T[]
+  types: T[],
+  options: { isLKE?: boolean } = {}
 ): Partial<PlansByType<T>> => {
   const plansByType: PlansByType<T> = planTypeOrder.reduce((acc, key) => {
     acc[key] = [];
     return acc;
   }, {} as PlansByType<T>);
+  const { isLKE = false } = options;
 
   // group plans by type
   for (const type of types) {
+    if (shouldExcludePlan(type, { isLKE })) {
+      continue;
+    }
     switch (type.class) {
       case 'nanode':
       case 'standard':

--- a/packages/manager/src/features/components/PlansPanel/utils.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.ts
@@ -1,4 +1,5 @@
 import { arrayToList } from '@linode/utilities';
+
 import { useFlags } from 'src/hooks/useFlags';
 import { useAccount } from 'src/queries/account/account';
 import { isFeatureEnabledV2 } from 'src/utilities/accountCapabilities';


### PR DESCRIPTION
## Description 📝

This PR fixes an issue where RTX 6000 GPU plans were incorrectly showing up in the LKE UI when they should not be available in that context. Only RTX 4000 plans are supported in LKE, while RTX 6000 plans should be filtered out.

## Changes  🔄

- Added filtering to hide RTX 6000 plans only in LKE contexts
- Updated plan selection functions to distinguish between LKE and regular Linode contexts
- Added test to verify filtering behavior

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img src="https://github.com/user-attachments/assets/df84f9c6-9d86-45e2-8f7a-12c5cf5209ef" /> | <img src="https://github.com/user-attachments/assets/60a99e46-4d8a-4b42-8e12-b44b982b2ff1" /> |

### Verification steps

- [ ] Verify that RTX 6000 plans no longer appear in the LKE UI
- [ ] Verify that RTX 6000 plans still appear in the regular Linode UI
- [ ] Verify that RTX 4000 plans continue to appear in both UIs

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>