### PR TITLE
change: [M3-9846] - Improve Network Interface Table for small screen sizes

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/InterfaceDetailsDrawer/InterfaceDetailsContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/InterfaceDetailsDrawer/InterfaceDetailsContent.tsx
@@ -12,7 +12,7 @@ import { VPCInterfaceDetailsContent } from './VPCInterfaceDetailsContent';
 import type { LinodeInterface } from '@linode/api-v4';
 
 export const InterfaceDetailsContent = (props: LinodeInterface) => {
-  const { created, default_route, id, mac_address, updated } = props;
+  const { created, default_route, id, mac_address, updated, version } = props;
   const type = getLinodeInterfaceType(props);
 
   return (
@@ -48,6 +48,12 @@ export const InterfaceDetailsContent = (props: LinodeInterface) => {
       {props.public && <PublicInterfaceDetailsContent {...props.public} />}
       {props.vpc && <VPCInterfaceDetailsContent {...props.vpc} />}
       {props.vlan && <VlanInterfaceDetailsContent {...props.vlan} />}
+      <Stack>
+        <Typography>
+          <strong>Version</strong>
+        </Typography>
+        <Typography>{version}</Typography>
+      </Stack>
       <Stack>
         <Typography>
           <strong>Created</strong>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/LinodeInterfaceIPs.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/LinodeInterfaceIPs.tsx
@@ -20,7 +20,7 @@ export const LinodeInterfaceIPs = ({ linodeInterface }: Props) => {
   }
 
   return (
-    <Stack direction="row" spacing={1.5}>
+    <Stack alignItems={'center'} direction="row" spacing={1.5}>
       <MaskableText isToggleable text={primary} />
       {ips.length > 0 && (
         <ShowMore

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/LinodeInterfaceTableRow.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/LinodeInterfaceTableRow.tsx
@@ -1,3 +1,4 @@
+import { Hidden } from '@linode/ui';
 import React from 'react';
 
 import { DateTimeDisplay } from 'src/components/DateTimeDisplay';
@@ -28,22 +29,30 @@ export const LinodeInterfaceTableRow = (props: Props) => {
     <TableRow>
       <TableCell>{type}</TableCell>
       <TableCell>{id}</TableCell>
-      <TableCell>
-        <MaskableText isToggleable text={mac_address} />
-      </TableCell>
+      <Hidden smDown>
+        <TableCell>
+          <MaskableText isToggleable text={mac_address} />
+        </TableCell>
+      </Hidden>
       <TableCell>
         <LinodeInterfaceIPs linodeInterface={props} />
       </TableCell>
-      <TableCell>{version}</TableCell>
+      <Hidden lgDown>
+        <TableCell>{version}</TableCell>
+      </Hidden>
       <TableCell>
         <LinodeInterfaceFirewall interfaceId={id} linodeId={linodeId} />
       </TableCell>
-      <TableCell>
-        <DateTimeDisplay value={updated} />
-      </TableCell>
-      <TableCell>
-        <DateTimeDisplay value={created} />
-      </TableCell>
+      <Hidden mdDown>
+        <TableCell>
+          <DateTimeDisplay value={updated} />
+        </TableCell>
+      </Hidden>
+      <Hidden smDown>
+        <TableCell>
+          <DateTimeDisplay value={created} />
+        </TableCell>
+      </Hidden>
       <TableCell actionCell>
         <LinodeInterfaceActionMenu handlers={handlers} id={id} type={type} />
       </TableCell>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/LinodeInterfacesTable.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/LinodeInterfacesTable.tsx
@@ -1,3 +1,4 @@
+import { Hidden } from '@linode/ui';
 import React from 'react';
 
 import { Table } from 'src/components/Table';
@@ -22,12 +23,20 @@ export const LinodeInterfacesTable = ({ handlers, linodeId }: Props) => {
         <TableRow>
           <TableCell>Type</TableCell>
           <TableCell>ID</TableCell>
-          <TableCell>MAC Address</TableCell>
+          <Hidden smDown>
+            <TableCell>MAC Address</TableCell>
+          </Hidden>
           <TableCell>IP Addresses</TableCell>
-          <TableCell>Version</TableCell>
+          <Hidden lgDown>
+            <TableCell>Version</TableCell>
+          </Hidden>
           <TableCell>Firewall</TableCell>
-          <TableCell>Updated</TableCell>
-          <TableCell>Created</TableCell>
+          <Hidden mdDown>
+            <TableCell>Updated</TableCell>
+          </Hidden>
+          <Hidden smDown>
+            <TableCell>Created</TableCell>
+          </Hidden>
           <TableCell />
         </TableRow>
       </TableHead>


### PR DESCRIPTION
## Description 📝
- make Network Interface table friendlier for smaller screen sizes (hide columns when viewport changes)
- add Version to details drawer

## Target release date 🗓️
5/20

## Preview 📷
| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- ...
- ...

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
