### PR TITLE
test: [M3-8668] - Disallow legacy regions from being selected via `chooseRegion`

### DIFF
--- a/packages/manager/.changeset/pr-11892-tests-1742564481277.md
+++ b/packages/manager/.changeset/pr-11892-tests-1742564481277.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Prevent legacy regions from being used by Cypress tests ([#11892](https://github.com/linode/manager/pull/11892))

--- a/packages/manager/cypress/support/util/regions.ts
+++ b/packages/manager/cypress/support/util/regions.ts
@@ -100,6 +100,36 @@ const disallowedRegionIds = [
 
   // Washington, DC
   'us-iad',
+
+  // Atlanta, GA
+  'us-southeast',
+
+  // Dallas, TX
+  'us-central',
+
+  // Frankfurt, DE
+  'eu-central',
+
+  // Fremont, CA
+  'us-west',
+
+  // London, GB
+  'eu-west',
+
+  // Mumbai, IN
+  'ap-west',
+
+  // Newark, NJ
+  'us-east',
+
+  // Singapore, SG
+  'ap-south',
+
+  // Sydney, AU
+  'ap-southeast',
+
+  // Toronto, CA
+  'ca-central',
 ];
 
 /**


### PR DESCRIPTION
## Description 📝

Disallow legacy regions from being chosen when using the `chooseRegion` util within our Cypress tests.

## Changes  🔄

- Add legacy regions to list of disallowed regions

## Target release date 🗓️

N/A.

## How to test 🧪

- We can rely on CI for this.
- Alternatively, run the tests or some subset of tests and confirm no resources get created in disallowed regions

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

