### PR TITLE
fix: [M3-9520] - Fix Broken `ActionsPanel` Imports

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/Actions.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/Actions.tsx
@@ -1,7 +1,6 @@
+import { ActionsPanel } from '@linode/ui';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
-
-import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 
 import type { CreateLinodeInterfacePayload } from '@linode/api-v4';
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/DeleteInterfaceDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/DeleteInterfaceDialog.tsx
@@ -1,7 +1,7 @@
+import { ActionsPanel } from '@linode/ui';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 
-import { ActionsPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
 import {
   useDeleteLinodeInterfaceMutation,


### PR DESCRIPTION
## Description 📝

It looks like it's caused by merging https://github.com/linode/manager/pull/11810 without rebasing. As a result, some of the `ActionsPanel` imports from the `ui` package were missed and not updated causing some CI errors.
![Screenshot 2025-03-11 at 4 10 30 PM](https://github.com/user-attachments/assets/21b4de32-8c7e-4a27-ab6b-2632e0b261e2)

## Changes  🔄
- Updates `ActionsPanel` to import from @linode/ui