### PR TITLE
change: [M3-9408] - Remove min length validation for tag

### DIFF
--- a/packages/manager/.changeset/pr-11944-changed-1743506054914.md
+++ b/packages/manager/.changeset/pr-11944-changed-1743506054914.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Remove min length validation for tag and added validation for empty string ([#11944](https://github.com/linode/manager/pull/11944))

--- a/packages/manager/src/components/TagCell/AddTag.tsx
+++ b/packages/manager/src/components/TagCell/AddTag.tsx
@@ -31,8 +31,9 @@ export const AddTag = (props: AddTagProps) => {
   const createTag =
     !!accountTags &&
     !!inputValue &&
+    inputValue.trim() !== '' &&
     !accountTags.some(
-      (tag) => tag.label.toLowerCase() == inputValue.toLowerCase()
+      (tag) => tag.label.toLowerCase() === inputValue.toLowerCase()
     );
 
   const tagOptions: { displayLabel?: string; label: string }[] = [

--- a/packages/manager/src/components/TagsInput/TagsInput.test.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.test.tsx
@@ -62,4 +62,42 @@ describe('TagsInput', () => {
       ])
     );
   });
+
+  it('validates the input tag when the tag is empty', async () => {
+    const onChangeMock = vi.fn();
+
+    renderWithTheme(<TagsInput onChange={onChangeMock} value={[]} />);
+
+    const input = screen.getByRole('combobox');
+
+    await userEvent.type(input, ' ');
+
+    const createOption = screen.getByText('Create " "');
+    userEvent.click(createOption);
+
+    await waitFor(() => {
+      expect(screen.getByText('Tag cannot be an empty')).toBeInTheDocument();
+    });
+  });
+
+  it('validates the input tag when the tag length is between 1 and 50 characters', async () => {
+    const onChangeMock = vi.fn();
+
+    renderWithTheme(<TagsInput onChange={onChangeMock} value={[]} />);
+
+    const input = screen.getByRole('combobox');
+
+    await userEvent.type(input, 'Ta');
+
+    const createOption = screen.getByText('Create "Ta"');
+    userEvent.click(createOption);
+
+    expect(
+      screen.queryByText('Length must be 1-50 characters')
+    ).not.toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(onChangeMock).toHaveBeenCalledWith([{ label: 'Ta', value: 'Ta' }])
+    );
+  });
 });

--- a/packages/manager/src/components/TagsInput/TagsInput.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.tsx
@@ -91,7 +91,9 @@ export const TagsInput = (props: TagsInputProps) => {
 
     const errors = [];
 
-    if (inputValue.trim() === '') {
+    inputValue = inputValue.trim();
+
+    if (inputValue === '') {
       errors.push({
         field: 'label',
         reason: 'Tag cannot be an empty',

--- a/packages/manager/src/components/TagsInput/TagsInput.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.tsx
@@ -89,13 +89,24 @@ export const TagsInput = (props: TagsInputProps) => {
     const newTag = { label: inputValue, value: inputValue };
     const updatedSelectedTags = concat(value, [newTag]);
 
-    if (inputValue.length < 3 || inputValue.length > 50) {
-      setErrors([
-        {
-          field: 'label',
-          reason: 'Length must be 3-50 characters',
-        },
-      ]);
+    const errors = [];
+
+    if (inputValue.trim() === '') {
+      errors.push({
+        field: 'label',
+        reason: 'Tag cannot be an empty',
+      });
+    }
+
+    if (inputValue.length < 1 || inputValue.length > 50) {
+      errors.push({
+        field: 'label',
+        reason: 'Length must be 1-50 characters',
+      });
+    }
+
+    if (errors.length > 0) {
+      setErrors(errors);
     } else {
       setErrors([]);
       onChange(updatedSelectedTags);


### PR DESCRIPTION
## Description 📝
This PR removes the validation requiring a minimum of 3 characters when adding tags. Additionally, it adds validation to handle the edge case where the tag is an empty string or contains only spaces (e.g., `" "`).

## Changes  🔄
- Removed the 3-character minimum validation for adding tags.
- Added validation to show an error when the tag is an empty string or contains only spaces (e.g., `" "`).

## Target release date 🗓️

## Preview 📷
| Before | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/4b78fc9d-a608-49f9-8ebe-b7bbc6caff0e"></video> | <video src="https://github.com/user-attachments/assets/8fd4b1ef-fa3a-44bc-8706-023791a1b175"></video> |
| <video src="https://github.com/user-attachments/assets/b6749aa1-7b7c-49c5-b0bc-71bc2a86142b"></video> | <video src="https://github.com/user-attachments/assets/088cb6f6-7b89-44d9-bf6d-a1d62725db09"></video> |

## How to test 🧪

### Reproduction steps
- Navigate to all locations where tags can be added.
- Attempt to add a tag with fewer than 3 characters or a tag that is just spaces (e.g., `" "`).
- Verify that no validation error occurs for tags with fewer than 3 characters and that an error is shown for tags with only spaces.

### Verification steps
- Ensure that tags with fewer than 3 characters can be added without issues.
- Verify that tags with only spaces or empty strings trigger a validation error.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review  
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)  
🤏 Splitting feature into small PRs  
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)  
🧪 Providing/improving test coverage  
🔐 Removing all sensitive information from the code and PR description  
🚩 Using a feature flag to protect the release  
👣 Providing comprehensive reproduction steps  
📑 Providing or updating our documentation  
🕛 Scheduling a pair reviewing session  
📱 Providing mobile support  
♿ Providing accessibility support  

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
