### PR TITLE
test: [M3-9477] - Allow Google Pay test to pass when using Braintree sandbox

### DIFF
--- a/packages/manager/.changeset/pr-11863-tests-1742223285423.md
+++ b/packages/manager/.changeset/pr-11863-tests-1742223285423.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix Google Pay test failures when using Braintree sandbox environment ([#11863](https://github.com/linode/manager/pull/11863))

--- a/packages/manager/cypress/e2e/core/billing/google-pay.spec.ts
+++ b/packages/manager/cypress/e2e/core/billing/google-pay.spec.ts
@@ -52,7 +52,8 @@ const mockPaymentMethodsExpired: PaymentMethod[] = [
 ];
 
 const pastDueExpiry = 'Expired 07/20';
-const braintreeURL = 'https://client-analytics.braintreegateway.com/*';
+const braintreeURL =
+  'https://+(payments.braintree-api.com|payments.sandbox.braintree-api.com)/*';
 
 describe('Google Pay', () => {
   it('adds google pay method', () => {


### PR DESCRIPTION
## Description 📝

This PR fixes a test in `google-pay.spec.ts` which fails when running against environments that use the Braintree sandbox. Refer to M3-9477 for more details.

## Changes  🔄

- Update intercept URL to match against Braintree prod and sandbox requests
- Change original URL from an analytics endpoint to the actual API endpoint -- not sure why this was set that way to begin with

## Target release date 🗓️

N/A. There's no urgency to this.

## How to test 🧪

1. We can use this PR's test run to confirm this test continues passing in CI
2. Refer to the ticket comment in M3-9477 for details about testing against other envs

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

