### PR TITLE
refactor: [DI-23972] - Updated redirection for invalid url to metrics & alerts home page

### DIFF
--- a/packages/manager/.changeset/pr-11837-added-1741874687278.md
+++ b/packages/manager/.changeset/pr-11837-added-1741874687278.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Add logic to redirect invalid paths to home page of /metrics & /alerts/definitions url ([#11837](https://github.com/linode/manager/pull/11837))

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsLanding/AlertsDefinitionLanding.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsLanding/AlertsDefinitionLanding.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Route, Switch, useRouteMatch } from 'react-router-dom';
+import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
 
 import { AlertDetail } from '../AlertsDetail/AlertDetail';
 import { AlertListing } from '../AlertsListing/AlertListing';
@@ -19,6 +19,7 @@ export const AlertDefinitionLanding = () => {
       <Route exact path={`${url}/edit/:serviceType/:alertId`}>
         <EditAlertLanding />
       </Route>
+      <Redirect from="*" to={`${url}`} />
     </Switch>
   );
 };

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsLanding/AlertsDefinitionLanding.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsLanding/AlertsDefinitionLanding.tsx
@@ -19,7 +19,7 @@ export const AlertDefinitionLanding = () => {
       <Route exact path={`${url}/edit/:serviceType/:alertId`}>
         <EditAlertLanding />
       </Route>
-      <Redirect from="*" to={`${url}`} />
+      <Redirect from="*" to={url} />
     </Switch>
   );
 };

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardLanding.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardLanding.tsx
@@ -13,6 +13,7 @@ import { defaultTimeDuration } from '../Utils/CloudPulseDateTimePickerUtils';
 import { CloudPulseDashboardRenderer } from './CloudPulseDashboardRenderer';
 
 import type { Dashboard, DateTimeWithPreset } from '@linode/api-v4';
+import {Redirect} from 'react-router-dom'
 
 export type FilterValueType = number | number[] | string | string[] | undefined;
 
@@ -112,6 +113,7 @@ export const CloudPulseDashboardLanding = () => {
           timeDuration={timeDuration}
         />
       </Grid>
+      <Redirect from="*" to ="/metrics"/>
     </React.Suspense>
   );
 };

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardLanding.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardLanding.tsx
@@ -2,6 +2,7 @@ import { Box, Paper } from '@linode/ui';
 import { Grid } from '@mui/material';
 import { createLazyRoute } from '@tanstack/react-router';
 import * as React from 'react';
+import { Redirect } from 'react-router-dom';
 
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { LandingHeader } from 'src/components/LandingHeader';
@@ -13,7 +14,6 @@ import { defaultTimeDuration } from '../Utils/CloudPulseDateTimePickerUtils';
 import { CloudPulseDashboardRenderer } from './CloudPulseDashboardRenderer';
 
 import type { Dashboard, DateTimeWithPreset } from '@linode/api-v4';
-import {Redirect} from 'react-router-dom'
 
 export type FilterValueType = number | number[] | string | string[] | undefined;
 
@@ -113,7 +113,7 @@ export const CloudPulseDashboardLanding = () => {
           timeDuration={timeDuration}
         />
       </Grid>
-      <Redirect from="*" to ="/metrics"/>
+      <Redirect from="*" to="/metrics" />
     </React.Suspense>
   );
 };


### PR DESCRIPTION
## Description 📝

Updated logic to handle for invalid paths after /metrics/ & /alerts/definitions/ to redirect to /metrics & /alerts/definitions respectively

## Changes  🔄

List any change(s) relevant to the reviewer.

1. Updated AlertsDefinitionLanding.tsx to add redirection logic
2. Updated CloudPulseDashboardLanding.tsx to add redirection logic

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
|<video src="https://github.com/user-attachments/assets/b1d2bbfb-a79b-40fa-9a5d-4dd0b3bb9ab1"/>|<video src="https://github.com/user-attachments/assets/ed7fad55-24f3-4948-9abe-865429acc7e8"/>|



## How to test 🧪

1.  Go to metrics from mega menu & update urls to anything after /metrics/, it should redirect to /metrics
2. Go to alerts from mega menu & update urls to anything after /alerts/definitions/, it should redirect to /alerts/definitions if it is an invalid path
### Prerequisites

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

