### PR TITLE
fix: [M3-9415] - NodeBalancer Create Summary broken dividers and spacing

### DIFF
--- a/packages/manager/.changeset/pr-11779-fixed-1741096736423.md
+++ b/packages/manager/.changeset/pr-11779-fixed-1741096736423.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+NodeBalancer Create Summary broken dividers and spacing ([#11779](https://github.com/linode/manager/pull/11779))

--- a/packages/manager/src/components/CheckoutSummary/CheckoutSummary.tsx
+++ b/packages/manager/src/components/CheckoutSummary/CheckoutSummary.tsx
@@ -51,11 +51,7 @@ export const CheckoutSummary = (props: CheckoutSummaryProps) => {
           Please configure your Linode.
         </StyledHeading>
       ) : null}
-      <StyledSummary
-        container
-        direction={matchesSmDown ? 'column' : 'row'}
-        spacing={3}
-      >
+      <StyledSummary container direction={matchesSmDown ? 'column' : 'row'}>
         {displaySections.map((item) => (
           <SummaryItem key={`${item.title}-${item.details}`} {...item} />
         ))}
@@ -78,10 +74,12 @@ const StyledHeading = styled(Typography)(({ theme }) => ({
 const StyledSummary = styled(Grid2)(({ theme }) => ({
   [theme.breakpoints.up('md')]: {
     '& > div': {
-      '&:last-child': {
-        borderRight: 'none',
+      '&:first-child': {
+        borderLeft: 'none',
+        paddingLeft: 0,
       },
-      borderRight: `solid 1px ${theme.tokens.color.Neutrals[50]}`,
+      borderLeft: `solid 1px ${theme.tokens.color.Neutrals[50]}`,
+      padding: `0 ${theme.spacing(1.5)}`,
     },
   },
 }));


### PR DESCRIPTION
## Description 📝

A small, quick PR to fix the NodeBalancer Create Summary broken dividers and spacing.

- The Summary on the NodeBalancer create page is messed up. 
- Linode Create is not affected because it has its own custom summary component.

- How to reproduce:
  - Go to the NodeBalancers landing page in the dev environment or on dev branch locally
  - Observe broken summary spacing at bottom of page

## Changes  🔄
- Fixed NodeBalancer Create Summary broken dividers and spacing

## Target release date 🗓️
N/A

## Preview 📷

| Before (on dev)  | After   |
| ------- | ------- |
| ![Screenshot 2025-03-04 at 7 19 30 PM](https://github.com/user-attachments/assets/7f41aab9-8c3b-427e-82b3-33cfc83cfa5d) | ![Screenshot 2025-03-04 at 7 18 10 PM](https://github.com/user-attachments/assets/f049c681-1af1-4727-9d28-9454e0879f5c) |
| ![Screenshot 2025-03-04 at 7 19 43 PM](https://github.com/user-attachments/assets/13c6e0db-e1c0-438a-865e-caf70aa816b2) | ![Screenshot 2025-03-04 at 7 18 32 PM](https://github.com/user-attachments/assets/386d1d9c-582b-48ef-aefc-2eae95e81b5c) | 


## How to test 🧪
- Go to preview branch or checkout this branch locally
- Ensure there is no broken summary spacing at bottom of page

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules