### PR TITLE
chore: [M3-10036] - Re-add `eslint-plugin-react-refresh` eslint plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint-plugin-prettier": "~5.2.6",
     "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "0.4.20",
     "eslint-plugin-sonarjs": "^3.0.2",
     "eslint-plugin-testing-library": "^7.1.1",
     "eslint-plugin-xss": "^0.1.12",

--- a/packages/manager/.changeset/pr-12267-tech-stories-1747942707347.md
+++ b/packages/manager/.changeset/pr-12267-tech-stories-1747942707347.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Re-add `eslint-plugin-react-refresh` eslint plugin ([#12267](https://github.com/linode/manager/pull/12267))

--- a/packages/manager/eslint.config.js
+++ b/packages/manager/eslint.config.js
@@ -9,6 +9,7 @@ import perfectionist from 'eslint-plugin-perfectionist';
 import prettier from 'eslint-plugin-prettier';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
 import sonarjs from 'eslint-plugin-sonarjs';
 import testingLibrary from 'eslint-plugin-testing-library';
 import xss from 'eslint-plugin-xss';
@@ -18,7 +19,6 @@ import tseslint from 'typescript-eslint';
 
 // Shared import restrictions between different rule contexts
 const restrictedImportPaths = [
-  'rxjs',
   '@mui/core',
   '@mui/system',
   '@mui/icons-material',
@@ -136,11 +136,12 @@ export const baseConfig = [
     },
   },
 
-  // 5. React and React Hooks
+  // 5. React, React Hooks, and React Refresh
   {
     files: ['**/*.{ts,tsx}'],
     plugins: {
       react,
+      'react-refresh': reactRefresh,
     },
     rules: {
       'react-hooks/exhaustive-deps': 'warn',
@@ -152,6 +153,7 @@ export const baseConfig = [
       'react/no-unescaped-entities': 'warn',
       'react/prop-types': 'off',
       'react/self-closing-comp': 'warn',
+      'react-refresh/only-export-components': 'warn', // @todo make this error once we fix all occurrences
     },
   },
 

--- a/packages/manager/src/components/Avatar/Avatar.tsx
+++ b/packages/manager/src/components/Avatar/Avatar.tsx
@@ -8,7 +8,7 @@ import AkamaiWave from 'src/assets/logo/akamai-wave.svg';
 
 import type { SxProps, Theme } from '@mui/material';
 
-export const DEFAULT_AVATAR_SIZE = 28;
+const DEFAULT_AVATAR_SIZE = 28;
 
 export interface AvatarProps {
   /**

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeDisks.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeDisks.tsx
@@ -23,6 +23,7 @@ import { TableRowLoading } from 'src/components/TableRowLoading/TableRowLoading'
 import { TableSortCell } from 'src/components/TableSortCell';
 import { sendEvent } from 'src/utilities/analytics/utils';
 
+import { addUsedDiskSpace } from '../utilities';
 import { CreateDiskDrawer } from './CreateDiskDrawer';
 import { DeleteDiskDialog } from './DeleteDiskDialog';
 import { LinodeDiskRow } from './LinodeDiskRow';
@@ -237,8 +238,4 @@ export const LinodeDisks = () => {
       />
     </Box>
   );
-};
-
-export const addUsedDiskSpace = (disks: Disk[]) => {
-  return disks.reduce((accum, eachDisk) => eachDisk.size + accum, 0);
 };

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
@@ -12,8 +12,8 @@ import { MBpsIntraDC } from 'src/constants';
 import { useEventsPollingActions } from 'src/queries/events/events';
 import { useTypeQuery } from 'src/queries/types';
 
-import { addUsedDiskSpace } from '../LinodeStorage/LinodeDisks';
 import { MutateDrawer } from '../MutateDrawer/MutateDrawer';
+import { addUsedDiskSpace } from '../utilities';
 
 interface Props {
   linodeId: number;

--- a/packages/manager/src/features/Linodes/LinodesDetail/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/utilities.ts
@@ -1,3 +1,5 @@
+import type { Disk } from '@linode/api-v4';
+
 export const sshLink = (ipv4: string) => {
   return `ssh root@${ipv4}`;
 };
@@ -18,4 +20,8 @@ export const getSelectedDeviceOption = (
     return null;
   }
   return optionList.find((option) => option.value === selectedValue) || null;
+};
+
+export const addUsedDiskSpace = (disks: Disk[]) => {
+  return disks.reduce((accum, eachDisk) => eachDisk.size + accum, 0);
 };

--- a/packages/manager/src/features/Linodes/MigrateLinode/MigrateLinode.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/MigrateLinode.tsx
@@ -43,7 +43,7 @@ import { getGDPRDetails } from 'src/utilities/formatRegion';
 import { getLinodeDescription } from 'src/utilities/getLinodeDescription';
 import { reportAgreementSigningError } from 'src/utilities/reportAgreementSigningError';
 
-import { addUsedDiskSpace } from '../LinodesDetail/LinodeStorage/LinodeDisks';
+import { addUsedDiskSpace } from '../LinodesDetail/utilities';
 import { CautionNotice } from './CautionNotice';
 import { ConfigureForm } from './ConfigureForm';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
         version: 5.2.0(eslint@9.23.0(jiti@2.4.2))
+      eslint-plugin-react-refresh:
+        specifier: 0.4.20
+        version: 0.4.20(eslint@9.23.0(jiti@2.4.2))
       eslint-plugin-sonarjs:
         specifier: ^3.0.2
         version: 3.0.2(eslint@9.23.0(jiti@2.4.2))
@@ -3876,6 +3879,11 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+
+  eslint-plugin-react-refresh@0.4.20:
+    resolution: {integrity: sha512-XpbHQ2q5gUF8BGOX4dHe+71qoirYMhApEPZ7sfhF/dNnOF1UXnCMGZf79SFTBO7Bz5YEIT4TMieSlJBWhP9WBA==}
+    peerDependencies:
+      eslint: '>=8.40'
 
   eslint-plugin-react@7.37.4:
     resolution: {integrity: sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ==}
@@ -10162,6 +10170,10 @@ snapshots:
       eslint-config-prettier: 10.1.1(eslint@9.23.0(jiti@2.4.2))
 
   eslint-plugin-react-hooks@5.2.0(eslint@9.23.0(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.23.0(jiti@2.4.2)
+
+  eslint-plugin-react-refresh@0.4.20(eslint@9.23.0(jiti@2.4.2)):
     dependencies:
       eslint: 9.23.0(jiti@2.4.2)
 


### PR DESCRIPTION
## Description 📝

- Brings back `eslint-plugin-react-refresh` after #11941  and configures it to `warn`
- Addresses the warning in a few places for the sake of example / testing 🧪  
- Removes `rxjs` as a restricted import. `rxjs` isn't a direct dependency in our repo so typescript will error if you try to import it. No need to lint it anymore. I think this rule is just left over from a long time ago when CLoud Manager dependend on rxjs 🤮 

## How to test 🧪

- Check out this PR
- Run `pnpm install`
- Restart the eslint server
  - If you use VSCode, you can do `cmd` + `shift` + `p` and type `Restart ESLint Server` and press `Enter`
- Open `packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeVolumes.tsx` in your editor
- Verify you see the following warning:

![Screenshot 2025-05-22 at 3 34 39 PM](https://github.com/user-attachments/assets/22f28f87-f59d-4ee3-bbcd-39cded775de5)

- Verify lint github actions pass
- Verify `pnpm --filter "*" lint` runs without issue
- Verify there are no issues or regressions with linting as a result of this change


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
