### PR TITLE
fix: [M3-9812, M3-9683] - Styling issues in DomainRecords and forwardRef console errors in Object Storage Access

### DIFF
--- a/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecordDrawerUtils.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecordDrawerUtils.tsx
@@ -189,8 +189,6 @@ export const filterDataByType = (
 ): Partial<EditableDomainFields | EditableRecordFields> => {
   switch (type) {
     case 'A':
-
-    // eslint-disable-next-line no-fallthrough
     case 'AAAA':
     case 'CNAME':
     case 'NS':

--- a/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecords.styles.ts
+++ b/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecords.styles.ts
@@ -10,15 +10,9 @@ export const StyledGrid = styled(Grid, { label: 'StyledGrid' })(
       paddingRight: 0,
     },
     '& .domain-btn': {
-      [theme.breakpoints.down('lg')]: {
-        marginRight: theme.spacing(),
-      },
+      marginBottom: theme.spacingFunction(8),
     },
     margin: 0,
-    [theme.breakpoints.down('md')]: {
-      marginLeft: theme.spacing(),
-      marginRight: theme.spacing(),
-    },
     width: '100%',
   })
 );
@@ -42,10 +36,3 @@ export const StyledTableCell = styled(TableCell, { label: 'StyledTableCell' })(
     width: 'auto',
   })
 );
-
-export const StyledDiv = styled('div', { label: 'StyledDiv' })(({ theme }) => ({
-  [theme.breakpoints.down('md')]: {
-    marginLeft: theme.spacing(),
-    marginRight: theme.spacing(),
-  },
-}));

--- a/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/DomainRecords/DomainRecords.tsx
@@ -16,7 +16,7 @@ import {
 import { storage } from 'src/utilities/storage';
 
 import { DomainRecordDrawer } from './DomainRecordDrawer';
-import { StyledDiv, StyledGrid } from './DomainRecords.styles';
+import { StyledGrid } from './DomainRecords.styles';
 import { DomainRecordTable } from './DomainRecordTable';
 import { generateTypes } from './generateTypes';
 
@@ -257,9 +257,16 @@ export const DomainRecords = (props: Props) => {
                 alignItems="center"
                 container
                 justifyContent="space-between"
-                spacing={2}
+                spacing={1}
               >
-                <Grid ref={ref} sx={{ paddingLeft: 0, paddingRight: 0 }}>
+                <Grid
+                  ref={ref}
+                  sx={(theme) => ({
+                    marginBottom: type.link
+                      ? `-${theme.spacingFunction(8)}`
+                      : theme.spacingFunction(4),
+                  })}
+                >
                   <Typography
                     aria-level={2}
                     className="m0"
@@ -270,12 +277,7 @@ export const DomainRecords = (props: Props) => {
                     {type.title}
                   </Typography>
                 </Grid>
-                {type.link && (
-                  <Grid sx={{ paddingLeft: 0, paddingRight: 0 }}>
-                    {' '}
-                    <StyledDiv>{type.link()}</StyledDiv>{' '}
-                  </Grid>
-                )}
+                {type.link && <Grid>{type.link()}</Grid>}
               </StyledGrid>
               <OrderBy
                 data={type.data}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.tsx
@@ -183,7 +183,6 @@ export const AccessSelect = React.memo((props: Props) => {
         name="acl"
         render={({ field }) => (
           <Autocomplete
-            {...field}
             data-testid="acl-select"
             disableClearable
             disabled={bucketAccessIsFetching || objectAccessIsFetching}
@@ -222,9 +221,9 @@ export const AccessSelect = React.memo((props: Props) => {
             <FormControlLabel
               control={
                 <Toggle
-                  {...field}
                   checked={field.value}
                   disabled={bucketAccessIsFetching || objectAccessIsFetching}
+                  onChange={field.onChange}
                 />
               }
               label={


### PR DESCRIPTION
## Description 📝
This PR addresses the following issues:
  1. Styling fixes in DomainRecords:
     - Missing spacing beneath the buttons on the Domain Details page
     - Unnecessary margin-right on buttons for screen sizes <= lg
  2. `forwardRef` console errors/warnings related to Autocomplete and Toggle components in Object Storage Access

## Changes  🔄
- Cleaned up unnecessary grid styles in `DomainRecords` 🧹
- Added appropriate spacing to the Domain Details page title (with adjustments to the SOA heading which don’t have the "Add" button). ♻️
- Fixed `forwardRef` console errors in Object Storage Access 🔧

## Target release date 🗓️
N/A

## How to test 🧪

### Reproduction steps
-  Issue 1: 
   - Navigate to the Domain Details page (/domains/:id)
   - Observe that there is no spacing beneath the "Add" buttons and the tables that they relate to
   - On screen sizes <= lg, notice an unnecessary margin-right applied to the buttons
- Issue 2: 
  - Navigate to Object Storage Buckets Details > Access
  - Observe console errors related to `forwardRef` in components like `Autocomplete` and `Toggle`

### Verification steps
- On Domain Details Page:
   - Ensure there is appropriate spacing beneath the buttons and their corresponding tables
   - Confirm there is no unnecessary `margin-right` on the buttons across all screen sizes
   - Verify there are no visual or styling regressions on all screen sizes
- On Object Storage Buckets > Access:
   - Ensure there are no console errors related to `forwardRef`
   - Verify the "Bucket Access" form submit/save functionality continues to work as expected

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules