### PR TITLE
chore: [M3-9606] - Use `unstable_createBreakpoints` to define our MUI breakpoints

### DIFF
--- a/packages/manager/.changeset/pr-12244-tech-stories-1747680484622.md
+++ b/packages/manager/.changeset/pr-12244-tech-stories-1747680484622.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Use `unstable_createBreakpoints` to define our MUI breakpoints ([#12244](https://github.com/linode/manager/pull/12244))

--- a/packages/ui/src/foundations/breakpoints.ts
+++ b/packages/ui/src/foundations/breakpoints.ts
@@ -1,16 +1,11 @@
-import { createTheme } from '@mui/material';
+import { unstable_createBreakpoints } from '@mui/material';
 
-// This is a hack to create breakpoints outside of the theme itself.
-// This will likely have to change at some point 😖
-export const breakpoints = createTheme({
-  breakpoints: {
-    values: {
-      lg: 1280,
-      md: 960,
-      sm: 600,
-      xl: 1920,
-      xs: 0,
-    },
+export const breakpoints = unstable_createBreakpoints({
+  values: {
+    lg: 1280,
+    md: 960,
+    sm: 600,
+    xl: 1920,
+    xs: 0,
   },
-  name: 'light',
-}).breakpoints;
+});


### PR DESCRIPTION
## Description 📝

- Migrates from a hacky way of creating breakpoints to what seems like a slightly less hacky way
  - The function is prefixed with `unstable_`, but I think it's okay.  Hopefully MUI will promote it to stable soon. Worst case we just revert this PR if we start seeing issues
  - The createBreakpints function has a confusing history. It existed a long time ago and we used it, but then it was removed in v5 (which is when we introduced the hacky approach), but then it was added back as `unstable_createBreakpoints` recently.  Hopefully it is here to stay.... 🤞 
  - In most cases, you can just define the breakpoints in the theme itself, but for our codebase, it is not that straightforward. See https://github.com/linode/manager/pull/11867#discussion_r2002030395 for a long explanation 

## How to test 🧪

- Checkout the PR or view preview link
- Verify breakpoints still work as they did before as you shrink/expand the viewport

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>