### PR TITLE
change: [M3-9743] - Rename `Analytics` tab to `Metrics` tab on Linode details page

### DIFF
--- a/packages/manager/.changeset/pr-12007-changed-1744290501828.md
+++ b/packages/manager/.changeset/pr-12007-changed-1744290501828.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Rename `Analytics` tab to `Metrics` tab on Linode details page ([#12007](https://github.com/linode/manager/pull/12007))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -54,8 +54,8 @@ const LinodesDetailNavigation = () => {
 
   const tabs = [
     {
-      routeName: `${url}/analytics`,
-      title: 'Analytics',
+      routeName: `${url}/metrics`,
+      title: 'Metrics',
     },
     {
       routeName: `${url}/networking`,

--- a/packages/utilities/src/helpers/arrayToList.test.ts
+++ b/packages/utilities/src/helpers/arrayToList.test.ts
@@ -13,11 +13,11 @@ describe('Array to delimiter-separated list', () => {
 
   it('should return a list with three or more items as Oxford comma separated', () => {
     expect(arrayToList(['hello', 'goodbye', 'good riddance'])).toEqual(
-      'hello, goodbye, and good riddance'
+      'hello, goodbye, and good riddance',
     );
 
     expect(arrayToList(['apples', 'peas', 'carrots', 'peaches'])).toEqual(
-      'apples, peas, carrots, and peaches'
+      'apples, peas, carrots, and peaches',
     );
   });
 
@@ -25,8 +25,8 @@ describe('Array to delimiter-separated list', () => {
     expect(
       arrayToList(
         ['Mumbai, IN', 'Toronto, ON', 'Sydney, AU', 'Atlanta, GA'],
-        ';'
-      )
+        ';',
+      ),
     ).toEqual('Mumbai, IN; Toronto, ON; Sydney, AU; and Atlanta, GA');
   });
 

--- a/packages/utilities/src/helpers/arrayToList.ts
+++ b/packages/utilities/src/helpers/arrayToList.ts
@@ -1,6 +1,6 @@
 export const arrayToList = (
   input: string[],
-  separator: string = ','
+  separator: string = ',',
 ): string => {
   if (!Array.isArray(input) || input.length === 0) {
     return '';


### PR DESCRIPTION
## Description 📝
As part of the CloudPulse Linode Integration, the "Analytics" tab on the Linode detail page needs to be renamed to "Metrics".

Since this is a Global change, feature flag is not required.

## Changes  🔄
- Renamed  `Analytics` tab to `Metrics` tab on Linode Details page
- Updated the `routeName` for this tab
- Random eslint fixes

## Target release date 🗓️
N/A

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-04-10 at 5 42 27 PM](https://github.com/user-attachments/assets/d53f419b-b212-43ec-9d83-57ef8fe8292f) | ![Screenshot 2025-04-10 at 5 44 43 PM](https://github.com/user-attachments/assets/3dcbddce-c9e2-49d1-a5f1-ccf6cd111ad3) |

## How to test 🧪
- All checks pass
- Ensure the `Analytics` tab is now displayed as `Metrics` tab on Linode details page

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules