### PR TITLE
change: [M3-9613, M3-9795] - Replace accordions with papers in Account Settings and fix FirewallRow services column width on FirewallLanding

### DIFF
--- a/packages/manager/.changeset/pr-12097-changed-1745441238928.md
+++ b/packages/manager/.changeset/pr-12097-changed-1745441238928.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Bring UI parity between Account Settings and Profile Settings section ([#12097](https://github.com/linode/manager/pull/12097))

--- a/packages/manager/.changeset/pr-12097-fixed-1745441307930.md
+++ b/packages/manager/.changeset/pr-12097-fixed-1745441307930.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Firewall Landing table column widths shifting due to length service entity labels ([#12097](https://github.com/linode/manager/pull/12097))
+Firewall Landing table column widths shifting due to lengthy service entity labels ([#12097](https://github.com/linode/manager/pull/12097))

--- a/packages/manager/.changeset/pr-12097-fixed-1745441307930.md
+++ b/packages/manager/.changeset/pr-12097-fixed-1745441307930.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Firewall Landing table column widths shifting due to length service entity labels ([#12097](https://github.com/linode/manager/pull/12097))

--- a/packages/manager/cypress/e2e/core/account/account-cancellation.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/account-cancellation.spec.ts
@@ -65,12 +65,10 @@ describe('Account cancellation', () => {
     cy.visitWithLogin('/account/settings');
     cy.wait(['@getAccount', '@getProfile']);
 
-    ui.accordion
-      .findByTitle('Close Account')
+    cy.findByTestId('close-account')
       .should('be.visible')
       .within(() => {
-        ui.button
-          .findByTitle('Close Account')
+        cy.findByTestId('close-account-button')
           .should('be.visible')
           .should('be.enabled')
           .click();
@@ -181,12 +179,10 @@ describe('Account cancellation', () => {
     cy.visitWithLogin('/account/settings');
     cy.wait(['@getAccount', '@getProfile']);
 
-    ui.accordion
-      .findByTitle('Close Account')
+    cy.findByTestId('close-account')
       .should('be.visible')
       .within(() => {
-        ui.button
-          .findByTitle('Close Account')
+        cy.findByTestId('close-account-button')
           .should('be.visible')
           .should('be.enabled')
           .click();
@@ -243,12 +239,10 @@ describe('Parent/Child account cancellation', () => {
     cy.visitWithLogin('/account/settings');
     cy.wait(['@getAccount', '@getProfile']);
 
-    ui.accordion
-      .findByTitle('Close Account')
+    cy.findByTestId('close-account')
       .should('be.visible')
       .within(() => {
-        ui.button
-          .findByTitle('Close Account')
+        cy.findByTestId('close-account-button')
           .should('be.visible')
           .should('be.disabled')
           .trigger('mouseover');
@@ -277,12 +271,10 @@ describe('Parent/Child account cancellation', () => {
     cy.visitWithLogin('/account/settings');
     cy.wait(['@getAccount', '@getProfile']);
 
-    ui.accordion
-      .findByTitle('Close Account')
+    cy.findByTestId('close-account')
       .should('be.visible')
       .within(() => {
-        ui.button
-          .findByTitle('Close Account')
+        cy.findByTestId('close-account-button')
           .should('be.visible')
           .should('be.disabled')
           .trigger('mouseover');
@@ -311,12 +303,10 @@ describe('Parent/Child account cancellation', () => {
     cy.visitWithLogin('/account/settings');
     cy.wait(['@getAccount', '@getProfile']);
 
-    ui.accordion
-      .findByTitle('Close Account')
+    cy.findByTestId('close-account')
       .should('be.visible')
       .within(() => {
-        ui.button
-          .findByTitle('Close Account')
+        cy.findByTestId('close-account-button')
           .should('be.visible')
           .should('be.disabled')
           .trigger('mouseover');
@@ -357,12 +347,10 @@ describe('Parent/Child account cancellation', () => {
     cy.visitWithLogin('/account/settings');
     cy.wait(['@getAccount', '@getProfile']);
 
-    ui.accordion
-      .findByTitle('Close Account')
+    cy.findByTestId('close-account')
       .should('be.visible')
       .within(() => {
-        ui.button
-          .findByTitle('Close Account')
+        cy.findByTestId('close-account-button')
           .should('be.visible')
           .should('be.enabled')
           .click();

--- a/packages/manager/cypress/e2e/core/account/network-settings.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/network-settings.spec.ts
@@ -74,10 +74,11 @@ describe('Account network settings', () => {
       mockGetAccountSettings(mockInitialAccountSettings).as('getSettings');
       cy.visitWithLogin('/account/settings');
 
-      ui.accordion
-        .findByTitle('Network Interface Type')
+      cy.findByTestId('network-interface-type')
         .should('be.visible')
         .within(() => {
+          cy.findByText('Network Interface Type').should('be.visible');
+
           // Confirm that selected interface type matches API response, and that
           // "Save" button is disabled by default.
           cy.findByLabelText('Interfaces for new Linodes').should(
@@ -156,10 +157,10 @@ describe('Account network settings', () => {
       mockGetAccountSettings(mockInitialAccountSettings);
       cy.visitWithLogin('/account/settings');
 
-      ui.accordion
-        .findByTitle('Network Interface Type')
+      cy.findByTestId('network-interface-type')
         .should('be.visible')
         .within(() => {
+          cy.findByText('Network Interface Type').should('be.visible');
           cy.findByLabelText('Interfaces for new Linodes')
             .should('be.visible')
             .click();
@@ -226,10 +227,10 @@ describe('Account network settings', () => {
 
       cy.visitWithLogin('/account/settings');
 
-      ui.accordion
-        .findByTitle('Default Firewalls')
+      cy.findByTestId('default-firewalls')
         .should('be.visible')
         .within(() => {
+          cy.findByText('Default Firewalls').should('be.visible');
           // Confirm that "Save" button is disabled until changes are made.
           ui.button
             .findByTitle('Save')
@@ -346,8 +347,7 @@ describe('Account network settings', () => {
 
       cy.visitWithLogin('/account/settings');
 
-      ui.accordion
-        .findByTitle('Default Firewalls')
+      cy.findByTestId('default-firewalls')
         .should('be.visible')
         .within(() => {
           // Confirm that "Save" button is disabled before making changes.
@@ -421,10 +421,11 @@ describe('Account network settings', () => {
 
       cy.visitWithLogin('/account/settings');
 
-      ui.accordion
-        .findByTitle('Default Firewalls')
+      cy.findByTestId('default-firewalls')
         .should('be.visible')
         .within(() => {
+          cy.findByText('Default Firewalls').should('be.visible');
+
           cy.findByLabelText(
             'Configuration Profile Interfaces Firewall'
           ).click();
@@ -490,12 +491,10 @@ describe('Account network settings', () => {
     cy.visitWithLogin('/account/settings');
 
     // Wait for content to load before asserting existence of networking settings.
-    ui.accordionHeading.findByTitle('Close Account').should('be.visible');
+    cy.findByTestId('close-account').should('be.visible');
 
     // Assert that "Network Interface Type" and "Default Firewalls" sections are absent.
-    ui.accordionHeading
-      .findByTitle('Network Interface Type')
-      .should('not.exist');
-    ui.accordionHeading.findByTitle('Default Firewalls').should('not.exist');
+    cy.findByTestId('network-interface-type').should('not.exist');
+    cy.findByTestId('default-firewalls').should('not.exist');
   });
 });

--- a/packages/manager/cypress/e2e/core/objectStorage/enable-object-storage.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/enable-object-storage.spec.ts
@@ -350,8 +350,7 @@ describe('Object Storage enrollment', () => {
     cy.visitWithLogin('/account/settings');
     cy.wait(['@getProfile', '@getAccountSettings']);
 
-    ui.accordion
-      .findByTitle('Object Storage')
+    cy.findByTestId('object-storage')
       .should('be.visible')
       .within(() => {
         // Confirm that the user is informed that cancelling OBJ will delete their buckets and keys.

--- a/packages/manager/src/components/TableSortCell/TableSortCell.tsx
+++ b/packages/manager/src/components/TableSortCell/TableSortCell.tsx
@@ -27,6 +27,7 @@ export const TableSortCell = (props: TableSortCellProps) => {
     isLoading,
     label,
     noWrap,
+    sx,
     ...rest
   } = props;
 
@@ -38,20 +39,21 @@ export const TableSortCell = (props: TableSortCellProps) => {
 
   return (
     <TableCell
-      sx={{
-        whiteSpace: noWrap ? 'nowrap' : '',
-      }}
       onClick={onHandleClick}
       role="columnheader"
       sortDirection={direction}
+      sx={{
+        whiteSpace: noWrap ? 'nowrap' : '',
+        ...sx,
+      }}
       {...rest}
     >
       <TableSortLabel
-        IconComponent={ArrowDown}
         active={active}
         aria-label={`Sort by ${label}`}
         direction={direction}
         hideSortIcon={true}
+        IconComponent={ArrowDown}
       >
         {children}
         {!active && <Sort />}

--- a/packages/manager/src/features/Account/AutoBackups.tsx
+++ b/packages/manager/src/features/Account/AutoBackups.tsx
@@ -1,7 +1,7 @@
 import {
-  Accordion,
   FormControlLabel,
   Notice,
+  Paper,
   Toggle,
   Typography,
 } from '@linode/ui';
@@ -25,7 +25,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
   icon: {
     display: 'inline-block',
     fontSize: '0.8em',
-    marginLeft: `calc(${theme.spacing(1)} / 3)`,
+    marginLeft: `calc(${theme.spacingFunction(8)} / 3)`,
   },
 }));
 
@@ -49,15 +49,16 @@ const AutoBackups = (props: Props) => {
   const { classes } = useStyles();
 
   return (
-    <Accordion defaultExpanded={true} heading="Backup Auto Enrollment">
-      <Grid container direction="column" spacing={2}>
+    <Paper>
+      <Typography variant="h2">Backup Auto Enrollment</Typography>
+      <Grid container direction="column" mt={1} spacing={1}>
         <Grid>
-          {!!isManagedCustomer ? (
-            <Notice spacingBottom={20} variant="info">
+          {isManagedCustomer && (
+            <Notice spacingBottom={20} spacingTop={8} variant="info">
               You&rsquo;re a Managed customer, which means your Linodes are
               already automatically backed up - no need to toggle this setting.
             </Notice>
-          ) : null}
+          )}
           <Typography variant="body1">
             This controls whether Linode Backups are enabled, by default, for
             all Linodes when they are initially created. For each Linode with
@@ -72,30 +73,22 @@ const AutoBackups = (props: Props) => {
             .
           </Typography>
         </Grid>
-        <Grid
-          container
-          direction="row"
-          sx={{
-            alignItems: 'center',
-          }}
-        >
-          <Grid>
-            <FormControlLabel
-              control={
-                <Toggle
-                  checked={!!isManagedCustomer ? true : backups_enabled}
-                  data-qa-toggle-auto-backup
-                  disabled={!!isManagedCustomer}
-                  onChange={onChange}
-                />
-              }
-              label={
-                backups_enabled || isManagedCustomer
-                  ? 'Enabled (Auto enroll all new Linodes in Backups)'
-                  : 'Disabled (Don\u{2019}t enroll new Linodes in Backups automatically)'
-              }
-            />
-          </Grid>
+        <Grid>
+          <FormControlLabel
+            control={
+              <Toggle
+                checked={isManagedCustomer ? true : backups_enabled}
+                data-qa-toggle-auto-backup
+                disabled={!!isManagedCustomer}
+                onChange={onChange}
+              />
+            }
+            label={
+              backups_enabled || isManagedCustomer
+                ? 'Enabled (Auto enroll all new Linodes in Backups)'
+                : 'Disabled (Don\u{2019}t enroll new Linodes in Backups automatically)'
+            }
+          />
         </Grid>
         {!isManagedCustomer && !backups_enabled && hasLinodesWithoutBackups && (
           <Grid>
@@ -113,7 +106,7 @@ const AutoBackups = (props: Props) => {
           </Grid>
         )}
       </Grid>
-    </Accordion>
+    </Paper>
   );
 };
 

--- a/packages/manager/src/features/Account/AutoBackups.tsx
+++ b/packages/manager/src/features/Account/AutoBackups.tsx
@@ -2,10 +2,10 @@ import {
   FormControlLabel,
   Notice,
   Paper,
+  Stack,
   Toggle,
   Typography,
 } from '@linode/ui';
-import Grid from '@mui/material/Grid2';
 import * as React from 'react';
 import { makeStyles } from 'tss-react/mui';
 
@@ -51,29 +51,27 @@ const AutoBackups = (props: Props) => {
   return (
     <Paper>
       <Typography variant="h2">Backup Auto Enrollment</Typography>
-      <Grid container direction="column" mt={1} spacing={1}>
-        <Grid>
-          {isManagedCustomer && (
-            <Notice spacingBottom={20} spacingTop={8} variant="info">
-              You&rsquo;re a Managed customer, which means your Linodes are
-              already automatically backed up - no need to toggle this setting.
-            </Notice>
-          )}
-          <Typography variant="body1">
-            This controls whether Linode Backups are enabled, by default, for
-            all Linodes when they are initially created. For each Linode with
-            Backups enabled, your account will be billed the additional hourly
-            rate noted on the&nbsp;
-            <Link
-              data-qa-backups-price
-              to="https://www.linode.com/products/backups/"
-            >
-              Backups pricing page
-            </Link>
-            .
-          </Typography>
-        </Grid>
-        <Grid>
+      {isManagedCustomer && (
+        <Notice spacingBottom={16} spacingTop={16} variant="info">
+          You&rsquo;re a Managed customer, which means your Linodes are already
+          automatically backed up - no need to toggle this setting.
+        </Notice>
+      )}
+      <Stack mt={1} spacing={1}>
+        <Typography variant="body1">
+          This controls whether Linode Backups are enabled, by default, for all
+          Linodes when they are initially created. For each Linode with Backups
+          enabled, your account will be billed the additional hourly rate noted
+          on the&nbsp;
+          <Link
+            data-qa-backups-price
+            to="https://www.linode.com/products/backups/"
+          >
+            Backups pricing page
+          </Link>
+          .
+        </Typography>
+        <Stack>
           <FormControlLabel
             control={
               <Toggle
@@ -89,23 +87,21 @@ const AutoBackups = (props: Props) => {
                 : 'Disabled (Don\u{2019}t enroll new Linodes in Backups automatically)'
             }
           />
-        </Grid>
+        </Stack>
         {!isManagedCustomer && !backups_enabled && hasLinodesWithoutBackups && (
-          <Grid>
-            <Typography className={classes.footnote} variant="body1">
-              For existing Linodes without backups,&nbsp;
-              <button
-                className={classes.enableBackupsButton}
-                data-qa-backup-existing
-                onClick={openBackupsDrawer}
-              >
-                enable now
-              </button>
-              .
-            </Typography>
-          </Grid>
+          <Typography className={classes.footnote} variant="body1">
+            For existing Linodes without backups,&nbsp;
+            <button
+              className={classes.enableBackupsButton}
+              data-qa-backup-existing
+              onClick={openBackupsDrawer}
+            >
+              enable now
+            </button>
+            .
+          </Typography>
         )}
-      </Grid>
+      </Stack>
     </Paper>
   );
 };

--- a/packages/manager/src/features/Account/CloseAccountSetting.test.tsx
+++ b/packages/manager/src/features/Account/CloseAccountSetting.test.tsx
@@ -25,13 +25,9 @@ vi.mock('@linode/queries', async () => {
 });
 
 describe('Close Account Settings', () => {
-  it('should render subheading text', () => {
-    const { container } = renderWithTheme(<CloseAccountSetting />);
-    const subheading = container.querySelector(
-      '[data-qa-panel-subheading="true"]'
-    );
-    expect(subheading).toBeInTheDocument();
-    expect(subheading?.textContent).toBe('Close Account');
+  it('should render a heading and button', () => {
+    const { getAllByText } = renderWithTheme(<CloseAccountSetting />);
+    expect(getAllByText('Close Account')).toHaveLength(2);
   });
 
   it('should render a Close Account Button', () => {

--- a/packages/manager/src/features/Account/CloseAccountSetting.tsx
+++ b/packages/manager/src/features/Account/CloseAccountSetting.tsx
@@ -1,6 +1,5 @@
 import { useProfile } from '@linode/queries';
-import { Button, Paper, Typography } from '@linode/ui';
-import Grid from '@mui/material/Grid2';
+import { Box, Button, Paper, Typography } from '@linode/ui';
 import * as React from 'react';
 
 import CloseAccountDialog from './CloseAccountDialog';
@@ -35,9 +34,9 @@ const CloseAccountSetting = () => {
 
   return (
     <>
-      <Paper>
+      <Paper data-testid="close-account">
         <Typography variant="h2">Close Account</Typography>
-        <Grid mt={1}>
+        <Box mt={1}>
           <Button
             buttonType="outlined"
             data-testid="close-account-button"
@@ -47,7 +46,7 @@ const CloseAccountSetting = () => {
           >
             Close Account
           </Button>
-        </Grid>
+        </Box>
       </Paper>
       <CloseAccountDialog
         closeDialog={() => setDialogOpen(false)}

--- a/packages/manager/src/features/Account/CloseAccountSetting.tsx
+++ b/packages/manager/src/features/Account/CloseAccountSetting.tsx
@@ -37,7 +37,7 @@ const CloseAccountSetting = () => {
     <>
       <Paper>
         <Typography variant="h2">Close Account</Typography>
-        <Grid mt={2}>
+        <Grid mt={1}>
           <Button
             buttonType="outlined"
             data-testid="close-account-button"

--- a/packages/manager/src/features/Account/CloseAccountSetting.tsx
+++ b/packages/manager/src/features/Account/CloseAccountSetting.tsx
@@ -1,5 +1,5 @@
 import { useProfile } from '@linode/queries';
-import { Accordion, Button } from '@linode/ui';
+import { Button, Paper, Typography } from '@linode/ui';
 import Grid from '@mui/material/Grid2';
 import * as React from 'react';
 
@@ -35,21 +35,20 @@ const CloseAccountSetting = () => {
 
   return (
     <>
-      <Accordion defaultExpanded={true} heading="Close Account">
-        <Grid container direction="column">
-          <Grid>
-            <Button
-              buttonType="outlined"
-              data-testid="close-account-button"
-              disabled={isCloseAccountDisabled}
-              onClick={() => setDialogOpen(true)}
-              tooltipText={closeAccountButtonTooltipText}
-            >
-              Close Account
-            </Button>
-          </Grid>
+      <Paper>
+        <Typography variant="h2">Close Account</Typography>
+        <Grid mt={2}>
+          <Button
+            buttonType="outlined"
+            data-testid="close-account-button"
+            disabled={isCloseAccountDisabled}
+            onClick={() => setDialogOpen(true)}
+            tooltipText={closeAccountButtonTooltipText}
+          >
+            Close Account
+          </Button>
         </Grid>
-      </Accordion>
+      </Paper>
       <CloseAccountDialog
         closeDialog={() => setDialogOpen(false)}
         open={dialogOpen}

--- a/packages/manager/src/features/Account/DefaultFirewalls.tsx
+++ b/packages/manager/src/features/Account/DefaultFirewalls.tsx
@@ -68,7 +68,7 @@ export const DefaultFirewalls = () => {
 
   if (isLoadingFirewallSettings) {
     return (
-      <Paper>
+      <Paper data-testid="default-firewalls">
         <Typography variant="h2">Default Firewalls</Typography>
         <CircleProgress />
       </Paper>
@@ -77,7 +77,7 @@ export const DefaultFirewalls = () => {
 
   if (firewallSettingsError) {
     return (
-      <Paper>
+      <Paper data-testid="default-firewalls">
         <Typography variant="h2">Default Firewalls</Typography>
         <ErrorState errorText="Unable to load your firewall settings and firewalls." />
       </Paper>
@@ -85,7 +85,7 @@ export const DefaultFirewalls = () => {
   }
 
   return (
-    <Paper>
+    <Paper data-testid="default-firewalls">
       <Typography mb={1} variant="h2">
         Default Firewalls
       </Typography>

--- a/packages/manager/src/features/Account/DefaultFirewalls.tsx
+++ b/packages/manager/src/features/Account/DefaultFirewalls.tsx
@@ -86,14 +86,14 @@ export const DefaultFirewalls = () => {
 
   return (
     <Paper>
-      <Typography variant="h2">Default Firewalls</Typography>
+      <Typography mb={1} variant="h2">
+        Default Firewalls
+      </Typography>
       <form onSubmit={handleSubmit(onSubmit)}>
         {errors.root?.message && (
-          <Notice marginTop={1} variant="error">
-            {errors.root.message}
-          </Notice>
+          <Notice variant="error">{errors.root.message}</Notice>
         )}
-        <Typography marginTop={1} sx={{ mb: 2 }}>
+        <Typography sx={{ mb: 2 }}>
           Set the default firewall that is assigned to each network interface
           type when creating a Linode. The same firewall (new or existing) can
           be assigned to each type of interface/connection.

--- a/packages/manager/src/features/Account/DefaultFirewalls.tsx
+++ b/packages/manager/src/features/Account/DefaultFirewalls.tsx
@@ -4,13 +4,13 @@ import {
   useMutateFirewallSettings,
 } from '@linode/queries';
 import {
-  Accordion,
   Box,
   Button,
   CircleProgress,
   Divider,
   ErrorState,
   Notice,
+  Paper,
   Stack,
   Typography,
 } from '@linode/ui';
@@ -68,27 +68,32 @@ export const DefaultFirewalls = () => {
 
   if (isLoadingFirewallSettings) {
     return (
-      <Accordion defaultExpanded heading="Default Firewalls">
+      <Paper>
+        <Typography variant="h2">Default Firewalls</Typography>
         <CircleProgress />
-      </Accordion>
+      </Paper>
     );
   }
 
   if (firewallSettingsError) {
     return (
-      <Accordion defaultExpanded heading="Default Firewalls">
+      <Paper>
+        <Typography variant="h2">Default Firewalls</Typography>
         <ErrorState errorText="Unable to load your firewall settings and firewalls." />
-      </Accordion>
+      </Paper>
     );
   }
 
   return (
-    <Accordion defaultExpanded heading="Default Firewalls">
+    <Paper>
+      <Typography variant="h2">Default Firewalls</Typography>
       <form onSubmit={handleSubmit(onSubmit)}>
         {errors.root?.message && (
-          <Notice variant="error">{errors.root.message}</Notice>
+          <Notice marginTop={1} variant="error">
+            {errors.root.message}
+          </Notice>
         )}
-        <Typography sx={{ mb: 2 }}>
+        <Typography marginTop={1} sx={{ mb: 2 }}>
           Set the default firewall that is assigned to each network interface
           type when creating a Linode. The same firewall (new or existing) can
           be assigned to each type of interface/connection.
@@ -97,6 +102,8 @@ export const DefaultFirewalls = () => {
           <Stack spacing={2}>
             <Typography variant="h3">Linodes</Typography>
             <Controller
+              control={control}
+              name="default_firewall_ids.linode"
               render={({ field, fieldState }) => (
                 <FirewallSelect
                   disableClearable
@@ -108,10 +115,10 @@ export const DefaultFirewalls = () => {
                   value={field.value}
                 />
               )}
-              control={control}
-              name="default_firewall_ids.linode"
             />
             <Controller
+              control={control}
+              name="default_firewall_ids.public_interface"
               render={({ field, fieldState }) => (
                 <FirewallSelect
                   disableClearable
@@ -123,10 +130,10 @@ export const DefaultFirewalls = () => {
                   value={field.value}
                 />
               )}
-              control={control}
-              name="default_firewall_ids.public_interface"
             />
             <Controller
+              control={control}
+              name="default_firewall_ids.vpc_interface"
               render={({ field, fieldState }) => (
                 <FirewallSelect
                   disableClearable
@@ -138,13 +145,13 @@ export const DefaultFirewalls = () => {
                   value={field.value}
                 />
               )}
-              control={control}
-              name="default_firewall_ids.vpc_interface"
             />
           </Stack>
           <Stack spacing={2}>
             <Typography variant="h3">NodeBalancers</Typography>
             <Controller
+              control={control}
+              name="default_firewall_ids.nodebalancer"
               render={({ field, fieldState }) => (
                 <FirewallSelect
                   disableClearable
@@ -156,12 +163,10 @@ export const DefaultFirewalls = () => {
                   value={field.value}
                 />
               )}
-              control={control}
-              name="default_firewall_ids.nodebalancer"
             />
           </Stack>
         </Stack>
-        <Box sx={(theme) => ({ marginTop: theme.spacing(2) })}>
+        <Box sx={(theme) => ({ marginTop: theme.spacingFunction(16) })}>
           <Button
             buttonType="outlined"
             disabled={!isDirty}
@@ -172,6 +177,6 @@ export const DefaultFirewalls = () => {
           </Button>
         </Box>
       </form>
-    </Accordion>
+    </Paper>
   );
 };

--- a/packages/manager/src/features/Account/EnableManaged.tsx
+++ b/packages/manager/src/features/Account/EnableManaged.tsx
@@ -1,8 +1,14 @@
 import { enableManaged } from '@linode/api-v4/lib/managed';
 import { updateAccountSettingsData, useLinodesQuery } from '@linode/queries';
-import { ActionsPanel, Button, Paper, Typography } from '@linode/ui';
+import {
+  ActionsPanel,
+  Box,
+  Button,
+  Paper,
+  Stack,
+  Typography,
+} from '@linode/ui';
 import { pluralize } from '@linode/utilities';
-import Grid from '@mui/material/Grid2';
 import { useQueryClient } from '@tanstack/react-query';
 import * as React from 'react';
 
@@ -35,21 +41,19 @@ export const ManagedContent = (props: ContentProps) => {
   }
 
   return (
-    <Grid container direction="column" spacing={2}>
-      <Grid>
-        <Typography variant="body1">
-          Linode Managed includes Backups, Longview Pro, cPanel, and
-          round-the-clock monitoring to help keep your systems up and running.
-          +$100/month per Linode.{'  '}
-          <Link to="https://linode.com/managed">Learn more</Link>.
-        </Typography>
-      </Grid>
-      <Grid>
+    <Stack spacing={2}>
+      <Typography variant="body1">
+        Linode Managed includes Backups, Longview Pro, cPanel, and
+        round-the-clock monitoring to help keep your systems up and running.
+        +$100/month per Linode.{'  '}
+        <Link to="https://linode.com/managed">Learn more</Link>.
+      </Typography>
+      <Box>
         <Button buttonType="outlined" onClick={openConfirmationModal}>
           Add Linode Managed
         </Button>
-      </Grid>
-    </Grid>
+      </Box>
+    </Stack>
   );
 };
 

--- a/packages/manager/src/features/Account/EnableManaged.tsx
+++ b/packages/manager/src/features/Account/EnableManaged.tsx
@@ -1,6 +1,6 @@
 import { enableManaged } from '@linode/api-v4/lib/managed';
 import { updateAccountSettingsData, useLinodesQuery } from '@linode/queries';
-import { Accordion, ActionsPanel, Button, Typography } from '@linode/ui';
+import { ActionsPanel, Button, Paper, Typography } from '@linode/ui';
 import { pluralize } from '@linode/utilities';
 import Grid from '@mui/material/Grid2';
 import { useQueryClient } from '@tanstack/react-query';
@@ -102,12 +102,15 @@ export const EnableManaged = (props: Props) => {
 
   return (
     <>
-      <Accordion defaultExpanded={true} heading="Linode Managed">
+      <Paper>
+        <Typography marginBottom={1} variant="h2">
+          Linode Managed
+        </Typography>
         <ManagedContent
           isManaged={isManaged}
           openConfirmationModal={() => setOpen(true)}
         />
-      </Accordion>
+      </Paper>
       <ConfirmationDialog
         actions={actions}
         error={error}

--- a/packages/manager/src/features/Account/GlobalSettings.tsx
+++ b/packages/manager/src/features/Account/GlobalSettings.tsx
@@ -3,7 +3,7 @@ import {
   useAllLinodesQuery,
   useMutateAccountSettings,
 } from '@linode/queries';
-import { CircleProgress, ErrorState } from '@linode/ui';
+import { CircleProgress, ErrorState, Stack } from '@linode/ui';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
 
@@ -84,26 +84,28 @@ const GlobalSettings = () => {
   return (
     <div>
       <DocumentTitleSegment segment="Settings" />
-      {isLinodeInterfacesEnabled && <NetworkInterfaceType />}
-      {isLinodeInterfacesEnabled && <DefaultFirewalls />}
-      <AutoBackups
-        backups_enabled={backups_enabled}
-        hasLinodesWithoutBackups={hasLinodesWithoutBackups}
-        isManagedCustomer={managed}
-        onChange={toggleAutomaticBackups}
-        openBackupsDrawer={() => setIsBackupsDrawerOpen(true)}
-      />
-      <NetworkHelper
-        networkHelperEnabled={network_helper}
-        onChange={toggleNetworkHelper}
-      />
-      <ObjectStorageSettings />
-      <EnableManaged isManaged={managed} />
-      <CloseAccountSetting />
-      <BackupDrawer
-        onClose={() => setIsBackupsDrawerOpen(false)}
-        open={isBackupsDrawerOpen}
-      />
+      <Stack spacing={2}>
+        {isLinodeInterfacesEnabled && <NetworkInterfaceType />}
+        {isLinodeInterfacesEnabled && <DefaultFirewalls />}
+        <AutoBackups
+          backups_enabled={backups_enabled}
+          hasLinodesWithoutBackups={hasLinodesWithoutBackups}
+          isManagedCustomer={managed}
+          onChange={toggleAutomaticBackups}
+          openBackupsDrawer={() => setIsBackupsDrawerOpen(true)}
+        />
+        <NetworkHelper
+          networkHelperEnabled={network_helper}
+          onChange={toggleNetworkHelper}
+        />
+        <ObjectStorageSettings />
+        <EnableManaged isManaged={managed} />
+        <CloseAccountSetting />
+        <BackupDrawer
+          onClose={() => setIsBackupsDrawerOpen(false)}
+          open={isBackupsDrawerOpen}
+        />
+      </Stack>
     </div>
   );
 };

--- a/packages/manager/src/features/Account/GlobalSettings.tsx
+++ b/packages/manager/src/features/Account/GlobalSettings.tsx
@@ -16,7 +16,7 @@ import AutoBackups from './AutoBackups';
 import CloseAccountSetting from './CloseAccountSetting';
 import { DefaultFirewalls } from './DefaultFirewalls';
 import { EnableManaged } from './EnableManaged';
-import NetworkHelper from './NetworkHelper';
+import { NetworkHelper } from './NetworkHelper';
 import { NetworkInterfaceType } from './NetworkInterfaceType';
 import { ObjectStorageSettings } from './ObjectStorageSettings';
 

--- a/packages/manager/src/features/Account/NetworkHelper.tsx
+++ b/packages/manager/src/features/Account/NetworkHelper.tsx
@@ -1,5 +1,4 @@
-import { FormControlLabel, Paper, Toggle, Typography } from '@linode/ui';
-import Grid from '@mui/material/Grid2';
+import { FormControlLabel, Paper, Stack, Toggle, Typography } from '@linode/ui';
 import * as React from 'react';
 
 interface Props {
@@ -11,14 +10,12 @@ export const NetworkHelper = ({ networkHelperEnabled, onChange }: Props) => {
   return (
     <Paper>
       <Typography variant="h2">Network Helper</Typography>
-      <Grid container direction="column" mt={1} spacing={1}>
-        <Grid>
-          <Typography variant="body1">
-            Network Helper automatically deposits a static networking
-            configuration into your Linode at boot.
-          </Typography>
-        </Grid>
-        <Grid>
+      <Stack mt={1} spacing={1}>
+        <Typography variant="body1">
+          Network Helper automatically deposits a static networking
+          configuration into your Linode at boot.
+        </Typography>
+        <Stack>
           <FormControlLabel
             control={
               <Toggle
@@ -31,8 +28,8 @@ export const NetworkHelper = ({ networkHelperEnabled, onChange }: Props) => {
               networkHelperEnabled ? 'Enabled (default behavior)' : 'Disabled'
             }
           />
-        </Grid>
-      </Grid>
+        </Stack>
+      </Stack>
     </Paper>
   );
 };

--- a/packages/manager/src/features/Account/NetworkHelper.tsx
+++ b/packages/manager/src/features/Account/NetworkHelper.tsx
@@ -1,4 +1,4 @@
-import { Accordion, FormControlLabel, Toggle, Typography } from '@linode/ui';
+import { FormControlLabel, Paper, Toggle, Typography } from '@linode/ui';
 import Grid from '@mui/material/Grid2';
 import * as React from 'react';
 
@@ -7,41 +7,32 @@ interface Props {
   onChange: () => void;
 }
 
-const NetworkHelper = ({ networkHelperEnabled, onChange }: Props) => {
+export const NetworkHelper = ({ networkHelperEnabled, onChange }: Props) => {
   return (
-    <Accordion defaultExpanded={true} heading="Network Helper">
-      <Grid container direction="column" spacing={2}>
+    <Paper>
+      <Typography variant="h2">Network Helper</Typography>
+      <Grid container direction="column" mt={1} spacing={1}>
         <Grid>
           <Typography variant="body1">
             Network Helper automatically deposits a static networking
             configuration into your Linode at boot.
           </Typography>
         </Grid>
-        <Grid
-          container
-          direction="row"
-          sx={{
-            alignItems: 'center',
-          }}
-        >
-          <Grid>
-            <FormControlLabel
-              control={
-                <Toggle
-                  checked={networkHelperEnabled}
-                  data-qa-toggle-network-helper
-                  onChange={onChange}
-                />
-              }
-              label={
-                networkHelperEnabled ? 'Enabled (default behavior)' : 'Disabled'
-              }
-            />
-          </Grid>
+        <Grid>
+          <FormControlLabel
+            control={
+              <Toggle
+                checked={networkHelperEnabled}
+                data-qa-toggle-network-helper
+                onChange={onChange}
+              />
+            }
+            label={
+              networkHelperEnabled ? 'Enabled (default behavior)' : 'Disabled'
+            }
+          />
         </Grid>
       </Grid>
-    </Accordion>
+    </Paper>
   );
 };
-
-export default NetworkHelper;

--- a/packages/manager/src/features/Account/NetworkInterfaceType.tsx
+++ b/packages/manager/src/features/Account/NetworkInterfaceType.tsx
@@ -1,9 +1,9 @@
 import { useAccountSettings, useMutateAccountSettings } from '@linode/queries';
 import {
-  Accordion,
   BetaChip,
   Box,
   Button,
+  Paper,
   Select,
   Stack,
   Typography,
@@ -25,24 +25,25 @@ type InterfaceSettingValues = Pick<
   'interfaces_for_new_linodes'
 >;
 
-const accountSettingInterfaceOptions: SelectOption<LinodeInterfaceAccountSetting>[] = [
-  {
-    label: 'Configuration Profile Interfaces but allow Linode Interfaces',
-    value: 'legacy_config_default_but_linode_allowed',
-  },
-  {
-    label: 'Linode Interfaces but allow Configuration Profile Interfaces',
-    value: 'linode_default_but_legacy_config_allowed',
-  },
-  {
-    label: 'Configuration Profile Interfaces Only',
-    value: 'legacy_config_only',
-  },
-  {
-    label: 'Linode Interfaces Only',
-    value: 'linode_only',
-  },
-];
+const accountSettingInterfaceOptions: SelectOption<LinodeInterfaceAccountSetting>[] =
+  [
+    {
+      label: 'Configuration Profile Interfaces but allow Linode Interfaces',
+      value: 'legacy_config_default_but_linode_allowed',
+    },
+    {
+      label: 'Linode Interfaces but allow Configuration Profile Interfaces',
+      value: 'linode_default_but_legacy_config_allowed',
+    },
+    {
+      label: 'Configuration Profile Interfaces Only',
+      value: 'legacy_config_only',
+    },
+    {
+      label: 'Linode Interfaces Only',
+      value: 'linode_only',
+    },
+  ];
 
 export const NetworkInterfaceType = () => {
   const { enqueueSnackbar } = useSnackbar();
@@ -78,26 +79,28 @@ export const NetworkInterfaceType = () => {
   };
 
   return (
-    <Accordion
-      defaultExpanded
-      heading="Network Interface Type"
-      headingChip={<BetaChip />}
-    >
+    <Paper>
+      <Typography variant="h2">Network Interface Type</Typography>
       <form onSubmit={handleSubmit(onSubmit)}>
-        <Stack>
+        <Stack marginTop={1}>
           <Typography variant="body1">
             Set the network interface for your Linode instances to use during
             creation. <Link to="/#">Learn more</Link>.
           </Typography>
           <Controller
+            control={control}
+            name="interfaces_for_new_linodes"
             render={({ field, fieldState }) => (
               <Select
+                errorText={fieldState.error?.message}
+                label="Interfaces for new Linodes"
                 onChange={(
                   _,
                   item: SelectOption<LinodeInterfaceAccountSetting>
                 ) => {
                   field.onChange(item?.value);
                 }}
+                options={accountSettingInterfaceOptions}
                 sx={(theme) => ({
                   [theme.breakpoints.up('md')]: {
                     minWidth: '480px',
@@ -114,13 +117,8 @@ export const NetworkInterfaceType = () => {
                 value={accountSettingInterfaceOptions.find(
                   (option) => option.value === field.value
                 )}
-                errorText={fieldState.error?.message}
-                label="Interfaces for new Linodes"
-                options={accountSettingInterfaceOptions}
               />
             )}
-            control={control}
-            name="interfaces_for_new_linodes"
           />
           <Box
             sx={(theme) => ({
@@ -138,6 +136,6 @@ export const NetworkInterfaceType = () => {
           </Box>
         </Stack>
       </form>
-    </Accordion>
+    </Paper>
   );
 };

--- a/packages/manager/src/features/Account/NetworkInterfaceType.tsx
+++ b/packages/manager/src/features/Account/NetworkInterfaceType.tsx
@@ -79,7 +79,7 @@ export const NetworkInterfaceType = () => {
   };
 
   return (
-    <Paper>
+    <Paper data-testid="network-interface-type">
       <Box alignItems={'center'} display={'flex'}>
         <Typography variant="h2">Network Interface Type</Typography>
         <BetaChip />

--- a/packages/manager/src/features/Account/NetworkInterfaceType.tsx
+++ b/packages/manager/src/features/Account/NetworkInterfaceType.tsx
@@ -80,9 +80,12 @@ export const NetworkInterfaceType = () => {
 
   return (
     <Paper>
-      <Typography variant="h2">Network Interface Type</Typography>
+      <Box alignItems={'center'} display={'flex'}>
+        <Typography variant="h2">Network Interface Type</Typography>
+        <BetaChip />
+      </Box>
       <form onSubmit={handleSubmit(onSubmit)}>
-        <Stack marginTop={1}>
+        <Stack mt={1}>
           <Typography variant="body1">
             Set the network interface for your Linode instances to use during
             creation. <Link to="/#">Learn more</Link>.
@@ -120,11 +123,7 @@ export const NetworkInterfaceType = () => {
               />
             )}
           />
-          <Box
-            sx={(theme) => ({
-              marginTop: theme.spacing(2),
-            })}
-          >
+          <Box marginTop={2}>
             <Button
               buttonType="outlined"
               disabled={!isDirty}

--- a/packages/manager/src/features/Account/ObjectStorageSettings.tsx
+++ b/packages/manager/src/features/Account/ObjectStorageSettings.tsx
@@ -51,7 +51,7 @@ export const ObjectStorageSettings = () => {
 
   return (
     <>
-      <Paper>
+      <Paper data-testid="object-storage">
         <Typography variant="h2">Object Storage</Typography>
         {accountSettings?.object_storage === 'active' ? (
           <Stack mt={1} spacing={2}>

--- a/packages/manager/src/features/Account/ObjectStorageSettings.tsx
+++ b/packages/manager/src/features/Account/ObjectStorageSettings.tsx
@@ -1,10 +1,10 @@
 import { useAccountSettings, useProfile } from '@linode/queries';
 import {
-  Accordion,
   Box,
   Button,
   CircleProgress,
   Notice,
+  Paper,
   Stack,
   Typography,
 } from '@linode/ui';
@@ -28,9 +28,8 @@ export const ObjectStorageSettings = () => {
 
   const username = profile?.username;
 
-  const [isCancelDialogOpen, setIsCancelDialogOpen] = React.useState<boolean>(
-    false
-  );
+  const [isCancelDialogOpen, setIsCancelDialogOpen] =
+    React.useState<boolean>(false);
 
   const handleCloseCancelDialog = () => {
     setIsCancelDialogOpen(false);
@@ -52,9 +51,10 @@ export const ObjectStorageSettings = () => {
 
   return (
     <>
-      <Accordion defaultExpanded heading="Object Storage">
+      <Paper>
+        <Typography variant="h2">Object Storage</Typography>
         {accountSettings?.object_storage === 'active' ? (
-          <Stack spacing={2}>
+          <Stack mt={1} spacing={2}>
             <Typography variant="body1">
               Object Storage is enabled on your account. Upon cancellation, all
               Object Storage Access Keys will be revoked, all buckets will be
@@ -83,7 +83,7 @@ export const ObjectStorageSettings = () => {
             .
           </Typography>
         )}
-      </Accordion>
+      </Paper>
       <TypeToConfirmDialog
         entity={{
           action: 'cancellation',

--- a/packages/manager/src/features/Backups/BackupDrawer.tsx
+++ b/packages/manager/src/features/Backups/BackupDrawer.tsx
@@ -56,10 +56,8 @@ export const BackupDrawer = (props: Props) => {
 
   const { data: types, isLoading: typesLoading } = useAllTypes(open);
 
-  const {
-    data: accountSettings,
-    isLoading: accountSettingsLoading,
-  } = useAccountSettings();
+  const { data: accountSettings, isLoading: accountSettingsLoading } =
+    useAccountSettings();
 
   const {
     error: updateAccountSettingsError,
@@ -67,9 +65,8 @@ export const BackupDrawer = (props: Props) => {
     mutateAsync: updateAccountSettings,
   } = useMutateAccountSettings();
 
-  const [shouldEnableAutoEnroll, setShouldEnableAutoEnroll] = React.useState(
-    true
-  );
+  const [shouldEnableAutoEnroll, setShouldEnableAutoEnroll] =
+    React.useState(true);
 
   const {
     data: enableBackupsResult,
@@ -100,10 +97,12 @@ export const BackupDrawer = (props: Props) => {
     return linodesWithoutBackups.map((linode) => (
       <BackupLinodeRow
         error={
-          (enableBackupsResult?.find(
-            (result) =>
-              result.linode.id === linode.id && result.status === 'rejected'
-          ) as EnableBackupsRejectedResult | undefined)?.reason?.[0]?.reason
+          (
+            enableBackupsResult?.find(
+              (result) =>
+                result.linode.id === linode.id && result.status === 'rejected'
+            ) as EnableBackupsRejectedResult | undefined
+          )?.reason?.[0]?.reason
         }
         key={linode.id}
         linode={linode}
@@ -119,8 +118,9 @@ export const BackupDrawer = (props: Props) => {
     const result = await enableBackups(linodesWithoutBackups);
 
     const hasFailures = result.some((r) => r.status === 'rejected');
-    const successfulEnables = result.filter((r) => r.status === 'fulfilled')
-      .length;
+    const successfulEnables = result.filter(
+      (r) => r.status === 'fulfilled'
+    ).length;
 
     if (hasFailures) {
       // Just stop because the React Query error state will update and
@@ -189,10 +189,10 @@ all new Linodes will automatically be backed up.`
           </StyledTypography>
           &nbsp;
           <DisplayPrice
+            interval="mo"
             price={
               isNumber(totalBackupsPrice) ? totalBackupsPrice : UNKNOWN_PRICE
             }
-            interval="mo"
           />
         </StyledPricingBox>
         <ActionsPanel

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
@@ -185,13 +185,13 @@ const FirewallLanding = () => {
               direction={order}
               handleClick={handleOrderChange}
               label="status"
-              sx={{ width: '15%' }}
+              sx={{ width: '10%' }}
             >
               Status
             </TableSortCell>
             <Hidden smDown>
               <TableCell sx={{ width: '15%' }}>Rules</TableCell>
-              <TableCell sx={{ width: '40%' }}>Services</TableCell>
+              <TableCell sx={{ width: '45%' }}>Services</TableCell>
             </Hidden>
             <TableCell sx={{ width: '10%' }} />
           </TableRow>

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
@@ -144,6 +144,7 @@ const FirewallLanding = () => {
         }`}
       />
       <LandingHeader
+        breadcrumbProps={{ pathname: '/firewalls' }}
         buttonDataAttrs={{
           tooltipText: getRestrictedResourceText({
             action: 'create',
@@ -151,6 +152,9 @@ const FirewallLanding = () => {
             resourceType: 'Firewalls',
           }),
         }}
+        disabledCreateButton={isFirewallsCreationRestricted}
+        docsLink="https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-cloud-firewalls"
+        entity="Firewall"
         extraActions={
           secureVMNoticesEnabled && flags.secureVmCopy?.generateActionText ? (
             <Button
@@ -161,10 +165,6 @@ const FirewallLanding = () => {
             </Button>
           ) : undefined
         }
-        breadcrumbProps={{ pathname: '/firewalls' }}
-        disabledCreateButton={isFirewallsCreationRestricted}
-        docsLink="https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-cloud-firewalls"
-        entity="Firewall"
         onButtonClick={onOpenCreateDrawer}
         title="Firewalls"
       />
@@ -176,6 +176,7 @@ const FirewallLanding = () => {
               direction={order}
               handleClick={handleOrderChange}
               label="label"
+              sx={{ width: '20%' }}
             >
               Label
             </TableSortCell>
@@ -184,14 +185,15 @@ const FirewallLanding = () => {
               direction={order}
               handleClick={handleOrderChange}
               label="status"
+              sx={{ width: '15%' }}
             >
               Status
             </TableSortCell>
             <Hidden smDown>
-              <TableCell>Rules</TableCell>
-              <TableCell>Services</TableCell>
+              <TableCell sx={{ width: '15%' }}>Rules</TableCell>
+              <TableCell sx={{ width: '40%' }}>Services</TableCell>
             </Hidden>
-            <TableCell />
+            <TableCell sx={{ width: '10%' }} />
           </TableRow>
         </TableHead>
         <TableBody>

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
@@ -1,4 +1,5 @@
 import { useAllLinodesQuery } from '@linode/queries';
+import { Box } from '@linode/ui';
 import { capitalize } from '@linode/utilities';
 import React from 'react';
 
@@ -57,16 +58,24 @@ export const FirewallRow = React.memo((props: FirewallRowProps) => {
   return (
     <TableRow data-testid={`firewall-row-${id}`}>
       <TableCell>
-        <Link tabIndex={0} to={`/firewalls/${id}`}>
-          {label}
-        </Link>
-        {isLinodeInterfacesEnabled && isDefault && (
-          <DefaultFirewallChip
-            chipProps={{ sx: { marginLeft: 1 } }}
-            defaultNumEntities={defaultNumEntities}
-            tooltipText={tooltipText}
-          />
-        )}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'flex-start',
+          }}
+        >
+          <Link tabIndex={0} to={`/firewalls/${id}`}>
+            {label}
+          </Link>
+          {isLinodeInterfacesEnabled && isDefault && (
+            <DefaultFirewallChip
+              chipProps={{ sx: { marginLeft: 1 } }}
+              defaultNumEntities={defaultNumEntities}
+              tooltipText={tooltipText}
+            />
+          )}
+        </Box>
       </TableCell>
       <TableCell statusCell>
         <StatusIcon status={status === 'enabled' ? 'active' : 'inactive'} />


### PR DESCRIPTION
## Description 📝
Tangentially related to Linode Interfaces
- Updating Account Settings to use papers instead of accordions (and updating headings to H2 instead of H3) to a) fix the heading hierarchy for Default Firewalls section and b) make Account Settings align more with Profile Settings
- Fix firewall row services column to not take up so much width if services have super long names
- update tests that depended on accordions 
  - (is there a better way to target the section than test ids? saw data-qa-paper but that didn't seem as specific)
- replace grids with stacks (not a 2d layout)

## Target release date 🗓️
n/a

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/923d4c98-ecb3-4594-a7c2-3bd2cdeaf9c1) | ![image](https://github.com/user-attachments/assets/0e5b933c-3cc1-48e7-a83d-7a1f65447fd5) |
| ![image](https://github.com/user-attachments/assets/8724c44b-0ef2-43e9-ac0f-3af2dcb66b88) | ![image](https://github.com/user-attachments/assets/47cca07b-1735-4fc8-98fa-bda1e61cbe8f) |

## How to test 🧪
- To view changes for the Default Firewalls section, you'll need the Linode Interface customer tag

### Verification steps
- confirm Account Settings section brought to parity with Profile settings section
- confirm firewall landing table column widths 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
