### PR TITLE
fix: [M3-9781] - Sizing bug on LKE Tier selection

### DIFF
--- a/packages/manager/.changeset/pr-12076-fixed-1745269382669.md
+++ b/packages/manager/.changeset/pr-12076-fixed-1745269382669.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Incorrect card sizing at 1920px+ in LKE Tier panel ([#12076](https://github.com/linode/manager/pull/12076))

--- a/packages/manager/.changeset/pr-12076-fixed-1745269382669.md
+++ b/packages/manager/.changeset/pr-12076-fixed-1745269382669.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Incorrect card sizing at 1920px+ in LKE Tier panel ([#12076](https://github.com/linode/manager/pull/12076))

--- a/packages/manager/.changeset/pr-12076-upcoming-features-1745347113083.md
+++ b/packages/manager/.changeset/pr-12076-upcoming-features-1745347113083.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Incorrect card sizing at 1920px+ in LKE Tier panel ([#12076](https://github.com/linode/manager/pull/12076))

--- a/packages/manager/.changeset/pr-12076-upcoming-features-1745347113083.md
+++ b/packages/manager/.changeset/pr-12076-upcoming-features-1745347113083.md
@@ -1,5 +1,5 @@
 ---
-"@linode/manager": Upcoming Features
+'@linode/manager': Upcoming Features
 ---
 
-Incorrect card sizing at 1920px+ in LKE Tier panel ([#12076](https://github.com/linode/manager/pull/12076))
+Fix incorrect card sizing at 1920px+ in LKE Tier panel ([#12076](https://github.com/linode/manager/pull/12076))

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTierPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTierPanel.tsx
@@ -1,7 +1,6 @@
 import { useAccount } from '@linode/queries';
 import { Stack, Typography } from '@linode/ui';
-import { useMediaQuery } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
+import { Grid2, useMediaQuery } from '@mui/material';
 import React from 'react';
 
 import { DocsLink } from 'src/components/DocsLink/DocsLink';
@@ -24,20 +23,12 @@ interface Props {
 
 export const ClusterTierPanel = (props: Props) => {
   const { handleClusterTierSelection, isUserRestricted, selectedTier } = props;
-  const theme = useTheme();
 
   const { data: account } = useAccount();
 
   const smDownBreakpoint = useMediaQuery((theme: Theme) =>
     theme.breakpoints.down('sm')
   );
-
-  const xlBreakpointGridStyle = {
-    [theme.breakpoints.up('xl')]: {
-      width:
-        'calc(100% * 4 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 4) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)))',
-    },
-  };
 
   const isLkeEnterpriseSelectionDisabled = !account?.capabilities?.includes(
     'Kubernetes Enterprise'
@@ -59,19 +50,15 @@ export const ClusterTierPanel = (props: Props) => {
         </StyledDocsLinkContainer>
       </StyledStackWithTabletBreakpoint>
 
-      <Stack
-        flexDirection={smDownBreakpoint ? 'column' : 'row'}
-        gap={2}
-        marginTop={2}
-      >
+      <Grid2 container marginTop={2} spacing={2}>
         <SelectionCard
           checked={selectedTier === 'standard' && !isUserRestricted}
           disabled={isUserRestricted}
+          gridSize={{ xs: 12, sm: 6, md: 4 }}
           heading="LKE"
           onClick={() => handleClusterTierSelection('standard')}
           subheadings={[StandardSubheadings]}
           sxCardBase={{ padding: '16px' }}
-          sxGrid={xlBreakpointGridStyle}
         />
         <SelectionCard
           tooltip={
@@ -81,14 +68,14 @@ export const ClusterTierPanel = (props: Props) => {
           }
           checked={selectedTier === 'enterprise' && !isUserRestricted}
           disabled={isLkeEnterpriseSelectionDisabled || isUserRestricted}
+          gridSize={{ xs: 12, sm: 6, md: 4 }}
           heading="LKE Enterprise"
           onClick={() => handleClusterTierSelection('enterprise')}
           subheadings={[EnterpriseSubheadings]}
           sxCardBase={{ padding: '16px' }}
-          sxGrid={xlBreakpointGridStyle}
           tooltipPlacement={smDownBreakpoint ? 'bottom' : 'right'}
         />
-      </Stack>
+      </Grid2>
     </Stack>
   );
 };

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTierPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTierPanel.tsx
@@ -85,8 +85,8 @@ export const ClusterTierPanel = (props: Props) => {
           onClick={() => handleClusterTierSelection('enterprise')}
           subheadings={[EnterpriseSubheadings]}
           sxCardBase={{ padding: '16px' }}
-          tooltipPlacement={smDownBreakpoint ? 'bottom' : 'right'}
           sxGrid={xlBreakpointGridStyle}
+          tooltipPlacement={smDownBreakpoint ? 'bottom' : 'right'}
         />
       </Stack>
     </Stack>

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTierPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ClusterTierPanel.tsx
@@ -1,6 +1,7 @@
 import { useAccount } from '@linode/queries';
 import { Stack, Typography } from '@linode/ui';
 import { useMediaQuery } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import React from 'react';
 
 import { DocsLink } from 'src/components/DocsLink/DocsLink';
@@ -23,12 +24,20 @@ interface Props {
 
 export const ClusterTierPanel = (props: Props) => {
   const { handleClusterTierSelection, isUserRestricted, selectedTier } = props;
+  const theme = useTheme();
 
   const { data: account } = useAccount();
 
   const smDownBreakpoint = useMediaQuery((theme: Theme) =>
     theme.breakpoints.down('sm')
   );
+
+  const xlBreakpointGridStyle = {
+    [theme.breakpoints.up('xl')]: {
+      width:
+        'calc(100% * 4 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 4) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)))',
+    },
+  };
 
   const isLkeEnterpriseSelectionDisabled = !account?.capabilities?.includes(
     'Kubernetes Enterprise'
@@ -62,6 +71,7 @@ export const ClusterTierPanel = (props: Props) => {
           onClick={() => handleClusterTierSelection('standard')}
           subheadings={[StandardSubheadings]}
           sxCardBase={{ padding: '16px' }}
+          sxGrid={xlBreakpointGridStyle}
         />
         <SelectionCard
           tooltip={
@@ -76,6 +86,7 @@ export const ClusterTierPanel = (props: Props) => {
           subheadings={[EnterpriseSubheadings]}
           sxCardBase={{ padding: '16px' }}
           tooltipPlacement={smDownBreakpoint ? 'bottom' : 'right'}
+          sxGrid={xlBreakpointGridStyle}
         />
       </Stack>
     </Stack>


### PR DESCRIPTION
## Description 📝

This PR fixes a sizing bug in the LKE Tier selection.

## Changes  🔄

- Set explicit width for `SelectionCard` components at 1920px+ breakpoints in `ClusterTierPanel.tsx`

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/a7fe4781-72b9-4fa1-8668-cb241a21a40b" /> | <video src="https://github.com/user-attachments/assets/ec378c67-2f5e-4fcb-8b59-564802e2f0f5" />  |

### Verification steps

- [ ] Navigate to the Create LKE Cluster page `/kubernetes/create`
- [ ] Resize your browser width to 1920px or larger
- [ ] Confirm both tier selection cards maintain consistent width
- [ ] Ensure no visual regressions in other breakpoints (sm, md, lg)

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>