### PR TITLE
upcoming: [DI-24902] - Fetch Alerting Time Period Options from LD flag

### DIFF
--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -104,10 +104,20 @@ interface LimitsEvolution {
   requestForIncreaseDisabledForInternalAccountsOnly: boolean;
 }
 
+interface AlertTimeDuration {
+  label: string;
+  value: number;
+}
+interface AclpAlertingTimeOptions {
+  evaluationPeriodOptions: AlertTimeDuration[];
+  pollingIntervalOptions: AlertTimeDuration[];
+}
+
 export interface Flags {
   acceleratedPlans: AcceleratedPlansFlag;
   aclp: AclpFlag;
   aclpAlerting: AclpAlerting;
+  aclpAlertingTimeOptions: AclpAlertingTimeOptions;
   aclpAlertServiceTypeConfig: AclpAlertServiceTypeConfig[];
   aclpIntegration: boolean;
   aclpReadEndpoint: string;

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/TriggerConditions.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/TriggerConditions.test.tsx
@@ -4,10 +4,6 @@ import * as React from 'react';
 
 import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
 
-import {
-  evaluationPeriodOptions,
-  pollingIntervalOptions,
-} from '../../constants';
 import { TriggerConditions } from './TriggerConditions';
 
 import type { CreateAlertDefinitionForm } from '../types';
@@ -15,28 +11,58 @@ import type { CreateAlertDefinitionForm } from '../types';
 const EvaluationPeriodTestId = 'evaluation-period';
 
 const PollingIntervalTestId = 'polling-interval';
+const evaluationPeriodOptions = [
+  { label: '5 min', value: 300 },
+  { label: '15 min', value: 900 },
+  { label: '30 min', value: 1800 },
+  { label: '1 hr', value: 3600 },
+];
+const pollingIntervalOptions = [
+  { label: '5 min', value: 300 },
+  { label: '15 min', value: 900 },
+  { label: '30 min', value: 1800 },
+  { label: '1 hr', value: 3600 },
+];
 
+const queryMocks = vi.hoisted(() => ({
+  useFlags: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('src/hooks/useFlags', () => {
+  const actual = vi.importActual('src/hooks/useFlags');
+  return {
+    ...actual,
+    useFlags: queryMocks.useFlags,
+  };
+});
+
+beforeEach(() => {
+  queryMocks.useFlags.mockReturnValue({
+    aclpAlertingTimeOptions: {
+      evaluationPeriodOptions,
+      pollingIntervalOptions,
+    },
+  });
+});
 describe('Trigger Conditions', () => {
   const user = userEvent.setup();
 
   it('should render all the components and names', () => {
-    const container = renderWithThemeAndHookFormContext({
+    renderWithThemeAndHookFormContext({
       component: (
         <TriggerConditions maxScrapingInterval={0} name="trigger_conditions" />
       ),
     });
-    expect(container.getByLabelText('Evaluation Period')).toBeInTheDocument();
-    expect(container.getByLabelText('Polling Interval')).toBeInTheDocument();
+    expect(screen.getByLabelText('Evaluation Period')).toBeVisible();
+    expect(screen.getByLabelText('Polling Interval')).toBeVisible();
     expect(
-      container.getByText('Trigger alert when all criteria are met for')
-    ).toBeInTheDocument();
-    expect(
-      container.getByText('consecutive occurrence(s).')
-    ).toBeInTheDocument();
+      screen.getByText('Trigger alert when all criteria are met for')
+    ).toBeVisible();
+    expect(screen.getByText('consecutive occurrence(s).')).toBeVisible();
   });
 
   it('should render the tooltips for the Autocomplete components', () => {
-    const container = renderWithThemeAndHookFormContext({
+    renderWithThemeAndHookFormContext({
       component: (
         <TriggerConditions maxScrapingInterval={0} name="trigger_conditions" />
       ),
@@ -47,19 +73,15 @@ describe('Trigger Conditions', () => {
       },
     });
 
-    const evaluationPeriodContainer = container.getByTestId(
-      EvaluationPeriodTestId
-    );
-    const evaluationPeriodToolTip = within(evaluationPeriodContainer).getByRole(
+    const evaluationPeriodscreen = screen.getByTestId(EvaluationPeriodTestId);
+    const evaluationPeriodToolTip = within(evaluationPeriodscreen).getByRole(
       'button',
       {
         name: 'Defines the timeframe for collecting data in polling intervals to understand the service performance. Choose the data lookback period where the thresholds are applied to gather the information impactful for your business.',
       }
     );
-    const pollingIntervalContainer = container.getByTestId(
-      PollingIntervalTestId
-    );
-    const pollingIntervalToolTip = within(pollingIntervalContainer).getByRole(
+    const pollingIntervalscreen = screen.getByTestId(PollingIntervalTestId);
+    const pollingIntervalToolTip = within(pollingIntervalscreen).getByRole(
       'button',
       {
         name: 'Choose how often you intend to evaluate the alert condition.',
@@ -70,24 +92,18 @@ describe('Trigger Conditions', () => {
   });
 
   it('should render the Evaluation Period component with options happy path and select an option', async () => {
-    const container =
-      renderWithThemeAndHookFormContext<CreateAlertDefinitionForm>({
-        component: (
-          <TriggerConditions
-            maxScrapingInterval={0}
-            name="trigger_conditions"
-          />
-        ),
-        useFormOptions: {
-          defaultValues: {
-            serviceType: 'linode',
-          },
+    renderWithThemeAndHookFormContext<CreateAlertDefinitionForm>({
+      component: (
+        <TriggerConditions maxScrapingInterval={0} name="trigger_conditions" />
+      ),
+      useFormOptions: {
+        defaultValues: {
+          serviceType: 'linode',
         },
-      });
-    const evaluationPeriodContainer = container.getByTestId(
-      EvaluationPeriodTestId
-    );
-    const evaluationPeriodInput = within(evaluationPeriodContainer).getByRole(
+      },
+    });
+    const evaluationPeriodscreen = screen.getByTestId(EvaluationPeriodTestId);
+    const evaluationPeriodInput = within(evaluationPeriodscreen).getByRole(
       'button',
       { name: 'Open' }
     );
@@ -95,46 +111,40 @@ describe('Trigger Conditions', () => {
     user.click(evaluationPeriodInput);
 
     expect(
-      await container.findByRole('option', {
-        name: evaluationPeriodOptions.linode[1].label,
+      await screen.findByRole('option', {
+        name: evaluationPeriodOptions[1].label,
       })
-    ).toBeInTheDocument();
+    ).toBeVisible();
     expect(
-      await container.findByRole('option', {
-        name: evaluationPeriodOptions.linode[2].label,
+      await screen.findByRole('option', {
+        name: evaluationPeriodOptions[2].label,
       })
-    );
+    ).toBeVisible();
 
     await user.click(
-      container.getByRole('option', {
-        name: evaluationPeriodOptions.linode[0].label,
+      screen.getByRole('option', {
+        name: evaluationPeriodOptions[0].label,
       })
     );
 
     expect(
-      within(evaluationPeriodContainer).getByRole('combobox')
-    ).toHaveAttribute('value', evaluationPeriodOptions.linode[0].label);
+      within(evaluationPeriodscreen).getByRole('combobox')
+    ).toHaveAttribute('value', evaluationPeriodOptions[0].label);
   });
 
   it('should render the Polling Interval component with options happy path and select an option', async () => {
-    const container =
-      renderWithThemeAndHookFormContext<CreateAlertDefinitionForm>({
-        component: (
-          <TriggerConditions
-            maxScrapingInterval={0}
-            name="trigger_conditions"
-          />
-        ),
-        useFormOptions: {
-          defaultValues: {
-            serviceType: 'linode',
-          },
+    renderWithThemeAndHookFormContext<CreateAlertDefinitionForm>({
+      component: (
+        <TriggerConditions maxScrapingInterval={0} name="trigger_conditions" />
+      ),
+      useFormOptions: {
+        defaultValues: {
+          serviceType: 'linode',
         },
-      });
-    const pollingIntervalContainer = container.getByTestId(
-      PollingIntervalTestId
-    );
-    const pollingIntervalInput = within(pollingIntervalContainer).getByRole(
+      },
+    });
+    const pollingIntervalscreen = screen.getByTestId(PollingIntervalTestId);
+    const pollingIntervalInput = within(pollingIntervalscreen).getByRole(
       'button',
       { name: 'Open' }
     );
@@ -142,32 +152,33 @@ describe('Trigger Conditions', () => {
     user.click(pollingIntervalInput);
 
     expect(
-      await container.findByRole('option', {
-        name: pollingIntervalOptions.linode[1].label,
+      await screen.findByRole('option', {
+        name: pollingIntervalOptions[1].label,
       })
-    ).toBeInTheDocument();
+    ).toBeVisible();
 
     expect(
-      await container.findByRole('option', {
-        name: pollingIntervalOptions.linode[2].label,
+      await screen.findByRole('option', {
+        name: pollingIntervalOptions[2].label,
       })
-    );
+    ).toBeVisible();
 
     await user.click(
-      container.getByRole('option', {
-        name: pollingIntervalOptions.linode[0].label,
+      screen.getByRole('option', {
+        name: pollingIntervalOptions[0].label,
       })
     );
-    expect(
-      within(pollingIntervalContainer).getByRole('combobox')
-    ).toHaveAttribute('value', pollingIntervalOptions.linode[0].label);
+    expect(within(pollingIntervalscreen).getByRole('combobox')).toHaveAttribute(
+      'value',
+      pollingIntervalOptions[0].label
+    );
   });
 
-  it('should be able to show the options that are greater than or equal to max scraping Interval', () => {
-    const container = renderWithThemeAndHookFormContext({
+  it('should be able to show the options that are greater than or equal to max scraping Interval', async () => {
+    renderWithThemeAndHookFormContext({
       component: (
         <TriggerConditions
-          maxScrapingInterval={120}
+          maxScrapingInterval={400}
           name="trigger_conditions"
         />
       ),
@@ -177,30 +188,26 @@ describe('Trigger Conditions', () => {
         },
       },
     });
-    const evaluationPeriodContainer = container.getByTestId(
-      EvaluationPeriodTestId
-    );
-    const evaluationPeriodInput = within(evaluationPeriodContainer).getByRole(
+    const evaluationPeriodscreen = screen.getByTestId(EvaluationPeriodTestId);
+    const evaluationPeriodInput = within(evaluationPeriodscreen).getByRole(
       'button',
       { name: 'Open' }
     );
 
-    user.click(evaluationPeriodInput);
+    await user.click(evaluationPeriodInput);
 
     expect(
-      screen.queryByText(evaluationPeriodOptions.linode[0].label)
+      screen.queryByText(evaluationPeriodOptions[0].label)
     ).not.toBeInTheDocument();
 
-    const pollingIntervalContainer = container.getByTestId(
-      PollingIntervalTestId
-    );
-    const pollingIntervalInput = within(pollingIntervalContainer).getByRole(
+    const pollingIntervalscreen = screen.getByTestId(PollingIntervalTestId);
+    const pollingIntervalInput = within(pollingIntervalscreen).getByRole(
       'button',
       { name: 'Open' }
     );
-    user.click(pollingIntervalInput);
+    await user.click(pollingIntervalInput);
     expect(
-      screen.queryByText(pollingIntervalOptions.linode[0].label)
+      screen.queryByText(pollingIntervalOptions[0].label)
     ).not.toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/TriggerConditions.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/TriggerConditions.tsx
@@ -4,10 +4,8 @@ import * as React from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import type { FieldPathByValue } from 'react-hook-form';
 
-import {
-  evaluationPeriodOptions,
-  pollingIntervalOptions,
-} from '../../constants';
+import { useFlags } from 'src/hooks/useFlags';
+
 import { getAlertBoxStyles } from '../../Utils/utils';
 
 import type { CreateAlertDefinitionForm } from '../types';
@@ -15,6 +13,7 @@ import type {
   CreateAlertDefinitionPayload,
   TriggerCondition,
 } from '@linode/api-v4';
+
 interface TriggerConditionProps {
   /**
    * maximum scraping interval value for a metric to filter the evaluation period and polling interval options
@@ -33,17 +32,16 @@ export const TriggerConditions = (props: TriggerConditionProps) => {
     control,
     name: 'serviceType',
   });
+  const { aclpAlertingTimeOptions } = useFlags();
   const getPollingIntervalOptions = () => {
-    const options = serviceTypeWatcher
-      ? pollingIntervalOptions[serviceTypeWatcher]
-      : [];
+    if (!serviceTypeWatcher || !aclpAlertingTimeOptions) return [];
+    const options = aclpAlertingTimeOptions.pollingIntervalOptions;
     return options.filter((item) => item.value >= maxScrapingInterval);
   };
 
   const getEvaluationPeriodOptions = () => {
-    const options = serviceTypeWatcher
-      ? evaluationPeriodOptions[serviceTypeWatcher]
-      : [];
+    if (!serviceTypeWatcher || !aclpAlertingTimeOptions) return [];
+    const options = aclpAlertingTimeOptions.pollingIntervalOptions;
     return options.filter((item) => item.value >= maxScrapingInterval);
   };
 
@@ -52,7 +50,7 @@ export const TriggerConditions = (props: TriggerConditionProps) => {
       sx={(theme) => ({
         ...getAlertBoxStyles(theme),
         borderRadius: 1,
-        marginTop: theme.spacing(2),
+        marginTop: theme.spacingFunction(2),
         p: 2,
       })}
     >

--- a/packages/manager/src/features/CloudPulse/Alerts/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/constants.ts
@@ -101,25 +101,7 @@ export const dimensionOperatorOptions: Item<
   },
 ];
 
-export const evaluationPeriodOptions = {
-  dbaas: [{ label: '5 min', value: 300 }],
-  linode: [
-    { label: '1 min', value: 60 },
-    { label: '5 min', value: 300 },
-    { label: '15 min', value: 900 },
-    { label: '30 min', value: 1800 },
-    { label: '1 hr', value: 3600 },
-  ],
-};
-
-export const pollingIntervalOptions = {
-  dbaas: [{ label: '5 min', value: 300 }],
-  linode: [
-    { label: '1 min', value: 60 },
-    { label: '5 min', value: 300 },
-    { label: '10 min', value: 600 },
-  ],
-};
+export const textFieldOperators = ['endswith', 'startswith'];
 
 export const severityMap: Record<AlertSeverityType, string> = {
   0: 'Severe',


### PR DESCRIPTION
## Description 📝

Fetching Evaluation Period, Polling Interval options from the LD flag

## Changes  🔄

List any change(s) relevant to the reviewer.

- Add a featureFlag `aclpAlertingTimeOptions`
- Changed logic to fetch options from the LD flag
- removed the Evaluation Period, Polling Interval options from the `Alerts/constants.ts`
- mocking the flag in the UT

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷

**Include a screenshot or screen recording of the change.**

No visible changes in UX. 

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Navigate to alerts (under Monitor)
- Try to either create or edit an user alert 
- For now the LD flag is enabled only in the lower environments and from API side only 5 mins is supported. So please test it in mock. (By the time this change is released into prod, we will raise a ticket for the LD flag to be available with appropriate values in prod).

### Verification steps

(How to verify changes)

- [ ] Behaviour of create and edit alert should be same as before.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
