### PR TITLE
fix: Surface IPv4 Range errors for Linode Interfaces in SubnetAssignLinodesDrawer

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/UpgradeInterfaces/DialogContents/PromptDialogContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/UpgradeInterfaces/DialogContents/PromptDialogContent.tsx
@@ -24,10 +24,8 @@ export const PromptDialogContent = (
 
   const [isDryRun, setIsDryRun] = React.useState<boolean>(true);
 
-  const {
-    data: configs,
-    isLoading: isLoadingConfigs,
-  } = useAllLinodeConfigsQuery(linodeId, open);
+  const { data: configs, isLoading: isLoadingConfigs } =
+    useAllLinodeConfigsQuery(linodeId, open);
 
   const { isPending, upgradeToLinodeInterfaces } = useUpgradeToLinodeInterfaces(
     {
@@ -95,7 +93,7 @@ export const PromptDialogContent = (
         </ListItem>{' '}
         <ListItem disablePadding sx={{ display: 'list-item' }}>
           All networking configurations will be deleted from the configuration
-          profile and re-assigned to the neew interfaces in the Linode Network
+          profile and re-assigned to the new interfaces in the Linode Network
           tab.
         </ListItem>
       </List>

--- a/packages/manager/src/features/VPCs/utils.test.ts
+++ b/packages/manager/src/features/VPCs/utils.test.ts
@@ -17,7 +17,10 @@ import {
   getVPCInterfacePayload,
   hasUnrecommendedConfiguration,
   hasUnrecommendedConfigurationLinodeInterface,
+  transformLinodeInterfaceErrorsToFormikErrors,
 } from './utils';
+
+import type { APIError } from '@linode/api-v4';
 
 const subnetLinodeInfoList1 = subnetAssignedLinodeDataFactory.buildList(4);
 const subnetLinodeInfoId1 = subnetAssignedLinodeDataFactory.build({ id: 1 });
@@ -252,5 +255,57 @@ describe('Linode Interface utility functions', () => {
       });
       expect('purpose' in iface).toBe(false);
     });
+  });
+});
+
+describe('transformLinodeInterfaceErrorsToFormikErrors', () => {
+  it('handles vpc range errors', () => {
+    const error: APIError[] = [
+      { field: 'vpc.ipv4.ranges[3].range', reason: 'Range is invalid.' },
+    ];
+
+    expect(transformLinodeInterfaceErrorsToFormikErrors(error)).toStrictEqual([
+      {
+        field: 'ip_ranges[3]',
+        reason: 'Range is invalid.',
+      },
+    ]);
+
+    const generalRangeError: APIError[] = [
+      { field: 'vpc.ipv4.ranges', reason: 'Range is invalid.' },
+    ];
+
+    expect(
+      transformLinodeInterfaceErrorsToFormikErrors(generalRangeError)
+    ).toStrictEqual([
+      {
+        field: 'ip_ranges',
+        reason: 'Range is invalid.',
+      },
+    ]);
+  });
+
+  it('handles vpc address errors', () => {
+    const error: APIError[] = [
+      { field: 'vpc.ipv4.addresses[0]', reason: 'address is invalid.' },
+    ];
+
+    expect(transformLinodeInterfaceErrorsToFormikErrors(error)).toStrictEqual([
+      {
+        field: 'ipv4.vpc',
+        reason: 'address is invalid.',
+      },
+    ]);
+
+    const error2: APIError[] = [
+      { field: 'vpc.ipv4.addresses', reason: 'address 2 is invalid.' },
+    ];
+
+    expect(transformLinodeInterfaceErrorsToFormikErrors(error2)).toStrictEqual([
+      {
+        field: 'ipv4.vpc',
+        reason: 'address 2 is invalid.',
+      },
+    ]);
   });
 });

--- a/packages/manager/src/features/VPCs/utils.ts
+++ b/packages/manager/src/features/VPCs/utils.ts
@@ -158,8 +158,15 @@ export const transformLinodeInterfaceErrorsToFormikErrors = (
   errors: APIError[]
 ): APIError[] => {
   for (const error of errors) {
-    if (error.field && error.field.match(/vpc.ipv4.ranges\[(\d+)\]/)) {
-      error.field = 'ip_ranges[$1]';
+    if (error.field && error.field.includes('vpc.ipv4.ranges')) {
+      if (error.field.match(/vpc.ipv4.ranges\[(\d+)\].range/)) {
+        error.field = error.field.replace(
+          /vpc.ipv4.ranges\[(\d+)\].range/,
+          'ip_ranges[$1]'
+        );
+      } else {
+        error.field = 'ip_ranges';
+      }
     }
     if (error.field && error.field.includes('vpc.ipv4.addresses')) {
       error.field = 'ipv4.vpc';


### PR DESCRIPTION
No changeset/changelog update bc this hasn't hit prod yet (it's part of the M3-9250)

## Description 📝
Surface IP range errors when assigning Linodes using Linode Interfaces to a subnet

## Changes  🔄
- use regex replace function... idk why I did what I had 🤦‍♀️ 
- add tests to check ensure logic

## Target release date 🗓️
4/22 release

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/60dd7b52-aa41-462d-a6c8-5eaca71a3f68) | ![image](https://github.com/user-attachments/assets/13e0a90f-9e24-4dca-acb5-912e0cb512d0) |

## How to test 🧪

See #12016 for testing instructions

### Reproduction steps
- Click 'add IPv4 range' and type 10.0.0.0 or 10.0.0.1
- notice how errors don't get surfaced

### Verification steps
- Confirm IP range errors now surface

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
