### PR TITLE
hotfix: [M3-9944] - State issue with Object Storage access key drawer

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2025-05-08] - v1.141.1
+## [2025-05-09] - v1.141.1
 
 ### fixed:
 

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [2025-05-09] - v1.141.1
 
-### fixed:
+### Fixed:
 
 - State issue with Object Storage access key drawer
 

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2025-05-08] - v1.141.1
+
+### fixed:
+
+- State issue with Object Storage access key drawer
+
 ## [2025-05-06] - v1.141.0
 
 ### Added:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.141.0",
+  "version": "1.141.1",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -104,6 +104,7 @@ export const ObjectStorageLanding = () => {
   const createButtonAction = () => {
     if (isAccessKeysTab) {
       navigate({ to: '/object-storage/access-keys/create' });
+      handleOpenAccessDrawer('creating');
     } else {
       navigate({ to: '/object-storage/buckets/create' });
     }


### PR DESCRIPTION
## Description 📝
Fixes a small bug with the Object Storage access key drawer resulting from the routing refactor 

## Changes  🔄
- fix Object Storage access key drawer state

## Target release date 🗓️
⚠️ 5/9/2025

## How to test 🧪

### Reproduction steps
- Navigate to /object-storage/access-keys
  - Click "Create Access Key" and close drawer
  - Click "Edit" in the action menu for any existing access key
  - Click "Create Access Key" > Notice edit drawer reopens

### Verification steps
- Navigate to /object-storage/access-keys
  - Click "Create Access Key" and close drawer
  - Click "Edit" in the action menu for any existing access key
  - Click "Create Access Key" > Confirm right drawer opens

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
