### PR TITLE
tech-story: [M3-8667] - Add eslint rule to to prevent import of Cypress code in main application

### DIFF
--- a/packages/manager/.changeset/pr-12100-tech-stories-1745464783439.md
+++ b/packages/manager/.changeset/pr-12100-tech-stories-1745464783439.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Restrict Cypress imports to Cypress directory only ([#12100](https://github.com/linode/manager/pull/12100))

--- a/packages/manager/eslint.config.js
+++ b/packages/manager/eslint.config.js
@@ -385,7 +385,7 @@ export const baseConfig = [
         'error',
         {
           paths: restrictedImportPaths,
-          // Intentionally omit patterns to allow Cypress imports in test files
+          // Intentionally omit patterns to allow Cypress imports in Cypress files
         },
       ],
     },

--- a/packages/manager/eslint.config.js
+++ b/packages/manager/eslint.config.js
@@ -380,12 +380,12 @@ export const baseConfig = [
       'sonarjs/no-hardcoded-ip': 'off',
       '@linode/cloud-manager/no-createLinode': 'error',
       '@typescript-eslint/no-unused-expressions': 'off',
-      // Maintain standard import restrictions but allow Cypress imports in Cypress files
+      // Maintain standard import restrictions but allow Cypress imports
       'no-restricted-imports': [
         'error',
         {
           paths: restrictedImportPaths,
-          // Intentionally omit patterns to allow Cypress imports in Cypress files
+          // Intentionally omit patterns to allow Cypress imports here
         },
       ],
     },

--- a/packages/manager/eslint.config.js
+++ b/packages/manager/eslint.config.js
@@ -103,7 +103,7 @@ export const baseConfig = [
           paths: restrictedImportPaths,
           patterns: [
             {
-              group: ['**/node_modules/cypress/**', 'cypress/**'],
+              group: ['**/cypress/**'],
               message:
                 'Cypress modules should only be imported in Cypress testing directories',
             },
@@ -127,6 +127,12 @@ export const baseConfig = [
       'object-shorthand': 'warn',
       'sort-keys': 'off',
       'spaced-comment': 'warn',
+    },
+  },
+  {
+    files: ['**/cypress.config.ts'],
+    rules: {
+      'no-restricted-imports': 'off',
     },
   },
 

--- a/packages/manager/eslint.config.js
+++ b/packages/manager/eslint.config.js
@@ -16,6 +16,26 @@ import { defineConfig } from 'eslint/config';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
+// Shared import restrictions applied across different rule contexts
+const restrictedImportPaths = [
+  'rxjs',
+  '@mui/core',
+  '@mui/system',
+  '@mui/icons-material',
+  {
+    name: '@mui/material',
+    importNames: ['Typography'],
+    message:
+      'Please use Typography component from @linode/ui instead of @mui/material',
+  },
+  {
+    name: 'react-router-dom',
+    importNames: ['Link'],
+    message:
+      'Please use the Link component from src/components/Link instead of react-router-dom',
+  },
+];
+
 export const baseConfig = [
   // 1. Ignores
   {
@@ -79,21 +99,15 @@ export const baseConfig = [
       'no-new-wrappers': 'error',
       'no-restricted-imports': [
         'error',
-        'rxjs',
-        '@mui/core',
-        '@mui/system',
-        '@mui/icons-material',
         {
-          importNames: ['Typography'],
-          message:
-            'Please use Typography component from @linode/ui instead of @mui/material',
-          name: '@mui/material',
-        },
-        {
-          importNames: ['Link'],
-          message:
-            'Please use the Link component from src/components/Link instead of react-router-dom',
-          name: 'react-router-dom',
+          paths: restrictedImportPaths,
+          patterns: [
+            {
+              group: ['**/node_modules/cypress/**', 'cypress/**'],
+              message:
+                'Cypress modules should only be imported in testing directories',
+            },
+          ],
         },
       ],
       'no-restricted-syntax': [
@@ -366,6 +380,14 @@ export const baseConfig = [
       'sonarjs/no-hardcoded-ip': 'off',
       '@linode/cloud-manager/no-createLinode': 'error',
       '@typescript-eslint/no-unused-expressions': 'off',
+      // Maintain standard import restrictions but allow Cypress imports in Cypress files
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: restrictedImportPaths,
+          // Intentionally omit patterns to allow Cypress imports in test files
+        },
+      ],
     },
   },
 

--- a/packages/manager/eslint.config.js
+++ b/packages/manager/eslint.config.js
@@ -16,7 +16,7 @@ import { defineConfig } from 'eslint/config';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
-// Shared import restrictions applied across different rule contexts
+// Shared import restrictions between different rule contexts
 const restrictedImportPaths = [
   'rxjs',
   '@mui/core',

--- a/packages/manager/eslint.config.js
+++ b/packages/manager/eslint.config.js
@@ -105,7 +105,7 @@ export const baseConfig = [
             {
               group: ['**/node_modules/cypress/**', 'cypress/**'],
               message:
-                'Cypress modules should only be imported in testing directories',
+                'Cypress modules should only be imported in Cypress testing directories',
             },
           ],
         },


### PR DESCRIPTION
## Description 📝

This PR adds an ESLint rule blocking Cypress imports in application code. Although this rule will work, there are already two unrelated mechanisms inherently restricting these types of Cypress imports already:

1. There's both the `cypress` node_module and our own `cypress/` directory (`packages/manager/cypress/`). Our module resolution checks for the local `cypress/` directory first at the `baseUrl` instead of the `cypress` node_module. So it doesn't look like we could import from `cypress` outside of the `cypress/` directory unless using an explicit relative path like `'../../../../../node_modules/cypress/types/net-stubbing'`
2. The explicit relative path is currently restricted by the SonarJS rule: `sonarjs/no-internal-api-use`

So this rule is really just some extra prevention and can be tested by disabling the sonar rule or adding a TypeScript path mapping in `tsconfig.json` that explicitly directs `'cypress'` imports to the node_module version.


## Changes  🔄

- Added ESLint rule blocking Cypress imports in app code
- Created exception for files in our own Cypress directory (`packages/manager/cypress`)
- Refactored this config as a shared `restrictedImportPaths` variable to reduce duplication

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img src="https://github.com/user-attachments/assets/9ca001b1-51a1-4d07-bbce-737d54458c54"> | <img src="https://github.com/user-attachments/assets/18c5be00-a3d8-4ce5-8384-c57cec9ea8ef"> |
| Note that `sonarjs/no-internal-api-use` already prevents this type of import but we can disable it temporarily with the disable comment for testing ||
---
| Before  | After   |
| ------- | ------- |
| <img src="https://github.com/user-attachments/assets/4d2fcd66-cb73-4731-8556-931a3cea1905"> | <img src="https://github.com/user-attachments/assets/6fab9628-5932-4e13-98b7-04ffaf07ddf6"> |
| Note that `'cyress'` currently refers to our own `cypress/` directory (and not the package) in this context but we can add the following to `packages/manager/tsconfig.json` temporarily for testing:

    "paths": {
      "src/*": ["src/*"],
      "cypress": ["./node_modules/cypress"],
      "cypress/*": ["./node_modules/cypress/*"]
    },

### Verification steps

- [ ] Add an import from the Cypress package inside any file in `packages/manager/src`. Note the current restrictions in place that would need to be temporarily disabled to test this (see description in Preview section).
- [ ] In the terminal, lint the app with `pnpm run lint:all` and confirm the `no-restricted-imports` error is triggered.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>