### PR TITLE
refactor: [M3-9170] - Move `betaUtils` and its associated factories to `utilities` package

### DIFF
--- a/packages/manager/.changeset/pr-11986-removed-1744096851575.md
+++ b/packages/manager/.changeset/pr-11986-removed-1744096851575.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Removed
+---
+
+Move `betaUtils` and its associated factories to `utilities` package ([#11986](https://github.com/linode/manager/pull/11986))

--- a/packages/manager/cypress/e2e/core/account/smoke-enroll-beta.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/smoke-enroll-beta.spec.ts
@@ -1,4 +1,4 @@
-import { accountBetaFactory, betaFactory } from '@src/factories';
+import { accountBetaFactory, betaFactory } from '@linode/utilities';
 import { DateTime } from 'luxon';
 import { authenticate } from 'support/api/authentication';
 import {

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -2,6 +2,7 @@
  * @file LKE creation end-to-end tests.
  */
 import {
+  accountBetaFactory,
   dedicatedTypeFactory,
   linodeTypeFactory,
   pluralize,
@@ -46,7 +47,6 @@ import { randomItem, randomLabel, randomNumber } from 'support/util/random';
 import { chooseRegion, getRegionById } from 'support/util/regions';
 
 import {
-  accountBetaFactory,
   accountFactory,
   kubeLinodeFactory,
   kubernetesClusterFactory,

--- a/packages/manager/src/factories/index.ts
+++ b/packages/manager/src/factories/index.ts
@@ -6,7 +6,6 @@ export * from './accountOAuth';
 export * from './accountPayment';
 export * from './accountSettings';
 export * from './accountUsers';
-export * from './betas';
 export * from './billing';
 export * from './databases';
 export * from './disk';

--- a/packages/manager/src/features/Betas/BetasLanding.tsx
+++ b/packages/manager/src/features/Betas/BetasLanding.tsx
@@ -1,16 +1,16 @@
+import { useAccountBetasQuery } from '@linode/queries';
 import { Stack } from '@linode/ui';
+import { categorizeBetasByStatus } from '@linode/utilities';
 import { createLazyRoute } from '@tanstack/react-router';
 import * as React from 'react';
 
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { LandingHeader } from 'src/components/LandingHeader/LandingHeader';
 import { ProductInformationBanner } from 'src/components/ProductInformationBanner/ProductInformationBanner';
 import { BetaDetailsList } from 'src/features/Betas/BetaDetailsList';
-import { useAccountBetasQuery } from '@linode/queries';
 import { useBetasQuery } from 'src/queries/betas';
-import { categorizeBetasByStatus } from 'src/utilities/betaUtils';
 
 import type { AccountBeta, Beta } from '@linode/api-v4';
-import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 
 export const BetasLanding = () => {
   const {

--- a/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
@@ -1,8 +1,7 @@
-import { linodeTypeFactory } from '@linode/utilities';
+import { accountBetaFactory, linodeTypeFactory } from '@linode/utilities';
 import { renderHook } from '@testing-library/react';
 
 import {
-  accountBetaFactory,
   kubeLinodeFactory,
   kubernetesEnterpriseTierVersionFactory,
   kubernetesVersionFactory,

--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -1,12 +1,15 @@
 import { useAccount, useAccountBetaQuery } from '@linode/queries';
-import { isFeatureEnabledV2, sortByVersion } from '@linode/utilities';
+import {
+  getBetaStatus,
+  isFeatureEnabledV2,
+  sortByVersion,
+} from '@linode/utilities';
 
 import { useFlags } from 'src/hooks/useFlags';
 import {
   useKubernetesTieredVersionsQuery,
   useKubernetesVersionQuery,
 } from 'src/queries/kubernetes';
-import { getBetaStatus } from 'src/utilities/betaUtils';
 
 import type { Account } from '@linode/api-v4/lib/account';
 import type {

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -8,6 +8,8 @@
  */
 import {
   accountAvailabilityFactory,
+  accountBetaFactory,
+  betaFactory,
   dedicatedTypeFactory,
   linodeFactory,
   linodeIPFactory,
@@ -31,7 +33,6 @@ import { MOCK_THEME_STORAGE_KEY } from 'src/dev-tools/ThemeSelector';
 import {
   VLANFactory,
   // abuseTicketNotificationFactory,
-  accountBetaFactory,
   accountFactory,
   accountMaintenanceFactory,
   accountTransferFactory,
@@ -39,7 +40,6 @@ import {
   alertFactory,
   alertRulesFactory,
   appTokenFactory,
-  betaFactory,
   contactFactory,
   credentialFactory,
   creditPaymentResponseFactory,

--- a/packages/utilities/.changeset/pr-11986-added-1744096873342.md
+++ b/packages/utilities/.changeset/pr-11986-added-1744096873342.md
@@ -1,0 +1,5 @@
+---
+"@linode/utilities": Added
+---
+
+Move `betaUtils` and its associated factories to `utilities` package ([#11986](https://github.com/linode/manager/pull/11986))

--- a/packages/utilities/src/factories/betas.ts
+++ b/packages/utilities/src/factories/betas.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon';
 
-import { Factory } from '@linode/utilities';
+import { Factory } from './factoryProxy';
 
 import type { AccountBeta, Beta } from '@linode/api-v4';
 

--- a/packages/utilities/src/factories/index.ts
+++ b/packages/utilities/src/factories/index.ts
@@ -1,4 +1,5 @@
 export * from './accountAvailability';
+export * from './betas';
 export * from './config';
 export * from './factoryProxy';
 export * from './linodes';

--- a/packages/utilities/src/helpers/betaUtils.test.ts
+++ b/packages/utilities/src/helpers/betaUtils.test.ts
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon';
-
-import { accountBetaFactory, betaFactory } from '../factories';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
   hasStarted,
@@ -12,6 +11,8 @@ import {
   wasCustomerEnrolled,
   getBetaStatus,
 } from './betaUtils';
+
+import { accountBetaFactory, betaFactory } from '../factories';
 
 const generateTestBetas = () => ({
   activeNeverEndingBeta: betaFactory.build({

--- a/packages/utilities/src/helpers/betaUtils.ts
+++ b/packages/utilities/src/helpers/betaUtils.ts
@@ -1,5 +1,4 @@
-import { AccountBeta } from '@linode/api-v4/lib/account';
-import { Beta } from '@linode/api-v4/lib/betas';
+import { AccountBeta, Beta } from '@linode/api-v4';
 import { DateTime } from 'luxon';
 
 type BetaStatus = 'active' | 'available' | 'historical' | 'no_status';

--- a/packages/utilities/src/helpers/index.ts
+++ b/packages/utilities/src/helpers/index.ts
@@ -3,6 +3,7 @@ export * from './accountCapabilities';
 export * from './areArraysEqual';
 export * from './arePropsEqual';
 export * from './arrayToList';
+export * from './betaUtils';
 export * from './breakpoints';
 export * from './capitalize';
 export * from './createDevicesFromStrings';


### PR DESCRIPTION
## Description 📝

Move `betaUtils` and its associated factories to `utilities` package

## How to test 🧪

### Verification steps

- [ ] Confirm all checks pass
- [ ] Ensure all unit tests pass in @linode/utilities

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>