### PR TITLE
fix: [M3-9478] - `Add an SSH Key` button spacing

### DIFF
--- a/packages/manager/.changeset/pr-11800-fixed-1741298651535.md
+++ b/packages/manager/.changeset/pr-11800-fixed-1741298651535.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+`Add an SSH Key` button spacing ([#11800](https://github.com/linode/manager/pull/11800))

--- a/packages/manager/src/features/Profile/SSHKeys/DeleteSSHKeyDialog.test.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/DeleteSSHKeyDialog.test.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { HttpResponse, http, server } from 'src/mocks/testServer';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
-import DeleteSSHKeyDialog from './DeleteSSHKeyDialog';
+import { DeleteSSHKeyDialog } from './DeleteSSHKeyDialog';
 
 const props = {
   id: 0,

--- a/packages/manager/src/features/Profile/SSHKeys/DeleteSSHKeyDialog.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/DeleteSSHKeyDialog.tsx
@@ -12,7 +12,7 @@ interface Props {
   open: boolean;
 }
 
-const DeleteSSHKeyDialog = ({ id, label, onClose, open }: Props) => {
+export const DeleteSSHKeyDialog = ({ id, label, onClose, open }: Props) => {
   const { error, isPending, mutateAsync } = useDeleteSSHKeyMutation(id);
 
   const onDelete = async () => {
@@ -46,5 +46,3 @@ const DeleteSSHKeyDialog = ({ id, label, onClose, open }: Props) => {
     </ConfirmationDialog>
   );
 };
-
-export default React.memo(DeleteSSHKeyDialog);

--- a/packages/manager/src/features/Profile/SSHKeys/EditSSHKeyDrawer.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/EditSSHKeyDrawer.tsx
@@ -17,7 +17,7 @@ interface Props {
   sshKey: SSHKey | undefined;
 }
 
-const EditSSHKeyDrawer = ({ onClose, open, sshKey }: Props) => {
+export const EditSSHKeyDrawer = ({ onClose, open, sshKey }: Props) => {
   const { enqueueSnackbar } = useSnackbar();
   const {
     error,
@@ -84,5 +84,3 @@ const EditSSHKeyDrawer = ({ onClose, open, sshKey }: Props) => {
     </Drawer>
   );
 };
-
-export default React.memo(EditSSHKeyDrawer);

--- a/packages/manager/src/features/Profile/SSHKeys/SSHKeyActionMenu.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/SSHKeyActionMenu.tsx
@@ -17,5 +17,3 @@ export const SSHKeyActionMenu = (props: Props) => {
     </>
   );
 };
-
-export default SSHKeyActionMenu;

--- a/packages/manager/src/features/Profile/SSHKeys/SSHKeys.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/SSHKeys.tsx
@@ -1,6 +1,4 @@
-import { Button, Typography } from '@linode/ui';
-import { styled } from '@mui/material/styles';
-import Grid from '@mui/material/Grid2';
+import { Box, Button, Stack, Typography } from '@linode/ui';
 import { createLazyRoute } from '@tanstack/react-router';
 import * as React from 'react';
 
@@ -15,15 +13,15 @@ import { TableRow } from 'src/components/TableRow';
 import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
 import { TableRowError } from 'src/components/TableRowError/TableRowError';
 import { TableRowLoading } from 'src/components/TableRowLoading/TableRowLoading';
-import DeleteSSHKeyDialog from 'src/features/Profile/SSHKeys/DeleteSSHKeyDialog';
-import SSHKeyActionMenu from 'src/features/Profile/SSHKeys/SSHKeyActionMenu';
+import { DeleteSSHKeyDialog } from 'src/features/Profile/SSHKeys/DeleteSSHKeyDialog';
+import { SSHKeyActionMenu } from 'src/features/Profile/SSHKeys/SSHKeyActionMenu';
 import { usePagination } from 'src/hooks/usePagination';
 import { useSSHKeysQuery } from 'src/queries/profile/profile';
 import { parseAPIDate } from 'src/utilities/date';
 import { getSSHKeyFingerprint } from 'src/utilities/ssh-fingerprint';
 
 import { CreateSSHKeyDrawer } from './CreateSSHKeyDrawer';
-import EditSSHKeyDrawer from './EditSSHKeyDrawer';
+import { EditSSHKeyDrawer } from './EditSSHKeyDrawer';
 
 const PREFERENCE_KEY = 'ssh-keys';
 
@@ -95,27 +93,16 @@ export const SSHKeys = () => {
   }, [data, error, isLoading]);
 
   return (
-    <>
+    <Stack spacing={1}>
       <DocumentTitleSegment segment="SSH Keys" />
-      <Grid
-        container
-        spacing={2}
-        sx={{
-          alignItems: 'flex-end',
-          justifyContent: 'flex-end',
-          margin: 0,
-          width: '100%',
-        }}
-      >
-        <StyledAddNewWrapperGridItem>
-          <Button
-            buttonType="primary"
-            onClick={() => setIsCreateDrawerOpen(true)}
-          >
-            Add an SSH Key
-          </Button>
-        </StyledAddNewWrapperGridItem>
-      </Grid>
+      <Box display="flex" justifyContent="flex-end">
+        <Button
+          buttonType="primary"
+          onClick={() => setIsCreateDrawerOpen(true)}
+        >
+          Add an SSH Key
+        </Button>
+      </Box>
       <Table>
         <TableHead>
           <TableRow>
@@ -152,18 +139,9 @@ export const SSHKeys = () => {
         onClose={() => setIsCreateDrawerOpen(false)}
         open={isCreateDrawerOpen}
       />
-    </>
+    </Stack>
   );
 };
-
-const StyledAddNewWrapperGridItem = styled(Grid)(({ theme }) => ({
-  paddingRight: 0,
-  paddingTop: 0,
-
-  [theme.breakpoints.down('md')]: {
-    marginRight: theme.spacing(),
-  },
-}));
 
 export const SSHKeysLazyRoute = createLazyRoute('/profile/keys')({
   component: SSHKeys,


### PR DESCRIPTION
## Description 📝

- Fixes spacing below the `Add an SSH Key` button
- I think this was caused by #11688 
- Cleans up some default exports and styled components too 🧹 

> [!note]
> I opted to not add any X-axis spacing on smaller viewports like we've done in some places in the app.
> - I did this because
>   - I prefer writing less one-off styles
>   - Our landing pages don't have X padding on small viewports. For example, the Linodes landing page
>      ![Screenshot 2025-03-06 at 5 01 46 PM](https://github.com/user-attachments/assets/0427c178-301f-4297-b4d4-01ef89b741c3)
> 
> Let me know if you object to this, we can talk about it in cafe

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-03-06 at 4 56 31 PM](https://github.com/user-attachments/assets/c65b1a7a-0e2e-4463-a1c9-3019fc087127) | ![Screenshot 2025-03-06 at 4 56 37 PM](https://github.com/user-attachments/assets/872004e1-a950-493d-8551-5462480bff1d) |

## How to test 🧪

- Go to http://localhost:3000/profile/keys
- Verify spacing looks good between button and table

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
