### PR TITLE
fix: [M3-9455] – Fix Linode Rebuild dialog for distributed instances

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/LinodeRebuildForm.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/LinodeRebuildForm.tsx
@@ -85,6 +85,11 @@ export const LinodeRebuildForm = (props: Props) => {
       values.metadata.user_data = utoa(values.metadata.user_data);
     }
 
+    // Distributed instances are encrypted by default and disk_encryption should not be included in the payload.
+    if (linode.site_type === 'distributed') {
+      values.disk_encryption = undefined;
+    }
+
     try {
       await rebuildLinode(values);
 


### PR DESCRIPTION
## Description 📝
After merging `master` --> `develop`, the Linode Rebuild dialog started returning the `Cannot change disk encryption of a linode in a distributed region.` error for distributed instances. This PR removes `disk_encryption` from the payload if `site_type` === `distributed` to prevent this.

No changeset since this is just fixing something in `develop`

## How to test 🧪
### Verification steps
- Ensure you are able to rebuild linodes in core and distributed regions

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [X] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [X] All unit tests are passing
- [X] TypeScript compilation succeeded without errors
- [X] Code passes all linting rules

</details>