### PR TITLE
test: [M3-9555] - Fix plan selection Cypress test against other environments

### DIFF
--- a/packages/manager/.changeset/pr-12023-tests-1744653408368.md
+++ b/packages/manager/.changeset/pr-12023-tests-1744653408368.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Allow plan selection tests to pass in non-Production environments ([#12023](https://github.com/linode/manager/pull/12023))

--- a/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
@@ -149,7 +149,9 @@ describe('displays linode plans panel based on availability', () => {
     cy.wait(['@getRegions', '@getLinodeTypes']);
 
     ui.regionSelect.find().click();
-    ui.regionSelect.findItemByRegionLabel(mockRegions[0].label).click();
+    ui.regionSelect
+      .findItemByRegionLabel(mockRegions[0].label, mockRegions)
+      .click();
 
     cy.wait(['@getRegionAvailability']);
 
@@ -245,7 +247,9 @@ describe('displays kubernetes plans panel based on availability', () => {
     cy.wait(['@getRegions', '@getLinodeTypes']);
 
     ui.regionSelect.find().click();
-    ui.regionSelect.findItemByRegionLabel(mockRegions[0].label).click();
+    ui.regionSelect
+      .findItemByRegionLabel(mockRegions[0].label, mockRegions)
+      .click();
 
     cy.wait(['@getRegionAvailability']);
 
@@ -381,7 +385,9 @@ describe('displays specific linode plans for GPU', () => {
     cy.visitWithLogin('/linodes/create');
     cy.wait(['@getRegions', '@getLinodeTypes', '@getFeatureFlags']);
     ui.regionSelect.find().click();
-    ui.regionSelect.findItemByRegionLabel(mockRegions[0].label).click();
+    ui.regionSelect
+      .findItemByRegionLabel(mockRegions[0].label, mockRegions)
+      .click();
 
     // GPU tab
     // Should display two separate tables
@@ -429,7 +435,9 @@ describe('displays specific kubernetes plans for GPU', () => {
     cy.visitWithLogin('/kubernetes/create');
     cy.wait(['@getRegions', '@getLinodeTypes', '@getFeatureFlags']);
     ui.regionSelect.find().click();
-    ui.regionSelect.findItemByRegionLabel(mockRegions[0].label).click();
+    ui.regionSelect
+      .findItemByRegionLabel(mockRegions[0].label, mockRegions)
+      .click();
 
     // GPU tab
     // Should display two separate tables
@@ -535,7 +543,9 @@ describe('Linode Accelerated plans', () => {
         ]);
 
         ui.regionSelect.find().click();
-        ui.regionSelect.findItemByRegionLabel(mockRegions[0].label).click();
+        ui.regionSelect
+          .findItemByRegionLabel(mockRegions[0].label, mockRegions)
+          .click();
 
         cy.findByText('Accelerated').click();
         cy.get(linodePlansPanel).within(() => {
@@ -588,7 +598,9 @@ describe('Linode Accelerated plans', () => {
         ]);
 
         ui.regionSelect.find().click();
-        ui.regionSelect.findItemByRegionLabel(mockRegions[0].label).click();
+        ui.regionSelect
+          .findItemByRegionLabel(mockRegions[0].label, mockRegions)
+          .click();
 
         cy.wait(['@getRegionAvailability']);
 


### PR DESCRIPTION
## Description 📝

This fixes a handful of tests in `plan-selection.spec.ts` when running against non-Production environments. All of the fixes involve passing an array of mock region objects to our `findItemByRegionLabel` helper which otherwise expects the specified regions to exist.

## Changes  🔄

- Allow tests in `plan-selection.spec.ts` to pass against environments where the mock region does not actually exist

## Target release date 🗓️

N/A. No urgency.

## How to test 🧪

- Confirm tests pass in CI
- Confirm tests pass against other environments
  - Refer to the comment on M3-9555 which includes a CI link demonstrating that the tests pass

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
