### PR TITLE
feat: [UIE-8672, UIE-8625] - IAM RBAC: fix not displaying empty state when no roles or no entities assigned

### DIFF
--- a/packages/manager/.changeset/pr-11984-upcoming-features-1744052007574.md
+++ b/packages/manager/.changeset/pr-11984-upcoming-features-1744052007574.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Fix displaying empty state when user doesn't have the assigned roles in iam ([#11984](https://github.com/linode/manager/pull/11984))

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/AssignedRolesTable.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/AssignedRolesTable.tsx
@@ -296,7 +296,6 @@ const getSearchableFields = (role: ExtendedRoleMap): string[] => {
     String(role.id),
     role.entity_type,
     role.name,
-    role.access,
     role.description,
     ...entityNames,
     ...role.permissions,

--- a/packages/manager/src/features/IAM/Users/UserDetails/UserDetailsPanel.test.tsx
+++ b/packages/manager/src/features/IAM/Users/UserDetails/UserDetailsPanel.test.tsx
@@ -23,19 +23,19 @@ describe('UserDetailsPanel', () => {
     expect(getByText(user.email)).toBeVisible();
   });
 
-  it("renders 'No Roles Assigned' if the user doesn't have the assigned roles", async () => {
+  it("renders '0' if the user doesn't have the assigned roles", async () => {
     const user = accountUserFactory.build({ restricted: true });
     const assignedRoles = { account_access: [], entity_access: [] };
 
-    const { getByText } = renderWithTheme(
+    const { getAllByText, getByText } = renderWithTheme(
       <UserDetailsPanel assignedRoles={assignedRoles} user={user} />
     );
 
-    expect(getByText('Access')).toBeVisible();
-    expect(getByText('No Roles Assigned')).toBeVisible();
+    expect(getByText('Assigned Roles')).toBeVisible();
+    expect(getAllByText('0')[0]).toBeVisible();
   });
 
-  it("renders '5 roles assigned' if the user has 5 different roles", async () => {
+  it("renders '5' if the user has 5 different roles", async () => {
     const user = accountUserFactory.build({ restricted: false });
     const assignedRoles: IamUserPermissions = {
       account_access: [
@@ -46,13 +46,13 @@ describe('UserDetailsPanel', () => {
       entity_access: [
         {
           id: 12345678,
-          type: 'linode',
           roles: ['linode_contributor', 'linode_creator'],
+          type: 'linode',
         },
         {
           id: 45678901,
-          type: 'firewall',
           roles: ['firewall_admin', 'firewall_creator'],
+          type: 'firewall',
         },
       ],
     };
@@ -61,11 +61,11 @@ describe('UserDetailsPanel', () => {
       <UserDetailsPanel assignedRoles={assignedRoles} user={user} />
     );
 
-    expect(getByText('Access')).toBeVisible();
-    expect(getByText('5 roles assigned')).toBeVisible();
+    expect(getByText('Assigned Roles')).toBeVisible();
+    expect(getByText('5')).toBeVisible();
   });
 
-  it("renders '3 roles assigned' if the user has 3 different roles", async () => {
+  it("renders '3' if the user has 3 different roles", async () => {
     const user = accountUserFactory.build({ restricted: false });
     const assignedRoles: IamUserPermissions = {
       account_access: [
@@ -76,8 +76,8 @@ describe('UserDetailsPanel', () => {
       entity_access: [
         {
           id: 12345678,
-          type: 'linode',
           roles: ['linode_contributor', 'linode_creator'],
+          type: 'linode',
         },
       ],
     };
@@ -86,8 +86,8 @@ describe('UserDetailsPanel', () => {
       <UserDetailsPanel assignedRoles={assignedRoles} user={user} />
     );
 
-    expect(getByText('Access')).toBeVisible();
-    expect(getByText('3 roles assigned')).toBeVisible();
+    expect(getByText('Assigned Roles')).toBeVisible();
+    expect(getByText('3')).toBeVisible();
   });
 
   it("renders the user's phone number", async () => {

--- a/packages/manager/src/features/IAM/Users/UserDetails/UserDetailsPanel.tsx
+++ b/packages/manager/src/features/IAM/Users/UserDetails/UserDetailsPanel.tsx
@@ -3,7 +3,6 @@ import Grid from '@mui/material/Grid2';
 import React from 'react';
 
 import { DateTimeDisplay } from 'src/components/DateTimeDisplay';
-import { Link } from 'src/components/Link';
 import { MaskableText } from 'src/components/MaskableText/MaskableText';
 import { StatusIcon } from 'src/components/StatusIcon/StatusIcon';
 import { TextTooltip } from 'src/components/TextTooltip';
@@ -34,19 +33,8 @@ export const UserDetailsPanel = ({ assignedRoles, user }: Props) => {
       value: <MaskableText isToggleable text={user.email} />,
     },
     {
-      label: 'Access',
-      value:
-        assignRolesCount > 0 ? (
-          <Typography>
-            <Link to={`/iam/users/${user.username}/roles`}>
-              {`${assignRolesCount} role${
-                assignRolesCount !== 1 ? 's' : ''
-              } assigned`}
-            </Link>
-          </Typography>
-        ) : (
-          <span>No Roles Assigned</span>
-        ),
+      label: 'Assigned Roles',
+      value: <Typography>{assignRolesCount}</Typography>,
     },
     {
       label: 'Last Login Status',

--- a/packages/manager/src/features/IAM/Users/UserEntities/UserEntities.test.tsx
+++ b/packages/manager/src/features/IAM/Users/UserEntities/UserEntities.test.tsx
@@ -42,7 +42,7 @@ vi.mock('src/queries/entities/entities', async () => {
 });
 
 describe('UserEntities', () => {
-  it('should display no entities text if there are no entity roles assigned to user', async () => {
+  it('should display no entities text if no entity roles are assigned to user', async () => {
     queryMocks.useAccountUserPermissions.mockReturnValue({
       data: userPermissionsFactory.build({
         account_access: ['account_admin'],
@@ -57,7 +57,7 @@ describe('UserEntities', () => {
     expect(getByText(NO_ASSIGNED_ENTITIES_TEXT)).toBeInTheDocument();
   });
 
-  it('should display no entities text if there are roles assigned to user', async () => {
+  it('should display no entities text if no roles are assigned to user', async () => {
     queryMocks.useAccountUserPermissions.mockReturnValue({
       data: userPermissionsFactory.build({
         account_access: [],

--- a/packages/manager/src/features/IAM/Users/UserEntities/UserEntities.test.tsx
+++ b/packages/manager/src/features/IAM/Users/UserEntities/UserEntities.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { accountEntityFactory } from 'src/factories/accountEntities';
+import { accountPermissionsFactory } from 'src/factories/accountPermissions';
+import { userPermissionsFactory } from 'src/factories/userPermissions';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { NO_ASSIGNED_ENTITIES_TEXT } from '../../Shared/constants';
+import { UserEntities } from './UserEntities';
+
+const mockEntities = [
+  accountEntityFactory.build({
+    id: 1,
+    label: 'firewall-1',
+    type: 'firewall',
+  }),
+];
+
+const queryMocks = vi.hoisted(() => ({
+  useAccountEntities: vi.fn().mockReturnValue({}),
+  useAccountPermissions: vi.fn().mockReturnValue({}),
+  useAccountUserPermissions: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('src/queries/iam/iam', async () => {
+  const actual = await vi.importActual<any>('src/queries/iam/iam');
+  return {
+    ...actual,
+    useAccountPermissions: queryMocks.useAccountPermissions,
+    useAccountUserPermissions: queryMocks.useAccountUserPermissions,
+  };
+});
+
+vi.mock('src/queries/entities/entities', async () => {
+  const actual = await vi.importActual<any>('src/queries/entities/entities');
+  return {
+    ...actual,
+    useAccountEntities: queryMocks.useAccountEntities,
+  };
+});
+
+describe('UserEntities', () => {
+  it('should display no entities text if there are no entity roles assigned to user', async () => {
+    queryMocks.useAccountUserPermissions.mockReturnValue({
+      data: userPermissionsFactory.build({
+        account_access: ['account_admin'],
+        entity_access: [],
+      }),
+    });
+
+    const { getByText } = renderWithTheme(<UserEntities />);
+
+    expect(getByText('Assigned Entities')).toBeInTheDocument();
+
+    expect(getByText(NO_ASSIGNED_ENTITIES_TEXT)).toBeInTheDocument();
+  });
+
+  it('should display no entities text if there are roles assigned to user', async () => {
+    queryMocks.useAccountUserPermissions.mockReturnValue({
+      data: userPermissionsFactory.build({
+        account_access: [],
+        entity_access: [],
+      }),
+    });
+
+    const { getByText } = renderWithTheme(<UserEntities />);
+
+    expect(getByText('Assigned Entities')).toBeInTheDocument();
+
+    expect(getByText(NO_ASSIGNED_ENTITIES_TEXT)).toBeInTheDocument();
+  });
+
+  it('should display entities and menu when data is available', async () => {
+    queryMocks.useAccountUserPermissions.mockReturnValue({
+      data: userPermissionsFactory.build(),
+    });
+
+    queryMocks.useAccountPermissions.mockReturnValue({
+      data: accountPermissionsFactory.build(),
+    });
+
+    queryMocks.useAccountEntities.mockReturnValue({
+      data: makeResourcePage(mockEntities),
+    });
+
+    const { getAllByLabelText, getByText } = renderWithTheme(<UserEntities />);
+
+    expect(getByText('firewall_admin')).toBeInTheDocument();
+    expect(getByText('firewall-1')).toBeInTheDocument();
+
+    const actionMenuButton = getAllByLabelText('action menu')[0];
+    expect(actionMenuButton).toBeInTheDocument();
+
+    fireEvent.click(actionMenuButton);
+    expect(getByText('Change Role')).toBeInTheDocument();
+    expect(getByText('Remove Assignment')).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/IAM/Users/UserEntities/UserEntities.tsx
+++ b/packages/manager/src/features/IAM/Users/UserEntities/UserEntities.tsx
@@ -14,7 +14,9 @@ export const UserEntities = () => {
   const { username } = useParams<{ username: string }>();
   const { data: assignedRoles } = useAccountUserPermissions(username ?? '');
 
-  const hasAssignedRoles = assignedRoles ? !isEmpty(assignedRoles) : false;
+  const hasAssignedRoles = assignedRoles
+    ? !isEmpty(assignedRoles.entity_access)
+    : false;
 
   return (
     <>

--- a/packages/manager/src/features/IAM/Users/UserRoles/UserRoles.test.tsx
+++ b/packages/manager/src/features/IAM/Users/UserRoles/UserRoles.test.tsx
@@ -41,9 +41,12 @@ vi.mock('src/queries/entities/entities', async () => {
 });
 
 describe('UserRoles', () => {
-  it('should display no roles text if there are no roles assigned to user', async () => {
+  it('should display no roles text if there are roles assigned to user', async () => {
     queryMocks.useAccountUserPermissions.mockReturnValue({
-      data: {},
+      data: userPermissionsFactory.build({
+        account_access: [],
+        entity_access: [],
+      }),
     });
 
     const { getByText } = renderWithTheme(<UserRoles />);
@@ -51,6 +54,59 @@ describe('UserRoles', () => {
     expect(getByText('Assigned Roles')).toBeInTheDocument();
 
     expect(getByText(NO_ASSIGNED_ROLES_TEXT)).toBeInTheDocument();
+  });
+
+  it('should display table if there are no entity access roles assigned to user', async () => {
+    queryMocks.useAccountUserPermissions.mockReturnValue({
+      data: userPermissionsFactory.build({
+        account_access: ['account_admin'],
+        entity_access: [],
+      }),
+    });
+
+    queryMocks.useAccountPermissions.mockReturnValue({
+      data: accountPermissionsFactory.build(),
+    });
+
+    queryMocks.useAccountEntities.mockReturnValue({
+      data: makeResourcePage(mockEntities),
+    });
+
+    const { getByText } = renderWithTheme(<UserRoles />);
+
+    expect(getByText('Assigned Roles')).toBeInTheDocument();
+
+    expect(getByText(/All Entities/i)).toBeInTheDocument();
+    expect(getByText('account_admin')).toBeInTheDocument();
+  });
+
+  it('should display table if there are no account access roles assigned to user', async () => {
+    queryMocks.useAccountUserPermissions.mockReturnValue({
+      data: userPermissionsFactory.build({
+        account_access: [],
+        entity_access: [
+          {
+            id: 1,
+            roles: ['firewall_admin'],
+            type: 'firewall',
+          },
+        ],
+      }),
+    });
+
+    queryMocks.useAccountPermissions.mockReturnValue({
+      data: accountPermissionsFactory.build(),
+    });
+
+    queryMocks.useAccountEntities.mockReturnValue({
+      data: makeResourcePage(mockEntities),
+    });
+
+    const { getByText } = renderWithTheme(<UserRoles />);
+
+    expect(getByText('Assigned Roles')).toBeInTheDocument();
+
+    expect(getByText('firewall_admin')).toBeInTheDocument();
   });
 
   it('should display roles and menu when data is available', async () => {
@@ -83,12 +139,12 @@ describe('UserRoles', () => {
 
   it('should open drawer when button is clicked', async () => {
     queryMocks.useAccountUserPermissions.mockReturnValue({
-      data: {},
+      data: userPermissionsFactory.build(),
     });
 
-    const { getByRole } = renderWithTheme(<UserRoles />);
+    const { getByRole, getByText } = renderWithTheme(<UserRoles />);
 
-    const btn = getByRole('button');
+    const btn = getByText('Assign New Role');
     fireEvent.click(btn);
     const drawer = getByRole('dialog');
 

--- a/packages/manager/src/features/IAM/Users/UserRoles/UserRoles.test.tsx
+++ b/packages/manager/src/features/IAM/Users/UserRoles/UserRoles.test.tsx
@@ -41,7 +41,7 @@ vi.mock('src/queries/entities/entities', async () => {
 });
 
 describe('UserRoles', () => {
-  it('should display no roles text if there are roles assigned to user', async () => {
+  it('should display no roles text if no roles are assigned to user', async () => {
     queryMocks.useAccountUserPermissions.mockReturnValue({
       data: userPermissionsFactory.build({
         account_access: [],
@@ -56,7 +56,7 @@ describe('UserRoles', () => {
     expect(getByText(NO_ASSIGNED_ROLES_TEXT)).toBeInTheDocument();
   });
 
-  it('should display table if there are no entity access roles assigned to user', async () => {
+  it('should display table if no entity access roles are assigned to user', async () => {
     queryMocks.useAccountUserPermissions.mockReturnValue({
       data: userPermissionsFactory.build({
         account_access: ['account_admin'],
@@ -80,7 +80,7 @@ describe('UserRoles', () => {
     expect(getByText('account_admin')).toBeInTheDocument();
   });
 
-  it('should display table if there are no account access roles assigned to user', async () => {
+  it('should display table if no account access roles are assigned to user', async () => {
     queryMocks.useAccountUserPermissions.mockReturnValue({
       data: userPermissionsFactory.build({
         account_access: [],

--- a/packages/manager/src/features/IAM/Users/UserRoles/UserRoles.tsx
+++ b/packages/manager/src/features/IAM/Users/UserRoles/UserRoles.tsx
@@ -6,9 +6,9 @@ import { useParams } from 'react-router-dom';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { useAccountUserPermissions } from 'src/queries/iam/iam';
 
+import { AssignedRolesTable } from '../../Shared/AssignedRolesTable/AssignedRolesTable';
 import { NO_ASSIGNED_ROLES_TEXT } from '../../Shared/constants';
 import { NoAssignedRoles } from '../../Shared/NoAssignedRoles/NoAssignedRoles';
-import { AssignedRolesTable } from '../../Shared/AssignedRolesTable/AssignedRolesTable';
 import { AssignNewRoleDrawer } from './AssignNewRoleDrawer';
 
 export const UserRoles = () => {
@@ -17,7 +17,10 @@ export const UserRoles = () => {
   const { data: assignedRoles } = useAccountUserPermissions(username ?? '');
   const [isDrawerOpen, setIsDrawerOpen] = React.useState<boolean>(false);
 
-  const hasAssignedRoles = assignedRoles ? !isEmpty(assignedRoles) : false;
+  const hasAssignedRoles = assignedRoles
+    ? !isEmpty(assignedRoles.account_access) ||
+      !isEmpty(assignedRoles.entity_access)
+    : false;
 
   return (
     <>


### PR DESCRIPTION
## Description 📝

Assigned Roles and Entities Tables - Not displaying empty state when no roles or no entities assigned.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Fix displaying empty state
- Add tests
- Change from `Access: 8 roles assigned `to `Assigned Roles: 8` without the hyperlinking behavior
- Remove searching by role access in the table

## Target release date 🗓️

(dev)

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/53251bad-be9f-4a0f-b2f6-47acbea462c7) | ![image](https://github.com/user-attachments/assets/f448ae19-1fd4-42f3-b8bf-26a7aaf84797) |
| ![image](https://github.com/user-attachments/assets/1719d26c-9cca-4354-a537-37a15bd12edd) | ![image](https://github.com/user-attachments/assets/221fe342-3202-496c-910a-32abb38ffef7) |
| ![image](https://github.com/user-attachments/assets/6228f498-d04b-492d-a9d6-312b5208e9ab) | ![image](https://github.com/user-attachments/assets/50888b5c-9729-40b2-933c-541c0f06587d) |
| ![image](https://github.com/user-attachments/assets/15f6ba6c-06a6-4713-a8f7-0263bae6aafd) | ![image](https://github.com/user-attachments/assets/95ab69ab-21d4-45cc-b9a6-0be3f11fa7c9) |
| ![image](https://github.com/user-attachments/assets/ec1b7966-3ba6-4315-9854-5510e89eaa2e)| ![image](https://github.com/user-attachments/assets/d1a3c36a-4297-4ae5-b284-1dba17543eba) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Ensure the Identity and Access Beta flag is enabled in dev tools
- Use devenv and login as vagrant user or use mock data
- Click on the any username in the users table and go to the tab Assigned Roles or click on the user's menu View User Roles
- Click on the any username in the users table and go to the tab Assigned Entities 


### Verification steps

(How to verify changes)

- [x] Empty state renders when user doesn't have assigned roles
- [x] `Assigned Roles: {number}` without the hyperlinking behavior
- [x] The search doesn't check the access of the roles

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

