### PR TITLE
test [M3-9567]: Fix Cypress LKE update tests in DevCloud

### DIFF
--- a/packages/manager/.changeset/pr-12014-tests-1744382864732.md
+++ b/packages/manager/.changeset/pr-12014-tests-1744382864732.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix  LKE update tests in DevCloud ([#12014](https://github.com/linode/manager/pull/12014))


### PR DESCRIPTION
## Description 📝

Fix Cypress LKE update tests in DevCloud by mocking region whose ID was hardcoded in other resources. 

## Changes  🔄

  

## How to test 🧪
pnpm run cy:e2e -s 'cypress/e2e/core/kubernetes/lke-update.spec.ts'
 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
 
