### PR TITLE
poc: "Zero-build" Local Development Setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "build:analyze": "pnpm run --filter linode-manager build:analyze",
     "bootstrap": "pnpm install:all && pnpm build:validation && pnpm build:sdk",
     "up:expose": "npm_config_package_import_method=clone-or-copy pnpm install:all && pnpm build:validation && pnpm build:sdk && pnpm start:all:expose",
-    "dev": "concurrently -n api-v4,validation,ui,utilities,queries,shared,manager -c blue,yellow,magenta,cyan,gray,blue,green \"pnpm run --filter @linode/api-v4 start\" \"pnpm run --filter @linode/validation start\" \"pnpm run --filter @linode/ui start\" \"pnpm run --filter @linode/utilities start\" \"pnpm run --filter @linode/queries start\" \"pnpm run --filter @linode/shared start\" \"pnpm run --filter linode-manager start\"",
+    "dev": "pnpm run --filter linode-manager start",
     "start:all:expose": "concurrently -n api-v4,validation,ui,utilities,queries,shared,manager -c blue,yellow,magenta,cyan,gray,blue,green \"pnpm run --filter @linode/api-v4 start\" \"pnpm run --filter @linode/validation start\" \"pnpm run --filter @linode/ui start\" \"pnpm run --filter @linode/utilities start\" \"pnpm run --filter @linode/queries start\" \"pnpm run --filter @linode/shared start\" \"pnpm run --filter linode-manager start:expose\"",
     "start:manager": "pnpm --filter linode-manager start",
     "start:manager:ci": "pnpm run --filter linode-manager start:ci",

--- a/packages/manager/tsconfig.json
+++ b/packages/manager/tsconfig.json
@@ -9,7 +9,9 @@
     "baseUrl": ".",
     "moduleResolution": "bundler",
     "paths": {
-      "src/*": ["src/*"]
+      "src/*": ["src/*"],
+      "@linode/api-v4": ["../api-v4"],
+      "@linode/validation": ["../validation"]
     },
     "resolveJsonModule": true,
     "rootDir": ".",
@@ -40,5 +42,5 @@
     /* Optimizations */
     "incremental": true
   },
-  "include": ["src", "package.json"]
+  "include": ["src", "package.json"],
 }

--- a/packages/manager/vite.config.ts
+++ b/packages/manager/vite.config.ts
@@ -17,6 +17,8 @@ export default defineConfig({
   resolve: {
     alias: {
       src: `${DIRNAME}/src`,
+      '@linode/api-v4*': `${DIRNAME}/../api-v4/src/index.ts`,
+      '@linode/validation*': `${DIRNAME}/../validation/src/index.ts`,
     },
   },
   server: {


### PR DESCRIPTION
## Description 📝

An early stage POC for trying a "zero-build" local development setup

Currently we build api-v4 and validation in order to build / run Cloud Manager. This "zero-build" setup would change our bundler and typescript setup so that no initial build is needed to build / run Cloud Manager. There are pros and cons to every approach, I'm just experimenting with this right now.

### Pros
- We don't need to run `tsc` for every package for local Cloud Manager development, one `tsc` instance will typecheck Cloud Manager and all of it's dependencies
- We don't need to run tsup in watch mode to bundle api-v4 and validation. The CLoud Manager vite dev server will do the bundling along with the CLoud Manager source code
- We don't need a `pnpm bootstrap` command
- Likely less TypeScript flakeyness / "ghost" types / residual type errors during local development like we've seen

### Cons
- Higher memory usage of the single `tsc` process because it is typechecking every package
- Likely slower typechecking in general for Cloud Manager
  - Not sure by how much. It might not be so bad because we use incremental mode
- Cloud Manager no longer consumes api-v4 and validation like a normal app would (For Cloud Manager, vite would now handle the bundling rather than tsup, but the code we publish to npm would still be built by tsup)


## Other Options not explored here

- Keeping build steps for api-v4 and validation, but using a tool like Turborepo or NX to cache builds, which will improve DX
- TypeScript project references
- Wait for tsgo to be stable and reevalueate


## How to test 🧪 

- Checkout this PR
- Run `pnpm --filter "*" typecheck` just to ensure all typechecking is working as expected
- Run `pnpm dev`
- Open your editor and just go around to random files (in manager and other packages too) and pretend you are working on some code. Change come code around to trigger typescript errors.
- Verify typechecking in your IDE is working normally
- Watch your console and verify you see typescript errors when you save code with errors
- Take note of typechekcing performance. Let me know what you observe. 