### PR TITLE
fix: [UIE-8447] - refresh drawer after config add/update

### DIFF
--- a/packages/api-v4/CHANGELOG.md
+++ b/packages/api-v4/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed:
 
 - DBaaS Advanced Configurations: remove `engine_config` from the DatabaseEngineConfig type ([#11885](https://github.com/linode/manager/pull/11885))
+- DBaaS Advanced Configurations: rename `restart_cluster` to `requires_restart` to align with the API response ([#11979](https://github.com/linode/manager/pull/11979))
 
 ### Fixed:
 

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -60,7 +60,7 @@ export interface ConfigurationItem {
   pattern?: string;
   type?: string | [string, null] | string[];
   enum?: string[];
-  restart_cluster?: boolean;
+  requires_restart?: boolean;
 }
 
 export type ConfigValue = number | string | boolean;

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - PAT Token drawer logic when Child Account Access is hidden ([#11935](https://github.com/linode/manager/pull/11935))
 - Profile Menu Icon Size Inconsistency ([#11946](https://github.com/linode/manager/pull/11946))
 - Unclearable ACL IP addresses for LKE clusters ([#11947](https://github.com/linode/manager/pull/11947))
+- DBaaS Advanced Configuration: drawer shows outdated config values after save and reopen ([#11979](https://github.com/linode/manager/pull/11979))
 
 ### Removed:
 

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -281,7 +281,7 @@ export const databaseEngineConfigFactory = Factory.Sync.makeFactory<DatabaseEngi
       example: 600,
       maximum: 86400,
       minimum: 600,
-      restart_cluster: false,
+      requires_restart: false,
       type: 'integer',
     },
     mysql: {
@@ -291,7 +291,7 @@ export const databaseEngineConfigFactory = Factory.Sync.makeFactory<DatabaseEngi
         example: 10,
         maximum: 3600,
         minimum: 2,
-        restart_cluster: false,
+        requires_restart: false,
         type: 'integer',
       },
       default_time_zone: {
@@ -301,7 +301,7 @@ export const databaseEngineConfigFactory = Factory.Sync.makeFactory<DatabaseEngi
         maxLength: 100,
         minLength: 2,
         pattern: '^([-+][\\d:]*|[\\w/]*)$',
-        restart_cluster: false,
+        requires_restart: false,
         type: 'string',
       },
       innodb_ft_min_token_size: {
@@ -310,7 +310,7 @@ export const databaseEngineConfigFactory = Factory.Sync.makeFactory<DatabaseEngi
         example: 3,
         maximum: 16,
         minimum: 0,
-        restart_cluster: true,
+        requires_restart: true,
         type: 'integer',
       },
       innodb_ft_server_stopword_table: {
@@ -319,14 +319,14 @@ export const databaseEngineConfigFactory = Factory.Sync.makeFactory<DatabaseEngi
         example: 'db_name/table_name',
         maxLength: 1024,
         pattern: '^.+/.+$',
-        restart_cluster: false,
+        requires_restart: false,
         type: ['null', 'string'],
       },
       innodb_print_all_deadlocks: {
         description:
           'When enabled, information about all deadlocks in InnoDB user transactions is recorded in the error log. Disabled by default.',
         example: true,
-        restart_cluster: false,
+        requires_restart: false,
         type: 'boolean',
       },
       log_output: {
@@ -334,7 +334,7 @@ export const databaseEngineConfigFactory = Factory.Sync.makeFactory<DatabaseEngi
           'The slow log output destination when slow_query_log is ON. To enable MySQL AI Insights, choose INSIGHTS. To use MySQL AI Insights and the mysql.slow_log table at the same time, choose INSIGHTS,TABLE. To only use the mysql.slow_log table, choose TABLE. To silence slow logs, choose NONE.',
         enum: ['INSIGHTS', 'NONE', 'TABLE', 'INSIGHTS,TABLE'],
         example: 'INSIGHTS',
-        restart_cluster: false,
+        requires_restart: false,
         type: 'string',
       },
       long_query_time: {
@@ -343,7 +343,7 @@ export const databaseEngineConfigFactory = Factory.Sync.makeFactory<DatabaseEngi
         example: 10,
         maximum: 3600,
         minimum: 0.0,
-        restart_cluster: false,
+        requires_restart: false,
         type: 'number',
       },
       sql_mode: {
@@ -352,14 +352,14 @@ export const databaseEngineConfigFactory = Factory.Sync.makeFactory<DatabaseEngi
         example: 'ANSI,TRADITIONAL',
         maxLength: 1024,
         pattern: '^[A-Z_]*(,[A-Z_]+)*$',
-        restart_cluster: false,
+        requires_restart: false,
         type: 'string',
       },
       sql_require_primary_key: {
         description:
           'Require primary key to be defined for new tables or old tables modified with ALTER TABLE and fail if missing. It is recommended to always have primary keys because various functionality may break if any large table is missing them.',
         example: true,
-        restart_cluster: false,
+        requires_restart: false,
         type: 'boolean',
       },
     },
@@ -367,7 +367,7 @@ export const databaseEngineConfigFactory = Factory.Sync.makeFactory<DatabaseEngi
       description:
         'Store logs for the service so that they are available in the HTTP API and console.',
       example: true,
-      restart_cluster: false,
+      requires_restart: false,
       type: ['boolean', 'null'],
     },
   }

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfigurationDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfigurationDrawer.tsx
@@ -97,10 +97,10 @@ export const DatabaseAdvancedConfigurationDrawer = (props: Props) => {
   const configs = watch('configs');
 
   useEffect(() => {
-    if (existingConfigsArray && open) {
+    if (existingConfigsArray) {
       reset({ configs: existingConfigsArray });
     }
-  }, [open, existingConfigsArray]);
+  }, [existingConfigsArray]);
 
   const usedConfigs = useMemo(
     () => new Set(fields.map((config) => config.label)),

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfigurationDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfigurationDrawer.tsx
@@ -97,10 +97,10 @@ export const DatabaseAdvancedConfigurationDrawer = (props: Props) => {
   const configs = watch('configs');
 
   useEffect(() => {
-    if (databaseConfig && open) {
+    if (existingConfigsArray && open) {
       reset({ configs: existingConfigsArray });
     }
-  }, [databaseConfig, open, reset, existingConfigsArray]);
+  }, [open, existingConfigsArray]);
 
   const usedConfigs = useMemo(
     () => new Set(fields.map((config) => config.label)),

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseConfigurationItem.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseConfigurationItem.tsx
@@ -27,12 +27,13 @@ interface Props {
   configItem?: ConfigurationOption;
   engine: string;
   errorText: string | undefined;
+  onBlur?: () => void;
   onChange: (config: ConfigValue) => void;
   onRemove?: (label: string) => void;
 }
 
 export const DatabaseConfigurationItem = (props: Props) => {
-  const { configItem, engine, errorText, onChange, onRemove } = props;
+  const { configItem, engine, errorText, onBlur, onChange, onRemove } = props;
   const configLabel = configItem?.label || '';
 
   const renderInputField = () => {
@@ -82,6 +83,7 @@ export const DatabaseConfigurationItem = (props: Props) => {
           fullWidth
           label=""
           name={configLabel}
+          onBlur={onBlur}
           onChange={(e) => onChange(Number(e.target.value))}
           type="number"
           value={Number(configItem.value)}
@@ -101,6 +103,7 @@ export const DatabaseConfigurationItem = (props: Props) => {
           fullWidth
           label=""
           name={configLabel}
+          onBlur={onBlur}
           onChange={(e) => onChange(e.target.value)}
           placeholder={String(configItem.example)}
           type="text"
@@ -126,7 +129,7 @@ export const DatabaseConfigurationItem = (props: Props) => {
         >
           {`${engine}.${configLabel}`}
         </Typography>
-        {configItem?.restart_cluster && (
+        {configItem?.requires_restart && (
           <StyledChip color="warning" label="restarts service" size="small" />
         )}
         {configItem?.description && (

--- a/packages/manager/src/features/Databases/utilities.test.ts
+++ b/packages/manager/src/features/Databases/utilities.test.ts
@@ -604,7 +604,7 @@ describe('findConfigItem', () => {
     example: 600,
     maximum: 86400,
     minimum: 600,
-    restart_cluster: false,
+    requires_restart: false,
     type: 'integer',
   };
 
@@ -614,7 +614,7 @@ describe('findConfigItem', () => {
     example: 10,
     maximum: 3600,
     minimum: 2,
-    restart_cluster: false,
+    requires_restart: false,
     type: 'integer',
   };
   it('should return the correct ConfigurationItem for a given targetKey', () => {
@@ -653,7 +653,7 @@ describe('convertExistingConfigsToArray', () => {
       label: 'connect_timeout',
       maximum: 3600,
       minimum: 2,
-      restart_cluster: false,
+      requires_restart: false,
       type: 'integer',
       value: 10,
     },
@@ -666,7 +666,7 @@ describe('convertExistingConfigsToArray', () => {
       maxLength: 100,
       minLength: 2,
       pattern: '^([-+][\\d:]*|[\\w/]*)$',
-      restart_cluster: false,
+      requires_restart: false,
       type: 'string',
       value: '+03:00',
     },
@@ -678,7 +678,7 @@ describe('convertExistingConfigsToArray', () => {
       label: 'binlog_retention_period',
       maximum: 86400,
       minimum: 600,
-      restart_cluster: false,
+      requires_restart: false,
       type: 'integer',
       value: 600,
     },

--- a/packages/manager/src/features/Databases/utilities.ts
+++ b/packages/manager/src/features/Databases/utilities.ts
@@ -456,6 +456,6 @@ export const getDefaultConfigValue = (config: ConfigurationOption) => {
     : isConfigStringWithEnum(config)
     ? config.enum?.[0] ?? ''
     : config?.type === 'number' || config?.type === 'integer'
-    ? 0
+    ? config.minimum ?? 0
     : '';
 };


### PR DESCRIPTION
## Description 📝

Fixed drawer showing outdated config values after save and reopen

## Changes  🔄

List any change(s) relevant to the reviewer.

- fixed the drawer to display updated config values after save and reopen
- fixed the UI to display newly added configs as existing (without remove button) after saving and reopening the drawer
- fixed showing the "Restart Service" label according to API data
- updated validation behavior to show error messages on blur instead of on submit
- updated the default value for newly added configs (number inputs) from 0 to the minimum value provided by the API

## Target release date 🗓️

04/08/25

## How to test 🧪

### Prerequisites

Database Advanced Config feature flag should be enabled

### Verification steps

(How to verify changes)

**Verify updated value for existing config:**

- select a database cluster
- navigate to the Advanced Configuration tab
- click the "Configure" button
- update the value for one of the existing configuration items
- click the "Save" button, the updated configuration appears in the table
- click the "Configure" button again
- verify that the updated config shows the new value, not the previous one

**Verify that the newly added config appears as an existing item (without the "Remove" button) after saving and closing the drawer:**

- select a database cluster
- navigate to the Advanced Configuration tab
- click the "Configure" button
- select a new configuration from the Autocomplete and click "Add"
- the new config is added to the list and shown with a "Remove" button
- change the value for the newly added config
- click the "Save" button, the configuration appears in the table
- click the "Configure" button again
- verify that the new config is shown as an existing item, without the "Remove" button

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>