### PR TITLE
fix: [M3-9891] - Actual fix for 'Improve validation and UX for ACL IP Address fields'

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Missing `PublicIPAddressesTooltip` for VPC-only Linodes without an explicitly marked primary VPC interface ([#12122](https://github.com/linode/manager/pull/12122))
 - Fix incorrect card sizing at 1920px+ in LKE Tier panel ([#12076](https://github.com/linode/manager/pull/12076))
 - Bugs in Linode Create, Landing & Detail Pages ([#12028](https://github.com/linode/manager/pull/12028))
+- Fix persisting ACL IP validation error on clear ([#12144](https://github.com/linode/manager/pull/12144))
 
 ### Tech Stories:
 
@@ -76,7 +77,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - IAM RBAC: Add logic for getting a description for the facade roles ([#12053](https://github.com/linode/manager/pull/12053))
 - IAM RBAC: Fix bugs in the Entities component and the loading state for tabs ([#12062](https://github.com/linode/manager/pull/12062))
 - CloudPulse: Update metrics API request payload and legend row titles as part of api upgrade from v1beta to v2beta ([#12063](https://github.com/linode/manager/pull/12063))
-- Fix persisting ACL IP validation error and disable fields if user selects to provide IPs later ([#12067](https://github.com/linode/manager/pull/12067))
+- Disable ACL IP address fields if user selects to provide IPs later ([#12067](https://github.com/linode/manager/pull/12067))
 - Add label field to CreateFirewallDrawer form when using firewall templates ([#12069](https://github.com/linode/manager/pull/12069))
 - CloudPulse: Show regions based on available resources and dependent filters in dashboards `GlobalFilter` section ([#12078](https://github.com/linode/manager/pull/12078))
 - Pass widget filters configuration from dashboards in metrics call in cloudpulse dashboards ([#12079](https://github.com/linode/manager/pull/12079))

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ControlPlaneACLPane.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ControlPlaneACLPane.tsx
@@ -12,7 +12,6 @@ import * as React from 'react';
 
 import { ErrorMessage } from 'src/components/ErrorMessage';
 import { MultipleIPInput } from 'src/components/MultipleIPInput/MultipleIPInput';
-import { validateIPs } from 'src/utilities/ipUtils';
 
 import {
   CREATE_CLUSTER_ENTERPRISE_TIER_ACL_COPY,
@@ -87,13 +86,6 @@ export const ControlPlaneACLPane = (props: ControlPlaneACLProps) => {
               disabled={isAcknowledgementChecked}
               ips={ipV4Addr}
               isLinkStyled
-              onBlur={(_ips: ExtendedIP[]) => {
-                const validatedIPs = validateIPs(_ips, {
-                  allowEmptyAddress: true,
-                  errorMessage: 'Must be a valid IPv4 address.',
-                });
-                handleIPv4Change(validatedIPs);
-              }}
               onChange={handleIPv4Change}
               title="IPv4 Addresses or CIDRs"
             />
@@ -103,13 +95,6 @@ export const ControlPlaneACLPane = (props: ControlPlaneACLProps) => {
                 disabled={isAcknowledgementChecked}
                 ips={ipV6Addr}
                 isLinkStyled
-                onBlur={(_ips: ExtendedIP[]) => {
-                  const validatedIPs = validateIPs(_ips, {
-                    allowEmptyAddress: true,
-                    errorMessage: 'Must be a valid IPv6 address.',
-                  });
-                  handleIPv6Change(validatedIPs);
-                }}
                 onChange={handleIPv6Change}
                 title="IPv6 Addresses or CIDRs"
               />

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ControlPlaneACLPane.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ControlPlaneACLPane.tsx
@@ -8,6 +8,7 @@ import {
   Typography,
 } from '@linode/ui';
 import { FormLabel, styled } from '@mui/material';
+import Grid from '@mui/material/Grid2';
 import * as React from 'react';
 
 import { ErrorMessage } from 'src/components/ErrorMessage';
@@ -66,17 +67,19 @@ export const ControlPlaneACLPane = (props: ControlPlaneACLProps) => {
             ? CREATE_CLUSTER_ENTERPRISE_TIER_ACL_COPY
             : CREATE_CLUSTER_STANDARD_TIER_ACL_COPY}
         </Typography>
-        <FormControlLabel
-          control={
-            <StyledACLToggle
-              checked={enableControlPlaneACL}
-              disabled={isEnterpriseCluster}
-              name="ipacl-checkbox"
-              onChange={() => setControlPlaneACL(!enableControlPlaneACL)}
-            />
-          }
-          label="Enable Control Plane ACL"
-        />
+        <Grid>
+          <FormControlLabel
+            control={
+              <StyledACLToggle
+                checked={enableControlPlaneACL}
+                disabled={isEnterpriseCluster}
+                name="ipacl-checkbox"
+                onChange={() => setControlPlaneACL(!enableControlPlaneACL)}
+              />
+            }
+            label="Enable Control Plane ACL"
+          />
+        </Grid>
       </FormControl>
       {enableControlPlaneACL && (
         <Box marginBottom={2}>

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -48,7 +48,7 @@ import { useAllTypes } from 'src/queries/types';
 import { getAPIErrorOrDefault, getErrorMap } from 'src/utilities/errorUtils';
 import { extendType } from 'src/utilities/extendType';
 import { filterCurrentTypes } from 'src/utilities/filterCurrentLinodeTypes';
-import { stringToExtendedIP } from 'src/utilities/ipUtils';
+import { stringToExtendedIP, validateIPs } from 'src/utilities/ipUtils';
 import {
   DOCS_LINK_LABEL_DC_PRICING,
   UNKNOWN_PRICE,
@@ -537,10 +537,18 @@ export const CreateCluster = () => {
                 enableControlPlaneACL={controlPlaneACL}
                 errorText={errorMap.control_plane}
                 handleIPv4Change={(newIpV4Addr: ExtendedIP[]) => {
-                  setIPv4Addr(newIpV4Addr);
+                  const validatedIPs = validateIPs(newIpV4Addr, {
+                    allowEmptyAddress: true,
+                    errorMessage: 'Must be a valid IPv4 address.',
+                  });
+                  setIPv4Addr(validatedIPs);
                 }}
                 handleIPv6Change={(newIpV6Addr: ExtendedIP[]) => {
-                  setIPv6Addr(newIpV6Addr);
+                  const validatedIPs = validateIPs(newIpV6Addr, {
+                    allowEmptyAddress: true,
+                    errorMessage: 'Must be a valid IPv6 address.',
+                  });
+                  setIPv6Addr(validatedIPs);
                 }}
                 handleIsAcknowledgementChecked={(isChecked: boolean) => {
                   setIsACLAcknowledgementChecked(isChecked);


### PR DESCRIPTION
## Description 📝

The first PR for this (#12067) didn't adequately address this issue for both cluster tiers. Users can still enter invalid text into the IP addresses field, delete it, and the error validation persists. The issue was less noticeable with LKE-E, because the user must either provide a valid IP or check the acknowledgement checkbox (at which point the field is cleared and disabled, so the error validation is gone). For LKE (standard), the user may create a cluster with ACL enabled _without_ providing IP addresses. Users are currently blocked by a validation error if they enter invalid text and clear the field because the error persists.

## Changes  🔄
- Moved the IP validation from onBlur to onChange... the reason that the validation wasn't being cleared was the IPs being validated were the old data, not the current field value
   - Validation will run as the user types, which means if they haven't input a full, valid IP address, the message will be there until they do. Should we avoid that (i.e. come up with a different solution)?

## Target release date 🗓️

⚠️  5/6 - this PR is pointed to staging, as it corrects a bug in the release

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/1eb3791d-9e38-43f7-9bd5-b097e2433c3e" /> | <video src="https://github.com/user-attachments/assets/bce9d110-da2d-49b5-a20f-b2a03527f80d" /> |

## How to test 🧪

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] On staging, go to the cluster create page and select the LKE tier
- [ ] Start typing anything, just not a correct IP address in IPv4 Addresses or IPv6 Addresses field
- [ ] Observe the validation error
- [ ] Clear the field
- [ ] Observe the validation error is still present on the blank IP address field and is preventing the cluster from being created

### Verification steps

(How to verify changes)

- [ ] Check out this branch and go to http://localhost:3000/kubernetes/create
- [ ] Select the LKE tier
- [ ]  Start typing anything, just not a correct IP address in IPv4 Addresses or IPv6 Addresses field
- [ ] Observe the validation error
- [ ] Clear the field
- [ ] Observe that the error is cleared and no longer blocking the cluster from being created

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
