### PR TITLE
test: [M3-9782] - Fix test failure in `bucket-details-multicluster.spec.ts`

### DIFF
--- a/packages/manager/cypress/e2e/core/objectStorageMulticluster/bucket-details-multicluster.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorageMulticluster/bucket-details-multicluster.spec.ts
@@ -1,7 +1,11 @@
 import { regionFactory } from '@linode/utilities';
 import { mockGetAccount } from 'support/intercepts/account';
 import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
-import { mockGetBucket } from 'support/intercepts/object-storage';
+import {
+  mockGetBucket,
+  mockGetBucketObjects,
+  mockGetBuckets,
+} from 'support/intercepts/object-storage';
 import { mockGetRegions } from 'support/intercepts/regions';
 import { ui } from 'support/ui';
 import { randomLabel } from 'support/util/random';
@@ -38,6 +42,8 @@ describe('Object Storage Multicluster Bucket Details Tabs', () => {
       const { label } = mockBucket;
 
       mockGetBucket(label, mockRegion.id);
+      mockGetBuckets([mockBucket]);
+      mockGetBucketObjects(label, mockRegion.id, []);
       mockGetRegions([mockRegion]);
 
       cy.visitWithLogin(


### PR DESCRIPTION
## Description 📝

This fixes a test failure that was brought in by #12011 -- the PR made changes to the logic that determines whether the "SSL/TLS" tab is shown on the bucket details page. Because the test doesn't mock some of the endpoints that are used by this logic, the tab doesn't appear in the test and the test fails.

This PR fixes the test failure by mocking the missing endpoints to ensure that the new logic works as expected.

I'm hoping to get this merged in with the release so that this test failure doesn't reach `master`. Because #12011 hasn't been released, I'm not planning to add a changeset (but I will if this PR doesn't make the cut).

## Changes  🔄

- Fix test failure in `bucket-details-multicluster.spec.ts`

## Target release date 🗓️

4/22

## How to test 🧪

We can rely on CI for this.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>