### PR TITLE
fix: [M3-9883] - Fix Upgrade Interface issues: URL navigation and `Unable to find this Interfaces Firewall device` in Edit Interface Drawer 

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -99,6 +99,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Add non-dismissible option support to Dismissible Banner ([#12115](https://github.com/linode/manager/pull/12115))
 - Add mocks and update `PlansPanel` to support `mtc-tt-2025` plans in selected regions (#12050)
 - IAM RBAC: Implement method to merge user-selected roles into existing roles ([#12125](https://github.com/linode/manager/pull/12125))
+- Add navigation to Linode Network tab after successfully upgrading interfaces ([#12146](https://github.com/linode/manager/pull/12146))
 
 ## [2025-04-22] - v1.140.0
 

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -100,6 +100,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Add mocks and update `PlansPanel` to support `mtc-tt-2025` plans in selected regions (#12050)
 - IAM RBAC: Implement method to merge user-selected roles into existing roles ([#12125](https://github.com/linode/manager/pull/12125))
 - Add navigation to Linode Network tab after successfully upgrading interfaces ([#12146](https://github.com/linode/manager/pull/12146))
+- Fix "Error retrieving Firewalls" message in Subnet Linode Row after upgrading interfaces ([#12146](https://github.com/linode/manager/pull/12146))
 
 ## [2025-04-22] - v1.140.0
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/UpgradeInterfaces/DialogContents/SuccessDialogContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/UpgradeInterfaces/DialogContents/SuccessDialogContent.tsx
@@ -97,8 +97,8 @@ export const SuccessDialogContent = (
             onClick={() => {
               const newPath = location.pathname
                 .split('/')
-                // remove 'upgrade-interfaces' from URL
-                .slice(0, -1)
+                // keep only xxx/linodes/:linodeId
+                .slice(0, 3)
                 // join everything back together
                 .join('/')
                 .concat('/networking');

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.test.tsx
@@ -15,7 +15,7 @@ import {
 } from 'src/factories';
 import { linodeConfigFactory } from 'src/factories/linodeConfigs';
 import { makeResourcePage } from 'src/mocks/serverHandlers';
-import { HttpResponse, http, server } from 'src/mocks/testServer';
+import { http, HttpResponse, server } from 'src/mocks/testServer';
 import {
   mockMatchMedia,
   renderWithTheme,
@@ -82,26 +82,22 @@ describe('SubnetLinodeRow', () => {
     const handlePowerActionsLinode = vi.fn();
     const handleUnassignLinode = vi.fn();
 
-    const {
-      getAllByRole,
-      getAllByText,
-      getByTestId,
-      getByText,
-    } = renderWithTheme(
-      wrapWithTableBody(
-        <SubnetLinodeRow
-          handlePowerActionsLinode={handlePowerActionsLinode}
-          handleUnassignLinode={handleUnassignLinode}
-          isVPCLKEEnterpriseCluster={false}
-          linodeId={linodeFactory1.id}
-          subnet={subnetFactory.build()}
-          subnetId={1}
-          subnetInterfaces={[{ active: true, config_id: config.id, id: 1 }]}
-        />
-      )
-    );
+    const { getAllByRole, getAllByText, getByTestId, getByText } =
+      renderWithTheme(
+        wrapWithTableBody(
+          <SubnetLinodeRow
+            handlePowerActionsLinode={handlePowerActionsLinode}
+            handleUnassignLinode={handleUnassignLinode}
+            isVPCLKEEnterpriseCluster={false}
+            linodeId={linodeFactory1.id}
+            subnet={subnetFactory.build()}
+            subnetId={1}
+            subnetInterfaces={[{ active: true, config_id: config.id, id: 1 }]}
+          />
+        )
+      );
 
-    // Loading state should render
+    // Loading states should render
     expect(getByTestId(loadingTestId)).toBeInTheDocument();
 
     await waitForElementToBeRemoved(getByTestId(loadingTestId));
@@ -113,7 +109,6 @@ describe('SubnetLinodeRow', () => {
     );
 
     getAllByText('10.0.0.0');
-    getByText(mockFirewall0);
 
     const plusChipButton = getAllByRole('button')[1];
     expect(plusChipButton).toHaveTextContent('+1');
@@ -127,6 +122,9 @@ describe('SubnetLinodeRow', () => {
     expect(unassignLinodeButton).toHaveTextContent('Unassign Linode');
     await userEvent.click(unassignLinodeButton);
     expect(handleUnassignLinode).toHaveBeenCalled();
+    waitFor(() => {
+      getByText(mockFirewall0);
+    });
   });
 
   it('should display the ip, range, and firewall for a Linode using Linode Interfaces', async () => {
@@ -148,24 +146,20 @@ describe('SubnetLinodeRow', () => {
     const handlePowerActionsLinode = vi.fn();
     const handleUnassignLinode = vi.fn();
 
-    const {
-      getAllByRole,
-      getAllByText,
-      getByTestId,
-      getByText,
-    } = renderWithTheme(
-      wrapWithTableBody(
-        <SubnetLinodeRow
-          handlePowerActionsLinode={handlePowerActionsLinode}
-          handleUnassignLinode={handleUnassignLinode}
-          isVPCLKEEnterpriseCluster={false}
-          linodeId={linodeFactory1.id}
-          subnet={subnetFactory.build()}
-          subnetId={1}
-          subnetInterfaces={[{ active: true, config_id: null, id: 1 }]}
-        />
-      )
-    );
+    const { getAllByRole, getAllByText, getByTestId, getByText } =
+      renderWithTheme(
+        wrapWithTableBody(
+          <SubnetLinodeRow
+            handlePowerActionsLinode={handlePowerActionsLinode}
+            handleUnassignLinode={handleUnassignLinode}
+            isVPCLKEEnterpriseCluster={false}
+            linodeId={linodeFactory1.id}
+            subnet={subnetFactory.build()}
+            subnetId={1}
+            subnetInterfaces={[{ active: true, config_id: null, id: 1 }]}
+          />
+        )
+      );
 
     // Loading state should render
     expect(getByTestId(loadingTestId)).toBeInTheDocument();
@@ -180,7 +174,9 @@ describe('SubnetLinodeRow', () => {
 
     getAllByText('10.0.0.0');
     getAllByText('10.0.0.1');
-    getByText(mockFirewall0);
+    waitFor(() => {
+      getByText(mockFirewall0);
+    });
   });
 
   it('should not display reboot linode button if the linode has all active interfaces', async () => {
@@ -215,15 +211,15 @@ describe('SubnetLinodeRow', () => {
     const { getAllByRole, getByTestId } = renderWithTheme(
       wrapWithTableBody(
         <SubnetLinodeRow
-          subnetInterfaces={[
-            { active: true, config_id: config.id, id: vpcInterface.id },
-          ]}
           handlePowerActionsLinode={handlePowerActionsLinode}
           handleUnassignLinode={handleUnassignLinode}
           isVPCLKEEnterpriseCluster={false}
           linodeId={linodeFactory1.id}
           subnet={subnetFactory.build()}
           subnetId={0}
+          subnetInterfaces={[
+            { active: true, config_id: config.id, id: vpcInterface.id },
+          ]}
         />
       )
     );

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.test.tsx
@@ -82,7 +82,7 @@ describe('SubnetLinodeRow', () => {
     const handlePowerActionsLinode = vi.fn();
     const handleUnassignLinode = vi.fn();
 
-    const { getAllByRole, getAllByText, getByTestId, getByText } =
+    const { getAllByRole, getAllByText, getByTestId, findByText } =
       renderWithTheme(
         wrapWithTableBody(
           <SubnetLinodeRow
@@ -122,9 +122,8 @@ describe('SubnetLinodeRow', () => {
     expect(unassignLinodeButton).toHaveTextContent('Unassign Linode');
     await userEvent.click(unassignLinodeButton);
     expect(handleUnassignLinode).toHaveBeenCalled();
-    waitFor(() => {
-      getByText(mockFirewall0);
-    });
+    const firewall = await findByText(mockFirewall0);
+    expect(firewall).toBeVisible();
   });
 
   it('should display the ip, range, and firewall for a Linode using Linode Interfaces', async () => {
@@ -146,7 +145,7 @@ describe('SubnetLinodeRow', () => {
     const handlePowerActionsLinode = vi.fn();
     const handleUnassignLinode = vi.fn();
 
-    const { getAllByRole, getAllByText, getByTestId, getByText } =
+    const { getAllByRole, getAllByText, getByTestId, findByText } =
       renderWithTheme(
         wrapWithTableBody(
           <SubnetLinodeRow
@@ -174,9 +173,8 @@ describe('SubnetLinodeRow', () => {
 
     getAllByText('10.0.0.0');
     getAllByText('10.0.0.1');
-    waitFor(() => {
-      getByText(mockFirewall0);
-    });
+    const firewall = await findByText(mockFirewall0);
+    expect(firewall).toBeVisible();
   });
 
   it('should not display reboot linode button if the linode has all active interfaces', async () => {

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
@@ -13,7 +13,7 @@ import { TableRow } from 'src/components/TableRow';
 import { getLinodeIconStatus } from 'src/features/Linodes/LinodesLanding/utils';
 import { determineNoneSingleOrMultipleWithChip } from 'src/utilities/noneSingleOrMultipleWithChip';
 
-import { useInterfaceAndFirewallDataForLinode } from '../../../hooks/useInterfaceAndFirewallDataForLinode';
+import { useInterfaceDataForLinode } from '../../../hooks/useInterfaceDataForLinode';
 import {
   VPC_REBOOT_MESSAGE,
   WARNING_ICON_UNRECOMMENDED_CONFIG,
@@ -25,10 +25,13 @@ import {
   hasUnrecommendedConfigurationLinodeInterface,
 } from '../utils';
 import { StyledWarningIcon } from './SubnetLinodeRow.styles';
+import {
+  ConfigInterfaceFirewallCell,
+  LinodeInterfaceFirewallCell,
+} from './SubnetLinodeRowFirewallsCell';
 
 import type {
   APIError,
-  Firewall,
   Interface,
   Linode,
   LinodeInterface,
@@ -82,18 +85,16 @@ export const SubnetLinodeRow = (props: Props) => {
 
   /**
    * We need to handle support for both legacy interfaces and Linode interfaces.
-   * The below hook gives us the relevant firewall and interface data depending on
+   * The below hook gives us the relevant interface data depending on
    * interface type.
    */
-  const { firewallsInfo, interfacesInfo } =
-    useInterfaceAndFirewallDataForLinode({
-      configId, // subnet.linodes.interfaces data now includes config_id, so we no longer have to fetch all configs
-      interfaceId,
-      isLinodeInterface,
-      linodeId,
-    });
+  const { interfacesInfo } = useInterfaceDataForLinode({
+    configId, // subnet.linodes.interfaces data now includes config_id, so we no longer have to fetch all configs
+    interfaceId,
+    isLinodeInterface,
+    linodeId,
+  });
 
-  const { attachedFirewalls, firewallsError, firewallsLoading } = firewallsInfo;
   const {
     config, // undefined if this Linode is using Linode Interfaces. Used to determine an unrecommended configuration
     configInterface, // undefined if this Linode is using Linode Interfaces
@@ -225,13 +226,14 @@ export const SubnetLinodeRow = (props: Props) => {
         </TableCell>
       </Hidden>
       <Hidden smDown>
-        <TableCell>
-          {getFirewallsCellString(
-            attachedFirewalls?.data ?? [],
-            firewallsLoading,
-            firewallsError ?? undefined
-          )}
-        </TableCell>
+        {isLinodeInterface ? (
+          <LinodeInterfaceFirewallCell
+            interfaceId={interfaceId}
+            linodeId={linodeId}
+          />
+        ) : (
+          <ConfigInterfaceFirewallCell linodeId={linodeId} />
+        )}
       </Hidden>
       <TableCell actionCell>
         {!isVPCLKEEnterpriseCluster && (
@@ -268,26 +270,6 @@ export const SubnetLinodeRow = (props: Props) => {
       </TableCell>
     </TableRow>
   );
-};
-
-const getFirewallsCellString = (
-  data: Firewall[],
-  loading: boolean,
-  error?: APIError[]
-): JSX.Element | string => {
-  if (loading) {
-    return 'Loading...';
-  }
-
-  if (error) {
-    return 'Error retrieving Firewalls';
-  }
-
-  if (data.length === 0) {
-    return 'None';
-  }
-
-  return getFirewallLinks(data);
 };
 
 const getSubnetLinodeIPv4CellString = (
@@ -355,30 +337,6 @@ const getIPRangesCellContents = (
       linodeInterfaceVPCRanges ?? []
     );
   }
-};
-
-const getFirewallLinks = (data: Firewall[]): JSX.Element => {
-  const firstThreeFirewalls = data.slice(0, 3);
-  return (
-    <>
-      {firstThreeFirewalls.map((firewall, idx) => (
-        <Link
-          className="link secondaryLink"
-          data-testid="firewall-row-link"
-          key={firewall.id}
-          to={`/firewalls/${firewall.id}`}
-        >
-          {idx > 0 && `, `}
-          {firewall.label}
-        </Link>
-      ))}
-      {data.length > 3 && (
-        <span>
-          {`, `}plus {data.length - 3} more.
-        </span>
-      )}
-    </>
-  );
 };
 
 export const SubnetLinodeTableRowHead = (

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRowFirewallsCell.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRowFirewallsCell.tsx
@@ -33,7 +33,6 @@ export const LinodeInterfaceFirewallCell = (props: {
   linodeId: number;
 }) => {
   const { linodeId, interfaceId } = props;
-  // query to fetch firewalls for a Linode Interface (firewalls are attached at the interface level)
   const {
     data: attachedFirewalls,
     error,

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRowFirewallsCell.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRowFirewallsCell.tsx
@@ -1,0 +1,96 @@
+import {
+  useLinodeFirewallsQuery,
+  useLinodeInterfaceFirewallsQuery,
+} from '@linode/queries';
+import * as React from 'react';
+
+import { Link } from 'src/components/Link';
+import { TableCell } from 'src/components/TableCell';
+
+import type { APIError, Firewall } from '@linode/api-v4';
+
+export const ConfigInterfaceFirewallCell = (props: { linodeId: number }) => {
+  const { linodeId } = props;
+  const {
+    data: attachedFirewalls,
+    error,
+    isLoading,
+  } = useLinodeFirewallsQuery(linodeId);
+
+  return (
+    <TableCell>
+      {getFirewallsCellString(
+        attachedFirewalls?.data ?? [],
+        isLoading,
+        error ?? undefined
+      )}
+    </TableCell>
+  );
+};
+
+export const LinodeInterfaceFirewallCell = (props: {
+  interfaceId: number;
+  linodeId: number;
+}) => {
+  const { linodeId, interfaceId } = props;
+  // query to fetch firewalls for a Linode Interface (firewalls are attached at the interface level)
+  const {
+    data: attachedFirewalls,
+    error,
+    isLoading,
+  } = useLinodeInterfaceFirewallsQuery(linodeId, interfaceId);
+
+  return (
+    <TableCell>
+      {getFirewallsCellString(
+        attachedFirewalls?.data ?? [],
+        isLoading,
+        error ?? undefined
+      )}
+    </TableCell>
+  );
+};
+
+const getFirewallsCellString = (
+  data: Firewall[],
+  loading: boolean,
+  error?: APIError[]
+): JSX.Element | string => {
+  if (loading) {
+    return 'Loading...';
+  }
+
+  if (error) {
+    return 'Error retrieving Firewalls';
+  }
+
+  if (data.length === 0) {
+    return 'None';
+  }
+
+  return getFirewallLinks(data);
+};
+
+const getFirewallLinks = (data: Firewall[]): JSX.Element => {
+  const firstThreeFirewalls = data.slice(0, 3);
+  return (
+    <>
+      {firstThreeFirewalls.map((firewall, idx) => (
+        <Link
+          className="link secondaryLink"
+          data-testid="firewall-row-link"
+          key={firewall.id}
+          to={`/firewalls/${firewall.id}`}
+        >
+          {idx > 0 && `, `}
+          {firewall.label}
+        </Link>
+      ))}
+      {data.length > 3 && (
+        <span>
+          {`, `}plus {data.length - 3} more.
+        </span>
+      )}
+    </>
+  );
+};

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.test.tsx
@@ -156,6 +156,11 @@ describe('VPC Subnets table', () => {
   });
 
   it('should disable Create Subnet button if the VPC is associated with a LKE-E cluster', async () => {
+    server.use(
+      http.get('*/networking/firewalls/settings', () => {
+        return HttpResponse.json(firewallSettingsFactory.build());
+      })
+    );
     const { getByRole, queryByTestId } = await renderWithThemeAndRouter(
       <VPCSubnetsTable
         isVPCLKEEnterpriseCluster={true}

--- a/packages/manager/src/hooks/useInterfaceAndFirewallDataForLinode.ts
+++ b/packages/manager/src/hooks/useInterfaceAndFirewallDataForLinode.ts
@@ -18,17 +18,13 @@ export const useInterfaceAndFirewallDataForLinode = (inputs: {
   linodeId: number;
 }) => {
   const { configId, interfaceId, isLinodeInterface, linodeId } = inputs;
-  console.log('explain', configId, interfaceId, isLinodeInterface, linodeId);
 
   // query to fetch firewalls if this Linode uses config profile interfaces
   const {
     data: attachedFirewallsConfig,
     error: firewallsErrorConfig,
     isLoading: firewallsLoadingConfig,
-  } = useLinodeFirewallsQuery(
-    linodeId,
-    Boolean(configId && linodeId && !isLinodeInterface)
-  );
+  } = useLinodeFirewallsQuery(linodeId, !isLinodeInterface);
 
   // query to fetch firewalls for a Linode Interface (firewalls are attached at the interface level)
   const {
@@ -38,9 +34,8 @@ export const useInterfaceAndFirewallDataForLinode = (inputs: {
   } = useLinodeInterfaceFirewallsQuery(
     linodeId,
     interfaceId,
-    Boolean(isLinodeInterface && interfaceId && !configId)
+    isLinodeInterface
   );
-  console.log(firewallsErrorConfig, firewallsErrorLinodeInterface);
 
   // Depending on which query was fired to fetch firewalls, return appropriate data
   const attachedFirewalls =

--- a/packages/manager/src/hooks/useInterfaceAndFirewallDataForLinode.ts
+++ b/packages/manager/src/hooks/useInterfaceAndFirewallDataForLinode.ts
@@ -18,13 +18,17 @@ export const useInterfaceAndFirewallDataForLinode = (inputs: {
   linodeId: number;
 }) => {
   const { configId, interfaceId, isLinodeInterface, linodeId } = inputs;
+  console.log('explain', configId, interfaceId, isLinodeInterface, linodeId);
 
   // query to fetch firewalls if this Linode uses config profile interfaces
   const {
     data: attachedFirewallsConfig,
     error: firewallsErrorConfig,
     isLoading: firewallsLoadingConfig,
-  } = useLinodeFirewallsQuery(linodeId, !isLinodeInterface);
+  } = useLinodeFirewallsQuery(
+    linodeId,
+    Boolean(configId && linodeId && !isLinodeInterface)
+  );
 
   // query to fetch firewalls for a Linode Interface (firewalls are attached at the interface level)
   const {
@@ -34,8 +38,9 @@ export const useInterfaceAndFirewallDataForLinode = (inputs: {
   } = useLinodeInterfaceFirewallsQuery(
     linodeId,
     interfaceId,
-    isLinodeInterface
+    Boolean(isLinodeInterface && interfaceId && !configId)
   );
+  console.log(firewallsErrorConfig, firewallsErrorLinodeInterface);
 
   // Depending on which query was fired to fetch firewalls, return appropriate data
   const attachedFirewalls =

--- a/packages/manager/src/hooks/useInterfaceDataForLinode.ts
+++ b/packages/manager/src/hooks/useInterfaceDataForLinode.ts
@@ -1,9 +1,4 @@
-import {
-  useLinodeConfigQuery,
-  useLinodeFirewallsQuery,
-  useLinodeInterfaceFirewallsQuery,
-  useLinodeInterfaceQuery,
-} from '@linode/queries';
+import { useLinodeConfigQuery, useLinodeInterfaceQuery } from '@linode/queries';
 
 /**
  * In some files, We need to handle support for both legacy interfaces and Linode interfaces.
@@ -11,38 +6,13 @@ import {
  * To fetch data, depending if the Linode with the given ID is a Linode Interface, we use Linode Interface related queries.
  * Otherwise, we use config profile interface related queries.
  */
-export const useInterfaceAndFirewallDataForLinode = (inputs: {
+export const useInterfaceDataForLinode = (inputs: {
   configId: null | number;
   interfaceId: number;
   isLinodeInterface: boolean;
   linodeId: number;
 }) => {
   const { configId, interfaceId, isLinodeInterface, linodeId } = inputs;
-
-  // query to fetch firewalls if this Linode uses config profile interfaces
-  const {
-    data: attachedFirewallsConfig,
-    error: firewallsErrorConfig,
-    isLoading: firewallsLoadingConfig,
-  } = useLinodeFirewallsQuery(linodeId, !isLinodeInterface);
-
-  // query to fetch firewalls for a Linode Interface (firewalls are attached at the interface level)
-  const {
-    data: attachedFirewallsLinodeInterface,
-    error: firewallsErrorLinodeInterface,
-    isLoading: firewallsLoadingLinodeInterface,
-  } = useLinodeInterfaceFirewallsQuery(
-    linodeId,
-    interfaceId,
-    isLinodeInterface
-  );
-
-  // Depending on which query was fired to fetch firewalls, return appropriate data
-  const attachedFirewalls =
-    attachedFirewallsConfig ?? attachedFirewallsLinodeInterface;
-  const firewallsError = firewallsErrorConfig ?? firewallsErrorLinodeInterface;
-  const firewallsLoading =
-    firewallsLoadingConfig || firewallsLoadingLinodeInterface;
 
   const {
     data: linodeInterface,
@@ -69,11 +39,6 @@ export const useInterfaceAndFirewallDataForLinode = (inputs: {
   const interfaceLoading = linodeInterfaceLoading ?? configLoading;
 
   return {
-    firewallsInfo: {
-      attachedFirewalls,
-      firewallsError,
-      firewallsLoading,
-    },
     interfacesInfo: {
       config, // undefined if this Linode is using Linode Interfaces. Used to determine an unrecommended configuration
       configInterface, // undefined if this Linode is using Linode Interfaces

--- a/packages/queries/src/linodes/interfaces.ts
+++ b/packages/queries/src/linodes/interfaces.ts
@@ -247,9 +247,6 @@ export const useUpgradeToLinodeInterfacesMutation = (linodeId: number) => {
           queryClient.invalidateQueries({
             queryKey: linodeQueries.linode(linodeId).queryKey,
           });
-          queryClient.invalidateQueries({
-            queryKey: linodeQueries.linode(linodeId)._ctx.configs.queryKey,
-          });
 
           // Simlar to deleting the interface - because we don't easily know the interface's Firewall here,
           // we'll just invalidate all firewall queries.

--- a/packages/queries/src/linodes/interfaces.ts
+++ b/packages/queries/src/linodes/interfaces.ts
@@ -265,10 +265,6 @@ export const useUpgradeToLinodeInterfacesMutation = (linodeId: number) => {
               queryClient.invalidateQueries({
                 queryKey: vpcQueries.vpc(iface.vpc.vpc_id).queryKey,
               });
-              queryClient.invalidateQueries({
-                queryKey: vpcQueries.vpc(iface.vpc.vpc_id)._ctx.subnets
-                  .queryKey,
-              });
             }
           }
         }

--- a/packages/queries/src/linodes/interfaces.ts
+++ b/packages/queries/src/linodes/interfaces.ts
@@ -247,6 +247,10 @@ export const useUpgradeToLinodeInterfacesMutation = (linodeId: number) => {
         queryClient.invalidateQueries({
           queryKey: linodeQueries.linode(linodeId)._ctx.configs.queryKey,
         });
+
+        // queryClient.invalidateQueries({
+        //   queryKey: linodeQueries.linode(linodeId)._ctx.firewalls.queryKey,
+        // });
       },
     },
   );

--- a/packages/queries/src/linodes/interfaces.ts
+++ b/packages/queries/src/linodes/interfaces.ts
@@ -9,6 +9,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { firewallQueries } from '../firewalls';
 import { networkingQueries } from '../networking';
+import { vpcQueries } from '../vpcs';
 import { linodeQueries } from './linodes';
 
 import type {
@@ -249,20 +250,27 @@ export const useUpgradeToLinodeInterfacesMutation = (linodeId: number) => {
           queryClient.invalidateQueries({
             queryKey: linodeQueries.linode(linodeId)._ctx.configs.queryKey,
           });
-          queryClient.invalidateQueries({
-            queryKey: linodeQueries.linode(linodeId)._ctx.firewalls.queryKey,
-          });
 
           // Simlar to deleting the interface - because we don't easily know the interface's Firewall here,
           // we'll just invalidate all firewall queries.
-          // If this ever needs to be optimized, we can fetch the interface's firewalls before deletion,
-          // and do a more granular invalidation knowing the firewall ID.
           queryClient.invalidateQueries({
             queryKey: firewallQueries.firewall._def,
           });
           queryClient.invalidateQueries({
             queryKey: firewallQueries.firewalls.queryKey,
           });
+
+          for (const iface of upgradeData.interfaces) {
+            if (iface.vpc) {
+              queryClient.invalidateQueries({
+                queryKey: vpcQueries.vpc(iface.vpc.vpc_id).queryKey,
+              });
+              queryClient.invalidateQueries({
+                queryKey: vpcQueries.vpc(iface.vpc.vpc_id)._ctx.subnets
+                  .queryKey,
+              });
+            }
+          }
         }
       },
     },


### PR DESCRIPTION
## Description 📝

> [!important]
> merging this into staging

Fixes error received when trying to update interface's firewall after upgrade
Fixes link issue when navigating to /networking

## Changes  🔄
- invalidate all firewalls for reasons similar to deleting an interface - we don't easily know the interface's firewall ID
- update link splicing

## Target release date 🗓️
5/6

these errors shouldn't appear anymore:
![image](https://github.com/user-attachments/assets/62c07c14-5255-4412-b42e-be63aa897305)
![image](https://github.com/user-attachments/assets/cef38748-39a8-4394-adae-2a6242022c73)


## How to test 🧪

### Prerequisites
- Have the customer tag and have Linode Interfaces flag enabled

### Reproduction steps
Issue 1:
- Upgrade an Linode with a firewall 
- Go to network tab and edit interfaces, changing the firewall
- Note how 'Unable to find this Interface's firewall device" appears

Issue 2:
- Upgrade an Linode with a firewall 
- Go to network tab and edit interfaces
- Notice how link may have an extra /networking

### Verification steps
- Confirm  'Unable to find this Interface's firewall device" error no longer shows up
- confirm url is correct when clicking 'go to network' button

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
