### PR TITLE
feat: [UIE-8514] - DBaaS : Initial Advanced Config Tab and Drawer Setup

### DIFF
--- a/packages/api-v4/.changeset/pr-11735-upcoming-features-1740581707757.md
+++ b/packages/api-v4/.changeset/pr-11735-upcoming-features-1740581707757.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Upcoming Features
+---
+
+DBaaS Advanced Configurations: added `engine_config` to the Database Instance ([#11735](https://github.com/linode/manager/pull/11735))

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -118,7 +118,7 @@ export interface DatabaseInstance {
   updated: string;
   updates: UpdatesSchedule;
   version: string;
-  engine_config: MySQLAdvancedConfig | PostgresAdvancedConfig;
+  engine_config?: MySQLAdvancedConfig | PostgresAdvancedConfig;
 }
 
 export type ClusterSize = 1 | 2 | 3;

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -70,7 +70,7 @@ interface DatabaseHosts {
 export interface SSLFields {
   ca_certificate: string;
 }
-// TODO: add all configurations
+// TODO: This will be changed in the next PR
 export interface MySQLAdvancedConfig {
   binlog_retention_period?: number;
   advanced?: {
@@ -82,7 +82,7 @@ export interface MySQLAdvancedConfig {
     sql_mode?: string;
   };
 }
-// TODO: add all configurations
+// TODO: This will be changed in the next PR
 export interface PostgresAdvancedConfig {
   advanced?: {
     max_files_per_process?: number;

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -70,7 +70,26 @@ interface DatabaseHosts {
 export interface SSLFields {
   ca_certificate: string;
 }
-
+// TODO: add all configurations
+export interface MySQLAdvancedConfig {
+  binlog_retention_period?: number;
+  advanced?: {
+    connect_timeout?: number;
+    default_time_zone?: string;
+    group_concat_max_len?: number;
+    information_schema_stats_expiry?: number;
+    innodb_print_all_deadlocks?: boolean;
+    sql_mode?: string;
+  };
+}
+// TODO: add all configurations
+export interface PostgresAdvancedConfig {
+  advanced?: {
+    max_files_per_process?: number;
+    timezone?: string;
+    pg_stat_monitor_enable?: boolean;
+  };
+}
 type MemberType = 'primary' | 'failover';
 
 // DatabaseInstance is the interface for the shape of data returned by the /databases/instances endpoint.
@@ -99,6 +118,7 @@ export interface DatabaseInstance {
   updated: string;
   updates: UpdatesSchedule;
   version: string;
+  engine_config: MySQLAdvancedConfig | PostgresAdvancedConfig;
 }
 
 export type ClusterSize = 1 | 2 | 3;

--- a/packages/manager/.changeset/pr-11735-upcoming-features-1740581501727.md
+++ b/packages/manager/.changeset/pr-11735-upcoming-features-1740581501727.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-DBaaS: Advanced Configuration initial set up (new tab, drawer) ([#11735](https://github.com/linode/manager/pull/11735))
+DBaaS: Advanced Configurations initial set up (new tab, drawer) ([#11735](https://github.com/linode/manager/pull/11735))

--- a/packages/manager/.changeset/pr-11735-upcoming-features-1740581501727.md
+++ b/packages/manager/.changeset/pr-11735-upcoming-features-1740581501727.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+DBaaS: Advanced Configuration initial set up (new tab, drawer) ([#11735](https://github.com/linode/manager/pull/11735))

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -35,6 +35,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'dbaasV2', label: 'Databases V2 Beta' },
   { flag: 'dbaasV2MonitorMetrics', label: 'Databases V2 Monitor' },
   { flag: 'databaseResize', label: 'Database Resize' },
+  { flag: 'databaseAdvancedConfig', label: 'Database Advanced Config' },
   { flag: 'apicliButtonCopy', label: 'APICLI Button Copy' },
   { flag: 'iam', label: 'Identity and Access Beta' },
 ];

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -137,6 +137,18 @@ export const databaseInstanceFactory = Factory.Sync.makeFactory<DatabaseInstance
     created: '2021-12-09T17:15:12',
     encrypted: false,
     engine: Factory.each((i) => ['mysql', 'postgresql'][i % 2] as Engine),
+    engine_config: {
+      advanced: {
+        connect_timeout: 10,
+        default_time_zone: '+03:00',
+        group_concat_max_len: 4,
+        information_schema_stats_expiry: 900,
+        innodb_print_all_deadlocks: true,
+        sql_mode:
+          'ANSI,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,STRICT_ALL_TABLES',
+      },
+      binlog_retention_period: 600,
+    },
     hosts: Factory.each((i) =>
       adb10(i)
         ? {
@@ -191,6 +203,18 @@ export const databaseFactory = Factory.Sync.makeFactory<Database>({
   created: '2021-12-09T17:15:12',
   encrypted: false,
   engine: 'mysql',
+  engine_config: {
+    advanced: {
+      connect_timeout: 10,
+      default_time_zone: '+03:00',
+      group_concat_max_len: 4,
+      information_schema_stats_expiry: 900,
+      innodb_print_all_deadlocks: true,
+      sql_mode:
+        'ANSI,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,STRICT_ALL_TABLES',
+    },
+    binlog_retention_period: 600,
+  },
   hosts: Factory.each((i) =>
     adb10(i)
       ? {

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -109,6 +109,7 @@ export interface Flags {
   apl: boolean;
   blockStorageEncryption: boolean;
   cloudManagerDesignUpdatesBanner: DesignUpdatesBannerFlag;
+  databaseAdvancedConfig: boolean;
   databaseBeta: boolean;
   databaseResize: boolean;
   databases: boolean;

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfiguration.style.ts
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfiguration.style.ts
@@ -1,0 +1,12 @@
+import { styled } from '@mui/material/styles';
+
+import { StyledValueGrid } from '../DatabaseSummary/DatabaseSummaryClusterConfiguration.style';
+
+export const StyledConfigValue = styled(StyledValueGrid, {
+  label: 'StyledValueGrid',
+})(({ theme }) => ({
+  padding: `${theme.spacing(0.5)}
+            ${theme.spacing(1.9)}
+            ${theme.spacing(0.5)}
+            ${theme.spacing(0.8)}`,
+}));

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfiguration.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfiguration.tsx
@@ -69,14 +69,14 @@ export const DatabaseAdvancedConfiguration = ({ database }: Props) => {
                 </React.Fragment>
               ))
             ) : (
-              <>
+              <React.Fragment key={`${key}`}>
                 <Grid size={{ lg: 4, md: 4, xs: 5 }}>
                   <StyledLabelTypography>{`${engine}.${key}`}</StyledLabelTypography>
                 </Grid>
                 <StyledConfigValue size={{ lg: 8, md: 8, xs: 7 }}>
                   {formatConfigValue(String(value))}
                 </StyledConfigValue>
-              </>
+              </React.Fragment>
             )
           )}
         </StyledGridContainer>

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfiguration.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfiguration.tsx
@@ -10,6 +10,7 @@ import {
   StyledLabelTypography,
 } from '../DatabaseSummary/DatabaseSummaryClusterConfiguration.style';
 import { StyledConfigValue } from './DatabaseAdvancedConfiguration.style';
+import { DatabaseAdvancedConfigurationDrawer } from './DatabaseAdvancedConfigurationDrawer';
 
 import type { Database } from '@linode/api-v4';
 
@@ -19,15 +20,13 @@ interface Props {
 }
 
 export const DatabaseAdvancedConfiguration = ({ database }: Props) => {
-  // const [
-  //   advancedConfigurationDrawerOpen,
-  //   setAdvancedConfigurationDrawerOpen,
-  // ] = React.useState<boolean>(false);
+  const [
+    advancedConfigurationDrawerOpen,
+    setAdvancedConfigurationDrawerOpen,
+  ] = React.useState<boolean>(false);
 
   const engine = database.engine;
   const engineConfigs = database.engine_config;
-
-  // const engineConfigs = undefined;
 
   return (
     <Paper sx={{ marginTop: 2, pb: 5 }}>
@@ -41,7 +40,7 @@ export const DatabaseAdvancedConfiguration = ({ database }: Props) => {
         </Grid>
         <Button
           buttonType="outlined"
-          // onClick={() => setAdvancedConfigurationDrawerOpen(true)}
+          onClick={() => setAdvancedConfigurationDrawerOpen(true)}
           sx={{ height: 1 }}
         >
           Configure
@@ -88,11 +87,11 @@ export const DatabaseAdvancedConfiguration = ({ database }: Props) => {
         </Box>
       )}
 
-      {/* <DatabaseAdvancedConfigurationDrawer
+      <DatabaseAdvancedConfigurationDrawer
         database={database}
         onClose={() => setAdvancedConfigurationDrawerOpen(false)}
         open={advancedConfigurationDrawerOpen}
-      /> */}
+      />
     </Paper>
   );
 };

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfiguration.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfiguration.tsx
@@ -1,0 +1,98 @@
+import { Box, Button, Paper, Typography } from '@linode/ui';
+import Grid from '@mui/material/Unstable_Grid2/Grid2';
+import React from 'react';
+
+import { Link } from 'src/components/Link';
+
+import { formatConfigValue } from '../../utilities';
+import {
+  StyledGridContainer,
+  StyledLabelTypography,
+} from '../DatabaseSummary/DatabaseSummaryClusterConfiguration.style';
+import { StyledConfigValue } from './DatabaseAdvancedConfiguration.style';
+
+import type { Database } from '@linode/api-v4';
+
+interface Props {
+  database: Database;
+  disabled?: boolean;
+}
+
+export const DatabaseAdvancedConfiguration = ({ database }: Props) => {
+  // const [
+  //   advancedConfigurationDrawerOpen,
+  //   setAdvancedConfigurationDrawerOpen,
+  // ] = React.useState<boolean>(false);
+
+  const engine = database.engine;
+  const engineConfigs = database.engine_config;
+
+  // const engineConfigs = undefined;
+
+  return (
+    <Paper sx={{ marginTop: 2, pb: 5 }}>
+      <Grid container justifyContent={'space-between'}>
+        <Grid lg={10}>
+          <Typography variant="h2">Advanced Configuration</Typography>
+          <Typography sx={{ mb: 1, mt: 1 }}>
+            Advanced parameters to configure your database cluster.{' '}
+            <Link to={''}>Learn more.</Link>
+          </Typography>
+        </Grid>
+        <Button
+          buttonType="outlined"
+          // onClick={() => setAdvancedConfigurationDrawerOpen(true)}
+          sx={{ height: 1 }}
+        >
+          Configure
+        </Button>
+      </Grid>
+
+      {engineConfigs ? (
+        <StyledGridContainer
+          container
+          lg={10}
+          mt={3}
+          spacing={0}
+          sx={{ wordBreak: 'break-all' }}
+        >
+          {Object.entries(engineConfigs).map(([key, value]) =>
+            typeof value === 'object' ? (
+              Object.entries(value!).map(([configLabel, configValue]) => (
+                <React.Fragment key={`${key}-${configLabel}`}>
+                  <Grid lg={5} md={4} xs={5}>
+                    <StyledLabelTypography>{`${engine}.${configLabel}`}</StyledLabelTypography>
+                  </Grid>
+                  <StyledConfigValue lg={7} md={8} xs={7}>
+                    {formatConfigValue(String(configValue))}
+                  </StyledConfigValue>
+                </React.Fragment>
+              ))
+            ) : (
+              <>
+                <Grid lg={5} md={4} xs={5}>
+                  <StyledLabelTypography>{`${engine}.${key}`}</StyledLabelTypography>
+                </Grid>
+                <StyledConfigValue lg={7} md={8} xs={7}>
+                  {formatConfigValue(String(value))}
+                </StyledConfigValue>
+              </>
+            )
+          )}
+        </StyledGridContainer>
+      ) : (
+        <Box display="flex" flexGrow={1} justifyContent="center">
+          <Typography sx={{ marginTop: 5 }}>
+            No advanced configurations have been added.
+          </Typography>
+        </Box>
+      )}
+
+      {/* <DatabaseAdvancedConfigurationDrawer
+        database={database}
+        onClose={() => setAdvancedConfigurationDrawerOpen(false)}
+        open={advancedConfigurationDrawerOpen}
+      /> */}
+    </Paper>
+  );
+};

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfiguration.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfiguration.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Paper, Typography } from '@linode/ui';
-import Grid from '@mui/material/Unstable_Grid2/Grid2';
+import Grid from '@mui/material/Grid2';
 import React from 'react';
 
 import { Link } from 'src/components/Link';
@@ -31,10 +31,11 @@ export const DatabaseAdvancedConfiguration = ({ database }: Props) => {
   return (
     <Paper sx={{ marginTop: 2, pb: 5 }}>
       <Grid container justifyContent={'space-between'}>
-        <Grid lg={10}>
+        <Grid size={10}>
           <Typography variant="h2">Advanced Configuration</Typography>
           <Typography sx={{ mb: 1, mt: 1 }}>
             Advanced parameters to configure your database cluster.{' '}
+            {/* TODO: update link when it's ready */}
             <Link to={''}>Learn more.</Link>
           </Typography>
         </Grid>
@@ -50,8 +51,8 @@ export const DatabaseAdvancedConfiguration = ({ database }: Props) => {
       {engineConfigs ? (
         <StyledGridContainer
           container
-          lg={10}
           mt={3}
+          size={11}
           spacing={0}
           sx={{ wordBreak: 'break-all' }}
         >
@@ -59,20 +60,20 @@ export const DatabaseAdvancedConfiguration = ({ database }: Props) => {
             typeof value === 'object' ? (
               Object.entries(value!).map(([configLabel, configValue]) => (
                 <React.Fragment key={`${key}-${configLabel}`}>
-                  <Grid lg={5} md={4} xs={5}>
+                  <Grid size={{ lg: 4, md: 4, xs: 5 }}>
                     <StyledLabelTypography>{`${engine}.${configLabel}`}</StyledLabelTypography>
                   </Grid>
-                  <StyledConfigValue lg={7} md={8} xs={7}>
+                  <StyledConfigValue size={{ lg: 8, md: 8, xs: 7 }}>
                     {formatConfigValue(String(configValue))}
                   </StyledConfigValue>
                 </React.Fragment>
               ))
             ) : (
               <>
-                <Grid lg={5} md={4} xs={5}>
+                <Grid size={{ lg: 4, md: 4, xs: 5 }}>
                   <StyledLabelTypography>{`${engine}.${key}`}</StyledLabelTypography>
                 </Grid>
-                <StyledConfigValue lg={7} md={8} xs={7}>
+                <StyledConfigValue size={{ lg: 8, md: 8, xs: 7 }}>
                   {formatConfigValue(String(value))}
                 </StyledConfigValue>
               </>

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfigurationDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfigurationDrawer.tsx
@@ -16,12 +16,14 @@ interface Props {
 }
 
 export const DatabaseAdvancedConfigurationDrawer = (props: Props) => {
-  const { database, onClose, open } = props;
+  const { onClose, open } = props;
 
   const [selectedConfig, setSelectedConfig] = useState('');
 
-  const engineConfigs = database.engine_config;
-
+  // const engineConfigs = database.engine_config;
+  // Placeholder for engine configurations (currently set to 'undefined' as the UI is not ready yet).
+  // The implementation will be updated in the second PR after UI work is completed.
+  const engineConfigs = undefined;
   return (
     <Drawer onClose={onClose} open={open} title="Advanced Configuration">
       <Typography>
@@ -45,9 +47,7 @@ export const DatabaseAdvancedConfigurationDrawer = (props: Props) => {
         />
 
         <Divider spacingBottom={20} spacingTop={24} />
-        {engineConfigs ? (
-          ''
-        ) : (
+        {!engineConfigs && (
           <Typography align="center">
             No advanced configurations have been added.
           </Typography>

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfigurationDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfigurationDrawer.tsx
@@ -1,0 +1,69 @@
+import { Divider, Notice, Typography } from '@linode/ui';
+import React, { useState } from 'react';
+
+import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
+import { Drawer } from 'src/components/Drawer';
+import { Link } from 'src/components/Link';
+
+import { DatabaseConfigurationSelect } from './DatabaseConfigurationSelect';
+
+import type { Database, DatabaseInstance } from '@linode/api-v4';
+
+interface Props {
+  database: Database | DatabaseInstance;
+  onClose: () => void;
+  open: boolean;
+}
+
+export const DatabaseAdvancedConfigurationDrawer = (props: Props) => {
+  const { database, onClose, open } = props;
+
+  const [selectedConfig, setSelectedConfig] = useState('');
+
+  const engineConfigs = database.engine_config;
+
+  return (
+    <Drawer onClose={onClose} open={open} title="Advanced Configuration">
+      <Typography>
+        Advanced parameters to configure your database cluster.
+      </Typography>
+      <Link to="">Learn more.</Link>
+
+      <Notice important top={24} variant="info">
+        <Typography>
+          There is no way to reset advanced configuration options to default.
+          Options that you add cannot be removed. Changing or adding some
+          options causes the service to restart.
+        </Typography>
+      </Notice>
+      <form>
+        <DatabaseConfigurationSelect
+          configurations={[]}
+          errorText={undefined}
+          onChange={(config) => setSelectedConfig(config)}
+          value={selectedConfig}
+        />
+
+        <Divider spacingBottom={20} spacingTop={24} />
+        {engineConfigs ? (
+          ''
+        ) : (
+          <Typography align="center">
+            No advanced configurations have been added.
+          </Typography>
+        )}
+        <Divider spacingBottom={20} spacingTop={24} />
+        <ActionsPanel
+          primaryButtonProps={{
+            label: 'Save and Restart Service',
+            type: 'submit',
+          }}
+          secondaryButtonProps={{
+            label: 'Cancel',
+            onClick: onClose,
+          }}
+        />
+      </form>
+    </Drawer>
+  );
+};

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseConfigurationSelect.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseConfigurationSelect.tsx
@@ -1,0 +1,79 @@
+import { Autocomplete, Button, TextField } from '@linode/ui';
+import Grid2 from '@mui/material/Unstable_Grid2';
+import React from 'react';
+
+interface ConfigurationOption {
+  category: string;
+  description: string;
+  label: string;
+}
+
+interface Props {
+  configurations: ConfigurationOption[];
+  errorText: string | undefined;
+  onChange: (value: string) => void;
+  value: string;
+}
+
+export const DatabaseConfigurationSelect = (props: Props) => {
+  const { configurations, errorText, onChange, value } = props;
+
+  const selectedConfiguration = React.useMemo(() => {
+    return configurations.find((val) => val.label === value);
+  }, [value, configurations]);
+
+  return (
+    <Grid2 alignItems={'end'} container justifyContent="space-between" lg={12}>
+      <Grid2 xs={9}>
+        <Autocomplete
+          groupBy={(option) => {
+            if (option.category === 'Other') {
+              return 'Other';
+            }
+            return option.category;
+          }}
+          isOptionEqualToValue={(option, selectedValue) =>
+            option.label === selectedValue.label
+          }
+          onChange={(_, selected) => {
+            onChange(selected.label);
+          }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              error={!!errorText}
+              helperText={errorText}
+              label="Add a Configuration Option"
+              placeholder="Select a configuration option"
+            />
+          )}
+          renderOption={(props, option) => (
+            <li {...props}>
+              <div>
+                <strong>{option.label}</strong>
+                {/* TODO: Add description if needed */}
+                {/* {option.description && <div>{option.description}</div>} */}
+              </div>
+            </li>
+          )}
+          value={selectedConfiguration}
+          autoHighlight
+          disableClearable
+          getOptionLabel={(option) => option.label}
+          options={configurations}
+          label={''}
+          sx={{ width: '336px' }}
+        />
+      </Grid2>
+      <Grid2 xs={2}>
+        <Button
+          buttonType="primary"
+          sx={{ minWidth: 'auto', width: '70px' }}
+          disabled={!selectedConfiguration}
+        >
+          Add
+        </Button>
+      </Grid2>
+    </Grid2>
+  );
+};

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseConfigurationSelect.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseConfigurationSelect.tsx
@@ -1,5 +1,5 @@
 import { Autocomplete, Button, TextField } from '@linode/ui';
-import Grid2 from '@mui/material/Unstable_Grid2';
+import Grid from '@mui/material/Grid2';
 import React from 'react';
 
 interface ConfigurationOption {
@@ -23,8 +23,13 @@ export const DatabaseConfigurationSelect = (props: Props) => {
   }, [value, configurations]);
 
   return (
-    <Grid2 alignItems={'end'} container justifyContent="space-between" lg={12}>
-      <Grid2 xs={9}>
+    <Grid
+      alignItems={'end'}
+      container
+      justifyContent="space-between"
+      size={{ lg: 12 }}
+    >
+      <Grid size={{ xs: 9 }}>
         <Autocomplete
           groupBy={(option) => {
             if (option.category === 'Other') {
@@ -56,24 +61,24 @@ export const DatabaseConfigurationSelect = (props: Props) => {
               </div>
             </li>
           )}
-          value={selectedConfiguration}
           autoHighlight
           disableClearable
           getOptionLabel={(option) => option.label}
-          options={configurations}
           label={''}
+          options={configurations}
           sx={{ width: '336px' }}
+          value={selectedConfiguration}
         />
-      </Grid2>
-      <Grid2 xs={2}>
+      </Grid>
+      <Grid size={{ xs: 2 }}>
         <Button
           buttonType="primary"
-          sx={{ minWidth: 'auto', width: '70px' }}
           disabled={!selectedConfiguration}
+          sx={{ minWidth: 'auto', width: '70px' }}
         >
           Add
         </Button>
-      </Grid2>
-    </Grid2>
+      </Grid>
+    </Grid>
   );
 };

--- a/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
@@ -112,6 +112,7 @@ export const DatabaseDetail = () => {
 
   const resizeIndex = isMonitorEnabled ? 3 : 2;
   const backupsIndex = isMonitorEnabled ? 2 : 1;
+  const settingsIndex = isMonitorEnabled ? 4 : 3;
 
   if (isMonitorEnabled) {
     tabs.splice(1, 0, {
@@ -236,7 +237,7 @@ export const DatabaseDetail = () => {
               />
             </SafeTabPanel>
           ) : null}
-          <SafeTabPanel index={tabs.length - 2}>
+          <SafeTabPanel index={settingsIndex}>
             <DatabaseSettings
               database={database}
               disabled={isDatabasesGrantReadOnly}

--- a/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
@@ -22,6 +22,8 @@ import {
 } from 'src/queries/databases/databases';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
+import { DatabaseAdvancedConfiguration } from './DatabaseAdvancedConfiguration/DatabaseAdvancedConfiguration';
+
 import type { Engine } from '@linode/api-v4/lib/databases/types';
 import type { APIError } from '@linode/api-v4/lib/types';
 import type { Tab } from 'src/components/Tabs/TabLinkList';
@@ -91,6 +93,7 @@ export const DatabaseDetail = () => {
 
   const isDefault = database.platform === 'rdbms-default';
   const isMonitorEnabled = isDefault && flags.dbaasV2MonitorMetrics?.enabled;
+  const isAdvancedConfigEnabled = isDefault && flags.databaseAdvancedConfig;
 
   const tabs: Tab[] = [
     {
@@ -122,6 +125,13 @@ export const DatabaseDetail = () => {
     tabs.splice(resizeIndex, 0, {
       routeName: `/databases/${engine}/${id}/resize`,
       title: 'Resize',
+    });
+  }
+
+  if (isAdvancedConfigEnabled) {
+    tabs.splice(5, 0, {
+      routeName: `/databases/${engine}/${id}/configs`,
+      title: 'Advanced Configuration',
     });
   }
 
@@ -226,12 +236,17 @@ export const DatabaseDetail = () => {
               />
             </SafeTabPanel>
           ) : null}
-          <SafeTabPanel index={tabs.length - 1}>
+          <SafeTabPanel index={tabs.length - 2}>
             <DatabaseSettings
               database={database}
               disabled={isDatabasesGrantReadOnly}
             />
           </SafeTabPanel>
+          {isAdvancedConfigEnabled && (
+            <SafeTabPanel index={tabs.length - 1}>
+              <DatabaseAdvancedConfiguration database={database} />
+            </SafeTabPanel>
+          )}
         </TabPanels>
       </Tabs>
       {isDefault && <DatabaseLogo />}

--- a/packages/manager/src/features/Databases/utilities.test.ts
+++ b/packages/manager/src/features/Databases/utilities.test.ts
@@ -7,6 +7,7 @@ import {
   databaseTypeFactory,
 } from 'src/factories';
 import {
+  formatConfigValue,
   getDatabasesDescription,
   hasPendingUpdates,
   isDateOutsideBackup,
@@ -557,5 +558,27 @@ describe('upgradableVersions', () => {
   it('should return undefined when no engines are provided', () => {
     const result = upgradableVersions('mysql', '8.0.26', undefined);
     expect(result).toBeUndefined();
+  });
+});
+
+describe('formatConfigValue', () => {
+  it('should return "Enabled" when configValue is "true"', () => {
+    const result = formatConfigValue('true');
+    expect(result).toBe('Enabled');
+  });
+
+  it('should return "Disabled" when configValue is "false"', () => {
+    const result = formatConfigValue('false');
+    expect(result).toBe('Disabled');
+  });
+
+  it('should return " -" when configValue is "undefined"', () => {
+    const result = formatConfigValue('undefined');
+    expect(result).toBe(' - ');
+  });
+
+  it('should return the original configValue for other values', () => {
+    const result = formatConfigValue('+03:00');
+    expect(result).toBe('+03:00');
   });
 });

--- a/packages/manager/src/features/Databases/utilities.ts
+++ b/packages/manager/src/features/Databases/utilities.ts
@@ -246,9 +246,21 @@ export const upgradableVersions = (
   engines?: Pick<DatabaseEngine, 'engine' | 'version'>[]
 ) => engines?.filter((e) => e.engine === engine && e.version > version);
 
+/**
+ * Formats the provided config value into a more user-friendly representation.
+ * - If the value is 'true', it will be displayed as 'Enabled'.
+ * - If the value is 'false', it will be displayed as 'Disabled'.
+ * - If the value is 'undefined', it will be displayed as ' - '.
+ * - Otherwise, the original value will be returned as-is.
+ *
+ * @param {string} configValue - The configuration value to be formatted.
+ * @returns {string} - The formatted string based on the configValue.
+ */
 export const formatConfigValue = (configValue: string) =>
   configValue === 'true'
     ? 'Enabled'
     : configValue === 'false'
     ? 'Disabled'
+    : configValue === 'undefined'
+    ? ' - '
     : configValue;

--- a/packages/manager/src/features/Databases/utilities.ts
+++ b/packages/manager/src/features/Databases/utilities.ts
@@ -245,3 +245,10 @@ export const upgradableVersions = (
   version: string,
   engines?: Pick<DatabaseEngine, 'engine' | 'version'>[]
 ) => engines?.filter((e) => e.engine === engine && e.version > version);
+
+export const formatConfigValue = (configValue: string) =>
+  configValue === 'true'
+    ? 'Enabled'
+    : configValue === 'false'
+    ? 'Disabled'
+    : configValue;


### PR DESCRIPTION
## Description 📝

DBaaS : Initial Advanced Config Tab and Drawer Setup

## Changes  🔄

List any change(s) relevant to the reviewer.

1. Initial Advanced Config Tab Setup
    - Added a new Advanced Configuration Tab
    - Added a feature flag for new Tab
    - Set up the default layout (empty state with no configurations)
    - Set up the table to display existing configurations
    - Added mock data for the GET request to populate the table
    
2. Initial Drawer Setup
    - Added a drawer for the Configure button
    - Set up autocomplete with an empty state

## Target release date 🗓️

Approximate 04/02/25

## Preview 📷

| Before (Figma template)  | After   |
| ------- | ------- |
| ![Screenshot 2025-02-26 at 2 10 42 PM](https://github.com/user-attachments/assets/7bb7c61f-30a1-4d78-a75f-b0f15048320a) | ![Screenshot 2025-02-26 at 2 09 36 PM](https://github.com/user-attachments/assets/0a79c65b-fa9d-4b1c-8626-645b51cfb6ca) |
| ![Screenshot 2025-02-26 at 2 12 43 PM](https://github.com/user-attachments/assets/0f067524-9f53-449f-9137-a2f637f23700) | ![Screenshot 2025-02-26 at 2 16 09 PM](https://github.com/user-attachments/assets/0c1396e7-2a44-48dd-ae68-09203bc41204) |
| ![Screenshot 2025-02-26 at 2 18 25 PM](https://github.com/user-attachments/assets/a2be9df0-9e89-4853-92f9-95bdef46e98b) | ![Screenshot 2025-02-26 at 2 19 12 PM](https://github.com/user-attachments/assets/1ce3c704-dc66-4453-a9a7-ceea0b27bef4) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Database Advanced Config feature flag should be enabled

### Verification steps

(How to verify changes)

- select a database cluster
- navigate to the Advanced Configuration Tab
- empty state with no configurations is shown
- use mock data to see table with existing configurations

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>