### PR TITLE
fix: [UIE-8684] - save button text fix, error message for Autocomplete, validation

### DIFF
--- a/packages/manager/.changeset/pr-12116-fixed-1745838194419.md
+++ b/packages/manager/.changeset/pr-12116-fixed-1745838194419.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-DBaaS: incorrect restart-related label on Save button, missing error message for Autocomplete ([#12116](https://github.com/linode/manager/pull/12116))
+DBaaS: Incorrect restart-related label on Save button, missing error message for Autocomplete ([#12116](https://github.com/linode/manager/pull/12116))

--- a/packages/manager/.changeset/pr-12116-fixed-1745838194419.md
+++ b/packages/manager/.changeset/pr-12116-fixed-1745838194419.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+DBaaS: incorrect restart-related label on Save button, missing error message for Autocomplete ([#12116](https://github.com/linode/manager/pull/12116))

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfigurationDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseAdvancedConfigurationDrawer.tsx
@@ -87,7 +87,7 @@ export const DatabaseAdvancedConfigurationDrawer = (props: Props) => {
 
   const {
     control,
-    formState: { isDirty, dirtyFields },
+    formState: { isDirty },
     handleSubmit,
     reset,
     watch,
@@ -252,7 +252,7 @@ export const DatabaseAdvancedConfigurationDrawer = (props: Props) => {
         <ActionsPanel
           primaryButtonProps={{
             disabled: !isDirty,
-            label: hasRestartCluster(dirtyFields, configs),
+            label: hasRestartCluster(configs, existingConfigurations),
             loading: isUpdating,
             type: 'submit',
             title: 'Save',

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseConfigurationItem.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/DatabaseConfigurationItem.tsx
@@ -66,7 +66,12 @@ export const DatabaseConfigurationItem = (props: Props) => {
           }}
           options={options}
           renderInput={(params) => (
-            <TextField {...params} label="" placeholder="Select an option" />
+            <TextField
+              {...params}
+              errorText={errorText}
+              label=""
+              placeholder="Select an option"
+            />
           )}
           value={selectedValue ?? options[0]}
         />
@@ -84,7 +89,8 @@ export const DatabaseConfigurationItem = (props: Props) => {
           name={configLabel}
           onBlur={onBlur}
           onChange={(e) => {
-            onChange(e.target.value);
+            const value = e.target.value;
+            onChange(value === '' ? '' : Number(value));
           }}
           placeholder={
             configItem.isNew ? String(configItem?.example ?? '') : ''

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/utilities.ts
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseAdvancedConfiguration/utilities.ts
@@ -239,13 +239,20 @@ export const getConfigAPIError = (
  * Determines if a restart is required based on dirty fields.
  */
 export const hasRestartCluster = (
-  dirtyFields: any,
-  configs: ConfigurationOption[]
+  currentConfigs: ConfigurationOption[],
+  initialConfigs: ConfigurationOption[]
 ): string => {
-  return configs.some((config, index) => {
-    const isDirtyValue = dirtyFields.configs?.[index]?.value;
-    return isDirtyValue && config.requires_restart;
-  })
-    ? 'Save and Restart Service'
-    : 'Save';
+  const requiresRestart = currentConfigs.some((currentConfig) => {
+    const initialConfig = initialConfigs.find(
+      (item) => item.label === currentConfig.label
+    );
+
+    const isNewConfig = !initialConfig;
+    const hasChangedValue =
+      initialConfig && initialConfig.value !== currentConfig.value;
+
+    return (isNewConfig || hasChangedValue) && currentConfig.requires_restart;
+  });
+
+  return requiresRestart ? 'Save and Restart Service' : 'Save';
 };

--- a/packages/validation/.changeset/pr-12116-added-1745838363692.md
+++ b/packages/validation/.changeset/pr-12116-added-1745838363692.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Added
+---
+
+validation for `mysql.group_concat_max_len` and `default_time_zone` ([#12116](https://github.com/linode/manager/pull/12116))

--- a/packages/validation/.changeset/pr-12116-added-1745838363692.md
+++ b/packages/validation/.changeset/pr-12116-added-1745838363692.md
@@ -2,4 +2,4 @@
 "@linode/validation": Added
 ---
 
-validation for `mysql.group_concat_max_len` and `default_time_zone` ([#12116](https://github.com/linode/manager/pull/12116))
+DBaaS: Validation for `mysql.group_concat_max_len` and `default_time_zone` ([#12116](https://github.com/linode/manager/pull/12116))


### PR DESCRIPTION
## Description 📝

Fix for Save button text when restart cluster is needed, add error message for configs with Autocomplete input, add validation for mysql.group_concat_max_len

## Changes  🔄

List any change(s) relevant to the reviewer.

- corrected Save button text when a cluster restart is required
- added error message handling for configuration fields using Autocomplete inputs
- implemented validation for the mysql.group_concat_max_len

## Target release date 🗓️

6 May 2025

## How to test 🧪

### Prerequisites

(How to setup test environment)

Database Advanced Config feature flag should be enabled.

### Verification steps

(How to verify changes)
Save button text:
- select a database cluster
- navigate to the Advanced Configuration tab
- click the "Configure" button
- update the value for one of the existing configuration items with `restarts service` label
- "Save" button text changed to "Save and Restart Service"

Error message:
- select database cluster with PostgreSQL v13
- navigate to the Advanced Configuration tab
- click "Configure" button
- select `default_toast_compression` from the dropdown and click "Add" button
- click "Save" button
- verify that an error message is shown


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
