### PR TITLE
fix: Fix styling for Linode Entity Details body and footer

### DIFF
--- a/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
@@ -348,7 +348,7 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
           }}
           container
           direction="column"
-          spacing={2}
+          spacing={1}
         >
           <StyledColumnLabelGrid data-testid="vpc-section-title">
             VPC
@@ -358,20 +358,18 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
               alignItems: 'center',
               margin: 0,
               padding: '0 0 8px 0',
-
               [theme.breakpoints.down('md')]: {
                 alignItems: 'start',
                 display: 'flex',
                 flexDirection: 'column',
-                paddingLeft: '8px',
               },
             }}
             container
             direction="row"
-            spacing={2}
+            spacing={0}
           >
             <StyledVPCBox>
-              <StyledListItem>
+              <StyledListItem sx={{ paddingLeft: 0 }}>
                 <StyledLabelBox component="span">Label:</StyledLabelBox>{' '}
                 <Link
                   data-testid="assigned-vpc-label"
@@ -418,7 +416,7 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
               1
             )} ${theme.spacing(2)}`,
             [theme.breakpoints.down('md')]: {
-              paddingLeft: 3,
+              paddingLeft: 2,
             },
           }}
           container
@@ -430,6 +428,7 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
                 ...(!attachedFirewall && !isLinodeInterfacesEnabled
                   ? { borderRight: 'unset' }
                   : {}),
+                paddingLeft: 0,
               }}
             >
               <StyledLabelBox component="span">LKE Cluster:</StyledLabelBox>{' '}
@@ -447,6 +446,7 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
             <StyledListItem
               sx={{
                 ...(!isLinodeInterfacesEnabled ? { borderRight: 'unset' } : {}),
+                ...(!linodeLkeClusterId ? { paddingLeft: 0 } : {}),
               }}
             >
               <StyledLabelBox component="span">Firewall:</StyledLabelBox>{' '}
@@ -461,7 +461,14 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
             </StyledListItem>
           )}
           {isLinodeInterfacesEnabled && (
-            <StyledListItem sx={{ borderRight: 'unset' }}>
+            <StyledListItem
+              sx={{
+                ...(!linodeLkeClusterId && !attachedFirewall
+                  ? { paddingLeft: 0 }
+                  : {}),
+                borderRight: 'unset',
+              }}
+            >
               <StyledLabelBox component="span">Interfaces:</StyledLabelBox>{' '}
               {isLinodeInterface ? (
                 'Linode'

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailFooter.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailFooter.tsx
@@ -1,11 +1,11 @@
-import { useTheme } from '@mui/material/styles';
+import { useLinodeUpdateMutation, useProfile } from '@linode/queries';
 import Grid from '@mui/material/Grid2';
+import { useTheme } from '@mui/material/styles';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
 
 import { TagCell } from 'src/components/TagCell/TagCell';
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
-import { useLinodeUpdateMutation, useProfile } from '@linode/queries';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { formatDate } from 'src/utilities/formatDate';
 
@@ -67,16 +67,15 @@ export const LinodeEntityDetailFooter = React.memo((props: FooterProps) => {
 
   return (
     <Grid
+      sx={{
+        alignItems: 'center',
+        flex: 1,
+        justifyContent: 'space-between',
+        paddingY: 0,
+      }}
       container
       direction="row"
       spacing={2}
-      sx={{
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        flex: 1,
-        paddingX: 1,
-        paddingY: 0,
-      }}
     >
       <Grid
         size={{
@@ -137,15 +136,15 @@ export const LinodeEntityDetailFooter = React.memo((props: FooterProps) => {
         </StyledBox>
       </Grid>
       <Grid
+        size={{
+          lg: 4,
+          xs: 12,
+        }}
         sx={{
           [theme.breakpoints.down('lg')]: {
             display: 'flex',
             justifyContent: 'flex-start',
           },
-        }}
-        size={{
-          lg: 4,
-          xs: 12,
         }}
       >
         <TagCell


### PR DESCRIPTION
## Description 📝
- some padding/margins seem off for Linode entity details vs prod, potentially another regression from MUIv6. I tried fixing them to make it look like prod again ... hopefully! 

No changeset needed - this hasn't hit prod yet

## Target release date 🗓️
3/25

## Preview 📷

|   | large   |  small screen |
| ------- | ------- | -- |
|  prod |  ![image](https://github.com/user-attachments/assets/4812e611-1d49-4d6e-95cc-35e10403a20e) |   ![image](https://github.com/user-attachments/assets/afdeaa9e-9f63-4c30-a6e8-136aefd7ec62)  | 
| before | ![image](https://github.com/user-attachments/assets/82a924c9-c241-4bb9-b955-78b0c543d9d8) | ![image](https://github.com/user-attachments/assets/4c652bae-9b3c-4af9-ab13-45544d49aee9) |
| after | ![image](https://github.com/user-attachments/assets/4a8fb0b8-5b14-49a0-bc56-ecafc7c395f0) | ![image](https://github.com/user-attachments/assets/2de7e6bd-7ee4-4ab8-b26d-bd4d92e1b602) |

## How to test 🧪

### Reproduction steps
- check out develop
- notice styling for Linode entity detail

### Verification steps
- Confirm styling is fixed

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
