### PR TITLE
fix: [M3-9894] - Use outlined warning icon in Firewall warning banner

### DIFF
--- a/packages/manager/.changeset/pr-12159-fixed-1746488156627.md
+++ b/packages/manager/.changeset/pr-12159-fixed-1746488156627.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Use outlined icon in Firewall warning banner ([#12159](https://github.com/linode/manager/pull/12159))
+Incorrect icon in Firewall warning banner to use outlined icon ([#12159](https://github.com/linode/manager/pull/12159))

--- a/packages/manager/.changeset/pr-12159-fixed-1746488156627.md
+++ b/packages/manager/.changeset/pr-12159-fixed-1746488156627.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Use outlined icon in Firewall warning banner ([#12159](https://github.com/linode/manager/pull/12159))

--- a/packages/manager/src/components/AkamaiBanner/AkamaiBanner.styles.ts
+++ b/packages/manager/src/components/AkamaiBanner/AkamaiBanner.styles.ts
@@ -1,4 +1,4 @@
-import { Box, omittedProps, Stack, WarningIcon } from '@linode/ui';
+import { Box, omittedProps, Stack, WarningOutlinedIcon } from '@linode/ui';
 import { styled } from '@mui/material/styles';
 
 import AkamaiLogo from 'src/assets/logo/akamai-logo.svg';
@@ -14,7 +14,7 @@ export const StyledAkamaiLogo = styled(AkamaiLogo, {
   },
 }));
 
-export const StyledWarningIcon = styled(WarningIcon, {
+export const StyledWarningIcon = styled(WarningOutlinedIcon, {
   label: 'StyledWarningIcon',
 })(({ theme }) => ({
   color: theme.tokens.color.Neutrals.Black,

--- a/packages/manager/src/components/AkamaiBanner/AkamaiBanner.styles.ts
+++ b/packages/manager/src/components/AkamaiBanner/AkamaiBanner.styles.ts
@@ -17,7 +17,9 @@ export const StyledAkamaiLogo = styled(AkamaiLogo, {
 export const StyledWarningIcon = styled(WarningOutlinedIcon, {
   label: 'StyledWarningIcon',
 })(({ theme }) => ({
-  color: theme.tokens.color.Neutrals.Black,
+  '& > path': {
+    fill: theme.tokens.color.Neutrals.Black,
+  },
 }));
 
 export const StyledBanner = styled(Stack, {

--- a/packages/manager/src/components/AkamaiBanner/AkamaiBanner.tsx
+++ b/packages/manager/src/components/AkamaiBanner/AkamaiBanner.tsx
@@ -43,7 +43,7 @@ export const AkamaiBanner = React.memo((props: AkamaiBannerProps) => {
       warning={warning}
     >
       <StyledBannerLabel warning={warning}>
-        <Stack alignItems="center" direction="row">
+        <Stack alignItems={warning ? 'start' : 'center'} direction="row">
           <Box sx={{ height: 18, width: 25 }}>
             {warning ? (
               <StyledWarningIcon height={18} />


### PR DESCRIPTION
## Description 📝

Fixes a visual regression in the internal Firewall warning banner caused by the switch to CDS icons.

## Changes  🔄

- Switch from `WarningIcon` to `WarningOutlinedIcon` in `AkamaiBanner.styles.ts`.

The original `WarningIcon` from MUI was outlined but the CDS one is not.

## Preview 📷

| | Prod  | This Branch   |
|-| ------- | ------- |
|Light Mode | ![Screenshot 2025-05-05 at 7 29 35 PM](https://github.com/user-attachments/assets/b4fd6f2b-4379-4b22-94ca-9ba8216e8406) | ![Screenshot 2025-05-05 at 7 29 15 PM](https://github.com/user-attachments/assets/90012e4c-1423-4e37-8ee3-d773ab690224) |
| Dark Mode | ![Screenshot 2025-05-05 at 7 29 42 PM](https://github.com/user-attachments/assets/389d6bd8-0488-4ee5-915b-8968d0ee5bcb) | ![Screenshot 2025-05-05 at 7 29 24 PM](https://github.com/user-attachments/assets/9361ae06-50fd-4233-80c4-f107d1e7ca73) |


## How to test 🧪

### Prerequisites

- In localhost or the preview link, navigate to the [Preference Editor](https://linode-cloud-pr-12159.website-us-east-1.linodeobjects.com/profile/settings?preferenceEditor=true)
- Add the following option:
```json
"secure_vm_notices": "always"
```

### Verification steps

- Attempt to create a Linode without assigning a firewall
- Verify the warning icon appears as expected

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
