### PR TITLE
change: [M3-9430] - Akamai Design System: Checkbox Component

### DIFF
--- a/packages/ui/.changeset/pr-11871-changed-1742300523305.md
+++ b/packages/ui/.changeset/pr-11871-changed-1742300523305.md
@@ -1,0 +1,5 @@
+---
+"@linode/ui": Changed
+---
+
+Add `Checkbox` design tokens and update styles to match Akamai Design System ([#11871](https://github.com/linode/manager/pull/11871))

--- a/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
@@ -9,6 +9,8 @@ const meta: Meta<typeof Checkbox> = {
   title: 'Foundations/Checkbox',
 };
 
+export default meta;
+
 type Story = StoryObj<typeof Checkbox>;
 
 export const Default: Story = {
@@ -30,13 +32,6 @@ export const Default: Story = {
   render: (args) => <Checkbox {...args} />,
 };
 
-export const Checked: Story = {
-  args: {
-    checked: true,
-  },
-  render: (args) => <Checkbox {...args} />,
-};
-
 export const Unchecked: Story = {
   args: {
     checked: false,
@@ -44,31 +39,16 @@ export const Unchecked: Story = {
   render: (args) => <Checkbox {...args} />,
 };
 
+export const Checked: Story = {
+  args: {
+    checked: true,
+  },
+  render: (args) => <Checkbox {...args} />,
+};
+
 export const Indeterminate: Story = {
   args: {
     indeterminate: true,
-  },
-  render: (args) => <Checkbox {...args} />,
-};
-
-export const WithLabel: Story = {
-  args: {
-    text: 'This Checkbox has a label',
-  },
-  render: (args) => <Checkbox {...args} />,
-};
-
-export const WithTooltip: Story = {
-  args: {
-    toolTipText: 'This is the tooltip!',
-  },
-  render: (args) => <Checkbox {...args} />,
-};
-
-export const WithLabelAndTooltip: Story = {
-  args: {
-    text: 'This Checkbox has a tooltip',
-    toolTipText: 'This is the tooltip!',
   },
   render: (args) => <Checkbox {...args} />,
 };
@@ -127,4 +107,24 @@ export const IndeterminateReadOnly: Story = {
   },
 };
 
-export default meta;
+export const WithLabel: Story = {
+  args: {
+    text: 'This Checkbox has a label',
+  },
+  render: (args) => <Checkbox {...args} />,
+};
+
+export const WithTooltip: Story = {
+  args: {
+    toolTipText: 'This is the tooltip!',
+  },
+  render: (args) => <Checkbox {...args} />,
+};
+
+export const WithLabelAndTooltip: Story = {
+  args: {
+    text: 'This Checkbox has a tooltip',
+    toolTipText: 'This is the tooltip!',
+  },
+  render: (args) => <Checkbox {...args} />,
+};

--- a/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
@@ -44,26 +44,87 @@ export const Unchecked: Story = {
   render: (args) => <Checkbox {...args} />,
 };
 
-export const Label: Story = {
+export const Indeterminate: Story = {
+  args: {
+    indeterminate: true,
+  },
+  render: (args) => <Checkbox {...args} />,
+};
+
+export const WithLabel: Story = {
   args: {
     text: 'This Checkbox has a label',
   },
   render: (args) => <Checkbox {...args} />,
 };
 
-export const Tooltip: Story = {
+export const WithTooltip: Story = {
   args: {
     toolTipText: 'This is the tooltip!',
   },
   render: (args) => <Checkbox {...args} />,
 };
 
-export const LabelAndTooltip: Story = {
+export const WithLabelAndTooltip: Story = {
   args: {
     text: 'This Checkbox has a tooltip',
     toolTipText: 'This is the tooltip!',
   },
   render: (args) => <Checkbox {...args} />,
+};
+
+// @todo: Akamai Design System
+// export const Focused: Story = {
+//   render: (args) => <Checkbox {...args} />,
+// };
+
+// @todo: Akamai Design System
+// export const ReadOnly: Story = {
+//   args: {
+//     readOnly: true,
+//   },
+//   render: (args) => <Checkbox {...args} />,
+// };
+
+// @todo: Akamai Design System
+export const UncheckedDisabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const CheckedDisabled: Story = {
+  args: {
+    checked: true,
+    disabled: true,
+  },
+};
+
+export const IndeterminateDisabled: Story = {
+  args: {
+    indeterminate: true,
+    disabled: true,
+  },
+};
+
+export const UncheckedReadOnly: Story = {
+  args: {
+    readOnly: true,
+  },
+};
+
+export const CheckedReadOnly: Story = {
+  args: {
+    readOnly: true,
+    checked: true,
+  },
+};
+
+export const IndeterminateReadOnly: Story = {
+  args: {
+    readOnly: true,
+    indeterminate: true,
+  },
 };
 
 export default meta;

--- a/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
@@ -2,11 +2,18 @@ import React from 'react';
 
 import { Checkbox } from './Checkbox';
 
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { Box } from '../Box';
 
 const meta: Meta<typeof Checkbox> = {
   component: Checkbox,
+  decorators: [
+    (Story: StoryFn) => (
+      <Box sx={(theme) => ({ margin: theme.tokens.spacing.S16 })}>
+        <Story />
+      </Box>
+    ),
+  ],
   title: 'Foundations/Checkbox',
 };
 
@@ -30,28 +37,24 @@ export const Default: Story = {
   args: {
     checked: false,
   },
-  render: (args) => <Checkbox {...args} />,
 };
 
 export const Unchecked: Story = {
   args: {
     checked: false,
   },
-  render: (args) => <Checkbox {...args} />,
 };
 
 export const Checked: Story = {
   args: {
     checked: true,
   },
-  render: (args) => <Checkbox {...args} />,
 };
 
 export const Indeterminate: Story = {
   args: {
     indeterminate: true,
   },
-  render: (args) => <Checkbox {...args} />,
 };
 
 export const UncheckedDisabled: Story = {
@@ -98,11 +101,6 @@ export const WithLabel: Story = {
   args: {
     text: 'This Checkbox has a label',
   },
-  render: (args) => (
-    <Box sx={{ pl: 1.5 }}>
-      <Checkbox {...args} />
-    </Box>
-  ),
 };
 
 export const WithTooltip: Story = {
@@ -116,9 +114,4 @@ export const WithLabelAndTooltip: Story = {
     text: 'This Checkbox has a tooltip',
     toolTipText: 'This is the tooltip!',
   },
-  render: (args) => (
-    <Box sx={{ pl: 1.5 }}>
-      <Checkbox {...args} />
-    </Box>
-  ),
 };

--- a/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
+import { Box } from '../Box';
 import { Checkbox } from './Checkbox';
 
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
-import { Box } from '../Box';
 
 const meta: Meta<typeof Checkbox> = {
   component: Checkbox,

--- a/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Checkbox } from './Checkbox';
 
 import type { Meta, StoryObj } from '@storybook/react';
+import { Box } from '../Box';
 
 const meta: Meta<typeof Checkbox> = {
   component: Checkbox,
@@ -53,20 +54,6 @@ export const Indeterminate: Story = {
   render: (args) => <Checkbox {...args} />,
 };
 
-// @todo: Akamai Design System
-// export const Focused: Story = {
-//   render: (args) => <Checkbox {...args} />,
-// };
-
-// @todo: Akamai Design System
-// export const ReadOnly: Story = {
-//   args: {
-//     readOnly: true,
-//   },
-//   render: (args) => <Checkbox {...args} />,
-// };
-
-// @todo: Akamai Design System
 export const UncheckedDisabled: Story = {
   args: {
     disabled: true,
@@ -111,14 +98,17 @@ export const WithLabel: Story = {
   args: {
     text: 'This Checkbox has a label',
   },
-  render: (args) => <Checkbox {...args} />,
+  render: (args) => (
+    <Box sx={{ pl: 1.5 }}>
+      <Checkbox {...args} />
+    </Box>
+  ),
 };
 
 export const WithTooltip: Story = {
   args: {
     toolTipText: 'This is the tooltip!',
   },
-  render: (args) => <Checkbox {...args} />,
 };
 
 export const WithLabelAndTooltip: Story = {
@@ -126,5 +116,9 @@ export const WithLabelAndTooltip: Story = {
     text: 'This Checkbox has a tooltip',
     toolTipText: 'This is the tooltip!',
   },
-  render: (args) => <Checkbox {...args} />,
+  render: (args) => (
+    <Box sx={{ pl: 1.5 }}>
+      <Checkbox {...args} />
+    </Box>
+  ),
 };

--- a/packages/ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.tsx
@@ -111,19 +111,35 @@ const StyledCheckbox = styled(_Checkbox)(({ theme, ...props }) => ({
     props.disabled && {
       color: `${theme.tokens.checkbox.Indeterminated.Disabled.Background} !important`,
     }),
-  // ...(props.readOnly && {
-  //   color: 'red !important',
-  //   pointerEvents: 'none',
-  // }),
-  // '&.Mui-checked': {
-  //   color: 'green !important', // Change color when checked
-  // },
-  // '&.Mui-disabled': {
-  //   color: 'yellow', // Change color when disabled
-  // },
-  // '&.Mui-checked.Mui-disabled': {
-  //   color: 'darkgray', // Change color when checked and disabled
-  // },
+  // Unchecked & Readonly
+  ...(props.readOnly && {
+    color: theme.tokens.checkbox.Empty.ReadOnly.Border,
+    pointerEvents: 'none',
+  }),
+  // Checked & Readonly
+  ...(props.checked &&
+    props.readOnly && {
+      color: `${theme.tokens.checkbox.Checked.ReadOnly.Background} !important`,
+      svg: {
+        '#Check': {
+          fill: theme.tokens.checkbox.Checked.ReadOnly.Icon,
+        },
+        border: `1px solid ${theme.tokens.checkbox.Checked.ReadOnly.Border}`,
+      },
+      pointerEvents: 'none',
+    }),
+  // Indeterminate & Readonly
+  ...(props.indeterminate &&
+    props.readOnly && {
+      color: `${theme.tokens.checkbox.Checked.ReadOnly.Background} !important`,
+      svg: {
+        'g rect:nth-of-type(2)': {
+          fill: theme.tokens.checkbox.Indeterminated.ReadOnly.Icon,
+        },
+        border: `1px solid ${theme.tokens.checkbox.Indeterminated.ReadOnly.Border}`,
+      },
+      pointerEvents: 'none',
+    }),
 }));
 
 const StyledFormControlLabel = styled(FormControlLabel)(() => ({

--- a/packages/ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.tsx
@@ -97,6 +97,10 @@ const StyledCheckbox = styled(_Checkbox)(({ theme, ...props }) => ({
     fill: `${theme.bg.main} !important`,
     pointerEvents: 'none',
   }),
+  // ...(props.readOnly && {
+  //   color: 'red !important',
+  //   pointerEvents: 'none',
+  // }),
 }));
 
 const StyledFormControlLabel = styled(FormControlLabel)(() => ({

--- a/packages/ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.tsx
@@ -81,26 +81,49 @@ const StyledCheckbox = styled(_Checkbox)(({ theme, ...props }) => ({
     transition: theme.transitions.create(['fill']),
   },
   '&:hover': {
-    color: theme.palette.primary.main,
+    color: `${theme.tokens.checkbox.Empty.Hover.Border} !important`,
   },
-  color: theme.tokens.color.Neutrals[40],
+  color: theme.tokens.checkbox.Empty.Default.Border,
   transition: theme.transitions.create(['color']),
+  // Checked
   ...(props.checked && {
-    color: theme.palette.primary.main,
+    color: `${theme.tokens.checkbox.Checked.Default.Background} !important`,
   }),
+  // Indeterminate
+  ...(props.indeterminate && {
+    color: `${theme.tokens.checkbox.Indeterminated.Default.Background} !important`,
+  }),
+  // Unchecked & Disabled
   ...(props.disabled && {
-    '& .defaultFill': {
-      fill: `${theme.bg.main}`,
-      opacity: 0.5,
+    color: `${theme.tokens.checkbox.Empty.Disabled.Border} !important`,
+    '& svg': {
+      backgroundColor: theme.tokens.checkbox.Empty.Disabled.Background,
     },
-    color: `${theme.tokens.color.Neutrals[40]} !important`,
-    fill: `${theme.bg.main} !important`,
     pointerEvents: 'none',
   }),
+  // Checked & Disabled
+  ...(props.checked &&
+    props.disabled && {
+      color: `${theme.tokens.checkbox.Checked.Disabled.Background} !important`,
+    }),
+  // Indeterminate & Disabled
+  ...(props.indeterminate &&
+    props.disabled && {
+      color: `${theme.tokens.checkbox.Indeterminated.Disabled.Background} !important`,
+    }),
   // ...(props.readOnly && {
   //   color: 'red !important',
   //   pointerEvents: 'none',
   // }),
+  // '&.Mui-checked': {
+  //   color: 'green !important', // Change color when checked
+  // },
+  // '&.Mui-disabled': {
+  //   color: 'yellow', // Change color when disabled
+  // },
+  // '&.Mui-checked.Mui-disabled': {
+  //   color: 'darkgray', // Change color when checked and disabled
+  // },
 }));
 
 const StyledFormControlLabel = styled(FormControlLabel)(() => ({

--- a/packages/ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.tsx
@@ -1,5 +1,3 @@
-// @todo: modularization - Import from 'ui' package once FormControlLabel is migrated.
-import { FormControlLabel } from '@mui/material';
 import _Checkbox from '@mui/material/Checkbox';
 import { styled } from '@mui/material/styles';
 import * as React from 'react';
@@ -10,6 +8,7 @@ import {
   CheckboxIndeterminateIcon,
 } from '../../assets/icons';
 import { TooltipIcon } from '../TooltipIcon';
+import { FormControlLabel } from '../FormControlLabel';
 
 import type { CheckboxProps } from '@mui/material/Checkbox';
 import type { SxProps, Theme } from '@mui/material/styles';
@@ -80,37 +79,8 @@ const StyledCheckbox = styled(_Checkbox)(({ theme, ...props }) => ({
   '& .defaultFill': {
     transition: theme.transitions.create(['fill']),
   },
-  '&:hover': {
-    color: `${theme.tokens.checkbox.Empty.Hover.Border} !important`,
-  },
-  color: theme.tokens.checkbox.Empty.Default.Border,
+  padding: 0,
   transition: theme.transitions.create(['color']),
-  // Checked
-  ...(props.checked && {
-    color: `${theme.tokens.checkbox.Checked.Default.Background} !important`,
-  }),
-  // Indeterminate
-  ...(props.indeterminate && {
-    color: `${theme.tokens.checkbox.Indeterminated.Default.Background} !important`,
-  }),
-  // Unchecked & Disabled
-  ...(props.disabled && {
-    color: `${theme.tokens.checkbox.Empty.Disabled.Border} !important`,
-    '& svg': {
-      backgroundColor: theme.tokens.checkbox.Empty.Disabled.Background,
-    },
-    pointerEvents: 'none',
-  }),
-  // Checked & Disabled
-  ...(props.checked &&
-    props.disabled && {
-      color: `${theme.tokens.checkbox.Checked.Disabled.Background} !important`,
-    }),
-  // Indeterminate & Disabled
-  ...(props.indeterminate &&
-    props.disabled && {
-      color: `${theme.tokens.checkbox.Indeterminated.Disabled.Background} !important`,
-    }),
   // Unchecked & Readonly
   ...(props.readOnly && {
     color: theme.tokens.checkbox.Empty.ReadOnly.Border,
@@ -119,29 +89,33 @@ const StyledCheckbox = styled(_Checkbox)(({ theme, ...props }) => ({
   // Checked & Readonly
   ...(props.checked &&
     props.readOnly && {
-      color: `${theme.tokens.checkbox.Checked.ReadOnly.Background} !important`,
       svg: {
         '#Check': {
           fill: theme.tokens.checkbox.Checked.ReadOnly.Icon,
         },
         border: `1px solid ${theme.tokens.checkbox.Checked.ReadOnly.Border}`,
       },
+      color: `${theme.tokens.checkbox.Checked.ReadOnly.Background} !important`,
       pointerEvents: 'none',
     }),
   // Indeterminate & Readonly
   ...(props.indeterminate &&
     props.readOnly && {
-      color: `${theme.tokens.checkbox.Checked.ReadOnly.Background} !important`,
       svg: {
         'g rect:nth-of-type(2)': {
           fill: theme.tokens.checkbox.Indeterminated.ReadOnly.Icon,
         },
         border: `1px solid ${theme.tokens.checkbox.Indeterminated.ReadOnly.Border}`,
       },
+      color: `${theme.tokens.checkbox.Checked.ReadOnly.Background} !important`,
       pointerEvents: 'none',
     }),
 }));
 
-const StyledFormControlLabel = styled(FormControlLabel)(() => ({
+const StyledFormControlLabel = styled(FormControlLabel)(({ theme }) => ({
+  '& .MuiFormControlLabel-label': {
+    paddingTop: theme.tokens.spacing.S2,
+  },
+  gap: theme.tokens.spacing.S8,
   marginRight: 0,
 }));

--- a/packages/ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.tsx
@@ -116,6 +116,5 @@ const StyledFormControlLabel = styled(FormControlLabel)(({ theme }) => ({
   '& .MuiFormControlLabel-label': {
     paddingTop: theme.tokens.spacing.S2,
   },
-  // gap: theme.tokens.spacing.S8,
   marginRight: 0,
 }));

--- a/packages/ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.tsx
@@ -79,11 +79,11 @@ const StyledCheckbox = styled(_Checkbox)(({ theme, ...props }) => ({
   '& .defaultFill': {
     transition: theme.transitions.create(['fill']),
   },
-  padding: 0,
+  padding: theme.tokens.spacing.S8,
   transition: theme.transitions.create(['color']),
   // Unchecked & Readonly
   ...(props.readOnly && {
-    color: theme.tokens.checkbox.Empty.ReadOnly.Border,
+    color: theme.tokens.component.Checkbox.Empty.ReadOnly.Border,
     pointerEvents: 'none',
   }),
   // Checked & Readonly
@@ -91,11 +91,11 @@ const StyledCheckbox = styled(_Checkbox)(({ theme, ...props }) => ({
     props.readOnly && {
       svg: {
         '#Check': {
-          fill: theme.tokens.checkbox.Checked.ReadOnly.Icon,
+          fill: theme.tokens.component.Checkbox.Checked.ReadOnly.Icon,
         },
-        border: `1px solid ${theme.tokens.checkbox.Checked.ReadOnly.Border}`,
+        border: `1px solid ${theme.tokens.component.Checkbox.Checked.ReadOnly.Border}`,
       },
-      color: `${theme.tokens.checkbox.Checked.ReadOnly.Background} !important`,
+      color: `${theme.tokens.component.Checkbox.Checked.ReadOnly.Background} !important`,
       pointerEvents: 'none',
     }),
   // Indeterminate & Readonly
@@ -103,11 +103,11 @@ const StyledCheckbox = styled(_Checkbox)(({ theme, ...props }) => ({
     props.readOnly && {
       svg: {
         'g rect:nth-of-type(2)': {
-          fill: theme.tokens.checkbox.Indeterminated.ReadOnly.Icon,
+          fill: theme.tokens.component.Checkbox.Indeterminated.ReadOnly.Icon,
         },
-        border: `1px solid ${theme.tokens.checkbox.Indeterminated.ReadOnly.Border}`,
+        border: `1px solid ${theme.tokens.component.Checkbox.Indeterminated.ReadOnly.Border}`,
       },
-      color: `${theme.tokens.checkbox.Checked.ReadOnly.Background} !important`,
+      color: `${theme.tokens.component.Checkbox.Checked.ReadOnly.Background} !important`,
       pointerEvents: 'none',
     }),
 }));
@@ -116,6 +116,6 @@ const StyledFormControlLabel = styled(FormControlLabel)(({ theme }) => ({
   '& .MuiFormControlLabel-label': {
     paddingTop: theme.tokens.spacing.S2,
   },
-  gap: theme.tokens.spacing.S8,
+  // gap: theme.tokens.spacing.S8,
   marginRight: 0,
 }));

--- a/packages/ui/src/foundations/themes/dark.ts
+++ b/packages/ui/src/foundations/themes/dark.ts
@@ -391,7 +391,6 @@ export const darkTheme: ThemeOptions = {
           '&:hover': {
             color: `${Checkbox.Empty.Hover.Border} !important`,
           },
-          color: Checkbox.Empty.Default.Border,
           // Checked
           '&.Mui-checked': {
             color: Checkbox.Checked.Default.Background,
@@ -416,6 +415,7 @@ export const darkTheme: ThemeOptions = {
           '&.MuiCheckbox-indeterminate.Mui-disabled': {
             color: Checkbox.Indeterminated.Disabled.Background,
           },
+          color: Checkbox.Empty.Default.Border,
         },
       },
     },

--- a/packages/ui/src/foundations/themes/dark.ts
+++ b/packages/ui/src/foundations/themes/dark.ts
@@ -385,6 +385,40 @@ export const darkTheme: ThemeOptions = {
         },
       },
     },
+    MuiCheckbox: {
+      styleOverrides: {
+        root: {
+          '&:hover': {
+            color: `${Checkbox.Empty.Hover.Border} !important`,
+          },
+          color: Checkbox.Empty.Default.Border,
+          // Checked
+          '&.Mui-checked': {
+            color: Checkbox.Checked.Default.Background,
+          },
+          // Indeterminate
+          '&.MuiCheckbox-indeterminate': {
+            color: Checkbox.Indeterminated.Default.Background,
+          },
+          // Unchecked & Disabled
+          '&.Mui-disabled': {
+            '& svg': {
+              backgroundColor: Checkbox.Empty.Disabled.Background,
+            },
+            color: Checkbox.Empty.Disabled.Border,
+            pointerEvents: 'none',
+          },
+          // Checked & Disabled
+          '&.Mui-checked.Mui-disabled': {
+            color: Checkbox.Checked.Disabled.Background,
+          },
+          // Indeterminate & Disabled
+          '&.MuiCheckbox-indeterminate.Mui-disabled': {
+            color: Checkbox.Indeterminated.Disabled.Background,
+          },
+        },
+      },
+    },
     MuiChip: {
       defaultProps: {
         // In dark mode, we decided our Chips will be our primary color by default.

--- a/packages/ui/src/foundations/themes/dark.ts
+++ b/packages/ui/src/foundations/themes/dark.ts
@@ -388,34 +388,23 @@ export const darkTheme: ThemeOptions = {
     MuiCheckbox: {
       styleOverrides: {
         root: {
-          '&:hover': {
-            color: `${Checkbox.Empty.Hover.Border} !important`,
-          },
-          // Checked
-          '&.Mui-checked': {
-            color: Checkbox.Checked.Default.Background,
-          },
-          // Indeterminate
-          '&.MuiCheckbox-indeterminate': {
-            color: Checkbox.Indeterminated.Default.Background,
-          },
           // Unchecked & Disabled
           '&.Mui-disabled': {
             '& svg': {
-              backgroundColor: Checkbox.Empty.Disabled.Background,
+              backgroundColor: Component.Checkbox.Empty.Disabled.Background,
             },
-            color: Checkbox.Empty.Disabled.Border,
+            color: Component.Checkbox.Empty.Disabled.Border,
             pointerEvents: 'none',
           },
           // Checked & Disabled
           '&.Mui-checked.Mui-disabled': {
-            color: Checkbox.Checked.Disabled.Background,
+            color: Component.Checkbox.Checked.Disabled.Background,
           },
           // Indeterminate & Disabled
           '&.MuiCheckbox-indeterminate.Mui-disabled': {
-            color: Checkbox.Indeterminated.Disabled.Background,
+            color: Component.Checkbox.Indeterminated.Disabled.Background,
           },
-          color: Checkbox.Empty.Default.Border,
+          color: Component.Checkbox.Empty.Default.Border,
         },
       },
     },

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -591,13 +591,9 @@ export const lightTheme: ThemeOptions = {
       styleOverrides: {
         root: {
           color: Checkbox.Empty.Default.Border,
-          // '&[aria-disabled="true"]': {
-          //   color: '#E5E5EA',
-          //   '& svg': {
-          //     border: '1px solid #C2C2CA'
-          //   }
+          // '&.Mui-checked.Mui-disabled': {
+          //   color: ${Checkbox.Checked.Disabled.Background},
           // },
-          // ':indeterminate': { color: 'red !important' },
         },
       },
     },

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -590,10 +590,34 @@ export const lightTheme: ThemeOptions = {
     MuiCheckbox: {
       styleOverrides: {
         root: {
+          '&:hover': {
+            color: `${Checkbox.Empty.Hover.Border} !important`,
+          },
           color: Checkbox.Empty.Default.Border,
-          // '&.Mui-checked.Mui-disabled': {
-          //   color: ${Checkbox.Checked.Disabled.Background},
-          // },
+          // Checked
+          '&.Mui-checked': {
+            color: Checkbox.Checked.Default.Background,
+          },
+          // Indeterminate
+          '&.MuiCheckbox-indeterminate': {
+            color: Checkbox.Indeterminated.Default.Background,
+          },
+          // Unchecked & Disabled
+          '&.Mui-disabled': {
+            '& svg': {
+              backgroundColor: Checkbox.Empty.Disabled.Background,
+            },
+            color: Checkbox.Empty.Disabled.Border,
+            pointerEvents: 'none',
+          },
+          // Checked & Disabled
+          '&.Mui-checked.Mui-disabled': {
+            color: Checkbox.Checked.Disabled.Background,
+          },
+          // Indeterminate & Disabled
+          '&.MuiCheckbox-indeterminate.Mui-disabled': {
+            color: Checkbox.Indeterminated.Disabled.Background,
+          },
         },
       },
     },

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -593,7 +593,6 @@ export const lightTheme: ThemeOptions = {
           '&:hover': {
             color: `${Checkbox.Empty.Hover.Border} !important`,
           },
-          color: Checkbox.Empty.Default.Border,
           // Checked
           '&.Mui-checked': {
             color: Checkbox.Checked.Default.Background,
@@ -618,6 +617,7 @@ export const lightTheme: ThemeOptions = {
           '&.MuiCheckbox-indeterminate.Mui-disabled': {
             color: Checkbox.Indeterminated.Disabled.Background,
           },
+          color: Checkbox.Empty.Default.Border,
         },
       },
     },

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -591,6 +591,12 @@ export const lightTheme: ThemeOptions = {
       styleOverrides: {
         root: {
           color: Color.Neutrals[40],
+          // '&[aria-disabled="true"]': {
+          //   color: '#E5E5EA',
+          //   '& svg': {
+          //     border: '1px solid #C2C2CA'
+          //   }
+          // },
         },
       },
     },

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -590,13 +590,14 @@ export const lightTheme: ThemeOptions = {
     MuiCheckbox: {
       styleOverrides: {
         root: {
-          color: Color.Neutrals[40],
+          color: Checkbox.Empty.Default.Border,
           // '&[aria-disabled="true"]': {
           //   color: '#E5E5EA',
           //   '& svg': {
           //     border: '1px solid #C2C2CA'
           //   }
           // },
+          // ':indeterminate': { color: 'red !important' },
         },
       },
     },

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -590,34 +590,38 @@ export const lightTheme: ThemeOptions = {
     MuiCheckbox: {
       styleOverrides: {
         root: {
+          '&:active': {
+            color: `${Component.Checkbox.Empty.Active.Border} !important`,
+          },
           '&:hover': {
-            color: `${Checkbox.Empty.Hover.Border} !important`,
+            color: `${Component.Checkbox.Empty.Hover.Border} !important`,
+            // backgroundColor: 'transparent',
           },
           // Checked
           '&.Mui-checked': {
-            color: Checkbox.Checked.Default.Background,
+            color: Component.Checkbox.Checked.Default.Background,
           },
           // Indeterminate
           '&.MuiCheckbox-indeterminate': {
-            color: Checkbox.Indeterminated.Default.Background,
+            color: Component.Checkbox.Indeterminated.Default.Background,
           },
           // Unchecked & Disabled
           '&.Mui-disabled': {
             '& svg': {
-              backgroundColor: Checkbox.Empty.Disabled.Background,
+              backgroundColor: Component.Checkbox.Empty.Disabled.Background,
             },
-            color: Checkbox.Empty.Disabled.Border,
+            color: Component.Checkbox.Empty.Disabled.Border,
             pointerEvents: 'none',
           },
           // Checked & Disabled
           '&.Mui-checked.Mui-disabled': {
-            color: Checkbox.Checked.Disabled.Background,
+            color: Component.Checkbox.Checked.Disabled.Background,
           },
           // Indeterminate & Disabled
           '&.MuiCheckbox-indeterminate.Mui-disabled': {
-            color: Checkbox.Indeterminated.Disabled.Background,
+            color: Component.Checkbox.Indeterminated.Disabled.Background,
           },
-          color: Checkbox.Empty.Default.Border,
+          color: Component.Checkbox.Empty.Default.Border,
         },
       },
     },

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -595,7 +595,6 @@ export const lightTheme: ThemeOptions = {
           },
           '&:hover': {
             color: `${Component.Checkbox.Empty.Hover.Border} !important`,
-            // backgroundColor: 'transparent',
           },
           // Checked
           '&.Mui-checked': {


### PR DESCRIPTION
## Description 📝
Update styles to match CDS for `Checkbox` component

## Changes  🔄
- Add `Checkbox` design tokens
- Add more stories for the `Checkbox` component in Storybook
- Update styles to match CDS for `Checkbox` component

## Target release date 🗓️
N/A

## Preview 📷

Some of the checkbox variants (from storybook):

| State | Light | Dark |
| ---- | ------- | ------- |
| _Default_: Unchecked, Checked, Indeterminate | ![Screenshot 2025-03-20 at 3 13 07 AM](https://github.com/user-attachments/assets/0d7b1467-7971-4bd6-b53a-22923959ee5a) ![Screenshot 2025-03-20 at 3 13 14 AM](https://github.com/user-attachments/assets/0e59f538-6eaa-4def-8f1f-710ddea5c477) ![Screenshot 2025-03-20 at 3 13 25 AM](https://github.com/user-attachments/assets/e6a7891b-04ee-40e2-baa9-c415e0d7e8f8) | ![Screenshot 2025-03-20 at 3 47 55 AM](https://github.com/user-attachments/assets/b15b4c60-7e8b-466a-bdd8-5d8a13410285) ![Screenshot 2025-03-20 at 3 48 05 AM](https://github.com/user-attachments/assets/1dbe4e3b-28f6-4105-9623-6615a0302292) ![Screenshot 2025-03-20 at 3 48 13 AM](https://github.com/user-attachments/assets/3bc302d5-486a-45bc-8fc0-c3252081fda0) |
| _Disabled_: Unchecked, Checked, Indeterminate | ![Screenshot 2025-03-20 at 3 13 36 AM](https://github.com/user-attachments/assets/c0c5bd42-74ac-44d3-b485-cc996849326e) ![Screenshot 2025-03-20 at 3 13 47 AM](https://github.com/user-attachments/assets/a93ef976-cb23-442f-9f8d-4a140c666404) ![Screenshot 2025-03-20 at 3 13 56 AM](https://github.com/user-attachments/assets/dd264faf-11c3-419d-b494-e7733eb97339) | ![Screenshot 2025-03-20 at 3 48 20 AM](https://github.com/user-attachments/assets/83ccedf9-1c97-43f0-82c5-17cecf0cad9e) ![Screenshot 2025-03-20 at 3 48 26 AM](https://github.com/user-attachments/assets/35480516-aee0-4a91-95e3-9dcc96c72b86) ![Screenshot 2025-03-20 at 3 48 34 AM](https://github.com/user-attachments/assets/7f184814-6bf8-42f4-a742-21fb34fc985b) |
| _Readonly_: Unchecked, Checked,  Indeterminate| ![Screenshot 2025-03-20 at 3 14 06 AM](https://github.com/user-attachments/assets/b2c4ba15-5bbb-4483-aba8-0d9f4bb250b1) ![Screenshot 2025-03-20 at 3 14 14 AM](https://github.com/user-attachments/assets/4dc908e7-c00c-4548-9047-9211c3cf6196) ![Screenshot 2025-03-20 at 3 14 24 AM](https://github.com/user-attachments/assets/512a812a-8b69-4e3f-bd0a-f61d8235d2f8) | ![Screenshot 2025-03-20 at 3 48 40 AM](https://github.com/user-attachments/assets/87a89b59-5ae3-4bc3-9236-4f43a4dc895e) ![Screenshot 2025-03-20 at 3 48 46 AM](https://github.com/user-attachments/assets/1a46f0e8-90e2-4456-8b6f-3a9085532468) ![Screenshot 2025-03-20 at 3 48 53 AM](https://github.com/user-attachments/assets/afd286b9-8331-49e1-9163-632dbcab5b0b) |
| Default Unchecked with Label | ![Screenshot 2025-03-20 at 3 14 35 AM](https://github.com/user-attachments/assets/9338a60e-bfce-4398-a21b-1fd575600fd0) | ![Screenshot 2025-03-20 at 3 49 01 AM](https://github.com/user-attachments/assets/c12cabce-2b18-4183-a11e-fae6fd3039cc) |
| Default Checked with Label | ![Screenshot 2025-03-20 at 3 14 48 AM](https://github.com/user-attachments/assets/9ba22e22-19bb-43e3-b245-88eccbccdff7) | ![Screenshot 2025-03-20 at 3 49 15 AM](https://github.com/user-attachments/assets/28099d76-3936-4ab2-978c-42470251fc6f) |

## How to test 🧪
- Confirm CI is passing
- Checkout the branch and verify figma changes for `Checkbox` component
   - Verify all the `Checkbox` variants:
      - Default
      - Hover
      - Active
      - Disabled
      - Readonly
   - Verify spacing
  - Verify the `Checkbox` component and its different variants in Storybook
- Confirm no visual regression in application
   - Verify `Checkbox` wherever used in CM (in both light and dark modes)

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules