### PR TITLE
refactor: [M3-9493] – Streamline/simplify LDE logic

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -68,7 +68,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fix CloudPulse test failures triggered by new notice ([#11728](https://github.com/linode/manager/pull/11728))
 - Remove Cypress test assertion involving Login app text ([#11737](https://github.com/linode/manager/pull/11737))
 - Delete region test suite ([#11780](https://github.com/linode/manager/pull/11780))
-- Revise LDE-related logic in unit tests for EnableBackupsDialog and NodeTable and in E2E test for Linode Create ([#11783](https://github.com/linode/manager/pull/11783))
 
 ### Upcoming Features:
 
@@ -91,7 +90,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fix LKE-E provisioning placeholder when filtering by status ([#11745](https://github.com/linode/manager/pull/11745))
 - Enable ACL by default for LKE-E clusters ([#11746](https://github.com/linode/manager/pull/11746))
 - Improve UX of CloudPulse Alerts create flow and resources section ([#11748](https://github.com/linode/manager/pull/11748))
-- Revise logic governing display of LDE sections and data ([#11783](https://github.com/linode/manager/pull/11783))
 - Fix CloudPulse document titles with appropriate keywords (#11662)
 - Update LKE checkout bar & NodeBalancer details summary ([#11653](https://github.com/linode/manager/pull/11653))
 

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-disk-encryption.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-disk-encryption.spec.ts
@@ -28,7 +28,7 @@ import {
 import type { Region } from '@linode/api-v4';
 
 describe('Create Linode with Disk Encryption', () => {
-  it('should not have a "Disk Encryption" section visible if the feature flag is off, user does not have capability, and the selected region does not support LDE', () => {
+  it('should not have a "Disk Encryption" section visible if the feature flag is off and user does not have capability', () => {
     // Mock feature flag -- @TODO LDE: Remove feature flag once LDE is fully rolled out
     mockAppendFeatureFlags({
       linodeDiskEncryption: makeFeatureFlagData(false),
@@ -41,23 +41,9 @@ describe('Create Linode with Disk Encryption', () => {
 
     mockGetAccount(mockAccount).as('getAccount');
 
-    // Mock regions response
-    const mockRegion = regionFactory.build({
-      capabilities: ['Linodes'],
-    });
-
-    const mockRegions = [mockRegion];
-
-    mockGetRegions(mockRegions);
-
     // intercept request
     cy.visitWithLogin('/linodes/create');
     cy.wait(['@getFeatureFlags', '@getAccount']);
-
-    ui.regionSelect.find().click();
-    ui.regionSelect
-      .findItemByRegionLabel(mockRegion.label, mockRegions)
-      .click();
 
     // Check if section is visible
     cy.get(`[data-testid=${headerTestId}]`).should('not.exist');
@@ -108,54 +94,6 @@ describe('Create Linode with Disk Encryption', () => {
       .click();
 
     cy.get(`[data-testid="${checkboxTestId}"]`).should('be.enabled');
-  });
-
-  it('should have a "Disk Encryption" section visible if the feature flag is off, user does not have the capability, but the selected region has the "Disk Encryption" capability', () => {
-    // Situation where LDE is in GA in the selected region/DC
-
-    // Mock feature flag -- @TODO LDE: Remove feature flag once LDE is fully rolled out
-    mockAppendFeatureFlags({
-      linodeDiskEncryption: makeFeatureFlagData(false),
-    }).as('getFeatureFlags');
-
-    // Mock account response
-    const mockAccount = accountFactory.build({
-      capabilities: ['Linodes'],
-    });
-
-    const mockRegion = regionFactory.build({
-      capabilities: ['Linodes', 'Disk Encryption'],
-    });
-
-    const mockRegionWithoutDiskEncryption = regionFactory.build({
-      capabilities: ['Linodes'],
-    });
-
-    const mockRegions = [mockRegion, mockRegionWithoutDiskEncryption];
-
-    mockGetAccount(mockAccount).as('getAccount');
-    mockGetRegions(mockRegions);
-
-    // intercept request
-    cy.visitWithLogin('/linodes/create');
-    cy.wait(['@getFeatureFlags', '@getAccount']);
-
-    // "Disk Encryption" section should not be visible if a region that does not support LDE is selected
-    ui.regionSelect.find().click();
-    ui.regionSelect
-      .findItemByRegionLabel(mockRegionWithoutDiskEncryption.label, mockRegions)
-      .click();
-
-    cy.get(`[data-testid="${headerTestId}"]`).should('not.exist');
-
-    // "Disk Encryption" section should be visible if a region that supports LDE is selected
-    ui.regionSelect.find().click();
-    ui.regionSelect
-      .findItemByRegionLabel(mockRegion.label, mockRegions)
-      .click();
-
-    cy.get(`[data-testid="${headerTestId}"]`).should('exist');
-    cy.get(`[data-testid="${checkboxTestId}"]`).should('be.enabled'); // "Encrypt Disk" checkbox should be enabled
   });
 
   // Confirm Linode Disk Encryption features when using Distributed Regions.

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -41,7 +41,6 @@ interface Props {
   openRecycleAllNodesDialog: (poolId: number) => void;
   openRecycleNodeDialog: (nodeID: string, linodeLabel: string) => void;
   poolId: number;
-  regionSupportsDiskEncryption: boolean;
   statusFilter: StatusFilter;
   tags: string[];
   typeLabel: string;
@@ -67,7 +66,6 @@ export const NodePool = (props: Props) => {
     openRecycleNodeDialog,
     poolId,
     statusFilter,
-    regionSupportsDiskEncryption,
     tags,
     typeLabel,
   } = props;
@@ -229,7 +227,6 @@ export const NodePool = (props: Props) => {
         nodes={nodes}
         openRecycleNodeDialog={openRecycleNodeDialog}
         poolId={poolId}
-        regionSupportsDiskEncryption={regionSupportsDiskEncryption}
         statusFilter={statusFilter}
         tags={tags}
         typeLabel={typeLabel}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -143,11 +143,6 @@ export const NodePoolsDisplay = (props: Props) => {
     setExpandedAccordions,
   } = useDefaultExpandedNodePools(clusterID, _pools);
 
-  const regionSupportsDiskEncryption =
-    regionsData
-      .find((regionDatum) => regionDatum.id === clusterRegionId)
-      ?.capabilities.includes('Disk Encryption') ?? false;
-
   if (isLoading || pools === undefined) {
     return <CircleProgress />;
   }
@@ -307,7 +302,6 @@ export const NodePoolsDisplay = (props: Props) => {
               key={id}
               nodes={nodes ?? []}
               poolId={thisPool.id}
-              regionSupportsDiskEncryption={regionSupportsDiskEncryption}
               statusFilter={statusFilter}
               tags={tags}
               typeLabel={typeLabel}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.test.tsx
@@ -34,7 +34,6 @@ const props: Props = {
   nodes: mockKubeNodes,
   openRecycleNodeDialog: vi.fn(),
   poolId: 1,
-  regionSupportsDiskEncryption: false,
   statusFilter: 'all',
   tags: [],
   typeLabel: 'Linode 2G',
@@ -113,27 +112,12 @@ describe('NodeTable', () => {
     ).toBeVisible();
   });
 
-  it('does not display the encryption status of the pool if the account lacks the capability or the feature flag is off, and the region does not have the capability', () => {
-    // situation where isDiskEncryptionFeatureEnabled === false and prop regionSupportsDiskEncryption === false
+  it('does not display the encryption status of the pool if the account lacks the capability or the feature flag is off', () => {
+    // situation where isDiskEncryptionFeatureEnabled === false
     const { queryByTestId } = renderWithTheme(<NodeTable {...props} />);
     const encryptionStatusFragment = queryByTestId(encryptionStatusTestId);
 
     expect(encryptionStatusFragment).not.toBeInTheDocument();
-  });
-
-  it('displays the encryption status of the pool if the cluster region supports Disk Encryption but the feature flag is off and the account does not have the capability', () => {
-    // situation where isDiskEncryptionFeatureEnabled === false but the region the cluster is in supports LDE
-    const propsWithRegionSupportingLDE = {
-      ...props,
-      regionSupportsDiskEncryption: true,
-    };
-
-    const { queryByTestId } = renderWithTheme(
-      <NodeTable {...propsWithRegionSupportingLDE} />
-    );
-    const encryptionStatusFragment = queryByTestId(encryptionStatusTestId);
-
-    expect(encryptionStatusFragment).toBeInTheDocument();
   });
 
   it('displays the encryption status of the pool if the feature flag is on and the account has the capability', () => {

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -51,7 +51,6 @@ export interface Props {
   nodes: PoolNodeResponse[];
   openRecycleNodeDialog: (nodeID: string, linodeLabel: string) => void;
   poolId: number;
-  regionSupportsDiskEncryption: boolean;
   statusFilter: StatusFilter;
   tags: string[];
   typeLabel: string;
@@ -68,7 +67,6 @@ export const NodeTable = React.memo((props: Props) => {
     nodes,
     openRecycleNodeDialog,
     poolId,
-    regionSupportsDiskEncryption,
     statusFilter,
     tags,
     typeLabel,
@@ -258,8 +256,7 @@ export const NodeTable = React.memo((props: Props) => {
               />
               <StyledTableFooter>
                 <StyledPoolInfoBox>
-                  {(isDiskEncryptionFeatureEnabled ||
-                    regionSupportsDiskEncryption) &&
+                  {isDiskEncryptionFeatureEnabled &&
                   encryptionStatus !== undefined ? (
                     <Box
                       alignItems="center"

--- a/packages/manager/src/features/Linodes/LinodeCreate/Region.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Region.tsx
@@ -92,10 +92,6 @@ export const Region = React.memo(() => {
 
     field.onChange(region.id);
 
-    const regionSupportsDiskEncryption = region.capabilities.includes(
-      'Disk Encryption'
-    );
-
     if (values.hasSignedEUAgreement) {
       // Reset the EU agreement checkbox if they checked it so they have to re-agree when they change regions
       setValue('hasSignedEUAgreement', false);
@@ -142,13 +138,15 @@ export const Region = React.memo(() => {
       setValue('private_ip', false);
     }
 
-    if (isDiskEncryptionFeatureEnabled || regionSupportsDiskEncryption) {
+    if (isDiskEncryptionFeatureEnabled) {
       if (region.site_type === 'distributed') {
         // If a distributed region is selected, make sure we don't send disk_encryption in the payload.
         setValue('disk_encryption', undefined);
       } else {
         // Enable disk encryption by default if the region supports it
-        const defaultDiskEncryptionValue = regionSupportsDiskEncryption
+        const defaultDiskEncryptionValue = region.capabilities.includes(
+          'Disk Encryption'
+        )
           ? 'enabled'
           : undefined;
 

--- a/packages/manager/src/features/Linodes/LinodeCreate/Security.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Security.tsx
@@ -93,7 +93,7 @@ export const Security = () => {
         control={control}
         name="authorized_users"
       />
-      {(isDiskEncryptionFeatureEnabled || regionSupportsDiskEncryption) && (
+      {isDiskEncryptionFeatureEnabled && (
         <>
           <Divider spacingBottom={20} spacingTop={24} />
           <Controller

--- a/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
@@ -90,11 +90,6 @@ export const LinodeEntityDetail = (props: Props) => {
     linode.region
   );
 
-  const regionSupportsDiskEncryption =
-    regions
-      ?.find((r) => r.id === linode.region)
-      ?.capabilities.includes('Disk Encryption') ?? false;
-
   let progress;
   let transitionText;
 
@@ -137,7 +132,6 @@ export const LinodeEntityDetail = (props: Props) => {
             numCPUs={linode.specs.vcpus}
             numVolumes={numberOfVolumes}
             region={linode.region}
-            regionSupportsDiskEncryption={regionSupportsDiskEncryption}
             vpcLinodeIsAssignedTo={vpcLinodeIsAssignedTo}
           />
         }

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
@@ -82,7 +82,6 @@ export interface BodyProps {
   numCPUs: number;
   numVolumes: number;
   region: string;
-  regionSupportsDiskEncryption: boolean;
   vpcLinodeIsAssignedTo?: VPC;
 }
 
@@ -106,7 +105,6 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
     numCPUs,
     numVolumes,
     region,
-    regionSupportsDiskEncryption,
     vpcLinodeIsAssignedTo,
   } = props;
 
@@ -132,8 +130,7 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
 
   // @TODO LDE: Remove usages of this variable once LDE is fully rolled out (being used to determine formatting adjustments currently)
   const isDisplayingEncryptedStatus =
-    (isDiskEncryptionFeatureEnabled || regionSupportsDiskEncryption) &&
-    Boolean(encryptionStatus);
+    isDiskEncryptionFeatureEnabled && Boolean(encryptionStatus);
 
   // Filter and retrieve subnets associated with a specific Linode ID
   const linodeAssociatedSubnets = vpcLinodeIsAssignedTo?.subnets.filter(
@@ -237,26 +234,25 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
                 )}
               </Box>
             </Grid>
-            {(isDiskEncryptionFeatureEnabled || regionSupportsDiskEncryption) &&
-              encryptionStatus && (
-                <Grid>
-                  <Box
-                    alignItems="center"
-                    data-testid={encryptionStatusTestId}
-                    display="flex"
-                    flexDirection="row"
-                  >
-                    <EncryptedStatus
-                      tooltipText={
-                        isLKELinode
-                          ? UNENCRYPTED_LKE_LINODE_GUIDANCE_COPY
-                          : UNENCRYPTED_STANDARD_LINODE_GUIDANCE_COPY
-                      }
-                      encryptionStatus={encryptionStatus}
-                    />
-                  </Box>
-                </Grid>
-              )}
+            {isDiskEncryptionFeatureEnabled && encryptionStatus && (
+              <Grid>
+                <Box
+                  alignItems="center"
+                  data-testid={encryptionStatusTestId}
+                  display="flex"
+                  flexDirection="row"
+                >
+                  <EncryptedStatus
+                    tooltipText={
+                      isLKELinode
+                        ? UNENCRYPTED_LKE_LINODE_GUIDANCE_COPY
+                        : UNENCRYPTED_STANDARD_LINODE_GUIDANCE_COPY
+                    }
+                    encryptionStatus={encryptionStatus}
+                  />
+                </Box>
+              </Grid>
+            )}
           </StyledSummaryGrid>
         </Grid>
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/EnableBackupsDialog.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/EnableBackupsDialog.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { DISK_ENCRYPTION_BACKUPS_CAVEAT_COPY } from 'src/components/Encryption/constants';
-import { linodeFactory, regionFactory } from 'src/factories';
+import { linodeFactory } from 'src/factories';
 import { typeFactory } from 'src/factories/types';
 import { PRICES_RELOAD_ERROR_NOTICE_TEXT } from 'src/utilities/pricing/constants';
 import { renderWithTheme } from 'src/utilities/testHelpers';
@@ -9,30 +9,13 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 import { EnableBackupsDialog } from './EnableBackupsDialog';
 
 const queryMocks = vi.hoisted(() => ({
-  useIsDiskEncryptionFeatureEnabled: vi.fn().mockReturnValue({
-    isDiskEncryptionFeatureEnabled: undefined,
-  }),
   useLinodeQuery: vi.fn().mockReturnValue({
     data: undefined,
-  }),
-  useRegionsQuery: vi.fn().mockReturnValue({
-    data: [],
   }),
   useTypeQuery: vi.fn().mockReturnValue({
     data: undefined,
   }),
 }));
-
-vi.mock('src/components/Encryption/utils.ts', async () => {
-  const actual = await vi.importActual<any>(
-    'src/components/Encryption/utils.ts'
-  );
-  return {
-    ...actual,
-    useIsDiskEncryptionFeatureEnabled:
-      queryMocks.useIsDiskEncryptionFeatureEnabled,
-  };
-});
 
 vi.mock('src/queries/linodes/linodes', async () => {
   const actual = await vi.importActual('src/queries/linodes/linodes');
@@ -42,19 +25,17 @@ vi.mock('src/queries/linodes/linodes', async () => {
   };
 });
 
-vi.mock('src/queries/regions/regions', async () => {
-  const actual = await vi.importActual('src/queries/regions/regions');
-  return {
-    ...actual,
-    useRegionsQuery: queryMocks.useRegionsQuery,
-  };
-});
-
 vi.mock('src/queries/types', async () => {
   const actual = await vi.importActual('src/queries/types');
   return {
     ...actual,
     useTypeQuery: queryMocks.useTypeQuery,
+  };
+});
+
+const diskEncryptionEnabledMock = vi.hoisted(() => {
+  return {
+    useIsDiskEncryptionFeatureEnabled: vi.fn(),
   };
 });
 
@@ -81,6 +62,23 @@ describe('EnableBackupsDialog component', () => {
         label: 'Mock Linode Type',
       }),
     });
+  });
+
+  vi.mock('src/components/Encryption/utils.ts', async () => {
+    const actual = await vi.importActual<any>(
+      'src/components/Encryption/utils.ts'
+    );
+    return {
+      ...actual,
+      __esModule: true,
+      useIsDiskEncryptionFeatureEnabled: diskEncryptionEnabledMock.useIsDiskEncryptionFeatureEnabled.mockImplementation(
+        () => {
+          return {
+            isDiskEncryptionFeatureEnabled: false, // indicates the feature flag is off or account capability is absent
+          };
+        }
+      ),
+    };
   });
 
   it('Displays the monthly backup price', async () => {
@@ -162,25 +160,7 @@ describe('EnableBackupsDialog component', () => {
     expect(getByTestId('confirm-enable-backups')).toBeDisabled();
   });
 
-  it('does not display a notice regarding Backups not being encrypted if the Disk Encryption feature is disabled and the region the linode is in does not support LDE', () => {
-    queryMocks.useLinodeQuery.mockReturnValue({
-      data: linodeFactory.build({
-        id: 1,
-        label: 'Mock Linode',
-        region: 'us-east',
-        type: 'mock-linode-type',
-      }),
-    });
-
-    queryMocks.useRegionsQuery.mockReturnValue({
-      data: [
-        regionFactory.build({
-          capabilities: [],
-          id: 'us-east',
-        }),
-      ],
-    });
-
+  it('does not display a notice regarding Backups not being encrypted if the Disk Encryption feature is disabled', () => {
     const { queryByText } = renderWithTheme(
       <EnableBackupsDialog linodeId={1} onClose={vi.fn()} open={true} />
     );
@@ -193,11 +173,13 @@ describe('EnableBackupsDialog component', () => {
   });
 
   it('displays a notice regarding Backups not being encrypted if the Disk Encryption feature is enabled', () => {
-    queryMocks.useIsDiskEncryptionFeatureEnabled.mockImplementationOnce(() => {
-      return {
-        isDiskEncryptionFeatureEnabled: true,
-      };
-    });
+    diskEncryptionEnabledMock.useIsDiskEncryptionFeatureEnabled.mockImplementationOnce(
+      () => {
+        return {
+          isDiskEncryptionFeatureEnabled: true,
+        };
+      }
+    );
 
     const { queryByText } = renderWithTheme(
       <EnableBackupsDialog linodeId={1} onClose={vi.fn()} open={true} />
@@ -208,39 +190,7 @@ describe('EnableBackupsDialog component', () => {
     );
 
     expect(encryptionBackupsCaveatNotice).toBeInTheDocument();
-  });
 
-  it('displays a notice regarding Backups not being encrypted if the Disk Encryption feature is disabled but the region the linode is in supports LDE', () => {
-    queryMocks.useLinodeQuery.mockReturnValue({
-      data: linodeFactory.build({
-        id: 1,
-        label: 'Mock Linode',
-        region: 'us-east',
-        type: 'mock-linode-type',
-      }),
-    });
-
-    queryMocks.useRegionsQuery.mockReturnValue({
-      data: [
-        regionFactory.build({
-          capabilities: ['Disk Encryption'],
-          id: 'us-east',
-        }),
-      ],
-    });
-
-    queryMocks.useIsDiskEncryptionFeatureEnabled.mockReturnValue({
-      isDiskEncryptionFeatureEnabled: false,
-    });
-
-    const { queryByText } = renderWithTheme(
-      <EnableBackupsDialog linodeId={1} onClose={vi.fn()} open={true} />
-    );
-
-    const encryptionBackupsCaveatNotice = queryByText(
-      DISK_ENCRYPTION_BACKUPS_CAVEAT_COPY
-    );
-
-    expect(encryptionBackupsCaveatNotice).toBeInTheDocument();
+    diskEncryptionEnabledMock.useIsDiskEncryptionFeatureEnabled.mockRestore();
   });
 });

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/EnableBackupsDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/EnableBackupsDialog.tsx
@@ -10,7 +10,6 @@ import { useIsDiskEncryptionFeatureEnabled } from 'src/components/Encryption/uti
 import { useEventsPollingActions } from 'src/queries/events/events';
 import { useLinodeBackupsEnableMutation } from 'src/queries/linodes/backups';
 import { useLinodeQuery } from 'src/queries/linodes/linodes';
-import { useRegionsQuery } from 'src/queries/regions/regions';
 import { useTypeQuery } from 'src/queries/types';
 import { getMonthlyBackupsPrice } from 'src/utilities/pricing/backups';
 import { PRICES_RELOAD_ERROR_NOTICE_TEXT } from 'src/utilities/pricing/constants';
@@ -43,17 +42,9 @@ export const EnableBackupsDialog = (props: Props) => {
     Boolean(linode?.type)
   );
 
-  const { data: regions } = useRegionsQuery();
-
   const {
     isDiskEncryptionFeatureEnabled,
   } = useIsDiskEncryptionFeatureEnabled();
-
-  // If `linode` is defined, the dialog was opened from Linode Details, so we will know the capabilities of the linode's region
-  const regionSupportsDiskEncryption =
-    regions
-      ?.find((regionDatum) => regionDatum.id === linode?.region)
-      ?.capabilities.includes('Disk Encryption') ?? false;
 
   const backupsMonthlyPrice:
     | PriceObject['monthly']
@@ -110,7 +101,7 @@ export const EnableBackupsDialog = (props: Props) => {
       open={open}
       title="Enable backups?"
     >
-      {(isDiskEncryptionFeatureEnabled || regionSupportsDiskEncryption) && ( // @TODO LDE: once LDE is GA in all DCs, remove this condition
+      {isDiskEncryptionFeatureEnabled && ( // @TODO LDE: once LDE is GA in all DCs, remove this condition
         <Notice
           spacingTop={8}
           text={DISK_ENCRYPTION_BACKUPS_CAVEAT_COPY}

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/DiskEncryption.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/DiskEncryption.tsx
@@ -31,7 +31,7 @@ export const DiskEncryption = (props: Props) => {
     isDiskEncryptionFeatureEnabled,
   } = useIsDiskEncryptionFeatureEnabled();
 
-  if (!isDiskEncryptionFeatureEnabled && !regionSupportsDiskEncryption) {
+  if (!isDiskEncryptionFeatureEnabled) {
     return null;
   }
 


### PR DESCRIPTION
## Description 📝
https://github.com/linode/manager/pull/11783 was done with the understanding that API would not be returning `Disk Encryption` as an account capability by default for all users; however, this is not the case as `Disk Encryption` _will_ be returned as an account capability by default for all users. The logic introduced in that PR therefore added unnecessary complexity.

## Changes  🔄
- Mostly revert changes introduced in #11783

## Target release date 🗓️
3/11/25

## How to test 🧪
```
pnpm test enablebackupsdialog
```

```
pnpm test nodetable
```

```
yarn cy:run -s "cypress/e2e/core/linodes/create-linode-with-disk-encryption.spec.ts"
```

The easiest way to test would be to have one regular window open and one incognito window. One should be logged into an account without the `Disk Encryption` account capability (`linode-disk-encryption-disabled` tag) and the other should be logged into an account with it (`linode_disk_encryption` tag). Point at the `staging` environment.

The following areas/points should be tested:

* `/regions` requests
  * User w/ capability: should see "Disk Encryption" as a capability for "Frankfurt, DE"
  * User w/o capability: should not see "Disk Encryption" as a capability for any regions
* Linode Create flow
  * User w/ capability: should always be able to see "Disk Encryption" section, regardless of selected region (unchanged from current behavior in prod)
  * User w/o capability: should not see "Disk Encryption" section
* Linode Details page
  * User w/ capability: should always be able to see encryption status indicator in the summary panel (unchanged from current behavior in prod)
  *  User w/o capability: should not see encryption status indicator
* Linode Rebuild flow
  * User w/ capability: should always be able to see "Disk Encryption" section, and default checkbox status should match the linode's current encryption status (i.e., unchecked if linode is currently not encrypted, checked if linode currently is) (unchanged from current behavior in prod)
  * User w/o capability: should not see "Disk Encryption" section

<details>
<summary>LKE landing page banner</summary>

![Screenshot 2025-03-05 at 1 30 24 PM](https://github.com/user-attachments/assets/54f0600e-6c6f-4b82-920d-011d644ddfaf)
</details>

* LKE landing page
  * User w/ capability: should see banner (unless it has been dismissed)
  * User w/o capability: should not see banner

* LKE Details page
  * User w/ capability: should always be able to see pool encryption status indicator (unchanged from current behavior in prod)
  * User w/o capability: should not see pool encryption status indicator

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [X] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [X] All unit tests are passing
- [X] TypeScript compilation succeeded without errors
- [X] Code passes all linting rules

</details>