### PR TITLE
refactor: [M3-9370] - Move Domain queries

### DIFF
--- a/packages/manager/src/features/Domains/CloneDomainDrawer.tsx
+++ b/packages/manager/src/features/Domains/CloneDomainDrawer.tsx
@@ -1,4 +1,4 @@
-import { useGrants, useProfile } from '@linode/queries';
+import { useCloneDomainMutation, useGrants, useProfile } from '@linode/queries';
 import {
   ActionsPanel,
   Drawer,
@@ -11,8 +11,6 @@ import {
 import { useNavigate } from '@tanstack/react-router';
 import { useFormik } from 'formik';
 import React from 'react';
-
-import { useCloneDomainMutation } from 'src/queries/domains';
 
 import type { APIError, Domain } from '@linode/api-v4';
 

--- a/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
+++ b/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
@@ -1,4 +1,8 @@
-import { useGrants, useProfile } from '@linode/queries';
+import {
+  useCreateDomainMutation,
+  useGrants,
+  useProfile,
+} from '@linode/queries';
 import { LinodeSelect } from '@linode/shared';
 import {
   ActionsPanel,
@@ -24,7 +28,6 @@ import { LandingHeader } from 'src/components/LandingHeader';
 import { MultipleIPInput } from 'src/components/MultipleIPInput/MultipleIPInput';
 import { reportException } from 'src/exceptionReporting';
 import { NodeBalancerSelect } from 'src/features/NodeBalancers/NodeBalancerSelect';
-import { useCreateDomainMutation } from 'src/queries/domains';
 import { sendCreateDomainEvent } from 'src/utilities/analytics/customEventAnalytics';
 import { getErrorMap } from 'src/utilities/errorUtils';
 import {

--- a/packages/manager/src/features/Domains/DeleteDomain.tsx
+++ b/packages/manager/src/features/Domains/DeleteDomain.tsx
@@ -1,10 +1,10 @@
+import { useDeleteDomainMutation } from '@linode/queries';
 import { Button, Notice, Typography } from '@linode/ui';
 import { styled } from '@mui/material/styles';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
 
 import { TypeToConfirmDialog } from 'src/components/TypeToConfirmDialog/TypeToConfirmDialog';
-import { useDeleteDomainMutation } from 'src/queries/domains';
 
 import type { APIError } from '@linode/api-v4';
 export interface DeleteDomainProps {

--- a/packages/manager/src/features/Domains/DisableDomainDialog.tsx
+++ b/packages/manager/src/features/Domains/DisableDomainDialog.tsx
@@ -1,8 +1,8 @@
+import { useUpdateDomainMutation } from '@linode/queries';
 import { ActionsPanel } from '@linode/ui';
 import * as React from 'react';
 
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
-import { useUpdateDomainMutation } from 'src/queries/domains';
 import { sendDomainStatusChangeEvent } from 'src/utilities/analytics/customEventAnalytics';
 
 import type { APIError, Domain } from '@linode/api-v4';

--- a/packages/manager/src/features/Domains/DomainDetail/DomainDetail.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/DomainDetail.tsx
@@ -1,4 +1,9 @@
 import {
+  useDomainQuery,
+  useDomainRecordsQuery,
+  useUpdateDomainMutation,
+} from '@linode/queries';
+import {
   CircleProgress,
   ErrorState,
   Notice,
@@ -14,11 +19,6 @@ import * as React from 'react';
 import { LandingHeader } from 'src/components/LandingHeader';
 import { TagCell } from 'src/components/TagCell/TagCell';
 import { useIsResourceRestricted } from 'src/hooks/useIsResourceRestricted';
-import {
-  useDomainQuery,
-  useDomainRecordsQuery,
-  useUpdateDomainMutation,
-} from 'src/queries/domains';
 
 import { DeleteDomain } from '../DeleteDomain';
 import { DownloadDNSZoneFileButton } from '../DownloadDNSZoneFileButton';

--- a/packages/manager/src/features/Domains/DomainDetail/index.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/index.tsx
@@ -1,9 +1,8 @@
+import { useDomainQuery } from '@linode/queries';
 import { CircleProgress, ErrorState } from '@linode/ui';
 import { NotFound } from '@linode/ui';
 import { useParams } from '@tanstack/react-router';
 import * as React from 'react';
-
-import { useDomainQuery } from 'src/queries/domains';
 
 const DomainsLanding = React.lazy(() =>
   import('../DomainsLanding').then((module) => ({

--- a/packages/manager/src/features/Domains/DomainZoneImportDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainZoneImportDrawer.tsx
@@ -1,10 +1,9 @@
-import { useGrants, useProfile } from '@linode/queries';
+import { useGrants, useImportZoneMutation, useProfile } from '@linode/queries';
 import { ActionsPanel, Drawer, Notice, TextField } from '@linode/ui';
 import { useNavigate } from '@tanstack/react-router';
 import { useFormik } from 'formik';
 import * as React from 'react';
 
-import { useImportZoneMutation } from 'src/queries/domains';
 import { getErrorMap } from 'src/utilities/errorUtils';
 
 import type { ImportZonePayload } from '@linode/api-v4/lib/domains';

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -1,4 +1,11 @@
-import { useLinodesQuery, useProfile } from '@linode/queries';
+import {
+  useDeleteDomainMutation,
+  useDomainQuery,
+  useDomainsQuery,
+  useLinodesQuery,
+  useProfile,
+  useUpdateDomainMutation,
+} from '@linode/queries';
 import {
   Button,
   CircleProgress,
@@ -29,12 +36,6 @@ import { TableSortCell } from 'src/components/TableSortCell';
 import { TypeToConfirmDialog } from 'src/components/TypeToConfirmDialog/TypeToConfirmDialog';
 import { useOrderV2 } from 'src/hooks/useOrderV2';
 import { usePaginationV2 } from 'src/hooks/usePaginationV2';
-import {
-  useDeleteDomainMutation,
-  useDomainQuery,
-  useDomainsQuery,
-  useUpdateDomainMutation,
-} from 'src/queries/domains';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 import { CloneDomainDrawer } from './CloneDomainDrawer';

--- a/packages/manager/src/features/Domains/EditDomainDrawer.tsx
+++ b/packages/manager/src/features/Domains/EditDomainDrawer.tsx
@@ -1,4 +1,8 @@
-import { useGrants, useProfile } from '@linode/queries';
+import {
+  useGrants,
+  useProfile,
+  useUpdateDomainMutation,
+} from '@linode/queries';
 import {
   ActionsPanel,
   Drawer,
@@ -13,7 +17,6 @@ import * as React from 'react';
 
 import { MultipleIPInput } from 'src/components/MultipleIPInput/MultipleIPInput';
 import { TagsInput } from 'src/components/TagsInput/TagsInput';
-import { useUpdateDomainMutation } from 'src/queries/domains';
 import { getErrorMap } from 'src/utilities/errorUtils';
 import { handleFormikBlur } from 'src/utilities/formikTrimUtil';
 import { extendedIPToString, stringToExtendedIP } from 'src/utilities/ipUtils';

--- a/packages/manager/src/features/Search/useAPISearch.ts
+++ b/packages/manager/src/features/Search/useAPISearch.ts
@@ -1,13 +1,15 @@
-import { useStackScriptsInfiniteQuery } from '@linode/queries';
-import { useInfiniteVolumesQuery } from '@linode/queries';
-import { useFirewallsInfiniteQuery } from '@linode/queries';
-import { useInfiniteNodebalancersQuery } from '@linode/queries';
-import { useInfiniteLinodesQuery } from '@linode/queries';
+import {
+  useDomainsInfiniteQuery,
+  useFirewallsInfiniteQuery,
+  useInfiniteLinodesQuery,
+  useInfiniteNodebalancersQuery,
+  useInfiniteVolumesQuery,
+  useStackScriptsInfiniteQuery,
+} from '@linode/queries';
 import { getAPIFilterFromQuery } from '@linode/search';
 import { useDebouncedValue } from '@linode/utilities';
 
 import { useDatabasesInfiniteQuery } from 'src/queries/databases/databases';
-import { useDomainsInfiniteQuery } from 'src/queries/domains';
 import { useImagesInfiniteQuery } from 'src/queries/images';
 import { useKubernetesClustersInfiniteQuery } from 'src/queries/kubernetes';
 import {

--- a/packages/manager/src/features/Search/useClientSideSearch.ts
+++ b/packages/manager/src/features/Search/useClientSideSearch.ts
@@ -1,12 +1,14 @@
-import { useAllLinodesQuery } from '@linode/queries';
-import { useAllFirewallsQuery } from '@linode/queries';
-import { useAllVolumesQuery } from '@linode/queries';
-import { useAllNodeBalancersQuery } from '@linode/queries';
-import { useAllAccountStackScriptsQuery } from '@linode/queries';
+import {
+  useAllAccountStackScriptsQuery,
+  useAllDomainsQuery,
+  useAllFirewallsQuery,
+  useAllLinodesQuery,
+  useAllNodeBalancersQuery,
+  useAllVolumesQuery,
+} from '@linode/queries';
 
 import { useKubernetesBetaEndpoint } from 'src/features/Kubernetes/kubeUtils';
 import { useAllDatabasesQuery } from 'src/queries/databases/databases';
-import { useAllDomainsQuery } from 'src/queries/domains';
 import { useAllImagesQuery } from 'src/queries/images';
 import { useAllKubernetesClustersQuery } from 'src/queries/kubernetes';
 import { useObjectStorageBuckets } from 'src/queries/object-storage/queries';

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketProductSelectionFields.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketProductSelectionFields.tsx
@@ -1,4 +1,5 @@
 import {
+  useAllDomainsQuery,
   useAllFirewallsQuery,
   useAllLinodesQuery,
   useAllNodeBalancersQuery,
@@ -11,7 +12,6 @@ import { Controller, useFormContext } from 'react-hook-form';
 
 import { useKubernetesBetaEndpoint } from 'src/features/Kubernetes/kubeUtils';
 import { useAllDatabasesQuery } from 'src/queries/databases/databases';
-import { useAllDomainsQuery } from 'src/queries/domains';
 import { useAllKubernetesClustersQuery } from 'src/queries/kubernetes';
 import { useObjectStorageBuckets } from 'src/queries/object-storage/queries';
 

--- a/packages/manager/src/hooks/useEventHandlers.ts
+++ b/packages/manager/src/hooks/useEventHandlers.ts
@@ -1,4 +1,5 @@
 import {
+  domainEventsHandler,
   firewallEventsHandler,
   nodebalancerEventHandler,
   oauthClientsEventHandler,
@@ -10,7 +11,6 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 
 import { databaseEventsHandler } from 'src/queries/databases/events';
-import { domainEventsHandler } from 'src/queries/domains';
 import { imageEventsHandler } from 'src/queries/images';
 import { stackScriptEventHandler } from 'src/queries/stackscripts';
 import { supportTicketEventHandler } from 'src/queries/support';

--- a/packages/queries/src/domains/domains.ts
+++ b/packages/queries/src/domains/domains.ts
@@ -38,7 +38,7 @@ export const getAllDomains = () =>
 
 const getAllDomainRecords = (domainId: number) =>
   getAll<DomainRecord>((params) => getDomainRecords(domainId, params))().then(
-    ({ data }) => data
+    ({ data }) => data,
   );
 
 const domainQueries = createQueryKeys('domains', {
@@ -121,7 +121,7 @@ export const useCreateDomainMutation = () => {
       // Set Domain in cache
       queryClient.setQueryData(
         domainQueries.domain(domain.id).queryKey,
-        domain
+        domain,
       );
 
       // If a restricted user creates an entity, we must make sure grants are up to date.
@@ -145,7 +145,7 @@ export const useCloneDomainMutation = (id: number) => {
       // Set Domain in cache
       queryClient.setQueryData(
         domainQueries.domain(domain.id).queryKey,
-        domain
+        domain,
       );
     },
   });
@@ -164,7 +164,7 @@ export const useImportZoneMutation = () => {
       // Set Domain in cache
       queryClient.setQueryData(
         domainQueries.domain(domain.id).queryKey,
-        domain
+        domain,
       );
     },
   });
@@ -205,7 +205,7 @@ export const useUpdateDomainMutation = () => {
       // Update domain in cache
       queryClient.setQueryData<Domain>(
         domainQueries.domain(domain.id).queryKey,
-        domain
+        domain,
       );
     },
   });

--- a/packages/queries/src/domains/index.ts
+++ b/packages/queries/src/domains/index.ts
@@ -1,0 +1,1 @@
+export * from './domains';

--- a/packages/queries/src/index.ts
+++ b/packages/queries/src/index.ts
@@ -1,5 +1,6 @@
 export * from './account';
 export * from './base';
+export * from './domains';
 export * from './eventHandlers';
 export * from './firewalls';
 export * from './linodes';


### PR DESCRIPTION
## Description 📝

Migrates Domains-related queries, as well as all dependencies, under the @linode/queries package.

## Changes  🔄
- Creates new `domains/` directory in the `@linode/queries` package with the following structure:
```
domains/
|__ index.ts
|__ domains.ts
```
- Updates import paths throughout `packages/manager`.

## Target release date 🗓️
5/20

## How to test 🧪
- Rely on e2e tests and CI pipeline to ensure changes do not break the application.
- No changes to the UI as a result of this PR.

### Verification steps
- Verify that the Stackscripts feature works as expected.
- Verify that other major flows continue to work as expected.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

---
