### PR TITLE
test [M3 9558]: replace hardcoded region id in clone linode test

### DIFF
--- a/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
@@ -2,6 +2,7 @@ import {
   createLinodeRequestFactory,
   linodeConfigInterfaceFactory,
   linodeFactory,
+  regionFactory,
 } from '@linode/utilities';
 import {
   VLANFactory,
@@ -43,7 +44,7 @@ import {
   randomNumber,
   randomString,
 } from 'support/util/random';
-import { chooseRegion, getRegionById } from 'support/util/regions';
+import { chooseRegion, extendRegion } from 'support/util/regions';
 
 import type { Linode } from '@linode/api-v4';
 
@@ -307,7 +308,24 @@ describe('clone linode', () => {
    * - Confirms that notice is shown when selecting a region with a different price structure.
    */
   it('shows DC-specific pricing information during clone flow', () => {
-    const mockRegions = [getRegionById('us-west'), getRegionById('us-east')];
+    const mockRegions = [
+      extendRegion(
+        regionFactory.build({
+          capabilities: ['Linodes'],
+          country: 'us',
+          id: 'us-west',
+          label: 'Fremont, CA',
+        })
+      ),
+      extendRegion(
+        regionFactory.build({
+          capabilities: ['Linodes'],
+          country: 'us',
+          id: 'us-east',
+          label: 'Newark, NJ',
+        })
+      ),
+    ];
     mockGetRegions(mockRegions).as('getRegions');
     const initialRegion = mockRegions[0];
     const newRegion = mockRegions[1];

--- a/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
@@ -31,6 +31,7 @@ import {
   mockGetLinodeVolumes,
   mockGetLinodes,
 } from 'support/intercepts/linodes';
+import { mockGetRegions } from 'support/intercepts/regions';
 import { mockGetVLANs } from 'support/intercepts/vlans';
 import { ui } from 'support/ui';
 import { linodeCreatePage } from 'support/ui/pages';
@@ -306,9 +307,10 @@ describe('clone linode', () => {
    * - Confirms that notice is shown when selecting a region with a different price structure.
    */
   it('shows DC-specific pricing information during clone flow', () => {
-    const initialRegion = getRegionById('us-west');
-    const newRegion = getRegionById('us-east');
-
+    const mockRegions = [getRegionById('us-west'), getRegionById('us-east')];
+    mockGetRegions(mockRegions).as('getRegions');
+    const initialRegion = mockRegions[0];
+    const newRegion = mockRegions[1];
     const mockLinode = linodeFactory.build({
       region: initialRegion.id,
       type: dcPricingMockLinodeTypes[0].id,
@@ -323,7 +325,7 @@ describe('clone linode', () => {
     mockGetLinodeTypes(dcPricingMockLinodeTypes).as('getLinodeTypes');
 
     cy.visitWithLogin(getLinodeCloneUrl(mockLinode));
-    cy.wait(['@getLinode', '@getLinodes', '@getLinodeTypes']);
+    cy.wait(['@getRegions', '@getLinode', '@getLinodes', '@getLinodeTypes']);
 
     // Confirm there is a docs link to the pricing page.
     cy.findByText(dcPricingDocsLabel)


### PR DESCRIPTION
## Description 📝

Replaced the region IDs which were hardcoded and may not exist in all environments. The mock pricing data had hardcoded region IDs, so it was easier to mock the regions to include these hardcoded IDs (us-west, us-east). 

## Changes  🔄

Added mock regions for us-west and us-east. 

## How to test 🧪
pnpm run cy:e2e -s 'cypress/e2e/core/linodes/clone-linode.spec.ts' 

(How to reproduce the issue, if applicable)

To repro the initial bug, run pnpm run cy:e2e -s 'cypress/e2e/core/linodes/clone-linode.spec.ts' in an environment that lacks us-west or us-east regions.  

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

---

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

---
