### PR TITLE
feat: [M3-9890] - Support Akamai Employee Banners on the Linode Create flow when using Linode Interfaces

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -99,6 +99,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Add non-dismissible option support to Dismissible Banner ([#12115](https://github.com/linode/manager/pull/12115))
 - Add mocks and update `PlansPanel` to support `mtc-tt-2025` plans in selected regions (#12050)
 - IAM RBAC: Implement method to merge user-selected roles into existing roles ([#12125](https://github.com/linode/manager/pull/12125))
+- Support Akamai Employee Banners on the Linode Create flow when using Linode Interfaces ([#12143](https://github.com/linode/manager/pull/12143))
 
 ## [2025-04-22] - v1.140.0
 

--- a/packages/manager/src/features/Linodes/LinodeCreate/Actions.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Actions.tsx
@@ -32,11 +32,13 @@ export const Actions = () => {
   const [
     legacyFirewallId,
     firstLinodeInterfaceFirewallId,
+    firstLinodeInterfaceType,
     interfaceGeneration,
   ] = useWatch({
     name: [
       'firewall_id',
       'linodeInterfaces.0.firewall_id',
+      'linodeInterfaces.0.purpose',
       'interface_generation',
     ],
     control,
@@ -48,7 +50,9 @@ export const Actions = () => {
       : legacyFirewallId;
 
   const userNeedsToTakeActionAboutInternalFirewallPolicy =
-    'firewallOverride' in formState.errors && !firewallId;
+    interfaceGeneration === 'linode' && firstLinodeInterfaceType === 'vlan'
+      ? false
+      : 'firewallOverride' in formState.errors && !firewallId;
 
   const disableSubmitButton =
     isLinodeCreateRestricted ||

--- a/packages/manager/src/features/Linodes/LinodeCreate/Actions.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Actions.tsx
@@ -1,7 +1,7 @@
 import { Box, Button } from '@linode/ui';
 import { scrollErrorIntoView } from '@linode/utilities';
 import React, { useState } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 import { sendApiAwarenessClickEvent } from 'src/utilities/analytics/customEventAnalytics';
@@ -22,18 +22,37 @@ export const Actions = () => {
 
   const { isLinodeInterfacesEnabled } = useIsLinodeInterfacesEnabled();
 
-  const {
-    formState,
-    getValues,
-    trigger,
-  } = useFormContext<LinodeCreateFormValues>();
+  const { formState, getValues, trigger, control } =
+    useFormContext<LinodeCreateFormValues>();
 
   const isLinodeCreateRestricted = useRestrictedGlobalGrantCheck({
     globalGrantType: 'add_linodes',
   });
 
+  const [
+    legacyFirewallId,
+    firstLinodeInterfaceFirewallId,
+    interfaceGeneration,
+  ] = useWatch({
+    name: [
+      'firewall_id',
+      'linodeInterfaces.0.firewall_id',
+      'interface_generation',
+    ],
+    control,
+  });
+
+  const firewallId =
+    interfaceGeneration === 'linode'
+      ? firstLinodeInterfaceFirewallId
+      : legacyFirewallId;
+
+  const userNeedsToTakeActionAboutInternalFirewallPolicy =
+    'firewallOverride' in formState.errors && !firewallId;
+
   const disableSubmitButton =
-    isLinodeCreateRestricted || 'firewallOverride' in formState.errors;
+    isLinodeCreateRestricted ||
+    userNeedsToTakeActionAboutInternalFirewallPolicy;
 
   const onOpenAPIAwareness = async () => {
     sendApiAwarenessClickEvent('Button', 'View Code Snippets');

--- a/packages/manager/src/features/Linodes/LinodeCreate/Firewall.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Firewall.tsx
@@ -1,6 +1,6 @@
 import { Box, Paper, Stack, Typography } from '@linode/ui';
 import React, { useState } from 'react';
-import { useController, useFormContext } from 'react-hook-form';
+import { useController } from 'react-hook-form';
 
 import { AkamaiBanner } from 'src/components/AkamaiBanner/AkamaiBanner';
 import { GenerateFirewallDialog } from 'src/components/GenerateFirewallDialog/GenerateFirewallDialog';
@@ -16,12 +16,10 @@ import { sendLinodeCreateFormInputEvent } from 'src/utilities/analytics/formEven
 
 import { useLinodeCreateQueryParams } from './utilities';
 
-import type { LinodeCreateFormValues } from './utilities';
 import type { CreateLinodeRequest } from '@linode/api-v4';
 import type { LinodeCreateFormEventOptions } from 'src/utilities/analytics/types';
 
 export const Firewall = () => {
-  const { clearErrors } = useFormContext<LinodeCreateFormValues>();
   const { field, fieldState } = useController<
     CreateLinodeRequest,
     'firewall_id'
@@ -41,13 +39,6 @@ export const Firewall = () => {
   const isLinodeCreateRestricted = useRestrictedGlobalGrantCheck({
     globalGrantType: 'add_linodes',
   });
-
-  const onChange = (firewallId: number | undefined) => {
-    if (firewallId !== undefined) {
-      clearErrors('firewallOverride');
-    }
-    field.onChange(firewallId);
-  };
 
   const firewallFormEventOptions: LinodeCreateFormEventOptions = {
     createType: params.type ?? 'OS',
@@ -95,7 +86,7 @@ export const Firewall = () => {
         <Stack spacing={1.5}>
           <FirewallSelect
             onChange={(e, firewall) => {
-              onChange(firewall?.id);
+              field.onChange(firewall?.id);
               if (!firewall?.id) {
                 sendLinodeCreateFormInputEvent({
                   ...firewallFormEventOptions,
@@ -141,11 +132,13 @@ export const Firewall = () => {
         onFirewallCreated={(firewall) => field.onChange(firewall.id)}
         open={isDrawerOpen}
       />
-      <GenerateFirewallDialog
-        onClose={() => setIsGenerateDialogOpen(false)}
-        onFirewallGenerated={(firewall) => onChange(firewall.id)}
-        open={isGenerateDialogOpen}
-      />
+      {secureVMNoticesEnabled && (
+        <GenerateFirewallDialog
+          onClose={() => setIsGenerateDialogOpen(false)}
+          onFirewallGenerated={(firewall) => field.onChange(firewall.id)}
+          open={isGenerateDialogOpen}
+        />
+      )}
     </Paper>
   );
 };

--- a/packages/manager/src/features/Linodes/LinodeCreate/FirewallAuthorization.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/FirewallAuthorization.tsx
@@ -1,7 +1,6 @@
 import { Checkbox, FormControlLabel } from '@linode/ui';
-import { isNotNullOrUndefined } from '@linode/utilities';
 import React from 'react';
-import { useController, useFormContext } from 'react-hook-form';
+import { useController, useFormContext, useWatch } from 'react-hook-form';
 
 import { AkamaiBanner } from 'src/components/AkamaiBanner/AkamaiBanner';
 import { useFlags } from 'src/hooks/useFlags';
@@ -10,33 +9,48 @@ import type { LinodeCreateFormValues } from './utilities';
 
 export const FirewallAuthorization = () => {
   const flags = useFlags();
-  const { control, watch } = useFormContext<LinodeCreateFormValues>();
+
+  const { control } = useFormContext<LinodeCreateFormValues>();
+
   const { field, fieldState } = useController({
     control,
     name: 'firewallOverride',
   });
 
-  const watchFirewall = watch('firewall_id');
+  const [
+    legacyFirewallId,
+    firstLinodeInterfaceFirewallId,
+    interfaceGeneration,
+  ] = useWatch({
+    name: [
+      'firewall_id',
+      'linodeInterfaces.0.firewall_id',
+      'interface_generation',
+    ],
+    control,
+  });
 
-  if (
-    isNotNullOrUndefined(watchFirewall) ||
-    !(fieldState.isDirty || fieldState.error)
-  ) {
-    return;
+  const firewallId =
+    interfaceGeneration === 'linode'
+      ? firstLinodeInterfaceFirewallId
+      : legacyFirewallId;
+
+  if (firewallId || !(fieldState.isDirty || fieldState.error)) {
+    return null;
   }
 
   return (
     <AkamaiBanner
       action={
         <FormControlLabel
-          label={
-            flags.secureVmCopy?.firewallAuthorizationLabel ??
-            'I am authorized to create a Linode without a firewall'
-          }
           checked={field.value ?? false}
           className="error-for-scroll"
           control={<Checkbox />}
           disableTypography
+          label={
+            flags.secureVmCopy?.firewallAuthorizationLabel ??
+            'I am authorized to create a Linode without a firewall'
+          }
           onChange={field.onChange}
           sx={{ fontSize: 14 }}
         />

--- a/packages/manager/src/features/Linodes/LinodeCreate/FirewallAuthorization.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/FirewallAuthorization.tsx
@@ -20,15 +20,24 @@ export const FirewallAuthorization = () => {
   const [
     legacyFirewallId,
     firstLinodeInterfaceFirewallId,
+    firstLinodeInterfaceType,
     interfaceGeneration,
   ] = useWatch({
     name: [
       'firewall_id',
       'linodeInterfaces.0.firewall_id',
+      'linodeInterfaces.0.purpose',
       'interface_generation',
     ],
     control,
   });
+
+  // Special case ❗️
+  // VLAN interfaces do not support Firewalls, so we hide this notice
+  // if that's what the user selects.
+  if (firstLinodeInterfaceType === 'vlan' && interfaceGeneration === 'linode') {
+    return null;
+  }
 
   const firewallId =
     interfaceGeneration === 'linode'

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/Firewall.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/Firewall.tsx
@@ -51,7 +51,7 @@ export const Firewall = () => {
             }
             text={
               flags.secureVmCopy?.linodeCreate?.text ??
-              'All Akamai accounts must apply an InfoSec-compliant firewall to all their Linodes.'
+              'All accounts must apply an compliant firewall to all their Linodes.'
             }
           />
         )}

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/Firewall.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/Firewall.tsx
@@ -2,10 +2,14 @@ import { Box, Stack } from '@linode/ui';
 import React, { useState } from 'react';
 import { useController } from 'react-hook-form';
 
+import { AkamaiBanner } from 'src/components/AkamaiBanner/AkamaiBanner';
+import { GenerateFirewallDialog } from 'src/components/GenerateFirewallDialog/GenerateFirewallDialog';
 import { LinkButton } from 'src/components/LinkButton';
 import { FirewallSelect } from 'src/features/Firewalls/components/FirewallSelect';
 import { CreateFirewallDrawer } from 'src/features/Firewalls/FirewallLanding/CreateFirewallDrawer';
+import { useFlags } from 'src/hooks/useFlags';
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
+import { useSecureVMNoticesEnabled } from 'src/hooks/useSecureVMNoticesEnabled';
 
 import type { LinodeCreateFormValues } from '../utilities';
 
@@ -17,6 +21,13 @@ export const Firewall = () => {
     name: 'firewall_id',
   });
 
+  const { secureVMNoticesEnabled } = useSecureVMNoticesEnabled();
+  const flags = useFlags();
+
+  const [
+    isGenerateAkamaiEmployeeFirewallDialogOpen,
+    setIsGenerateAkamaiEmployeeFirewallDialogOpen,
+  ] = useState(false);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   const isLinodeCreateRestricted = useRestrictedGlobalGrantCheck({
@@ -26,6 +37,24 @@ export const Firewall = () => {
   return (
     <Stack spacing={2}>
       <Stack spacing={1.5}>
+        {secureVMNoticesEnabled && (
+          <AkamaiBanner
+            action={
+              <LinkButton
+                onClick={() =>
+                  setIsGenerateAkamaiEmployeeFirewallDialogOpen(true)
+                }
+              >
+                {flags.secureVmCopy?.generateActionText ??
+                  'Generate Compliant Firewall'}
+              </LinkButton>
+            }
+            text={
+              flags.secureVmCopy?.linodeCreate?.text ??
+              'All Akamai accounts must apply an InfoSec-compliant firewall to all their Linodes.'
+            }
+          />
+        )}
         <FirewallSelect
           disabled={isLinodeCreateRestricted}
           errorText={fieldState.error?.message}
@@ -49,6 +78,13 @@ export const Firewall = () => {
         onFirewallCreated={(firewall) => field.onChange(firewall.id)}
         open={isDrawerOpen}
       />
+      {secureVMNoticesEnabled && (
+        <GenerateFirewallDialog
+          onClose={() => setIsGenerateAkamaiEmployeeFirewallDialogOpen(false)}
+          onFirewallGenerated={(firewall) => field.onChange(firewall.id)}
+          open={isGenerateAkamaiEmployeeFirewallDialogOpen}
+        />
+      )}
     </Stack>
   );
 };

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceFirewall.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceFirewall.tsx
@@ -61,7 +61,7 @@ export const InterfaceFirewall = ({ index }: Props) => {
             }
             text={
               flags.secureVmCopy?.linodeCreate?.text ??
-              'All Akamai accounts must apply an InfoSec-compliant firewall to all their Linodes.'
+              'All accounts must apply an compliant firewall to all their Linodes.'
             }
           />
         )}

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceFirewall.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceFirewall.tsx
@@ -2,10 +2,14 @@ import { Box, Stack } from '@linode/ui';
 import React, { useState } from 'react';
 import { useController, useFormContext, useWatch } from 'react-hook-form';
 
+import { AkamaiBanner } from 'src/components/AkamaiBanner/AkamaiBanner';
+import { GenerateFirewallDialog } from 'src/components/GenerateFirewallDialog/GenerateFirewallDialog';
 import { LinkButton } from 'src/components/LinkButton';
 import { FirewallSelect } from 'src/features/Firewalls/components/FirewallSelect';
 import { CreateFirewallDrawer } from 'src/features/Firewalls/FirewallLanding/CreateFirewallDrawer';
+import { useFlags } from 'src/hooks/useFlags';
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
+import { useSecureVMNoticesEnabled } from 'src/hooks/useSecureVMNoticesEnabled';
 
 import type { LinodeCreateFormValues } from '../utilities';
 
@@ -14,6 +18,14 @@ interface Props {
 }
 
 export const InterfaceFirewall = ({ index }: Props) => {
+  const { secureVMNoticesEnabled } = useSecureVMNoticesEnabled();
+  const flags = useFlags();
+
+  const [
+    isGenerateAkamaiEmployeeFirewallDialogOpen,
+    setIsGenerateAkamaiEmployeeFirewallDialogOpen,
+  ] = useState(false);
+
   const { control } = useFormContext<LinodeCreateFormValues>();
 
   const interfaceType = useWatch({
@@ -35,6 +47,24 @@ export const InterfaceFirewall = ({ index }: Props) => {
   return (
     <Stack spacing={2}>
       <Stack spacing={1.5}>
+        {secureVMNoticesEnabled && (
+          <AkamaiBanner
+            action={
+              <LinkButton
+                onClick={() =>
+                  setIsGenerateAkamaiEmployeeFirewallDialogOpen(true)
+                }
+              >
+                {flags.secureVmCopy?.generateActionText ??
+                  'Generate Compliant Firewall'}
+              </LinkButton>
+            }
+            text={
+              flags.secureVmCopy?.linodeCreate?.text ??
+              'All Akamai accounts must apply an InfoSec-compliant firewall to all their Linodes.'
+            }
+          />
+        )}
         <FirewallSelect
           disabled={isLinodeCreateRestricted}
           errorText={fieldState.error?.message}
@@ -59,6 +89,13 @@ export const InterfaceFirewall = ({ index }: Props) => {
         onFirewallCreated={(firewall) => field.onChange(firewall.id)}
         open={isDrawerOpen}
       />
+      {secureVMNoticesEnabled && (
+        <GenerateFirewallDialog
+          onClose={() => setIsGenerateAkamaiEmployeeFirewallDialogOpen(false)}
+          onFirewallGenerated={(firewall) => field.onChange(firewall.id)}
+          open={isGenerateAkamaiEmployeeFirewallDialogOpen}
+        />
+      )}
     </Stack>
   );
 };

--- a/packages/manager/src/features/Linodes/LinodeCreate/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/index.tsx
@@ -265,7 +265,7 @@ export const LinodeCreate = () => {
           <EUAgreement />
           <Summary />
           <SMTP />
-          <FirewallAuthorization />
+          {secureVMNoticesEnabled && <FirewallAuthorization />}
           <Actions />
         </Stack>
       </form>

--- a/packages/manager/src/features/Linodes/LinodeCreate/resolvers.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreate/resolvers.ts
@@ -98,6 +98,7 @@ export const getLinodeCreateResolver = (
 
       if (!firewallId) {
         (errors as FieldErrors<LinodeCreateFormValues>)['firewallOverride'] = {
+          // This message does not get surfaced, see FirewallAuthorization.tsx
           message: 'You must select a Firewall or bypass the Firewall policy.',
           type: 'validate',
         };

--- a/packages/manager/src/features/Linodes/LinodeCreate/resolvers.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreate/resolvers.ts
@@ -87,7 +87,6 @@ export const getLinodeCreateResolver = (
       }
     }
 
-    console.log(context?.secureVMNoticesEnabled, values.firewallOverride)
     // If we're dealing with an employee account and they did not bypass
     // the firewall banner....
     if (context?.secureVMNoticesEnabled && !values.firewallOverride) {
@@ -96,7 +95,7 @@ export const getLinodeCreateResolver = (
         values.interface_generation === 'linode'
           ? values.linodeInterfaces[0].firewall_id
           : values.firewall_id;
-      console.log('here!');
+
       if (!firewallId) {
         (errors as FieldErrors<LinodeCreateFormValues>)['firewallOverride'] = {
           message: 'You must select a Firewall or bypass the Firewall policy.',

--- a/packages/manager/src/hooks/useSecureVMNoticesEnabled.ts
+++ b/packages/manager/src/hooks/useSecureVMNoticesEnabled.ts
@@ -14,12 +14,11 @@ export const useSecureVMNoticesEnabled = () => {
   const flags = useFlags();
 
   return {
-    // secureVMNoticesEnabled: getSecureVMNoticesEnabled(
-    //   secureVMsNoticePreference,
-    //   isInternalAccount,
-    //   flags
-    // ),
-    secureVMNoticesEnabled: true,
+    secureVMNoticesEnabled: getSecureVMNoticesEnabled(
+      secureVMsNoticePreference,
+      isInternalAccount,
+      flags
+    ),
   };
 };
 

--- a/packages/manager/src/hooks/useSecureVMNoticesEnabled.ts
+++ b/packages/manager/src/hooks/useSecureVMNoticesEnabled.ts
@@ -14,11 +14,12 @@ export const useSecureVMNoticesEnabled = () => {
   const flags = useFlags();
 
   return {
-    secureVMNoticesEnabled: getSecureVMNoticesEnabled(
-      secureVMsNoticePreference,
-      isInternalAccount,
-      flags
-    ),
+    // secureVMNoticesEnabled: getSecureVMNoticesEnabled(
+    //   secureVMsNoticePreference,
+    //   isInternalAccount,
+    //   flags
+    // ),
+    secureVMNoticesEnabled: true,
   };
 };
 


### PR DESCRIPTION
## Description 📝

> [!important]
> merging this into staging

- Updates the Linode Create flow to support Akamai Employee Banners when using the new Linode Interfaces UI 😐

## Preview 📷

![Screenshot 2025-05-01 at 5 01 50 PM](https://github.com/user-attachments/assets/937d248e-8a87-4036-b398-07bc66d8a8d2)

## How to test 🧪

### Prerequisites

> [!important]
> You'll want to test both with Linode Interfaces enabled and disabled. (We need to ensure the old Linode Create UI still works as expected)
> To enable Linode Interfaces, you need the `new-interfaces-beta` customer tag and to enable Cloud Manager's Linode Interfaces feature flag

- Check out locally
- Go into `packages/manager/src/hooks/useSecureVMNoticesEnabled.ts` and edit the code so that `secureVMNoticesEnabled` is forcefully enabled for the sake of testing

### Verification steps

- Verify that the Linode Create flow internal only Akamai employee banners work correctly and show in the correct conditions

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>