### PR TITLE
test: Remove Cypress test assertion involving login page content

### DIFF
--- a/packages/manager/.changeset/pr-11737-tests-1740586626716.md
+++ b/packages/manager/.changeset/pr-11737-tests-1740586626716.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Remove Cypress test assertion involving Login app text ([#11737](https://github.com/linode/manager/pull/11737))

--- a/packages/manager/cypress/e2e/core/general/account-login-redirect.spec.ts
+++ b/packages/manager/cypress/e2e/core/general/account-login-redirect.spec.ts
@@ -15,7 +15,6 @@ describe('account login redirect', () => {
     cy.visitWithLogin('/linodes/create');
 
     cy.url().should('contain', `${loginBaseUrl}/login?`, { exact: false });
-    cy.findByText('Please log in to continue.').should('be.visible');
   });
 
   /**


### PR DESCRIPTION
## Description 📝

This is intended to resolve some test flake we're seeing in one of the `account-login-redirect.spec.ts` tests since this morning's login update. Login is displaying the "Please log in to continue." message twice in some cases, causing our tests to occasionally fail when attempting to select the text.

I'm opting to remove the assertion for this text altogether since it's outside the scope of Cloud Manager; the only thing Cloud Manager needs to be concerned with for this test's sake is that Cloud successfully redirects the user to the login page. The Login team's tests can assert the contents and functionality of the login page instead.

## Changes  🔄

- Remove assertion for "Please log in to continue." text on login app

## Target release date 🗓️

N/A

## How to test 🧪

We can rely on CI for this. To run the test locally, however, you can use this command:

```
yarn cy:run -s "cypress/e2e/core/general/account-login-redirect.spec.ts"
```

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

