### PR TITLE
fix: [UIE-8447] - autofill fix and clear errors on blur

### DIFF
--- a/packages/manager/.changeset/pr-12032-fixed-1744732437757.md
+++ b/packages/manager/.changeset/pr-12032-fixed-1744732437757.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-autofill fix and clear API errors on blur for config item input ([#12032](https://github.com/linode/manager/pull/12032))
+incorrect restart-related label on Save button, autofill not applying values, and API errors not clearing on config field blur ([#12032](https://github.com/linode/manager/pull/12032))

--- a/packages/manager/.changeset/pr-12032-fixed-1744732437757.md
+++ b/packages/manager/.changeset/pr-12032-fixed-1744732437757.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+autofill fix and clear API errors on blur for config item input ([#12032](https://github.com/linode/manager/pull/12032))

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfigurationDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfigurationDrawer.tsx
@@ -238,7 +238,10 @@ export const DatabaseAdvancedConfigurationDrawer = (props: Props) => {
                     fieldState.error?.message ||
                     getConfigAPIError(config, updateDatabaseError)
                   }
-                  onBlur={field.onBlur}
+                  onBlur={() => {
+                    setUpdateDatabaseError(null);
+                    field.onBlur();
+                  }}
                   onChange={field.onChange}
                   onRemove={() => handleRemoveConfig(index)}
                 />

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfigurationDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfigurationDrawer.tsx
@@ -140,7 +140,6 @@ export const DatabaseAdvancedConfigurationDrawer = (props: Props) => {
 
   const handleRemoveConfig = (index: number) => {
     remove(index);
-    reset(watch(), { keepDirty: true });
   };
 
   const handleClose = () => {

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseConfigurationItem.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseConfigurationItem.tsx
@@ -57,6 +57,7 @@ export const DatabaseConfigurationItem = (props: Props) => {
       );
       return (
         <Autocomplete
+          autoHighlight
           disableClearable
           isOptionEqualToValue={(option, value) => option.label === value.label}
           label={''}

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/utilities.ts
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/utilities.ts
@@ -242,9 +242,10 @@ export const hasRestartCluster = (
   dirtyFields: any,
   configs: ConfigurationOption[]
 ): string => {
-  return Object.keys(dirtyFields.configs || {}).some(
-    (key) => configs[Number(key)]?.requires_restart
-  )
+  return configs.some((config, index) => {
+    const isDirtyValue = dirtyFields.configs?.[index]?.value;
+    return isDirtyValue && config.requires_restart;
+  })
     ? 'Save and Restart Service'
     : 'Save';
 };


### PR DESCRIPTION
## Description 📝

Autofill fix and clear API errors on blur for config item input.

## Changes  🔄

List any change(s) relevant to the reviewer.

- autofill fix
- clear API errors on blur for config item input
- correct Save button label when modifying configs with `requires_restart`

## Target release date 🗓️

04/22/25


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
