### PR TITLE
change: [M3-9925] - Add validation rules on changeset description

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -46,6 +46,7 @@ Two reviews from members of the Cloud Manager team are required before merge. Af
 
 Follow these best practices to write a good changeset:
 
+- Summarize your changes succinctly in 150 characters or less. A changeset shouldn't describe every line of code edited in the PR.
 - Use a consistent tense in all changeset entries. We have chosen to use **imperative (present)** tense. (This follows established [git commit message best practices](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).)
 - Avoid starting a changeset with the verb "Add", "Remove", "Change" or "Fix" when listed under that respective `Added`, `Removed`, `Changed` or `Fixed` section. It is unnecessary repetition.
 - For `Fixed` changesets, describe the bug that needed to be fixed, rather than the fix itself. (e.g. say "Missing button labels in action buttons" rather than "Make label prop required for action buttons").

--- a/scripts/changelog/changeset.mjs
+++ b/scripts/changelog/changeset.mjs
@@ -59,7 +59,32 @@ async function generateChangeset() {
       type: "input",
       prefix: `📝 Description`,
       name: "description",
-      message: "\nDescribe the change (don't include the PR number):",
+      message: "\nBriefly describe the change (see https://linode.github.io/manager/CONTRIBUTING.html#writing-a-changeset for best practices):",
+      validate: (input) => {
+        const trimmed = input.trim();
+
+        if (trimmed.length < 1) {
+          return "Description must be between 1-150 characters. Please add a description.";
+        }
+
+        if (trimmed.length > 150) {
+          return "Description must be no more than 150 characters. Please summarize your changes.";
+        }
+
+        if (/#[0-9]+/.test(trimmed) || /\bPR\s?#?\d+\b/i.test(trimmed)) {
+          return "Description should not include the PR number (e.g., #123 or PR 456).";
+        }
+
+        if (!/^[A-Z]/.test(trimmed)) {
+          return "Description should start with a capital letter.";
+        }
+
+        if (/[.]$/.test(trimmed)) {
+          return "Description should not end with a period.";
+        }
+
+        return true;
+      },
     },
   ]);
   const { commit } = await inquirer.prompt([


### PR DESCRIPTION
## Description 📝

During our last team retro, we discussed ways to automate some of the issues we've seen with changeset inconsistencies to reduce the need for manual editing of the changelog.

This PR implements some basic validation rules based on our existing best practices ([docs](https://linode.github.io/manager/CONTRIBUTING.html#writing-a-changeset)) and things we've discussed, such as changesets that are too long because they're overly descriptive.

## Changes  🔄
- Adds validation to the description prompt in `changeset.mjs`
- Links the best practices in the description prompt when generating a changeset for easy reference
- Updates our docs to mention the character limit

## Preview 📷

| Bad description | Error   |
| ------- | ------- |
| Changeset starts with lowercase letter | ![Screenshot 2025-05-07 at 11 00 08 AM](https://github.com/user-attachments/assets/3716293d-ea42-446f-a2d3-4fd963736f9c) |
| Changeset ends with a period | ![Screenshot 2025-05-07 at 11 00 28 AM](https://github.com/user-attachments/assets/94e6735f-4bfc-431e-9b9a-361a3af5db70) |
| Changeset is too long | ![Screenshot 2025-05-07 at 11 01 24 AM](https://github.com/user-attachments/assets/84e8532c-b42c-4d53-ab71-25cf8c46aa57) |
| Changeset is empty | ![Screenshot 2025-05-07 at 11 01 50 AM](https://github.com/user-attachments/assets/e6263b45-798a-4b86-8bca-3f183dea0dfd) |
| Changeset includes the PR # | ![Screenshot 2025-05-07 at 11 02 25 AM](https://github.com/user-attachments/assets/a83297ab-d52a-4d39-a177-31686ea0149b) |


## How to test 🧪

### Verification steps

(How to verify changes)

- [ ] Check out this PR and run `pnpm changeset`
- [ ] Write a bad changeset, breaking one of the rules we have validation for, and observe the error is present until the issue is fixed
- [ ] Confirm whether this validation all seems reasonable
- [ ] Let me know whether there's anything else you think we can easily validate via regex

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
