### PR TITLE
change: [M3-9687] - Prepare LKE APL for GA

### DIFF
--- a/packages/manager/.changeset/pr-12268-changed-1747968191432.md
+++ b/packages/manager/.changeset/pr-12268-changed-1747968191432.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Update LKE flows for APL General Availability ([#12268](https://github.com/linode/manager/pull/12268))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -426,9 +426,8 @@ describe('LKE Cluster Creation with APL enabled', () => {
       nanodeType,
     ];
     mockAppendFeatureFlags({
-      apl: {
-        enabled: true,
-      },
+      apl: true,
+      aplGeneralAvailability: false,
     }).as('getFeatureFlags');
     mockGetAccountBeta({
       description:

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -24,6 +24,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'aclpIntegration', label: 'ACLP Integration' },
   { flag: 'aclpLogs', label: 'ACLP Logs' },
   { flag: 'apl', label: 'Akamai App Platform' },
+  { flag: 'aplGeneralAvailability', label: 'Akamai App Platform GA' },
   { flag: 'blockStorageEncryption', label: 'Block Storage Encryption (BSE)' },
   { flag: 'disableLargestGbPlans', label: 'Disable Largest GB Plans' },
   { flag: 'gecko2', label: 'Gecko' },

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -116,6 +116,7 @@ export interface Flags {
   apicliButtonCopy: string;
   apiMaintenance: APIMaintenance;
   apl: boolean;
+  aplGeneralAvailability: boolean;
   blockStorageEncryption: boolean;
   cloudManagerDesignUpdatesBanner: DesignUpdatesBannerFlag;
   databaseAdvancedConfig: boolean;

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ApplicationPlatform.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ApplicationPlatform.tsx
@@ -11,7 +11,7 @@ import * as React from 'react';
 
 import { FormLabel } from 'src/components/FormLabel';
 import { Link } from 'src/components/Link';
-
+import { useAPLAvailability } from 'src/features/Kubernetes/kubeUtils';
 export interface APLProps {
   isSectionDisabled: boolean;
   setAPL: (apl: boolean) => void;
@@ -28,17 +28,16 @@ export const APLCopy = () => (
   </Typography>
 );
 
-const APL_UNSUPPORTED_CHIP_COPY = ' - COMING SOON';
-
 export const ApplicationPlatform = (props: APLProps) => {
   const { isSectionDisabled, setAPL, setHighAvailability } = props;
-
+  const { isAPLGeneralAvailability } = useAPLAvailability();
   const [isAPLChecked, setIsAPLChecked] = React.useState<boolean | undefined>(
     isSectionDisabled ? false : undefined
   );
   const [isAPLNotChecked, setIsAPLNotChecked] = React.useState<
     boolean | undefined
   >(isSectionDisabled ? true : undefined);
+  const APL_UNSUPPORTED_CHIP_COPY = `${!isAPLGeneralAvailability ? ' - ' : ''}${isSectionDisabled ? 'COMING SOON' : ''}`;
 
   /**
    * Reset the radio buttons to the correct default state once the user toggles cluster tiers.
@@ -48,7 +47,7 @@ export const ApplicationPlatform = (props: APLProps) => {
     setIsAPLNotChecked(isSectionDisabled ? true : undefined);
   }, [isSectionDisabled]);
 
-  const CHIP_COPY = `BETA${isSectionDisabled ? APL_UNSUPPORTED_CHIP_COPY : ''}`;
+  const CHIP_COPY = `${!isAPLGeneralAvailability ? 'BETA' : ''}${isSectionDisabled ? APL_UNSUPPORTED_CHIP_COPY : ''}`;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setAPL(e.target.value === 'yes');
@@ -69,13 +68,15 @@ export const ApplicationPlatform = (props: APLProps) => {
       >
         <Box alignItems="center" display="flex" flexDirection="row">
           <Typography data-testid="apl-label">Akamai App Platform</Typography>
-          <Chip
-            color="primary"
-            data-testid="apl-beta-chip"
-            label={CHIP_COPY}
-            size="small"
-            sx={{ ml: 1 }}
-          />
+          {(!isAPLGeneralAvailability || isSectionDisabled) && (
+            <Chip
+              color="primary"
+              data-testid="apl-beta-chip"
+              label={CHIP_COPY}
+              size="small"
+              sx={{ ml: 1 }}
+            />
+          )}
         </Box>
       </FormLabel>
       <APLCopy />

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -281,9 +281,6 @@ export const CreateCluster = () => {
       payload = { ...payload, tier: selectedTier };
     }
 
-    // Use beta endpoint if either:
-    // 1. LKE Enterprise is enabled
-    // 2. APL is supported but not in GA
     const createClusterFn = isUsingBetaEndpoint
       ? createKubernetesClusterBeta
       : createKubernetesCluster;

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -6,11 +6,11 @@ import { useLocation, useParams } from 'react-router-dom';
 
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { LandingHeader } from 'src/components/LandingHeader';
-import { useKubernetesBetaEndpoint } from 'src/features/Kubernetes/kubeUtils';
 import {
-  getKubeHighAvailability,
   useAPLAvailability,
+  useKubernetesBetaEndpoint,
 } from 'src/features/Kubernetes/kubeUtils';
+import { getKubeHighAvailability } from 'src/features/Kubernetes/kubeUtils';
 import {
   useKubernetesClusterMutation,
   useKubernetesClusterQuery,
@@ -29,7 +29,6 @@ export const KubernetesClusterDetail = () => {
   const id = Number(clusterID);
   const location = useLocation();
   const { showAPL } = useAPLAvailability();
-
   const { isUsingBetaEndpoint } = useKubernetesBetaEndpoint();
 
   const {


### PR DESCRIPTION
## Description 📝
Kubernetes APL is in the BETA program and is going GA on June 16. The timing of the GA release is unfortunate; since it is one day before the 6/17 release, this one needs to go out on the 6/3 release.

As a result, we do not need to check the BETA program to see if the user opted in, and we need to switch to using the `v4` endpoint since it's been promoted from `v4beta`.

This PR implements the UI logic while keeping LKE enterprise checks in mind (since LKE enterprise does not support APL quite yet). The flow reflects those changes, both in the display of the APL panel and its `BETA` labeling.

> [!NOTE]
> Because of the ephemeral nature of this logic (both the `apl` and `aplGeneralAvailability` will be promptly removed once GA has been validated, no coverage has been added to cover this particular case. Since the LKE flows are using mocks, this should not create instability.

## Changes  🔄
- Add a new `aplGeneralAvailability` flag
- Modify hooks to account for new condition
- Update components to use hook for UI display logic
- Update tests

## Target release date 🗓️
⚠️ 06/03/2025

## Preview 📷
There isn't any pertinent visual change to this update, except for the APL BETA chip copy which is altered once the  `aplGeneralAvailability` is ON.

## How to test 🧪

### Verification steps
The various cases should be evaluated to confirm the updated conditional logic:

- **LKE**
  - no regression with the `aplGeneralAvailability` flag disabled
  - with the `aplGeneralAvailability` flag enabled:
    - the BETA chip should not display
    - The request should hit the `v4` namepsace

- **LKE enterprise**
  - no regression with the `aplGeneralAvailability` flag disabled
  - with the `aplGeneralAvailability` flag enabled:
    - the "COMING SOON" chip should not display "BETA"
    - The request should hit the `v4beta` namepsace

👉 if LKE enterprise is enabled, it should **always** be the `v4beta` namepsace
👉 the  `v4` namepsace should **only** be used if:
1. LKE enterprise is disabled
2. `aplGeneralAvailability` flag is on

---

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>
---

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
