### PR TITLE
change: [M3-9742] - Add dedicated `Alerts` tab on Linode details page

### DIFF
--- a/packages/manager/.changeset/pr-12013-changed-1744375580329.md
+++ b/packages/manager/.changeset/pr-12013-changed-1744375580329.md
@@ -1,5 +1,5 @@
 ---
-"@linode/manager": Changed
+'@linode/manager': Added
 ---
 
-Add dedicated `Alerts` tab on Linode details page ([#12013](https://github.com/linode/manager/pull/12013))
+Dedicated `Alerts` tab on Linode details page ([#12013](https://github.com/linode/manager/pull/12013))

--- a/packages/manager/.changeset/pr-12013-changed-1744375580329.md
+++ b/packages/manager/.changeset/pr-12013-changed-1744375580329.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Add dedicated `Alerts` tab on Linode details page ([#12013](https://github.com/linode/manager/pull/12013))

--- a/packages/manager/cypress/e2e/core/linodes/smoke-delete-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/smoke-delete-linode.spec.ts
@@ -129,7 +129,6 @@ describe('delete linode', () => {
       // Check elements in setting tab
       cy.findByText('Linode Label').should('be.visible');
       cy.findByText('Reset Root Password').should('be.visible');
-      cy.findByText('Notification Thresholds').should('be.visible');
       cy.findByText('Shutdown Watchdog').should('be.visible');
       cy.findByText('Delete Linode').should('be.visible');
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/LinodeAlerts.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/LinodeAlerts.tsx
@@ -1,0 +1,20 @@
+import { useGrants } from '@linode/queries';
+import * as React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { LinodeSettingsAlertsPanel } from '../LinodeSettings/LinodeSettingsAlertsPanel';
+
+const LinodeAlerts = () => {
+  const { linodeId } = useParams<{ linodeId: string }>();
+  const id = Number(linodeId);
+  const { data: grants } = useGrants();
+
+  const isReadOnly =
+    grants !== undefined &&
+    grants?.linode.find((grant) => grant.id === id)?.permissions ===
+      'read_only';
+
+  return <LinodeSettingsAlertsPanel isReadOnly={isReadOnly} linodeId={id} />;
+};
+
+export default LinodeAlerts;

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
@@ -1,9 +1,7 @@
+import { useGrants } from '@linode/queries';
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
 
-import { useGrants } from '@linode/queries';
-
-import { LinodeSettingsAlertsPanel } from './LinodeSettingsAlertsPanel';
 import { LinodeSettingsDeletePanel } from './LinodeSettingsDeletePanel';
 import { LinodeSettingsLabelPanel } from './LinodeSettingsLabelPanel';
 import { LinodeSettingsPasswordPanel } from './LinodeSettingsPasswordPanel';
@@ -24,7 +22,6 @@ const LinodeSettings = () => {
     <>
       <LinodeSettingsLabelPanel isReadOnly={isReadOnly} linodeId={id} />
       <LinodeSettingsPasswordPanel isReadOnly={isReadOnly} linodeId={id} />
-      <LinodeSettingsAlertsPanel isReadOnly={isReadOnly} linodeId={id} />
       <LinodeWatchdogPanel isReadOnly={isReadOnly} linodeId={id} />
       <LinodeSettingsDeletePanel isReadOnly={isReadOnly} linodeId={id} />
     </>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
@@ -76,8 +76,7 @@ export const LinodeSettingsAlertsPanel = (props: Props) => {
 
   const alertSections = [
     {
-      copy:
-        'Average CPU usage over 2 hours exceeding this value triggers this alert.',
+      copy: 'Average CPU usage over 2 hours exceeding this value triggers this alert.',
       endAdornment: '%',
       error: hasErrorFor('alerts.cpu'),
       hidden: isBareMetalInstance,
@@ -103,8 +102,7 @@ export const LinodeSettingsAlertsPanel = (props: Props) => {
       value: formik.values.cpu,
     },
     {
-      copy:
-        'Average Disk I/O ops/sec over 2 hours exceeding this value triggers this alert.',
+      copy: 'Average Disk I/O ops/sec over 2 hours exceeding this value triggers this alert.',
       endAdornment: 'IOPS',
       error: hasErrorFor('alerts.io'),
       hidden: isBareMetalInstance,
@@ -225,7 +223,7 @@ export const LinodeSettingsAlertsPanel = (props: Props) => {
     <Accordion
       actions={renderExpansionActions}
       defaultExpanded
-      heading="Notification Thresholds"
+      heading="Alerts"
     >
       {generalError && <Notice variant="error">{generalError}</Notice>}
       {alertSections.map((p, idx) => (

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -33,6 +33,7 @@ const LinodeBackup = React.lazy(() => import('./LinodeBackup/LinodeBackups'));
 const LinodeActivity = React.lazy(
   () => import('./LinodeActivity/LinodeActivity')
 );
+const LinodeAlerts = React.lazy(() => import('./LinodeAlerts/LinodeAlerts'));
 const LinodeSettings = React.lazy(
   () => import('./LinodeSettings/LinodeSettings')
 );
@@ -79,6 +80,10 @@ const LinodesDetailNavigation = () => {
     {
       routeName: `${url}/activity`,
       title: 'Activity Feed',
+    },
+    {
+      routeName: `${url}/alerts`,
+      title: 'Alerts',
     },
     {
       routeName: `${url}/settings`,
@@ -164,6 +169,9 @@ const LinodesDetailNavigation = () => {
               )}
               <SafeTabPanel index={idx++}>
                 <LinodeActivity />
+              </SafeTabPanel>
+              <SafeTabPanel index={idx++}>
+                <LinodeAlerts />
               </SafeTabPanel>
               <SafeTabPanel index={idx++}>
                 <LinodeSettings />


### PR DESCRIPTION
## Description 📝
Add dedicated `Alerts` tab on Linode details page.

Since this is a global change, no feature flag is required. 

## Changes  🔄
- Created a new `Alerts` tab and added a new route for this tab
- Removed "Notification Thresholds" section from the settings section
- Added "Notification Thresholds" section to the new `Alerts` tab
- Updated  "Notification Thresholds" heading name to "Alerts" in `Alerts` tab

## Target release date 🗓️
N/A

## Preview 📷

![Screenshot 2025-04-11 at 6 20 59 PM](https://github.com/user-attachments/assets/f5e83b4b-140b-46d0-966c-f837ef551df2)

## How to test 🧪
- Verify new `Alerts` tab appears in Linode detail navigation
- Ensure all alert settings are accessible and functional in the new tab 
- Ensure no alert functionality remains in the `Settings` tab
- Ensure UI is consistent with existing design patterns

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules