### PR TITLE
upcoming: [M3-9861] - Support Linode Interfaces in the Linode Create Summary

### DIFF
--- a/packages/manager/src/features/Linodes/LinodeCreate/Summary/Summary.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Summary/Summary.test.tsx
@@ -1,13 +1,14 @@
 import { regionFactory } from '@linode/utilities';
 import React from 'react';
 
-import { imageFactory, typeFactory } from 'src/factories';
+import { accountFactory, imageFactory, typeFactory } from 'src/factories';
 import { makeResourcePage } from 'src/mocks/serverHandlers';
 import { http, HttpResponse, server } from 'src/mocks/testServer';
 import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
 
 import { Summary } from './Summary';
 
+import type { LinodeCreateFormValues } from '../utilities';
 import type { CreateLinodeRequest } from '@linode/api-v4';
 
 describe('Linode Create Summary', () => {
@@ -278,5 +279,106 @@ describe('Linode Create Summary', () => {
     });
 
     await findByText('Encrypted');
+  });
+
+  describe('Legacy Interfaces', () => {
+    it('should render "VPC Assigned" if a VPC is selected', () => {
+      const { getByText } =
+        renderWithThemeAndHookFormContext<LinodeCreateFormValues>({
+          component: <Summary />,
+          useFormOptions: {
+            defaultValues: { interfaces: [{ vpc_id: 1, subnet_id: 2 }] },
+          },
+          options: { flags: { linodeInterfaces: { enabled: false } } },
+        });
+
+      expect(getByText('VPC Assigned')).toBeVisible();
+    });
+
+    it('should render "VLAN Attached" if a VLAN is selected', () => {
+      const { getByText } =
+        renderWithThemeAndHookFormContext<LinodeCreateFormValues>({
+          component: <Summary />,
+          useFormOptions: {
+            // VLAN interface is always stored at index 1 for legacy interfaces
+            defaultValues: { interfaces: [{}, { label: 'my-vlan-label' }] },
+          },
+          options: { flags: { linodeInterfaces: { enabled: false } } },
+        });
+
+      expect(getByText('VLAN Attached')).toBeVisible();
+    });
+
+    it('should render "Firewall Assigned" if a Firewall is selected', () => {
+      const { getByText } =
+        renderWithThemeAndHookFormContext<LinodeCreateFormValues>({
+          component: <Summary />,
+          useFormOptions: {
+            defaultValues: { firewall_id: 5 },
+          },
+          options: { flags: { linodeInterfaces: { enabled: false } } },
+        });
+
+      expect(getByText('Firewall Assigned')).toBeVisible();
+    });
+  });
+
+  describe('Linode Interfaces', () => {
+    // Account capability must be present for Linode Interfaces
+    beforeEach(() => {
+      const account = accountFactory.build({
+        capabilities: ['Linodes', 'Linode Interfaces'],
+      });
+
+      server.use(
+        http.get('*/v4/account', () => {
+          return HttpResponse.json(account);
+        })
+      );
+    });
+
+    it('should render "VPC Assigned" if a VPC is selected', async () => {
+      const { findByText } =
+        renderWithThemeAndHookFormContext<LinodeCreateFormValues>({
+          component: <Summary />,
+          useFormOptions: {
+            defaultValues: { linodeInterfaces: [{ vpc: { subnet_id: 2 } }] },
+          },
+          options: { flags: { linodeInterfaces: { enabled: true } } },
+        });
+
+      const text = await findByText('VPC Assigned');
+      expect(text).toBeVisible();
+    });
+
+    it('should render "VLAN Attached" if a VLAN is selected', async () => {
+      const { findByText } =
+        renderWithThemeAndHookFormContext<LinodeCreateFormValues>({
+          component: <Summary />,
+          useFormOptions: {
+            defaultValues: {
+              linodeInterfaces: [{ vlan: { vlan_label: 'my-test-vlan-1' } }],
+            },
+          },
+          options: { flags: { linodeInterfaces: { enabled: true } } },
+        });
+
+      const text = await findByText('VLAN Attached');
+      expect(text).toBeVisible();
+    });
+
+    it('should render "Firewall Assigned" if a Firewall is selected', async () => {
+      const { findByText } =
+        renderWithThemeAndHookFormContext<LinodeCreateFormValues>({
+          component: <Summary />,
+          useFormOptions: {
+            defaultValues: { linodeInterfaces: [{ firewall_id: 5 }] },
+          },
+          options: { flags: { linodeInterfaces: { enabled: true } } },
+        });
+
+      const text = await findByText('Firewall Assigned');
+      expect(text).toBeVisible();
+    });
   });
 });

--- a/packages/manager/src/features/Linodes/LinodeCreate/Summary/Summary.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Summary/Summary.tsx
@@ -8,18 +8,20 @@ import { useFormContext, useWatch } from 'react-hook-form';
 
 import { useImageQuery } from 'src/queries/images';
 import { useTypeQuery } from 'src/queries/types';
+import { useIsLinodeInterfacesEnabled } from 'src/utilities/linodes';
 import { getMonthlyBackupsPrice } from 'src/utilities/pricing/backups';
 import { renderMonthlyPriceToCorrectDecimalPlace } from 'src/utilities/pricing/dynamicPricing';
 
 import { getLinodePrice } from './utilities';
 
-import type { CreateLinodeRequest } from '@linode/api-v4';
+import type { LinodeCreateFormValues } from '../utilities';
 
 export const Summary = () => {
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
+  const { isLinodeInterfacesEnabled } = useIsLinodeInterfacesEnabled();
 
-  const { control } = useFormContext<CreateLinodeRequest>();
+  const { control } = useFormContext<LinodeCreateFormValues>();
 
   const [
     label,
@@ -34,6 +36,7 @@ export const Summary = () => {
     vpcId,
     diskEncryption,
     clusterSize,
+    linodeInterfaces,
   ] = useWatch({
     control,
     name: [
@@ -49,6 +52,7 @@ export const Summary = () => {
       'interfaces.0.vpc_id',
       'disk_encryption',
       'stackscript_data.cluster_size',
+      'linodeInterfaces',
     ],
   });
 
@@ -63,6 +67,18 @@ export const Summary = () => {
   );
 
   const price = getLinodePrice({ clusterSize, regionId, type });
+
+  const hasVPC = isLinodeInterfacesEnabled
+    ? linodeInterfaces?.some((i) => i.vpc?.subnet_id)
+    : vpcId;
+
+  const hasVLAN = isLinodeInterfacesEnabled
+    ? linodeInterfaces?.some((i) => i.vlan?.vlan_label)
+    : vlanLabel;
+
+  const hasFirewall = isLinodeInterfacesEnabled
+    ? linodeInterfaces.some((i) => i.firewall_id)
+    : firewallId;
 
   const summaryItems = [
     {
@@ -95,7 +111,7 @@ export const Summary = () => {
       item: {
         title: 'VLAN Attached',
       },
-      show: Boolean(vlanLabel),
+      show: hasVLAN,
     },
     {
       item: {
@@ -113,13 +129,13 @@ export const Summary = () => {
       item: {
         title: 'VPC Assigned',
       },
-      show: Boolean(vpcId),
+      show: hasVPC,
     },
     {
       item: {
         title: 'Firewall Assigned',
       },
-      show: Boolean(firewallId),
+      show: hasFirewall,
     },
     {
       item: {


### PR DESCRIPTION
## Description 📝

- Updates the Linode Create page Summary section to support the new Linode Interfaces UI

## Preview 📷

![Screenshot 2025-05-05 at 9 01 26 PM](https://github.com/user-attachments/assets/917f8e6f-c31b-4081-9bc2-3030f2205a8d)

## How to test 🧪

### Prerequisites

- Have `new-interfaces-beta` customer tag
- Turn on Linode Interfaces feature flag using Cloud Manager's local dev tools (if it is not already enabled)

> [!note]
> Please test this PR with the flag on and off to ensure both old/new flows work as expected

### Verification steps

- Go to the Linode Create flow
- Verify that the Summary at the bottom of the Linode Create page shows "VPC Assigned", "VLAN Attached", and `Firewall Assigned` at the appropriate times
- Check unit test and verify they are meaningful  

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>