### PR TITLE
test: [M3-9476] - Use "chooseRegion" util when mocking VPCs so tests pass in other envs

### DIFF
--- a/packages/manager/.changeset/pr-11862-tests-1742223400134.md
+++ b/packages/manager/.changeset/pr-11862-tests-1742223400134.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix VPC test failures when factory default region does not exist ([#11862](https://github.com/linode/manager/pull/11862))

--- a/packages/manager/cypress/e2e/core/vpc/vpc-details-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/vpc/vpc-details-page.spec.ts
@@ -40,6 +40,7 @@ describe('VPC details page', () => {
     const mockVPC: VPC = vpcFactory.build({
       id: randomNumber(),
       label: randomLabel(),
+      region: chooseRegion().id,
     });
 
     const mockVPCUpdated = {
@@ -137,6 +138,7 @@ describe('VPC details page', () => {
     const mockVPC = vpcFactory.build({
       id: randomNumber(),
       label: randomLabel(),
+      region: chooseRegion().id,
     });
 
     const mockVPCAfterSubnetCreation = vpcFactory.build({

--- a/packages/manager/cypress/e2e/core/vpc/vpc-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/vpc/vpc-landing-page.spec.ts
@@ -18,7 +18,9 @@ describe('VPC landing page', () => {
    * - Confirms that VPCs are listed on the VPC landing page.
    */
   it('lists VPC instances', () => {
-    const mockVPCs = vpcFactory.buildList(5);
+    const mockVPCs = vpcFactory.buildList(5, {
+      region: chooseRegion().id,
+    });
     mockGetVPCs(mockVPCs).as('getVPCs');
 
     cy.visitWithLogin('/vpcs');


### PR DESCRIPTION
## Description 📝

This PR fixes a few VPC tests so that they use the `chooseRegion` util rather than relying on the factory default when creating mock VPC objects. This allows the tests to pass in environments where the default region may not exist.

## Changes  🔄

- Specify a region when creating mock objects, use `chooseRegion` to select region

## Target release date 🗓️

N/A. No urgency to this whatsoever.

## How to test 🧪

We want to confirm that these tests continue to pass in Prod and pass in other environments. We can rely on this PR's CI to confirm the tests still pass against Prod. Refer to the comment in M3-9476 for details about other environments.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
