### PR TITLE
test: [M3-9915] - Improve Cypress OBJ bucket clean up stability

### DIFF
--- a/packages/manager/.changeset/pr-12164-tests-1746553359993.md
+++ b/packages/manager/.changeset/pr-12164-tests-1746553359993.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Improve stability of Object Storage bucket clean up during Cypress tests ([#12164](https://github.com/linode/manager/pull/12164))


### PR DESCRIPTION
## Description 📝

This improves the stability of our Object Storage bucket clean up that occurs before our end-to-end OBJ tests run. During clean up, our tests fetch all of our buckets using the `/object-storage/buckets` endpoint. If any clusters are down, this endpoint responds with a 500 and causes the tests to fail.

This PR takes inspiration from our OBJ landing page by fetching buckets by region, accounting for API errors that might occur on a region-by-region basis, and cleaning up any buckets that were successfully fetched.

## Changes  🔄

- Improve OBJ bucket clean up resiliency when one or more clusters are down

## Target release date 🗓️

N/A

## How to test 🧪

We can rely on CI to confirm that this change doesn't break our Object Storage tests. Testing that it behaves as expected is slightly more difficult. Right now I'm observing intermittent issues with some OBJ clusters so you may be able to reproduce the issue and confirm that this logic handles those cases gracefully by running `object-storage.e2e.spec` and observing the network responses.

If you can't reproduce an error from the API, you can modify the code to intentionally attempt to fetch buckets from a non-existent cluster and observe that the clean up function handles the error gracefully and allows the tests to run.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
