### PR TITLE
feat[UIE-8726]: IAM disable API check when feature flag is off

### DIFF
--- a/packages/manager/.changeset/pr-12068-upcoming-features-1745003586699.md
+++ b/packages/manager/.changeset/pr-12068-upcoming-features-1745003586699.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-IAM disable API check when feature flag is off ([#12068](https://github.com/linode/manager/pull/12068))

--- a/packages/manager/.changeset/pr-12068-upcoming-features-1745003586699.md
+++ b/packages/manager/.changeset/pr-12068-upcoming-features-1745003586699.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+IAM disable API check when feature flag is off ([#12068](https://github.com/linode/manager/pull/12068))

--- a/packages/manager/src/features/IAM/hooks/useIsIAMEnabled.test.ts
+++ b/packages/manager/src/features/IAM/hooks/useIsIAMEnabled.test.ts
@@ -63,7 +63,10 @@ describe('useIsIAMEnabled', () => {
 
     await waitFor(() => {
       expect(result.current.isIAMBeta).toBe(false);
+       // eslint-disable-next-line testing-library/no-wait-for-multiple-assertions
       expect(result.current.isIAMEnabled).toBe(true);
+      // eslint-disable-next-line testing-library/no-wait-for-multiple-assertions
+      expect(queryMocks.useAccountPermissions).toHaveBeenCalledWith(true);
     });
   });
 
@@ -87,7 +90,10 @@ describe('useIsIAMEnabled', () => {
 
     await waitFor(() => {
       expect(result.current.isIAMBeta).toBe(false);
+      // eslint-disable-next-line testing-library/no-wait-for-multiple-assertions
       expect(result.current.isIAMEnabled).toBe(false);
+      // eslint-disable-next-line testing-library/no-wait-for-multiple-assertions
+      expect(queryMocks.useAccountPermissions).toHaveBeenCalledWith(false);
     });
   });
 
@@ -110,7 +116,10 @@ describe('useIsIAMEnabled', () => {
 
     await waitFor(() => {
       expect(result.current.isIAMBeta).toBe(true);
+       // eslint-disable-next-line testing-library/no-wait-for-multiple-assertions
       expect(result.current.isIAMEnabled).toBe(false);
+      // eslint-disable-next-line testing-library/no-wait-for-multiple-assertions
+      expect(queryMocks.useAccountPermissions).toHaveBeenCalledWith(true);
     });
   });
 });

--- a/packages/manager/src/features/IAM/hooks/useIsIAMEnabled.ts
+++ b/packages/manager/src/features/IAM/hooks/useIsIAMEnabled.ts
@@ -8,7 +8,7 @@ import { useAccountPermissions } from 'src/queries/iam/iam';
  */
 export const useIsIAMEnabled = () => {
   const flags = useFlags();
-  const { data: rolePermissions } = useAccountPermissions();
+  const { data: rolePermissions } = useAccountPermissions(flags.iam?.enabled);
 
   const hasAccountAccess = rolePermissions?.account_access?.length;
   const hasEntityAccess = rolePermissions?.entity_access?.length;

--- a/packages/manager/src/queries/iam/iam.ts
+++ b/packages/manager/src/queries/iam/iam.ts
@@ -17,11 +17,12 @@ export const useAccountUserPermissions = (username?: string) => {
   });
 };
 
-export const useAccountPermissions = () => {
+export const useAccountPermissions = (enabled = true) => {
   return useQuery<IamAccountPermissions, APIError[]>({
     ...iamQueries.permissions,
     ...queryPresets.oneTimeFetch,
     ...queryPresets.noRetry,
+    enabled,
   });
 };
 


### PR DESCRIPTION
## Description 📝

Disable API check when feature flag is off

## Changes  🔄

List any change(s) relevant to the reviewer.

- Pass the feature flag to the query to disable the API call when the flag is off
- Add unit test

## Target release date 🗓️
4/22/25

## Preview 📷

| Before  | After   |
| ------- | ------- |
| 📷 | 
![Screenshot 2025-04-18 at 3 09 41 PM](https://github.com/user-attachments/assets/bb4af556-6ab5-4928-8d4a-75ce6a44d617)
 |

## How to test 🧪

### Prerequisites

- Regular env without IAM access

### Reproduction steps

- [ ] Login

### Verification steps

- [ ] There are no IAM API calls

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
