### PR TITLE
upcoming: [M3-9884] - Show Linode Interface firewalls in Linode's entity details

### DIFF
--- a/packages/manager/src/features/Linodes/LinodeEntityDetail.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetail.test.tsx
@@ -241,9 +241,8 @@ describe('Linode Entity Detail', () => {
     });
   });
 
-  it('should display the interface type for a Linode with Linode interfaces and does not display firewall link', async () => {
+  it('should display the interface type for a Linode with Linode interfaces', async () => {
     const mockLinode = linodeFactory.build({ interface_generation: 'linode' });
-    const mockFirewall = firewallFactory.build({ label: 'test-firewall' });
     const account = accountFactory.build({
       capabilities: ['Linode Interfaces'],
     });
@@ -254,9 +253,6 @@ describe('Linode Entity Detail', () => {
       }),
       http.get('*/linode/instances/:linodeId', () => {
         return HttpResponse.json(mockLinode);
-      }),
-      http.get('*/linode/instances/:linodeId/firewalls', () => {
-        return HttpResponse.json(makeResourcePage([mockFirewall]));
       })
     );
 

--- a/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
@@ -1,8 +1,4 @@
-import {
-  useLinodeFirewallsQuery,
-  useLinodeVolumesQuery,
-  useRegionsQuery,
-} from '@linode/queries';
+import { useLinodeVolumesQuery, useRegionsQuery } from '@linode/queries';
 import { Notice } from '@linode/ui';
 import { formatStorageUnits } from '@linode/utilities';
 import * as React from 'react';
@@ -70,13 +66,6 @@ export const LinodeEntityDetail = (props: Props) => {
       linodeId: linode.id,
     });
 
-  const { data: attachedFirewallData } = useLinodeFirewallsQuery(
-    linode.id,
-    !isLinodeInterface
-  );
-
-  const attachedFirewalls = attachedFirewallData?.data ?? [];
-
   const isLinodesGrantReadOnly = useIsResourceRestricted({
     grantLevel: 'read_only',
     grantType: 'linode',
@@ -129,7 +118,6 @@ export const LinodeEntityDetail = (props: Props) => {
         body={
           <LinodeEntityDetailBody
             encryptionStatus={linode.disk_encryption}
-            firewalls={attachedFirewalls}
             gbRAM={linode.specs.memory / 1024}
             gbStorage={linode.specs.disk / 1024}
             interfaceGeneration={linode.interface_generation}

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailRowConfigFirewall.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailRowConfigFirewall.tsx
@@ -4,12 +4,18 @@ import Grid from '@mui/material/Grid2';
 import * as React from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
-import { Link } from 'src/components/Link';
 import { useCanUpgradeInterfaces } from 'src/hooks/useCanUpgradeInterfaces';
 import { useIsLinodeInterfacesEnabled } from 'src/utilities/linodes';
 
-import { StyledLabelBox, StyledListItem } from './LinodeEntityDetail.styles';
-import { LKEClusterCell } from './LinodeEntityDetailRowInterfaceFirewall';
+import {
+  StyledBox,
+  StyledLabelBox,
+  StyledListItem,
+} from './LinodeEntityDetail.styles';
+import {
+  FirewallCell,
+  LKEClusterCell,
+} from './LinodeEntityDetailRowInterfaceFirewall';
 import { DEFAULT_UPGRADE_BUTTON_HELPER_TEXT } from './LinodesDetail/LinodeConfigs/LinodeConfigs';
 import { getUnableToUpgradeTooltipText } from './LinodesDetail/LinodeConfigs/UpgradeInterfaces/utils';
 
@@ -36,7 +42,10 @@ export const LinodeEntityDetailRowConfigFirewall = (props: Props) => {
 
   const { isLinodeInterfacesEnabled } = useIsLinodeInterfacesEnabled();
 
-  const { data: attachedFirewallData } = useLinodeFirewallsQuery(linodeId);
+  const { data: attachedFirewallData } = useLinodeFirewallsQuery(
+    linodeId,
+    interfaceGeneration !== 'linode'
+  );
   const attachedFirewalls = attachedFirewallData?.data ?? [];
   const attachedFirewall =
     attachedFirewalls.find((firewall) => firewall.status === 'enabled') ??
@@ -68,35 +77,37 @@ export const LinodeEntityDetailRowConfigFirewall = (props: Props) => {
         )} ${theme.spacingFunction(8)} ${theme.spacingFunction(16)}`,
         [theme.breakpoints.down('md')]: {
           paddingLeft: 2,
+          display: 'grid',
+          gridTemplateColumns: '50% 2fr',
+        },
+        [theme.breakpoints.down('sm')]: {
+          paddingLeft: 2,
+          display: 'flex',
         },
       }}
     >
-      {linodeLkeClusterId && (
-        <LKEClusterCell
-          cluster={cluster}
-          hideLKECellRightBorder={
-            !attachedFirewall && !isLinodeInterfacesEnabled
-          }
-          linodeLkeClusterId={linodeLkeClusterId}
-        />
-      )}
-      {attachedFirewall && (
-        <StyledListItem
-          sx={{
-            ...(!isLinodeInterfacesEnabled ? { borderRight: 'unset' } : {}),
-            ...(!linodeLkeClusterId ? { paddingLeft: 0 } : {}),
-          }}
-        >
-          <StyledLabelBox component="span">Firewall:</StyledLabelBox>{' '}
-          <Link
-            data-testid="assigned-firewall"
-            to={`/firewalls/${attachedFirewall.id}`}
-          >
-            {attachedFirewall.label ?? `${attachedFirewall.id}`}
-          </Link>
-          &nbsp;
-          {attachedFirewall && `(ID: ${attachedFirewall.id})`}
-        </StyledListItem>
+      {(linodeLkeClusterId || attachedFirewall) && (
+        <StyledBox>
+          {linodeLkeClusterId && (
+            <LKEClusterCell
+              cluster={cluster}
+              hideLKECellRightBorder={
+                !attachedFirewall && !isLinodeInterfacesEnabled
+              }
+              linodeLkeClusterId={linodeLkeClusterId ?? 1}
+            />
+          )}
+          {attachedFirewall && (
+            <FirewallCell
+              additionalSx={
+                !isLinodeInterfacesEnabled ? { borderRight: 'unset' } : {}
+              }
+              cellLabel="Firewall:"
+              firewall={attachedFirewall}
+              hidePaddingLeft={!linodeLkeClusterId}
+            />
+          )}
+        </StyledBox>
       )}
       {isLinodeInterfacesEnabled && (
         <StyledListItem

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailRowConfigFirewall.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailRowConfigFirewall.tsx
@@ -2,7 +2,7 @@ import { useLinodeFirewallsQuery } from '@linode/queries';
 import { Box, Chip, Tooltip, TooltipIcon, useTheme } from '@linode/ui';
 import Grid from '@mui/material/Grid2';
 import * as React from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 
 import { Link } from 'src/components/Link';
 import { useCanUpgradeInterfaces } from 'src/hooks/useCanUpgradeInterfaces';
@@ -29,6 +29,7 @@ export const LinodeEntityDetailRowConfigFirewall = (props: Props) => {
   const { cluster, linodeId, linodeLkeClusterId, interfaceGeneration, region } =
     props;
 
+  const location = useLocation();
   const history = useHistory();
   const theme = useTheme();
 

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailRowConfigFirewall.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailRowConfigFirewall.tsx
@@ -1,0 +1,161 @@
+import { useLinodeFirewallsQuery } from '@linode/queries';
+import { Box, Chip, Tooltip, TooltipIcon, useTheme } from '@linode/ui';
+import Grid from '@mui/material/Grid2';
+import * as React from 'react';
+import { useHistory } from 'react-router-dom';
+
+import { Link } from 'src/components/Link';
+import { useCanUpgradeInterfaces } from 'src/hooks/useCanUpgradeInterfaces';
+import { useIsLinodeInterfacesEnabled } from 'src/utilities/linodes';
+
+import { StyledLabelBox, StyledListItem } from './LinodeEntityDetail.styles';
+import { DEFAULT_UPGRADE_BUTTON_HELPER_TEXT } from './LinodesDetail/LinodeConfigs/LinodeConfigs';
+import { getUnableToUpgradeTooltipText } from './LinodesDetail/LinodeConfigs/UpgradeInterfaces/utils';
+
+import type {
+  InterfaceGenerationType,
+  KubernetesCluster,
+} from '@linode/api-v4';
+
+interface Props {
+  cluster: KubernetesCluster | undefined;
+  interfaceGeneration: InterfaceGenerationType | undefined;
+  linodeId: number;
+  linodeLkeClusterId: null | number;
+  region: string;
+}
+
+export const LinodeEntityDetailRowConfigFirewall = (props: Props) => {
+  const { cluster, linodeId, linodeLkeClusterId, interfaceGeneration, region } =
+    props;
+
+  const history = useHistory();
+  const theme = useTheme();
+
+  const { isLinodeInterfacesEnabled } = useIsLinodeInterfacesEnabled();
+
+  const { data: attachedFirewallData } = useLinodeFirewallsQuery(linodeId);
+  const attachedFirewalls = attachedFirewallData?.data ?? [];
+  const attachedFirewall =
+    attachedFirewalls.find((firewall) => firewall.status === 'enabled') ??
+    (attachedFirewalls.length > 0 ? attachedFirewalls[0] : undefined);
+
+  const { canUpgradeInterfaces, unableToUpgradeReasons } =
+    useCanUpgradeInterfaces(linodeLkeClusterId, region, interfaceGeneration);
+
+  const unableToUpgradeTooltipText = getUnableToUpgradeTooltipText(
+    unableToUpgradeReasons
+  );
+
+  const openUpgradeInterfacesDialog = () => {
+    history.replace(`${location.pathname}/upgrade-interfaces`);
+  };
+
+  if (!isLinodeInterfacesEnabled && !linodeLkeClusterId && !attachedFirewall) {
+    return null;
+  }
+
+  return (
+    <Grid
+      container
+      direction="row"
+      sx={{
+        borderTop: `1px solid ${theme.borderColors.borderTable}`,
+        padding: `${theme.spacingFunction(16)} ${theme.spacingFunction(
+          16
+        )} ${theme.spacingFunction(8)} ${theme.spacingFunction(16)}`,
+        [theme.breakpoints.down('md')]: {
+          paddingLeft: 2,
+        },
+      }}
+    >
+      {linodeLkeClusterId && (
+        <StyledListItem
+          sx={{
+            ...(!attachedFirewall && !isLinodeInterfacesEnabled
+              ? { borderRight: 'unset' }
+              : {}),
+            paddingLeft: 0,
+          }}
+        >
+          <StyledLabelBox component="span">LKE Cluster:</StyledLabelBox>{' '}
+          <Link
+            data-testid="assigned-lke-cluster-label"
+            to={`/kubernetes/clusters/${linodeLkeClusterId}`}
+          >
+            {cluster?.label ?? `${linodeLkeClusterId}`}
+          </Link>
+          &nbsp;
+          {cluster ? `(ID: ${linodeLkeClusterId})` : undefined}
+        </StyledListItem>
+      )}
+      {attachedFirewall && (
+        <StyledListItem
+          sx={{
+            ...(!isLinodeInterfacesEnabled ? { borderRight: 'unset' } : {}),
+            ...(!linodeLkeClusterId ? { paddingLeft: 0 } : {}),
+          }}
+        >
+          <StyledLabelBox component="span">Firewall:</StyledLabelBox>{' '}
+          <Link
+            data-testid="assigned-firewall"
+            to={`/firewalls/${attachedFirewall.id}`}
+          >
+            {attachedFirewall.label ?? `${attachedFirewall.id}`}
+          </Link>
+          &nbsp;
+          {attachedFirewall && `(ID: ${attachedFirewall.id})`}
+        </StyledListItem>
+      )}
+      {isLinodeInterfacesEnabled && (
+        <StyledListItem
+          sx={{
+            ...(!linodeLkeClusterId && !attachedFirewall
+              ? { paddingLeft: 0 }
+              : {}),
+            borderRight: 'unset',
+          }}
+        >
+          <StyledLabelBox component="span">Interfaces:</StyledLabelBox>{' '}
+          <Box component="span" sx={{ alignItems: 'center', display: 'flex' }}>
+            Configuration Profile
+            <span>
+              <Tooltip
+                slotProps={{
+                  tooltip: {
+                    sx: {
+                      maxWidth: '260px',
+                    },
+                  },
+                }}
+                sx={{ width: '500px' }}
+                title={DEFAULT_UPGRADE_BUTTON_HELPER_TEXT}
+              >
+                <Chip
+                  aria-label="Upgrade Configuration Profile Interfaces to Linode Interfaces"
+                  component="span"
+                  disabled={!canUpgradeInterfaces}
+                  label="UPGRADE"
+                  onClick={openUpgradeInterfacesDialog}
+                  size="small"
+                  sx={(theme) => ({
+                    backgroundColor: theme.color.tagButtonBg,
+                    color: theme.tokens.color.Neutrals[80],
+                    marginLeft: theme.spacingFunction(12),
+                  })}
+                />
+              </Tooltip>
+              {!canUpgradeInterfaces && unableToUpgradeTooltipText && (
+                <TooltipIcon
+                  status="help"
+                  sxTooltipIcon={{ padding: 0 }}
+                  text={unableToUpgradeTooltipText}
+                />
+              )}
+            </span>
+          </Box>
+        </StyledListItem>
+      )}
+    </Grid>
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailRowConfigFirewall.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailRowConfigFirewall.tsx
@@ -9,6 +9,7 @@ import { useCanUpgradeInterfaces } from 'src/hooks/useCanUpgradeInterfaces';
 import { useIsLinodeInterfacesEnabled } from 'src/utilities/linodes';
 
 import { StyledLabelBox, StyledListItem } from './LinodeEntityDetail.styles';
+import { LKEClusterCell } from './LinodeEntityDetailRowInterfaceFirewall';
 import { DEFAULT_UPGRADE_BUTTON_HELPER_TEXT } from './LinodesDetail/LinodeConfigs/LinodeConfigs';
 import { getUnableToUpgradeTooltipText } from './LinodesDetail/LinodeConfigs/UpgradeInterfaces/utils';
 
@@ -71,24 +72,13 @@ export const LinodeEntityDetailRowConfigFirewall = (props: Props) => {
       }}
     >
       {linodeLkeClusterId && (
-        <StyledListItem
-          sx={{
-            ...(!attachedFirewall && !isLinodeInterfacesEnabled
-              ? { borderRight: 'unset' }
-              : {}),
-            paddingLeft: 0,
-          }}
-        >
-          <StyledLabelBox component="span">LKE Cluster:</StyledLabelBox>{' '}
-          <Link
-            data-testid="assigned-lke-cluster-label"
-            to={`/kubernetes/clusters/${linodeLkeClusterId}`}
-          >
-            {cluster?.label ?? `${linodeLkeClusterId}`}
-          </Link>
-          &nbsp;
-          {cluster ? `(ID: ${linodeLkeClusterId})` : undefined}
-        </StyledListItem>
+        <LKEClusterCell
+          cluster={cluster}
+          hideLKECellRightBorder={
+            !attachedFirewall && !isLinodeInterfacesEnabled
+          }
+          linodeLkeClusterId={linodeLkeClusterId}
+        />
       )}
       {attachedFirewall && (
         <StyledListItem

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailRowInterfaceFirewall.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailRowInterfaceFirewall.tsx
@@ -22,7 +22,7 @@ interface Props {
   linodeLkeClusterId: null | number;
 }
 
-export const LinodeEntityDetailRowConfigFirewall = (props: Props) => {
+export const LinodeEntityDetailRowInterfaceFirewall = (props: Props) => {
   const { cluster, linodeId, linodeLkeClusterId } = props;
 
   const theme = useTheme();

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailRowInterfaceFirewall.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailRowInterfaceFirewall.tsx
@@ -1,0 +1,128 @@
+import { useLinodeInterfacesQuery } from '@linode/queries';
+import { useTheme } from '@linode/ui';
+import Grid from '@mui/material/Grid2';
+import * as React from 'react';
+
+import { Link } from 'src/components/Link';
+import { useIsLinodeInterfacesEnabled } from 'src/utilities/linodes';
+
+import { StyledLabelBox, StyledListItem } from './LinodeEntityDetail.styles';
+
+import type { KubernetesCluster } from '@linode/api-v4';
+
+interface Props {
+  cluster: KubernetesCluster | undefined;
+  linodeId: number;
+  linodeLkeClusterId: null | number;
+}
+
+export const LinodeEntityDetailRowConfigFirewall = (props: Props) => {
+  const { cluster, linodeId, linodeLkeClusterId } = props;
+
+  const theme = useTheme();
+
+  const { isLinodeInterfacesEnabled } = useIsLinodeInterfacesEnabled();
+
+  const { data: linodeInterfaces } = useLinodeInterfacesQuery(linodeId);
+
+  const nonVlanInterfaces =
+    linodeInterfaces?.interfaces.filter((iface) => !iface.vlan) ?? [];
+
+  const attachedFirewall = {
+    label: 'will delete soon',
+    id: 1,
+  };
+
+  if (!isLinodeInterfacesEnabled && !linodeLkeClusterId && !attachedFirewall) {
+    return null;
+  }
+
+  return (
+    <Grid
+      container
+      direction="row"
+      sx={{
+        borderTop: `1px solid ${theme.borderColors.borderTable}`,
+        padding: `${theme.spacingFunction(16)} ${theme.spacingFunction(
+          16
+        )} ${theme.spacingFunction(8)} ${theme.spacingFunction(16)}`,
+        [theme.breakpoints.down('md')]: {
+          paddingLeft: 2,
+        },
+      }}
+    >
+      {linodeLkeClusterId && (
+        <StyledListItem
+          sx={{
+            ...(!attachedFirewall && !isLinodeInterfacesEnabled
+              ? { borderRight: 'unset' }
+              : {}),
+            paddingLeft: 0,
+          }}
+        >
+          <StyledLabelBox component="span">LKE Cluster:</StyledLabelBox>{' '}
+          <Link
+            data-testid="assigned-lke-cluster-label"
+            to={`/kubernetes/clusters/${linodeLkeClusterId}`}
+          >
+            {cluster?.label ?? `${linodeLkeClusterId}`}
+          </Link>
+          &nbsp;
+          {cluster ? `(ID: ${linodeLkeClusterId})` : undefined}
+        </StyledListItem>
+      )}
+      {attachedFirewall && (
+        <>
+          <StyledListItem
+            sx={{
+              ...(!isLinodeInterfacesEnabled ? { borderRight: 'unset' } : {}),
+              ...(!linodeLkeClusterId ? { paddingLeft: 0 } : {}),
+            }}
+          >
+            <StyledLabelBox component="span">
+              Public Interface Firewall:
+            </StyledLabelBox>{' '}
+            <Link
+              data-testid="assigned-firewall"
+              to={`/firewalls/${attachedFirewall.id}`}
+            >
+              {attachedFirewall.label ?? `${attachedFirewall.id}`}
+            </Link>
+            &nbsp;
+            {attachedFirewall && `(ID: ${attachedFirewall.id})`}
+          </StyledListItem>
+          <StyledListItem
+            sx={{
+              ...(!isLinodeInterfacesEnabled ? { borderRight: 'unset' } : {}),
+              ...(!linodeLkeClusterId ? { paddingLeft: 0 } : {}),
+            }}
+          >
+            <StyledLabelBox component="span">
+              VPC Interface Firewall:
+            </StyledLabelBox>{' '}
+            <Link
+              data-testid="assigned-firewall"
+              to={`/firewalls/${attachedFirewall.id}`}
+            >
+              {attachedFirewall.label ?? `${attachedFirewall.id}`}
+            </Link>
+            &nbsp;
+            {attachedFirewall && `(ID: ${attachedFirewall.id})`}
+          </StyledListItem>
+        </>
+      )}
+      {isLinodeInterfacesEnabled && (
+        <StyledListItem
+          sx={{
+            ...(!linodeLkeClusterId && !attachedFirewall
+              ? { paddingLeft: 0 }
+              : {}),
+            borderRight: 'unset',
+          }}
+        >
+          <StyledLabelBox component="span">Interfaces:</StyledLabelBox> Linode
+        </StyledListItem>
+      )}
+    </Grid>
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailRowInterfaceFirewall.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailRowInterfaceFirewall.tsx
@@ -158,3 +158,32 @@ export const LinodeEntityDetailRowInterfaceFirewall = (props: Props) => {
     </Grid>
   );
 };
+
+export const LKEClusterCell = ({
+  hideLKECellRightBorder,
+  cluster,
+  linodeLkeClusterId,
+}: {
+  cluster: KubernetesCluster | undefined;
+  hideLKECellRightBorder: boolean;
+  linodeLkeClusterId: number;
+}) => {
+  return (
+    <StyledListItem
+      sx={{
+        ...(hideLKECellRightBorder ? { borderRight: 'unset' } : {}),
+        paddingLeft: 0,
+      }}
+    >
+      <StyledLabelBox component="span">LKE Cluster:</StyledLabelBox>{' '}
+      <Link
+        data-testid="assigned-lke-cluster-label"
+        to={`/kubernetes/clusters/${linodeLkeClusterId}`}
+      >
+        {cluster?.label ?? `${linodeLkeClusterId}`}
+      </Link>
+      &nbsp;
+      {cluster ? `(ID: ${linodeLkeClusterId})` : undefined}
+    </StyledListItem>
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailRowInterfaceFirewall.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailRowInterfaceFirewall.tsx
@@ -8,7 +8,6 @@ import Grid from '@mui/material/Grid2';
 import * as React from 'react';
 
 import { Link } from 'src/components/Link';
-import { useIsLinodeInterfacesEnabled } from 'src/utilities/linodes';
 
 import { StyledLabelBox, StyledListItem } from './LinodeEntityDetail.styles';
 import { getLinodeInterfaceType } from './LinodesDetail/LinodeNetworking/LinodeInterfaces/utilities';
@@ -26,8 +25,6 @@ export const LinodeEntityDetailRowInterfaceFirewall = (props: Props) => {
   const { cluster, linodeId, linodeLkeClusterId } = props;
 
   const theme = useTheme();
-
-  const { isLinodeInterfacesEnabled } = useIsLinodeInterfacesEnabled();
 
   const { data: linodeInterfaces } = useLinodeInterfacesQuery(linodeId);
 
@@ -64,7 +61,6 @@ export const LinodeEntityDetailRowInterfaceFirewall = (props: Props) => {
   const vpcInterfaceFirewall = interfaceFirewalls.VPC;
 
   if (
-    !isLinodeInterfacesEnabled &&
     !linodeLkeClusterId &&
     !publicInterfaceFirewall &&
     !vpcInterfaceFirewall
@@ -73,9 +69,7 @@ export const LinodeEntityDetailRowInterfaceFirewall = (props: Props) => {
   }
 
   const hideLKECellRightBorder =
-    !publicInterfaceFirewall &&
-    !vpcInterfaceFirewall &&
-    !isLinodeInterfacesEnabled;
+    !publicInterfaceFirewall && !vpcInterfaceFirewall;
 
   return (
     <Grid
@@ -149,20 +143,18 @@ export const LinodeEntityDetailRowInterfaceFirewall = (props: Props) => {
           {vpcInterfaceFirewall && `(ID: ${vpcInterfaceFirewall.id})`}
         </StyledListItem>
       )}
-      {isLinodeInterfacesEnabled && (
-        <StyledListItem
-          sx={{
-            ...(!linodeLkeClusterId &&
-            !vpcInterfaceFirewall &&
-            !publicInterfaceFirewall
-              ? { paddingLeft: 0 }
-              : {}),
-            borderRight: 'unset',
-          }}
-        >
-          <StyledLabelBox component="span">Interfaces:</StyledLabelBox> Linode
-        </StyledListItem>
-      )}
+      <StyledListItem
+        sx={{
+          ...(!linodeLkeClusterId &&
+          !vpcInterfaceFirewall &&
+          !publicInterfaceFirewall
+            ? { paddingLeft: 0 }
+            : {}),
+          borderRight: 'unset',
+        }}
+      >
+        <StyledLabelBox component="span">Interfaces:</StyledLabelBox> Linode
+      </StyledListItem>
     </Grid>
   );
 };


### PR DESCRIPTION
## Description 📝
- shows Linode Interface firewalls in Linode Entity details (public and vpc firewalls if they exist)

❓ a bit worried about the extra queries these changes require when using Linode interfaces (especially for the landing page Detail View). lmk if there's ways to optimize this!

## Changes  🔄
- Move the LKE/Firewall/Interface row into separate components for query/mounting issues
- Add support to show Linode Interface firewalls 

## Target release date 🗓️
5/20

## Preview 📷

![image](https://github.com/user-attachments/assets/4b0c47c7-a58a-4243-a9c7-e9bfebcafe03)
![image](https://github.com/user-attachments/assets/4c38d284-48de-42ed-b027-c828c770f975)

## How to test 🧪

### Prerequisites
- have customer tag
- feature flag on 

### Verification steps
- Confirm entity detail still looks as expected for Linodes using old interfaces
- Confirm if Linode using new interfaces has firewalls for their (non-VLAN) interfaces, the firewalls appear in the entity details 
- Confirm if feature flag off - for Linodes using old interfaces, the upgrade chip is still hidden & for new interfaces, public/vpc firewall info and interface type is hidden

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
