### PR TITLE
hotfix: [M3-9771] – Remove references to disk encryption for LKE

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2025-04-16] - v1.139.1
+
+### Removed:
+
+- References to disk encryption in relation to LKE ([#12034](https://github.com/linode/manager/pull/12034))
+
 ## [2025-04-08] - v1.139.0
 
 

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.139.0",
+  "version": "1.139.1",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/manager/src/components/Encryption/constants.tsx
+++ b/packages/manager/src/components/Encryption/constants.tsx
@@ -41,9 +41,6 @@ export const DISK_ENCRYPTION_DEFAULT_DISTRIBUTED_INSTANCES =
   'Distributed Compute Instances are encrypted. This setting can not be changed.';
 
 // Guidance
-export const DISK_ENCRYPTION_NODE_POOL_GUIDANCE_COPY =
-  'To enable disk encryption, delete the node pool and create a new node pool. New node pools are always encrypted.';
-
 export const UNENCRYPTED_STANDARD_LINODE_GUIDANCE_COPY =
   'Rebuild this Linode to enable or disable disk encryption.';
 

--- a/packages/manager/src/features/Kubernetes/ClusterList/constants.ts
+++ b/packages/manager/src/features/Kubernetes/ClusterList/constants.ts
@@ -3,9 +3,3 @@ export const ADD_NODE_POOLS_DESCRIPTION =
 
 export const ADD_NODE_POOLS_ENTERPRISE_DESCRIPTION =
   'Add groups of Linodes to your cluster. You can have a maximum of 100 Linodes per node pool.';
-
-export const ADD_NODE_POOLS_ENCRYPTION_DESCRIPTION =
-  'Node Pool data is encrypted at rest.';
-
-export const ADD_NODE_POOLS_NO_ENCRYPTION_DESCRIPTION =
-  'Node Pool data is not encrypted at rest for LKE Enterprise clusters.';

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -91,10 +91,9 @@ const Panel = (props: NodePoolPanelProps) => {
   };
 
   const getPlansPanelCopy = () => {
-    if (selectedTier === 'enterprise') {
-      return ADD_NODE_POOLS_ENTERPRISE_DESCRIPTION;
-    }
-    return ADD_NODE_POOLS_DESCRIPTION;
+    return selectedTier === 'enterprise'
+      ? ADD_NODE_POOLS_ENTERPRISE_DESCRIPTION
+      : ADD_NODE_POOLS_DESCRIPTION;
   };
 
   return (

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -1,18 +1,13 @@
-import { useRegionsQuery } from '@linode/queries';
 import { CircleProgress, ErrorState } from '@linode/ui';
-import { doesRegionSupportFeature } from '@linode/utilities';
 import Grid from '@mui/material/Grid2';
 import * as React from 'react';
-import { useFlags } from 'src/hooks/useFlags';
 
 import { useIsAcceleratedPlansEnabled } from 'src/features/components/PlansPanel/utils';
 import { extendType } from 'src/utilities/extendType';
 
 import {
   ADD_NODE_POOLS_DESCRIPTION,
-  ADD_NODE_POOLS_ENCRYPTION_DESCRIPTION,
   ADD_NODE_POOLS_ENTERPRISE_DESCRIPTION,
-  ADD_NODE_POOLS_NO_ENCRYPTION_DESCRIPTION,
 } from '../ClusterList/constants';
 import { KubernetesPlansPanel } from '../KubernetesPlansPanel/KubernetesPlansPanel';
 
@@ -73,11 +68,7 @@ const Panel = (props: NodePoolPanelProps) => {
     types,
   } = props;
 
-  const flags = useFlags();
-
   const { isAcceleratedLKEPlansEnabled } = useIsAcceleratedPlansEnabled();
-
-  const regions = useRegionsQuery().data ?? [];
 
   const [typeCountMap, setTypeCountMap] = React.useState<Map<string, number>>(
     new Map()
@@ -99,28 +90,11 @@ const Panel = (props: NodePoolPanelProps) => {
     setSelectedType(planId);
   };
 
-  // "Disk Encryption" indicates general availability and "LA Disk Encryption" indicates limited availability
-  const regionSupportsDiskEncryption =
-    doesRegionSupportFeature(
-      selectedRegionId ?? '',
-      regions,
-      'Disk Encryption'
-    ) ||
-    doesRegionSupportFeature(
-      selectedRegionId ?? '',
-      regions,
-      'LA Disk Encryption'
-    );
-
   const getPlansPanelCopy = () => {
-    // TODO - LKE-E: Remove the 'ADD_NODE_POOLS_NO_ENCRYPTION_DESCRIPTION' copy once LDE is enabled on LKE-E.
     if (selectedTier === 'enterprise') {
-      return `${ADD_NODE_POOLS_ENTERPRISE_DESCRIPTION} ${ADD_NODE_POOLS_NO_ENCRYPTION_DESCRIPTION}`;
+      return ADD_NODE_POOLS_ENTERPRISE_DESCRIPTION;
     }
-    // @TODO LDE: once LDE has been fully rolled out and is in GA in all regions, remove the feature flag condition
-    return regionSupportsDiskEncryption && flags.linodeDiskEncryption
-      ? `${ADD_NODE_POOLS_DESCRIPTION} ${ADD_NODE_POOLS_ENCRYPTION_DESCRIPTION}`
-      : ADD_NODE_POOLS_DESCRIPTION;
+    return ADD_NODE_POOLS_DESCRIPTION;
   };
 
   return (

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -7,7 +7,6 @@ import * as React from 'react';
 import EmptyStateCloud from 'src/assets/icons/empty-state-cloud.svg';
 import Lock from 'src/assets/icons/lock.svg';
 import Unlock from 'src/assets/icons/unlock.svg';
-import { DISK_ENCRYPTION_NODE_POOL_GUIDANCE_COPY } from 'src/components/Encryption/constants';
 import { useIsDiskEncryptionFeatureEnabled } from 'src/components/Encryption/utils';
 import OrderBy from 'src/components/OrderBy';
 import Paginate from 'src/components/Paginate';
@@ -272,17 +271,8 @@ export const NodeTable = React.memo((props: Props) => {
                         regionSupportsDiskEncryption={
                           regionSupportsDiskEncryption
                         }
-                        /**
-                         * M3-9517: Once LDE starts releasing regions with LDE enabled, LDE will still be disabled for the LKE-E LA launch, so hide this tooltip
-                         * explaining how LDE can be enabled on LKE-E node pools.
-                         * TODO - LKE-E: Clean up this enterprise cluster checks once LDE is enabled for LKE-E.
-                         */
-                        tooltipText={
-                          clusterTier === 'enterprise'
-                            ? undefined
-                            : DISK_ENCRYPTION_NODE_POOL_GUIDANCE_COPY
-                        }
                         encryptionStatus={encryptionStatus}
+                        tooltipText={undefined}
                       />
                     </Box>
                   ) : (

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailBody.tsx
@@ -9,10 +9,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
 
 import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
-import {
-  DISK_ENCRYPTION_NODE_POOL_GUIDANCE_COPY as UNENCRYPTED_LKE_LINODE_GUIDANCE_COPY,
-  UNENCRYPTED_STANDARD_LINODE_GUIDANCE_COPY,
-} from 'src/components/Encryption/constants';
+import { UNENCRYPTED_STANDARD_LINODE_GUIDANCE_COPY } from 'src/components/Encryption/constants';
 import { useIsDiskEncryptionFeatureEnabled } from 'src/components/Encryption/utils';
 import { Link } from 'src/components/Link';
 import { useKubernetesBetaEndpoint } from 'src/features/Kubernetes/kubeUtils';
@@ -258,16 +255,9 @@ export const LinodeEntityDetailBody = React.memo((props: BodyProps) => {
                   flexDirection="row"
                 >
                   <EncryptedStatus
-                    /**
-                     * M3-9517: Once LDE starts releasing regions with LDE enabled, LDE will still be disabled for the LKE-E LA launch, so hide this tooltip
-                     * explaining how LDE can be enabled on LKE-E node pools.
-                     * TODO - LKE-E: Clean up this enterprise cluster checks once LDE is enabled for LKE-E.
-                     */
                     tooltipText={
-                      isLKELinode && cluster?.tier === 'enterprise'
+                      isLKELinode
                         ? undefined
-                        : isLKELinode
-                        ? UNENCRYPTED_LKE_LINODE_GUIDANCE_COPY
                         : UNENCRYPTED_STANDARD_LINODE_GUIDANCE_COPY
                     }
                     encryptionStatus={encryptionStatus}


### PR DESCRIPTION
## Description 📝
With the rollout of LDE GA beginning tomorrow, this PR removes references to disk encryption as it relates to LKE because LDE will not be applied to LKE for the time being.

## Changes  🔄
The following pieces of copy have been removed from CM:
- "Node Pool data is encrypted at rest." (LKE Create flow)
- "Node Pool data is not encrypted at rest for LKE Enterprise clusters." (LKE Create flow)
- "To enable disk encryption, delete the node pool and create a new node pool. New node pools are always encrypted." (unencrypted status indicator tooltip in Linode Details summary panel & node pool table footer)

## Target release date 🗓️
4/16/25

## How to test 🧪
Have the `linode_disk_encryption` tag on your account.
For LKE-E: have the `lke-enterprise-eap` tag on your account.

### Verification steps
- After selecting a region in the LKE Create flow, you should not see `Node Pool data is encrypted at rest.` in the "Add Node Pools" section (if you have "LKE" selected as the Cluster Tier) nor `Node Pool data is not encrypted at rest for LKE Enterprise clusters.` (if you selected "LKE Enterprise" as the Cluster Tier)
- If a node pool cluster has a status of "Not Encrypted" in the node pool table footer, you should not see a tooltip to its right (unlike in prod)
- If an LKE linode has a status of "Not Encrypted" in the Linode Details summary panel, you should not see a tooltip to its right (unlike in prod)

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [X] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅
- [X] All unit tests are passing
- [X] TypeScript compilation succeeded without errors
- [X] Code passes all linting rules

</details>