### PR TITLE
test: [M3-9619] - Un-skip Cypress Firewall E2E tests

### DIFF
--- a/packages/manager/.changeset/pr-12218-tests-1747241849916.md
+++ b/packages/manager/.changeset/pr-12218-tests-1747241849916.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Unskip Cypress Firewall end-to-end tests ([#12218](https://github.com/linode/manager/pull/12218))

--- a/packages/manager/cypress/e2e/core/firewalls/create-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/create-firewall.spec.ts
@@ -7,9 +7,8 @@ import { createTestLinode } from 'support/util/linodes';
 import { randomLabel, randomString } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
 authenticate();
-// Firewall GET API request performance issues need to be addressed in order to unskip this test
-// See M3-9619
-describe.skip('create firewall', () => {
+
+describe('create firewall', () => {
   before(() => {
     cleanUp(['lke-clusters', 'linodes', 'firewalls']);
   });
@@ -101,7 +100,7 @@ describe.skip('create firewall', () => {
             .should('be.visible')
             .click();
 
-          cy.findByLabelText('Linodes').should('be.visible').click();
+          cy.focused().type('{esc}');
 
           ui.buttonGroup
             .findButtonByTitle('Create Firewall')

--- a/packages/manager/cypress/e2e/core/firewalls/delete-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/delete-firewall.spec.ts
@@ -7,6 +7,7 @@ import {
   mockGetFirewallSettings,
 } from 'support/intercepts/firewalls';
 import { ui } from 'support/ui';
+import { cleanUp } from 'support/util/cleanup';
 import { randomLabel } from 'support/util/random';
 
 import { accountFactory, firewallFactory } from 'src/factories';
@@ -15,13 +16,11 @@ import { DEFAULT_FIREWALL_TOOLTIP_TEXT } from 'src/features/Firewalls/FirewallLa
 import type { Firewall } from '@linode/api-v4';
 
 authenticate();
-// Firewall GET API request performance issues need to be addressed in order to unskip this test
-// See M3-9619
 describe('delete firewall', () => {
-  // TODO Restore clean-up when `deletes a firewall` test is unskipped.
-  // before(() => {
-  //   cleanUp('firewalls');
-  // });
+  before(() => {
+    cleanUp('firewalls');
+  });
+
   beforeEach(() => {
     cy.tag('method:e2e');
   });
@@ -32,7 +31,7 @@ describe('delete firewall', () => {
    * - Confirms that firewall is still in landing page list after canceled operation.
    * - Confirms that firewall is removed from landing page list after confirmed operation.
    */
-  it.skip('deletes a firewall', () => {
+  it('deletes a firewall', () => {
     const firewallRequest = firewallFactory.build({
       label: randomLabel(),
     });

--- a/packages/manager/cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/migrate-linode-with-firewall.spec.ts
@@ -143,7 +143,7 @@ describe('Migrate Linode With Firewall', () => {
   /*
    * - Uses real API data to create a Firewall, attach a Linode to it, then migrate the Linode.
    */
-  it.skip('migrates linode with firewall - real data', () => {
+  it('migrates linode with firewall - real data', () => {
     cy.tag('method:e2e', 'purpose:dcTesting', 'env:multipleRegions');
 
     // Execute the body of the test inside Cypress's command queue to ensure
@@ -188,8 +188,8 @@ describe('Migrate Linode With Firewall', () => {
               .should('be.visible')
               .click();
 
-            // Click on the Select again to dismiss the autocomplete popper.
-            cy.findByLabelText('Linodes').should('be.visible').click();
+            // Dismiss the autocomplete popper.
+            cy.focused().type('{esc}');
 
             ui.buttonGroup
               .findButtonByTitle('Create Firewall')

--- a/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
@@ -1,4 +1,4 @@
-import { createFirewall, createLinode } from '@linode/api-v4';
+import { createFirewall } from '@linode/api-v4';
 import { createLinodeRequestFactory } from '@linode/utilities';
 import { authenticate } from 'support/api/authentication';
 import {
@@ -7,6 +7,7 @@ import {
 } from 'support/intercepts/firewalls';
 import { ui } from 'support/ui';
 import { cleanUp } from 'support/util/cleanup';
+import { createTestLinode } from 'support/util/linodes';
 import { randomItem, randomLabel, randomString } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
 
@@ -149,7 +150,7 @@ const addLinodesToFirewall = (firewall: Firewall, linode: Linode) => {
         .should('be.visible')
         .click();
 
-      cy.findByLabelText('Linodes').should('be.visible').click();
+      cy.focused().type('{esc}');
 
       ui.button.findByTitle('Add').should('be.visible').click();
     });
@@ -160,8 +161,7 @@ const createLinodeAndFirewall = async (
   firewallRequestPayload: CreateFirewallPayload
 ) => {
   return Promise.all([
-    // eslint-disable-next-line @linode/cloud-manager/no-createLinode
-    createLinode(linodeRequestPayload),
+    createTestLinode(linodeRequestPayload, { securityMethod: 'powered_off' }),
     createFirewall(firewallRequestPayload),
   ]);
 };
@@ -169,7 +169,7 @@ const createLinodeAndFirewall = async (
 authenticate();
 // Firewall GET API request performance issues need to be addressed in order to unskip this test
 // See M3-9619
-describe.skip('update firewall', () => {
+describe('update firewall', () => {
   before(() => {
     cleanUp('firewalls');
   });

--- a/packages/manager/cypress/support/util/linodes.ts
+++ b/packages/manager/cypress/support/util/linodes.ts
@@ -121,6 +121,7 @@ export const createTestLinode = async (
   const resolvedCreatePayload = {
     ...createLinodeRequestFactory.build({
       interface_generation: 'legacy_config',
+      firewall_id: null,
       booted: false,
       image: 'linode/ubuntu24.04',
       label: randomLabel(),


### PR DESCRIPTION
## Description 📝

This unskips the Firewall E2E tests that we started skipping a couple months ago due to some API issues (#11898). It also makes a few additional changes in order to get the tests to play nicely with some of the Linode Interfaces improvements that have been made in the meantime.

## Changes  🔄

- Unskip Firewall E2E tests
- Update `createTestLinode` to prevent implicit Firewall creation

## Target release date 🗓️

N/A

## How to test 🧪

We can rely on CI for this. However, you can also run the Firewall tests locally using this command:

```bash
pnpm cy:run -s "cypress/e2e/core/firewalls"
```

I was able to run all the Firewall tests 10 times in a row without encountering any failures.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
