### PR TITLE
fix: [M3-9957] - Remove the feature flag check so that beta customers can add Node Pools to existing LKE-E cluster

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
@@ -27,7 +27,6 @@ import { getLinodeRegionPrice } from 'src/utilities/pricing/linodes';
 
 import { PremiumCPUPlanNotice } from '../../CreateCluster/PremiumCPUPlanNotice';
 import { KubernetesPlansPanel } from '../../KubernetesPlansPanel/KubernetesPlansPanel';
-import { useIsLkeEnterpriseEnabled } from '../../kubeUtils';
 import { hasInvalidNodePoolPrice } from './utils';
 
 import type { KubernetesTier, Region } from '@linode/api-v4';
@@ -87,8 +86,6 @@ export const AddNodePoolDrawer = (props: Props) => {
   } = props;
   const { classes } = useStyles();
   const { data: types } = useAllTypes(open);
-
-  const { isLkeEnterpriseLAFeatureEnabled } = useIsLkeEnterpriseEnabled();
 
   const {
     error: errorBeta,
@@ -163,7 +160,7 @@ export const AddNodePoolDrawer = (props: Props) => {
     if (!selectedTypeInfo) {
       return;
     }
-    if (isLkeEnterpriseLAFeatureEnabled && clusterTier === 'enterprise') {
+    if (clusterTier === 'enterprise') {
       return createPoolBeta({
         count: selectedTypeInfo.count,
         type: selectedTypeInfo.planId,


### PR DESCRIPTION
## Description 📝

Quick follow up to correct something in #12188: we should just check the `clusterTier` here (Hana was right) rather than feature flag + cluster tier because it will allow Beta users with existing LKE-E clusters to add node pools to their clusters via UI.

Should we need to support this yet? Not really, because UI support for Beta users isn't intended. But LKE-E clusters *are* still visible in the UI as normal LKE clusters, and the reality is that users are sometimes trying to use the UI to do things that could cause unexpected behavior when they switch back over to CLI tools.

## Changes  🔄
- Removes the feature flag check gating the use of the v4beta endpoint. Having an LKE-E cluster is enough.
- No changeset since 12188 wasn't released.

## Target release date 🗓️

5/20

## How to test 🧪

### Prerequisites

(How to setup test environment)

- See the linked PR.

### Verification steps

(How to verify changes)

- [ ] Follow the steps in the linked PR with the LKE-Enterprise feature flag off and confirm that the node pool is added using v4beta.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
