### PR TITLE
fix: [M3-9270] - Confusing wording on DBaaS suspend dialog

### DIFF
--- a/packages/manager/.changeset/pr-11769-fixed-1740985683618.md
+++ b/packages/manager/.changeset/pr-11769-fixed-1740985683618.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Confusing wording on DBaaS suspend dialog ([#11769](https://github.com/linode/manager/pull/11769))

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsSuspendClusterDialog.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsSuspendClusterDialog.tsx
@@ -57,9 +57,7 @@ export const DatabaseSettingsSuspendClusterDialog = (
     setHasConfirmed(false);
   };
 
-  const suspendClusterCopy = `A suspended cluster stops working immediately and you won't be billed for it.
-    You can resume the clusters work within 180 days from its suspension.
-    After that time, the cluster will be deleted permanently.`;
+  const suspendClusterCopy = `A suspended cluster stops immediately and you won't be billed for it. You can resume the cluster within 180 days from its suspension. After that time, the cluster will be deleted permanently.`;
 
   const actions = (
     <ActionsPanel

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsSuspendClusterDialog.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsSuspendClusterDialog.tsx
@@ -57,7 +57,8 @@ export const DatabaseSettingsSuspendClusterDialog = (
     setHasConfirmed(false);
   };
 
-  const suspendClusterCopy = `A suspended cluster stops immediately and you won't be billed for it. You can resume the cluster within 180 days from its suspension. After that time, the cluster will be deleted permanently.`;
+  const SUSPENDED_CLUSTER_COPY =
+    "A suspended cluster stops immediately and you won't be billed for it. You can resume the cluster within 180 days from its suspension. After that time, the cluster will be deleted permanently.";
 
   const actions = (
     <ActionsPanel
@@ -88,7 +89,7 @@ export const DatabaseSettingsSuspendClusterDialog = (
     >
       <Notice variant="warning">
         <Typography style={{ fontSize: '0.875rem' }}>
-          <b>{suspendClusterCopy}</b>
+          <b>{SUSPENDED_CLUSTER_COPY}</b>
         </Typography>
       </Notice>
       <Checkbox


### PR DESCRIPTION
# PR Description 📝  
This PR updates the wording in the DBaaS Suspend Dialog to eliminate any confusion.

## Changes 🔄  
- Improved the wording of the Suspend Dialog message to make it clearer.

## Target release date 🗓️  
N/A  

## Preview  📸
| Before | After |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/863d1551-cc48-4f16-8793-af69c887bea9) | ![After](https://github.com/user-attachments/assets/35c3845a-e91b-439a-a331-6e18e0dee237) |

### Verification steps  
- [ ] Confirm that the Suspend Dialog message is clear and easy to understand.

<details>
<summary> Author Checklists </summary>

- [x] All unit tests are passing  
- [x] TypeScript compilation succeeded  
- [x] Code passes all linting rules

</details>
