### PR TITLE
upcoming: [M3-9511] - VPC IPv6 - Update endpoints and types for VPC Entity

### DIFF
--- a/packages/api-v4/.changeset/pr-11852-upcoming-features-1742414634244.md
+++ b/packages/api-v4/.changeset/pr-11852-upcoming-features-1742414634244.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Upcoming Features
+---
+
+Added optional ipv6 property to VPC entity ([#11852](https://github.com/linode/manager/pull/11852))

--- a/packages/api-v4/src/vpcs/types.ts
+++ b/packages/api-v4/src/vpcs/types.ts
@@ -1,3 +1,12 @@
+interface VPCIPv6 {
+  range?: string[];
+}
+
+interface CreateVPCIPV6 extends VPCIPv6 {
+  // Omitted from VPC response, only permitted in requests
+  allocation_class?: string[]
+}
+
 export interface VPC {
   id: number;
   label: string;
@@ -6,12 +15,14 @@ export interface VPC {
   subnets: Subnet[];
   created: string;
   updated: string;
+  ipv6?: VPCIPv6[];
 }
 
 export interface CreateVPCPayload {
   label: string;
   description?: string;
   region: string;
+  ipv6?: CreateVPCIPV6[];
   subnets?: CreateSubnetPayload[];
 }
 

--- a/packages/api-v4/src/vpcs/types.ts
+++ b/packages/api-v4/src/vpcs/types.ts
@@ -1,10 +1,9 @@
 interface VPCIPv6 {
-  range?: string[];
+  range?: string;
 }
 
 interface CreateVPCIPV6 extends VPCIPv6 {
-  // Omitted from VPC response, only permitted in requests
-  allocation_class?: string[]
+  allocation_class?: string;
 }
 
 export interface VPC {

--- a/packages/validation/.changeset/pr-11852-upcoming-features-1742414737915.md
+++ b/packages/validation/.changeset/pr-11852-upcoming-features-1742414737915.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Upcoming Features
+---
+
+Added optional ipv6 to `createVPCIPv6Schema` ([#11852](https://github.com/linode/manager/pull/11852))

--- a/packages/validation/src/vpcs.schema.ts
+++ b/packages/validation/src/vpcs.schema.ts
@@ -214,29 +214,31 @@ export const createSubnetSchema = object().shape(
   ]
 );
 
-const createVPCIPv6Schema = object().shape({
-  range: array().of(string().test({
-    name: 'IPv6 prefix length',
-    message: 'Must be the prefix length 52, 48, or 44 of the IP, e.g. /52',
-    test: (value) => {
-      if (value && value !== 'auto' && value.length > 0) {
-        vpcsValidateIP({
-          value,
-          shouldHaveIPMask: true,
-          mustBeIPMask: false,
-        })
-      }
-    }
-  })),
-  allocation_class: array().of(string()).optional()
-})
+const createVPCIPv6Schema = object({
+  range: string()
+    .optional()
+    .test({
+      name: 'IPv6 prefix length',
+      message: 'Must be the prefix length 52, 48, or 44 of the IP, e.g. /52',
+      test: (value) => {
+        if (value && value !== 'auto' && value.length > 0) {
+          vpcsValidateIP({
+            value,
+            shouldHaveIPMask: true,
+            mustBeIPMask: false,
+          });
+        }
+      },
+    }),
+  allocation_class: string().optional(),
+});
 
 export const createVPCSchema = object({
   label: labelValidation.required(LABEL_REQUIRED),
   description: string(),
   region: string().required('Region is required'),
   subnets: array().of(createSubnetSchema),
-  ipv6: array().of(createVPCIPv6Schema).length(1).notRequired()
+  ipv6: array().of(createVPCIPv6Schema).max(1).optional(),
 });
 
 export const modifySubnetSchema = object({


### PR DESCRIPTION
## Description 📝
Update endpoints and types for VPC Entity

## Changes  🔄
- Add optional `ipv6` property to `VPC` and `CreateVPCPayload` interface
- Add optional `ipv6` validation to `createVPCSchema`

### Verification steps

(How to verify changes)

- [ ] Cross-reference VPC IPv6 API spec (linked in parent ticket) and updated types for 
POST /v4/vpcs
GET /v4/vpcs
GET /v4/vpcs/{vpcId}

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>