### PR TITLE
fix: [M3-9526] - Fix database cluster config MUIv6 regressions

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.tsx
@@ -73,7 +73,7 @@ export const DatabaseSummaryClusterConfiguration = (props: Props) => {
       <Typography className={classes.header} variant="h3">
         Cluster Configuration
       </Typography>
-      <StyledGridContainer container spacing={0}>
+      <StyledGridContainer container size={{ md: 11 }} spacing={0}>
         <Grid
           size={{
             lg: 1,

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.tsx
@@ -73,7 +73,7 @@ export const DatabaseSummaryClusterConfiguration = (props: Props) => {
       <Typography className={classes.header} variant="h3">
         Cluster Configuration
       </Typography>
-      <StyledGridContainer container spacing={0} sx={{ md: 11 }}>
+      <StyledGridContainer container spacing={0}>
         <Grid
           size={{
             lg: 1,
@@ -131,7 +131,7 @@ export const DatabaseSummaryClusterConfiguration = (props: Props) => {
         >
           <StyledLabelTypography>Engine</StyledLabelTypography>
         </Grid>
-        <StyledValueGrid sx={{ lg: 2, md: 4, xs: 8 }}>
+        <StyledValueGrid size={{ lg: 2, md: 4, xs: 8 }}>
           <DatabaseEngineVersion
             databaseEngine={database.engine}
             databaseID={database.id}
@@ -189,7 +189,6 @@ export const DatabaseSummaryClusterConfiguration = (props: Props) => {
             convertMegabytesTo(type.disk, true)
           )}
         </StyledValueGrid>
-        s
       </StyledGridContainer>
     </>
   );


### PR DESCRIPTION
## Description 📝

Noticed a couple of regressions tracing back to the MUIv6 PR this afternoon. We need to get this into our release to avoid introducing the regressions, so this is pointed to `staging`.

No changeset since MUIv6 is not yet released.

## Changes  🔄
- Removed a stray `s` in the UI
- Swapped out the `sx` prop for the correct `size` prop to retain correct table layout

## Target release date 🗓️

⚠️  3/12 with our release

## Preview 📷

| Prod  | Staging   | This Branch |
| ------- | ------- | --- |
| ![Screenshot 2025-03-11 at 2 59 02 PM](https://github.com/user-attachments/assets/953fccc7-f3bc-465c-86cc-737f8ef389d1) | ![Screenshot 2025-03-11 at 2 58 33 PM](https://github.com/user-attachments/assets/7d35b578-667d-438a-a1cb-e7315ee958b8) | ![Screenshot 2025-03-11 at 2 58 18 PM](https://github.com/user-attachments/assets/2cfd56b4-a4d5-4d77-ad2a-317087435d19) |

## How to test 🧪

### Reproduction steps

(How to reproduce the issue, if applicable)

*On staging:*
- [ ] Have an avien database on your account
- [ ] Go to the cluster details page and observe the regression on the first tab

### Verification steps

(How to verify changes)

*On this branch:*
- [ ] Go to the cluster details page and observe the regressions are fixed

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
