### PR TITLE
change: [UIE-8744] - Replace text field in DBaaS create page with Akamai CDS text field Web Component

### DIFF
--- a/packages/manager/.changeset/pr-12225-changed-1747318195258.md
+++ b/packages/manager/.changeset/pr-12225-changed-1747318195258.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+DBaaS: Replace the text field component under DBAAS create DB cluster page with Akamai CDS text field web component ([#12225](https://github.com/linode/manager/pull/12225))

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -45,7 +45,7 @@
     "@tanstack/react-query-devtools": "5.51.24",
     "@tanstack/react-router": "^1.111.11",
     "@xterm/xterm": "^5.5.0",
-    "akamai-cds-react-components": "0.0.1-alpha.6",
+    "akamai-cds-react-components": "0.0.1-alpha.8",
     "algoliasearch": "^4.14.3",
     "axios": "~1.8.3",
     "braintree-web": "^3.92.2",

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.style.ts
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.style.ts
@@ -1,7 +1,9 @@
-import { Box, Button, TextField, Typography } from '@linode/ui';
+import { Box, Button, Typography } from '@linode/ui';
 import { Grid, styled } from '@mui/material';
 
 import { PlansPanel } from 'src/features/components/PlansPanel/PlansPanel';
+
+import { TextFieldWrapper } from '../TextFieldWrapper';
 
 export const StyledLabelTooltip = styled(Box, {
   label: 'StyledLabelTooltip',
@@ -14,7 +16,7 @@ export const StyledLabelTooltip = styled(Box, {
   },
 }));
 
-export const StyledTextField = styled(TextField, {
+export const StyledTextField = styled(TextFieldWrapper, {
   label: 'StyledTextField',
 })(({ theme }) => ({
   '& .MuiTooltip-tooltip': {

--- a/packages/manager/src/features/Databases/TextFieldWrapper.test.tsx
+++ b/packages/manager/src/features/Databases/TextFieldWrapper.test.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { TextFieldWrapper } from './TextFieldWrapper';
+
+describe('TextFieldWrapper', () => {
+  const props = {
+    label: 'Cluster Label',
+    value: 'test',
+  };
+
+  it('Renders a TextField with the given label and initial value', async () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <TextFieldWrapper {...props} />
+    );
+    const textFieldHost = await getByTestId('textfield-input');
+    const shadowTextField = textFieldHost?.shadowRoot?.querySelector('input');
+
+    expect(getByText('Cluster Label')).toBeInTheDocument();
+    expect(shadowTextField).toHaveValue('test');
+  });
+
+  it('Renders an error message on error', async () => {
+    const { getByText } = renderWithTheme(
+      <TextFieldWrapper errorText="There was an error" {...props} />
+    );
+    expect(getByText(/There was an error/i)).toBeInTheDocument();
+  });
+
+  it('text field should be disabled on disable', async () => {
+    const { getByTestId } = renderWithTheme(
+      <TextFieldWrapper disabled {...props} />
+    );
+    const textFieldHost = await getByTestId('textfield-input');
+
+    expect(textFieldHost).toBeDisabled();
+  });
+});

--- a/packages/manager/src/features/Databases/TextFieldWrapper.tsx
+++ b/packages/manager/src/features/Databases/TextFieldWrapper.tsx
@@ -1,0 +1,171 @@
+import { convertToKebabCase } from '@linode/ui';
+import { Box, FormHelperText, InputLabel, TooltipIcon } from '@linode/ui';
+import { useTheme } from '@mui/material/styles';
+import { TextField } from 'akamai-cds-react-components';
+import React, { useId, useRef } from 'react';
+
+interface BaseProps {
+  disabled?: boolean;
+  /**
+   * When defined, makes the input show an error state with the defined text
+   */
+  errorText?: string;
+  label: string;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  value?: Value;
+}
+
+type Value = string | undefined;
+
+interface InputToolTipProps {
+  tooltipText?: JSX.Element | string;
+}
+
+type TextFieldWrapperProps = BaseProps & InputToolTipProps;
+
+export const TextFieldWrapper = (props: TextFieldWrapperProps) => {
+  const { disabled, errorText, label, onChange, tooltipText, value } = props;
+
+  const [_value, setValue] = React.useState<Value>(value ?? '');
+  const theme = useTheme();
+  const inputRef = useRef<HTMLInputElement | null>(null); // Ref for the input field
+
+  const isControlled = value !== undefined;
+
+  const useFieldIds = ({
+    hasError = false,
+    label,
+  }: {
+    hasError?: boolean;
+    label: string;
+  }) => {
+    const fallbackId = useId();
+    const validInputId = label ? convertToKebabCase(label) : fallbackId;
+    const helperTextId = `${validInputId}-helper-text`;
+    const errorTextId = `${validInputId}-error-text`;
+    const errorScrollClassName = hasError ? `error-for-scroll` : '';
+
+    return {
+      errorScrollClassName,
+      errorTextId,
+      helperTextId,
+      validInputId,
+    };
+  };
+
+  const { errorScrollClassName, errorTextId, validInputId } = useFieldIds({
+    hasError: Boolean(errorText),
+    label,
+  });
+
+  React.useEffect(() => {
+    if (isControlled) {
+      setValue(value);
+    }
+  }, [value, isControlled]);
+
+  // Simulate htmlFor for the label as it doesn't work with shadow DOM
+  const handleLabelClick = () => {
+    if (inputRef.current) {
+      const shadowRoot = inputRef.current.shadowRoot;
+      if (shadowRoot) {
+        const inputElement = shadowRoot.querySelector('input');
+        if (inputElement) {
+          (inputElement as HTMLElement).focus();
+        }
+      }
+    }
+  };
+
+  return (
+    <Box
+      className={`${errorText ? errorScrollClassName : ''}`}
+      sx={{
+        ...(Boolean(tooltipText) && {
+          alignItems: 'flex-end',
+          display: 'flex',
+          flexWrap: 'wrap',
+        }),
+      }}
+    >
+      <Box
+        alignItems={'center'}
+        data-testid="inputLabelWrapper"
+        display="flex"
+        sx={{
+          marginBottom: theme.spacingFunction(8),
+          marginTop: theme.spacingFunction(16),
+        }}
+      >
+        <InputLabel
+          data-qa-textfield-label={label}
+          htmlFor={validInputId}
+          onClick={handleLabelClick}
+          sx={{
+            marginBottom: 0,
+            transform: 'none',
+          }}
+        >
+          {label}
+        </InputLabel>
+      </Box>
+      <Box
+        sx={{
+          ...(Boolean(tooltipText) && {
+            display: 'flex',
+            width: '100%',
+          }),
+        }}
+      >
+        <Box
+          sx={{
+            width: '416px',
+            minWidth: '120px',
+          }}
+        >
+          <TextField
+            aria-errormessage={errorText ? errorTextId : undefined}
+            aria-invalid={!!errorText}
+            className={errorText ? 'error' : ''}
+            data-testid="textfield-input"
+            disabled={disabled}
+            id={validInputId}
+            onChange={(e) =>
+              onChange?.(e as unknown as React.ChangeEvent<HTMLInputElement>)
+            }
+            ref={inputRef as React.RefObject<never>}
+            value={_value}
+          />
+        </Box>
+        {tooltipText && (
+          <TooltipIcon
+            status="help"
+            sxTooltipIcon={{
+              height: '34px',
+              margin: '0px 0px 0px 4px',
+              padding: '17px',
+              width: '34px',
+            }}
+            text={tooltipText}
+          />
+        )}
+      </Box>
+      {errorText && (
+        <FormHelperText
+          data-qa-textfield-error-text={label}
+          role="alert"
+          sx={{
+            alignItems: 'center',
+            color: theme.palette.error.dark,
+            display: 'flex',
+            left: 5,
+            top: 42,
+            width: '100%',
+          }}
+        >
+          {errorText}
+        </FormHelperText>
+      )}
+    </Box>
+  );
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,8 +204,8 @@ importers:
         specifier: ^5.5.0
         version: 5.5.0
       akamai-cds-react-components:
-        specifier: 0.0.1-alpha.6
-        version: 0.0.1-alpha.6(@linode/design-language-system@4.0.0)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.0.1-alpha.8
+        version: 0.0.1-alpha.8(@linode/design-language-system@4.0.0)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       algoliasearch:
         specifier: ^4.14.3
         version: 4.24.0
@@ -2898,14 +2898,14 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
-  akamai-cds-react-components@0.0.1-alpha.6:
-    resolution: {integrity: sha512-dmhw1YF8ZKIw/xS7n/Fq6mFV9bG7TmRS85uVHAl+W1Qc4oXFmXGIKwZhXFN1Ue7fePTrU1pz8v3GNTwtv0sWUg==}
+  akamai-cds-react-components@0.0.1-alpha.8:
+    resolution: {integrity: sha512-/zYlYX6WIrGqQooD/uUDYxREo4mYABL0vktHZVyPqsRbCQf3dj8TZfpa0dp8btEkBQnQSbaL/EZOdH45uGGKpg==}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  akamai-cds-web-components@0.0.1-alpha.6:
-    resolution: {integrity: sha512-yc0NNkX8kzV+U8dK+CSbKz5QswkNfcX9GHqDSlRzly83aRGASGQYIRsxEquteobzcZkErflKfh/6iW5Rv4HHOg==}
+  akamai-cds-web-components@0.0.1-alpha.8:
+    resolution: {integrity: sha512-SRxPY4umilXWkvRvx4m3Ig8ya+qgmYUohtKYKgsp5y/CAZKlncHYx2LqcKXH+eAnibIVDcL/ZQh9LxsD88Xgqg==}
     peerDependencies:
       '@linode/design-language-system': ^4.0.0
 
@@ -8970,17 +8970,17 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  akamai-cds-react-components@0.0.1-alpha.6(@linode/design-language-system@4.0.0)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  akamai-cds-react-components@0.0.1-alpha.8(@linode/design-language-system@4.0.0)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@lit/react': 1.0.7(@types/react@18.3.12)
-      akamai-cds-web-components: 0.0.1-alpha.6(@linode/design-language-system@4.0.0)
+      akamai-cds-web-components: 0.0.1-alpha.8(@linode/design-language-system@4.0.0)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - '@linode/design-language-system'
       - '@types/react'
 
-  akamai-cds-web-components@0.0.1-alpha.6(@linode/design-language-system@4.0.0):
+  akamai-cds-web-components@0.0.1-alpha.8(@linode/design-language-system@4.0.0):
     dependencies:
       '@linode/design-language-system': 4.0.0
       lit: 3.3.0


### PR DESCRIPTION
## Description 📝

This PR is to replace text field in DBAAS create DB cluster page with Akamai CDS [text field](https://git.source.akamai.com/projects/FEE/repos/cds-web-components/browse/packages/cds-react-components/src/components/TextField) Web Component.

## Changes  🔄

- Replaced text field in DBaaS create DB cluster page with Akamai CDS text field Web Component.
- No other text fields are replaced as they are components that are used in features outside DBaaS as well.

## Target release date 🗓️

6/3

## Preview 📷

| Before  | After   |
|---------|-------|
| ![Screenshot 2025-05-15 at 6 09 00 PM](https://github.com/user-attachments/assets/65e6d25b-8cf9-4f13-bfe9-6c5feedfa789) | ![Screenshot 2025-05-15 at 6 09 42 PM](https://github.com/user-attachments/assets/e11268cc-8fbb-4417-badf-c1ed9ff27d64) |

## How to test 🧪

- Go to Databases -> Create Database cluster
- Verify text field under cluster label field.

### Verification steps

- [x] Cluster label text field under create Database cluster should work same as before. All the validations should behave the same.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
