### PR TITLE
test: [M3-9151] - Cypress test for Volume create page for restricted users

### DIFF
--- a/packages/manager/.changeset/pr-11743-tests-1741276809069.md
+++ b/packages/manager/.changeset/pr-11743-tests-1741276809069.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add Cypress test for Volume create page for restricted users ([#11743](https://github.com/linode/manager/pull/11743))

--- a/packages/manager/cypress/e2e/core/volumes/create-volume.spec.ts
+++ b/packages/manager/cypress/e2e/core/volumes/create-volume.spec.ts
@@ -4,6 +4,16 @@ import {
   createLinodeRequestFactory,
   linodeFactory,
 } from 'src/factories/linodes';
+import {
+  accountUserFactory,
+  grantsFactory,
+  profileFactory,
+} from '@src/factories';
+import {
+  mockGetProfile,
+  mockGetProfileGrants,
+} from 'support/intercepts/profile';
+import { mockGetUser } from 'support/intercepts/account';
 import { authenticate } from 'support/api/authentication';
 import { cleanUp } from 'support/util/cleanup';
 import {
@@ -432,5 +442,60 @@ describe('volume create flow', () => {
           });
       }
     );
+  });
+
+  it('does not allow creation of a volume for restricted users from volume create page', () => {
+    // Mock setup for user profile, account user, and user grants with restricted permissions,
+    // simulating a default user without the ability to add Linodes.
+    const mockProfile = profileFactory.build({
+      username: randomLabel(),
+      restricted: true,
+    });
+
+    const mockUser = accountUserFactory.build({
+      username: mockProfile.username,
+      restricted: true,
+      user_type: 'default',
+    });
+
+    const mockGrants = grantsFactory.build({
+      global: {
+        add_volumes: false,
+      },
+    });
+
+    mockGetProfile(mockProfile);
+    mockGetProfileGrants(mockGrants);
+    mockGetUser(mockUser);
+
+    cy.visitWithLogin('/volumes/create', {
+      localStorageOverrides: pageSizeOverride,
+    });
+
+    // Confirm that a notice should be shown informing the user they do not have permission to create a Linode.
+    cy.findByText(
+      "You don't have permissions to create this Volume. Please contact your account administrator to request the necessary permissions."
+    ).should('be.visible');
+
+    // Confirm that the "Label" field should be disabled.
+    cy.get('[id="label"]').should('be.visible').should('be.disabled');
+
+    // Confirm that the "Tags" field should be disabled.
+    cy.findByLabelText('Tags').should('be.visible').should('be.disabled');
+
+    // Confirm that the "Region" field should be disabled.
+    ui.regionSelect.find().should('be.visible').should('be.disabled');
+
+    // Confirm that the "Linode" field should be disabled.
+    cy.findByLabelText('Linode').should('be.visible').should('be.disabled');
+
+    // Confirm that the "Config" field should be disabled.
+    cy.findByLabelText('Config').should('be.visible').should('be.disabled');
+
+    // Confirm that the "Size" field should be disabled.
+    cy.get('[id="size"]').should('be.visible').should('be.disabled');
+
+    // Confirm that the "Create Volume" button is disabled.
+    cy.findByText('Create Volume').should('be.visible').should('be.disabled');
   });
 });


### PR DESCRIPTION
## Description 📝
Add test to check the warning message and disabled fields in volume create page for restricted users

## Major Changes 🔄
- Add test to check the disabled fields on `/volumes/create` page

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/volumes/create-volumes.spec.ts"
```