### PR TITLE
upcoming: [M3-9250] - Fix Subnet Assign and Unassign drawers for Linode Interfaces

### DIFF
--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -694,9 +694,9 @@ export interface ResizeLinodePayload {
 }
 
 export interface DeleteLinodeConfigInterfacePayload {
-  linodeId: number;
-  configId: number;
+  configId: null | number;
   interfaceId: number;
+  linodeId: number;
 }
 
 export interface LinodeLishData {

--- a/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsListTable.tsx
+++ b/packages/manager/src/components/RemovableSelectionsList/RemovableSelectionsListTable.tsx
@@ -7,6 +7,10 @@ import { TableBody } from 'src/components/TableBody';
 import { TableCell } from 'src/components/TableCell';
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
+import {
+  getLinodeInterfacePrimaryIPv4,
+  getLinodeInterfaceRanges,
+} from 'src/features/VPCs/utils';
 import { determineNoneSingleOrMultipleWithChip } from 'src/utilities/noneSingleOrMultipleWithChip';
 
 import { TableRowEmpty } from '../TableRowEmpty/TableRowEmpty';
@@ -87,10 +91,16 @@ export const RemovableSelectionsListTable = (
                 : selection.label}
             </StyledLabel>
           </TableCell>
-          <TableCell>{selection.interfaceData?.ipv4?.vpc ?? null}</TableCell>
+          <TableCell>
+            {selection.interfaceData?.ipv4?.vpc ??
+              getLinodeInterfacePrimaryIPv4(selection.interfaceData) ??
+              null}
+          </TableCell>
           <TableCell>
             {determineNoneSingleOrMultipleWithChip(
-              selection.interfaceData?.ip_ranges ?? []
+              selection.interfaceData?.ip_ranges ??
+                getLinodeInterfaceRanges(selection.interfaceData) ??
+                []
             )}
           </TableCell>
           <TableCell>

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.test.tsx
@@ -47,7 +47,7 @@ describe('Subnet Assign Linodes Drawer', () => {
     );
     expect(header).toBeVisible();
     const notice = getByText(
-      'Assigning a Linode to a subnet requires you to reboot the Linode to update its configuration.'
+      'Assigning a Linode using Configuration Profile Interfaces to a subnet requires you to reboot the Linode to update its configuration.'
     );
     expect(notice).toBeVisible();
     const helperText = getByText(

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
@@ -20,6 +20,8 @@ import {
 } from '../constants';
 import {
   hasUnrecommendedConfiguration as _hasUnrecommendedConfiguration,
+  getLinodeInterfacePrimaryIPv4,
+  getLinodeInterfaceRanges,
   hasUnrecommendedConfigurationLinodeInterface,
 } from '../utils';
 import { StyledWarningIcon } from './SubnetLinodeRow.styles';
@@ -83,15 +85,13 @@ export const SubnetLinodeRow = (props: Props) => {
    * The below hook gives us the relevant firewall and interface data depending on
    * interface type.
    */
-  const {
-    firewallsInfo,
-    interfacesInfo,
-  } = useInterfaceAndFirewallDataForLinode({
-    configId, // subnet.linodes.interfaces data now includes config_id, so we no longer have to fetch all configs
-    interfaceId,
-    isLinodeInterface,
-    linodeId,
-  });
+  const { firewallsInfo, interfacesInfo } =
+    useInterfaceAndFirewallDataForLinode({
+      configId, // subnet.linodes.interfaces data now includes config_id, so we no longer have to fetch all configs
+      interfaceId,
+      isLinodeInterface,
+      linodeId,
+    });
 
   const { attachedFirewalls, firewallsError, firewallsLoading } = firewallsInfo;
   const {
@@ -310,9 +310,7 @@ const getSubnetLinodeIPv4CellString = (
   if ('purpose' in interfaceData) {
     return getIPv4LinkForConfigInterface(interfaceData);
   } else {
-    const primaryIPv4 = interfaceData.vpc?.ipv4.addresses.find(
-      (address) => address.primary
-    )?.address;
+    const primaryIPv4 = getLinodeInterfacePrimaryIPv4(interfaceData);
     return <span key={interfaceData.id}>{primaryIPv4 ?? 'None'}</span>;
   }
 };
@@ -352,9 +350,7 @@ const getIPRangesCellContents = (
       interfaceData?.ip_ranges ?? []
     );
   } else {
-    const linodeInterfaceVPCRanges = interfaceData.vpc?.ipv4.ranges.map(
-      (range) => range.range
-    );
+    const linodeInterfaceVPCRanges = getLinodeInterfaceRanges(interfaceData);
     return determineNoneSingleOrMultipleWithChip(
       linodeInterfaceVPCRanges ?? []
     );

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
@@ -64,11 +64,8 @@ export const SubnetUnassignLinodesDrawer = React.memo(
     const vpcPermissions = grants?.vpc.find((v) => v.id === vpcId);
 
     const queryClient = useQueryClient();
-    const {
-      setUnassignLinodesErrors,
-      unassignLinode,
-      unassignLinodesErrors,
-    } = useUnassignLinode();
+    const { setUnassignLinodesErrors, unassignLinode, unassignLinodesErrors } =
+      useUnassignLinode();
 
     const csvRef = React.useRef<any>();
     const formattedDate = useFormattedDate();
@@ -76,21 +73,15 @@ export const SubnetUnassignLinodesDrawer = React.memo(
     const [selectedLinodes, setSelectedLinodes] = React.useState<Linode[]>(
       singleLinodeToBeUnassigned ? [singleLinodeToBeUnassigned] : []
     );
-    const [
-      selectedLinodesAndConfigData,
-      setSelectedLinodesAndConfigData,
-    ] = React.useState<ConfigInterfaceAndLinodeData[]>([]);
+    const [selectedLinodesAndConfigData, setSelectedLinodesAndConfigData] =
+      React.useState<ConfigInterfaceAndLinodeData[]>([]);
 
     const hasError = React.useRef(false); // This flag is used to prevent the drawer from closing if an error occurs.
 
-    const [
-      linodeOptionsToUnassign,
-      setLinodeOptionsToUnassign,
-    ] = React.useState<Linode[]>([]);
-    const [
-      configInterfacesToDelete,
-      setConfigInterfacesToDelete,
-    ] = React.useState<DeleteLinodeConfigInterfacePayload[]>([]);
+    const [linodeOptionsToUnassign, setLinodeOptionsToUnassign] =
+      React.useState<Linode[]>([]);
+    const [configInterfacesToDelete, setConfigInterfacesToDelete] =
+      React.useState<DeleteLinodeConfigInterfacePayload[]>([]);
 
     const { linodes: subnetLinodeIds } = subnet || {};
 
@@ -289,13 +280,13 @@ export const SubnetUnassignLinodesDrawer = React.memo(
 
     return (
       <Drawer
+        isFetching={isFetching}
+        NotFoundComponent={NotFound}
+        onClose={handleOnClose}
+        open={open}
         title={`Unassign Linodes from subnet: ${subnet?.label} (${
           subnet?.ipv4 ?? subnet?.ipv6
         })`}
-        NotFoundComponent={NotFound}
-        isFetching={isFetching}
-        onClose={handleOnClose}
-        open={open}
       >
         {userCannotUnassignLinodes && (
           <Notice
@@ -322,14 +313,14 @@ export const SubnetUnassignLinodesDrawer = React.memo(
           <Stack>
             {!singleLinodeToBeUnassigned && (
               <Autocomplete
-                onChange={(_, value) => {
-                  setSelectedLinodes(value);
-                  getConfigWithVPCInterface(value);
-                }}
                 disabled={userCannotUnassignLinodes}
                 errorText={linodesError ? linodesError[0].reason : undefined}
                 label="Linodes"
                 multiple
+                onChange={(_, value) => {
+                  setSelectedLinodes(value);
+                  getConfigWithVPCInterface(value);
+                }}
                 options={linodeOptionsToUnassign}
                 placeholder="Select Linodes or type to search"
                 renderTags={() => null}
@@ -339,7 +330,7 @@ export const SubnetUnassignLinodesDrawer = React.memo(
             <Box sx={(theme) => ({ marginTop: theme.spacing(2) })}>
               <RemovableSelectionsListTable
                 headerText={`Linodes to be Unassigned from Subnet (${selectedLinodes.length})`}
-                isRemovable={!Boolean(singleLinodeToBeUnassigned)}
+                isRemovable={!singleLinodeToBeUnassigned}
                 noDataText="Select Linodes to be Unassigned from Subnet."
                 onRemove={handleRemoveLinode}
                 selectionData={selectedLinodesAndConfigData}
@@ -348,6 +339,12 @@ export const SubnetUnassignLinodesDrawer = React.memo(
             </Box>
             {selectedLinodesAndConfigData.length > 0 && (
               <DownloadCSV
+                buttonType="styledLink"
+                csvRef={csvRef}
+                data={selectedLinodesAndConfigData}
+                filename={`linodes-unassigned-${formattedDate}.csv`}
+                headers={SUBNET_LINODE_CSV_HEADERS}
+                onClick={downloadCSV}
                 sx={{
                   alignItems: 'flex-start',
                   display: 'flex',
@@ -355,12 +352,6 @@ export const SubnetUnassignLinodesDrawer = React.memo(
                   marginTop: 2,
                   textAlign: 'left',
                 }}
-                buttonType="styledLink"
-                csvRef={csvRef}
-                data={selectedLinodesAndConfigData}
-                filename={`linodes-unassigned-${formattedDate}.csv`}
-                headers={SUBNET_LINODE_CSV_HEADERS}
-                onClick={downloadCSV}
                 text={'Download List of Linodes to be Unassigned (.csv)'}
               />
             )}

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
@@ -126,9 +126,12 @@ export const SubnetUnassignLinodesDrawer = React.memo(
         try {
           const updatedConfigInterfaces = await Promise.all(
             selectedLinodes.map(async (linode) => {
-              const response = await queryClient.fetchQuery(
-                linodeQueries.linode(linode.id)._ctx.configs._ctx.configs
-              );
+              let response;
+              if (linode.interface_generation === 'legacy_config') {
+                response = await queryClient.fetchQuery(
+                  linodeQueries.linode(linode.id)._ctx.configs._ctx.configs
+                );
+              }
 
               if (response) {
                 const configWithVpcInterface = response.find((config) =>

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
@@ -25,6 +25,8 @@ import { SUBNET_UNASSIGN_LINODES_WARNING } from 'src/features/VPCs/constants';
 import { useUnassignLinode } from 'src/hooks/useUnassignLinode';
 import { SUBNET_LINODE_CSV_HEADERS } from 'src/utilities/subnets';
 
+import { mapInterfaceDataToDownloadableData } from '../utils';
+
 import type {
   APIError,
   DeleteLinodeConfigInterfacePayload,
@@ -44,7 +46,7 @@ interface Props {
   vpcId: number;
 }
 
-interface ConfigInterfaceAndLinodeData extends Linode {
+export interface InterfaceAndLinodeData extends Linode {
   configId: null | number;
   interfaceData: Interface | LinodeInterface;
   interfaceId: number;
@@ -75,7 +77,7 @@ export const SubnetUnassignLinodesDrawer = React.memo(
       singleLinodeToBeUnassigned ? [singleLinodeToBeUnassigned] : []
     );
     const [selectedLinodesAndConfigData, setSelectedLinodesAndConfigData] =
-      React.useState<ConfigInterfaceAndLinodeData[]>([]);
+      React.useState<InterfaceAndLinodeData[]>([]);
 
     const hasError = React.useRef(false); // This flag is used to prevent the drawer from closing if an error occurs.
 
@@ -116,7 +118,7 @@ export const SubnetUnassignLinodesDrawer = React.memo(
     const getConfigWithVPCInterface = React.useCallback(
       async (selectedLinodes: Linode[]) => {
         try {
-          const updatedConfigInterfaces: (ConfigInterfaceAndLinodeData | null)[] =
+          const updatedConfigInterfaces: (InterfaceAndLinodeData | null)[] =
             await Promise.all(
               // TODO: clean this logic up at some point now that we have config ids
               selectedLinodes.map(async (linode) => {
@@ -180,7 +182,7 @@ export const SubnetUnassignLinodesDrawer = React.memo(
 
           // Filter out any null values and ensure item conforms to type using `is` type guard.
           const _selectedLinodesAndConfigData = updatedConfigInterfaces.filter(
-            (item): item is ConfigInterfaceAndLinodeData => item !== null
+            (item): item is InterfaceAndLinodeData => item !== null
           );
 
           // Remove interface property for the DeleteLinodeConfigInterfacePayload data
@@ -225,9 +227,7 @@ export const SubnetUnassignLinodesDrawer = React.memo(
       csvRef.current.link.click();
     };
 
-    const handleRemoveLinode = (
-      optionToRemove: ConfigInterfaceAndLinodeData
-    ) => {
+    const handleRemoveLinode = (optionToRemove: InterfaceAndLinodeData) => {
       setSelectedLinodes((prevSelectedLinodes) =>
         prevSelectedLinodes.filter((option) => option.id !== optionToRemove.id)
       );
@@ -350,7 +350,7 @@ export const SubnetUnassignLinodesDrawer = React.memo(
                 value={selectedLinodes}
               />
             )}
-            <Box sx={(theme) => ({ marginTop: theme.spacing(2) })}>
+            <Box sx={(theme) => ({ marginTop: theme.spacingFunction(16) })}>
               <RemovableSelectionsListTable
                 headerText={`Linodes to be Unassigned from Subnet (${selectedLinodes.length})`}
                 isRemovable={!singleLinodeToBeUnassigned}
@@ -364,7 +364,9 @@ export const SubnetUnassignLinodesDrawer = React.memo(
               <DownloadCSV
                 buttonType="styledLink"
                 csvRef={csvRef}
-                data={selectedLinodesAndConfigData}
+                data={mapInterfaceDataToDownloadableData(
+                  selectedLinodesAndConfigData
+                )}
                 filename={`linodes-unassigned-${formattedDate}.csv`}
                 headers={SUBNET_LINODE_CSV_HEADERS}
                 onClick={downloadCSV}

--- a/packages/manager/src/features/VPCs/constants.ts
+++ b/packages/manager/src/features/VPCs/constants.ts
@@ -15,7 +15,7 @@ export const REGION_CAVEAT_HELPER_TEXT =
   'A Linode may be assigned only to a VPC in the same region.';
 
 export const ASSIGN_LINODES_DRAWER_REBOOT_MESSAGE =
-  'Assigning a Linode to a subnet requires you to reboot the Linode to update its configuration.';
+  'Assigning a Linode using Configuration Profile Interfaces to a subnet requires you to reboot the Linode to update its configuration.';
 
 export const REGIONAL_LINODE_MESSAGE = `Select the Linodes you would like to assign to this subnet. Only Linodes in this VPC's region are displayed.`;
 
@@ -23,9 +23,9 @@ export const MULTIPLE_CONFIGURATIONS_MESSAGE =
   'This Linode has multiple configurations. Select which configuration you would like added to the subnet.';
 
 export const REBOOT_LINODE_WARNING_VPCDETAILS =
-  'Assigned or unassigned Linodes will not take affect until the Linodes are rebooted.';
+  'Assigned or unassigned Linodes using Configuration Profile Interfaces will not take affect until the Linodes are rebooted.';
 
-export const SUBNET_UNASSIGN_LINODES_WARNING = `Unassigning Linodes from a subnet requires you to reboot the Linodes to update its configuration.`;
+export const SUBNET_UNASSIGN_LINODES_WARNING = `Unassigning Linodes using Configuration Profile Interfaces from a subnet requires you to reboot the Linodes to update its configuration.`;
 
 export const VPC_AUTO_ASSIGN_IPV4_TOOLTIP =
   'Automatically assign an IPv4 address as the private IP address for this Linode in the VPC.';

--- a/packages/manager/src/features/VPCs/utils.ts
+++ b/packages/manager/src/features/VPCs/utils.ts
@@ -1,5 +1,7 @@
 import { getPrimaryInterfaceIndex } from '../Linodes/LinodesDetail/LinodeConfigs/utilities';
 
+import type { LinodeAndConfigData } from './VPCDetail/SubnetAssignLinodesDrawer';
+import type { InterfaceAndLinodeData } from './VPCDetail/SubnetUnassignLinodesDrawer';
 import type { Config, LinodeInterface, Subnet, VPC } from '@linode/api-v4';
 
 export const getUniqueLinodesFromSubnets = (subnets: Subnet[]) => {
@@ -72,3 +74,30 @@ export const hasUnrecommendedConfiguration = (
 export const getIsVPCLKEEnterpriseCluster = (vpc: VPC) =>
   /^workload VPC for LKE Enterprise Cluster lke\d+/i.test(vpc.description) &&
   /^lke\d+/i.test(vpc.label);
+
+export const getLinodeInterfacePrimaryIPv4 = (iface: LinodeInterface) =>
+  iface.vpc?.ipv4.addresses.find((address) => address.primary)?.address;
+
+export const getLinodeInterfaceRanges = (iface: LinodeInterface) =>
+  iface.vpc?.ipv4.ranges.map((range) => range.range);
+
+export const mapInterfaceDataToDownloadableData = (
+  interfacesData: InterfaceAndLinodeData[] | LinodeAndConfigData[]
+) => {
+  return interfacesData.map((data) => {
+    const { interfaceData } = data;
+    const vpcIPv4 =
+      interfaceData && 'vpc' in interfaceData
+        ? getLinodeInterfacePrimaryIPv4(interfaceData)
+        : interfaceData?.ipv4?.vpc;
+    const vpcRanges =
+      interfaceData && 'vpc' in interfaceData
+        ? getLinodeInterfaceRanges(interfaceData)
+        : interfaceData?.ip_ranges;
+    return {
+      ...data,
+      vpcIPv4,
+      vpcRanges,
+    };
+  });
+};

--- a/packages/manager/src/hooks/useUnassignLinode.ts
+++ b/packages/manager/src/hooks/useUnassignLinode.ts
@@ -1,14 +1,17 @@
-import { deleteLinodeConfigInterface } from '@linode/api-v4';
+import {
+  deleteLinodeConfigInterface,
+  deleteLinodeInterface,
+} from '@linode/api-v4';
 import { linodeQueries, vpcQueries } from '@linode/queries';
 import { useQueryClient } from '@tanstack/react-query';
 import * as React from 'react';
 
-import type { APIError } from '@linode/api-v4';
+import type {
+  APIError,
+  DeleteLinodeConfigInterfacePayload,
+} from '@linode/api-v4';
 
-interface IdsForUnassignLinode {
-  configId: null | number;
-  interfaceId: number;
-  linodeId: number;
+interface IdsForUnassignLinode extends DeleteLinodeConfigInterfacePayload {
   vpcId: number;
 }
 
@@ -52,7 +55,7 @@ export const useUnassignLinode = () => {
     if (configId) {
       await deleteLinodeConfigInterface(linodeId, configId, interfaceId);
     } else {
-      // delete Linode Interface
+      await deleteLinodeInterface(linodeId, interfaceId);
     }
     invalidateQueries({ configId, linodeId, vpcId });
   };

--- a/packages/manager/src/hooks/useUnassignLinode.ts
+++ b/packages/manager/src/hooks/useUnassignLinode.ts
@@ -6,10 +6,10 @@ import * as React from 'react';
 import type { APIError } from '@linode/api-v4';
 
 interface IdsForUnassignLinode {
-  vpcId: number;  
-  linodeId: number;
-  configId: number | null;
+  configId: null | number;
   interfaceId: number;
+  linodeId: number;
+  vpcId: number;
 }
 
 type InvalidateSubnetLinodeConfigQueryIds = Omit<
@@ -28,7 +28,9 @@ export const useUnassignLinode = () => {
     vpcId,
     configId,
   }: InvalidateSubnetLinodeConfigQueryIds) => {
-    const interfacesQueryKey = configId ? linodeQueries.linode(linodeId)._ctx.configs.queryKey : linodeQueries.linode(linodeId)._ctx.interfaces.queryKey
+    const interfacesQueryKey = configId
+      ? linodeQueries.linode(linodeId)._ctx.configs.queryKey
+      : linodeQueries.linode(linodeId)._ctx.interfaces.queryKey;
     const queryKeys = [
       vpcQueries.all._def,
       vpcQueries.paginated._def,

--- a/packages/manager/src/utilities/subnets.ts
+++ b/packages/manager/src/utilities/subnets.ts
@@ -8,8 +8,8 @@ export const SUBNET_LINODE_CSV_HEADERS = [
   { key: 'label', label: 'Linode Label' },
   { key: 'id', label: 'Linode ID' },
   { key: 'ipv4', label: 'IPv4' },
-  { key: 'interfaceData.ipv4.vpc', label: 'IPv4 VPC' },
-  { key: 'interfaceData.ip_ranges', label: 'IPv4 VPC Ranges' },
+  { key: 'vpcIPv4', label: 'IPv4 VPC' },
+  { key: 'vpcRanges', label: 'IPv4 VPC Ranges' },
 ];
 
 /**
@@ -112,12 +112,8 @@ export const getRecommendedSubnetIPv4 = (
   lastRecommendedIPv4: string,
   otherIPv4s: string[]
 ): string => {
-  const [
-    firstOctet,
-    secondOctet,
-    thirdOctet,
-    fourthOctet,
-  ] = lastRecommendedIPv4.split('.');
+  const [firstOctet, secondOctet, thirdOctet, fourthOctet] =
+    lastRecommendedIPv4.split('.');
   const parsedThirdOctet = parseInt(thirdOctet, 10);
   let ipv4ToReturn = '';
 


### PR DESCRIPTION
## Description 📝
TODO: 
- figure out assigning pls pls pls
- clean it up pls pls pls pls 

## Changes  🔄

List any change(s) relevant to the reviewer.

- ...
- ...

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- ...
- ...

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
