### PR TITLE
fix: [M3-10011] - Disable the Kubernetes Dashboard request for LKE-E clusters

### DIFF
--- a/packages/manager/.changeset/pr-12266-upcoming-features-1747938663753.md
+++ b/packages/manager/.changeset/pr-12266-upcoming-features-1747938663753.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Disable the Kubernetes Dashboard request for LKE-E clusters ([#12266](https://github.com/linode/manager/pull/12266))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -958,7 +958,7 @@ describe('LKE Cluster Creation with ACL', () => {
      * - Confirms at least one IP must be provided for ACL unless acknowledgement is checked
      * - Confirms the cluster details page shows ACL is enabled
      */
-    it('creates an LKE cluster with ACL enabled by default and handles IP address validation', () => {
+    it('creates an LKE-E cluster with ACL enabled by default and handles IP address validation', () => {
       const clusterLabel = randomLabel();
       const mockedEnterpriseCluster = kubernetesClusterFactory.build({
         k8s_version: latestEnterpriseTierKubernetesVersion.id,
@@ -1012,7 +1012,6 @@ describe('LKE Cluster Creation with ACL', () => {
         mockedEnterpriseCluster.id,
         mockedEnterpriseClusterPools
       ).as('getClusterPools');
-      mockGetDashboardUrl(mockedEnterpriseCluster.id).as('getDashboardUrl');
       mockGetApiEndpoints(mockedEnterpriseCluster.id).as('getApiEndpoints');
 
       cy.visitWithLogin('/kubernetes/clusters');
@@ -1152,7 +1151,6 @@ describe('LKE Cluster Creation with ACL', () => {
         '@createCluster',
         '@getLKEEnterpriseClusterTypes',
         '@getLinodeTypes',
-        '@getDashboardUrl',
         '@getApiEndpoints',
         '@getControlPlaneACL',
       ]);
@@ -1409,7 +1407,6 @@ describe('LKE Cluster Creation with LKE-E', () => {
         mockedEnterpriseCluster.id,
         mockedEnterpriseClusterPools
       ).as('getClusterPools');
-      mockGetDashboardUrl(mockedEnterpriseCluster.id).as('getDashboardUrl');
       mockGetApiEndpoints(mockedEnterpriseCluster.id).as('getApiEndpoints');
 
       cy.visitWithLogin('/kubernetes/clusters');
@@ -1594,7 +1591,6 @@ describe('LKE Cluster Creation with LKE-E', () => {
         '@createCluster',
         '@getLKEEnterpriseClusterTypes',
         '@getLinodeTypes',
-        '@getDashboardUrl',
         '@getApiEndpoints',
         '@getControlPlaneACL',
       ]);

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -55,7 +55,7 @@ export const KubeSummaryPanel = React.memo((props: Props) => {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
 
   const { data: dashboard, error: dashboardError } =
-    useKubernetesDashboardQuery(cluster.id);
+    useKubernetesDashboardQuery(cluster.id, cluster.tier !== 'enterprise');
 
   const {
     error: resetKubeConfigError,

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -54,6 +54,7 @@ export const KubeSummaryPanel = React.memo((props: Props) => {
     React.useState<boolean>(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
 
+  // Access to the Kubernetes Dashboard is not supported for LKE-E clusters.
   const { data: dashboard, error: dashboardError } =
     useKubernetesDashboardQuery(cluster.id, cluster.tier !== 'enterprise');
 

--- a/packages/manager/src/queries/kubernetes.ts
+++ b/packages/manager/src/queries/kubernetes.ts
@@ -506,10 +506,14 @@ export const useAllKubernetesNodePoolQuery = (
   });
 };
 
-export const useKubernetesDashboardQuery = (clusterId: number) => {
-  return useQuery<KubernetesDashboardResponse, APIError[]>(
-    kubernetesQueries.cluster(clusterId)._ctx.dashboard
-  );
+export const useKubernetesDashboardQuery = (
+  clusterId: number,
+  enabled: boolean = true
+) => {
+  return useQuery<KubernetesDashboardResponse, APIError[]>({
+    ...kubernetesQueries.cluster(clusterId)._ctx.dashboard,
+    enabled,
+  });
 };
 
 export const useKubernetesVersionQuery = () =>


### PR DESCRIPTION
## Description 📝

The Kubernetes Dashboard is not available to LKE-E clusters (note that the button is not shown in the UI), so we should disable that query when the cluster tier is enterprise. We weren't conditionally enabling useKubernetesDashboardQuery and should be.

## Changes  🔄
- Update the `useKubernetesDashboardQuery` to accept an enabled prop
- Pass in a check for the cluster tier to enable the query in the Kubernetes summary panel
- Update Cypress test

## Target release date 🗓️

6/3/25

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-05-22 at 10 58 35 AM](https://github.com/user-attachments/assets/5059e366-d137-463f-9381-2f385f8767c1) | ![Screenshot 2025-05-22 at 11 03 15 AM](https://github.com/user-attachments/assets/bb5edb81-92b1-49f4-82ff-ef99843a8f0c) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have an LKE-E cluster on your account or log into `prod-test-004-fe` with our credentials
- Have the LKE-Enterprise feature flag on

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] In another environment, go to an LKE-E cluster's details page and open the network tab
- [ ] Observe failing 503 requests to the dashboards endpoint

### Verification steps

(How to verify changes)

- [ ] Check out this PR/use preview link, go to an LKE-E cluster's details page, and open the network tab
- [ ] Observe no failing 503 requests to the dashboards endpoint
- [ ] Go to a *standard* LKE cluster's details page
- [ ] With and without the LKE-Enterprise feature flag toggled on, observe that a request to the dashboards endpoint is successful

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>