### PR TITLE
fix: [M3-9669] – Adjust conditions for displaying encryption status on Linode Details page & encryption copy on LKE Create page

### DIFF
--- a/packages/manager/.changeset/pr-11930-upcoming-features-1743025907787.md
+++ b/packages/manager/.changeset/pr-11930-upcoming-features-1743025907787.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Adjust logic for displaying encryption status on Linode Details page and encryption copy on LKE Create page ([#11930](https://github.com/linode/manager/pull/11930))

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -117,7 +117,8 @@ const Panel = (props: NodePoolPanelProps) => {
     if (selectedTier === 'enterprise') {
       return `${ADD_NODE_POOLS_ENTERPRISE_DESCRIPTION} ${ADD_NODE_POOLS_NO_ENCRYPTION_DESCRIPTION}`;
     }
-    return regionSupportsDiskEncryption && Boolean(flags.linodeDiskEncryption)
+    // @TODO LDE: once LDE has been fully rolled out and is in GA in all regions, remove the feature flag condition
+    return regionSupportsDiskEncryption && flags.linodeDiskEncryption
       ? `${ADD_NODE_POOLS_DESCRIPTION} ${ADD_NODE_POOLS_ENCRYPTION_DESCRIPTION}`
       : ADD_NODE_POOLS_DESCRIPTION;
   };

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -3,6 +3,7 @@ import { CircleProgress, ErrorState } from '@linode/ui';
 import { doesRegionSupportFeature } from '@linode/utilities';
 import Grid from '@mui/material/Grid2';
 import * as React from 'react';
+import { useFlags } from 'src/hooks/useFlags';
 
 import { useIsAcceleratedPlansEnabled } from 'src/features/components/PlansPanel/utils';
 import { extendType } from 'src/utilities/extendType';
@@ -72,6 +73,8 @@ const Panel = (props: NodePoolPanelProps) => {
     types,
   } = props;
 
+  const flags = useFlags();
+
   const { isAcceleratedLKEPlansEnabled } = useIsAcceleratedPlansEnabled();
 
   const regions = useRegionsQuery().data ?? [];
@@ -114,7 +117,7 @@ const Panel = (props: NodePoolPanelProps) => {
     if (selectedTier === 'enterprise') {
       return `${ADD_NODE_POOLS_ENTERPRISE_DESCRIPTION} ${ADD_NODE_POOLS_NO_ENCRYPTION_DESCRIPTION}`;
     }
-    return regionSupportsDiskEncryption
+    return regionSupportsDiskEncryption && Boolean(flags.linodeDiskEncryption)
       ? `${ADD_NODE_POOLS_DESCRIPTION} ${ADD_NODE_POOLS_ENCRYPTION_DESCRIPTION}`
       : ADD_NODE_POOLS_DESCRIPTION;
   };

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
@@ -242,36 +242,33 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
                 )}
               </Box>
             </Grid>
-            {(isDiskEncryptionFeatureEnabled || regionSupportsDiskEncryption) &&
-              encryptionStatus && (
-                <Grid>
-                  <Box
-                    alignItems="center"
-                    data-testid={encryptionStatusTestId}
-                    display="flex"
-                    flexDirection="row"
-                  >
-                    <EncryptedStatus
-                      regionSupportsDiskEncryption={
-                        regionSupportsDiskEncryption
-                      }
-                      /**
-                       * M3-9517: Once LDE starts releasing regions with LDE enabled, LDE will still be disabled for the LKE-E LA launch, so hide this tooltip
-                       * explaining how LDE can be enabled on LKE-E node pools.
-                       * TODO - LKE-E: Clean up this enterprise cluster checks once LDE is enabled for LKE-E.
-                       */
-                      tooltipText={
-                        isLKELinode && cluster?.tier === 'enterprise'
-                          ? undefined
-                          : isLKELinode
-                          ? UNENCRYPTED_LKE_LINODE_GUIDANCE_COPY
-                          : UNENCRYPTED_STANDARD_LINODE_GUIDANCE_COPY
-                      }
-                      encryptionStatus={encryptionStatus}
-                    />
-                  </Box>
-                </Grid>
-              )}
+            {isDiskEncryptionFeatureEnabled && encryptionStatus && (
+              <Grid>
+                <Box
+                  alignItems="center"
+                  data-testid={encryptionStatusTestId}
+                  display="flex"
+                  flexDirection="row"
+                >
+                  <EncryptedStatus
+                    /**
+                     * M3-9517: Once LDE starts releasing regions with LDE enabled, LDE will still be disabled for the LKE-E LA launch, so hide this tooltip
+                     * explaining how LDE can be enabled on LKE-E node pools.
+                     * TODO - LKE-E: Clean up this enterprise cluster checks once LDE is enabled for LKE-E.
+                     */
+                    tooltipText={
+                      isLKELinode && cluster?.tier === 'enterprise'
+                        ? undefined
+                        : isLKELinode
+                        ? UNENCRYPTED_LKE_LINODE_GUIDANCE_COPY
+                        : UNENCRYPTED_STANDARD_LINODE_GUIDANCE_COPY
+                    }
+                    encryptionStatus={encryptionStatus}
+                    regionSupportsDiskEncryption={regionSupportsDiskEncryption}
+                  />
+                </Box>
+              </Grid>
+            )}
           </Grid>
         </Grid>
 


### PR DESCRIPTION
## Description 📝
While auditing the app after turning the LDE feature flag off this afternoon (see ticket for further explanation), I noticed a couple of minor issues:

1. The encryption status indicator still displays in the summary panel on the Linode Details page -- this is due to logic introduced in https://github.com/linode/manager/pull/11783 that should have been removed in https://github.com/linode/manager/pull/11817 but was not.
2. The `Node Pool data is encrypted at rest.` copy in the "Add Node Pools" panel in the LKE Create flow is visible if the region has the `Disk Encryption` capability. Since the account capability is not relevant as all LKE clusters should be encrypted by default if deployed in regions supporting the feature, we should control the display of this copy by checking for the feature flag (not `isDiskEncryptionFeatureEnabled` in this specific case).

## Target release date 🗓️
4/8/25

## Preview 📷
| "Linode Disk Encryption (LDE)" flag OFF  | "Linode Disk Encryption (LDE)" flag ON |
| ------------- | ------------- |
| ![Screenshot 2025-03-26 at 5 22 59 PM](https://github.com/user-attachments/assets/e49dec54-033a-45b4-b6db-205df5f77e4d)  | ![Screenshot 2025-03-26 at 5 23 08 PM](https://github.com/user-attachments/assets/0bdf2737-584e-4fb9-81ec-aef950077984)  |
| ![Screenshot 2025-03-26 at 5 24 21 PM](https://github.com/user-attachments/assets/5a4608d8-a620-497c-a216-bcc1afe6c877)  | ![Screenshot 2025-03-26 at 5 24 28 PM](https://github.com/user-attachments/assets/79a03a24-0598-41a1-a89d-57cefbd5adfb)  |

## How to test 🧪
### Prerequisites
Have the `linode_disk_encryption` tag on your account

### Reproduction steps
Observe: in prod where the feature flag is off at the moment, you will see the encryption status indicator on the Linode Create page and the encryption-related copy in the LKE Create flow _once you've selected a cluster region that supports LDE_.

### Verification steps
Confirm you see what is shown in the screenshots under the same conditions (toggle the LDE feature flag in our Dev Tool accordingly)

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [X] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅
- [X] All unit tests are passing
- [X] TypeScript compilation succeeded without errors
- [X] Code passes all linting rules

</details>