### PR TITLE
fix: [M3-9465] - Make LKE/LKE-E spacing tweaks

### DIFF
--- a/packages/manager/.changeset/pr-11827-fixed-1741723772655.md
+++ b/packages/manager/.changeset/pr-11827-fixed-1741723772655.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Minor spacing inconsistencies throughout LKE ([#11827](https://github.com/linode/manager/pull/11827))

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTierPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTierPanel.tsx
@@ -56,22 +56,14 @@ export const ClusterTierPanel = (props: Props) => {
         marginTop={2}
       >
         <SelectionCard
-          subheadings={[
-            'Small to medium deployments',
-            'Up to 250 nodes, 1000 pods',
-            'Shared control plane',
-          ]}
           checked={selectedTier === 'standard' && !isUserRestricted}
           disabled={isUserRestricted}
           heading="LKE"
           onClick={() => handleClusterTierSelection('standard')}
+          subheadings={[StandardSubheadings]}
+          sxCardBase={{ padding: '16px' }}
         />
         <SelectionCard
-          subheadings={[
-            'Large deployments',
-            'Up to 500 nodes, 5000 pods',
-            'Dedicated HA control plane',
-          ]}
           tooltip={
             isLkeEnterpriseSelectionDisabled && !isUserRestricted
               ? 'LKE Enterprise is not currently enabled on this account. Please contact your account manager or our sales team using the request form or sales@linode.com.'
@@ -81,9 +73,27 @@ export const ClusterTierPanel = (props: Props) => {
           disabled={isLkeEnterpriseSelectionDisabled || isUserRestricted}
           heading="LKE Enterprise"
           onClick={() => handleClusterTierSelection('enterprise')}
+          subheadings={[EnterpriseSubheadings]}
+          sxCardBase={{ padding: '16px' }}
           tooltipPlacement={smDownBreakpoint ? 'bottom' : 'right'}
         />
       </Stack>
     </Stack>
   );
 };
+
+const StandardSubheadings = (
+  <Typography sx={{ marginTop: '4px' }}>
+    Small to medium deployments <br />
+    Up to 250 nodes, 1000 pods <br />
+    Shared control plane <br />
+  </Typography>
+);
+
+const EnterpriseSubheadings = (
+  <Typography sx={{ marginTop: '4px' }}>
+    Large deployments <br />
+    Up to 500 nodes, 5000 pods <br />
+    Dedicated HA control plane <br />
+  </Typography>
+);

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/LabelsAndTaints/LabelAndTaintDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/LabelsAndTaints/LabelAndTaintDrawer.tsx
@@ -119,7 +119,11 @@ export const LabelAndTaintDrawer = (props: Props) => {
       title={`Labels and Taints: ${planType?.formattedLabel ?? 'Unknown'} Plan`}
     >
       {formState.errors.root?.message ? (
-        <Notice text={formState.errors.root.message} variant="error" />
+        <Notice
+          spacingBottom={16}
+          text={formState.errors.root.message}
+          variant="error"
+        />
       ) : null}
       <FormProvider
         control={control}
@@ -130,7 +134,7 @@ export const LabelAndTaintDrawer = (props: Props) => {
       >
         <form onSubmit={form.handleSubmit(onSubmit)}>
           <Typography
-            marginBottom={(theme) => theme.spacing(4)}
+            marginBottom={(theme) => theme.spacing(3)}
             marginTop={(theme) => theme.spacing()}
           >
             Manage custom labels and taints directly through LKE. Changes are

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/LabelsAndTaints/LabelTable.styles.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/LabelsAndTaints/LabelTable.styles.tsx
@@ -5,5 +5,5 @@ import { Table } from 'src/components/Table';
 export const StyledLabelTable = styled(Table, {
   label: 'StyledLabelTable',
 })(({ theme }) => ({
-  margin: `${theme.spacing()} 0`,
+  margin: `${theme.spacing()} 0 12px`,
 }));

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/LabelsAndTaints/LabelTable.styles.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/LabelsAndTaints/LabelTable.styles.tsx
@@ -5,5 +5,5 @@ import { Table } from 'src/components/Table';
 export const StyledLabelTable = styled(Table, {
   label: 'StyledLabelTable',
 })(({ theme }) => ({
-  margin: `${theme.spacing()} 0 12px`,
+  margin: `${theme.spacing()} 0 ${theme.spacing(1.5)}`,
 }));

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -8,7 +8,6 @@ import {
 } from '@linode/ui';
 import { pluralize } from '@linode/utilities';
 import Divider from '@mui/material/Divider';
-import { styled } from '@mui/material/styles';
 import * as React from 'react';
 
 import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
@@ -74,177 +73,168 @@ export const NodePool = (props: Props) => {
   } = props;
 
   return (
-    <StyledDiv>
-      <Accordion
-        heading={
-          <Box
-            sx={{
-              alignItems: 'center',
-              display: 'flex',
-              justifyContent: 'space-between',
-              p: 0,
-            }}
-          >
-            <Box display="flex">
-              <Typography variant="h2">{typeLabel}</Typography>
-              <Divider
-                sx={(theme) => ({
-                  height: 16,
-                  margin: `4px ${theme.spacing(1)}`,
-                })}
-                orientation="vertical"
-              />
-              <Typography variant="h2">
-                {pluralize('Node', 'Nodes', count)}
-              </Typography>
-            </Box>
-            <Hidden lgUp>
-              {autoscaler.enabled && (
-                <Box position="absolute" right={(theme) => theme.spacing(10)}>
-                  <Typography mx={1}>
-                    (Min {autoscaler.min} / Max {autoscaler.max})
-                  </Typography>
-                </Box>
-              )}
-              <Box
-                alignItems="center"
-                position="absolute"
-                right={(theme) => theme.spacing(5)}
-              >
-                <ActionMenu
-                  actionsList={[
-                    {
-                      onClick: () => handleClickLabelsAndTaints(poolId),
-                      title: 'Labels and Taints',
-                    },
-                    {
-                      onClick: () => openAutoscalePoolDialog(poolId),
-                      title: 'Autoscale Pool',
-                    },
-                    {
-                      onClick: () => handleClickResize(poolId),
-                      title: 'Resize Pool',
-                    },
-                    {
-                      onClick: () => openRecycleAllNodesDialog(poolId),
-                      title: 'Recycle Pool Nodes',
-                    },
-                    {
-                      disabled: isOnlyNodePool,
-                      onClick: () => openDeletePoolDialog(poolId),
-                      title: 'Delete Pool',
-                      tooltip: isOnlyNodePool
-                        ? 'Clusters must contain at least one node pool.'
-                        : undefined,
-                    },
-                  ]}
-                  ariaLabel={`Action menu for Node Pool ${poolId}`}
-                  stopClickPropagation
-                />
-              </Box>
-            </Hidden>
-            <Hidden lgDown>
-              <Stack
-                alignItems="center"
-                data-testid="node-pool-actions"
-                direction="row"
-                position="absolute"
-                right={(theme) => theme.spacing(5)}
-              >
-                <StyledActionButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleClickLabelsAndTaints(poolId);
-                  }}
-                  compactY
-                >
-                  Labels and Taints
-                </StyledActionButton>
-                <StyledActionButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    openAutoscalePoolDialog(poolId);
-                  }}
-                  compactY
-                >
-                  Autoscale Pool
-                </StyledActionButton>
-                {autoscaler.enabled && (
-                  <Typography mx={1}>
-                    (Min {autoscaler.min} / Max {autoscaler.max})
-                  </Typography>
-                )}
-                <StyledActionButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleClickResize(poolId);
-                  }}
-                  compactY
-                >
-                  Resize Pool
-                </StyledActionButton>
-                <StyledActionButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    openRecycleAllNodesDialog(poolId);
-                  }}
-                  compactY
-                >
-                  Recycle Pool Nodes
-                </StyledActionButton>
-                <Tooltip
-                  disableFocusListener={!isOnlyNodePool}
-                  disableHoverListener={!isOnlyNodePool}
-                  disableTouchListener={!isOnlyNodePool}
-                  onClick={(e) => e.stopPropagation()}
-                  title="Clusters must contain at least one node pool."
-                >
-                  <div>
-                    <StyledActionButton
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        openDeletePoolDialog(poolId);
-                      }}
-                      compactY
-                      disabled={isOnlyNodePool}
-                    >
-                      Delete Pool
-                    </StyledActionButton>
-                  </div>
-                </Tooltip>
-              </Stack>
-            </Hidden>
+    <Accordion
+      heading={
+        <Box
+          sx={{
+            alignItems: 'center',
+            display: 'flex',
+            justifyContent: 'space-between',
+            p: 0,
+          }}
+        >
+          <Box display="flex">
+            <Typography variant="h2">{typeLabel}</Typography>
+            <Divider
+              sx={(theme) => ({
+                height: 16,
+                margin: `4px ${theme.spacing(1)}`,
+              })}
+              orientation="vertical"
+            />
+            <Typography variant="h2">
+              {pluralize('Node', 'Nodes', count)}
+            </Typography>
           </Box>
-        }
-        data-qa-node-pool-id={poolId}
-        data-qa-node-pool-section
-        expanded={accordionExpanded}
-        onChange={handleAccordionClick}
-        // Improve performance by unmounting large content from the DOM when collapsed
-        slotProps={{ transition: { unmountOnExit: nodes.length > 25 } }}
-      >
-        <NodeTable
-          clusterCreated={clusterCreated}
-          clusterId={clusterId}
-          clusterTier={clusterTier}
-          encryptionStatus={encryptionStatus}
-          nodes={nodes}
-          openRecycleNodeDialog={openRecycleNodeDialog}
-          poolId={poolId}
-          regionSupportsDiskEncryption={regionSupportsDiskEncryption}
-          statusFilter={statusFilter}
-          tags={tags}
-          typeLabel={typeLabel}
-        />
-      </Accordion>
-    </StyledDiv>
+          <Hidden lgUp>
+            {autoscaler.enabled && (
+              <Box position="absolute" right={(theme) => theme.spacing(10)}>
+                <Typography mx={1}>
+                  (Min {autoscaler.min} / Max {autoscaler.max})
+                </Typography>
+              </Box>
+            )}
+            <Box
+              alignItems="center"
+              position="absolute"
+              right={(theme) => theme.spacing(5)}
+            >
+              <ActionMenu
+                actionsList={[
+                  {
+                    onClick: () => handleClickLabelsAndTaints(poolId),
+                    title: 'Labels and Taints',
+                  },
+                  {
+                    onClick: () => openAutoscalePoolDialog(poolId),
+                    title: 'Autoscale Pool',
+                  },
+                  {
+                    onClick: () => handleClickResize(poolId),
+                    title: 'Resize Pool',
+                  },
+                  {
+                    onClick: () => openRecycleAllNodesDialog(poolId),
+                    title: 'Recycle Pool Nodes',
+                  },
+                  {
+                    disabled: isOnlyNodePool,
+                    onClick: () => openDeletePoolDialog(poolId),
+                    title: 'Delete Pool',
+                    tooltip: isOnlyNodePool
+                      ? 'Clusters must contain at least one node pool.'
+                      : undefined,
+                  },
+                ]}
+                ariaLabel={`Action menu for Node Pool ${poolId}`}
+                stopClickPropagation
+              />
+            </Box>
+          </Hidden>
+          <Hidden lgDown>
+            <Stack
+              alignItems="center"
+              data-testid="node-pool-actions"
+              direction="row"
+              position="absolute"
+              right={(theme) => theme.spacing(5)}
+            >
+              <StyledActionButton
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleClickLabelsAndTaints(poolId);
+                }}
+                compactY
+              >
+                Labels and Taints
+              </StyledActionButton>
+              <StyledActionButton
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openAutoscalePoolDialog(poolId);
+                }}
+                compactY
+              >
+                Autoscale Pool
+              </StyledActionButton>
+              {autoscaler.enabled && (
+                <Typography mx={1}>
+                  (Min {autoscaler.min} / Max {autoscaler.max})
+                </Typography>
+              )}
+              <StyledActionButton
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleClickResize(poolId);
+                }}
+                compactY
+              >
+                Resize Pool
+              </StyledActionButton>
+              <StyledActionButton
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openRecycleAllNodesDialog(poolId);
+                }}
+                compactY
+              >
+                Recycle Pool Nodes
+              </StyledActionButton>
+              <Tooltip
+                disableFocusListener={!isOnlyNodePool}
+                disableHoverListener={!isOnlyNodePool}
+                disableTouchListener={!isOnlyNodePool}
+                onClick={(e) => e.stopPropagation()}
+                title="Clusters must contain at least one node pool."
+              >
+                <div>
+                  <StyledActionButton
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      openDeletePoolDialog(poolId);
+                    }}
+                    compactY
+                    disabled={isOnlyNodePool}
+                  >
+                    Delete Pool
+                  </StyledActionButton>
+                </div>
+              </Tooltip>
+            </Stack>
+          </Hidden>
+        </Box>
+      }
+      data-qa-node-pool-id={poolId}
+      data-qa-node-pool-section
+      detailProps={{ sx: { paddingBottom: 1 } }}
+      expanded={accordionExpanded}
+      onChange={handleAccordionClick}
+      // Improve performance by unmounting large content from the DOM when collapsed
+      slotProps={{ transition: { unmountOnExit: nodes.length > 25 } }}
+    >
+      <NodeTable
+        clusterCreated={clusterCreated}
+        clusterId={clusterId}
+        clusterTier={clusterTier}
+        encryptionStatus={encryptionStatus}
+        nodes={nodes}
+        openRecycleNodeDialog={openRecycleNodeDialog}
+        poolId={poolId}
+        regionSupportsDiskEncryption={regionSupportsDiskEncryption}
+        statusFilter={statusFilter}
+        tags={tags}
+        typeLabel={typeLabel}
+      />
+    </Accordion>
   );
 };
-
-export const StyledDiv = styled('div', {
-  label: 'StyledDiv',
-})(({ theme }) => ({
-  '& .MuiAccordionDetails-root': {
-    paddingBottom: theme.spacing(1),
-  },
-}));

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -8,6 +8,7 @@ import {
 } from '@linode/ui';
 import { pluralize } from '@linode/utilities';
 import Divider from '@mui/material/Divider';
+import { styled } from '@mui/material/styles';
 import * as React from 'react';
 
 import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
@@ -66,174 +67,184 @@ export const NodePool = (props: Props) => {
     openRecycleAllNodesDialog,
     openRecycleNodeDialog,
     poolId,
-    statusFilter,
     regionSupportsDiskEncryption,
+    statusFilter,
     tags,
     typeLabel,
   } = props;
 
   return (
-    <Accordion
-      heading={
-        <Box
-          sx={{
-            alignItems: 'center',
-            display: 'flex',
-            justifyContent: 'space-between',
-            p: 0,
-          }}
-        >
-          <Box display="flex">
-            <Typography variant="h2">{typeLabel}</Typography>
-            <Divider
-              sx={(theme) => ({
-                height: 16,
-                margin: `4px ${theme.spacing(1)}`,
-              })}
-              orientation="vertical"
-            />
-            <Typography variant="h2">
-              {pluralize('Node', 'Nodes', count)}
-            </Typography>
-          </Box>
-          <Hidden lgUp>
-            {autoscaler.enabled && (
-              <Box position="absolute" right={(theme) => theme.spacing(10)}>
-                <Typography mx={1}>
-                  (Min {autoscaler.min} / Max {autoscaler.max})
-                </Typography>
-              </Box>
-            )}
-            <Box
-              alignItems="center"
-              position="absolute"
-              right={(theme) => theme.spacing(5)}
-            >
-              <ActionMenu
-                actionsList={[
-                  {
-                    onClick: () => handleClickLabelsAndTaints(poolId),
-                    title: 'Labels and Taints',
-                  },
-                  {
-                    onClick: () => openAutoscalePoolDialog(poolId),
-                    title: 'Autoscale Pool',
-                  },
-                  {
-                    onClick: () => handleClickResize(poolId),
-                    title: 'Resize Pool',
-                  },
-                  {
-                    onClick: () => openRecycleAllNodesDialog(poolId),
-                    title: 'Recycle Pool Nodes',
-                  },
-                  {
-                    disabled: isOnlyNodePool,
-                    onClick: () => openDeletePoolDialog(poolId),
-                    title: 'Delete Pool',
-                    tooltip: isOnlyNodePool
-                      ? 'Clusters must contain at least one node pool.'
-                      : undefined,
-                  },
-                ]}
-                ariaLabel={`Action menu for Node Pool ${poolId}`}
-                stopClickPropagation
+    <StyledDiv>
+      <Accordion
+        heading={
+          <Box
+            sx={{
+              alignItems: 'center',
+              display: 'flex',
+              justifyContent: 'space-between',
+              p: 0,
+            }}
+          >
+            <Box display="flex">
+              <Typography variant="h2">{typeLabel}</Typography>
+              <Divider
+                sx={(theme) => ({
+                  height: 16,
+                  margin: `4px ${theme.spacing(1)}`,
+                })}
+                orientation="vertical"
               />
+              <Typography variant="h2">
+                {pluralize('Node', 'Nodes', count)}
+              </Typography>
             </Box>
-          </Hidden>
-          <Hidden lgDown>
-            <Stack
-              alignItems="center"
-              data-testid="node-pool-actions"
-              direction="row"
-              position="absolute"
-              right={(theme) => theme.spacing(5)}
-            >
-              <StyledActionButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleClickLabelsAndTaints(poolId);
-                }}
-                compactY
-              >
-                Labels and Taints
-              </StyledActionButton>
-              <StyledActionButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                  openAutoscalePoolDialog(poolId);
-                }}
-                compactY
-              >
-                Autoscale Pool
-              </StyledActionButton>
+            <Hidden lgUp>
               {autoscaler.enabled && (
-                <Typography mx={1}>
-                  (Min {autoscaler.min} / Max {autoscaler.max})
-                </Typography>
+                <Box position="absolute" right={(theme) => theme.spacing(10)}>
+                  <Typography mx={1}>
+                    (Min {autoscaler.min} / Max {autoscaler.max})
+                  </Typography>
+                </Box>
               )}
-              <StyledActionButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleClickResize(poolId);
-                }}
-                compactY
+              <Box
+                alignItems="center"
+                position="absolute"
+                right={(theme) => theme.spacing(5)}
               >
-                Resize Pool
-              </StyledActionButton>
-              <StyledActionButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                  openRecycleAllNodesDialog(poolId);
-                }}
-                compactY
+                <ActionMenu
+                  actionsList={[
+                    {
+                      onClick: () => handleClickLabelsAndTaints(poolId),
+                      title: 'Labels and Taints',
+                    },
+                    {
+                      onClick: () => openAutoscalePoolDialog(poolId),
+                      title: 'Autoscale Pool',
+                    },
+                    {
+                      onClick: () => handleClickResize(poolId),
+                      title: 'Resize Pool',
+                    },
+                    {
+                      onClick: () => openRecycleAllNodesDialog(poolId),
+                      title: 'Recycle Pool Nodes',
+                    },
+                    {
+                      disabled: isOnlyNodePool,
+                      onClick: () => openDeletePoolDialog(poolId),
+                      title: 'Delete Pool',
+                      tooltip: isOnlyNodePool
+                        ? 'Clusters must contain at least one node pool.'
+                        : undefined,
+                    },
+                  ]}
+                  ariaLabel={`Action menu for Node Pool ${poolId}`}
+                  stopClickPropagation
+                />
+              </Box>
+            </Hidden>
+            <Hidden lgDown>
+              <Stack
+                alignItems="center"
+                data-testid="node-pool-actions"
+                direction="row"
+                position="absolute"
+                right={(theme) => theme.spacing(5)}
               >
-                Recycle Pool Nodes
-              </StyledActionButton>
-              <Tooltip
-                disableFocusListener={!isOnlyNodePool}
-                disableHoverListener={!isOnlyNodePool}
-                disableTouchListener={!isOnlyNodePool}
-                onClick={(e) => e.stopPropagation()}
-                title="Clusters must contain at least one node pool."
-              >
-                <div>
-                  <StyledActionButton
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      openDeletePoolDialog(poolId);
-                    }}
-                    compactY
-                    disabled={isOnlyNodePool}
-                  >
-                    Delete Pool
-                  </StyledActionButton>
-                </div>
-              </Tooltip>
-            </Stack>
-          </Hidden>
-        </Box>
-      }
-      data-qa-node-pool-id={poolId}
-      data-qa-node-pool-section
-      expanded={accordionExpanded}
-      onChange={handleAccordionClick}
-      // Improve performance by unmounting large content from the DOM when collapsed
-      slotProps={{ transition: { unmountOnExit: nodes.length > 25 } }}
-    >
-      <NodeTable
-        clusterCreated={clusterCreated}
-        clusterId={clusterId}
-        clusterTier={clusterTier}
-        encryptionStatus={encryptionStatus}
-        nodes={nodes}
-        openRecycleNodeDialog={openRecycleNodeDialog}
-        poolId={poolId}
-        regionSupportsDiskEncryption={regionSupportsDiskEncryption}
-        statusFilter={statusFilter}
-        tags={tags}
-        typeLabel={typeLabel}
-      />
-    </Accordion>
+                <StyledActionButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleClickLabelsAndTaints(poolId);
+                  }}
+                  compactY
+                >
+                  Labels and Taints
+                </StyledActionButton>
+                <StyledActionButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    openAutoscalePoolDialog(poolId);
+                  }}
+                  compactY
+                >
+                  Autoscale Pool
+                </StyledActionButton>
+                {autoscaler.enabled && (
+                  <Typography mx={1}>
+                    (Min {autoscaler.min} / Max {autoscaler.max})
+                  </Typography>
+                )}
+                <StyledActionButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleClickResize(poolId);
+                  }}
+                  compactY
+                >
+                  Resize Pool
+                </StyledActionButton>
+                <StyledActionButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    openRecycleAllNodesDialog(poolId);
+                  }}
+                  compactY
+                >
+                  Recycle Pool Nodes
+                </StyledActionButton>
+                <Tooltip
+                  disableFocusListener={!isOnlyNodePool}
+                  disableHoverListener={!isOnlyNodePool}
+                  disableTouchListener={!isOnlyNodePool}
+                  onClick={(e) => e.stopPropagation()}
+                  title="Clusters must contain at least one node pool."
+                >
+                  <div>
+                    <StyledActionButton
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        openDeletePoolDialog(poolId);
+                      }}
+                      compactY
+                      disabled={isOnlyNodePool}
+                    >
+                      Delete Pool
+                    </StyledActionButton>
+                  </div>
+                </Tooltip>
+              </Stack>
+            </Hidden>
+          </Box>
+        }
+        data-qa-node-pool-id={poolId}
+        data-qa-node-pool-section
+        expanded={accordionExpanded}
+        onChange={handleAccordionClick}
+        // Improve performance by unmounting large content from the DOM when collapsed
+        slotProps={{ transition: { unmountOnExit: nodes.length > 25 } }}
+      >
+        <NodeTable
+          clusterCreated={clusterCreated}
+          clusterId={clusterId}
+          clusterTier={clusterTier}
+          encryptionStatus={encryptionStatus}
+          nodes={nodes}
+          openRecycleNodeDialog={openRecycleNodeDialog}
+          poolId={poolId}
+          regionSupportsDiskEncryption={regionSupportsDiskEncryption}
+          statusFilter={statusFilter}
+          tags={tags}
+          typeLabel={typeLabel}
+        />
+      </Accordion>
+    </StyledDiv>
   );
 };
+
+export const StyledDiv = styled('div', {
+  label: 'StyledDiv',
+})(({ theme }) => ({
+  '& .MuiAccordionDetails-root': {
+    paddingBottom: theme.spacing(1),
+  },
+}));

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.styles.ts
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.styles.ts
@@ -53,7 +53,8 @@ export const StyledTableFooter = styled(Box, {
   background: theme.bg.bgPaper,
   display: 'flex',
   justifyContent: 'space-between',
-  paddingLeft: theme.spacing(),
+  paddingLeft: 0,
+  paddingTop: theme.spacing(),
   [theme.breakpoints.down('md')]: {
     display: 'block',
     flexDirection: 'column',

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -255,7 +255,7 @@ export const NodeTable = React.memo((props: Props) => {
                  **/
                 sx={{ position: 'relative' }}
               />
-              <StyledTableFooter sx={{ paddingLeft: 0, paddingTop: '8px' }}>
+              <StyledTableFooter>
                 <StyledPoolInfoBox>
                   {(isDiskEncryptionFeatureEnabled ||
                     regionSupportsDiskEncryption) &&

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -255,7 +255,7 @@ export const NodeTable = React.memo((props: Props) => {
                  **/
                 sx={{ position: 'relative' }}
               />
-              <StyledTableFooter>
+              <StyledTableFooter sx={{ paddingLeft: 0, paddingTop: '8px' }}>
                 <StyledPoolInfoBox>
                   {(isDiskEncryptionFeatureEnabled ||
                     regionSupportsDiskEncryption) &&


### PR DESCRIPTION
## Description 📝

This PR makes some minor spacing changes to improve some inconsistencies throughout LKE as requested by UX during review of LKE-E.

## Changes  🔄

- Update the Cluster Tier selection card padding to `16px` all around and the space between the card heading and first subheading to `4px`
- Update the spacing at the bottom of the NodeTable to be equal on top and bottom (`8px`)
- Decrease the spacing at the top of the Labels & Taints drawer to be more standard (`24px`) and increase the spacing between the tables and the 'Add' buttons (`12px`)

## Target release date 🗓️

3/25

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![CardPaddingOld](https://github.com/user-attachments/assets/db5d7224-585a-416d-8cfd-ff77f208d791) | ![CardPaddingNew](https://github.com/user-attachments/assets/2edab014-922e-46b2-8c47-7bf1d38206c8) |
| ![CardInnerMarginOld](https://github.com/user-attachments/assets/39e306f2-81a5-4d4e-b2d5-fdcc4c18d7ab)| ![CardInnerMarginNew](https://github.com/user-attachments/assets/3770290a-192d-4cc7-8136-ebc3affe0c82) | 
| ![NodeTableOld](https://github.com/user-attachments/assets/59b80d91-3574-444a-b92e-6a0b6a5d0b6f) | ![NodeTableFixed](https://github.com/user-attachments/assets/a28a43ff-ae83-482c-aa82-7ad2a87e5358)|
| ![LTCopyOld](https://github.com/user-attachments/assets/5eff473d-070c-42a3-a457-3f1aba1d2131) | ![LTCopyNew](https://github.com/user-attachments/assets/5a195f58-4264-4673-a333-d8f8065eef9d) |
| ![LabelTaintTableOld](https://github.com/user-attachments/assets/ce859b7f-cee3-47ad-9b93-d11300d29441) | ![LabelTaintTableNew](https://github.com/user-attachments/assets/c46d5903-4dd7-4308-a7ba-0ec55308726d) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have the LKE-E customer tag on your account (see project tracker) and have the feature flag enabled

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Check out dev and see the current spacing inconsistencies

### Verification steps

(How to verify changes)

- [ ] Confirm spacing looks more consistent with the changes above

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
