### PR TITLE
upcoming: [DI-24085] - Added info message for failed alerts

### DIFF
--- a/packages/manager/.changeset/pr-12104-upcoming-features-1745508732060.md
+++ b/packages/manager/.changeset/pr-12104-upcoming-features-1745508732060.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+add `notice for failed alerts` in `AlertListing` and `AlertDetail` ([#12104](https://github.com/linode/manager/pull/12104))

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.test.tsx
@@ -142,7 +142,7 @@ describe('AlertDetail component tests', () => {
 
     const element = screen.getByTestId('notice-error').textContent;
     expect(element).toEqual(
-      `${alert.label} alert creation has failed. Please contact support to resolve the issue.`
+      `${alert.label} alert creation has failed. Please open a support ticket for assistance.`
     );
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.test.tsx
@@ -1,4 +1,5 @@
 import { linodeFactory, regionFactory } from '@linode/utilities';
+import { screen } from '@testing-library/react';
 import React from 'react';
 
 import {
@@ -137,9 +138,9 @@ describe('AlertDetail component tests', () => {
       isLoadiing: false,
     });
 
-    const { getByTestId } = renderWithTheme(<AlertDetail />);
+    renderWithTheme(<AlertDetail />);
 
-    const element = getByTestId('notice-error').textContent;
+    const element = screen.getByTestId('notice-error').textContent;
     expect(element).toEqual(
       `${alert.label} alert creation has failed. Please contact support to resolve the issue.`
     );

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.test.tsx
@@ -137,13 +137,12 @@ describe('AlertDetail component tests', () => {
       isLoadiing: false,
     });
 
-    const { getByText } = renderWithTheme(<AlertDetail />);
+    const { getByTestId } = renderWithTheme(<AlertDetail />);
 
-    expect(
-      getByText(
-        `${alert.label} alert creation has failed. Please contact support to resolve the issue.`
-      )
-    ).toBeInTheDocument();
+    const element = getByTestId('notice-error').textContent;
+    expect(element).toEqual(
+      `${alert.label} alert creation has failed. Please contact support to resolve the issue.`
+    );
   });
 });
 

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.test.tsx
@@ -126,6 +126,25 @@ describe('AlertDetail component tests', () => {
     expect(getByText('Name:')).toBeInTheDocument();
     expect(getByText('Description:')).toBeInTheDocument();
   });
+
+  it('should show error notice for failed alert', () => {
+    const alert = alertFactory.build({
+      status: 'failed',
+    });
+    queryMocks.useAlertDefinitionQuery.mockReturnValue({
+      data: alert,
+      isError: false,
+      isLoadiing: false,
+    });
+
+    const { getByText } = renderWithTheme(<AlertDetail />);
+
+    expect(
+      getByText(
+        `${alert.label} alert creation has failed. Please contact support to resolve the issue.`
+      )
+    ).toBeInTheDocument();
+  });
 });
 
 const validateBreadcrumbs = (link: HTMLElement) => {

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
@@ -3,10 +3,11 @@ import {
   Chip,
   CircleProgress,
   ErrorState,
+  Notice,
   Stack,
   Typography,
 } from '@linode/ui';
-import { styled, useTheme } from '@mui/material';
+import { Link, styled, useTheme } from '@mui/material';
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -17,7 +18,6 @@ import { Placeholder } from 'src/components/Placeholder/Placeholder';
 import { useAlertDefinitionQuery } from 'src/queries/cloudpulse/alerts';
 
 import { AlertResources } from '../AlertsResources/AlertsResources';
-import { AlertListNoticeMessages } from '../Utils/AlertListNoticeMessages';
 import { getAlertBoxStyles } from '../Utils/utils';
 import { AlertDetailCriteria } from './AlertDetailCriteria';
 import { AlertDetailNotification } from './AlertDetailNotification';
@@ -113,19 +113,27 @@ export const AlertDetail = () => {
       <DocumentTitleSegment segment={`${alertDetails.label}`} />
       <Stack spacing={2}>
         <Breadcrumb crumbOverrides={crumbOverrides} pathname={pathname} />
+
         {status === 'failed' && (
-          <AlertListNoticeMessages
-            errorMessage={`${label} alert creation has failed. Please contact support to resolve the issue.`}
-            separator=","
-            sx={(theme) => ({
-              '&>p': {
-                fontWeight: theme.typography.fontWeightBold,
+          <Notice variant="error">
+            <Typography
+              sx={(theme) => ({
+                font: theme.font.bold,
                 fontSize: theme.spacingFunction(16),
-              },
-            })}
-            variant="error"
-          />
+              })}
+            >
+              {label} alert creation has failed. Please{' '}
+              <Link
+                href="https://cloud.linode.com/support/tickets"
+                underline="hover"
+              >
+                contact support
+              </Link>{' '}
+              to resolve the issue.
+            </Typography>
+          </Notice>
         )}
+
         <Box display="flex" flexDirection="column" gap={2}>
           <Box
             display="flex"

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
@@ -1,4 +1,11 @@
-import { Box, Chip, CircleProgress, ErrorState, Typography } from '@linode/ui';
+import {
+  Box,
+  Chip,
+  CircleProgress,
+  ErrorState,
+  Stack,
+  Typography,
+} from '@linode/ui';
 import { styled, useTheme } from '@mui/material';
 import React from 'react';
 import { useParams } from 'react-router-dom';
@@ -10,6 +17,7 @@ import { Placeholder } from 'src/components/Placeholder/Placeholder';
 import { useAlertDefinitionQuery } from 'src/queries/cloudpulse/alerts';
 
 import { AlertResources } from '../AlertsResources/AlertsResources';
+import { AlertListNoticeMessages } from '../Utils/AlertListNoticeMessages';
 import { getAlertBoxStyles } from '../Utils/utils';
 import { AlertDetailCriteria } from './AlertDetailCriteria';
 import { AlertDetailNotification } from './AlertDetailNotification';
@@ -29,10 +37,11 @@ export interface AlertRouteParams {
 export const AlertDetail = () => {
   const { alertId, serviceType } = useParams<AlertRouteParams>();
 
-  const { data: alertDetails, isError, isLoading } = useAlertDefinitionQuery(
-    alertId,
-    serviceType
-  );
+  const {
+    data: alertDetails,
+    isError,
+    isLoading,
+  } = useAlertDefinitionQuery(alertId, serviceType);
 
   const { crumbOverrides, pathname } = React.useMemo(() => {
     const overrides = [
@@ -95,60 +104,82 @@ export const AlertDetail = () => {
     entity_ids: entityIds,
     service_type: alertServiceType,
     type,
+    status,
+    label,
   } = alertDetails;
 
   return (
     <>
       <DocumentTitleSegment segment={`${alertDetails.label}`} />
-      <Breadcrumb crumbOverrides={crumbOverrides} pathname={pathname} />
-      <Box display="flex" flexDirection="column" gap={2}>
-        <Box display="flex" flexDirection={{ md: 'row', xs: 'column' }} gap={2}>
+      <Stack spacing={2}>
+        <Breadcrumb crumbOverrides={crumbOverrides} pathname={pathname} />
+        {status === 'failed' && (
+          <AlertListNoticeMessages
+            errorMessage={`${label} alert creation has failed. Please contact support to resolve the issue.`}
+            separator=","
+            sx={(theme) => ({
+              '&>p': {
+                fontWeight: theme.typography.fontWeightBold,
+                fontSize: theme.spacingFunction(16),
+              },
+            })}
+            variant="error"
+          />
+        )}
+        <Box display="flex" flexDirection="column" gap={2}>
           <Box
-            data-qa-section="Overview"
-            flexBasis="50%"
-            maxHeight={sectionMaxHeight}
-            sx={{ ...getAlertBoxStyles(theme), overflow: 'auto' }}
+            display="flex"
+            flexDirection={{ md: 'row', xs: 'column' }}
+            gap={2}
           >
-            <AlertDetailOverview alertDetails={alertDetails} />
+            <Box
+              data-qa-section="Overview"
+              flexBasis="50%"
+              maxHeight={sectionMaxHeight}
+              sx={{ ...getAlertBoxStyles(theme), overflow: 'auto' }}
+            >
+              <AlertDetailOverview alertDetails={alertDetails} />
+            </Box>
+            <Box
+              data-qa-section="Criteria"
+              flexBasis="50%"
+              maxHeight={sectionMaxHeight}
+              sx={{
+                ...getAlertBoxStyles(theme),
+                overflow: 'auto',
+              }}
+            >
+              <AlertDetailCriteria alertDetails={alertDetails} />
+            </Box>
           </Box>
           <Box
+            data-qa-section="Resources"
+            maxHeight={sectionMaxHeight}
             sx={{
               ...getAlertBoxStyles(theme),
               overflow: 'auto',
             }}
-            data-qa-section="Criteria"
-            flexBasis="50%"
-            maxHeight={sectionMaxHeight}
           >
-            <AlertDetailCriteria alertDetails={alertDetails} />
+            <AlertResources
+              alertClass={alertClass}
+              alertResourceIds={entityIds}
+              alertType={type}
+              serviceType={alertServiceType}
+            />
+          </Box>
+          <Box
+            data-qa-section="Notification Channels"
+            sx={{
+              ...getAlertBoxStyles(theme),
+              overflow: 'auto',
+            }}
+          >
+            <AlertDetailNotification
+              channelIds={alertDetails.alert_channels.map(({ id }) => id)}
+            />
           </Box>
         </Box>
-        <Box
-          sx={{
-            ...getAlertBoxStyles(theme),
-            overflow: 'auto',
-          }}
-          data-qa-section="Resources"
-        >
-          <AlertResources
-            alertClass={alertClass}
-            alertResourceIds={entityIds}
-            alertType={type}
-            serviceType={alertServiceType}
-          />
-        </Box>
-        <Box
-          sx={{
-            ...getAlertBoxStyles(theme),
-            overflow: 'auto',
-          }}
-          data-qa-section="Notification Channels"
-        >
-          <AlertDetailNotification
-            channelIds={alertDetails.alert_channels.map(({ id }) => id)}
-          />
-        </Box>
-      </Box>
+      </Stack>
     </>
   );
 };

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
@@ -7,7 +7,7 @@ import {
   Stack,
   Typography,
 } from '@linode/ui';
-import { Link, styled, useTheme } from '@mui/material';
+import { styled, useTheme } from '@mui/material';
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -15,6 +15,7 @@ import AlertsIcon from 'src/assets/icons/entityIcons/alerts.svg';
 import { Breadcrumb } from 'src/components/Breadcrumb/Breadcrumb';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { Placeholder } from 'src/components/Placeholder/Placeholder';
+import { SupportLink } from 'src/components/SupportLink';
 import { useAlertDefinitionQuery } from 'src/queries/cloudpulse/alerts';
 
 import { AlertResources } from '../AlertsResources/AlertsResources';
@@ -123,13 +124,7 @@ export const AlertDetail = () => {
               })}
             >
               {label} alert creation has failed. Please{' '}
-              <Link
-                href="https://cloud.linode.com/support/tickets"
-                underline="hover"
-              >
-                open a support ticket
-              </Link>{' '}
-              for assistance.
+              <SupportLink text="open a support ticket" /> for assistance.
             </Typography>
           </Notice>
         )}

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
@@ -127,9 +127,9 @@ export const AlertDetail = () => {
                 href="https://cloud.linode.com/support/tickets"
                 underline="hover"
               >
-                contact support
+                open a support ticket
               </Link>{' '}
-              to resolve the issue.
+              for assistance.
             </Typography>
           </Notice>
         )}

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.test.tsx
@@ -232,4 +232,23 @@ describe('Alert Listing', () => {
       expect(screen.getByText(alertToolTipText)).toBeVisible();
     });
   });
+
+  it('should show error notice for failed alerts', () => {
+    const alerts = alertFactory.buildList(3, {
+      status: 'failed',
+    });
+    queryMocks.useAllAlertDefinitionsQuery.mockReturnValue({
+      data: alerts,
+      isError: false,
+      isLoading: false,
+    });
+
+    const { getByText } = renderWithTheme(<AlertListing />);
+
+    expect(
+      getByText(
+        'Creation of some alerts has failed. Please contact support for assistance.'
+      )
+    ).toBeInTheDocument();
+  });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.test.tsx
@@ -247,7 +247,7 @@ describe('Alert Listing', () => {
 
     const element = getByTestId('notice-error').textContent;
     expect(element).toEqual(
-      'Creation of some alerts has failed. Please contact support for assistance.'
+      'Creation of 3 alerts has failed as indicated in the status column. Please open a support ticket for assistance.'
     );
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.test.tsx
@@ -243,12 +243,11 @@ describe('Alert Listing', () => {
       isLoading: false,
     });
 
-    const { getByText } = renderWithTheme(<AlertListing />);
+    const { getByTestId } = renderWithTheme(<AlertListing />);
 
-    expect(
-      getByText(
-        'Creation of some alerts has failed. Please contact support for assistance.'
-      )
-    ).toBeInTheDocument();
+    const element = getByTestId('notice-error').textContent;
+    expect(element).toEqual(
+      'Creation of some alerts has failed. Please contact support for assistance.'
+    );
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
@@ -283,7 +283,7 @@ export const AlertListing = () => {
           Create Alert
         </Button>
       </Box>
-      {!hasFailedAlerts && (
+      {hasFailedAlerts && (
         <Notice variant="error">
           <Typography
             sx={(theme) => ({

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
@@ -18,6 +18,7 @@ import { useCloudPulseServiceTypes } from 'src/queries/cloudpulse/services';
 
 import { usePreferencesToggle } from '../../Utils/UserPreference';
 import { alertStatusOptions } from '../constants';
+import { AlertListNoticeMessages } from '../Utils/AlertListNoticeMessages';
 import { scrollToElement } from '../Utils/AlertResourceUtils';
 import { AlertsListTable } from './AlertListTable';
 import {

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
@@ -6,13 +6,13 @@ import {
   Stack,
   Typography,
 } from '@linode/ui';
-import { Link } from '@mui/material';
 import * as React from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 
 import AlertsIcon from 'src/assets/icons/entityIcons/alerts.svg';
 import { DebouncedSearchTextField } from 'src/components/DebouncedSearchTextField';
 import { Placeholder } from 'src/components/Placeholder/Placeholder';
+import { SupportLink } from 'src/components/SupportLink';
 import { useAllAlertDefinitionsQuery } from 'src/queries/cloudpulse/alerts';
 import { useCloudPulseServiceTypes } from 'src/queries/cloudpulse/services';
 
@@ -294,13 +294,7 @@ export const AlertListing = () => {
           >
             Creation of {failedAlertsCount} alerts has failed as indicated in
             the status column. Please{' '}
-            <Link
-              href="https://cloud.linode.com/support/tickets"
-              underline="hover"
-            >
-              open a support ticket
-            </Link>{' '}
-            for assistance.
+            <SupportLink text="open a support ticket" /> for assistance.
           </Typography>
         </Notice>
       )}

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
@@ -170,8 +170,10 @@ export const AlertListing = () => {
     );
   }
 
+  const hasFailedAlerts = alerts?.some((alert) => alert.status === 'failed');
+
   return (
-    <Stack spacing={2}>
+    <Stack spacing={3}>
       {(isAlertLimitReached || isMetricLimitReached) && (
         <AlertsLimitErrorMessage
           isAlertLimitReached={isAlertLimitReached}
@@ -259,6 +261,7 @@ export const AlertListing = () => {
           onClick={() => {
             history.push(`${url}/create`);
           }}
+          ref={topRef}
           sx={{
             height: '34px',
             paddingBottom: 0,
@@ -272,6 +275,19 @@ export const AlertListing = () => {
           Create Alert
         </Button>
       </Box>
+      {hasFailedAlerts && (
+        <AlertListNoticeMessages
+          errorMessage="Creation of some alerts has failed. Please contact support for assistance."
+          separator=","
+          sx={(theme) => ({
+            '&>p': {
+              fontWeight: theme.typography.fontWeightBold,
+              fontSize: theme.spacingFunction(16),
+            },
+          })}
+          variant="error"
+        />
+      )}
       <AlertsListTable
         alerts={getAlertsList}
         error={error ?? undefined}

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
@@ -297,7 +297,7 @@ export const AlertListing = () => {
             >
               contact support
             </Link>{' '}
-            for assistance
+            for assistance.
           </Typography>
         </Notice>
       )}

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
@@ -1,4 +1,12 @@
-import { Autocomplete, Box, Button, Stack } from '@linode/ui';
+import {
+  Autocomplete,
+  Box,
+  Button,
+  Notice,
+  Stack,
+  Typography,
+} from '@linode/ui';
+import { Link } from '@mui/material';
 import * as React from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 
@@ -275,6 +283,25 @@ export const AlertListing = () => {
           Create Alert
         </Button>
       </Box>
+      {!hasFailedAlerts && (
+        <Notice variant="error">
+          <Typography
+            sx={(theme) => ({
+              font: theme.font.bold,
+              fontSize: theme.spacingFunction(16),
+            })}
+          >
+            Creation of some alerts has failed. Please{' '}
+            <Link
+              href="https://cloud.linode.com/support/tickets"
+              underline="hover"
+            >
+              contact support
+            </Link>{' '}
+            for assistance
+          </Typography>
+        </Notice>
+      )}
       {hasFailedAlerts && (
         <AlertListNoticeMessages
           errorMessage="Creation of some alerts has failed. Please contact support for assistance."

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
@@ -18,7 +18,6 @@ import { useCloudPulseServiceTypes } from 'src/queries/cloudpulse/services';
 
 import { usePreferencesToggle } from '../../Utils/UserPreference';
 import { alertStatusOptions } from '../constants';
-import { AlertListNoticeMessages } from '../Utils/AlertListNoticeMessages';
 import { scrollToElement } from '../Utils/AlertResourceUtils';
 import { AlertsListTable } from './AlertListTable';
 import {
@@ -302,19 +301,7 @@ export const AlertListing = () => {
           </Typography>
         </Notice>
       )}
-      {hasFailedAlerts && (
-        <AlertListNoticeMessages
-          errorMessage="Creation of some alerts has failed. Please contact support for assistance."
-          separator=","
-          sx={(theme) => ({
-            '&>p': {
-              fontWeight: theme.typography.fontWeightBold,
-              fontSize: theme.spacingFunction(16),
-            },
-          })}
-          variant="error"
-        />
-      )}
+
       <AlertsListTable
         alerts={getAlertsList}
         error={error ?? undefined}

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListing.tsx
@@ -177,7 +177,8 @@ export const AlertListing = () => {
     );
   }
 
-  const hasFailedAlerts = alerts?.some((alert) => alert.status === 'failed');
+  const failedAlertsCount =
+    alerts?.filter((alert: Alert) => alert.status === 'failed').length ?? 0;
 
   return (
     <Stack spacing={3}>
@@ -282,7 +283,7 @@ export const AlertListing = () => {
           Create Alert
         </Button>
       </Box>
-      {hasFailedAlerts && (
+      {failedAlertsCount > 0 && (
         <Notice variant="error">
           <Typography
             sx={(theme) => ({
@@ -290,12 +291,13 @@ export const AlertListing = () => {
               fontSize: theme.spacingFunction(16),
             })}
           >
-            Creation of some alerts has failed. Please{' '}
+            Creation of {failedAlertsCount} alerts has failed as indicated in
+            the status column. Please{' '}
             <Link
               href="https://cloud.linode.com/support/tickets"
               underline="hover"
             >
-              contact support
+              open a support ticket
             </Link>{' '}
             for assistance.
           </Typography>


### PR DESCRIPTION
## Description 📝

Added an info message for failed alerts in both list & details page.

## Changes  🔄

List any change(s) relevant to the reviewer.

1. Added Notice for failed alert in AlertDetail.tsx
2. Added Notice for failed alert in AlertListing.tsx

## Target release date 🗓️

Next release cycle

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
|![Screenshot 2025-04-24 at 7 09 40 PM](https://github.com/user-attachments/assets/174a6d40-d8cf-4217-b0b9-c4bfbf0e0bb1)|![Screenshot 2025-04-24 at 7 08 46 PM](https://github.com/user-attachments/assets/66f72f1a-9987-4804-905f-9bafef678ff7)|
|![Screenshot 2025-04-24 at 7 11 00 PM](https://github.com/user-attachments/assets/b97265bd-d55e-483c-94b5-b29ae2a08180)|![Screenshot 2025-04-24 at 7 07 52 PM](https://github.com/user-attachments/assets/bc7eea00-c1fb-4a1c-837f-404555d3a7ce)|

## How to test 🧪
1. Switch as mock user
2. Go to alerts tab
3. On the listing page you'll see the error notice with number of failed alerts in the list
4. Select the alert, if the status is failed then you'll see similar error notice for that particular alert.


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

