### PR TITLE
fix: [M3-9464] - Linode Backups Drawer styles

### DIFF
--- a/packages/manager/src/features/Backups/AutoEnroll.tsx
+++ b/packages/manager/src/features/Backups/AutoEnroll.tsx
@@ -2,11 +2,11 @@ import {
   FormControlLabel,
   Notice,
   Paper,
+  Stack,
   Toggle,
   Typography,
 } from '@linode/ui';
-import { styled } from '@mui/material/styles';
-import * as React from 'react';
+import React from 'react';
 
 import { Link } from 'src/components/Link';
 
@@ -20,14 +20,17 @@ export const AutoEnroll = (props: AutoEnrollProps) => {
   const { enabled, error, toggle } = props;
 
   return (
-    <StyledPaper>
+    <Paper
+      sx={(theme) => ({ backgroundColor: theme.palette.background.default })}
+      variant="outlined"
+    >
       {error && <Notice text={error} variant="error" />}
-      <StyledFormControlLabel
+      <FormControlLabel
         label={
-          <StyledDiv>
-            <StyledTypography>
+          <Stack spacing={0.5}>
+            <Typography sx={(theme) => ({ font: theme.font.bold })}>
               Auto Enroll All New Linodes in Backups
-            </StyledTypography>
+            </Typography>
             <Typography variant="body1">
               Enroll all future Linodes in backups. Your account will be billed
               the additional hourly rate noted on the{' '}
@@ -39,39 +42,13 @@ export const AutoEnroll = (props: AutoEnrollProps) => {
               </Link>
               .
             </Typography>
-          </StyledDiv>
+          </Stack>
         }
-        control={<Toggle checked={enabled} onChange={toggle} />}
+        checked={enabled}
+        control={<Toggle />}
+        onChange={toggle}
+        sx={{ gap: 1 }}
       />
-    </StyledPaper>
+    </Paper>
   );
 };
-
-const StyledPaper = styled(Paper, {
-  label: 'StyledPaper',
-})(({ theme }) => ({
-  backgroundColor: theme.bg.offWhite,
-  padding: theme.spacing(1),
-}));
-
-const StyledFormControlLabel = styled(FormControlLabel, {
-  label: 'StyledFormControlLabel',
-})(({ theme }) => ({
-  alignItems: 'flex-start',
-  display: 'flex',
-  marginBottom: theme.spacing(1),
-  marginLeft: 0,
-}));
-
-const StyledDiv = styled('div', {
-  label: 'StyledDiv',
-})(({ theme }) => ({
-  marginTop: theme.spacing(1.5),
-}));
-
-const StyledTypography = styled(Typography, {
-  label: 'StyledTypography',
-})(({ theme }) => ({
-  fontSize: 17,
-  marginBottom: theme.spacing(1),
-}));

--- a/packages/manager/src/features/Backups/BackupDrawer.tsx
+++ b/packages/manager/src/features/Backups/BackupDrawer.tsx
@@ -86,8 +86,8 @@ export const BackupDrawer = (props: Props) => {
   const linodeCount = linodesWithoutBackups.length;
 
   const renderBackupsTable = () => {
-    if (linodesLoading || typesLoading || accountSettingsLoading) {
-      return <TableRowLoading columns={3} />;
+    if (linodesLoading || typesLoading || accountSettingsLoading || true) {
+      return <TableRowLoading columns={4} />;
     }
     if (linodesError) {
       return <TableRowError colSpan={4} message={linodesError?.[0]?.reason} />;

--- a/packages/manager/src/features/Backups/BackupDrawer.tsx
+++ b/packages/manager/src/features/Backups/BackupDrawer.tsx
@@ -86,7 +86,7 @@ export const BackupDrawer = (props: Props) => {
   const linodeCount = linodesWithoutBackups.length;
 
   const renderBackupsTable = () => {
-    if (linodesLoading || typesLoading || accountSettingsLoading || true) {
+    if (linodesLoading || typesLoading || accountSettingsLoading) {
       return <TableRowLoading columns={4} />;
     }
     if (linodesError) {


### PR DESCRIPTION
## Description 📝

- Fixes the broken loading state in the Linode Backups Drawer 🔧 
- Fixes the dark mode regressions with the "AutoEnroll" Paper within the Drawer 🔧 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-03-03 at 4 53 29 PM](https://github.com/user-attachments/assets/ab89fc9b-3b77-4e7b-8113-0a21e5ee6fcd) | ![Screenshot 2025-03-03 at 4 53 45 PM](https://github.com/user-attachments/assets/b561647b-4ee1-4de9-8424-84c13fc63bb3) | 

## How to test 🧪

- Check styles of the Linode Backups Drawer
  - Verify it looks good in both light and dark mode
  - Verify the loading state looks good and is not broken

> [!note] 
> This drawer is only openable under certain condtitions
> https://github.com/linode/manager/blob/deb8915f89528523a26954a017d0c8b377b69314/packages/manager/src/features/Backups/BackupsCTA.tsx#L37-L44
> ![Screenshot 2025-03-03 at 5 01 54 PM](https://github.com/user-attachments/assets/40311a2d-9dad-4d9d-9bee-852264be02e4)

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>