### PR TITLE
fix: [M3-9243] - Added show detail dailog for selected Stackscript

### DIFF
--- a/packages/manager/.changeset/pr-11765-fixed-1740766037419.md
+++ b/packages/manager/.changeset/pr-11765-fixed-1740766037419.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Show details button for selected Stackscript ([#11765](https://github.com/linode/manager/pull/11765))

--- a/packages/manager/src/features/Linodes/LinodeCreate/Tabs/StackScripts/StackScriptSelectionList.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Tabs/StackScripts/StackScriptSelectionList.tsx
@@ -81,7 +81,10 @@ export const StackScriptSelectionList = ({ type }: Props) => {
 
   const hasPreselectedStackScript = Boolean(params.stackScriptID);
 
-  const { data: stackscript } = useStackScriptQuery(
+  const {
+    data: stackscript,
+    isLoading: isSelectedStackScriptLoading,
+  } = useStackScriptQuery(
     params.stackScriptID ?? -1,
     hasPreselectedStackScript
   );
@@ -132,11 +135,13 @@ export const StackScriptSelectionList = ({ type }: Props) => {
           <TableBody>
             {stackscript && (
               <StackScriptSelectionRow
-                disabled
                 isSelected={field.value === stackscript.id}
                 onOpenDetails={() => setSelectedStackScriptId(stackscript.id)}
                 stackscript={stackscript}
               />
+            )}
+            {isSelectedStackScriptLoading && (
+              <TableRowLoading columns={3} rows={1} />
             )}
           </TableBody>
         </Table>
@@ -151,6 +156,11 @@ export const StackScriptSelectionList = ({ type }: Props) => {
             Choose Another StackScript
           </Button>
         </Box>
+        <StackScriptDetailsDialog
+          id={selectedStackScriptId}
+          onClose={() => setSelectedStackScriptId(undefined)}
+          open={selectedStackScriptId !== undefined}
+        />
       </Stack>
     );
   }

--- a/packages/manager/src/features/Linodes/LinodeCreate/Tabs/StackScripts/StackScriptSelectionList.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Tabs/StackScripts/StackScriptSelectionList.tsx
@@ -159,7 +159,7 @@ export const StackScriptSelectionList = ({ type }: Props) => {
         <StackScriptDetailsDialog
           id={selectedStackScriptId}
           onClose={() => setSelectedStackScriptId(undefined)}
-          open={selectedStackScriptId !== undefined}
+          open={Boolean(selectedStackScriptId)}
         />
       </Stack>
     );
@@ -249,7 +249,7 @@ export const StackScriptSelectionList = ({ type }: Props) => {
       <StackScriptDetailsDialog
         id={selectedStackScriptId}
         onClose={() => setSelectedStackScriptId(undefined)}
-        open={selectedStackScriptId !== undefined}
+        open={Boolean(selectedStackScriptId)}
       />
     </Box>
   );

--- a/packages/manager/src/features/Linodes/LinodeCreate/Tabs/StackScripts/StackScriptSelectionRow.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Tabs/StackScripts/StackScriptSelectionRow.tsx
@@ -66,6 +66,7 @@ export const StackScriptSelectionRow = (props: Props) => {
           justifyContent: 'flex-end',
           minWidth: 120,
           paddingRight: 0,
+          height: 44,
         }}
         actionCell
       >


### PR DESCRIPTION
# PR Description 📝  
This PR fixes an issue where the `Show Details` button for StackScripts was unresponsive when deploying a new Linode using a StackScript. Now, the button works as expected and users can view the StackScript details.

## Changes 🔄  
- Fixed the unresponsive `Show Details` button during the deployment of a new Linode via StackScript.

## Target release date 🗓️  
N/A  

| Before | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/92f6b15c-8d2b-4e2f-983e-442b1fa7a7ac"></video> | <video src="https://github.com/user-attachments/assets/76805676-648f-428f-a1ac-b7bee53b08cf"></video> |
| ![Before](https://github.com/user-attachments/assets/0c311b8b-d13a-42f5-9915-8240a867a262)| ![After](https://github.com/user-attachments/assets/3f7bebe3-98f9-43a8-967f-e5524cd97bf4) |

### Verification steps  
- [ ] Verify the `Show Details` button is responsive during deployment.  
- [ ] Confirm that StackScript details display correctly after clicking "Show Details."
- [ ] Verify that for loading state we have added a `TableRowLoading`
- [ ] Verify there is no line gap in border of `TableBody`

<details>
<summary> Author Checklists </summary>

- [x] All unit tests are passing  
- [x] TypeScript compilation succeeded  
- [x] Code passes all linting rules

</details>
