### PR TITLE
upcoming: [DPS-33114] Add General Information and Data Set forms

### DIFF
--- a/packages/manager/.changeset/pr-12278-upcoming-features-1748242133984.md
+++ b/packages/manager/.changeset/pr-12278-upcoming-features-1748242133984.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+DataStream: add General Information and Data Sets forms in Create Stream view ([#12278](https://github.com/linode/manager/pull/12278))

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/EventTypeDetails.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/EventTypeDetails.tsx
@@ -1,0 +1,18 @@
+import { Typography } from '@linode/ui';
+import React from 'react';
+
+export interface EventTypeDetails {
+  details: string;
+  header: string;
+}
+
+export const EventTypeDetails = (props: EventTypeDetails) => {
+  const { details, header } = props;
+
+  return (
+    <>
+      <Typography variant="subtitle1">{header}</Typography>
+      <Typography variant="body1">{details}</Typography>
+    </>
+  );
+};

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreate.styles.ts
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreate.styles.ts
@@ -3,6 +3,9 @@ import { makeStyles } from 'tss-react/mui';
 import type { Theme } from '@mui/material/styles';
 
 export const useStyles = makeStyles()((theme: Theme) => ({
+  input: {
+    width: 416,
+  },
   root: {
     '& .mlMain': {
       [theme.breakpoints.down('lg')]: {

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreate.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreate.tsx
@@ -1,18 +1,30 @@
 import { Stack } from '@linode/ui';
 import Grid from '@mui/material/Grid';
 import * as React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
 
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { LandingHeader } from 'src/components/LandingHeader';
-import { StreamCreateCheckoutBar } from 'src/features/DataStream/Streams/StreamCreate/StreamCreateCheckoutBar';
-import { StreamCreateDataSet } from 'src/features/DataStream/Streams/StreamCreate/StreamCreateDataSet';
-import { StreamCreateDelivery } from 'src/features/DataStream/Streams/StreamCreate/StreamCreateDelivery';
-import { StreamCreateGeneralInfo } from 'src/features/DataStream/Streams/StreamCreate/StreamCreateGeneralInfo';
 
 import { useStyles } from './StreamCreate.styles';
+import { StreamCreateCheckoutBar } from './StreamCreateCheckoutBar';
+import { StreamCreateDataSet } from './StreamCreateDataSet';
+import { StreamCreateDelivery } from './StreamCreateDelivery';
+import { StreamCreateGeneralInfo } from './StreamCreateGeneralInfo';
+import { type CreateStreamForm, EventType, StreamType } from './types';
 
 export const StreamCreate = () => {
   const { classes } = useStyles();
+  const form = useForm<CreateStreamForm>({
+    defaultValues: {
+      type: StreamType.AuditLogs,
+      [EventType.Authorization]: false,
+      [EventType.Authentication]: false,
+      [EventType.Configuration]: false,
+    },
+  });
+
+  const { handleSubmit } = form;
 
   const landingHeaderProps = {
     breadcrumbProps: {
@@ -28,21 +40,28 @@ export const StreamCreate = () => {
     title: 'Create Stream',
   };
 
+  const onSubmit = () => {};
+
   return (
-    <Grid className={classes.root} container>
+    <>
       <DocumentTitleSegment segment="Create Stream" />
       <LandingHeader {...landingHeaderProps} />
-
-      <Grid className="mlMain">
-        <Stack spacing={2}>
-          <StreamCreateGeneralInfo />
-          <StreamCreateDataSet />
-          <StreamCreateDelivery />
-        </Stack>
-      </Grid>
-      <Grid className="mlSidebar">
-        <StreamCreateCheckoutBar />
-      </Grid>
-    </Grid>
+      <FormProvider {...form}>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <Grid className={classes.root} container>
+            <Grid className="mlMain">
+              <Stack spacing={2}>
+                <StreamCreateGeneralInfo />
+                <StreamCreateDataSet />
+                <StreamCreateDelivery />
+              </Stack>
+            </Grid>
+            <Grid className="mlSidebar">
+              <StreamCreateCheckoutBar />
+            </Grid>
+          </Grid>
+        </form>
+      </FormProvider>
+    </>
   );
 };

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateDataSet.test.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateDataSet.test.tsx
@@ -1,0 +1,18 @@
+import { screen } from '@testing-library/react';
+import React from 'react';
+
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
+
+import { StreamCreateDataSet } from './StreamCreateDataSet';
+
+describe('StreamCreateDataSet', () => {
+  it('should render table with proper headers', async () => {
+    renderWithThemeAndHookFormContext({
+      component: <StreamCreateDataSet />,
+    });
+
+    expect(screen.getByRole('table')).toBeVisible();
+    expect(screen.getByText('Event Type')).toBeVisible();
+    expect(screen.getByText('Description')).toBeVisible();
+  });
+});

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateDataSet.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateDataSet.tsx
@@ -20,13 +20,15 @@ export const StreamCreateDataSet = () => {
 
   const getControlledToggle = (
     control: Control<CreateStreamForm>,
-    id: EventType
+    id: EventType,
+    name: string
   ) => (
     <Controller
       control={control}
       name={id}
       render={({ field }) => (
         <Toggle
+          aria-label={`Toggle ${name} event type`}
           checked={field.value}
           onChange={(_, checked) => field.onChange(checked)}
         />
@@ -40,7 +42,7 @@ export const StreamCreateDataSet = () => {
       OuterTableCells: (
         <>
           <TableCell>{description}</TableCell>
-          <TableCell>{getControlledToggle(control, id)}</TableCell>
+          <TableCell>{getControlledToggle(control, id, name)}</TableCell>
         </>
       ),
       id,

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateDataSet.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateDataSet.tsx
@@ -1,9 +1,61 @@
-import { Box, Paper, Typography } from '@linode/ui';
+import { Box, Paper, Toggle, Typography } from '@linode/ui';
 import React from 'react';
+import type { Control } from 'react-hook-form';
+import { Controller, useFormContext } from 'react-hook-form';
 
+import { CollapsibleTable } from 'src/components/CollapsibleTable/CollapsibleTable';
 import { DocsLink } from 'src/components/DocsLink/DocsLink';
+import { TableCell } from 'src/components/TableCell';
+import { TableRow } from 'src/components/TableRow';
+import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
+
+import { EventTypeDetails } from './EventTypeDetails';
+import { dataSets } from './StreamCreateDataSetData';
+
+import type { CreateStreamForm, EventType } from './types';
+import type { TableItem } from 'src/components/CollapsibleTable/CollapsibleTable';
 
 export const StreamCreateDataSet = () => {
+  const { control } = useFormContext<CreateStreamForm>();
+
+  const getControlledToggle = (
+    control: Control<CreateStreamForm>,
+    id: EventType
+  ) => (
+    <Controller
+      control={control}
+      name={id}
+      render={({ field }) => (
+        <Toggle
+          checked={field.value}
+          onChange={(_, checked) => field.onChange(checked)}
+        />
+      )}
+    />
+  );
+
+  const getTableItems = (): TableItem[] => {
+    return dataSets.map(({ id, name, description, details }) => ({
+      InnerTable: <EventTypeDetails {...details} />,
+      OuterTableCells: (
+        <>
+          <TableCell>{description}</TableCell>
+          <TableCell>{getControlledToggle(control, id)}</TableCell>
+        </>
+      ),
+      id,
+      label: name,
+    }));
+  };
+
+  const DataSetTableRowHead = (
+    <TableRow>
+      <TableCell sx={{ width: '30%' }}>Event Type</TableCell>
+      <TableCell sx={{ width: '55%' }}>Description</TableCell>
+      <TableCell sx={{ width: '15%' }} />
+    </TableRow>
+  );
+
   return (
     <Paper>
       <Box display="flex" justifyContent="space-between">
@@ -12,6 +64,21 @@ export const StreamCreateDataSet = () => {
           // TODO: Change the link when proper documentation is ready
           href="https://techdocs.akamai.com/cloud-computing/docs"
           label="Docs"
+        />
+      </Box>
+      <Typography sx={{ marginTop: '12px' }}>
+        Select the event types you want to capture for monitoring and analysis.
+      </Typography>
+      <Box sx={{ my: 2 }}>
+        <CollapsibleTable
+          TableItems={getTableItems()}
+          TableRowEmpty={
+            <TableRowEmpty
+              colSpan={3}
+              message={'No Data Sets to choose from.'}
+            />
+          }
+          TableRowHead={DataSetTableRowHead}
         />
       </Box>
     </Paper>

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateDataSetData.ts
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateDataSetData.ts
@@ -1,0 +1,31 @@
+import { EventType } from './types';
+
+export const dataSets = [
+  {
+    id: EventType.Configuration,
+    name: 'Configuration',
+    description: 'Resource creation, modification, and deletion.',
+    details: {
+      header: 'Header',
+      details: 'Details',
+    },
+  },
+  {
+    id: EventType.Authentication,
+    name: 'Authentication',
+    description: 'Login and identity verification events.',
+    details: {
+      header: 'Header',
+      details: 'Details',
+    },
+  },
+  {
+    id: EventType.Authorization,
+    name: 'Authorization',
+    description: 'User roles, permissions, and access control changes.',
+    details: {
+      header: 'Header',
+      details: 'Details',
+    },
+  },
+];

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateGeneralInfo.test.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateGeneralInfo.test.tsx
@@ -1,0 +1,50 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
+
+import { StreamCreateGeneralInfo } from './StreamCreateGeneralInfo';
+import { StreamType } from './types';
+
+describe('StreamCreateGeneralInfo', () => {
+  it('should render Name input and allow to type text', async () => {
+    renderWithThemeAndHookFormContext({
+      component: <StreamCreateGeneralInfo />,
+    });
+
+    // Type test value inside the input
+    const nameInput = screen.getByPlaceholderText('Stream name...');
+    await userEvent.type(nameInput, 'Test');
+
+    await waitFor(() => {
+      expect(nameInput.getAttribute('value')).toEqual('Test');
+    });
+  });
+
+  it('should render Stream type input and allow to select different options', async () => {
+    renderWithThemeAndHookFormContext({
+      component: <StreamCreateGeneralInfo />,
+      useFormOptions: {
+        defaultValues: {
+          type: StreamType.AuditLogs,
+        },
+      },
+    });
+
+    const streamTypesAutocomplete = screen.getByRole('combobox');
+
+    expect(streamTypesAutocomplete).toHaveValue('Audit Logs');
+
+    // Open the dropdown
+    await userEvent.click(streamTypesAutocomplete);
+
+    // Select the "Error Logs" option
+    const errorLogs = await screen.findByText('Error Logs');
+    await userEvent.click(errorLogs);
+
+    await waitFor(() => {
+      expect(streamTypesAutocomplete).toHaveValue('Error Logs');
+    });
+  });
+});

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateGeneralInfo.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateGeneralInfo.tsx
@@ -28,6 +28,7 @@ export const StreamCreateGeneralInfo = () => {
         name="label"
         render={({ field }) => (
           <TextField
+            aria-required
             className={classes.input}
             label="Name"
             onChange={(value) => {

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateGeneralInfo.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateGeneralInfo.tsx
@@ -1,10 +1,65 @@
-import { Paper, Typography } from '@linode/ui';
+import { Autocomplete, Box, Paper, TextField, Typography } from '@linode/ui';
 import React from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+
+import { useStyles } from './StreamCreate.styles';
+import { type CreateStreamForm, StreamType } from './types';
 
 export const StreamCreateGeneralInfo = () => {
+  const { control } = useFormContext<CreateStreamForm>();
+  const { classes } = useStyles();
+
+  const streamTypeOptions = [
+    {
+      value: StreamType.AuditLogs,
+      label: 'Audit Logs',
+    },
+    {
+      value: StreamType.ErrorLogs,
+      label: 'Error Logs',
+    },
+  ];
+
   return (
     <Paper>
       <Typography variant="h2">General Information</Typography>
+      <Controller
+        control={control}
+        name="label"
+        render={({ field }) => (
+          <TextField
+            className={classes.input}
+            label="Name"
+            onChange={(value) => {
+              field.onChange(value);
+            }}
+            placeholder="Stream name..."
+            value={field.value}
+          />
+        )}
+        rules={{ required: true }}
+      />
+      <Box alignItems="flex-end" display="flex">
+        <Controller
+          control={control}
+          name="type"
+          render={({ field }) => (
+            <Autocomplete
+              className={classes.input}
+              disableClearable
+              label="Stream type"
+              onChange={(_, { value }) => {
+                field.onChange(value);
+              }}
+              options={streamTypeOptions}
+              value={streamTypeOptions.find(
+                ({ value }) => value === field.value
+              )}
+            />
+          )}
+          rules={{ required: true }}
+        />
+      </Box>
     </Paper>
   );
 };

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/types.ts
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/types.ts
@@ -1,0 +1,25 @@
+export enum StreamType {
+  AuditLogs = 'audit_logs',
+  ErrorLogs = 'error_logs',
+}
+
+export enum StreamStatus {
+  Active = 'active',
+  Inactive = 'inactive',
+}
+
+export enum EventType {
+  Authentication = 'authn',
+  Authorization = 'authz',
+  Configuration = 'configuration',
+}
+
+export interface CreateStreamForm {
+  [EventType.Authentication]: boolean;
+  [EventType.Authorization]: boolean;
+  [EventType.Configuration]: boolean;
+  destination_id: number;
+  label: string;
+  status: StreamStatus;
+  type: StreamType;
+}


### PR DESCRIPTION
## Description 📝

DataStream: General Information and Data Set forms

## Changes  🔄
- General Information form
- Data Set form 

## Target release date 🗓️

July 2025

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![before](https://github.com/user-attachments/assets/8cd5796e-d54e-4070-8f6d-57c871c62502) | ![after](https://github.com/user-attachments/assets/99606ab8-b1c2-4fdd-8d55-b8eb4436bde4) |

## How to test 🧪
- navigate to datastream/streams/create
- check both forms

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
