### PR TITLE
change: Add a dummy PR to intentionally omit from the next release

### DIFF
--- a/packages/manager/.changeset/pr-11952-tech-stories-1743537321600.md
+++ b/packages/manager/.changeset/pr-11952-tech-stories-1743537321600.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Add a stray console log and a silly test change for intended revert ([#11952](https://github.com/linode/manager/pull/11952))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -1276,8 +1276,7 @@ describe('LKE Cluster Creation with LKE-E', () => {
    * - Confirms LKE-E flow does not exist if account doesn't have the corresponding capability
    * @todo LKE-E: Remove this test once LKE-E is fully rolled out
    */
-  // TODO: revert me before we release on 4/8!
-  it.skip('does not show the LKE-E flow with the feature flag off', () => {
+  it('does not show the LKE-E flow with the feature flag off', () => {
     mockAppendFeatureFlags({
       lkeEnterprise: { enabled: false, la: false },
     }).as('getFeatureFlags');
@@ -1291,7 +1290,9 @@ describe('LKE Cluster Creation with LKE-E', () => {
 
     cy.url().should('endWith', '/kubernetes/create');
 
-    cy.contains('Cluster Tier').should('not.exist');
+    // TODO: revert me before we release on 4/8!
+    cy.contains('Cluster').should('not.exist');
+    cy.contains('Tier').should('not.exist');
   });
 
   describe('shows the LKE-E flow with the feature flag on', () => {

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -1291,7 +1291,6 @@ describe('LKE Cluster Creation with LKE-E', () => {
     cy.url().should('endWith', '/kubernetes/create');
 
     // TODO: revert me before we release on 4/8!
-    cy.contains('Cluster').should('not.exist');
     cy.contains('Tier').should('not.exist');
   });
 

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -1276,7 +1276,8 @@ describe('LKE Cluster Creation with LKE-E', () => {
    * - Confirms LKE-E flow does not exist if account doesn't have the corresponding capability
    * @todo LKE-E: Remove this test once LKE-E is fully rolled out
    */
-  it('does not show the LKE-E flow with the feature flag off', () => {
+  // TODO: revert me before we release on 4/8!
+  it.skip('does not show the LKE-E flow with the feature flag off', () => {
     mockAppendFeatureFlags({
       lkeEnterprise: { enabled: false, la: false },
     }).as('getFeatureFlags');

--- a/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
@@ -34,9 +34,6 @@ import { KubernetesEmptyState } from './KubernetesLandingEmptyState';
 
 import type { KubeNodePoolResponse, KubernetesTier } from '@linode/api-v4';
 
-// TODO: revert me before we release on 4/8!
-// eslint-disable-next-line no-console
-console.log('Delete me!');
 interface ClusterDialogState {
   loading: boolean;
   open: boolean;

--- a/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
@@ -34,6 +34,9 @@ import { KubernetesEmptyState } from './KubernetesLandingEmptyState';
 
 import type { KubeNodePoolResponse, KubernetesTier } from '@linode/api-v4';
 
+// TODO: revert me before we release on 4/8!
+// eslint-disable-next-line no-console
+console.log('Delete me!');
 interface ClusterDialogState {
   loading: boolean;
   open: boolean;

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewList.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewList.tsx
@@ -16,6 +16,10 @@ import { LongviewListRows } from './LongviewListRows';
 import type { LongviewClient } from '@linode/api-v4/lib/longview/types';
 import type { Props as LVProps } from 'src/containers/longview.container';
 
+// TODO: revert me before we release on 4/8!
+// eslint-disable-next-line no-console
+console.log('Delete me!');
+
 type LongviewProps = Omit<
   LVProps,
   | 'createLongviewClient'


### PR DESCRIPTION
## Description 📝

These changes should be **REVERTED** on `release-v1.139.0` using the steps "How to omit PRs from a release branch" in our deploy docs to test that our process is sound.

## Changes  🔄
- Added a stray console.log statement to LongviewLanding
- Modified a `lke-create.spec.ts` test to check for strings not existing in an unideal way
- Added a changeset that should be removed from the changelog

## Target release date 🗓️
N/A

## How to test 🧪

### Verification steps

(How to verify changes)

- [ ] Merge this into `develop` just before the release is cut
- [ ] After cutting the release branch, the Fire Chief follows the "How to omit PRs from a release branch" steps to successfully revert the changes this PR
- [ ] If there are steps missing/incorrect, the deploy docs section is corrected

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>


