### PR TITLE
feat: [UIE-8141] - IAM RBAC: remove preselected role from autocomplete

### DIFF
--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.test.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.test.tsx
@@ -95,13 +95,6 @@ describe('ChangeRoleDrawer', () => {
 
     const autocomplete = screen.getByRole('combobox');
 
-    await waitFor(
-      () => {
-        expect(autocomplete).toHaveValue('account_admin');
-      },
-      { interval: 100, timeout: 5000 }
-    );
-
     act(() => {
       // Open the dropdown
       fireEvent.click(autocomplete);

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.tsx
@@ -3,6 +3,7 @@ import {
   Autocomplete,
   Drawer,
   Notice,
+  TextField,
   Typography,
 } from '@linode/ui';
 import { useTheme } from '@mui/material/styles';
@@ -76,24 +77,9 @@ export const ChangeRoleDrawer = ({ onClose, open, role }: Props) => {
     watch,
   } = useForm<{ roleName: RolesType }>({
     defaultValues: {
-      roleName: {
-        access: role?.access,
-        label: role?.name,
-        resource_type: role?.resource_type,
-        value: role?.name,
-      },
+      roleName: undefined,
     },
     mode: 'onBlur',
-    values: role
-      ? {
-          roleName: {
-            access: role.access,
-            label: role.name,
-            resource_type: role.resource_type,
-            value: role.name,
-          },
-        }
-      : undefined,
   });
 
   // Watch the selected role
@@ -157,25 +143,34 @@ export const ChangeRoleDrawer = ({ onClose, open, role }: Props) => {
           <Link to=""> Learn more about roles and permissions.</Link>
         </Typography>
 
-        <Typography sx={{ marginBottom: 2.5 }}>
-          Change from role{' '}
-          <span style={{ font: theme.font.bold }}>{role?.name}</span> to:
+        <Typography sx={{ marginBottom: theme.tokens.spacing.S12 }}>
+          Change from role <strong>{role?.name}</strong> to:
         </Typography>
 
         <Controller
-          render={({ field }) => (
+          render={({ field, fieldState }) => (
             <Autocomplete
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  errorText={fieldState.error?.message}
+                  hiddenLabel
+                  label=""
+                  noMarginTop
+                />
+              )}
               label="Assign New Roles"
               loading={accountPermissionsLoading}
               onChange={(_, value) => field.onChange(value)}
               options={allRoles}
               placeholder="Select a Role"
               textFieldProps={{ hideLabel: true, noMarginTop: true }}
-              value={field.value}
+              value={field.value || null}
             />
           )}
           control={control}
           name="roleName"
+          rules={{ required: 'Role is required' }}
         />
 
         {selectedRole && (


### PR DESCRIPTION
## Description 📝

Remove preselected role from autocomplete in the drawer for Change Role

## Changes  🔄

List any change(s) relevant to the reviewer.

- Remove preselected statement
- Update test

## Target release date 🗓️

(dev)

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/2bd463a2-bef7-4968-ba26-d1eef2fb22e3)| ![image](https://github.com/user-attachments/assets/1fd8839f-a37a-40df-9f0e-a15f8acebdc8)|

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Ensure the `Identity and Access Beta flag` is enabled in dev tools
- Ensure the MSW is enabled in dev tools
- Click on the any username in the users table and go to the tab `Assigned Roles` or click on the user's menu View User Roles
- Click on the user's menu `Change Role`


### Verification steps

(How to verify changes)

- [x] Drawer renders
- [x] By default there is an empty autocomplete

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

