### PR TITLE
feat: [UIE-8600] - IAM RBAC: add new drawer for unassigning role flow

### DIFF
--- a/packages/manager/.changeset/pr-11893-upcoming-features-1742481856731.md
+++ b/packages/manager/.changeset/pr-11893-upcoming-features-1742481856731.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add a new confirmation dialog for the unassigning role flow in IAM ([#11893](https://github.com/linode/manager/pull/11893))

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/AssignedRolesActionMenu.test.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/AssignedRolesActionMenu.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { AssignedRolesActionMenu } from './AssignedRolesActionMenu';
+
+import type { ExtendedRoleMap } from '../utilities';
+
+const mockOnChangeRole = vi.fn();
+const mockOnUnassignRole = vi.fn();
+const mockOnViewEntities = vi.fn();
+
+const mockAccountRole: ExtendedRoleMap = {
+  access: 'account_access',
+  description:
+    'Access to perform any supported action on all resources in the account',
+  id: 'account_admin',
+  name: 'account_admin',
+  permissions: ['create_linode', 'update_linode', 'update_firewall'],
+  resource_ids: null,
+  resource_type: 'account',
+};
+
+const mockEntityRole: ExtendedRoleMap = {
+  access: 'resource_access',
+  description: 'Access to update a linode instance',
+  id: 'linode_contributor',
+  name: 'linode_contributor',
+  permissions: ['update_linode', 'view_linode'],
+  resource_ids: [12345678],
+  resource_type: 'linode',
+};
+
+describe('AssignedRolesActionMenu', () => {
+  it('should render actions for account access roles correctly', () => {
+    const { getByRole, queryByText } = renderWithTheme(
+      <AssignedRolesActionMenu
+        handleChangeRole={mockOnChangeRole}
+        handleUnassignRole={mockOnUnassignRole}
+        handleViewEntities={mockOnViewEntities}
+        role={mockAccountRole}
+      />
+    );
+
+    const actionBtn = getByRole('button');
+    expect(actionBtn).toBeInTheDocument();
+    fireEvent.click(actionBtn);
+
+    expect(queryByText('Change Role')).toBeInTheDocument();
+    expect(queryByText('Unassign Role')).toBeInTheDocument();
+    expect(queryByText('Update List of Entities')).not.toBeInTheDocument();
+    expect(queryByText('View Entities')).not.toBeInTheDocument();
+  });
+
+  it('should render actions for entity access roles correctly', () => {
+    const { getByRole, queryByText } = renderWithTheme(
+      <AssignedRolesActionMenu
+        handleChangeRole={mockOnChangeRole}
+        handleUnassignRole={mockOnUnassignRole}
+        handleViewEntities={mockOnViewEntities}
+        role={mockEntityRole}
+      />
+    );
+
+    // Check if "Manage Access" action is present
+    const actionBtn = getByRole('button');
+    expect(actionBtn).toBeInTheDocument();
+    fireEvent.click(actionBtn);
+
+    expect(queryByText('View Entities')).toBeInTheDocument();
+    expect(queryByText('Update List of Entities')).toBeInTheDocument();
+    expect(queryByText('Change Role')).toBeInTheDocument();
+    expect(queryByText('Unassign Role')).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/AssignedRolesActionMenu.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/AssignedRolesActionMenu.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
+
+import type { ExtendedRoleMap } from '../utilities';
+import type { Action } from 'src/components/ActionMenu/ActionMenu';
+
+interface Props {
+  handleChangeRole: (role: ExtendedRoleMap) => void;
+  handleUnassignRole: (role: ExtendedRoleMap) => void;
+  handleViewEntities: (role: string) => void;
+  role: ExtendedRoleMap;
+}
+
+export const AssignedRolesActionMenu = ({
+  handleChangeRole,
+  handleUnassignRole,
+  handleViewEntities,
+  role,
+}: Props) => {
+  const accountMenu: Action[] = [
+    {
+      onClick: () => {
+        handleChangeRole(role);
+      },
+      title: 'Change Role',
+    },
+    {
+      onClick: () => {
+        handleUnassignRole(role);
+      },
+      title: 'Unassign Role',
+    },
+  ];
+
+  const entitiesMenu: Action[] = [
+    {
+      onClick: () => handleViewEntities(role.name),
+      title: 'View Entities',
+    },
+    {
+      onClick: () => {
+        // mock
+      },
+      title: 'Update List of Entities',
+    },
+    {
+      onClick: () => {
+        handleChangeRole(role);
+      },
+      title: 'Change Role',
+    },
+    {
+      onClick: () => {
+        handleUnassignRole(role);
+      },
+      title: 'Unassign Role',
+    },
+  ];
+
+  const actions = role.access === 'account_access' ? accountMenu : entitiesMenu;
+
+  return <ActionMenu actionsList={actions} ariaLabel="action menu" />;
+};

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/UnassignRoleConfirmationDialog.test.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/UnassignRoleConfirmationDialog.test.tsx
@@ -1,0 +1,139 @@
+import { fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { accountPermissionsFactory } from 'src/factories/accountPermissions';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { UnassignRoleConfirmationDialog } from './UnassignRoleConfirmationDialog';
+
+import type { ExtendedRoleMap } from '../utilities';
+
+const mockRole: ExtendedRoleMap = {
+  access: 'account_access',
+  description:
+    'Access to perform any supported action on all resources in the account',
+  id: 'account_admin',
+  name: 'account_admin',
+  permissions: ['create_linode', 'update_linode', 'update_firewall'],
+  resource_ids: null,
+  resource_type: 'account',
+};
+
+const props = {
+  onClose: vi.fn(),
+  onSuccess: vi.fn(),
+  open: true,
+  role: mockRole,
+};
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useParams: () => ({ username: 'test_user' }),
+  };
+});
+
+const queryMocks = vi.hoisted(() => ({
+  useAccountPermissions: vi.fn().mockReturnValue({}),
+  useAccountUserPermissions: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('src/queries/iam/iam', async () => {
+  const actual = await vi.importActual<any>('src/queries/iam/iam');
+  return {
+    ...actual,
+    useAccountPermissions: queryMocks.useAccountPermissions,
+    useAccountUserPermissions: queryMocks.useAccountUserPermissions,
+  };
+});
+
+const mockDeleteUserRole = vi.fn();
+vi.mock('@linode/api-v4', async () => {
+  return {
+    ...(await vi.importActual<any>('@linode/api-v4')),
+    updateUserPermissions: (username: string, data: any) => {
+      mockDeleteUserRole(data);
+      return Promise.resolve(props);
+    },
+  };
+});
+
+describe('UnassignRoleConfirmationDialog', () => {
+  it('should render', () => {
+    const { getAllByRole, getByText } = renderWithTheme(
+      <MemoryRouter>
+        <UnassignRoleConfirmationDialog {...props} />{' '}
+      </MemoryRouter>
+    );
+
+    const headerText = getByText('Unassign the account_admin role?');
+    expect(headerText).toBeVisible();
+
+    const paragraph = getByText(/You’re about to remove the/i).closest('p');
+
+    expect(paragraph).toBeInTheDocument();
+    expect(paragraph).toHaveTextContent(/account_admin/i);
+    expect(paragraph).toHaveTextContent(/test_user/i);
+    expect(
+      getByText(/The change will be applied immidiately./i)
+    ).toBeInTheDocument();
+
+    const buttons = getAllByRole('button');
+    expect(buttons?.length).toBe(3);
+  });
+
+  it('calls the corresponding functions when buttons are clicked', async () => {
+    const { getByText } = renderWithTheme(
+      <UnassignRoleConfirmationDialog {...props} />
+    );
+
+    const deleteButton = getByText('Remove');
+    expect(deleteButton).toBeVisible();
+
+    const cancelButton = getByText('Cancel');
+    expect(cancelButton).toBeVisible();
+    fireEvent.click(cancelButton);
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it('should allow unassign `account_admin` role', async () => {
+    queryMocks.useAccountUserPermissions.mockReturnValue({
+      data: {
+        account_access: ['account_linode_admin', 'account_admin'],
+        resource_access: [
+          {
+            resource_id: 12345678,
+            resource_type: 'linode',
+            roles: ['linode_contributor'],
+          },
+        ],
+      },
+    });
+
+    queryMocks.useAccountPermissions.mockReturnValue({
+      data: accountPermissionsFactory.build(),
+    });
+
+    const { getByText } = renderWithTheme(
+      <UnassignRoleConfirmationDialog {...props} />
+    );
+
+    await userEvent.click(getByText('Remove'));
+
+    await waitFor(() => {
+      expect(mockDeleteUserRole).toHaveBeenCalledWith({
+        account_access: ['account_linode_admin'],
+        resource_access: [
+          {
+            resource_id: 12345678,
+            resource_type: 'linode',
+            roles: ['linode_contributor'],
+          },
+        ],
+      });
+    });
+  });
+});

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/UnassignRoleConfirmationDialog.test.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/UnassignRoleConfirmationDialog.test.tsx
@@ -78,7 +78,7 @@ describe('UnassignRoleConfirmationDialog', () => {
     expect(paragraph).toHaveTextContent(/account_admin/i);
     expect(paragraph).toHaveTextContent(/test_user/i);
     expect(
-      getByText(/The change will be applied immidiately./i)
+      getByText(/The change will be applied immediately./i)
     ).toBeInTheDocument();
 
     const buttons = getAllByRole('button');

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/UnassignRoleConfirmationDialog.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/UnassignRoleConfirmationDialog.tsx
@@ -1,5 +1,4 @@
 import { ActionsPanel, Notice, Typography } from '@linode/ui';
-import { useTheme } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 import { useParams } from 'react-router-dom';
@@ -24,8 +23,6 @@ interface Props {
 export const UnassignRoleConfirmationDialog = (props: Props) => {
   const { onClose: _onClose, onSuccess, open, role } = props;
   const { username } = useParams<{ username: string }>();
-
-  const theme = useTheme();
 
   const { enqueueSnackbar } = useSnackbar();
 
@@ -87,10 +84,8 @@ export const UnassignRoleConfirmationDialog = (props: Props) => {
     >
       <Notice variant="warning">
         <Typography>
-          You’re about to remove the{' '}
-          <span style={{ font: theme.font.bold }}>{role?.name}</span> role from{' '}
-          <span style={{ font: theme.font.bold }}>{username}</span>. The change
-          will be applied immidiately.
+          You’re about to remove the <strong>{role?.name}</strong> role from{' '}
+          <strong>{username}</strong>. The change will be applied immediately.
         </Typography>
       </Notice>
     </ConfirmationDialog>

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/UnassignRoleConfirmationDialog.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/UnassignRoleConfirmationDialog.tsx
@@ -1,0 +1,98 @@
+import { ActionsPanel, Notice, Typography } from '@linode/ui';
+import { useTheme } from '@mui/material';
+import { useSnackbar } from 'notistack';
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
+import {
+  useAccountUserPermissions,
+  useAccountUserPermissionsMutation,
+} from 'src/queries/iam/iam';
+
+import { deleteUserRole } from '../utilities';
+
+import type { ExtendedRoleMap } from '../utilities';
+
+interface Props {
+  onClose: () => void;
+  onSuccess?: () => void;
+  open: boolean;
+  role: ExtendedRoleMap | undefined;
+}
+
+export const UnassignRoleConfirmationDialog = (props: Props) => {
+  const { onClose: _onClose, onSuccess, open, role } = props;
+  const { username } = useParams<{ username: string }>();
+
+  const theme = useTheme();
+
+  const { enqueueSnackbar } = useSnackbar();
+
+  const {
+    error,
+    isPending,
+    mutateAsync: updateUserPermissions,
+    reset,
+  } = useAccountUserPermissionsMutation(username);
+
+  const { data: assignedRoles } = useAccountUserPermissions(username ?? '');
+
+  const onClose = () => {
+    reset(); // resets the error state of the useMutation
+    _onClose();
+  };
+
+  const onDelete = async () => {
+    const initialRole = role?.name;
+    const access = role?.access;
+
+    const updatedUserRoles = deleteUserRole({
+      access,
+      assignedRoles,
+      initialRole,
+    });
+
+    await updateUserPermissions(updatedUserRoles);
+
+    enqueueSnackbar(`Role ${role?.name} has been deleted successfully.`, {
+      variant: 'success',
+    });
+    if (onSuccess) {
+      onSuccess();
+    }
+    onClose();
+  };
+
+  return (
+    <ConfirmationDialog
+      actions={
+        <ActionsPanel
+          primaryButtonProps={{
+            label: 'Remove',
+            loading: isPending,
+            onClick: onDelete,
+          }}
+          secondaryButtonProps={{
+            label: 'Cancel',
+            onClick: onClose,
+          }}
+          style={{ padding: 0 }}
+        />
+      }
+      error={error?.[0].reason}
+      onClose={onClose}
+      open={open}
+      title={`Unassign the ${role?.name} role?`}
+    >
+      <Notice variant="warning">
+        <Typography>
+          You’re about to remove the{' '}
+          <span style={{ font: theme.font.bold }}>{role?.name}</span> role from{' '}
+          <span style={{ font: theme.font.bold }}>{username}</span>. The change
+          will be applied immidiately.
+        </Typography>
+      </Notice>
+    </ConfirmationDialog>
+  );
+};

--- a/packages/manager/src/features/IAM/Shared/utilities.test.ts
+++ b/packages/manager/src/features/IAM/Shared/utilities.test.ts
@@ -1,5 +1,8 @@
+import { userPermissionsFactory } from 'src/factories/userPermissions';
+
 import {
   combineRoles,
+  deleteUserRole,
   getAllRoles,
   getRoleByName,
   mapRolesToPermissions,
@@ -197,6 +200,84 @@ describe('updateUserRoles', () => {
         assignedRoles: userPermissions,
         initialRole,
         newRole,
+      })
+    ).toEqual(expectedRoles);
+  });
+});
+
+describe('deleteUserRole', () => {
+  it('should return an object of updated users roles with resource access', () => {
+    const initialRole = 'linode_contributor';
+
+    const expectedRoles = {
+      account_access: ['account_linode_admin', 'linode_creator'],
+      resource_access: [],
+    };
+
+    expect(
+      deleteUserRole({
+        access: resourceAccess,
+        assignedRoles: userPermissions,
+        initialRole,
+      })
+    ).toEqual(expectedRoles);
+  });
+
+  it('should return an object of updated users roles with resource access', () => {
+    const initialRole = 'linode_contributor';
+
+    const userPermissions = userPermissionsFactory.build();
+
+    const expectedRoles = {
+      account_access: [
+        'account_linode_admin',
+        'linode_creator',
+        'firewall_creator',
+        'account_admin',
+        'account_viewer',
+      ],
+      resource_access: [
+        {
+          resource_id: 23456789,
+          resource_type: 'linode',
+          roles: ['linode_viewer'],
+        },
+        {
+          resource_id: 45678901,
+          resource_type: 'firewall',
+          roles: ['update_firewall'],
+        },
+      ],
+    };
+
+    expect(
+      deleteUserRole({
+        access: resourceAccess,
+        assignedRoles: userPermissions,
+        initialRole,
+      })
+    ).toEqual(expectedRoles);
+  });
+
+  it('should return an object of updated users roles with account access', () => {
+    const initialRole = 'account_linode_admin';
+
+    const expectedRoles = {
+      account_access: ['linode_creator'],
+      resource_access: [
+        {
+          resource_id: 12345678,
+          resource_type: 'linode',
+          roles: ['linode_contributor'],
+        },
+      ],
+    };
+
+    expect(
+      deleteUserRole({
+        access: accountAccess,
+        assignedRoles: userPermissions,
+        initialRole,
       })
     ).toEqual(expectedRoles);
   });

--- a/packages/manager/src/features/IAM/Shared/utilities.ts
+++ b/packages/manager/src/features/IAM/Shared/utilities.ts
@@ -446,7 +446,14 @@ export const deleteUserRole = ({
   assignedRoles,
   initialRole,
 }: DeleteUserRolesProps): IamUserPermissions => {
-  if (access === 'account_access' && assignedRoles) {
+  if (!assignedRoles) {
+    return {
+      account_access: [],
+      resource_access: [],
+    };
+  }
+
+  if (access === 'account_access') {
     return {
       ...assignedRoles,
       account_access: assignedRoles.account_access.filter(
@@ -455,7 +462,7 @@ export const deleteUserRole = ({
     };
   }
 
-  if (access === 'resource_access' && assignedRoles) {
+  if (access === 'resource_access') {
     return {
       ...assignedRoles,
       resource_access: assignedRoles.resource_access
@@ -470,10 +477,5 @@ export const deleteUserRole = ({
   }
 
   // If access type is invalid, return unchanged object
-  return (
-    assignedRoles ?? {
-      account_access: [],
-      resource_access: [],
-    }
-  );
+  return assignedRoles;
 };

--- a/packages/manager/src/features/IAM/Shared/utilities.ts
+++ b/packages/manager/src/features/IAM/Shared/utilities.ts
@@ -435,3 +435,45 @@ export interface AssignNewRoleFormValues {
     role: RolesType | null;
   }[];
 }
+interface DeleteUserRolesProps {
+  access?: 'account_access' | 'resource_access';
+  assignedRoles?: IamUserPermissions;
+  initialRole?: string;
+}
+
+export const deleteUserRole = ({
+  access,
+  assignedRoles,
+  initialRole,
+}: DeleteUserRolesProps): IamUserPermissions => {
+  if (access === 'account_access' && assignedRoles) {
+    return {
+      ...assignedRoles,
+      account_access: assignedRoles.account_access.filter(
+        (role: AccountAccessType) => role !== initialRole
+      ),
+    };
+  }
+
+  if (access === 'resource_access' && assignedRoles) {
+    return {
+      ...assignedRoles,
+      resource_access: assignedRoles.resource_access
+        .map((resource: ResourceAccess) => ({
+          ...resource,
+          roles: resource.roles.filter(
+            (role: RoleType) => role !== initialRole
+          ),
+        }))
+        .filter((resource: ResourceAccess) => resource.roles.length > 0),
+    };
+  }
+
+  // If access type is invalid, return unchanged object
+  return (
+    assignedRoles ?? {
+      account_access: [],
+      resource_access: [],
+    }
+  );
+};

--- a/packages/manager/src/features/IAM/Users/UserRoles/AssignedEntities.tsx
+++ b/packages/manager/src/features/IAM/Users/UserRoles/AssignedEntities.tsx
@@ -54,7 +54,10 @@ export const AssignedEntities = ({
     >
       <Chip
         sx={{
-          backgroundColor: theme.tokens.color.Ultramarine[20],
+          backgroundColor:
+            theme.name === 'light'
+              ? theme.tokens.color.Ultramarine[20]
+              : theme.tokens.color.Neutrals.Black,
           color: theme.tokens.alias.Content.Text.Primary.Default,
         }}
         data-testid="entities"
@@ -83,7 +86,10 @@ export const AssignedEntities = ({
         <Box
           sx={{
             aligIitems: 'center',
-            backgroundColor: theme.tokens.color.Ultramarine[20],
+            backgroundColor:
+              theme.name === 'light'
+                ? theme.tokens.color.Ultramarine[20]
+                : theme.tokens.color.Neutrals.Black,
             borderRadius: 1,
             display: 'flex',
             height: '20px',


### PR DESCRIPTION
## Description 📝

Add a new confirmation dialog for the unassigning role flow. The design for this component is the same as the one used for deleting a user in the users table.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Add a new component for the unassigning role flow
- Add a new component for the actions menu in the table

## Target release date 🗓️

(dev)

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/c8e748ba-74cf-403f-ae5e-2547f7ea7dba) | ![image](https://github.com/user-attachments/assets/9f0de1d7-7b2d-4e48-a662-367558366f39) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Ensure the Identity and Access Beta flag is enabled in dev tools
- Ensure the MSW is enabled in dev tools
- Click on the any username in the users table and go to the tab Assigned Roles or click on the user's menu View User Roles
- Click on the role's menu Unassign Role

### Verification steps

(How to verify changes)

- [ ]  Confirm confirmation dialog opens
- [ ]  Confirm that user can unassign the role

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
