### PR TITLE
POC: [M3-8978] - Mobile native selects

### DIFF
--- a/packages/manager/src/components/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.tsx
@@ -111,6 +111,7 @@ export const RegionSelect = <
         enableNativeSelectOnMobile={{
           getOptionValue: (option) => option.id,
           optionMatcher: (option, value) => option.id === value,
+          transformSelection: (option) => option,
         }}
         getOptionLabel={(region) =>
           isGeckoLAEnabled ? region.label : `${region.label} (${region.id})`

--- a/packages/manager/src/components/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.tsx
@@ -108,6 +108,10 @@ export const RegionSelect = <
   return (
     <StyledAutocompleteContainer sx={{ width }}>
       <Autocomplete<Region, false, DisableClearable>
+        enableNativeSelectOnMobile={{
+          getOptionValue: (option) => option.id,
+          optionMatcher: (option, value) => option.id === value,
+        }}
         getOptionLabel={(region) =>
           isGeckoLAEnabled ? region.label : `${region.label} (${region.id})`
         }

--- a/packages/ui/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/ui/src/components/Autocomplete/Autocomplete.tsx
@@ -122,7 +122,7 @@ export const Autocomplete = <
 
   const optionsWithSelectAll = [selectAllOption, ...options] as T[];
 
-  if (!isMobileDevice && enableNativeSelectOnMobile && !multiple) {
+  if (isMobileDevice && enableNativeSelectOnMobile && !multiple) {
     return (
       <Stack direction="column">
         <NativeSelect

--- a/packages/ui/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/ui/src/components/Autocomplete/Autocomplete.tsx
@@ -43,6 +43,10 @@ export interface EnhancedAutocompleteProps<
   enableNativeSelectOnMobile?: {
     optionMatcher: (option: T, value: string) => boolean;
     getOptionValue: (option: T) => string;
+    transformSelection: (
+      option: T,
+      event: React.ChangeEvent<HTMLSelectElement>
+    ) => AutocompleteValue<T, Multiple, DisableClearable, FreeSolo>;
   };
   /** A required label for the Autocomplete to ensure accessibility. */
   label: string;
@@ -118,7 +122,7 @@ export const Autocomplete = <
 
   const optionsWithSelectAll = [selectAllOption, ...options] as T[];
 
-  if (isMobileDevice && enableNativeSelectOnMobile && !multiple) {
+  if (!isMobileDevice && enableNativeSelectOnMobile && !multiple) {
     return (
       <Stack direction="column">
         <NativeSelect
@@ -126,16 +130,13 @@ export const Autocomplete = <
             const selectedOption = options.find((option) =>
               enableNativeSelectOnMobile.optionMatcher(option, e.target.value)
             );
-            onChange?.(
-              e,
-              selectedOption as AutocompleteValue<
-                T,
-                Multiple,
-                DisableClearable,
-                FreeSolo
-              >,
-              'selectOption'
-            );
+            if (selectedOption && onChange) {
+              const transformedValue = enableNativeSelectOnMobile.transformSelection(
+                selectedOption,
+                e
+              );
+              onChange(e, transformedValue, 'selectOption');
+            }
           }}
           sx={{
             width: '100%',

--- a/packages/ui/src/utilities/useIsMobileDevice.ts
+++ b/packages/ui/src/utilities/useIsMobileDevice.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+export const useIsMobileDevice = () => {
+  const [isMobileDevice, setIsMobileDevice] = useState(false);
+
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobileDevice(
+        'ontouchstart' in window ||
+          navigator.maxTouchPoints > 0 ||
+          window.matchMedia('(hover: none) and (pointer: coarse)').matches
+      );
+    };
+
+    checkMobile();
+    // eslint-disable-next-line scanjs-rules/call_addEventListener
+    window.addEventListener('resize', checkMobile);
+
+    return () => window.removeEventListener('resize', checkMobile);
+  }, []);
+
+  return { isMobileDevice };
+};


### PR DESCRIPTION
## Description 📝
https://github.com/user-attachments/assets/409234a3-6f77-405b-ae46-e32ce13c2dbb

## Changes  🔄

List any change(s) relevant to the reviewer.

- ...
- ...

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- ...
- ...

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
