### PR TITLE
upcoming: [M3-9420] – Support NB-VPC feature flag

### DIFF
--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -28,6 +28,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'linodeDiskEncryption', label: 'Linode Disk Encryption (LDE)' },
   { flag: 'linodeInterfaces', label: 'Linode Interfaces' },
   { flag: 'lkeEnterprise', label: 'LKE-Enterprise' },
+  { flag: 'nodebalancerVPC', label: 'NodeBalancer-VPC Integration' },
   { flag: 'objMultiCluster', label: 'OBJ Multi-Cluster' },
   { flag: 'objectStorageGen2', label: 'OBJ Gen2' },
   { flag: 'selfServeBetas', label: 'Self Serve Betas' },

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -126,6 +126,7 @@ export interface Flags {
   mainContentBanner: MainContentBanner;
   marketplaceAppOverrides: MarketplaceAppOverride[];
   metadata: boolean;
+  nodebalancerVPC: boolean;
   objMultiCluster: boolean;
   objectStorageGen2: BaseFeatureFlag;
   productInformationBanners: ProductInformationBannerFlag[];


### PR DESCRIPTION
## Description 📝
Create a boolean feature flag for NB-VPC and support it in Cloud

## Changes  🔄
- NB-VPC feature flag toggle added to our dev tool

## Target release date 🗓️
3/11/24

## How to test 🧪
### Verification steps
- Confirm a toggle for "NodeBalancer-VPC Integration" is present in our dev tool
- (optional) Filter network requests for "LaunchDarkly" and observe the presence of a "nodebalancerVPC" object that has a `false` value

![Screenshot 2025-02-26 at 3 11 52 PM](https://github.com/user-attachments/assets/425e1a7b-cc3a-449a-810a-8c3e46f2fd21)

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [X] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [X] All unit tests are passing
- [X] TypeScript compilation succeeded without errors
- [X] Code passes all linting rules

</details>