### PR TITLE
refactor: [M3-9767] - Use simple Select in `RegionTypeFilter`

### DIFF
--- a/packages/manager/.changeset/pr-12018-tech-stories-1744408988818.md
+++ b/packages/manager/.changeset/pr-12018-tech-stories-1744408988818.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Use Simple select component in `RegionTypeFilter` ([#12018](https://github.com/linode/manager/pull/12018))

--- a/packages/manager/src/features/Linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -57,6 +57,7 @@ interface DisplayGroupedLinodesProps
     linodeLabel: string,
     linodeConfigs: Config[]
   ) => void;
+  regionFilter: RegionFilter;
   someLinodesHaveMaintenance: boolean;
   toggleGroupLinodes: () => boolean;
   toggleLinodeView: () => 'grid' | 'list';
@@ -74,6 +75,7 @@ export const DisplayGroupedLinodes = (props: DisplayGroupedLinodesProps) => {
     linodesAreGrouped,
     order,
     orderBy,
+    regionFilter,
     toggleGroupLinodes,
     toggleLinodeView,
     ...rest
@@ -114,7 +116,10 @@ export const DisplayGroupedLinodes = (props: DisplayGroupedLinodesProps) => {
         <Grid className={'px0'} size={12}>
           {isGeckoLAEnabled && (
             <Paper sx={{ padding: 1 }}>
-              <RegionTypeFilter handleRegionFilter={handleRegionFilter} />
+              <RegionTypeFilter
+                handleRegionFilter={handleRegionFilter}
+                regionFilter={regionFilter}
+              />
             </Paper>
           )}
           <StyledControlHeader>
@@ -240,7 +245,10 @@ export const DisplayGroupedLinodes = (props: DisplayGroupedLinodesProps) => {
       <>
         {isGeckoLAEnabled && (
           <Paper sx={{ padding: 1 }}>
-            <RegionTypeFilter handleRegionFilter={handleRegionFilter} />
+            <RegionTypeFilter
+              handleRegionFilter={handleRegionFilter}
+              regionFilter={regionFilter}
+            />
           </Paper>
         )}
         <TableWrapper

--- a/packages/manager/src/features/Linodes/LinodesLanding/DisplayLinodes.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/DisplayLinodes.tsx
@@ -55,6 +55,7 @@ interface DisplayLinodesProps extends OrderByProps<LinodeWithMaintenance> {
     linodeLabel: string,
     linodeConfigs: Config[]
   ) => void;
+  regionFilter: RegionFilter;
   someLinodesHaveMaintenance: boolean;
   toggleGroupLinodes: () => boolean;
   toggleLinodeView: () => 'grid' | 'list';
@@ -73,6 +74,7 @@ export const DisplayLinodes = React.memo((props: DisplayLinodesProps) => {
     linodesAreGrouped,
     order,
     orderBy,
+    regionFilter,
     toggleGroupLinodes,
     toggleLinodeView,
     updatePageUrl,
@@ -152,7 +154,10 @@ export const DisplayLinodes = React.memo((props: DisplayLinodesProps) => {
                     sx={{ borderBottom: 0, padding: 1 }}
                     variant="outlined"
                   >
-                    <RegionTypeFilter handleRegionFilter={handleRegionFilter} />
+                    <RegionTypeFilter
+                      regionFilter={regionFilter}
+                      handleRegionFilter={handleRegionFilter}
+                    />
                   </Paper>
                 )}
                 <TableWrapper
@@ -182,6 +187,7 @@ export const DisplayLinodes = React.memo((props: DisplayLinodesProps) => {
                     >
                       <RegionTypeFilter
                         handleRegionFilter={handleRegionFilter}
+                        regionFilter={regionFilter}
                       />
                     </Paper>
                   )}

--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodesLanding.tsx
@@ -88,6 +88,7 @@ export interface LinodesLandingProps {
   linodesInTransition: Set<number>;
   linodesRequestError?: APIError[];
   linodesRequestLoading: boolean;
+  regionFilter: RegionFilter;
   someLinodesHaveScheduledMaintenance: boolean;
   /** Keep track of total number of linodes for filtering and empty state landing page logic */
   totalNumLinodes: number;
@@ -198,6 +199,7 @@ class ListLinodes extends React.Component<CombinedProps, State> {
       linodesRequestError,
       linodesRequestLoading,
       profile,
+      regionFilter,
       totalNumLinodes,
     } = this.props;
 
@@ -215,8 +217,8 @@ class ListLinodes extends React.Component<CombinedProps, State> {
     const componentProps = {
       openDialog: this.openDialog,
       openPowerActionDialog: this.openPowerDialog,
-      someLinodesHaveMaintenance: this.props
-        .someLinodesHaveScheduledMaintenance,
+      someLinodesHaveMaintenance:
+        this.props.someLinodesHaveScheduledMaintenance,
     };
 
     if (linodesRequestError) {
@@ -413,6 +415,7 @@ class ListLinodes extends React.Component<CombinedProps, State> {
                               handleRegionFilter={handleRegionFilter}
                               linodeViewPreference={linodeViewPreference}
                               linodesAreGrouped={true}
+                              regionFilter={regionFilter}
                               toggleGroupLinodes={toggleGroupLinodes}
                               toggleLinodeView={toggleLinodeView}
                             />
@@ -429,6 +432,7 @@ class ListLinodes extends React.Component<CombinedProps, State> {
                               handleRegionFilter={handleRegionFilter}
                               linodeViewPreference={linodeViewPreference}
                               linodesAreGrouped={false}
+                              regionFilter={regionFilter}
                               toggleGroupLinodes={toggleGroupLinodes}
                               toggleLinodeView={toggleLinodeView}
                               updatePageUrl={this.updatePageUrl}

--- a/packages/manager/src/features/Linodes/LinodesLanding/RegionTypeFilter.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/RegionTypeFilter.tsx
@@ -1,9 +1,8 @@
-import { Autocomplete, Box } from '@linode/ui';
+import { Box, Select } from '@linode/ui';
 import { Typography } from '@linode/ui';
 import * as React from 'react';
 
 import { FormLabel } from 'src/components/FormLabel';
-import { storage } from 'src/utilities/storage';
 
 import type { RegionFilter } from 'src/utilities/storage';
 
@@ -12,7 +11,7 @@ interface RegionFilterOption {
   value: RegionFilter;
 }
 
-const regionFilterOptions: RegionFilterOption[] = [
+export const regionFilterOptions: RegionFilterOption[] = [
   {
     label: 'All',
     value: 'all',
@@ -27,21 +26,17 @@ const regionFilterOptions: RegionFilterOption[] = [
   },
 ];
 
-const regionFilterMap = {
-  all: 'All',
-  core: 'Core',
-  distributed: 'Distributed',
-};
-
 const ariaIdentifier = 'region-type-filter';
 
 interface Props {
   handleRegionFilter: (regionFilter: RegionFilter) => void;
+  regionFilter: RegionFilter;
 }
 
-export const RegionTypeFilter = ({ handleRegionFilter }: Props) => {
-  const regionFilter = storage.regionFilter.get();
-
+export const RegionTypeFilter = ({
+  handleRegionFilter,
+  regionFilter,
+}: Props) => {
   return (
     <Box alignItems="end" display="flex">
       <FormLabel htmlFor={ariaIdentifier}>
@@ -49,28 +44,24 @@ export const RegionTypeFilter = ({ handleRegionFilter }: Props) => {
           Region Type:
         </Typography>
       </FormLabel>
-      <Autocomplete
-        defaultValue={
-          regionFilterOptions.find((filter) => filter.value === regionFilter) ??
-          regionFilterOptions[0]
-        }
+      <Select
+        hideLabel
+        id={ariaIdentifier}
+        label="Region Type"
         onChange={(_, selectedOption) => {
           if (selectedOption?.value) {
             handleRegionFilter(selectedOption.value);
           }
         }}
+        options={regionFilterOptions}
         sx={{
           display: 'inline-block',
           width: 140,
         }}
-        textFieldProps={{
-          hideLabel: true,
-        }}
-        disableClearable
-        id={ariaIdentifier}
-        label="Region Type"
-        options={regionFilterOptions}
-        placeholder={regionFilterMap[regionFilter]}
+        value={
+          regionFilterOptions.find((filter) => filter.value === regionFilter) ??
+          regionFilterOptions[0]
+        }
       />
     </Box>
   );

--- a/packages/manager/src/features/Linodes/index.tsx
+++ b/packages/manager/src/features/Linodes/index.tsx
@@ -14,6 +14,7 @@ import { addMaintenanceToLinodes } from 'src/utilities/linodes';
 import { storage } from 'src/utilities/storage';
 
 import { PENDING_MAINTENANCE_FILTER } from '../Account/Maintenance/utilities';
+import { regionFilterOptions } from './LinodesLanding/RegionTypeFilter';
 import { linodesInTransition } from './transitions';
 
 import type { RegionFilter } from 'src/utilities/storage';
@@ -62,15 +63,13 @@ export const LinodesLandingWrapper = React.memo(() => {
     flags.gecko2?.la
   );
 
-  const [regionFilter, setRegionFilter] = React.useState<
-    RegionFilter | undefined
-  >(storage.regionFilter.get());
+  const [regionFilter, setRegionFilter] = React.useState<RegionFilter>(
+    storage.regionFilter.get() ?? regionFilterOptions[0].value
+  );
 
   // We need to grab all linodes so a filtered result of 0 does not display the empty state landing page
-  const {
-    data: allLinodes,
-    isLoading: allLinodesLoading,
-  } = useAllLinodesQuery();
+  const { data: allLinodes, isLoading: allLinodesLoading } =
+    useAllLinodesQuery();
   const {
     data: filteredLinodes,
     error,
@@ -107,6 +106,7 @@ export const LinodesLandingWrapper = React.memo(() => {
       linodesInTransition={linodesInTransition(events ?? [])}
       linodesRequestError={error ?? undefined}
       linodesRequestLoading={allLinodesLoading}
+      regionFilter={regionFilter}
       totalNumLinodes={allLinodes?.length ?? 0}
     />
   );


### PR DESCRIPTION
## Description 📝

Update `RegionTypeFilter` to use the new basic Select component instead of `Autocomplete`.

## Changes  🔄

- Update `RegionTypeFilter` to use basic Select
- Drill `regionFilter` prop from `LinodesLandingWrapper` > `LinodesLanding` > `DisplayLinodes`
    - Previously the Autocomplete was used in uncontrolled mode and internally stored the current value of the select. The basic Select component does not support being uncontrolled.
    - Advantages: avoids multiple sources of truth for the currently active Region filter
    - Disadvantages: prop drilling
    - Alternatives: adding support for uncontrolled input in the simple Select component; custom React context

I invite feedback/suggestions for the best way to move forward.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/e3161f1d-2bed-44c2-8a58-120e9ae70fc2" /> | <video src="https://github.com/user-attachments/assets/fb7556f0-d4a6-4cc6-aaee-44ff33057af4" /> |

## How to test 🧪

* Navigate to the Linodes landing page
* Select between "All", "Core" and "Distributed" region type filters
* Verify only Linodes in the selected Region type are displayed
* Refresh the page and verify the selection is maintained through local storage

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
