### PR TITLE
feat: [M3-9984] Add support for entities to have multiple firewalls on CM

### DIFF
--- a/packages/manager/src/features/Firewalls/components/FirewallSelect.tsx
+++ b/packages/manager/src/features/Firewalls/components/FirewallSelect.tsx
@@ -28,9 +28,14 @@ interface Props<DisableClearable extends boolean>
   label?: string;
   /**
    * Optionally pass your own array of Firewalls.
-   * All Firewall will show if this is omitted.
+   * All Firewalls will show if this is omitted.
    */
   options?: Firewall[];
+  /**
+   * Determine which firewalls should be available as options.
+   * If the options prop is used, this is filter ignored.
+   */
+  optionsFilter?: (firewall: Firewall) => boolean;
   /**
    * The ID of the selected Firewall
    */
@@ -47,9 +52,20 @@ interface Props<DisableClearable extends boolean>
 export const FirewallSelect = <DisableClearable extends boolean>(
   props: Props<DisableClearable>
 ) => {
-  const { errorText, hideDefaultChips, loading, value, ...rest } = props;
+  const {
+    errorText,
+    hideDefaultChips,
+    loading,
+    value,
+    options,
+    optionsFilter,
+    ...rest
+  } = props;
 
-  const { data: firewalls, error, isLoading } = useAllFirewallsQuery();
+  const { data: firewalls, error, isLoading } = useAllFirewallsQuery(!options);
+
+  const firewallOptions =
+    options || (optionsFilter ? firewalls?.filter(optionsFilter) : firewalls);
 
   const { defaultNumEntities, isDefault, tooltipText } =
     useDefaultFirewallChipInformation(value, hideDefaultChips);
@@ -65,7 +81,7 @@ export const FirewallSelect = <DisableClearable extends boolean>(
       label="Firewall"
       loading={isLoading || loading}
       noMarginTop
-      options={firewalls ?? []}
+      options={firewallOptions ?? []}
       placeholder="None"
       renderOption={({ key, ...props }, option, state) => (
         <FirewallSelectOption

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeFirewalls/AddFirewallForm.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeFirewalls/AddFirewallForm.tsx
@@ -11,7 +11,7 @@ import { Link } from 'src/components/Link';
 import { FirewallSelect } from 'src/features/Firewalls/components/FirewallSelect';
 import { formattedTypes } from 'src/features/Firewalls/FirewallDetail/Devices/constants';
 
-import type { FirewallDeviceEntityType } from '@linode/api-v4';
+import type { Firewall, FirewallDeviceEntityType } from '@linode/api-v4';
 
 interface Values {
   firewallId: number;
@@ -22,13 +22,14 @@ const schema = object({
 });
 
 interface Props {
+  attachedFirewalls: Firewall[];
   entityId: number;
   entityType: FirewallDeviceEntityType;
   onCancel: () => void;
 }
 
 export const AddFirewallForm = (props: Props) => {
-  const { entityId, entityType, onCancel } = props;
+  const { attachedFirewalls, entityId, entityType, onCancel } = props;
   const { enqueueSnackbar } = useSnackbar();
 
   const entityLabel = formattedTypes[entityType] ?? entityType;
@@ -51,6 +52,10 @@ export const AddFirewallForm = (props: Props) => {
     }
   };
 
+  const optionsFilter = (firewall: Firewall) => {
+    return !attachedFirewalls?.some((fw) => fw.id === firewall.id);
+  };
+
   return (
     <form onSubmit={form.handleSubmit(onSubmit)}>
       <Stack spacing={2}>
@@ -66,6 +71,7 @@ export const AddFirewallForm = (props: Props) => {
               errorText={fieldState.error?.message}
               label="Firewall"
               onChange={(e, value) => field.onChange(value?.id)}
+              optionsFilter={optionsFilter}
               placeholder="Select a Firewall"
               textFieldProps={{
                 inputRef: field.ref,

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeFirewalls/LinodeFirewalls.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeFirewalls/LinodeFirewalls.tsx
@@ -123,6 +123,7 @@ export const LinodeFirewalls = (props: LinodeFirewallsProps) => {
         title="Add Firewall"
       >
         <AddFirewallForm
+          attachedFirewalls={attachedFirewalls ?? []}
           entityId={linodeID}
           entityType="linode"
           onCancel={() => setIsAddFirewalDrawerOpen(false)}

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeFirewalls/LinodeFirewalls.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeFirewalls/LinodeFirewalls.tsx
@@ -86,9 +86,14 @@ export const LinodeFirewalls = (props: LinodeFirewallsProps) => {
         </Typography>
         <Button
           buttonType="primary"
-          disabled={attachedFirewallData && attachedFirewallData.results >= 1}
+          disabled={
+            attachedFirewallData &&
+            attachedFirewallData.data.some(
+              (firewall) => firewall.status === 'enabled'
+            )
+          }
           onClick={() => setIsAddFirewalDrawerOpen(true)}
-          tooltipText="Linodes can only have one Firewall assigned."
+          tooltipText="Linodes can only have one enabled Firewall assigned."
         >
           Add Firewall
         </Button>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeFirewalls/LinodeFirewalls.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeFirewalls/LinodeFirewalls.tsx
@@ -86,14 +86,7 @@ export const LinodeFirewalls = (props: LinodeFirewallsProps) => {
         </Typography>
         <Button
           buttonType="primary"
-          disabled={
-            attachedFirewallData &&
-            attachedFirewallData.data.some(
-              (firewall) => firewall.status === 'enabled'
-            )
-          }
           onClick={() => setIsAddFirewalDrawerOpen(true)}
-          tooltipText="Linodes can only have one enabled Firewall assigned."
         >
           Add Firewall
         </Button>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/EditInterfaceDrawer/EditInterfaceForm.utils.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/EditInterfaceDrawer/EditInterfaceForm.utils.ts
@@ -53,6 +53,8 @@ export const useUpdateLinodeInterfaceFirewallMutation = (
           ._ctx.interfaces._ctx.interface(interfaceId)._ctx.firewalls
       );
 
+      // todo connie: think about what we want to do here
+      // >> assign multiple firewalls at once? assign one firewall at a time but replace the enabled one only?
       // For now, assume the first Firewall is the Interface's firewall.
       // (we are not supporting multiple firewalls per interface right now)
       const currentFirewall = interfaceFirewalls.data[0] as

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/EditInterfaceDrawer/EditInterfaceForm.utils.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/EditInterfaceDrawer/EditInterfaceForm.utils.ts
@@ -53,8 +53,6 @@ export const useUpdateLinodeInterfaceFirewallMutation = (
           ._ctx.interfaces._ctx.interface(interfaceId)._ctx.firewalls
       );
 
-      // todo connie: think about what we want to do here
-      // >> assign multiple firewalls at once? assign one firewall at a time but replace the enabled one only?
       // For now, assume the first Firewall is the Interface's firewall.
       // (we are not supporting multiple firewalls per interface right now)
       const currentFirewall = interfaceFirewalls.data[0] as

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/LinodeInterfaceFirewall.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/LinodeInterfaceFirewall.tsx
@@ -27,7 +27,8 @@ export const LinodeInterfaceFirewall = ({ interfaceId, linodeId }: Props) => {
     return 'None';
   }
 
-  const firewall = data.data[0];
+  const firewall =
+    data.data.find((firewall) => firewall.status === 'enabled') ?? data.data[0];
 
   return <Link to={`/firewalls/${firewall.id}`}>{firewall.label}</Link>;
 };

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/LinodeInterfaceFirewall.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/LinodeInterfaceFirewall.tsx
@@ -1,7 +1,9 @@
 import { useLinodeInterfaceFirewallsQuery } from '@linode/queries';
+import { Stack } from '@linode/ui';
 import React from 'react';
 
 import { Link } from 'src/components/Link';
+import { ShowMore } from 'src/components/ShowMore/ShowMore';
 import { Skeleton } from 'src/components/Skeleton';
 
 interface Props {
@@ -27,8 +29,34 @@ export const LinodeInterfaceFirewall = ({ interfaceId, linodeId }: Props) => {
     return 'None';
   }
 
-  const firewall =
+  // display the enabled firewall if it exists, otherwise display the first firewall
+  const displayedFirewall =
     data.data.find((firewall) => firewall.status === 'enabled') ?? data.data[0];
 
-  return <Link to={`/firewalls/${firewall.id}`}>{firewall.label}</Link>;
+  const firewalls = data.data.filter(
+    (firewall) => firewall.id !== displayedFirewall.id
+  );
+
+  return (
+    <Stack alignItems={'center'} direction="row" spacing={1.5}>
+      <Link to={`/firewalls/${displayedFirewall.id}`}>
+        {displayedFirewall.label}
+      </Link>
+      {firewalls.length > 0 && (
+        <ShowMore
+          ariaItemType="Interface Firewalls"
+          items={firewalls}
+          render={(firewalls) => (
+            <Stack>
+              {firewalls.map((firewall) => (
+                <Link key={firewall.id} to={`/firewalls/${firewall.id}`}>
+                  {firewall.label}
+                </Link>
+              ))}
+            </Stack>
+          )}
+        />
+      )}
+    </Stack>
+  );
 };

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerFirewalls.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerFirewalls.tsx
@@ -112,14 +112,19 @@ export const NodeBalancerFirewalls = (props: Props) => {
         </Typography>
         <Button
           buttonType="primary"
-          disabled={attachedFirewallData && attachedFirewallData.results >= 1}
+          disabled={
+            attachedFirewallData &&
+            attachedFirewallData.data.some(
+              (firewall) => firewall.status === 'enabled'
+            )
+          }
           onClick={() =>
             navigate({
               params: { id: String(nodeBalancerId) },
               to: '/nodebalancers/$id/settings/add-firewall',
             })
           }
-          tooltipText="NodeBalanacers can only have one Firewall assigned."
+          tooltipText="NodeBalanacers can only have one enabled Firewall assigned."
         >
           Add Firewall
         </Button>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerFirewalls.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerFirewalls.tsx
@@ -112,19 +112,12 @@ export const NodeBalancerFirewalls = (props: Props) => {
         </Typography>
         <Button
           buttonType="primary"
-          disabled={
-            attachedFirewallData &&
-            attachedFirewallData.data.some(
-              (firewall) => firewall.status === 'enabled'
-            )
-          }
           onClick={() =>
             navigate({
               params: { id: String(nodeBalancerId) },
               to: '/nodebalancers/$id/settings/add-firewall',
             })
           }
-          tooltipText="NodeBalanacers can only have one enabled Firewall assigned."
         >
           Add Firewall
         </Button>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerFirewalls.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerFirewalls.tsx
@@ -173,6 +173,7 @@ export const NodeBalancerFirewalls = (props: Props) => {
         title="Add Firewall"
       >
         <AddFirewallForm
+          attachedFirewalls={attachedFirewalls ?? []}
           entityId={nodeBalancerId}
           entityType="nodebalancer"
           onCancel={() =>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -38,10 +38,7 @@ export const SummaryPanel = () => {
   const { data: attachedFirewallData } = useNodeBalancersFirewallsQuery(
     Number(id)
   );
-  const firewallToDisplay = // display either the enabled firewall or, if none are enabled, the first firewall
-    attachedFirewallData?.data.find(
-      (firewall) => firewall.status === 'enabled'
-    ) ?? attachedFirewallData?.data[0];
+  const firewalls = attachedFirewallData?.data ?? [];
   const region = regions?.find((r) => r.id === nodebalancer?.region);
   const { mutateAsync: updateNodeBalancer } = useNodebalancerUpdateMutation(
     Number(id)
@@ -162,20 +159,24 @@ export const SummaryPanel = () => {
           </StyledSection>
         </StyledSummarySection>
       </StyledSummarySectionWrapper>
-      {firewallToDisplay && (
+      {firewalls.length > 0 && (
         <StyledSummarySection>
           <StyledTitle data-qa-title variant="h3">
-            Firewall
+            {firewalls.length > 1 ? 'Firewalls' : 'Firewall'}
           </StyledTitle>
-          <Typography data-qa-firewall variant="body1">
-            <Link
-              accessibleAriaLabel={`Firewall ${firewallToDisplay.label}`}
-              className="secondaryLink"
-              to={`/firewalls/${firewallToDisplay.id}`}
-            >
-              {firewallToDisplay.label}
-            </Link>
-          </Typography>
+          {firewalls.map((firewall) => {
+            return (
+              <Typography data-qa-firewall key={firewall.id} variant="body1">
+                <Link
+                  accessibleAriaLabel={`Firewall ${firewall.label}`}
+                  className="secondaryLink"
+                  to={`/firewalls/${firewall.id}`}
+                >
+                  {firewall.label}
+                </Link>
+              </Typography>
+            );
+          })}
         </StyledSummarySection>
       )}
       <StyledSummarySection>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -38,13 +38,14 @@ export const SummaryPanel = () => {
   const { data: attachedFirewallData } = useNodeBalancersFirewallsQuery(
     Number(id)
   );
-  const linkText = attachedFirewallData?.data[0]?.label;
-  const linkID = attachedFirewallData?.data[0]?.id;
+  const firewallToDisplay = // display either the enabled firewall or, if none are enabled, the first firewall
+    attachedFirewallData?.data.find(
+      (firewall) => firewall.status === 'enabled'
+    ) ?? attachedFirewallData?.data[0];
   const region = regions?.find((r) => r.id === nodebalancer?.region);
   const { mutateAsync: updateNodeBalancer } = useNodebalancerUpdateMutation(
     Number(id)
   );
-  const displayFirewallLink = !!attachedFirewallData?.data?.length;
 
   const isNodeBalancerReadOnly = useIsResourceRestricted({
     grantLevel: 'read_only',
@@ -161,18 +162,18 @@ export const SummaryPanel = () => {
           </StyledSection>
         </StyledSummarySection>
       </StyledSummarySectionWrapper>
-      {displayFirewallLink && (
+      {firewallToDisplay && (
         <StyledSummarySection>
           <StyledTitle data-qa-title variant="h3">
             Firewall
           </StyledTitle>
           <Typography data-qa-firewall variant="body1">
             <Link
-              accessibleAriaLabel={`Firewall ${linkText}`}
+              accessibleAriaLabel={`Firewall ${firewallToDisplay.label}`}
               className="secondaryLink"
-              to={`/firewalls/${linkID}`}
+              to={`/firewalls/${firewallToDisplay.id}`}
             >
-              {linkText}
+              {firewallToDisplay.label}
             </Link>
           </Typography>
         </StyledSummarySection>


### PR DESCRIPTION
## Description 📝
- Adds support for multiple firewalls for Linodes/Nodebalancers
- Updates Linode/Nodebalancer firewalls table to continue adding firewalls even after one has already been assigned
- Update NodeBalancer summary panel to show all firewalls
- Update Linode Interface table to have a 'Show More' if there exist additional firewalls

See #12220 and #12176 for additional multiple firewall support

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/22ef1e0c-9092-44f6-9413-abc5cc07e38c) | ![image](https://github.com/user-attachments/assets/8e371468-4d17-4bc2-bf83-107cb932ce62) |
| ![image](https://github.com/user-attachments/assets/3e0ededd-829d-4a38-a5f9-c4e29fb329ee) | ![image](https://github.com/user-attachments/assets/7bc53c71-6623-48cf-81cb-ec68896e49dd) |
| ![image](https://github.com/user-attachments/assets/19a2ee70-58a0-4261-88ca-08291def7e52) | ![image](https://github.com/user-attachments/assets/dbdcb9a7-0c43-491c-a068-4e2e9e764012) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- ...
- ...

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
