### PR TITLE
test: [M3-9578] - Use mock regions for Linode Migrate integration tests

### DIFF
--- a/packages/manager/.changeset/pr-12029-tests-1744725232756.md
+++ b/packages/manager/.changeset/pr-12029-tests-1744725232756.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Allow Linode migration tests to pass in non-Prod environments ([#12029](https://github.com/linode/manager/pull/12029))

--- a/packages/manager/cypress/e2e/core/linodes/migrate-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/migrate-linode.spec.ts
@@ -1,4 +1,4 @@
-import { linodeFactory } from '@linode/utilities';
+import { linodeFactory, regionFactory } from '@linode/utilities';
 import { linodeDiskFactory } from '@src/factories';
 import { authenticate } from 'support/api/authentication';
 import {
@@ -13,25 +13,67 @@ import {
   mockGetLinodeVolumes,
   mockMigrateLinode,
 } from 'support/intercepts/linodes';
+import { mockGetRegion, mockGetRegions } from 'support/intercepts/regions';
 import { ui } from 'support/ui';
 import { apiMatcher } from 'support/util/intercepts';
-import { getRegionById } from 'support/util/regions';
+import { extendRegion } from 'support/util/regions';
+
+const mockRegionStart = extendRegion(
+  regionFactory.build({
+    id: 'us-west',
+    capabilities: ['Linodes'],
+  })
+);
+
+const mockRegionStartSimilarPricing = extendRegion(
+  regionFactory.build({
+    id: 'us-central',
+    capabilities: ['Linodes'],
+  })
+);
+
+const mockRegionEnd = extendRegion(
+  regionFactory.build({
+    id: 'us-east',
+    capabilities: ['Linodes'],
+  })
+);
+
+const mockRegionEndSimilarPricing = extendRegion(
+  regionFactory.build({
+    id: 'eu-central',
+    capabilities: ['Linodes'],
+  })
+);
+
+const mockRegions = [
+  mockRegionStart,
+  mockRegionStartSimilarPricing,
+  mockRegionEnd,
+  mockRegionEndSimilarPricing,
+];
 
 authenticate();
 describe('Migrate linodes', () => {
+  beforeEach(() => {
+    mockGetRegions(mockRegions);
+    mockGetRegion(mockRegionStart);
+    mockGetRegion(mockRegionStartSimilarPricing);
+    mockGetRegion(mockRegionEnd);
+    mockGetRegion(mockRegionEndSimilarPricing);
+  });
+
   /*
    * - Confirms that flow works as expected during Linode migration between two regions without pricing changes.
    */
   it('can migrate linodes', () => {
-    const initialRegion = getRegionById('us-west');
-    const newRegion = getRegionById('us-east');
-
     const mockLinode = linodeFactory.build({
-      region: initialRegion.id,
+      region: mockRegionStart.id,
     });
 
     const mockLinodeDisks = linodeDiskFactory.buildList(3);
 
+    mockGetRegions(mockRegions);
     mockGetLinodeDetails(mockLinode.id, mockLinode).as('getLinode');
 
     // Mock request to get Linode volumes and disks
@@ -42,12 +84,16 @@ describe('Migrate linodes', () => {
     cy.wait(['@getLinode', '@getLinodeDisks', '@getLinodeVolumes']);
 
     ui.button.findByTitle('Enter Migration Queue').should('be.disabled');
-    cy.findByText(`${initialRegion.label}`).should('be.visible');
+    cy.findByText(`${mockRegionStart.label}`).should('be.visible');
     cy.get('[data-qa-checked="false"]').click();
-    cy.findByText(`North America: ${initialRegion.label}`).should('be.visible');
+    cy.findByText(`North America: ${mockRegionStart.label}`).should(
+      'be.visible'
+    );
 
     ui.regionSelect.find().click();
-    ui.regionSelect.findItemByRegionLabel(newRegion.label).click();
+    ui.regionSelect
+      .findItemByRegionLabel(mockRegionEnd.label, mockRegions)
+      .click();
 
     // intercept migration request and stub it, respond with 200
     cy.intercept(
@@ -72,11 +118,8 @@ describe('Migrate linodes', () => {
    * - Confirms that pricing comparison is shown in "Region" section when migration occurs in DCs with different price structures.
    */
   it('shows DC-specific pricing information when migrating linodes between differently priced DCs', () => {
-    const initialRegion = getRegionById('us-west');
-    const newRegion = getRegionById('us-east');
-
     const mockLinode = linodeFactory.build({
-      region: initialRegion.id,
+      region: mockRegionStart.id,
       type: dcPricingMockLinodeTypes[0].id,
     });
 
@@ -96,20 +139,25 @@ describe('Migrate linodes', () => {
     cy.wait(['@getLinode', '@getLinodeDisks', '@getLinodeVolumes']);
 
     ui.button.findByTitle('Enter Migration Queue').should('be.disabled');
-    cy.findByText(`${initialRegion.label}`).should('be.visible');
+    cy.findByText(`${mockRegionStart.label}`).should('be.visible');
     cy.get('[data-qa-checked="false"]').click();
-    cy.findByText(`North America: ${initialRegion.label}`).should('be.visible');
+    cy.findByText(`North America: ${mockRegionStart.label}`).should(
+      'be.visible'
+    );
 
     ui.regionSelect.find().click();
-    ui.regionSelect.findItemByRegionLabel(newRegion.label).click();
+    ui.regionSelect
+      .findItemByRegionLabel(mockRegionEnd.label, mockRegions)
+      .click();
 
     cy.findByText(dcPricingCurrentPriceLabel).should('be.visible');
     const currentPrice = dcPricingMockLinodeTypes[0].region_prices.find(
-      (regionPrice) => regionPrice.id === initialRegion.id
+      (regionPrice) => regionPrice.id === mockRegionStart.id
     )!;
-    const currentBackupPrice = dcPricingMockLinodeTypes[0].addons.backups.region_prices.find(
-      (regionPrice) => regionPrice.id === initialRegion.id
-    )!;
+    const currentBackupPrice =
+      dcPricingMockLinodeTypes[0].addons.backups.region_prices.find(
+        (regionPrice) => regionPrice.id === mockRegionStart.id
+      )!;
     cy.get('[data-testid="current-price-panel"]').within(() => {
       cy.findByText(`$${currentPrice.monthly!.toFixed(2)}`).should(
         'be.visible'
@@ -120,11 +168,12 @@ describe('Migrate linodes', () => {
 
     cy.findByText(dcPricingNewPriceLabel).should('be.visible');
     const newPrice = dcPricingMockLinodeTypes[1].region_prices.find(
-      (linodeType) => linodeType.id === newRegion.id
+      (linodeType) => linodeType.id === mockRegionEnd.id
     )!;
-    const newBackupPrice = dcPricingMockLinodeTypes[1].addons.backups.region_prices.find(
-      (regionPrice) => regionPrice.id === newRegion.id
-    )!;
+    const newBackupPrice =
+      dcPricingMockLinodeTypes[1].addons.backups.region_prices.find(
+        (regionPrice) => regionPrice.id === mockRegionEnd.id
+      )!;
     cy.get('[data-testid="new-price-panel"]').within(() => {
       cy.findByText(`$${newPrice.monthly!.toFixed(2)}`).should('be.visible');
       cy.findByText(`$${newPrice.hourly}`).should('be.visible');
@@ -147,11 +196,8 @@ describe('Migrate linodes', () => {
    * - Confirms that pricing comparison is not shown in "Region" section if migration occurs in a DC with the same price structure.
    */
   it('shows DC-specific pricing information when migrating linodes to similarly priced DCs', () => {
-    const initialRegion = getRegionById('eu-central');
-    const newRegion = getRegionById('us-central');
-
     const mockLinode = linodeFactory.build({
-      region: initialRegion.id,
+      region: mockRegionStartSimilarPricing.id,
       type: dcPricingMockLinodeTypes[0].id,
     });
 
@@ -171,15 +217,20 @@ describe('Migrate linodes', () => {
     cy.wait(['@getLinode', '@getLinodeDisks', '@getLinodeVolumes']);
 
     ui.button.findByTitle('Enter Migration Queue').should('be.disabled');
-    cy.findByText(`${initialRegion.label}`).should('be.visible');
+    cy.findByText(`${mockRegionStartSimilarPricing.label}`).should(
+      'be.visible'
+    );
     cy.get('[data-qa-checked="false"]').click();
 
     // Confirm that user cannot select the Linode's current DC when migrating.
     // TODO Consider refactoring this flow into its own test.
-    ui.autocomplete.findByLabel('New Region').click().type(initialRegion.id);
+    ui.autocomplete
+      .findByLabel('New Region')
+      .click()
+      .type(mockRegionStartSimilarPricing.id);
 
     ui.autocompletePopper.find().within(() => {
-      cy.contains(initialRegion.id).should('not.exist');
+      cy.contains(mockRegionStartSimilarPricing.id).should('not.exist');
       cy.findByText('No results').should('be.visible');
     });
 
@@ -189,7 +240,11 @@ describe('Migrate linodes', () => {
     cy.findByText(dcPricingNewPriceLabel).should('not.exist');
     cy.get('[data-testid="new-price-panel"]').should('not.exist');
     // Change region selection to another region with the same price structure.
-    ui.regionSelect.find().click().clear().type(`${newRegion.label}{enter}`);
+    ui.regionSelect
+      .find()
+      .click()
+      .clear()
+      .type(`${mockRegionEndSimilarPricing.label}{enter}`);
     // Confirm that DC pricing information still does not show up.
     cy.findByText(dcPricingCurrentPriceLabel).should('not.exist');
     cy.get('[data-testid="current-price-panel"]').should('not.exist');

--- a/packages/manager/cypress/e2e/core/linodes/migrate-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/migrate-linode.spec.ts
@@ -106,6 +106,7 @@ describe('Migrate linodes', () => {
 
     ui.button
       .findByTitle('Enter Migration Queue')
+      .scrollIntoView()
       .should('be.visible')
       .should('be.enabled')
       .click();
@@ -185,9 +186,11 @@ describe('Migrate linodes', () => {
 
     ui.button
       .findByTitle('Enter Migration Queue')
+      .scrollIntoView()
       .should('be.visible')
       .should('be.enabled')
       .click();
+
     cy.wait('@migrateReq').its('response.statusCode').should('eq', 200);
   });
 
@@ -253,6 +256,7 @@ describe('Migrate linodes', () => {
     // Confirm that migration queue button is enabled.
     ui.button
       .findByTitle('Enter Migration Queue')
+      .scrollIntoView()
       .should('be.visible')
       .should('be.enabled');
   });

--- a/packages/manager/cypress/support/intercepts/regions.ts
+++ b/packages/manager/cypress/support/intercepts/regions.ts
@@ -12,6 +12,7 @@ import {
 } from 'support/util/regions';
 
 import type { ExtendedRegion } from 'support/util/regions';
+import { makeResponse } from 'support/util/response';
 
 /**
  * Intercepts GET request to fetch Linode regions and mocks response.
@@ -40,6 +41,31 @@ export const mockGetRegions = (
     'GET',
     apiMatcher('regions*'),
     paginateResponse(mockResponseRegions)
+  );
+};
+
+/**
+ * Intercepts GET request to fetch a region and mocks response.
+ *
+ * The mock region can contain an actual API region object, or a Cypress-specific
+ * `ExtendedRegion` instance. If an `ExtendedRegion` is passed, it will be mocked
+ * as a regular `Region`.
+ *
+ * @param region - Region for which to intercept request and mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetRegion = (
+  region: Region | ExtendedRegion
+): Cypress.Chainable<null> => {
+  const mockRegion = isExtendedRegion(region)
+    ? getRegionFromExtendedRegion(region)
+    : region;
+
+  return cy.intercept(
+    'GET',
+    apiMatcher(`regions/${mockRegion.id}`),
+    makeResponse(mockRegion)
   );
 };
 

--- a/packages/manager/cypress/support/intercepts/regions.ts
+++ b/packages/manager/cypress/support/intercepts/regions.ts
@@ -10,9 +10,9 @@ import {
   isExtendedRegion,
   getRegionFromExtendedRegion,
 } from 'support/util/regions';
+import { makeResponse } from 'support/util/response';
 
 import type { ExtendedRegion } from 'support/util/regions';
-import { makeResponse } from 'support/util/response';
 
 /**
  * Intercepts GET request to fetch Linode regions and mocks response.
@@ -26,7 +26,7 @@ import { makeResponse } from 'support/util/response';
  * @returns Cypress chainable.
  */
 export const mockGetRegions = (
-  regions: Region[] | ExtendedRegion[]
+  regions: ExtendedRegion[] | Region[]
 ): Cypress.Chainable<null> => {
   const mockResponseRegions = regions.map(
     (region: Region | ExtendedRegion): Region => {
@@ -56,7 +56,7 @@ export const mockGetRegions = (
  * @returns Cypress chainable.
  */
 export const mockGetRegion = (
-  region: Region | ExtendedRegion
+  region: ExtendedRegion | Region
 ): Cypress.Chainable<null> => {
   const mockRegion = isExtendedRegion(region)
     ? getRegionFromExtendedRegion(region)


### PR DESCRIPTION
## Description 📝

This allows the three tests in `migrate-linode.spec.ts` to pass against environments where `us-east`, `us-west`, `us-central`, and `eu-central` do not exist by mocking the regions instead.

## Changes  🔄

- Mock regions in `migrate-linode.spec.ts` to allow tests to pass in environments where Prod regions do not exist
- Add `mockGetRegion` intercept util

## Target release date 🗓️

N/A. No urgency.

## How to test 🧪

- Confirm test passes against Prod environments (we can rely on CI for this)
- Confirm test passes against other environments (refer to comment in Jira ticket)

To run the spec locally, you can run the following command:

```bash
pnpm cy:run -s "cypress/e2e/core/linodes/migrate-linode.spec.ts
```

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
