### PR TITLE
fix: [M3-9886] - Update how UpgradeVersionModal handles versioning to account for upgrades to versions older than the latest

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Missing `PublicIPAddressesTooltip` for VPC-only Linodes without an explicitly marked primary VPC interface ([#12122](https://github.com/linode/manager/pull/12122))
 - Fix incorrect card sizing at 1920px+ in LKE Tier panel ([#12076](https://github.com/linode/manager/pull/12076))
 - Bugs in Linode Create, Landing & Detail Pages ([#12028](https://github.com/linode/manager/pull/12028))
+- Bug displaying the incorrect cluster version number in upgrade completion dialog on LKE cluster details page ([#12139](https://github.com/linode/manager/pull/12139))
 
 ### Tech Stories:
 

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -35,7 +35,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fix incorrect card sizing at 1920px+ in LKE Tier panel ([#12076](https://github.com/linode/manager/pull/12076))
 - Bugs in Linode Create, Landing & Detail Pages ([#12028](https://github.com/linode/manager/pull/12028))
 - Bug displaying the incorrect cluster version number in upgrade completion dialog on LKE cluster details page ([#12139](https://github.com/linode/manager/pull/12139))
-- Fix persisting ACL IP validation error on clear ([#12144](https://github.com/linode/manager/pull/12144))
+- Persisting ACL IP validation error on clear ([#12144](https://github.com/linode/manager/pull/12144))
 
 ### Tech Stories:
 

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-landing-page.spec.ts
@@ -1,6 +1,7 @@
 import { mockGetAccount } from 'support/intercepts/account';
 import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
 import {
+  mockGetCluster,
   mockGetClusterPools,
   mockGetClusters,
   mockGetKubeconfig,
@@ -237,6 +238,7 @@ describe('LKE landing page', () => {
 
     const updatedCluster = { ...cluster, k8s_version: newVersion };
 
+    mockGetCluster(cluster).as('getCluster');
     mockGetClusters([cluster]).as('getClusters');
     mockGetKubernetesVersions([newVersion, oldVersion]).as('getVersions');
     mockUpdateCluster(cluster.id, updatedCluster).as('updateCluster');
@@ -249,6 +251,8 @@ describe('LKE landing page', () => {
     cy.findByText(oldVersion).should('be.visible');
 
     cy.findByText('UPGRADE').should('be.visible').should('be.enabled').click();
+
+    cy.wait(['@getCluster']);
 
     ui.dialog
       .findByTitle(
@@ -303,6 +307,7 @@ describe('LKE landing page', () => {
 
     const updatedCluster = { ...cluster, k8s_version: newVersion };
 
+    mockGetCluster(cluster).as('getCluster');
     mockGetClusters([cluster]).as('getClusters');
     mockGetTieredKubernetesVersions('enterprise', [
       { id: newVersion, tier: 'enterprise' },
@@ -318,6 +323,8 @@ describe('LKE landing page', () => {
     cy.findByText(oldVersion).should('be.visible');
 
     cy.findByText('UPGRADE').should('be.visible').should('be.enabled').click();
+
+    cy.wait(['@getCluster']);
 
     ui.dialog
       .findByTitle(

--- a/packages/manager/src/factories/kubernetesCluster.ts
+++ b/packages/manager/src/factories/kubernetesCluster.ts
@@ -78,7 +78,7 @@ export const kubernetesAPIResponse =
 
 export const kubernetesVersionFactory =
   Factory.Sync.makeFactory<KubernetesVersion>({
-    id: '1.24',
+    id: Factory.each((id) => `1.3${id}`),
   });
 
 export const kubernetesStandardTierVersionFactory =

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -32,20 +32,21 @@ export const KubernetesClusterDetail = () => {
 
   const { isUsingBetaEndpoint } = useKubernetesBetaEndpoint();
 
-  const { data: cluster, error, isLoading } = useKubernetesClusterQuery({
+  const {
+    data: cluster,
+    error,
+    isLoading,
+  } = useKubernetesClusterQuery({
     id,
     isUsingBetaEndpoint,
   });
   const { data: regionsData } = useRegionsQuery();
 
-  const { mutateAsync: updateKubernetesCluster } = useKubernetesClusterMutation(
-    id
-  );
+  const { mutateAsync: updateKubernetesCluster } =
+    useKubernetesClusterMutation(id);
 
-  const {
-    isClusterHighlyAvailable,
-    showHighAvailability,
-  } = getKubeHighAvailability(account, cluster);
+  const { isClusterHighlyAvailable, showHighAvailability } =
+    getKubeHighAvailability(account, cluster);
 
   const [updateError, setUpdateError] = React.useState<string | undefined>();
   const [isUpgradeToHAOpen, setIsUpgradeToHAOpen] = React.useState(false);
@@ -89,7 +90,6 @@ export const KubernetesClusterDetail = () => {
       />
       <UpgradeKubernetesVersionBanner
         clusterID={cluster?.id}
-        clusterLabel={cluster?.label}
         clusterTier={cluster?.tier ?? 'standard'} // TODO LKE: remove fallback once LKE-E is in GA and tier is required
         currentVersion={cluster?.k8s_version}
       />

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
@@ -19,7 +19,7 @@ interface Props {
 }
 
 export const UpgradeKubernetesVersionBanner = (props: Props) => {
-  const { clusterID, clusterLabel, clusterTier, currentVersion } = props;
+  const { clusterID, clusterTier, currentVersion } = props;
 
   const { versions } = useLkeStandardOrEnterpriseVersions(clusterTier);
   const nextVersion = getNextVersion(currentVersion, versions ?? []);
@@ -47,9 +47,6 @@ export const UpgradeKubernetesVersionBanner = (props: Props) => {
       ) : null}
       <UpgradeVersionModal
         clusterID={clusterID}
-        clusterLabel={clusterLabel}
-        clusterTier={clusterTier}
-        currentVersion={currentVersion}
         isOpen={dialogOpen}
         onClose={() => setDialogOpen(false)}
       />

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
@@ -13,7 +13,6 @@ import type { KubernetesTier } from '@linode/api-v4';
 
 interface Props {
   clusterID: number;
-  clusterLabel: string;
   clusterTier: KubernetesTier;
   currentVersion: string;
 }

--- a/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
@@ -32,7 +32,7 @@ import { useKubernetesBetaEndpoint } from '../kubeUtils';
 import UpgradeVersionModal from '../UpgradeVersionModal';
 import { KubernetesEmptyState } from './KubernetesLandingEmptyState';
 
-import type { KubeNodePoolResponse, KubernetesTier } from '@linode/api-v4';
+import type { KubeNodePoolResponse } from '@linode/api-v4';
 
 interface ClusterDialogState {
   loading: boolean;
@@ -43,11 +43,8 @@ interface ClusterDialogState {
 }
 
 interface UpgradeDialogState {
-  currentVersion: string;
   open: boolean;
   selectedClusterID: number;
-  selectedClusterLabel: string;
-  selectedClusterTier: KubernetesTier;
 }
 
 const defaultDialogState = {
@@ -59,12 +56,8 @@ const defaultDialogState = {
 };
 
 const defaultUpgradeDialogState = {
-  currentVersion: '',
-  nextVersion: null,
   open: false,
   selectedClusterID: 0,
-  selectedClusterLabel: '',
-  selectedClusterTier: 'standard' as KubernetesTier,
 };
 
 const preferenceKey = 'kubernetes';
@@ -73,14 +66,11 @@ export const KubernetesLanding = () => {
   const { push } = useHistory();
   const pagination = usePagination(1, preferenceKey);
 
-  const [dialog, setDialogState] = React.useState<ClusterDialogState>(
-    defaultDialogState
-  );
+  const [dialog, setDialogState] =
+    React.useState<ClusterDialogState>(defaultDialogState);
 
-  const [
-    upgradeDialog,
-    setUpgradeDialogState,
-  ] = React.useState<UpgradeDialogState>(defaultUpgradeDialogState);
+  const [upgradeDialog, setUpgradeDialogState] =
+    React.useState<UpgradeDialogState>(defaultUpgradeDialogState);
 
   const { handleOrderChange, order, orderBy } = useOrder(
     {
@@ -110,22 +100,13 @@ export const KubernetesLanding = () => {
     isUsingBetaEndpoint,
   });
 
-  const {
-    isDiskEncryptionFeatureEnabled,
-  } = useIsDiskEncryptionFeatureEnabled();
+  const { isDiskEncryptionFeatureEnabled } =
+    useIsDiskEncryptionFeatureEnabled();
 
-  const openUpgradeDialog = (
-    clusterID: number,
-    clusterLabel: string,
-    clusterTier: KubernetesTier,
-    currentVersion: string
-  ) => {
+  const openUpgradeDialog = (clusterID: number) => {
     setUpgradeDialogState({
-      currentVersion,
       open: true,
       selectedClusterID: clusterID,
-      selectedClusterLabel: clusterLabel,
-      selectedClusterTier: clusterTier,
     });
   };
 
@@ -246,17 +227,10 @@ export const KubernetesLanding = () => {
         <TableBody>
           {data?.data.map((cluster) => (
             <KubernetesClusterRow
-              openUpgradeDialog={() =>
-                openUpgradeDialog(
-                  cluster.id,
-                  cluster.label,
-                  cluster?.tier ?? 'standard', // TODO LKE: remove fallback once LKE-E is in GA and tier is required
-                  cluster.k8s_version
-                )
-              }
               cluster={cluster}
               key={`kubernetes-cluster-list-${cluster.id}`}
               openDeleteDialog={openDialog}
+              openUpgradeDialog={() => openUpgradeDialog(cluster.id)}
             />
           ))}
         </TableBody>
@@ -278,9 +252,6 @@ export const KubernetesLanding = () => {
       />
       <UpgradeVersionModal
         clusterID={upgradeDialog.selectedClusterID}
-        clusterLabel={upgradeDialog.selectedClusterLabel}
-        clusterTier={upgradeDialog.selectedClusterTier}
-        currentVersion={upgradeDialog.currentVersion}
         isOpen={upgradeDialog.open}
         onClose={closeUpgradeDialog}
       />

--- a/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx
+++ b/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx
@@ -132,7 +132,7 @@ export const UpgradeDialog = (props: Props) => {
         {hasUpdatedSuccessfully ? (
           <>
             The cluster’s Kubernetes version has been updated successfully to{' '}
-            <strong>{nextVersion}</strong>. <br /> <br />
+            <strong>{currentVersion}</strong>. <br /> <br />
             To upgrade your existing worker nodes, you can recycle all nodes
             (which may have a performance impact) or perform other upgrade
             methods. When recycling nodes, all nodes are deleted on a rolling

--- a/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx
+++ b/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx
@@ -7,6 +7,7 @@ import { ConfirmationDialog } from 'src/components/ConfirmationDialog/Confirmati
 import { Link } from 'src/components/Link';
 import {
   getNextVersion,
+  useKubernetesBetaEndpoint,
   useLkeStandardOrEnterpriseVersions,
 } from 'src/features/Kubernetes/kubeUtils';
 import {
@@ -27,7 +28,12 @@ export const UpgradeDialog = (props: Props) => {
 
   const { enqueueSnackbar } = useSnackbar();
 
-  const { data: cluster } = useKubernetesClusterQuery({ id: clusterID });
+  const { isUsingBetaEndpoint } = useKubernetesBetaEndpoint();
+
+  const { data: cluster } = useKubernetesClusterQuery({
+    id: clusterID,
+    isUsingBetaEndpoint,
+  });
 
   const { mutateAsync: updateKubernetesCluster } =
     useKubernetesClusterMutation(clusterID);

--- a/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx
+++ b/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx
@@ -9,44 +9,40 @@ import {
   getNextVersion,
   useLkeStandardOrEnterpriseVersions,
 } from 'src/features/Kubernetes/kubeUtils';
-import { useKubernetesClusterMutation } from 'src/queries/kubernetes';
+import {
+  useKubernetesClusterMutation,
+  useKubernetesClusterQuery,
+} from 'src/queries/kubernetes';
 
 import { LocalStorageWarningNotice } from './KubernetesClusterDetail/LocalStorageWarningNotice';
 
-import type { KubernetesTier } from '@linode/api-v4/lib/kubernetes';
-
 interface Props {
   clusterID: number;
-  clusterLabel: string;
-  clusterTier: KubernetesTier;
-  currentVersion: string;
   isOpen: boolean;
   onClose: () => void;
 }
 
 export const UpgradeDialog = (props: Props) => {
-  const {
-    clusterID,
-    clusterLabel,
-    clusterTier,
-    currentVersion,
-    isOpen,
-    onClose,
-  } = props;
+  const { clusterID, isOpen, onClose } = props;
 
   const { enqueueSnackbar } = useSnackbar();
 
-  const { mutateAsync: updateKubernetesCluster } = useKubernetesClusterMutation(
-    clusterID
+  const { data: cluster } = useKubernetesClusterQuery({ id: clusterID });
+
+  const { mutateAsync: updateKubernetesCluster } =
+    useKubernetesClusterMutation(clusterID);
+
+  const { versions } = useLkeStandardOrEnterpriseVersions(
+    cluster?.tier ?? 'standard'
+  ); // TODO LKE: remove fallback once LKE-E is in GA and tier is required
+
+  const nextVersion = getNextVersion(
+    cluster?.k8s_version ?? '',
+    versions ?? []
   );
 
-  const { versions } = useLkeStandardOrEnterpriseVersions(clusterTier);
-
-  const nextVersion = getNextVersion(currentVersion, versions ?? []);
-
-  const [hasUpdatedSuccessfully, setHasUpdatedSuccessfully] = React.useState(
-    false
-  );
+  const [hasUpdatedSuccessfully, setHasUpdatedSuccessfully] =
+    React.useState(false);
 
   const [error, setError] = React.useState<string | undefined>();
   const [submitting, setSubmitting] = React.useState(false);
@@ -99,7 +95,7 @@ export const UpgradeDialog = (props: Props) => {
     ? 'Upgrade complete'
     : `Upgrade Kubernetes version ${
         nextVersion ? `to ${nextVersion}` : ''
-      } on ${clusterLabel}?`;
+      } on ${cluster?.label}?`;
 
   const actions = (
     <ActionsPanel
@@ -132,7 +128,7 @@ export const UpgradeDialog = (props: Props) => {
         {hasUpdatedSuccessfully ? (
           <>
             The cluster’s Kubernetes version has been updated successfully to{' '}
-            <strong>{currentVersion}</strong>. <br /> <br />
+            <strong>{cluster?.k8s_version}</strong>. <br /> <br />
             To upgrade your existing worker nodes, you can recycle all nodes
             (which may have a performance impact) or perform other upgrade
             methods. When recycling nodes, all nodes are deleted on a rolling
@@ -146,8 +142,8 @@ export const UpgradeDialog = (props: Props) => {
           </>
         ) : (
           <>
-            Upgrade the Kubernetes version on <strong>{clusterLabel}</strong>{' '}
-            from <strong>{currentVersion}</strong> to{' '}
+            Upgrade the Kubernetes version on <strong>{cluster?.label}</strong>{' '}
+            from <strong>{cluster?.k8s_version}</strong> to{' '}
             <strong>{nextVersion}</strong>. This upgrades the control plane on
             your cluster and ensures that any new worker nodes are created using
             the newer Kubernetes version.{' '}


### PR DESCRIPTION
## Description 📝
When upgrading an LKE cluster, Cloud Manager should tell you what version you upgraded to upon completion. However, it seems that the upgraded version reported can be incorrect if you're upgrading an older version to a version that isn't the latest. 

Users have observed this from the cluster details page, but not the cluster landing page:
The [pre-upgrade message](https://github.com/linode/manager/blob/develop/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx#L148-L158) calls currentVersion and [nextVersion](https://github.com/linode/manager/blob/develop/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx#L45), which is expected behavior.

However, the [upgrade-complete message](https://github.com/linode/manager/blob/develop/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx#L133-L146) calls nextVersion, when it should be calling currentVersion. 

## Changes  🔄
- Updated the kubernetesVersionFactory to dynamically number versions to allow us to test this
- Changed the variable called from `nextVersion` to `currentVersion` on line 135 of UpgradeVersionModal
   - Uncovered a bug in how we're handling the versioning from the cluster landing page - i.e. with state that is passed down and then gets out of sync, so when the currentVersion is updated, it displayed the (old) currentVersion when the modal opened... which is why we used `nextVersion`
   - Let UpgradeVersionModal maintain its own state by fetching the currentVersion of the cluster within the component, not passing it as a prop

## Target release date 🗓️
As soon as it can get squeezed in. It's purely a visual/UI change and isn't critical but can be misleading/confusing to customers.

⚠️  5/6 - this PR is pointed to staging

## Preview 📷

| develop | this branch |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/acc9187d-d1a5-4a42-a377-5f4647e6bb93"/> | <video src="https://github.com/user-attachments/assets/714aabac-06a9-4d4a-a44a-cda778f04456"/> | 

## How to test 🧪
Requires an LKE cluster with a version of 1.30 or older in order to test. See the mentioned ticket (intook [that is definitely not a word] as a PDI) for screenshots and examples. **We can also test this with the MSW.**

### Reproduction steps
(How to reproduce the issue, if applicable)

  1. Check out develop and modify the kubernetesVersionFactory to use dynamic versions, as done [here](https://github.com/linode/manager/pull/12139/files#diff-26e4ceb011ffff7b3102188a81237874ae6506630197e3f3b8a7a69db63c5586R81).
  2. Have an LKE cluster with a version of 1.30 or older. We can mock this by turning on the MSW with the CRUD preset and seeding a couple of kubernetes clusters. The mocks will start the cluster at 1.21. Also, turn the LKE-Enterprise feature flag OFF to see what the customer was seeing.
  3. From the clusters landing page, click the Upgrade chip in the table row to upgrade one of the clusters. Observe that the upgrade complete message displays the correct version.
  4. Go to the other cluster's details/summary page.
  5. Using the banner at the top of the page, upgrade the cluster to a version older than the latest (ex. if latest is 1.32, upgrade from 1.21 to 1.31). 
  6. Observe that the upgrade complete message will say you upgraded to 1.32, even though the upgrade was actually to 1.31.

### Verification steps
(How to verify changes)

  1. Check out this PR.
  2. Have an LKE cluster with a version of 1.30 or older. We can mock this by turning on the MSW with the CRUD preset and seeding a couple of kubernetes clusters. Also, turn the LKE-Enterprise feature flag OFF to see what the customer was seeing.
  3. From the clusters landing page, click the Upgrade chip in the table row to upgrade one of the clusters. Observe that the upgrade complete message displays the correct version.
  4. Go to the other cluster's details/summary page.
  5. Using the banner at the top of the page, upgrade the cluster to a version older than the latest (ex. if latest is 1.32, upgrade from 1.21 to 1.31).
  6.  Upgrade complete message displays the correct version.
  7. Turn the LKE-Enterprise feature flag *on* and confirm version upgrade flow shows expected versioning using the non-beta endpoints.
  8. Create a mock LKE-E cluster and confirm version upgrade flow shows expected versioning.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [X ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [X] All unit tests are passing
- [X] TypeScript compilation succeeded without errors
- [X] Code passes all linting rules

</details>
