### PR TITLE
change: [M3-9997] - Update estimated time for LKE-E node pool pending creation message

### DIFF
--- a/packages/manager/.changeset/pr-12251-upcoming-features-1747763494658.md
+++ b/packages/manager/.changeset/pr-12251-upcoming-features-1747763494658.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update estimated time for LKE-E node pool pending creation message ([#12251](https://github.com/linode/manager/pull/12251))

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.test.tsx
@@ -91,7 +91,7 @@ describe('NodeTable', () => {
     getByText('Pool ID 1');
   });
 
-  it('displays a provisioning message if the cluster was created within the first 10 mins and there are no nodes yet', async () => {
+  it('displays a provisioning message if the cluster was created within the first 20 mins and there are no nodes yet', async () => {
     const clusterProps = {
       ...props,
       clusterCreated: DateTime.local().toISO(),
@@ -108,7 +108,7 @@ describe('NodeTable', () => {
     ).toBeVisible();
 
     expect(
-      await findByText('Provisioning can take up to 10 minutes.')
+      await findByText('Provisioning can take up to ~20 minutes.')
     ).toBeVisible();
   });
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -110,9 +110,9 @@ export const NodeTable = React.memo((props: Props) => {
       })
     : null;
 
-  // It takes ~5 minutes for LKE-E cluster nodes to be provisioned and we want to explain this to the user
+  // It takes anywhere between 5-20+ minutes for LKE-E cluster nodes to be provisioned and we want to explain this to the user
   // since nodes are not returned right away unlike standard LKE
-  const isEnterpriseClusterWithin10MinsOfCreation = () => {
+  const isEnterpriseClusterWithin20MinsOfCreation = () => {
     if (clusterTier !== 'enterprise') {
       return false;
     }
@@ -188,7 +188,7 @@ export const NodeTable = React.memo((props: Props) => {
                 </TableHead>
                 <TableBody>
                   {rowData.length === 0 &&
-                    isEnterpriseClusterWithin10MinsOfCreation() && (
+                    isEnterpriseClusterWithin20MinsOfCreation() && (
                       <TableRow>
                         <TableCell colSpan={4}>
                           <ErrorState
@@ -205,7 +205,7 @@ export const NodeTable = React.memo((props: Props) => {
                                   provisioning is complete.
                                 </Typography>
                                 <Typography>
-                                  Provisioning can take up to 10 minutes.
+                                  Provisioning can take up to ~20 minutes.
                                 </Typography>
                               </Box>
                             }
@@ -214,7 +214,7 @@ export const NodeTable = React.memo((props: Props) => {
                       </TableRow>
                     )}
                   {(rowData.length > 0 ||
-                    !isEnterpriseClusterWithin10MinsOfCreation()) && (
+                    !isEnterpriseClusterWithin20MinsOfCreation()) && (
                     <TableContentWrapper
                       length={paginatedAndOrderedData.length}
                       loading={isLoading}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -121,7 +121,7 @@ export const NodeTable = React.memo((props: Props) => {
 
     const interval = Interval.fromDateTimes(
       createdTime,
-      createdTime.plus({ minutes: 10 })
+      createdTime.plus({ minutes: 20 })
     );
 
     const currentTime = DateTime.fromISO(DateTime.now().toISO(), {


### PR DESCRIPTION
## Description 📝

As reported by LKE QA, the amount of time it takes to fully provision LKE-E cluster nodes has increased since we originally determined that nodes were provisioned within 10 minutes or less. (On staging, it takes ~1110s, or ~18 minutes.)

This PR updates the util and copy to display this message for the first 20 minutes after cluster creation.

## Changes  🔄
- Renamed the util for `20` min and updated the interval
- Updated the copy to mention 20 minutes
- Updated test coverage

## Target release date 🗓️

6/3

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-05-20 at 10 41 39 AM](https://github.com/user-attachments/assets/9e092420-e7ad-4a9a-961b-ac0020f13919) | ![Screenshot 2025-05-20 at 10 41 22 AM](https://github.com/user-attachments/assets/de4b66ef-ff61-447c-9dd4-4c3b7b1f63eb)|

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have the LKE-E customer tag on your account or use `prod-test-004-fe` using our shared credentials
- Have the LKE-E feature flag on

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Check out `develop` and create a new LKE-E cluster
- [ ] Observe the node pools section has a placeholder message stating 10 minutes
- [ ] Observe that if the cluster is not ready after 10 minutes, the message disappears and the empty table state message is displayed

### Verification steps

(How to verify changes)

- [ ] Check out this branch and create a new LKE-E cluster
- [ ] Observe that after 10 minutes and up to 20 minutes, the placeholder message displays, stating 20 minutes
- [ ] Observe that the message continues to display until your node pools appear - the idea is that 20 minutes should generally be enough time - let me know if that's not the case

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>