### PR TITLE
poc: TypeScript Project References

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:analyze": "pnpm run --filter linode-manager build:analyze",
     "bootstrap": "pnpm install:all && pnpm build:validation && pnpm build:sdk",
     "up:expose": "npm_config_package_import_method=clone-or-copy pnpm install:all && pnpm build:validation && pnpm build:sdk && pnpm start:all:expose",
-    "dev": "concurrently -n api-v4,validation,ui,utilities,queries,manager -c blue,yellow,magenta,cyan,gray,green \"pnpm run --filter @linode/api-v4 start\" \"pnpm run --filter @linode/validation start\" \"pnpm run --filter @linode/ui start\" \"pnpm run --filter @linode/utilities start\" \"pnpm run --filter @linode/queries start\" \"pnpm run --filter linode-manager start\"",
+    "dev": "concurrently --raw \"tsc -b --watch --preserveWatchOutput\" \"pnpm run --filter '*' --color --stream --parallel start\"",
     "start:all:expose": "concurrently -n api-v4,validation,ui,utilities,queries,manager -c blue,yellow,magenta,cyan,gray,green \"pnpm run --filter @linode/api-v4 start\" \"pnpm run --filter @linode/validation start\" \"pnpm run --filter @linode/ui start\" \"pnpm run --filter @linode/utilities start\" \"pnpm run --filter @linode/queries start\" \"pnpm run --filter linode-manager start:expose\"",
     "start:manager": "pnpm --filter linode-manager start",
     "start:manager:ci": "pnpm run --filter linode-manager start:ci",

--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -46,7 +46,7 @@
     "yup": "1.4.0"
   },
   "scripts": {
-    "start": "concurrently --raw \"tsc -w --preserveWatchOutput\" \"tsup --watch\"",
+    "start": "tsup --watch",
     "build": "concurrently --raw \"tsc\" \"tsup\"",
     "test": "vitest run",
     "lint": "eslint . --quiet --ext .js,.ts,.tsx",

--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -43,7 +43,7 @@
     "@linode/validation": "workspace:*",
     "axios": "~1.7.4",
     "ipaddr.js": "^2.0.0",
-    "yup": "^1.4.0"
+    "yup": "1.4.0"
   },
   "scripts": {
     "start": "concurrently --raw \"tsc -w --preserveWatchOutput\" \"tsup --watch\"",

--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -1,7 +1,7 @@
 import type { Region, RegionSite } from '../regions';
 import type { IPAddress, IPRange } from '../networking/types';
 import type { LinodePlacementGroupPayload } from '../placement-groups/types';
-import { InferType } from 'yup';
+import type { InferType } from 'yup';
 import {
   CreateLinodeInterfaceSchema,
   ModifyLinodeInterfaceSchema,

--- a/packages/api-v4/tsconfig.json
+++ b/packages/api-v4/tsconfig.json
@@ -10,11 +10,15 @@
     "skipLibCheck": true,
     "strict": true,
     "baseUrl": ".",
+    "rootDir": "src",
     "noUnusedLocals": true,
     "declarationMap": true,
-    "incremental": true
+    "composite": true
   },
   "include": [
     "src"
+  ],
+  "references": [
+    { "path": "../validation" }
   ]
 }

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -94,7 +94,7 @@
     "zxcvbn": "^4.4.2"
   },
   "scripts": {
-    "start": "concurrently --raw \"NODE_OPTIONS='--max-old-space-size=4096' vite\" \"NODE_OPTIONS='--max-old-space-size=4096' tsc --watch --preserveWatchOutput\"",
+    "start": "vite",
     "start:expose": "concurrently --raw \"vite --host\" \"tsc --watch --preserveWatchOutput\"",
     "start:ci": "vite preview --port 3000 --host",
     "lint": "eslint . --ext .js,.ts,.tsx --quiet",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -91,7 +91,7 @@
     "typescript-fsa": "^3.0.0",
     "typescript-fsa-reducers": "^1.2.0",
     "yup": "1.4.0",
-    "zxcvbn": "^4.4.2"
+    "zxcvbn":"^4.4.2"
   },
   "scripts": {
     "start": "vite",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -90,7 +90,7 @@
     "tss-react": "^4.8.2",
     "typescript-fsa": "^3.0.0",
     "typescript-fsa-reducers": "^1.2.0",
-    "yup": "^1.4.0",
+    "yup": "1.4.0",
     "zxcvbn": "^4.4.2"
   },
   "scripts": {

--- a/packages/manager/tsconfig.json
+++ b/packages/manager/tsconfig.json
@@ -13,13 +13,14 @@
     },
     "resolveJsonModule": true,
     "rootDir": ".",
+    "outDir": "./lib",
 
     /* JavaScript Support */
     "allowJs": false,
 
     /* Emit */
     "sourceMap": true,
-    "noEmit": true,
+    "emitDeclarationOnly": true,
 
     /* Interop Constraints */
     "allowSyntheticDefaultImports": true,
@@ -39,10 +40,18 @@
     "skipLibCheck": true,
 
     /* Optimizations */
-    "incremental": true
+    "composite": true
   },
   "include": [
     "src",
     "package.json"
+  ],
+  "references": [
+    { "path": "../api-v4" },
+    { "path": "../validation" },
+    { "path": "../utilities" },
+    { "path": "../queries" },
+    { "path": "../ui" },
+    { "path": "../search" },
   ]
 }

--- a/packages/manager/tsconfig.json
+++ b/packages/manager/tsconfig.json
@@ -13,14 +13,13 @@
     },
     "resolveJsonModule": true,
     "rootDir": ".",
-    "outDir": "./lib",
 
     /* JavaScript Support */
     "allowJs": false,
 
     /* Emit */
     "sourceMap": true,
-    "emitDeclarationOnly": true,
+    "noEmit": true,
 
     /* Interop Constraints */
     "allowSyntheticDefaultImports": true,
@@ -40,7 +39,7 @@
     "skipLibCheck": true,
 
     /* Optimizations */
-    "composite": true
+    "incremental": true
   },
   "include": [
     "src",

--- a/packages/queries/package.json
+++ b/packages/queries/package.json
@@ -15,7 +15,6 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "start": "tsc -w --preserveWatchOutput",
     "lint": "eslint . --quiet --ext .js,.ts,.tsx",
     "typecheck": "tsc",
     "precommit": "lint-staged"

--- a/packages/queries/package.json
+++ b/packages/queries/package.json
@@ -4,7 +4,7 @@
   "description": "Linode Utility functions library",
   "main": "src/index.js",
   "module": "src/index.ts",
-  "types": "src/index.ts",
+  "types": "lib/src/index.d.ts",
   "author": "Linode",
   "license": "Apache-2.0",
   "repository": {
@@ -31,7 +31,8 @@
     "@lukemorales/query-key-factory": "^1.3.4",
     "@tanstack/react-query": "5.51.24",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "yup": "1.4.0"
   },
   "devDependencies": {
     "@linode/eslint-plugin-cloud-manager": "^0.0.7",
@@ -61,6 +62,7 @@
     "eslint-plugin-xss": "^0.1.10",
 
     "lint-staged": "^15.2.9",
-    "prettier": "~2.2.1"
+    "prettier": "~2.2.1",
+    "yup": "1.4.0"
   }
 }

--- a/packages/queries/tsconfig.json
+++ b/packages/queries/tsconfig.json
@@ -5,7 +5,9 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "skipLibCheck": true,
-    "noEmit": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "outDir": "./lib",
     "allowUnreachableCode": false,
     "noImplicitAny": true,
     "noImplicitReturns": true,
@@ -13,7 +15,10 @@
     "noUnusedLocals": true,
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
-    "incremental": true
+    "composite": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [
+    { "path": "../api-v4" },
+  ]
 }

--- a/packages/queries/tsconfig.json
+++ b/packages/queries/tsconfig.json
@@ -19,6 +19,6 @@
   },
   "include": ["src"],
   "references": [
-    { "path": "../api-v4" },
+    { "path": "../api-v4" }
   ]
 }

--- a/packages/search/tsconfig.json
+++ b/packages/search/tsconfig.json
@@ -4,11 +4,14 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "skipLibCheck": true,
-    "noEmit": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "outDir": "./lib",
     "strict": true,
     "noUnusedLocals": true,
     "forceConsistentCasingInFileNames": true,
-    "incremental": true
+    "incremental": true,
+    "composite": true,
   },
   "include": ["src"]
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,7 +29,6 @@
     "tss-react": "^4.8.2"
   },
   "scripts": {
-    "start": "tsc -w --preserveWatchOutput",
     "lint": "eslint . --quiet --ext .js,.ts,.tsx",
     "typecheck": "tsc",
     "test": "vitest run",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,6 +21,7 @@
     "@linode/design-language-system": "^4.0.0",
     "@mui/icons-material": "^6.4.5",
     "@mui/material": "^6.4.5",
+    "@mui/system": "^6.4.5",
     "@mui/utils": "^6.4.3",
     "@mui/x-date-pickers": "^7.27.0",
     "luxon": "3.4.4",

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -5,11 +5,14 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "skipLibCheck": true,
-    "noEmit": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "outDir": "./lib",
     "strict": true,
     "noUnusedLocals": true,
     "forceConsistentCasingInFileNames": true,
-    "incremental": true
+    "incremental": true,
+    "composite": true
   },
   "include": ["src"],
 }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -15,7 +15,6 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "start": "tsc -w --preserveWatchOutput",
     "lint": "eslint . --quiet --ext .js,.ts,.tsx",
     "typecheck": "tsc",
     "test": "vitest run",

--- a/packages/utilities/tsconfig.json
+++ b/packages/utilities/tsconfig.json
@@ -5,11 +5,16 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "skipLibCheck": true,
-    "noEmit": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "outDir": "./lib",
     "strict": true,
     "noUnusedLocals": true,
     "forceConsistentCasingInFileNames": true,
-    "incremental": true
+    "composite": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [
+    { "path": "../api-v4" }
+  ]
 }

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -26,7 +26,7 @@
     "lib"
   ],
   "scripts": {
-    "start": "concurrently --raw \"tsc -w --preserveWatchOutput\" \"tsup --watch\"",
+    "start": "tsup --watch",
     "build": "concurrently --raw \"tsc\" \"tsup\"",
     "lint": "eslint . --quiet --ext .js,.ts,.tsx",
     "typecheck": "tsc --noEmit true --emitDeclarationOnly false"

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "ipaddr.js": "^2.0.0",
     "libphonenumber-js": "^1.10.6",
-    "yup": "^1.4.0"
+    "yup": "1.4.0"
   },
   "devDependencies": {
     "concurrently": "^9.0.1",

--- a/packages/validation/tsconfig.json
+++ b/packages/validation/tsconfig.json
@@ -12,7 +12,8 @@
     "baseUrl": ".",
     "noUnusedLocals": true,
     "declarationMap": true,
-    "incremental": true
+    "composite": true,
+    "rootDir": "src"
   },
   "include": [
     "src"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,7 +132,7 @@ importers:
         version: 6.4.3(@types/react@18.3.12)(react@18.3.1)
       '@mui/x-date-pickers':
         specifier: ^7.27.0
-        version: 7.27.0(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@mui/material@6.4.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.4.3(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(dayjs@1.11.13)(luxon@3.4.4)(moment@2.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 7.27.0(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@mui/material@6.4.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.4.7(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(dayjs@1.11.13)(luxon@3.4.4)(moment@2.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@paypal/react-paypal-js':
         specifier: ^7.8.3
         version: 7.8.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -590,6 +590,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      yup:
+        specifier: 1.4.0
+        version: 1.4.0
     devDependencies:
       '@linode/eslint-plugin-cloud-manager':
         specifier: ^0.0.7
@@ -693,12 +696,15 @@ importers:
       '@mui/material':
         specifier: ^6.4.5
         version: 6.4.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/system':
+        specifier: ^6.4.5
+        version: 6.4.7(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)
       '@mui/utils':
         specifier: ^6.4.3
         version: 6.4.3(@types/react@18.3.12)(react@18.3.1)
       '@mui/x-date-pickers':
         specifier: ^7.27.0
-        version: 7.27.0(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@mui/material@6.4.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.4.3(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(dayjs@1.11.13)(luxon@3.4.4)(moment@2.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 7.27.0(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@mui/material@6.4.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.4.7(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(dayjs@1.11.13)(luxon@3.4.4)(moment@2.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       luxon:
         specifier: 3.4.4
         version: 3.4.4
@@ -1817,8 +1823,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/private-theming@6.4.3':
-    resolution: {integrity: sha512-7x9HaNwDCeoERc4BoEWLieuzKzXu5ZrhRnEM6AUcRXUScQLvF1NFkTlP59+IJfTbEMgcGg1wWHApyoqcksrBpQ==}
+  '@mui/private-theming@6.4.6':
+    resolution: {integrity: sha512-T5FxdPzCELuOrhpA2g4Pi6241HAxRwZudzAuL9vBvniuB5YU82HCmrARw32AuCiyTfWzbrYGGpZ4zyeqqp9RvQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1827,8 +1833,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/styled-engine@6.4.3':
-    resolution: {integrity: sha512-OC402VfK+ra2+f12Gef8maY7Y9n7B6CZcoQ9u7mIkh/7PKwW/xH81xwX+yW+Ak1zBT3HYcVjh2X82k5cKMFGoQ==}
+  '@mui/styled-engine@6.4.6':
+    resolution: {integrity: sha512-vSWYc9ZLX46be5gP+FCzWVn5rvDr4cXC5JBZwSIkYk9xbC7GeV+0kCvB8Q6XLFQJy+a62bbqtmdwS4Ghi9NBlQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.4.1
@@ -1840,8 +1846,8 @@ packages:
       '@emotion/styled':
         optional: true
 
-  '@mui/system@6.4.3':
-    resolution: {integrity: sha512-Q0iDwnH3+xoxQ0pqVbt8hFdzhq1g2XzzR4Y5pVcICTNtoCLJmpJS3vI4y/OIM1FHFmpfmiEC2IRIq7YcZ8nsmg==}
+  '@mui/system@6.4.7':
+    resolution: {integrity: sha512-7wwc4++Ak6tGIooEVA9AY7FhH2p9fvBMORT4vNLMAysH3Yus/9B9RYMbrn3ANgsOyvT3Z7nE+SP8/+3FimQmcg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -1866,6 +1872,16 @@ packages:
 
   '@mui/utils@6.4.3':
     resolution: {integrity: sha512-jxHRHh3BqVXE9ABxDm+Tc3wlBooYz/4XPa0+4AI+iF38rV1/+btJmSUgG4shDtSWVs/I97aDn5jBCt6SF2Uq2A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/utils@6.4.6':
+    resolution: {integrity: sha512-43nZeE1pJF2anGafNydUcYFPtHwAqiBiauRtaMvurdrZI3YrUjHkAu43RBsxef7OFtJMXGiHFvq43kb7lig0sA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -7839,7 +7855,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.26.0
       '@mui/core-downloads-tracker': 6.4.5
-      '@mui/system': 6.4.3(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)
+      '@mui/system': 6.4.7(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)
       '@mui/types': 7.2.21(@types/react@18.3.12)
       '@mui/utils': 6.4.3(@types/react@18.3.12)(react@18.3.1)
       '@popperjs/core': 2.11.8
@@ -7856,16 +7872,16 @@ snapshots:
       '@emotion/styled': 11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)
       '@types/react': 18.3.12
 
-  '@mui/private-theming@6.4.3(@types/react@18.3.12)(react@18.3.1)':
+  '@mui/private-theming@6.4.6(@types/react@18.3.12)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.26.0
-      '@mui/utils': 6.4.3(@types/react@18.3.12)(react@18.3.1)
+      '@mui/utils': 6.4.6(@types/react@18.3.12)(react@18.3.1)
       prop-types: 15.8.1
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.12
 
-  '@mui/styled-engine@6.4.3(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)':
+  '@mui/styled-engine@6.4.6(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.26.0
       '@emotion/cache': 11.13.5
@@ -7878,13 +7894,13 @@ snapshots:
       '@emotion/react': 11.13.5(@types/react@18.3.12)(react@18.3.1)
       '@emotion/styled': 11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)
 
-  '@mui/system@6.4.3(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)':
+  '@mui/system@6.4.7(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.26.0
-      '@mui/private-theming': 6.4.3(@types/react@18.3.12)(react@18.3.1)
-      '@mui/styled-engine': 6.4.3(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)
+      '@mui/private-theming': 6.4.6(@types/react@18.3.12)(react@18.3.1)
+      '@mui/styled-engine': 6.4.6(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)
       '@mui/types': 7.2.21(@types/react@18.3.12)
-      '@mui/utils': 6.4.3(@types/react@18.3.12)(react@18.3.1)
+      '@mui/utils': 6.4.6(@types/react@18.3.12)(react@18.3.1)
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
@@ -7910,11 +7926,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.12
 
-  '@mui/x-date-pickers@7.27.0(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@mui/material@6.4.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.4.3(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(dayjs@1.11.13)(luxon@3.4.4)(moment@2.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@mui/utils@6.4.6(@types/react@18.3.12)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@mui/types': 7.2.21(@types/react@18.3.12)
+      '@types/prop-types': 15.7.14
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-is: 19.0.0
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  '@mui/x-date-pickers@7.27.0(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@mui/material@6.4.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.4.7(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(dayjs@1.11.13)(luxon@3.4.4)(moment@2.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.26.0
       '@mui/material': 6.4.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mui/system': 6.4.3(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)
+      '@mui/system': 6.4.7(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)
       '@mui/utils': 6.4.3(@types/react@18.3.12)(react@18.3.1)
       '@mui/x-internals': 7.26.0(@types/react@18.3.12)(react@18.3.1)
       '@types/react-transition-group': 4.4.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^2.0.0
         version: 2.2.0
       yup:
-        specifier: ^1.4.0
-        version: 1.5.0
+        specifier: 1.4.0
+        version: 1.4.0
     devDependencies:
       axios-mock-adapter:
         specifier: ^1.22.0
@@ -299,8 +299,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.2(typescript-fsa@3.0.0)
       yup:
-        specifier: ^1.4.0
-        version: 1.5.0
+        specifier: 1.4.0
+        version: 1.4.0
       zxcvbn:
         specifier: ^4.4.2
         version: 4.4.2
@@ -840,8 +840,8 @@ importers:
         specifier: ^1.10.6
         version: 1.11.14
       yup:
-        specifier: ^1.4.0
-        version: 1.5.0
+        specifier: 1.4.0
+        version: 1.4.0
     devDependencies:
       concurrently:
         specifier: ^9.0.1
@@ -6976,8 +6976,8 @@ packages:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
 
-  yup@1.5.0:
-    resolution: {integrity: sha512-NJfBIHnp1QbqZwxcgl6irnDMIsb/7d1prNhFx02f1kp8h+orpi4xs3w90szNpOh68a/iHPdMsYvhZWoDmUvXBQ==}
+  yup@1.4.0:
+    resolution: {integrity: sha512-wPbgkJRCqIf+OHyiTBQoJiP5PFuAXaWiJK6AmYkzQAh5/c2K9hzSApBZG5wV9KoKSePF7sAxmNSvh/13YHkFDg==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -13760,7 +13760,7 @@ snapshots:
 
   yoctocolors-cjs@2.1.2: {}
 
-  yup@1.5.0:
+  yup@1.4.0:
     dependencies:
       property-expr: 2.0.6
       tiny-case: 1.0.3

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./packages/manager" },
+    { "path": "./packages/api-v4" },
+    { "path": "./packages/validation" },
+    { "path": "./packages/utilities" },
+    { "path": "./packages/queries" },
+    { "path": "./packages/search" },
+    { "path": "./packages/ui" },
+  ]
+}


### PR DESCRIPTION
## Description 📝

- Attempt to use TypeScript's project references feature to improve typechecking stability and performance

### Benefits
- Only runs **one instance** of `tsc` instead of one per-project
  - In theory, this should improve resource usage, but I'm still seeing 3+ GB  ram usage so idk 🤷‍♂️ 
- Packages get built **in order** based on what they depend on


## Findings 🔍 
- Seems to be working as intended, but not seeing performance gains that I would expect, not sure why yet...