### PR TITLE
fix: [M3-100041] - Make `quota_id` type a string

### DIFF
--- a/packages/api-v4/.changeset/pr-12272-fixed-1748009649223.md
+++ b/packages/api-v4/.changeset/pr-12272-fixed-1748009649223.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Fixed
+---
+
+Make quota_id a string ([#12272](https://github.com/linode/manager/pull/12272))

--- a/packages/api-v4/src/quotas/quotas.ts
+++ b/packages/api-v4/src/quotas/quotas.ts
@@ -45,9 +45,9 @@ export const getQuotas = (
  * Returns the usage for a single quota within a particular service specified by `type`.
  *
  * @param type { QuotaType } retrieve a quota within this service type.
- * @param id { number } the quota ID to look up.
+ * @param id { string } the quota ID to look up.
  */
-export const getQuotaUsage = (type: QuotaType, id: number) =>
+export const getQuotaUsage = (type: QuotaType, id: string) =>
   Request<QuotaUsage>(
     setURL(`${BETA_API_ROOT}/${type}/quotas/${id}/usage`),
     setMethod('GET'),

--- a/packages/api-v4/src/quotas/types.ts
+++ b/packages/api-v4/src/quotas/types.ts
@@ -20,7 +20,7 @@ export interface Quota {
   /**
    * A unique identifier for the quota.
    */
-  quota_id: number;
+  quota_id: string;
 
   /**
    * The account-wide limit for this service, measured in units

--- a/packages/manager/.changeset/pr-12272-fixed-1748009662401.md
+++ b/packages/manager/.changeset/pr-12272-fixed-1748009662401.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Make quota_id a string ([#12272](https://github.com/linode/manager/pull/12272))

--- a/packages/manager/src/factories/quotas.ts
+++ b/packages/manager/src/factories/quotas.ts
@@ -4,7 +4,7 @@ import type { Quota, QuotaUsage } from '@linode/api-v4/lib/quotas/types';
 
 export const quotaFactory = Factory.Sync.makeFactory<Quota>({
   description: 'Maximimum number of vCPUs allowed',
-  quota_id: Factory.each((id) => id),
+  quota_id: Factory.each((id) => id.toString()),
   quota_limit: 50,
   quota_name: 'Linode Dedicated vCPUs',
   region_applied: 'us-east',

--- a/packages/manager/src/mocks/presets/crud/handlers/quotas.ts
+++ b/packages/manager/src/mocks/presets/crud/handlers/quotas.ts
@@ -169,7 +169,7 @@ export const getQuotas = () => [
     '*/v4*/:service/quotas/:id',
     async ({ params }): Promise<StrictResponse<APIErrorResponse | Quota>> => {
       const quota = mockQuotas[params.service as QuotaType].find(
-        ({ quota_id }) => quota_id === +params.id
+        ({ quota_id }) => quota_id === params.id
       );
 
       if (!quota) {
@@ -187,7 +187,7 @@ export const getQuotas = () => [
     }): Promise<StrictResponse<APIErrorResponse | QuotaUsage>> => {
       const service = params.service as QuotaType;
       const quota = mockQuotas[service].find(
-        ({ quota_id }) => quota_id === +params.id
+        ({ quota_id }) => quota_id === params.id
       );
 
       if (!quota) {

--- a/packages/queries/src/quotas/keys.ts
+++ b/packages/queries/src/quotas/keys.ts
@@ -20,7 +20,7 @@ export const quotaQueries = createQueryKeys('quotas', {
         queryFn: () => getQuota(type, id),
         queryKey: [id],
       }),
-      usage: (id: number) => ({
+      usage: (id: string) => ({
         queryFn: () => getQuotaUsage(type, id),
         queryKey: [id],
       }),

--- a/packages/queries/src/quotas/quotas.ts
+++ b/packages/queries/src/quotas/quotas.ts
@@ -43,7 +43,7 @@ export const useAllQuotasQuery = (
 
 export const useQuotaUsageQuery = (
   service: QuotaType,
-  id: number,
+  id: string,
   enabled = true,
 ) =>
   useQuery<QuotaUsage, APIError[]>({


### PR DESCRIPTION
## Description 📝
Small fix to correct the `quota_id` type to be a string as outlined in the [docs](https://techdocs.akamai.com/linode-api/reference/get-object-storage-quotas)

This was an omission when switching from the Compute quotas to the OBJ quotas since these have different types.

Run code is essentially unaffected since we were already doing the right transformations

## Changes  🔄
- change `quota_id` type to string
- update run time code

## Target release date 🗓️
⚠️ 06/03/2025

## Preview 📷
There should be no change or regression as a part of this PR

## How to test 🧪

### Verification steps
Confirm the Quotas UI (/account/quotas) is unaffected

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
