### PR TITLE
test: [M3-9152] - Cypress test for LKE create page for restricted users

### DIFF
--- a/packages/manager/.changeset/pr-11793-tests-1741276889132.md
+++ b/packages/manager/.changeset/pr-11793-tests-1741276889132.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add Cypress test for LKE create page for restricted users ([#11793](https://github.com/linode/manager/pull/11793))

--- a/packages/manager/cypress/e2e/core/kubernetes/smoke-lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/smoke-lke-create.spec.ts
@@ -1,4 +1,14 @@
-import { kubernetesClusterFactory } from '@src/factories';
+import {
+  accountUserFactory,
+  grantsFactory,
+  kubernetesClusterFactory,
+  profileFactory,
+} from '@src/factories';
+import {
+  mockGetProfile,
+  mockGetProfileGrants,
+} from 'support/intercepts/profile';
+import { mockGetUser } from 'support/intercepts/account';
 import { randomLabel, randomNumber } from 'support/util/random';
 import { mockCreateCluster } from 'support/intercepts/lke';
 import { ui } from 'support/ui';
@@ -95,5 +105,69 @@ describe('LKE Create Cluster', () => {
       'endWith',
       `/kubernetes/clusters/${mockCluster.id}/summary`
     );
+  });
+
+  it('should not allow creating cluster for restricted users', () => {
+    // Mock setup for user profile, account user, and user grants with restricted permissions,
+    // simulating a default user without the ability to add Linodes.
+    const mockProfile = profileFactory.build({
+      username: randomLabel(),
+      restricted: true,
+    });
+
+    const mockUser = accountUserFactory.build({
+      username: mockProfile.username,
+      restricted: true,
+      user_type: 'default',
+    });
+
+    const mockGrants = grantsFactory.build({
+      global: {
+        add_kubernetes: false,
+      },
+    });
+
+    const mockCluster = kubernetesClusterFactory.build({
+      label: randomLabel(),
+      id: randomNumber(10000, 99999),
+    });
+
+    mockGetProfile(mockProfile);
+    mockGetProfileGrants(mockGrants);
+    mockGetUser(mockUser);
+    mockCreateCluster(mockCluster).as('createCluster');
+
+    cy.visitWithLogin('/kubernetes/create');
+    cy.findByText('Add Node Pools').should('be.visible');
+
+    // Confirm that a notice should be shown informing the user they do not have permission to create a Cluster.
+    cy.findByText(
+      "You don't have permissions to create LKE Clusters. Please contact your account administrator to request the necessary permissions."
+    ).should('be.visible');
+
+    // Confirm that "Cluster Label" field is disabled.
+    cy.findByLabelText('Cluster Label')
+      .should('be.visible')
+      .should('be.disabled');
+
+    // Confirm that "Region" field is disabled.
+    ui.regionSelect.find().should('be.visible').should('be.disabled');
+
+    // Confirm that "Kubernetes Version" field is disabled.
+    cy.get('[data-qa-autocomplete="Kubernetes Version"] input')
+      .should('be.visible')
+      .should('be.disabled');
+
+    // Confirm that "HA" field is disabled.
+    cy.get('[data-testid="ha-radio-button-yes"]').should('be.visible').click();
+    cy.get('[data-testid="ha-radio-button-yes"]').should('not.be.checked');
+
+    cy.get('[data-testid="kube-checkout-bar"]').within(() => {
+      // Confirm that "Create Cluster" field is disabled.
+      ui.button
+        .findByTitle('Create Cluster')
+        .should('be.visible')
+        .should('be.disabled');
+    });
   });
 });


### PR DESCRIPTION
## Description 📝
Add test to check the warning message and disabled fields in LKE cluster create page for restricted users

## Major Changes 🔄
- Add test to check the disabled fields on `/kubernetes/create` page

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/kubernetes/smoke-lke-create.spec.ts"
```