### PR TITLE
fix: [M3-9070] - Exclude `child_account` grant from PAT token calculations when it is hidden

### DIFF
--- a/packages/manager/.changeset/pr-11935-fixed-1743110166866.md
+++ b/packages/manager/.changeset/pr-11935-fixed-1743110166866.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+PAT Token drawer logic when Child Account Access is hidden ([#11935](https://github.com/linode/manager/pull/11935))

--- a/packages/manager/cypress/e2e/core/account/personal-access-tokens.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/personal-access-tokens.spec.ts
@@ -179,6 +179,72 @@ describe('Personal access tokens', () => {
       });
   });
 
+  it('sends scope as "*" when all permissions are set to read/write', () => {
+    const token = appTokenFactory.build({
+      label: randomLabel(),
+      token: randomString(64),
+    });
+
+    mockCreatePersonalAccessToken(token).as('createToken');
+
+    cy.visitWithLogin('/profile/tokens');
+
+    // Click create button, fill out and submit PAT create form.
+    ui.button
+      .findByTitle('Create a Personal Access Token')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    ui.drawer
+      .findByTitle('Add Personal Access Token')
+      .should('be.visible')
+      .within(() => {
+        // Confirm that the “Child account access” grant is not visible in the list of permissions.
+        cy.findAllByText('Child Account Access').should('not.exist');
+
+        // Confirm submit button is disabled without specifying scopes.
+        ui.buttonGroup.findButtonByTitle('Create Token').scrollIntoView();
+        ui.buttonGroup.findButtonByTitle('Create Token').should('be.disabled');
+
+        // Select "Read/Write" for all scopes.
+        cy.get(
+          '[aria-label="Personal Access Token Permissions"] tr:gt(1)'
+        ).each((row) =>
+          cy.wrap(row).within(() => {
+            cy.get('[type="radio"]').eq(2).click();
+          })
+        );
+
+        // Verify "Select All" radio for "Read/Write" is active
+        cy.get('[data-qa-perm-rw-radio]').should(
+          'have.attr',
+          'data-qa-radio',
+          'true'
+        );
+
+        // Specify a label and submit.
+        cy.findByLabelText('Label').scrollIntoView();
+        cy.findByLabelText('Label')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+        cy.findByLabelText('Label').type(token.label);
+
+        ui.buttonGroup.findButtonByTitle('Create Token').scrollIntoView();
+        ui.buttonGroup
+          .findButtonByTitle('Create Token')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    // Confirm that new PAT's scopes are '*'
+    cy.wait('@createToken').then((xhr) => {
+      expect(xhr.request.body.scopes).to.equal('*');
+    });
+  });
+
   /*
    * - Uses mocked API requests to confirm UI flow when renaming and revoking tokens
    * - Confirms that list shows the correct label after renaming a token

--- a/packages/manager/src/features/Profile/APITokens/utils.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.ts
@@ -53,6 +53,7 @@ export const inverseLevelMap = ['none', 'read_only', 'read_write'];
 export const levelMap = {
   create: 2,
   delete: 2,
+  hidden: -1,
   modify: 2,
   none: 0,
   read_only: 1,
@@ -160,21 +161,24 @@ export const scopeStringToPermTuples = (
 
 export const allMaxPerm = (
   scopeTups: Permission[],
-  perms: typeof basePerms
+  perms: typeof basePerms,
+  exclude: PermissionKey[] = []
 ): boolean => {
   if (scopeTups.length !== perms.length) {
     return false;
   }
 
-  return scopeTups.reduce(
-    (acc: boolean, [key, value]: Permission) =>
-      value === levelMap.read_write && acc,
-    true
+  const excludeSet = new Set(exclude);
+  return scopeTups.every(
+    ([key, value]) => value === levelMap.read_write || excludeSet.has(key)
   );
 };
 
-export const permTuplesToScopeString = (scopeTups: Permission[]): string => {
-  if (allMaxPerm(scopeTups, basePerms)) {
+export const permTuplesToScopeString = (
+  scopeTups: Permission[],
+  exclude: PermissionKey[]
+): string => {
+  if (allMaxPerm(scopeTups, basePerms, exclude)) {
     return '*';
   }
   const joinedTups = scopeTups.reduce((acc, [key, value]) => {


### PR DESCRIPTION
## Description 📝
This PR corrects some logic errors in the Create PAT Token drawer affecting the majority of accounts (except for parent accounts). For these accounts, the "Child Account Access" grant is hidden. Despite this:

- Individually selecting all the grants does not cause the "Select All" radio to be selected.
- Individually selecting all the grants and then submitting the form sends a list of grants to the API instead of the "*" wildcard character.

## Changes  🔄

- Update `excludedScopesFromSelectAll` value to exclude `child_account` when it is hidden
- Update `permTuplesToScopeString` with new `exclude` argument to determine when to return "*"

## Preview 📷

|Prod|This Branch|
|-|-|
|<video src="https://github.com/user-attachments/assets/8cd58512-c841-4d7a-8ea5-d730ec726e3c" />|<video src="https://github.com/user-attachments/assets/9dd272b5-9a46-4fe9-9272-bdc776cc2759"/>|

## How to test 🧪

### Prerequisites

- Navigate to the Profile > API Tokens page
- Click on "Create A Personal Access Token" to open the PAT drawer
- Individually select all permissions under "Read/Write"

### Reproduction steps

- When logged into a regular account, restricted parent or child account, observe that after individually selecting all scopes, the "Select All" radio button **IS NOT** selected.
- Open the Network panel and observe that when submitting the form, the POST request scopes are listed out individually, instead of being listed as "*"

### Verification steps

- Switch to this branch or use the preview link
- When logged into a regular account, restricted parent or child account, observe that after individually selecting all scopes, the "Select All" radio button **IS** selected.
- Open the Network panel and observe that when submitting the form, the POST request scopes are set to "*"