### PR TITLE
test: [M3-9703] - Improve stability of Linode config Cypress tests

### DIFF
--- a/packages/manager/.changeset/pr-11951-tests-1743535607155.md
+++ b/packages/manager/.changeset/pr-11951-tests-1743535607155.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Improve stability of Linode config Cypress tests ([#11951](https://github.com/linode/manager/pull/11951))

--- a/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
@@ -692,7 +692,7 @@ describe('Linode Config management', () => {
      * - When the user sets primary interface to eth0, sets eth0 to "Public Internet", sets eth1 to "VPC", and checks "Assign a public IPv4 address for this Linode", confirm that correct notice appears.
      * - Confirms that "REBOOT NEEDED" status indicator appears upon creating VPC config.
      */
-    it.only('Creates a new config using non-recommended settings and confirm the informational notices', () => {
+    it('Creates a new config using non-recommended settings and confirm the informational notices', () => {
       const region = chooseRegion({ capabilities: ['VPCs'] });
       const mockLinode = linodeFactory.build({
         id: randomNumber(),

--- a/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
@@ -26,6 +26,7 @@ import {
   interceptRebootLinode,
   mockGetLinodeDetails,
   mockGetLinodeDisks,
+  mockGetLinodeFirewalls,
   mockGetLinodeKernel,
   mockGetLinodeKernels,
   mockGetLinodeVolumes,
@@ -315,7 +316,7 @@ describe('Linode Config management', () => {
           ),
           createTestLinode(
             { booted: true },
-            { securityMethod: 'vlan_no_internet' }
+            { securityMethod: 'vlan_no_internet', waitForBoot: true }
           ),
         ]);
       };
@@ -394,7 +395,8 @@ describe('Linode Config management', () => {
 
         // Confirm toast message and that UI updates to reflect clone in progress.
         ui.toast.assertMessage(
-          `Linode ${sourceLinode.label} has been cloned to ${destLinode.label}.`
+          `Linode ${sourceLinode.label} has been cloned to ${destLinode.label}.`,
+          { timeout: LINODE_CLONE_TIMEOUT }
         );
         cy.findByText(/CLONING \(\d+%\)/).should('be.visible');
       });
@@ -690,7 +692,7 @@ describe('Linode Config management', () => {
      * - When the user sets primary interface to eth0, sets eth0 to "Public Internet", sets eth1 to "VPC", and checks "Assign a public IPv4 address for this Linode", confirm that correct notice appears.
      * - Confirms that "REBOOT NEEDED" status indicator appears upon creating VPC config.
      */
-    it('Creates a new config using non-recommended settings and confirm the informational notices', () => {
+    it.only('Creates a new config using non-recommended settings and confirm the informational notices', () => {
       const region = chooseRegion({ capabilities: ['VPCs'] });
       const mockLinode = linodeFactory.build({
         id: randomNumber(),
@@ -729,13 +731,15 @@ describe('Linode Config management', () => {
 
       // Mock a Linode with no existing configs, then visit its details page.
       mockGetLinodeKernel(mockKernel.id, mockKernel);
-      mockGetLinodeKernels([mockKernel]);
+      mockGetLinodeKernels([mockKernel]).as('getKernels');
       mockGetLinodeDetails(mockLinode.id, mockLinode).as('getLinode');
       mockGetLinodeDisks(mockLinode.id, []).as('getDisks');
       mockGetLinodeVolumes(mockLinode.id, []).as('getVolumes');
       mockGetLinodeConfigs(mockLinode.id, []).as('getConfigs');
+      mockGetLinodeFirewalls(mockLinode.id, []);
       mockGetVPC(mockVPC).as('getVPC');
       mockGetVPCs([mockVPC]).as('getVPCs');
+      mockGetVLANs([]).as('getVLANs');
 
       cy.visitWithLogin(`/linodes/${mockLinode.id}/configurations`);
       cy.wait(['@getConfigs', '@getDisks', '@getLinode', '@getVolumes']);
@@ -753,8 +757,10 @@ describe('Linode Config management', () => {
         'getLinodeConfigs'
       );
 
-      // Create new config.
+      // Create new config. Wait for VLAN GET response before interacting with form.
       cy.findByText('Add Configuration').click();
+      cy.wait('@getVLANs');
+
       ui.dialog
         .findByTitle('Add Configuration')
         .should('be.visible')

--- a/packages/manager/cypress/support/setup/defer-command.ts
+++ b/packages/manager/cypress/support/setup/defer-command.ts
@@ -220,6 +220,9 @@ Cypress.Commands.add(
       return result;
     };
 
-    return cy.wrap<Promise<T>, T>(wrapPromise(), wrapOptions);
+    return cy.wrap<Promise<T>, T>(wrapPromise(), {
+      timeout: timeoutLength,
+      ...wrapOptions,
+    });
   }
 );

--- a/packages/manager/cypress/support/util/linodes.ts
+++ b/packages/manager/cypress/support/util/linodes.ts
@@ -8,6 +8,8 @@ import { pollLinodeDiskStatuses, pollLinodeStatus } from 'support/util/polling';
 import { randomLabel, randomString } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
 
+import { LINODE_CREATE_TIMEOUT } from 'support/constants/linodes';
+
 import { depaginate } from './paginate';
 
 import type {
@@ -184,6 +186,7 @@ export const createTestLinode = async (
     },
     message: `Create Linode '${linode.label}' (ID ${linode.id})`,
     name: 'createTestLinode',
+    timeout: LINODE_CREATE_TIMEOUT,
   });
 
   return {


### PR DESCRIPTION
## Description 📝

This makes a few fixes intended to improve the stability of our tests in `linode-config.spec.ts`. Some of the fixes involve the `cy.defer()` command and `createTestLinode` util which may also improve stability of other tests.

With these changes in place, I was able to run the spec locally on repeat and:
- The clone test passed 20/20 times
- Additionally, the entire spec passed 10/10 times

## Changes  🔄

- In the Linode config clone test, wait for both source and destination Linodes to boot before attempting the config clone operation.
- In the Linode non-recommended config test, wait for VLAN GET request to resolve before interacting with form to prevent UI update mid interaction
- Wait for `LINODE_CLONE_TIMEOUT` duration (5 minutes currently) when waiting for config clone success toast notification
- Fix a pair of issues where `LINODE_CREATE_TIMEOUT` wasn't being honored when using `cy.defer` and `createTestLinode`

## Target release date 🗓️

N/A. No urgency.

## How to test 🧪

We can rely on CI for this. Ideally {{linode-config.spec.ts}} will pass on its first attempt.

You may optionally check out the PR and run the spec manually:

```
pnpm cy:run -s "cypress/e2e/core/linodes/linode-config.spec.ts"
```

It may take repeated runs to gain confidence that the changes are working as intended.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
