### PR TITLE
test [M3-9926]: fix for misc test failures

### DIFF
--- a/packages/manager/cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts
@@ -83,6 +83,7 @@ describe('Migrate Linode With Firewall', () => {
    * - Confirms that user is warned of migration consequences.
    */
   it('test migrate flow - mocking all data', () => {
+    cy.tag('env:multipleRegions');
     const mockLinode = linodeFactory.build({
       id: randomNumber(),
       label: randomLabel(),

--- a/packages/manager/cypress/e2e/core/objectStorage/access-key.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/access-key.e2e.spec.ts
@@ -12,6 +12,7 @@ import {
 } from 'support/intercepts/object-storage';
 import { ui } from 'support/ui';
 import { cleanUp } from 'support/util/cleanup';
+import { chooseCluster } from 'support/util/clusters';
 import { randomLabel } from 'support/util/random';
 
 import { accountFactory } from 'src/factories';
@@ -120,9 +121,9 @@ describe('object storage access key end-to-end tests', () => {
    */
   it('can create an access key with limited access - e2e', () => {
     const bucketLabel = randomLabel();
-    const bucketCluster = 'us-east-1';
+    const bucketClusterObj = chooseCluster();
     const bucketRequest = createObjectStorageBucketFactoryLegacy.build({
-      cluster: bucketCluster,
+      cluster: bucketClusterObj.id,
       label: bucketLabel,
       // Default factory sets `cluster` and `region`, but API does not accept `region` yet.
       region: undefined,
@@ -208,7 +209,7 @@ describe('object storage access key end-to-end tests', () => {
             });
         });
 
-        const permissionLabel = `This token has read-only access for ${bucketCluster}-${bucketLabel}`;
+        const permissionLabel = `This token has read-only access for ${bucketClusterObj.id}-${bucketLabel}`;
         cy.findByLabelText(permissionLabel).should('be.visible');
       });
     });

--- a/packages/manager/cypress/e2e/core/objectStorageMulticluster/object-storage-objects-multicluster.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorageMulticluster/object-storage-objects-multicluster.spec.ts
@@ -133,7 +133,6 @@ describe('Object Storage Multicluster objects', () => {
   it('can upload, access, and delete objects', () => {
     const bucketLabel = randomLabel();
     const bucketClusterObj = chooseCluster();
-    console.log('bucketClusterObj ', bucketClusterObj);
     const bucketRegionId = bucketClusterObj.region;
     const bucketPage = `/object-storage/buckets/${bucketRegionId}/${bucketLabel}/objects`;
     const bucketFolderName = randomLabel();
@@ -149,7 +148,7 @@ describe('Object Storage Multicluster objects', () => {
     ).then(() => {
       interceptUploadBucketObjectS3(
         bucketLabel,
-        bucketClusterObj.id,
+        bucketClusterObj.domain,
         bucketFiles[0].name
       ).as('uploadObject');
 
@@ -202,7 +201,7 @@ describe('Object Storage Multicluster objects', () => {
       cy.findByText(emptyFolderMessage).should('be.visible');
       interceptUploadBucketObjectS3(
         bucketLabel,
-        bucketClusterObj.id,
+        bucketClusterObj.domain,
         `${bucketFolderName}/${bucketFiles[1].name}`
       ).as('uploadObject');
       uploadFile(bucketFiles[1].path, bucketFiles[1].name);

--- a/packages/manager/cypress/e2e/core/objectStorageMulticluster/object-storage-objects-multicluster.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorageMulticluster/object-storage-objects-multicluster.spec.ts
@@ -5,6 +5,7 @@ import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
 import { interceptUploadBucketObjectS3 } from 'support/intercepts/object-storage';
 import { ui } from 'support/ui';
 import { cleanUp } from 'support/util/cleanup';
+import { chooseCluster } from 'support/util/clusters';
 import { randomLabel } from 'support/util/random';
 
 import { createObjectStorageBucketFactoryGen1 } from 'src/factories';
@@ -131,8 +132,9 @@ describe('Object Storage Multicluster objects', () => {
    */
   it('can upload, access, and delete objects', () => {
     const bucketLabel = randomLabel();
-    const bucketCluster = 'us-southeast-1';
-    const bucketRegionId = 'us-southeast';
+    const bucketClusterObj = chooseCluster();
+    console.log('bucketClusterObj ', bucketClusterObj);
+    const bucketRegionId = bucketClusterObj.region;
     const bucketPage = `/object-storage/buckets/${bucketRegionId}/${bucketLabel}/objects`;
     const bucketFolderName = randomLabel();
 
@@ -147,7 +149,7 @@ describe('Object Storage Multicluster objects', () => {
     ).then(() => {
       interceptUploadBucketObjectS3(
         bucketLabel,
-        bucketCluster,
+        bucketClusterObj.id,
         bucketFiles[0].name
       ).as('uploadObject');
 
@@ -200,7 +202,7 @@ describe('Object Storage Multicluster objects', () => {
       cy.findByText(emptyFolderMessage).should('be.visible');
       interceptUploadBucketObjectS3(
         bucketLabel,
-        bucketCluster,
+        bucketClusterObj.id,
         `${bucketFolderName}/${bucketFiles[1].name}`
       ).as('uploadObject');
       uploadFile(bucketFiles[1].path, bucketFiles[1].name);

--- a/packages/manager/cypress/support/intercepts/object-storage.ts
+++ b/packages/manager/cypress/support/intercepts/object-storage.ts
@@ -303,13 +303,10 @@ export const mockUploadBucketObject = (
  */
 export const interceptUploadBucketObjectS3 = (
   label: string,
-  cluster: string,
+  domain: string,
   filename: string
 ): Cypress.Chainable<null> => {
-  return cy.intercept(
-    'PUT',
-    `https://${cluster}.linodeobjects.com/${label}/${filename}*`
-  );
+  return cy.intercept('PUT', `https://${domain}/${label}/${filename}*`);
 };
 
 /**


### PR DESCRIPTION
## Description 📝

Attempt to fix the remaining test failures due to hardcoded region and cluster IDs that may not exist in all test environments. 

## Changes  🔄

Use chooseRegion and chooseCluster instead of hardcoded regions.  

## How to test 🧪

pnpm run cy:run 

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
 
