### PR TITLE
change: [M3-9947] - Remove Accordion wrapper from default Alerts tab on Linode details page

### DIFF
--- a/packages/manager/.changeset/pr-12215-changed-1747223125401.md
+++ b/packages/manager/.changeset/pr-12215-changed-1747223125401.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Remove the `Accordion` wrapper from the default Alerts tab and replace it with `Paper` on the Linode details page ([#12215](https://github.com/linode/manager/pull/12215))

--- a/packages/manager/.changeset/pr-12215-fixed-1747230804629.md
+++ b/packages/manager/.changeset/pr-12215-fixed-1747230804629.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Manual clearing of default Alerts fields now resets values to zero, preventing empty string/NaN and ensuring consistency with toggle off ([#12215](https://github.com/linode/manager/pull/12215))

--- a/packages/manager/.changeset/pr-12215-fixed-1747230804629.md
+++ b/packages/manager/.changeset/pr-12215-fixed-1747230804629.md
@@ -1,5 +1,5 @@
 ---
-"@linode/manager": Fixed
+'@linode/manager': Fixed
 ---
 
-Manual clearing of default Alerts fields now resets values to zero, preventing empty string/NaN and ensuring consistency with toggle off ([#12215](https://github.com/linode/manager/pull/12215))
+Manual clearing of default Alerts fields now resets values to zero, preventing empty string/NaN and ensuring consistency with toggle off state ([#12215](https://github.com/linode/manager/pull/12215))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/AlertSection.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/AlertSection.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  Divider,
   fadeIn,
   FormControlLabel,
   InputAdornment,
@@ -43,106 +42,103 @@ export const AlertSection = (props: Props) => {
   } = props;
 
   return (
-    <>
+    <Grid
+      container
+      data-qa-alerts-panel
+      spacing={2}
+      sx={{
+        '&:last-of-type': {
+          marginBottom: 0,
+        },
+        '&:last-of-type + hr': {
+          display: 'none',
+        },
+        alignItems: 'flex-start',
+        flex: 1,
+        marginBottom: theme.spacing(2),
+      }}
+    >
       <Grid
-        container
-        data-qa-alerts-panel
-        spacing={2}
+        size={{
+          lg: 7,
+          md: 9,
+          xs: 12,
+        }}
         sx={{
-          '&:last-of-type': {
-            marginBottom: 0,
-          },
-          '&:last-of-type + hr': {
-            display: 'none',
-          },
-          alignItems: 'flex-start',
-          flex: 1,
-          marginBottom: theme.spacing(2),
+          display: 'flex',
+          flexDirection: 'column',
         }}
       >
-        <Grid
-          size={{
-            lg: 7,
-            md: 9,
-            xs: 12,
-          }}
-          sx={{
-            display: 'flex',
-            flexDirection: 'column',
-          }}
-        >
-          <Box>
-            <FormControlLabel
-              control={
-                <Toggle
-                  checked={state}
-                  disabled={readOnly}
-                  onChange={onStateChange}
-                />
-              }
-              data-qa-alert={title}
-              label={title}
-              sx={{
-                '& > span:last-child': {
-                  ...theme.typography.h3,
-                },
-                '.MuiFormControlLabel-label': {
-                  paddingLeft: '12px',
-                },
-              }}
-            />
-          </Box>
-          <Box
+        <Box>
+          <FormControlLabel
+            control={
+              <Toggle
+                checked={state}
+                disabled={readOnly}
+                onChange={onStateChange}
+              />
+            }
+            data-qa-alert={title}
+            label={title}
             sx={{
-              paddingLeft: '70px',
-              [theme.breakpoints.down('md')]: {
-                marginTop: '-12px',
+              '& > span:last-child': {
+                ...theme.typography.h3,
+              },
+              '.MuiFormControlLabel-label': {
+                paddingLeft: '12px',
               },
             }}
-          >
-            <Typography>{copy}</Typography>
-          </Box>
-        </Grid>
-        <Grid
-          size={{
-            lg: 5,
-            md: 3,
-            xs: 12,
-          }}
+          />
+        </Box>
+        <Box
           sx={{
-            paddingBottom: '0',
-            paddingTop: '0',
+            paddingLeft: '70px',
             [theme.breakpoints.down('md')]: {
-              paddingLeft: '78px',
+              marginTop: '-12px',
             },
           }}
         >
-          <TextField
-            disabled={!state || readOnly}
-            error={Boolean(error)}
-            errorText={error}
-            InputProps={{
-              endAdornment: (
-                <InputAdornment position="end">{endAdornment}</InputAdornment>
-              ),
-            }}
-            label={textTitle}
-            max={Infinity}
-            min={0}
-            onChange={onValueChange}
-            sx={{
-              '.MuiInput-root': {
-                animation: `${fadeIn} .3s ease-in-out forwards`,
-                marginTop: 0,
-                maxWidth: 150,
-              },
-            }}
-            type="number"
-            value={value}
-          />
-        </Grid>
+          <Typography>{copy}</Typography>
+        </Box>
       </Grid>
-      <Divider />
-    </>
+      <Grid
+        size={{
+          lg: 5,
+          md: 3,
+          xs: 12,
+        }}
+        sx={{
+          paddingBottom: '0',
+          paddingTop: '0',
+          [theme.breakpoints.down('md')]: {
+            paddingLeft: '78px',
+          },
+        }}
+      >
+        <TextField
+          disabled={!state || readOnly}
+          error={Boolean(error)}
+          errorText={error}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">{endAdornment}</InputAdornment>
+            ),
+          }}
+          label={textTitle}
+          max={Infinity}
+          min={0}
+          onChange={onValueChange}
+          sx={{
+            '.MuiInput-root': {
+              animation: `${fadeIn} .3s ease-in-out forwards`,
+              marginTop: 0,
+              maxWidth: 150,
+            },
+          }}
+          type="number"
+          value={value}
+        />
+      </Grid>
+    </Grid>
   );
 };

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
@@ -93,7 +93,10 @@ export const LinodeSettingsAlertsPanel = (props: Props) => {
             : 0
         ),
       onValueChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-        formik.setFieldValue('cpu', e.target.valueAsNumber),
+        formik.setFieldValue(
+          'cpu',
+          !Number.isNaN(e.target.valueAsNumber) ? e.target.valueAsNumber : 0
+        ),
       radioInputLabel: 'cpu_usage_state',
       state: formik.values.cpu > 0,
       textInputLabel: 'cpu_usage_threshold',
@@ -115,7 +118,10 @@ export const LinodeSettingsAlertsPanel = (props: Props) => {
           checked ? (linode?.alerts.io ? linode?.alerts.io : 10000) : 0
         ),
       onValueChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-        formik.setFieldValue('io', e.target.valueAsNumber),
+        formik.setFieldValue(
+          'io',
+          !Number.isNaN(e.target.valueAsNumber) ? e.target.valueAsNumber : 0
+        ),
       radioInputLabel: 'disk_io_state',
       state: formik.values.io > 0,
       textInputLabel: 'disk_io_threshold',
@@ -141,7 +147,10 @@ export const LinodeSettingsAlertsPanel = (props: Props) => {
             : 0
         ),
       onValueChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-        formik.setFieldValue('network_in', e.target.valueAsNumber),
+        formik.setFieldValue(
+          'network_in',
+          !Number.isNaN(e.target.valueAsNumber) ? e.target.valueAsNumber : 0
+        ),
       radioInputLabel: 'incoming_traffic_state',
       state: formik.values.network_in > 0,
       textInputLabel: 'incoming_traffic_threshold',
@@ -167,7 +176,10 @@ export const LinodeSettingsAlertsPanel = (props: Props) => {
             : 0
         ),
       onValueChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-        formik.setFieldValue('network_out', e.target.valueAsNumber),
+        formik.setFieldValue(
+          'network_out',
+          !Number.isNaN(e.target.valueAsNumber) ? e.target.valueAsNumber : 0
+        ),
       radioInputLabel: 'outbound_traffic_state',
       state: formik.values.network_out > 0,
       textInputLabel: 'outbound_traffic_threshold',
@@ -193,7 +205,10 @@ export const LinodeSettingsAlertsPanel = (props: Props) => {
             : 0
         ),
       onValueChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-        formik.setFieldValue('transfer_quota', e.target.valueAsNumber),
+        formik.setFieldValue(
+          'transfer_quota',
+          !Number.isNaN(e.target.valueAsNumber) ? e.target.valueAsNumber : 0
+        ),
       radioInputLabel: 'transfer_quota_state',
       state: formik.values.transfer_quota > 0,
       textInputLabel: 'transfer_quota_threshold',

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
@@ -1,5 +1,5 @@
 import { useLinodeQuery, useLinodeUpdateMutation } from '@linode/queries';
-import { Accordion, ActionsPanel, Notice } from '@linode/ui';
+import { ActionsPanel, Divider, Notice, Paper, Typography } from '@linode/ui';
 import { styled } from '@mui/material/styles';
 import { useFormik } from 'formik';
 import { useSnackbar } from 'notistack';
@@ -203,8 +203,23 @@ export const LinodeSettingsAlertsPanel = (props: Props) => {
     },
   ].filter((thisAlert) => !thisAlert.hidden);
 
-  const renderExpansionActions = () => {
-    return (
+  const generalError = hasErrorFor('none');
+
+  return (
+    <Paper sx={(theme) => ({ pb: theme.spacingFunction(17) })}>
+      <Typography
+        sx={(theme) => ({ mb: theme.spacingFunction(12) })}
+        variant="h2"
+      >
+        Alerts
+      </Typography>
+      {generalError && <Notice variant="error">{generalError}</Notice>}
+      {alertSections.map((p, idx) => (
+        <>
+          <AlertSection key={`alert-${idx}`} {...p} readOnly={isReadOnly} />
+          {idx !== alertSections.length - 1 ? <Divider /> : null}
+        </>
+      ))}
       <StyledActionsPanel
         primaryButtonProps={{
           'data-testid': 'alerts-save',
@@ -214,22 +229,7 @@ export const LinodeSettingsAlertsPanel = (props: Props) => {
           onClick: () => formik.handleSubmit(),
         }}
       />
-    );
-  };
-
-  const generalError = hasErrorFor('none');
-
-  return (
-    <Accordion
-      actions={renderExpansionActions}
-      defaultExpanded
-      heading="Alerts"
-    >
-      {generalError && <Notice variant="error">{generalError}</Notice>}
-      {alertSections.map((p, idx) => (
-        <AlertSection key={idx} {...p} readOnly={isReadOnly} />
-      ))}
-    </Accordion>
+    </Paper>
   );
 };
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
@@ -221,7 +221,7 @@ export const LinodeSettingsAlertsPanel = (props: Props) => {
   const generalError = hasErrorFor('none');
 
   return (
-    <Paper sx={(theme) => ({ pb: theme.spacingFunction(17) })}>
+    <Paper sx={(theme) => ({ pb: theme.spacingFunction(16) })}>
       <Typography
         sx={(theme) => ({ mb: theme.spacingFunction(12) })}
         variant="h2"

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
@@ -215,10 +215,10 @@ export const LinodeSettingsAlertsPanel = (props: Props) => {
       </Typography>
       {generalError && <Notice variant="error">{generalError}</Notice>}
       {alertSections.map((p, idx) => (
-        <>
-          <AlertSection key={`alert-${idx}`} {...p} readOnly={isReadOnly} />
+        <React.Fragment key={`alert-${idx}`}>
+          <AlertSection {...p} readOnly={isReadOnly} />
           {idx !== alertSections.length - 1 ? <Divider /> : null}
-        </>
+        </React.Fragment>
       ))}
       <StyledActionsPanel
         primaryButtonProps={{

--- a/packages/ui/src/components/Paper/Paper.tsx
+++ b/packages/ui/src/components/Paper/Paper.tsx
@@ -41,8 +41,8 @@ const StyledPaper = styled(_Paper, {
   shouldForwardProp: (prop) => prop !== 'error',
 })<Props>(({ theme, ...props }) => ({
   borderColor: props.error ? theme.palette.error.dark : undefined,
-  padding: theme.spacing(3),
-  paddingTop: 17,
+  padding: theme.spacingFunction(24),
+  paddingTop: theme.spacingFunction(16),
 }));
 
 const StyledErrorText = styled(FormHelperText)(({ theme }) => ({


### PR DESCRIPTION
## Description 📝
Currently, 
- The Alerts form on Linode Details page is enclosed within an accordion component, which includes a dropdown arrow to expand/collapse the form section. The goal is to remove the accordion functionality so that the form is always visible on the page. The form should always be visible (expanded), and there should be no toggle/arrow element.
- Toggling off correctly resets the value to zero, but this does not happen when clearing the fields manually, even though the toggle turns off. This PR fixes the issue by resetting the values to zero (avoiding them being set to an empty string/ NaN) when the fields are cleared manually.

## Changes  🔄
- ♻️ Removed the `Accordion` wrapper from the default Alerts tab and replaced it with `Paper` on the Linode details page
- 🔧 Fixed the issue where clearing the fields manually would set the value to an `empty string/NaN`; now it resets to zero instead, with no console errors 

## Target release date 🗓️
03 June 2025

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-05-14 at 5 08 29 PM](https://github.com/user-attachments/assets/81f9b2c3-9201-48d4-8e6c-f481a12be0b2) ![Screenshot 2025-05-14 at 5 08 43 PM](https://github.com/user-attachments/assets/e874ab81-ba5a-4fc6-a1b5-61a459b5a5a6) | ![Screenshot 2025-05-14 at 5 07 57 PM](https://github.com/user-attachments/assets/b5e13a44-96aa-4f07-9bb2-9661c8577d26) |
| <video src="https://github.com/user-attachments/assets/4dab7f8f-7699-44bc-a282-589109aec952"/> | Fixed for all the fields: <video src="https://github.com/user-attachments/assets/f009e1d9-cd00-40a3-997a-d7617b0be2a4"/> |

## How to test 🧪

### Verification steps
- Verify the Accordion is removed
- Ensure No styling issues and no console errors 
- Ensure all default alert settings are accessible and continue to function as they did before
- Ensure clearing the fields manually will toggle off and set the values to 0, with no console errors 
   - Ensure form field updates continue to work as expected, including verifying the request payload for each field action

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules