### PR TITLE
chore: [M3-10045] - Mark event read endpoint as deprecated

### DIFF
--- a/packages/api-v4/src/account/events.ts
+++ b/packages/api-v4/src/account/events.ts
@@ -33,7 +33,7 @@ export const getEvent = (eventId: number) =>
 /**
  * markEventSeen
  *
- * Set the "seen" property of an event to true
+ * Marks all events up to and including the referenced event-id as "seen"
  *
  * @param eventId { number } ID of the event to designate as seen
  */
@@ -50,6 +50,10 @@ export const markEventSeen = (eventId: number) =>
  *
  * @param eventId { number } ID of the event to designate as read
  *
+ * @deprecated As of `5/20/2025`, this endpoint is deprecated. It will be sunset on `6/17/2025`.
+ *
+ * To avoid any disruptions, update any API calls using markEventRead to markEventSeen.
+ * Please note that the seen endpoint functions differently and will mark all events up to and including the referenced event-id as "seen" rather than individual events.
  */
 export const markEventRead = (eventId: number) =>
   Request<{}>(

--- a/packages/api-v4/src/account/events.ts
+++ b/packages/api-v4/src/account/events.ts
@@ -33,7 +33,7 @@ export const getEvent = (eventId: number) =>
 /**
  * markEventSeen
  *
- * Marks all events up to and including the referenced event-id as "seen"
+ * Marks all events up to and including the referenced event ID as "seen"
  *
  * @param eventId { number } ID of the event to designate as seen
  */
@@ -52,7 +52,7 @@ export const markEventSeen = (eventId: number) =>
  *
  * @deprecated As of `5/20/2025`, this endpoint is deprecated. It will be sunset on `6/17/2025`.
  *
- * To avoid any disruptions, update any API calls using markEventRead to markEventSeen.
+ * If you depend on using `read`, you may be able to use `markEventSeen` and `seen` instead.
  * Please note that the seen endpoint functions differently and will mark all events up to and including the referenced event-id as "seen" rather than individual events.
  */
 export const markEventRead = (eventId: number) =>


### PR DESCRIPTION
## Description 📝

- Marks `/v4/account/events/:id/read` (`markEventRead`) as deprecated 🪦 
- Cloud Manager does not use this endpoint. I'm just doing this for informational purposes for anyone using our SDK 📦 


## How to test 🧪

- Just verify my comment is good and doesn't have any typos 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>