### PR TITLE
change: [M3-9735] - Add encryption icon to Image edit drawer

### DIFF
--- a/packages/manager/.changeset/pr-11993-added-1744134925847.md
+++ b/packages/manager/.changeset/pr-11993-added-1744134925847.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Display encryption status with lock icon in Image Edit Drawer ([#11993](https://github.com/linode/manager/pull/11993))

--- a/packages/manager/src/features/Images/ImagesLanding/EditImageDrawer.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/EditImageDrawer.tsx
@@ -7,6 +7,8 @@ import { Controller, useForm } from 'react-hook-form';
 import { NotFound } from 'src/components/NotFound';
 import { TagsInput } from 'src/components/TagsInput/TagsInput';
 import { useUpdateImageMutation } from 'src/queries/images';
+import Lock from 'src/assets/icons/lock.svg';
+import { Stack, Typography } from '@linode/ui';
 
 import { useImageAndLinodeGrantCheck } from '../utils';
 
@@ -101,6 +103,15 @@ export const EditImageDrawer = (props: Props) => {
           variant="error"
         />
       )}
+
+      <Stack direction="row" spacing={1} alignItems="center">
+        <Lock />
+        <Typography
+          sx={(theme) => ({ color: theme.textColors.textAccessTable })}
+        >
+          Encrypted
+        </Typography>
+      </Stack>
 
       <Controller
         render={({ field, fieldState }) => (

--- a/packages/manager/src/features/Images/ImagesLanding/EditImageDrawer.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/EditImageDrawer.tsx
@@ -104,14 +104,16 @@ export const EditImageDrawer = (props: Props) => {
         />
       )}
 
-      <Stack direction="row" spacing={1} alignItems="center">
-        <Lock />
-        <Typography
-          sx={(theme) => ({ color: theme.textColors.textAccessTable })}
-        >
-          Encrypted
-        </Typography>
-      </Stack>
+      {image?.capabilities?.includes('distributed-sites') && (
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Lock />
+          <Typography
+            sx={(theme) => ({ color: theme.textColors.textAccessTable })}
+          >
+            Encrypted
+          </Typography>
+        </Stack>
+      )}
 
       <Controller
         render={({ field, fieldState }) => (


### PR DESCRIPTION
## Description 📝

This PR adds the "Encrypted" label to the `EditImageDrawer` component.

## Changes  🔄

- Adds "Encrypted" label to Edit Image Drawer
- Includes Lock icon next to text 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img src="https://github.com/user-attachments/assets/eb18f836-c6cb-4ae1-8d05-61293a2dabcb" /> | <img src="https://github.com/user-attachments/assets/028911b1-d260-4479-8261-94090a5bfc4f" />  |

### Verification steps

- [ ] Navigate to `/images` and create or find an existing custom image.
- [ ] Click the ellipsis menu next to a custom image and click Edit.
- [ ] Confirm addition of "Encrypted" text and icon in the Edit Image drawer.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>