### PR TITLE
test [M3-9564]: Fix Cypress Linode rebuild test against DevCloud

### DIFF
--- a/packages/manager/cypress/e2e/core/linodes/rebuild-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/rebuild-linode.spec.ts
@@ -244,7 +244,7 @@ describe('rebuild linode', () => {
   it('rebuilds a linode from Account StackScript', () => {
     cy.tag('method:e2e');
     const image = 'Alpine 3.18';
-    const region = 'us-east';
+    const region = chooseRegion().id;
 
     // Create a StackScript to rebuild a Linode.
     const linodeRequest = createLinodeRequestFactory.build({
@@ -351,7 +351,10 @@ describe('rebuild linode', () => {
   });
 
   it('can rebuild a Linode reusing existing user data', () => {
-    const region = regionFactory.build({ capabilities: ['Metadata'] });
+    const region = regionFactory.build({
+      capabilities: ['Metadata'],
+      id: chooseRegion().id,
+    });
     const linode = linodeFactory.build({
       region: region.id,
       // has_user_data: true - add this when we add the type to make this test more realistic


### PR DESCRIPTION
## Description 📝

Replace hardcoded region ID with randomly selected region in rebuild-linode.spec.ts tests. 

## How to test 🧪
pnpm cy:e2e -s "cypress/e2e/core/linodes/rebuild-linode.spec.ts"

The 'rebuilds a linode from Community StackScript' test will fail in test environments missing the hardcoded community stackscript, but can skip this test with custom tag appended to test command:
CY_TEST_TAGS="-env:stackScripts" pnpm cy:e2e -s "cypress/e2e/core/linodes/rebuild-linode.spec.ts" 
<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

---

## Commit message and pull request title format standards
 