### PR TITLE
tech story: [M3-9964] - Delete root level `.eslintrc.js`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,0 @@
-module.exports = {
-  root: true,
-  ignorePatterns: ["**/node_modules/", "**/build/"],
-  parser: "@typescript-eslint/parser",
-};

--- a/packages/manager/.changeset/pr-12195-tech-stories-1747064399669.md
+++ b/packages/manager/.changeset/pr-12195-tech-stories-1747064399669.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Delete root level `.eslintrc.js` ([#12195](https://github.com/linode/manager/pull/12195))


### PR DESCRIPTION
## Description 📝

- Small clean up following https://github.com/linode/manager/pull/11941
- Removes the root level `.eslintrc.js` because it is not used and not needed that we are on ESLint v9 using the new flat config approach

## How to test 🧪

### Prerequisites

- Checkout this PR
- Run `pnpm lint:all`
  - Verify linting succeeds for all packages without any issue
- Verify all linting-related Github Actions pass 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>