### PR TITLE
change: [M3-9516] - Update body text color to use proper color token

### DIFF
--- a/packages/manager/.changeset/pr-11820-changed-1741642386020.md
+++ b/packages/manager/.changeset/pr-11820-changed-1741642386020.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Remove unnecessary styled component for Linode Detail summary ([#11820](https://github.com/linode/manager/pull/11820))

--- a/packages/manager/src/components/Markdown/__snapshots__/Markdown.test.tsx.snap
+++ b/packages/manager/src/components/Markdown/__snapshots__/Markdown.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Markdown component > should highlight text consistently 1`] = `
 <DocumentFragment>
   <p
-    class="MuiTypography-root MuiTypography-body1 css-rhmp6-MuiTypography-root"
+    class="MuiTypography-root MuiTypography-body1 css-1ewp9t3-MuiTypography-root"
   />
   <h1>
     Some markdown

--- a/packages/manager/src/features/Linodes/LinodeEntityDetail.styles.ts
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetail.styles.ts
@@ -45,14 +45,6 @@ export const StyledColumnLabelGrid = styled(Grid, {
   font: theme.font.bold,
 }));
 
-export const StyledSummaryGrid = styled(Grid, { label: 'StyledSummaryGrid' })(
-  ({ theme }) => ({
-    '& p': {
-      color: theme.textColors.tableStatic,
-    },
-  })
-);
-
 export const StyledVPCBox = styled(Box, { label: 'StyledVPCBox' })(
   ({ theme }) => ({
     padding: 0,

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
@@ -31,7 +31,6 @@ import {
   StyledIPv4Label,
   StyledLabelBox,
   StyledListItem,
-  StyledSummaryGrid,
   StyledVPCBox,
   sxLastListItem,
 } from './LinodeEntityDetail.styles';
@@ -174,7 +173,7 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
           >
             Summary
           </StyledColumnLabelGrid>
-          <StyledSummaryGrid container spacing={1}>
+          <Grid container spacing={1}>
             <Grid
               size={{
                 lg: 6,
@@ -257,7 +256,7 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
                   </Box>
                 </Grid>
               )}
-          </StyledSummaryGrid>
+          </Grid>
         </Grid>
 
         <Grid

--- a/packages/ui/.changeset/pr-11820-changed-1741642411797.md
+++ b/packages/ui/.changeset/pr-11820-changed-1741642411797.md
@@ -1,0 +1,5 @@
+---
+"@linode/ui": Changed
+---
+
+Update body text color to use proper color token ([#11820](https://github.com/linode/manager/pull/11820))

--- a/packages/ui/src/foundations/themes/dark.ts
+++ b/packages/ui/src/foundations/themes/dark.ts
@@ -32,7 +32,7 @@ const primaryColors = {
   headline: Color.Neutrals[5],
   light: Color.Brand[60],
   main: Color.Brand[80],
-  text: Color.Neutrals.White,
+  text: Content.Text.Primary.Default,
   white: Color.Neutrals.Black,
 };
 
@@ -83,7 +83,7 @@ export const customDarkModeOptions = {
     grey6: Color.Neutrals[50],
     grey7: Color.Neutrals[80],
     grey9: primaryColors.divider,
-    headline: primaryColors.headline,
+    headline: Content.Text.Primary.Default,
     label: Color.Neutrals[40],
     offBlack: Color.Neutrals.White,
     red: Color.Red[70],
@@ -272,7 +272,7 @@ export const darkTheme: ThemeOptions = {
           color: Color.Neutrals.White,
         },
         tag: {
-          '.MuiChip-deleteIcon': { color: primaryColors.text },
+          '.MuiChip-deleteIcon': { color: Content.Text.Primary.Default },
           backgroundColor: customDarkModeOptions.bg.lightBlue1,
         },
       },
@@ -455,13 +455,13 @@ export const darkTheme: ThemeOptions = {
         },
         outlined: {
           '& .MuiChip-label': {
-            color: primaryColors.text,
+            color: Content.Text.Primary.Default,
           },
           backgroundColor: 'transparent',
           borderRadius: 1,
         },
         root: {
-          color: primaryColors.text,
+          color: Content.Text.Primary.Default,
         },
       },
     },
@@ -476,7 +476,7 @@ export const darkTheme: ThemeOptions = {
       styleOverrides: {
         root: {
           borderBottom: `1px solid ${Color.Neutrals[100]}`,
-          color: primaryColors.headline,
+          color: Content.Text.Primary.Default,
         },
       },
     },
@@ -512,7 +512,7 @@ export const darkTheme: ThemeOptions = {
           '&.Mui-disabled': {
             color: `${Color.Neutrals[50]} !important`,
           },
-          color: primaryColors.text,
+          color: Content.Text.Primary.Default,
         },
         root: {},
       },
@@ -619,9 +619,9 @@ export const darkTheme: ThemeOptions = {
       styleOverrides: {
         root: {
           '&.selectHeader': {
-            color: primaryColors.text,
+            color: Content.Text.Primary.Default,
           },
-          color: primaryColors.text,
+          color: Content.Text.Primary.Default,
         },
       },
     },
@@ -629,7 +629,7 @@ export const darkTheme: ThemeOptions = {
       styleOverrides: {
         root: {
           '&.loading': {
-            backgroundColor: primaryColors.text,
+            backgroundColor: Content.Text.Primary.Default,
           },
           '&:active': {
             backgroundColor: Dropdown.Background.Default,
@@ -793,7 +793,7 @@ export const darkTheme: ThemeOptions = {
         root: {
           backgroundColor: Color.Neutrals[100],
           boxShadow: `0 0 5px ${Color.Neutrals[100]}`,
-          color: primaryColors.text,
+          color: Content.Text.Primary.Default,
         },
       },
     },
@@ -965,13 +965,13 @@ export const darkTheme: ThemeOptions = {
             color: Action.Primary.Default,
           },
           '& a.black': {
-            color: primaryColors.text,
+            color: Content.Text.Primary.Default,
           },
           '& a.black:hover': {
-            color: primaryColors.text,
+            color: Content.Text.Primary.Default,
           },
           '& a.black:visited': {
-            color: primaryColors.text,
+            color: Content.Text.Primary.Default,
           },
           '& a:hover': {
             color: Action.Primary.Hover,
@@ -1054,7 +1054,7 @@ export const darkTheme: ThemeOptions = {
     mode: 'dark',
     primary: primaryColors,
     text: {
-      primary: primaryColors.text,
+      primary: Content.Text.Primary.Default,
     },
   },
   textColors: customDarkModeOptions.textColors,
@@ -1077,22 +1077,22 @@ export const darkTheme: ThemeOptions = {
   },
   typography: {
     body1: {
-      color: primaryColors.text,
+      color: Content.Text.Primary.Default,
     },
     caption: {
-      color: primaryColors.text,
+      color: Content.Text.Primary.Default,
     },
     h1: {
-      color: primaryColors.headline,
+      color: Content.Text.Primary.Default,
     },
     h2: {
-      color: primaryColors.headline,
+      color: Content.Text.Primary.Default,
     },
     h3: {
-      color: primaryColors.headline,
+      color: Content.Text.Primary.Default,
     },
     subtitle1: {
-      color: primaryColors.text,
+      color: Content.Text.Primary.Default,
     },
   },
 };

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -54,7 +54,7 @@ const primaryColors = {
   headline: Color.Neutrals[100],
   light: Color.Brand[60],
   main: Color.Brand[80],
-  text: Color.Neutrals[70],
+  text: Content.Text.Primary.Default,
   white: Color.Neutrals.White,
 };
 
@@ -80,7 +80,7 @@ export const color = {
   grey8: Color.Neutrals[30],
   grey9: Color.Neutrals[5],
   grey10: Color.Neutrals[10],
-  headline: primaryColors.headline,
+  headline: Content.Text.Primary.Default,
   label: Color.Neutrals[70],
   offBlack: Color.Neutrals[90],
   orange: Color.Amber[70],
@@ -449,7 +449,7 @@ export const lightTheme: ThemeOptions = {
               color: primaryColors.white,
             },
             borderRadius: '50%',
-            color: primaryColors.text,
+            color: Content.Text.Primary.Default,
             fontSize: '16px',
             margin: '0 4px',
           },
@@ -646,7 +646,7 @@ export const lightTheme: ThemeOptions = {
           color: color.white,
         },
         deleteIcon: {
-          color: primaryColors.text,
+          color: Content.Text.Primary.Default,
           margin: 0,
           padding: 2,
         },
@@ -676,7 +676,7 @@ export const lightTheme: ThemeOptions = {
           },
           alignItems: 'center',
           borderRadius: 4,
-          color: primaryColors.text,
+          color: Content.Text.Primary.Default,
           display: 'inline-flex',
           fontSize: '.8rem',
           height: 20,
@@ -751,7 +751,7 @@ export const lightTheme: ThemeOptions = {
             lineHeight: 1.2,
           },
           borderBottom: `1px solid ${Color.Neutrals[20]}`,
-          color: primaryColors.headline,
+          color: Content.Text.Primary.Default,
           marginBottom: 20,
           padding: '16px 24px',
         },
@@ -796,7 +796,7 @@ export const lightTheme: ThemeOptions = {
     MuiFormControlLabel: {
       styleOverrides: {
         label: {
-          color: primaryColors.text,
+          color: Content.Text.Primary.Default,
         },
         root: {
           marginLeft: -11,
@@ -935,7 +935,7 @@ export const lightTheme: ThemeOptions = {
             maxWidth: '100%',
             width: '100%',
           },
-          color: primaryColors.text,
+          color: Content.Text.Primary.Default,
           lineHeight: 1,
           maxWidth: inputMaxWidth,
           minHeight: 34,
@@ -1023,11 +1023,11 @@ export const lightTheme: ThemeOptions = {
             color: primaryColors.main,
           },
           '&.selectHeader': {
-            color: primaryColors.text,
+            color: Content.Text.Primary.Default,
             font: Typography.Body.Bold,
             opacity: 1,
           },
-          color: primaryColors.text,
+          color: Content.Text.Primary.Default,
         },
       },
     },
@@ -1080,7 +1080,7 @@ export const lightTheme: ThemeOptions = {
       styleOverrides: {
         root: {
           '&.loading': {
-            backgroundColor: primaryColors.text,
+            backgroundColor: Content.Text.Primary.Default,
           },
           '&:active': {
             backgroundColor: Dropdown.Background.Default,
@@ -1164,7 +1164,7 @@ export const lightTheme: ThemeOptions = {
             maxWidth: '100%',
             width: '100%',
           },
-          color: primaryColors.text,
+          color: Content.Text.Primary.Default,
           height: '34px',
           lineHeight: 1,
           maxWidth: inputMaxWidth,
@@ -1390,7 +1390,7 @@ export const lightTheme: ThemeOptions = {
       styleOverrides: {
         root: {
           '&$selected, &$selected:hover': {
-            color: primaryColors.headline,
+            color: Content.Text.Primary.Default,
             font: Typography.Body.Bold,
           },
           '&:hover': {
@@ -1845,7 +1845,7 @@ export const lightTheme: ThemeOptions = {
       main: Color.Green[40],
     },
     text: {
-      primary: primaryColors.text,
+      primary: Content.Text.Primary.Default,
     },
     warning: {
       dark: Color.Amber[70],
@@ -1908,12 +1908,12 @@ export const lightTheme: ThemeOptions = {
   typography: {
     body1: {
       ...typographyPropertiesReset,
-      color: primaryColors.text,
+      color: Content.Text.Primary.Default,
       font: Typography.Body.Regular,
     },
     caption: {
       ...typographyPropertiesReset,
-      color: primaryColors.text,
+      color: Content.Text.Primary.Default,
       font: Typography.Heading.Overline,
       letterSpacing: Typography.Heading.OverlineLetterSpacing,
       textTransform: Typography.Heading.OverlineTextCase,
@@ -1925,23 +1925,23 @@ export const lightTheme: ThemeOptions = {
       [breakpoints.up('lg')]: {
         font: Typography.Heading.Xl,
       },
-      color: primaryColors.headline,
+      color: Content.Text.Primary.Default,
       font: Typography.Heading.L,
     },
     h2: {
       ...typographyPropertiesReset,
-      color: primaryColors.headline,
+      color: Content.Text.Primary.Default,
       font: Typography.Heading.M,
     },
     h3: {
       ...typographyPropertiesReset,
-      color: primaryColors.headline,
+      color: Content.Text.Primary.Default,
       font: Typography.Heading.S,
     },
     htmlFontSize: undefined,
     subtitle1: {
       ...typographyPropertiesReset,
-      color: primaryColors.text,
+      color: Content.Text.Primary.Default,
       font: Typography.Heading.Xs,
     },
   },


### PR DESCRIPTION
## Description 📝
Body text color is currently `#696970` instead of using the designated color token. Update to use the correct design system token: Content.Text.Primary.Default (`#343438`).

## Changes  🔄
Essentially all our headers and body text use the same color now, we will clean the theme as part of the larger refactor.

## Target release date 🗓️
3/25

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![cloud linode com_linodes_72766266](https://github.com/user-attachments/assets/242868e8-989a-45b4-9d21-7c4526492347) | ![localhost_3000_linodes_72766266 (2)](https://github.com/user-attachments/assets/efe94f03-4f79-4853-a24e-89bfa7241af4) |

## How to test 🧪
### Verification steps
- Observe new color to be `#343438`

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>