### PR TITLE
fix: [M3-9969] - Fix console warnings related to first-child pseudo class in LandingHeader component

### DIFF
--- a/packages/manager/.changeset/pr-12200-fixed-1747084073178.md
+++ b/packages/manager/.changeset/pr-12200-fixed-1747084073178.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fix console warnings related to first-child pseudo class in LandingHeader component ([#12200](https://github.com/linode/manager/pull/12200))

--- a/packages/manager/src/components/LandingHeader/LandingHeader.tsx
+++ b/packages/manager/src/components/LandingHeader/LandingHeader.tsx
@@ -170,7 +170,7 @@ const StyledActions = styled('div')(({ theme }) => ({
 }));
 
 const StyledLandingHeaderGrid = styled(Grid)(({ theme }) => ({
-  '&:not(:first-child)': {
+  '&:not(:first-of-type)': {
     marginTop: theme.spacingFunction(24),
   },
 }));


### PR DESCRIPTION
## Description 📝

Fix console warnings related to "**:first-child"** pseudo class in LAndingHeader component.
![image](https://github.com/user-attachments/assets/cd6b9915-0dc0-4226-b8d6-94a3b982de75)


## Target release date 🗓️
5/20


## How to test 🧪

(How to reproduce the issue, if applicable)

- [ ] Checkout develop branch and navigate to linodes or any landing page.
- [ ] Open console and notice warnings related to pseudo class (attached screenshot for reference).

### Verification steps

(How to verify changes)

- [ ] Checkout the branch and run the app locally.
- [ ] Verify no console warnings related to the **":first-child"** pseudo class in the console. 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

