### PR TITLE
upcoming: [M3-9534] - Initial VPC Support in the `Add Interface` Drawer

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceDrawer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceDrawer.tsx
@@ -9,10 +9,11 @@ interface Props {
   linodeId: number;
   onClose: () => void;
   open: boolean;
+  regionId: string;
 }
 
 export const AddInterfaceDrawer = (props: Props) => {
-  const { linodeId, onClose, open } = props;
+  const { linodeId, onClose, open, regionId } = props;
 
   return (
     <Drawer
@@ -21,7 +22,11 @@ export const AddInterfaceDrawer = (props: Props) => {
       open={open}
       title="Add Network Interface"
     >
-      <AddInterfaceForm linodeId={linodeId} onClose={onClose} />
+      <AddInterfaceForm
+        linodeId={linodeId}
+        onClose={onClose}
+        regionId={regionId}
+      />
     </Drawer>
   );
 };

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceForm.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceForm.tsx
@@ -12,16 +12,18 @@ import { InterfaceFirewall } from './InterfaceFirewall';
 import { InterfaceType } from './InterfaceType';
 import { CreateLinodeInterfaceFormSchema } from './utilities';
 import { VLANInterface } from './VLANInterface';
+import { VPCInterface } from './VPCInterface';
 
 import type { CreateInterfaceFormValues } from './utilities';
 
 interface Props {
   linodeId: number;
   onClose: () => void;
+  regionId: string;
 }
 
 export const AddInterfaceForm = (props: Props) => {
-  const { linodeId, onClose } = props;
+  const { linodeId, regionId, onClose } = props;
   const { enqueueSnackbar } = useSnackbar();
 
   const { mutateAsync } = useCreateLinodeInterfaceMutation(linodeId);
@@ -76,6 +78,9 @@ export const AddInterfaceForm = (props: Props) => {
           )}
           <InterfaceType />
           {selectedInterfacePurpose === 'vlan' && <VLANInterface />}
+          {selectedInterfacePurpose === 'vpc' && (
+            <VPCInterface regionId={regionId} />
+          )}
           <InterfaceFirewall />
           <Actions onClose={onClose} />
         </Stack>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/VPCInterface.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/VPCInterface.tsx
@@ -1,0 +1,82 @@
+import { useAllVPCsQuery } from '@linode/queries';
+import { Autocomplete, Stack } from '@linode/ui';
+import React from 'react';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
+
+import type { CreateInterfaceFormValues } from './utilities';
+
+interface Props {
+  regionId: string;
+}
+
+export const VPCInterface = (props: Props) => {
+  const { regionId } = props;
+  const {
+    control,
+    resetField,
+    setValue,
+  } = useFormContext<CreateInterfaceFormValues>();
+
+  const { data: vpcs, error, isLoading } = useAllVPCsQuery({
+    filter: { region: regionId },
+  });
+
+  const [vpcId] = useWatch({ control, name: ['vpc.vpc_id'] });
+
+  const selectedVPC = vpcs?.find((vpc) => vpc.id === vpcId) ?? null;
+
+  return (
+    <Stack spacing={2}>
+      <Controller
+        render={({ field, fieldState }) => (
+          <Autocomplete
+            onChange={(e, vpc) => {
+              field.onChange(vpc?.id ?? null);
+
+              if (vpc && vpc.subnets.length === 1) {
+                // If the user selectes a VPC and the VPC only has one subnet,
+                // preselect that subnet for the user.
+                setValue('vpc.subnet_id', vpc.subnets[0].id, {
+                  shouldValidate: true,
+                });
+              } else {
+                // Otherwise, just clear the selected subnet
+                resetField('vpc.subnet_id');
+              }
+            }}
+            errorText={fieldState.error?.message ?? error?.[0].reason}
+            label="VPC"
+            loading={isLoading}
+            noMarginTop
+            onBlur={field.onBlur}
+            options={vpcs ?? []}
+            placeholder="Select a VPC"
+            value={selectedVPC}
+          />
+        )}
+        control={control}
+        name="vpc.vpc_id"
+      />
+      <Controller
+        render={({ field, fieldState }) => (
+          <Autocomplete
+            value={
+              selectedVPC?.subnets.find((s) => s.id === field.value) ?? null
+            }
+            disabled={!selectedVPC}
+            errorText={fieldState.error?.message}
+            label="Subnet"
+            loading={isLoading}
+            noMarginTop
+            onBlur={field.onBlur}
+            onChange={(e, subnet) => field.onChange(subnet?.id ?? null)}
+            options={selectedVPC?.subnets ?? []}
+            placeholder="Select a Subnet"
+          />
+        )}
+        control={control}
+        name="vpc.subnet_id"
+      />
+    </Stack>
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/LinodeInterfaces.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/LinodeInterfaces.tsx
@@ -7,9 +7,10 @@ import { LinodeInterfacesTable } from './LinodeInterfacesTable';
 
 interface Props {
   linodeId: number;
+  regionId: string;
 }
 
-export const LinodeInterfaces = ({ linodeId }: Props) => {
+export const LinodeInterfaces = ({ linodeId, regionId }: Props) => {
   const [isAddDrawerOpen, setIsAddDrawerOpen] = useState(false);
   const [isDeleteDrawerOpen, setIsDeleteDrawerOpen] = useState(false);
   const [selectedInterfaceId, setSelectedInterfaceId] = useState<number>();
@@ -41,6 +42,7 @@ export const LinodeInterfaces = ({ linodeId }: Props) => {
         linodeId={linodeId}
         onClose={() => setIsAddDrawerOpen(false)}
         open={isAddDrawerOpen}
+        regionId={regionId}
       />
       <DeleteInterfaceDialog
         interfaceId={selectedInterfaceId}

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -36,7 +36,9 @@ export const LinodeNetworking = () => {
     <Stack spacing={2}>
       <LinodeNetworkingSummaryPanel linodeId={id} />
       {showFirewallsTable && <LinodeFirewalls linodeID={id} />}
-      {showInterfacesTable && <LinodeInterfaces linodeId={id} />}
+      {showInterfacesTable && (
+        <LinodeInterfaces linodeId={id} regionId={linode.region} />
+      )}
       <LinodeIPAddresses linodeID={id} />
     </Stack>
   );


### PR DESCRIPTION
## Description 📝

- Adds initial support for VPC in the `Add Interface` Drawer on the Linode Details page

## Preview 📷

![Screenshot 2025-03-19 at 1 12 39 PM](https://github.com/user-attachments/assets/69b42c47-3051-4e41-bd22-6edea044b5e6)

## How to test 🧪

### Prerequisites

- Use the **DevCloud** API
- Use Cloud Manager's local dev tools to enable the Linode Interfaces feature flag

### Verification steps

- Create a Linode with new Linode Interfaces on http://localhost:3000/linodes/create
- Go to that Linode's Details page
- Go to the Network Tab
- Click `Add Network Interface`
- Verify you can add a VPC interface
- Test the `Add Interface` Drawer as a whole

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>