### PR TITLE
test: [M3-9618] - Temporarily skip Firewall end-to-end tests

### DIFF
--- a/packages/manager/.changeset/pr-11898-tests-1742493507045.md
+++ b/packages/manager/.changeset/pr-11898-tests-1742493507045.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Temporarily skip Firewall end-to-end tests ([#11898](https://github.com/linode/manager/pull/11898))

--- a/packages/manager/cypress/e2e/core/firewalls/create-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/create-firewall.spec.ts
@@ -9,7 +9,7 @@ import { chooseRegion } from 'support/util/regions';
 import { createLinodeRequestFactory } from 'src/factories/linodes';
 
 authenticate();
-describe('create firewall', () => {
+describe.skip('create firewall', () => {
   before(() => {
     cleanUp(['lke-clusters', 'linodes', 'firewalls']);
   });

--- a/packages/manager/cypress/e2e/core/firewalls/delete-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/delete-firewall.spec.ts
@@ -9,7 +9,7 @@ import { firewallFactory } from 'src/factories/firewalls';
 import type { Firewall } from '@linode/api-v4';
 
 authenticate();
-describe('delete firewall', () => {
+describe.skip('delete firewall', () => {
   before(() => {
     cleanUp('firewalls');
   });

--- a/packages/manager/cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts
@@ -144,7 +144,7 @@ describe('Migrate Linode With Firewall', () => {
   /*
    * - Uses real API data to create a Firewall, attach a Linode to it, then migrate the Linode.
    */
-  it('migrates linode with firewall - real data', () => {
+  it.skip('migrates linode with firewall - real data', () => {
     cy.tag('method:e2e', 'purpose:dcTesting');
     const [migrationRegionStart, migrationRegionEnd] = chooseRegions(2);
     const firewallLabel = randomLabel();

--- a/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
@@ -167,7 +167,7 @@ const createLinodeAndFirewall = async (
 };
 
 authenticate();
-describe('update firewall', () => {
+describe.skip('update firewall', () => {
   before(() => {
     cleanUp('firewalls');
   });


### PR DESCRIPTION
## Description 📝

This temporarily skips our Cypress Firewall end-to-end tests. We should be able to unskip them soon! See also M3-9619.

## Changes  🔄

- Skips Firewall end-to-end tests

## Target release date 🗓️

N/A

## How to test 🧪

We can rely on CI for this. We just need to confirm that end-to-end tests have been skipped but integration tests that use mock API requests are still enabled.

If you want, you can test this locally using this command:

```bash
pnpm cy:run -s "cypress/e2e/core/firewalls/*"
```

All tests but 2 should be skipped, and the 2 that do run should pass.

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
