### PR TITLE
chore: [M3-9992] - Remove `recompose` from Longview

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
@@ -2,7 +2,6 @@ import { useProfile } from '@linode/queries';
 import { CircleProgress, ErrorState, Notice, Paper } from '@linode/ui';
 import { NotFound } from '@linode/ui';
 import * as React from 'react';
-import { compose } from 'recompose';
 
 import { LandingHeader } from 'src/components/LandingHeader';
 import { SuspenseLoader } from 'src/components/SuspenseLoader';
@@ -294,39 +293,38 @@ export const LongviewDetail = (props: CombinedProps) => {
   );
 };
 
-type LongviewDetailParams = {
-  id: string;
-};
+interface LongviewDetailParams {
+  id: number;
+}
 
-const EnhancedLongviewDetail = compose<CombinedProps, {}>(
-  React.memo,
-
+const EnhancedLongviewDetail = React.memo(
   withClientStats<{ match: { params: LongviewDetailParams } }>((ownProps) => {
-    return +(ownProps?.match?.params?.id ?? '');
-  }),
-  withLongviewClients<Props, { match: { params: LongviewDetailParams } }>(
-    (
-      own,
-      {
-        longviewClientsData,
-        longviewClientsError,
-        longviewClientsLastUpdated,
-        longviewClientsLoading,
-      }
-    ) => {
-      // This is explicitly typed, otherwise `client` would be typed as
-      // `LongviewClient`, even though there's a chance it could be undefined.
-      const client: LongviewClient | undefined =
-        longviewClientsData[own?.match.params.id ?? ''];
+    return ownProps.match.params.id;
+  })(
+    withLongviewClients<Props, { match: { params: LongviewDetailParams } }>(
+      (
+        own,
+        {
+          longviewClientsData,
+          longviewClientsError,
+          longviewClientsLastUpdated,
+          longviewClientsLoading,
+        }
+      ) => {
+        // This is explicitly typed, otherwise `client` would be typed as
+        // `LongviewClient`, even though there's a chance it could be undefined.
+        const client: LongviewClient | undefined =
+          longviewClientsData[own?.match.params.id ?? ''];
 
-      return {
-        client,
-        longviewClientsError,
-        longviewClientsLastUpdated,
-        longviewClientsLoading,
-      };
-    }
+        return {
+          client,
+          longviewClientsError,
+          longviewClientsLastUpdated,
+          longviewClientsLoading,
+        };
+      }
+    )(LongviewDetail)
   )
-)(LongviewDetail);
+);
 
 export default EnhancedLongviewDetail;

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Network.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Network.tsx
@@ -1,7 +1,6 @@
 import { Typography } from '@linode/ui';
 import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
-import { compose } from 'recompose';
 
 import { GaugePercent } from 'src/components/GaugePercent/GaugePercent';
 import withClientStats from 'src/containers/longview.stats.container';
@@ -102,10 +101,9 @@ const Network = (props: NetworkProps) => {
   );
 };
 
-export const NetworkGauge = compose<NetworkProps, Props>(
-  React.memo,
-  withClientStats<Props>((ownProps) => ownProps.clientID)
-)(Network);
+export const NetworkGauge = React.memo(
+  withClientStats<Props>((ownProps) => ownProps.clientID)(Network)
+);
 
 /*
   What's returned from Network is a bit of an unknown, but assuming that

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
@@ -3,7 +3,6 @@ import { Typography } from '@linode/ui';
 import { formatUptime } from '@linode/utilities';
 import Grid from '@mui/material/Grid';
 import * as React from 'react';
-import { compose } from 'recompose';
 
 import { EditableEntityLabel } from 'src/components/EditableEntityLabel/EditableEntityLabel';
 import { Link } from 'src/components/Link';
@@ -34,115 +33,111 @@ interface Props {
   userCanModifyClient: boolean;
 }
 
-interface LongviewClientHeaderProps extends Props, DispatchProps, LVDataProps {}
+interface LongviewClientHeaderProps extends Props, LVDataProps {}
 
-const enhanced = compose<LongviewClientHeaderProps, Props>(
-  withClientStats((ownProps: Props) => ownProps.clientID)
-);
+export const LongviewClientHeader = withClientStats(
+  (ownProps: Props) => ownProps.clientID
+)((props: LongviewClientHeaderProps) => {
+  const {
+    clientID,
+    clientLabel,
+    lastUpdatedError,
+    longviewClientData,
+    longviewClientDataLoading,
+    longviewClientLastUpdated,
+    openPackageDrawer,
+    updateLongviewClient,
+    userCanModifyClient,
+  } = props;
 
-export const LongviewClientHeader = enhanced(
-  (props: LongviewClientHeaderProps) => {
-    const {
-      clientID,
-      clientLabel,
-      lastUpdatedError,
-      longviewClientData,
-      longviewClientDataLoading,
-      longviewClientLastUpdated,
-      openPackageDrawer,
-      updateLongviewClient,
-      userCanModifyClient,
-    } = props;
+  const [updating, setUpdating] = React.useState<boolean>(false);
 
-    const [updating, setUpdating] = React.useState<boolean>(false);
+  const { data: profile } = useProfile();
 
-    const { data: profile } = useProfile();
+  const handleUpdateLabel = (newLabel: string) => {
+    setUpdating(true);
+    return updateLongviewClient(clientID, newLabel)
+      .then((_) => {
+        setUpdating(false);
+      })
+      .catch((error) => {
+        setUpdating(false);
+        return Promise.reject(
+          getAPIErrorOrDefault(error, 'Error updating label')[0].reason
+        );
+      });
+  };
 
-    const handleUpdateLabel = (newLabel: string) => {
-      setUpdating(true);
-      return updateLongviewClient(clientID, newLabel)
-        .then((_) => {
-          setUpdating(false);
-        })
-        .catch((error) => {
-          setUpdating(false);
-          return Promise.reject(
-            getAPIErrorOrDefault(error, 'Error updating label')[0].reason
-          );
-        });
-    };
+  const hostname =
+    longviewClientData.SysInfo?.hostname ?? 'Hostname not available';
+  const uptime = longviewClientData?.Uptime ?? null;
+  const formattedUptime =
+    uptime !== null ? `Up ${formatUptime(uptime)}` : 'Uptime not available';
+  const packages = longviewClientData?.Packages ?? null;
+  const numPackagesToUpdate = packages ? packages.length : 0;
+  const packagesToUpdate = getPackageNoticeText(packages);
 
-    const hostname =
-      longviewClientData.SysInfo?.hostname ?? 'Hostname not available';
-    const uptime = longviewClientData?.Uptime ?? null;
-    const formattedUptime =
-      uptime !== null ? `Up ${formatUptime(uptime)}` : 'Uptime not available';
-    const packages = longviewClientData?.Packages ?? null;
-    const numPackagesToUpdate = packages ? packages.length : 0;
-    const packagesToUpdate = getPackageNoticeText(packages);
+  const formattedlastUpdatedTime =
+    longviewClientLastUpdated !== undefined
+      ? `Last updated ${formatDate(longviewClientLastUpdated, {
+          timezone: profile?.timezone,
+        })}`
+      : 'Latest update time not available';
 
-    const formattedlastUpdatedTime =
-      longviewClientLastUpdated !== undefined
-        ? `Last updated ${formatDate(longviewClientLastUpdated, {
-            timezone: profile?.timezone,
-          })}`
-        : 'Latest update time not available';
+  /**
+   * The pathOrs ahead will default to 'not available' values if
+   * there's an error, so the only case we need to handle is
+   * the loading state, which should be displayed only if
+   * data is loading for the first time and there are no errors.
+   */
+  const loading =
+    longviewClientDataLoading &&
+    !lastUpdatedError &&
+    longviewClientLastUpdated !== 0;
 
-    /**
-     * The pathOrs ahead will default to 'not available' values if
-     * there's an error, so the only case we need to handle is
-     * the loading state, which should be displayed only if
-     * data is loading for the first time and there are no errors.
-     */
-    const loading =
-      longviewClientDataLoading &&
-      !lastUpdatedError &&
-      longviewClientLastUpdated !== 0;
-
-    return (
-      <StyledRootGrid container spacing={2}>
-        <Grid>
-          {userCanModifyClient ? (
-            <EditableEntityLabel
-              loading={updating}
-              onEdit={handleUpdateLabel}
-              subText={hostname}
-              text={clientLabel}
-            />
-          ) : (
-            <RestrictedUserLabel label={clientLabel} subtext={hostname} />
-          )}
-        </Grid>
-        <StyledUpdatesGrid>
-          {loading ? (
-            <Typography>Loading...</Typography>
-          ) : (
-            <>
-              <Typography>{formattedUptime}</Typography>
-              {numPackagesToUpdate > 0 ? (
-                <StyledButton
-                  onClick={() => openPackageDrawer()}
-                  title={packagesToUpdate}
-                >
-                  {packagesToUpdate}
-                </StyledButton>
-              ) : (
-                <Typography>{packagesToUpdate}</Typography>
-              )}
-            </>
-          )}
-        </StyledUpdatesGrid>
-        <Grid>
-          <Link to={`/longview/clients/${clientID}`}>View Details</Link>
-          {!loading && (
-            <StyledDiv>
-              <Typography sx={{ fontSize: '0.75rem' }} variant="caption">
-                {formattedlastUpdatedTime}
-              </Typography>
-            </StyledDiv>
-          )}
-        </Grid>
-      </StyledRootGrid>
-    );
-  }
-);
+  return (
+    <StyledRootGrid container spacing={2}>
+      <Grid>
+        {userCanModifyClient ? (
+          <EditableEntityLabel
+            loading={updating}
+            onEdit={handleUpdateLabel}
+            subText={hostname}
+            text={clientLabel}
+          />
+        ) : (
+          <RestrictedUserLabel label={clientLabel} subtext={hostname} />
+        )}
+      </Grid>
+      <StyledUpdatesGrid>
+        {loading ? (
+          <Typography>Loading...</Typography>
+        ) : (
+          <>
+            <Typography>{formattedUptime}</Typography>
+            {numPackagesToUpdate > 0 ? (
+              <StyledButton
+                onClick={() => openPackageDrawer()}
+                title={packagesToUpdate}
+              >
+                {packagesToUpdate}
+              </StyledButton>
+            ) : (
+              <Typography>{packagesToUpdate}</Typography>
+            )}
+          </>
+        )}
+      </StyledUpdatesGrid>
+      <Grid>
+        <Link to={`/longview/clients/${clientID}`}>View Details</Link>
+        {!loading && (
+          <StyledDiv>
+            <Typography sx={{ fontSize: '0.75rem' }} variant="caption">
+              {formattedlastUpdatedTime}
+            </Typography>
+          </StyledDiv>
+        )}
+      </Grid>
+    </StyledRootGrid>
+  );
+});

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -2,7 +2,6 @@ import { useGrants } from '@linode/queries';
 import { Paper } from '@linode/ui';
 import Grid from '@mui/material/Grid';
 import * as React from 'react';
-import { compose } from 'recompose';
 
 import withLongviewClients from 'src/containers/longview.container';
 import withClientStats from 'src/containers/longview.stats.container';
@@ -19,7 +18,6 @@ import { LongviewClientHeader } from './LongviewClientHeader';
 import { LongviewClientInstructions } from './LongviewClientInstructions';
 
 import type { ActionHandlers } from './LongviewActionMenu';
-import type { Grant } from '@linode/api-v4';
 import type { DispatchProps } from 'src/containers/longview.container';
 import type { Props as LVDataProps } from 'src/containers/longview.stats.container';
 
@@ -31,11 +29,7 @@ interface Props extends ActionHandlers {
   openPackageDrawer: () => void;
 }
 
-interface LongviewClientRowProps
-  extends Props,
-    LVDataProps,
-    DispatchProps,
-    GrantProps {}
+interface LongviewClientRowProps extends Props, LVDataProps, DispatchProps {}
 
 const LongviewClientRow = (props: LongviewClientRowProps) => {
   const {
@@ -58,9 +52,7 @@ const LongviewClientRow = (props: LongviewClientRowProps) => {
 
   const longviewPermissions = grants?.longview || [];
 
-  const thisPermission = (longviewPermissions as Grant[]).find(
-    (r) => r.id === clientID
-  );
+  const thisPermission = longviewPermissions.find((r) => r.id === clientID);
 
   const userCanModifyClient = thisPermission
     ? thisPermission.permissions === 'read_write'
@@ -213,13 +205,8 @@ const LongviewClientRow = (props: LongviewClientRowProps) => {
   );
 };
 
-interface GrantProps {
-  userCanModifyClient: boolean;
-}
-
-export default compose<LongviewClientRowProps, Props>(
-  React.memo,
-  withClientStats<Props>((ownProps) => ownProps.clientID),
-  /** We only need the update action here, easier than prop drilling through 4 components */
-  withLongviewClients(() => ({}))
-)(LongviewClientRow);
+export default React.memo(
+  withClientStats<Props>((ownProps) => ownProps.clientID)(
+    withLongviewClients(() => ({}))(LongviewClientRow)
+  )
+);

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -3,7 +3,6 @@ import { Autocomplete, Typography } from '@linode/ui';
 import { useLocation, useNavigate } from '@tanstack/react-router';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { compose } from 'recompose';
 
 import { DebouncedSearchTextField } from 'src/components/DebouncedSearchTextField';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
@@ -289,11 +288,7 @@ const mapStateToProps: MapState<StateProps, Props> = (state, _ownProps) => {
 
 const connected = connect(mapStateToProps);
 
-export default compose<LongviewClientsCombinedProps, Props>(
-  React.memo,
-  connected,
-  withLongviewClients()
-)(LongviewClients);
+export default React.memo(connected(withLongviewClients()(LongviewClients)));
 
 /**
  * Helper function for sortClientsBy,


### PR DESCRIPTION
## Description 📝

- Removes `recompose` (🗑️ ) from Longview
  - I really want to React Queryify Longview, but untill then, let's just remove recompose
  - Hoping this will help unblock React 19

## Preview 📷

> [!note]
> No UI changes expected

## How to test 🧪

### Prerequisites

- Create a Linode
- Create a Lonview Client
- Install Lonview on the Linode
- Start the longview service on the Linode using `service longview start`

### Verification steps

- Test that longview still works as expected
- Compare to production to ensure there are no regressions

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>