### PR TITLE
fix: [M3-9607] - Tabs keyboard navigation on Tanstack rerouted features

### DIFF
--- a/packages/manager/.changeset/pr-11894-fixed-1742495460894.md
+++ b/packages/manager/.changeset/pr-11894-fixed-1742495460894.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Tabs keyboard navigation on some Tanstack rerouted features ([#11894](https://github.com/linode/manager/pull/11894))

--- a/packages/manager/cypress/component/components/tabs.spec.tsx
+++ b/packages/manager/cypress/component/components/tabs.spec.tsx
@@ -1,0 +1,155 @@
+import { createRoute } from '@tanstack/react-router';
+import * as React from 'react';
+import { ui } from 'support/ui';
+import { checkComponentA11y } from 'support/util/accessibility';
+import { componentTests, visualTests } from 'support/util/components';
+
+import { SuspenseLoader } from 'src/components/SuspenseLoader';
+import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
+import { TabPanels } from 'src/components/Tabs/TabPanels';
+import { Tabs } from 'src/components/Tabs/Tabs';
+import { TanStackTabLinkList } from 'src/components/Tabs/TanStackTabLinkList';
+import { useTabs } from 'src/hooks/useTabs';
+
+const CustomTabs = () => {
+  const { handleTabChange, tabIndex, tabs } = useTabs([
+    {
+      title: 'Tab 1',
+      to: '/tab-1',
+    },
+    {
+      title: 'Tab 2',
+      to: '/tab-2',
+    },
+    {
+      title: 'Tab 3',
+      to: '/tab-3',
+    },
+  ]);
+
+  return (
+    <Tabs index={tabIndex} onChange={handleTabChange}>
+      <TanStackTabLinkList tabs={tabs} />
+      <React.Suspense fallback={<SuspenseLoader />}>
+        <TabPanels>
+          <SafeTabPanel index={0}>
+            <div>Tab 1 content</div>
+          </SafeTabPanel>
+          <SafeTabPanel index={1}>
+            <div>Tab 2 content</div>
+          </SafeTabPanel>
+          <SafeTabPanel index={2}>
+            <div>Tab 3 content</div>
+          </SafeTabPanel>
+        </TabPanels>
+      </React.Suspense>
+    </Tabs>
+  );
+};
+
+componentTests(
+  'Tabs',
+  (mount) => {
+    describe('Tabs', () => {
+      it('should render all tabs and default to the first tab', () => {
+        mount(<CustomTabs />);
+        ui.tabList
+          .findTabByTitle('Tab 1')
+          .should('exist')
+          .should('have.attr', 'aria-selected', 'true');
+        ui.tabList
+          .findTabByTitle('Tab 2')
+          .should('exist')
+          .should('have.attr', 'aria-selected', 'false');
+        ui.tabList
+          .findTabByTitle('Tab 3')
+          .should('exist')
+          .should('have.attr', 'aria-selected', 'false');
+
+        cy.get('[data-reach-tab-panels]').should('have.text', 'Tab 1 content');
+      });
+
+      it('should render the correct tab content when a tab is clicked', () => {
+        mount(<CustomTabs />);
+
+        ui.tabList.findTabByTitle('Tab 2').click();
+        ui.tabList
+          .findTabByTitle('Tab 2')
+          .should('exist')
+          .should('have.attr', 'aria-selected', 'true');
+        cy.get('[data-reach-tab-panels]').should('have.text', 'Tab 2 content');
+
+        ui.tabList.findTabByTitle('Tab 3').click();
+        ui.tabList
+          .findTabByTitle('Tab 3')
+          .should('exist')
+          .should('have.attr', 'aria-selected', 'true');
+        cy.get('[data-reach-tab-panels]').should('have.text', 'Tab 3 content');
+      });
+
+      it('should handle keyboard navigation', () => {
+        mount(<CustomTabs />);
+
+        ui.tabList.findTabByTitle('Tab 1').focus();
+        cy.get('body').type('{rightArrow}');
+        ui.tabList
+          .findTabByTitle('Tab 2')
+          .should('exist')
+          .should('have.attr', 'aria-selected', 'true');
+        cy.get('[data-reach-tab-panels]').should('have.text', 'Tab 2 content');
+
+        cy.get('body').type('{rightArrow}');
+        ui.tabList
+          .findTabByTitle('Tab 3')
+          .should('exist')
+          .should('have.attr', 'aria-selected', 'true');
+        cy.get('[data-reach-tab-panels]').should('have.text', 'Tab 3 content');
+
+        cy.get('body').type('{leftArrow}');
+        ui.tabList
+          .findTabByTitle('Tab 2')
+          .should('exist')
+          .should('have.attr', 'aria-selected', 'true');
+        cy.get('[data-reach-tab-panels]').should('have.text', 'Tab 2 content');
+
+        cy.get('body').type('{leftArrow}');
+        ui.tabList
+          .findTabByTitle('Tab 1')
+          .should('exist')
+          .should('have.attr', 'aria-selected', 'true');
+        cy.get('[data-reach-tab-panels]').should('have.text', 'Tab 1 content');
+      });
+    });
+  },
+  {
+    routeTree: (parentRoute) => [
+      createRoute({
+        getParentRoute: () => parentRoute,
+        path: '/tab-1',
+      }),
+      createRoute({
+        getParentRoute: () => parentRoute,
+        path: '/tab-2',
+      }),
+      createRoute({
+        getParentRoute: () => parentRoute,
+        path: '/tab-3',
+      }),
+    ],
+    useTanstackRouter: true,
+  }
+);
+
+visualTests(
+  (mount) => {
+    describe('Accessibility checks', () => {
+      it('passes aXe check when menu is closed without an item selected', () => {
+        mount(<CustomTabs />);
+        checkComponentA11y();
+      });
+    });
+  },
+  {
+    useTanstackRouter: true,
+  }
+);

--- a/packages/manager/cypress/support/component/setup.tsx
+++ b/packages/manager/cypress/support/component/setup.tsx
@@ -35,7 +35,7 @@ import { LinodeThemeWrapper } from 'src/LinodeThemeWrapper';
 import { storeFactory } from 'src/store';
 
 import type { ThemeName } from '@linode/ui';
-import type { AnyRouter } from '@tanstack/react-router';
+import type { AnyRoute, AnyRouter } from '@tanstack/react-router';
 import type { Flags } from 'src/featureFlags';
 
 /**
@@ -48,7 +48,8 @@ export const mountWithTheme = (
   jsx: React.ReactNode,
   theme: ThemeName = 'light',
   flags: Partial<Flags> = {},
-  useTanstackRouter: boolean = false
+  useTanstackRouter: boolean = false,
+  routeTree?: (parentRoute: AnyRoute) => AnyRoute[]
 ) => {
   const queryClient = queryClientFactory();
   const store = storeFactory();
@@ -59,10 +60,13 @@ export const mountWithTheme = (
     path: '/',
   });
   const router: AnyRouter = createRouter({
+    defaultNotFoundComponent: () => <div>Not Found</div>,
     history: createMemoryHistory({
       initialEntries: ['/'],
     }),
-    routeTree: rootRoute.addChildren([indexRoute]),
+    routeTree: routeTree
+      ? rootRoute.addChildren([indexRoute, ...routeTree(indexRoute)])
+      : rootRoute.addChildren([indexRoute]),
   });
 
   return mount(

--- a/packages/manager/cypress/support/util/components.ts
+++ b/packages/manager/cypress/support/util/components.ts
@@ -3,9 +3,9 @@
  */
 
 import type { ThemeName } from '@linode/ui';
+import type { AnyRoute } from '@tanstack/react-router';
 import type { MountReturn } from 'cypress/react';
 import type { Flags } from 'src/featureFlags';
-
 /**
  * Array of themes for which to test components.
  */
@@ -49,11 +49,18 @@ export const componentTests = (
   componentName: string,
   callback: (mountCommand: MountCommand) => void,
   options: {
+    routeTree?: (parentRoute: AnyRoute) => AnyRoute[];
     useTanstackRouter?: boolean;
   } = {}
 ) => {
   const mountCommand = (jsx: React.ReactNode, flags?: Flags) =>
-    cy.mountWithTheme(jsx, defaultTheme, flags, options.useTanstackRouter);
+    cy.mountWithTheme(
+      jsx,
+      defaultTheme,
+      flags,
+      options.useTanstackRouter,
+      options.routeTree
+    );
   describe(`${componentName} component tests`, () => {
     callback(mountCommand);
   });
@@ -71,11 +78,23 @@ export const componentTests = (
  *
  * @param callback - Test scope callback.
  */
-export const visualTests = (callback: (mountCommand: MountCommand) => void) => {
+export const visualTests = (
+  callback: (mountCommand: MountCommand) => void,
+  options: {
+    routeTree?: (parentRoute: AnyRoute) => AnyRoute[];
+    useTanstackRouter?: boolean;
+  } = {}
+) => {
   describe('Visual tests', () => {
     componentThemes.forEach((themeName: ThemeName) => {
       const mountCommand = (jsx: React.ReactNode, flags?: any) =>
-        cy.mountWithTheme(jsx, themeName, flags);
+        cy.mountWithTheme(
+          jsx,
+          themeName,
+          flags,
+          options.useTanstackRouter,
+          options.routeTree
+        );
       describe(`${capitalize(themeName)} theme`, () => {
         callback(mountCommand);
       });

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -36,7 +36,7 @@
     "@mui/utils": "^6.4.3",
     "@mui/x-date-pickers": "^7.27.0",
     "@paypal/react-paypal-js": "^7.8.3",
-    "@reach/tabs": "^0.10.5",
+    "@reach/tabs": "^0.18.0",
     "@sentry/react": "^7.119.1",
     "@shikijs/langs": "^3.1.0",
     "@shikijs/themes": "^3.1.0",

--- a/packages/manager/src/components/Tabs/SafeTabPanel.test.tsx
+++ b/packages/manager/src/components/Tabs/SafeTabPanel.test.tsx
@@ -1,6 +1,8 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
 
+import { Tabs } from 'src/components/Tabs/Tabs';
+
 import { SafeTabPanel } from './SafeTabPanel';
 
 vi.mock('@reach/tabs', async () => {
@@ -14,9 +16,11 @@ vi.mock('@reach/tabs', async () => {
 describe('SafeTabPanel', () => {
   it('renders children when the tab is selected', () => {
     const { getByText } = render(
-      <SafeTabPanel index={0}>
-        <div>Child Content</div>
-      </SafeTabPanel>
+      <Tabs>
+        <SafeTabPanel index={0}>
+          <div>Child Content</div>
+        </SafeTabPanel>
+      </Tabs>
     );
 
     expect(getByText('Child Content')).toBeInTheDocument();
@@ -24,9 +28,11 @@ describe('SafeTabPanel', () => {
 
   it('does not render children when the tab is not selected', () => {
     const { queryByText } = render(
-      <SafeTabPanel index={1}>
-        <div>Child Content</div>
-      </SafeTabPanel>
+      <Tabs>
+        <SafeTabPanel index={1}>
+          <div>Child Content</div>
+        </SafeTabPanel>
+      </Tabs>
     );
 
     expect(queryByText('Child Content')).toBeNull();
@@ -34,11 +40,13 @@ describe('SafeTabPanel', () => {
 
   it('renders empty when the index is null', () => {
     const { container } = render(
-      <SafeTabPanel index={null}>
-        <div>Child Content</div>
-      </SafeTabPanel>
+      <Tabs>
+        <SafeTabPanel index={null}>
+          <div>Child Content</div>
+        </SafeTabPanel>
+      </Tabs>
     );
 
-    expect(container.firstChild).toBeEmptyDOMElement();
+    expect(container.firstChild?.firstChild).toBeEmptyDOMElement();
   });
 });

--- a/packages/manager/src/components/Tabs/Tab.test.tsx
+++ b/packages/manager/src/components/Tabs/Tab.test.tsx
@@ -1,31 +1,44 @@
 import { screen } from '@testing-library/react';
 import React from 'react';
 
+import { Tabs } from 'src/components/Tabs/Tabs';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { Tab } from './Tab';
 
 describe('Tab Component', () => {
   it('renders tab with children', () => {
-    renderWithTheme(<Tab>Hello Tab</Tab>);
+    renderWithTheme(
+      <Tabs>
+        <Tab>Hello Tab</Tab>
+      </Tabs>
+    );
 
     const tabElement = screen.getByText('Hello Tab');
     expect(tabElement).toBeInTheDocument();
   });
 
   it('applies styles correctly', () => {
-    renderWithTheme(<Tab>Hello Tab</Tab>);
+    renderWithTheme(
+      <Tabs>
+        <Tab>Hello Tab</Tab>
+      </Tabs>
+    );
 
     const tabElement = screen.getByText('Hello Tab');
 
     expect(tabElement).toHaveStyle(`
       display: inline-flex;
-      color: rgb(1, 116, 188);
+      color: rgb(52, 52, 56);
     `);
   });
 
   it('handles disabled state', () => {
-    renderWithTheme(<Tab disabled>Click Me</Tab>);
+    renderWithTheme(
+      <Tabs>
+        <Tab disabled>Click Me</Tab>
+      </Tabs>
+    );
 
     const tabElement = screen.getByText('Click Me');
 

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsLanding/AlertsLanding.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsLanding/AlertsLanding.tsx
@@ -66,11 +66,7 @@ export const AlertsLanding = React.memo(() => {
         docsLabel="Docs"
         docsLink="https://techdocs.akamai.com/cloud-computing/docs/akamai-cloud-pulse"
       />
-      <Tabs
-        index={activeTabIndex}
-        onChange={handleChange}
-        style={{ width: '100%' }}
-      >
+      <Tabs index={activeTabIndex} onChange={handleChange}>
         <TabLinkList tabs={accessibleTabs} />
         <React.Fragment>
           <DocumentTitleSegment segment="Alerts" />

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsLanding/AlertsLanding.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsLanding/AlertsLanding.tsx
@@ -69,7 +69,7 @@ export const AlertsLanding = React.memo(() => {
       <Tabs
         index={activeTabIndex}
         onChange={handleChange}
-        sx={{ width: '100%' }}
+        style={{ width: '100%' }}
       >
         <TabLinkList tabs={accessibleTabs} />
         <React.Fragment>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -25,6 +25,7 @@ import { useTabs } from 'src/hooks/useTabs';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
 import { checkIfUserCanModifyFirewall } from '../shared';
+import { SuspenseLoader } from 'src/components/SuspenseLoader';
 
 const FirewallRulesLanding = React.lazy(() =>
   import('./Rules/FirewallRulesLanding').then((module) => ({
@@ -153,33 +154,35 @@ export const FirewallDetail = () => {
           {...secureVMFirewallBanner.firewallDetails}
         />
       )}
-      <Tabs index={tabIndex === -1 ? 0 : tabIndex} onChange={handleTabChange}>
+      <Tabs index={tabIndex} onChange={handleTabChange}>
         <TanStackTabLinkList tabs={tabs} />
-        <TabPanels>
-          <SafeTabPanel index={0}>
-            <FirewallRulesLanding
-              disabled={!userCanModifyFirewall}
-              firewallID={firewallId}
-              rules={firewall.rules}
-            />
-          </SafeTabPanel>
-          <SafeTabPanel index={1}>
-            <FirewallDeviceLanding
-              disabled={!userCanModifyFirewall}
-              firewallId={firewallId}
-              firewallLabel={firewall.label}
-              type="linode"
-            />
-          </SafeTabPanel>
-          <SafeTabPanel index={2}>
-            <FirewallDeviceLanding
-              disabled={!userCanModifyFirewall}
-              firewallId={firewallId}
-              firewallLabel={firewall.label}
-              type="nodebalancer"
-            />
-          </SafeTabPanel>
-        </TabPanels>
+        <React.Suspense fallback={<SuspenseLoader />}>
+          <TabPanels>
+            <SafeTabPanel index={0}>
+              <FirewallRulesLanding
+                disabled={!userCanModifyFirewall}
+                firewallID={firewallId}
+                rules={firewall.rules}
+              />
+            </SafeTabPanel>
+            <SafeTabPanel index={1}>
+              <FirewallDeviceLanding
+                disabled={!userCanModifyFirewall}
+                firewallId={firewallId}
+                firewallLabel={firewall.label}
+                type="linode"
+              />
+            </SafeTabPanel>
+            <SafeTabPanel index={2}>
+              <FirewallDeviceLanding
+                disabled={!userCanModifyFirewall}
+                firewallId={firewallId}
+                firewallLabel={firewall.label}
+                type="nodebalancer"
+              />
+            </SafeTabPanel>
+          </TabPanels>
+        </React.Suspense>
       </Tabs>
       <GenerateFirewallDialog
         onClose={() => setIsGenerateDialogOpen(false)}

--- a/packages/manager/src/features/Linodes/LinodeCreate/ApiAwarenessModal/IntegrationsTabPanel.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/ApiAwarenessModal/IntegrationsTabPanel.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 
+import { Tabs } from 'src/components/Tabs/Tabs';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { gettingStartedGuides as ansibleResources } from './AnsibleIntegrationResources';
@@ -30,13 +31,21 @@ vi.mock('@reach/tabs', async () => {
 
 describe('IntegrationsTabPanel', () => {
   it('Should render IntegrationsTabPanel', () => {
-    renderWithTheme(<IntegrationsTabPanel {...defaultProps} />);
+    renderWithTheme(
+      <Tabs>
+        <IntegrationsTabPanel {...defaultProps} />
+      </Tabs>
+    );
     expect(
       screen.getByPlaceholderText('Select Integration')
     ).toBeInTheDocument();
   });
   it('Should update the state correctly and render relevant resources when Ansible is selected', async () => {
-    renderWithTheme(<IntegrationsTabPanel {...defaultProps} />);
+    renderWithTheme(
+      <Tabs>
+        <IntegrationsTabPanel {...defaultProps} />
+      </Tabs>
+    );
 
     // Check initial value of the Inegrations field
     expect(screen.getByPlaceholderText('Select Integration')).toHaveValue('');
@@ -69,7 +78,11 @@ describe('IntegrationsTabPanel', () => {
     });
   });
   it('Should update the state correctly and render relevant resources when Terraform is selected', async () => {
-    renderWithTheme(<IntegrationsTabPanel {...defaultProps} />);
+    renderWithTheme(
+      <Tabs>
+        <IntegrationsTabPanel {...defaultProps} />
+      </Tabs>
+    );
 
     // Check initial value of the Inegrations field
     expect(screen.getByPlaceholderText('Select Integration')).toHaveValue('');

--- a/packages/manager/src/features/Linodes/LinodeCreate/ApiAwarenessModal/SDKTabPanel.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/ApiAwarenessModal/SDKTabPanel.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 
+import { Tabs } from 'src/components/Tabs/Tabs';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { gettingStartedGuides as goResources } from './GoSDKResources';
@@ -30,11 +31,19 @@ vi.mock('@reach/tabs', async () => {
 
 describe('SDKTabPanel', () => {
   it('Should render SDKTabPanel', () => {
-    renderWithTheme(<SDKTabPanel {...defaultProps} />);
+    renderWithTheme(
+      <Tabs>
+        <SDKTabPanel {...defaultProps} />
+      </Tabs>
+    );
     expect(screen.getByPlaceholderText('Select An SDK')).toBeInTheDocument();
   });
   it('Should update the state correctly and render relevant resources when Go is selected', async () => {
-    renderWithTheme(<SDKTabPanel {...defaultProps} />);
+    renderWithTheme(
+      <Tabs>
+        <SDKTabPanel {...defaultProps} />
+      </Tabs>
+    );
 
     // Check initial value of the SDK field
     expect(screen.getByPlaceholderText('Select An SDK')).toHaveValue('');
@@ -67,7 +76,11 @@ describe('SDKTabPanel', () => {
     });
   });
   it('Should update the state correctly and render relevant resources when Python is selected', async () => {
-    renderWithTheme(<SDKTabPanel {...defaultProps} />);
+    renderWithTheme(
+      <Tabs>
+        <SDKTabPanel {...defaultProps} />
+      </Tabs>
+    );
 
     // Check initial value of the SDK field
     expect(screen.getByPlaceholderText('Select An SDK')).toHaveValue('');

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -8,6 +8,7 @@ import { useMatch, useParams } from '@tanstack/react-router';
 import * as React from 'react';
 
 import { LandingHeader } from 'src/components/LandingHeader';
+import { SuspenseLoader } from 'src/components/SuspenseLoader';
 import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
 import { TabPanels } from 'src/components/Tabs/TabPanels';
 import { Tabs } from 'src/components/Tabs/Tabs';
@@ -120,22 +121,23 @@ export const NodeBalancerDetail = () => {
       )}
       <Tabs index={tabIndex} onChange={handleTabChange}>
         <TanStackTabLinkList tabs={tabs} />
-
-        <TabPanels>
-          <SafeTabPanel index={0}>
-            <NodeBalancerSummary />
-          </SafeTabPanel>
-          <SafeTabPanel index={1}>
-            <NodeBalancerConfigurationWrapper
-              grants={grants}
-              nodeBalancerLabel={nodebalancer.label}
-              nodeBalancerRegion={nodebalancer.region}
-            />
-          </SafeTabPanel>
-          <SafeTabPanel index={2}>
-            <NodeBalancerSettings />
-          </SafeTabPanel>
-        </TabPanels>
+        <React.Suspense fallback={<SuspenseLoader />}>
+          <TabPanels>
+            <SafeTabPanel index={0}>
+              <NodeBalancerSummary />
+            </SafeTabPanel>
+            <SafeTabPanel index={1}>
+              <NodeBalancerConfigurationWrapper
+                grants={grants}
+                nodeBalancerLabel={nodebalancer.label}
+                nodeBalancerRegion={nodebalancer.region}
+              />
+            </SafeTabPanel>
+            <SafeTabPanel index={2}>
+              <NodeBalancerSettings />
+            </SafeTabPanel>
+          </TabPanels>
+        </React.Suspense>
       </Tabs>
     </React.Fragment>
   );

--- a/packages/manager/src/hooks/useTabs.ts
+++ b/packages/manager/src/hooks/useTabs.ts
@@ -1,4 +1,4 @@
-import { useMatchRoute } from '@tanstack/react-router';
+import { useMatchRoute, useNavigate } from '@tanstack/react-router';
 import * as React from 'react';
 
 import type { LinkProps } from '@tanstack/react-router';
@@ -35,6 +35,7 @@ export interface Tab {
  * since Reach Tabs maintains its own index state.
  */
 export function useTabs<T extends Tab>(tabs: T[]) {
+  const navigate = useNavigate();
   const matchRoute = useMatchRoute();
 
   // Filter out hidden tabs
@@ -55,10 +56,15 @@ export function useTabs<T extends Tab>(tabs: T[]) {
     return index === -1 ? 0 : index;
   }, [visibleTabs, matchRoute]);
 
-  // Simple handler to satisfy Reach Tabs props
-  const handleTabChange = React.useCallback(() => {
-    // No-op - navigation is handled by Tanstack Router `Link`
-  }, []);
+  const handleTabChange = React.useCallback(
+    (index: number) => {
+      const tab = visibleTabs[index];
+      if (tab) {
+        navigate({ to: tab.to });
+      }
+    },
+    [visibleTabs, navigate]
+  );
 
   return {
     handleTabChange,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,8 +137,8 @@ importers:
         specifier: ^7.8.3
         version: 7.8.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@reach/tabs':
-        specifier: ^0.10.5
-        version: 0.10.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^0.18.0
+        version: 0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/react':
         specifier: ^7.119.1
         version: 7.120.0(react@18.3.1)
@@ -1849,29 +1849,34 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
-  '@reach/auto-id@0.10.5':
-    resolution: {integrity: sha512-we4/bwjFxJ3F+2eaddQ1HltbKvJ7AB8clkN719El7Zugpn/vOjfPMOVUiBqTmPGLUvkYrq4tpuFwLvk2HyOVHg==}
+  '@reach/auto-id@0.18.0':
+    resolution: {integrity: sha512-XwY1IwhM7mkHZFghhjiqjQ6dstbOdpbFLdggeke75u8/8icT8uEHLbovFUgzKjy9qPvYwZIB87rLiR8WdtOXCg==}
     peerDependencies:
-      react: ^16.8.0
-      react-dom: ^16.8.0
+      react: ^16.8.0 || 17.x
+      react-dom: ^16.8.0 || 17.x
 
-  '@reach/descendants@0.10.5':
-    resolution: {integrity: sha512-8HhN4DwS/HsPQ+Ym/Ft/XJ1spXBYdE8hqpnbYR9UcU7Nx3oDbTIdhjA6JXXt23t5avYIx2jRa8YHCtVKSHuiwA==}
+  '@reach/descendants@0.18.0':
+    resolution: {integrity: sha512-GXUxnM6CfrX5URdnipPIl3Tlc6geuz4xb4n61y4tVWXQX1278Ra9Jz9DMRN8x4wheHAysvrYwnR/SzAlxQzwtA==}
     peerDependencies:
-      react: ^16.8.0
-      react-dom: ^16.8.0
+      react: ^16.8.0 || 17.x
+      react-dom: ^16.8.0 || 17.x
 
-  '@reach/tabs@0.10.5':
-    resolution: {integrity: sha512-oQJxQ9FwFsXo2HxEzJxFU/wP31bPVh4VU54NlhHW9f49uofyYkIKBbAhdF0Zb3TnaFp4cGKPHX39pXBYGPDkAQ==}
+  '@reach/polymorphic@0.18.0':
+    resolution: {integrity: sha512-N9iAjdMbE//6rryZZxAPLRorzDcGBnluf7YQij6XDLiMtfCj1noa7KyLpEc/5XCIB/EwhX3zCluFAwloBKdblA==}
     peerDependencies:
-      react: ^16.8.0
-      react-dom: ^16.8.0
+      react: ^16.8.0 || 17.x
 
-  '@reach/utils@0.10.5':
-    resolution: {integrity: sha512-5E/xxQnUbmpI/LrufBAOXjunl96DnqX6B4zC2MO2KH/dRzLug5gM5VuOwV26egsp0jvsSPxojwciOhS43px3qw==}
+  '@reach/tabs@0.18.0':
+    resolution: {integrity: sha512-gTRJzStWJJtgMhn9FDEmKogAJMcqNaGZx0i1SGoTdVM+D29DBhVeRdO8qEg+I2l2k32DkmuZxG/Mrh+GZTjczQ==}
     peerDependencies:
-      react: ^16.8.0
-      react-dom: ^16.8.0
+      react: ^16.8.0 || 17.x
+      react-dom: ^16.8.0 || 17.x
+
+  '@reach/utils@0.18.0':
+    resolution: {integrity: sha512-KdVMdpTgDyK8FzdKO9SCpiibuy/kbv3pwgfXshTI6tEcQT1OOwj7BAksnzGC0rPz0UholwC+AgkqEl3EJX3M1A==}
+    peerDependencies:
+      react: ^16.8.0 || 17.x
+      react-dom: ^16.8.0 || 17.x
 
   '@rollup/pluginutils@5.1.3':
     resolution: {integrity: sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==}
@@ -2643,9 +2648,6 @@ packages:
 
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
-
-  '@types/warning@3.0.3':
-    resolution: {integrity: sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==}
 
   '@types/xml2js@0.4.14':
     resolution: {integrity: sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==}
@@ -6594,9 +6596,6 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
-  warning@4.0.3:
-    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
-
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -7735,37 +7734,35 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
-  '@reach/auto-id@0.10.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@reach/auto-id@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@reach/utils': 0.10.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@reach/utils': 0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tslib: 2.8.1
 
-  '@reach/descendants@0.10.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@reach/descendants@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@reach/utils': 0.10.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@reach/utils': 0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tslib: 2.8.1
 
-  '@reach/tabs@0.10.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@reach/polymorphic@0.18.0(react@18.3.1)':
     dependencies:
-      '@reach/auto-id': 0.10.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@reach/descendants': 0.10.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@reach/utils': 0.10.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      prop-types: 15.8.1
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      tslib: 2.8.1
 
-  '@reach/utils@0.10.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@reach/tabs@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@types/warning': 3.0.3
+      '@reach/auto-id': 0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@reach/descendants': 0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@reach/polymorphic': 0.18.0(react@18.3.1)
+      '@reach/utils': 0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tslib: 2.8.1
-      warning: 4.0.3
+
+  '@reach/utils@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@rollup/pluginutils@5.1.3(rollup@4.34.8)':
     dependencies:
@@ -8572,8 +8569,6 @@ snapshots:
   '@types/uuid@3.4.13': {}
 
   '@types/uuid@9.0.8': {}
-
-  '@types/warning@3.0.3': {}
 
   '@types/xml2js@0.4.14':
     dependencies:
@@ -13197,10 +13192,6 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
-
-  warning@4.0.3:
-    dependencies:
-      loose-envify: 1.4.0
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
## Description 📝
It was pointed in a recent routing refactor (thanks @dwiley-akamai 🥇) that the keyboard navigation was broken on newly Tanstack router tabs. This PR fixes that and add coverage to prevent future regressions.

## Changes  🔄
- Bump `@reach/tabs` to latest version
- Fix `useTabs` onChange handler to properly propagate `@reach/tabs` event listeners
- Fix missing `<React.Suspense />` instances
- Add new Tabs component test
- Fix missing Tabs wrapper in tests (new type requirement from version bump)

## Preview 📷

https://github.com/user-attachments/assets/28f57b82-4dc0-45e8-8fef-351ab14cd28c

## How to test 🧪
### Reproduction steps
use `develop` branch 
- navigate to nodebalancers/{id}/summary
- try navigating the tabs via left/right arrows once focused
- confirm not working

### Verification steps
use `this` branch 
- navigate to nodebalancers/{id}/summary
- try navigating the tabs via left/right arrows once focused
- confirm working

👉 Confirm `@reach/tabs` update does not bring any regression to existing tabs
👉 Confirm new component test is testing the right things and working

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
---

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
