### PR TITLE
upcoming: [M3-9512] - Update types and validation for VPC subnet

### DIFF
--- a/packages/api-v4/.changeset/pr-11896-upcoming-features-1742491246746.md
+++ b/packages/api-v4/.changeset/pr-11896-upcoming-features-1742491246746.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Upcoming Features
+---
+
+Updated `ipv6` type in `CreateSubnetPayload` ([#11896](https://github.com/linode/manager/pull/11896))

--- a/packages/api-v4/.changeset/pr-11896-upcoming-features-1742491246746.md
+++ b/packages/api-v4/.changeset/pr-11896-upcoming-features-1742491246746.md
@@ -2,4 +2,4 @@
 "@linode/api-v4": Upcoming Features
 ---
 
-Updated `ipv6` type in `CreateSubnetPayload` ([#11896](https://github.com/linode/manager/pull/11896))
+Updated `ipv6` type in `CreateSubnetPayload` and renamed `createSubnetSchema` to `createSubnetSchemaIPv4` ([#11896](https://github.com/linode/manager/pull/11896))

--- a/packages/api-v4/.changeset/pr-11896-upcoming-features-1742491246746.md
+++ b/packages/api-v4/.changeset/pr-11896-upcoming-features-1742491246746.md
@@ -2,4 +2,4 @@
 "@linode/api-v4": Upcoming Features
 ---
 
-Updated `ipv6` type in `CreateSubnetPayload` and renamed `createSubnetSchema` to `createSubnetSchemaIPv4` ([#11896](https://github.com/linode/manager/pull/11896))
+Update `ipv6` type in `CreateSubnetPayload` and rename `createSubnetSchema` to `createSubnetSchemaIPv4` ([#11896](https://github.com/linode/manager/pull/11896))

--- a/packages/api-v4/src/vpcs/types.ts
+++ b/packages/api-v4/src/vpcs/types.ts
@@ -2,7 +2,7 @@ interface VPCIPv6 {
   range?: string;
 }
 
-interface CreateVPCIPV6 extends VPCIPv6 {
+interface CreateVPCIPv6 extends VPCIPv6 {
   allocation_class?: string;
 }
 
@@ -21,7 +21,7 @@ export interface CreateVPCPayload {
   label: string;
   description?: string;
   region: string;
-  ipv6?: CreateVPCIPV6[];
+  ipv6?: CreateVPCIPv6[];
   subnets?: CreateSubnetPayload[];
 }
 
@@ -30,10 +30,14 @@ export interface UpdateVPCPayload {
   description?: string;
 }
 
+interface VPCIPv6Subnet {
+  range: string;
+}
+
 export interface CreateSubnetPayload {
   label: string;
   ipv4?: string;
-  ipv6?: string;
+  ipv6?: VPCIPv6Subnet[];
 }
 
 export interface Subnet extends CreateSubnetPayload {

--- a/packages/api-v4/src/vpcs/vpcs.ts
+++ b/packages/api-v4/src/vpcs/vpcs.ts
@@ -1,5 +1,5 @@
 import {
-  createSubnetSchema,
+  createSubnetSchemaIPv4,
   createVPCSchema,
   modifySubnetSchema,
   updateVPCSchema,
@@ -129,7 +129,7 @@ export const createSubnet = (vpcID: number, data: CreateSubnetPayload) =>
   Request<Subnet>(
     setURL(`${API_ROOT}/vpcs/${encodeURIComponent(vpcID)}/subnets`),
     setMethod('POST'),
-    setData(data, createSubnetSchema)
+    setData(data, createSubnetSchemaIPv4)
   );
 
 /**

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetCreateDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetCreateDrawer.tsx
@@ -13,7 +13,7 @@ import {
   Stack,
   TextField,
 } from '@linode/ui';
-import { createSubnetSchema } from '@linode/validation';
+import { createSubnetSchemaIPv4 } from '@linode/validation';
 import * as React from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
@@ -25,7 +25,7 @@ import {
   getRecommendedSubnetIPv4,
 } from 'src/utilities/subnets';
 
-import type { CreateSubnetPayload } from '@linode/api-v4';
+import type { CreateSubnetPayload, Subnet } from '@linode/api-v4';
 
 interface Props {
   onClose: () => void;
@@ -44,7 +44,7 @@ export const SubnetCreateDrawer = (props: Props) => {
 
   const recommendedIPv4 = getRecommendedSubnetIPv4(
     DEFAULT_SUBNET_IPV4_VALUE,
-    vpc?.subnets?.map((subnet) => subnet.ipv4 ?? '') ?? []
+    vpc?.subnets?.map((subnet: Subnet) => subnet.ipv4 ?? '') ?? []
   );
 
   const {
@@ -66,7 +66,7 @@ export const SubnetCreateDrawer = (props: Props) => {
       label: '',
     },
     mode: 'onBlur',
-    resolver: yupResolver(createSubnetSchema),
+    resolver: yupResolver(createSubnetSchemaIPv4),
   });
 
   const ipv4 = watch('ipv4');

--- a/packages/validation/.changeset/pr-11896-upcoming-features-1742491352504.md
+++ b/packages/validation/.changeset/pr-11896-upcoming-features-1742491352504.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Upcoming Features
+---
+
+Updated `ipv6` vpc schema validation for subnets ([#11896](https://github.com/linode/manager/pull/11896))

--- a/packages/validation/.changeset/pr-11896-upcoming-features-1742491352504.md
+++ b/packages/validation/.changeset/pr-11896-upcoming-features-1742491352504.md
@@ -2,4 +2,4 @@
 "@linode/validation": Upcoming Features
 ---
 
-Updated `ipv6` vpc schema validation for subnets, separated `createSubnetSchema` to `createSubnetSchemaIPv4` and `createSubnetSchemaWithIPv6` ([#11896](https://github.com/linode/manager/pull/11896))
+Update `ipv6` vpc schema validation for subnets, separate `createSubnetSchema` into `createSubnetSchemaIPv4` and `createSubnetSchemaWithIPv6` ([#11896](https://github.com/linode/manager/pull/11896))

--- a/packages/validation/.changeset/pr-11896-upcoming-features-1742491352504.md
+++ b/packages/validation/.changeset/pr-11896-upcoming-features-1742491352504.md
@@ -2,4 +2,4 @@
 "@linode/validation": Upcoming Features
 ---
 
-Updated `ipv6` vpc schema validation for subnets ([#11896](https://github.com/linode/manager/pull/11896))
+Updated `ipv6` vpc schema validation for subnets and renamed `createSubnetSchema` to `createSubnetSchemaIPv4` ([#11896](https://github.com/linode/manager/pull/11896))

--- a/packages/validation/.changeset/pr-11896-upcoming-features-1742491352504.md
+++ b/packages/validation/.changeset/pr-11896-upcoming-features-1742491352504.md
@@ -2,4 +2,4 @@
 "@linode/validation": Upcoming Features
 ---
 
-Updated `ipv6` vpc schema validation for subnets and renamed `createSubnetSchema` to `createSubnetSchemaIPv4` ([#11896](https://github.com/linode/manager/pull/11896))
+Updated `ipv6` vpc schema validation for subnets, separated `createSubnetSchema` to `createSubnetSchemaIPv4` and `createSubnetSchemaWithIPv6` ([#11896](https://github.com/linode/manager/pull/11896))

--- a/packages/validation/src/vpcs.schema.ts
+++ b/packages/validation/src/vpcs.schema.ts
@@ -13,8 +13,6 @@ const labelTestDetails = {
 
 const IP_EITHER_BOTH_NOT_NEITHER =
   'A subnet must have either IPv4 or IPv6, or both, but not neither.';
-// @TODO VPC - remove below constant when IPv6 is added
-const TEMPORARY_IPV4_REQUIRED_MESSAGE = 'A subnet must have an IPv4 range.';
 
 export const determineIPType = (ip: string) => {
   try {
@@ -38,16 +36,19 @@ export const determineIPType = (ip: string) => {
  * @param { value } - the IP address string to be validated
  * @param { shouldHaveIPMask } - a boolean indicating whether the value should have a mask (e.g., /32) or not
  * @param { mustBeIPMask } - a boolean indicating whether the value MUST be an IP mask/prefix length or not
+ * @param { isIPv6Subnet } - a boolean indicating whether the IPv6 value is for a subnet
  */
 
 export const vpcsValidateIP = ({
   value,
   shouldHaveIPMask,
   mustBeIPMask,
+  isIPv6Subnet,
 }: {
   value: string | undefined | null;
   shouldHaveIPMask: boolean;
   mustBeIPMask: boolean;
+  isIPv6Subnet?: boolean;
 }): boolean => {
   if (!value) {
     return false;
@@ -95,9 +96,17 @@ export const vpcsValidateIP = ({
 
     if (isIPv6) {
       // VPCs must be assigned an IPv6 prefix of /52, /48, or /44
-      if (!['52', '48', '44'].includes(mask)) {
+      const invalidVPCIPv6Prefix = !['52', '48', '44'].includes(mask);
+      if (!isIPv6Subnet && invalidVPCIPv6Prefix) {
         return false;
       }
+
+      // VPC subnets must be assigned an IPv6 prefix of 52-62
+      const invalidVPCIPv6SubnetPrefix = +mask < 52 || +mask > 62;
+      if (isIPv6Subnet && invalidVPCIPv6SubnetPrefix) {
+        return false;
+      }
+
       if (shouldHaveIPMask) {
         ipaddr.IPv6.parseCIDR(value);
       } else {
@@ -127,6 +136,43 @@ export const updateVPCSchema = object({
   description: string(),
 });
 
+const VPCIPv6Schema = object({
+  range: string()
+    .optional()
+    .test({
+      name: 'IPv6 prefix length',
+      message: 'Must be the prefix length 52, 48, or 44 of the IP, e.g. /52',
+      test: (value) => {
+        if (value && value.length > 0) {
+          vpcsValidateIP({
+            value,
+            shouldHaveIPMask: true,
+            mustBeIPMask: false,
+          });
+        }
+      },
+    }),
+});
+
+const VPCIPv6SubnetSchema = object({
+  range: string()
+    .required()
+    .test({
+      name: 'IPv6 prefix length',
+      message: 'Must be the prefix length (52-62) the IP, e.g. /52',
+      test: (value) => {
+        if (value && value !== 'auto' && value.length > 0) {
+          vpcsValidateIP({
+            value,
+            shouldHaveIPMask: true,
+            mustBeIPMask: false,
+            isIPv6Subnet: true,
+          });
+        }
+      },
+    }),
+});
+
 export const createSubnetSchema = object().shape(
   {
     label: labelValidation.required(LABEL_REQUIRED),
@@ -134,9 +180,7 @@ export const createSubnetSchema = object().shape(
       is: (value: unknown) =>
         value === '' || value === null || value === undefined,
       then: (schema) =>
-        // @TODO VPC - change required message back to IP_EITHER_BOTH_NOT_NEITHER when IPv6 is supported
-        // Since only IPv4 is currently supported, subnets must have an IPv4
-        schema.required(TEMPORARY_IPV4_REQUIRED_MESSAGE).test({
+        schema.required(IP_EITHER_BOTH_NOT_NEITHER).test({
           name: 'IPv4 CIDR format',
           message: 'The IPv4 range must be in CIDR format.',
           test: (value) =>
@@ -169,44 +213,13 @@ export const createSubnetSchema = object().shape(
           }
         }),
     }),
-    ipv6: string().when('ipv4', {
-      is: (value: unknown) =>
-        value === '' || value === null || value === undefined,
-      then: (schema) =>
-        schema.required(IP_EITHER_BOTH_NOT_NEITHER).test({
-          name: 'IPv6 prefix length',
-          message: 'Must be the prefix length (64-125) of the IP, e.g. /64',
-          test: (value) =>
-            vpcsValidateIP({
-              value,
-              shouldHaveIPMask: true,
-              mustBeIPMask: true,
-            }),
-        }),
-      otherwise: (schema) =>
-        lazy((value: string | undefined) => {
-          switch (typeof value) {
-            case 'undefined':
-              return schema.notRequired().nullable();
-
-            case 'string':
-              return schema.notRequired().test({
-                name: 'IPv6 prefix length',
-                message:
-                  'Must be the prefix length (64-125) of the IP, e.g. /64',
-                test: (value) =>
-                  vpcsValidateIP({
-                    value,
-                    shouldHaveIPMask: true,
-                    mustBeIPMask: true,
-                  }),
-              });
-
-            default:
-              return schema.notRequired().nullable();
-          }
-        }),
-    }),
+    ipv6: array()
+      .of(VPCIPv6SubnetSchema)
+      .when('ipv4', {
+        is: (value: unknown) =>
+          value === '' || value === null || value === undefined,
+        then: (schema) => schema.required(IP_EITHER_BOTH_NOT_NEITHER),
+      }),
   },
   [
     ['ipv6', 'ipv4'],
@@ -214,24 +227,11 @@ export const createSubnetSchema = object().shape(
   ]
 );
 
-const createVPCIPv6Schema = object({
-  range: string()
-    .optional()
-    .test({
-      name: 'IPv6 prefix length',
-      message: 'Must be the prefix length 52, 48, or 44 of the IP, e.g. /52',
-      test: (value) => {
-        if (value && value !== 'auto' && value.length > 0) {
-          vpcsValidateIP({
-            value,
-            shouldHaveIPMask: true,
-            mustBeIPMask: false,
-          });
-        }
-      },
-    }),
-  allocation_class: string().optional(),
-});
+const createVPCIPv6Schema = VPCIPv6Schema.concat(
+  object({
+    allocation_class: string().optional(),
+  })
+);
 
 export const createVPCSchema = object({
   label: labelValidation.required(LABEL_REQUIRED),

--- a/packages/validation/src/vpcs.schema.ts
+++ b/packages/validation/src/vpcs.schema.ts
@@ -13,7 +13,7 @@ const labelTestDetails = {
 
 const IP_EITHER_BOTH_NOT_NEITHER =
   'A subnet must have either IPv4 or IPv6, or both, but not neither.';
-// @TODO VPC - remove below constant when IPv6 is in GA
+// @TODO VPC IPv6 - remove below constant when IPv6 is in GA
 const TEMPORARY_IPV4_REQUIRED_MESSAGE = 'A subnet must have an IPv4 range.';
 
 export const determineIPType = (ip: string) => {
@@ -161,7 +161,7 @@ const VPCIPv6SubnetSchema = object({
     .required()
     .test({
       name: 'IPv6 prefix length',
-      message: 'Must be the prefix length (52-62) the IP, e.g. /52',
+      message: 'Must be the prefix length (52-62) of the IP, e.g. /52',
       test: (value) => {
         if (value && value !== 'auto' && value.length > 0) {
           vpcsValidateIP({
@@ -175,7 +175,7 @@ const VPCIPv6SubnetSchema = object({
     }),
 });
 
-// @TODO VPC: Delete this when IPv6 is in GA
+// @TODO VPC IPv6: Delete this when IPv6 is in GA
 export const createSubnetSchemaIPv4 = object({
   label: labelValidation.required(LABEL_REQUIRED),
   ipv4: string().when('ipv6', {


### PR DESCRIPTION
## Description 📝
Update types and validation for VPC Subnet

## Changes  🔄
- Updated `ipv6` type for `CreateSubnetPayload`
- Separated `createSubnetSchema` into `createSubnetSchemaIPv4` and `createSubnetSchemaWithIPv6`
- Added ipv6 prefix length validation for subnets in `vpcsValidateIP`
- Updated `ipv6 subnet` schema validation in `vpcs.schema.ts`
- Minor variable refactoring

## How to test 🧪
### Verification steps

Cross-reference VPC IPv6 API spec (linked in parent ticket) and updated types for:
- [ ] POST /v4/vpcs/{vpcId}/subnets
- [ ] GET /v4/vpcs/{vpcId}/subnets
- [ ] GET v4/vpcs/{vpcId}/subnets/{vpcSubnetId}

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>