### PR TITLE
fix: [M3-9796] - Notice icon, padding, and dark mode

### DIFF
--- a/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-object-gen2.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-object-gen2.spec.ts
@@ -413,7 +413,7 @@ describe('Object Storage Gen2 bucket object tests', () => {
         cy.findByText(mockRegions[0].label).should('be.visible');
       });
     // warning message
-    cy.findByTestId('notice-warning-important').within(() => {
+    cy.findByTestId('notice-warning').within(() => {
       cy.contains(
         `There was an error loading buckets in ${mockRegions[1].label}`
       );
@@ -463,7 +463,7 @@ describe('Object Storage Gen2 bucket object tests', () => {
     // table with retrieved bucket
     cy.get('table tbody tr').should('have.length', 1);
     // warning message
-    cy.findByTestId('notice-warning-important').within(() => {
+    cy.findByTestId('notice-warning').within(() => {
       cy.contains(
         'There was an error loading buckets in the following regions:'
       );

--- a/packages/manager/src/components/AbuseTicketBanner/AbuseTicketBanner.tsx
+++ b/packages/manager/src/components/AbuseTicketBanner/AbuseTicketBanner.tsx
@@ -33,7 +33,7 @@ export const AbuseTicketBanner = () => {
 
   const href = multiple
     ? '/support/tickets'
-    : abuseTickets[0].entity?.url ?? '';
+    : (abuseTickets[0].entity?.url ?? '');
   const isViewingTicket = location.pathname.match(href);
 
   return (
@@ -43,7 +43,6 @@ export const AbuseTicketBanner = () => {
           expiry: DateTime.utc().plus({ days: 7 }).toISO(),
           label: preferenceKey,
         }}
-        important
         preferenceKey={preferenceKey}
         variant="warning"
       >

--- a/packages/manager/src/components/DismissibleBanner/DismissibleBanner.stories.tsx
+++ b/packages/manager/src/components/DismissibleBanner/DismissibleBanner.stories.tsx
@@ -11,7 +11,7 @@ type Story = StoryObj<typeof DismissibleBanner>;
 
 export const Default: Story = {
   render: (args) => (
-    <DismissibleBanner {...args} important variant="info">
+    <DismissibleBanner {...args} variant="info">
       <Typography>This is an example of a dismissible banner.</Typography>
     </DismissibleBanner>
   ),
@@ -29,7 +29,6 @@ export const CallToActionBanner: Story = {
         </Button>
       }
       forceImportantIconVerticalCenter
-      important
       preferenceKey="cluster-v1"
       variant="info"
     >
@@ -60,12 +59,11 @@ export const BetaBanner: Story = {
 export const InfoWithLongTextAndMarkup: StoryObj = {
   render: () => (
     <DismissibleBanner
-      important
       preferenceKey="lenghty-dismissible-banner"
       variant="info"
     >
       <Typography variant="h2">
-        This is an important, dismissible informational notice with a title.
+        This is a dismissible informational notice with a title.
       </Typography>
       <Typography>This notice contains long text that should wrap.</Typography>
     </DismissibleBanner>

--- a/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
+++ b/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
@@ -63,6 +63,9 @@ export const DismissibleBanner = (props: Props) => {
         '& svg': {
           width: 16,
           height: 16,
+          '& path': {
+            fill: theme.tokens.component.NotificationBanner.Icon,
+          },
         },
       })}
     >

--- a/packages/manager/src/components/MaintenanceBanner/MaintenanceBanner.tsx
+++ b/packages/manager/src/components/MaintenanceBanner/MaintenanceBanner.tsx
@@ -68,7 +68,7 @@ export const MaintenanceBanner = React.memo((props: Props) => {
   }
 
   return (
-    <Notice important variant="warning">
+    <Notice variant="warning">
       <Typography lineHeight="20px">
         {generateIntroText(type, maintenanceStart, maintenanceEnd)}
       </Typography>

--- a/packages/manager/src/components/ProductInformationBanner/ProductInformationBanner.tsx
+++ b/packages/manager/src/components/ProductInformationBanner/ProductInformationBanner.tsx
@@ -29,13 +29,6 @@ export const ProductInformationBanner = React.memo(
       return null;
     }
 
-    const isImportantBanner =
-      thisBanner.decoration.important === 'true'
-        ? true
-        : thisBanner.decoration.important === 'false'
-        ? false
-        : true;
-
     let hasBannerExpired = true;
     try {
       hasBannerExpired = isAfter(
@@ -52,7 +45,6 @@ export const ProductInformationBanner = React.memo(
 
     return (
       <DismissibleBanner
-        important={isImportantBanner}
         preferenceKey={`${bannerLocation}-${thisBanner.expirationDate}`}
         variant={thisBanner.decoration.variant ?? 'warning'}
         {...rest}

--- a/packages/manager/src/components/ProductNotification/ProductNotification.tsx
+++ b/packages/manager/src/components/ProductNotification/ProductNotification.tsx
@@ -22,9 +22,5 @@ export const ProductNotification = ({
   const level = (severityLevelMap[severity] as NoticeVariant) ?? 'warning';
   const props = { variant: level };
 
-  return (
-    <Notice {...props} important>
-      {text}
-    </Notice>
-  );
+  return <Notice {...props}>{text}</Notice>;
 };

--- a/packages/manager/src/features/Account/AccountLogins.tsx
+++ b/packages/manager/src/features/Account/AccountLogins.tsx
@@ -165,7 +165,6 @@ const AccountLogins = () => {
         isChildUser,
         resourceType: 'Account',
       })}
-      important
       variant="warning"
     />
   );

--- a/packages/manager/src/features/Account/CloseAccountDialog.tsx
+++ b/packages/manager/src/features/Account/CloseAccountDialog.tsx
@@ -19,9 +19,8 @@ interface Props {
 }
 
 const CloseAccountDialog = ({ closeDialog, open }: Props) => {
-  const [isClosingAccount, setIsClosingAccount] = React.useState<boolean>(
-    false
-  );
+  const [isClosingAccount, setIsClosingAccount] =
+    React.useState<boolean>(false);
   const [errors, setErrors] = React.useState<APIError[] | undefined>(undefined);
   const [comments, setComments] = React.useState<string>('');
   const history = useHistory();
@@ -103,11 +102,10 @@ const CloseAccountDialog = ({ closeDialog, open }: Props) => {
       ) : null}
       <StyledNoticeWrapper>
         <Notice
+          spacingBottom={12}
           sx={(theme) => ({
             border: `1px solid ${theme.tokens.alias.Action.Negative.Default}`,
           })}
-          important
-          spacingBottom={12}
           variant="error"
         >
           <Typography sx={{ fontSize: '0.875rem' }}>

--- a/packages/manager/src/features/Backups/BackupsCTA.tsx
+++ b/packages/manager/src/features/Backups/BackupsCTA.tsx
@@ -66,7 +66,12 @@ export const BackupsCTA = () => {
         <IconButton
           aria-label="Dismiss notice enabling Linode backups"
           onClick={handleDismiss}
-          sx={{ padding: 0.25 }}
+          sx={(theme) => ({
+            padding: 0.25,
+            '& path': {
+              fill: theme.tokens.component.NotificationBanner.Icon,
+            },
+          })}
         >
           <CloseIcon />
         </IconButton>

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -250,12 +250,11 @@ const DatabaseCreate = () => {
         />
         {isRestricted && (
           <Notice
+            spacingTop={16}
             text={getRestrictedResourceText({
               action: 'create',
               resourceType: 'Databases',
             })}
-            important
-            spacingTop={16}
             variant="error"
           />
         )}

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfigurationDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfigurationDrawer.tsx
@@ -183,7 +183,7 @@ export const DatabaseAdvancedConfigurationDrawer = (props: Props) => {
         </Typography>
         <Link to={ADVANCED_CONFIG_LEARN_MORE_LINK}>Learn more.</Link>
 
-        <Notice important sx={{ mb: 1, mt: 3 }} variant="info">
+        <Notice sx={{ mb: 1, mt: 3 }} variant="info">
           <Typography>{ADVANCED_CONFIG_INFO}</Typography>
         </Notice>
 

--- a/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
@@ -65,11 +65,8 @@ export const DatabaseDetail = () => {
     id,
   });
 
-  const {
-    editableLabelError,
-    resetEditableLabel,
-    setEditableLabelError,
-  } = useEditableLabelState();
+  const { editableLabelError, resetEditableLabel, setEditableLabelError } =
+    useEditableLabelState();
 
   if (error) {
     return (
@@ -207,7 +204,6 @@ export const DatabaseDetail = () => {
             text={
               "You don't have permissions to modify this Database. Please contact an account administrator for details."
             }
-            important
             variant="warning"
           />
         )}

--- a/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
+++ b/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
@@ -81,18 +81,14 @@ export const CreateDomain = () => {
     },
   ];
 
-  const [
-    defaultRecordsSetting,
-    setDefaultRecordsSetting,
-  ] = React.useState<DefaultRecordsSetting>(defaultRecords[0]);
+  const [defaultRecordsSetting, setDefaultRecordsSetting] =
+    React.useState<DefaultRecordsSetting>(defaultRecords[0]);
 
   const [selectedDefaultLinode, setSelectedDefaultLinode] = React.useState<
     Linode | undefined
   >(undefined);
-  const [
-    selectedDefaultNodeBalancer,
-    setSelectedDefaultNodeBalancer,
-  ] = React.useState<NodeBalancer | undefined>(undefined);
+  const [selectedDefaultNodeBalancer, setSelectedDefaultNodeBalancer] =
+    React.useState<NodeBalancer | undefined>(undefined);
 
   const { values, ...formik } = useFormik({
     initialValues: {
@@ -303,7 +299,6 @@ export const CreateDomain = () => {
             text={
               "You don't have permissions to create a new Domain. Please contact an account administrator for details."
             }
-            important
             variant="error"
           />
         )}

--- a/packages/manager/src/features/Domains/DomainBanner.tsx
+++ b/packages/manager/src/features/Domains/DomainBanner.tsx
@@ -25,7 +25,6 @@ export const DomainBanner = React.memo((props: DomainBannerProps) => {
         expiry: DateTime.utc().plus({ days: 30 }).toISO(),
         label: KEY,
       }}
-      important
       preferenceKey={KEY}
       variant="warning"
     >

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceLanding.tsx
@@ -82,7 +82,6 @@ export const FirewallDeviceLanding = React.memo(
             text={
               "You don't have permissions to modify this Firewall. Please contact an account administrator for details."
             }
-            important
             variant="error"
           />
         ) : null}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
@@ -53,9 +53,8 @@ interface Drawer {
 
 export const FirewallRulesLanding = React.memo((props: Props) => {
   const { disabled, firewallID, rules } = props;
-  const { mutateAsync: updateFirewallRules } = useUpdateFirewallRulesMutation(
-    firewallID
-  );
+  const { mutateAsync: updateFirewallRules } =
+    useUpdateFirewallRulesMutation(firewallID);
   const { data: devices } = useAllFirewallDevicesQuery(firewallID);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -95,10 +94,8 @@ export const FirewallRulesLanding = React.memo((props: Props) => {
   const [generalErrors, setGeneralErrors] = React.useState<
     APIError[] | undefined
   >();
-  const [
-    discardChangesModalOpen,
-    setDiscardChangesModalOpen,
-  ] = React.useState<boolean>(false);
+  const [discardChangesModalOpen, setDiscardChangesModalOpen] =
+    React.useState<boolean>(false);
 
   const openRuleDrawer = (
     category: Category,
@@ -116,10 +113,10 @@ export const FirewallRulesLanding = React.memo((props: Props) => {
         category === 'inbound' && mode === 'create'
           ? '/firewalls/$id/rules/add/inbound'
           : category === 'inbound' && mode === 'edit'
-          ? `/firewalls/$id/rules/edit/inbound/$ruleId`
-          : category === 'outbound' && mode === 'create'
-          ? '/firewalls/$id/rules/add/outbound'
-          : `/firewalls/$id/rules/edit/outbound/$ruleId`,
+            ? `/firewalls/$id/rules/edit/inbound/$ruleId`
+            : category === 'outbound' && mode === 'create'
+              ? '/firewalls/$id/rules/add/outbound'
+              : `/firewalls/$id/rules/edit/outbound/$ruleId`,
     });
   };
 
@@ -319,12 +316,14 @@ export const FirewallRulesLanding = React.memo((props: Props) => {
     }
   }, [status, reset]);
 
-  const inboundRules = React.useMemo(() => editorStateToRules(inboundState), [
-    inboundState,
-  ]);
-  const outboundRules = React.useMemo(() => editorStateToRules(outboundState), [
-    outboundState,
-  ]);
+  const inboundRules = React.useMemo(
+    () => editorStateToRules(inboundState),
+    [inboundState]
+  );
+  const outboundRules = React.useMemo(
+    () => editorStateToRules(outboundState),
+    [outboundState]
+  );
 
   // This is for the Rule Drawer. If there is a rule to modify,
   // we need to pass it to the drawer to pre-populate the form fields.
@@ -385,7 +384,6 @@ export const FirewallRulesLanding = React.memo((props: Props) => {
           text={
             "You don't have permissions to modify this Firewall. Please contact an account administrator for details."
           }
-          important
           variant="error"
         />
       ) : null}
@@ -495,8 +493,8 @@ interface DiscardChangesDialogProps {
   isOpen: boolean;
 }
 
-export const DiscardChangesDialog: React.FC<DiscardChangesDialogProps> = React.memo(
-  (props) => {
+export const DiscardChangesDialog: React.FC<DiscardChangesDialogProps> =
+  React.memo((props) => {
     const { handleClose, handleDiscard, isOpen } = props;
 
     const actions = React.useCallback(
@@ -527,5 +525,4 @@ export const DiscardChangesDialog: React.FC<DiscardChangesDialogProps> = React.m
         </Typography>
       </ConfirmationDialog>
     );
-  }
-);
+  });

--- a/packages/manager/src/features/GlobalNotifications/APIMaintenanceBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/APIMaintenanceBanner.tsx
@@ -64,7 +64,6 @@ export const APIMaintenanceBanner = React.memo((props: Props) => {
 
     return (
       <DismissibleBanner
-        important
         key={scheduledAPIMaintenance.id}
         preferenceKey={scheduledAPIMaintenance.id}
         variant="warning"

--- a/packages/manager/src/features/GlobalNotifications/ComplianceBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceBanner.tsx
@@ -27,7 +27,6 @@ export const ComplianceBanner = () => {
           Review Update
         </StyledActionButton>
       }
-      important
       preferenceKey="gdpr-compliance"
       variant="warning"
     >

--- a/packages/manager/src/features/GlobalNotifications/CreditCardExpiredBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/CreditCardExpiredBanner.tsx
@@ -35,7 +35,6 @@ export const CreditCardExpiredBanner = () => {
         </Button>
       }
       forceImportantIconVerticalCenter
-      important
       preferenceKey={'credit-card-expired'}
       variant="error"
     >

--- a/packages/manager/src/features/GlobalNotifications/DatabaseMigrationInfoBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/DatabaseMigrationInfoBanner.tsx
@@ -5,12 +5,12 @@ import { SupportLink } from 'src/components/SupportLink';
 
 export const DatabaseMigrationInfoBanner = () => {
   return (
-    <Notice important top={10} variant="warning">
+    <Notice top={10} variant="warning">
       <Typography
+        lineHeight="20px"
         sx={(theme) => ({
           font: theme.font.bold,
         })}
-        lineHeight="20px"
       >
         Legacy clusters decommission
       </Typography>

--- a/packages/manager/src/features/GlobalNotifications/EmailBounce.tsx
+++ b/packages/manager/src/features/GlobalNotifications/EmailBounce.tsx
@@ -131,7 +131,7 @@ const EmailBounceNotification = React.memo((props: Props) => {
   }
 
   return (
-    <Notice forceImportantIconVerticalCenter important variant="warning">
+    <Notice forceImportantIconVerticalCenter variant="warning">
       <Grid
         container
         display="flex"

--- a/packages/manager/src/features/GlobalNotifications/RegionStatusBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/RegionStatusBanner.tsx
@@ -63,7 +63,7 @@ export const RegionStatusBanner = React.memo(() => {
   }
 
   return (
-    <Notice data-testid="status-banner" important variant="warning">
+    <Notice data-testid="status-banner" variant="warning">
       {renderBanner(labelsOfRegionsWithOutages)}
     </Notice>
   );

--- a/packages/manager/src/features/GlobalNotifications/TaxCollectionBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/TaxCollectionBanner.tsx
@@ -68,7 +68,6 @@ export const TaxCollectionBanner = () => {
     !isBannerDateWithinFiveWeeksPrior ? (
     <DismissibleBanner
       actionButton={actionButton}
-      important
       preferenceKey="tax-collection-banner"
       variant="warning"
     >

--- a/packages/manager/src/features/GlobalNotifications/VerificationDetailsBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/VerificationDetailsBanner.tsx
@@ -24,7 +24,7 @@ export const VerificationDetailsBanner = ({
   }
 
   return (
-    <Notice forceImportantIconVerticalCenter important variant="warning">
+    <Notice forceImportantIconVerticalCenter variant="warning">
       <Box
         alignItems="center"
         display="flex"

--- a/packages/manager/src/features/Help/StatusBanners.tsx
+++ b/packages/manager/src/features/Help/StatusBanners.tsx
@@ -73,7 +73,6 @@ export const IncidentBanner = React.memo((props: IncidentProps) => {
       variant={
         variantMap.error ? 'error' : variantMap.warning ? 'warning' : undefined
       }
-      important
       preferenceKey={preferenceKey}
       sx={{ marginBottom: theme.spacing() }}
     >

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -163,7 +163,6 @@ export const CreateImageTab = () => {
               isSingular: false,
               resourceType: 'Images',
             })}
-            important
             variant="error"
           />
         )}

--- a/packages/manager/src/features/Images/ImagesCreate/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/ImageUpload.tsx
@@ -192,7 +192,6 @@ export const ImageUpload = () => {
                 isSingular: false,
                 resourceType: 'Images',
               })}
-              important
               variant="error"
             />
           )}

--- a/packages/manager/src/features/Images/ImagesLanding/ImageRegions/ManageImageRegionsForm.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImageRegions/ManageImageRegionsForm.tsx
@@ -113,7 +113,7 @@ export const ManageImageReplicasForm = (props: Props) => {
         </Link>{' '}
         for details on managing your Linux system's disk space.
       </Typography>
-      <Notice important spacingTop={16} variant="info">
+      <Notice spacingTop={16} variant="info">
         <Typography fontSize="inherit">
           As part of our limited promotional period, image replicas are free of
           charge until Q4 2025. Starting in Q4, replicas will be subject to our

--- a/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding/ImagesLanding.tsx
@@ -429,7 +429,6 @@ export const ImagesLanding = () => {
     <React.Fragment>
       {isCreateImageRestricted && (
         <Notice
-          important
           sx={{ marginBottom: 2 }}
           text={getRestrictedResourceText({
             action: 'create',

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -115,13 +115,10 @@ export const CreateCluster = () => {
   const [ipV6Addr, setIPv6Addr] = React.useState<ExtendedIP[]>([
     stringToExtendedIP(''),
   ]);
-  const [selectedTier, setSelectedTier] = React.useState<KubernetesTier>(
-    'standard'
-  );
-  const [
-    isACLAcknowledgementChecked,
-    setIsACLAcknowledgementChecked,
-  ] = React.useState(false);
+  const [selectedTier, setSelectedTier] =
+    React.useState<KubernetesTier>('standard');
+  const [isACLAcknowledgementChecked, setIsACLAcknowledgementChecked] =
+    React.useState(false);
 
   const {
     data: kubernetesHighAvailabilityTypesData,
@@ -174,18 +171,14 @@ export const CreateCluster = () => {
   // Only want to use current types here.
   const typesData = filterCurrentTypes(allTypes?.map(extendType));
 
-  const {
-    mutateAsync: createKubernetesCluster,
-  } = useCreateKubernetesClusterMutation();
+  const { mutateAsync: createKubernetesCluster } =
+    useCreateKubernetesClusterMutation();
 
-  const {
-    mutateAsync: createKubernetesClusterBeta,
-  } = useCreateKubernetesClusterBetaMutation();
+  const { mutateAsync: createKubernetesClusterBeta } =
+    useCreateKubernetesClusterBetaMutation();
 
-  const {
-    isLkeEnterpriseLAFeatureEnabled,
-    isLkeEnterpriseLAFlagEnabled,
-  } = useIsLkeEnterpriseEnabled();
+  const { isLkeEnterpriseLAFeatureEnabled, isLkeEnterpriseLAFlagEnabled } =
+    useIsLkeEnterpriseEnabled();
 
   const {
     isLoadingVersions,
@@ -384,13 +377,12 @@ export const CreateCluster = () => {
         )}
         {isCreateClusterRestricted && (
           <Notice
+            sx={{ marginBottom: 2 }}
             text={getRestrictedResourceText({
               action: 'create',
               isSingular: false,
               resourceType: 'LKE Clusters',
             })}
-            important
-            sx={{ marginBottom: 2 }}
             variant="error"
           />
         )}

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -170,12 +170,7 @@ export const KubeCheckoutBar = (props: Props) => {
         ))}
         <Divider dark spacingBottom={0} spacingTop={16} />
         {showWarning && (
-          <Notice
-            important
-            spacingTop={16}
-            text={nodeWarning}
-            variant="warning"
-          />
+          <Notice spacingTop={16} text={nodeWarning} variant="warning" />
         )}
       </>
     </CheckoutBar>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
@@ -104,8 +104,10 @@ export const AddNodePoolDrawer = (props: Props) => {
     ? extendedTypes.find((thisType) => thisType.id === selectedTypeInfo.planId)
     : undefined;
 
-  const pricePerNode = getLinodeRegionPrice(selectedType, clusterRegionId)
-    ?.monthly;
+  const pricePerNode = getLinodeRegionPrice(
+    selectedType,
+    clusterRegionId
+  )?.monthly;
 
   const totalPrice =
     selectedTypeInfo && isNumber(pricePerNode)
@@ -203,7 +205,6 @@ export const AddNodePoolDrawer = (props: Props) => {
           selectedTypeInfo.count > 0 &&
           selectedTypeInfo.count < 3 && (
             <Notice
-              important
               spacingBottom={16}
               spacingTop={8}
               text={nodeWarning}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/ResizeNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/ResizeNodePoolDrawer.tsx
@@ -51,13 +51,8 @@ const resizeWarning = `Resizing to fewer nodes will delete random nodes from
 the pool.`;
 
 export const ResizeNodePoolDrawer = (props: Props) => {
-  const {
-    kubernetesClusterId,
-    kubernetesRegionId,
-    nodePool,
-    onClose,
-    open,
-  } = props;
+  const { kubernetesClusterId, kubernetesRegionId, nodePool, onClose, open } =
+    props;
   const { classes } = useStyles();
 
   const typesQuery = useSpecificTypes(nodePool?.type ? [nodePool.type] : []);
@@ -71,9 +66,8 @@ export const ResizeNodePoolDrawer = (props: Props) => {
     isPending,
     mutateAsync: updateNodePool,
   } = useUpdateNodePoolMutation(kubernetesClusterId, nodePool?.id ?? -1);
-  const [resizeNodePoolError, setResizeNodePoolError] = React.useState<string>(
-    ''
-  );
+  const [resizeNodePoolError, setResizeNodePoolError] =
+    React.useState<string>('');
 
   const [updatedCount, setUpdatedCount] = React.useState<number>(
     nodePool?.count ?? 0
@@ -111,8 +105,10 @@ export const ResizeNodePoolDrawer = (props: Props) => {
     });
   };
 
-  const pricePerNode = getLinodeRegionPrice(planType, kubernetesRegionId)
-    ?.monthly;
+  const pricePerNode = getLinodeRegionPrice(
+    planType,
+    kubernetesRegionId
+  )?.monthly;
 
   const totalMonthlyPrice =
     planType &&
@@ -186,12 +182,10 @@ export const ResizeNodePoolDrawer = (props: Props) => {
           </div>
 
           {updatedCount < nodePool.count && (
-            <Notice important text={resizeWarning} variant="warning" />
+            <Notice text={resizeWarning} variant="warning" />
           )}
 
-          {updatedCount < 3 && (
-            <Notice important text={nodeWarning} variant="warning" />
-          )}
+          {updatedCount < 3 && <Notice text={nodeWarning} variant="warning" />}
 
           {nodePool.count && hasInvalidPrice && (
             <Notice

--- a/packages/manager/src/features/Linodes/LinodeCreate/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/index.tsx
@@ -97,9 +97,8 @@ export const LinodeCreate = () => {
   const { mutateAsync: cloneLinode } = useCloneLinodeMutation();
   const { mutateAsync: updateAccountAgreements } = useMutateAccountAgreements();
 
-  const {
-    handleLinodeCreateAnalyticsFormError,
-  } = useHandleLinodeCreateAnalyticsFormError(params.type ?? 'OS');
+  const { handleLinodeCreateAnalyticsFormError } =
+    useHandleLinodeCreateAnalyticsFormError(params.type ?? 'OS');
 
   const currentTabIndex = getTabIndex(params.type);
 
@@ -218,13 +217,12 @@ export const LinodeCreate = () => {
             </TabList>
             {isLinodeCreateRestricted && (
               <Notice
+                sx={{ marginBottom: 2 }}
                 text={getRestrictedResourceText({
                   action: 'create',
                   isSingular: false,
                   resourceType: 'Linodes',
                 })}
-                important
-                sx={{ marginBottom: 2 }}
                 variant="error"
               />
             )}

--- a/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
@@ -119,7 +119,6 @@ export const LinodeEntityDetail = (props: Props) => {
     <>
       {isLinodesGrantReadOnly && (
         <Notice
-          important
           text={getRestrictedResourceText({
             resourceType: 'Linodes',
           })}

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/UpgradeInterfaces/DialogContents/ErrorDialogContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/UpgradeInterfaces/DialogContents/ErrorDialogContent.tsx
@@ -24,7 +24,7 @@ export const ErrorDialogContent = (
 
   return (
     <Stack gap={2}>
-      <Notice important variant="error">
+      <Notice variant="error">
         <Typography>
           {isDryRun ? ERROR_DRY_RUN_COPY : 'Unable to upgrade interfaces.'}
         </Typography>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/UpgradeInterfaces/DialogContents/SuccessDialogContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/UpgradeInterfaces/DialogContents/SuccessDialogContent.tsx
@@ -26,7 +26,7 @@ export const SuccessDialogContent = (
 
   return (
     <Stack gap={2}>
-      <Notice important variant="success">
+      <Notice variant="success">
         <Typography>
           {isDryRun ? SUCCESS_DRY_RUN_COPY : SUCCESS_UPGRADE_COPY}
         </Typography>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferContent.tsx
@@ -60,11 +60,10 @@ export const TransferContent = (props: ContentProps) => {
   if (error) {
     return (
       <Notice
+        spacingBottom={0}
         text={
           'Network transfer information for this Linode is currently unavailable.'
         }
-        important
-        spacingBottom={0}
         variant="error"
       />
     );

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/HostMaintenance.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/HostMaintenance.tsx
@@ -13,7 +13,7 @@ export const HostMaintenance = (props: Props) => {
     return null;
   }
   return (
-    <Notice important variant="warning">
+    <Notice variant="warning">
       <Typography style={{ paddingBottom: '8px' }} variant="h3">
         <strong>
           An issue affecting the physical host this Linode resides on has been

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/MigrationNotification.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/MigrationNotification.tsx
@@ -33,15 +33,8 @@ export const MigrationNotification = React.memo((props: Props) => {
 
   const { data: profile } = useProfile();
 
-  const {
-    closeDialog,
-    dialog,
-    handleError,
-    openDialog,
-    submitDialog,
-  } = useDialog<number>((linodeID: number) =>
-    scheduleOrQueueMigration(linodeID)
-  );
+  const { closeDialog, dialog, handleError, openDialog, submitDialog } =
+    useDialog<number>((linodeID: number) => scheduleOrQueueMigration(linodeID));
 
   const onSubmit = () => {
     submitDialog(linodeID)
@@ -106,7 +99,7 @@ export const MigrationNotification = React.memo((props: Props) => {
 
   return (
     <>
-      <Notice important variant="warning">
+      <Notice variant="warning">
         <Typography>
           {notificationType === 'migration_scheduled'
             ? migrationScheduledText()

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
@@ -74,7 +74,7 @@ export const MutationNotification = (props: Props) => {
 
   return (
     <>
-      <Notice important variant="warning">
+      <Notice variant="warning">
         <Typography>
           You have a pending upgrade. The estimated time to complete this
           upgrade is

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
@@ -120,7 +120,6 @@ export const LongviewLanding = (props: LongviewProps) => {
     <>
       {isLongviewCreationRestricted && (
         <Notice
-          important
           sx={{ marginBottom: 2 }}
           text={getRestrictedResourceText({
             action: 'create',

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
@@ -187,7 +187,6 @@ export const LongviewPlans = (props: LongviewPlansProps) => {
           )}
           {!mayUserModifyLVSubscription && (
             <Notice
-              important
               text="You don't have permissions to change the Longview plan. Please contact an account administrator for details."
               variant="error"
             />

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -116,24 +116,19 @@ const NodeBalancerCreate = () => {
     mutateAsync: createNodeBalancer,
   } = useNodebalancerCreateMutation();
 
-  const [
-    nodeBalancerFields,
-    setNodeBalancerFields,
-  ] = React.useState<NodeBalancerFieldsState>(defaultFieldsStates);
+  const [nodeBalancerFields, setNodeBalancerFields] =
+    React.useState<NodeBalancerFieldsState>(defaultFieldsStates);
 
-  const [hasSignedAgreement, setHasSignedAgreement] = React.useState<boolean>(
-    false
-  );
+  const [hasSignedAgreement, setHasSignedAgreement] =
+    React.useState<boolean>(false);
 
-  const [
-    deleteConfigConfirmDialog,
-    setDeleteConfigConfirmDialog,
-  ] = React.useState<{
-    errors?: APIError[];
-    idxToDelete?: number;
-    open: boolean;
-    submitting: boolean;
-  }>(defaultDeleteConfigConfirmDialogState);
+  const [deleteConfigConfirmDialog, setDeleteConfigConfirmDialog] =
+    React.useState<{
+      errors?: APIError[];
+      idxToDelete?: number;
+      open: boolean;
+      submitting: boolean;
+    }>(defaultDeleteConfigConfirmDialogState);
 
   const { mutateAsync: updateAgreements } = useMutateAccountAgreements();
 
@@ -164,16 +159,15 @@ const NodeBalancerCreate = () => {
       return { ...prev, configs: newConfigs };
     });
 
-  const removeNodeBalancerConfigNode = (configIdx: number) => (
-    nodeIdx: number
-  ) =>
-    setNodeBalancerFields((prev) => {
-      const newConfigs = [...prev.configs];
-      newConfigs[configIdx].nodes = newConfigs[configIdx].nodes.filter(
-        (_, idx) => idx !== nodeIdx
-      );
-      return { ...prev, configs: newConfigs };
-    });
+  const removeNodeBalancerConfigNode =
+    (configIdx: number) => (nodeIdx: number) =>
+      setNodeBalancerFields((prev) => {
+        const newConfigs = [...prev.configs];
+        newConfigs[configIdx].nodes = newConfigs[configIdx].nodes.filter(
+          (_, idx) => idx !== nodeIdx
+        );
+        return { ...prev, configs: newConfigs };
+      });
 
   const setNodeValue = (
     cidx: number,
@@ -358,7 +352,7 @@ const NodeBalancerCreate = () => {
   };
 
   const onConfigValueChange = <
-    Key extends keyof NodeBalancerConfigFieldsWithStatusAndErrors
+    Key extends keyof NodeBalancerConfigFieldsWithStatusAndErrors,
   >(
     configId: number,
     key: Key,
@@ -438,8 +432,9 @@ const NodeBalancerCreate = () => {
     selectedRegionId: nodeBalancerFields.region ?? '',
   });
 
-  const regionLabel = regions?.find((r) => r.id === nodeBalancerFields.region)
-    ?.label;
+  const regionLabel = regions?.find(
+    (r) => r.id === nodeBalancerFields.region
+  )?.label;
 
   const price = getDCSpecificPriceByType({
     regionId: nodeBalancerFields.region,
@@ -501,12 +496,11 @@ const NodeBalancerCreate = () => {
       )}
       {isRestricted && (
         <Notice
+          spacingTop={16}
           text={getRestrictedResourceText({
             action: 'create',
             resourceType: 'NodeBalancers',
           })}
-          important
-          spacingTop={16}
           variant="error"
         />
       )}
@@ -583,9 +577,9 @@ const NodeBalancerCreate = () => {
       </Stack>
       <Box marginBottom={2} marginTop={2}>
         {nodeBalancerFields.configs.map((nodeBalancerConfig, idx) => {
-          const onChange = (key: keyof NodeBalancerConfigFieldsWithStatus) => (
-            value: any
-          ) => onConfigValueChange(idx, key, value);
+          const onChange =
+            (key: keyof NodeBalancerConfigFieldsWithStatus) => (value: any) =>
+              onConfigValueChange(idx, key, value);
 
           return (
             <Accordion
@@ -746,9 +740,9 @@ const NodeBalancerCreate = () => {
 };
 
 /* @todo: move to own file */
-export const lensFrom = (p1: (number | string)[]) => (
-  p2: (number | string)[]
-) => lensPath([...p1, ...p2]);
+export const lensFrom =
+  (p1: (number | string)[]) => (p2: (number | string)[]) =>
+    lensPath([...p1, ...p2]);
 
 const getPathAndFieldFromFieldString = (value: string) => {
   let field = value;

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -31,15 +31,14 @@ export const NodeBalancerDetail = () => {
   const [label, setLabel] = React.useState<string>();
   const { data: grants } = useGrants();
 
-  const {
-    error: updateError,
-    mutateAsync: updateNodeBalancer,
-  } = useNodebalancerUpdateMutation(Number(id));
+  const { error: updateError, mutateAsync: updateNodeBalancer } =
+    useNodebalancerUpdateMutation(Number(id));
 
-  const { data: nodebalancer, error, isLoading } = useNodeBalancerQuery(
-    Number(id),
-    Boolean(id)
-  );
+  const {
+    data: nodebalancer,
+    error,
+    isLoading,
+  } = useNodeBalancerQuery(Number(id), Boolean(id));
 
   const isNodeBalancerReadOnly = useIsResourceRestricted({
     grantLevel: 'read_only',
@@ -115,7 +114,6 @@ export const NodeBalancerDetail = () => {
           text={getRestrictedResourceText({
             resourceType: 'NodeBalancers',
           })}
-          important
           variant="warning"
         />
       )}

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -281,7 +281,7 @@ const Banner = React.memo(({ regionsAffected }: BannerProps) => {
   const moreThanOneRegionAffected = regionsAffected.length > 1;
 
   return (
-    <Notice important variant="warning">
+    <Notice variant="warning">
       <Typography component="div" style={{ fontSize: '1rem' }}>
         There was an error loading buckets in{' '}
         {moreThanOneRegionAffected

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/OMC_BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/OMC_BucketLanding.tsx
@@ -293,7 +293,7 @@ const Banner = React.memo(({ regionsAffected }: BannerProps) => {
   const moreThanOneRegionAffected = regionsAffected.length > 1;
 
   return (
-    <Notice important variant="warning">
+    <Notice variant="warning">
       <Typography component="div" style={{ fontSize: '1rem' }}>
         There was an error loading buckets in{' '}
         {moreThanOneRegionAffected

--- a/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -203,7 +203,6 @@ export const BillingNotice = React.memo(() => {
         expiry: DateTime.utc().plus({ days: 30 }).toISO(),
         label: NOTIFICATION_KEY,
       }}
-      important
       preferenceKey={NOTIFICATION_KEY}
       variant="warning"
     >

--- a/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -76,13 +76,12 @@ export const StackScriptCreate = () => {
         <Stack spacing={2}>
           {isStackScriptCreationRestricted && (
             <Notice
+              spacingBottom={12}
               text={getRestrictedResourceText({
                 action: 'create',
                 isSingular: false,
                 resourceType: 'StackScripts',
               })}
-              important
-              spacingBottom={12}
               variant="error"
             />
           )}

--- a/packages/manager/src/features/VPCs/VPCCreate/FormComponents/CannotCreateVPCNotice.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/FormComponents/CannotCreateVPCNotice.tsx
@@ -5,7 +5,6 @@ import { CANNOT_CREATE_VPC_MESSAGE } from '../../constants';
 
 export const CannotCreateVPCNotice = (
   <Notice
-    important
     spacingTop={16}
     text={`${CANNOT_CREATE_VPC_MESSAGE}`}
     variant="error"

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.tsx
@@ -478,7 +478,6 @@ export const SubnetAssignLinodesDrawer = (
     >
       {userCannotAssignLinodes && (
         <Notice
-          important
           text={`You don't have permissions to assign Linodes to ${subnet?.label}. Please contact an account administrator for details.`}
           variant="error"
         />

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetCreateDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetCreateDrawer.tsx
@@ -101,12 +101,11 @@ export const SubnetCreateDrawer = (props: Props) => {
       )}
       {userCannotAddSubnet && (
         <Notice
+          spacingBottom={8}
+          spacingTop={16}
           text={
             "You don't have permissions to create a new Subnet. Please contact an account administrator for details."
           }
-          important
-          spacingBottom={8}
-          spacingTop={16}
           variant="error"
         />
       )}

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetEditDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetEditDrawer.tsx
@@ -88,7 +88,6 @@ export const SubnetEditDrawer = (props: Props) => {
       )}
       {readOnly && (
         <Notice
-          important
           text={`You don't have permissions to edit ${subnet?.label}. Please contact an account administrator for details.`}
           variant="error"
         />

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
@@ -318,7 +318,6 @@ export const SubnetUnassignLinodesDrawer = React.memo(
       >
         {userCannotUnassignLinodes && (
           <Notice
-            important
             text={`You don't have permissions to unassign Linodes from ${subnet?.label}. Please contact an account administrator for details.`}
             variant="error"
           />

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCEditDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCEditDrawer.tsx
@@ -81,7 +81,6 @@ export const VPCEditDrawer = (props: Props) => {
       )}
       {readOnly && (
         <Notice
-          important
           text={`You don't have permissions to edit ${vpc?.label}. Please contact an account administrator for details.`}
           variant="error"
         />

--- a/packages/manager/src/features/Volumes/Drawers/VolumeDrawer/LinodeVolumeAttachForm.tsx
+++ b/packages/manager/src/features/Volumes/Drawers/VolumeDrawer/LinodeVolumeAttachForm.tsx
@@ -115,7 +115,6 @@ export const LinodeVolumeAttachForm = (props: Props) => {
           text={
             "You don't have permissions to add a Volume for this Linode. Please contact an account administrator for details."
           }
-          important
           variant="error"
         />
       )}

--- a/packages/manager/src/features/Volumes/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate.tsx
@@ -148,9 +148,8 @@ export const VolumeCreate = () => {
   const [hasSignedAgreement, setHasSignedAgreement] = React.useState(false);
   const { mutateAsync: updateAccountAgreements } = useMutateAccountAgreements();
 
-  const {
-    isBlockStorageEncryptionFeatureEnabled,
-  } = useIsBlockStorageEncryptionFeatureEnabled();
+  const { isBlockStorageEncryptionFeatureEnabled } =
+    useIsBlockStorageEncryptionFeatureEnabled();
 
   const regionsWithBlockStorage =
     regions
@@ -193,15 +192,8 @@ export const VolumeCreate = () => {
   } = useFormik({
     initialValues,
     onSubmit: (values, { resetForm, setErrors, setStatus, setSubmitting }) => {
-      const {
-        config_id,
-        encryption,
-        label,
-        linode_id,
-        region,
-        size,
-        tags,
-      } = values;
+      const { config_id, encryption, label, linode_id, region, size, tags } =
+        values;
 
       setSubmitting(true);
 
@@ -339,12 +331,11 @@ export const VolumeCreate = () => {
       />
       {doesNotHavePermission && (
         <Notice
+          spacingTop={16}
           text={getRestrictedResourceText({
             action: 'create',
             resourceType: 'Volumes',
           })}
-          important
-          spacingTop={16}
           variant="error"
         />
       )}
@@ -394,7 +385,7 @@ export const VolumeCreate = () => {
                   touched.tags
                     ? errors.tags
                       ? getErrorStringOrDefault(
-                          (errors.tags as unknown) as APIError[],
+                          errors.tags as unknown as APIError[],
                           'Unable to tag volume.'
                         )
                       : undefined

--- a/packages/manager/src/routes/images/ImagesRoute.tsx
+++ b/packages/manager/src/routes/images/ImagesRoute.tsx
@@ -12,7 +12,6 @@ export const ImagesRoute = () => {
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <DismissibleBanner
-        important
         preferenceKey="image-encryption-is-standard"
         spacingBottom={8}
         variant="info"

--- a/packages/ui/src/components/Notice/Notice.stories.tsx
+++ b/packages/ui/src/components/Notice/Notice.stories.tsx
@@ -19,6 +19,12 @@ export const Info: StoryObj<NoticeProps> = {
   ),
 };
 
+export const Tip: StoryObj<NoticeProps> = {
+  render: (args) => (
+    <Notice {...args} text="This is a tip notice" variant="tip" />
+  ),
+};
+
 export const InfoWithLongTextAndMarkup: StoryObj<NoticeProps> = {
   render: () => (
     <Notice variant="info">
@@ -39,61 +45,6 @@ export const Error: StoryObj<NoticeProps> = {
 export const Warning: StoryObj<NoticeProps> = {
   render: (args) => (
     <Notice {...args} text="This is a warning notice" variant="warning" />
-  ),
-};
-
-export const ImportantSuccess: StoryObj<NoticeProps> = {
-  render: (args) => (
-    <Notice
-      {...args}
-      important
-      text="This is an important success notice"
-      variant="success"
-    />
-  ),
-};
-
-export const ImportantInfo: StoryObj<NoticeProps> = {
-  render: (args) => (
-    <Notice
-      {...args}
-      important
-      text="This is an important informational notice"
-      variant="info"
-    />
-  ),
-};
-
-export const ImportantTip: StoryObj<NoticeProps> = {
-  render: (args) => (
-    <Notice
-      {...args}
-      important
-      text="This is an important tip notice"
-      variant="tip"
-    />
-  ),
-};
-
-export const ImportantError: StoryObj<NoticeProps> = {
-  render: (args) => (
-    <Notice
-      {...args}
-      important
-      text="This is an important error notice"
-      variant="error"
-    />
-  ),
-};
-
-export const ImportantWarning: StoryObj<NoticeProps> = {
-  render: (args) => (
-    <Notice
-      {...args}
-      important
-      text="This is an important warning notice"
-      variant="warning"
-    />
   ),
 };
 

--- a/packages/ui/src/components/Notice/Notice.styles.ts
+++ b/packages/ui/src/components/Notice/Notice.styles.ts
@@ -4,6 +4,9 @@ export const useStyles = makeStyles()((theme) => ({
   error: {
     borderLeft: `4px solid ${theme.tokens.component.NotificationBanner.Error.Border}`,
     background: theme.tokens.component.NotificationBanner.Error.Background,
+    '& path': {
+      fill: theme.tokens.component.NotificationBanner.Error.StatusIcon,
+    },
   },
   icon: {
     '& g': {
@@ -21,6 +24,9 @@ export const useStyles = makeStyles()((theme) => ({
     borderLeft: `4px solid ${theme.tokens.component.NotificationBanner.Informative.Border}`,
     background:
       theme.tokens.component.NotificationBanner.Informative.Background,
+    '& path': {
+      fill: theme.tokens.component.NotificationBanner.Informative.StatusIcon,
+    },
   },
   root: {
     display: 'flex',
@@ -29,7 +35,7 @@ export const useStyles = makeStyles()((theme) => ({
       marginTop: `${theme.spacingFunction(8)} !important`,
     },
     borderRadius: 1,
-    padding: `${theme.spacingFunction(8)} ${theme.spacingFunction(16)}`,
+    padding: `${theme.spacingFunction(8)} ${theme.spacingFunction(12)}`,
     '& .MuiTypography-root': {
       width: '100%',
     },
@@ -46,9 +52,15 @@ export const useStyles = makeStyles()((theme) => ({
   success: {
     borderLeft: `4px solid ${theme.tokens.component.NotificationBanner.Success.Border}`,
     background: theme.tokens.component.NotificationBanner.Success.Background,
+    '& path': {
+      fill: theme.tokens.component.NotificationBanner.Success.StatusIcon,
+    },
   },
   warning: {
     borderLeft: `4px solid ${theme.tokens.component.NotificationBanner.Warning.Border}`,
     background: theme.tokens.component.NotificationBanner.Warning.Background,
+    '& path:first-of-type': {
+      fill: theme.tokens.component.NotificationBanner.Warning.StatusIcon,
+    },
   },
 }));

--- a/packages/ui/src/components/Notice/Notice.styles.ts
+++ b/packages/ui/src/components/Notice/Notice.styles.ts
@@ -17,9 +17,6 @@ export const useStyles = makeStyles()((theme) => ({
     height: 20,
     position: 'relative',
   },
-  important: {
-    font: theme.font.normal,
-  },
   info: {
     borderLeft: `4px solid ${theme.tokens.component.NotificationBanner.Informative.Border}`,
     background:
@@ -59,7 +56,8 @@ export const useStyles = makeStyles()((theme) => ({
   warning: {
     borderLeft: `4px solid ${theme.tokens.component.NotificationBanner.Warning.Border}`,
     background: theme.tokens.component.NotificationBanner.Warning.Background,
-    '& path:first-of-type': {
+    // Only update outer triangle color
+    '& .css-1j6o9qe-icon path:first-of-type': {
       fill: theme.tokens.component.NotificationBanner.Warning.StatusIcon,
     },
   },

--- a/packages/ui/src/components/Notice/Notice.test.tsx
+++ b/packages/ui/src/components/Notice/Notice.test.tsx
@@ -67,13 +67,6 @@ describe('Notice Component', () => {
     expect(container.firstChild).toHaveStyle('background: #ffe5e5;');
   });
 
-  it('displays icon for important notices', () => {
-    const { getByTestId } = renderWithTheme(<Notice important />);
-    const icon = getByTestId('notice-important');
-
-    expect(icon).toBeInTheDocument();
-  });
-
   it('handles bypassValidation prop', () => {
     const { container } = renderWithTheme(<Notice bypassValidation />);
 

--- a/packages/ui/src/components/Notice/Notice.tsx
+++ b/packages/ui/src/components/Notice/Notice.tsx
@@ -36,10 +36,6 @@ export interface NoticeProps extends BoxProps {
    */
   forceImportantIconVerticalCenter?: boolean;
   /**
-   * If true, an icon will be displayed to the left of the error, reflecting the variant of the error.
-   */
-  important?: boolean;
-  /**
    * The amount of spacing to apply to the bottom of the error.
    */
   spacingBottom?: 0 | 4 | 8 | 12 | 16 | 20 | 24 | 32;
@@ -88,7 +84,6 @@ export const Notice = (props: NoticeProps) => {
     dataTestId,
     errorGroup,
     forceImportantIconVerticalCenter = false,
-    important,
     spacingBottom,
     spacingLeft,
     spacingTop,
@@ -133,17 +128,12 @@ export const Notice = (props: NoticeProps) => {
           [classes.info]: variantMap.info || variantMap.tip,
           [classes.success]: variantMap.success,
           [classes.warning]: variantMap.warning,
-          // The order we apply styles matters - important must be applied last
-          [classes.important]: important,
           [errorScrollClassName]: variantMap.error,
         },
         'notice',
         className,
       )}
-      data-testid={
-        dataTestId ??
-        `notice${variant ? `-${variant}` : ''}${important ? '-important' : ''}`
-      }
+      data-testid={dataTestId ?? `notice${variant ? `-${variant}` : ''}`}
       role="alert"
       sx={[
         (theme) => ({
@@ -159,23 +149,19 @@ export const Notice = (props: NoticeProps) => {
       {...dataAttributes}
       {...rest}
     >
-      {important && (
-        <Box
-          sx={(theme) => ({
-            display: 'flex',
-            alignSelf: forceImportantIconVerticalCenter
-              ? 'center'
-              : 'flex-start',
-            marginRight: theme.spacingFunction(8),
-          })}
-        >
-          {variantMap.error && <ErrorIcon className={classes.icon} />}
-          {variantMap.info && <InfoIcon className={classes.icon} />}
-          {variantMap.success && <CheckIcon className={classes.icon} />}
-          {variantMap.tip && <LightBulbIcon className={classes.icon} />}
-          {variantMap.warning && <WarningIcon className={classes.icon} />}
-        </Box>
-      )}
+      <Box
+        sx={(theme) => ({
+          display: 'flex',
+          alignSelf: forceImportantIconVerticalCenter ? 'center' : 'flex-start',
+          marginRight: theme.spacingFunction(8),
+        })}
+      >
+        {variantMap.error && <ErrorIcon className={classes.icon} />}
+        {variantMap.info && <InfoIcon className={classes.icon} />}
+        {variantMap.success && <CheckIcon className={classes.icon} />}
+        {variantMap.tip && <LightBulbIcon className={classes.icon} />}
+        {variantMap.warning && <WarningIcon className={classes.icon} />}
+      </Box>
       <Box sx={{ display: 'flex', flexWrap: 'wrap', width: '100%' }}>
         {text || typeof children === 'string' ? (
           <Typography {...typeProps}>{text ?? children}</Typography>


### PR DESCRIPTION
## Changes  🔄
- Fix icon not changing in dark mode
- Fix left padding
- All notices/banners have icons associated now without the need for important
  - Removed important references from the codebase and stories

No need for changeset since this isn't released yet. I did a quick pass-through and haven't noticed any regressions

## Target release date 🗓️
4/22

## Preview 📷
| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/61cf47c3-7b96-4142-b72d-423a4ed7785f" /> | <video src="https://github.com/user-attachments/assets/671e25af-cc50-4a77-8836-636e80c91152" /> |

## How to test 🧪

### Verification steps

(How to verify changes)

- [ ] Check notices/banners for regressions across the codebase in dark mode, various sizes, and storybook

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>