### PR TITLE
fix: [M3-9900] - Simplify `linode_resize` started event

### DIFF
--- a/packages/manager/.changeset/pr-12252-fixed-1747765194838.md
+++ b/packages/manager/.changeset/pr-12252-fixed-1747765194838.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Make linode_resize "started "event generic ([#12252](https://github.com/linode/manager/pull/12252))

--- a/packages/manager/.changeset/pr-12252-fixed-1747765194838.md
+++ b/packages/manager/.changeset/pr-12252-fixed-1747765194838.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Make linode_resize "started "event generic ([#12252](https://github.com/linode/manager/pull/12252))

--- a/packages/manager/.changeset/pr-12252-fixed-1747765254237.md
+++ b/packages/manager/.changeset/pr-12252-fixed-1747765254237.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Make `linode_resize` started event generic ([#12252](https://github.com/linode/manager/pull/12252))

--- a/packages/manager/src/features/Events/factories/linode.tsx
+++ b/packages/manager/src/features/Events/factories/linode.tsx
@@ -1,14 +1,10 @@
-import { useLinodeQuery } from '@linode/queries';
-import { formatStorageUnits } from '@linode/utilities';
 import * as React from 'react';
 
 import { Link } from 'src/components/Link';
-import { useTypeQuery } from 'src/queries/types';
 
 import { EventLink } from '../EventLink';
 
 import type { PartialEventMap } from '../types';
-import type { Event } from '@linode/api-v4';
 
 export const linode: PartialEventMap<'linode'> = {
   linode_addip: {
@@ -488,7 +484,12 @@ export const linode: PartialEventMap<'linode'> = {
         <strong>resizing</strong>.
       </>
     ),
-    started: (e) => <LinodeResizeStartedMessage event={e} />,
+    started: (e) => (
+      <>
+        Linode <EventLink event={e} to="entity" /> is <strong>resizing</strong>{' '}
+        to the selected plan.
+      </>
+    ),
   },
   linode_resize_create: {
     notification: (e) => (
@@ -570,27 +571,4 @@ export const linode: PartialEventMap<'linode'> = {
       </>
     ),
   },
-};
-
-const LinodeResizeStartedMessage = ({ event }: { event: Event }) => {
-  const { data: linode } = useLinodeQuery(event.entity?.id ?? -1);
-  const type = useTypeQuery(linode?.type ?? '');
-
-  return (
-    <>
-      Linode <EventLink event={event} to="entity" /> is{' '}
-      <strong>resizing</strong>
-      {type && (
-        <>
-          {' '}
-          to the{' '}
-          {type.data?.label && (
-            <strong>{formatStorageUnits(type.data.label)}</strong>
-          )}{' '}
-          Plan
-        </>
-      )}
-      .
-    </>
-  );
 };


### PR DESCRIPTION
## Description 📝
When resizing a Linode without the "Auto Resize Disk" option checked off, the events menu/feed in Cloud Manager will say "Resizing Linode to $current_plan" rather than the plan that the user is resizing to.

There's no way to really fix this on our end since the plan info is returned from the API (which may be intentional). Rather than going through a lot of troubleshooting to achieve something we may not be able to, this PR simplifies the event to make it more generic and will avoid confusion for some users.

## Changes  🔄
- Make `linode_resize` "started "event generic

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/64dbd3c0-30e3-4830-b491-98f2c6dfad37" /> | ![Screen Shot 2025-05-20 at 14 17 35](https://github.com/user-attachments/assets/d174e54b-9156-452a-b44d-bbfd91d0031e) |

## How to test 🧪

### Reproduction steps
- Select Linode and click the resize button.
- Choose plan to resize to.
- Leave the "Auto Resize Disk" option unchecked/disabled.
- Click "Resize Linode"
- Notice wrong plan in the "started" message (usually after a minute of triggering the resize)

### Verification steps
- Select Linode and click the resize button.
- Choose plan to resize to.
- Leave the "Auto Resize Disk" option unchecked/disabled.
- Click "Resize Linode"
- Confirm the new generic message

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
