### PR TITLE
fix: [M3-9958] - StackScripts Landing description truncation

### DIFF
--- a/packages/manager/.changeset/pr-12194-fixed-1747062971408.md
+++ b/packages/manager/.changeset/pr-12194-fixed-1747062971408.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+StackScripts Landing description truncation ([#12194](https://github.com/linode/manager/pull/12194))

--- a/packages/manager/src/features/StackScripts/StackScriptLanding/StackScriptRow.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptLanding/StackScriptRow.tsx
@@ -24,19 +24,25 @@ export const StackScriptRow = (props: Props) => {
 
   return (
     <TableRow data-qa-table-row={stackscript.label}>
-      <TableCell noWrap sx={{ maxWidth: 300 }}>
-        <Stack>
-          <Typography sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
-            <Link to={`/stackscripts/${stackscript.id}`}>
-              {stackscript.username} / <span>{stackscript.label}</span>
-            </Link>
-          </Typography>
+      <TableCell>
+        <Stack sx={{ maxWidth: 400 }}>
+          <Link
+            style={{
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+            }}
+            to={`/stackscripts/${stackscript.id}`}
+          >
+            {stackscript.username} / <span>{stackscript.label}</span>
+          </Link>
           <Typography
             sx={(theme) => ({
               color: theme.textColors.tableHeader,
               fontSize: '.75rem',
               overflow: 'hidden',
               textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
             })}
           >
             {stackscript.description}

--- a/packages/manager/src/features/StackScripts/StackScriptLanding/StackScriptRow.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptLanding/StackScriptRow.tsx
@@ -24,8 +24,8 @@ export const StackScriptRow = (props: Props) => {
 
   return (
     <TableRow data-qa-table-row={stackscript.label}>
-      <TableCell>
-        <Stack sx={{ maxWidth: 400 }}>
+      <TableCell sx={{ maxWidth: { lg: 400, md: 300, sm: 200, xs: 225 } }}>
+        <Stack>
           <Link
             style={{
               textOverflow: 'ellipsis',


### PR DESCRIPTION
## Description 📝

- Fixes truncation on the StackScript landing page 
- I don't remember the cause. I think it was MUI v6 or the UI overhaul a few weeks back

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-05-12 at 11 12 53 AM](https://github.com/user-attachments/assets/bea35395-037e-4fd2-b023-c8b2581613ad) | ![Screenshot 2025-05-12 at 11 12 44 AM](https://github.com/user-attachments/assets/3480e408-82ac-4cf4-8e4b-e23bcdd51cbc) |

## How to test 🧪

- Checkout this PR or use the internal preview link
- Go to http://localhost:3000/stackscripts/community
- Verify that StackScript descriptions and labels are gracefully truncated
- Verify it looks acceptable on all viewports

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>