### PR TITLE
upcoming: [M3-9108] - Update Firewall landing table to account for Linode Interfaces

### DIFF
--- a/packages/manager/src/features/Account/DefaultFirewalls.tsx
+++ b/packages/manager/src/features/Account/DefaultFirewalls.tsx
@@ -21,18 +21,21 @@ import { useSnackbar } from 'notistack';
 import * as React from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
+import { useIsLinodeInterfacesEnabled } from 'src/utilities/linodes';
+
 import type { UpdateFirewallSettings } from '@linode/api-v4';
 
 const DEFAULT_FIREWALL_PLACEHOLDER = 'None';
 
 export const DefaultFirewalls = () => {
   const { enqueueSnackbar } = useSnackbar();
+  const { isLinodeInterfacesEnabled } = useIsLinodeInterfacesEnabled();
 
   const {
     data: firewallSettings,
     error: firewallSettingsError,
     isLoading: isLoadingFirewallSettings,
-  } = useFirewallSettingsQuery();
+  } = useFirewallSettingsQuery({ enabled: isLinodeInterfacesEnabled });
 
   const { mutateAsync: updateFirewallSettings } = useMutateFirewallSettings();
 

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallActionMenu.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallActionMenu.tsx
@@ -1,13 +1,20 @@
-import { FirewallStatus } from '@linode/api-v4/lib/firewalls';
-import { Theme, useTheme } from '@mui/material/styles';
+import { useGrants, useProfile } from '@linode/queries';
+import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import * as React from 'react';
 
-import { Action, ActionMenu } from 'src/components/ActionMenu/ActionMenu';
+import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
 import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
-import { useGrants, useProfile } from '@linode/queries';
 
 import { checkIfUserCanModifyFirewall } from '../shared';
+import {
+  DEFAULT_FIREWALL_TOOLTIP_TEXT,
+  NO_PERMISSIONS_TOOLTIP_TEXT,
+} from './constants';
+
+import type { FirewallStatus } from '@linode/api-v4/lib/firewalls';
+import type { Theme } from '@mui/material/styles';
+import type { Action } from 'src/components/ActionMenu/ActionMenu';
 
 export interface ActionHandlers {
   [index: string]: any;
@@ -20,10 +27,8 @@ interface Props extends ActionHandlers {
   firewallID: number;
   firewallLabel: string;
   firewallStatus: FirewallStatus;
+  isDefaultFirewall: boolean;
 }
-
-export const noPermissionTooltipText =
-  "You don't have permissions to modify this Firewall.";
 
 export const FirewallActionMenu = React.memo((props: Props) => {
   const theme = useTheme<Theme>();
@@ -35,6 +40,7 @@ export const FirewallActionMenu = React.memo((props: Props) => {
     firewallID,
     firewallLabel,
     firewallStatus,
+    isDefaultFirewall,
     triggerDeleteFirewall,
     triggerDisableFirewall,
     triggerEnableFirewall,
@@ -46,12 +52,15 @@ export const FirewallActionMenu = React.memo((props: Props) => {
     grants
   );
 
-  const disabledProps = !userCanModifyFirewall
-    ? {
-        disabled: true,
-        tooltip: noPermissionTooltipText,
-      }
-    : {};
+  const disabledProps =
+    !userCanModifyFirewall || isDefaultFirewall
+      ? {
+          disabled: true,
+          tooltip: isDefaultFirewall
+            ? DEFAULT_FIREWALL_TOOLTIP_TEXT
+            : NO_PERMISSIONS_TOOLTIP_TEXT,
+        }
+      : {};
 
   const actions: Action[] = [
     {

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
@@ -1,3 +1,4 @@
+import { useFirewallSettingsQuery, useFirewallsQuery } from '@linode/queries';
 import { Button, CircleProgress, ErrorState } from '@linode/ui';
 import { useLocation, useNavigate } from '@tanstack/react-router';
 import * as React from 'react';
@@ -19,8 +20,8 @@ import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 import { useSecureVMNoticesEnabled } from 'src/hooks/useSecureVMNoticesEnabled';
-import { useFirewallsQuery } from '@linode/queries';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { useIsLinodeInterfacesEnabled } from 'src/utilities/linodes';
 
 import { CreateFirewallDrawer } from './CreateFirewallDrawer';
 import { FirewallDialog } from './FirewallDialog';
@@ -35,6 +36,7 @@ const preferenceKey = 'firewalls';
 const FirewallLanding = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { isLinodeInterfacesEnabled } = useIsLinodeInterfacesEnabled();
   const pagination = usePagination(1, preferenceKey);
   const { handleOrderChange, order, orderBy } = useOrder(
     {
@@ -53,6 +55,10 @@ const FirewallLanding = () => {
     page: pagination.page,
     page_size: pagination.pageSize,
   };
+
+  const { data: firewallSettings } = useFirewallSettingsQuery({
+    enabled: isLinodeInterfacesEnabled,
+  });
 
   const { data, error, isLoading } = useFirewallsQuery(params, filter);
 
@@ -189,14 +195,19 @@ const FirewallLanding = () => {
             </TableSortCell>
             <Hidden smDown>
               <TableCell>Rules</TableCell>
-              <TableCell>Services</TableCell>
+              <TableCell sx={{ width: '40%' }}>Services</TableCell>
             </Hidden>
             <TableCell />
           </TableRow>
         </TableHead>
         <TableBody>
           {data?.data.map((firewall) => (
-            <FirewallRow key={firewall.id} {...firewall} {...handlers} />
+            <FirewallRow
+              key={firewall.id}
+              {...firewall}
+              {...handlers}
+              firewallSettings={firewallSettings}
+            />
           ))}
         </TableBody>
       </Table>

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.test.tsx
@@ -49,10 +49,32 @@ describe('FirewallRow', () => {
 
     const baseProps = {
       ...firewall,
+      firewallSettings: undefined,
       triggerDeleteFirewall: mockTriggerDeleteFirewall,
       triggerDisableFirewall: mockTriggerDisableFirewall,
       triggerEnableFirewall: mockTriggerEnableFirewall,
     };
+
+    it('renders a TableRow with the default firewall chip, status, rules, and Linodes', () => {
+      const { getByTestId, getByText } = render(
+        wrapWithTableBody(
+          <FirewallRow
+            {...baseProps}
+            firewallSettings={{
+              default_firewall_ids: {
+                linode: 1,
+                nodebalancer: null,
+                public_interface: null,
+                vpc_interface: null,
+              },
+            }}
+          />
+        )
+      );
+      getByTestId('firewall-row-1');
+      getByText(firewall.label);
+      getByText('DEFAULT');
+    });
 
     it('renders a TableRow with label, status, rules, and Linodes', () => {
       const { getByTestId, getByText } = render(
@@ -68,21 +90,33 @@ describe('FirewallRow', () => {
   describe('getDeviceLinks', () => {
     it('should return a single Link if one Device is attached', () => {
       const device = firewallDeviceFactory.build();
-      const links = getDeviceLinks([device.entity]);
+      const links = getDeviceLinks({
+        entities: [device.entity],
+        isLoading: false,
+        linodesWithInterfaceDevices: undefined,
+      });
       const { getByText } = renderWithTheme(links);
       expect(getByText(device.entity.label ?? ''));
     });
 
     it('should render up to three comma-separated links', () => {
       const devices = firewallDeviceFactory.buildList(3);
-      const links = getDeviceLinks(devices.map((device) => device.entity));
+      const links = getDeviceLinks({
+        entities: devices.map((device) => device.entity),
+        isLoading: false,
+        linodesWithInterfaceDevices: undefined,
+      });
       const { queryAllByTestId } = renderWithTheme(links);
       expect(queryAllByTestId('firewall-row-link')).toHaveLength(3);
     });
 
     it('should render "plus N more" text for any devices over three', () => {
       const devices = firewallDeviceFactory.buildList(13);
-      const links = getDeviceLinks(devices.map((device) => device.entity));
+      const links = getDeviceLinks({
+        entities: devices.map((device) => device.entity),
+        isLoading: false,
+        linodesWithInterfaceDevices: undefined,
+      });
       const { getByText, queryAllByTestId } = renderWithTheme(links);
       expect(queryAllByTestId('firewall-row-link')).toHaveLength(3);
       expect(getByText(/10 more/));

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
@@ -1,21 +1,67 @@
+import { useAllLinodesQuery } from '@linode/queries';
 import { capitalize } from '@linode/utilities';
 import React from 'react';
 
 import { Hidden } from 'src/components/Hidden';
 import { Link } from 'src/components/Link';
+import { Skeleton } from 'src/components/Skeleton';
 import { StatusIcon } from 'src/components/StatusIcon/StatusIcon';
 import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
+import { useIsLinodeInterfacesEnabled } from 'src/utilities/linodes';
 
+import { DefaultFirewallChip } from '../components/DefaultFirewallChip';
+import { getDefaultFirewallDescription } from '../components/FirewallSelectOption.utils';
 import { FirewallActionMenu } from './FirewallActionMenu';
 
 import type { ActionHandlers } from './FirewallActionMenu';
-import type { Firewall, FirewallDeviceEntity } from '@linode/api-v4';
+import type {
+  Filter,
+  Firewall,
+  FirewallDeviceEntity,
+  FirewallSettings,
+  Linode,
+} from '@linode/api-v4';
 
-export interface FirewallRowProps extends Firewall, ActionHandlers {}
+export interface FirewallRowProps extends Firewall, ActionHandlers {
+  firewallSettings: FirewallSettings | undefined;
+}
 
 export const FirewallRow = React.memo((props: FirewallRowProps) => {
-  const { entities, id, label, rules, status, ...actionHandlers } = props;
+  const {
+    entities,
+    firewallSettings,
+    id,
+    label,
+    rules,
+    status,
+    ...actionHandlers
+  } = props;
+
+  const tooltipText =
+    firewallSettings && getDefaultFirewallDescription(id, firewallSettings);
+  const isDefaultFirewall = !!tooltipText;
+
+  const { isLinodeInterfacesEnabled } = useIsLinodeInterfacesEnabled();
+
+  const neededLinodeIdsForInterfaceDevices = entities
+    .slice(0, 3) // only take the first three entities since we only show those entity links
+    .filter((entity) => entity.type === 'interface')
+    .map((entity) => {
+      return { id: Number(entity.url.split('/')[4]) };
+    });
+
+  const filterForInterfaceDeviceLinodes: Filter = {
+    ['+or']: neededLinodeIdsForInterfaceDevices,
+  };
+
+  // only fire this query if we have linode interface devices. We fetch the Linodes those devices are attached to
+  // so that we can add a label to the devices for sorting and display purposes
+  const { data: linodesWithInterfaceDevices, isLoading } = useAllLinodesQuery(
+    {},
+    filterForInterfaceDeviceLinodes,
+    isLinodeInterfacesEnabled && neededLinodeIdsForInterfaceDevices.length > 0
+  );
 
   const count = getCountOfRules(rules);
 
@@ -25,6 +71,12 @@ export const FirewallRow = React.memo((props: FirewallRowProps) => {
         <Link tabIndex={0} to={`/firewalls/${id}`}>
           {label}
         </Link>
+        {isDefaultFirewall && (
+          <DefaultFirewallChip
+            chipProps={{ sx: { marginLeft: 1 } }}
+            tooltipText={tooltipText}
+          />
+        )}
       </TableCell>
       <TableCell statusCell>
         <StatusIcon status={status === 'enabled' ? 'active' : 'inactive'} />
@@ -32,7 +84,13 @@ export const FirewallRow = React.memo((props: FirewallRowProps) => {
       </TableCell>
       <Hidden smDown>
         <TableCell>{getRuleString(count)}</TableCell>
-        <TableCell>{getDevicesCellString(entities)}</TableCell>
+        <TableCell>
+          {getDevicesCellString({
+            entities,
+            isLoading,
+            linodesWithInterfaceDevices,
+          })}
+        </TableCell>
       </Hidden>
       <TableCell
         sx={{ paddingRight: 0, textAlign: 'end', whiteSpace: 'nowrap' }}
@@ -41,6 +99,7 @@ export const FirewallRow = React.memo((props: FirewallRowProps) => {
           firewallID={id}
           firewallLabel={label}
           firewallStatus={status}
+          isDefaultFirewall={isDefaultFirewall}
           {...actionHandlers}
         />
       </TableCell>
@@ -77,31 +136,58 @@ export const getCountOfRules = (rules: Firewall['rules']): [number, number] => {
   return [(rules.inbound || []).length, (rules.outbound || []).length];
 };
 
-const getDevicesCellString = (entities: FirewallDeviceEntity[]) => {
+interface DeviceLinkInputs {
+  entities: FirewallDeviceEntity[];
+  isLoading: boolean;
+  linodesWithInterfaceDevices: Linode[] | undefined;
+}
+const getDevicesCellString = (inputs: DeviceLinkInputs) => {
+  const { entities, isLoading, linodesWithInterfaceDevices } = inputs;
   if (entities.length === 0) {
     return 'None assigned';
   }
 
-  return getDeviceLinks(entities);
+  return getDeviceLinks({ entities, isLoading, linodesWithInterfaceDevices });
 };
 
-export const getDeviceLinks = (entities: FirewallDeviceEntity[]) => {
+export const getDeviceLinks = (inputs: DeviceLinkInputs) => {
+  const { entities, isLoading, linodesWithInterfaceDevices } = inputs;
   const firstThree = entities.slice(0, 3);
+
+  if (isLoading) {
+    return <Skeleton />;
+  }
 
   return (
     <>
-      {firstThree.map((entity, idx) => (
-        <React.Fragment key={entity.url}>
-          {idx > 0 && ', '}
-          <Link
-            className="link secondaryLink"
-            data-testid="firewall-row-link"
-            to={`/${entity.type}s/${entity.id}`}
-          >
-            {entity.label}
-          </Link>
-        </React.Fragment>
-      ))}
+      {firstThree.map((entity, idx) => {
+        // TODO @Linode Interfaces - switch to parent entity when endpoints are updated
+        // TODO @Linode Interfaces - update interface links to interface details soon
+        const entityId =
+          entity.type === 'interface'
+            ? Number(entity.url.split('/')[4])
+            : entity.id;
+        const entityLabel =
+          entity.type === 'interface'
+            ? linodesWithInterfaceDevices?.find(
+                (linode) => linode.id === entityId
+              )?.label ?? entity.label
+            : entity.label;
+        const entityLink = entity.type === 'interface' ? 'linode' : entity.type;
+
+        return (
+          <React.Fragment key={entity.url}>
+            {idx > 0 && ', '}
+            <Link
+              className="link secondaryLink"
+              data-testid="firewall-row-link"
+              to={`/${entityLink}s/${entityId}`}
+            >
+              {entityLabel}
+            </Link>
+          </React.Fragment>
+        );
+      })}
       {entities.length > 3 && <span>, plus {entities.length - 3} more.</span>}
     </>
   );

--- a/packages/manager/src/features/Firewalls/FirewallLanding/constants.ts
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/constants.ts
@@ -12,3 +12,8 @@ export const NODEBALANCER_HELPER_TEXT =
 
 export const STRENGTHEN_TEMPLATE_RULES =
   'It is recommended to further strengthen these rules by limiting the allowed IPv4 and IPv6 ranges.';
+
+export const NO_PERMISSIONS_TOOLTIP_TEXT =
+  "You don't have permissions to modify this Firewall.";
+export const DEFAULT_FIREWALL_TOOLTIP_TEXT =
+  'This firewall is used as an interface default and cannot be modified. Change the firewall default assignment in Account Settings to modify the firewall.';

--- a/packages/manager/src/features/Firewalls/components/DefaultFirewallChip.tsx
+++ b/packages/manager/src/features/Firewalls/components/DefaultFirewallChip.tsx
@@ -1,0 +1,22 @@
+import { Chip, Tooltip } from '@linode/ui';
+import React from 'react';
+
+import type { SxProps } from '@mui/material';
+
+interface Props {
+  chipProps?: {
+    sx?: SxProps;
+  };
+  tooltipText: React.ReactNode;
+}
+
+export const DefaultFirewallChip = (props: Props) => {
+  return (
+    <Tooltip
+      slotProps={{ tooltip: { sx: { minWidth: 245 } } }}
+      title={props.tooltipText}
+    >
+      <Chip label="DEFAULT" size="small" {...props.chipProps} />
+    </Tooltip>
+  );
+};

--- a/packages/manager/src/features/Firewalls/components/FirewallSelectOption.utils.tsx
+++ b/packages/manager/src/features/Firewalls/components/FirewallSelectOption.utils.tsx
@@ -1,0 +1,85 @@
+import { List, ListItem, Stack, Typography } from '@linode/ui';
+import React from 'react';
+
+import type { FirewallSettings } from '@linode/api-v4';
+
+export type FirewallDefaultEntity = keyof FirewallSettings['default_firewall_ids'];
+
+/**
+ * Maps an entity that supports default firewalls to a readable name.
+ */
+const FIREWALL_DEFAULT_ENTITY_TO_READABLE_NAME: Record<
+  FirewallDefaultEntity,
+  string
+> = {
+  linode: 'Configuration Profile Interfaces',
+  nodebalancer: 'NodeBalancers',
+  public_interface: 'Public (Linode Interfaces)',
+  vpc_interface: 'VPC (Linode Interfaces)',
+};
+
+/**
+ * getEntitiesThatFirewallIsDefaultFor
+ *
+ * @param firewallId The ID of the Firewall
+ * @param firewallSettings The account FirewallSettings from the API
+ *
+ * @returns An array of entities that this Firewall is a default for.
+ * @example ['nodebalancer', 'vpc_interface']
+ */
+export function getEntitiesThatFirewallIsDefaultFor(
+  firewallId: number,
+  firewallSettings: FirewallSettings
+) {
+  const defaultFor: FirewallDefaultEntity[] = [];
+
+  for (const key in firewallSettings.default_firewall_ids) {
+    const entity = key as FirewallDefaultEntity;
+    if (firewallSettings.default_firewall_ids[entity] === firewallId) {
+      defaultFor.push(entity);
+    }
+  }
+
+  return defaultFor;
+}
+
+/**
+ * getDefaultFirewallDescription
+ *
+ * @param firewallId The ID of the Firewall
+ * @param firewallSettings The account FirewallSettings from the API
+ *
+ * @returns A human readable string that explains what entities this Firewall is a default for.
+ *          It will return `null` if this Firewall is not a default for anything.
+ */
+export function getDefaultFirewallDescription(
+  firewallId: number,
+  firewallSettings: FirewallSettings
+) {
+  const entitiesThatFirewallIsDefaultFor = getEntitiesThatFirewallIsDefaultFor(
+    firewallId,
+    firewallSettings
+  );
+
+  if (entitiesThatFirewallIsDefaultFor.length === 0) {
+    // This means that a Firewall is not a default.
+    return null;
+  }
+
+  const readableEntities = entitiesThatFirewallIsDefaultFor.map(
+    (entity) => FIREWALL_DEFAULT_ENTITY_TO_READABLE_NAME[entity]
+  );
+
+  return (
+    <Stack>
+      <Typography>Default Firewall for:</Typography>
+      <List sx={{ listStyleType: 'disc', pl: 3 }}>
+        {readableEntities.map((entity) => (
+          <ListItem disablePadding key={entity} sx={{ display: 'list-item' }}>
+            {entity}
+          </ListItem>
+        ))}
+      </List>
+    </Stack>
+  );
+}

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeFirewalls/LinodeFirewallsActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeFirewalls/LinodeFirewallsActionMenu.tsx
@@ -1,10 +1,11 @@
+import { useGrants, useProfile } from '@linode/queries';
 import * as React from 'react';
 
-import { Action } from 'src/components/ActionMenu/ActionMenu';
 import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
-import { noPermissionTooltipText } from 'src/features/Firewalls/FirewallLanding/FirewallActionMenu';
+import { NO_PERMISSIONS_TOOLTIP_TEXT } from 'src/features/Firewalls/FirewallLanding/constants';
 import { checkIfUserCanModifyFirewall } from 'src/features/Firewalls/shared';
-import { useGrants, useProfile } from '@linode/queries';
+
+import type { Action } from 'src/components/ActionMenu/ActionMenu';
 
 interface LinodeFirewallsActionMenuProps {
   firewallID: number;
@@ -28,7 +29,7 @@ export const LinodeFirewallsActionMenu = (
   const disabledProps = !userCanModifyFirewall
     ? {
         disabled: true,
-        tooltip: noPermissionTooltipText,
+        tooltip: NO_PERMISSIONS_TOOLTIP_TEXT,
       }
     : {};
 

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerFirewallsActionMenu.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerFirewallsActionMenu.tsx
@@ -2,7 +2,7 @@ import { useGrants, useProfile } from '@linode/queries';
 import * as React from 'react';
 
 import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
-import { noPermissionTooltipText } from 'src/features/Firewalls/FirewallLanding/FirewallActionMenu';
+import { NO_PERMISSIONS_TOOLTIP_TEXT } from 'src/features/Firewalls/FirewallLanding/constants';
 import { checkIfUserCanModifyFirewall } from 'src/features/Firewalls/shared';
 
 import type { Action } from 'src/components/ActionMenu/ActionMenu';
@@ -27,7 +27,7 @@ export const NodeBalancerFirewallsActionMenu = (props: Props) => {
   const disabledProps = !userCanModifyFirewall
     ? {
         disabled: true,
-        tooltip: noPermissionTooltipText,
+        tooltip: NO_PERMISSIONS_TOOLTIP_TEXT,
       }
     : {};
 

--- a/packages/queries/src/firewalls/firewalls.ts
+++ b/packages/queries/src/firewalls/firewalls.ts
@@ -5,12 +5,12 @@ import {
   deleteFirewallDevice,
   getFirewall,
   getFirewallDevices,
+  getFirewallSettings,
   getFirewalls,
   getTemplate,
   getTemplates,
   updateFirewall,
   updateFirewallRules,
-  getFirewallSettings,
   updateFirewallSettings,
 } from '@linode/api-v4/lib/firewalls';
 import { getAll } from '@linode/utilities';
@@ -36,14 +36,15 @@ import type {
   FirewallDevice,
   FirewallDevicePayload,
   FirewallRules,
+  FirewallSettings,
   FirewallTemplate,
   FirewallTemplateSlug,
   Params,
   ResourcePage,
   UpdateFirewallRules,
-  FirewallSettings,
   UpdateFirewallSettings,
 } from '@linode/api-v4';
+import type { UseQueryOptions } from '@tanstack/react-query';
 
 const getAllFirewallDevices = (
   id: number,
@@ -285,8 +286,13 @@ export const useFirewallsQuery = (params?: Params, filter?: Filter) => {
   });
 };
 
-export const useFirewallSettingsQuery = () => {
-  return useQuery<FirewallSettings, APIError[]>(firewallQueries.settings);
+export const useFirewallSettingsQuery = (
+  options?: Partial<UseQueryOptions<FirewallSettings, APIError[]>>
+) => {
+  return useQuery<FirewallSettings, APIError[]>({
+    ...firewallQueries.settings,
+    ...options,
+  });
 };
 
 export const useFirewallTemplatesQuery = () => {

--- a/packages/ui/src/components/Chip/Chip.tsx
+++ b/packages/ui/src/components/Chip/Chip.tsx
@@ -10,6 +10,8 @@ export interface ChipProps extends _ChipProps {
   component?: React.ElementType;
 }
 
-export const Chip = (props: ChipProps) => {
-  return <_Chip {...props} />;
-};
+export const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
+  (props: ChipProps, ref) => {
+    return <_Chip ref={ref} {...props} />;
+  }
+);


### PR DESCRIPTION
## Description 📝
- Adds linking for Interface devices
- Adds default firewall chip and disables actions if firewall is a default firewall

## Changes  🔄
- Update FirewallRow to show default chip and interface services
- Update firewall action menu to disable delete/disabling if firewall is default

## Target release date 🗓️
- 4/2 release cut

## Preview 📷

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪
Using devenv

When feature flag is on
- Confirm default firewall chip shows up if firewall is default + firewall actions are disabled
- Confirm links to Linode Interface devices

When feature flag is off
- confirm defaults and Linode interface devices do not appear

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
