### PR TITLE
fix: [M3-9719] - Fix a couple of errors with v4beta requests on the NodeBalancer details page

### DIFF
--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -13,16 +13,26 @@ import * as React from 'react';
 
 import { Link } from 'src/components/Link';
 import { TagCell } from 'src/components/TagCell/TagCell';
-import { useKubernetesBetaEndpoint } from 'src/features/Kubernetes/kubeUtils';
+import {
+  useIsLkeEnterpriseEnabled,
+  useKubernetesBetaEndpoint,
+} from 'src/features/Kubernetes/kubeUtils';
 import { IPAddress } from 'src/features/Linodes/LinodesLanding/IPAddress';
 import { useIsResourceRestricted } from 'src/hooks/useIsResourceRestricted';
 import { useKubernetesClusterQuery } from 'src/queries/kubernetes';
 
 export const SummaryPanel = () => {
+  const { isUsingBetaEndpoint } = useKubernetesBetaEndpoint();
+  const { isLkeEnterpriseLAFeatureEnabled } = useIsLkeEnterpriseEnabled();
+
   const { id } = useParams({
     from: '/nodebalancers/$id/summary',
   });
-  const { data: nodebalancer } = useNodeBalancerQuery(Number(id), Boolean(id));
+  const { data: nodebalancer } = useNodeBalancerQuery(
+    Number(id),
+    Boolean(id),
+    isLkeEnterpriseLAFeatureEnabled
+  );
   const { data: configs } = useAllNodeBalancerConfigsQuery(Number(id));
   const { data: regions } = useRegionsQuery();
   const { data: attachedFirewallData } = useNodeBalancersFirewallsQuery(
@@ -42,19 +52,17 @@ export const SummaryPanel = () => {
     id: nodebalancer?.id,
   });
 
-  const { isUsingBetaEndpoint } = useKubernetesBetaEndpoint();
-
   // If we can't get the cluster (status === 'error'), we can assume it's been deleted
   const { status: clusterStatus } = useKubernetesClusterQuery({
-    enabled: nodebalancer && Boolean(nodebalancer.lke_cluster),
+    enabled: Boolean(nodebalancer?.lke_cluster),
     id: nodebalancer?.lke_cluster?.id ?? -1,
+    isUsingBetaEndpoint,
     options: {
       refetchOnMount: false,
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
       retry: false,
     },
-    isUsingBetaEndpoint,
   });
 
   const configPorts = configs?.reduce((acc, config) => {

--- a/packages/manager/src/features/NodeBalancers/utils.ts
+++ b/packages/manager/src/features/NodeBalancers/utils.ts
@@ -19,7 +19,6 @@ import type {
   NodeBalancerConfigNode,
   Protocol,
 } from '@linode/api-v4';
-import { useIsLkeEnterpriseEnabled } from '../Kubernetes/kubeUtils';
 
 export const createNewNodeBalancerConfigNode = (): NodeBalancerConfigNodeFields => ({
   address: '',
@@ -228,12 +227,4 @@ export const useIsNodebalancerVPCEnabled = () => {
   // @TODO NB-VPC: check for customer tag/account capability when it exists
 
   return { isNodebalancerVPCEnabled: flags.nodebalancerVpc ?? false };
-};
-
-/**
- * Returns true if the v4beta GET nodebalancer endpoint should be used, based on the LKE-E feature flag.
- */
-export const useNodebalancerBetaEndpoint = () => {
-  const { isLkeEnterpriseLAFeatureEnabled } = useIsLkeEnterpriseEnabled();
-  return isLkeEnterpriseLAFeatureEnabled;
 };

--- a/packages/manager/src/features/NodeBalancers/utils.ts
+++ b/packages/manager/src/features/NodeBalancers/utils.ts
@@ -19,6 +19,7 @@ import type {
   NodeBalancerConfigNode,
   Protocol,
 } from '@linode/api-v4';
+import { useIsLkeEnterpriseEnabled } from '../Kubernetes/kubeUtils';
 
 export const createNewNodeBalancerConfigNode = (): NodeBalancerConfigNodeFields => ({
   address: '',
@@ -227,4 +228,12 @@ export const useIsNodebalancerVPCEnabled = () => {
   // @TODO NB-VPC: check for customer tag/account capability when it exists
 
   return { isNodebalancerVPCEnabled: flags.nodebalancerVpc ?? false };
+};
+
+/**
+ * Returns true if the v4beta GET nodebalancer endpoint should be used, based on the LKE-E feature flag.
+ */
+export const useNodebalancerBetaEndpoint = () => {
+  const { isLkeEnterpriseLAFeatureEnabled } = useIsLkeEnterpriseEnabled();
+  return isLkeEnterpriseLAFeatureEnabled;
 };

--- a/packages/manager/src/queries/kubernetes.ts
+++ b/packages/manager/src/queries/kubernetes.ts
@@ -184,8 +184,8 @@ export const kubernetesQueries = createQueryKeys('kubernetes', {
 export const useKubernetesClusterQuery = ({
   enabled = true,
   id = -1,
-  options = {},
   isUsingBetaEndpoint = false,
+  options = {},
 }) => {
   return useQuery<KubernetesCluster, APIError[]>({
     ...kubernetesQueries.cluster(id)._ctx.cluster(isUsingBetaEndpoint),
@@ -215,8 +215,8 @@ export const useKubernetesClustersInfiniteQuery = (
 interface KubernetesClustersQueryOptions {
   enabled: boolean;
   filter: Filter;
-  params: Params;
   isUsingBetaEndpoint: boolean;
+  params: Params;
 }
 
 export const useKubernetesClustersQuery = ({

--- a/packages/queries/src/nodebalancers/nodebalancers.ts
+++ b/packages/queries/src/nodebalancers/nodebalancers.ts
@@ -68,10 +68,10 @@ export const nodebalancerQueries = createQueryKeys('nodebalancers', {
         queryFn: () => getNodeBalancerFirewalls(id),
         queryKey: null,
       },
-      nodebalancer: () => ({
-        queryFn: (useBetaEndpoint) =>
-          useBetaEndpoint ? getNodeBalancerBeta(id) : getNodeBalancer(id),
-        queryKey: ['v4'],
+      nodebalancer: (isUsingBetaEndpoint: boolean = false) => ({
+        queryFn: () =>
+          isUsingBetaEndpoint ? getNodeBalancerBeta(id) : getNodeBalancer(id),
+        queryKey: [isUsingBetaEndpoint ? 'v4beta' : 'v4'],
       }),
       stats: {
         queryFn: () => getNodeBalancerStats(id),
@@ -122,9 +122,15 @@ export const useNodeBalancersQuery = (params: Params, filter: Filter) =>
     placeholderData: keepPreviousData,
   });
 
-export const useNodeBalancerQuery = (id: number, enabled = true) => {
+export const useNodeBalancerQuery = (
+  id: number,
+  enabled = true,
+  isUsingBetaEndpoint = false
+) => {
   return useQuery<NodeBalancer, APIError[]>({
-    ...nodebalancerQueries.nodebalancer(id)._ctx.nodebalancer(),
+    ...nodebalancerQueries
+      .nodebalancer(id)
+      ._ctx.nodebalancer(isUsingBetaEndpoint),
     enabled,
   });
 };


### PR DESCRIPTION
## Description 📝

When the nodebalancer queries were [recently migrated](https://github.com/linode/manager/pull/11774/files) to the linode/queries package, dependencies on feature flags were removed from the queries file. Use of the `getNodeBalancerBeta` over the `getNodeBalancer` endpoint depended on the lkeEnterprise feature flag. Currently, the v4beta endpoint is being used all the time, not respecting the feature flag enablement.
 
Another [recent PR for M3-9416](https://github.com/linode/manager/pull/11922/files#diff-9fe16b4e86dc963b779071391448b45668e789b1bdf3a38d3d1e97448d8e9940) correctly removed the feature flag out of the kubernetes queries so it can be migrated, while retaining the logic to enable beta endpoints with the LKE-E feature. NodeBalancers was not included in that PR. This PR corrects that.

## Changes  🔄
- Pass a param for enabling the beta endpoint on the `useNodeBalancerQuery`
   - Corrects the bug that prevents the `v4` endpoint from being used when the `lkeEnterprise` flag is off
- Update the enabled criteria for the `useKubernetesClusterQuery`
   - The existing logic was causing the kubernetes query to with an invalid lke cluster id (-1); it wasn't truly disabled. This seems related to the value of `nodebalancer`, because when it's `undefined`, `enabled` can briefly become `undefined`, which is not actually `false`, so the query runs. (Others have [seen this too](https://github.com/TanStack/query/issues/1196#issuecomment-2043328137)). (At least, that's what I think is happening.)

## Target release date 🗓️

4/22

## Preview 📷

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Check out develop
- Have a nodebalancer on your account
- Log into `prod-test-004-fe`- this account has an LKE-E cluster with an associated nodebalancer created for it

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] On another branch, turn the lkeEnterprise feature flag **off** locally (uncheck 'enabled')
- [ ] Click on any nodebalancer to view the nodebalancer details page and observe that the network request uses v4beta as the endpoint when it should not
- [ ] Visit the details page of the nodebalancer associated with the LKE-E cluster (ccm-4cfa90f7fc20)
   - [ ] Open the network requests and observe the erroneous request for an LKE cluster with an id of -1

### Verification steps

(How to verify changes)

On this branch, with the lkeEnterprise feature flag **off** locally:
- [ ] Click on any nodebalancer to view the nodebalancer details page and observe that the network request uses v4 endpoint
On this branch, with the lkeEnterprise feature flag **on** locally:
- [ ] Refresh the page and confirm the GET nodebalancer network request uses the v4beta endpoint
- [ ] Visit the details page of the nodebalancer associated with the LKE-E cluster (ccm-4cfa90f7fc20)
   - [ ] Open the network requests and observe there is no erroneous request for an LKE cluster with an id of -1

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
