### PR TITLE
refactor: [DI-24193] - Update query cache on api success

### DIFF
--- a/packages/manager/src/queries/cloudpulse/alerts.ts
+++ b/packages/manager/src/queries/cloudpulse/alerts.ts
@@ -4,6 +4,7 @@ import {
   deleteEntityFromAlert,
   editAlertDefinition,
 } from '@linode/api-v4/lib/cloudpulse';
+import { queryPresets } from '@linode/queries';
 import {
   keepPreviousData,
   useMutation,
@@ -11,7 +12,6 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 
-import { queryPresets } from '@linode/queries';
 import { queryFactory } from './queries';
 
 import type {
@@ -78,8 +78,37 @@ export const useEditAlertDefinition = () => {
   return useMutation<Alert, APIError[], EditAlertPayloadWithService>({
     mutationFn: ({ alertId, serviceType, ...data }) =>
       editAlertDefinition(data, serviceType, alertId),
-    onSuccess() {
-      queryClient.invalidateQueries(queryFactory.alerts);
+
+    onSuccess(data) {
+      const allAlertsQueryKey = queryFactory.alerts._ctx.all().queryKey;
+      queryClient.cancelQueries({ queryKey: allAlertsQueryKey });
+      queryClient.setQueryData<Alert[]>(allAlertsQueryKey, (oldData) => {
+        return (
+          oldData?.map((alert) => {
+            if (alert.id === data.id) {
+              return data;
+            }
+            return alert;
+          }) ?? [data]
+        );
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: queryFactory.alerts._ctx.alertByServiceTypeAndId(
+          data.service_type,
+          String(data.id)
+        ).queryKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: allAlertsQueryKey,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: queryFactory.alerts._ctx.alertsByServiceType(
+          data.service_type
+        ).queryKey,
+      });
     },
   });
 };


### PR DESCRIPTION
## Description 📝

Updated alerts.ts queries to update the cache on success of alert edit api.

## Changes  🔄

List any change(s) relevant to the reviewer.

1. alerts.ts file is updated to handle cache updation.

## Target release date 🗓️

5th April

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
|<video src="https://github.com/user-attachments/assets/a947960b-53ea-4d45-8894-2dbaa3a6bb33"/>|<video src="https://github.com/user-attachments/assets/7eb25a8a-a072-4a26-9d22-6240ba66827e"/>|

## How to test 🧪

1. Switch to mocker user
2. Go to alerts tab
3. click on the 3 dots of any of the alert which is not system alert
4. select enable/disable

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

