### PR TITLE
upcoming: [M3-9988] - Allow auto-assign of Subnet IPv4 ranges when a Nodebalancer is assigned to a VPC

### DIFF
--- a/packages/api-v4/src/nodebalancers/types.ts
+++ b/packages/api-v4/src/nodebalancers/types.ts
@@ -135,7 +135,7 @@ export interface NodeBalancerStats {
 }
 
 export interface NodeBalancerVpcPayload {
-  ipv4_range: string;
+  ipv4_range?: string;
   ipv6_range?: string;
   subnet_id: number;
 }

--- a/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
@@ -1,24 +1,32 @@
 import { useAllVPCsQuery, useRegionQuery } from '@linode/queries';
 import {
   Autocomplete,
+  Box,
+  Checkbox,
+  FormControlLabel,
   InputAdornment,
   Paper,
   Stack,
   TextField,
+  TooltipIcon,
   Typography,
 } from '@linode/ui';
+import { useMediaQuery, useTheme } from '@mui/material';
 import React from 'react';
 
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
-import { NODEBALANCER_REGION_CAVEAT_HELPER_TEXT } from '../VPCs/constants';
+import {
+  NB_AUTO_ASSIGN_CIDR_TOOLTIP,
+  NODEBALANCER_REGION_CAVEAT_HELPER_TEXT,
+} from '../VPCs/constants';
 
 import type { APIError, NodeBalancerVpcPayload, VPC } from '@linode/api-v4';
 
 export interface Props {
   disabled?: boolean;
   errors?: APIError[];
-  ipv4Change: (ipv4Range: string, index: number) => void;
+  ipv4Change: (ipv4Range: null | string, index: number) => void;
   regionSelected: string;
   setIsVpcSelected: (vpc: boolean) => void;
   subnetChange: (subnetIds: null | number[]) => void;
@@ -36,6 +44,9 @@ export const VPCPanel = (props: Props) => {
     subnetChange,
   } = props;
 
+  const theme = useTheme();
+  const isSmallBp = useMediaQuery(theme.breakpoints.down('sm'));
+
   const { data: region } = useRegionQuery(regionSelected);
 
   const regionSupportsVPC = region?.capabilities.includes('VPCs') || false;
@@ -49,6 +60,8 @@ export const VPCPanel = (props: Props) => {
     filter: { region: regionSelected },
   });
 
+  const [autoAssignIPv4WithinVPC, toggleAutoAssignIPv4Range] =
+    React.useState<boolean>(true);
   const [VPCSelected, setVPCSelected] = React.useState<null | VPC>(null);
 
   React.useEffect(() => {
@@ -126,31 +139,78 @@ export const VPCPanel = (props: Props) => {
                   ) ?? null
                 }
               />
-              {subnets &&
-                subnets.map((vpc, index) => (
-                  <TextField
-                    errorText={
-                      errors?.find((err) =>
-                        err.field?.includes(`vpcs[${index}].ipv4_range`)
-                      )?.reason
-                    }
-                    key={`${vpc.subnet_id}`}
-                    label={`NodeBalancer IPv4 CIDR for ${getVPCSubnetLabelFromId(vpc.subnet_id)}`}
-                    noMarginTop
-                    onChange={(e) => ipv4Change(e.target.value ?? '', index)}
-                    // eslint-disable-next-line sonarjs/no-hardcoded-ip
-                    placeholder="10.0.0.24"
-                    required
-                    slotProps={{
-                      input: {
-                        endAdornment: (
-                          <InputAdornment position="end">/30</InputAdornment>
-                        ),
-                      },
-                    }}
-                    value={vpc.ipv4_range}
-                  />
-                ))}
+              {subnets && (
+                <>
+                  <Box
+                    alignItems="center"
+                    display="flex"
+                    flexDirection="row"
+                    sx={(theme) => ({
+                      marginLeft: '2px',
+                      paddingTop: theme.spacing(),
+                    })}
+                  >
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          checked={autoAssignIPv4WithinVPC}
+                          onChange={(_, checked) => {
+                            if (checked) {
+                              ipv4Change(null, 0);
+                            }
+                            toggleAutoAssignIPv4Range(checked);
+                          }}
+                        />
+                      }
+                      data-testid="vpc-ipv4-checkbox"
+                      label={
+                        <Box
+                          alignItems="center"
+                          display="flex"
+                          flexDirection="row"
+                        >
+                          <Typography noWrap={!isSmallBp}>
+                            Auto-assign a /30 CIDR in each subnet for this
+                            NodeBalancer
+                          </Typography>
+                          <TooltipIcon
+                            status="help"
+                            text={NB_AUTO_ASSIGN_CIDR_TOOLTIP}
+                          />
+                        </Box>
+                      }
+                    />
+                  </Box>
+                  {!autoAssignIPv4WithinVPC &&
+                    subnets.map((vpc, index) => (
+                      <TextField
+                        errorText={
+                          errors?.find((err) =>
+                            err.field?.includes(`vpcs[${index}].ipv4_range`)
+                          )?.reason
+                        }
+                        key={`${vpc.subnet_id}`}
+                        label={`NodeBalancer IPv4 CIDR for ${getVPCSubnetLabelFromId(vpc.subnet_id)}`}
+                        noMarginTop
+                        onChange={(e) =>
+                          ipv4Change(e.target.value ?? '', index)
+                        }
+                        // eslint-disable-next-line sonarjs/no-hardcoded-ip
+                        placeholder="10.0.0.24"
+                        slotProps={{
+                          input: {
+                            endAdornment: (
+                              <InputAdornment position="end">
+                                /30
+                              </InputAdornment>
+                            ),
+                          },
+                        }}
+                        value={vpc.ipv4_range}
+                      />
+                    ))}
+                </>
+              )}
             </>
           )}
         </Stack>

--- a/packages/manager/src/features/VPCs/constants.ts
+++ b/packages/manager/src/features/VPCs/constants.ts
@@ -23,6 +23,9 @@ export const REGIONAL_LINODE_MESSAGE =
 export const MULTIPLE_CONFIGURATIONS_MESSAGE =
   'This Linode has multiple configurations. Select which configuration you would like added to the subnet.';
 
+export const NB_AUTO_ASSIGN_CIDR_TOOLTIP =
+  'A /30 CIDR is needed for the NodeBalancer to communicate with the subnet. Deselect this option to define a custom IP range.';
+
 export const VPC_AUTO_ASSIGN_IPV4_TOOLTIP =
   'Automatically assign an IPv4 address as the private IP address for this Linode in the VPC.';
 


### PR DESCRIPTION
## Description 📝

Highlight the Pull Request's context and intentions.

## Changes  🔄

List any change(s) relevant to the reviewer.

- ...
- ...

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- ...
- ...

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
