### PR TITLE
test: [M3-9924] - Fix Cypress rebuild test by using Alpine Linux 3.20 Image following deprecation of 3.18

### DIFF
--- a/packages/manager/.changeset/pr-12172-tests-1746640484987.md
+++ b/packages/manager/.changeset/pr-12172-tests-1746640484987.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix Linode Rebuild test failures stemming from Alpine 3.18 Image deprecation ([#12172](https://github.com/linode/manager/pull/12172))

--- a/packages/manager/cypress/e2e/core/linodes/rebuild-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/rebuild-linode.spec.ts
@@ -108,7 +108,8 @@ const passwordComplexityError = 'Password does not meet strength requirement.';
 
 authenticate();
 describe('rebuild linode', () => {
-  const image = 'Alpine 3.18';
+  // TODO M3-9872 - Dynamically retrieve most recent Alpine Image label.
+  const image = 'Alpine 3.20';
   const rootPassword = randomString(16);
 
   before(() => {
@@ -180,6 +181,7 @@ describe('rebuild linode', () => {
     cy.tag('method:e2e', 'env:stackScripts');
     const stackScriptId = 443929;
     const stackScriptName = 'OpenLiteSpeed-WordPress';
+    // TODO M3-9872 - Dynamically retrieve latest AlmaLinux version's label.
     const image = 'AlmaLinux 9';
 
     const linodeCreatePayload = createLinodeRequestFactory.build({
@@ -243,12 +245,13 @@ describe('rebuild linode', () => {
    */
   it('rebuilds a linode from Account StackScript', () => {
     cy.tag('method:e2e');
-    const image = 'Alpine 3.18';
+    // TODO M3-9872 - Dynamically retrieve most recent Alpine Image label.
+    const image = 'Alpine 3.20';
     const region = chooseRegion().id;
 
     // Create a StackScript to rebuild a Linode.
     const linodeRequest = createLinodeRequestFactory.build({
-      image: 'linode/alpine3.18',
+      image: 'linode/alpine3.20',
       label: randomLabel(),
       region,
       root_pass: randomString(16),
@@ -258,7 +261,7 @@ describe('rebuild linode', () => {
       deployments_active: 0,
       deployments_total: 0,
       description: randomString(),
-      images: ['linode/alpine3.18'],
+      images: ['linode/alpine3.20'],
       is_public: false,
       label: randomLabel(),
       logo_url: '',


### PR DESCRIPTION
## Description 📝

This is a quick fix for the Linode rebuild tests, which are currently failing due to the Alpine 3.18 Image being deprecated. This fixes it by using 3.20 instead, but M3-9872 will properly address this by fetching the latest Image label/ID dynamically.

## Changes  🔄

- Use Alpine 3.20 instead of Alpine 3.18 in Linode rebuild test

## Target release date 🗓️

N/A

## How to test 🧪

- Confirm that rebuild tests pass in CI
  - **Note:** the Linode rebuild tests are flaky outside of this issue, so it's not unlikely that these tests may still fail. If so, the important point is that they don't fail because they're trying to select Alpine 3.18 from the Image dropdown.
  - See also M3-9872 which aims to improve the stability of the tests in `linode-rebuild.spec.ts`
 
<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
