### PR TITLE
test: [M3-9178] - Update/Add integration tests for Create Linode

### DIFF
--- a/packages/manager/.changeset/pr-12187-tests-1746812945790.md
+++ b/packages/manager/.changeset/pr-12187-tests-1746812945790.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Update/Add integration tests for Create Linode ([#12187](https://github.com/linode/manager/pull/12187))

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-firewall.spec.ts
@@ -1,4 +1,5 @@
 import { linodeFactory } from '@linode/utilities';
+import { linodeInterfacesLabelText } from 'support/constants/linode-interfaces';
 import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
 import {
   mockCreateFirewall,
@@ -13,12 +14,13 @@ import {
 } from 'support/intercepts/linodes';
 import { ui } from 'support/ui';
 import { linodeCreatePage } from 'support/ui/pages';
+import { checkLinodeInterfacesElements } from 'support/util/linodes';
 import { randomLabel, randomNumber, randomString } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
 
 import { firewallFactory, firewallTemplateFactory } from 'src/factories';
 
-describe('Create Linode with Firewall', () => {
+describe('Create Linode with Firewall (Legacy)', () => {
   beforeEach(() => {
     mockAppendFeatureFlags({
       linodeInterfaces: { enabled: false },
@@ -54,6 +56,9 @@ describe('Create Linode with Firewall', () => {
     linodeCreatePage.selectRegionById(linodeRegion.id);
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));
+
+    // Confirm the Linode Interfaces section is not present.
+    checkLinodeInterfacesElements(false);
 
     // Confirm that mocked Firewall is shown in the Autocomplete, and then select it.
     cy.findByText('Assign Firewall').click();
@@ -120,6 +125,9 @@ describe('Create Linode with Firewall', () => {
     linodeCreatePage.selectRegionById(linodeRegion.id);
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));
+
+    // Confirm the Linode Interfaces section is not present.
+    checkLinodeInterfacesElements(false);
 
     cy.findByText('Create Firewall').should('be.visible').click();
 
@@ -217,6 +225,9 @@ describe('Create Linode with Firewall', () => {
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));
 
+    // Confirm the Linode Interfaces section is not present.
+    checkLinodeInterfacesElements(false);
+
     // Creating the linode without a firewall should display a warning.
     ui.button
       .findByTitle('Create Linode')
@@ -272,6 +283,625 @@ describe('Create Linode with Firewall', () => {
     cy.wait('@createLinode').then((xhr) => {
       const requestPayload = xhr.request.body;
       const firewallId = requestPayload['firewall_id'];
+      expect(firewallId).to.equal(mockFirewall.id);
+    });
+
+    // Confirm redirect to new Linode.
+    cy.url().should('endWith', `/linodes/${mockLinode.id}`);
+    // Confirm toast notification should appear on Linode create.
+    ui.toast.assertMessage(`Your Linode ${mockLinode.label} is being created.`);
+  });
+
+  /*
+   * - Mocks the internal header to enable the Generate Compliant Firewall banner.
+   * - Mocks an error response to the Create Firewall call.
+   */
+  it('displays errors encountered while trying to generate a compliant firewall', () => {
+    const mockFirewall = firewallFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+    });
+
+    const mockTemplate = firewallTemplateFactory.build({
+      slug: 'akamai-non-prod',
+    });
+
+    const mockError = 'Mock error';
+
+    mockApiInternalUser();
+    mockGetFirewalls([mockFirewall]).as('getFirewall');
+    mockGetFirewallTemplate(mockTemplate).as('getTemplate');
+    mockCreateFirewallError(mockError).as('createFirewall');
+
+    cy.visitWithLogin('/linodes/create');
+
+    // Confirm the Linode Interfaces section is not present.
+    checkLinodeInterfacesElements(false);
+
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled');
+
+    cy.findByText('Generate Compliant Firewall').should('be.visible').click();
+
+    ui.dialog
+      .findByTitle('Generate an Akamai Compliant Firewall')
+      .should('be.visible')
+      .within(() => {
+        cy.findByText('Generate Firewall Now')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+        cy.findByText('Generating Firewall');
+        cy.findByText(mockError);
+        cy.findByText('Retry').should('be.visible').should('be.enabled');
+        cy.findByText('Close').should('be.visible').should('be.enabled');
+      });
+    cy.wait('@createFirewall');
+  });
+});
+
+describe('Create Linode with Firewall (Linode Interfaces)', () => {
+  beforeEach(() => {
+    mockAppendFeatureFlags({
+      linodeInterfaces: { enabled: true },
+    });
+  });
+
+  /*
+   * Legacy Configuration Profile Interfaces
+   * - Confirms UI flow to create a Linode with an existing Firewall using mock API data.
+   * - Confirms that Firewall is reflected in create summary section.
+   * - Confirms that outgoing Linode Create API request specifies the selected Firewall to be attached.
+   */
+  it('can assign existing Firewall during Linode Create flow (legacy)', () => {
+    const linodeRegion = chooseRegion({ capabilities: ['Cloud Firewall'] });
+
+    const mockFirewall = firewallFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+    });
+
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+    });
+
+    mockGetFirewalls([mockFirewall]).as('getFirewall');
+    mockCreateLinode(mockLinode).as('createLinode');
+    mockGetLinodeDetails(mockLinode.id, mockLinode);
+
+    cy.visitWithLogin('/linodes/create');
+
+    linodeCreatePage.setLabel(mockLinode.label);
+    linodeCreatePage.selectImage('Debian 12');
+    linodeCreatePage.selectRegionById(linodeRegion.id);
+    linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
+    linodeCreatePage.setRootPassword(randomString(32));
+
+    // Confirm the Linode Interfaces section is shown.
+    checkLinodeInterfacesElements();
+
+    // Confirm that mocked Firewall is shown in the Autocomplete, and then select it.
+    cy.findByLabelText('Firewall').should('be.visible');
+    cy.get('[data-qa-autocomplete="Firewall"]').within(() => {
+      cy.get('[data-testid="textfield-input"]').click();
+      cy.focused().type(`${mockFirewall.label}`);
+    });
+
+    ui.autocompletePopper
+      .findByTitle(mockFirewall.label)
+      .should('be.visible')
+      .click();
+
+    // Confirm Firewall assignment indicator is shown in Linode summary.
+    cy.get('[data-qa-linode-create-summary]').scrollIntoView();
+    cy.get('[data-qa-linode-create-summary]').within(() => {
+      cy.findByText('Firewall Assigned').should('be.visible');
+    });
+
+    // Create Linode and confirm contents of outgoing API request payload.
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.wait('@createLinode').then((xhr) => {
+      const requestPayload = xhr.request.body;
+      const firewallId = requestPayload['firewall_id'];
+      expect(firewallId).to.equal(mockFirewall.id);
+    });
+
+    // Confirm redirect to new Linode.
+    cy.url().should('endWith', `/linodes/${mockLinode.id}`);
+    // Confirm toast notification should appear on Linode create.
+    ui.toast.assertMessage(`Your Linode ${mockLinode.label} is being created.`);
+  });
+
+  /*
+   * Linode Interfaces
+   * - Confirms UI flow to create a Linode with an existing Firewall using mock API data.
+   * - Confirms that Firewall is reflected in create summary section.
+   * - Confirms that outgoing Linode Create API request specifies the selected Firewall to be attached.
+   */
+  it('can assign existing Firewall during Linode Create flow (Linode Interfaces)', () => {
+    const linodeRegion = chooseRegion({ capabilities: ['Cloud Firewall'] });
+
+    const mockFirewall = firewallFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+    });
+
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+    });
+
+    mockGetFirewalls([mockFirewall]).as('getFirewall');
+    mockCreateLinode(mockLinode).as('createLinode');
+    mockGetLinodeDetails(mockLinode.id, mockLinode);
+
+    cy.visitWithLogin('/linodes/create');
+
+    linodeCreatePage.setLabel(mockLinode.label);
+    linodeCreatePage.selectImage('Debian 12');
+    linodeCreatePage.selectRegionById(linodeRegion.id);
+    linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
+    linodeCreatePage.setRootPassword(randomString(32));
+
+    // Confirm the Linode Interfaces section is shown.
+    checkLinodeInterfacesElements();
+
+    // Switch to Linode Interfaces
+    cy.findByText(linodeInterfacesLabelText).click();
+
+    // Confirm that mocked Firewall is shown in the Autocomplete, and then select it.
+    cy.findByLabelText('Public Interface Firewall').should('be.visible');
+    cy.get('[data-qa-autocomplete="Public Interface Firewall"]').within(() => {
+      cy.get('[data-testid="textfield-input"]').click();
+      cy.focused().type(`${mockFirewall.label}`);
+    });
+
+    ui.autocompletePopper
+      .findByTitle(mockFirewall.label)
+      .should('be.visible')
+      .click();
+
+    // Confirm Firewall assignment indicator is shown in Linode summary.
+    cy.get('[data-qa-linode-create-summary]').scrollIntoView();
+    cy.get('[data-qa-linode-create-summary]').within(() => {
+      // TODO: M3-9955 Missing info in Summary section
+      // cy.findByText('Firewall Assigned').should('be.visible');
+    });
+
+    // Create Linode and confirm contents of outgoing API request payload.
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.wait('@createLinode').then((xhr) => {
+      const requestPayload = xhr.request.body;
+      const firewallId = requestPayload['interfaces'][0]['firewall_id'];
+      expect(firewallId).to.equal(mockFirewall.id);
+    });
+
+    // Confirm redirect to new Linode.
+    cy.url().should('endWith', `/linodes/${mockLinode.id}`);
+    // Confirm toast notification should appear on Linode create.
+    ui.toast.assertMessage(`Your Linode ${mockLinode.label} is being created.`);
+  });
+
+  /*
+   * Legacy Configuration Profile Interfaces
+   * - Uses mock API data to confirm Firewall creation and attachment UI flow during Linode create.
+   * - Confirms that Firewall is reflected in create summary section.
+   * - Confirms that outgoing Linode Create API request specifies the selected Firewall to be attached.
+   */
+  it('can assign new Firewall during Linode Create flow (legacy)', () => {
+    const linodeRegion = chooseRegion({ capabilities: ['Cloud Firewall'] });
+
+    const mockFirewall = firewallFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+    });
+
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+    });
+
+    mockCreateFirewall(mockFirewall).as('createFirewall');
+    mockGetFirewalls([mockFirewall]).as('getFirewall');
+    mockCreateLinode(mockLinode).as('createLinode');
+    mockGetLinodeDetails(mockLinode.id, mockLinode);
+
+    cy.visitWithLogin('/linodes/create');
+
+    linodeCreatePage.setLabel(mockLinode.label);
+    linodeCreatePage.selectImage('Debian 12');
+    linodeCreatePage.selectRegionById(linodeRegion.id);
+    linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
+    linodeCreatePage.setRootPassword(randomString(32));
+
+    // Confirm the Linode Interfaces section is shown.
+    checkLinodeInterfacesElements();
+
+    cy.findByText('Create Firewall').should('be.visible').click();
+
+    ui.drawer
+      .findByTitle('Create Firewall')
+      .should('be.visible')
+      .within(() => {
+        // An error message appears when attempting to create a Firewall without a label
+        cy.get('[data-testid="submit"]').click();
+        cy.findByText('Label is required.');
+        // Fill out and submit firewall create form.
+        cy.contains('Label').click();
+        cy.focused().type(mockFirewall.label);
+        ui.buttonGroup
+          .findButtonByTitle('Create Firewall')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+    cy.wait('@getFirewall');
+    // Confirm toast notification should appear on Linode create.
+    ui.toast.assertMessage(
+      `Firewall ${mockFirewall.label} successfully created`
+    );
+
+    // Confirm that mocked Firewall is shown in the Autocomplete, and then select it.
+    cy.findByLabelText('Firewall').should('be.visible');
+    cy.get('[data-qa-autocomplete="Firewall"]').within(() => {
+      cy.get('[data-testid="textfield-input"]').click();
+      cy.focused().type(`${mockFirewall.label}`);
+    });
+
+    ui.autocompletePopper
+      .findByTitle(mockFirewall.label)
+      .should('be.visible')
+      .click();
+
+    // Confirm Firewall assignment indicator is shown in Linode summary.
+    cy.get('[data-qa-linode-create-summary]').scrollIntoView();
+    cy.get('[data-qa-linode-create-summary]').within(() => {
+      cy.findByText('Firewall Assigned').should('be.visible');
+    });
+
+    // Create Linode and confirm contents of outgoing API request payload.
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.wait('@createLinode').then((xhr) => {
+      const requestPayload = xhr.request.body;
+      const firewallId = requestPayload['firewall_id'];
+      expect(firewallId).to.equal(mockFirewall.id);
+    });
+
+    // Confirm redirect to new Linode.
+    cy.url().should('endWith', `/linodes/${mockLinode.id}`);
+    // Confirm toast notification should appear on Linode create.
+    ui.toast.assertMessage(`Your Linode ${mockLinode.label} is being created.`);
+  });
+
+  /*
+   * Linode Interfaces
+   * - Uses mock API data to confirm Firewall creation and attachment UI flow during Linode create.
+   * - Confirms that Firewall is reflected in create summary section.
+   * - Confirms that outgoing Linode Create API request specifies the selected Firewall to be attached.
+   */
+  it('can assign new Firewall during Linode Create flow (Linode Interfaces)', () => {
+    const linodeRegion = chooseRegion({ capabilities: ['Cloud Firewall'] });
+
+    const mockFirewall = firewallFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+    });
+
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+    });
+
+    mockCreateFirewall(mockFirewall).as('createFirewall');
+    mockGetFirewalls([mockFirewall]).as('getFirewall');
+    mockCreateLinode(mockLinode).as('createLinode');
+    mockGetLinodeDetails(mockLinode.id, mockLinode);
+
+    cy.visitWithLogin('/linodes/create');
+
+    linodeCreatePage.setLabel(mockLinode.label);
+    linodeCreatePage.selectImage('Debian 12');
+    linodeCreatePage.selectRegionById(linodeRegion.id);
+    linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
+    linodeCreatePage.setRootPassword(randomString(32));
+
+    // Confirm the Linode Interfaces section is shown.
+    checkLinodeInterfacesElements();
+
+    // Switch to Linode Interfaces
+    cy.findByText(linodeInterfacesLabelText).click();
+
+    cy.findByText('Create Firewall').should('be.visible').click();
+
+    ui.drawer
+      .findByTitle('Create Firewall')
+      .should('be.visible')
+      .within(() => {
+        // An error message appears when attempting to create a Firewall without a label
+        cy.get('[data-testid="submit"]').click();
+        cy.findByText('Label is required.');
+        // Fill out and submit firewall create form.
+        cy.contains('Label').click();
+        cy.focused().type(mockFirewall.label);
+        ui.buttonGroup
+          .findButtonByTitle('Create Firewall')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+    cy.wait('@getFirewall');
+    // Confirm toast notification should appear on Linode create.
+    ui.toast.assertMessage(
+      `Firewall ${mockFirewall.label} successfully created`
+    );
+
+    // Confirm that mocked Firewall is shown in the Autocomplete, and then select it.
+    cy.findByLabelText('Public Interface Firewall').should('be.visible');
+    cy.get('[data-qa-autocomplete="Public Interface Firewall"]').within(() => {
+      cy.get('[data-testid="textfield-input"]').click();
+      cy.focused().type(`${mockFirewall.label}`);
+    });
+
+    ui.autocompletePopper
+      .findByTitle(mockFirewall.label)
+      .should('be.visible')
+      .click();
+
+    // Confirm Firewall assignment indicator is shown in Linode summary.
+    cy.get('[data-qa-linode-create-summary]').scrollIntoView();
+    cy.get('[data-qa-linode-create-summary]').within(() => {
+      // TODO: M3-9955 Missing info in Summary section
+      // cy.findByText('Firewall Assigned').should('be.visible');
+    });
+
+    // Create Linode and confirm contents of outgoing API request payload.
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.wait('@createLinode').then((xhr) => {
+      const requestPayload = xhr.request.body;
+      const firewallId = requestPayload['interfaces'][0]['firewall_id'];
+      expect(firewallId).to.equal(mockFirewall.id);
+    });
+
+    // Confirm redirect to new Linode.
+    cy.url().should('endWith', `/linodes/${mockLinode.id}`);
+    // Confirm toast notification should appear on Linode create.
+    ui.toast.assertMessage(`Your Linode ${mockLinode.label} is being created.`);
+  });
+
+  /*
+   * Legacy Configuration Profile Interfaces
+   * - Mocks the internal header to enable the Generate Compliant Firewall banner.
+   * - Confirms that Firewall is reflected in create summary section.
+   * - Confirms that outgoing Linode Create API request specifies the selected Firewall to be attached.
+   */
+  it('can generate and assign a compliant Firewall during Linode Create flow (legacy)', () => {
+    const linodeRegion = chooseRegion({ capabilities: ['Cloud Firewall'] });
+
+    const mockFirewall = firewallFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+    });
+
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+    });
+
+    const mockTemplate = firewallTemplateFactory.build({
+      slug: 'akamai-non-prod',
+    });
+
+    mockApiInternalUser();
+    mockCreateFirewall(mockFirewall).as('createFirewall');
+    mockGetFirewalls([mockFirewall]).as('getFirewall');
+    mockGetFirewallTemplate(mockTemplate).as('getTemplate');
+    mockCreateLinode(mockLinode).as('createLinode');
+    mockGetLinodeDetails(mockLinode.id, mockLinode);
+
+    cy.visitWithLogin('/linodes/create');
+
+    linodeCreatePage.setLabel(mockLinode.label);
+    linodeCreatePage.selectImage('Debian 12');
+    linodeCreatePage.selectRegionById(linodeRegion.id);
+    linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
+    linodeCreatePage.setRootPassword(randomString(32));
+
+    // Confirm the Linode Interfaces section is shown.
+    checkLinodeInterfacesElements();
+
+    // Creating the linode without a firewall should display a warning.
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.disabled');
+
+    cy.findByLabelText(
+      'I am authorized to create a Linode without a Cloud Firewall'
+    ).click();
+
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled');
+
+    cy.findByText('Generate Compliant Firewall').should('be.visible').click();
+
+    ui.dialog
+      .findByTitle('Generate an Akamai Compliant Firewall')
+      .should('be.visible')
+      .within(() => {
+        cy.findByText('Generate Firewall Now')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+        cy.findByText('Generating Firewall');
+        cy.findByText('Complete!');
+        cy.findByText('OK').should('be.visible').should('be.enabled').click();
+      });
+    cy.wait('@createFirewall');
+
+    cy.findByText(mockFirewall.label).should('be.visible');
+
+    // Confirm Firewall assignment indicator is shown in Linode summary.
+    cy.get('[data-qa-linode-create-summary]').scrollIntoView();
+    cy.get('[data-qa-linode-create-summary]').within(() => {
+      cy.findByText('Firewall Assigned').should('be.visible');
+    });
+
+    // Create Linode and confirm contents of outgoing API request payload.
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.wait('@createLinode').then((xhr) => {
+      const requestPayload = xhr.request.body;
+      const firewallId = requestPayload['firewall_id'];
+      expect(firewallId).to.equal(mockFirewall.id);
+    });
+
+    // Confirm redirect to new Linode.
+    cy.url().should('endWith', `/linodes/${mockLinode.id}`);
+    // Confirm toast notification should appear on Linode create.
+    ui.toast.assertMessage(`Your Linode ${mockLinode.label} is being created.`);
+  });
+
+  /*
+   * Linode Interfaces
+   * - Mocks the internal header to enable the Generate Compliant Firewall banner.
+   * - Confirms that Firewall is reflected in create summary section.
+   * - Confirms that outgoing Linode Create API request specifies the selected Firewall to be attached.
+   */
+  it('can generate and assign a compliant Firewall during Linode Create flow (Linode Interfaces)', () => {
+    const linodeRegion = chooseRegion({ capabilities: ['Cloud Firewall'] });
+
+    const mockFirewall = firewallFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+    });
+
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+    });
+
+    const mockTemplate = firewallTemplateFactory.build({
+      slug: 'akamai-non-prod',
+    });
+
+    mockApiInternalUser();
+    mockCreateFirewall(mockFirewall).as('createFirewall');
+    mockGetFirewalls([mockFirewall]).as('getFirewall');
+    mockGetFirewallTemplate(mockTemplate).as('getTemplate');
+    mockCreateLinode(mockLinode).as('createLinode');
+    mockGetLinodeDetails(mockLinode.id, mockLinode);
+
+    cy.visitWithLogin('/linodes/create');
+
+    linodeCreatePage.setLabel(mockLinode.label);
+    linodeCreatePage.selectImage('Debian 12');
+    linodeCreatePage.selectRegionById(linodeRegion.id);
+    linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
+    linodeCreatePage.setRootPassword(randomString(32));
+
+    // Confirm the Linode Interfaces section is shown.
+    checkLinodeInterfacesElements();
+
+    // Switch to Linode Interfaces
+    cy.findByText(linodeInterfacesLabelText).click();
+
+    // Creating the linode without a firewall should display a warning.
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.disabled');
+
+    cy.findByLabelText(
+      'I am authorized to create a Linode without a Cloud Firewall'
+    ).click();
+
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled');
+
+    cy.findByText('Generate Compliant Firewall').should('be.visible').click();
+
+    ui.dialog
+      .findByTitle('Generate an Akamai Compliant Firewall')
+      .should('be.visible')
+      .within(() => {
+        cy.findByText('Generate Firewall Now')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+        cy.findByText('Generating Firewall');
+        cy.findByText('Complete!');
+        cy.findByText('OK').should('be.visible').should('be.enabled').click();
+      });
+    cy.wait('@createFirewall');
+
+    cy.findByText(mockFirewall.label).should('be.visible');
+
+    // Confirm Firewall assignment indicator is shown in Linode summary.
+    cy.get('[data-qa-linode-create-summary]').scrollIntoView();
+    cy.get('[data-qa-linode-create-summary]').within(() => {
+      // TODO: M3-9955 Missing info in Summary section
+      // cy.findByText('Firewall Assigned').should('be.visible');
+    });
+
+    // Create Linode and confirm contents of outgoing API request payload.
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.wait('@createLinode').then((xhr) => {
+      const requestPayload = xhr.request.body;
+      const firewallId = requestPayload['interfaces'][0]['firewall_id'];
       expect(firewallId).to.equal(mockFirewall.id);
     });
 

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-vlan.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-vlan.spec.ts
@@ -1,10 +1,12 @@
 import { linodeFactory, regionFactory } from '@linode/utilities';
+import { linodeInterfacesLabelText } from 'support/constants/linode-interfaces';
 import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
 import { mockCreateLinode } from 'support/intercepts/linodes';
 import { mockGetRegions } from 'support/intercepts/regions';
 import { mockGetVLANs } from 'support/intercepts/vlans';
 import { ui } from 'support/ui';
 import { linodeCreatePage } from 'support/ui/pages';
+import { checkLinodeInterfacesElements } from 'support/util/linodes';
 import {
   randomIp,
   randomLabel,
@@ -15,7 +17,7 @@ import { chooseRegion } from 'support/util/regions';
 
 import { VLANFactory } from 'src/factories';
 
-describe('Create Linode with VLANs', () => {
+describe('Create Linode with VLANs (Legacy)', () => {
   beforeEach(() => {
     mockAppendFeatureFlags({
       linodeInterfaces: { enabled: false },
@@ -55,6 +57,9 @@ describe('Create Linode with VLANs', () => {
     linodeCreatePage.setLabel(mockLinode.label);
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));
+
+    // Confirm the Linode Interfaces section is not present.
+    checkLinodeInterfacesElements(false);
 
     // Open VLAN accordion and select existing VLAN.
     ui.accordionHeading.findByTitle('VLAN').click();
@@ -143,6 +148,9 @@ describe('Create Linode with VLANs', () => {
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));
 
+    // Confirm the Linode Interfaces section is not present.
+    checkLinodeInterfacesElements(false);
+
     // Open VLAN accordion and specify new VLAN.
     ui.accordionHeading.findByTitle('VLAN').click();
     ui.accordion
@@ -176,6 +184,8 @@ describe('Create Linode with VLANs', () => {
       const expectedPublicInterface = requestPayload['interfaces'][0];
       const expectedVlanInterface = requestPayload['interfaces'][1];
 
+      console.log(`requestPayload: ${requestPayload}`);
+
       // Confirm that first interface is for public internet.
       expect(expectedPublicInterface['purpose']).to.equal('public');
 
@@ -208,6 +218,9 @@ describe('Create Linode with VLANs', () => {
 
     linodeCreatePage.selectRegionById(nonVlanRegion.id);
 
+    // Confirm the Linode Interfaces section is not present.
+    checkLinodeInterfacesElements(false);
+
     // Expand VLAN accordion, confirm VLAN availability notice is displayed and
     // that VLAN fields are disabled while no region is selected.
     ui.accordionHeading.findByTitle('VLAN').click();
@@ -233,5 +246,395 @@ describe('Create Linode with VLANs', () => {
         cy.findByLabelText('VLAN').should('be.disabled');
         cy.findByLabelText(/IPAM Address/).should('be.disabled');
       });
+  });
+});
+
+describe('Create Linode with VLANs (Linode Interfaces)', () => {
+  beforeEach(() => {
+    mockAppendFeatureFlags({
+      linodeInterfaces: { enabled: true },
+    });
+  });
+
+  /*
+   * Legacy Configuration Profile Interfaces
+   * - Uses mock API data to confirm VLAN attachment UI flow during Linode create.
+   * - Confirms that outgoing Linode create API request contains expected data for VLAN.
+   * - Confirms that attached VLAN is reflected in the Linode create summary.
+   */
+  it('can assign existing VLANs during Linode create flow (legacy)', () => {
+    const mockLinodeRegion = chooseRegion({
+      capabilities: ['Linodes', 'Vlans'],
+    });
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: mockLinodeRegion.id,
+    });
+
+    const mockVlan = VLANFactory.build({
+      cidr_block: `${randomIp()}/24`,
+      id: randomNumber(),
+      label: randomLabel(),
+      linodes: [],
+      region: mockLinodeRegion.id,
+    });
+
+    mockGetVLANs([mockVlan]);
+    mockCreateLinode(mockLinode).as('createLinode');
+    cy.visitWithLogin('/linodes/create');
+
+    // Fill out necessary Linode create fields.
+    linodeCreatePage.selectRegionById(mockLinodeRegion.id);
+    linodeCreatePage.selectImage('Debian 12');
+    linodeCreatePage.setLabel(mockLinode.label);
+    linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
+    linodeCreatePage.setRootPassword(randomString(32));
+
+    // Confirm the Linode Interfaces section is shown.
+    checkLinodeInterfacesElements();
+
+    // Open VLAN accordion and select existing VLAN.
+    cy.get('[data-qa-select-card-heading="VLAN"]').should('be.visible').click();
+    cy.findByLabelText('VLAN').should('be.enabled').type(mockVlan.label);
+    ui.autocompletePopper
+      .findByTitle(mockVlan.label)
+      .should('be.visible')
+      .click();
+    cy.findByLabelText(/IPAM Address/)
+      .should('be.enabled')
+      .type(mockVlan.cidr_block);
+
+    // Confirm that VLAN attachment is listed in summary, then create Linode.
+    cy.get('[data-qa-linode-create-summary]').scrollIntoView();
+    cy.get('[data-qa-linode-create-summary]').within(() => {
+      // TODO: M3-9955 Missing info in Summary section
+      // cy.findByText('VLAN Attached').should('be.visible');
+    });
+
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    // Confirm outgoing API request payload has expected data.
+    cy.wait('@createLinode').then((xhr) => {
+      const requestPayload = xhr.request.body;
+      const expectedVlanInterface = requestPayload['interfaces'][0];
+
+      // Confirm that second interface is our chosen VLAN.
+      expect(expectedVlanInterface['purpose']).to.equal('vlan');
+      expect(expectedVlanInterface['label']).to.equal(mockVlan.label);
+      expect(expectedVlanInterface['ipam_address']).to.equal(
+        mockVlan.cidr_block
+      );
+    });
+
+    cy.url().should('endWith', `/linodes/${mockLinode.id}`);
+    // Confirm toast notification should appear on Linode create.
+    ui.toast.assertMessage(`Your Linode ${mockLinode.label} is being created.`);
+  });
+
+  /*
+   * Linode Interfaces
+   * - Uses mock API data to confirm VLAN attachment UI flow during Linode create.
+   * - Confirms that outgoing Linode create API request contains expected data for VLAN.
+   * - Confirms that attached VLAN is reflected in the Linode create summary.
+   */
+  it('can assign existing VLANs during Linode create flow (Linode Interfaces)', () => {
+    const mockLinodeRegion = chooseRegion({
+      capabilities: ['Linodes', 'Vlans'],
+    });
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: mockLinodeRegion.id,
+    });
+
+    const mockVlan = VLANFactory.build({
+      cidr_block: `${randomIp()}/24`,
+      id: randomNumber(),
+      label: randomLabel(),
+      linodes: [],
+      region: mockLinodeRegion.id,
+    });
+
+    mockGetVLANs([mockVlan]);
+    mockCreateLinode(mockLinode).as('createLinode');
+    cy.visitWithLogin('/linodes/create');
+
+    // Fill out necessary Linode create fields.
+    linodeCreatePage.selectRegionById(mockLinodeRegion.id);
+    linodeCreatePage.selectImage('Debian 12');
+    linodeCreatePage.setLabel(mockLinode.label);
+    linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
+    linodeCreatePage.setRootPassword(randomString(32));
+
+    // Confirm the Linode Interfaces section is shown.
+    checkLinodeInterfacesElements();
+
+    // Switch to Linode Interfaces
+    cy.findByText(linodeInterfacesLabelText).click();
+
+    // Select VLAN card
+    cy.get('[data-qa-select-card-heading="VLAN"]').should('be.visible').click();
+
+    // Open VLAN accordion and select existing VLAN.
+    cy.findByLabelText('VLAN').should('be.enabled').type(mockVlan.label);
+    ui.autocompletePopper
+      .findByTitle(mockVlan.label)
+      .should('be.visible')
+      .click();
+    cy.findByLabelText(/IPAM Address/)
+      .should('be.enabled')
+      .type(mockVlan.cidr_block);
+
+    // Confirm that VLAN attachment is listed in summary, then create Linode.
+    cy.get('[data-qa-linode-create-summary]').scrollIntoView();
+    cy.get('[data-qa-linode-create-summary]').within(() => {
+      // TODO: M3-9955 Missing info in Summary section
+      // cy.findByText('VLAN Attached').should('be.visible');
+    });
+
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    // Confirm outgoing API request payload has expected data.
+    cy.wait('@createLinode').then((xhr) => {
+      const requestPayload = xhr.request.body;
+      const expectedVlanInterface = requestPayload['interfaces'][0]['vlan'];
+
+      // Confirm that vlan interface is our chosen VLAN.
+      expect(expectedVlanInterface).to.not.equal(null);
+      expect(expectedVlanInterface['vlan_label']).to.equal(mockVlan.label);
+      expect(expectedVlanInterface['ipam_address']).to.equal(
+        mockVlan.cidr_block
+      );
+    });
+
+    cy.url().should('endWith', `/linodes/${mockLinode.id}`);
+    // Confirm toast notification should appear on Linode create.
+    ui.toast.assertMessage(`Your Linode ${mockLinode.label} is being created.`);
+  });
+
+  /*
+   * Legacy Configuration Profile Interfaces
+   * - Uses mock API data to confirm VLAN creation and attachment UI flow during Linode create.
+   * - Confirms that outgoing Linode create API request contains expected data for new VLAN.
+   * - Confirms that attached VLAN is reflected in the Linode create summary.
+   */
+  it('can assign new VLANs during Linode create flow (legacy)', () => {
+    const mockLinodeRegion = chooseRegion({
+      capabilities: ['Linodes', 'Vlans'],
+    });
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: mockLinodeRegion.id,
+    });
+
+    const mockVlan = VLANFactory.build({
+      cidr_block: `${randomIp()}/24`,
+      id: randomNumber(),
+      label: randomLabel(),
+      linodes: [],
+      region: mockLinodeRegion.id,
+    });
+
+    mockGetVLANs([]);
+    mockCreateLinode(mockLinode).as('createLinode');
+    cy.visitWithLogin('/linodes/create');
+
+    // Fill out necessary Linode create fields.
+    linodeCreatePage.selectRegionById(mockLinodeRegion.id);
+    linodeCreatePage.selectImage('Debian 12');
+    linodeCreatePage.setLabel(mockLinode.label);
+    linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
+    linodeCreatePage.setRootPassword(randomString(32));
+
+    // Confirm the Linode Interfaces section is shown.
+    checkLinodeInterfacesElements();
+
+    // Select VLAN card
+    cy.get('[data-qa-select-card-heading="VLAN"]').should('be.visible').click();
+
+    // Open VLAN accordion and specify new VLAN.
+    cy.findByLabelText('VLAN').should('be.enabled').type(mockVlan.label);
+    ui.autocompletePopper
+      .findByTitle(`Create "${mockVlan.label}"`)
+      .should('be.visible')
+      .click();
+    cy.findByLabelText(/IPAM Address/)
+      .should('be.enabled')
+      .type(mockVlan.cidr_block);
+
+    // Confirm that VLAN attachment is listed in summary, then create Linode.
+    cy.get('[data-qa-linode-create-summary]').scrollIntoView();
+    cy.get('[data-qa-linode-create-summary]').within(() => {
+      // TODO: M3-9955 Missing info in Summary section
+      // cy.findByText('VLAN Attached').should('be.visible');
+    });
+
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    // Confirm outgoing API request payload has expected data.
+    cy.wait('@createLinode').then((xhr) => {
+      const requestPayload = xhr.request.body;
+      const expectedVlanInterface = requestPayload['interfaces'][0];
+
+      // Confirm that first interface is our chosen VLAN.
+      expect(expectedVlanInterface['purpose']).to.equal('vlan');
+      expect(expectedVlanInterface['label']).to.equal(mockVlan.label);
+      expect(expectedVlanInterface['ipam_address']).to.equal(
+        mockVlan.cidr_block
+      );
+    });
+
+    cy.url().should('endWith', `/linodes/${mockLinode.id}`);
+    // Confirm toast notification should appear on Linode create.
+    ui.toast.assertMessage(`Your Linode ${mockLinode.label} is being created.`);
+  });
+
+  /*
+   * Linode Interfaces
+   * - Uses mock API data to confirm VLAN creation and attachment UI flow during Linode create.
+   * - Confirms that outgoing Linode create API request contains expected data for new VLAN.
+   * - Confirms that attached VLAN is reflected in the Linode create summary.
+   */
+  it('can assign new VLANs during Linode create flow (Linode Interfaces)', () => {
+    const mockLinodeRegion = chooseRegion({
+      capabilities: ['Linodes', 'Vlans'],
+    });
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: mockLinodeRegion.id,
+    });
+
+    const mockVlan = VLANFactory.build({
+      cidr_block: `${randomIp()}/24`,
+      id: randomNumber(),
+      label: randomLabel(),
+      linodes: [],
+      region: mockLinodeRegion.id,
+    });
+
+    mockGetVLANs([]);
+    mockCreateLinode(mockLinode).as('createLinode');
+    cy.visitWithLogin('/linodes/create');
+
+    // Fill out necessary Linode create fields.
+    linodeCreatePage.selectRegionById(mockLinodeRegion.id);
+    linodeCreatePage.selectImage('Debian 12');
+    linodeCreatePage.setLabel(mockLinode.label);
+    linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
+    linodeCreatePage.setRootPassword(randomString(32));
+
+    // Confirm the Linode Interfaces section is shown.
+    checkLinodeInterfacesElements();
+
+    // Switch to Linode Interfaces
+    cy.findByText(linodeInterfacesLabelText).click();
+
+    // Select VLAN card
+    cy.get('[data-qa-select-card-heading="VLAN"]').should('be.visible').click();
+
+    // Open VLAN accordion and specify new VLAN.
+    cy.findByLabelText('VLAN').should('be.enabled').type(mockVlan.label);
+    ui.autocompletePopper
+      .findByTitle(`Create "${mockVlan.label}"`)
+      .should('be.visible')
+      .click();
+    cy.findByLabelText(/IPAM Address/)
+      .should('be.enabled')
+      .type(mockVlan.cidr_block);
+
+    // Confirm that VLAN attachment is listed in summary, then create Linode.
+    cy.get('[data-qa-linode-create-summary]').scrollIntoView();
+    cy.get('[data-qa-linode-create-summary]').within(() => {
+      // TODO: M3-9955 Missing info in Summary section
+      // cy.findByText('VLAN Attached').should('be.visible');
+    });
+
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    // Confirm outgoing API request payload has expected data.
+    cy.wait('@createLinode').then((xhr) => {
+      const requestPayload = xhr.request.body;
+      const expectedVlanInterface = requestPayload['interfaces'][0]['vlan'];
+
+      // Confirm that vlan interface is our chosen VLAN.
+      expect(expectedVlanInterface).to.not.equal(null);
+      expect(expectedVlanInterface['vlan_label']).to.equal(mockVlan.label);
+      expect(expectedVlanInterface['ipam_address']).to.equal(
+        mockVlan.cidr_block
+      );
+    });
+
+    cy.url().should('endWith', `/linodes/${mockLinode.id}`);
+    // Confirm toast notification should appear on Linode create.
+    ui.toast.assertMessage(`Your Linode ${mockLinode.label} is being created.`);
+  });
+
+  /*
+   * - Uses mock API data to confirm that VLANs cannot be assigned to Linodes in regions without capability.
+   * - Confirms that VLAN fields are disabled before and after selecting a region.
+   */
+  it('cannot assign VLANs in regions without capability', () => {
+    const nonVlanRegion = regionFactory.build({
+      capabilities: ['Linodes'],
+    });
+
+    const vlanRegion = regionFactory.build({
+      capabilities: ['Linodes', 'Vlans'],
+    });
+
+    mockGetRegions([nonVlanRegion, vlanRegion]);
+    cy.visitWithLogin('/linodes/create');
+
+    linodeCreatePage.selectRegionById(nonVlanRegion.id);
+
+    // Confirm the Linode Interfaces section is shown.
+    checkLinodeInterfacesElements();
+
+    // Select VLAN card
+    cy.get('[data-qa-select-card-heading="VLAN"]').should('be.visible').click();
+
+    // Expand VLAN accordion, confirm VLAN availability notice is displayed and
+    // that VLAN fields are disabled while no region is selected.
+    cy.findByText('VLAN is not available in the selected region.', {
+      exact: false,
+    }).should('be.visible');
+    cy.get('[data-qa-autocomplete="VLAN"]').within(() => {
+      cy.findByLabelText('VLAN').should('be.visible');
+      cy.get('[data-testid="textfield-input"]')
+        .should('be.visible')
+        .should('be.disabled');
+    });
+    cy.findByLabelText(/IPAM Address/).should('be.disabled');
+
+    // Select a region that is known not to have VLAN capability.
+    linodeCreatePage.selectRegionById(nonVlanRegion.id);
+
+    // Confirm that VLAN fields are still disabled.
+    cy.get('[data-qa-autocomplete="VLAN"]').within(() => {
+      cy.findByLabelText('VLAN').should('be.visible');
+      cy.get('[data-testid="textfield-input"]')
+        .should('be.visible')
+        .should('be.disabled');
+    });
+    cy.findByLabelText(/IPAM Address/).should('be.disabled');
   });
 });

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-vpc.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-vpc.spec.ts
@@ -3,6 +3,7 @@ import {
   linodeFactory,
   regionFactory,
 } from '@linode/utilities';
+import { linodeInterfacesLabelText } from 'support/constants/linode-interfaces';
 import { mockGetLinodeConfig } from 'support/intercepts/configs';
 import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
 import {
@@ -19,6 +20,7 @@ import {
 } from 'support/intercepts/vpc';
 import { ui } from 'support/ui';
 import { linodeCreatePage, vpcCreateDrawer } from 'support/ui/pages';
+import { checkLinodeInterfacesElements } from 'support/util/linodes';
 import {
   randomIp,
   randomLabel,
@@ -31,7 +33,7 @@ import { chooseRegion } from 'support/util/regions';
 import { linodeConfigFactory, subnetFactory, vpcFactory } from 'src/factories';
 import { WARNING_ICON_UNRECOMMENDED_CONFIG } from 'src/features/VPCs/constants';
 
-describe('Create Linode with VPCs', () => {
+describe('Create Linode with VPCs (Legacy)', () => {
   beforeEach(() => {
     mockAppendFeatureFlags({
       linodeInterfaces: { enabled: false },
@@ -105,6 +107,9 @@ describe('Create Linode with VPCs', () => {
     linodeCreatePage.selectRegionById(linodeRegion.id);
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));
+
+    // Confirm the Linode Interfaces section is not present.
+    checkLinodeInterfacesElements(false);
 
     // Confirm that mocked VPC is shown in the Autocomplete, and then select it.
     cy.findByText('Assign VPC').click();
@@ -234,6 +239,9 @@ describe('Create Linode with VPCs', () => {
     linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
     linodeCreatePage.setRootPassword(randomString(32));
 
+    // Confirm the Linode Interfaces section is not present.
+    checkLinodeInterfacesElements(false);
+
     cy.findByText('Create VPC').should('be.visible').click();
 
     ui.drawer
@@ -350,8 +358,708 @@ describe('Create Linode with VPCs', () => {
 
     linodeCreatePage.selectRegionById(mockRegion.id);
 
+    // Confirm the Linode Interfaces section is not present.
+    checkLinodeInterfacesElements(false);
+
     cy.findByLabelText('Assign VPC').scrollIntoView();
     cy.findByLabelText('Assign VPC').should('be.visible').should('be.disabled');
+
+    cy.findByText(vpcNotAvailableMessage).should('be.visible');
+  });
+});
+
+describe('Create Linode with VPCs (Linode Interfaces)', () => {
+  beforeEach(() => {
+    mockAppendFeatureFlags({
+      linodeInterfaces: { enabled: true },
+    });
+  });
+
+  /*
+   * Legacy Configuration Profile Interfaces
+   * - Confirms UI flow to create a Linode with an existing VPC assigned using mock API data.
+   * - Confirms that VPC assignment is reflected in create summary section.
+   * - Confirms that outgoing API request contains expected VPC interface data.
+   * - Confirms newly assigned Linode does not have an unrecommended config notice inside VPC
+   */
+  it('can assign existing VPCs during Linode Create flow (legacy)', () => {
+    const linodeRegion = chooseRegion({ capabilities: ['VPCs'] });
+
+    const mockSubnet = subnetFactory.build({
+      id: randomNumber(),
+      ipv4: `${randomIp()}/0`,
+      label: randomLabel(),
+      linodes: [],
+    });
+
+    const mockVPC = vpcFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+      subnets: [mockSubnet],
+    });
+
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+    });
+
+    const mockInterface = linodeConfigInterfaceFactoryWithVPC.build({
+      active: true,
+      primary: true,
+      subnet_id: mockSubnet.id,
+      vpc_id: mockVPC.id,
+    });
+
+    const mockLinodeConfig = linodeConfigFactory.build({
+      interfaces: [mockInterface],
+    });
+
+    const mockUpdatedSubnet = {
+      ...mockSubnet,
+      linodes: [
+        {
+          id: mockLinode.id,
+          interfaces: [
+            {
+              active: true,
+              config_id: mockLinodeConfig.id,
+              id: mockInterface.id,
+            },
+          ],
+        },
+      ],
+    };
+
+    mockGetVPCs([mockVPC]).as('getVPCs');
+    mockGetVPC(mockVPC).as('getVPC');
+    mockCreateLinode(mockLinode).as('createLinode');
+    mockGetLinodeDetails(mockLinode.id, mockLinode);
+
+    cy.visitWithLogin('/linodes/create');
+
+    linodeCreatePage.setLabel(mockLinode.label);
+    linodeCreatePage.selectImage('Debian 12');
+    linodeCreatePage.selectRegionById(linodeRegion.id);
+    linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
+    linodeCreatePage.setRootPassword(randomString(32));
+
+    // Confirm the Linode Interfaces section is shown.
+    checkLinodeInterfacesElements();
+
+    // Select VPC card
+    cy.get('[data-qa-select-card-heading="VPC"]').should('be.visible').click();
+
+    // Confirm that mocked VPC is shown in the Autocomplete, and then select it.
+    cy.get('[data-qa-autocomplete="VPC"]').within(() => {
+      cy.findByLabelText('VPC').should('be.visible');
+      cy.get('[data-testid="textfield-input"]').click();
+      cy.focused().type(`${mockVPC.label}`);
+    });
+
+    ui.autocompletePopper
+      .findByTitle(mockVPC.label)
+      .should('be.visible')
+      .click();
+
+    // Confirm that VPC's subnet gets selected
+    cy.findByLabelText('Subnet').should(
+      'have.value',
+      `${mockSubnet.label} (${mockSubnet.ipv4})`
+    );
+
+    // Confirm VPC assignment indicator is shown in Linode summary.
+    cy.get('[data-qa-linode-create-summary]').scrollIntoView();
+    cy.get('[data-qa-linode-create-summary]').within(() => {
+      // TODO: M3-9955 Missing info in Summary section
+      // cy.findByText('VPC Assigned').should('be.visible');
+    });
+
+    // Create Linode and confirm contents of outgoing API request payload.
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.wait('@createLinode').then((xhr) => {
+      const requestPayload = xhr.request.body;
+      const expectedVpcInterface = requestPayload['interfaces'][0];
+
+      // Confirm that request payload includes VPC interface.
+      expect(expectedVpcInterface['vpc_id']).to.equal(mockVPC.id);
+      expect(expectedVpcInterface['ipv4']).to.deep.equal({
+        nat_1_1: null,
+        vpc: null,
+      });
+      expect(expectedVpcInterface['subnet_id']).to.equal(mockSubnet.id);
+      expect(expectedVpcInterface['purpose']).to.equal('vpc');
+    });
+
+    // Confirm redirect to new Linode.
+    cy.url().should('endWith', `/linodes/${mockLinode.id}`);
+    // Confirm toast notification should appear on Linode create.
+    ui.toast.assertMessage(`Your Linode ${mockLinode.label} is being created.`);
+
+    // Confirm newly created Linode does not have unrecommended configuration notice
+    mockGetVPC(mockVPC).as('getVPC');
+    mockGetSubnets(mockVPC.id, [mockUpdatedSubnet]).as('getSubnets');
+    mockGetLinodeDetails(mockLinode.id, mockLinode).as('getLinode');
+    mockGetLinodeConfig(mockLinode.id, mockLinodeConfig).as('getLinodeConfig');
+
+    cy.visit(`/vpcs/${mockVPC.id}`);
+    cy.findByLabelText(`expand ${mockSubnet.label} row`).click();
+    cy.wait('@getLinodeConfig');
+    cy.findByTestId(WARNING_ICON_UNRECOMMENDED_CONFIG).should('not.exist');
+  });
+
+  /*
+   * Linode Interfaces
+   * - Confirms UI flow to create a Linode with an existing VPC assigned using mock API data.
+   * - Confirms that VPC assignment is reflected in create summary section.
+   * - Confirms that outgoing API request contains expected VPC interface data.
+   * - Confirms newly assigned Linode does not have an unrecommended config notice inside VPC
+   */
+  it('can assign existing VPCs during Linode Create flow (Linode Inteface)', () => {
+    const linodeRegion = chooseRegion({ capabilities: ['VPCs'] });
+
+    const mockSubnet = subnetFactory.build({
+      id: randomNumber(),
+      ipv4: `${randomIp()}/0`,
+      label: randomLabel(),
+      linodes: [],
+    });
+
+    const mockVPC = vpcFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+      subnets: [mockSubnet],
+    });
+
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+    });
+
+    const mockInterface = linodeConfigInterfaceFactoryWithVPC.build({
+      active: true,
+      primary: true,
+      subnet_id: mockSubnet.id,
+      vpc_id: mockVPC.id,
+    });
+
+    const mockLinodeConfig = linodeConfigFactory.build({
+      interfaces: [mockInterface],
+    });
+
+    const mockUpdatedSubnet = {
+      ...mockSubnet,
+      linodes: [
+        {
+          id: mockLinode.id,
+          interfaces: [
+            {
+              active: true,
+              config_id: mockLinodeConfig.id,
+              id: mockInterface.id,
+            },
+          ],
+        },
+      ],
+    };
+
+    mockGetVPCs([mockVPC]).as('getVPCs');
+    mockGetVPC(mockVPC).as('getVPC');
+    mockCreateLinode(mockLinode).as('createLinode');
+    mockGetLinodeDetails(mockLinode.id, mockLinode);
+
+    cy.visitWithLogin('/linodes/create');
+
+    linodeCreatePage.setLabel(mockLinode.label);
+    linodeCreatePage.selectImage('Debian 12');
+    linodeCreatePage.selectRegionById(linodeRegion.id);
+    linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
+    linodeCreatePage.setRootPassword(randomString(32));
+
+    // Confirm the Linode Interfaces section is shown.
+    checkLinodeInterfacesElements();
+
+    // Switch to Linode Interfaces
+    cy.findByText(linodeInterfacesLabelText).click();
+
+    // Select VPC card
+    cy.get('[data-qa-select-card-heading="VPC"]').should('be.visible').click();
+
+    // Confirm that mocked VPC is shown in the Autocomplete, and then select it.
+    cy.get('[data-qa-autocomplete="VPC"]').within(() => {
+      cy.findByLabelText('VPC').should('be.visible');
+      cy.get('[data-testid="textfield-input"]').click();
+      cy.focused().type(`${mockVPC.label}`);
+    });
+
+    ui.autocompletePopper
+      .findByTitle(mockVPC.label)
+      .should('be.visible')
+      .click();
+
+    // Confirm that VPC's subnet gets selected
+    cy.findByLabelText('Subnet').should(
+      'have.value',
+      `${mockSubnet.label} (${mockSubnet.ipv4})`
+    );
+
+    // Confirm VPC assignment indicator is shown in Linode summary.
+    cy.get('[data-qa-linode-create-summary]').scrollIntoView();
+    cy.get('[data-qa-linode-create-summary]').within(() => {
+      // TODO: M3-9955 Missing info in Summary section
+      // cy.findByText('VPC Assigned').should('be.visible');
+    });
+
+    // Create Linode and confirm contents of outgoing API request payload.
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.wait('@createLinode').then((xhr) => {
+      const requestPayload = xhr.request.body;
+      const expectedVpcInterface = requestPayload['interfaces'][0]['vpc'];
+
+      console.log(`requestPayload: ${JSON.stringify(requestPayload)}`);
+
+      // Confirm that request payload includes VPC interface.
+      expect(expectedVpcInterface).to.not.deep.equal({});
+      expect(expectedVpcInterface['ipv4']).to.not.deep.equal({});
+      expect(expectedVpcInterface['subnet_id']).to.equal(mockSubnet.id);
+    });
+
+    // Confirm redirect to new Linode.
+    cy.url().should('endWith', `/linodes/${mockLinode.id}`);
+    // Confirm toast notification should appear on Linode create.
+    ui.toast.assertMessage(`Your Linode ${mockLinode.label} is being created.`);
+
+    // Confirm newly created Linode does not have unrecommended configuration notice
+    mockGetVPC(mockVPC).as('getVPC');
+    mockGetSubnets(mockVPC.id, [mockUpdatedSubnet]).as('getSubnets');
+    mockGetLinodeDetails(mockLinode.id, mockLinode).as('getLinode');
+    mockGetLinodeConfig(mockLinode.id, mockLinodeConfig).as('getLinodeConfig');
+
+    cy.visit(`/vpcs/${mockVPC.id}`);
+    cy.findByLabelText(`expand ${mockSubnet.label} row`).click();
+    cy.wait('@getLinodeConfig');
+    cy.findByTestId(WARNING_ICON_UNRECOMMENDED_CONFIG).should('not.exist');
+  });
+
+  /*
+   * Legacy Configuration Profile Interfaces
+   * - Confirms UI flow to create a Linode with a new VPC assigned using mock API data.
+   * - Creates a VPC and a subnet from within the Linode Create flow.
+   * - Confirms that Cloud responds gracefully when VPC create API request fails.
+   * - Confirms that outgoing API request contains correct VPC interface data.
+   * - Confirms newly assigned Linode does not have an unrecommended config notice inside VPC
+   */
+  it('can assign new VPCs during Linode Create flow (legacy)', () => {
+    const linodeRegion = chooseRegion({ capabilities: ['VPCs'] });
+
+    const mockErrorMessage = 'An unknown error occurred.';
+
+    const mockSubnet = subnetFactory.build({
+      id: randomNumber(),
+      ipv4: '10.0.0.0/24',
+      label: randomLabel(),
+      linodes: [],
+    });
+
+    const mockVPC = vpcFactory.build({
+      description: randomPhrase(),
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+      subnets: [mockSubnet],
+    });
+
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+    });
+
+    const mockInterface = linodeConfigInterfaceFactoryWithVPC.build({
+      active: true,
+      primary: true,
+      subnet_id: mockSubnet.id,
+      vpc_id: mockVPC.id,
+    });
+
+    const mockLinodeConfig = linodeConfigFactory.build({
+      interfaces: [mockInterface],
+    });
+
+    const mockUpdatedSubnet = {
+      ...mockSubnet,
+      linodes: [
+        {
+          id: mockLinode.id,
+          interfaces: [
+            {
+              active: true,
+              config_id: mockLinodeConfig.id,
+              id: mockInterface.id,
+            },
+          ],
+        },
+      ],
+    };
+
+    mockGetVPCs([]);
+    mockCreateLinode(mockLinode).as('createLinode');
+    cy.visitWithLogin('/linodes/create');
+
+    linodeCreatePage.setLabel(mockLinode.label);
+    linodeCreatePage.selectImage('Debian 12');
+    linodeCreatePage.selectRegionById(linodeRegion.id);
+    linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
+    linodeCreatePage.setRootPassword(randomString(32));
+
+    // Confirm the Linode Interfaces section is shown.
+    checkLinodeInterfacesElements();
+
+    // Select VPC card
+    cy.get('[data-qa-select-card-heading="VPC"]').should('be.visible').click();
+
+    cy.findByText('Create VPC').should('be.visible').click();
+
+    ui.drawer
+      .findByTitle('Create VPC')
+      .should('be.visible')
+      .within(() => {
+        vpcCreateDrawer.setLabel(mockVPC.label);
+        vpcCreateDrawer.setDescription(mockVPC.description);
+        vpcCreateDrawer.setSubnetLabel(mockSubnet.label);
+        vpcCreateDrawer.setSubnetIpRange(mockSubnet.ipv4!);
+
+        // Confirm that unexpected API errors are handled gracefully upon
+        // failed VPC creation.
+        mockCreateVPCError(mockErrorMessage, 500).as('createVpc');
+        vpcCreateDrawer.submit();
+
+        cy.wait('@createVpc');
+        cy.findByText(mockErrorMessage).scrollIntoView();
+        cy.findByText(mockErrorMessage).should('be.visible');
+
+        // Create VPC with successful API response mocked.
+        mockCreateVPC(mockVPC).as('createVpc');
+        mockGetVPCs([mockVPC]);
+        vpcCreateDrawer.submit();
+      });
+
+    // Verify the VPC field gets populated
+    cy.get('[data-qa-autocomplete="VPC"]').within(() => {
+      cy.findByLabelText('VPC').should('be.visible');
+      cy.get('[data-testid="textfield-input"]').click();
+      cy.focused().type(`${mockVPC.label}`);
+    });
+
+    ui.autocompletePopper
+      .findByTitle(mockVPC.label)
+      .should('be.visible')
+      .click();
+
+    // Verify the subnet gets populated
+    cy.findByLabelText('Subnet').should(
+      'have.value',
+      `${mockSubnet.label} (${mockSubnet.ipv4})`
+    );
+
+    // Clear the subnet value
+    cy.get('[data-qa-autocomplete="Subnet"]').within(() => {
+      cy.findByLabelText('Clear').click();
+    });
+
+    // Try to submit the form without a subnet selected
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    // Verify a validation error shows
+    cy.findByText('Subnet is required.').should('be.visible');
+
+    cy.findByLabelText('Subnet').should('be.visible').type(mockSubnet.label);
+
+    ui.autocompletePopper
+      .findByTitle(`${mockSubnet.label} (${mockSubnet.ipv4})`)
+      .should('be.visible')
+      .click();
+
+    // Check box to assign public IPv4.
+    cy.findByText('Assign a public IPv4 address for this Linode')
+      .should('be.visible')
+      .click();
+
+    // Create Linode and confirm contents of outgoing API request payload.
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.wait('@createLinode').then((xhr) => {
+      const requestPayload = xhr.request.body;
+      const expectedVpcInterface = requestPayload['interfaces'][0];
+
+      // Confirm that request payload includes VPC interface.
+      expect(expectedVpcInterface['vpc_id']).to.equal(mockVPC.id);
+      expect(expectedVpcInterface['ipv4']).to.deep.equal({
+        nat_1_1: 'any',
+        vpc: null,
+      });
+      expect(expectedVpcInterface['subnet_id']).to.equal(mockSubnet.id);
+      expect(expectedVpcInterface['purpose']).to.equal('vpc');
+    });
+
+    cy.url().should('endWith', `/linodes/${mockLinode.id}`);
+    // Confirm toast notification should appear on Linode create.
+    ui.toast.assertMessage(`Your Linode ${mockLinode.label} is being created.`);
+
+    // Confirm newly created Linode does not have unrecommended configuration notice
+    mockGetVPC(mockVPC).as('getVPC');
+    mockGetSubnets(mockVPC.id, [mockUpdatedSubnet]).as('getSubnets');
+    mockGetLinodeDetails(mockLinode.id, mockLinode).as('getLinode');
+    mockGetLinodeConfig(mockLinode.id, mockLinodeConfig).as('getLinodeConfig');
+
+    cy.visit(`/vpcs/${mockVPC.id}`);
+    cy.findByLabelText(`expand ${mockSubnet.label} row`).click();
+    cy.wait('@getLinodeConfig');
+    cy.findByTestId(WARNING_ICON_UNRECOMMENDED_CONFIG).should('not.exist');
+  });
+
+  /*
+   * Linode Interfaces
+   * - Confirms UI flow to create a Linode with a new VPC assigned using mock API data.
+   * - Creates a VPC and a subnet from within the Linode Create flow.
+   * - Confirms that Cloud responds gracefully when VPC create API request fails.
+   * - Confirms that outgoing API request contains correct VPC interface data.
+   * - Confirms newly assigned Linode does not have an unrecommended config notice inside VPC
+   */
+  it('can assign new VPCs during Linode Create flow (Linode Interface)', () => {
+    const linodeRegion = chooseRegion({ capabilities: ['VPCs'] });
+
+    const mockErrorMessage = 'An unknown error occurred.';
+
+    const mockSubnet = subnetFactory.build({
+      id: randomNumber(),
+      ipv4: '10.0.0.0/24',
+      label: randomLabel(),
+      linodes: [],
+    });
+
+    const mockVPC = vpcFactory.build({
+      description: randomPhrase(),
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+      subnets: [mockSubnet],
+    });
+
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(),
+      label: randomLabel(),
+      region: linodeRegion.id,
+    });
+
+    const mockInterface = linodeConfigInterfaceFactoryWithVPC.build({
+      active: true,
+      primary: true,
+      subnet_id: mockSubnet.id,
+      vpc_id: mockVPC.id,
+    });
+
+    const mockLinodeConfig = linodeConfigFactory.build({
+      interfaces: [mockInterface],
+    });
+
+    const mockUpdatedSubnet = {
+      ...mockSubnet,
+      linodes: [
+        {
+          id: mockLinode.id,
+          interfaces: [
+            {
+              active: true,
+              config_id: mockLinodeConfig.id,
+              id: mockInterface.id,
+            },
+          ],
+        },
+      ],
+    };
+
+    mockGetVPCs([]);
+    mockCreateLinode(mockLinode).as('createLinode');
+    cy.visitWithLogin('/linodes/create');
+
+    linodeCreatePage.setLabel(mockLinode.label);
+    linodeCreatePage.selectImage('Debian 12');
+    linodeCreatePage.selectRegionById(linodeRegion.id);
+    linodeCreatePage.selectPlan('Shared CPU', 'Nanode 1 GB');
+    linodeCreatePage.setRootPassword(randomString(32));
+
+    // Confirm the Linode Interfaces section is shown.
+    checkLinodeInterfacesElements();
+
+    // Switch to Linode Interfaces
+    cy.findByText(linodeInterfacesLabelText).click();
+
+    // Select VPC card
+    cy.get('[data-qa-select-card-heading="VPC"]').should('be.visible').click();
+
+    cy.findByText('Create VPC').should('be.visible').click();
+
+    ui.drawer
+      .findByTitle('Create VPC')
+      .should('be.visible')
+      .within(() => {
+        vpcCreateDrawer.setLabel(mockVPC.label);
+        vpcCreateDrawer.setDescription(mockVPC.description);
+        vpcCreateDrawer.setSubnetLabel(mockSubnet.label);
+        vpcCreateDrawer.setSubnetIpRange(mockSubnet.ipv4!);
+
+        // Confirm that unexpected API errors are handled gracefully upon
+        // failed VPC creation.
+        mockCreateVPCError(mockErrorMessage, 500).as('createVpc');
+        vpcCreateDrawer.submit();
+
+        cy.wait('@createVpc');
+        cy.findByText(mockErrorMessage).scrollIntoView();
+        cy.findByText(mockErrorMessage).should('be.visible');
+
+        // Create VPC with successful API response mocked.
+        mockCreateVPC(mockVPC).as('createVpc');
+        mockGetVPCs([mockVPC]);
+        vpcCreateDrawer.submit();
+      });
+
+    // Verify the VPC field gets populated
+    cy.get('[data-qa-autocomplete="VPC"]').within(() => {
+      cy.findByLabelText('VPC').should('be.visible');
+      cy.get('[data-testid="textfield-input"]').click();
+    });
+
+    ui.autocompletePopper
+      .findByTitle(mockVPC.label)
+      .should('be.visible')
+      .click();
+
+    // Verify the subnet gets populated
+    cy.findByLabelText('Subnet').should(
+      'have.value',
+      `${mockSubnet.label} (${mockSubnet.ipv4})`
+    );
+
+    // Clear the subnet value
+    cy.get('[data-qa-autocomplete="Subnet"]').within(() => {
+      cy.findByLabelText('Clear').click();
+    });
+
+    // Try to submit the form without a subnet selected
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    // Verify a validation error shows
+    cy.findByText('Subnet is required.').should('be.visible');
+
+    cy.findByLabelText('Subnet').should('be.visible').type(mockSubnet.label);
+
+    ui.autocompletePopper
+      .findByTitle(`${mockSubnet.label} (${mockSubnet.ipv4})`)
+      .should('be.visible')
+      .click();
+
+    // Check box to assign public IPv4.
+    cy.findByText('Assign a public IPv4 address for this Linode')
+      .should('be.visible')
+      .click();
+
+    // Create Linode and confirm contents of outgoing API request payload.
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.wait('@createLinode').then((xhr) => {
+      const requestPayload = xhr.request.body;
+      const expectedVpcInterface = requestPayload['interfaces'][0]['vpc'];
+
+      // Confirm that request payload includes VPC interface.
+      expect(expectedVpcInterface).to.not.equal(null);
+      expect(expectedVpcInterface['ipv4']).to.not.equal({});
+      expect(expectedVpcInterface['ipv4']['addresses'][0]).to.deep.equal({
+        address: 'auto',
+        nat_1_1_address: 'auto',
+      });
+      expect(expectedVpcInterface['subnet_id']).to.equal(mockSubnet.id);
+    });
+
+    cy.url().should('endWith', `/linodes/${mockLinode.id}`);
+    // Confirm toast notification should appear on Linode create.
+    ui.toast.assertMessage(`Your Linode ${mockLinode.label} is being created.`);
+
+    // Confirm newly created Linode does not have unrecommended configuration notice
+    mockGetVPC(mockVPC).as('getVPC');
+    mockGetSubnets(mockVPC.id, [mockUpdatedSubnet]).as('getSubnets');
+    mockGetLinodeDetails(mockLinode.id, mockLinode).as('getLinode');
+    mockGetLinodeConfig(mockLinode.id, mockLinodeConfig).as('getLinodeConfig');
+
+    cy.visit(`/vpcs/${mockVPC.id}`);
+    cy.findByLabelText(`expand ${mockSubnet.label} row`).click();
+    cy.wait('@getLinodeConfig');
+    cy.findByTestId(WARNING_ICON_UNRECOMMENDED_CONFIG).should('not.exist');
+  });
+
+  /*
+   * - Confirms UI flow when attempting to assign VPC to Linode in region without capability.
+   * - Confirms that VPCs selection is disabled.
+   * - Confirms that notice text is present to explain that VPCs are unavailable.
+   */
+  it('cannot assign VPCs to Linodes in regions without VPC capability', () => {
+    const mockRegion = regionFactory.build({
+      capabilities: ['Linodes'],
+    });
+
+    const vpcNotAvailableMessage =
+      'VPC is not available in the selected region.';
+
+    mockGetRegions([mockRegion]);
+    cy.visitWithLogin('/linodes/create');
+
+    linodeCreatePage.selectRegionById(mockRegion.id);
+
+    // Confirm the Linode Interfaces section is shown.
+    checkLinodeInterfacesElements();
+
+    // Select VPC card.
+    cy.get('[data-qa-select-card-heading="VPC"]').should('be.visible').click();
+
+    // Confirm that VPC selection is disabled.
+    cy.get('[data-qa-autocomplete="VPC"]').within(() => {
+      cy.findByLabelText('VPC').should('be.visible');
+      cy.get('[data-testid="textfield-input"]')
+        .should('be.visible')
+        .should('be.disabled');
+    });
+
+    // Confirm that VPC's subnet selection is disabled.
+    cy.findByLabelText('Subnet').should('be.visible').should('be.disabled');
 
     cy.findByText(vpcNotAvailableMessage).should('be.visible');
   });

--- a/packages/manager/cypress/support/constants/linode-interfaces.ts
+++ b/packages/manager/cypress/support/constants/linode-interfaces.ts
@@ -1,16 +1,27 @@
+export const configSelectSharedText =
+  'This Linode has multiple configuration profiles. Choose one to continue.';
+
 export const dryRunButtonText = 'Perform Dry Run';
+
+export const errorDryRunText =
+  'The dry run found the following issues. After correcting them, perform another dry run.';
 
 export const upgradeInterfacesButtonText = 'Upgrade Interfaces';
 
-export const upgradeTooltipText1 = 'Configuration Profile interfaces from a single profile can be upgraded to Linode Interfaces.';
+export const upgradeTooltipText1 =
+  'Configuration Profile interfaces from a single profile can be upgraded to Linode Interfaces.';
 
-export const upgradeTooltipText2 = 'After the upgrade, the Linode can only use Linode Interfaces and cannot revert to Configuration Profile interfaces. Use the dry-run feature to review the changes before committing.';
+export const upgradeTooltipText2 =
+  'After the upgrade, the Linode can only use Linode Interfaces and cannot revert to Configuration Profile interfaces. Use the dry-run feature to review the changes before committing.';
 
-export const promptDialogDescription1 = 'Upgrading allows interface connections to be associated directly with the Linode, rather than its configuration profile.';
+export const promptDialogDescription1 =
+  'Upgrading allows interface connections to be associated directly with the Linode, rather than its configuration profile.';
 
-export const promptDialogDescription2 = 'We recommend performing a dry run before upgrading to identify and resolve any potential conflicts.';
+export const promptDialogDescription2 =
+  'We recommend performing a dry run before upgrading to identify and resolve any potential conflicts.';
 
-export const promptDialogUpgradeWhatHappensTitle = 'What happens after the upgrade:';
+export const promptDialogUpgradeWhatHappensTitle =
+  'What happens after the upgrade:';
 
 export const promptDialogUpgradeDetails = [
   'New Linode Interfaces are created to match the existing Configuration Profile Interfaces.',
@@ -21,14 +32,8 @@ export const promptDialogUpgradeDetails = [
   'Configuration Profile Interfaces are removed from the Configurations tab. The new Linode Interfaces will appear in the Network tab.',
 ];
 
-export const configSelectSharedText =
-  'This Linode has multiple configuration profiles. Choose one to continue.';
-
 export const upgradeInterfacesWarningText =
   'After upgrading, the Linode will use only Linode Interfaces and cannot revert back to Configuration Profile Interfaces. Private IPv4 addresses are not supported on public Linode Interfaces. Services depending on a private IPv4 will no longer function.';
-
-export const errorDryRunText =
-  'The dry run found the following issues. After correcting them, perform another dry run.';
 
 export const networkingTitleText = 'Networking';
 
@@ -38,16 +43,22 @@ export const linodeInterfacesLabelText = 'Linode Interfaces';
 
 export const betaLabelText = 'beta';
 
-export const linodeInterfacesDescriptionText1 = 'Linode Interfaces are the preferred option for VPCs and are managed directly through a Linode’s Network settings.';
+export const linodeInterfacesDescriptionText1 =
+  'Linode Interfaces are the preferred option for VPCs and are managed directly through a Linode’s Network settings.';
 
-export const linodeInterfacesDescriptionText2 = 'Cloud Firewalls are assigned to individual VPC and public interfaces.';
+export const linodeInterfacesDescriptionText2 =
+  'Cloud Firewalls are assigned to individual VPC and public interfaces.';
 
-export const legacyInterfacesLabelText = 'Configuration Profile Interfaces (Legacy)';
+export const legacyInterfacesLabelText =
+  'Configuration Profile Interfaces (Legacy)';
 
-export const legacyInterfacesDescriptionText1 = 'Interfaces in the Configuration Profile are part of a Linode’s configuration.';
+export const legacyInterfacesDescriptionText1 =
+  'Interfaces in the Configuration Profile are part of a Linode’s configuration.';
 
-export const legacyInterfacesDescriptionText2 = 'Cloud Firewalls are applied at the Linode level and automatically cover all non-VLAN interfaces in the Configuration Profile.';
+export const legacyInterfacesDescriptionText2 =
+  'Cloud Firewalls are applied at the Linode level and automatically cover all non-VLAN interfaces in the Configuration Profile.';
 
 export const networkConnectionSectionText = 'Network Connection';
 
-export const networkConnectionDescriptionText = 'The default interface used by this Linode to route network traffic. Additional interfaces can be added after the Linode is created.';
+export const networkConnectionDescriptionText =
+  'The default interface used by this Linode to route network traffic. Additional interfaces can be added after the Linode is created.';

--- a/packages/manager/cypress/support/constants/linode-interfaces.ts
+++ b/packages/manager/cypress/support/constants/linode-interfaces.ts
@@ -29,3 +29,25 @@ export const upgradeInterfacesWarningText =
 
 export const errorDryRunText =
   'The dry run found the following issues. After correcting them, perform another dry run.';
+
+export const networkingTitleText = 'Networking';
+
+export const networkInterfaceTypeSectionText = 'Network Interface Type';
+
+export const linodeInterfacesLabelText = 'Linode Interfaces';
+
+export const betaLabelText = 'beta';
+
+export const linodeInterfacesDescriptionText1 = 'Linode Interfaces are the preferred option for VPCs and are managed directly through a Linode’s Network settings.';
+
+export const linodeInterfacesDescriptionText2 = 'Cloud Firewalls are assigned to individual VPC and public interfaces.';
+
+export const legacyInterfacesLabelText = 'Configuration Profile Interfaces (Legacy)';
+
+export const legacyInterfacesDescriptionText1 = 'Interfaces in the Configuration Profile are part of a Linode’s configuration.';
+
+export const legacyInterfacesDescriptionText2 = 'Cloud Firewalls are applied at the Linode level and automatically cover all non-VLAN interfaces in the Configuration Profile.';
+
+export const networkConnectionSectionText = 'Network Connection';
+
+export const networkConnectionDescriptionText = 'The default interface used by this Linode to route network traffic. Additional interfaces can be added after the Linode is created.';

--- a/packages/manager/cypress/support/ui/pages/linode-create-page.ts
+++ b/packages/manager/cypress/support/ui/pages/linode-create-page.ts
@@ -125,4 +125,29 @@ export const linodeCreatePage = {
 
     cy.get('@rootPasswordField').type(linodePassword, { log: false });
   },
+
+  /**
+   * Select the Linode Interfaces Type.
+   */
+  selectLinodeInterfacesType: () => {
+    cy.findByText('Linode Interfaces').click();
+  },
+
+  /**
+   * Select the Legacy Interfaces Type.
+   */
+  selectLegacyConfigInterfacesType: () => {
+    cy.findByText('Configuration Profile Interfaces (Legacy)').click();
+  },
+
+  /**
+   * Select the interfaces' card.
+   *
+   * @param title - Interfaces' card title to select.
+   */
+  selectInterfaceCard: (title: string) => {
+    cy.get(`[data-qa-select-card-heading="${title}"]`)
+      .should('be.visible')
+      .click();
+  },
 };

--- a/packages/manager/cypress/support/util/linodes.ts
+++ b/packages/manager/cypress/support/util/linodes.ts
@@ -10,6 +10,15 @@ import {
   promptDialogUpgradeDetails,
   promptDialogUpgradeWhatHappensTitle,
   upgradeInterfacesButtonText,
+  legacyInterfacesDescriptionText1,
+  legacyInterfacesDescriptionText2,
+  legacyInterfacesLabelText,
+  linodeInterfacesDescriptionText1,
+  linodeInterfacesDescriptionText2,
+  linodeInterfacesLabelText,
+  networkConnectionDescriptionText,
+  networkConnectionSectionText,
+  networkInterfaceTypeSectionText,
 } from 'support/constants/linode-interfaces';
 import { LINODE_CREATE_TIMEOUT } from 'support/constants/linodes';
 import { ui } from 'support/ui';
@@ -308,4 +317,24 @@ export const assertUpgradeSummary = (
       'be.visible'
     );
   }
+};
+
+/**
+ * Check the elements of Linode Interfaces.
+ *
+ * @param linodeInterfacesEnabled - Indicator if Linode Interfaces feature is enabled.
+ */
+export const checkLinodeInterfacesElements = (
+  linodeInterfacesEnabled: boolean = true
+): void => {
+  const expectedBehavior = linodeInterfacesEnabled ? 'be.visible' : 'not.exist';
+  cy.findByText(networkInterfaceTypeSectionText).should(expectedBehavior);
+  cy.findByText(linodeInterfacesLabelText).should(expectedBehavior);
+  cy.findByText(linodeInterfacesDescriptionText1).should(expectedBehavior);
+  cy.findByText(linodeInterfacesDescriptionText2).should(expectedBehavior);
+  cy.findByText(legacyInterfacesLabelText).should(expectedBehavior);
+  cy.findByText(legacyInterfacesDescriptionText1).should(expectedBehavior);
+  cy.findByText(legacyInterfacesDescriptionText2).should(expectedBehavior);
+  cy.findByText(networkConnectionSectionText).should(expectedBehavior);
+  cy.findByText(networkConnectionDescriptionText).should(expectedBehavior);
 };

--- a/packages/manager/cypress/support/util/linodes.ts
+++ b/packages/manager/cypress/support/util/linodes.ts
@@ -5,11 +5,6 @@ import { findOrCreateDependencyVlan } from 'support/api/vlans';
 import { pageSize } from 'support/constants/api';
 import {
   dryRunButtonText,
-  promptDialogDescription1,
-  promptDialogDescription2,
-  promptDialogUpgradeDetails,
-  promptDialogUpgradeWhatHappensTitle,
-  upgradeInterfacesButtonText,
   legacyInterfacesDescriptionText1,
   legacyInterfacesDescriptionText2,
   legacyInterfacesLabelText,
@@ -19,6 +14,11 @@ import {
   networkConnectionDescriptionText,
   networkConnectionSectionText,
   networkInterfaceTypeSectionText,
+  promptDialogDescription1,
+  promptDialogDescription2,
+  promptDialogUpgradeDetails,
+  promptDialogUpgradeWhatHappensTitle,
+  upgradeInterfacesButtonText,
 } from 'support/constants/linode-interfaces';
 import { LINODE_CREATE_TIMEOUT } from 'support/constants/linodes';
 import { ui } from 'support/ui';
@@ -324,7 +324,7 @@ export const assertUpgradeSummary = (
  *
  * @param linodeInterfacesEnabled - Indicator if Linode Interfaces feature is enabled.
  */
-export const checkLinodeInterfacesElements = (
+export const assertNewLinodeInterfacesIsAvailable = (
   linodeInterfacesEnabled: boolean = true
 ): void => {
   const expectedBehavior = linodeInterfacesEnabled ? 'be.visible' : 'not.exist';


### PR DESCRIPTION
## Description 📝

Update / Add integration tests for Create Linode

## Changes  🔄

List any change(s) relevant to the reviewer.

- Add function `checkLinodeInterfacesElements()`
- Update legacy integration tests for Create Linode
- Add Linode Interfaces integration tests for Create Linode

## How to test 🧪
```
yarn cy:run -s "cypress/e2e/core/linodes/create-linode-with-firewall.spec.ts"
yarn cy:run -s "cypress/e2e/core/linodes/create-linode-with-vlan.spec.ts"
yarn cy:run -s "cypress/e2e/core/linodes/create-linode-with-vpc.spec.ts"
```

## Issues
- M3-9955