### PR TITLE
fix: [M3-9459] - show details button misalignment for selected stackscript

### DIFF
--- a/packages/manager/.changeset/pr-11838-fixed-1741862453402.md
+++ b/packages/manager/.changeset/pr-11838-fixed-1741862453402.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+show details button misalignment for selected stackscript ([#11838](https://github.com/linode/manager/pull/11838))

--- a/packages/manager/.changeset/pr-11838-fixed-1741862453402.md
+++ b/packages/manager/.changeset/pr-11838-fixed-1741862453402.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-show details button misalignment for selected stackscript ([#11838](https://github.com/linode/manager/pull/11838))
+Show details button misalignment for selected StackScript ([#11838](https://github.com/linode/manager/pull/11838))

--- a/packages/manager/src/features/Linodes/LinodeCreate/Tabs/StackScripts/StackScriptSelectionRow.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Tabs/StackScripts/StackScriptSelectionRow.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import { Radio, Stack, Typography } from '@linode/ui';
 import { truncate } from '@linode/utilities';
+import { styled } from '@mui/material';
 import React from 'react';
 
 import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
@@ -60,18 +61,19 @@ export const StackScriptSelectionRow = (props: Props) => {
           </Stack>
         </label>
       </TableCell>
-      <TableCell
-        sx={{
-          display: 'flex',
-          justifyContent: 'flex-end',
-          minWidth: 120,
-          paddingRight: 0,
-          height: 44,
-        }}
-        actionCell
-      >
-        <InlineMenuAction actionText="Show Details" onClick={onOpenDetails} />
+      <TableCell noWrap sx={{ paddingRight: 0 }}>
+        <StyledRootContainer>
+          <InlineMenuAction actionText="Show Details" onClick={onOpenDetails} />
+        </StyledRootContainer>
       </TableCell>
     </TableRow>
   );
 };
+
+const StyledRootContainer = styled('div', {
+  label: 'StyledRootContainer',
+})(() => ({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  padding: 0,
+}));

--- a/packages/manager/src/features/Linodes/LinodeCreate/Tabs/StackScripts/StackScriptSelectionRow.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Tabs/StackScripts/StackScriptSelectionRow.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import { Radio, Stack, Typography } from '@linode/ui';
 import { truncate } from '@linode/utilities';
-import { styled } from '@mui/material';
 import React from 'react';
 
 import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
@@ -61,19 +60,9 @@ export const StackScriptSelectionRow = (props: Props) => {
           </Stack>
         </label>
       </TableCell>
-      <TableCell noWrap sx={{ paddingRight: 0 }}>
-        <StyledRootContainer>
-          <InlineMenuAction actionText="Show Details" onClick={onOpenDetails} />
-        </StyledRootContainer>
+      <TableCell actionCell>
+        <InlineMenuAction actionText="Show Details" onClick={onOpenDetails} />
       </TableCell>
     </TableRow>
   );
 };
-
-const StyledRootContainer = styled('div', {
-  label: 'StyledRootContainer',
-})(() => ({
-  display: 'flex',
-  justifyContent: 'flex-end',
-  padding: 0,
-}));


### PR DESCRIPTION
# PR Description 📝  
This PR fixes the display issue with the `Show Details` button for Selected StackScripts on smaller screen sizes. The button now appears correctly and is centered.

## Changes 🔄  
- Fixed the display of the `Show Details` button on smaller screens.
- Centered the button for better alignment.

## Target release date 🗓️  
N/A  

| Before | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/23b2e970-ac69-4d1a-98d2-43f527ad76fe"></video> | <video src="https://github.com/user-attachments/assets/293b685f-5dc0-4d2c-9e71-9c0b741d4853"></video> |

### Verification steps  
- Verify the button displays correctly and is centered on smaller screens.  
- Confirm the button remains functional when clicked.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

