### PR TITLE
test: [M3-9179] - Add cypress tests for adding Linodes to firewalls

### DIFF
--- a/packages/manager/.changeset/pr-12117-tests-1745841831406.md
+++ b/packages/manager/.changeset/pr-12117-tests-1745841831406.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add tests for adding Linode and Interface devices to a firewall ([#12117](https://github.com/linode/manager/pull/12117))

--- a/packages/manager/cypress/e2e/core/firewalls/add-device-to-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/add-device-to-firewall.spec.ts
@@ -198,7 +198,7 @@ describe('Can add Linode and Linode Interface devices to firewalls', () => {
   });
 
   /**
-   * - Confirms if selected Linode have more than one eligible interface to assign, an additional interface select appear
+   * - Confirms if selected Linode has more than one eligible interface to assign, an additional interface select appears
    * - Confirms if selected Linode has multiple interfaces but only one eligible interface to assign, an additional interface select does not appear
    * - Confirms toasts appear if firewall successfully assigned
    */
@@ -246,7 +246,6 @@ describe('Can add Linode and Linode Interface devices to firewalls', () => {
       .should('be.visible')
       .click();
 
-    // Confirm Linode using legacy interfaces can be selected
     ui.drawer
       .findByTitle(`Add Linode to Firewall: ${mockFirewall.label}`)
       .should('be.visible')
@@ -263,7 +262,7 @@ describe('Can add Linode and Linode Interface devices to firewalls', () => {
           .should('be.visible')
           .click();
 
-        // confirm Interface select doesn't appear for mockLinode - only one eligible interface
+        // confirm Interface select doesn't appear for mockLinode - only one eligible interface exists
         cy.findByText(`${mockLinode.label} Interface`).should('not.exist');
 
         cy.findByLabelText('Linodes').should('be.visible').click();
@@ -291,6 +290,9 @@ describe('Can add Linode and Linode Interface devices to firewalls', () => {
           )
           .should('be.visible')
           .click();
+        ui.autocompletePopper
+          .findByTitle(`Public Interface (ID: ${mockPublicInterface1.id})`)
+          .should('be.visible');
         ui.autocompletePopper
           .findByTitle(`VPC Interface (ID: ${mockVPCInterface.id})`)
           .should('be.visible')
@@ -466,6 +468,7 @@ describe('Can add Linode and Linode Interface devices to firewalls', () => {
           .should('be.enabled')
           .click();
 
+        // confirm error is displayed upon failure
         cy.findByText('Unable to add firewall device.').should('be.visible');
       });
   });

--- a/packages/manager/cypress/support/intercepts/firewalls.ts
+++ b/packages/manager/cypress/support/intercepts/firewalls.ts
@@ -1,7 +1,7 @@
 /**
  * @file Cypress intercepts and mocks for Firewall API requests.
  */
-import { APIErrorContents, makeErrorResponse } from 'support/util/errors';
+import { makeErrorResponse } from 'support/util/errors';
 import { apiMatcher } from 'support/util/intercepts';
 import { paginateResponse } from 'support/util/paginate';
 import { makeResponse } from 'support/util/response';
@@ -12,6 +12,7 @@ import type {
   FirewallSettings,
   FirewallTemplate,
 } from '@linode/api-v4';
+import type { APIErrorContents } from 'support/util/errors';
 
 /**
  * Intercepts GET request to fetch Firewalls.
@@ -20,6 +21,22 @@ import type {
  */
 export const interceptGetFirewalls = (): Cypress.Chainable<null> => {
   return cy.intercept('GET', apiMatcher('networking/firewalls*'));
+};
+
+/**
+ * Mocks the GET request to get a single Firewall
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetFirewall = (
+  firewallId: number,
+  firewall: Firewall,
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher(`networking/firewalls/${firewallId}`),
+    firewall
+  );
 };
 
 /**
@@ -128,6 +145,22 @@ export const interceptUpdateFirewallLinodes = (
   return cy.intercept(
     'POST',
     apiMatcher(`networking/firewalls/${firewallId}/devices`)
+  );
+};
+
+/**
+ * Mocks the GET request to get a Firewall's devices
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetFirewallDevices = (
+  firewallId: number,
+  firewallDevices: FirewallDevice[]
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher(`networking/firewalls/${firewallId}/devices*`),
+    paginateResponse(firewallDevices)
   );
 };
 

--- a/packages/manager/cypress/support/intercepts/firewalls.ts
+++ b/packages/manager/cypress/support/intercepts/firewalls.ts
@@ -30,7 +30,7 @@ export const interceptGetFirewalls = (): Cypress.Chainable<null> => {
  */
 export const mockGetFirewall = (
   firewallId: number,
-  firewall: Firewall,
+  firewall: Firewall
 ): Cypress.Chainable<null> => {
   return cy.intercept(
     'GET',
@@ -177,6 +177,26 @@ export const mockAddFirewallDevice = (
     'POST',
     apiMatcher(`networking/firewalls/${firewallId}/devices`),
     firewallDevice
+  );
+};
+
+/**
+ * Intercepts POST request to add a firewall device and mocks an API error response.
+ *
+ * @param errorContents - API error with which to mock response.
+ * @param statusCode - HTTP status code with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockAddFirewallDeviceError = (
+  firewallId: number,
+  errorContents: APIErrorContents = 'Unable to add firewall device.',
+  statusCode: number = 400
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`networking/firewalls/${firewallId}/devices`),
+    makeErrorResponse(errorContents, statusCode)
   );
 };
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddLinodeDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddLinodeDrawer.tsx
@@ -136,7 +136,7 @@ export const AddLinodeDrawer = (props: Props) => {
       const ifaceInfo = interfacesToAdd[index];
       if (result.status === 'fulfilled') {
         enqueueSnackbar(
-          `Interface (ID ${id}) from Linode ${ifaceInfo.linodeLabel} successfully added.`,
+          `Interface (ID ${ifaceInfo.interfaceId}) from Linode ${ifaceInfo.linodeLabel} successfully added.`,
           {
             variant: 'success',
           }


### PR DESCRIPTION
## Description 📝
- Add cypress tests for the Add Linode to Firewall flow
- fix small bug with toast upon successfully adding an interface device to firewall (accidentally used device's ID instead of interface's ID)

## Target release date 🗓️
5/6

## How to test 🧪

- confirm toast when adding interface device uses interface's ID

```
pnpm cy:run -s "cypress/e2e/core/firewalls/add-device-to-firewall.spec.ts"
```

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
