### PR TITLE
test: [DBAAS1-1149] Cypress test for suspend and resume db cluster feature

### DIFF
--- a/packages/manager/cypress/e2e/core/databases/update-database.spec.ts
+++ b/packages/manager/cypress/e2e/core/databases/update-database.spec.ts
@@ -10,12 +10,15 @@ import {
 import { mockGetAccount } from 'support/intercepts/account';
 import {
   mockGetDatabase,
+  mockGetDatabases,
   mockGetDatabaseCredentials,
   mockGetDatabaseTypes,
   mockResetPassword,
-  mockResetPasswordProvisioningDatabase,
+  mockResetPasswordSuspendResumeDatabase,
   mockUpdateDatabase,
-  mockUpdateProvisioningDatabase,
+  mockUpdateSuspendResumeDatabase,
+  mockSuspendDatabase,
+  mockResumeDatabase,
 } from 'support/intercepts/databases';
 import { ui } from 'support/ui';
 import {
@@ -26,7 +29,7 @@ import {
 } from 'support/util/random';
 
 import { databaseFactory } from 'src/factories/databases';
-
+import type { Database } from '@linode/api-v4';
 import type { DatabaseClusterConfiguration } from 'support/constants/databases';
 
 /**
@@ -181,141 +184,309 @@ const modifyMaintenanceWindow = (label: string, windowValue: string) => {
   ui.button.findByTitle('Save Changes').should('be.visible').click();
 };
 
+/**
+ * Suspend an active cluster
+ *
+ * @param label - cluster name
+ */
+
+const suspendCluster = (label: string) => {
+  ui.dialog
+    .findByTitle(`Suspend ${label} cluster?`)
+    .should('be.visible')
+    .within(() => {
+      ui.buttonGroup
+        .findButtonByTitle('Suspend Cluster')
+        .should('be.visible')
+        .should('be.disabled');
+
+      cy.get('[data-qa-checked="false"]').click();
+
+      ui.buttonGroup
+        .findButtonByTitle('Suspend Cluster')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+    });
+};
+
+/**
+ * Validates no updates can be performed for a suspended or resuming cluster
+ *
+ * This requires that the cluster is 'Suspended' or 'Resuming'
+ *
+ * @param engine - db engine
+ * @param id - cluster id
+ * @param initialLabel - cluster name
+ * @param updateAttemptLabel - cluster updated name
+ * @param errorMessage - error thrown for updating a suspended/resuming cluster
+ * @param hostnameRegex - connection settings hostname
+ * @param allowedIp - ip for manage access actions
+ */
+
+const validateSuspendResume = (
+  engine: string,
+  id: number,
+  initialLabel: string,
+  updateAttemptLabel: string,
+  errorMessage: string,
+  hostnameRegex: RegExp,
+  allowedIp: string
+) => {
+  cy.visit(`/databases/${engine}/${id}`);
+  cy.wait('@getDatabase');
+
+  // Cannot update database label.
+  updateDatabaseLabel(initialLabel, updateAttemptLabel);
+  cy.wait('@updateDatabase');
+  cy.findByText(errorMessage).should('be.visible');
+  cy.get('[data-qa-cancel-edit="true"]')
+    .should('be.visible')
+    .should('be.enabled')
+    .click();
+
+  cy.findByText('Connection Details');
+  // DBaaS hostnames are not available until database/cluster has provisioned.
+  cy.findByText(hostnameRegex).should('be.visible');
+
+  // DBaaS passwords cannot be revealed until database/cluster has provisioned.
+  ui.button.findByTitle('Show').should('be.visible').should('be.enabled');
+
+  // Navigate to "Settings" tab.
+  ui.tabList.findTabByTitle('Settings').click();
+
+  // Cannot reset root password before database/cluster has provisioned.
+  resetRootPassword();
+  cy.wait('@resetRootPassword');
+  ui.dialog
+    .findByTitle('Reset Root Password')
+    .should('be.visible')
+    .within(() => {
+      cy.findByText(errorMessage).should('be.visible');
+
+      ui.buttonGroup
+        .findButtonByTitle('Cancel')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+    });
+
+  // Cannot add or remove allowed IPs before database/cluster has provisioned.
+  removeAllowedIp(allowedIp);
+  cy.wait('@updateDatabase');
+  ui.dialog
+    .findByTitle(`Remove IP Address ${allowedIp}`)
+    .should('be.visible')
+    .within(() => {
+      cy.findByText(errorMessage).should('be.visible');
+      ui.buttonGroup.findButtonByTitle('Cancel').should('be.visible').click();
+    });
+
+  manageAccessControl([randomIp()], 1);
+  cy.wait('@updateDatabase');
+  ui.drawer.findByTitle('Manage Access').within(() => {
+    cy.findByText(errorMessage).should('be.visible');
+    ui.drawerCloseButton.find().click();
+  });
+
+  // Cannot change maintenance schedule before database/cluster has provisioned.
+  modifyMaintenanceWindow('Day of Week', 'Wednesday');
+  cy.wait('@updateDatabase');
+  cy.findByText(errorMessage).should('be.visible');
+};
+
+const validateActionItems = (state: string, label: string) => {
+  const menuStates: Record<string, Record<string, boolean>> = {
+    suspended: {
+      Delete: true,
+      'Manage Access Controls': false,
+      'Reset Root Password': false,
+      Resize: false,
+      Resume: true,
+      Suspend: false,
+    },
+    resuming: {
+      Delete: true,
+      'Manage Access Controls': true,
+      'Reset Root Password': true,
+      Resize: true,
+      Resume: false,
+      Suspend: false,
+    },
+  };
+  const expectedItems = menuStates[state];
+  ui.actionMenu
+    .findByTitle(`Action menu for Database ${label}`)
+    .should('be.visible')
+    .click();
+
+  Object.entries(expectedItems).forEach(([label, enabled]) => {
+    ui.actionMenuItem
+      .findByTitle(label)
+      .should('be.visible')
+      .should(enabled ? 'be.enabled' : 'be.disabled');
+  });
+  cy.get('body').click(0, 0);
+};
+
 describe('Update database clusters', () => {
+  const successStatus = ['active', 'provisioning'];
+  // const successStatus = ['active', 'provisioning'];
+
   databaseConfigurations.forEach(
     (configuration: DatabaseClusterConfiguration) => {
       describe(`updates a ${configuration.linodeType} ${configuration.engine} v${configuration.version}.x ${configuration.clusterSize}-node cluster`, () => {
-        /*
-         * - Tests active database update UI flows using mocked data.
-         * - Confirms that users can change database label.
-         * - Confirms that users can change access controls.
-         * - Confirms that users can reset root passwords.
-         * - Confirms that users can change maintenance schedules.
-         */
-        it('Can update active database clusters', () => {
-          const initialLabel = configuration.label;
-          const updatedLabel = randomLabel();
-          const allowedIp = randomIp();
-          const newAllowedIp = randomIp();
-          const initialPassword = randomString(16);
-          const database = databaseFactory.build({
-            allow_list: [allowedIp],
-            engine: configuration.dbType,
-            id: randomNumber(1, 1000),
-            label: initialLabel,
-            platform: 'rdbms-default',
-            region: configuration.region.id,
-            status: 'active',
-            type: configuration.linodeType,
-            version: configuration.version,
+        successStatus.forEach((state) => {
+          /*
+           * - Tests active and provisioning database update UI flows using mocked data.
+           * - Confirms that users can change database label.
+           * - Confirms that users can change access controls.
+           * - Confirms that users can reset root passwords.
+           * - Confirms that users can change maintenance schedules.
+           */
+          it(`Can update ${state} database clusters`, () => {
+            const currentState = state === 'active' ? 'active' : 'provisioning';
+            const initialLabel = configuration.label;
+            const updatedLabel = randomLabel();
+            const allowedIp = randomIp();
+            const newAllowedIp = randomIp();
+            const initialPassword = randomString(16);
+            const database = databaseFactory.build({
+              allow_list: [allowedIp],
+              engine: configuration.dbType,
+              id: randomNumber(1, 1000),
+              label: initialLabel,
+              platform: 'rdbms-default',
+              region: configuration.region.id,
+              status: currentState,
+              type: configuration.linodeType,
+              version: configuration.version,
+            });
+
+            mockGetAccount(accountFactory.build()).as('getAccount');
+            mockGetDatabase(database).as('getDatabase');
+            mockGetDatabaseTypes(mockDatabaseNodeTypes).as('getDatabaseTypes');
+            mockResetPassword(database.id, database.engine).as(
+              'resetRootPassword'
+            );
+            mockGetDatabaseCredentials(
+              database.id,
+              database.engine,
+              initialPassword
+            ).as('getCredentials');
+
+            cy.visitWithLogin(`/databases/${database.engine}/${database.id}`);
+            cy.wait(['@getDatabase', '@getDatabaseTypes']);
+
+            // Validation for summary page details
+            cy.findByText('Cluster Configuration');
+            cy.findByText(configuration.region.label).should('be.visible');
+            cy.findByText(database.total_disk_size_gb + ' GB').should(
+              'be.visible'
+            );
+
+            cy.findByText('Connection Details');
+
+            if (state === 'provisioning') {
+              // DBaaS passwords cannot be revealed until database/cluster has provisioned.
+              ui.button
+                .findByTitle('Show')
+                .should('be.visible')
+                .should('be.disabled');
+            } else {
+              // "Show" button should be enabled to reveal password when DB is active.
+              ui.button
+                .findByTitle('Show')
+                .should('be.visible')
+                .should('be.enabled')
+                .click();
+
+              cy.wait('@getCredentials');
+              cy.findByText(`${initialPassword}`);
+
+              // "Hide" button should be enabled to hide password when password is revealed.
+              ui.button
+                .findByTitle('Hide')
+                .should('be.visible')
+                .should('be.enabled')
+                .click();
+            }
+
+            // Update labels for cluster in active/provisioning state
+            mockUpdateDatabase(database.id, database.engine, {
+              ...database,
+              label: updatedLabel,
+            }).as('updateDatabaseLabel');
+            updateDatabaseLabel(initialLabel, updatedLabel);
+            cy.wait('@updateDatabaseLabel');
+            cy.get('[data-qa-header]')
+              .should('be.visible')
+              .should('have.text', updatedLabel);
+
+            // Navigate to "Settings" tab.
+            ui.tabList.findTabByTitle('Settings').click();
+
+            // Reset root password.
+            resetRootPassword();
+            cy.wait('@resetRootPassword');
+
+            // Remove allowed IP, manage IP access control.
+            mockUpdateDatabase(database.id, database.engine, {
+              ...database,
+              allow_list: [],
+            }).as('updateDatabaseAllowedIp');
+            removeAllowedIp(allowedIp);
+            cy.wait('@updateDatabaseAllowedIp');
+
+            mockUpdateDatabase(database.id, database.engine, {
+              ...database,
+              allow_list: [newAllowedIp],
+            }).as('updateAccessControl');
+            manageAccessControl([newAllowedIp]);
+            cy.wait('@updateAccessControl');
+            cy.get('[data-qa-access-controls]').within(() => {
+              cy.findByText(newAllowedIp).should('be.visible');
+            });
+
+            // Change maintenance window and databe version upgrade.
+            mockUpdateDatabase(database.id, database.engine, database).as(
+              'updateDatabaseMaintenance'
+            );
+            upgradeEngineVersion(database.engine, database.version);
+
+            modifyMaintenanceWindow('Day of Week', 'Wednesday');
+            cy.wait('@updateDatabaseMaintenance');
+            ui.toast.assertMessage(
+              'Maintenance Window settings saved successfully.'
+            );
+
+            modifyMaintenanceWindow('Time', '12:00');
+            cy.wait('@updateDatabaseMaintenance');
+            ui.toast.assertMessage(
+              'Maintenance Window settings saved successfully.'
+            );
+
+            if (state === 'provisioning') {
+              cy.get('[data-qa-settings-button="Suspend Cluster"]').should(
+                'be.disabled'
+              );
+            }
           });
-
-          mockGetAccount(accountFactory.build()).as('getAccount');
-          mockGetDatabase(database).as('getDatabase');
-          mockGetDatabaseTypes(mockDatabaseNodeTypes).as('getDatabaseTypes');
-          mockResetPassword(database.id, database.engine).as(
-            'resetRootPassword'
-          );
-          mockGetDatabaseCredentials(
-            database.id,
-            database.engine,
-            initialPassword
-          ).as('getCredentials');
-
-          cy.visitWithLogin(`/databases/${database.engine}/${database.id}`);
-          cy.wait(['@getDatabase', '@getDatabaseTypes']);
-
-          cy.findByText('Cluster Configuration');
-          cy.findByText(configuration.region.label).should('be.visible');
-          cy.findByText(database.total_disk_size_gb + ' GB').should(
-            'be.visible'
-          );
-
-          cy.findByText('Connection Details');
-          // "Show" button should be enabled to reveal password when DB is active.
-          ui.button
-            .findByTitle('Show')
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-
-          cy.wait('@getCredentials');
-          cy.findByText(`${initialPassword}`);
-
-          // "Hide" button should be enabled to hide password when password is revealed.
-          ui.button
-            .findByTitle('Hide')
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-
-          mockUpdateDatabase(database.id, database.engine, {
-            ...database,
-            label: updatedLabel,
-          }).as('updateDatabaseLabel');
-          updateDatabaseLabel(initialLabel, updatedLabel);
-          cy.wait('@updateDatabaseLabel');
-          cy.get('[data-qa-header]')
-            .should('be.visible')
-            .should('have.text', updatedLabel);
-
-          // Navigate to "Settings" tab.
-          ui.tabList.findTabByTitle('Settings').click();
-
-          // Reset root password.
-          resetRootPassword();
-          cy.wait('@resetRootPassword');
-
-          // Remove allowed IP, manage IP access control.
-          mockUpdateDatabase(database.id, database.engine, {
-            ...database,
-            allow_list: [],
-          }).as('updateDatabaseAllowedIp');
-          removeAllowedIp(allowedIp);
-          cy.wait('@updateDatabaseAllowedIp');
-
-          mockUpdateDatabase(database.id, database.engine, {
-            ...database,
-            allow_list: [newAllowedIp],
-          }).as('updateAccessControl');
-          manageAccessControl([newAllowedIp]);
-          cy.wait('@updateAccessControl');
-          cy.get('[data-qa-access-controls]').within(() => {
-            cy.findByText(newAllowedIp).should('be.visible');
-          });
-
-          // Change maintenance window and databe version upgrade.
-          mockUpdateDatabase(database.id, database.engine, database).as(
-            'updateDatabaseMaintenance'
-          );
-          upgradeEngineVersion(database.engine, database.version);
-
-          modifyMaintenanceWindow('Day of Week', 'Wednesday');
-          cy.wait('@updateDatabaseMaintenance');
-          ui.toast.assertMessage(
-            'Maintenance Window settings saved successfully.'
-          );
-
-          modifyMaintenanceWindow('Time', '12:00');
-          cy.wait('@updateDatabaseMaintenance');
-          ui.toast.assertMessage(
-            'Maintenance Window settings saved successfully.'
-          );
         });
 
         /*
-         * - Tests provisioning database update UI flows using mocked data.
+         * - Tests suspend/resume database update UI flows using mocked data.
          * - Confirms that database update flows work under error conditions.
-         * - Confirms that users cannot change database label for provisioning DBs.
-         * - Confirms that users cannot change access controls for provisioning DBs.
-         * - Confirms that users cannot reset root passwords for provisioning DBs.
-         * - Confirms that users cannot change maintenance schedules for provisioning DBs.
+         * - Confirms that users cannot change database label for suspended DBs.
+         * - Confirms that users cannot change access controls for suspended DBs.
+         * - Confirms that users cannot reset root passwords for suspended DBs.
+         * - Confirms that users cannot change maintenance schedules for suspended DBs.
          */
-        it('Cannot update database clusters while they are provisioning', () => {
+        it(`Cannot update database clusters while they are suspended via Settings`, () => {
           const initialLabel = configuration.label;
           const updateAttemptLabel = randomLabel();
           const allowedIp = randomIp();
-          const database = databaseFactory.build({
+          const database: Database = databaseFactory.build({
             allow_list: [allowedIp],
             engine: configuration.dbType,
             hosts: {
@@ -326,12 +497,11 @@ describe('Update database clusters', () => {
             label: initialLabel,
             platform: 'rdbms-default',
             region: configuration.region.id,
-            status: 'provisioning',
+            status: 'active',
             type: configuration.linodeType,
           });
 
-          const errorMessage =
-            'Your database is provisioning; please wait until provisioning is complete to perform this operation.';
+          const errorMessage = `Your database is suspended; please wait until it becomes active to perform this operation.`;
           const hostnameRegex =
             /your hostnames? will appear here once (it is|they are) available./i;
 
@@ -339,84 +509,194 @@ describe('Update database clusters', () => {
           mockGetDatabase(database).as('getDatabase');
           mockGetDatabaseTypes(mockDatabaseNodeTypes).as('getDatabaseTypes');
 
-          mockUpdateProvisioningDatabase(
+          mockUpdateSuspendResumeDatabase(
             database.id,
             database.engine,
             errorMessage
           ).as('updateDatabase');
 
-          mockResetPasswordProvisioningDatabase(
+          mockResetPasswordSuspendResumeDatabase(
             database.id,
             database.engine,
             errorMessage
           ).as('resetRootPassword');
 
-          cy.visitWithLogin(`/databases/${database.engine}/${database.id}`);
+          mockSuspendDatabase(database.id, database.engine).as(
+            'suspendDatabase'
+          );
+
+          // Database mock once instance has been suspended.
+          const databaseMockSuspend: Database = {
+            ...database,
+            status: 'suspended',
+          };
+
+          cy.visitWithLogin(
+            `/databases/${database.engine}/${database.id}/Settings`
+          );
           cy.wait(['@getAccount', '@getDatabase', '@getDatabaseTypes']);
-
-          // Cannot update database label.
-          updateDatabaseLabel(initialLabel, updateAttemptLabel);
-          cy.wait('@updateDatabase');
-          cy.findByText(errorMessage).should('be.visible');
-          cy.get('[data-qa-cancel-edit="true"]')
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-
-          cy.findByText('Connection Details');
-          // DBaaS hostnames are not available until database/cluster has provisioned.
-          cy.findByText(hostnameRegex).should('be.visible');
-
-          // DBaaS passwords cannot be revealed until database/cluster has provisioned.
-          ui.button
-            .findByTitle('Show')
-            .should('be.visible')
-            .should('be.disabled');
 
           // Navigate to "Settings" tab.
           ui.tabList.findTabByTitle('Settings').click();
 
-          // Cannot reset root password before database/cluster has provisioned.
-          resetRootPassword();
-          cy.wait('@resetRootPassword');
-          ui.dialog
-            .findByTitle('Reset Root Password')
-            .should('be.visible')
-            .within(() => {
-              cy.findByText(errorMessage).should('be.visible');
+          // Suspend an active cluster
+          cy.get('[data-qa-settings-button="Suspend Cluster"]').click();
+          suspendCluster(initialLabel);
+          cy.wait('@suspendDatabase');
 
-              ui.buttonGroup
-                .findButtonByTitle('Cancel')
-                .should('be.visible')
-                .should('be.enabled')
-                .click();
+          cy.url().should('endWith', '/databases');
+          ui.toast.assertMessage('Database Cluster suspended successfully.');
+
+          // Mock next request to fetch databases so that instance appears suspended.
+          mockGetDatabases([databaseMockSuspend]).as('getDatabases');
+
+          cy.findByText(database.label).should('be.visible');
+
+          // Mock database with updated action - Suspend
+          mockGetDatabase(databaseMockSuspend).as('getDatabase');
+          cy.wait('@getDatabase');
+
+          // Confirm enabled dropdown option when cluster is in suspended state
+          validateActionItems('suspended', initialLabel);
+
+          // Validate updates are not allowed when a cluster is suspended
+          validateSuspendResume(
+            database.engine,
+            database.id,
+            initialLabel,
+            updateAttemptLabel,
+            errorMessage,
+            hostnameRegex,
+            allowedIp
+          );
+        });
+
+        /*
+         * - Tests suspend/resume database update UI flows using mocked data.
+         * - Confirms that database update flows work under error conditions.
+         * - Confirms that users cannot change database label for suspended/resuming DBs.
+         * - Confirms that users cannot change access controls for suspended/resuming DBs.
+         * - Confirms that users cannot reset root passwords for suspended/resuming DBs.
+         * - Confirms that users cannot change maintenance schedules for suspended/resuming DBs.
+         */
+
+        const actionItemState = ['suspended', 'resuming'];
+        actionItemState.forEach((action) => {
+          it(`Cannot update database clusters while they are ${action}`, () => {
+            const currentState = action === 'resuming' ? 'suspended' : 'active';
+            const initialLabel = configuration.label;
+            const updateAttemptLabel = randomLabel();
+            const allowedIp = randomIp();
+            const database: Database = databaseFactory.build({
+              allow_list: [allowedIp],
+              engine: configuration.dbType,
+              hosts: {
+                primary: undefined,
+                secondary: undefined,
+              },
+              id: randomNumber(1, 1000),
+              label: initialLabel,
+              platform: 'rdbms-default',
+              region: configuration.region.id,
+              status: currentState,
+              type: configuration.linodeType,
             });
 
-          // Cannot add or remove allowed IPs before database/cluster has provisioned.
-          removeAllowedIp(allowedIp);
-          cy.wait('@updateDatabase');
-          ui.dialog
-            .findByTitle(`Remove IP Address ${allowedIp}`)
-            .should('be.visible')
-            .within(() => {
-              cy.findByText(errorMessage).should('be.visible');
-              ui.buttonGroup
-                .findButtonByTitle('Cancel')
-                .should('be.visible')
-                .click();
-            });
+            const errorMessage = `Your database is ${action}; please wait until it becomes active to perform this operation.`;
+            const hostnameRegex =
+              /your hostnames? will appear here once (it is|they are) available./i;
 
-          manageAccessControl([randomIp()], 1);
-          cy.wait('@updateDatabase');
-          ui.drawer.findByTitle('Manage Access').within(() => {
-            cy.findByText(errorMessage).should('be.visible');
-            ui.drawerCloseButton.find().click();
+            mockGetAccount(accountFactory.build()).as('getAccount');
+            mockGetDatabases([database]).as('getDatabases');
+            mockGetDatabase(database).as('getDatabase');
+            mockGetDatabaseTypes(mockDatabaseNodeTypes).as('getDatabaseTypes');
+
+            mockUpdateSuspendResumeDatabase(
+              database.id,
+              database.engine,
+              errorMessage
+            ).as('updateDatabase');
+
+            mockResetPasswordSuspendResumeDatabase(
+              database.id,
+              database.engine,
+              errorMessage
+            ).as('resetRootPassword');
+
+            mockSuspendDatabase(database.id, database.engine).as(
+              'suspendDatabase'
+            );
+
+            mockResumeDatabase(database.id, database.engine).as(
+              'resumeDatabase'
+            );
+
+            const changeState =
+              action === 'resuming' ? 'resuming' : 'suspended';
+
+            // Database mock once instance has been suspended or resuming.
+            const databaseMockSuspendResume: Database = {
+              ...database,
+              status: changeState,
+            };
+
+            cy.visitWithLogin(`/databases/`);
+            cy.wait(['@getAccount', '@getDatabases', '@getDatabaseTypes']);
+
+            cy.get(`[data-qa-database-cluster-id=${database.id}]`).within(
+              () => {
+                cy.findByText(initialLabel).should('be.visible');
+              }
+            );
+
+            // Suspend/Resume cluster via action item menu on homepage
+            ui.actionMenu
+              .findByTitle(`Action menu for Database ${initialLabel}`)
+              .should('be.visible')
+              .click();
+
+            const menuAction = action === 'resuming' ? 'Resume' : 'Suspend';
+
+            ui.actionMenuItem
+              .findByTitle(menuAction)
+              .should('be.visible')
+              .should('be.enabled')
+              .click();
+
+            if (action === 'resuming') {
+              cy.wait('@resumeDatabase');
+              ui.toast.assertMessage('Database Cluster resumed successfully.');
+            } else {
+              suspendCluster(initialLabel);
+              cy.wait('@suspendDatabase');
+              ui.toast.assertMessage(
+                'Database Cluster suspended successfully.'
+              );
+            }
+
+            // Mock next request to fetch databases so that instance appears suspended or resuming
+            mockGetDatabases([databaseMockSuspendResume]).as('getDatabases');
+            cy.wait('@getDatabases');
+
+            cy.findByText(database.label).should('be.visible');
+
+            // Mock database with updated action - Suspend/Resume
+            mockGetDatabase(databaseMockSuspendResume).as('getDatabase');
+
+            // Confirm enabled dropdown option when cluster is in suspended/resuming state
+            validateActionItems(action, initialLabel);
+
+            // Validate updates are not allowed when a cluster is suspended/resuming
+            validateSuspendResume(
+              database.engine,
+              database.id,
+              initialLabel,
+              updateAttemptLabel,
+              errorMessage,
+              hostnameRegex,
+              allowedIp
+            );
           });
-
-          // Cannot change maintenance schedule before database/cluster has provisioned.
-          modifyMaintenanceWindow('Day of Week', 'Wednesday');
-          cy.wait('@updateDatabase');
-          cy.findByText(errorMessage).should('be.visible');
         });
       });
     }

--- a/packages/manager/cypress/support/intercepts/databases.ts
+++ b/packages/manager/cypress/support/intercepts/databases.ts
@@ -127,6 +127,46 @@ export const mockUpdateDatabase = (
 };
 
 /**
+ * Intercepts PUT request to suspend an active database and mocks response.
+ *
+ * @param id - Database ID.
+ * @param engine - Database engine type.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockSuspendDatabase = (
+  id: number,
+  engine: string,
+  responseData: any = {}
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`databases/${engine}/instances/${id}/suspend`),
+    responseData
+  );
+};
+
+/**
+ * Intercepts PUT request to suspend an active database and mocks response.
+ *
+ * @param id - Database ID.
+ * @param engine - Database engine type.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockResumeDatabase = (
+  id: number,
+  engine: string,
+  responseData: any = {}
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`databases/${engine}/instances/${id}/resume`),
+    responseData
+  );
+};
+
+/**
  * Intercepts POST request to reset an active database's password and mocks response.
  *
  * @param id - Database ID.
@@ -171,7 +211,7 @@ export const mockResizeProvisioningDatabase = (
  *
  * @returns Cypress chainable.
  */
-export const mockUpdateProvisioningDatabase = (
+export const mockUpdateSuspendResumeDatabase = (
   id: number,
   engine: string,
   responseErrorMessage?: string | undefined
@@ -214,7 +254,7 @@ export const mockResetPassword = (
  *
  * @returns Cypress chainable.
  */
-export const mockResetPasswordProvisioningDatabase = (
+export const mockResetPasswordSuspendResumeDatabase = (
   id: number,
   engine: string,
   responseErrorMessage?: string | undefined


### PR DESCRIPTION
## Description 📝

- Test coverage for dbaas v2 suspend and resume update cluster feature

## Changes  🔄
-  Cluster in provisioning state can be updated with dbaas v2 validations
-  Cluster in suspended state cannot be updated validations
- Cluster in resumed state cannot be updated validations
- Clusters can be suspended/resumed from homepage action item menu

## Target release date 🗓️

N/A

## How to test 🧪
`pnpm cy:run -s "cypress/e2e/core/databases/update-database.spec.ts"`

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
