### PR TITLE
test: [M3-9481 & more] - Apply environment-specific tags to tests

### DIFF
--- a/packages/manager/.changeset/pr-11958-tests-1743610427083.md
+++ b/packages/manager/.changeset/pr-11958-tests-1743610427083.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add `env:marketplaceApps`, `env:multipleRegions`, and `env:stackScripts` tags for Cypress tests ([#11958](https://github.com/linode/manager/pull/11958))

--- a/packages/manager/cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts
@@ -144,98 +144,103 @@ describe('Migrate Linode With Firewall', () => {
    * - Uses real API data to create a Firewall, attach a Linode to it, then migrate the Linode.
    */
   it.skip('migrates linode with firewall - real data', () => {
-    cy.tag('method:e2e', 'purpose:dcTesting');
-    const [migrationRegionStart, migrationRegionEnd] = chooseRegions(2);
-    const firewallLabel = randomLabel();
-    const linodePayload = createLinodeRequestFactory.build({
-      label: randomLabel(),
-      region: migrationRegionStart.id,
-    });
+    cy.tag('method:e2e', 'purpose:dcTesting', 'env:multipleRegions');
 
-    interceptCreateFirewall().as('createFirewall');
-    interceptGetFirewalls().as('getFirewalls');
-
-    // Create a Linode, then navigate to the Firewalls landing page.
-    cy.defer(() =>
-      createTestLinode(linodePayload, { securityMethod: 'powered_off' })
-    ).then((linode: Linode) => {
-      interceptMigrateLinode(linode.id).as('migrateLinode');
-      cy.visitWithLogin('/firewalls');
-      cy.wait('@getFirewalls');
-
-      ui.button
-        .findByTitle('Create Firewall')
-        .should('be.visible')
-        .should('be.enabled')
-        .click();
-
-      ui.drawer
-        .findByTitle('Create Firewall')
-        .should('be.visible')
-        .within(() => {
-          cy.findByText('Label').should('be.visible').click();
-          cy.focused().type(firewallLabel);
-
-          cy.findByText('Linodes').should('be.visible').click();
-          cy.focused().type(linode.label);
-
-          ui.autocompletePopper
-            .findByTitle(linode.label)
-            .should('be.visible')
-            .click();
-
-          // Click on the Select again to dismiss the autocomplete popper.
-          cy.findByLabelText('Linodes').should('be.visible').click();
-
-          ui.buttonGroup
-            .findButtonByTitle('Create Firewall')
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-        });
-
-      cy.wait('@createFirewall');
-      cy.visitWithLogin(`/linodes/${linode.id}`);
-      cy.get('[data-qa-link-text="true"]')
-        .should('be.visible')
-        .within(() => {
-          cy.findByText('linodes').should('be.visible');
-        });
-
-      // Make sure Linode is running before attempting to migrate.
-      cy.get('[data-qa-linode-status]').within(() => {
-        cy.findByText('OFFLINE');
+    // Execute the body of the test inside Cypress's command queue to ensure
+    // that logic that requires multiple regions only executes after tags are evaluated.
+    cy.defer(async () => {}).then(() => {
+      const [migrationRegionStart, migrationRegionEnd] = chooseRegions(2);
+      const firewallLabel = randomLabel();
+      const linodePayload = createLinodeRequestFactory.build({
+        label: randomLabel(),
+        region: migrationRegionStart.id,
       });
 
-      ui.actionMenu
-        .findByTitle(`Action menu for Linode ${linode.label}`)
-        .should('be.visible')
-        .click();
+      interceptCreateFirewall().as('createFirewall');
+      interceptGetFirewalls().as('getFirewalls');
 
-      ui.actionMenuItem.findByTitle('Migrate').should('be.visible').click();
+      // Create a Linode, then navigate to the Firewalls landing page.
+      cy.defer(() =>
+        createTestLinode(linodePayload, { securityMethod: 'powered_off' })
+      ).then((linode: Linode) => {
+        interceptMigrateLinode(linode.id).as('migrateLinode');
+        cy.visitWithLogin('/firewalls');
+        cy.wait('@getFirewalls');
 
-      ui.dialog
-        .findByTitle(`Migrate Linode ${linode.label} to another region`)
-        .should('be.visible')
-        .within(() => {
-          // Click "Accept" check box.
-          cy.findByText('Accept').should('be.visible').click();
+        ui.button
+          .findByTitle('Create Firewall')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
 
-          // Select region for migration.
-          ui.regionSelect.find().click();
-          ui.regionSelect
-            .findItemByRegionLabel(migrationRegionEnd.label)
-            .click();
+        ui.drawer
+          .findByTitle('Create Firewall')
+          .should('be.visible')
+          .within(() => {
+            cy.findByText('Label').should('be.visible').click();
+            cy.focused().type(firewallLabel);
 
-          // Initiate migration.
-          ui.button
-            .findByTitle('Enter Migration Queue')
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
+            cy.findByText('Linodes').should('be.visible').click();
+            cy.focused().type(linode.label);
+
+            ui.autocompletePopper
+              .findByTitle(linode.label)
+              .should('be.visible')
+              .click();
+
+            // Click on the Select again to dismiss the autocomplete popper.
+            cy.findByLabelText('Linodes').should('be.visible').click();
+
+            ui.buttonGroup
+              .findButtonByTitle('Create Firewall')
+              .should('be.visible')
+              .should('be.enabled')
+              .click();
+          });
+
+        cy.wait('@createFirewall');
+        cy.visitWithLogin(`/linodes/${linode.id}`);
+        cy.get('[data-qa-link-text="true"]')
+          .should('be.visible')
+          .within(() => {
+            cy.findByText('linodes').should('be.visible');
+          });
+
+        // Make sure Linode is running before attempting to migrate.
+        cy.get('[data-qa-linode-status]').within(() => {
+          cy.findByText('OFFLINE');
         });
 
-      cy.wait('@migrateLinode').its('response.statusCode').should('eq', 200);
+        ui.actionMenu
+          .findByTitle(`Action menu for Linode ${linode.label}`)
+          .should('be.visible')
+          .click();
+
+        ui.actionMenuItem.findByTitle('Migrate').should('be.visible').click();
+
+        ui.dialog
+          .findByTitle(`Migrate Linode ${linode.label} to another region`)
+          .should('be.visible')
+          .within(() => {
+            // Click "Accept" check box.
+            cy.findByText('Accept').should('be.visible').click();
+
+            // Select region for migration.
+            ui.regionSelect.find().click();
+            ui.regionSelect
+              .findItemByRegionLabel(migrationRegionEnd.label)
+              .click();
+
+            // Initiate migration.
+            ui.button
+              .findByTitle('Enter Migration Queue')
+              .should('be.visible')
+              .should('be.enabled')
+              .click();
+          });
+
+        cy.wait('@migrateLinode').its('response.statusCode').should('eq', 200);
+      });
     });
   });
 });

--- a/packages/manager/cypress/e2e/core/linodes/rebuild-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/rebuild-linode.spec.ts
@@ -176,7 +176,7 @@ describe('rebuild linode', () => {
    * - Confirms that a Linode can be rebuilt using a Community StackScript.
    */
   it('rebuilds a linode from Community StackScript', () => {
-    cy.tag('method:e2e');
+    cy.tag('method:e2e', 'env:stackScripts');
     const stackScriptId = 443929;
     const stackScriptName = 'OpenLiteSpeed-WordPress';
     const image = 'AlmaLinux 9';

--- a/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
+++ b/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
@@ -180,7 +180,7 @@ describe('OneClick Apps (OCA)', () => {
       cy.findByText('New apps').should('be.visible');
 
       // Check that the app is listed and select it
-      cy.get('[data-qa-selection-card="true"]').should('have.length', 2);
+      // The app may be listed 2 or 3 times.
       cy.findAllByText(stackscript.label).first().should('be.visible').click();
     });
 

--- a/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
+++ b/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
@@ -249,7 +249,7 @@ describe('OneClick Apps (OCA)', () => {
   });
 
   // leave test disabled by default
-  xit('Validate the summaries of all the OneClick Apps', () => {
+  it.skip('Validate the summaries of all the OneClick Apps', () => {
     cy.tag('method:e2e', 'env:marketplaceApps');
 
     interceptGetStackScripts().as('getStackScripts');

--- a/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
+++ b/packages/manager/cypress/e2e/core/oneClickApps/one-click-apps.spec.ts
@@ -20,7 +20,7 @@ import type { StackScript } from '@linode/api-v4';
 
 describe('OneClick Apps (OCA)', () => {
   it('Lists all the OneClick Apps', () => {
-    cy.tag('method:e2e');
+    cy.tag('method:e2e', 'env:marketplaceApps');
 
     interceptGetStackScripts().as('getStackScripts');
     cy.visitWithLogin(`/linodes/create?type=One-Click`);
@@ -57,7 +57,7 @@ describe('OneClick Apps (OCA)', () => {
   });
 
   it('Can view app details of a marketplace app', () => {
-    cy.tag('method:e2e');
+    cy.tag('method:e2e', 'env:marketplaceApps');
 
     interceptGetStackScripts().as('getStackScripts');
     cy.visitWithLogin(`/linodes/create?type=One-Click`);
@@ -250,7 +250,7 @@ describe('OneClick Apps (OCA)', () => {
 
   // leave test disabled by default
   xit('Validate the summaries of all the OneClick Apps', () => {
-    cy.tag('method:e2e');
+    cy.tag('method:e2e', 'env:marketplaceApps');
 
     interceptGetStackScripts().as('getStackScripts');
     cy.visitWithLogin(`/linodes/create?type=One-Click`);

--- a/packages/manager/cypress/e2e/core/stackscripts/smoke-community-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/smoke-community-stackscripts.spec.ts
@@ -190,7 +190,7 @@ describe('Community Stackscripts integration tests', () => {
    * - Confirms that pagination works as expected.
    */
   it('pagination works with infinite scrolling', () => {
-    cy.tag('method:e2e');
+    cy.tag('method:e2e', 'env:stackScripts');
     interceptGetStackScripts().as('getStackScripts');
 
     // Fetch all public Images to later use while filtering StackScripts.
@@ -236,7 +236,7 @@ describe('Community Stackscripts integration tests', () => {
    * - Confirms that search can filter the expected results.
    */
   it('search function filters results correctly', () => {
-    cy.tag('method:e2e');
+    cy.tag('method:e2e', 'env:stackScripts');
     const stackScript = mockStackScripts[0];
 
     interceptGetStackScripts().as('getStackScripts');
@@ -267,6 +267,7 @@ describe('Community Stackscripts integration tests', () => {
    * - Confirms that the deployment flow works.
    */
   it('deploys a new linode as expected', () => {
+    cy.tag('method:e2e', 'env:stackScripts');
     const stackScriptId = '37239';
     const stackScriptName = 'setup-ipsec-vpn';
     const sharedKey = randomString();

--- a/packages/manager/cypress/support/setup/test-tagging.ts
+++ b/packages/manager/cypress/support/setup/test-tagging.ts
@@ -19,7 +19,7 @@ const query = Cypress.env('CY_TEST_TAGS') ?? '';
  */
 Cypress.on('test:before:run', (_test: Test, _runnable: Runnable) => {
   /*
-   * Looks for the first command that does not belong in a hook and evalutes tags.
+   * Looks for the first command that does not belong in a hook and evaluates tags.
    *
    * Waiting for the first command to begin executing ensures that test context
    * is set up and that tags have been assigned to the test.
@@ -27,7 +27,13 @@ Cypress.on('test:before:run', (_test: Test, _runnable: Runnable) => {
   const commandHandler = () => {
     const context = cy.state('ctx');
     if (context && context.test?.type !== 'hook') {
-      const tags = context?.tags ?? [];
+      const tags = context?.tags ? [...context.tags] : [];
+
+      // Remove tags from context now that we've read them and can evaluate them.
+      // This prevents tags from persisting between tests in certain situations.
+      if (tags.length) {
+        context.tags = [];
+      }
 
       if (!evaluateQuery(query, tags)) {
         context.skip();

--- a/packages/manager/cypress/support/util/tag.ts
+++ b/packages/manager/cypress/support/util/tag.ts
@@ -9,7 +9,10 @@ const queryRegex = /(?:-|\+)?([^\s]+)/g;
 export type TestTag =
   // Environment-related tags.
   // Used to identify tests where certain environment-specific features are required.
+  | 'env:marketplaceApps'
+  | 'env:multipleRegions'
   | 'env:premiumPlans'
+  | 'env:stackScripts'
 
   // Feature-related tags.
   // Used to identify tests which deal with a certain feature or features.


### PR DESCRIPTION
## Description 📝

This adds a few new tags to our Cypress tests surrounding environment-specific functionality. Specifically, it adds the following new tags:

- `env:marketplaceApps`: for tests that require an environment where Marketplace apps are available
- `env:multipleRegions`: for tests that require an environment where more than one region is available
- `env:stackScripts`: for tests that require an environment where Community StackScripts are available.

It applies these tags to a few tests to ensure they can be skipped when running against environments that don't meet the tests' requirements.

(Addresses M3-9481, M3-9485, M3-9554)

## Changes  🔄

- Add `env:marketplaceApps`, `env:multipleRegions`, and `env:stackScripts` tags
- Apply tags to relevant E2E tests
- Fix a small issue with our tagging logic where tags would persist between tests in certain cases
- Fix a small issue in a One-Click App test where an assertion may fail depending on randomly generated mock data

## Target release date 🗓️

N/A. No urgency.

## How to test 🧪

We want to confirm 2 things:

- The tagged tests are not skipped by default
- The tagged tests are skipped when desired

We can rely on CI to confirm the first point. For the other, you can run the following command and confirm that the expected tests were skipped:

```bash
CY_TEST_TAGS='-env:stackScripts -env:multipleRegions -env:marketplaceApps' pnpm cy:run -s "cypress/e2e/core/linodes/rebuild-linode.spec.ts,cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts,cypress/e2e/core/oneClickApps/one-click-apps.spec.ts,cypress/e2e/core/stackscripts/smoke-community-stackscripts.spec.ts
```

8 tests should be skipped:
- `rebuild-linode.spec.ts` > `rebuilds a linode from Community StackScript`
- `one-click-apps.spec.ts` > `Lists all the OneClick Apps`
- `one-click-apps.spec.ts` > `Can view app details of a marketplace app`
- `one-click-apps.spec.ts` > `Validate the summaries of all the OneClick Apps` (this one is currently skipped regardless)
- `migrate-linode-with-firewall.spec.ts` > `migrates linode with firewall - real data` (this one is currently skipped regardless)
- `smoke-community-stackscripts.spec.ts` > `pagination works with infinite scrolling`
- `smoke-community-stackscripts.spec.ts` > `search function filters results correctly`
- `smoke-community-stackscripts.spec.ts` > `deploys a new linode as expected`

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

