### PR TITLE
change: [UIE-8685] - Advanced Config: custom validation for wal_sender_timeout

### DIFF
--- a/packages/api-v4/.changeset/pr-12022-added-1744640457876.md
+++ b/packages/api-v4/.changeset/pr-12022-added-1744640457876.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Added
----
-
-DBaaS: `anyOf` field to the `ConfigurationItem`  ([#12022](https://github.com/linode/manager/pull/12022))

--- a/packages/api-v4/.changeset/pr-12022-added-1744640457876.md
+++ b/packages/api-v4/.changeset/pr-12022-added-1744640457876.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Added
+---
+
+DBaaS: `anyOf` field to the `ConfigurationItem`  ([#12022](https://github.com/linode/manager/pull/12022))

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -51,12 +51,7 @@ export interface DatabaseBackup {
   type: DatabaseBackupType;
 }
 
-type Range = {
-  maximum: number;
-  minimum: number;
-};
 export interface ConfigurationItem {
-  anyOf?: Range[];
   description?: string;
   enum?: string[];
   example?: boolean | number | string;

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -50,7 +50,13 @@ export interface DatabaseBackup {
   label: string;
   type: DatabaseBackupType;
 }
+
+type Range = {
+  maximum: number;
+  minimum: number;
+};
 export interface ConfigurationItem {
+  anyOf?: Range[];
   description?: string;
   enum?: string[];
   example?: boolean | number | string;

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -126,8 +126,8 @@ export const databaseTypeFactory = Factory.Sync.makeFactory<DatabaseType>({
 
 const adb10 = (i: number) => i % 2 === 0;
 
-export const databaseInstanceFactory = Factory.Sync.makeFactory<DatabaseInstance>(
-  {
+export const databaseInstanceFactory =
+  Factory.Sync.makeFactory<DatabaseInstance>({
     allow_list: [],
     cluster_size: Factory.each((i) =>
       adb10(i)
@@ -187,8 +187,7 @@ export const databaseInstanceFactory = Factory.Sync.makeFactory<DatabaseInstance
       week_of_month: null,
     },
     version: Factory.each((i) => ['8.0.30', '15.7'][i % 2]),
-  }
-);
+  });
 
 export const databaseFactory = Factory.Sync.makeFactory<Database>({
   allow_list: [...IPv4List],
@@ -273,8 +272,8 @@ export const databaseEngineFactory = Factory.Sync.makeFactory<DatabaseEngine>({
   version: Factory.each((i) => `${i}`),
 });
 
-export const databaseEngineConfigFactory = Factory.Sync.makeFactory<DatabaseEngineConfig>(
-  {
+export const databaseEngineConfigFactory =
+  Factory.Sync.makeFactory<DatabaseEngineConfig>({
     binlog_retention_period: {
       description:
         'The minimum amount of time in seconds to keep binlog entries before deletion. This may be extended for services that require binlog entries for longer than the default for example if using the MySQL Debezium Kafka connector.',
@@ -283,6 +282,16 @@ export const databaseEngineConfigFactory = Factory.Sync.makeFactory<DatabaseEngi
       minimum: 600,
       requires_restart: false,
       type: 'integer',
+    },
+    wal_sender_timeout: {
+      description:
+        'Terminate replication connections that are inactive for longer than this amount of time, in milliseconds. Setting this value to zero disables the timeout.',
+      type: 'integer',
+      example: 60000,
+      anyOf: [
+        { minimum: 0, maximum: 0 },
+        { minimum: 5000, maximum: 10800000 },
+      ],
     },
     mysql: {
       connect_timeout: {
@@ -370,5 +379,4 @@ export const databaseEngineConfigFactory = Factory.Sync.makeFactory<DatabaseEngi
       requires_restart: false,
       type: ['boolean', 'null'],
     },
-  }
-);
+  });

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -288,10 +288,6 @@ export const databaseEngineConfigFactory =
         'Terminate replication connections that are inactive for longer than this amount of time, in milliseconds. Setting this value to zero disables the timeout.',
       type: 'integer',
       example: 60000,
-      anyOf: [
-        { minimum: 0, maximum: 0 },
-        { minimum: 5000, maximum: 10800000 },
-      ],
     },
     mysql: {
       connect_timeout: {

--- a/packages/validation/.changeset/pr-12022-added-1744640788599.md
+++ b/packages/validation/.changeset/pr-12022-added-1744640788599.md
@@ -2,4 +2,4 @@
 "@linode/validation": Added
 ---
 
-validation for config items with an `anyOf` field that defines a range ([#12022](https://github.com/linode/manager/pull/12022))
+custom validation for `wal_sender_timeout` ([#12022](https://github.com/linode/manager/pull/12022))

--- a/packages/validation/.changeset/pr-12022-added-1744640788599.md
+++ b/packages/validation/.changeset/pr-12022-added-1744640788599.md
@@ -2,4 +2,4 @@
 "@linode/validation": Added
 ---
 
-custom validation for `wal_sender_timeout` ([#12022](https://github.com/linode/manager/pull/12022))
+custom validation for `wal_sender_timeout` and `max_failover_replication_time_lag` ([#12022](https://github.com/linode/manager/pull/12022))

--- a/packages/validation/.changeset/pr-12022-added-1744640788599.md
+++ b/packages/validation/.changeset/pr-12022-added-1744640788599.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Added
+---
+
+validation for config items with an `anyOf` field that defines a range ([#12022](https://github.com/linode/manager/pull/12022))

--- a/packages/validation/src/databases.schema.ts
+++ b/packages/validation/src/databases.schema.ts
@@ -103,29 +103,15 @@ const applyConstraints = (validator: any, key: string, field: any) => {
       `Please ensure that ${key} follows the format ${field.example}`,
     );
   }
-
-  if (field.anyOf) {
-    const allowedRanges = field.anyOf;
-
+  // custom validation for wal_sender_timeout since it has a special case
+  // where it can be 0 or between 5000 and 10800000
+  if (key === 'wal_sender_timeout') {
     validator = validator.test(
-      'is-in-range',
-      () => {
-        const rangesText = allowedRanges
-          .map((range: { maximum: number; minimum: number }) =>
-            range.minimum === range.maximum
-              ? `${range.minimum}`
-              : `between ${range.minimum} and ${range.maximum}`,
-          )
-          .join(' or ');
-
-        return `Value must be ${rangesText}`;
-      },
+      'is-zero-or-in-range',
+      `${key} must be 0 or between 5000 and 10800000`,
       (value: boolean | number | string) => {
         if (typeof value !== 'number') return false;
-        return allowedRanges.some(
-          (range: { maximum: number; minimum: number }) =>
-            value >= range.minimum && value <= range.maximum,
-        );
+        return value === 0 || (value >= 5000 && value <= 10800000);
       },
     );
   }

--- a/packages/validation/src/databases.schema.ts
+++ b/packages/validation/src/databases.schema.ts
@@ -103,6 +103,32 @@ const applyConstraints = (validator: any, key: string, field: any) => {
       `Please ensure that ${key} follows the format ${field.example}`,
     );
   }
+
+  if (field.anyOf) {
+    const allowedRanges = field.anyOf;
+
+    validator = validator.test(
+      'is-in-range',
+      () => {
+        const rangesText = allowedRanges
+          .map((range: { maximum: number; minimum: number }) =>
+            range.minimum === range.maximum
+              ? `${range.minimum}`
+              : `between ${range.minimum} and ${range.maximum}`,
+          )
+          .join(' or ');
+
+        return `Value must be ${rangesText}`;
+      },
+      (value: boolean | number | string) => {
+        if (typeof value !== 'number') return false;
+        return allowedRanges.some(
+          (range: { maximum: number; minimum: number }) =>
+            value >= range.minimum && value <= range.maximum,
+        );
+      },
+    );
+  }
   if (key === 'timezone') {
     if (!field.value) {
       validator = validator.required('timezone cannot be empty');

--- a/packages/validation/src/databases.schema.ts
+++ b/packages/validation/src/databases.schema.ts
@@ -120,6 +120,11 @@ const applyConstraints = (validator: any, key: string, field: any) => {
       validator = validator.required('timezone cannot be empty');
     }
   }
+  // temporary custom validation for max_failover_replication_time_lag
+  // TODO: remove this when the API is updated
+  if (key === 'max_failover_replication_time_lag') {
+    validator = validator.max(999999, `${key} must be at most 999999`);
+  }
 
   return validator;
 };


### PR DESCRIPTION
## Description 📝

Add custom validation for `wal_sender_timeout` and `max_failover_replication_time_lag` configs.

## Changes  🔄

- added validation for wal_sender_timeout
- added validation for max_failover_replication_time_lag

## Target release date 🗓️

04/22/25

## How to test 🧪

### Prerequisites

Database Advanced Config feature flag should be enabled. 
Use mock data to test.

### Verification steps

(How to verify changes)

- select a database cluster
- navigate to the Advanced Configuration tab
- click the "Configure" button
- select a new `wal_sender_timeout` configuration from the Autocomplete and click "Add"
- modify the value of the newly added configuration (e.g., -1 or 5) to verify that the error is shown

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>