### PR TITLE
change: [M3-9460] - RegionSelect placement group tooltiptext copy

### DIFF
--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -1194,7 +1194,9 @@ describe('LKE Cluster Creation with LKE-E', () => {
 
       // Confirm that there is a tooltip explanation for the region dropdown options
       ui.tooltip
-        .findByText('Only regions that support placement groups are listed.')
+        .findByText(
+          'Only regions that support LKE Enterprise clusters are listed.'
+        )
         .should('be.visible');
 
       // Selects an enterprise version

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -400,7 +400,7 @@ export const CreateCluster = () => {
                 tooltipText={
                   isLkeEnterpriseLAFeatureEnabled &&
                   selectedTier === 'enterprise'
-                    ? 'Only regions that support placement groups are listed.'
+                    ? 'Only regions that support LKE Enterprise clusters are listed.'
                     : undefined
                 }
                 disableClearable


### PR DESCRIPTION
## Description 📝

Currently, the copy in the help tooltip for PG creation Region selection is: "Only Linode data center regions that support placement groups are listed."

While finalizing the copy for LKE-E Region selection, which takes the same help tooltip approach, Tech Docs has recommended the copy: "Only regions that support LKE Enterprise clusters are listed." UX would like the PG tooltip to be consistent.

The new PG creation Region selection tooltip copy would be:

"Only regions that support placement groups are listed."

## Changes  🔄
- Update RegionSelect placement group tooltiptext copy for PG


## Target release date 🗓️
N/A


## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-03-06 at 5 51 47 PM](https://github.com/user-attachments/assets/4a3d0d56-fec0-4b27-8b17-4b329854e6eb) | ![Screenshot 2025-03-06 at 5 45 07 PM](https://github.com/user-attachments/assets/eb1bf6a0-74eb-47e5-9198-a05d8cb1bac0)|


## How to test 🧪

- Ensure PG and LKE-E Region selection tooltip copy are consistent

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules