### PR TITLE
fix: [M3-9770] - Fix incorrect max autoscaler limit validation for LKE-E

### DIFF
--- a/packages/manager/.changeset/pr-12033-upcoming-features-1744745488820.md
+++ b/packages/manager/.changeset/pr-12033-upcoming-features-1744745488820.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Fix incorrect max autoscaler limit validation for LKE-E ([#12033](https://github.com/linode/manager/pull/12033))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -516,19 +516,19 @@ describe('LKE cluster updates', () => {
 
     /*
      * - Confirms UI flow when enabling and disabling node pool autoscaling using mocked API responses.
-     * - Confirms that errors are shown when attempting to autoscale using invalid values.
+     * - Confirms that errors are shown when attempting to autoscale using invalid values based on the cluster tier.
      * - Confirms that UI updates to reflect node pool autoscale state.
      */
-    it('can toggle autoscaling', () => {
+    it('can toggle autoscaling on a standard tier cluster', () => {
       const autoscaleMin = 3;
       const autoscaleMax = 10;
-
       const minWarning =
         'Minimum must be between 1 and 99 nodes and cannot be greater than Maximum.';
       const maxWarning = 'Maximum must be between 1 and 100 nodes.';
 
       const mockCluster = kubernetesClusterFactory.build({
         k8s_version: latestKubernetesVersion,
+        tier: 'standard',
       });
 
       const mockNodePool = nodePoolFactory.build({
@@ -551,9 +551,18 @@ describe('LKE cluster updates', () => {
       mockGetKubernetesVersions().as('getVersions');
       mockGetDashboardUrl(mockCluster.id);
       mockGetApiEndpoints(mockCluster.id);
+      mockGetAccount(
+        accountFactory.build({
+          capabilities: ['Kubernetes Enterprise'],
+        })
+      ).as('getAccount');
+      // TODO LKE-E: Remove once feature is in GA
+      mockAppendFeatureFlags({
+        lkeEnterprise: { enabled: true, la: true },
+      });
 
       cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
-      cy.wait(['@getCluster', '@getNodePools', '@getVersions']);
+      cy.wait(['@getAccount', '@getCluster', '@getNodePools', '@getVersions']);
 
       // Click "Autoscale Pool", enable autoscaling, and set min and max values.
       mockUpdateNodePool(mockCluster.id, mockNodePoolAutoscale).as(
@@ -635,6 +644,115 @@ describe('LKE cluster updates', () => {
       );
       cy.findByText(`(Min ${autoscaleMin} / Max ${autoscaleMax})`).should(
         'not.exist'
+      );
+    });
+
+    /*
+     * - Confirms UI flow when enabling and disabling node pool autoscaling using mocked API responses.
+     * - Confirms that errors are shown when attempting to autoscale using invalid values based on the cluster tier.
+     * - Confirms that UI updates to reflect node pool autoscale state.
+     */
+    it('can toggle autoscaling on an enterprise tier cluster', () => {
+      const autoscaleMin = 1;
+      const autoscaleMax = 500;
+
+      const minWarning =
+        'Minimum must be between 1 and 499 nodes and cannot be greater than Maximum.';
+      const maxWarning = 'Maximum must be between 1 and 500 nodes.';
+
+      const mockCluster = kubernetesClusterFactory.build({
+        k8s_version: latestKubernetesVersion,
+        tier: 'enterprise',
+      });
+
+      const mockNodePool = nodePoolFactory.build({
+        count: 1,
+        nodes: kubeLinodeFactory.buildList(1),
+        type: 'g6-dedicated-4',
+      });
+
+      const mockNodePoolAutoscale = {
+        ...mockNodePool,
+        autoscaler: {
+          enabled: true,
+          max: autoscaleMax,
+          min: autoscaleMin,
+        },
+      };
+
+      mockGetCluster(mockCluster).as('getCluster');
+      mockGetClusterPools(mockCluster.id, [mockNodePool]).as('getNodePools');
+      mockGetKubernetesVersions().as('getVersions');
+      mockGetDashboardUrl(mockCluster.id);
+      mockGetApiEndpoints(mockCluster.id);
+      mockGetAccount(
+        accountFactory.build({
+          capabilities: ['Kubernetes Enterprise'],
+        })
+      ).as('getAccount');
+      // TODO LKE-E: Remove once feature is in GA
+      mockAppendFeatureFlags({
+        lkeEnterprise: { enabled: true, la: true },
+      });
+
+      cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
+      cy.wait(['@getAccount', '@getCluster', '@getNodePools', '@getVersions']);
+
+      // Click "Autoscale Pool", enable autoscaling, and set min and max values.
+      mockUpdateNodePool(mockCluster.id, mockNodePoolAutoscale).as(
+        'toggleAutoscale'
+      );
+      mockGetClusterPools(mockCluster.id, [mockNodePoolAutoscale]).as(
+        'getNodePools'
+      );
+      ui.button
+        .findByTitle('Autoscale Pool')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+
+      ui.dialog
+        .findByTitle('Autoscale Pool')
+        .should('be.visible')
+        .within(() => {
+          cy.findByText('Autoscale').should('be.visible').click();
+
+          cy.findByLabelText('Min').should('be.visible').click();
+          cy.focused().clear();
+          cy.focused().type(`${autoscaleMin - 1}`);
+
+          cy.findByText(minWarning).should('be.visible');
+
+          cy.findByLabelText('Max').should('be.visible').click();
+          cy.focused().clear();
+          cy.focused().type('501');
+
+          cy.findByText(minWarning).should('not.exist');
+          cy.findByText(maxWarning).should('be.visible');
+
+          cy.findByLabelText('Max').should('be.visible').click();
+          cy.focused().clear();
+          cy.focused().type(`${autoscaleMax}`);
+
+          cy.findByText(minWarning).should('not.exist');
+          cy.findByText(maxWarning).should('not.exist');
+
+          ui.button.findByTitle('Save Changes').should('be.disabled');
+
+          cy.findByLabelText('Min').should('be.visible').click();
+          cy.focused().clear();
+          cy.focused().type(`${autoscaleMin + 1}`);
+
+          ui.button.findByTitle('Save Changes').should('be.visible').click();
+        });
+
+      // Wait for API response and confirm that UI updates to reflect autoscale.
+      cy.wait(['@toggleAutoscale', '@getNodePools']);
+      ui.toast.assertMessage(
+        `Autoscaling updated for Node Pool ${mockNodePool.id}.`
+      );
+      cy.findByText(`(Min ${autoscaleMin} / Max ${autoscaleMax})`).should(
+        'be.visible'
       );
     });
 

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -727,8 +727,8 @@ describe('LKE cluster updates', () => {
           cy.focused().clear();
           cy.focused().type('501');
 
-          cy.findByText(minWarning).should('not.exist');
           cy.findByText(maxWarning).should('be.visible');
+          cy.findByText(minWarning).should('not.exist');
 
           cy.findByLabelText('Max').should('be.visible').click();
           cy.focused().clear();

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
@@ -128,7 +128,6 @@ export const AutoscalePoolDialog = (props: Props) => {
       min: autoscaler?.min ?? 1,
     },
     onSubmit,
-    // validationSchema: AutoscaleNodePoolSchema,
     validate: (values) => {
       const errors: { max?: string; min?: string } = {};
       const maxLimit =

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
@@ -151,7 +151,7 @@ export const AutoscalePoolDialog = (props: Props) => {
   });
 
   const warning =
-    autoscaler && autoscaler?.max > 1 && +values.max < autoscaler?.max
+    autoscaler && autoscaler.max > 1 && +values.max < autoscaler.max
       ? 'The Node Pool will only be scaled down if there are unneeded nodes.'
       : undefined;
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
@@ -107,12 +107,6 @@ export const AutoscalePoolDialog = (props: Props) => {
     handleReset(values);
   };
 
-  // TODO: revert back to autoscaler.max once the API returns the correct max for LKE-E.
-  const AUTOSCALE_MAX_VALUE =
-    clusterTier === 'enterprise'
-      ? MAX_NODES_PER_POOL_ENTERPRISE_TIER
-      : (autoscaler?.max ?? 1);
-
   const {
     errors,
     handleChange,
@@ -124,7 +118,7 @@ export const AutoscalePoolDialog = (props: Props) => {
     enableReinitialize: true,
     initialValues: {
       enabled: autoscaler?.enabled ?? false,
-      max: AUTOSCALE_MAX_VALUE,
+      max: autoscaler?.max ?? 1,
       min: autoscaler?.min ?? 1,
     },
     onSubmit,
@@ -157,7 +151,7 @@ export const AutoscalePoolDialog = (props: Props) => {
   });
 
   const warning =
-    autoscaler && AUTOSCALE_MAX_VALUE > 1 && +values.max < AUTOSCALE_MAX_VALUE
+    autoscaler && autoscaler?.max > 1 && +values.max < autoscaler?.max
       ? 'The Node Pool will only be scaled down if there are unneeded nodes.'
       : undefined;
 
@@ -170,7 +164,7 @@ export const AutoscalePoolDialog = (props: Props) => {
             disabled:
               (values.enabled === autoscaler?.enabled &&
                 values.min === autoscaler?.min &&
-                values.max === AUTOSCALE_MAX_VALUE) ||
+                values.max === autoscaler?.max) ||
               Object.keys(errors).length !== 0,
             label: 'Save Changes',
             loading: isPending || isSubmitting,

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -91,14 +91,11 @@ export const NodePoolsDisplay = (props: Props) => {
   const selectedPool = pools?.find((pool) => pool.id === selectedPoolId);
 
   const [isDeleteNodePoolOpen, setIsDeleteNodePoolOpen] = useState(false);
-  const [
-    isLabelsAndTaintsDrawerOpen,
-    setIsLabelsAndTaintsDrawerOpen,
-  ] = useState(false);
+  const [isLabelsAndTaintsDrawerOpen, setIsLabelsAndTaintsDrawerOpen] =
+    useState(false);
   const [isResizeDrawerOpen, setIsResizeDrawerOpen] = useState(false);
-  const [isRecycleAllPoolNodesOpen, setIsRecycleAllPoolNodesOpen] = useState(
-    false
-  );
+  const [isRecycleAllPoolNodesOpen, setIsRecycleAllPoolNodesOpen] =
+    useState(false);
   const [isRecycleNodeOpen, setIsRecycleNodeOpen] = useState(false);
   const [isRecycleClusterOpen, setIsRecycleClusterOpen] = useState(false);
 
@@ -348,6 +345,7 @@ export const NodePoolsDisplay = (props: Props) => {
       />
       <AutoscalePoolDialog
         clusterId={clusterID}
+        clusterTier={clusterTier}
         handleOpenResizeDrawer={handleOpenResizeDrawer}
         nodePool={selectedPool}
         onClose={() => setIsAutoscaleDialogOpen(false)}

--- a/packages/manager/src/features/Kubernetes/constants.ts
+++ b/packages/manager/src/features/Kubernetes/constants.ts
@@ -36,3 +36,6 @@ export const LKE_ENTERPRISE_VPC_WARNING =
 
 export const LKE_ENTERPRISE_LINODE_VPC_CONFIG_WARNING =
   'This VPC has been automatically generated for your LKE Enterprise cluster. Making edits may disrupt cluster communication.';
+
+export const MAX_NODES_PER_POOL_ENTERPRISE_TIER = 500;
+export const MAX_NODES_PER_POOL_STANDARD_TIER = 100;

--- a/packages/validation/.changeset/pr-12033-removed-1744745547794.md
+++ b/packages/validation/.changeset/pr-12033-removed-1744745547794.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Removed
+---
+
+AutoscaleNodePoolSchema from kubenetes.schema.ts ([#12033](https://github.com/linode/manager/pull/12033))

--- a/packages/validation/src/kubernetes.schema.ts
+++ b/packages/validation/src/kubernetes.schema.ts
@@ -27,7 +27,7 @@ export const AutoscaleNodePoolSchema = object({
               return false;
             }
             return true;
-          }
+          },
         ),
   }),
   max: number().when('enabled', {
@@ -35,8 +35,7 @@ export const AutoscaleNodePoolSchema = object({
     then: (schema) =>
       schema
         .required('Maximum is a required field.')
-        .min(1, 'Maximum must be between 1 and 100 nodes.')
-        .max(100, 'Maximum must be between 1 and 100 nodes.'),
+        .min(1, 'Maximum must be between 1 and 100 nodes.'),
   }),
 });
 
@@ -48,7 +47,7 @@ export const clusterLabelSchema = string()
    */
   .matches(
     /^[a-zA-Z0-9-]+$/,
-    'Cluster labels cannot contain special characters, spaces, or underscores.'
+    'Cluster labels cannot contain special characters, spaces, or underscores.',
   )
   .min(3, 'Length must be between 3 and 32 characters.')
   .max(32, 'Length must be between 3 and 32 characters.');
@@ -111,7 +110,7 @@ export const createKubeClusterWithRequiredACLSchema = object({
         const { ipv4, ipv6 } = controlPlane.acl.addresses;
         // Pass validation if either IP address has a value.
         return (ipv4 && ipv4.length > 0) || (ipv6 && ipv6.length > 0);
-      }
+      },
     )
     .required(),
 });
@@ -131,15 +130,17 @@ export const kubernetesEnterpriseControlPlaneACLPayloadSchema = object({
         (ipv4 && ipv4.length > 0 && ipv4[0] !== '') ||
         (ipv6 && ipv6.length > 0 && ipv6[0] !== '')
       );
-    }
+    },
   ),
 });
 
 // Starts and ends with a letter or number and contains letters, numbers, hyphens, dots, and underscores
-const alphaNumericValidCharactersRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-._]*[a-zA-Z0-9])?$/;
+const alphaNumericValidCharactersRegex =
+  /^[a-zA-Z0-9]([a-zA-Z0-9-._]*[a-zA-Z0-9])?$/;
 
 // DNS subdomain key (example.com/my-app)
-const dnsKeyRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-._/]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/;
+const dnsKeyRegex =
+  /^[a-zA-Z0-9]([a-zA-Z0-9-._/]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/;
 
 const MAX_DNS_KEY_TOTAL_LENGTH = 128;
 const MAX_DNS_KEY_SUFFIX_LENGTH = 62;
@@ -210,19 +211,19 @@ export const kubernetesTaintSchema = object({
           alphaNumericValidCharactersRegex.test(value) ||
           dnsKeyRegex.test(value)
         );
-      }
+      },
     )
     .max(253, 'Key must be between 1 and 253 characters.')
     .min(1, 'Key must be between 1 and 253 characters.'),
   value: string()
     .matches(
       alphaNumericValidCharactersRegex,
-      'Value must start with a letter or number and may contain letters, numbers, hyphens, dots, and underscores, up to 63 characters.'
+      'Value must start with a letter or number and may contain letters, numbers, hyphens, dots, and underscores, up to 63 characters.',
     )
     .max(63, 'Value must be between 0 and 63 characters.')
     .notOneOf(
       ['kubernetes.io', 'linode.com'],
-      'Value cannot be "kubernetes.io" or "linode.com".'
+      'Value cannot be "kubernetes.io" or "linode.com".',
     )
     .notRequired(),
 });

--- a/packages/validation/src/kubernetes.schema.ts
+++ b/packages/validation/src/kubernetes.schema.ts
@@ -6,39 +6,6 @@ export const nodePoolSchema = object({
   count: number(),
 });
 
-export const AutoscaleNodePoolSchema = object({
-  enabled: boolean(),
-  min: number().when('enabled', {
-    is: true,
-    then: (schema) =>
-      schema
-        .required('Minimum is a required field.')
-        .test(
-          'min',
-          'Minimum must be between 1 and 99 nodes and cannot be greater than Maximum.',
-          function (min) {
-            if (!min) {
-              return false;
-            }
-            if (min < 1 || min > 99) {
-              return false;
-            }
-            if (min > this.parent['max']) {
-              return false;
-            }
-            return true;
-          },
-        ),
-  }),
-  max: number().when('enabled', {
-    is: true,
-    then: (schema) =>
-      schema
-        .required('Maximum is a required field.')
-        .min(1, 'Maximum must be between 1 and 100 nodes.'),
-  }),
-});
-
 export const clusterLabelSchema = string()
   .required('Label is required.')
   /**


### PR DESCRIPTION
## Description 📝

Current limit for LKE-E node pool autoscaler max is 100, when 500 is expected. This is because LKE-E allows up to 500 nodes in a node pool (and 500 nodes in a cluster) for initial LA launch.

## Changes  🔄

- Moved the validation from the schema file to the AutoscalePoolDialog to determine min and max error messages based on the clusterTier
- Added clusterTier as a prop to AutoscalePoolDialog
- Updated test coverage to check for LKE-E max limit in lke-update.test.spec
- The linter fixed some misc issues

## Target release date 🗓️

4/22

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/292ed7da-3ce0-4d0b-b756-e4198ac1735d)| <video src="https://github.com/user-attachments/assets/0325d949-a7dd-4750-8bfb-5e552110f56e" /> |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Use `prod-test-004-fe` for an account with an LKE-E cluster
- Temporarily adjust your Thing Limit and LKE Thing Limit to `1000` for testing purposes

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Go to the LKE details page of an LKE-E cluster and try to autoscale to 500
- [ ] Observe the validation error

### Verification steps

(How to verify changes)

- [ ] Go to the LKE details page of an LKE-E cluster and try to autoscale to 500
- [ ] Observe the validation error is gone.
- [ ] Submit the form and confirm the UI shows the min and max values next to the autoscale button.
- [ ] Reopen the Autoscale Dialog and confirm a number >500 shows validation. 
- [ ] Confirm existing validation still works. Confirm that when autoscaling a standard cluster, the max limit is still 100 and there are no regressions to validation.
- [ ] Confirm test coverage passes:
```
pnpm cy:run -s "cypress/e2e/core/kubernetes/lke-update.spec.ts"
```

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
