### PR TITLE
upcoming: Enable Linode Interface query only when Delete Interface dialog is open

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/DeleteInterfaceDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/DeleteInterfaceDialog.tsx
@@ -26,7 +26,11 @@ export const DeleteInterfaceDialog = (props: Props) => {
     data: linodeInterface,
     error: interfaceError,
     isLoading,
-  } = useLinodeInterfaceQuery(linodeId, interfaceId ?? -1);
+  } = useLinodeInterfaceQuery(
+    linodeId,
+    interfaceId ?? -1,
+    open && Boolean(interfaceId)
+  );
 
   const { error, isPending, mutate } = useDeleteLinodeInterfaceMutation(
     linodeId,
@@ -63,7 +67,7 @@ export const DeleteInterfaceDialog = (props: Props) => {
       isFetching={isLoading}
       onClose={onClose}
       open={open}
-      title={`Delete ${type} Interface?`}
+      title={`Delete ${type} Interface ID #${interfaceId}?`}
     >
       Are you sure you want to delete this {type} interface?
     </ConfirmationDialog>

--- a/packages/queries/src/linodes/interfaces.ts
+++ b/packages/queries/src/linodes/interfaces.ts
@@ -27,13 +27,14 @@ export const useLinodeInterfacesQuery = (linodeId: number) => {
 
 export const useLinodeInterfaceQuery = (
   linodeId: number,
-  interfaceId: number
+  interfaceId: number,
+  enabled: boolean = true
 ) => {
   return useQuery<LinodeInterface, APIError[]>({
     ...linodeQueries
       .linode(linodeId)
       ._ctx.interfaces._ctx.interface(interfaceId),
-    enabled: Boolean(interfaceId),
+    enabled,
   });
 };
 


### PR DESCRIPTION
## Description 📝
- small PR to only enable useLinodeInterfaceQuery in Delete Interface dialog if dialog is open

## Changes  🔄
- enable query when dialog is open (and when interface ID exists)
- updated dialog title a bit 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/be375d80-8dac-406c-987d-df4bc401ba74) | ![image](https://github.com/user-attachments/assets/d661784e-22ca-41dd-8c0f-859f71f26708) |
| ![image](https://github.com/user-attachments/assets/fd19b66d-802f-4224-a83c-a242c7863daf) | no queries when delete dialog closed |

## How to test 🧪
Using devenv
Have a linode using new interfaces

### Reproduction steps
- On the develop branch, navigate to the Linode's network section
- notice queries to get a linode interface erroring out

### Verification
- On this branch, confirm that there are no queries to linode/instances/{id}/interfaces/{interfaceId} when Delete Dialog isn't open

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

