### PR TITLE
fix: Add pnpm to `e2e_schedule_and_push.yml`

### DIFF
--- a/.github/workflows/e2e_schedule_and_push.yml
+++ b/.github/workflows/e2e_schedule_and_push.yml
@@ -28,6 +28,10 @@ jobs:
       - name: install command line utilities
         run: sudo apt-get install -y expect
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: "20.17"


### PR DESCRIPTION
## Description 📝

![Screenshot 2025-02-26 at 4 16 37 PM](https://github.com/user-attachments/assets/7ba42ac2-22e5-4a43-aa56-977e5bb7fca4)

- Fixes a small oversight with pnpm. See https://github.com/linode/manager/actions/runs/13553086426/job/37882376961
- I forgot to add the `pnpm/action-setup` action to our Github Actions workflow that runs the Cypress suite 😖 
- Hopefully they run smoothly once this is merged 🤞 

