### PR TITLE
fix: [M3-9652] - Packages unable to publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
       - run: pnpm publish -r --filter @linode/api-v4 --filter @linode/validation --no-git-checks --access public
       - name: slack-notify
         uses: rtCamp/action-slack-notify@master

--- a/packages/manager/.changeset/pr-11923-tech-stories-1742933716536.md
+++ b/packages/manager/.changeset/pr-11923-tech-stories-1742933716536.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Fix incorrect secret in `publish-packages` Github Action  ([#11923](https://github.com/linode/manager/pull/11923))

--- a/packages/manager/cypress/e2e/core/linodes/rebuild-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/rebuild-linode.spec.ts
@@ -1,9 +1,9 @@
 import { createStackScript } from '@linode/api-v4/lib';
+import { regionFactory } from '@linode/utilities';
 import {
   createLinodeRequestFactory,
   imageFactory,
   linodeFactory,
-  regionFactory,
 } from '@src/factories';
 import { authenticate } from 'support/api/authentication';
 import { LINODE_CREATE_TIMEOUT } from 'support/constants/linodes';

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/EnableBackupsDialog.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/EnableBackupsDialog.test.tsx
@@ -1,4 +1,3 @@
-import { regionFactory } from '@linode/utilities';
 import * as React from 'react';
 
 import { DISK_ENCRYPTION_BACKUPS_CAVEAT_COPY } from 'src/components/Encryption/constants';


### PR DESCRIPTION
## Description 📝

- Fixes some type errors caused when we merged `staging` into  `develop` 
- Fixes issue introduced when we migrated to pnpm (https://github.com/linode/manager/pull/11297) causing packages not to publish
  - I think I just used an invalid secret key

## How to test 🧪

- Verify CI passes ✅ 
- We can't really test the job that publishes packages but I'm pretty sure this will fix the issue for our next release

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>