### PR TITLE
fix: [M3-0836] - Wrong history instance for bucket deep navigation

### DIFF
--- a/packages/manager/.changeset/pr-12112-fixed-1745593237854.md
+++ b/packages/manager/.changeset/pr-12112-fixed-1745593237854.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+OBJ bucket nested breadcrumb navigation ([#12112](https://github.com/linode/manager/pull/12112))

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketBreadcrumb.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketBreadcrumb.tsx
@@ -1,3 +1,4 @@
+import { useNavigate, useParams } from '@tanstack/react-router';
 import * as React from 'react';
 
 import { useWindowDimensions } from 'src/hooks/useWindowDimensions';
@@ -13,12 +14,15 @@ import {
 
 interface Props {
   bucketName: string;
-  history: any;
   prefix: string;
 }
 
 export const BucketBreadcrumb = (props: Props) => {
-  const { bucketName, history, prefix } = props;
+  const { bucketName, prefix } = props;
+  const navigate = useNavigate();
+  const { clusterId } = useParams({
+    from: '/object-storage/buckets/$clusterId/$bucketName',
+  });
   const { width } = useWindowDimensions();
   const bucketPath = bucketName + '/' + prefix;
 
@@ -38,7 +42,11 @@ export const BucketBreadcrumb = (props: Props) => {
         {/* Bucket name */}
         <StyledLink
           onClick={() => {
-            history.push({ search: '?prefix=' });
+            navigate({
+              to: '/object-storage/buckets/$clusterId/$bucketName',
+              params: { clusterId, bucketName },
+              search: { prefix: '' },
+            });
           }}
           variant="body1"
         >
@@ -66,7 +74,11 @@ export const BucketBreadcrumb = (props: Props) => {
                   }
 
                   const prefixString = prefixArrayToString(prefixArray, idx);
-                  history.push({ search: '?prefix=' + prefixString });
+                  navigate({
+                    to: '/object-storage/buckets/$clusterId/$bucketName',
+                    params: { clusterId, bucketName },
+                    search: { prefix: prefixString },
+                  });
                 }}
                 variant="body1"
               >
@@ -76,7 +88,7 @@ export const BucketBreadcrumb = (props: Props) => {
           );
         })}
       </StyledPrefixWrapper>
-      <StyledCopyTooltip text={bucketPath} placement="bottom" />
+      <StyledCopyTooltip placement="bottom" text={bucketPath} />
     </StyledRootContainer>
   );
 };

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -355,11 +355,7 @@ export const BucketDetail = () => {
   return (
     <>
       <DocumentTitleSegment segment={`${bucketName} | Bucket`} />
-      <BucketBreadcrumb
-        bucketName={bucketName}
-        history={history}
-        prefix={prefix}
-      />
+      <BucketBreadcrumb bucketName={bucketName} prefix={prefix} />
       <ObjectUploader
         bucketName={bucketName}
         clusterId={clusterId}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketProperties.tsx
@@ -24,7 +24,7 @@ export const BucketProperties = React.memo((props: Props) => {
 
   return (
     <>
-      <BucketBreadcrumb bucketName={label} history={history} prefix={prefix} />
+      <BucketBreadcrumb bucketName={label} prefix={prefix} />
       <StyledText>{hostname}</StyledText>
 
       <StyledRootContainer>


### PR DESCRIPTION
## Description 📝
The recent routing refactor of OBJ left a bug behind, which is the abaility to navigate through the nested bucket breadcrumb navigation. It was an unfortunate omission of an instance of `history` typed as any that was neither `react-router-dom` nor `@tanstack/react-router`. Just a stray browser native history that was working until we re-routed.

## Changes  🔄
- fix bucket detail breadcrumb navigation

## Target release date 🗓️
⚠️  06/05/2025

## Preview 📷
https://github.com/user-attachments/assets/6b6cc20a-7b65-44e5-ba76-d54455885948


## How to test 🧪

### Prerequisites
- Have nested folders in a bucket

### Reproduction steps
- In production, notice the bucket detail nested breadcrumb navigation is broken

### Verification steps
- In this PR notice the bucket detail nested breadcrumb navigation is working

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
