### PR TITLE
change: [UIE-8841] - custom validation for net_buffer_length

### DIFF
--- a/packages/validation/.changeset/pr-12126-added-1745937083422.md
+++ b/packages/validation/.changeset/pr-12126-added-1745937083422.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Added
+---
+
+DBaaS: Custom validation for `net_buffer_length` ([#12126](https://github.com/linode/manager/pull/12126))

--- a/packages/validation/src/databases.schema.ts
+++ b/packages/validation/src/databases.schema.ts
@@ -131,7 +131,16 @@ const applyConstraints = (validator: any, key: string, field: any) => {
       validator = validator.required('timezone cannot be empty');
     }
   }
-
+  if (key === 'net_buffer_length') {
+    validator = validator.test(
+      'is-multiple-of-1024',
+      `${key} must be a multiple of 1024`,
+      (value: boolean | number | string) => {
+        if (typeof value !== 'number') return false;
+        return value % 1024 === 0;
+      },
+    );
+  }
   return validator;
 };
 


### PR DESCRIPTION
## Description 📝

Custom validation for `net_buffer_length`

## Changes  🔄

List any change(s) relevant to the reviewer.

- added custom validation for `net_buffer_length`

## Target release date 🗓️

6 May 2025

## How to test 🧪

### Prerequisites

(How to setup test environment)

Database Advanced Config feature flag should be enabled.

### Verification steps

(How to verify changes)

- select database cluster with MySQL
- navigate to the Advanced Configuration tab
- click "Configure" button
- select `net_buffer_length` from the dropdown and click "Add" button
- enter a value that is not a multiple of 1024
- verify that an error message is shown

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>