### PR TITLE
upcoming: [DI-23235] - Alerting UI changes: validations, limits, Error Messages

### DIFF
--- a/packages/manager/.changeset/pr-11773-upcoming-features-1741023864014.md
+++ b/packages/manager/.changeset/pr-11773-upcoming-features-1741023864014.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+ UI enhancements across Alerting feature: Notification Error message, Limits for Metrics, Dimensions, Notifications, and other UI enhancements across the Alerting features with relevant unit test cases([#11773](https://github.com/linode/manager/pull/11773))

--- a/packages/manager/.changeset/pr-11773-upcoming-features-1741023864014.md
+++ b/packages/manager/.changeset/pr-11773-upcoming-features-1741023864014.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
- UI enhancements across Alerting feature: Notification Error message, Limits for Metrics, Dimensions, Notifications, and other UI enhancements across the Alerting features with relevant unit test cases([#11773](https://github.com/linode/manager/pull/11773))
+UI enhancements across Alerting feature: Notification Error message, Limits for Metrics, Dimensions, Notifications, and other UI enhancements with relevant unit test cases([#11773](https://github.com/linode/manager/pull/11773))

--- a/packages/manager/cypress/e2e/core/cloudpulse/create-user-alert.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/create-user-alert.spec.ts
@@ -190,11 +190,11 @@ describe('Create Alert', () => {
     cy.visitWithLogin('monitor/alerts/definitions/create');
 
     // Enter Name and Description
-    cy.findByPlaceholderText('Enter Name')
+    cy.findByPlaceholderText('Enter a Name')
       .should('be.visible')
       .type(customAlertDefinition.label);
 
-    cy.findByPlaceholderText('Enter Description')
+    cy.findByPlaceholderText('Enter a Description')
       .should('be.visible')
       .type(customAlertDefinition.description ?? '');
 
@@ -227,7 +227,7 @@ describe('Create Alert', () => {
     const cpuUsageMetricDetails = {
       aggregationType: 'Average',
       dataField: 'CPU Utilization',
-      operator: '==',
+      operator: '=',
       ruleIndex: 0,
       threshold: '1000',
     };
@@ -273,7 +273,7 @@ describe('Create Alert', () => {
     const memoryUsageMetricDetails = {
       aggregationType: 'Average',
       dataField: 'Memory Usage',
-      operator: '==',
+      operator: '=',
       ruleIndex: 1,
       threshold: '1000',
     };

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.test.tsx
@@ -21,11 +21,16 @@ queryMocks.useEditAlertDefinition.mockReturnValue({
   mutateAsync: vi.fn().mockResolvedValue({}),
   reset: vi.fn(),
 });
-
+const mockScroll = vi.fn();
 describe('Alert List Table test', () => {
   it('should render the alert landing table ', async () => {
     const { getByText } = renderWithTheme(
-      <AlertsListTable alerts={[]} isLoading={false} services={[]} />
+      <AlertsListTable
+        alerts={[]}
+        isLoading={false}
+        scrollToElement={mockScroll}
+        services={[]}
+      />
     );
     expect(getByText('Alert Name')).toBeVisible();
     expect(getByText('Service')).toBeVisible();
@@ -40,6 +45,7 @@ describe('Alert List Table test', () => {
         alerts={[]}
         error={[{ reason: 'Error in fetching the alerts' }]}
         isLoading={false}
+        scrollToElement={mockScroll}
         services={[]}
       />
     );
@@ -60,6 +66,7 @@ describe('Alert List Table test', () => {
           }),
         ]}
         isLoading={false}
+        scrollToElement={mockScroll}
         services={[{ label: 'Linode', value: 'linode' }]}
       />
     );
@@ -82,6 +89,7 @@ describe('Alert List Table test', () => {
       <AlertsListTable
         alerts={[alert]}
         isLoading={false}
+        scrollToElement={mockScroll}
         services={[{ label: 'Linode', value: 'linode' }]}
       />
     );
@@ -98,6 +106,7 @@ describe('Alert List Table test', () => {
       <AlertsListTable
         alerts={[alert]}
         isLoading={false}
+        scrollToElement={mockScroll}
         services={[{ label: 'Linode', value: 'linode' }]}
       />
     );
@@ -118,6 +127,7 @@ describe('Alert List Table test', () => {
       <AlertsListTable
         alerts={[alert]}
         isLoading={false}
+        scrollToElement={mockScroll}
         services={[{ label: 'Linode', value: 'linode' }]}
       />
     );
@@ -139,6 +149,7 @@ describe('Alert List Table test', () => {
       <AlertsListTable
         alerts={[alert]}
         isLoading={false}
+        scrollToElement={mockScroll}
         services={[{ label: 'Linode', value: 'linode' }]}
       />
     );

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.tsx
@@ -34,7 +34,7 @@ export interface AlertsListTableProps {
    */
   isLoading: boolean;
   /**
-   * Callback to scroll till the button element element on page change
+   * Callback to scroll to the button element on page change
    */
   scrollToElement: () => void;
   /**

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.tsx
@@ -34,13 +34,17 @@ export interface AlertsListTableProps {
    */
   isLoading: boolean;
   /**
+   * Callback to scroll till the button element element on page change
+   */
+  scrollToElement: () => void;
+  /**
    * The list of services to display in the table
    */
   services: Item<string, AlertServiceType>[];
 }
 
 export const AlertsListTable = React.memo((props: AlertsListTableProps) => {
-  const { alerts, error, isLoading, services } = props;
+  const { alerts, error, isLoading, scrollToElement, services } = props;
   const _error = error
     ? getAPIErrorOrDefault(error, 'Error in fetching the alerts.')
     : undefined;
@@ -85,7 +89,7 @@ export const AlertsListTable = React.memo((props: AlertsListTableProps) => {
     <OrderBy
       data={alerts}
       order="asc"
-      orderBy="service"
+      orderBy="service_type"
       preferenceKey="alerts-landing"
     >
       {({ data: orderedData, handleOrderChange, order, orderBy }) => (
@@ -109,11 +113,16 @@ export const AlertsListTable = React.memo((props: AlertsListTableProps) => {
                     <TableRow>
                       {AlertListingTableLabelMap.map((value) => (
                         <TableSortCell
+                          handleClick={(orderBy, order) => {
+                            if (order) {
+                              handleOrderChange(orderBy, order);
+                              handlePageChange(1);
+                            }
+                          }}
                           active={orderBy === value.label}
                           data-qa-header={value.label}
                           data-qa-sorting={value.label}
                           direction={order}
-                          handleClick={handleOrderChange}
                           key={value.label}
                           label={value.label}
                           noWrap
@@ -147,12 +156,24 @@ export const AlertsListTable = React.memo((props: AlertsListTableProps) => {
                 </Table>
               </Grid>
               <PaginationFooter
+                handlePageChange={(page) => {
+                  handlePageChange(page);
+                  requestAnimationFrame(() => {
+                    scrollToElement();
+                  });
+                }}
+                handleSizeChange={(pageSize) => {
+                  handlePageSizeChange(pageSize);
+                  handlePageChange(1);
+                  requestAnimationFrame(() => {
+                    scrollToElement();
+                  });
+                }}
                 count={count}
                 eventCategory="Alert Definitions Table"
-                handlePageChange={handlePageChange}
-                handleSizeChange={handlePageSizeChange}
                 page={page}
                 pageSize={pageSize}
+                sx={{ border: 0 }}
               />
             </>
           )}

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
@@ -163,7 +163,6 @@ export const AlertListing = () => {
         >
           <DebouncedSearchTextField
             sx={{
-              height: '34px',
               width: searchAndSelectSx,
             }}
             data-qa-filter="alert-search"

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
@@ -9,14 +9,16 @@ import { useAllAlertDefinitionsQuery } from 'src/queries/cloudpulse/alerts';
 import { useCloudPulseServiceTypes } from 'src/queries/cloudpulse/services';
 
 import { alertStatusOptions } from '../constants';
+import { scrollToElement } from '../Utils/AlertResourceUtils';
 import { AlertsListTable } from './AlertListTable';
 
 import type { Item } from '../constants';
 import type { Alert, AlertServiceType, AlertStatusType } from '@linode/api-v4';
 
 const searchAndSelectSx = {
+  lg: '250px',
   md: '300px',
-  sm: '500px',
+  sm: '400px',
   xs: '300px',
 };
 
@@ -30,6 +32,7 @@ export const AlertListing = () => {
     isLoading: serviceTypesLoading,
   } = useCloudPulseServiceTypes(true);
 
+  const topRef = React.useRef<HTMLButtonElement>(null);
   const getServicesList = React.useMemo((): Item<
     string,
     AlertServiceType
@@ -146,6 +149,7 @@ export const AlertListing = () => {
         flexWrap="wrap"
         gap={3}
         justifyContent="space-between"
+        ref={topRef}
       >
         <Box
           flexDirection={{
@@ -159,6 +163,7 @@ export const AlertListing = () => {
         >
           <DebouncedSearchTextField
             sx={{
+              height: '34px',
               width: searchAndSelectSx,
             }}
             data-qa-filter="alert-search"
@@ -184,7 +189,7 @@ export const AlertListing = () => {
             data-qa-filter="alert-service-filter"
             data-testid="alert-service-filter"
             label=""
-            limitTags={2}
+            limitTags={1}
             loading={serviceTypesLoading}
             multiple
             noMarginTop
@@ -203,6 +208,7 @@ export const AlertListing = () => {
             data-qa-filter="alert-status-filter"
             data-testid="alert-status-filter"
             label=""
+            limitTags={1}
             multiple
             noMarginTop
             options={alertStatusOptions}
@@ -219,7 +225,7 @@ export const AlertListing = () => {
             paddingBottom: 0,
             paddingTop: 0,
             whiteSpace: 'noWrap',
-            width: { md: '150px', xs: '200px' },
+            width: { lg: '120px', md: '120px', sm: '150px', xs: '150px' },
           }}
           buttonType="primary"
           data-qa-button="create-alert"
@@ -233,6 +239,7 @@ export const AlertListing = () => {
         alerts={getAlertsList}
         error={error ?? undefined}
         isLoading={isLoading}
+        scrollToElement={() => scrollToElement(topRef.current ?? null)}
         services={getServicesList}
       />
     </Stack>

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.test.tsx
@@ -21,6 +21,7 @@ const queryMocks = vi.hoisted(() => ({
 }));
 
 beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn();
   queryMocks.useResourcesQuery.mockReturnValue({
     data: [],
     isError: false,
@@ -79,9 +80,9 @@ describe('AlertDefinition Create', () => {
     await user.click(
       container.getByRole('button', { name: 'Add dimension filter' })
     );
-    const submitButton = container.getByText('Submit').closest('button');
+    const submitButton = container.getByText('Submit');
     await user.click(submitButton!);
-    expect(container.getAllByText('This field is required.').length).toBe(10);
+    expect(container.getAllByText('This field is required.').length).toBe(11);
     container.getAllByText(errorMessage).forEach((element) => {
       expect(element).toBeVisible();
     });
@@ -101,5 +102,32 @@ describe('AlertDefinition Create', () => {
     expect(
       await container.findByText('The value should be a number.')
     ).toBeInTheDocument();
+
+    expect(
+      await container.findByText(
+        'At least one notification channel is required.'
+      )
+    );
+  });
+
+  it('should validate the checks of Alert Name and Description', async () => {
+    const user = userEvent.setup();
+    const container = renderWithTheme(<CreateAlertDefinition />);
+    const nameInput = container.getByLabelText('Name');
+    const descriptionInput = container.getByLabelText('Description (optional)');
+    await user.type(nameInput, '*#&+:<>"?@%');
+    await user.type(
+      descriptionInput,
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    );
+    await user.click(container.getByText('Submit'));
+    expect(
+      await container.findByText(
+        'Name cannot contain special characters: * # & + : \< \> ? @ % { } \\ /.'
+      )
+    ).toBeVisible();
+    expect(
+      await container.findByText('Description must be 100 characters or less.')
+    ).toBeVisible();
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
@@ -11,7 +11,6 @@ import { Breadcrumb } from 'src/components/Breadcrumb/Breadcrumb';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { useCreateAlertDefinition } from 'src/queries/cloudpulse/alerts';
 import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
-import { scrollErrorIntoViewV2 } from 'src/utilities/scrollErrorIntoViewV2';
 
 import { MetricCriteriaField } from './Criteria/MetricCriteria';
 import { TriggerConditions } from './Criteria/TriggerConditions';
@@ -72,7 +71,6 @@ const overrides = [
 export const CreateAlertDefinition = () => {
   const history = useHistory();
   const alertCreateExit = () => history.push('/monitor/alerts/definitions');
-  const formRef = React.useRef<HTMLFormElement>(null);
 
   const formMethods = useForm<CreateAlertDefinitionForm>({
     defaultValues: initialValues,
@@ -83,7 +81,7 @@ export const CreateAlertDefinition = () => {
   });
   const {
     control,
-    formState: { errors, isSubmitting },
+    formState: { errors, isSubmitting, submitCount },
     getValues,
     handleSubmit,
     setError,
@@ -107,7 +105,6 @@ export const CreateAlertDefinition = () => {
       alertCreateExit();
     } catch (errors) {
       for (const error of errors) {
-        scrollErrorIntoViewV2(formRef);
         if (error.field) {
           setError(error.field, { message: error.reason });
         } else {
@@ -120,11 +117,12 @@ export const CreateAlertDefinition = () => {
     }
   });
 
+  const previousSubmitCount = React.useRef<number>(0);
   React.useEffect(() => {
-    if (!isEmpty(errors)) {
+    if (!isEmpty(errors) && submitCount > previousSubmitCount.current) {
       scrollErrorIntoView(undefined, { behavior: 'smooth' });
     }
-  }, [errors]);
+  }, [errors, submitCount]);
 
   return (
     <React.Fragment>

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
@@ -85,6 +85,7 @@ export const CreateAlertDefinition = () => {
     getValues,
     handleSubmit,
     setError,
+    setValue,
   } = formMethods;
 
   const { enqueueSnackbar } = useSnackbar();
@@ -123,6 +124,19 @@ export const CreateAlertDefinition = () => {
       scrollErrorIntoView(undefined, { behavior: 'smooth' });
     }
   }, [errors, submitCount]);
+
+  const handleServiceTypeChange = React.useCallback(() => {
+    // Reset the criteria to initial state
+    setValue('rule_criteria.rules', [
+      {
+        aggregate_function: null,
+        dimension_filters: [],
+        metric: null,
+        operator: null,
+        threshold: 0,
+      },
+    ]);
+  }, [setValue]);
 
   return (
     <React.Fragment>
@@ -166,14 +180,16 @@ export const CreateAlertDefinition = () => {
               control={control}
               name="description"
             />
-            <CloudPulseServiceSelect name="serviceType" />
+            <CloudPulseServiceSelect
+              handleServiceTypeChange={handleServiceTypeChange}
+              name="serviceType"
+            />
             <CloudPulseAlertSeveritySelect name="severity" />
             <CloudPulseModifyAlertResources name="entity_ids" />
             <MetricCriteriaField
               setMaxInterval={(interval: number) =>
                 setMaxScrapeInterval(interval)
               }
-              isCreateMode
               name="rule_criteria.rules"
               serviceType={serviceTypeWatcher!}
             />

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilter.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilter.test.tsx
@@ -6,7 +6,7 @@ import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
 
 import { DimensionFilters } from './DimensionFilter';
 
-import type { CreateAlertDefinitionForm } from '../types';
+import type { CreateAlertDefinitionForm, DimensionFilterForm } from '../types';
 import type { MetricDefinition } from '@linode/api-v4';
 
 const mockData: MetricDefinition[] = [
@@ -138,6 +138,47 @@ describe('DimensionFilterField', () => {
     );
     await waitFor(() =>
       expect(container.queryByTestId(dimensionFilterID)).not.toBeInTheDocument()
+    );
+  });
+  it('should show tooltip when the max limit of dimension filters is reached', async () => {
+    const dimensionFilterValue: DimensionFilterForm = {
+      dimension_label: 'state',
+      operator: 'eq',
+      value: 'free',
+    };
+    const {
+      getByText,
+    } = renderWithThemeAndHookFormContext<CreateAlertDefinitionForm>({
+      component: (
+        <DimensionFilters
+          dataFieldDisabled={true}
+          dimensionOptions={mockData[0].dimensions}
+          name={`rule_criteria.rules.${0}.dimension_filters`}
+        />
+      ),
+      useFormOptions: {
+        defaultValues: {
+          rule_criteria: {
+            rules: [
+              {
+                ...mockData[0],
+                dimension_filters: Array(5).fill(dimensionFilterValue),
+              },
+            ],
+          },
+          serviceType: 'linode',
+        },
+      },
+    });
+    const addButton = screen.getByRole('button', {
+      name: dimensionFilterButton,
+    });
+    expect(addButton).toBeDisabled();
+    userEvent.hover(addButton);
+    await waitFor(() =>
+      expect(
+        getByText('You can add up to 5 dimension filters.')
+      ).toBeInTheDocument()
     );
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilter.tsx
@@ -1,7 +1,7 @@
 import { Box } from '@linode/ui';
 import { Button, Stack, Typography } from '@linode/ui';
 import React from 'react';
-import { useFieldArray, useFormContext } from 'react-hook-form';
+import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 
 import { DimensionFilterField } from './DimensionFilterField';
 
@@ -31,6 +31,9 @@ export const DimensionFilters = (props: DimensionFilterProps) => {
     control,
     name,
   });
+
+  const dimensionFilterWatcher = useWatch({ control, name });
+
   return (
     <Box display="flex" flexDirection="column" gap={1}>
       <Typography variant="h3">
@@ -61,8 +64,11 @@ export const DimensionFilters = (props: DimensionFilterProps) => {
         buttonType="secondary"
         compactX
         data-qa-buttons="true"
+        disabled={dimensionFilterWatcher && dimensionFilterWatcher.length === 5}
         size="small"
         sx={{ justifyContent: 'start', width: '150px' }}
+        sxEndIcon={{ display: 'none' }}
+        tooltipText="You can add up to 5 dimension filters."
       >
         Add dimension filter
       </Button>

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterField.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterField.tsx
@@ -86,11 +86,11 @@ export const DimensionFilterField = (props: DimensionFilterFieldProps) => {
 
   return (
     <Grid
-      container
-      data-testid={`${name}-id`}
       sx={{
         gap: 2,
       }}
+      container
+      data-testid={`${name}-id`}
     >
       <Grid item md={3} xs={12}>
         <Controller
@@ -115,7 +115,7 @@ export const DimensionFilterField = (props: DimensionFilterFieldProps) => {
               label="Data Field"
               onBlur={field.onBlur}
               options={dataFieldOptions}
-              placeholder="Select a Data field"
+              placeholder="Select a Data Field"
             />
           )}
           control={control}
@@ -147,6 +147,7 @@ export const DimensionFilterField = (props: DimensionFilterFieldProps) => {
               label="Operator"
               onBlur={field.onBlur}
               options={dimensionOperatorOptions}
+              placeholder="Select an Operator"
             />
           )}
           control={control}

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/Metric.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/Metric.test.tsx
@@ -196,7 +196,7 @@ describe('Metric component tests', () => {
     expect(
       await container.findByRole('option', { name: '>' })
     ).toBeInTheDocument();
-    expect(container.getByRole('option', { name: '==' })).toBeInTheDocument();
+    expect(container.getByRole('option', { name: '=' })).toBeInTheDocument();
     expect(container.getByRole('option', { name: '<' })).toBeInTheDocument();
     const option = await container.findByRole('option', { name: '>' });
     await user.click(option);

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/Metric.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/Metric.tsx
@@ -130,7 +130,7 @@ export const Metric = (props: MetricCriteriaProps) => {
         </Box>
 
         <Grid container spacing={2}>
-          <Grid item md={3} sm={6} xs={12}>
+          <Grid item lg={3} md={4} sm={6} xs={12}>
             <Controller
               render={({ field, fieldState }) => (
                 <Autocomplete
@@ -175,7 +175,7 @@ export const Metric = (props: MetricCriteriaProps) => {
               name={`${name}.metric`}
             />
           </Grid>
-          <Grid item md={3} sm={6} xs={12}>
+          <Grid item lg={3} md={4} sm={6} xs={12}>
             <Controller
               render={({ field, fieldState }) => (
                 <Autocomplete
@@ -209,7 +209,7 @@ export const Metric = (props: MetricCriteriaProps) => {
               name={`${name}.aggregate_function`}
             />
           </Grid>
-          <Grid item lg={2} md={3} sm={6} xs={12}>
+          <Grid item lg={3} md={4} sm={6} xs={12}>
             <Controller
               render={({ field, fieldState }) => (
                 <Autocomplete
@@ -246,14 +246,20 @@ export const Metric = (props: MetricCriteriaProps) => {
               name={`${name}.operator`}
             />
           </Grid>
-          <Grid item lg={2} md={3} sm={6} xs={12}>
+          <Grid item lg={3} md={2} sm={6} xs={12}>
             <Box display="flex" gap={1}>
               <Controller
                 render={({ field, fieldState }) => (
                   <TextField
+                    containerProps={{
+                      sx: { paddingTop: 1 },
+                    }}
                     onWheel={(event: React.SyntheticEvent<Element, Event>) =>
                       event.target instanceof HTMLElement && event.target.blur()
                     }
+                    sx={{
+                      height: '34px',
+                    }}
                     data-qa-metric-threshold={`${name}-threshold`}
                     data-qa-threshold="threshold"
                     data-testid="threshold"
@@ -264,7 +270,6 @@ export const Metric = (props: MetricCriteriaProps) => {
                     noMarginTop
                     onBlur={field.onBlur}
                     onChange={(e) => field.onChange(e.target.value)}
-                    sx={{ height: '34px', marginTop: { sm: 1, xs: 0 } }}
                     type="number"
                     value={field.value ?? 0}
                   />
@@ -277,6 +282,7 @@ export const Metric = (props: MetricCriteriaProps) => {
                   alignItems: 'flex-end',
                   display: 'flex',
                   height: '56px',
+                  marginTop: { lg: '5px', md: '5px', sm: '5px' },
                 }}
                 variant="body1"
               >

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/MetricCriteria.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/MetricCriteria.test.tsx
@@ -245,4 +245,40 @@ describe('MetricCriteriaField', () => {
 
     expect(setMaxInterval).toBeCalledWith(firstOptionConvertedTime);
   });
+  it('displays tooltip when the button is disabled', async () => {
+    const {
+      getByText,
+    } = renderWithThemeAndHookFormContext<CreateAlertDefinitionForm>({
+      component: (
+        <MetricCriteriaField
+          name="rule_criteria.rules"
+          serviceType="linode"
+          setMaxInterval={vi.fn()}
+        />
+      ),
+      useFormOptions: {
+        defaultValues: {
+          rule_criteria: {
+            rules: [
+              mockData.data[0],
+              mockData.data[0],
+              mockData.data[1],
+              mockData.data[1],
+              mockData.data[0],
+            ],
+          },
+        },
+      },
+    });
+
+    const addButton = screen.getByRole('button', {
+      name: 'Add metric',
+    });
+
+    expect(addButton).toBeDisabled();
+    userEvent.hover(addButton);
+    await waitFor(() =>
+      expect(getByText('You can add up to 5 metrics.')).toBeInTheDocument()
+    );
+  });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/MetricCriteria.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/MetricCriteria.tsx
@@ -12,10 +12,6 @@ import type { AlertServiceType } from '@linode/api-v4';
 import type { FieldPathByValue } from 'react-hook-form';
 
 interface MetricCriteriaProps {
-  /*
-   * boolean value to check if the component is in create mode
-   */
-  isCreateMode?: boolean;
   /**
    * name used for the component to set formik field
    */
@@ -33,7 +29,7 @@ interface MetricCriteriaProps {
 }
 
 export const MetricCriteriaField = (props: MetricCriteriaProps) => {
-  const { isCreateMode, name, serviceType, setMaxInterval } = props;
+  const { name, serviceType, setMaxInterval } = props;
   const {
     data: metricDefinitions,
     isError: isMetricDefinitionError,
@@ -64,25 +60,10 @@ export const MetricCriteriaField = (props: MetricCriteriaProps) => {
     setMaxInterval(maxInterval);
   }, [maxInterval, setMaxInterval]);
 
-  const { append, fields, remove, replace } = useFieldArray({
+  const { append, fields, remove } = useFieldArray({
     control,
     name,
   });
-  const serviceWatcher = useWatch({ control, name: 'serviceType' });
-
-  React.useEffect(() => {
-    if (isCreateMode) {
-      replace([
-        {
-          aggregate_function: null,
-          dimension_filters: [],
-          metric: null,
-          operator: null,
-          threshold: 0,
-        },
-      ]);
-    }
-  }, [isCreateMode, replace, serviceWatcher]);
 
   return (
     <Box sx={(theme) => ({ marginTop: theme.spacing(3) })}>

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/MetricCriteria.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/MetricCriteria.tsx
@@ -12,6 +12,10 @@ import type { AlertServiceType } from '@linode/api-v4';
 import type { FieldPathByValue } from 'react-hook-form';
 
 interface MetricCriteriaProps {
+  /*
+   * boolean value to check if the component is in create mode
+   */
+  isCreateMode?: boolean;
   /**
    * name used for the component to set formik field
    */
@@ -29,7 +33,7 @@ interface MetricCriteriaProps {
 }
 
 export const MetricCriteriaField = (props: MetricCriteriaProps) => {
-  const { name, serviceType, setMaxInterval } = props;
+  const { isCreateMode, name, serviceType, setMaxInterval } = props;
   const {
     data: metricDefinitions,
     isError: isMetricDefinitionError,
@@ -60,10 +64,26 @@ export const MetricCriteriaField = (props: MetricCriteriaProps) => {
     setMaxInterval(maxInterval);
   }, [maxInterval, setMaxInterval]);
 
-  const { append, fields, remove } = useFieldArray({
+  const { append, fields, remove, replace } = useFieldArray({
     control,
     name,
   });
+  const serviceWatcher = useWatch({ control, name: 'serviceType' });
+
+  React.useEffect(() => {
+    if (isCreateMode) {
+      replace([
+        {
+          aggregate_function: null,
+          dimension_filters: [],
+          metric: null,
+          operator: null,
+          threshold: 0,
+        },
+      ]);
+    }
+  }, [isCreateMode, replace, serviceWatcher]);
+
   return (
     <Box sx={(theme) => ({ marginTop: theme.spacing(3) })}>
       <Box
@@ -102,8 +122,11 @@ export const MetricCriteriaField = (props: MetricCriteriaProps) => {
           })
         }
         buttonType="outlined"
+        disabled={metricCriteriaWatcher.length === 5}
         size="medium"
         sx={(theme) => ({ marginTop: theme.spacing(2) })}
+        sxEndIcon={{ display: 'none' }}
+        tooltipText="You can add up to 5 metrics."
       >
         Add metric
       </Button>

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/TriggerConditions.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/TriggerConditions.test.tsx
@@ -53,7 +53,8 @@ describe('Trigger Conditions', () => {
     const evaluationPeriodToolTip = within(evaluationPeriodContainer).getByRole(
       'button',
       {
-        name: 'Choose how often you intend to evaluate the alert condition.',
+        name:
+          'Defines the timeframe for collecting data in polling intervals to understand the service performance. Choose the data lookback period where the thresholds are applied to gather the information impactful for your business.',
       }
     );
     const pollingIntervalContainer = container.getByTestId(
@@ -62,8 +63,7 @@ describe('Trigger Conditions', () => {
     const pollingIntervalToolTip = within(pollingIntervalContainer).getByRole(
       'button',
       {
-        name:
-          'Defines the timeframe for collecting data in polling intervals to understand the service performance. Choose the data lookback period where the thresholds are applied to gather the information impactful for your business.',
+        name: 'Choose how often you intend to evaluate the alert condition.',
       }
     );
     expect(evaluationPeriodToolTip).toBeInTheDocument();

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/TriggerConditions.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/TriggerConditions.tsx
@@ -79,7 +79,7 @@ export const TriggerConditions = (props: TriggerConditionProps) => {
                 }}
                 textFieldProps={{
                   labelTooltipText:
-                    'Choose how often you intend to evaluate the alert condition.',
+                    'Defines the timeframe for collecting data in polling intervals to understand the service performance. Choose the data lookback period where the thresholds are applied to gather the information impactful for your business.',
                 }}
                 value={
                   getEvaluationPeriodOptions().find(
@@ -114,7 +114,7 @@ export const TriggerConditions = (props: TriggerConditionProps) => {
                 }}
                 textFieldProps={{
                   labelTooltipText:
-                    'Defines the timeframe for collecting data in polling intervals to understand the service performance. Choose the data lookback period where the thresholds are applied to gather the information impactful for your business.',
+                    'Choose how often you intend to evaluate the alert condition.',
                 }}
                 value={
                   getPollingIntervalOptions().find(
@@ -127,7 +127,7 @@ export const TriggerConditions = (props: TriggerConditionProps) => {
                 label="Polling Interval"
                 onBlur={field.onBlur}
                 options={getPollingIntervalOptions()}
-                placeholder="Select a Polling"
+                placeholder="Select a Polling Interval"
               />
             )}
             control={control}
@@ -136,49 +136,64 @@ export const TriggerConditions = (props: TriggerConditionProps) => {
         </Grid>
         <Grid
           sx={{
-            alignItems: 'center',
-            display: 'flex',
-            gap: 1,
             mt: { lg: 3.5, xs: 0 },
           }}
+          alignItems="start"
+          display="flex"
+          flexDirection={{ sm: 'row', xs: 'column' }}
+          gap={1}
           item
+          justifyContent={{ sm: 'left', xs: 'center' }}
           md="auto"
           sm={12}
           xs={12}
         >
-          <Typography mt={3} variant="body1">
+          <Typography
+            marginTop={{ sm: '32px', xs: '0px' }}
+            maxWidth={{ lg: '270px', md: '220px' }}
+            mt={3}
+            variant="body1"
+          >
             Trigger alert when all criteria are met for
           </Typography>
 
           <Controller
             render={({ field, fieldState }) => (
-              <Box sx={{ maxHeight: '54px' }}>
-                <TextField
-                  onWheel={(event) =>
-                    event.target instanceof HTMLElement && event.target.blur()
-                  }
-                  sx={{
-                    height: '30px',
-                    width: '30px',
-                  }}
-                  data-qa-trigger-occurrences
-                  data-testid="trigger-occurences"
-                  errorText={fieldState.error?.message}
-                  label=""
-                  min={0}
-                  name={`${name}.trigger_occurrences`}
-                  onBlur={field.onBlur}
-                  onChange={(e) => field.onChange(e.target.value)}
-                  type="number"
-                  value={field.value ?? 0}
-                />
-              </Box>
+              <TextField
+                containerProps={{
+                  maxWidth: '120px',
+                }}
+                onWheel={(event) =>
+                  event.target instanceof HTMLElement && event.target.blur()
+                }
+                sx={{
+                  height: '34px',
+                  marginTop: { sm: '16px', xs: '0px' },
+                  width: '100px',
+                }}
+                data-qa-trigger-occurrences
+                data-testid="trigger-occurences"
+                errorText={fieldState.error?.message}
+                label=""
+                min={0}
+                name={`${name}.trigger_occurrences`}
+                noMarginTop
+                onBlur={field.onBlur}
+                onChange={(e) => field.onChange(e.target.value)}
+                type="number"
+                value={field.value ?? 0}
+              />
             )}
             control={control}
             name={`${name}.trigger_occurrences`}
           />
 
-          <Typography mt={3} textAlign="start" variant="body1">
+          <Typography
+            marginTop={{ sm: '32px', xs: '0px' }}
+            mt={3}
+            textAlign="start"
+            variant="body1"
+          >
             consecutive occurrence(s).
           </Typography>
         </Grid>

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ServiceTypeSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/ServiceTypeSelect.tsx
@@ -11,6 +11,11 @@ import type { FieldPathByValue } from 'react-hook-form';
 
 interface CloudPulseServiceSelectProps {
   /**
+   * @returns vsoid
+   * function to handle the service type change
+   */
+  handleServiceTypeChange?: () => void;
+  /**
    * Boolean value to check if service select is disabled in the edit flow
    */
   isDisabled?: boolean;
@@ -23,7 +28,7 @@ interface CloudPulseServiceSelectProps {
 export const CloudPulseServiceSelect = (
   props: CloudPulseServiceSelectProps
 ) => {
-  const { isDisabled, name } = props;
+  const { handleServiceTypeChange, isDisabled, name } = props;
   const {
     data: serviceOptions,
     error: serviceTypesError,
@@ -61,6 +66,9 @@ export const CloudPulseServiceSelect = (
             }
             if (reason === 'clear') {
               field.onChange(null);
+            }
+            if (handleServiceTypeChange !== undefined) {
+              handleServiceTypeChange();
             }
           }}
           value={

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/NotificationChannels/AddChannelListing.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/NotificationChannels/AddChannelListing.test.tsx
@@ -1,5 +1,5 @@
 import { capitalize } from '@linode/utilities';
-import { within } from '@testing-library/react';
+import { waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
@@ -78,5 +78,32 @@ describe('Channel Listing component', () => {
     await user.click(clearButton);
 
     expect(notificationContainer).not.toBeInTheDocument();
+  });
+  it('should show tooltip when the max limit of notification channels is reached', async () => {
+    // Mock the `notificationChannelWatcher` length to simulate the max limit
+    const mockMaxLimit = 5;
+    const {
+      getByRole,
+      getByText,
+    } = renderWithThemeAndHookFormContext<CreateAlertDefinitionForm>({
+      component: <AddChannelListing name="channel_ids" />,
+      useFormOptions: {
+        defaultValues: {
+          channel_ids: Array(mockMaxLimit).fill(mockNotificationData[0].id), // simulate 5 channels
+        },
+      },
+    });
+
+    const addButton = getByRole('button', {
+      name: 'Add notification channel',
+    });
+
+    expect(addButton).toBeDisabled();
+    userEvent.hover(addButton);
+    await waitFor(() =>
+      expect(
+        getByText('You can add up to 5 notification channels.')
+      ).toBeInTheDocument()
+    );
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/NotificationChannels/AddChannelListing.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/NotificationChannels/AddChannelListing.tsx
@@ -1,7 +1,7 @@
-import { Box, Button, Stack, Typography } from '@linode/ui';
+import { Box, Button, Notice, Stack, Typography } from '@linode/ui';
 import { capitalize } from '@linode/utilities';
 import React from 'react';
-import { useFormContext, useWatch } from 'react-hook-form';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
 
 import { useAllAlertNotificationChannelsQuery } from 'src/queries/cloudpulse/alerts';
 
@@ -32,7 +32,7 @@ interface NotificationChannelsProps {
    */
   notification: NotificationChannel;
 }
-export const AddChannelListing = React.memo((props: AddChannelListingProps) => {
+export const AddChannelListing = (props: AddChannelListingProps) => {
   const { name } = props;
   const { control, setValue } = useFormContext<CreateAlertDefinitionForm>();
   const [openAddNotification, setOpenAddNotification] = React.useState(false);
@@ -67,7 +67,7 @@ export const AddChannelListing = React.memo((props: AddChannelListingProps) => {
 
   const handleRemove = (index: number) => {
     const newList = notificationChannelWatcher.filter((_, i) => i !== index);
-    setValue(name, newList);
+    setValue(name, newList, { shouldValidate: true });
   };
 
   const handleOpenDrawer = () => {
@@ -79,7 +79,9 @@ export const AddChannelListing = React.memo((props: AddChannelListingProps) => {
   };
 
   const handleAddNotification = (notificationId: number) => {
-    setValue(name, [...notificationChannelWatcher, notificationId]);
+    setValue(name, [...notificationChannelWatcher, notificationId], {
+      shouldValidate: true,
+    });
     handleCloseDrawer();
   };
 
@@ -135,39 +137,53 @@ export const AddChannelListing = React.memo((props: AddChannelListingProps) => {
   );
 
   return (
-    <>
-      <Typography marginBottom={1} marginTop={3} variant="h2">
-        4. Notification Channels
-      </Typography>
-      <Stack spacing={1}>
-        {selectedNotifications.length > 0 &&
-          selectedNotifications.map((notification, id) => (
-            <NotificationChannelCard
-              id={id}
-              key={id}
-              notification={notification}
-            />
-          ))}
-      </Stack>
-      <Button
-        buttonType="outlined"
-        data-qa-buttons="true"
-        onClick={handleOpenDrawer}
-        size="medium"
-        sx={(theme) => ({ marginTop: theme.spacing(2) })}
-        type="button"
-      >
-        Add notification channel
-      </Button>
+    <Controller
+      render={({ fieldState, formState }) => (
+        <>
+          <Typography marginBottom={1} marginTop={3} variant="h2">
+            4. Notification Channels
+          </Typography>
+          {(formState.isSubmitted || fieldState.isTouched) && fieldState.error && (
+            <Notice spacingBottom={0} spacingTop={12} variant="error">
+              {fieldState.error.message}
+            </Notice>
+          )}
+          <Stack spacing={1}>
+            {selectedNotifications.length > 0 &&
+              selectedNotifications.map((notification, id) => (
+                <NotificationChannelCard
+                  id={id}
+                  key={id}
+                  notification={notification}
+                />
+              ))}
+          </Stack>
+          <Button
+            buttonType="outlined"
+            data-qa-buttons="true"
+            disabled={notificationChannelWatcher.length === 5}
+            onClick={handleOpenDrawer}
+            size="medium"
+            sx={(theme) => ({ marginTop: theme.spacing(2) })}
+            sxEndIcon={{ display: 'none' }}
+            tooltipText="You can add up to 5 notification channels."
+            type="button"
+          >
+            Add notification channel
+          </Button>
 
-      <AddNotificationChannelDrawer
-        handleCloseDrawer={handleCloseDrawer}
-        isNotificationChannelsError={notificationChannelsError}
-        isNotificationChannelsLoading={notificationChannelsLoading}
-        onSubmitAddNotification={handleAddNotification}
-        open={openAddNotification}
-        templateData={notifications ?? []}
-      />
-    </>
+          <AddNotificationChannelDrawer
+            handleCloseDrawer={handleCloseDrawer}
+            isNotificationChannelsError={notificationChannelsError}
+            isNotificationChannelsLoading={notificationChannelsLoading}
+            onSubmitAddNotification={handleAddNotification}
+            open={openAddNotification}
+            templateData={notifications ?? []}
+          />
+        </>
+      )}
+      control={control}
+      name={name}
+    />
   );
-});
+};

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/NotificationChannels/AddNotificationChannelDrawer.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/NotificationChannels/AddNotificationChannelDrawer.tsx
@@ -90,12 +90,13 @@ export const AddNotificationChannelDrawer = (
     (template) => template.label === channelLabelWatcher
   );
 
+  const resetDrawer = () => {
+    handleCloseDrawer();
+    reset();
+  };
+
   return (
-    <Drawer
-      onClose={handleCloseDrawer}
-      open={open}
-      title="Add Notification Channel"
-    >
+    <Drawer onClose={resetDrawer} open={open} title="Add Notification Channel">
       <FormProvider {...formMethods}>
         <form onSubmit={onSubmit}>
           <Box
@@ -164,6 +165,11 @@ export const AddNotificationChannelDrawer = (
                         reason === 'selectOption' ? selected.label : null
                       );
                     }}
+                    slotProps={{
+                      popper: {
+                        placement: 'bottom',
+                      },
+                    }}
                     value={
                       selectedChannelTypeTemplate?.find(
                         (option) => option.label === field.value
@@ -190,13 +196,13 @@ export const AddNotificationChannelDrawer = (
                     <Typography variant="h3">To:</Typography>
                   </Grid>
                   <Grid
-                    item
-                    md="auto"
-                    xs={12}
                     sx={{
                       overflow: 'auto',
                       paddingRight: 1,
                     }}
+                    item
+                    md="auto"
+                    xs={12}
                   >
                     <RenderChannelDetails template={selectedTemplate} />
                   </Grid>
@@ -212,7 +218,7 @@ export const AddNotificationChannelDrawer = (
             }}
             secondaryButtonProps={{
               label: 'Cancel',
-              onClick: handleCloseDrawer,
+              onClick: resetDrawer,
             }}
           />
         </form>

--- a/packages/manager/src/features/CloudPulse/Alerts/EditAlert/EditAlertDefinition.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/EditAlert/EditAlertDefinition.test.tsx
@@ -23,6 +23,7 @@ vi.mock('src/queries/cloudpulse/alerts', () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  Element.prototype.scrollIntoView = vi.fn();
   queryMocks.useEditAlertDefinition.mockReturnValue({
     mutateAsync: vi.fn().mockResolvedValue({}),
     reset: vi.fn(),
@@ -88,8 +89,8 @@ describe('EditAlertDefinition component', () => {
       );
       const descriptionValue = 'Updated Description';
       const nameValue = 'Updated Label';
-      const nameInput = getByPlaceholderText('Enter Name');
-      const descriptionInput = getByPlaceholderText('Enter Description');
+      const nameInput = getByPlaceholderText('Enter a Name');
+      const descriptionInput = getByPlaceholderText('Enter a Description');
       await userEvent.clear(nameInput);
       await userEvent.clear(descriptionInput);
       await userEvent.type(nameInput, nameValue);

--- a/packages/manager/src/features/CloudPulse/Alerts/EditAlert/EditAlertDefinition.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/EditAlert/EditAlertDefinition.tsx
@@ -10,7 +10,6 @@ import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { Breadcrumb } from 'src/components/Breadcrumb/Breadcrumb';
 import { useEditAlertDefinition } from 'src/queries/cloudpulse/alerts';
 import { scrollErrorIntoView } from 'src/utilities/scrollErrorIntoView';
-import { scrollErrorIntoViewV2 } from 'src/utilities/scrollErrorIntoViewV2';
 
 import { MetricCriteriaField } from '../CreateAlert/Criteria/MetricCriteria';
 import { TriggerConditions } from '../CreateAlert/Criteria/TriggerConditions';
@@ -42,7 +41,6 @@ export interface EditAlertProps {
 export const EditAlertDefinition = (props: EditAlertProps) => {
   const { alertDetails, serviceType } = props;
   const history = useHistory();
-  const formRef = React.useRef<HTMLFormElement>(null);
 
   const { enqueueSnackbar } = useSnackbar();
 
@@ -72,7 +70,6 @@ export const EditAlertDefinition = (props: EditAlertProps) => {
       history.push(definitionLanding);
     } catch (errors) {
       for (const error of errors) {
-        scrollErrorIntoViewV2(formRef);
         if (error.field) {
           setError(error.field, { message: error.reason });
         } else {
@@ -99,17 +96,21 @@ export const EditAlertDefinition = (props: EditAlertProps) => {
     },
   ];
 
+  const previousSubmitCount = React.useRef<number>(0);
   React.useEffect(() => {
-    if (!isEmpty(formState.errors)) {
+    if (
+      !isEmpty(formState.errors) &&
+      formState.submitCount > previousSubmitCount.current
+    ) {
       scrollErrorIntoView(undefined, { behavior: 'smooth' });
     }
-  }, [formState.errors]);
+  }, [formState.errors, formState.submitCount]);
 
   return (
     <Paper sx={{ paddingLeft: 1, paddingRight: 1, paddingTop: 2 }}>
       <Breadcrumb crumbOverrides={overrides} pathname={'/Definitions/Edit'} />
       <FormProvider {...formMethods}>
-        <form onSubmit={onSubmit} ref={formRef}>
+        <form onSubmit={onSubmit}>
           <Typography marginTop={2} variant="h2">
             1. General Information
           </Typography>

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertResourceUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertResourceUtils.ts
@@ -259,7 +259,9 @@ const applyAdditionalFilter = (
  * This methods scrolls to the given HTML Element
  * @param scrollToElement The HTML Element to which we need to scroll
  */
-export const scrollToElement = (scrollToElement: HTMLDivElement | null) => {
+export const scrollToElement = (
+  scrollToElement: HTMLButtonElement | HTMLDivElement | null
+) => {
   if (scrollToElement) {
     window.scrollTo({
       behavior: 'smooth',

--- a/packages/manager/src/features/CloudPulse/Alerts/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/constants.ts
@@ -48,7 +48,7 @@ export const metricOperatorOptions: Item<string, MetricOperatorType>[] = [
     value: 'lte',
   },
   {
-    label: '==',
+    label: '=',
     value: 'eq',
   },
 ];

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -2557,7 +2557,7 @@ export const handlers = [
   ),
   http.get('*/monitor/alert-channels', () => {
     return HttpResponse.json(
-      makeResourcePage(notificationChannelFactory.buildList(3))
+      makeResourcePage(notificationChannelFactory.buildList(7))
     );
   }),
   http.get('*/monitor/services', () => {

--- a/packages/validation/.changeset/pr-11773-upcoming-features-1741023892137.md
+++ b/packages/validation/.changeset/pr-11773-upcoming-features-1741023892137.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Upcoming Features
+---
+
+Added new rule for Name, Description for create alert form ([#11773](https://github.com/linode/manager/pull/11773))

--- a/packages/validation/.changeset/pr-11773-upcoming-features-1741023892137.md
+++ b/packages/validation/.changeset/pr-11773-upcoming-features-1741023892137.md
@@ -2,4 +2,4 @@
 "@linode/validation": Upcoming Features
 ---
 
-Added new rule for Name, Description for create alert form ([#11773](https://github.com/linode/manager/pull/11773))
+Add new rule for Name and Description of Create Alert form ([#11773](https://github.com/linode/manager/pull/11773))

--- a/packages/validation/src/cloudpulse.schema.ts
+++ b/packages/validation/src/cloudpulse.schema.ts
@@ -3,7 +3,7 @@ import { array, number, object, string } from 'yup';
 const fieldErrorMessage = 'This field is required.';
 
 const dimensionFilters = object({
-  dimension_label: string().required('Label for the filter is required.'),
+  dimension_label: string().required(fieldErrorMessage),
   operator: string().required(fieldErrorMessage),
   value: string().required(fieldErrorMessage),
 });
@@ -24,13 +24,29 @@ const triggerConditionValidation = object({
   evaluation_period_seconds: number().required(fieldErrorMessage),
   trigger_occurrences: number()
     .required(fieldErrorMessage)
-    .positive("The value can't be 0.")
-    .typeError(fieldErrorMessage),
+    .positive('Enter a positive value.')
+    .typeError('The value should be a number.'),
 });
 
+const specialStartEndRegex = /^[^a-zA-Z0-9]/;
 export const createAlertDefinitionSchema = object({
-  label: string().required(fieldErrorMessage),
-  description: string().optional(),
+  label: string()
+    .required(fieldErrorMessage)
+    .matches(
+      /^[^*#&+:<>"?@%{}\\\/]+$/,
+      'Name cannot contain special characters: * # & + : < > ? @ % { } \\ /.'
+    )
+    .max(100, 'Name must be 100 characters or less.'),
+  description: string()
+    .max(100, 'Description must be 100 characters or less.')
+    .test(
+      'no-special-start-end',
+      'Description cannot start or end with a special character.',
+      (value) => {
+        return !specialStartEndRegex.test(value ?? '');
+      }
+    )
+    .optional(),
   severity: number().oneOf([0, 1, 2, 3]).required(fieldErrorMessage),
   rule_criteria: object({
     rules: array()
@@ -38,6 +54,8 @@ export const createAlertDefinitionSchema = object({
       .min(1, 'At least one metric criteria is required.'),
   }),
   trigger_conditions: triggerConditionValidation,
-  channel_ids: array(number()),
+  channel_ids: array()
+    .of(number())
+    .min(1, 'At least one notification channel is required.'),
   tags: array().of(string()).notRequired(),
 });

--- a/packages/validation/src/cloudpulse.schema.ts
+++ b/packages/validation/src/cloudpulse.schema.ts
@@ -36,7 +36,14 @@ export const createAlertDefinitionSchema = object({
       /^[^*#&+:<>"?@%{}\\\/]+$/,
       'Name cannot contain special characters: * # & + : < > ? @ % { } \\ /.'
     )
-    .max(100, 'Name must be 100 characters or less.'),
+    .max(100, 'Name must be 100 characters or less.')
+    .test(
+      'no-special-start-end',
+      'Name cannot start or end with a special character.',
+      (value) => {
+        return !specialStartEndRegex.test(value ?? '');
+      }
+    ),
   description: string()
     .max(100, 'Description must be 100 characters or less.')
     .test(


### PR DESCRIPTION
## Description 📝
UI changes across the Alerting feature validations, limits, error messages

## Changes  🔄

List any change(s) relevant to the reviewer.

- Added an error Notice when trying to submit a Create Alert without selecting any Notification Channel
- Added maximum limit of 5 to Metric Threshold, Dimension Filters and Notification Channels.
- Resetting the AddNotificationChannelDrawer when closing or clearing the Drawer
- Resetting the Metric Threshold components when Service is changed
- Fixed the tooltip texts for Evaluation Period and Polling Interval
- Styling changes for mobile screen compatibility and consistency for Metric Threshold and Trigger Condition components
- Added scrollToView to the components when validation or api error messages pop up
- Added scrolling to the top animation for PageChange, PageSizeChange, Order change for AlertListing component
- Fixed the Notification Channel popper component to pop down
- Added extra validation for the text inputs Name and Description in Create/Edit forms: Character Limits and Special Characters checks
- Relevant Test cases to Unit Tests to test the changes
- UI changes to sizes, tags, placeholder text for consistency with mockups

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷
### Placeholder text changes
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-02-20 at 11 04 38](https://github.com/user-attachments/assets/3ba63b91-a6dc-41c4-886a-389d9a2c9957) | ![image](https://github.com/user-attachments/assets/14695084-4873-4186-889f-572e0ea7f3f7)|
|![Screenshot 2025-02-20 at 11 04 51](https://github.com/user-attachments/assets/6db0f944-c5a8-4ca5-8028-6349c1fe7465)| ![image](https://github.com/user-attachments/assets/a749d4b3-89ba-4891-9356-41d713e50152)|
|![Screenshot 2025-02-20 at 11 05 00](https://github.com/user-attachments/assets/35335d5b-6aa2-4bcf-84f4-1485ebf981bd)|![image](https://github.com/user-attachments/assets/eb9ce57f-ba56-4211-a326-9d22250bd5cd)|
---
### Notification Channel Dropdown Popper 
| Before  | After   |
| ------- | ------- |
|![Screenshot 2025-02-20 at 11 05 15](https://github.com/user-attachments/assets/fcb39600-4701-4472-8448-de33ed9a8389)|![image](https://github.com/user-attachments/assets/82790c53-c612-493e-8151-fd13d9b5fbab)|
---
### Heights, Widths for AlertListing component
| Before  | After   |
| ------- | ------- |
|![Screenshot 2025-02-20 at 11 05 28](https://github.com/user-attachments/assets/d8179113-c759-43ff-ba8b-f34cfff1c02e)|![image](https://github.com/user-attachments/assets/1c4d8dc6-2a3c-4939-98e0-137947a40539)|
---
### Limits for Metric Threshold, Dimension Filters, Notifications Channels in Create/Edit forms
| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/48b5f3a3-52c1-4230-8801-2ede21fb2a58)| ![image](https://github.com/user-attachments/assets/64493442-2f8a-4f83-bab4-6d71dfa888a0)|
| ![image](https://github.com/user-attachments/assets/36372e17-7dd7-41a7-a5d8-51dc35a88b9e)| ![image](https://github.com/user-attachments/assets/5a793a76-9739-4a43-9aad-4de5613a44a4)|
| ![image](https://github.com/user-attachments/assets/2931cf66-38ed-4965-9f95-f9258c2f7fb9)| ![image](https://github.com/user-attachments/assets/c59328e3-8a08-4b67-a6a7-28daa8aa5f90)|
---
### Validation error messages for Name, Description fields in Create/Edit forms
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-02-17 at 18 21 51](https://github.com/user-attachments/assets/573280dc-13f8-4c4a-8f69-ac537af1c303) | ![image](https://github.com/user-attachments/assets/5241dded-77f1-490c-ad95-094709d38c40)|
---
### Error Notice for Submitting Create/Edit forms with zero Notification Channels
| Before  | After   |
| ------- | ------- |
|![Screenshot 2025-02-17 at 18 22 00](https://github.com/user-attachments/assets/f54cedf6-5d3c-436c-ae99-786e9988a6fb)|![image](https://github.com/user-attachments/assets/5505fe14-252b-4b25-a391-411d837f0fe8)|

## How to test 🧪

### Prerequisites

(How to setup test environment)
- Login as mock user as some endpoints are not available.
- Navigate to the monitor tab and then to alerts tab

### Verification steps

(How to verify changes)

- [ ] Scrolling to the field for validation errors in Create/Edit forms
- [ ] Scrolling to the top for AlertLanding pagesize, pagechange, order
- [ ] Notification Channel selection Autocomplete popper popping down
- [ ] Notification Channel Drawer component resetting after closing the drawer
- [ ] Metric Threshold component resetting after changing Service
- [ ] Notification Channel Error Notice when Create/Edit form is submitted without any Notification Channel
- [ ] The Add button for Metric Threshold, Dimension filters, Notification channels disabling and showing relevant tool tip texts after 5 of each exist in Create/Edit forms
- [ ] Name, Description validation errors with character limit of 100 and special characters limits

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>