### PR TITLE
upcoming: [M3-9849] - Hide Firewall Select for VLAN Interfaces for Linode Interfaces

### DIFF
--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceType.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceType.tsx
@@ -32,11 +32,8 @@ const interfaceTypes = [
 ] as const;
 
 export const InterfaceType = ({ index }: Props) => {
-  const {
-    control,
-    getFieldState,
-    setValue,
-  } = useFormContext<LinodeCreateFormValues>();
+  const { control, getFieldState, setValue } =
+    useFormContext<LinodeCreateFormValues>();
 
   const { data: firewallSettings } = useFirewallSettingsQuery();
 
@@ -54,8 +51,15 @@ export const InterfaceType = ({ index }: Props) => {
       firewallSettings
     );
 
+    // VLAN interfaces do not support Firewalls, so set
+    // the Firewall ID to null and early return.
+    if (value === 'vlan') {
+      setValue(`linodeInterfaces.${index}.firewall_id`, null);
+      return;
+    }
+
     // Set the Firewall based on defaults if:
-    // - there is a default firewall for this interface type
+    // - there is a default firewall for the selected interface type
     // - the user has not touched the Firewall field
     if (
       defaultFirewall &&
@@ -75,18 +79,18 @@ export const InterfaceType = ({ index }: Props) => {
         <Grid2 container spacing={1}>
           {interfaceTypes.map((interfaceType) => (
             <SelectionCard
+              checked={field.value === interfaceType.purpose}
               gridSize={{
                 md: 3,
                 sm: 12,
                 xs: 12,
               }}
-              renderIcon={() => (
-                <Radio checked={field.value === interfaceType.purpose} />
-              )}
-              checked={field.value === interfaceType.purpose}
               heading={interfaceType.label}
               key={interfaceType.purpose}
               onClick={() => onChange(interfaceType.purpose)}
+              renderIcon={() => (
+                <Radio checked={field.value === interfaceType.purpose} />
+              )}
               subheadings={[]}
               sxCardBaseIcon={{ svg: { fontSize: '24px !important' } }}
             />

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/LinodeInterface.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/LinodeInterface.tsx
@@ -20,12 +20,12 @@ export const LinodeInterface = ({ index }: Props) => {
     formState: { errors },
   } = useFormContext<LinodeCreateFormValues>();
 
-  const interfaceGeneration = useWatch<LinodeCreateFormValues>({
+  const interfaceGeneration = useWatch({
     control,
     name: 'interface_generation',
   });
 
-  const interfaceType = useWatch<LinodeCreateFormValues>({
+  const interfaceType = useWatch({
     control,
     name: `linodeInterfaces.${index}.purpose`,
   });
@@ -50,7 +50,9 @@ export const LinodeInterface = ({ index }: Props) => {
       </Stack>
       {interfaceType === 'vlan' && <VLAN index={index} />}
       {interfaceType === 'vpc' && <VPC index={index} />}
-      {interfaceGeneration === 'linode' && <InterfaceFirewall index={index} />}
+      {interfaceGeneration === 'linode' && interfaceType !== 'vlan' && (
+        <InterfaceFirewall index={index} />
+      )}
     </Stack>
   );
 };

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceForm.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceForm.tsx
@@ -99,7 +99,7 @@ export const AddInterfaceForm = (props: Props) => {
           {selectedInterfacePurpose === 'vpc' && (
             <VPCInterface regionId={regionId} />
           )}
-          <InterfaceFirewall />
+          {selectedInterfacePurpose !== 'vlan' && <InterfaceFirewall />}
           <Actions onClose={onClose} />
         </Stack>
       </form>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/InterfaceType.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/InterfaceType.tsx
@@ -10,34 +10,47 @@ import { useQueryClient } from '@tanstack/react-query';
 import React from 'react';
 import { useController, useFormContext } from 'react-hook-form';
 
-import { INTERFACE_PURPOSE_TO_DEFAULT_FIREWALL_KEY } from './utilities';
+import { getDefaultFirewallForInterfacePurpose } from 'src/features/Linodes/LinodeCreate/Networking/utilities';
 
 import type { CreateInterfaceFormValues } from './utilities';
 import type { InterfacePurpose } from '@linode/api-v4';
 
 export const InterfaceType = () => {
   const queryClient = useQueryClient();
-  const { setValue } = useFormContext<CreateInterfaceFormValues>();
+
+  const { setValue, getFieldState } =
+    useFormContext<CreateInterfaceFormValues>();
+
   const { field, fieldState } = useController<CreateInterfaceFormValues>({
     name: 'purpose',
   });
 
   const onChange = async (value: InterfacePurpose) => {
-    // Change the selected interface type (Public, VPC, VLAN)
+    // Change the interface purpose (Public, VPC, VLAN)
     field.onChange(value);
 
-    // Update the form's `firewall_id` based on the defaults
-    const firewallSettings = await queryClient.ensureQueryData(
-      firewallQueries.settings
-    );
-    const firewallSettingKey = INTERFACE_PURPOSE_TO_DEFAULT_FIREWALL_KEY[value];
-    if (firewallSettingKey) {
-      setValue(
-        'firewall_id',
-        firewallSettings.default_firewall_ids[firewallSettingKey]
-      );
-    } else {
+    // VLAN interfaces do not support Firewalls, so set
+    // the Firewall ID to `null` to be safe and early return.
+    if (value === 'vlan') {
       setValue('firewall_id', null);
+      return;
+    }
+
+    // If the user has not touched the Firewall field...
+    if (!getFieldState('firewall_id').isTouched) {
+      const firewallSettings = await queryClient.ensureQueryData(
+        firewallQueries.settings
+      );
+
+      const defaultFirewall = getDefaultFirewallForInterfacePurpose(
+        value,
+        firewallSettings
+      );
+
+      // If this Interface type has a default firewall, set it
+      if (defaultFirewall) {
+        setValue('firewall_id', defaultFirewall);
+      }
     }
   };
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/utilities.ts
@@ -4,8 +4,6 @@ import {
 } from '@linode/validation';
 import { number, object, string } from 'yup';
 
-import type { InterfacePurpose } from '@linode/api-v4';
-import type { FirewallDefaultEntity } from 'src/features/Firewalls/components/FirewallSelectOption.utils';
 import type { InferType } from 'yup';
 
 export const CreateLinodeInterfaceFormSchema =
@@ -26,12 +24,3 @@ export const CreateLinodeInterfaceFormSchema =
 export type CreateInterfaceFormValues = InferType<
   typeof CreateLinodeInterfaceFormSchema
 >;
-
-export const INTERFACE_PURPOSE_TO_DEFAULT_FIREWALL_KEY: Record<
-  InterfacePurpose,
-  FirewallDefaultEntity | null
-> = {
-  public: 'public_interface',
-  vlan: null,
-  vpc: 'vpc_interface',
-};


### PR DESCRIPTION
## Description 📝

- Hides the Firewall Select for VLAN Interfaces because VLAN interfaces do not support Firewalls
- Aligns "Linode Create" and "Add Interface Drawer" behavior in relation to default firewalls

## Target release date 🗓️

- Needed in this upcoming release (May 6th)

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-04-28 at 1 01 40 PM](https://github.com/user-attachments/assets/97fe590a-057a-4d84-ba31-a8217d258cb9) | ![Screenshot 2025-04-28 at 1 01 24 PM](https://github.com/user-attachments/assets/2af86fe7-0de7-481c-bccc-00305b3fc49f) |
| ![Screenshot 2025-04-28 at 1 01 11 PM](https://github.com/user-attachments/assets/7ab4b46b-6bf7-4700-bc4a-bc4035ed6217) | ![Screenshot 2025-04-28 at 1 02 31 PM](https://github.com/user-attachments/assets/90e09dca-9061-487f-bbec-f037c25c5193) |


## How to test 🧪

### Prerequisites

- `new-interfaces-beta` customer tag
- Enable Linode Interfaces Cloud Manager feature flag locally

### Verification steps

- Verify you **do not** see a Firewall select on the Linode Create flow when Linode Interfaces is selected and VLAN is the selected Interface type
- Verify you **do not** see a Firewall select when creating a VLAN Interface in the "Add Network Interface Drawer"
- Verify default firewall preselection still works as expected
- Verify you can create VLAN interfaces without any issue

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
