### PR TITLE
fix: [M3-9968] - Input placholder opacity

### DIFF
--- a/packages/ui/.changeset/pr-12208-fixed-1747157830376.md
+++ b/packages/ui/.changeset/pr-12208-fixed-1747157830376.md
@@ -1,0 +1,5 @@
+---
+"@linode/ui": Fixed
+---
+
+Input placholder opacity ([#12208](https://github.com/linode/manager/pull/12208))

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -958,6 +958,7 @@ export const lightTheme: ThemeOptions = {
             color: TextField.Placeholder.Text,
             font: Typography.Label.Regular.Placeholder,
             fontStyle: 'italic',
+            opacity: 1,
           },
           '&:disabled, &.Mui-disabled': {
             cursor: 'not-allowed',


### PR DESCRIPTION
## Description 📝
Small PR to fix the placeholder opacity so we are showing the right color. Right now the placeholder text is barely readable (likely failing most accessibility standards), because of the default opacity applied to it in the MUI styles.

This style change will apply to all text inputs (Textfield, Text area, Autocomplete etc)

## Changes  🔄
- Set placeholder opacity back to `1` to get the proper CDS placeholder color

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screen Shot 2025-05-13 at 13 27 04](https://github.com/user-attachments/assets/de9962c1-2cc4-4626-ae7d-793e18a64129) | ![Screen Shot 2025-05-13 at 13 20 02](https://github.com/user-attachments/assets/8747920c-b27d-4a51-a5ba-5c8bfd5520a5) |
| ![Screen Shot 2025-05-13 at 13 32 22](https://github.com/user-attachments/assets/90f9ca35-43aa-4fea-827a-7f21c84ab363) | ![Screen Shot 2025-05-13 at 13 31 34](https://github.com/user-attachments/assets/66111ea3-5aeb-4e14-923d-28e0084f52cd) |

## How to test 🧪

### Verification steps
Check placeholder treatment for inputs through the application

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
