### PR TITLE
feat: [UIE-8672, UIE-8702, UIE-8703] - IAM RBAC: fix bugs

### DIFF
--- a/packages/manager/.changeset/pr-12062-upcoming-features-1744990576571.md
+++ b/packages/manager/.changeset/pr-12062-upcoming-features-1744990576571.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+fix bugs with entities component and loading state for tabs ([#12062](https://github.com/linode/manager/pull/12062))

--- a/packages/manager/.changeset/pr-12062-upcoming-features-1744990576571.md
+++ b/packages/manager/.changeset/pr-12062-upcoming-features-1744990576571.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-fix bugs with entities component and loading state for tabs ([#12062](https://github.com/linode/manager/pull/12062))
+IAM RBAC: Fix bugs in the Entities component and the loading state for tabs ([#12062](https://github.com/linode/manager/pull/12062))

--- a/packages/manager/src/features/IAM/Shared/AssignedPermissionsPanel/AssignedPermissionsPanel.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedPermissionsPanel/AssignedPermissionsPanel.tsx
@@ -6,14 +6,9 @@ import { Link } from 'src/components/Link';
 
 import { Entities } from '../Entities/Entities';
 import { Permissions } from '../Permissions/Permissions';
-import {
-  type DrawerModes,
-  type EntitiesOption,
-  type ExtendedRole,
-  type ExtendedRoleMap,
-  getFacadeRoleDescription,
-} from '../utilities';
 
+import type { EntitiesOption } from '../types';
+import { getFacadeRoleDescription, type DrawerModes, type ExtendedRole, type ExtendedRoleMap } from '../utilities';
 import type { SxProps, Theme } from '@mui/material';
 
 interface Props {

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/AssignedRolesTable.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/AssignedRolesTable.tsx
@@ -29,7 +29,7 @@ import {
   getFormattedEntityType,
   mapEntityTypes,
   mapRolesToPermissions,
-  transformedAccountEntities,
+  groupAccountEntitiesByType,
 } from '../utilities';
 import { AssignedRolesActionMenu } from './AssignedRolesActionMenu';
 import { ChangeRoleDrawer } from './ChangeRoleDrawer';
@@ -112,7 +112,7 @@ export const AssignedRolesTable = () => {
     const resourceTypes = getResourceTypes(roles);
 
     if (entities) {
-      const transformedEntities = transformedAccountEntities(entities.data);
+      const transformedEntities = groupAccountEntitiesByType(entities.data);
 
       roles = addEntitiesNamesToRoles(roles, transformedEntities);
     }

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.tsx
@@ -21,12 +21,8 @@ import {
 import { AssignedPermissionsPanel } from '../AssignedPermissionsPanel/AssignedPermissionsPanel';
 import { getAllRoles, getRoleByName, updateUserRoles } from '../utilities';
 
-import type {
-  DrawerModes,
-  EntitiesOption,
-  ExtendedRoleMap,
-  RolesType,
-} from '../utilities';
+import type { EntitiesOption } from '../types';
+import type { DrawerModes, ExtendedRoleMap, RolesType } from '../utilities';
 
 interface Props {
   mode: DrawerModes;
@@ -76,7 +72,7 @@ export const ChangeRoleDrawer = ({ mode, onClose, open, role }: Props) => {
     reset,
     setError,
     watch,
-  } = useForm<{ roleName: RolesType | null }>({
+  } = useForm<{ roleName: null | RolesType }>({
     defaultValues: {
       roleName: null,
     },
@@ -149,6 +145,8 @@ export const ChangeRoleDrawer = ({ mode, onClose, open, role }: Props) => {
         </Typography>
 
         <Controller
+          control={control}
+          name="roleName"
           render={({ field, fieldState }) => (
             <Autocomplete
               errorText={fieldState.error?.message}
@@ -161,8 +159,6 @@ export const ChangeRoleDrawer = ({ mode, onClose, open, role }: Props) => {
               value={field.value || null}
             />
           )}
-          control={control}
-          name="roleName"
           rules={{ required: 'Role is required.' }}
         />
 

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/UpdateEntitiesDrawer.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/UpdateEntitiesDrawer.tsx
@@ -13,11 +13,8 @@ import {
 import { AssignedPermissionsPanel } from '../AssignedPermissionsPanel/AssignedPermissionsPanel';
 import { toEntityAccess } from '../utilities';
 
-import type {
-  EntitiesOption,
-  ExtendedRoleMap,
-  UpdateEntitiesFormValues,
-} from '../utilities';
+import type { EntitiesOption } from '../types';
+import type { ExtendedRoleMap, UpdateEntitiesFormValues } from '../utilities';
 import type { EntityAccessRole } from '@linode/api-v4';
 
 interface Props {

--- a/packages/manager/src/features/IAM/Shared/Entities/Entities.test.tsx
+++ b/packages/manager/src/features/IAM/Shared/Entities/Entities.test.tsx
@@ -7,8 +7,7 @@ import { makeResourcePage } from 'src/mocks/serverHandlers';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { Entities } from './Entities';
-
-import type { EntitiesOption } from '../utilities';
+import { EntitiesOption } from '../types';
 
 const queryMocks = vi.hoisted(() => ({
   useAccountEntities: vi.fn().mockReturnValue({}),

--- a/packages/manager/src/features/IAM/Shared/Entities/Entities.tsx
+++ b/packages/manager/src/features/IAM/Shared/Entities/Entities.tsx
@@ -1,4 +1,4 @@
-import { Autocomplete, Notice, Typography } from '@linode/ui';
+import { Autocomplete, Notice, TextField, Typography } from '@linode/ui';
 import { useTheme } from '@mui/material';
 import React from 'react';
 
@@ -54,8 +54,10 @@ export const Entities = ({
       <>
         <FormLabel>
           <Typography
-            marginBottom={0.5}
-            sx={{ marginTop: theme.tokens.spacing.S12 }}
+            sx={{
+              marginTop: theme.tokens.spacing.S12,
+              marginBottom: theme.tokens.spacing.S4,
+            }}
             variant="inherit"
           >
             Entities
@@ -73,7 +75,7 @@ export const Entities = ({
   return (
     <>
       <Autocomplete
-        errorText={errorText}
+        disabled={!memoizedEntities.length}
         getOptionLabel={(option) => option.label}
         isOptionEqualToValue={(option, value) => option.value === value.value}
         label="Entities"
@@ -88,7 +90,20 @@ export const Entities = ({
           value.length,
           memoizedEntities.length
         )}
-        readOnly={getReadonlyState(mode, memoizedEntities.length)}
+        readOnly={mode === 'change-role'}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            error={!!errorText}
+            errorText={errorText}
+            label="Entities"
+            placeholder={getPlaceholder(
+              type,
+              value.length,
+              memoizedEntities.length
+            )}
+          />
+        )}
         sx={{ marginTop: theme.tokens.spacing.S12 }}
         value={value || []}
       />
@@ -116,11 +131,6 @@ const getPlaceholder = (
     : possibleEntitiesLength === 0
       ? 'None'
       : placeholderMap[type] || 'Select';
-
-const getReadonlyState = (
-  mode: DrawerModes | undefined,
-  possibleEntitiesLength: number
-): boolean => mode === 'change-role' || possibleEntitiesLength === 0;
 
 const transformedEntities = (
   entities: { id: number; label: string }[]

--- a/packages/manager/src/features/IAM/Shared/Entities/Entities.tsx
+++ b/packages/manager/src/features/IAM/Shared/Entities/Entities.tsx
@@ -6,20 +6,14 @@ import { FormLabel } from 'src/components/FormLabel';
 import { Link } from 'src/components/Link';
 import { useAccountEntities } from 'src/queries/entities/entities';
 
-import {
-  getCreateLinkForEntityType,
-  getFormattedEntityType,
-  placeholderMap,
-  transformedAccountEntities,
-} from '../utilities';
-
-import type { DrawerModes, EntitiesOption } from '../utilities';
+import type { EntitiesOption } from '../types';
+import { getFormattedEntityType, type DrawerModes } from '../utilities';
 import type {
-  AccountEntity,
   EntityType,
   EntityTypePermissions,
   IamAccessType,
 } from '@linode/api-v4/lib/iam/types';
+import { getEntitiesByType, getPlaceholder, mapEntitiesToOptions } from './utils';
 
 interface Props {
   access: IamAccessType;
@@ -46,7 +40,7 @@ export const Entities = ({
       return [];
     }
     const typeEntities = getEntitiesByType(type, entities.data);
-    return typeEntities ? transformedEntities(typeEntities) : [];
+    return typeEntities ? mapEntitiesToOptions(typeEntities) : [];
   }, [entities, access, type]);
 
   if (access === 'account_access') {
@@ -119,34 +113,4 @@ export const Entities = ({
       )}
     </>
   );
-};
-
-const getPlaceholder = (
-  type: EntityType | EntityTypePermissions,
-  currentValueLength: number,
-  possibleEntitiesLength: number
-): string =>
-  currentValueLength > 0
-    ? ' '
-    : possibleEntitiesLength === 0
-      ? 'None'
-      : placeholderMap[type] || 'Select';
-
-const transformedEntities = (
-  entities: { id: number; label: string }[]
-): EntitiesOption[] => {
-  return entities.map((entity) => ({
-    label: entity.label,
-    value: entity.id,
-  }));
-};
-
-const getEntitiesByType = (
-  roleEntityType: EntityType | EntityTypePermissions,
-  entities: AccountEntity[]
-): Pick<AccountEntity, 'id' | 'label'>[] | undefined => {
-  const entitiesMap = transformedAccountEntities(entities);
-
-  // Find the first matching entity by type
-  return entitiesMap.get(roleEntityType as EntityType);
 };

--- a/packages/manager/src/features/IAM/Shared/Entities/Entities.tsx
+++ b/packages/manager/src/features/IAM/Shared/Entities/Entities.tsx
@@ -6,14 +6,20 @@ import { FormLabel } from 'src/components/FormLabel';
 import { Link } from 'src/components/Link';
 import { useAccountEntities } from 'src/queries/entities/entities';
 
+import { type DrawerModes, getFormattedEntityType } from '../utilities';
+import {
+  getCreateLinkForEntityType,
+  getEntitiesByType,
+  getPlaceholder,
+  mapEntitiesToOptions,
+} from './utils';
+
 import type { EntitiesOption } from '../types';
-import { getFormattedEntityType, type DrawerModes } from '../utilities';
 import type {
   EntityType,
   EntityTypePermissions,
   IamAccessType,
 } from '@linode/api-v4/lib/iam/types';
-import { getEntitiesByType, getPlaceholder, mapEntitiesToOptions } from './utils';
 
 interface Props {
   access: IamAccessType;

--- a/packages/manager/src/features/IAM/Shared/Entities/utils.test.ts
+++ b/packages/manager/src/features/IAM/Shared/Entities/utils.test.ts
@@ -1,0 +1,68 @@
+import { accountEntityFactory } from 'src/factories/accountEntities';
+
+import {
+  getCreateLinkForEntityType,
+  getEntitiesByType,
+  getPlaceholder,
+  placeholderMap,
+} from './utils';
+
+describe('getCreateLinkForEntityType', () => {
+  it('should return the correct create link for a given entity type', () => {
+    expect(getCreateLinkForEntityType('linode')).toBe('/linodes/create');
+    expect(getCreateLinkForEntityType('volume')).toBe('/volumes/create');
+    expect(getCreateLinkForEntityType('firewall')).toBe('/firewalls/create');
+  });
+});
+
+describe('getPlaceholder', () => {
+  it('should return a space if currentValueLength is greater than 0', () => {
+    expect(getPlaceholder('linode', 1, 10)).toBe(' ');
+  });
+
+  it('should return "None" if possibleEntitiesLength is 0', () => {
+    expect(getPlaceholder('linode', 0, 0)).toBe('None');
+  });
+
+  it('should return the placeholder from placeholderMap if type exists', () => {
+    expect(getPlaceholder('linode', 0, 10)).toBe(placeholderMap['linode']);
+  });
+});
+
+describe('getEntitiesByType', () => {
+  it('should return entities of the type "linode', () => {
+    const mockEntities = [
+      ...accountEntityFactory.buildList(3, {
+        type: 'linode',
+      }),
+      accountEntityFactory.build({
+        type: 'firewall',
+      }),
+    ];
+
+    const result = getEntitiesByType('linode', mockEntities);
+
+    expect(result).toEqual([
+      { id: 1, label: 'test-1' },
+      { id: 2, label: 'test-2' },
+      { id: 3, label: 'test-3' },
+    ]);
+  });
+
+  it('should return entities of the type "linode', () => {
+    const mockEntities = [
+      ...accountEntityFactory.buildList(3, {
+        type: 'linode',
+      }),
+      accountEntityFactory.build({
+        id: 1,
+        label: 'firewall-1',
+        type: 'firewall',
+      }),
+    ];
+
+    const result = getEntitiesByType('firewall', mockEntities);
+
+    expect(result).toEqual([{ id: 1, label: 'firewall-1' }]);
+  });
+});

--- a/packages/manager/src/features/IAM/Shared/Entities/utils.ts
+++ b/packages/manager/src/features/IAM/Shared/Entities/utils.ts
@@ -32,12 +32,19 @@ export const getPlaceholder = (
   type: EntityType | EntityTypePermissions,
   currentValueLength: number,
   possibleEntitiesLength: number
-): string =>
-  currentValueLength > 0
-    ? ' '
-    : possibleEntitiesLength === 0
-      ? 'None'
-      : placeholderMap[type] || 'Select';
+): string => {
+  let placeholder: string;
+
+  if (currentValueLength > 0) {
+    placeholder = ' ';
+  } else if (possibleEntitiesLength === 0) {
+    placeholder = 'None';
+  } else {
+    placeholder = placeholderMap[type] || 'Select';
+  }
+
+  return placeholder;
+};
 
 export const mapEntitiesToOptions = (
   entities: { id: number; label: string }[]

--- a/packages/manager/src/features/IAM/Shared/Entities/utils.ts
+++ b/packages/manager/src/features/IAM/Shared/Entities/utils.ts
@@ -1,0 +1,59 @@
+import { groupAccountEntitiesByType } from '../utilities';
+
+import type { EntitiesOption } from '../types';
+import type {
+  AccountEntity,
+  EntityType,
+  EntityTypePermissions,
+} from '@linode/api-v4';
+
+export const placeholderMap: Record<string, string> = {
+  account: 'Select Account',
+  database: 'Select Databases',
+  domain: 'Select Domains',
+  firewall: 'Select Firewalls',
+  image: 'Select Images',
+  linode: 'Select Linodes',
+  longview: 'Select Longviews',
+  nodebalancer: 'Select Nodebalancers',
+  stackscript: 'Select Stackscripts',
+  volume: 'Select Volumes',
+  vpc: 'Select VPCs',
+};
+
+export const getCreateLinkForEntityType = (
+  entityType: EntityType | EntityTypePermissions
+): string => {
+  // TODO - find the exceptions to this rule - most use the route of /{entityType}s/create (note the "s")
+  return `/${entityType}s/create`;
+};
+
+export const getPlaceholder = (
+  type: EntityType | EntityTypePermissions,
+  currentValueLength: number,
+  possibleEntitiesLength: number
+): string =>
+  currentValueLength > 0
+    ? ' '
+    : possibleEntitiesLength === 0
+      ? 'None'
+      : placeholderMap[type] || 'Select';
+
+export const mapEntitiesToOptions = (
+  entities: { id: number; label: string }[]
+): EntitiesOption[] => {
+  return entities.map((entity) => ({
+    label: entity.label,
+    value: entity.id,
+  }));
+};
+
+export const getEntitiesByType = (
+  roleEntityType: EntityType | EntityTypePermissions,
+  entities: AccountEntity[]
+): Pick<AccountEntity, 'id' | 'label'>[] | undefined => {
+  const entitiesMap = groupAccountEntitiesByType(entities);
+
+  // Find the first matching entity by type
+  return entitiesMap.get(roleEntityType as EntityType);
+};

--- a/packages/manager/src/features/IAM/Shared/types.ts
+++ b/packages/manager/src/features/IAM/Shared/types.ts
@@ -1,0 +1,4 @@
+export interface EntitiesOption {
+  label: string;
+  value: number;
+}

--- a/packages/manager/src/features/IAM/Shared/utilities.ts
+++ b/packages/manager/src/features/IAM/Shared/utilities.ts
@@ -17,20 +17,7 @@ import type {
   Roles,
 } from '@linode/api-v4';
 import type { SelectOption } from '@linode/ui';
-
-export const placeholderMap: Record<string, string> = {
-  account: 'Select Account',
-  database: 'Select Databases',
-  domain: 'Select Domains',
-  firewall: 'Select Firewalls',
-  image: 'Select Images',
-  linode: 'Select Linodes',
-  longview: 'Select Longviews',
-  nodebalancer: 'Select Nodebalancers',
-  stackscript: 'Select Stackscripts',
-  volume: 'Select Volumes',
-  vpc: 'Select VPCs',
-};
+import { EntitiesOption } from './types';
 
 export interface RoleMap {
   access: 'account_access' | 'entity_access';
@@ -365,11 +352,6 @@ export const addEntitiesNamesToRoles = (
   });
 };
 
-export interface EntitiesOption {
-  label: string;
-  value: number;
-}
-
 interface UpdateUserRolesProps {
   access: 'account_access' | 'entity_access';
   assignedRoles?: IamUserPermissions;
@@ -472,7 +454,7 @@ export const deleteUserRole = ({
   return assignedRoles;
 };
 
-export const transformedAccountEntities = (
+export const groupAccountEntitiesByType = (
   entities: AccountEntity[]
 ): Map<EntityType, Pick<AccountEntity, 'id' | 'label'>[]> => {
   const result: Map<EntityType, Pick<AccountEntity, 'id' | 'label'>[]> =

--- a/packages/manager/src/features/IAM/Shared/utilities.ts
+++ b/packages/manager/src/features/IAM/Shared/utilities.ts
@@ -573,13 +573,6 @@ export const deleteUserEntity = (
     .filter((entity) => entity.roles.length > 0);
 };
 
-export const getCreateLinkForEntityType = (
-  entityType: EntityType | EntityTypePermissions
-): string => {
-  // TODO - find the exceptions to this rule - most use the route of /{entityType}s/create (note the "s")
-  return `/${entityType}s/create`;
-};
-
 export const getFacadeRoleDescription = (
   role: ExtendedRole | ExtendedRoleMap
 ): string => {

--- a/packages/manager/src/features/IAM/Users/UserEntities/AssignedEntitiesTable.tsx
+++ b/packages/manager/src/features/IAM/Users/UserEntities/AssignedEntitiesTable.tsx
@@ -22,8 +22,8 @@ import { RemoveAssignmentConfirmationDialog } from '../../Shared/RemoveAssignmen
 import {
   getFilteredRoles,
   getFormattedEntityType,
+  groupAccountEntitiesByType,
   mapEntityTypes,
-  transformedAccountEntities,
 } from '../../Shared/utilities';
 import { ChangeRoleForEntityDrawer } from './ChangeRoleForEntityDrawer';
 
@@ -80,7 +80,7 @@ export const AssignedEntitiesTable = () => {
     if (!assignedRoles || !entities) {
       return { entityTypes: [], roles: [] };
     }
-    const transformedEntities = transformedAccountEntities(entities.data);
+    const transformedEntities = groupAccountEntitiesByType(entities.data);
 
     const roles = addEntityNamesToRoles(assignedRoles, transformedEntities);
 

--- a/packages/manager/src/features/IAM/Users/UserEntities/UserEntities.tsx
+++ b/packages/manager/src/features/IAM/Users/UserEntities/UserEntities.tsx
@@ -1,4 +1,4 @@
-import { Paper, Stack, Typography } from '@linode/ui';
+import { CircleProgress, Paper, Stack, Typography } from '@linode/ui';
 import { isEmpty } from 'ramda';
 import React from 'react';
 import { useParams } from 'react-router-dom';
@@ -12,16 +12,22 @@ import { AssignedEntitiesTable } from './AssignedEntitiesTable';
 
 export const UserEntities = () => {
   const { username } = useParams<{ username: string }>();
-  const { data: assignedRoles } = useAccountUserPermissions(username ?? '');
+  const { data: assignedRoles, isLoading } = useAccountUserPermissions(
+    username ?? ''
+  );
 
   const hasAssignedRoles = assignedRoles
     ? !isEmpty(assignedRoles.entity_access)
     : false;
 
+  if (isLoading) {
+    return <CircleProgress />;
+  }
+
   return (
     <>
       <DocumentTitleSegment segment={`${username} - User Entities`} />
-      <Paper sx={(theme) => ({ marginTop: theme.spacing(2) })}>
+      <Paper sx={(theme) => ({ marginTop: theme.tokens.spacing.S16 })}>
         <Stack spacing={3}>
           <Typography variant="h2">Assigned Entities</Typography>
           {hasAssignedRoles ? (

--- a/packages/manager/src/features/IAM/Users/UserRoles/UserRoles.tsx
+++ b/packages/manager/src/features/IAM/Users/UserRoles/UserRoles.tsx
@@ -1,4 +1,4 @@
-import { Button, Paper, Stack, Typography } from '@linode/ui';
+import { Button, CircleProgress, Paper, Stack, Typography } from '@linode/ui';
 import { isEmpty } from 'ramda';
 import React from 'react';
 import { useParams } from 'react-router-dom';
@@ -14,7 +14,9 @@ import { AssignNewRoleDrawer } from './AssignNewRoleDrawer';
 export const UserRoles = () => {
   const { username } = useParams<{ username: string }>();
 
-  const { data: assignedRoles } = useAccountUserPermissions(username ?? '');
+  const { data: assignedRoles, isLoading } = useAccountUserPermissions(
+    username ?? ''
+  );
   const [isDrawerOpen, setIsDrawerOpen] = React.useState<boolean>(false);
 
   const hasAssignedRoles = assignedRoles
@@ -22,10 +24,14 @@ export const UserRoles = () => {
       !isEmpty(assignedRoles.entity_access)
     : false;
 
+  if (isLoading) {
+    return <CircleProgress />;
+  }
+
   return (
     <>
       <DocumentTitleSegment segment={`${username} - User Roles`} />
-      <Paper sx={(theme) => ({ marginTop: theme.spacing(2) })}>
+      <Paper sx={(theme) => ({ marginTop: theme.tokens.spacing.S16 })}>
         <Stack spacing={3}>
           <Stack
             alignItems="center"

--- a/packages/manager/src/queries/entities/entities.ts
+++ b/packages/manager/src/queries/entities/entities.ts
@@ -8,7 +8,6 @@ import type { AccountEntity, APIError, ResourcePage } from '@linode/api-v4';
 export const useAccountEntities = () => {
   return useQuery<ResourcePage<AccountEntity>, APIError[]>({
     ...entitiesQueries.entities,
-    ...queryPresets.oneTimeFetch,
-    ...queryPresets.noRetry,
+    ...queryPresets.shortLived,
   });
 };


### PR DESCRIPTION
## Description 📝
small bug fixies

## Changes  🔄

List any change(s) relevant to the reviewer.

- Disabled typing in the text field when it enters read-only mode
- Ensured that newly created entities are included in the options list when navigating via the navbar (not when opening a new tab)
- Added a loading state that displays while data is being fetched from the API.
- Minor cleanup in the `Entities` component and related parts of `utilities.ts`

## Target release date 🗓️

(dev)

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Ensure the Identity and Access Beta flag is enabled in dev tools
- Use devenv and login as vagrant user
- Click on the any username in the users table and go to the tab Assigned Roles

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Click in the action menu `Change role` for entity role (ex. stacksript_admin)
- [ ] Try to type the text in the text field


(How to reproduce the issue, if applicable)
- [ ] Go to Assigned Roles tab
- [ ] Go the StackScripts page using the navbar
- [ ] Create a new StackScript
- [ ] Go the Assigned Roles Page for a user the navbar.
- [ ] Click the "Assign New Role" button
- [ ] Select the "stackscript_viewer" role

(How to reproduce the issue, if applicable)
- [ ]  Go to Assigned Roles tab
- [ ]  Go to Assigned Entities tab

### Verification steps

(How to verify changes)

- [ ] It’s not allowed to type in the text field once it is in read-only mode
- [ ] The newly created entity will appear in the options list
- [ ] A loading state appears while the API is fetching data

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

