### PR TITLE
fix: Linode Rebuild dialog erroring when `Reuse user data previously provide` is checked

### DIFF
--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -190,6 +190,25 @@ export const interceptRebuildLinode = (
 };
 
 /**
+ * Intercepts POST request to rebuild a Linode and mocks the response.
+ *
+ * @param linodeId - ID of Linode for intercepted request.
+ * @param linode - Linode for the mocked response
+ *
+ * @returns Cypress chainable.
+ */
+export const mockRebuildLinode = (
+  linodeId: number,
+  linode: Linode
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`linode/instances/${linodeId}/rebuild`),
+    makeResponse(linode)
+  );
+};
+
+/**
  * Intercepts POST request to rebuild a Linode and mocks an error response.
  *
  * @param linodeId - ID of Linode for intercepted request.

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/LinodeRebuildForm.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/LinodeRebuildForm.tsx
@@ -77,10 +77,21 @@ export const LinodeRebuildForm = (props: Props) => {
   });
 
   const onSubmit = async (values: RebuildLinodeFormValues) => {
-    if (values.reuseUserData) {
-      values.metadata = undefined;
-    } else if (values.metadata?.user_data) {
+    /**
+     * User Data logic (see https://github.com/linode/manager/pull/8850)
+     * 1) if user data has been provided, encode it and include it in the payload
+     *    The backend will use the newly provided user data.
+     * 2) if the "Reuse User Data" checkbox is checked, remove the Metadata property from the payload
+     *    The backend will continue to use the existing user data.
+     * 3) if user data has not been provided and the Reuse User Data checkbox is not checked, send null in the payload
+     *    The backend deletes the Linode's user data. The Linode will no longer use user data.
+     */
+    if (values.metadata?.user_data) {
       values.metadata.user_data = utoa(values.metadata.user_data);
+    } else if (values.reuseUserData) {
+      values.metadata = undefined;
+    } else {
+      values.metadata = { user_data: null };
     }
 
     // Distributed instances are encrypted by default and disk_encryption should not be included in the payload.

--- a/packages/validation/src/linodes.schema.ts
+++ b/packages/validation/src/linodes.schema.ts
@@ -390,7 +390,10 @@ export const RebuildLinodeSchema = object({
   stackscript_id: number().optional(),
   stackscript_data: stackscript_data.notRequired(),
   booted: boolean().optional(),
-  metadata: MetadataSchema.optional(),
+  /**
+   * `metadata` is an optional object with required properties (see https://github.com/jquense/yup/issues/772)
+   */
+  metadata: MetadataSchema.optional().default(undefined),
   disk_encryption: string().oneOf(['enabled', 'disabled']).optional(),
 });
 


### PR DESCRIPTION
## Description 📝

- Fixes validation bug affecting the Linode Rebuild flow 

## The Bug 🐛 

- When trying to rebuild a Linode with the `Reuse user data previously provided` checkbox checked, a client-side validation error would occur
- Caused by https://github.com/linode/manager/pull/11847
  - In that PR, _I think_ I correctly aligned our validation schemas with the API's behavior, but I failed to realize that the changes I made to `MetadataSchema` would break this flow. 

![Screenshot 2025-03-20 at 7 16 47 PM](https://github.com/user-attachments/assets/fd3ef710-e428-424f-bcce-7f9eb7e02858)


## How to test 🧪

- Checkout this PR
- Verify you can rebuild a Linode with various configurations of User Data
  -  Verify you can rebuild a Linode with the `Reuse user data previously provided` checkbox checked
- Check for general issues with the Linode Rebuild dialog

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>