### PR TITLE
fix: [M3-9693] - Unexpected empty object pattern fix post eslint merge

### DIFF
--- a/packages/manager/cypress/e2e/core/cloudpulse/alerts-listing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alerts-listing-page.spec.ts
@@ -347,7 +347,7 @@ describe('Integration Tests for CloudPulse Alerts Listing Page', () => {
             .click();
         });
 
-      cy.wait(alias).then(({}) => {
+      cy.wait(alias).then(() => {
         ui.toast.assertMessage(successMessage);
       });
     };


### PR DESCRIPTION
fix needed after mergin ghttps://github.com/linode/manager/pull/11941 to make develop lint-healthy