### PR TITLE
upcoming: [M3-9999] - Event message tweaks for Linode Interfaces

### DIFF
--- a/packages/manager/.changeset/pr-12243-upcoming-features-1747670800164.md
+++ b/packages/manager/.changeset/pr-12243-upcoming-features-1747670800164.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Event message tweaks for Linode Interfaces ([#12243](https://github.com/linode/manager/pull/12243))

--- a/packages/manager/src/components/Snackbar/ToastNotifications.stories.tsx
+++ b/packages/manager/src/components/Snackbar/ToastNotifications.stories.tsx
@@ -3,6 +3,7 @@ import { useSnackbar } from 'notistack';
 import React from 'react';
 
 import { Snackbar } from 'src/components/Snackbar/Snackbar';
+import { eventFactory } from 'src/factories';
 import { getEventMessage } from 'src/features/Events/utils';
 
 import type { Meta, StoryObj } from '@storybook/react';
@@ -97,18 +98,20 @@ export const WithEventMessage: Story = {
   render: (args) => {
     const WithEventMessage = () => {
       const { enqueueSnackbar } = useSnackbar();
-      const message = getEventMessage({
-        action: 'placement_group_assign',
-        entity: {
-          label: 'Entity',
-          url: 'https://google.com',
-        },
-        secondary_entity: {
-          label: 'Secondary Entity',
-          url: 'https://google.com',
-        },
-        status: 'notification',
-      });
+      const message = getEventMessage(
+        eventFactory.build({
+          action: 'placement_group_assign',
+          entity: {
+            label: 'Entity',
+            url: 'https://google.com',
+          },
+          secondary_entity: {
+            label: 'Secondary Entity',
+            url: 'https://google.com',
+          },
+          status: 'notification',
+        })
+      );
 
       return (
         <Button

--- a/packages/manager/src/features/Events/factories/interface.tsx
+++ b/packages/manager/src/features/Events/factories/interface.tsx
@@ -6,80 +6,29 @@ import type { PartialEventMap } from '../types';
 
 export const linodeInterface: PartialEventMap<'interface'> = {
   interface_create: {
-    failed: (e) => (
-      <>
-        Linode Interface {e.entity!.id} could <strong>not</strong> be{' '}
-        <strong>created</strong>.
-      </>
-    ),
-    finished: (e) => (
+    notification: (e) => (
       <>
         Linode Interface <EventLink event={e} to="entity" /> has been{' '}
         <strong>created</strong> for Linode{' '}
         <EventLink event={e} to="secondaryEntity" />.
       </>
     ),
-    scheduled: (e) => (
-      <>
-        Linode Interface {e.entity!.id} is scheduled for{' '}
-        <strong>creation</strong>.
-      </>
-    ),
-    started: (e) => (
-      <>
-        Linode Interface {e.entity!.id} is being <strong>created</strong>.
-      </>
-    ),
   },
   interface_delete: {
-    failed: (e) => (
-      <>
-        Linode Interface {e.entity!.id} could <strong>not</strong> be{' '}
-        <strong>deleted</strong>.
-      </>
-    ),
-    finished: (e) => (
+    notification: (e) => (
       <>
         Linode Interface <EventLink event={e} to="entity" /> has been{' '}
         <strong>deleted</strong> from Linode{' '}
         <EventLink event={e} to="secondaryEntity" />.
       </>
     ),
-    scheduled: (e) => (
-      <>
-        Linode Interface {e.entity!.id} is scheduled for{' '}
-        <strong>deletion</strong>.
-      </>
-    ),
-    started: (e) => (
-      <>
-        Linode Interface {e.entity!.id} is being <strong>deleted</strong>.
-      </>
-    ),
   },
   interface_update: {
-    failed: (e) => (
-      <>
-        Linode Interface {e.entity!.id} could <strong>not</strong> be{' '}
-        <strong>updated</strong>.
-      </>
-    ),
-    finished: (e) => (
+    notification: (e) => (
       <>
         Linode Interface <EventLink event={e} to="entity" /> has been{' '}
-        <strong>updated</strong> from Linode{' '}
+        <strong>updated</strong> on Linode{' '}
         <EventLink event={e} to="secondaryEntity" />.
-      </>
-    ),
-    scheduled: (e) => (
-      <>
-        Linode Interface {e.entity!.id} is scheduled for{' '}
-        <strong>updating</strong>.
-      </>
-    ),
-    started: (e) => (
-      <>
-        Linode Interface {e.entity!.label} is being <strong>updated</strong>.
       </>
     ),
   },

--- a/packages/manager/src/features/Events/utils.test.tsx
+++ b/packages/manager/src/features/Events/utils.test.tsx
@@ -66,15 +66,17 @@ describe('getEventMessage', () => {
   });
 
   it('returns the correct message for a manual input event', () => {
-    const message = getEventMessage({
-      action: 'linode_create',
-      entity: {
-        id: 123,
-        label: 'test-linode',
-        type: 'linode',
-      },
-      status: 'failed',
-    });
+    const message = getEventMessage(
+      eventFactory.build({
+        action: 'linode_create',
+        entity: {
+          id: 123,
+          label: 'test-linode',
+          type: 'linode',
+        },
+        status: 'failed',
+      })
+    );
 
     const { container } = renderWithTheme(message);
 

--- a/packages/manager/src/features/Events/utils.tsx
+++ b/packages/manager/src/features/Events/utils.tsx
@@ -44,6 +44,13 @@ export function getEventMessage(
 
   const message = eventMessages[event?.action]?.[event.status];
 
+  if (!message && import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `⚠️ No event message factory found for event "${event.action}" with status "${event.status}"`
+    );
+  }
+
   return message ? message(event as Event) : null;
 }
 

--- a/packages/manager/src/features/Events/utils.tsx
+++ b/packages/manager/src/features/Events/utils.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { formatDuration } from '@linode/utilities';
 import { Duration } from 'luxon';
 
@@ -10,48 +11,41 @@ import { eventMessages } from './factory';
 
 import type { Event } from '@linode/api-v4';
 
-type EventMessageManualInput = {
-  action: Event['action'];
-  entity?: Partial<Event['entity']>;
-  secondary_entity?: Partial<Event['secondary_entity']>;
-  status: Event['status'];
-};
-
 /**
- * The event Message Getter
+ * The event Message Getter gets an event message (JSX) from an `Event`
+ *
  * Intentionally avoiding parsing and formatting, and should remain as such.
- *
- * Defining two function signatures for getEventMessage:
- * - A function that takes a full Event object (event page and notification center)
- * - A function that takes an object with action, status, entity, and secondary_entity (getting a message for a snackbar for instance, where we manually pass the action & status)
- *
- * Using typescript overloads allows for both Event and EventMessageInput types.
  *
  * We don't include defaulting to the API message response here because:
  * - we want to control the message output (our types require us to define one) and rather show nothing than a broken message.
  * - the API message is empty 99% of the time and when present, isn't meant to be displayed as a full message, rather a part of it. (ex: `domain_record_create`)
  */
-export function getEventMessage(event: Event): JSX.Element | null | string;
-export function getEventMessage(
-  event: EventMessageManualInput
-): JSX.Element | null | string;
-export function getEventMessage(
-  event: Event | EventMessageManualInput
-): JSX.Element | null | string {
-  if (!event?.action || !event?.status) {
+export function getEventMessage(event: Event): JSX.Element | null | string {
+  const eventActionFactory = eventMessages[event.action];
+
+  if (!eventActionFactory) {
+    if (import.meta.env.DEV) {
+      console.warn(
+        `⚠️ No event message factory found for event "${event.action}"`
+      );
+    }
+
     return null;
   }
 
-  const message = eventMessages[event?.action]?.[event.status];
+  const eventMessageFunction = eventActionFactory[event.status];
 
-  if (!message && import.meta.env.DEV) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `⚠️ No event message factory found for event "${event.action}" with status "${event.status}"`
-    );
+  if (!eventMessageFunction) {
+    if (import.meta.env.DEV) {
+      console.warn(
+        `⚠️ Event message factory for "${event.action}" was found, but a function for status "${event.status}" was not defined.`
+      );
+    }
+
+    return null;
   }
 
-  return message ? message(event as Event) : null;
+  return eventMessageFunction(event);
 }
 
 /**

--- a/packages/manager/src/hooks/useEventHandlers.ts
+++ b/packages/manager/src/hooks/useEventHandlers.ts
@@ -18,6 +18,7 @@ import { volumeEventsHandler } from 'src/queries/volumes/events';
 
 import {
   diskEventHandler,
+  interfaceEventHandler,
   linodeEventsHandler,
 } from '../queries/linodes/events';
 
@@ -91,6 +92,10 @@ export const eventHandlers: {
   {
     filter: (event) => event.action.startsWith('tax_id'),
     handler: taxIdEventHandler,
+  },
+  {
+    filter: (event) => event.action.startsWith('interface'),
+    handler: interfaceEventHandler,
   },
 ];
 

--- a/packages/manager/src/queries/linodes/events.ts
+++ b/packages/manager/src/queries/linodes/events.ts
@@ -152,6 +152,20 @@ export const diskEventHandler = ({
   });
 };
 
+export const interfaceEventHandler = ({
+  event,
+  invalidateQueries,
+}: EventHandlerData) => {
+  // For Interface events, the `entity` is the Interface and the `secondary_entity` is the Linode.
+
+  if (event.secondary_entity) {
+    invalidateQueries({
+      queryKey: linodeQueries.linode(event.secondary_entity.id)._ctx.interfaces
+        .queryKey,
+    });
+  }
+};
+
 /**
  * shouldRequestNotifications
  *


### PR DESCRIPTION
## Description 📝

- Makes some tweaks to the Linode Interface event messages so that they show up
  - They are being returned with status `notification` rather than `started`, `failed`, `finished`, etc...
- Does some clean up on our Event Message factory utils 🏭 
- Added a React Query event handler for Linode Interfaces to give a realtime-like experience

## Preview 📷

### Linode Interface Event Messages

| Before  | After   |
| ------- | ------- |
| Event messages for Linode Interfaces were not showing up | ![Screenshot 2025-05-19 at 11 53 22 AM](https://github.com/user-attachments/assets/19a657f3-6b0c-4b45-acdb-31b13ed12c69) |

### Warnings

I added some console warning for when an event message factory is not defined

![Screenshot 2025-05-19 at 11 55 24 AM](https://github.com/user-attachments/assets/0cc9acc0-7d23-4f60-aa4d-32a8dd99c4cb)

![Screenshot 2025-05-19 at 11 55 10 AM](https://github.com/user-attachments/assets/2ad7f218-754d-4bb6-96fb-0d09c6c40462)

### Event Handlers for fake realtime behavior

https://github.com/user-attachments/assets/65b5b770-bf7c-4da4-b33a-4c764f222add

## How to test 🧪

### Prerequisites

- `new-interfaces-beta` customer tag
- Linode Interfaces feature flag enabled
- Create a Linode that uses New Linode Interfaces

### Verification steps

- Do some create / update/ delete actions on our Linode's interfaces
- Verify that you see event messages for the actions you did

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>