### PR TITLE
fix: [M3-9253] - Incorrect helper text in `Add SSH Key` drawer

### DIFF
--- a/packages/manager/.changeset/pr-11771-fixed-1740992423294.md
+++ b/packages/manager/.changeset/pr-11771-fixed-1740992423294.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Incorrect helper text in `Add an SSH Key` Drawer ([#11771](https://github.com/linode/manager/pull/11771))

--- a/packages/manager/src/features/Profile/SSHKeys/CreateSSHKeyDrawer.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/CreateSSHKeyDrawer.tsx
@@ -53,12 +53,13 @@ export const CreateSSHKeyDrawer = React.memo(({ onClose, open }: Props) => {
 
   const SSHTextAreaHelperText = () => (
     <Typography component="span">
-      <Link to="https://www.linode.com/docs/guides/use-public-key-authentication-with-ssh/">
-        Learn about
-      </Link>{' '}
-      uploading an SSH key or generating a new key pair. Note that the public
-      key begins with <Code>ssh-rsa</Code> and ends with{' '}
-      <Code>your_username@hostname</Code>.
+      Paste your public key into this field. Supported key formats include
+      Ed25519 and RSA and begin with <Code>ssh-rsa</Code>, <Code>ssh-dss</Code>,{' '}
+      <Code>ecdsa-sha2-nistp</Code>, <Code>ssh-ed25519</Code>, or{' '}
+      <Code>sk-ecdsa-sha2-nistp256</Code>.{' '}
+      <Link to="https://techdocs.akamai.com/cloud-computing/docs/manage-ssh-keys#add-a-public-key">
+        Learn more.
+      </Link>
     </Typography>
   );
 

--- a/packages/manager/src/features/Profile/SSHKeys/CreateSSHKeyDrawer.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/CreateSSHKeyDrawer.tsx
@@ -58,8 +58,9 @@ export const CreateSSHKeyDrawer = React.memo(({ onClose, open }: Props) => {
       <Code>ecdsa-sha2-nistp</Code>, <Code>ssh-ed25519</Code>, or{' '}
       <Code>sk-ecdsa-sha2-nistp256</Code>.{' '}
       <Link to="https://techdocs.akamai.com/cloud-computing/docs/manage-ssh-keys#add-a-public-key">
-        Learn more.
+        Learn more
       </Link>
+      .
     </Typography>
   );
 


### PR DESCRIPTION
# PR Description 📝  
This PR updates the wording for adding SSH keys to reflect the support for multiple key formats.

## Changes 🔄  
- Updated the helper text for adding SSH keys to mention support for different key formats in addition to `ssh-rsa`.

## Target release date 🗓️  
N/A  

## Preview 📸
| Before | After |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/b26ee586-8145-43da-9320-f61722645e44) | ![After](https://github.com/user-attachments/assets/c815f72e-3b18-498b-a811-98fd1519dea5) |

### Verification steps  
- [ ] Confirm that the updated helper text is displayed correctly on both:  
  - My Profile > SSH Keys > Add An SSH Key  
  - Linodes > Create Linode > SSH Keys > Add An SSH Key

<details>
<summary> Author Checklists </summary>

- [x] All unit tests are passing  
- [x] TypeScript compilation succeeded  
- [x] Code passes all linting rules

</details>
