### PR TITLE
remove: [M3-9580] - Bucket rate limit table from Object Storage details drawer

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Removed:
 
+- Rate limits table from Object Storage details drawer
 - Move `capitalize` utility and `useInterval` hook to `@linode/utilities` package ([#11666](https://github.com/linode/manager/pull/11666))
 - Migrate utilities from `manager` to `utilities` package ([#11711](https://github.com/linode/manager/pull/11711))
 - Migrate ErrorState to `ui` package ([#11718](https://github.com/linode/manager/pull/11718))

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -37,7 +37,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Removed:
 
-- Rate limits table from Object Storage details drawer
+- Rate limits table from Object Storage details drawer ([#11848](https://github.com/linode/manager/pull/11848))
 - Move `capitalize` utility and `useInterval` hook to `@linode/utilities` package ([#11666](https://github.com/linode/manager/pull/11666))
 - Migrate utilities from `manager` to `utilities` package ([#11711](https://github.com/linode/manager/pull/11711))
 - Migrate ErrorState to `ui` package ([#11718](https://github.com/linode/manager/pull/11718))

--- a/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-create-gen2.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-create-gen2.spec.ts
@@ -97,8 +97,6 @@ describe('Object Storage Gen2 create bucket tests', () => {
         endpointType === 'Standard (E3)' ||
         endpointType === 'Standard (E2)'
       ) {
-        cy.contains(bucketRateLimitsNotice).should('be.visible');
-        cy.get('[data-testid="bucket-rate-limit-table"]').should('be.visible');
         cy.contains(CORSNotice).should('be.visible');
         ui.toggle.find().should('not.exist');
       } else {

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.test.tsx
@@ -260,24 +260,6 @@ describe('BucketDetailDrawer: Gen2 UI', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders the Bucket Rate Limit Table for E2 and E3 buckets', async () => {
-    const { findByTestId } = renderWithThemeAndHookFormContext({
-      component: (
-        <BucketDetailsDrawer
-          onClose={mockOnClose}
-          open={true}
-          selectedBucket={e3Bucket}
-        />
-      ),
-      options: {
-        flags: { objMultiCluster: false, objectStorageGen2: { enabled: true } },
-      },
-    });
-
-    const rateLimitTable = await findByTestId('bucket-rate-limit-table');
-    expect(rateLimitTable).toBeVisible();
-  });
-
   it('renders the Bucket Rate Limit Text for E0 and E1 buckets', async () => {
     const { findByText } = renderWithThemeAndHookFormContext({
       component: (

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.test.tsx
@@ -204,9 +204,6 @@ describe('BucketDetailsDrawer: Legacy UI', () => {
 
 describe('BucketDetailDrawer: Gen2 UI', () => {
   const e3Bucket = objectStorageBucketFactoryGen2.build();
-  const e1Bucket = objectStorageBucketFactoryGen2.build({
-    endpoint_type: 'E1',
-  });
 
   const region = regionFactory.build({
     id: e3Bucket.region,
@@ -256,26 +253,6 @@ describe('BucketDetailDrawer: Gen2 UI', () => {
     expect(
       getByText(
         /CORS \(Cross Origin Sharing\) is not available for endpoint types E2 and E3./
-      )
-    ).toBeInTheDocument();
-  });
-
-  it('renders the Bucket Rate Limit Text for E0 and E1 buckets', async () => {
-    const { findByText } = renderWithThemeAndHookFormContext({
-      component: (
-        <BucketDetailsDrawer
-          onClose={mockOnClose}
-          open={true}
-          selectedBucket={e1Bucket}
-        />
-      ),
-      options: {
-        flags: { objMultiCluster: false, objectStorageGen2: { enabled: true } },
-      },
-    });
-    expect(
-      await findByText(
-        /This endpoint type supports up to 750 Requests Per Second \(RPS\)./
       )
     ).toBeInTheDocument();
   });

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
@@ -18,7 +18,6 @@ import { truncateMiddle } from 'src/utilities/truncate';
 import { readableBytes } from 'src/utilities/unitConversions';
 
 import { AccessSelect } from '../BucketDetail/AccessSelect';
-import { BucketRateLimitTable } from './BucketRateLimitTable';
 
 import type { ObjectStorageBucket } from '@linode/api-v4/lib/object-storage';
 
@@ -49,12 +48,6 @@ export const BucketDetailsDrawer = React.memo(
     const isObjMultiClusterEnabled = isFeatureEnabledV2(
       'Object Storage Access Key Regions',
       Boolean(flags.objMultiCluster),
-      account?.capabilities ?? []
-    );
-
-    const isObjectStorageGen2Enabled = isFeatureEnabledV2(
-      'Object Storage Endpoint Types',
-      Boolean(flags.objectStorageGen2?.enabled),
       account?.capabilities ?? []
     );
 
@@ -138,20 +131,6 @@ export const BucketDetailsDrawer = React.memo(
         )}
         {(typeof size === 'number' || typeof objects === 'number') && (
           <Divider spacingBottom={16} spacingTop={16} />
-        )}
-        {/* @TODO OBJ Multicluster: use region instead of cluster if isObjMultiClusterEnabled
-         to getBucketAccess and updateBucketAccess.  */}
-        {isObjectStorageGen2Enabled && (
-          <>
-            <BucketRateLimitTable
-              typographyProps={{
-                marginTop: 1,
-                variant: 'inherit',
-              }}
-              endpointType={endpoint_type}
-            />
-            <Divider spacingBottom={16} spacingTop={16} />
-          </>
         )}
         {cluster && label && (
           <AccessSelect


### PR DESCRIPTION
## Description 📝
Rate limits should not be displayed in the details drawer, consistent with their removal from the properties tab.

## Target release date 🗓️
3/13

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-03-13 at 6 43 24 PM](https://github.com/user-attachments/assets/09f3ba65-0486-490c-bc46-d7ef7ed86dbb) | ![Screenshot 2025-03-13 at 6 43 16 PM](https://github.com/user-attachments/assets/ebac2870-d494-4060-a6d1-27db8560b35b) |

## How to test 🧪
### Verification steps
- Create an E3 object storage bucket in `DE, Frankfurt 2`.
- Go to details drawer for bucket
- Observe rate limit table is no longer rendered 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>