### PR TITLE
fix: Add missing scripts in `package.json` for `utilities` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "build:analyze": "pnpm run --filter linode-manager build:analyze",
     "bootstrap": "pnpm install:all && pnpm build:validation && pnpm build:sdk",
     "up:expose": "npm_config_package_import_method=clone-or-copy pnpm install:all && pnpm build:validation && pnpm build:sdk && pnpm start:all:expose",
-    "dev": "concurrently -n api-v4,validation,ui,manager -c blue,yellow,magenta,green \"pnpm run --filter @linode/api-v4 start\" \"pnpm run --filter @linode/validation start\" \"pnpm run --filter @linode/ui start\" \"pnpm run --filter linode-manager start\"",
-    "start:all:expose": "concurrently -n api-v4,validation,ui,manager -c blue,yellow,magenta,green \"pnpm run --filter @linode/api-v4 start\" \"pnpm run --filter @linode/validation start\" \"pnpm run --filter @linode/ui start\" \"pnpm run --filter linode-manager start:expose\"",
+    "dev": "concurrently -n api-v4,validation,ui,utilities,manager -c blue,yellow,magenta,cyan,green \"pnpm run --filter @linode/api-v4 start\" \"pnpm run --filter @linode/validation start\" \"pnpm run --filter @linode/ui start\" \"pnpm run --filter @linode/utilities start\" \"pnpm run --filter linode-manager start\"",
+    "start:all:expose": "concurrently -n api-v4,validation,ui,utilities,manager -c blue,yellow,magenta,cyan,green \"pnpm run --filter @linode/api-v4 start\" \"pnpm run --filter @linode/validation start\" \"pnpm run --filter @linode/ui start\" \"pnpm run --filter @linode/utilities start\" \"pnpm run --filter linode-manager start:expose\"",
     "start:manager": "pnpm --filter linode-manager start",
     "start:manager:ci": "pnpm run --filter linode-manager start:ci",
     "docs": "bunx vitepress@1.0.0-rc.44 dev docs",
@@ -29,6 +29,7 @@
     "test:sdk": "pnpm run --filter @linode/api-v4 test",
     "test:search": "pnpm run --filter @linode/search test",
     "test:ui": "pnpm run --filter @linode/ui test",
+    "test:utilities": "pnpm run --filter @linode/utilities test",
     "coverage": "pnpm run --filter linode-manager coverage",
     "coverage:summary": "pnpm run --filter linode-manager coverage:summary",
     "cy:run": "pnpm run --filter linode-manager cy:run",
@@ -43,7 +44,7 @@
     "package-versions": "pnpm run --filter @linode/scripts package-versions",
     "junit:summary": "pnpm run --filter @linode/scripts --silent junit:summary",
     "generate-tod": "pnpm run --filter @linode/scripts --silent generate-tod",
-    "clean": "rm -rf node_modules && rm -rf packages/api-v4/node_modules && rm -rf packages/manager/node_modules && rm -rf packages/validation/node_modules && rm -rf packages/api-v4/lib && rm -rf packages/validation/lib",
+    "clean": "rm -rf node_modules && rm -rf packages/manager/node_modules && rm -rf packages/api-v4/node_modules && rm -rf packages/validation/node_modules && rm -rf packages/api-v4/lib && rm -rf packages/validation/lib && rm -rf packages/ui/node_modules && rm -rf packages/utilities/node_modules",
     "prepare": "husky"
   },
   "resolutions": {


### PR DESCRIPTION
## Description 📝

It looks like some of the scripts related to the `utilities` and `ui` packages in the `package.json` were removed when PR https://github.com/linode/manager/pull/11297 was merge. This PR restores those missing scripts to ensure proper functionality. 

## Changes  🔄
- Updated `dev` script to include the `utilities` package
- Added `test:utilities` script to support the `utilities` package
- Updated `clean` script to include both the `ui` and `utilities` packages

## Target release date 🗓️
N/A

## How to test 🧪
- Ensure scripts work properly using `pnpm`

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules