### PR TITLE
test: [M3-9870] - Fix test failure in `access-keys-multicluster.spec.ts`

### DIFF
--- a/packages/manager/src/components/RegionSelect/RegionMultiSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionMultiSelect.tsx
@@ -142,7 +142,7 @@ export const RegionMultiSelect = React.memo((props: RegionMultiSelectProps) => {
               <Chip
                 {...getTagProps({ index })}
                 data-testid={option.id}
-                deleteIcon={<CloseIcon />}
+                deleteIcon={<CloseIcon data-testid="CloseIcon" />}
                 key={index}
                 label={<RegionChipLabel region={option} />}
                 onDelete={() => handleRemoveOption(option.id)}


### PR DESCRIPTION
## Description 📝

Fixes a test failure in `access-keys-multicluster.spec.ts` caused by the switch to `CloseIcon` from `@linode/ui` in #12072.

## Changes  🔄

- Add a `data-testid` attribute the the Chip delete button in `RegionMultiSelect`.

## How to test 🧪

Verify CI passes.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

