### PR TITLE
test [M3-9569]: Fix for OBJ multicluster delete test app crash in DevCloud

### DIFF
--- a/packages/manager/.changeset/pr-12085-tests-1745337050128.md
+++ b/packages/manager/.changeset/pr-12085-tests-1745337050128.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix for OBJ multicluster delete test app crash in DevCloud ([#12085](https://github.com/linode/manager/pull/12085))

--- a/packages/manager/cypress/e2e/core/objectStorageMulticluster/bucket-delete-multicluster.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorageMulticluster/bucket-delete-multicluster.spec.ts
@@ -6,6 +6,7 @@ import {
 } from 'support/intercepts/object-storage';
 import { ui } from 'support/ui';
 import { randomLabel } from 'support/util/random';
+import { chooseRegion } from 'support/util/regions';
 
 import { accountFactory, objectStorageBucketFactory } from 'src/factories';
 
@@ -17,12 +18,13 @@ describe('Object Storage Multicluster Bucket delete', () => {
    */
   it('can delete object storage bucket with OBJ Multicluster', () => {
     const bucketLabel = randomLabel();
-    const bucketCluster = 'us-southeast-1';
+    const region = chooseRegion().id;
     const bucketMock = objectStorageBucketFactory.build({
-      cluster: bucketCluster,
-      hostname: `${bucketLabel}.${bucketCluster}.linodeobjects.com`,
+      cluster: region,
+      hostname: `${bucketLabel}.${region}.linodeobjects.com`,
       label: bucketLabel,
       objects: 0,
+      region,
     });
 
     mockGetAccount(
@@ -34,10 +36,8 @@ describe('Object Storage Multicluster Bucket delete', () => {
       objMultiCluster: true,
       objectStorageGen2: { enabled: false },
     });
-
     mockGetBuckets([bucketMock]).as('getBuckets');
     mockDeleteBucket(bucketLabel, bucketMock.region!).as('deleteBucket');
-
     cy.visitWithLogin('/object-storage');
     cy.wait('@getBuckets');
 


### PR DESCRIPTION
## Description 📝

Fix OBJ multicluster delete test app crash in cypress/e2e/core/objectStorageMulticluster/bucket-delete-multicluster.spec.ts by ensuring an available region is used in the created cluster. Test fn objectStorageBucketFactory.build() defaults to using hardcoded region id of 'us-east' which is not available in all test environments. 

## Changes  🔄

List any change(s) relevant to the reviewer.

Ensure that objectStorageBucketFactory.build() uses an available region.  

## How to test 🧪
```
pnpm cy:run -s "cypress/e2e/core/objectStorageMulticluster/bucket-delete-multicluster.spec.ts" 
``` 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
 