### PR TITLE
fix: [M3-9990] - Image Select overflows off screen on mobile viewports

### DIFF
--- a/packages/manager/.changeset/pr-12269-fixed-1747981241068.md
+++ b/packages/manager/.changeset/pr-12269-fixed-1747981241068.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Image Select overflows off screen on mobile viewports ([#12269](https://github.com/linode/manager/pull/12269))

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -189,12 +189,6 @@ export const ImageSelect = (props: Props) => {
             />
           );
         }}
-        sx={(theme) => ({
-          ...sx,
-          [theme.breakpoints.up('sm')]: {
-            width: '416px',
-          },
-        })}
         textFieldProps={{
           InputProps: {
             startAdornment:

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -67,7 +67,6 @@ export const ImageSelect = (props: Props) => {
     selectIfOnlyOneOption,
     siteType,
     variant,
-    sx,
     ...rest
   } = props;
 

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -67,6 +67,7 @@ export const ImageSelect = (props: Props) => {
     selectIfOnlyOneOption,
     siteType,
     variant,
+    sx,
     ...rest
   } = props;
 
@@ -157,7 +158,7 @@ export const ImageSelect = (props: Props) => {
   }
 
   return (
-    <Box>
+    <Box sx={{ width: '100%' }}>
       <Autocomplete
         clearOnBlur
         disableSelectAll
@@ -188,6 +189,12 @@ export const ImageSelect = (props: Props) => {
             />
           );
         }}
+        sx={(theme) => ({
+          ...sx,
+          [theme.breakpoints.up('sm')]: {
+            width: '416px',
+          },
+        })}
         textFieldProps={{
           InputProps: {
             startAdornment:

--- a/packages/manager/src/features/Linodes/LinodeCreate/Tabs/Images.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Tabs/Images.tsx
@@ -97,7 +97,6 @@ export const Images = () => {
             onBlur={field.onBlur}
             onChange={onChange}
             siteType={selectedRegion?.site_type}
-            sx={{ width: '416px' }}
             value={field.value ?? null}
             variant="private"
           />


### PR DESCRIPTION
## Description 📝  
Fixes the image select input overflowing off-screen on mobile viewports.

## Changes 🔄  
- Updated the width of the image select input on mobile to align with other select components.

## Preview  
| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/5faf2bff-511d-4656-97d7-3a8f8cfab687) | ![After](https://github.com/user-attachments/assets/11630a91-26d8-4449-8b49-30398435242a) |

## How to Test 🧪  
1. Navigate to `/linodes/create?type=Images`.  
2. On a mobile viewport, confirm the image select input fits within the screen and aligns with other inputs.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules