### PR TITLE
fix: [M3-9533] Storybook crypto.randomUUID Error

### DIFF
--- a/packages/manager/.changeset/pr-11835-fixed-1741797017641.md
+++ b/packages/manager/.changeset/pr-11835-fixed-1741797017641.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Storybook not rendering due to crytpto.randomUUID not being available in Storybook context ([#11835](https://github.com/linode/manager/pull/11835))

--- a/packages/manager/src/factories/kubernetesCluster.ts
+++ b/packages/manager/src/factories/kubernetesCluster.ts
@@ -56,13 +56,13 @@ export const kubernetesClusterFactory = Factory.Sync.makeFactory<KubernetesClust
 
 export const kubeEndpointFactory = Factory.Sync.makeFactory<KubernetesEndpointResponse>(
   {
-    endpoint: `https://${crypto.randomUUID()}`,
+    endpoint: `https://${crypto.randomUUID && crypto.randomUUID()}`,
   }
 );
 
 export const kubernetesDashboardUrlFactory = Factory.Sync.makeFactory<KubernetesDashboardResponse>(
   {
-    url: `https://${crypto.randomUUID()}`,
+    url: `https://${crypto.randomUUID && crypto.randomUUID()}`,
   }
 );
 

--- a/packages/manager/src/factories/statusPage.ts
+++ b/packages/manager/src/factories/statusPage.ts
@@ -22,7 +22,7 @@ export const pageFactory = Factory.Sync.makeFactory<IncidentPage>({
 export const incidentUpdateFactory = Factory.Sync.makeFactory<IncidentUpdate>({
   affected_components: [
     {
-      code: crypto.randomUUID(),
+      code: crypto.randomUUID && crypto.randomUUID(),
       name:
         'Linode Kubernetes Engine - US-East (Newark) Linode Kubernetes Engine',
       new_status: 'major_outage',
@@ -36,7 +36,7 @@ export const incidentUpdateFactory = Factory.Sync.makeFactory<IncidentUpdate>({
   deliver_notifications: true,
   display_at: DATE,
   id: Factory.each((i) => String(i)),
-  incident_id: crypto.randomUUID(),
+  incident_id: crypto.randomUUID && crypto.randomUUID(),
   status: 'investigating',
   tweet_id: Math.floor(Math.random() * 1000000),
   updated_at: DATE,
@@ -49,7 +49,7 @@ export const incidentFactory = Factory.Sync.makeFactory<Incident>({
   incident_updates: incidentUpdateFactory.buildList(5),
   monitoring_at: DATE,
   name: 'Service Issue - Linode Kubernetes Engine',
-  page_id: crypto.randomUUID(),
+  page_id: crypto.randomUUID && crypto.randomUUID(),
   resolved_at: DATE,
   shortlink: 'https://stspg.io/gm27wxnn653m',
   started_at: DATE,


### PR DESCRIPTION
## Description 📝

This PR fixes a Storybook rendering issue where components fail with "TypeError: crypto.randomUUID is not a function". Components using `crypto.randomUUID` in factory files were unable to render properly in the Storybook environment.

## Changes  🔄

- Added a conditional check for `crypto.randomUUID`

## Preview 📷
| Before  | After   |
| ------- | ------- |
| <img src="https://github.com/user-attachments/assets/38815cb1-ae69-4efc-b6fe-690cbe713913" /> | <img src="https://github.com/user-attachments/assets/7fa67cd7-2e6f-4728-bbff-b563a5409469" /> |

### Verification steps

- [ ] Rebuild Storybook locally with `pnpm run --filter linode-manager build-storybook`
- [ ] Start local Storybook server with `pnpm storybook`
- [ ] Verify that any component is rendering in Storybook without error above

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>