### PR TITLE
fix: [M3-9521] - Warning message in the images landing page for the restricted user

### DIFF
--- a/packages/manager/.changeset/pr-12019-fixed-1744606971621.md
+++ b/packages/manager/.changeset/pr-12019-fixed-1744606971621.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Warning message in the image details page for the restricted user ([#12019](https://github.com/linode/manager/pull/12019))

--- a/packages/manager/.changeset/pr-12019-fixed-1744606971621.md
+++ b/packages/manager/.changeset/pr-12019-fixed-1744606971621.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Warning message in the image details page for the restricted user ([#12019](https://github.com/linode/manager/pull/12019))
+Missing warning message in the Images Landing page for a restricted user ([#12019](https://github.com/linode/manager/pull/12019))

--- a/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.tsx
@@ -77,17 +77,17 @@ import type { ImageAction, ImagesSearchParams } from 'src/routes/images';
 
 const useStyles = makeStyles()((theme: Theme) => ({
   imageTable: {
-    marginBottom: theme.spacingFunction(3),
+    marginBottom: theme.spacingFunction(24),
     padding: 0,
   },
   imageTableHeader: {
     border: `1px solid ${theme.tokens.alias.Border.Normal}`,
     borderBottom: 0,
-    padding: theme.spacingFunction(),
-    paddingLeft: theme.spacingFunction(1.5),
+    padding: theme.spacingFunction(8),
+    paddingLeft: theme.spacingFunction(12),
   },
   imageTableSubheader: {
-    marginTop: theme.spacingFunction(),
+    marginTop: theme.spacingFunction(8),
   },
 }));
 
@@ -115,7 +115,7 @@ export const ImagesLanding = () => {
   const history = useHistory();
   const navigate = useNavigate();
   const { enqueueSnackbar } = useSnackbar();
-  const isImagesReadOnly = useRestrictedGlobalGrantCheck({
+  const isCreateImageRestricted = useRestrictedGlobalGrantCheck({
     globalGrantType: 'add_images',
   });
   const queryClient = useQueryClient();
@@ -123,10 +123,6 @@ export const ImagesLanding = () => {
     React.useState<ImageDialogState>(defaultDialogState);
   const dialogStatus =
     dialogState.status === 'pending_upload' ? 'cancel' : 'delete';
-
-  const isCreateImageRestricted = useRestrictedGlobalGrantCheck({
-    globalGrantType: 'add_images',
-  });
 
   /**
    * At the time of writing: `label`, `tags`, `size`, `status`, `region` are filterable.
@@ -455,7 +451,7 @@ export const ImagesLanding = () => {
             resourceType: 'Images',
           }),
         }}
-        disabledCreateButton={isImagesReadOnly}
+        disabledCreateButton={isCreateImageRestricted}
         docsLink="https://techdocs.akamai.com/cloud-computing/docs/images"
         entity="Image"
         onButtonClick={() =>


### PR DESCRIPTION
## Description 📝  
Add Permission Notice for Restricted User when Navigating to Image Details Page.

## Changes 🔄  
- Add a warning notice for restricted users navigating to the `/images`

## Target release date 🗓️  
N/A

## Preview 📷
| Before | After |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/e4560708-11ca-49eb-9b3c-bbcbd54260f6)| ![After](https://github.com/user-attachments/assets/06feaaac-3e1f-46d7-9bbd-684295c3645a) |

### Verification steps
- [ ] Ensure that when restricted users navigate to `/images` they see a warning message at the top of the page that explains they do not have permission to create a new `Image`.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>