### PR TITLE
fix: Update `pnpm clean` command to include all new packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "package-versions": "pnpm run --filter @linode/scripts package-versions",
     "junit:summary": "pnpm run --filter @linode/scripts --silent junit:summary",
     "generate-tod": "pnpm run --filter @linode/scripts --silent generate-tod",
-    "clean": "rm -rf node_modules && rm -rf packages/manager/node_modules && rm -rf packages/api-v4/node_modules && rm -rf packages/validation/node_modules && rm -rf packages/api-v4/lib && rm -rf packages/validation/lib && rm -rf packages/ui/node_modules && rm -rf packages/utilities/node_modules && rm -rf packages/shared/node_modules && rm -rf packages/queries/node_modules && rm -rf packages/search/node_modules",
+    "clean": "concurrently \"rm -rf node_modules\" \"pnpm -r exec rm -rf node_modules lib dist\" \"pnpm store prune\"",
     "prepare": "husky"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "package-versions": "pnpm run --filter @linode/scripts package-versions",
     "junit:summary": "pnpm run --filter @linode/scripts --silent junit:summary",
     "generate-tod": "pnpm run --filter @linode/scripts --silent generate-tod",
-    "clean": "rm -rf node_modules && rm -rf packages/manager/node_modules && rm -rf packages/api-v4/node_modules && rm -rf packages/validation/node_modules && rm -rf packages/api-v4/lib && rm -rf packages/validation/lib && rm -rf packages/ui/node_modules && rm -rf packages/utilities/node_modules",
+    "clean": "rm -rf node_modules && rm -rf packages/manager/node_modules && rm -rf packages/api-v4/node_modules && rm -rf packages/validation/node_modules && rm -rf packages/api-v4/lib && rm -rf packages/validation/lib && rm -rf packages/ui/node_modules && rm -rf packages/utilities/node_modules && rm -rf packages/shared/node_modules && rm -rf packages/queries/node_modules && rm -rf packages/search/node_modules",
     "prepare": "husky"
   },
   "resolutions": {


### PR DESCRIPTION
## Description 📝

Fixes an issue where `pnpm clean` doesn't actually clean all our new packages.

Didn't include a changeset since this is a one-liner, tech story, and not technically part of any package.

## Changes  🔄

- Updated the `clean` command in `package.json`.

## Target release date 🗓️
N/A

## How to test 🧪

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] On another branch, run the command and confirm in the `shared`, `queries` and `search` packages that the node_modules folder has been deleted. This created issues as discovered in https://github.com/linode/manager/pull/11941#pullrequestreview-2744040198.

### Verification steps

(How to verify changes)

- [ ] On this branch, locally run the command and confirm in the `shared`, `queries` and `search` packages that the node_modules folder has been deleted.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
