### PR TITLE
fix: [M3-9586] - Warning message in the Longview landing page for the restricted user

### DIFF
--- a/packages/manager/.changeset/pr-12021-fixed-1744625544934.md
+++ b/packages/manager/.changeset/pr-12021-fixed-1744625544934.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Warning message in the longview landing page for the restricted user ([#12021](https://github.com/linode/manager/pull/12021))

--- a/packages/manager/.changeset/pr-12021-fixed-1744625544934.md
+++ b/packages/manager/.changeset/pr-12021-fixed-1744625544934.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Warning message in the longview landing page for the restricted user ([#12021](https://github.com/linode/manager/pull/12021))
+Missing warning message in the Longview landing page for the restricted user ([#12021](https://github.com/linode/manager/pull/12021))

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
@@ -2,6 +2,7 @@ import {
   getActiveLongviewPlan,
   getLongviewSubscriptions,
 } from '@linode/api-v4/lib/longview';
+import { useAccountSettings } from '@linode/queries';
 import { styled } from '@mui/material/styles';
 import { useLocation, useNavigate } from '@tanstack/react-router';
 import { useSnackbar } from 'notistack';
@@ -18,7 +19,6 @@ import { getRestrictedResourceText } from 'src/features/Account/utils';
 import { useAPIRequest } from 'src/hooks/useAPIRequest';
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 import { useTabs } from 'src/hooks/useTabs';
-import { useAccountSettings } from '@linode/queries';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 import { SubscriptionDialog } from './SubscriptionDialog';
@@ -29,6 +29,7 @@ import type {
 } from '@linode/api-v4/lib/longview/types';
 import type { Props as LongviewProps } from 'src/containers/longview.container';
 import type { LongviewState } from 'src/routes/longview';
+import { Notice } from '@linode/ui';
 
 const LongviewClients = React.lazy(() => import('./LongviewClients'));
 const LongviewPlans = React.lazy(() => import('./LongviewPlans'));
@@ -53,13 +54,10 @@ export const LongviewLanding = (props: LongviewProps) => {
 
   const isManaged = Boolean(accountSettings?.managed);
 
-  const [newClientLoading, setNewClientLoading] = React.useState<boolean>(
-    false
-  );
-  const [
-    subscriptionDialogOpen,
-    setSubscriptionDialogOpen,
-  ] = React.useState<boolean>(false);
+  const [newClientLoading, setNewClientLoading] =
+    React.useState<boolean>(false);
+  const [subscriptionDialogOpen, setSubscriptionDialogOpen] =
+    React.useState<boolean>(false);
 
   const { handleTabChange, tabIndex, tabs } = useTabs([
     {
@@ -120,6 +118,18 @@ export const LongviewLanding = (props: LongviewProps) => {
 
   return (
     <>
+      {isLongviewCreationRestricted && (
+        <Notice
+          important
+          sx={{ marginBottom: 2 }}
+          text={getRestrictedResourceText({
+            action: 'create',
+            isSingular: false,
+            resourceType: 'Images',
+          })}
+          variant="error"
+        />
+      )}
       <LandingHeader
         buttonDataAttrs={{
           tooltipText: getRestrictedResourceText({

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
@@ -3,6 +3,7 @@ import {
   getLongviewSubscriptions,
 } from '@linode/api-v4/lib/longview';
 import { useAccountSettings } from '@linode/queries';
+import { Notice } from '@linode/ui';
 import { styled } from '@mui/material/styles';
 import { useLocation, useNavigate } from '@tanstack/react-router';
 import { useSnackbar } from 'notistack';
@@ -29,7 +30,6 @@ import type {
 } from '@linode/api-v4/lib/longview/types';
 import type { Props as LongviewProps } from 'src/containers/longview.container';
 import type { LongviewState } from 'src/routes/longview';
-import { Notice } from '@linode/ui';
 
 const LongviewClients = React.lazy(() => import('./LongviewClients'));
 const LongviewPlans = React.lazy(() => import('./LongviewPlans'));
@@ -125,7 +125,7 @@ export const LongviewLanding = (props: LongviewProps) => {
           text={getRestrictedResourceText({
             action: 'create',
             isSingular: false,
-            resourceType: 'Images',
+            resourceType: 'Longview Clients',
           })}
           variant="error"
         />


### PR DESCRIPTION
## Description 📝  
Add Permission Notice for Restricted User when Navigating to Longview Landing Page.

## Changes 🔄  
- Add a warning notice for restricted users navigating to the `/longview/clients`

## Target release date 🗓️  
N/A

## Preview 📷
| Before | After |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/8d4eb04d-e7f5-43ae-a595-7e5f65bf62b8)| ![After](https://github.com/user-attachments/assets/b25c52d0-ff91-4916-85b6-99349e9d6bec) |

### Verification steps
- [ ] Ensure that when restricted users navigate to `/longview/clients` they see a warning message at the top of the page that explains they do not have permission to create a new `Longview Client`.
- [ ] Verify that for the user with `read only` access should not delete the Longview Client.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>