### PR TITLE
test [M3-10000]:  Account quotas navigation and permissions

### DIFF
--- a/packages/manager/cypress/e2e/core/cloudpulse/quotas.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/quotas.spec.ts
@@ -1,0 +1,84 @@
+import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
+import { ui } from 'support/ui';
+
+describe('Quotas accessible when limitsEvolution feature flag enabled', () => {
+  beforeEach(() => {
+    mockAppendFeatureFlags({
+      limitsEvolution: {
+        enabled: true,
+      },
+    }).as('getFeatureFlags');
+  });
+  it('can navigate directly to Quotas page', () => {
+    cy.visitWithLogin('/account/quotas');
+    cy.wait('@getFeatureFlags');
+    cy.url().should('endWith', '/quotas');
+    cy.findByText('Object Storage').should('be.visible');
+  });
+
+  it('can navigate to the Quotas page via the User Menu', () => {
+    cy.visitWithLogin('/');
+    cy.wait('@getFeatureFlags');
+    cy.get('[data-testid="nav-group-profile"]').should('be.visible').click();
+    ui.userMenu.find().within(() => {
+      cy.get('[data-testid="menu-item-Quotas"]').should('be.visible').click();
+      cy.url().should('endWith', '/quotas');
+    });
+  });
+
+  it('Quotas tab is visible from all other tabs in Account tablist', () => {
+    cy.visitWithLogin('/account/billing');
+    cy.wait('@getFeatureFlags');
+    ui.tabList.find().within(() => {
+      cy.get('a').each(($link) => {
+        cy.wrap($link).click();
+        cy.get('[data-testid="Quotas"]').should('be.visible');
+      });
+    });
+    cy.get('[data-testid="Quotas"]').should('be.visible').click();
+    cy.url().should('endWith', '/quotas');
+  });
+});
+
+describe('Quotas inaccessible when limitsEvolution feature flag disabled', () => {
+  beforeEach(() => {
+    mockAppendFeatureFlags({
+      limitsEvolution: {
+        enabled: false,
+      },
+    }).as('getFeatureFlags');
+  });
+  it('Quotas page is inaccessible', () => {
+    cy.visitWithLogin('/account/quotas');
+    cy.wait('@getFeatureFlags');
+    cy.url().should('endWith', '/billing');
+  });
+
+  it('cannot navigate to the Quotas tab via the Users & Grants link in the User Menu', () => {
+    cy.visitWithLogin('/');
+    cy.wait('@getFeatureFlags');
+    cy.get('[data-testid="nav-group-profile"]').should('be.visible').click();
+    ui.userMenu.find().within(() => {
+      cy.get('[data-testid="menu-item-Quotas"]').should('not.exist');
+      cy.get('[data-testid="menu-item-Users & Grants"]')
+        .should('be.visible')
+        .click();
+    });
+    cy.url().should('endWith', '/users');
+    cy.get('[data-testid="Quotas"]').should('not.exist');
+  });
+
+  it('cannot navigate to the Quotas tab via the Billing link in the User Menu', () => {
+    cy.visitWithLogin('/');
+    cy.wait('@getFeatureFlags');
+    cy.get('[data-testid="nav-group-profile"]').should('be.visible').click();
+    ui.userMenu.find().within(() => {
+      cy.get('[data-testid="menu-item-Quotas"]').should('not.exist');
+      cy.get('[data-testid="menu-item-Billing & Contact Information"]')
+        .should('be.visible')
+        .click();
+    });
+    cy.url().should('endWith', '/billing');
+    cy.get('[data-testid="Quotas"]').should('not.exist');
+  });
+});

--- a/packages/manager/cypress/e2e/core/cloudpulse/quotas.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/quotas.spec.ts
@@ -3,6 +3,7 @@ import { ui } from 'support/ui';
 
 describe('Quotas accessible when limitsEvolution feature flag enabled', () => {
   beforeEach(() => {
+    // TODO M3-10003 - Remove mock once `limitsEvolution` feature flag is removed.
     mockAppendFeatureFlags({
       limitsEvolution: {
         enabled: true,

--- a/packages/manager/cypress/e2e/core/cloudpulse/quotas.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/quotas.spec.ts
@@ -19,7 +19,8 @@ describe('Quotas accessible when limitsEvolution feature flag enabled', () => {
   it('can navigate to the Quotas page via the User Menu', () => {
     cy.visitWithLogin('/');
     cy.wait('@getFeatureFlags');
-    cy.get('[data-testid="nav-group-profile"]').should('be.visible').click();
+    // Open user menu
+    ui.userMenuButton.find().click();
     ui.userMenu.find().within(() => {
       cy.get('[data-testid="menu-item-Quotas"]').should('be.visible').click();
       cy.url().should('endWith', '/quotas');
@@ -57,7 +58,8 @@ describe('Quotas inaccessible when limitsEvolution feature flag disabled', () =>
   it('cannot navigate to the Quotas tab via the Users & Grants link in the User Menu', () => {
     cy.visitWithLogin('/');
     cy.wait('@getFeatureFlags');
-    cy.get('[data-testid="nav-group-profile"]').should('be.visible').click();
+    // Open user menu
+    ui.userMenuButton.find().click();
     ui.userMenu.find().within(() => {
       cy.get('[data-testid="menu-item-Quotas"]').should('not.exist');
       cy.get('[data-testid="menu-item-Users & Grants"]')
@@ -71,7 +73,7 @@ describe('Quotas inaccessible when limitsEvolution feature flag disabled', () =>
   it('cannot navigate to the Quotas tab via the Billing link in the User Menu', () => {
     cy.visitWithLogin('/');
     cy.wait('@getFeatureFlags');
-    cy.get('[data-testid="nav-group-profile"]').should('be.visible').click();
+    ui.userMenuButton.find().click();
     ui.userMenu.find().within(() => {
       cy.get('[data-testid="menu-item-Quotas"]').should('not.exist');
       cy.get('[data-testid="menu-item-Billing & Contact Information"]')


### PR DESCRIPTION
## Description 📝

Test access to /account/quotas route, using the limitsEvolution feature flag. If the limitsEvolution is disabled, the quotas tab and content should not be accessible or visible, and the menu button should not be present in the user menu.

## Changes  🔄

Tests for when limitsEvolution is enabled:
1. navigation directly to account/quotas   
2. navigation to Quotas page via the User Menu  
3. navigation to Quotas page from account/billing tab, and that the Quotas tab link is visible in all other tabs in Account tablist

Tests for when limitsEvolution is disabled:
1.  account/quotas is not accessible  
2. navigation to the Quotas tab via the Users & Grants link in the User Menu is not possible  
3. cannot navigate to the Quotas tab via the Billing link in the User Menu
 
## How to test 🧪

npm run cy:run -s cypress/e2e/core/cloudpulse/quotas.spec.ts 

<details>
<summary> Author Checklists </summary>
 

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
 