### PR TITLE
upcoming: [M3-9650] - Edit VPC Interface Drawer UI for Linode Interfaces

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/EditInterfaceDrawer/EditInterfaceForm.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/EditInterfaceDrawer/EditInterfaceForm.tsx
@@ -20,6 +20,8 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { getLinodeInterfaceType } from '../utilities';
 import { PublicIPv4Addresses } from './PublicInterface/IPv4Addresses';
 import { IPv6Ranges } from './PublicInterface/IPv6Ranges';
+import { VPCIPv4Addresses } from './VPCInterface/VPCIPv4Addresses';
+import { VPCIPv4Ranges } from './VPCInterface/VPCIPv4Ranges';
 
 import type { ModifyLinodeInterfacePayload } from '@linode/api-v4';
 
@@ -58,6 +60,7 @@ export const EditInterfaceForm = (props: Props) => {
       enqueueSnackbar('Interface successfully updated.', {
         variant: 'success',
       });
+      onClose();
     } catch (errors) {
       for (const error of errors) {
         form.setError(error.field ?? 'root', { message: error.reason });
@@ -100,10 +103,10 @@ export const EditInterfaceForm = (props: Props) => {
             </Stack>
           )}
           {interfaceType === 'VPC' && (
-            <Notice
-              text="TODO: Support editing a VPC interface"
-              variant="warning"
-            />
+            <Stack divider={<Divider />} spacing={3}>
+              <VPCIPv4Addresses linodeInterface={linodeInterface} />
+              <VPCIPv4Ranges />
+            </Stack>
           )}
           {interfaceType === 'VLAN' && (
             <Notice

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/EditInterfaceDrawer/VPCInterface/VPCIPv4Address.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/EditInterfaceDrawer/VPCInterface/VPCIPv4Address.tsx
@@ -1,6 +1,14 @@
-import { Checkbox, FormControlLabel, Stack, TextField } from '@linode/ui';
+import {
+  Checkbox,
+  FormControlLabel,
+  Notice,
+  Stack,
+  TextField,
+} from '@linode/ui';
 import React from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
+
+import { VPCPublicIPLabel } from 'src/features/VPCs/components/VPCPublicIPLabel';
 
 import type {
   LinodeInterface,
@@ -19,39 +27,59 @@ export const VPCIPv4Address = (props: Props) => {
     formState: { errors },
   } = useFormContext<ModifyLinodeInterfacePayload>();
 
+  const error = errors.vpc?.ipv4?.addresses?.[index]?.message;
+
   return (
-    <Controller
-      control={control}
-      name={`vpc.ipv4.addresses.${index}.address`}
-      render={({ field, fieldState }) => (
-        <Stack>
-          <FormControlLabel
-            checked={field.value === 'auto'}
-            control={<Checkbox />}
-            label="Auto-assign a VPC IPv4 Address"
-            onChange={(e, checked) =>
-              field.onChange(
-                checked
-                  ? 'auto'
-                  : (linodeInterface.vpc?.ipv4.addresses[index].address ?? '')
-              )
-            }
-          />
-          {field.value !== 'auto' && (
-            <TextField
-              errorText={
-                fieldState.error?.message ??
-                errors.vpc?.ipv4?.addresses?.[index]?.message
-              }
-              label="VPC IPv4 Address" // @todo update this when we support many VPC IPv4s
-              onChange={field.onChange}
-              // eslint-disable-next-line sonarjs/no-hardcoded-ip
-              placeholder="10.0.0.5"
-              value={field.value}
+    <Stack spacing={1}>
+      {error && <Notice text={error} variant="error" />}
+      <Stack spacing={1.5}>
+        <Controller
+          control={control}
+          name={`vpc.ipv4.addresses.${index}.address`}
+          render={({ field, fieldState }) => (
+            <Stack rowGap={1}>
+              <FormControlLabel
+                checked={field.value === 'auto'}
+                control={<Checkbox />}
+                label="Auto-assign a VPC IPv4 Address"
+                sx={{ pl: 0.3 }}
+                onChange={(e, checked) =>
+                  field.onChange(
+                    checked
+                      ? 'auto'
+                      : (linodeInterface.vpc?.ipv4.addresses[index].address ??
+                          '')
+                  )
+                }
+              />
+              {field.value !== 'auto' && (
+                <TextField
+                  errorText={fieldState.error?.message}
+                  label="VPC IPv4 Address"
+                  noMarginTop
+                  onChange={field.onChange}
+                  // eslint-disable-next-line sonarjs/no-hardcoded-ip
+                  placeholder="10.0.0.5"
+                  value={field.value}
+                />
+              )}
+            </Stack>
+          )}
+        />
+        <Controller
+          control={control}
+          name={`vpc.ipv4.addresses.${index}.nat_1_1_address`}
+          render={({ field }) => (
+            <FormControlLabel
+              checked={Boolean(field.value)}
+              control={<Checkbox />}
+              label={<VPCPublicIPLabel />}
+              onChange={(e, checked) => field.onChange(checked ? 'auto' : null)}
+              sx={{ ml: '-8px !important' }}
             />
           )}
-        </Stack>
-      )}
-    />
+        />
+      </Stack>
+    </Stack>
   );
 };

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/EditInterfaceDrawer/VPCInterface/VPCIPv4Address.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/EditInterfaceDrawer/VPCInterface/VPCIPv4Address.tsx
@@ -1,0 +1,57 @@
+import { Checkbox, FormControlLabel, Stack, TextField } from '@linode/ui';
+import React from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+
+import type {
+  LinodeInterface,
+  ModifyLinodeInterfacePayload,
+} from '@linode/api-v4';
+
+interface Props {
+  index: number;
+  linodeInterface: LinodeInterface;
+}
+
+export const VPCIPv4Address = (props: Props) => {
+  const { index, linodeInterface } = props;
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext<ModifyLinodeInterfacePayload>();
+
+  return (
+    <Controller
+      control={control}
+      name={`vpc.ipv4.addresses.${index}.address`}
+      render={({ field, fieldState }) => (
+        <Stack>
+          <FormControlLabel
+            checked={field.value === 'auto'}
+            control={<Checkbox />}
+            label="Auto-assign a VPC IPv4 Address"
+            onChange={(e, checked) =>
+              field.onChange(
+                checked
+                  ? 'auto'
+                  : (linodeInterface.vpc?.ipv4.addresses[index].address ?? '')
+              )
+            }
+          />
+          {field.value !== 'auto' && (
+            <TextField
+              errorText={
+                fieldState.error?.message ??
+                errors.vpc?.ipv4?.addresses?.[index]?.message
+              }
+              label="VPC IPv4 Address" // @todo update this when we support many VPC IPv4s
+              onChange={field.onChange}
+              // eslint-disable-next-line sonarjs/no-hardcoded-ip
+              placeholder="10.0.0.5"
+              value={field.value}
+            />
+          )}
+        </Stack>
+      )}
+    />
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/EditInterfaceDrawer/VPCInterface/VPCIPv4Addresses.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/EditInterfaceDrawer/VPCInterface/VPCIPv4Addresses.tsx
@@ -1,0 +1,45 @@
+import { Stack, Typography } from '@linode/ui';
+import React from 'react';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+
+import { VPCIPv4Address } from './VPCIPv4Address';
+
+import type {
+  LinodeInterface,
+  ModifyLinodeInterfacePayload,
+} from '@linode/api-v4';
+
+interface Props {
+  linodeInterface: LinodeInterface;
+}
+
+export const VPCIPv4Addresses = (props: Props) => {
+  const { linodeInterface } = props;
+  const { control } = useFormContext<ModifyLinodeInterfacePayload>();
+
+  /**
+   * We currently enforce a hard limit of one IPv4 address per VPC interface.
+   * See VPC-2044.
+   *
+   * @todo Eventually, when the API supports it, we should all the user to append/remove more VPC IPs
+   */
+  const { fields } = useFieldArray({
+    control,
+    name: 'vpc.ipv4.addresses',
+  });
+
+  return (
+    <Stack spacing={1}>
+      <Typography variant="h3">IPv4 Addresses</Typography>
+      <Stack spacing={2}>
+        {fields.map((field, index) => (
+          <VPCIPv4Address
+            index={index}
+            key={field.id}
+            linodeInterface={linodeInterface}
+          />
+        ))}
+      </Stack>
+    </Stack>
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/EditInterfaceDrawer/VPCInterface/VPCIPv4Ranges.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/EditInterfaceDrawer/VPCInterface/VPCIPv4Ranges.tsx
@@ -1,0 +1,65 @@
+import {
+  Box,
+  CloseIcon,
+  IconButton,
+  Stack,
+  TextField,
+  Typography,
+} from '@linode/ui';
+import React from 'react';
+import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
+
+import { LinkButton } from 'src/components/LinkButton';
+import { VPCRangesDescription } from 'src/features/VPCs/components/VPCRangesDescription';
+
+import type { ModifyLinodeInterfacePayload } from '@linode/api-v4';
+
+export const VPCIPv4Ranges = () => {
+  const { control } = useFormContext<ModifyLinodeInterfacePayload>();
+  const { fields, remove, append } = useFieldArray({
+    control,
+    name: 'vpc.ipv4.ranges',
+  });
+
+  return (
+    <Stack spacing={1}>
+      <Typography variant="h3">IPv4 Ranges</Typography>
+      <VPCRangesDescription />
+      {fields.map((field, index) => (
+        <Stack
+          alignItems="flex-start"
+          direction="row"
+          key={field.id}
+          spacing={1}
+        >
+          <Controller
+            control={control}
+            name={`vpc.ipv4.ranges.${index}.range`}
+            render={({ field, fieldState }) => (
+              <TextField
+                containerProps={{ flexGrow: 1 }}
+                errorText={fieldState.error?.message}
+                hideLabel
+                label={`VPC IPv4 Range ${index}`}
+                onChange={field.onChange}
+                value={field.value}
+              />
+            )}
+          />
+          <IconButton
+            onClick={() => remove(index)}
+            sx={{ p: 1 }}
+            title="Remove"
+          >
+            <CloseIcon />
+          </IconButton>
+        </Stack>
+      ))}
+      <Box>
+        <LinkButton onClick={() => append({ range: '' })}>
+          Add IPv4 Range
+        </LinkButton>
+      </Box>
+    </Stack>
+  );
+};


### PR DESCRIPTION
## Description 📝

- Adds UI that allows users to edit their VPC Interfaces on Linodes that use new Linode Interfaces

## Preview 📷

![Screenshot 2025-04-15 at 5 23 39 PM](https://github.com/user-attachments/assets/1a931a72-c9f5-45b6-9d04-eead23e2c518)

## How to test 🧪

### Prerequisites

- Add `new-interfaces-beta` customer tag to your account
- Use preview link or checkout PR locally and enable the Linode Interfaces feature flag using local dev tools


### Verification steps

- Create a Linode using new Linode Interfaces
- Go to the _Networking_ tab on the Linode details page
- Test the `Edit` dialog for a VPC Linode Interface
  - Test error handling
  - Verify you can edit desired fields

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>