### PR TITLE
test: [M3-9985] - Exclude distributed regions from `chooseRegion` output by default

### DIFF
--- a/packages/manager/.changeset/pr-12226-tests-1747314916451.md
+++ b/packages/manager/.changeset/pr-12226-tests-1747314916451.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Exclude distributed regions when selecting regions for API operations ([#12226](https://github.com/linode/manager/pull/12226))

--- a/packages/manager/cypress/support/util/regions.ts
+++ b/packages/manager/cypress/support/util/regions.ts
@@ -228,7 +228,7 @@ export const getRegionByLabel = (label: string, searchRegions?: Region[]) => {
 interface ChooseRegionOptions {
   /**
    * If specified, the region returned will support the defined capabilities
-   * @example 'Managed Databases'
+   * @example ['Managed Databases']
    */
   capabilities?: Capabilities[];
 
@@ -236,6 +236,11 @@ interface ChooseRegionOptions {
    * Array of region IDs to exclude from results, in addition to `disallowedRegionIds` regions.
    */
   exclude?: string[];
+
+  /**
+   * Whether or not to include distributed regions in potential output.
+   */
+  includeDistributed?: boolean;
 
   /**
    * Regions from which to choose. If unspecified, Regions exposed by the API will be used.
@@ -323,7 +328,17 @@ const resolveSearchRegions = (
   const capableRegions = regionsWithCapabilities(
     options?.regions ?? regions,
     requiredCapabilities
-  ).filter((region: Region) => !allDisallowedRegionIds.includes(region.id));
+  ).filter((region: Region) => {
+    const isDisallowed = !allDisallowedRegionIds.includes(region.id);
+    const isDistributed = region.site_type === 'distributed';
+
+    // Exclude distributed regions in output if `options.distributed` is not true.
+    if (isDistributed && options?.includeDistributed !== true) {
+      return false;
+    }
+
+    return isDisallowed;
+  });
 
   if (!capableRegions.length) {
     throw new Error(


### PR DESCRIPTION
## Description 📝

This fixes test failures for accounts that have Gecko enabled when Cypress performs API operations using randomly chosen regions. Because distributed sites don't support all Linode types, etc., we'll exclude them from the `chooseRegion` output by default.

## Changes  🔄

- Exclude distributed sites from `chooseRegion` output by default
- Add `includeDistributed` option to `chooseRegion`

## Target release date 🗓️

N/A

## How to test 🧪

- Enable Gecko on your account
- Observe that there are no test failures stemming from distributed region incompatibilities

To make testing easier, I wrote a quick test to check the output of `chooseRegions`, which you can also insert into some spec and run:

```typescript
  it.only('test chooseRegion', () => {
    for(let i = 0; i < 1000; i += 1) {
      const region = chooseRegion();
      expect(region.site_type).to.equal('core');
    }
    // When allowing distributed regions, log output to console so we can observe that both types of regions are being returned.
    for(let i = 0; i < 100; i += 1) {
      const region = chooseRegion({ includeDistributed: true });
      console.log(region);
    }
  });
```

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>