### PR TITLE
test: [M3-9508] - Fix GHA Cypress pipeline by using literal values in matrix

### DIFF
--- a/.github/workflows/e2e_schedule_and_push.yml
+++ b/.github/workflows/e2e_schedule_and_push.yml
@@ -27,10 +27,10 @@ jobs:
       fail-fast: false
       matrix:
         user:
-          - { index: 1, pat: "${{ secrets.USER_1 }}" }
-          - { index: 2, pat: "${{ secrets.USER_2 }}" }
-          - { index: 3, pat: "${{ secrets.USER_3 }}" }
-          - { index: 4, pat: "${{ secrets.USER_4 }}" }
+          - { index: 1, name: 'USER_1' }
+          - { index: 2, name: 'USER_2' }
+          - { index: 3, name: 'USER_3' }
+          - { index: 4, name: 'USER_4' }
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -49,7 +49,7 @@ jobs:
           echo "REACT_APP_API_ROOT=${{ secrets.REACT_APP_API_ROOT }}" >> ./packages/manager/.env
           echo "REACT_APP_APP_ROOT=${{ secrets.REACT_APP_APP_ROOT }}" >> ./packages/manager/.env
           echo "REACT_APP_DISABLE_NEW_RELIC=1" >> ./packages/manager/.env
-          echo "MANAGER_OAUTH=${{ matrix.user.pat }}"
+          echo "MANAGER_OAUTH=${{ secrets[matrix.user.name] }}"
           echo "CY_TEST_SPLIT_RUN_INDEX=${{ matrix.user.index }}"
       - run: pnpm install --frozen-lockfile
       - run: pnpm run --filter @linode/validation build


### PR DESCRIPTION
## Description 📝

Sorry! I just merged #11845 which unfortunately broke the GHA Cypress pipeline. It's failing because we're trying to refer to a secret in the `matrix` section, but you can only use literal values there.

## Changes  🔄

- Attempt to fix pipeline by removing variable from `matrix` section

## Target release date 🗓️

ASAP

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- ...
- ...

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
