### PR TITLE
test [M3-9596]:  test for VPC create page for restricted users

### DIFF
--- a/packages/manager/.changeset/pr-12234-tests-1747393162692.md
+++ b/packages/manager/.changeset/pr-12234-tests-1747393162692.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Test for VPC create page for restricted users ([#12234](https://github.com/linode/manager/pull/12234))


### PR DESCRIPTION
## Description 📝

Add  test for VPC create page for restricted users on packages/manager/cypress/e2e/core/firewalls/create-firewall.spec.ts. 

## Changes  🔄

Verify that 'Create Firewall' button is disabled on landing page (/firewalls) and drawer (/firewalls/create). Inputs within drawer should all be disabled as well. 

## How to test 🧪

pnpm run cy:run -s cypress/e2e/core/firewalls/create-firewall.spec.ts 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

