### PR TITLE
change: [M3-9598] - Form fields on Firewall Create page are enabled for restricted user

### DIFF
--- a/packages/manager/.changeset/pr-11954-changed-1743543232723.md
+++ b/packages/manager/.changeset/pr-11954-changed-1743543232723.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Disable form fields on Firewall Create page for restricted users ([#11954](https://github.com/linode/manager/pull/11954))

--- a/packages/manager/src/features/Firewalls/FirewallLanding/CustomFirewallFields.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/CustomFirewallFields.tsx
@@ -141,11 +141,15 @@ export const CustomFirewallFields = (props: CustomFirewallProps) => {
             value={field.value}
           >
             <FormControlLabel
-              control={<Radio />}
+              control={<Radio disabled={_isRestrictedUser} />}
               label="Accept"
               value="ACCEPT"
             />
-            <FormControlLabel control={<Radio />} label="Drop" value="DROP" />
+            <FormControlLabel
+              control={<Radio disabled={_isRestrictedUser} />}
+              label="Drop"
+              value="DROP"
+            />
           </RadioGroup>
         )}
         control={control}
@@ -164,11 +168,15 @@ export const CustomFirewallFields = (props: CustomFirewallProps) => {
             value={field.value}
           >
             <FormControlLabel
-              control={<Radio />}
+              control={<Radio disabled={_isRestrictedUser} />}
               label="Accept"
               value="ACCEPT"
             />
-            <FormControlLabel control={<Radio />} label="Drop" value="DROP" />
+            <FormControlLabel
+              control={<Radio disabled={_isRestrictedUser} />}
+              label="Drop"
+              value="DROP"
+            />
           </RadioGroup>
         )}
         control={control}
@@ -206,6 +214,7 @@ export const CustomFirewallFields = (props: CustomFirewallProps) => {
             onSelectionChange={(linodes) => {
               field.onChange(linodes.map((linode) => linode.id));
             }}
+            disabled={_isRestrictedUser}
             errorText={fieldState.error?.message}
             helperText={deviceSelectGuidance}
             multiple
@@ -229,6 +238,7 @@ export const CustomFirewallFields = (props: CustomFirewallProps) => {
                 nodebalancers.map((nodebalancer) => nodebalancer.id)
               );
             }}
+            disabled={_isRestrictedUser}
             errorText={fieldState.error?.message}
             helperText={deviceSelectGuidance}
             multiple


### PR DESCRIPTION
## Description 📝
This PR fixes a UI inconsistency where Firewall Create page form fields were improperly enabled for restricted users.

## Changes  🔄

- Disabled radio buttons for Default Inbound/Outbound Policy for restricted users
- Disabled dropdown menus for Linode and NodeBalancers selections for restricted users

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img src="https://github.com/user-attachments/assets/e308ca1e-19f8-4ccc-a5f5-d3943b188e1f" /> | <img src="https://github.com/user-attachments/assets/1cf72a38-5ffb-4822-bc51-6b30dfe12d39" /> |

### Verification steps

- [ ] Log in as a restricted user
- [ ] Navigate to `/firewalls/create`
- [ ] Verify all form fields are disabled

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>