### PR TITLE
refactor: [DI-24450] - Added logic to update the alert in cache when it is created

### DIFF
--- a/packages/manager/.changeset/pr-11969-added-1743779981445.md
+++ b/packages/manager/.changeset/pr-11969-added-1743779981445.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Add `cache update` logic in alerts.ts query file ([#11969](https://github.com/linode/manager/pull/11969))

--- a/packages/manager/cypress/e2e/core/cloudpulse/create-user-alert.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/create-user-alert.spec.ts
@@ -165,7 +165,7 @@ describe('Create Alert', () => {
     mockGetDatabases(databaseMock);
     mockGetAllAlertDefinitions([mockAlerts]).as('getAlertDefinitionsList');
     mockGetAlertChannels([notificationChannels]);
-    mockCreateAlertDefinition(serviceType, customAlertDefinition).as(
+    mockCreateAlertDefinition(serviceType, mockAlerts).as(
       'createAlertDefinition'
     );
   });

--- a/packages/manager/cypress/e2e/core/cloudpulse/edit-user-alert.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/edit-user-alert.spec.ts
@@ -150,7 +150,7 @@ describe('Integration Tests for Edit Alert', () => {
     mockUpdateAlertDefinitions(service_type, id, alertDetails).as(
       'updateDefinitions'
     );
-    mockCreateAlertDefinition(service_type, customAlertDefinition).as(
+    mockCreateAlertDefinition(service_type, alertDetails).as(
       'createAlertDefinition'
     );
     mockGetCloudPulseMetricDefinitions(service_type, metricDefinitions);

--- a/packages/manager/cypress/e2e/core/cloudpulse/edit-user-alert.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/edit-user-alert.spec.ts
@@ -30,7 +30,6 @@ import { ui } from 'support/ui';
 
 import {
   accountFactory,
-  alertDefinitionFactory,
   alertFactory,
   cpuRulesFactory,
   dashboardMetricFactory,
@@ -48,20 +47,6 @@ import type { Flags } from 'src/featureFlags';
 // Feature flag setup
 const flags: Partial<Flags> = { aclp: { beta: true, enabled: true } };
 const mockAccount = accountFactory.build();
-
-// Mock alert definition
-const customAlertDefinition = alertDefinitionFactory.build({
-  channel_ids: [1],
-  description: 'update-description',
-  entity_ids: ['1', '2', '3', '4', '5'],
-  label: 'Alert-1',
-  rule_criteria: {
-    rules: [cpuRulesFactory.build(), memoryRulesFactory.build()],
-  },
-  severity: 0,
-  tags: [''],
-  trigger_conditions: triggerConditionFactory.build(),
-});
 
 // Mock alert details
 const alertDetails = alertFactory.build({

--- a/packages/manager/cypress/support/intercepts/cloudpulse.ts
+++ b/packages/manager/cypress/support/intercepts/cloudpulse.ts
@@ -14,7 +14,6 @@ import { makeResponse } from 'support/util/response';
 import type {
   Alert,
   CloudPulseMetricsResponse,
-  CreateAlertDefinitionPayload,
   Dashboard,
   MetricDefinition,
   NotificationChannel,
@@ -355,12 +354,12 @@ export const mockGetAlertChannels = (
 
 export const mockCreateAlertDefinition = (
   serviceType: string,
-  createAlertRequest: CreateAlertDefinitionPayload
+  alert: Alert
 ): Cypress.Chainable<null> => {
   return cy.intercept(
     'POST',
     apiMatcher(`/monitor/services/${serviceType}/alert-definitions`),
-    paginateResponse(createAlertRequest)
+    makeResponse(alert)
   );
 };
 /**

--- a/packages/manager/src/queries/cloudpulse/alerts.ts
+++ b/packages/manager/src/queries/cloudpulse/alerts.ts
@@ -28,8 +28,29 @@ export const useCreateAlertDefinition = (serviceType: AlertServiceType) => {
   const queryClient = useQueryClient();
   return useMutation<Alert, APIError[], CreateAlertDefinitionPayload>({
     mutationFn: (data) => createAlertDefinition(data, serviceType),
-    onSuccess() {
-      queryClient.invalidateQueries(queryFactory.alerts);
+    onSuccess(newAlert) {
+      queryClient.cancelQueries({
+        queryKey: queryFactory.alerts._ctx.all().queryKey,
+      });
+
+      queryClient.setQueryData<Alert[]>(
+        queryFactory.alerts._ctx.all().queryKey,
+        (oldData) => (oldData ? [...oldData, newAlert] : [newAlert])
+      );
+
+      queryClient.setQueryData(
+        queryFactory.alerts._ctx.alertByServiceTypeAndId(
+          newAlert.service_type,
+          String(newAlert.id)
+        ).queryKey,
+        newAlert
+      );
+
+      queryClient.invalidateQueries({
+        queryKey: queryFactory.alerts._ctx.alertsByServiceType(
+          newAlert.service_type
+        ).queryKey,
+      });
     },
   });
 };
@@ -91,12 +112,13 @@ export const useEditAlertDefinition = () => {
         );
       });
 
-      queryClient.invalidateQueries({
-        queryKey: queryFactory.alerts._ctx.alertByServiceTypeAndId(
+      queryClient.setQueryData<Alert>(
+        queryFactory.alerts._ctx.alertByServiceTypeAndId(
           data.service_type,
           String(data.id)
         ).queryKey,
-      });
+        data
+      );
 
       queryClient.invalidateQueries({
         queryKey: queryFactory.alerts._ctx.alertsByServiceType(


### PR DESCRIPTION
## Description 📝

Updated alerts.ts file to push newly created alert to cache.

## Changes  🔄

List any change(s) relevant to the reviewer.

1. Updated alerts.ts query to set the new alert to cache
2. Updated cloudpulse.ts intercept to return new alert instead of paginated response.

## Target release date 🗓️

22 April

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
|<video src="https://github.com/user-attachments/assets/4bdcf31c-089b-4f0c-a5c8-9f89235f9c77"/>|<video src="https://github.com/user-attachments/assets/4d8b8c2a-f880-41d3-bc63-7f6aa0b78b60"/>|

## How to test 🧪

1. Switch to mock user
2. Go to alert tab
3. Click on create alert button
4. fill all the details
5. click submit
6. you'll see now the alert in the list without calling the alert list api again that you can verify from the network tab.



<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

