### PR TITLE
feat: [UIE-8141] - IAM RBAC: add new drawer for changing role flow

### DIFF
--- a/packages/api-v4/.changeset/pr-11840-upcoming-features-1741881740441.md
+++ b/packages/api-v4/.changeset/pr-11840-upcoming-features-1741881740441.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Upcoming Features
+---
+
+Fix the type of parametr in api in IAM ([#11840](https://github.com/linode/manager/pull/11840))

--- a/packages/api-v4/.changeset/pr-11840-upcoming-features-1741881740441.md
+++ b/packages/api-v4/.changeset/pr-11840-upcoming-features-1741881740441.md
@@ -2,4 +2,4 @@
 "@linode/api-v4": Upcoming Features
 ---
 
-Fix the type of parametr in api in IAM ([#11840](https://github.com/linode/manager/pull/11840))
+Fix the type of parameter in api in IAM ([#11840](https://github.com/linode/manager/pull/11840))

--- a/packages/api-v4/src/iam/iam.ts
+++ b/packages/api-v4/src/iam/iam.ts
@@ -31,7 +31,7 @@ export const getUserPermissions = (username: string) =>
  */
 export const updateUserPermissions = (
   username: string,
-  data: Partial<IamUserPermissions>
+  data: IamUserPermissions
 ) =>
   Request<IamUserPermissions>(
     setURL(

--- a/packages/manager/.changeset/pr-11840-upcoming-features-1741881680603.md
+++ b/packages/manager/.changeset/pr-11840-upcoming-features-1741881680603.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add a new drawer for changing role flow in IAM ([#11840](https://github.com/linode/manager/pull/11840))

--- a/packages/manager/src/features/IAM/Shared/AssignedPermissionsPanel/AssignedPermissionsPanel.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedPermissionsPanel/AssignedPermissionsPanel.tsx
@@ -61,7 +61,6 @@ export const AssignedPermissionsPanel = ({ assignedEntities, role }: Props) => {
               width: 'max-content',
             }}
             onClick={() => setShowFullDescription((show) => !show)}
-            type="button"
           >
             {showFullDescription ? 'Hide' : 'Expand'}
           </StyledLinkButton>

--- a/packages/manager/src/features/IAM/Shared/AssignedPermissionsPanel/AssignedPermissionsPanel.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedPermissionsPanel/AssignedPermissionsPanel.tsx
@@ -61,6 +61,7 @@ export const AssignedPermissionsPanel = ({ assignedEntities, role }: Props) => {
               width: 'max-content',
             }}
             onClick={() => setShowFullDescription((show) => !show)}
+            type="button"
           >
             {showFullDescription ? 'Hide' : 'Expand'}
           </StyledLinkButton>

--- a/packages/manager/src/features/IAM/Shared/AssignedPermissionsPanel/AssignedPermissionsPanel.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedPermissionsPanel/AssignedPermissionsPanel.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { Entities } from '../Entities/Entities';
 import { Permissions } from '../Permissions/Permissions';
 
+import type { EntitiesOption } from '../utilities';
 import type {
   IamAccessType,
   ResourceTypePermissions,
@@ -17,11 +18,12 @@ interface ExtendedRole extends Roles {
   resource_type: ResourceTypePermissions;
 }
 
-type Props = {
+interface Props {
+  assignedEntities?: EntitiesOption[];
   role: ExtendedRole;
-};
+}
 
-export const AssignedPermissionsPanel = ({ role }: Props) => {
+export const AssignedPermissionsPanel = ({ assignedEntities, role }: Props) => {
   const [showFullDescription, setShowFullDescription] = React.useState(false);
 
   const theme = useTheme();
@@ -59,13 +61,18 @@ export const AssignedPermissionsPanel = ({ role }: Props) => {
               width: 'max-content',
             }}
             onClick={() => setShowFullDescription((show) => !show)}
+            type="button"
           >
             {showFullDescription ? 'Hide' : 'Expand'}
           </StyledLinkButton>
         )}
       </Typography>
       <Permissions permissions={role.permissions} />
-      <Entities access={role.access} type={role.resource_type} />
+      <Entities
+        access={role.access}
+        assignedEntities={assignedEntities ?? []}
+        type={role.resource_type}
+      />
     </Paper>
   );
 };

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/AssignedRolesTable.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/AssignedRolesTable.tsx
@@ -37,12 +37,24 @@ import type { AccountAccessType, RoleType } from '@linode/api-v4';
 import type { Action } from 'src/components/ActionMenu/ActionMenu';
 import type { TableItem } from 'src/components/CollapsibleTable/CollapsibleTable';
 import { capitalize, truncate } from '@linode/utilities';
+import { ChangeRoleDrawer } from './ChangeRoleDrawer';
 
 export const AssignedRolesTable = () => {
   const { username } = useParams<{ username: string }>();
   const history = useHistory();
   const { handleOrderChange, order, orderBy } = useOrder();
   const theme = useTheme();
+
+  const [
+    isChangeRoleDrawerOpen,
+    setIsChangeRoleDrawerOpen,
+  ] = React.useState<boolean>(false);
+  const [selectedRole, setSelectedRole] = React.useState<ExtendedRoleMap>();
+
+  const handleChangeRole = (role: ExtendedRoleMap) => {
+    setIsChangeRoleDrawerOpen(true);
+    setSelectedRole(role);
+  };
 
   const {
     data: accountPermissions,
@@ -100,7 +112,7 @@ export const AssignedRolesTable = () => {
       const accountMenu: Action[] = [
         {
           onClick: () => {
-            // mock
+            handleChangeRole(role);
           },
           title: 'Change Role',
         },
@@ -125,7 +137,7 @@ export const AssignedRolesTable = () => {
         },
         {
           onClick: () => {
-            // mock
+            handleChangeRole(role);
           },
           title: 'Change Role',
         },
@@ -137,11 +149,12 @@ export const AssignedRolesTable = () => {
         },
       ];
 
-      const actions = role.access === 'account' ? accountMenu : entitiesMenu;
+      const actions =
+        role.access === 'account_access' ? accountMenu : entitiesMenu;
 
       const OuterTableCells = (
         <>
-          {role.access === 'account' ? (
+          {role.access === 'account_access' ? (
             <TableCell sx={{ display: { sm: 'table-cell', xs: 'none' } }}>
               <Typography>
                 {role.resource_type === 'account'
@@ -288,6 +301,11 @@ export const AssignedRolesTable = () => {
         }
         TableItems={memoizedTableItems}
         TableRowHead={RoleTableRowHead}
+      />
+      <ChangeRoleDrawer
+        onClose={() => setIsChangeRoleDrawerOpen(false)}
+        open={isChangeRoleDrawerOpen}
+        role={selectedRole}
       />
     </Grid>
   );

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.test.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.test.tsx
@@ -1,0 +1,138 @@
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { accountPermissionsFactory } from 'src/factories/accountPermissions';
+import { accountResourcesFactory } from 'src/factories/accountResources';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { ChangeRoleDrawer } from './ChangeRoleDrawer';
+
+import type { ExtendedRoleMap } from '../utilities';
+
+const queryMocks = vi.hoisted(() => ({
+  useAccountPermissions: vi.fn().mockReturnValue({}),
+  useAccountResources: vi.fn().mockReturnValue({}),
+  useAccountUserPermissions: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('src/queries/iam/iam', async () => {
+  const actual = await vi.importActual<any>('src/queries/iam/iam');
+  return {
+    ...actual,
+    useAccountPermissions: queryMocks.useAccountPermissions,
+    useAccountUserPermissions: queryMocks.useAccountUserPermissions,
+  };
+});
+
+vi.mock('src/queries/resources/resources', async () => {
+  const actual = await vi.importActual<any>('src/queries/resources/resources');
+  return {
+    ...actual,
+    useAccountResources: queryMocks.useAccountResources,
+  };
+});
+
+const mockRole: ExtendedRoleMap = {
+  access: 'account_access',
+  description:
+    'Access to perform any supported action on all resources in the account',
+  id: 'account_admin',
+  name: 'account_admin',
+  permissions: ['create_linode', 'update_linode', 'update_firewall'],
+  resource_ids: null,
+  resource_type: 'account',
+};
+
+const props = {
+  onClose: vi.fn(),
+  open: true,
+  role: mockRole,
+};
+
+const mockUpdateUserRole = vi.fn();
+vi.mock('@linode/api-v4', async () => {
+  return {
+    ...(await vi.importActual<any>('@linode/api-v4')),
+    updateUserPermissions: (username: string, data: any) => {
+      mockUpdateUserRole(data);
+      return Promise.resolve(props);
+    },
+  };
+});
+
+describe('ChangeRoleDrawer', () => {
+  it('should render', async () => {
+    const { getByText } = renderWithTheme(<ChangeRoleDrawer {...props} />);
+
+    // Verify title renders
+    getByText('Change Role');
+  });
+
+  it('should allow changing role', async () => {
+    queryMocks.useAccountUserPermissions.mockReturnValue({
+      data: {
+        account_access: ['account_linode_admin', 'account_admin'],
+        resource_access: [
+          {
+            resource_id: 12345678,
+            resource_type: 'linode',
+            roles: ['linode_contributor'],
+          },
+        ],
+      },
+    });
+
+    queryMocks.useAccountPermissions.mockReturnValue({
+      data: accountPermissionsFactory.build(),
+    });
+
+    queryMocks.useAccountResources.mockReturnValue({
+      data: accountResourcesFactory.build(),
+    });
+
+    const { getByText } = renderWithTheme(<ChangeRoleDrawer {...props} />);
+
+    const autocomplete = screen.getByRole('combobox');
+
+    await waitFor(
+      () => {
+        expect(autocomplete).toHaveValue('account_admin');
+      },
+      { interval: 100, timeout: 5000 }
+    );
+
+    act(() => {
+      // Open the dropdown
+      fireEvent.click(autocomplete);
+
+      // Type to filter options
+      fireEvent.change(autocomplete, {
+        target: { value: 'account_viewer' },
+      });
+    });
+
+    // Wait for and select the "account_viewer Read" option
+    const newRole = await screen.findByText('account_viewer');
+    await userEvent.click(newRole);
+
+    await waitFor(() => {
+      expect(autocomplete).toHaveValue('account_viewer');
+    });
+
+    await userEvent.click(getByText('Save Change'));
+
+    await waitFor(() => {
+      expect(mockUpdateUserRole).toHaveBeenCalledWith({
+        account_access: ['account_linode_admin', 'account_viewer'],
+        resource_access: [
+          {
+            resource_id: 12345678,
+            resource_type: 'linode',
+            roles: ['linode_contributor'],
+          },
+        ],
+      });
+    });
+  });
+});

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.tsx
@@ -70,24 +70,25 @@ export const ChangeRoleDrawer = ({ onClose, open, role }: Props) => {
     watch,
   } = useForm<{ roleName: RolesType }>({
     defaultValues: {
-      roleName: undefined,
+      roleName: {
+        access: role?.access,
+        label: role?.name,
+        resource_type: role?.resource_type,
+        value: role?.name,
+      },
     },
     mode: 'onBlur',
+    values: role
+      ? {
+          roleName: {
+            access: role.access,
+            label: role.name,
+            resource_type: role.resource_type,
+            value: role.name,
+          },
+        }
+      : undefined,
   });
-
-  // Effect to update form values when role changes
-  React.useEffect(() => {
-    if (role) {
-      reset({
-        roleName: {
-          access: role.access,
-          label: role.name,
-          resource_type: role.resource_type,
-          value: role.name,
-        },
-      });
-    }
-  }, [role, reset]);
 
   // Watch the selected role
   const selectedOptions = watch('roleName');
@@ -111,12 +112,12 @@ export const ChangeRoleDrawer = ({ onClose, open, role }: Props) => {
       const newRole = data.roleName.label;
       const access = data.roleName.access;
 
-      const updatedUserRoles = updateUserRoles(
-        assignedRoles!,
-        initialRole!,
+      const updatedUserRoles = updateUserRoles({
+        access,
+        assignedRoles,
+        initialRole,
         newRole,
-        access
-      );
+      });
 
       await updateUserPermissions(updatedUserRoles);
 
@@ -139,12 +140,7 @@ export const ChangeRoleDrawer = ({ onClose, open, role }: Props) => {
       {errors.root?.message && (
         <Notice text={errors.root?.message} variant="error" />
       )}
-      <form
-        onSubmit={(e: React.ChangeEvent<HTMLFormElement>) => {
-          e.preventDefault();
-          handleSubmit(onSubmit);
-        }}
-      >
+      <form onSubmit={handleSubmit(onSubmit)}>
         <Typography sx={{ marginBottom: 2.5 }}>
           Select a role you want to assign.
           <Link to=""> Learn more about roles and permissions.</Link>

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.tsx
@@ -1,0 +1,238 @@
+import { ActionsPanel, Autocomplete, Notice, Typography } from '@linode/ui';
+import { useTheme } from '@mui/material/styles';
+import React from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { useParams } from 'react-router-dom';
+
+import { Drawer } from 'src/components/Drawer';
+import { Link } from 'src/components/Link';
+import {
+  useAccountPermissions,
+  useAccountUserPermissions,
+  useAccountUserPermissionsMutation,
+} from 'src/queries/iam/iam';
+
+import { AssignedPermissionsPanel } from '../AssignedPermissionsPanel/AssignedPermissionsPanel';
+import { getAllRoles, getRoleByName } from '../utilities';
+
+import type { EntitiesOption, ExtendedRoleMap, RolesType } from '../utilities';
+import type {
+  AccountAccessType,
+  IamUserPermissions,
+  ResourceAccess,
+  RoleType,
+} from '@linode/api-v4';
+
+interface Props {
+  onClose: () => void;
+  open: boolean;
+  role: ExtendedRoleMap | undefined;
+}
+
+export const ChangeRoleDrawer = ({ onClose, open, role }: Props) => {
+  const theme = useTheme();
+  const { username } = useParams<{ username: string }>();
+
+  const {
+    data: accountPermissions,
+    isLoading: accountPermissionsLoading,
+  } = useAccountPermissions();
+
+  const { data: assignedRoles } = useAccountUserPermissions(username ?? '');
+
+  const {
+    mutateAsync: updateUserPermissions,
+  } = useAccountUserPermissionsMutation(username);
+
+  const formattedAssignedEntities: EntitiesOption[] = React.useMemo(() => {
+    if (!role || !role.resource_names || !role.resource_ids) {
+      return [];
+    }
+
+    return role.resource_names.map((name, index) => ({
+      label: name,
+      value: role.resource_ids![index],
+    }));
+  }, [role]);
+
+  // filtered roles by resource_type and access
+  const allRoles = React.useMemo(() => {
+    if (!accountPermissions) {
+      return [];
+    }
+
+    return getAllRoles(accountPermissions).filter(
+      (el) =>
+        el.resource_type === role?.resource_type && el.access === role?.access
+    );
+  }, [accountPermissions, role]);
+
+  const {
+    control,
+    formState: { errors, isSubmitting },
+    handleSubmit,
+    reset,
+    setError,
+    watch,
+  } = useForm<{ roleName: RolesType }>({
+    defaultValues: {
+      roleName: undefined,
+    },
+    mode: 'onBlur',
+  });
+
+  // Effect to update form values when role changes
+  React.useEffect(() => {
+    if (role) {
+      reset({
+        roleName: {
+          access: role.access,
+          label: role.name,
+          resource_type: role.resource_type,
+          value: role.name,
+        },
+      });
+    }
+  }, [role, reset]);
+
+  // Watch the selected role
+  const selectedOptions = watch('roleName');
+
+  // Get the selected role based on the `selectedOptions`
+  const selectedRole = React.useMemo(() => {
+    if (!selectedOptions || !accountPermissions) {
+      return null;
+    }
+
+    return getRoleByName(accountPermissions, selectedOptions.value);
+  }, [selectedOptions, accountPermissions]);
+
+  const onSubmit = async (data: { roleName: RolesType }) => {
+    if (role?.name === data.roleName.label) {
+      handleClose();
+    }
+    try {
+      const initialRole = role?.name;
+      const newRole = data.roleName.label;
+      const access = data.roleName.access;
+
+      const updatedUserRoles = updateUserRoles(
+        assignedRoles!,
+        initialRole!,
+        newRole,
+        access
+      );
+
+      updateUserPermissions(updatedUserRoles);
+
+      handleClose();
+    } catch (errors) {
+      for (const error of errors) {
+        setError(error?.field ?? 'root', { message: error.reason });
+      }
+    }
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  // TODO - add a link 'Learn more" - UIE-8534
+  return (
+    <Drawer onClose={handleClose} open={open} title="Change Role">
+      {errors.root?.message && (
+        <Notice text={errors.root?.message} variant="error" />
+      )}
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Typography sx={{ marginBottom: 2.5 }}>
+          Select a role you want to assign.
+          <Link to=""> Learn more about roles and permissions.</Link>
+        </Typography>
+
+        <Typography sx={{ marginBottom: 2.5 }}>
+          Change from role{' '}
+          <span style={{ font: theme.font.bold }}>{role?.name}</span> to:
+        </Typography>
+
+        <Controller
+          render={({ field }) => (
+            <Autocomplete
+              renderOption={(props, option) => (
+                <li {...props} key={option.label}>
+                  {option.label}
+                </li>
+              )}
+              label="Assign New Roles"
+              loading={accountPermissionsLoading}
+              onChange={(_, value) => field.onChange(value)}
+              options={allRoles}
+              placeholder="Select a Role"
+              textFieldProps={{ hideLabel: true, noMarginTop: true }}
+              value={field.value}
+            />
+          )}
+          control={control}
+          name="roleName"
+        />
+
+        {selectedRole && (
+          <AssignedPermissionsPanel
+            assignedEntities={formattedAssignedEntities ?? []}
+            key={selectedRole.name}
+            role={selectedRole}
+          />
+        )}
+
+        <ActionsPanel
+          primaryButtonProps={{
+            'data-testid': 'submit',
+            label: 'Save Change',
+            loading: isSubmitting,
+            type: 'submit',
+          }}
+          secondaryButtonProps={{
+            'data-testid': 'cancel',
+            label: 'Cancel',
+            onClick: handleClose,
+          }}
+          sx={{ marginTop: 2 }}
+        />
+      </form>
+    </Drawer>
+  );
+};
+
+const updateUserRoles = (
+  assignedRoles: IamUserPermissions,
+  initialRole: string,
+  newRole: string,
+  access: 'account_access' | 'resource_access'
+): IamUserPermissions => {
+  if (access === 'account_access') {
+    return {
+      ...assignedRoles,
+      account_access: assignedRoles.account_access.map(
+        (role: AccountAccessType) =>
+          role === initialRole ? (newRole as AccountAccessType) : role
+      ),
+    };
+  }
+
+  if (access === 'resource_access') {
+    return {
+      ...assignedRoles,
+      resource_access: assignedRoles.resource_access.map(
+        (resource: ResourceAccess) => ({
+          ...resource,
+          roles: resource.roles.map((role: RoleType) =>
+            role === initialRole ? (newRole as RoleType) : role
+          ),
+        })
+      ),
+    };
+  }
+
+  // If access type is invalid, return unchanged object
+  return assignedRoles;
+};

--- a/packages/manager/src/features/IAM/Shared/Entities/Entities.tsx
+++ b/packages/manager/src/features/IAM/Shared/Entities/Entities.tsx
@@ -1,3 +1,4 @@
+import { isEmpty } from '@linode/api-v4';
 import { Autocomplete, Typography } from '@linode/ui';
 import { useTheme } from '@mui/material';
 import React from 'react';
@@ -7,31 +8,34 @@ import { useAccountResources } from 'src/queries/resources/resources';
 
 import { placeholderMap } from '../utilities';
 
+import type { EntitiesOption } from '../utilities';
 import type {
   IamAccessType,
   IamAccountResource,
   Resource,
   ResourceType,
   ResourceTypePermissions,
-} from '@linode/api-v4';
+} from '@linode/api-v4/lib/iam/types';
 
 interface Props {
   access: IamAccessType;
+  assignedEntities?: EntitiesOption[];
   type: ResourceType | ResourceTypePermissions;
 }
 
-interface EntitiesOption {
-  label: string;
-  value: number;
-}
-
-export const Entities = ({ access, type }: Props) => {
+export const Entities = ({ access, assignedEntities, type }: Props) => {
   const { data: resources } = useAccountResources();
   const theme = useTheme();
 
   const [selectedEntities, setSelectedEntities] = React.useState<
     EntitiesOption[]
   >([]);
+
+  React.useEffect(() => {
+    if (!isEmpty(assignedEntities) && assignedEntities !== undefined) {
+      setSelectedEntities(assignedEntities);
+    }
+  }, [assignedEntities]);
 
   const memoizedEntities = React.useMemo(() => {
     if (access !== 'resource_access' || !resources) {
@@ -68,12 +72,14 @@ export const Entities = ({ access, type }: Props) => {
         </li>
       )}
       ListboxProps={{ sx: { overflowX: 'hidden' } }}
+      getOptionLabel={(option) => option.label}
       label="Entities"
       multiple
       noMarginTop
       onChange={(_, value) => setSelectedEntities(value)}
       options={memoizedEntities}
       placeholder={selectedEntities.length ? ' ' : getPlaceholder(type)}
+      readOnly={!isEmpty(assignedEntities)}
       sx={{ marginTop: theme.tokens.spacing.S12 }}
       value={selectedEntities}
     />

--- a/packages/manager/src/features/IAM/Shared/Permissions/Permissions.tsx
+++ b/packages/manager/src/features/IAM/Shared/Permissions/Permissions.tsx
@@ -80,10 +80,7 @@ export const Permissions = ({ permissions }: Props) => {
 
         {(numHiddenItems > 0 || showAll) && (
           <StyledBox>
-            <StyledLinkButton
-              onClick={() => setShowAll(!showAll)}
-              type="button"
-            >
+            <StyledLinkButton onClick={() => setShowAll(!showAll)}>
               {showAll ? 'Hide' : ` Expand (+${numHiddenItems})`}
             </StyledLinkButton>
           </StyledBox>

--- a/packages/manager/src/features/IAM/Shared/Permissions/Permissions.tsx
+++ b/packages/manager/src/features/IAM/Shared/Permissions/Permissions.tsx
@@ -80,7 +80,10 @@ export const Permissions = ({ permissions }: Props) => {
 
         {(numHiddenItems > 0 || showAll) && (
           <StyledBox>
-            <StyledLinkButton onClick={() => setShowAll(!showAll)}>
+            <StyledLinkButton
+              onClick={() => setShowAll(!showAll)}
+              type="button"
+            >
               {showAll ? 'Hide' : ` Expand (+${numHiddenItems})`}
             </StyledLinkButton>
           </StyledBox>

--- a/packages/manager/src/features/IAM/Shared/utilities.test.ts
+++ b/packages/manager/src/features/IAM/Shared/utilities.test.ts
@@ -192,7 +192,12 @@ describe('updateUserRoles', () => {
     const initialRole = 'linode_contributor';
     const newRole = 'linode_admin';
     expect(
-      updateUserRoles(userPermissions, initialRole, newRole, resourceAccess)
+      updateUserRoles({
+        access: resourceAccess,
+        assignedRoles: userPermissions,
+        initialRole,
+        newRole,
+      })
     ).toEqual(expectedRoles);
   });
 });

--- a/packages/manager/src/features/IAM/Shared/utilities.test.ts
+++ b/packages/manager/src/features/IAM/Shared/utilities.test.ts
@@ -3,10 +3,14 @@ import {
   getAllRoles,
   getRoleByName,
   mapRolesToPermissions,
+  updateUserRoles,
 } from './utilities';
 
 import type { CombinedRoles } from './utilities';
 import type { IamAccountPermissions, IamUserPermissions } from '@linode/api-v4';
+
+const accountAccess = 'account_access';
+const resourceAccess = 'resource_access';
 
 const accountPermissions: IamAccountPermissions = {
   account_access: [
@@ -62,19 +66,19 @@ describe('getAllRoles', () => {
   it('should return a list of roles for each access type', () => {
     const expectedRoles = [
       {
-        access: 'account_access',
+        access: accountAccess,
         label: 'account_admin',
         resource_type: 'account',
         value: 'account_admin',
       },
       {
-        access: 'account_access',
+        access: accountAccess,
         label: 'account_linode_admin',
         resource_type: 'linode',
         value: 'account_linode_admin',
       },
       {
-        access: 'resource_access',
+        access: resourceAccess,
         label: 'linode_contributor',
         resource_type: 'linode',
         value: 'linode_contributor',
@@ -89,7 +93,7 @@ describe('getRoleByName', () => {
   it('should return an object with details about this role account_access', () => {
     const roleName = 'account_admin';
     const expectedRole = {
-      access: 'account_access',
+      access: accountAccess,
       description:
         'Access to perform any supported action on all resources in the account',
       name: 'account_admin',
@@ -103,7 +107,7 @@ describe('getRoleByName', () => {
   it('should return an object with details about this role resource_access', () => {
     const roleName = 'linode_contributor';
     const expectedRole = {
-      access: 'resource_access',
+      access: resourceAccess,
       description: 'Access to update a linode instance',
       name: 'linode_contributor',
       permissions: ['update_linode', 'view_linode'],
@@ -136,7 +140,7 @@ describe('mapRolesToPermissions', () => {
 
     const expectedRoles = [
       {
-        access: 'account_access',
+        access: accountAccess,
         description:
           'Access to perform any supported action on all resources in the account',
         id: 'account_admin',
@@ -146,7 +150,7 @@ describe('mapRolesToPermissions', () => {
         resource_type: 'account',
       },
       {
-        access: 'account_access',
+        access: accountAccess,
         description:
           'Access to perform any supported action on all linode instances in the account',
         id: 'account_linode_admin',
@@ -156,7 +160,7 @@ describe('mapRolesToPermissions', () => {
         resource_type: 'linode',
       },
       {
-        access: 'resource_access',
+        access: resourceAccess,
         description: 'Access to update a linode instance',
         id: 'linode_contributor',
         name: 'linode_contributor',
@@ -169,5 +173,26 @@ describe('mapRolesToPermissions', () => {
     expect(mapRolesToPermissions(accountPermissions, userRoles)).toEqual(
       expectedRoles
     );
+  });
+});
+
+describe('updateUserRoles', () => {
+  it('should return an object of updated users roles with resource access', () => {
+    const expectedRoles = {
+      account_access: ['account_linode_admin', 'linode_creator'],
+      resource_access: [
+        {
+          resource_id: 12345678,
+          resource_type: 'linode',
+          roles: ['linode_admin'],
+        },
+      ],
+    };
+
+    const initialRole = 'linode_contributor';
+    const newRole = 'linode_admin';
+    expect(
+      updateUserRoles(userPermissions, initialRole, newRole, resourceAccess)
+    ).toEqual(expectedRoles);
   });
 });

--- a/packages/manager/src/features/IAM/Shared/utilities.test.ts
+++ b/packages/manager/src/features/IAM/Shared/utilities.test.ts
@@ -61,9 +61,24 @@ const userPermissions: IamUserPermissions = {
 describe('getAllRoles', () => {
   it('should return a list of roles for each access type', () => {
     const expectedRoles = [
-      { label: 'account_admin', value: 'account_admin' },
-      { label: 'account_linode_admin', value: 'account_linode_admin' },
-      { label: 'linode_contributor', value: 'linode_contributor' },
+      {
+        access: 'account_access',
+        label: 'account_admin',
+        resource_type: 'account',
+        value: 'account_admin',
+      },
+      {
+        access: 'account_access',
+        label: 'account_linode_admin',
+        resource_type: 'linode',
+        value: 'account_linode_admin',
+      },
+      {
+        access: 'resource_access',
+        label: 'linode_contributor',
+        resource_type: 'linode',
+        value: 'linode_contributor',
+      },
     ];
 
     expect(getAllRoles(accountPermissions)).toEqual(expectedRoles);
@@ -121,7 +136,7 @@ describe('mapRolesToPermissions', () => {
 
     const expectedRoles = [
       {
-        access: 'account',
+        access: 'account_access',
         description:
           'Access to perform any supported action on all resources in the account',
         id: 'account_admin',
@@ -131,7 +146,7 @@ describe('mapRolesToPermissions', () => {
         resource_type: 'account',
       },
       {
-        access: 'account',
+        access: 'account_access',
         description:
           'Access to perform any supported action on all linode instances in the account',
         id: 'account_linode_admin',
@@ -141,7 +156,7 @@ describe('mapRolesToPermissions', () => {
         resource_type: 'linode',
       },
       {
-        access: 'resource',
+        access: 'resource_access',
         description: 'Access to update a linode instance',
         id: 'linode_contributor',
         name: 'linode_contributor',

--- a/packages/manager/src/features/IAM/Shared/utilities.ts
+++ b/packages/manager/src/features/IAM/Shared/utilities.ts
@@ -11,6 +11,7 @@ import type {
   IamAccountResource,
   IamUserPermissions,
   PermissionType,
+  ResourceAccess,
   ResourceType,
   ResourceTypePermissions,
   RoleType,
@@ -382,3 +383,37 @@ export interface EntitiesOption {
   label: string;
   value: number;
 }
+
+export const updateUserRoles = (
+  assignedRoles: IamUserPermissions,
+  initialRole: string,
+  newRole: string,
+  access: 'account_access' | 'resource_access'
+): IamUserPermissions => {
+  if (access === 'account_access') {
+    return {
+      ...assignedRoles,
+      account_access: assignedRoles.account_access.map(
+        (role: AccountAccessType) =>
+          role === initialRole ? (newRole as AccountAccessType) : role
+      ),
+    };
+  }
+
+  if (access === 'resource_access') {
+    return {
+      ...assignedRoles,
+      resource_access: assignedRoles.resource_access.map(
+        (resource: ResourceAccess) => ({
+          ...resource,
+          roles: resource.roles.map((role: RoleType) =>
+            role === initialRole ? (newRole as RoleType) : role
+          ),
+        })
+      ),
+    };
+  }
+
+  // If access type is invalid, return unchanged object
+  return assignedRoles;
+};

--- a/packages/manager/src/features/IAM/Shared/utilities.ts
+++ b/packages/manager/src/features/IAM/Shared/utilities.ts
@@ -49,7 +49,7 @@ export const placeholderMap: Record<string, string> = {
 };
 
 export interface RoleMap {
-  access: 'account' | 'resource';
+  access: 'account_access' | 'resource_access';
   description: string;
   id: AccountAccessType | RoleType;
   name: AccountAccessType | RoleType;
@@ -128,7 +128,9 @@ const getDoesRolesMatchQuery = (
 };
 
 export interface RolesType {
+  access: IamAccessType;
   label: string;
+  resource_type: ResourceTypePermissions;
   value: string;
 }
 
@@ -145,7 +147,9 @@ export const getAllRoles = (
   return accessTypes.flatMap((accessType: IamAccessType) =>
     permissions[accessType].flatMap((resource: IamAccess) =>
       resource.roles.map((role: Roles) => ({
+        access: accessType,
         label: role.name,
+        resource_type: resource.resource_type,
         value: role.name,
       }))
     )
@@ -247,7 +251,7 @@ export const combineRoles = (data: IamUserPermissions): CombinedRoles[] => {
 
 interface AllResources {
   resource: IamAccess;
-  type: 'account' | 'resource';
+  type: 'account_access' | 'resource_access';
 }
 
 /**
@@ -263,11 +267,11 @@ export const mapRolesToPermissions = (
   const allResources: AllResources[] = [
     ...accountPermissions.account_access.map((resource) => ({
       resource,
-      type: 'account' as const,
+      type: 'account_access' as const,
     })),
     ...accountPermissions.resource_access.map((resource) => ({
       resource,
-      type: 'resource' as const,
+      type: 'resource_access' as const,
     })),
   ];
 
@@ -373,3 +377,8 @@ export const useCalculateHiddenItems = (
 
   return { calculateHiddenItems, containerRef, itemRefs, numHiddenItems };
 };
+
+export interface EntitiesOption {
+  label: string;
+  value: number;
+}

--- a/packages/manager/src/features/IAM/Shared/utilities.ts
+++ b/packages/manager/src/features/IAM/Shared/utilities.ts
@@ -384,13 +384,20 @@ export interface EntitiesOption {
   value: number;
 }
 
-export const updateUserRoles = (
-  assignedRoles: IamUserPermissions,
-  initialRole: string,
-  newRole: string,
-  access: 'account_access' | 'resource_access'
-): IamUserPermissions => {
-  if (access === 'account_access') {
+interface UpdateUserRolesProps {
+  access: 'account_access' | 'resource_access';
+  assignedRoles?: IamUserPermissions;
+  initialRole?: string;
+  newRole: string;
+}
+
+export const updateUserRoles = ({
+  access,
+  assignedRoles,
+  initialRole,
+  newRole,
+}: UpdateUserRolesProps): IamUserPermissions => {
+  if (access === 'account_access' && assignedRoles) {
     return {
       ...assignedRoles,
       account_access: assignedRoles.account_access.map(
@@ -400,7 +407,7 @@ export const updateUserRoles = (
     };
   }
 
-  if (access === 'resource_access') {
+  if (access === 'resource_access' && assignedRoles) {
     return {
       ...assignedRoles,
       resource_access: assignedRoles.resource_access.map(
@@ -415,5 +422,10 @@ export const updateUserRoles = (
   }
 
   // If access type is invalid, return unchanged object
-  return assignedRoles;
+  return (
+    assignedRoles ?? {
+      account_access: [],
+      resource_access: [],
+    }
+  );
 };

--- a/packages/manager/src/queries/iam/iam.ts
+++ b/packages/manager/src/queries/iam/iam.ts
@@ -1,5 +1,6 @@
+import { updateUserPermissions } from '@linode/api-v4';
 import { queryPresets, useProfile } from '@linode/queries';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { iamQueries } from './queries';
 
@@ -24,5 +25,21 @@ export const useAccountPermissions = () => {
     ...queryPresets.oneTimeFetch,
     ...queryPresets.noRetry,
     enabled: !profile?.restricted,
+  });
+};
+
+export const useAccountUserPermissionsMutation = (username: string) => {
+  const queryClient = useQueryClient();
+  return useMutation<IamUserPermissions, APIError[], IamUserPermissions>({
+    mutationFn: (data) => updateUserPermissions(username, data),
+    onSuccess(role) {
+      queryClient.invalidateQueries({
+        queryKey: iamQueries.user(username).queryKey,
+      });
+      queryClient.setQueryData<IamUserPermissions>(
+        iamQueries.user(username).queryKey,
+        role
+      );
+    },
   });
 };

--- a/packages/manager/src/queries/iam/iam.ts
+++ b/packages/manager/src/queries/iam/iam.ts
@@ -33,9 +33,6 @@ export const useAccountUserPermissionsMutation = (username: string) => {
   return useMutation<IamUserPermissions, APIError[], IamUserPermissions>({
     mutationFn: (data) => updateUserPermissions(username, data),
     onSuccess(role) {
-      queryClient.invalidateQueries({
-        queryKey: iamQueries.user(username).queryKey,
-      });
       queryClient.setQueryData<IamUserPermissions>(
         iamQueries.user(username).queryKey,
         role

--- a/packages/manager/src/queries/iam/iam.ts
+++ b/packages/manager/src/queries/iam/iam.ts
@@ -34,7 +34,7 @@ export const useAccountUserPermissionsMutation = (username: string) => {
     mutationFn: (data) => updateUserPermissions(username, data),
     onSuccess(role) {
       queryClient.setQueryData<IamUserPermissions>(
-        iamQueries.user(username).queryKey,
+        iamQueries.user(username)._ctx.permissions.queryKey,
         role
       );
     },

--- a/packages/queries/.changeset/pr-11840-upcoming-features-1741881790593.md
+++ b/packages/queries/.changeset/pr-11840-upcoming-features-1741881790593.md
@@ -1,0 +1,5 @@
+---
+"@linode/queries": Upcoming Features
+---
+
+Add a new query for updating roles in IAM ([#11840](https://github.com/linode/manager/pull/11840))


### PR DESCRIPTION
## Description 📝

Add a new drawer for changing role flow

## Changes  🔄

List any change(s) relevant to the reviewer.

- Add a new flow for changing role

## Target release date 🗓️

(dev)

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/38605af7-a47b-4766-b3f5-8d6ce7421a27) | ![image](https://github.com/user-attachments/assets/5bff3316-c996-4e3c-bfb1-85cf91df3df4) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Ensure the Identity and Access Beta flag is enabled in dev tools
- Ensure the MSW is enabled in dev tools
- Click on the any username in the users table and go to the tab `Assigned Roles` or click on the user's menu `View User Roles`
- Click on the user's menu `Change Role`

### Verification steps

(How to verify changes)

- [ ] Confirm drawer opens
- [ ] Confirm that user can change only the role (not entities)

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

