### PR TITLE
upcoming: [M3-9517] - Update LKE-E flows to account for LDE being disabled at LA launch

### DIFF
--- a/packages/manager/.changeset/pr-11880-upcoming-features-1742329364209.md
+++ b/packages/manager/.changeset/pr-11880-upcoming-features-1742329364209.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update LKE-E flows to account for LDE status at LA launch ([#11880](https://github.com/linode/manager/pull/11880))

--- a/packages/manager/src/features/Kubernetes/ClusterList/constants.ts
+++ b/packages/manager/src/features/Kubernetes/ClusterList/constants.ts
@@ -1,5 +1,11 @@
 export const ADD_NODE_POOLS_DESCRIPTION =
   'Add groups of Linodes to your cluster. You can have a maximum of 100 Linodes per node pool and a maximum of 250 Linodes per cluster.';
 
+export const ADD_NODE_POOLS_ENTERPRISE_DESCRIPTION =
+  'Add groups of Linodes to your cluster. You can have a maximum of 100 Linodes per node pool.';
+
 export const ADD_NODE_POOLS_ENCRYPTION_DESCRIPTION =
   'Node Pool data is encrypted at rest.';
+
+export const ADD_NODE_POOLS_NO_ENCRYPTION_DESCRIPTION =
+  'Node Pool data is not encrypted at rest for LKE Enterprise clusters.';

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -1,15 +1,17 @@
+import { useRegionsQuery } from '@linode/queries';
 import { CircleProgress, ErrorState } from '@linode/ui';
 import Grid from '@mui/material/Grid2';
 import * as React from 'react';
 
 import { useIsAcceleratedPlansEnabled } from 'src/features/components/PlansPanel/utils';
-import { useRegionsQuery } from '@linode/queries';
 import { doesRegionSupportFeature } from 'src/utilities/doesRegionSupportFeature';
 import { extendType } from 'src/utilities/extendType';
 
 import {
   ADD_NODE_POOLS_DESCRIPTION,
   ADD_NODE_POOLS_ENCRYPTION_DESCRIPTION,
+  ADD_NODE_POOLS_ENTERPRISE_DESCRIPTION,
+  ADD_NODE_POOLS_NO_ENCRYPTION_DESCRIPTION,
 } from '../ClusterList/constants';
 import { KubernetesPlansPanel } from '../KubernetesPlansPanel/KubernetesPlansPanel';
 
@@ -100,15 +102,20 @@ const Panel = (props: NodePoolPanelProps) => {
     'Disk Encryption'
   );
 
+  const getPlansPanelCopy = () => {
+    // TODO - LKE-E: Remove the 'ADD_NODE_POOLS_NO_ENCRYPTION_DESCRIPTION' copy once LDE is enabled on LKE-E.
+    if (selectedTier === 'enterprise') {
+      return `${ADD_NODE_POOLS_ENTERPRISE_DESCRIPTION} ${ADD_NODE_POOLS_NO_ENCRYPTION_DESCRIPTION}`;
+    }
+    return regionSupportsDiskEncryption
+      ? `${ADD_NODE_POOLS_DESCRIPTION} ${ADD_NODE_POOLS_ENCRYPTION_DESCRIPTION}`
+      : ADD_NODE_POOLS_DESCRIPTION;
+  };
+
   return (
     <Grid container direction="column">
       <Grid>
         <KubernetesPlansPanel
-          copy={
-            regionSupportsDiskEncryption
-              ? `${ADD_NODE_POOLS_DESCRIPTION} ${ADD_NODE_POOLS_ENCRYPTION_DESCRIPTION}`
-              : ADD_NODE_POOLS_DESCRIPTION
-          }
           getTypeCount={(planId) =>
             typeCountMap.get(planId) ?? DEFAULT_PLAN_COUNT
           }
@@ -121,6 +128,7 @@ const Panel = (props: NodePoolPanelProps) => {
             // No Nanodes in Kubernetes clusters
             return t.class !== 'nanode';
           })}
+          copy={getPlansPanelCopy()}
           error={apiError}
           hasSelectedRegion={hasSelectedRegion}
           header="Add Node Pools"

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -1,3 +1,4 @@
+import { useAllLinodesQuery, useProfile } from '@linode/queries';
 import { Box, ErrorState, TooltipIcon, Typography } from '@linode/ui';
 import { DateTime, Interval } from 'luxon';
 import { enqueueSnackbar } from 'notistack';
@@ -20,7 +21,6 @@ import { TableRow } from 'src/components/TableRow';
 import { TableSortCell } from 'src/components/TableSortCell';
 import { TagCell } from 'src/components/TagCell/TagCell';
 import { useUpdateNodePoolMutation } from 'src/queries/kubernetes';
-import { useAllLinodesQuery, useProfile } from '@linode/queries';
 import { parseAPIDate } from 'src/utilities/date';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
@@ -270,8 +270,17 @@ export const NodeTable = React.memo((props: Props) => {
                       </Typography>
                       <StyledVerticalDivider />
                       <EncryptedStatus
+                        /**
+                         * M3-9517: Once LDE starts releasing regions with LDE enabled, LDE will still be disabled for the LKE-E LA launch, so hide this tooltip
+                         * explaining how LDE can be enabled on LKE-E node pools.
+                         * TODO - LKE-E: Clean up this enterprise cluster checks once LDE is enabled for LKE-E.
+                         */
+                        tooltipText={
+                          clusterTier === 'enterprise'
+                            ? undefined
+                            : DISK_ENCRYPTION_NODE_POOL_GUIDANCE_COPY
+                        }
                         encryptionStatus={encryptionStatus}
-                        tooltipText={DISK_ENCRYPTION_NODE_POOL_GUIDANCE_COPY}
                       />
                     </Box>
                   ) : (

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
@@ -253,8 +253,15 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
                     flexDirection="row"
                   >
                     <EncryptedStatus
+                      /**
+                       * M3-9517: Once LDE starts releasing regions with LDE enabled, LDE will still be disabled for the LKE-E LA launch, so hide this tooltip
+                       * explaining how LDE can be enabled on LKE-E node pools.
+                       * TODO - LKE-E: Clean up this enterprise cluster checks once LDE is enabled for LKE-E.
+                       */
                       tooltipText={
-                        isLKELinode
+                        isLKELinode && cluster?.tier === 'enterprise'
+                          ? undefined
+                          : isLKELinode
                           ? UNENCRYPTED_LKE_LINODE_GUIDANCE_COPY
                           : UNENCRYPTED_STANDARD_LINODE_GUIDANCE_COPY
                       }


### PR DESCRIPTION
## Description 📝

This is a late add that came out of reviews ahead of LKE-E's LA release.

The ask is to expose the fact that LDE is not enabled for the cluster during the cluster creation time. It is not sufficient to show it in the UI after the cluster is created or to just have it in tech docs.

Reasons LDE may not be enabled:
- LDE is turned off by LKE-E (this is expected to be the case for LA launch with a global flag on the backend; we don't have access to this flag)
- DC in which the LKE-E cluster is created does not support LDE (this is already being handled today)

_This changes will be reversed in coming weeks when LDE becomes available for LKE-E. Given potential merge conflicts with the last LDE changes in staging and the fact that this is not long-lasting, I did not go through the hassle of adding test coverage._

## Changes  🔄
- Update copy in "Add Node Pools" section of the LKE Create page to explicitly mention that LKE-E node pools are not encrypted at rest
- Also update that same copy to take out an incorrect limit that's not applicable for LKE-E
- Hide the incorrect tooltip that would display for regions with LDE enabled, even if it wasn't possible for an LKE-E cluster to enable LDE

## Target release date 🗓️

3/25

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-03-18 at 12 39 38 PM](https://github.com/user-attachments/assets/44843f9d-3759-4767-bef3-5f9238107c83) | ![Screenshot 2025-03-18 at 12 39 12 PM](https://github.com/user-attachments/assets/38daeb34-0273-46d3-a8d6-9cbb366462d5) |
| ![Screenshot 2025-03-18 at 12 42 43 PM](https://github.com/user-attachments/assets/e6b12b24-060d-4ab0-84ea-e515d0f3f0b0) | ![Screenshot 2025-03-18 at 12 39 51 PM](https://github.com/user-attachments/assets/6c3b3680-d317-403e-85ae-ba9e6d06536a) |

> NOTE: The expectation is that by LKE-E LA launch, nodes in node pools will have disk encryption disabled too. This doesn't seem to be the case yet on the backend today. (See LKE-6592.)


## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have LKE-E feature flag on and have the LKE-E customer tag on your account (see project tracker)
- If your account can no longer create an LKE-E cluster due to recent backend pre-prod changes, use Hana's prod test account listed in our password manager.

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Create an LKE-E cluster. Observe there is no mention of LDE status on the create flow.
- [ ] Go to the cluster details page and observe the node pool encryption status. There is an incorrect tooltip suggesting that LDE can be enabled.
- [ ] Go to the Linode details page of any node in the node pool and observe the node pool encryption status. There is an incorrect tooltip suggesting that LDE can be enabled.

### Verification steps

(How to verify changes)

- [ ] Create an LKE-E cluster. Observe there is a mention of LDE status on the create flow in the node pools section.
- [ ] Go to the cluster details page and observe the node pool encryption status. Observer there is NOT a tooltip suggesting that LDE can be enabled.
- [ ] Go to the Linode details page of any node in the node pool and observe the node pool encryption status. Observe there is NOT is a tooltip suggesting that LDE can be enabled.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
