### PR TITLE
change: [M3-9835] - Move Linode create flow PG warning to helper text

### DIFF
--- a/packages/manager/.changeset/pr-12145-changed-1746135077680.md
+++ b/packages/manager/.changeset/pr-12145-changed-1746135077680.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Move Linode create flow PG warning to helper text ([#12145](https://github.com/linode/manager/pull/12145))

--- a/packages/manager/cypress/e2e/core/placementGroups/create-linode-with-placement-groups.spec.ts
+++ b/packages/manager/cypress/e2e/core/placementGroups/create-linode-with-placement-groups.spec.ts
@@ -53,9 +53,9 @@ describe('Linode create flow with Placement Group', () => {
   it('can create a linode with a newly created Placement Group', () => {
     cy.visitWithLogin('/linodes/create');
     cy.wait('@getRegions');
-    cy.findByText(
-      'Select a Region for your Linode to see existing placement groups.'
-    ).should('be.visible');
+    cy.findByText('Select a Region to see available placement groups.').should(
+      'be.visible'
+    );
 
     // Region without capability
     // Choose region

--- a/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
+++ b/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
@@ -102,6 +102,11 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
       disabled={Boolean(!selectedRegion?.id) || disabled}
       errorText={error?.[0]?.reason}
       getOptionLabel={(placementGroup: PlacementGroup) => placementGroup.label}
+      helperText={
+        !selectedRegion
+          ? 'Select a Region for your Linode to see existing placement groups.'
+          : undefined
+      }
       label={label}
       loading={isFetching}
       noOptionsText={

--- a/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
+++ b/packages/manager/src/components/PlacementGroupsSelect/PlacementGroupsSelect.tsx
@@ -104,7 +104,7 @@ export const PlacementGroupsSelect = (props: PlacementGroupsSelectProps) => {
       getOptionLabel={(placementGroup: PlacementGroup) => placementGroup.label}
       helperText={
         !selectedRegion
-          ? 'Select a Region for your Linode to see existing placement groups.'
+          ? 'Select a Region to see available placement groups.'
           : undefined
       }
       label={label}

--- a/packages/manager/src/features/Linodes/LinodeCreate/Details/Details.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Details/Details.test.tsx
@@ -46,9 +46,7 @@ describe('Linode Create Details', () => {
 
     await waitFor(() => {
       expect(
-        getByText(
-          'Select a Region for your Linode to see existing placement groups.'
-        )
+        getByText('Select a Region to see available placement groups.')
       ).toBeVisible();
     });
   });

--- a/packages/manager/src/features/Linodes/LinodeCreate/Details/PlacementGroupPanel.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Details/PlacementGroupPanel.test.tsx
@@ -20,9 +20,7 @@ describe('PlacementGroupPanel', () => {
       });
 
     expect(
-      getByText(
-        'Select a Region for your Linode to see existing placement groups.'
-      )
+      getByText('Select a Region to see available placement groups.')
     ).toBeVisible();
   });
 

--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsDetailPanel.tsx
@@ -73,18 +73,6 @@ export const PlacementGroupsDetailPanel = (props: Props) => {
 
   return (
     <>
-      {!selectedRegion && (
-        <Notice
-          dataTestId="placement-groups-no-region-notice"
-          spacingBottom={0}
-          spacingTop={16}
-          variant="warning"
-        >
-          <Typography sx={{ font: theme.font.bold }}>
-            Select a Region for your Linode to see existing placement groups.
-          </Typography>
-        </Notice>
-      )}
       {selectedRegion && !hasRegionPlacementGroupCapability && (
         <Notice
           dataTestId="placement-groups-no-capability-notice"


### PR DESCRIPTION
## Description 📝
Tiny PR (for real this time 😉) to move the Linode create flow PG warning to the Select helper text. As we have revamped out Notices, this one needed some TLC, following the same treatment done on the VPC panel.

The banner for availability is remaining the same above the select (in case the region does not have PG capability, which seems like it's almost never displayed since they all do).

## Changes  🔄

List any change(s) relevant to the reviewer.
- Move Linode create flow PG warning to PG select helper text

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Create Linode OS (1)](https://github.com/user-attachments/assets/adb53aa0-13eb-4d51-9485-bf7ca250f56c) | ![Create Linode OS](https://github.com/user-attachments/assets/4d87389a-2cc4-453e-bf86-60b9807342df) |

## How to test 🧪

### Verification steps
- Navigate to Linode crate flow
- Confirm UI change

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
