### PR TITLE
fix: [M3-9957] - Add `/v4beta` endpoints for Node Pools and use POST `/v4beta` when adding a new LKE-E Node Pool

### DIFF
--- a/packages/api-v4/.changeset/pr-12188-upcoming-features-1747068993421.md
+++ b/packages/api-v4/.changeset/pr-12188-upcoming-features-1747068993421.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Upcoming Features
+---
+
+Add `/v4beta` endpoints and types for Node Pool requests ([#12188](https://github.com/linode/manager/pull/12188))

--- a/packages/api-v4/src/kubernetes/nodePools.ts
+++ b/packages/api-v4/src/kubernetes/nodePools.ts
@@ -1,6 +1,9 @@
-import { nodePoolSchema } from '@linode/validation/lib/kubernetes.schema';
+import {
+  nodePoolBetaSchema,
+  nodePoolSchema,
+} from '@linode/validation/lib/kubernetes.schema';
 
-import { API_ROOT } from '../constants';
+import { API_ROOT, BETA_API_ROOT } from '../constants';
 import Request, {
   setData,
   setMethod,
@@ -14,6 +17,7 @@ import type {
   CreateNodePoolData,
   CreateNodePoolDataBeta,
   KubeNodePoolResponse,
+  KubeNodePoolResponseBeta,
   UpdateNodePoolData,
 } from './types';
 

--- a/packages/api-v4/src/kubernetes/nodePools.ts
+++ b/packages/api-v4/src/kubernetes/nodePools.ts
@@ -19,6 +19,7 @@ import type {
   KubeNodePoolResponse,
   KubeNodePoolResponseBeta,
   UpdateNodePoolData,
+  UpdateNodePoolDataBeta,
 } from './types';
 
 /**
@@ -48,6 +49,21 @@ export const getNodePool = (clusterID: number, nodePoolID: number) =>
     setMethod('GET'),
     setURL(
       `${API_ROOT}/lke/clusters/${encodeURIComponent(
+        clusterID,
+      )}/pools/${encodeURIComponent(nodePoolID)}`,
+    ),
+  );
+
+/**
+ * getNodePoolBeta
+ *
+ * Returns a single node pool with additional beta fields
+ */
+export const getNodePoolBeta = (clusterID: number, nodePoolID: number) =>
+  Request<KubeNodePoolResponseBeta>(
+    setMethod('GET'),
+    setURL(
+      `${BETA_API_ROOT}/lke/clusters/${encodeURIComponent(
         clusterID,
       )}/pools/${encodeURIComponent(nodePoolID)}`,
     ),
@@ -100,6 +116,26 @@ export const updateNodePool = (
       )}/pools/${encodeURIComponent(nodePoolID)}`,
     ),
     setData(data, nodePoolSchema),
+  );
+
+/**
+ * updateNodePoolBeta
+ *
+ * Change the type, count, upgrade_strategy, or k8_version of a node pool
+ */
+export const updateNodePoolBeta = (
+  clusterID: number,
+  nodePoolID: number,
+  data: Partial<UpdateNodePoolDataBeta>,
+) =>
+  Request<KubeNodePoolResponseBeta>(
+    setMethod('PUT'),
+    setURL(
+      `${BETA_API_ROOT}/lke/clusters/${encodeURIComponent(
+        clusterID,
+      )}/pools/${encodeURIComponent(nodePoolID)}`,
+    ),
+    setData(data, nodePoolBetaSchema),
   );
 
 /**

--- a/packages/api-v4/src/kubernetes/nodePools.ts
+++ b/packages/api-v4/src/kubernetes/nodePools.ts
@@ -12,6 +12,7 @@ import Request, {
 import type { Filter, ResourcePage as Page, Params } from '../types';
 import type {
   CreateNodePoolData,
+  CreateNodePoolDataBeta,
   KubeNodePoolResponse,
   UpdateNodePoolData,
 } from './types';
@@ -58,6 +59,23 @@ export const createNodePool = (clusterID: number, data: CreateNodePoolData) =>
     setMethod('POST'),
     setURL(`${API_ROOT}/lke/clusters/${encodeURIComponent(clusterID)}/pools`),
     setData(data, nodePoolSchema),
+  );
+
+/**
+ * createNodePool
+ *
+ * Adds a node pool to the specified cluster with beta fields.
+ */
+export const createNodePoolBeta = (
+  clusterID: number,
+  data: CreateNodePoolDataBeta,
+) =>
+  Request<KubeNodePoolResponseBeta>(
+    setMethod('POST'),
+    setURL(
+      `${BETA_API_ROOT}/lke/clusters/${encodeURIComponent(clusterID)}/pools`,
+    ),
+    setData(data, nodePoolBetaSchema),
   );
 
 /**

--- a/packages/api-v4/src/kubernetes/types.ts
+++ b/packages/api-v4/src/kubernetes/types.ts
@@ -57,6 +57,11 @@ export interface CreateNodePoolData {
   type: string;
 }
 
+export interface CreateNodePoolDataBeta extends CreateNodePoolData {
+  k8s_version: string;
+  update_strategy: NodePoolUpdateStrategy;
+}
+
 export interface UpdateNodePoolData {
   autoscaler: AutoscaleSettings;
   count: number;

--- a/packages/api-v4/src/kubernetes/types.ts
+++ b/packages/api-v4/src/kubernetes/types.ts
@@ -58,8 +58,8 @@ export interface CreateNodePoolData {
 }
 
 export interface CreateNodePoolDataBeta extends CreateNodePoolData {
-  k8s_version: string;
-  update_strategy: NodePoolUpdateStrategy;
+  k8s_version?: string;
+  update_strategy?: NodePoolUpdateStrategy;
 }
 
 export interface UpdateNodePoolData {

--- a/packages/api-v4/src/kubernetes/types.ts
+++ b/packages/api-v4/src/kubernetes/types.ts
@@ -79,6 +79,12 @@ export interface UpdateNodePoolData {
   taints: Taint[];
 }
 
+export interface UpdateNodePoolDataBeta extends UpdateNodePoolData {
+  firewall_id?: number;
+  k8s_version?: string;
+  update_strategy?: NodePoolUpdateStrategy;
+}
+
 export interface AutoscaleSettings {
   enabled: boolean;
   max: number;

--- a/packages/api-v4/src/kubernetes/types.ts
+++ b/packages/api-v4/src/kubernetes/types.ts
@@ -66,6 +66,7 @@ export interface CreateNodePoolData {
 }
 
 export interface CreateNodePoolDataBeta extends CreateNodePoolData {
+  firewall_id?: number;
   k8s_version?: string;
   update_strategy?: NodePoolUpdateStrategy;
 }

--- a/packages/api-v4/src/kubernetes/types.ts
+++ b/packages/api-v4/src/kubernetes/types.ts
@@ -11,6 +11,8 @@ export type Label = {
   [key: string]: string;
 };
 
+export type NodePoolUpdateStrategy = 'on_recycle' | 'rolling_update';
+
 export interface Taint {
   effect: KubernetesTaintEffect;
   key: string;
@@ -44,6 +46,12 @@ export interface KubeNodePoolResponse {
   tags: string[];
   taints: Taint[];
   type: string;
+}
+
+export interface KubeNodePoolResponseBeta extends KubeNodePoolResponse {
+  firewall_id: number;
+  k8s_version: string;
+  update_strategy: NodePoolUpdateStrategy;
 }
 
 export interface PoolNodeResponse {

--- a/packages/manager/.changeset/pr-12188-upcoming-features-1747069173199.md
+++ b/packages/manager/.changeset/pr-12188-upcoming-features-1747069173199.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Fix incorrect endpoint use when adding a new LKE-E cluster node pool by using `/v4beta` endpoint ([#12188](https://github.com/linode/manager/pull/12188))

--- a/packages/manager/src/factories/kubernetesCluster.ts
+++ b/packages/manager/src/factories/kubernetesCluster.ts
@@ -3,6 +3,7 @@ import { Factory } from '@linode/utilities';
 import type {
   ControlPlaneACLOptions,
   KubeNodePoolResponse,
+  KubeNodePoolResponseBeta,
   KubernetesCluster,
   KubernetesControlPlaneACLPayload,
   KubernetesDashboardResponse,
@@ -39,6 +40,32 @@ export const nodePoolFactory = Factory.Sync.makeFactory<KubeNodePoolResponse>({
   ],
   type: 'g6-standard-1',
 });
+
+export const nodePoolBetaFactory =
+  Factory.Sync.makeFactory<KubeNodePoolResponseBeta>({
+    autoscaler: {
+      enabled: false,
+      max: 1,
+      min: 1,
+    },
+    count: 3,
+    disk_encryption: 'enabled',
+    id: Factory.each((id) => id),
+    labels: {},
+    nodes: kubeLinodeFactory.buildList(3),
+    tags: [],
+    taints: [
+      {
+        effect: 'NoExecute',
+        key: 'example.com/my-app',
+        value: 'my-taint',
+      },
+    ],
+    type: 'g6-standard-1',
+    firewall_id: 0,
+    k8s_version: 'v1.31.1+lke4',
+    update_strategy: 'on_recycle',
+  });
 
 export const kubernetesClusterFactory =
   Factory.Sync.makeFactory<KubernetesCluster>({

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
@@ -163,7 +163,7 @@ export const AddNodePoolDrawer = (props: Props) => {
     if (!selectedTypeInfo) {
       return;
     }
-    if (isLkeEnterpriseLAFeatureEnabled) {
+    if (isLkeEnterpriseLAFeatureEnabled && clusterTier === 'enterprise') {
       return createPoolBeta({
         count: selectedTypeInfo.count,
         type: selectedTypeInfo.planId,

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
@@ -14,7 +14,10 @@ import {
   ADD_NODE_POOLS_ENTERPRISE_DESCRIPTION,
   nodeWarning,
 } from 'src/features/Kubernetes/constants';
-import { useCreateNodePoolMutation } from 'src/queries/kubernetes';
+import {
+  useCreateNodePoolBetaMutation,
+  useCreateNodePoolMutation,
+} from 'src/queries/kubernetes';
 import { useAllTypes } from 'src/queries/types';
 import { extendType } from 'src/utilities/extendType';
 import { filterCurrentTypes } from 'src/utilities/filterCurrentLinodeTypes';
@@ -24,6 +27,7 @@ import { getLinodeRegionPrice } from 'src/utilities/pricing/linodes';
 
 import { PremiumCPUPlanNotice } from '../../CreateCluster/PremiumCPUPlanNotice';
 import { KubernetesPlansPanel } from '../../KubernetesPlansPanel/KubernetesPlansPanel';
+import { useIsLkeEnterpriseEnabled } from '../../kubeUtils';
 import { hasInvalidNodePoolPrice } from './utils';
 
 import type { KubernetesTier, Region } from '@linode/api-v4';
@@ -83,11 +87,20 @@ export const AddNodePoolDrawer = (props: Props) => {
   } = props;
   const { classes } = useStyles();
   const { data: types } = useAllTypes(open);
+
+  const { isLkeEnterpriseLAFeatureEnabled } = useIsLkeEnterpriseEnabled();
+
+  const {
+    error: errorBeta,
+    isPending: isPendingBeta,
+    mutateAsync: createPoolBeta,
+  } = useCreateNodePoolBetaMutation(clusterId);
   const {
     error,
     isPending,
     mutateAsync: createPool,
   } = useCreateNodePoolMutation(clusterId);
+
   const drawerRef = React.useRef<HTMLDivElement>(null);
 
   // Only want to use current types here.
@@ -132,7 +145,11 @@ export const AddNodePoolDrawer = (props: Props) => {
       setAddNodePoolError(error?.[0].reason);
       scrollErrorIntoViewV2(drawerRef);
     }
-  }, [error]);
+    if (errorBeta) {
+      setAddNodePoolError(errorBeta?.[0].reason);
+      scrollErrorIntoViewV2(drawerRef);
+    }
+  }, [error, errorBeta]);
 
   const resetDrawer = () => {
     setSelectedTypeInfo(undefined);
@@ -145,6 +162,14 @@ export const AddNodePoolDrawer = (props: Props) => {
   const handleAdd = () => {
     if (!selectedTypeInfo) {
       return;
+    }
+    if (isLkeEnterpriseLAFeatureEnabled) {
+      return createPoolBeta({
+        count: selectedTypeInfo.count,
+        type: selectedTypeInfo.planId,
+      }).then(() => {
+        onClose();
+      });
     }
     return createPool({
       count: selectedTypeInfo.count,
@@ -196,7 +221,7 @@ export const AddNodePoolDrawer = (props: Props) => {
           hasSelectedRegion={hasSelectedRegion}
           isPlanPanelDisabled={isPlanPanelDisabled}
           isSelectedRegionEligibleForPlan={isSelectedRegionEligibleForPlan}
-          isSubmitting={isPending}
+          isSubmitting={isPending || isPendingBeta}
           notice={<PremiumCPUPlanNotice spacingBottom={16} spacingTop={16} />}
           onSelect={(newType: string) => {
             if (selectedTypeInfo?.planId !== newType) {

--- a/packages/manager/src/queries/kubernetes.ts
+++ b/packages/manager/src/queries/kubernetes.ts
@@ -42,6 +42,7 @@ import type {
   CreateNodePoolData,
   CreateNodePoolDataBeta,
   KubeNodePoolResponse,
+  KubeNodePoolResponseBeta,
   KubernetesCluster,
   KubernetesControlPlaneACLPayload,
   KubernetesDashboardResponse,

--- a/packages/manager/src/queries/kubernetes.ts
+++ b/packages/manager/src/queries/kubernetes.ts
@@ -2,6 +2,7 @@ import {
   createKubernetesCluster,
   createKubernetesClusterBeta,
   createNodePool,
+  createNodePoolBeta,
   deleteKubernetesCluster,
   deleteNodePool,
   getKubeConfig,
@@ -39,6 +40,7 @@ import {
 import type {
   CreateKubeClusterPayload,
   CreateNodePoolData,
+  CreateNodePoolDataBeta,
   KubeNodePoolResponse,
   KubernetesCluster,
   KubernetesControlPlaneACLPayload,
@@ -360,6 +362,26 @@ export const useCreateNodePoolMutation = (clusterId: number) => {
   const queryClient = useQueryClient();
   return useMutation<KubeNodePoolResponse, APIError[], CreateNodePoolData>({
     mutationFn: (data) => createNodePool(clusterId, data),
+    onSuccess() {
+      queryClient.invalidateQueries({
+        queryKey: kubernetesQueries.cluster(clusterId)._ctx.pools.queryKey,
+      });
+    },
+  });
+};
+
+/**
+ * Beta mutation to allow for the update of k8_version and update_strategy via beta endpoint
+ * TODO LKE-E: Remove this mutation once LKE-E is GA and /v4 endpoints are used
+ */
+export const useCreateNodePoolBetaMutation = (clusterId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    KubeNodePoolResponseBeta,
+    APIError[],
+    CreateNodePoolDataBeta
+  >({
+    mutationFn: (data) => createNodePoolBeta(clusterId, data),
     onSuccess() {
       queryClient.invalidateQueries({
         queryKey: kubernetesQueries.cluster(clusterId)._ctx.pools.queryKey,

--- a/packages/manager/src/queries/kubernetes.ts
+++ b/packages/manager/src/queries/kubernetes.ts
@@ -17,6 +17,7 @@ import {
   getKubernetesTypes,
   getKubernetesTypesBeta,
   getKubernetesVersions,
+  getNodePoolBeta,
   getNodePools,
   recycleAllNodes,
   recycleClusterNodes,
@@ -25,6 +26,7 @@ import {
   updateKubernetesCluster,
   updateKubernetesClusterControlPlaneACL,
   updateNodePool,
+  updateNodePoolBeta,
 } from '@linode/api-v4';
 import { profileQueries, queryPresets } from '@linode/queries';
 import { getAll } from '@linode/utilities';
@@ -50,6 +52,7 @@ import type {
   KubernetesTieredVersion,
   KubernetesVersion,
   UpdateNodePoolData,
+  UpdateNodePoolDataBeta,
 } from '@linode/api-v4';
 import type {
   APIError,
@@ -133,6 +136,12 @@ export const kubernetesQueries = createQueryKeys('kubernetes', {
         queryKey: null,
       },
       pools: {
+        contextQueries: {
+          pool: (poolId: number) => ({
+            queryFn: () => getNodePoolBeta(id, poolId),
+            queryKey: [poolId],
+          }),
+        },
         queryFn: () => getAllNodePoolsForCluster(id),
         queryKey: null,
       },
@@ -402,6 +411,29 @@ export const useUpdateNodePoolMutation = (
     Partial<UpdateNodePoolData>
   >({
     mutationFn: (data) => updateNodePool(clusterId, poolId, data),
+    onSuccess() {
+      queryClient.invalidateQueries({
+        queryKey: kubernetesQueries.cluster(clusterId)._ctx.pools.queryKey,
+      });
+    },
+  });
+};
+
+/**
+ * Beta mutation to allow for the update of k8_version and update_strategy via beta endpoint
+ * TODO LKE-E: Remove this mutation once LKE-E is GA and /v4 endpoints are used
+ */
+export const useUpdateNodePoolBetaMutation = (
+  clusterId: number,
+  poolId: number
+) => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    KubeNodePoolResponseBeta,
+    APIError[],
+    Partial<UpdateNodePoolDataBeta>
+  >({
+    mutationFn: (data) => updateNodePoolBeta(clusterId, poolId, data),
     onSuccess() {
       queryClient.invalidateQueries({
         queryKey: kubernetesQueries.cluster(clusterId)._ctx.pools.queryKey,

--- a/packages/validation/.changeset/pr-12188-upcoming-features-1747069233094.md
+++ b/packages/validation/.changeset/pr-12188-upcoming-features-1747069233094.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Upcoming Features
+---
+
+Add new LKE-E schema for nodePoolBetaSchema ([#12188](https://github.com/linode/manager/pull/12188))

--- a/packages/validation/src/kubernetes.schema.ts
+++ b/packages/validation/src/kubernetes.schema.ts
@@ -7,6 +7,14 @@ export const nodePoolSchema = object({
   count: number(),
 });
 
+export const nodePoolBetaSchema = nodePoolSchema.concat(
+  object({
+    upgrade_strategy: string(),
+    k8_version: string(),
+    firewall_id: number(),
+  }),
+);
+
 export const clusterLabelSchema = string()
   .required('Label is required.')
   /**


### PR DESCRIPTION
## Description 📝

Ahead of supporting the ability to update a Node Pool's `k8_version` and `update_strategy` in the UI (M3-9200 - designated as post-LA), we should update 'Add a Node Pool' for existing LKE-E clusters to use the `/v4beta` POST endpoint. The new node pools will be created with the default values assigned for the fields because neither field is required.

This should be done now, pre-LA before version/update support, because newly created NPs should have the same fields as NPs that were created when the cluster was first created. Also, LKE-6988 was raised and the cause/fix was determined to be the unintended enablement of the firewall feature in devcloud, but it is also correct to state that we should be using v4beta. With the v4beta endpoint, `firewall_id` is assigned its default 0.

## Changes  🔄
- New beta endpoints are added in apiv4 package (nodePools.ts) with updated types
   - This PR only needed the POST request `createNodePoolBeta`, but I added the GET and PUT request too so they're present for routing refactor work
- A new `useCreateNodePoolBetaMutation` is added to kubernetes.ts (plus queries updates for GET and PUT)
- The new create mutation is used in the Add a Node Pool drawer when the LKE-E feature is enabled
- MSW support is added for the POST endpoint; MSW support for GET and PUT will come with #12179

## Target release date 🗓️

5/20 (5/15 devcloud)

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/11f61ff1-d486-4b8e-ba8d-ab9daeb5e524" /> | <video src="https://github.com/user-attachments/assets/dc7e25f4-f5e4-4b71-8beb-7676b244e048" /> |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have the LKE-E feature flag on, the customer tag, and log into `prod-test-004-fe` with our creds.
- Alternatively, use the MSW 2.0 and create an LKE-E cluster in CRUD mode.

### Reproduction steps

(How to reproduce the issue, if applicable)

- In staging or with develop branch checked out:
   - Have an LKE-E cluster
   - Add a Node Pool to the existing cluster
   - Look at the request and observe it's /v4. Observe the response doesn't have the update_strategy, k8_version, or firewall_id fields.

### Verification steps

(How to verify changes)

- [ ] Check out this branch/use preview link
- [ ] Have an LKE-E cluster
- [ ] Add a Node Pool to the existing cluster
- [ ] Look at the request and observe it's /v4beta. Observe the response has default values for the update_strategy, k8_version, or firewall_id fields.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
