### PR TITLE
fix: [M3-9856] - Fix text layout for `Notice`s with multiple children

### DIFF
--- a/packages/manager/.changeset/pr-12120-tech-stories-1745864893717.md
+++ b/packages/manager/.changeset/pr-12120-tech-stories-1745864893717.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Change `DismissibleBanner` to `display: flex` ([#12120](https://github.com/linode/manager/pull/12120))

--- a/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
+++ b/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
@@ -75,17 +75,19 @@ export const DismissibleBanner = (props: Props) => {
 
   return (
     <Notice bgcolor={(theme) => theme.palette.background.paper} {...rest}>
-      <Stack direction="column" flex={1} justifyContent="center">
-        {children}
-      </Stack>
-      <Stack
-        alignSelf="flex-start"
-        direction="row"
-        justifyContent="flex-end"
-        spacing={1}
-      >
-        {actionButton}
-        {dismissibleButton}
+      <Stack direction="row">
+        <Stack direction="column" flex={1} justifyContent="center">
+          {children}
+        </Stack>
+        <Stack
+          alignSelf="flex-start"
+          direction="row"
+          justifyContent="flex-end"
+          spacing={1}
+        >
+          {actionButton}
+          {dismissibleButton}
+        </Stack>
       </Stack>
     </Notice>
   );

--- a/packages/ui/.changeset/pr-12120-fixed-1745864924644.md
+++ b/packages/ui/.changeset/pr-12120-fixed-1745864924644.md
@@ -1,0 +1,5 @@
+---
+"@linode/ui": Fixed
+---
+
+Broken text layout for `Notice`s with multiple child elements ([#12120](https://github.com/linode/manager/pull/12120))

--- a/packages/ui/src/components/Notice/Notice.tsx
+++ b/packages/ui/src/components/Notice/Notice.tsx
@@ -162,7 +162,7 @@ export const Notice = (props: NoticeProps) => {
         {variantMap.tip && <LightBulbIcon className={classes.icon} />}
         {variantMap.warning && <WarningIcon className={classes.icon} />}
       </Box>
-      <Box sx={{ display: 'flex', flexWrap: 'wrap', width: '100%' }}>
+      <Box sx={{ width: '100%' }}>
         {text || typeof children === 'string' ? (
           <Typography {...typeProps}>{text ?? children}</Typography>
         ) : (


### PR DESCRIPTION
## Description 📝

Fixes a visual regression following the CDS refactor of the `Notice` component in #12004. 

## Changes  🔄

- Removes `display: flex` from the children of the Notice components
   - Alternatively, we can wrap the contents in `Typography` for each affected Notice -- I am open to discussion surrounding this approach
- Adds an additional stack in `DismissibleNotice` to replace the flexbox removed above

## Preview 📷

| Prod  | This Branch   |
| ------- | ------- |
| ![Screenshot 2025-04-28 at 1 39 00 PM](https://github.com/user-attachments/assets/72cb93c1-682a-457b-99ad-958a6a4394da) | ![Screenshot 2025-04-28 at 1 29 11 PM](https://github.com/user-attachments/assets/03f8c710-8cd0-497d-90cf-b9f9f93005fd) |

## How to test 🧪

* Verify `Notice`s with multiple children render text and whitespace correctly.
   * An example of an affected Notice can be found when creating an image in a distributed region (see screenshot above)
* Verify existing `Notice`s continue to render as expected. Several variations are included in the screenshot above.
   * `DismissibleBanner`
   * Notices with action button
   * Notices with `forceImportantIconVerticalCenter` enabled

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>