### PR TITLE
fix: [M3-9831] - Broken Payment Method `Default` Chip in the Make a Payment Drawer

### DIFF
--- a/packages/manager/.changeset/pr-12101-fixed-1745467362526.md
+++ b/packages/manager/.changeset/pr-12101-fixed-1745467362526.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Broken Payment Method Default Chip in the Make a Payment Drawer ([#12101](https://github.com/linode/manager/pull/12101))

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
@@ -107,10 +107,6 @@ export const PaymentMethodCard = (props: Props) => {
       sxCardBaseSubheading={{
         color: cardIsExpired ? theme.color.red : undefined,
       }}
-      sxGrid={{
-        minWidth: '100%',
-        padding: 0,
-      }}
     />
   );
 };

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
@@ -114,5 +114,3 @@ export const PaymentMethodCard = (props: Props) => {
     />
   );
 };
-
-export default PaymentMethodCard;

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
@@ -1,6 +1,5 @@
 import { Chip } from '@linode/ui';
 import { useTheme } from '@mui/material/styles';
-import Grid from '@mui/material/Grid2';
 import * as React from 'react';
 
 import {
@@ -83,55 +82,36 @@ export const PaymentMethodCard = (props: Props) => {
     return <Icon />;
   };
 
-  const sxVariant = {
-    flexShrink: 0,
-    paddingLeft: { sm: 1, xs: 0 },
-  };
-
-  const renderVariant = () => {
-    return is_default ? (
-      <Grid
-        sx={sxVariant}
-        size={{
-          md: 2,
-          xs: 3,
-        }}
-      >
-        <Chip component="span" label="DEFAULT" size="small" />
-      </Grid>
-    ) : null;
-  };
-
   return (
-    <Grid size={12}>
-      <SelectionCard
-        sxCardBase={{
-          flexWrap: 'nowrap',
-        }}
-        sxCardBaseHeading={{
-          flex: 'inherit',
-        }}
-        sxCardBaseIcon={{
-          justifyContent: 'center',
-          padding: 0,
-          width: 45,
-        }}
-        sxCardBaseSubheading={{
-          color: cardIsExpired ? theme.color.red : undefined,
-        }}
-        sxGrid={{
-          minWidth: '100%',
-          padding: 0,
-        }}
-        checked={id === paymentMethodId}
-        disabled={disabled}
-        heading={heading}
-        onClick={() => handlePaymentMethodChange(id, cardIsExpired)}
-        renderIcon={renderIcon}
-        renderVariant={renderVariant}
-        subheadings={[subHeading]}
-      />
-    </Grid>
+    <SelectionCard
+      checked={id === paymentMethodId}
+      disabled={disabled}
+      heading={heading}
+      onClick={() => handlePaymentMethodChange(id, cardIsExpired)}
+      renderIcon={renderIcon}
+      renderVariant={
+        is_default ? () => <Chip label="DEFAULT" size="small" /> : undefined
+      }
+      subheadings={[subHeading]}
+      sxCardBase={{
+        flexWrap: 'nowrap',
+      }}
+      sxCardBaseHeading={{
+        flex: 'inherit',
+      }}
+      sxCardBaseIcon={{
+        justifyContent: 'center',
+        padding: 0,
+        width: 45,
+      }}
+      sxCardBaseSubheading={{
+        color: cardIsExpired ? theme.color.red : undefined,
+      }}
+      sxGrid={{
+        minWidth: '100%',
+        padding: 0,
+      }}
+    />
   );
 };
 


### PR DESCRIPTION
## Description 📝

- Fixes the broken looking `Default` chip in the  _Make a Payment_ Drawer

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-04-23 at 11 57 50 PM](https://github.com/user-attachments/assets/2de0907b-3dc9-4948-a50f-c02f57ac07ca) | ![Screenshot 2025-04-23 at 11 57 44 PM](https://github.com/user-attachments/assets/c4a7b06b-1425-4dca-8e64-7a6b7033ac67) |

## How to test 🧪

### Prerequisites

- Ensure you have at least 1 payment method on your account

### Verification steps

- Open the _Make a Payment_ Drawer (http://localhost:3000/account/billing/make-payment)
- Verify the `Default` chip looks good
- Check for UI regressions - check on various screen sizes

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>