### PR TITLE
fix: [M3-9522] - Recovery images table headers alignment with data column

### DIFF
--- a/packages/manager/.changeset/pr-12043-fixed-1744782995123.md
+++ b/packages/manager/.changeset/pr-12043-fixed-1744782995123.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Recovery Images Table Header alignment with the data column ([#12043](https://github.com/linode/manager/pull/12043))

--- a/packages/manager/.changeset/pr-12043-fixed-1744782995123.md
+++ b/packages/manager/.changeset/pr-12043-fixed-1744782995123.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Recovery Images Table Header alignment with the data column ([#12043](https://github.com/linode/manager/pull/12043))

--- a/packages/manager/.changeset/pr-12043-tests-1744782995123.md
+++ b/packages/manager/.changeset/pr-12043-tests-1744782995123.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Corrected alignment between Recovery Images Table Header and data column ([#12043](https://github.com/linode/manager/pull/12043))

--- a/packages/manager/cypress/e2e/core/images/images-non-empty-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/images-non-empty-landing-page.spec.ts
@@ -1,6 +1,10 @@
-import { grantsFactory, profileFactory } from '@linode/utilities';
+import { profileFactory } from '@linode/utilities';
+import { grantsFactory } from '@linode/utilities';
 import { mockGetUser } from 'support/intercepts/account';
-import { mockGetAllImages } from 'support/intercepts/images';
+import {
+  mockGetCustomImages,
+  mockGetRecoveryImages,
+} from 'support/intercepts/images';
 import {
   mockGetProfile,
   mockGetProfileGrants,
@@ -49,20 +53,32 @@ function checkActionMenu(tableAlias: string, mockImages: any[]) {
 
 describe('image landing checks for non-empty state with restricted user', () => {
   beforeEach(() => {
-    const mockImages: Image[] = new Array(3)
+    const mockCustomImages: Image[] = new Array(3)
       .fill(null)
       .map((_item: null, index: number): Image => {
         return imageFactory.build({
           label: `Image ${index}`,
-          tags: [index % 2 == 0 ? 'even' : 'odd', 'nums'],
+          tags: [index % 2 === 0 ? 'even' : 'odd', 'nums'],
+          type: 'manual',
+        });
+      });
+
+    const mockRecoveryImages: Image[] = new Array(3)
+      .fill(null)
+      .map((_item: null, index: number): Image => {
+        return imageFactory.build({
+          label: `Image ${index}`,
+          tags: [index % 2 === 0 ? 'even' : 'odd', 'nums'],
+          type: 'automatic',
         });
       });
 
     // Mock setup to display the Image landing page in an non-empty state
-    mockGetAllImages(mockImages).as('getImages');
+    mockGetCustomImages(mockCustomImages).as('getCustomImages');
+    mockGetRecoveryImages(mockRecoveryImages).as('getRecoveryImages');
 
     // Alias the mockImages array
-    cy.wrap(mockImages).as('mockImages');
+    cy.wrap(mockCustomImages).as('mockCustomImages');
   });
 
   it('checks restricted user with read access has no access to create image and can see existing images', () => {
@@ -90,7 +106,8 @@ describe('image landing checks for non-empty state with restricted user', () => 
 
     // Login and wait for application to load
     cy.visitWithLogin('/images');
-    cy.wait('@getImages');
+    cy.wait('@getCustomImages');
+    cy.wait('@getRecoveryImages');
     cy.url().should('endWith', '/images');
 
     cy.contains('h3', 'Custom Images')
@@ -119,7 +136,7 @@ describe('image landing checks for non-empty state with restricted user', () => 
       )
       .should('be.visible');
 
-    cy.get<Image[]>('@mockImages').then((mockImages) => {
+    cy.get<Image[]>('@mockCustomImages').then((mockImages) => {
       // Assert that the correct number of Image entries are present in the customImageTable
       cy.get('@customImageTable')
         .find('tbody tr')

--- a/packages/manager/cypress/support/intercepts/images.ts
+++ b/packages/manager/cypress/support/intercepts/images.ts
@@ -68,7 +68,7 @@ export const mockGetCustomImages = (
 };
 
 /**
- * Intercepts GET request to retrieve custom images and mocks response.
+ * Intercepts GET request to retrieve recovery images and mocks response.
  *
  * @param images - Array of Image objects with which to mock response.
  *

--- a/packages/manager/src/factories/images.ts
+++ b/packages/manager/src/factories/images.ts
@@ -1,5 +1,6 @@
-import { Image } from '@linode/api-v4/lib/images/types';
 import { Factory } from '@linode/utilities';
+
+import type { Image } from '@linode/api-v4/lib/images/types';
 
 export const imageFactory = Factory.Sync.makeFactory<Image>({
   capabilities: [],

--- a/packages/manager/src/factories/images.ts
+++ b/packages/manager/src/factories/images.ts
@@ -1,6 +1,6 @@
 import { Factory } from '@linode/utilities';
 
-import type { Image } from '@linode/api-v4/lib/images/types';
+import type { Image } from '@linode/api-v4';
 
 export const imageFactory = Factory.Sync.makeFactory<Image>({
   capabilities: [],


### PR DESCRIPTION
## Description 📝  
This PR fixes the Recovery Images Table Header alignment with the data column in mock tests.

## Changes 🔄  
- Fixed Recovery Images Table Header alignment with the data column in mock tests.

## Target release date 🗓️  
N/A

## Preview 📷
| Before | After |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/ca1dacfc-35b5-44fa-8066-a993df181098)| ![After](https://github.com/user-attachments/assets/8f2ba35f-6220-41cc-82f5-4ac5f2197224) |

### Verification steps
- [ ] Verify Recovery Images Table Header alignment with the data column in mock tests.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>