### PR TITLE
test: [M3-9176] - Add integration test for Upgrade to new Linode Interface flow

### DIFF
--- a/packages/manager/.changeset/pr-12259-tests-1747849345030.md
+++ b/packages/manager/.changeset/pr-12259-tests-1747849345030.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add integration test for Upgrade to new Linode Interface flow ([#12259](https://github.com/linode/manager/pull/12259))

--- a/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
@@ -47,6 +47,7 @@ import {
   mockUpgradeNewLinodeInterface,
   mockUpgradeNewLinodeInterfaceError,
 } from 'support/intercepts/linodes';
+import { mockGetRegion, mockGetRegions } from 'support/intercepts/regions';
 import { mockGetVLANs } from 'support/intercepts/vlans';
 import { mockGetVPC, mockGetVPCs } from 'support/intercepts/vpc';
 import { ui } from 'support/ui';
@@ -481,7 +482,7 @@ describe('Linode Config management', () => {
 
   describe('Mocked', () => {
     const region: Region = regionFactory.build({
-      capabilities: ['Linodes'],
+      capabilities: ['Linodes', 'Linode Interfaces'],
       country: 'us',
       id: 'us-southeast',
     });
@@ -875,6 +876,14 @@ describe('Linode Config management', () => {
             capabilities: ['Linodes', 'Linode Interfaces'],
           })
         );
+
+        const mockRegion: Region = regionFactory.build({
+          id: 'us-east',
+          label: 'Newark, NJ',
+          capabilities: ['Linodes', 'Linode Interfaces'],
+        });
+        mockGetRegions([mockRegion]);
+        mockGetRegion(mockRegion);
       });
 
       /*
@@ -885,7 +894,7 @@ describe('Linode Config management', () => {
         const mockLinode = linodeFactory.build({
           id: randomNumber(1000, 99999),
           label: randomLabel(),
-          region: chooseRegion().id,
+          region: 'us-east',
           interface_generation: 'linode',
         });
 
@@ -966,7 +975,7 @@ describe('Linode Config management', () => {
         const mockLinode = linodeFactory.build({
           id: randomNumber(1000, 99999),
           label: randomLabel(),
-          region: chooseRegion().id,
+          region: 'us-east',
         });
 
         const mockConfig = configFactory.build({
@@ -1072,7 +1081,7 @@ describe('Linode Config management', () => {
         const mockLinode = linodeFactory.build({
           id: randomNumber(1000, 99999),
           label: randomLabel(),
-          region: chooseRegion().id,
+          region: 'us-east',
         });
 
         const mockConfig = configFactory.build({

--- a/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/linode-config.spec.ts
@@ -55,7 +55,7 @@ import { cleanUp } from 'support/util/cleanup';
 import { fetchAllKernels, findKernelById } from 'support/util/kernels';
 import {
   assertPromptDialogContent,
-  assertUpgradeSummay,
+  assertUpgradeSummary,
   createTestLinode,
   fetchLinodeConfigs,
 } from 'support/util/linodes';
@@ -941,7 +941,7 @@ describe('Linode Config management', () => {
             ui.button.findByTitle('Cancel').click();
           });
 
-        // Confirm asbence of the interfaces section when adding a new config.
+        // Confirm absence of the interfaces section when adding a new config.
         ui.button
           .findByTitle('Add Configuration')
           .should('be.visible')
@@ -1038,7 +1038,7 @@ describe('Linode Config management', () => {
               .should('be.enabled')
               .click();
 
-            assertUpgradeSummay(mockPublicInterface, true);
+            assertUpgradeSummary(mockPublicInterface, true);
 
             ui.button
               .findByTitle('Continue to Upgrade')
@@ -1046,7 +1046,7 @@ describe('Linode Config management', () => {
               .should('be.enabled')
               .click();
 
-            assertUpgradeSummay(mockPublicInterface, false);
+            assertUpgradeSummary(mockPublicInterface, false);
 
             ui.button.findByTitle('Close').should('be.visible').click();
           });
@@ -1067,10 +1067,16 @@ describe('Linode Config management', () => {
               .should('be.enabled')
               .click();
 
-            assertUpgradeSummay(mockPublicInterface, false);
+            assertUpgradeSummary(mockPublicInterface, false);
 
-            ui.button.findByTitle('Close').should('be.visible').click();
+            ui.button
+              .findByTitle('View Network Settings')
+              .should('be.visible')
+              .click();
           });
+
+        // Confirm can navigate to linode/networking after success
+        cy.url().should('endWith', `linodes/${mockLinode.id}/networking`);
       });
 
       /*

--- a/packages/manager/cypress/e2e/core/linodes/upgrade-linode-interface.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/upgrade-linode-interface.spec.ts
@@ -29,7 +29,7 @@ import { ui } from 'support/ui';
 import { cleanUp } from 'support/util/cleanup';
 import {
   assertPromptDialogContent,
-  assertUpgradeSummay,
+  assertUpgradeSummary,
 } from 'support/util/linodes';
 import { randomLabel, randomNumber } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
@@ -59,7 +59,7 @@ describe('upgrade to new Linode Interface flow', () => {
    * - Confirms that config dialog interfaces section is absent on Linodes that use new interfaces.
    * - Confirms absence on edit and add config dialog.
    */
-  it('does not show interfaces section when upgrading to Linodes with new interfaces', () => {
+  it('does not show interfaces section in the config dialog for Linodes using new interfaces', () => {
     const mockLinode = linodeFactory.build({
       id: randomNumber(1000, 99999),
       label: randomLabel(),
@@ -82,7 +82,7 @@ describe('upgrade to new Linode Interface flow', () => {
       'be.visible'
     );
 
-    // "UPGRADE" button is absence
+    // "UPGRADE" button is absent
     cy.findByText('Linode').should('be.visible');
     cy.findByText('Configuration Profile').should('not.exist');
     cy.findByText('UPGRADE').should('not.exist');
@@ -118,7 +118,7 @@ describe('upgrade to new Linode Interface flow', () => {
         ui.button.findByTitle('Cancel').click();
       });
 
-    // Confirm asbence of the interfaces section when adding a new config.
+    // Confirm absence of the interfaces section when adding a new config.
     ui.button
       .findByTitle('Add Configuration')
       .should('be.visible')
@@ -197,7 +197,7 @@ describe('upgrade to new Linode Interface flow', () => {
           .should('be.enabled')
           .click();
 
-        assertUpgradeSummay(mockPublicInterface, true);
+        assertUpgradeSummary(mockPublicInterface, true);
 
         ui.button
           .findByTitle('Continue to Upgrade')
@@ -205,7 +205,7 @@ describe('upgrade to new Linode Interface flow', () => {
           .should('be.enabled')
           .click();
 
-        assertUpgradeSummay(mockPublicInterface, false);
+        assertUpgradeSummary(mockPublicInterface, false);
 
         ui.button.findByTitle('Close').should('be.visible').click();
       });
@@ -222,10 +222,16 @@ describe('upgrade to new Linode Interface flow', () => {
           .should('be.enabled')
           .click();
 
-        assertUpgradeSummay(mockPublicInterface, false);
+        assertUpgradeSummary(mockPublicInterface, false);
 
-        ui.button.findByTitle('Close').should('be.visible').click();
+        ui.button
+          .findByTitle('View Network Settings')
+          .should('be.visible')
+          .click();
       });
+
+    // Confirm can navigate to linode/networking after success
+    cy.url().should('endWith', `linodes/${mockLinode.id}/networking`);
   });
 
   /*
@@ -312,7 +318,7 @@ describe('upgrade to new Linode Interface flow', () => {
           .should('be.enabled')
           .click();
 
-        assertUpgradeSummay(mockPublicInterface, true);
+        assertUpgradeSummary(mockPublicInterface, true);
 
         ui.button
           .findByTitle('Continue to Upgrade')
@@ -320,7 +326,7 @@ describe('upgrade to new Linode Interface flow', () => {
           .should('be.enabled')
           .click();
 
-        assertUpgradeSummay(mockPublicInterface, false);
+        assertUpgradeSummary(mockPublicInterface, false);
 
         ui.button.findByTitle('Close').should('be.visible').click();
       });
@@ -361,10 +367,13 @@ describe('upgrade to new Linode Interface flow', () => {
           .should('be.enabled')
           .click();
 
-        assertUpgradeSummay(mockPublicInterface, false);
+        assertUpgradeSummary(mockPublicInterface, false);
 
         ui.button.findByTitle('Close').should('be.visible').click();
       });
+
+    // Confirm can navigate to Linode after success
+    cy.url().should('endWith', `linodes/${mockLinode.id}`);
   });
 
   /*

--- a/packages/manager/cypress/e2e/core/linodes/upgrade-linode-interface.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/upgrade-linode-interface.spec.ts
@@ -1,0 +1,455 @@
+import {
+  configFactory,
+  linodeFactory,
+  linodeInterfaceFactoryPublic,
+  upgradeLinodeInterfaceFactory,
+} from '@linode/utilities';
+import { accountFactory } from '@src/factories';
+import { authenticate } from 'support/api/authentication';
+import {
+  configSelectSharedText,
+  dryRunButtonText,
+  errorDryRunText,
+  upgradeInterfacesButtonText,
+  upgradeInterfacesWarningText,
+} from 'support/constants/linode-interfaces';
+import { LINODE_CREATE_TIMEOUT } from 'support/constants/linodes';
+import { mockGetAccount } from 'support/intercepts/account';
+import {
+  mockGetLinodeConfig,
+  mockGetLinodeConfigs,
+} from 'support/intercepts/configs';
+import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
+import {
+  mockGetLinodeDetails,
+  mockUpgradeNewLinodeInterface,
+  mockUpgradeNewLinodeInterfaceError,
+} from 'support/intercepts/linodes';
+import { ui } from 'support/ui';
+import { cleanUp } from 'support/util/cleanup';
+import { 
+  assertPromptDialogContent,
+  assertUpgradeSummay,
+} from 'support/util/linodes';
+import { randomLabel, randomNumber } from 'support/util/random';
+import { chooseRegion } from 'support/util/regions';
+
+authenticate();
+describe('upgrade to new Linode Interface flow', () => {
+  beforeEach(() => {
+    cleanUp(['linodes']);
+    cy.tag('method:e2e');
+
+    // TODO M3-9775: Remove mock when `linodeInterfaces` feature flag is removed.
+    mockAppendFeatureFlags({
+      linodeInterfaces: {
+        enabled: true,
+      },
+    });
+
+    // TODO Remove account mock when 'Linode Interfaces' capability is generally available.
+    mockGetAccount(
+      accountFactory.build({
+        capabilities: ['Linodes', 'Linode Interfaces'],
+      })
+    );
+  });
+
+ /*
+  * - Confirms that config dialog interfaces section is absent on Linodes that use new interfaces.
+  * - Confirms absence on edit and add config dialog.
+  */
+  it('does not show interfaces section when upgrading to Linodes with new interfaces', () => {
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(1000, 99999),
+      label: randomLabel(),
+      region: chooseRegion().id,
+      interface_generation: 'linode',
+    });
+
+    const mockConfig = configFactory.build({
+      label: randomLabel(),
+      id: randomNumber(1000, 99999),
+      interfaces: null,
+    });
+
+    mockGetLinodeDetails(mockLinode.id, mockLinode);
+    mockGetLinodeConfigs(mockLinode.id, [mockConfig]);
+    mockGetLinodeConfig(mockLinode.id, mockConfig);
+
+    cy.visitWithLogin(`/linodes/${mockLinode.id}`);
+    cy.contains('RUNNING', { timeout: LINODE_CREATE_TIMEOUT }).should(
+      'be.visible'
+    );
+
+    // "UPGRADE" button is absence
+    cy.findByText('Linode').should('be.visible');
+    cy.findByText('Configuration Profile').should('not.exist');
+    cy.findByText('UPGRADE').should('not.exist');
+
+    cy.get('[data-testid="Configurations"]')
+      .should('be.visible')
+      .click();
+
+    cy.findByLabelText('List of Configurations')
+      .should('be.visible')
+      .within(() => {
+        ui.button
+          .findByTitle('Edit')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    // Confirm absence of the interfaces section when editing an existing config.
+    ui.dialog
+      .findByTitle('Edit Configuration')
+      .should('be.visible')
+      .within(() => {
+        // Scroll "Networking" section into view, and confirm that Interfaces
+        // options are absent and informational text is shown instead.
+        cy.findByText('Networking').scrollIntoView();
+        cy.contains(
+          "Go to Network to view your Linode's Network interfaces."
+        ).should('be.visible');
+        cy.findByText('Primary Interface (Default Route)').should(
+          'not.exist'
+        );
+        cy.findByText('eth0').should('not.exist');
+        cy.findByText('eth1').should('not.exist');
+        cy.findByText('eth2').should('not.exist');
+
+        ui.button.findByTitle('Cancel').click();
+      });
+
+    // Confirm asbence of the interfaces section when adding a new config.
+    ui.button
+      .findByTitle('Add Configuration')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    ui.dialog
+      .findByTitle('Add Configuration')
+      .should('be.visible')
+      .within(() => {
+        // Scroll "Networking" section into view, and confirm that Interfaces
+        // options are absent and informational text is shown instead.
+        cy.findByText('Networking').scrollIntoView();
+        cy.contains(
+          "Go to Network to view your Linode's Network interfaces."
+        ).should('be.visible');
+        cy.findByText('Primary Interface (Default Route)').should(
+          'not.exist'
+        );
+        cy.findByText('eth0').should('not.exist');
+        cy.findByText('eth1').should('not.exist');
+        cy.findByText('eth2').should('not.exist');
+      });
+  });
+  
+ /*
+  * - Confirm button appears in Details footer for linodes with legacy interfaces.
+  * - Confirm clicking 'UPGRADE' button flow.
+  */
+  it('upgrades from a single legacy configuration to new Linode interfaces (Public) from details page', () => {
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(1000, 99999),
+      label: randomLabel(),
+      region: chooseRegion().id,
+    });
+
+    const mockConfig = configFactory.build({
+      label: randomLabel(),
+      id: randomNumber(1000, 99999),
+      interfaces: null,
+    });
+    
+    const mockPublicInterface = linodeInterfaceFactoryPublic.build({
+      id: randomNumber(1000, 99999),
+    });
+
+    const mockUpgradeLinodeInterface = upgradeLinodeInterfaceFactory.build({
+      config_id: mockConfig.id,
+      dry_run: true,
+      interfaces: [
+        mockPublicInterface,
+      ],
+    });
+
+    mockGetLinodeDetails(mockLinode.id, mockLinode);
+    mockGetLinodeConfigs(mockLinode.id, [mockConfig]);
+    mockGetLinodeConfig(mockLinode.id, mockConfig);
+    mockUpgradeNewLinodeInterface(mockLinode.id, mockUpgradeLinodeInterface);
+
+    cy.visitWithLogin(`/linodes/${mockLinode.id}`);
+    cy.contains('RUNNING', { timeout: LINODE_CREATE_TIMEOUT }).should(
+      'be.visible'
+    );
+
+    // "UPGRADE" button appears and works as expected.
+    cy.findByText('Configuration Profile').should('be.visible');
+    cy.findByText('UPGRADE').should('be.visible').click();
+
+    // Assert the prompt dialog content.
+    assertPromptDialogContent();
+
+    // Check "Dry Run" flow
+    ui.dialog
+      .findByTitle('Upgrade to Linode Interfaces')
+      .should('be.visible')
+      .within(() => {
+        ui.button
+          .findByTitle(dryRunButtonText)
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+
+        assertUpgradeSummay(mockPublicInterface, true);
+
+        ui.button
+          .findByTitle('Continue to Upgrade')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+
+        assertUpgradeSummay(mockPublicInterface, false);
+
+        ui.button
+          .findByTitle('Close')
+          .should('be.visible')
+          .click();
+      });
+
+    // Check "Upgrade Interfaces" flow
+    cy.findByText('UPGRADE').should('be.visible').click();
+    ui.dialog
+      .findByTitle('Upgrade to Linode Interfaces')
+      .should('be.visible')
+      .within(() => {
+        ui.button
+          .findByTitle(upgradeInterfacesButtonText)
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+
+        assertUpgradeSummay(mockPublicInterface, false);
+
+        ui.button
+          .findByTitle('Close')
+          .should('be.visible')
+          .click();
+      });
+  });
+
+ /*
+  * - Confirm Linode with multiple configurations can be upgraded to new Linode Interfaces.
+  */
+  it('upgrades from multiple legacy configurations to new Linode interfaces from details page', () => {
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(1000, 99999),
+      label: randomLabel(),
+      region: chooseRegion().id,
+    });
+
+    const mockConfig1 = configFactory.build({
+      label: randomLabel(),
+      id: randomNumber(1000, 99999),
+      interfaces: null,
+    });
+    
+    const mockConfig2 = configFactory.build({
+      label: randomLabel(),
+      id: randomNumber(1000, 99999),
+      interfaces: null,
+    });
+
+    const mockPublicInterface = linodeInterfaceFactoryPublic.build({
+      id: randomNumber(1000, 99999),
+    });
+
+    const mockUpgradeLinodeInterface = upgradeLinodeInterfaceFactory.build({
+      config_id: mockConfig1.id,
+      dry_run: true,
+      interfaces: [
+        mockPublicInterface,
+      ],
+    });
+
+    mockGetLinodeDetails(mockLinode.id, mockLinode);
+    mockGetLinodeConfigs(mockLinode.id, [mockConfig1, mockConfig2]);
+    mockGetLinodeConfig(mockLinode.id, mockConfig1);
+    mockUpgradeNewLinodeInterface(mockLinode.id, mockUpgradeLinodeInterface);
+
+    cy.visitWithLogin(`/linodes/${mockLinode.id}`);
+    cy.contains('RUNNING', { timeout: LINODE_CREATE_TIMEOUT }).should(
+      'be.visible'
+    );
+
+    // "UPGRADE" button appears and works as expected.
+    cy.findByText('Configuration Profile').should('be.visible');
+    cy.findByText('UPGRADE')
+      .should('be.visible')
+      .click();
+
+    // Assert the prompt dialog content.
+    assertPromptDialogContent();
+
+    // Check "Dry Run" flow
+    ui.dialog
+      .findByTitle('Upgrade to Linode Interfaces')
+      .should('be.visible')
+      .within(() => {
+        ui.button
+          .findByTitle(dryRunButtonText)
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+
+        // Find the config select and open it
+        cy.get('[placeholder="Select Configuration Profile"]')
+          .should('be.visible')
+          .click();
+        cy.focused().type(`${mockConfig1.label}{enter}`);
+
+        // Select the config
+        ui.autocompletePopper
+          .findByTitle(mockConfig1.label)
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+
+        // Confirm config select text for multiple configurations
+        cy.findByText(configSelectSharedText, {exact: false}).should('be.visible');
+
+        cy.findAllByText(dryRunButtonText)
+          .last()
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+
+        assertUpgradeSummay(mockPublicInterface, true);
+
+        ui.button
+          .findByTitle('Continue to Upgrade')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+
+        assertUpgradeSummay(mockPublicInterface, false);
+
+        ui.button
+          .findByTitle('Close')
+          .should('be.visible')
+          .click();
+      });
+
+    // Check "Upgrade Interfaces" flow
+    cy.findByText('UPGRADE')
+      .should('be.visible')
+      .click();
+    ui.dialog
+      .findByTitle('Upgrade to Linode Interfaces')
+      .should('be.visible')
+      .within(() => {
+        ui.button
+          .findByTitle(upgradeInterfacesButtonText)
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+
+        cy.findByText(configSelectSharedText).should('be.visible');
+
+        // Find the config select and open it
+        cy.get('[placeholder="Select Configuration Profile"]')
+          .should('be.visible')
+          .click();
+        cy.focused().type(`${mockConfig1.label}{enter}`);
+
+        // Select the config
+        ui.autocompletePopper
+          .findByTitle(mockConfig1.label)
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+
+        // Confirm multiple configuration warning text for multiple configurations
+        cy.findByText(upgradeInterfacesWarningText).should('be.visible');
+
+        cy.findAllByText(upgradeInterfacesButtonText)
+          .last()
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+
+        assertUpgradeSummay(mockPublicInterface, false);
+
+        ui.button
+          .findByTitle('Close')
+          .should('be.visible')
+          .click();
+      });
+  });
+
+ /*
+  * - Confirm upgrade error flow.
+  * - Confirm "Return to Overview" works.
+  * - Confirm the error message shows up.
+  */
+  it('Displays error message when having upgrade issue', () => {
+    const mockLinode = linodeFactory.build({
+      id: randomNumber(1000, 99999),
+      label: randomLabel(),
+      region: chooseRegion().id,
+    });
+
+    const mockConfig = configFactory.build({
+      label: randomLabel(),
+      id: randomNumber(1000, 99999),
+      interfaces: null,
+    });
+
+    const mockErrorMessage = 'Custom Error';
+
+    mockGetLinodeDetails(mockLinode.id, mockLinode);
+    mockGetLinodeConfigs(mockLinode.id, [mockConfig]);
+    mockGetLinodeConfig(mockLinode.id, mockConfig);
+    mockUpgradeNewLinodeInterfaceError(mockLinode.id, mockErrorMessage, 500).as('upgradeError');
+
+    cy.visitWithLogin(`/linodes/${mockLinode.id}`);
+    cy.contains('RUNNING', { timeout: LINODE_CREATE_TIMEOUT }).should(
+      'be.visible'
+    );
+
+    // "UPGRADE" button appears and works as expected.
+    cy.findByText('Configuration Profile').should('be.visible');
+    cy.findByText('UPGRADE').should('be.visible').click();;
+
+    ui.dialog
+      .findByTitle('Upgrade to Linode Interfaces')
+      .should('be.visible')
+      .within(() => {
+        // Check error flow
+        ui.button
+          .findByTitle(dryRunButtonText)
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+        
+        // Confirm the error message shows up.
+        cy.wait('@upgradeError');
+        cy.findByText(mockErrorMessage).should('be.visible');
+        cy.findByText(errorDryRunText).should('be.visible');
+
+        // Confirm "Return to Overview" button back to the dialog.
+        ui.button
+          .findByTitle('Return to Overview')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    assertPromptDialogContent();
+  });
+
+});

--- a/packages/manager/cypress/e2e/core/linodes/upgrade-linode-interface.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/upgrade-linode-interface.spec.ts
@@ -27,7 +27,7 @@ import {
 } from 'support/intercepts/linodes';
 import { ui } from 'support/ui';
 import { cleanUp } from 'support/util/cleanup';
-import { 
+import {
   assertPromptDialogContent,
   assertUpgradeSummay,
 } from 'support/util/linodes';
@@ -55,10 +55,10 @@ describe('upgrade to new Linode Interface flow', () => {
     );
   });
 
- /*
-  * - Confirms that config dialog interfaces section is absent on Linodes that use new interfaces.
-  * - Confirms absence on edit and add config dialog.
-  */
+  /*
+   * - Confirms that config dialog interfaces section is absent on Linodes that use new interfaces.
+   * - Confirms absence on edit and add config dialog.
+   */
   it('does not show interfaces section when upgrading to Linodes with new interfaces', () => {
     const mockLinode = linodeFactory.build({
       id: randomNumber(1000, 99999),
@@ -87,9 +87,7 @@ describe('upgrade to new Linode Interface flow', () => {
     cy.findByText('Configuration Profile').should('not.exist');
     cy.findByText('UPGRADE').should('not.exist');
 
-    cy.get('[data-testid="Configurations"]')
-      .should('be.visible')
-      .click();
+    cy.get('[data-testid="Configurations"]').should('be.visible').click();
 
     cy.findByLabelText('List of Configurations')
       .should('be.visible')
@@ -112,9 +110,7 @@ describe('upgrade to new Linode Interface flow', () => {
         cy.contains(
           "Go to Network to view your Linode's Network interfaces."
         ).should('be.visible');
-        cy.findByText('Primary Interface (Default Route)').should(
-          'not.exist'
-        );
+        cy.findByText('Primary Interface (Default Route)').should('not.exist');
         cy.findByText('eth0').should('not.exist');
         cy.findByText('eth1').should('not.exist');
         cy.findByText('eth2').should('not.exist');
@@ -139,19 +135,17 @@ describe('upgrade to new Linode Interface flow', () => {
         cy.contains(
           "Go to Network to view your Linode's Network interfaces."
         ).should('be.visible');
-        cy.findByText('Primary Interface (Default Route)').should(
-          'not.exist'
-        );
+        cy.findByText('Primary Interface (Default Route)').should('not.exist');
         cy.findByText('eth0').should('not.exist');
         cy.findByText('eth1').should('not.exist');
         cy.findByText('eth2').should('not.exist');
       });
   });
-  
- /*
-  * - Confirm button appears in Details footer for linodes with legacy interfaces.
-  * - Confirm clicking 'UPGRADE' button flow.
-  */
+
+  /*
+   * - Confirm button appears in Details footer for linodes with legacy interfaces.
+   * - Confirm clicking 'UPGRADE' button flow.
+   */
   it('upgrades from a single legacy configuration to new Linode interfaces (Public) from details page', () => {
     const mockLinode = linodeFactory.build({
       id: randomNumber(1000, 99999),
@@ -164,7 +158,7 @@ describe('upgrade to new Linode Interface flow', () => {
       id: randomNumber(1000, 99999),
       interfaces: null,
     });
-    
+
     const mockPublicInterface = linodeInterfaceFactoryPublic.build({
       id: randomNumber(1000, 99999),
     });
@@ -172,9 +166,7 @@ describe('upgrade to new Linode Interface flow', () => {
     const mockUpgradeLinodeInterface = upgradeLinodeInterfaceFactory.build({
       config_id: mockConfig.id,
       dry_run: true,
-      interfaces: [
-        mockPublicInterface,
-      ],
+      interfaces: [mockPublicInterface],
     });
 
     mockGetLinodeDetails(mockLinode.id, mockLinode);
@@ -189,7 +181,7 @@ describe('upgrade to new Linode Interface flow', () => {
 
     // "UPGRADE" button appears and works as expected.
     cy.findByText('Configuration Profile').should('be.visible');
-    cy.findByText('UPGRADE').should('be.visible').click();
+    cy.findByText('UPGRADE').should('be.visible').click({ force: true });
 
     // Assert the prompt dialog content.
     assertPromptDialogContent();
@@ -215,14 +207,11 @@ describe('upgrade to new Linode Interface flow', () => {
 
         assertUpgradeSummay(mockPublicInterface, false);
 
-        ui.button
-          .findByTitle('Close')
-          .should('be.visible')
-          .click();
+        ui.button.findByTitle('Close').should('be.visible').click();
       });
 
     // Check "Upgrade Interfaces" flow
-    cy.findByText('UPGRADE').should('be.visible').click();
+    cy.findByText('UPGRADE').should('be.visible').click({ force: true });
     ui.dialog
       .findByTitle('Upgrade to Linode Interfaces')
       .should('be.visible')
@@ -235,16 +224,13 @@ describe('upgrade to new Linode Interface flow', () => {
 
         assertUpgradeSummay(mockPublicInterface, false);
 
-        ui.button
-          .findByTitle('Close')
-          .should('be.visible')
-          .click();
+        ui.button.findByTitle('Close').should('be.visible').click();
       });
   });
 
- /*
-  * - Confirm Linode with multiple configurations can be upgraded to new Linode Interfaces.
-  */
+  /*
+   * - Confirm Linode with multiple configurations can be upgraded to new Linode Interfaces.
+   */
   it('upgrades from multiple legacy configurations to new Linode interfaces from details page', () => {
     const mockLinode = linodeFactory.build({
       id: randomNumber(1000, 99999),
@@ -257,7 +243,7 @@ describe('upgrade to new Linode Interface flow', () => {
       id: randomNumber(1000, 99999),
       interfaces: null,
     });
-    
+
     const mockConfig2 = configFactory.build({
       label: randomLabel(),
       id: randomNumber(1000, 99999),
@@ -271,9 +257,7 @@ describe('upgrade to new Linode Interface flow', () => {
     const mockUpgradeLinodeInterface = upgradeLinodeInterfaceFactory.build({
       config_id: mockConfig1.id,
       dry_run: true,
-      interfaces: [
-        mockPublicInterface,
-      ],
+      interfaces: [mockPublicInterface],
     });
 
     mockGetLinodeDetails(mockLinode.id, mockLinode);
@@ -288,9 +272,7 @@ describe('upgrade to new Linode Interface flow', () => {
 
     // "UPGRADE" button appears and works as expected.
     cy.findByText('Configuration Profile').should('be.visible');
-    cy.findByText('UPGRADE')
-      .should('be.visible')
-      .click();
+    cy.findByText('UPGRADE').should('be.visible').click({ force: true });
 
     // Assert the prompt dialog content.
     assertPromptDialogContent();
@@ -320,7 +302,9 @@ describe('upgrade to new Linode Interface flow', () => {
           .click();
 
         // Confirm config select text for multiple configurations
-        cy.findByText(configSelectSharedText, {exact: false}).should('be.visible');
+        cy.findByText(configSelectSharedText, { exact: false }).should(
+          'be.visible'
+        );
 
         cy.findAllByText(dryRunButtonText)
           .last()
@@ -338,16 +322,11 @@ describe('upgrade to new Linode Interface flow', () => {
 
         assertUpgradeSummay(mockPublicInterface, false);
 
-        ui.button
-          .findByTitle('Close')
-          .should('be.visible')
-          .click();
+        ui.button.findByTitle('Close').should('be.visible').click();
       });
 
     // Check "Upgrade Interfaces" flow
-    cy.findByText('UPGRADE')
-      .should('be.visible')
-      .click();
+    cy.findByText('UPGRADE').should('be.visible').click({ force: true });
     ui.dialog
       .findByTitle('Upgrade to Linode Interfaces')
       .should('be.visible')
@@ -384,18 +363,15 @@ describe('upgrade to new Linode Interface flow', () => {
 
         assertUpgradeSummay(mockPublicInterface, false);
 
-        ui.button
-          .findByTitle('Close')
-          .should('be.visible')
-          .click();
+        ui.button.findByTitle('Close').should('be.visible').click();
       });
   });
 
- /*
-  * - Confirm upgrade error flow.
-  * - Confirm "Return to Overview" works.
-  * - Confirm the error message shows up.
-  */
+  /*
+   * - Confirm upgrade error flow.
+   * - Confirm "Return to Overview" works.
+   * - Confirm the error message shows up.
+   */
   it('Displays error message when having upgrade issue', () => {
     const mockLinode = linodeFactory.build({
       id: randomNumber(1000, 99999),
@@ -414,7 +390,9 @@ describe('upgrade to new Linode Interface flow', () => {
     mockGetLinodeDetails(mockLinode.id, mockLinode);
     mockGetLinodeConfigs(mockLinode.id, [mockConfig]);
     mockGetLinodeConfig(mockLinode.id, mockConfig);
-    mockUpgradeNewLinodeInterfaceError(mockLinode.id, mockErrorMessage, 500).as('upgradeError');
+    mockUpgradeNewLinodeInterfaceError(mockLinode.id, mockErrorMessage, 500).as(
+      'upgradeError'
+    );
 
     cy.visitWithLogin(`/linodes/${mockLinode.id}`);
     cy.contains('RUNNING', { timeout: LINODE_CREATE_TIMEOUT }).should(
@@ -423,7 +401,7 @@ describe('upgrade to new Linode Interface flow', () => {
 
     // "UPGRADE" button appears and works as expected.
     cy.findByText('Configuration Profile').should('be.visible');
-    cy.findByText('UPGRADE').should('be.visible').click();;
+    cy.findByText('UPGRADE').should('be.visible').click({ force: true });
 
     ui.dialog
       .findByTitle('Upgrade to Linode Interfaces')
@@ -435,7 +413,7 @@ describe('upgrade to new Linode Interface flow', () => {
           .should('be.visible')
           .should('be.enabled')
           .click();
-        
+
         // Confirm the error message shows up.
         cy.wait('@upgradeError');
         cy.findByText(mockErrorMessage).should('be.visible');
@@ -451,5 +429,4 @@ describe('upgrade to new Linode Interface flow', () => {
 
     assertPromptDialogContent();
   });
-
 });

--- a/packages/manager/cypress/support/constants/linode-interfaces.ts
+++ b/packages/manager/cypress/support/constants/linode-interfaces.ts
@@ -1,0 +1,31 @@
+export const dryRunButtonText = 'Perform Dry Run';
+
+export const upgradeInterfacesButtonText = 'Upgrade Interfaces';
+
+export const upgradeTooltipText1 = 'Configuration Profile interfaces from a single profile can be upgraded to Linode Interfaces.';
+
+export const upgradeTooltipText2 = 'After the upgrade, the Linode can only use Linode Interfaces and cannot revert to Configuration Profile interfaces. Use the dry-run feature to review the changes before committing.';
+
+export const promptDialogDescription1 = 'Upgrading allows interface connections to be associated directly with the Linode, rather than its configuration profile.';
+
+export const promptDialogDescription2 = 'We recommend performing a dry run before upgrading to identify and resolve any potential conflicts.';
+
+export const promptDialogUpgradeWhatHappensTitle = 'What happens after the upgrade:';
+
+export const promptDialogUpgradeDetails = [
+  'New Linode Interfaces are created to match the existing Configuration Profile Interfaces.',
+  'The Linode will only use Linode Interfaces and cannot revert to Configuration Profile Interfaces.',
+  'Private IPv4 addresses are not supported on public Linode Interfaces—services relying on a private IPv4 will no longer function.',
+  'All firewalls are removed from the Linode. Any previously attached firewalls are reassigned to the new public and VPC interfaces. Default firewalls are not applied if none were originally attached.',
+  'Public interfaces retain the Linode’s existing MAC address and SLAAC IPv6 address.',
+  'Configuration Profile Interfaces are removed from the Configurations tab. The new Linode Interfaces will appear in the Network tab.',
+];
+
+export const configSelectSharedText =
+  'This Linode has multiple configuration profiles. Choose one to continue.';
+
+export const upgradeInterfacesWarningText =
+  'After upgrading, the Linode will use only Linode Interfaces and cannot revert back to Configuration Profile Interfaces. Private IPv4 addresses are not supported on public Linode Interfaces. Services depending on a private IPv4 will no longer function.';
+
+export const errorDryRunText =
+  'The dry run found the following issues. After correcting them, perform another dry run.';

--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -17,6 +17,7 @@ import type {
   LinodeInterfaces,
   LinodeIPsResponse,
   LinodeType,
+  UpgradeInterfaceData,
   Volume,
 } from '@linode/api-v4';
 
@@ -698,6 +699,45 @@ export const mockCreateLinodeInterfaceError = (
   return cy.intercept(
     'POST',
     apiMatcher(`linode/instances/${linodeId}/interfaces`),
+    makeErrorResponse(errorMessage, statusCode)
+  );
+};
+
+/**
+ * Intercepts POST request to create a Linode Interface.
+ *
+ * @param linodeId - the Linodes ID to add the interface to.
+ * @param linodeInterface - a mock upgrade linode interface object.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockUpgradeNewLinodeInterface = (
+  linodeId: number,
+  linodeInterface: UpgradeInterfaceData
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`linode/instances/${linodeId}/upgrade-interfaces`),
+    makeResponse(linodeInterface)
+  );
+};
+
+/**
+ * Intercepts POST request to create a Linode Interface and mocks an error response.
+ *
+ * @param errorMessage - Error message to be included in the mocked HTTP response.
+ * @param statusCode - HTTP status code for mocked error response. Default is `400`.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockUpgradeNewLinodeInterfaceError = (
+  linodeId: number,
+  errorMessage: string,
+  statusCode: number = 400
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`linode/instances/${linodeId}/upgrade-interfaces`),
     makeErrorResponse(errorMessage, statusCode)
   );
 };

--- a/packages/manager/cypress/support/util/linodes.ts
+++ b/packages/manager/cypress/support/util/linodes.ts
@@ -227,15 +227,21 @@ export const fetchLinodeConfigs = async (
 /**
  * Check the content of prompt dialog
  */
-export const assertPromptDialogContent = (() => {
+export const assertPromptDialogContent = () => {
   ui.dialog
     .findByTitle('Upgrade to Linode Interfaces')
     .should('be.visible')
     .within(() => {
-      cy.findByText(promptDialogDescription1, {exact: false}).should('be.visible');
-      cy.findByText(promptDialogDescription2, {exact: false}).should('be.visible');
-      cy.findByText(promptDialogUpgradeWhatHappensTitle, {exact: false}).should('be.visible');
-      promptDialogUpgradeDetails.forEach(item => {
+      cy.findByText(promptDialogDescription1, { exact: false }).should(
+        'be.visible'
+      );
+      cy.findByText(promptDialogDescription2, { exact: false }).should(
+        'be.visible'
+      );
+      cy.findByText(promptDialogUpgradeWhatHappensTitle, {
+        exact: false,
+      }).should('be.visible');
+      promptDialogUpgradeDetails.forEach((item) => {
         cy.findByText(item).should('be.visible');
       });
 
@@ -248,26 +254,32 @@ export const assertPromptDialogContent = (() => {
         .should('be.visible')
         .should('be.enabled');
     });
-});
+};
 
 /**
  * Check the upgrade summary
- * 
+ *
  * @param linodeInterface - Linode interface to check.
  * @param isDryRun - Boolean to indicate if the upgrade performs dry run.
- * 
+ *
  */
-export const assertUpgradeSummay = ((linodeInterface: LinodeInterface, isDryRun: boolean = false) => {
-
+export const assertUpgradeSummary = (
+  linodeInterface: LinodeInterface,
+  isDryRun: boolean = false
+) => {
   if (isDryRun) {
     // Confirm that dry run status is successful
     cy.findByText('Dry run successful').should('be.visible');
-    cy.findByText('No issues were found. You can proceed with upgrading to Linode Interfaces.').should('be.visible');
+    cy.findByText(
+      'No issues were found. You can proceed with upgrading to Linode Interfaces.'
+    ).should('be.visible');
 
     // Confirm that dry run summary details display.
     cy.findByText('Dry Run Summary').should('be.visible');
     cy.findByText('Interface Meta Info').should('be.visible');
-    cy.findByText(`MAC Address: ${linodeInterface.mac_address}`).should('be.visible');
+    cy.findByText(`MAC Address: ${linodeInterface.mac_address}`).should(
+      'be.visible'
+    );
     cy.findByText(`Created: ${linodeInterface.created}`).should('be.visible');
     cy.findByText(`Updated: ${linodeInterface.updated}`).should('be.visible');
     cy.findByText(`Version: ${linodeInterface.version}`).should('be.visible');
@@ -275,17 +287,25 @@ export const assertUpgradeSummay = ((linodeInterface: LinodeInterface, isDryRun:
   } else {
     // Confirm that upgrade status is successful
     cy.findByText('Upgrade successful').should('be.visible');
-    cy.findByText('Your Linode now uses Linode Interfaces. Existing interfaces were migrated, firewalls reassigned, and changes are visible', {exact: false}).should('be.visible');
+    cy.findByText(
+      'Your Linode now uses Linode Interfaces. Existing interfaces were migrated, firewalls reassigned, and changes are visible',
+      { exact: false }
+    ).should('be.visible');
 
     // Confirm that upgrade summary details display.
     cy.findByText('Upgrade Summary').should('be.visible');
-    cy.findByText(`Interface Meta Info: Interface #${linodeInterface.id}`).should('be.visible');
+    cy.findByText(
+      `Interface Meta Info: Interface #${linodeInterface.id}`
+    ).should('be.visible');
     cy.findByText(`ID: ${linodeInterface.id}`).should('be.visible');
-    cy.findByText(`MAC Address: ${linodeInterface.mac_address}`).should('be.visible');
+    cy.findByText(`MAC Address: ${linodeInterface.mac_address}`).should(
+      'be.visible'
+    );
     cy.findByText(`Created: ${linodeInterface.created}`).should('be.visible');
     cy.findByText(`Updated: ${linodeInterface.updated}`).should('be.visible');
     cy.findByText(`Version: ${linodeInterface.version}`).should('be.visible');
-    cy.findByText('Public Interface successfully upgraded.').should('be.visible');
+    cy.findByText('Public Interface successfully upgraded.').should(
+      'be.visible'
+    );
   }
-
-});
+};

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/UpgradeInterfaces/DialogContents/ConfigSelectDialogContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/UpgradeInterfaces/DialogContents/ConfigSelectDialogContent.tsx
@@ -63,6 +63,7 @@ export const ConfigSelectDialogContent = (
         onChange={(_, item) => setSelectedConfigId(item.value)}
         options={configOptions}
         placeholder="Select Configuration Profile"
+        searchable
         value={
           configOptions.find((options) => options.value === selectedConfigId) ??
           null

--- a/packages/utilities/src/factories/linodeInterface.ts
+++ b/packages/utilities/src/factories/linodeInterface.ts
@@ -2,7 +2,11 @@
 
 import { Factory } from './factoryProxy';
 
-import type { LinodeInterface, LinodeInterfaceSettings } from '@linode/api-v4';
+import type {
+  LinodeInterface,
+  LinodeInterfaceSettings,
+  UpgradeInterfaceData
+} from '@linode/api-v4';
 
 export const linodeInterfaceSettingsFactory =
   Factory.Sync.makeFactory<LinodeInterfaceSettings>({
@@ -14,6 +18,13 @@ export const linodeInterfaceSettingsFactory =
       ipv6_eligible_interface_ids: [],
     },
   });
+
+export const upgradeLinodeInterfaceFactory = 
+ Factory.Sync.makeFactory<UpgradeInterfaceData>({
+    config_id: Factory.each((i) => i),
+    dry_run: true,
+    interfaces: [],
+});
 
 export const linodeInterfaceFactoryVlan =
   Factory.Sync.makeFactory<LinodeInterface>({

--- a/packages/utilities/src/factories/linodeInterface.ts
+++ b/packages/utilities/src/factories/linodeInterface.ts
@@ -5,7 +5,7 @@ import { Factory } from './factoryProxy';
 import type {
   LinodeInterface,
   LinodeInterfaceSettings,
-  UpgradeInterfaceData
+  UpgradeInterfaceData,
 } from '@linode/api-v4';
 
 export const linodeInterfaceSettingsFactory =
@@ -19,12 +19,12 @@ export const linodeInterfaceSettingsFactory =
     },
   });
 
-export const upgradeLinodeInterfaceFactory = 
- Factory.Sync.makeFactory<UpgradeInterfaceData>({
+export const upgradeLinodeInterfaceFactory =
+  Factory.Sync.makeFactory<UpgradeInterfaceData>({
     config_id: Factory.each((i) => i),
     dry_run: true,
     interfaces: [],
-});
+  });
 
 export const linodeInterfaceFactoryVlan =
   Factory.Sync.makeFactory<LinodeInterface>({


### PR DESCRIPTION
## Description 📝

Add integration tests for Upgrade legacy interface to new Linode Interface flow

## Changes  🔄

List any change(s) relevant to the reviewer.

- Add test cases `Upgrade new Linode Interfaces flow` in `linode-config.spec.ts`
- Add integration test `upgrade-linode-interface.spec.ts`

## How to test 🧪
```
pnpm cy:run -s "cypress/e2e/core/linodes/linode-config.spec.ts"
pnpm cy:run -s "cypress/e2e/core/linodes/upgrade-linode-interface.spec.ts"
```