### PR TITLE
test: [M3-9479] - Fix DBaaS Cypress test region mocks so tests pass in DevCloud

### DIFF
--- a/packages/manager/.changeset/pr-12127-tests-1745948285700.md
+++ b/packages/manager/.changeset/pr-12127-tests-1745948285700.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix DBaaS Cypress test region mocks so tests pass in DevCloud ([#12127](https://github.com/linode/manager/pull/12127))

--- a/packages/manager/cypress/e2e/core/databases/create-database.spec.ts
+++ b/packages/manager/cypress/e2e/core/databases/create-database.spec.ts
@@ -317,8 +317,12 @@ describe('restricted user cannot create database', () => {
   });
 
   it('cannot create database from Create menu', () => {
+    mockGetDatabaseEngines(mockDatabaseEngineTypes).as('getDatabaseEngines');
+    mockGetDatabaseTypes(mockDatabaseNodeTypes).as('getDatabaseTypes');
+
     // Login and wait for application to load
     cy.visitWithLogin('/databases/create');
+    cy.wait(['@getDatabaseTypes', '@getDatabaseEngines']);
 
     // table present for restricted user but its inputs will be disabled
     cy.get('table[aria-label="List of Linode Plans"]').should('exist');

--- a/packages/manager/cypress/support/util/regions.ts
+++ b/packages/manager/cypress/support/util/regions.ts
@@ -132,6 +132,44 @@ const disallowedRegionIds = [
   'ca-central',
 ];
 
+const databaseMockRegion: ExtendedRegion = {
+  id: 'pl-labkrk-2',
+  label: 'PL, Krakow',
+  country: 'pl',
+  capabilities: [
+    'Linodes',
+    'Block Storage Encryption',
+    'Backups',
+    'NodeBalancers',
+    'Block Storage',
+    'Object Storage',
+    'GPU Linodes',
+    'Kubernetes',
+    'Cloud Firewall',
+    'Vlans',
+    'VPCs',
+    'Block Storage Migrations',
+    'Managed Databases',
+    'Metadata',
+    'Premium Plans',
+    'Placement Group',
+    'StackScripts',
+    'NETINT Quadra T1U',
+    'Linode Interfaces',
+  ],
+  status: 'ok',
+  resolvers: {
+    ipv4: '172.24.224.240,172.24.224.229,172.24.224.236,172.24.224.238,172.24.224.235,172.24.224.241,172.24.224.230,172.24.224.239,172.24.224.233,172.24.224.234',
+    ipv6: '2600:3c11:e001::1,2600:3c11:e001::2,2600:3c11:e001::3,2600:3c11:e001::4,2600:3c11:e001::5,2600:3c11:e001::6,2600:3c11:e001::7,2600:3c11:e001::8,2600:3c11:e001::9,2600:3c11:e001::10',
+  },
+  placement_group_limits: {
+    maximum_pgs_per_customer: null,
+    maximum_linodes_per_pg: 5,
+  },
+  site_type: 'core',
+  apiLabel: 'Krakow, PL',
+};
+
 /**
  * Returns an object describing a Cloud Manager region if specified by the user.
  *
@@ -326,11 +364,16 @@ const resolveSearchRegions = (
   ).filter((region: Region) => !allDisallowedRegionIds.includes(region.id));
 
   if (!capableRegions.length) {
-    throw new Error(
-      `No regions are available with the required capabilities: ${requiredCapabilities.join(
-        ', '
-      )}`
-    );
+    if (requiredCapabilities.includes('Managed Databases')) {
+      // Return a mock region if it searchs for Database
+      capableRegions.push(databaseMockRegion);
+    } else {
+      throw new Error(
+        `No regions are available with the required capabilities: ${requiredCapabilities.join(
+          ', '
+        )}`
+      );
+    }
   }
 
   return capableRegions;


### PR DESCRIPTION
## Description 📝
Fix DBaaS Cypress test region mocks so tests pass in DevCloud

## Changes  🔄
- Add mock region to the regions list of DBaaS capabilities
- Fix minor issue in test `cannot create database from Create menu`

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/databases/create-database.spec.ts"
yarn cy:run -s "cypress/e2e/core/databases/delete-database.spec.ts"
yarn cy:run -s "cypress/e2e/core/databases/resize-database.spec.ts"
yarn cy:run -s "cypress/e2e/core/databases/update-database.spec.ts"
```