### PR TITLE
fix: [M3-10008] - Fix erroneous Sentry error condition in Adobe Analytics hook

### DIFF
--- a/packages/manager/.changeset/pr-12265-tech-stories-1747931205927.md
+++ b/packages/manager/.changeset/pr-12265-tech-stories-1747931205927.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Fix erroneous Sentry error in useAdobeAnalytics hook ([#12265](https://github.com/linode/manager/pull/12265))

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -76,7 +76,6 @@ export const OAUTH_TOKEN_REFRESH_TIMEOUT = LOGIN_SESSION_LIFETIME_MS / 2;
 /** Adobe Analytics */
 export const ADOBE_ANALYTICS_URL = import.meta.env
   .REACT_APP_ADOBE_ANALYTICS_URL;
-export const NUM_ADOBE_SCRIPTS = 3;
 
 /** Pendo */
 export const PENDO_API_KEY = import.meta.env.REACT_APP_PENDO_API_KEY;

--- a/packages/manager/src/hooks/useAdobeAnalytics.ts
+++ b/packages/manager/src/hooks/useAdobeAnalytics.ts
@@ -2,7 +2,7 @@ import { loadScript } from '@linode/utilities'; // `loadScript` from `useScript`
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 
-import { ADOBE_ANALYTICS_URL, NUM_ADOBE_SCRIPTS } from 'src/constants';
+import { ADOBE_ANALYTICS_URL } from 'src/constants';
 import { reportException } from 'src/exceptionReporting';
 
 /**
@@ -16,15 +16,8 @@ export const useAdobeAnalytics = () => {
     if (ADOBE_ANALYTICS_URL) {
       loadScript(ADOBE_ANALYTICS_URL, { location: 'head' })
         .then((data) => {
-          const adobeScriptTags = document.querySelectorAll(
-            'script[src^="https://assets.adobedtm.com/"]'
-          );
-          // Log an error; if the promise resolved, the _satellite object and 3 Adobe scripts should be present in the DOM.
-          if (
-            data.status !== 'ready' ||
-            !window._satellite ||
-            adobeScriptTags.length !== NUM_ADOBE_SCRIPTS
-          ) {
+          // Log an error; if the promise resolved and the _satellite object should be present in the DOM.
+          if (data.status !== 'ready' || !window._satellite) {
             reportException(
               'Adobe Analytics error: Not all Adobe Launch scripts and extensions were loaded correctly; analytics cannot be sent.'
             );

--- a/packages/manager/src/hooks/useAdobeAnalytics.ts
+++ b/packages/manager/src/hooks/useAdobeAnalytics.ts
@@ -16,7 +16,7 @@ export const useAdobeAnalytics = () => {
     if (ADOBE_ANALYTICS_URL) {
       loadScript(ADOBE_ANALYTICS_URL, { location: 'head' })
         .then((data) => {
-          // Log an error; if the promise resolved and the _satellite object should be present in the DOM.
+          // Log a Sentry error if the Launch script isn't ready or the _satellite object isn't present in the DOM.
           if (data.status !== 'ready' || !window._satellite) {
             reportException(
               'Adobe Analytics error: Not all Adobe Launch scripts and extensions were loaded correctly; analytics cannot be sent.'


### PR DESCRIPTION
## Description 📝

We're currently firing a Sentry error in the `useAdobeAnalytics` hook where one of the conditions checks that the number of Adobe-related scripts is 3. When we shared an Adobe Launch script with Login, 3 scripts were always loaded.

With the switch to the new Adobe Launch script, we're loading less Adobe-related scripts (2, but if the user's cookie preferences enable us to load Pendo, 3). 

The Sentry error was misleading because Adobe Analytics was still loading and sending events. It also caused rate limiting by Sentry due to the number of users seeing the error, so Sentry errors started getting dropped.

It would be best to just remove the number of scripts check altogether, since we can't really be certain how many scripts Adobe is loading.

## Changes  🔄
- Updated the conditional for the error and removed the associated constant

## Target release date 🗓️

6/3/25

## Preview 📷

| Sentry Error  | Scripts   |
| ------- | ------- |
| ![Screenshot 2025-05-22 at 9 14 36 AM](https://github.com/user-attachments/assets/be232fc4-dad5-4997-914b-24820113de9a) | ![Screenshot 2025-05-22 at 9 14 46 AM](https://github.com/user-attachments/assets/17351719-3a2c-442c-9994-3126a9f90201) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Set your cookie preferences to **deny** Performance Cookies on login.linode.com and save preferences

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Log in to cloud.linode.com
- [ ] Once the landing page loads, open the browser console and paste:
```
document.querySelectorAll(
            'script[src^="https://assets.adobedtm.com/"]'
          );
```
- [ ] Observe only two scripts are returned in the list
- [ ] Go to the network tab and filter requests on "sentry". Observe there was a POST request (200 OK response since we've silenced the error for 2 weeks) for the Adobe Analytics error

### Verification steps

(How to verify changes)
- [ ] Confirm the code change makes sense; this is difficult to verify in a local environment because the OptanonConsent cookie has a different domain

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>