### PR TITLE
fix: [M3-9779, M3-9787] - Improve validation and UX for ACL IP Address fields

### DIFF
--- a/packages/manager/.changeset/pr-12067-upcoming-features-1745002359136.md
+++ b/packages/manager/.changeset/pr-12067-upcoming-features-1745002359136.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Fix persisting ACL IP validation error and disable fields if user selects to provide IPs later ([#12067](https://github.com/linode/manager/pull/12067))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -1111,8 +1111,7 @@ describe('LKE Cluster Creation with ACL', () => {
       cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0').within(() => {
         cy.get('input').should('be.visible').should('be.disabled');
       });
-
-      cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0').within(() => {
+      cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0').within(() => {
         cy.get('input').should('be.visible').should('be.disabled');
       });
 

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -335,8 +335,10 @@ describe('LKE Cluster Creation', () => {
       // how many identical labels for each plan will exist and confirm that
       // the expected number is present.
       const nodePoolLabel = clusterPlan.planName;
-      const similarNodePoolCount = getSimilarPlans(clusterPlan, clusterPlans)
-        .length;
+      const similarNodePoolCount = getSimilarPlans(
+        clusterPlan,
+        clusterPlans
+      ).length;
 
       // Confirm that the cluster created with the expected parameters.
       cy.findAllByText(`${clusterRegion.label}`).should('be.visible');
@@ -379,7 +381,8 @@ describe('LKE Cluster Creation with APL enabled', () => {
       region: clusterRegion.id,
     });
     const mockedLKEClusterPools = [nanodeMemoryPool, dedicatedCpuPool];
-    const mockedLKEClusterControlPlane = kubernetesControlPlaneACLFactory.build();
+    const mockedLKEClusterControlPlane =
+      kubernetesControlPlaneACLFactory.build();
     const dedicated4Type = dedicatedTypeFactory.build({
       disk: 163840,
       id: 'g6-dedicated-4',
@@ -1078,7 +1081,7 @@ describe('LKE Cluster Creation with ACL', () => {
         'At least one IP address or CIDR range is required for LKE Enterprise.'
       ).should('be.visible');
 
-      // Add an IP,
+      // Add an IP.
       cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0')
         .should('be.visible')
         .click();
@@ -1104,12 +1107,14 @@ describe('LKE Cluster Creation with ACL', () => {
       // Check the acknowledgement to prevent IP validation.
       cy.findByRole('checkbox', { name: /Provide an ACL later/ }).check();
 
-      // Clear the IP address field and check the acknowledgement to confirm the form can now submit without IP address validation.
-      cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0')
-        .should('be.visible')
-        .click();
-      cy.focused().clear();
-      cy.findByRole('checkbox', { name: /Provide an ACL later/ }).check();
+      // Confirm the fields are disabled.
+      cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0').within(() => {
+        cy.get('input').should('be.visible').should('be.disabled');
+      });
+
+      cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0').within(() => {
+        cy.get('input').should('be.visible').should('be.disabled');
+      });
 
       // Finally, add a label, so the form will submit.
       cy.findByLabelText('Cluster Label').should('be.visible').click();

--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
@@ -206,7 +206,9 @@ export const MultipleIPInput = React.memo((props: MultipeIPInputProps) => {
   const addIPButton =
     forVPCIPv4Ranges || isLinkStyled ? (
       <StyledLinkButtonBox sx={{ marginTop: isLinkStyled ? '8px' : '12px' }}>
-        <LinkButton onClick={addNewInput}>{buttonText}</LinkButton>
+        <LinkButton isDisabled={disabled} onClick={addNewInput}>
+          {buttonText}
+        </LinkButton>
       </StyledLinkButtonBox>
     ) : (
       <Button

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ControlPlaneACLPane.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ControlPlaneACLPane.tsx
@@ -83,6 +83,10 @@ export const ControlPlaneACLPane = (props: ControlPlaneACLProps) => {
         <Box marginBottom={2}>
           <Box sx={{ marginBottom: 1, maxWidth: 450 }}>
             <MultipleIPInput
+              buttonText="Add IPv4 Address"
+              disabled={isAcknowledgementChecked}
+              ips={ipV4Addr}
+              isLinkStyled
               onBlur={(_ips: ExtendedIP[]) => {
                 const validatedIPs = validateIPs(_ips, {
                   allowEmptyAddress: true,
@@ -90,14 +94,15 @@ export const ControlPlaneACLPane = (props: ControlPlaneACLProps) => {
                 });
                 handleIPv4Change(validatedIPs);
               }}
-              buttonText="Add IPv4 Address"
-              ips={ipV4Addr}
-              isLinkStyled
               onChange={handleIPv4Change}
               title="IPv4 Addresses or CIDRs"
             />
             <Box marginTop={2}>
               <MultipleIPInput
+                buttonText="Add IPv6 Address"
+                disabled={isAcknowledgementChecked}
+                ips={ipV6Addr}
+                isLinkStyled
                 onBlur={(_ips: ExtendedIP[]) => {
                   const validatedIPs = validateIPs(_ips, {
                     allowEmptyAddress: true,
@@ -105,9 +110,6 @@ export const ControlPlaneACLPane = (props: ControlPlaneACLProps) => {
                   });
                   handleIPv6Change(validatedIPs);
                 }}
-                buttonText="Add IPv6 Address"
-                ips={ipV6Addr}
-                isLinkStyled
                 onChange={handleIPv6Change}
                 title="IPv6 Addresses or CIDRs"
               />
@@ -117,10 +119,10 @@ export const ControlPlaneACLPane = (props: ControlPlaneACLProps) => {
             <FormControlLabel
               control={
                 <Checkbox
+                  name="acl-acknowledgement"
                   onChange={() =>
                     handleIsAcknowledgementChecked(!isAcknowledgementChecked)
                   }
-                  name="acl-acknowledgement"
                 />
               }
               data-qa-checkbox="acl-acknowledgement"

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -144,6 +144,7 @@ export const CreateCluster = () => {
     } else {
       setHighAvailability(undefined);
       setControlPlaneACL(false);
+      setIsACLAcknowledgementChecked(false);
 
       // Clear the ACL error if the tier is switched, since standard tier doesn't require it
       setErrors(undefined);

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -115,13 +115,10 @@ export const CreateCluster = () => {
   const [ipV6Addr, setIPv6Addr] = React.useState<ExtendedIP[]>([
     stringToExtendedIP(''),
   ]);
-  const [selectedTier, setSelectedTier] = React.useState<KubernetesTier>(
-    'standard'
-  );
-  const [
-    isACLAcknowledgementChecked,
-    setIsACLAcknowledgementChecked,
-  ] = React.useState(false);
+  const [selectedTier, setSelectedTier] =
+    React.useState<KubernetesTier>('standard');
+  const [isACLAcknowledgementChecked, setIsACLAcknowledgementChecked] =
+    React.useState(false);
 
   const {
     data: kubernetesHighAvailabilityTypesData,
@@ -174,18 +171,14 @@ export const CreateCluster = () => {
   // Only want to use current types here.
   const typesData = filterCurrentTypes(allTypes?.map(extendType));
 
-  const {
-    mutateAsync: createKubernetesCluster,
-  } = useCreateKubernetesClusterMutation();
+  const { mutateAsync: createKubernetesCluster } =
+    useCreateKubernetesClusterMutation();
 
-  const {
-    mutateAsync: createKubernetesClusterBeta,
-  } = useCreateKubernetesClusterBetaMutation();
+  const { mutateAsync: createKubernetesClusterBeta } =
+    useCreateKubernetesClusterBetaMutation();
 
-  const {
-    isLkeEnterpriseLAFeatureEnabled,
-    isLkeEnterpriseLAFlagEnabled,
-  } = useIsLkeEnterpriseEnabled();
+  const { isLkeEnterpriseLAFeatureEnabled, isLkeEnterpriseLAFlagEnabled } =
+    useIsLkeEnterpriseEnabled();
 
   const {
     isLoadingVersions,
@@ -523,17 +516,19 @@ export const CreateCluster = () => {
                 sx={{ marginTop: selectedTier === 'enterprise' ? 4 : 1 }}
               />
               <ControlPlaneACLPane
+                enableControlPlaneACL={controlPlaneACL}
+                errorText={errorMap.control_plane}
                 handleIPv4Change={(newIpV4Addr: ExtendedIP[]) => {
                   setIPv4Addr(newIpV4Addr);
                 }}
                 handleIPv6Change={(newIpV6Addr: ExtendedIP[]) => {
                   setIPv6Addr(newIpV6Addr);
                 }}
-                handleIsAcknowledgementChecked={(isChecked: boolean) =>
-                  setIsACLAcknowledgementChecked(isChecked)
-                }
-                enableControlPlaneACL={controlPlaneACL}
-                errorText={errorMap.control_plane}
+                handleIsAcknowledgementChecked={(isChecked: boolean) => {
+                  setIsACLAcknowledgementChecked(isChecked);
+                  setIPv4Addr([stringToExtendedIP('')]);
+                  setIPv6Addr([stringToExtendedIP('')]);
+                }}
                 ipV4Addr={ipV4Addr}
                 ipV6Addr={ipV6Addr}
                 isAcknowledgementChecked={isACLAcknowledgementChecked}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeControlPaneACLDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeControlPaneACLDrawer.tsx
@@ -227,6 +227,8 @@ export const KubeControlPlaneACLDrawer = (
           </StyledTypography>
           <Box sx={{ marginTop: 1 }}>
             <Controller
+              control={control}
+              name="acl.enabled"
               render={({ field }) => (
                 <FormControlLabel
                   control={
@@ -234,6 +236,9 @@ export const KubeControlPlaneACLDrawer = (
                       checked={
                         isEnterpriseCluster ? true : (field.value ?? false)
                       }
+                      disabled={isEnterpriseCluster}
+                      name="ipacl-checkbox"
+                      onBlur={field.onBlur}
                       onChange={() => {
                         setValue('acl.enabled', !field.value, {
                           shouldDirty: true,
@@ -262,16 +267,11 @@ export const KubeControlPlaneACLDrawer = (
                           );
                         }
                       }}
-                      disabled={isEnterpriseCluster}
-                      name="ipacl-checkbox"
-                      onBlur={field.onBlur}
                     />
                   }
                   label="Enable Control Plane ACL"
                 />
               )}
-              control={control}
-              name="acl.enabled"
             />
           </Box>
           <Divider sx={{ marginBottom: 3, marginTop: 1.5 }} />
@@ -286,6 +286,8 @@ export const KubeControlPlaneACLDrawer = (
                 string to use for tracking this change.
               </StyledTypography>
               <Controller
+                control={control}
+                name="acl.revision-id"
                 render={({ field, fieldState }) => (
                   <TextField
                     disabled={!acl.enabled}
@@ -296,8 +298,6 @@ export const KubeControlPlaneACLDrawer = (
                     value={field.value}
                   />
                 )}
-                control={control}
-                name="acl.revision-id"
               />
               <Divider sx={{ marginBottom: 3, marginTop: 3 }} />
             </>
@@ -316,10 +316,12 @@ export const KubeControlPlaneACLDrawer = (
           )}
           <Box sx={{ maxWidth: 450 }}>
             <Controller
+              control={control}
+              name="acl.addresses.ipv4"
               render={({ field }) => (
                 <MultipleNonExtendedIPInput
                   buttonText="Add IPv4 Address"
-                  disabled={!acl.enabled}
+                  disabled={!acl.enabled || isACLAcknowledgementChecked}
                   ipErrors={errors.acl?.addresses?.ipv4}
                   isLinkStyled
                   nonExtendedIPs={field.value ?? ['']}
@@ -328,15 +330,15 @@ export const KubeControlPlaneACLDrawer = (
                   title="IPv4 Addresses or CIDRs"
                 />
               )}
-              control={control}
-              name="acl.addresses.ipv4"
             />
             <Box marginTop={2}>
               <Controller
+                control={control}
+                name="acl.addresses.ipv6"
                 render={({ field }) => (
                   <MultipleNonExtendedIPInput
                     buttonText="Add IPv6 Address"
-                    disabled={!acl.enabled}
+                    disabled={!acl.enabled || isACLAcknowledgementChecked}
                     ipErrors={errors.acl?.addresses?.ipv6}
                     isLinkStyled
                     nonExtendedIPs={field.value ?? ['']}
@@ -345,8 +347,6 @@ export const KubeControlPlaneACLDrawer = (
                     title="IPv6 Addresses or CIDRs"
                   />
                 )}
-                control={control}
-                name="acl.addresses.ipv6"
               />
             </Box>
           </Box>
@@ -354,10 +354,10 @@ export const KubeControlPlaneACLDrawer = (
             <FormControlLabel
               control={
                 <Checkbox
+                  name="acl-acknowledgement"
                   onChange={() =>
                     setIsACLAcknowledgementChecked(!isACLAcknowledgementChecked)
                   }
-                  name="acl-acknowledgement"
                 />
               }
               data-qa-checkbox="acl-acknowledgement"


### PR DESCRIPTION
## Description 📝

This PR includes a couple improvements to the ACL IP Address section:
- Bug fix: resets the IP addresses when the acknowledgement checkbox is selected so that validation errors don't incorrectly persist
- UX improvement: disables the fields when the acknowledgement is selected so that it is clear to the user: either provide the addresses or select the checkbox

## Changes  🔄

- Add the disabled prop to the IP fields to check for `isAcknowledgementChecked`
- Add a missing disabled prop to the styled MultipleIP button (the "Add IPv4/6 Address" button) so that the button can also be disabled
- Call setState functions for both IP address types in `handleIsAcknowledgementChecked`
- Fix some linting warnings

## Target release date 🗓️

LKE-E QA has tagged this with Phase1 label, meaning they want it in the LA launch and we should include this in a release that goes out prior to LA. That being said: this isn't a blocker; the user could refresh the page to clear the error and fill out the IPs correctly or just check the acknowledgement.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/e18eff2d-9e20-40f6-ae34-eee834b242a9"/> | <video src="https://github.com/user-attachments/assets/1631a2a2-2ea3-4db0-842f-d85f0409f992" /> |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Use `prod-test-004-fe` to test LKE-E; log in using shared creds
- Ensure that the LKE-Enterprise feature flag is on locally

### Reproduction steps

(How to reproduce the issue, if applicable)

1. Start typing anything, just not a correct IP address in `IPv4 Addresses or CIDRs` form
2. Delete that content and select the `Provide an ACL later. The control plane will be unreachable until an ACL is defined.` checkbox
3. Click `Create Cluster` button
4. Observe the validation error is still present on the blank IP address field and is preventing the cluster from being created

### Verification steps

(How to verify changes)

- [ ] Check out this branch logged into the correct account and go to http://localhost:3000/kubernetes/create
- [ ]  Start typing anything, just not a correct IP address in `IPv4 Addresses or CIDRs` form
- [ ] Delete that content and select the `Provide an ACL later. The control plane will be unreachable until an ACL is defined.` checkbox
- [ ] Observe that the error is cleared
- [ ] Observe that the fields are disabled once the checkbox is checked
- [ ] Click `Create Cluster` button
- [ ] Confirm the cluster creates and ACL is enabled with 0 IP addresses

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
