### PR TITLE
feat: [UIE-8615] - DBaaS - Adding Networking section to Create with Assign VPC functionality

### DIFF
--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -127,6 +127,12 @@ export interface DatabaseInstance {
 
 export type ClusterSize = 1 | 2 | 3;
 
+export interface PrivateNetwork {
+  public_access: boolean;
+  subnet_id: null | number;
+  vpc_id: null | number;
+}
+
 type ReadonlyCount = 0 | 2;
 
 /** @deprecated TODO (UIE-8214) remove POST GA */
@@ -139,6 +145,7 @@ export interface CreateDatabasePayload {
   encrypted?: boolean;
   engine?: Engine;
   label: string;
+  private_network?: null | PrivateNetwork;
   region: string;
   /** @Deprecated used by rdbms-legacy only */
   replication_type?: MySQLReplicationType | PostgresReplicationType;

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -41,6 +41,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'dbaasV2MonitorMetrics', label: 'Databases V2 Monitor' },
   { flag: 'databaseResize', label: 'Database Resize' },
   { flag: 'databaseAdvancedConfig', label: 'Database Advanced Config' },
+  { flag: 'databaseVpc', label: 'Database VPC' },
   { flag: 'apicliButtonCopy', label: 'APICLI Button Copy' },
   { flag: 'iam', label: 'Identity and Access Beta' },
   {

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -122,6 +122,7 @@ export interface Flags {
   databaseBeta: boolean;
   databaseResize: boolean;
   databases: boolean;
+  databaseVpc: boolean;
   dbaasV2: BetaFeatureFlag;
   dbaasV2MonitorMetrics: BetaFeatureFlag;
   disableLargestGbPlans: boolean;

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseClusterData.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseClusterData.tsx
@@ -17,6 +17,7 @@ import type {
   ClusterSize,
   DatabaseEngine,
   Engine,
+  PrivateNetwork,
   Region,
 } from '@linode/api-v4';
 import type { FormikErrors } from 'formik';
@@ -28,6 +29,7 @@ export interface DatabaseCreateValues {
   cluster_size: ClusterSize;
   engine: Engine;
   label: string;
+  private_network: PrivateNetwork;
   region: string;
   type: string;
 }

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.test.tsx
@@ -45,6 +45,17 @@ describe('Database Create', () => {
     getAllByText('Create Database Cluster');
   });
 
+  it('should render VPC content when feature flag is present', async () => {
+    const { getAllByTestId, getAllByText } = renderWithTheme(
+      <DatabaseCreate />,
+      {
+        flags: { databaseVpc: true },
+      }
+    );
+    await waitForElementToBeRemoved(getAllByTestId(loadingTestId));
+    getAllByText('Configure Networking');
+  });
+
   it('should display the correct node price and disable 3 nodes for 1 GB plans', async () => {
     const standardTypes = [
       databaseTypeFactory.build({

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -1,7 +1,7 @@
 import { useRegionsQuery } from '@linode/queries';
 import { CircleProgress, Divider, ErrorState, Notice, Paper } from '@linode/ui';
 import { formatStorageUnits, scrollErrorIntoViewV2 } from '@linode/utilities';
-import { createDatabaseSchema } from '@linode/validation/lib/databases.schema';
+import { getDynamicDatabaseSchema } from '@linode/validation/lib/databases.schema';
 import Grid from '@mui/material/Grid';
 import { createLazyRoute } from '@tanstack/react-router';
 import { useFormik } from 'formik';
@@ -24,6 +24,7 @@ import { DatabaseSummarySection } from 'src/features/Databases/DatabaseCreate/Da
 import { DatabaseLogo } from 'src/features/Databases/DatabaseLanding/DatabaseLogo';
 import { enforceIPMasks } from 'src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.utils';
 import { typeLabelDetails } from 'src/features/Linodes/presentation';
+import { useFlags } from 'src/hooks/useFlags';
 import { useRestrictedGlobalGrantCheck } from 'src/hooks/useRestrictedGlobalGrantCheck';
 import {
   useCreateDatabaseMutation,
@@ -35,11 +36,14 @@ import { validateIPs } from 'src/utilities/ipUtils';
 
 import { ACCESS_CONTROLS_IP_VALIDATION_ERROR_TEXT } from '../constants';
 import { DatabaseCreateAccessControls } from './DatabaseCreateAccessControls';
+import { DatabaseCreateNetworkingConfiguration } from './DatabaseCreateNetworkingConfiguration';
 
+import type { AccessProps } from './DatabaseCreateAccessControls';
 import type {
   ClusterSize,
   CreateDatabasePayload,
   Engine,
+  VPC,
 } from '@linode/api-v4/lib/databases/types';
 import type { APIError } from '@linode/api-v4/lib/types';
 import type { PlanSelectionWithDatabaseType } from 'src/features/components/PlansPanel/types';
@@ -71,12 +75,17 @@ const DatabaseCreate = () => {
     platform: 'rdbms-default',
   });
 
+  const flags = useFlags();
+  const isVPCEnabled = flags.databaseVpc;
+
   const formRef = React.useRef<HTMLFormElement>(null);
   const { mutateAsync: createDatabase } = useCreateDatabaseMutation();
 
   const [createError, setCreateError] = React.useState<string>();
   const [ipErrorsFromAPI, setIPErrorsFromAPI] = React.useState<APIError[]>();
   const [selectedTab, setSelectedTab] = React.useState(0);
+  const [selectedVPC, setSelectedVPC] = React.useState<null | VPC>(null);
+  const isVPCSelected = Boolean(selectedVPC);
 
   const handleIPBlur = (ips: ExtendedIP[]) => {
     const ipsWithMasks = enforceIPMasks(ips);
@@ -118,11 +127,19 @@ const DatabaseCreate = () => {
       }
       return accum;
     }, []);
+    const hasVpc =
+      values.private_network.vpc_id && values.private_network.subnet_id;
+    const privateNetwork = hasVpc ? values.private_network : null;
 
     const createPayload: CreateDatabasePayload = {
       ...values,
       allow_list: _allow_list,
+      private_network: privateNetwork,
     };
+
+    if (!isVPCEnabled) {
+      delete createPayload.private_network;
+    }
     try {
       const response = await createDatabase(createPayload);
       history.push(`/databases/${response.engine}/${response.id}`);
@@ -151,12 +168,18 @@ const DatabaseCreate = () => {
     label: '',
     region: '',
     type: '',
+    private_network: {
+      vpc_id: null,
+      subnet_id: null,
+      public_access: false,
+    },
   };
 
   const {
     errors,
     handleSubmit,
     isSubmitting,
+    resetForm,
     setFieldError,
     setFieldValue,
     setSubmitting,
@@ -169,7 +192,7 @@ const DatabaseCreate = () => {
       scrollErrorIntoViewV2(formRef);
     },
     validateOnChange: false,
-    validationSchema: createDatabaseSchema,
+    validationSchema: getDynamicDatabaseSchema(isVPCSelected),
   });
 
   React.useEffect(() => {
@@ -215,6 +238,15 @@ const DatabaseCreate = () => {
     return displayTypes?.find((type) => type.id === values.type);
   }, [displayTypes, values.type]);
 
+  const accessControlsConfiguration: AccessProps = {
+    disabled: isRestricted,
+    errors: ipErrorsFromAPI,
+    ips: values.allow_list,
+    onBlur: handleIPBlur,
+    onChange: (ips: ExtendedIP[]) => setFieldValue('allow_list', ips),
+    variant: isVPCEnabled ? 'networking' : 'standard',
+  };
+
   const handleTabChange = (index: number) => {
     setSelectedTab(index);
     setFieldValue('type', undefined);
@@ -232,6 +264,24 @@ const DatabaseCreate = () => {
   const handleNodeChange = (size: ClusterSize | undefined) => {
     setFieldValue('cluster_size', size);
   };
+
+  const handleNetworkingConfigurationChange = (vpc: null | VPC) => {
+    setSelectedVPC(vpc);
+  };
+
+  const handleResetForm = (partialValues?: Partial<DatabaseCreateValues>) => {
+    if (partialValues) {
+      resetForm({
+        values: {
+          ...values,
+          ...partialValues,
+        },
+      });
+    } else {
+      resetForm();
+    }
+  };
+
   return (
     <>
       <DocumentTitleSegment segment="Create a Database" />
@@ -309,19 +359,31 @@ const DatabaseCreate = () => {
             />
           </Grid>
           <Divider spacingBottom={12} spacingTop={26} />
-          <DatabaseCreateAccessControls
-            disabled={isRestricted}
-            errors={ipErrorsFromAPI}
-            ips={values.allow_list}
-            onBlur={handleIPBlur}
-            onChange={(ips: ExtendedIP[]) => setFieldValue('allow_list', ips)}
-          />
+          {isVPCEnabled ? (
+            <DatabaseCreateNetworkingConfiguration
+              accessControlsConfiguration={accessControlsConfiguration}
+              errors={errors}
+              onChange={(field: string, value: boolean | null | number) =>
+                setFieldValue(field, value)
+              }
+              onNetworkingConfigurationChange={
+                handleNetworkingConfigurationChange
+              }
+              privateNetworkValues={values.private_network}
+              resetFormFields={handleResetForm}
+              selectedRegionId={values.region}
+            />
+          ) : (
+            <DatabaseCreateAccessControls {...accessControlsConfiguration} />
+          )}
         </Paper>
         <Paper sx={{ marginTop: 3 }}>
           <DatabaseSummarySection
             currentClusterSize={values.cluster_size}
             currentEngine={selectedEngine}
             currentPlan={selectedPlan}
+            isCreate
+            selectedVPC={selectedVPC}
           />
         </Paper>
         <StyledBtnCtn>

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreateAccessControls.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreateAccessControls.tsx
@@ -36,17 +36,26 @@ const useStyles = makeStyles()((theme: Theme) => ({
 }));
 
 export type AccessOption = 'none' | 'specific';
+export type AccessVariant = 'networking' | 'standard';
 
-interface Props {
+export interface AccessProps {
   disabled?: boolean;
   errors?: APIError[];
   ips: ExtendedIP[];
   onBlur: (ips: ExtendedIP[]) => void;
   onChange: (ips: ExtendedIP[]) => void;
+  variant?: AccessVariant;
 }
 
-export const DatabaseCreateAccessControls = (props: Props) => {
-  const { disabled = false, errors, ips, onBlur, onChange } = props;
+export const DatabaseCreateAccessControls = (props: AccessProps) => {
+  const {
+    disabled = false,
+    errors,
+    ips,
+    onBlur,
+    onChange,
+    variant = 'standard',
+  } = props;
   const { classes } = useStyles();
   const [accessOption, setAccessOption] = useState<AccessOption>('specific');
 
@@ -59,7 +68,10 @@ export const DatabaseCreateAccessControls = (props: Props) => {
 
   return (
     <Grid>
-      <Typography className={classes.header} variant="h2">
+      <Typography
+        className={classes.header}
+        variant={variant === 'networking' ? 'h3' : 'h2'}
+      >
         Manage Access
       </Typography>
       <Typography>

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreateNetworkingConfiguration.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreateNetworkingConfiguration.test.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { describe, it, vi } from 'vitest';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { DatabaseCreateNetworkingConfiguration } from './DatabaseCreateNetworkingConfiguration';
+
+import type { AccessProps } from './DatabaseCreateAccessControls';
+import type { PrivateNetwork } from '@linode/api-v4';
+describe('DatabaseCreateNetworkingConfiguration', () => {
+  const mockAccessControlConfig: AccessProps = {
+    disabled: false,
+    errors: [],
+    ips: [],
+    onBlur: vi.fn(),
+    onChange: vi.fn(),
+    variant: 'networking',
+  };
+
+  const mockPrivateNetwork: PrivateNetwork = {
+    vpc_id: null,
+    subnet_id: null,
+    public_access: false,
+  };
+
+  const mockProps = {
+    accessControlsConfiguration: mockAccessControlConfig,
+    errors: {},
+    onChange: vi.fn(),
+    onNetworkingConfigurationChange: vi.fn(),
+    privateNetworkValues: mockPrivateNetwork,
+    resetFormFields: vi.fn(),
+    selectedRegionId: 'us-east',
+  };
+
+  it('renders the networking configuration heading and description', () => {
+    const { getByText } = renderWithTheme(
+      <DatabaseCreateNetworkingConfiguration {...mockProps} />
+    );
+    expect(
+      getByText('Configure Networking', {
+        exact: true,
+      })
+    ).toBeInTheDocument();
+    expect(
+      getByText('Configure networking options for the cluster.', {
+        exact: true,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('renders DatabaseCreateAccessControls and DatabaseVPCSelector', () => {
+    const { getByText, getByTestId } = renderWithTheme(
+      <DatabaseCreateNetworkingConfiguration {...mockProps} />
+    );
+    expect(getByTestId('database-vpc-selector')).toBeInTheDocument();
+    expect(getByText('Manage Access')).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreateNetworkingConfiguration.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreateNetworkingConfiguration.tsx
@@ -1,0 +1,58 @@
+import { Typography } from '@linode/ui';
+import * as React from 'react';
+
+import { DatabaseCreateAccessControls } from './DatabaseCreateAccessControls';
+import { DatabaseVPCSelector } from './DatabaseVPCSelector';
+
+import type { DatabaseCreateValues } from './DatabaseClusterData';
+import type { AccessProps } from './DatabaseCreateAccessControls';
+import type { PrivateNetwork, VPC } from '@linode/api-v4';
+import type { Theme } from '@mui/material/styles';
+import type { FormikErrors } from 'formik';
+
+interface NetworkingConfigurationProps {
+  accessControlsConfiguration: AccessProps;
+  errors: FormikErrors<DatabaseCreateValues>;
+  onChange: (field: string, value: boolean | null | number) => void;
+  onNetworkingConfigurationChange: (vpcSelected: null | VPC) => void;
+  privateNetworkValues: PrivateNetwork;
+  resetFormFields: (partialValues?: Partial<DatabaseCreateValues>) => void;
+  selectedRegionId: string;
+}
+
+export const DatabaseCreateNetworkingConfiguration = (
+  props: NetworkingConfigurationProps
+) => {
+  const {
+    accessControlsConfiguration,
+    errors,
+    onNetworkingConfigurationChange,
+    onChange,
+    selectedRegionId,
+    resetFormFields,
+    privateNetworkValues,
+  } = props;
+
+  return (
+    <>
+      <Typography variant="h2">Configure Networking</Typography>
+      <Typography
+        sx={(theme: Theme) => ({
+          marginBottom: theme.spacingFunction(20),
+        })}
+      >
+        Configure networking options for the cluster.
+      </Typography>
+
+      <DatabaseCreateAccessControls {...accessControlsConfiguration} />
+      <DatabaseVPCSelector
+        errors={errors}
+        onChange={onChange}
+        onConfigurationChange={onNetworkingConfigurationChange}
+        privateNetworkValues={privateNetworkValues}
+        resetFormFields={resetFormFields}
+        selectedRegionId={selectedRegionId}
+      />
+    </>
+  );
+};

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseSummarySection.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseSummarySection.test.tsx
@@ -2,7 +2,11 @@ import { waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
-import { databaseFactory, databaseTypeFactory } from 'src/factories';
+import {
+  databaseFactory,
+  databaseTypeFactory,
+  vpcFactory,
+} from 'src/factories';
 import DatabaseCreate from 'src/features/Databases/DatabaseCreate/DatabaseCreate';
 import { DatabaseResize } from 'src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize';
 import { makeResourcePage } from 'src/mocks/serverHandlers';
@@ -19,9 +23,10 @@ describe('database summary section', () => {
       beta: false,
       enabled: true,
     },
+    databaseVpc: true,
   };
 
-  it('should render the correct number of node radio buttons, associated costs, and summary', async () => {
+  it('should render the correct number of node radio buttons, associated costs, vpc label and summary', async () => {
     const standardTypes = databaseTypeFactory.buildList(7, {
       class: 'standard',
     });
@@ -40,10 +45,15 @@ describe('database summary section', () => {
         return HttpResponse.json(
           makeResourcePage([...mockDedicatedTypes, ...standardTypes])
         );
+      }),
+      http.get('*/vpcs', () => {
+        return HttpResponse.json(
+          makeResourcePage([vpcFactory.build({ label: 'VPC 1' })])
+        );
       })
     );
 
-    const { getByTestId } = renderWithTheme(<DatabaseCreate />, {
+    const { getByTestId, findByText } = renderWithTheme(<DatabaseCreate />, {
       MemoryRouter: { initialEntries: ['/databases/create'] },
       flags,
     });
@@ -53,6 +63,26 @@ describe('database summary section', () => {
     );
     await userEvent.click(selectedPlan);
 
+    // Simulate Region Selection
+    const regionSelect = getByTestId('region-select').querySelector(
+      'input'
+    ) as HTMLInputElement;
+
+    // Open the autocomplete dropdown
+    await userEvent.click(regionSelect);
+
+    const regionOption = await findByText('US, Newark, NJ (us-east)');
+    await userEvent.click(regionOption);
+
+    // Simulate VPC Selection
+    const vpcSelector = getByTestId('database-vpc-selector').querySelector(
+      'input'
+    ) as HTMLInputElement;
+    await userEvent.click(vpcSelector);
+    const newVPC = await findByText('VPC 1');
+    await userEvent.click(newVPC);
+
+    // Check summary contents (ie. plan, nodes, VPC)
     const summary = getByTestId('currentSummary');
     const selectedPlanText = 'Dedicated 4 GB $60/month';
     expect(summary).toHaveTextContent(selectedPlanText);

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseVPCSelector.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseVPCSelector.test.tsx
@@ -1,0 +1,489 @@
+import { regionFactory } from '@linode/utilities';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { subnetFactory, vpcFactory } from 'src/factories';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { DatabaseVPCSelector } from './DatabaseVPCSelector';
+
+import type { PrivateNetwork } from '@linode/api-v4';
+
+// Hoist query mocks
+const queryMocks = vi.hoisted(() => ({
+  useRegionQuery: vi.fn().mockReturnValue({ data: {} }),
+  useAllVPCsQuery: vi.fn().mockReturnValue({ data: [], isLoading: false }),
+}));
+
+vi.mock('@linode/queries', async () => {
+  const actual = await vi.importActual('@linode/queries');
+  return {
+    ...actual,
+    useRegionQuery: queryMocks.useRegionQuery,
+    useAllVPCsQuery: queryMocks.useAllVPCsQuery,
+  };
+});
+
+const mockIpv4 = '10.0.0.0/24';
+
+const mockRegion = regionFactory.build({
+  capabilities: ['VPCs'],
+  id: 'us-east',
+  label: 'Newark, NJ',
+});
+
+const mockSubnets = subnetFactory.buildList(1, {
+  ipv4: mockIpv4,
+  id: 123,
+  label: 'Subnet 1',
+});
+
+const mockVPCWithSubnet = vpcFactory.build({
+  id: 1234,
+  label: 'VPC 1',
+  region: 'us-east',
+  subnets: mockSubnets,
+});
+
+const setUpBaseMocks = () => {
+  queryMocks.useRegionQuery.mockReturnValue({ data: mockRegion });
+  queryMocks.useAllVPCsQuery.mockReturnValue({
+    data: [mockVPCWithSubnet],
+    isLoading: false,
+  });
+};
+
+describe('DatabaseVPCSelector', () => {
+  const mockProps = {
+    errors: {},
+    onChange: vi.fn(),
+    onConfigurationChange: vi.fn(),
+    privateNetworkValues: {
+      vpc_id: null,
+      subnet_id: null,
+      public_access: false,
+    },
+    resetFormFields: vi.fn(),
+    selectedRegionId: '',
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    queryMocks.useRegionQuery.mockReturnValue({
+      data: null,
+    });
+
+    queryMocks.useAllVPCsQuery.mockReturnValue({
+      data: null,
+      isLoading: false,
+    });
+  });
+
+  it('Should render the VPC selector heading', () => {
+    const { getByText } = renderWithTheme(
+      <DatabaseVPCSelector {...mockProps} />
+    );
+    expect(getByText('Assign a VPC', { exact: true })).toBeInTheDocument();
+  });
+
+  it('Should render VPC autocomplete in initial disabled state', () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <DatabaseVPCSelector {...mockProps} />
+    );
+    const vpcSelector = getByTestId('database-vpc-selector');
+    expect(vpcSelector).toBeInTheDocument();
+    expect(vpcSelector.querySelector('input')).toBeDisabled();
+    expect(
+      getByText(
+        'In the Select Engine and Region section, select a region with an existing VPC to see available VPCs.',
+        { exact: true }
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('Should enable VPC autocomplete when VPCs are available', () => {
+    const subnets = subnetFactory.buildList(3, { ipv4: mockIpv4 });
+
+    const vpcWithSubnet = vpcFactory.build({
+      subnets,
+      region: 'us-east',
+    });
+
+    queryMocks.useRegionQuery.mockReturnValue({
+      data: mockRegion,
+    });
+
+    queryMocks.useAllVPCsQuery.mockReturnValue({
+      data: [vpcWithSubnet],
+      isLoading: false,
+    });
+
+    const mockEnabledProps = { ...mockProps, selectedRegionId: 'us-east' };
+    const { getByTestId } = renderWithTheme(
+      <DatabaseVPCSelector {...mockEnabledProps} />
+    );
+
+    const vpcSelector = getByTestId('database-vpc-selector');
+    expect(vpcSelector).toBeInTheDocument();
+    expect(vpcSelector.querySelector('input')).toBeEnabled();
+  });
+
+  it('Should enable Subnet autocomplete when VPC is selected', async () => {
+    queryMocks.useRegionQuery.mockReturnValue({
+      data: mockRegion,
+    });
+
+    queryMocks.useAllVPCsQuery.mockReturnValue({
+      data: [mockVPCWithSubnet],
+      isLoading: false,
+    });
+
+    const mockPrivateNetwork: PrivateNetwork = {
+      vpc_id: 1234,
+      subnet_id: null,
+      public_access: false,
+    };
+
+    const mockEnabledProps = {
+      ...mockProps,
+      privateNetworkValues: mockPrivateNetwork,
+      selectedRegionId: 'us-east',
+    };
+    const { getByTestId } = renderWithTheme(
+      <DatabaseVPCSelector {...mockEnabledProps} />
+    );
+
+    const vpcSelector = getByTestId('database-vpc-selector');
+    const vpcSelectorInput = vpcSelector.querySelector(
+      'input'
+    ) as HTMLInputElement;
+    expect(vpcSelectorInput?.value).toBe(mockVPCWithSubnet.label);
+    const subnetSelector = getByTestId('database-subnet-selector');
+    expect(subnetSelector).toBeInTheDocument();
+    expect(subnetSelector.querySelector('input')).toBeEnabled();
+  });
+
+  it('Should set fields for VPC, Subnet, and Public Access based on privateNetworkValues values', async () => {
+    queryMocks.useRegionQuery.mockReturnValue({
+      data: mockRegion,
+    });
+
+    queryMocks.useAllVPCsQuery.mockReturnValue({
+      data: [mockVPCWithSubnet],
+      isLoading: false,
+    });
+
+    const mockPrivateNetwork: PrivateNetwork = {
+      vpc_id: 1234,
+      subnet_id: 123,
+      public_access: true,
+    };
+
+    const mockEnabledProps = {
+      ...mockProps,
+      privateNetworkValues: mockPrivateNetwork,
+      selectedRegionId: 'us-east',
+    };
+    const { getByTestId } = renderWithTheme(
+      <DatabaseVPCSelector {...mockEnabledProps} />
+    );
+
+    const vpcSelector = getByTestId('database-vpc-selector');
+    const vpcSelectorInput = vpcSelector.querySelector(
+      'input'
+    ) as HTMLInputElement;
+    const subnetSelector = getByTestId('database-subnet-selector');
+    const expectedSubnetValue = `${mockSubnets[0].label} (${mockSubnets[0].ipv4})`;
+    const publicAccessCheckbox = getByTestId('database-public-access-checkbox');
+
+    expect(vpcSelectorInput?.value).toBe(mockVPCWithSubnet.label);
+    expect(subnetSelector).toBeInTheDocument();
+    expect(subnetSelector.querySelector('input')?.value).toBe(
+      expectedSubnetValue
+    );
+    expect(publicAccessCheckbox).toBeInTheDocument();
+    expect(publicAccessCheckbox.querySelector('input')).toBeChecked();
+  });
+
+  it('Should clear VPC and subnet when selectedRegionId changes', () => {
+    // Initial region, VPC, and subnet
+    const region1 = regionFactory.build({
+      capabilities: ['VPCs'],
+      id: 'us-east',
+      label: 'Newark, NJ',
+    });
+    const region2 = regionFactory.build({
+      capabilities: ['VPCs'],
+      id: 'us-west',
+      label: 'Fremont, CA',
+    });
+
+    // Set up mocks for initial render
+    queryMocks.useRegionQuery.mockReturnValue({ data: region1 });
+    queryMocks.useAllVPCsQuery.mockReturnValue({
+      data: [mockVPCWithSubnet],
+      isLoading: false,
+    });
+
+    const mockPrivateNetwork: PrivateNetwork = {
+      vpc_id: 1234,
+      subnet_id: 123,
+      public_access: true,
+    };
+
+    const resetFormFields = vi.fn();
+    const onConfigurationChange = vi.fn();
+
+    const { rerender, getByTestId } = renderWithTheme(
+      <DatabaseVPCSelector
+        {...mockProps}
+        onConfigurationChange={onConfigurationChange}
+        privateNetworkValues={mockPrivateNetwork}
+        resetFormFields={resetFormFields}
+        selectedRegionId="us-east"
+      />
+    );
+
+    // Change region to a new one
+    queryMocks.useRegionQuery.mockReturnValue({ data: region2 });
+    queryMocks.useAllVPCsQuery.mockReturnValue({ data: [], isLoading: false });
+
+    rerender(
+      <DatabaseVPCSelector
+        {...mockProps}
+        onConfigurationChange={onConfigurationChange}
+        privateNetworkValues={mockPrivateNetwork}
+        resetFormFields={resetFormFields}
+        selectedRegionId="us-west"
+      />
+    );
+
+    expect(resetFormFields).toHaveBeenCalled();
+    expect(onConfigurationChange).toHaveBeenCalledWith(null);
+    const vpcSelector = getByTestId('database-vpc-selector');
+    expect((vpcSelector.querySelector('input') as HTMLInputElement).value).toBe(
+      ''
+    );
+  });
+
+  it('Should NOT clear VPC and subnet when selectedRegionId changes from undefined to a valid region', () => {
+    // Initial render with no region selected
+    queryMocks.useRegionQuery.mockReturnValue({ data: null });
+    queryMocks.useAllVPCsQuery.mockReturnValue({ data: [], isLoading: false });
+
+    const resetFormFields = vi.fn();
+    const onConfigurationChange = vi.fn();
+
+    const { rerender } = renderWithTheme(
+      <DatabaseVPCSelector
+        {...mockProps}
+        onConfigurationChange={onConfigurationChange}
+        resetFormFields={resetFormFields}
+        selectedRegionId=""
+      />
+    );
+
+    // Now render with a valid region
+    queryMocks.useRegionQuery.mockReturnValue({ data: mockRegion });
+    queryMocks.useAllVPCsQuery.mockReturnValue({ data: [], isLoading: false });
+
+    rerender(
+      <DatabaseVPCSelector
+        {...mockProps}
+        onConfigurationChange={onConfigurationChange}
+        resetFormFields={resetFormFields}
+        selectedRegionId="us-east"
+      />
+    );
+
+    expect(resetFormFields).not.toHaveBeenCalled();
+    expect(onConfigurationChange).not.toHaveBeenCalledWith(null);
+  });
+
+  it('Should show long helper text when no region is selected', () => {
+    const { getByText } = renderWithTheme(
+      <DatabaseVPCSelector {...mockProps} selectedRegionId="" />
+    );
+    expect(
+      getByText(
+        'In the Select Engine and Region section, select a region with an existing VPC to see available VPCs.',
+        { exact: true }
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('Should show short helper text when a region is selected but no VPCs are available', () => {
+    queryMocks.useRegionQuery.mockReturnValue({ data: mockRegion });
+    queryMocks.useAllVPCsQuery.mockReturnValue({ data: [], isLoading: false });
+
+    const { getByText } = renderWithTheme(
+      <DatabaseVPCSelector {...mockProps} selectedRegionId="us-east" />
+    );
+    expect(
+      getByText('No VPC is available in the selected region.', { exact: true })
+    ).toBeInTheDocument();
+  });
+
+  it('Should NOT show helper text when VPCs are available', () => {
+    const vpcWithSubnet = vpcFactory.build({
+      region: 'us-east',
+      subnets: subnetFactory.buildList(1, { ipv4: mockIpv4 }),
+    });
+    queryMocks.useRegionQuery.mockReturnValue({ data: mockRegion });
+    queryMocks.useAllVPCsQuery.mockReturnValue({
+      data: [vpcWithSubnet],
+      isLoading: false,
+    });
+
+    const { queryByText } = renderWithTheme(
+      <DatabaseVPCSelector {...mockProps} selectedRegionId="us-east" />
+    );
+    expect(
+      queryByText('No VPC is available in the selected region.')
+    ).not.toBeInTheDocument();
+    expect(
+      queryByText(
+        'In the Select Engine and Region section, select a region with an existing VPC to see available VPCs.'
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  it('Should show subnet validation error text when there is a subnet error', () => {
+    setUpBaseMocks();
+    const mockPrivateNetwork: PrivateNetwork = {
+      vpc_id: 1234,
+      subnet_id: null,
+      public_access: false,
+    };
+
+    const mockErrors = {
+      private_network: {
+        subnet_id: 'Subnet is required.',
+      },
+    };
+
+    const { getByTestId, getByText } = renderWithTheme(
+      <DatabaseVPCSelector
+        {...mockProps}
+        errors={mockErrors}
+        privateNetworkValues={mockPrivateNetwork}
+        selectedRegionId="us-east"
+      />
+    );
+
+    const subnetSelector = getByTestId('database-subnet-selector');
+    expect(subnetSelector).toBeInTheDocument();
+    expect(getByText('Subnet is required.')).toBeInTheDocument();
+  });
+
+  it('Should clear subnet field when the VPC field is cleared', async () => {
+    setUpBaseMocks();
+    const onChange = vi.fn();
+
+    // Start with both VPC and subnet selected
+    const mockPrivateNetwork: PrivateNetwork = {
+      vpc_id: 1234,
+      subnet_id: 123,
+      public_access: false,
+    };
+
+    const { getByTestId } = renderWithTheme(
+      <DatabaseVPCSelector
+        {...mockProps}
+        onChange={onChange}
+        privateNetworkValues={mockPrivateNetwork}
+        selectedRegionId="us-east"
+      />
+    );
+
+    // Simulate clearing the VPC field (user clears the Autocomplete)
+    const vpcSelector = getByTestId('database-vpc-selector');
+    const clearButton = vpcSelector.querySelector(
+      'button[title="Clear"]'
+    ) as HTMLElement;
+    await userEvent.click(clearButton);
+    // ...assertions as above...
+    expect(onChange).toHaveBeenCalledWith('private_network.vpc_id', null);
+    expect(onChange).toHaveBeenCalledWith('private_network.subnet_id', null);
+    expect(onChange).toHaveBeenCalledWith(
+      'private_network.public_access',
+      false
+    );
+  });
+
+  it('Should call onChange for the VPC field when a value is selected', async () => {
+    setUpBaseMocks();
+    const onChange = vi.fn();
+
+    // Start with no VPC selected
+    const mockPrivateNetwork: PrivateNetwork = {
+      vpc_id: null,
+      subnet_id: null,
+      public_access: false,
+    };
+
+    const { getByTestId, findByText } = renderWithTheme(
+      <DatabaseVPCSelector
+        {...mockProps}
+        onChange={onChange}
+        privateNetworkValues={mockPrivateNetwork}
+        selectedRegionId="us-east"
+      />
+    );
+
+    // Simulate selecting a VPC from the Autocomplete
+    const vpcSelector = getByTestId('database-vpc-selector').querySelector(
+      'input'
+    ) as HTMLInputElement;
+    // Open the autocomplete dropdown
+    await userEvent.click(vpcSelector);
+
+    // Select the option
+    const newVPC = await findByText('VPC 1');
+    await userEvent.click(newVPC);
+
+    expect(onChange).toHaveBeenCalledWith(
+      'private_network.vpc_id',
+      mockVPCWithSubnet.id
+    );
+  });
+
+  it('Should call onChange for the Subnet field when subnet value is selected', async () => {
+    setUpBaseMocks();
+    const onChange = vi.fn();
+
+    // Start with VPC selected and no subnet selection
+    const mockPrivateNetwork: PrivateNetwork = {
+      vpc_id: 1234,
+      subnet_id: null,
+      public_access: false,
+    };
+
+    const { getByTestId, findByText } = renderWithTheme(
+      <DatabaseVPCSelector
+        {...mockProps}
+        onChange={onChange}
+        privateNetworkValues={mockPrivateNetwork}
+        selectedRegionId="us-east"
+      />
+    );
+
+    // Simulate selecting a Subnet from the Autocomplete
+    const subnetSelector = getByTestId(
+      'database-subnet-selector'
+    ).querySelector('input') as HTMLInputElement;
+
+    await userEvent.click(subnetSelector);
+
+    // Select the option
+    const expectedSubnetLabel = `${mockSubnets[0].label} (${mockSubnets[0].ipv4})`;
+    const newSubnet = await findByText(expectedSubnetLabel);
+    await userEvent.click(newSubnet);
+
+    expect(onChange).toHaveBeenCalledWith(
+      'private_network.subnet_id',
+      mockSubnets[0].id
+    );
+  });
+});

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseVPCSelector.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseVPCSelector.tsx
@@ -1,0 +1,190 @@
+import { useAllVPCsQuery, useRegionQuery } from '@linode/queries';
+import {
+  Autocomplete,
+  Box,
+  Checkbox,
+  Notice,
+  TooltipIcon,
+  Typography,
+} from '@linode/ui';
+import * as React from 'react';
+
+import type { DatabaseCreateValues } from './DatabaseClusterData';
+import type { PrivateNetwork, VPC } from '@linode/api-v4';
+import type { Theme } from '@mui/material/styles';
+import type { FormikErrors } from 'formik';
+
+interface DatabaseVPCSelectorProps {
+  errors: FormikErrors<DatabaseCreateValues>;
+  onChange: (field: string, value: boolean | null | number) => void;
+  onConfigurationChange: (vpc: null | VPC) => void;
+  privateNetworkValues: PrivateNetwork;
+  resetFormFields: (partialValues?: Partial<DatabaseCreateValues>) => void;
+  selectedRegionId: string;
+}
+
+export const DatabaseVPCSelector = (props: DatabaseVPCSelectorProps) => {
+  const {
+    errors,
+    onConfigurationChange,
+    onChange,
+    selectedRegionId,
+    resetFormFields,
+    privateNetworkValues,
+  } = props;
+
+  const { data: selectedRegion } = useRegionQuery(selectedRegionId);
+  const regionSupportsVPCs = selectedRegion?.capabilities.includes('VPCs');
+
+  const {
+    data: vpcs,
+    error,
+    isLoading,
+  } = useAllVPCsQuery({
+    enabled: regionSupportsVPCs,
+    filter: { region: selectedRegionId },
+  });
+
+  const selectedVPC = React.useMemo(
+    () => vpcs?.find((vpc) => vpc.id === privateNetworkValues.vpc_id),
+    [vpcs, privateNetworkValues.vpc_id]
+  );
+  const selectedSubnet = React.useMemo(
+    () =>
+      selectedVPC?.subnets.find(
+        (subnet) => subnet.id === privateNetworkValues.subnet_id
+      ),
+    [selectedVPC, privateNetworkValues.subnet_id]
+  );
+
+  const prevRegionId = React.useRef<string | undefined>();
+  const regionHasVPCs = Boolean(vpcs && vpcs.length > 0);
+  const disableVPCSelectors = !regionSupportsVPCs || !regionHasVPCs;
+
+  const resetVPCConfiguration = () => {
+    resetFormFields({
+      private_network: {
+        vpc_id: null,
+        subnet_id: null,
+        public_access: false,
+      },
+    });
+  };
+
+  React.useEffect(() => {
+    // When the selected region has changed, reset VPC configuration.
+    // Then switch back to default validation behavior
+    if (prevRegionId.current && prevRegionId.current !== selectedRegionId) {
+      resetVPCConfiguration();
+      onConfigurationChange(null);
+    }
+    prevRegionId.current = selectedRegionId;
+  }, [selectedRegionId]);
+
+  const vpcHelperTextCopy = !selectedRegionId
+    ? 'In the Select Engine and Region section, select a region with an existing VPC to see available VPCs.'
+    : 'No VPC is available in the selected region.';
+
+  /** Returns dynamic marginTop value used to center TooltipIcon in different scenarios */
+  const getVPCTooltipIconMargin = () => {
+    const margins = {
+      longHelperText: '.75rem',
+      shortHelperText: '1.75rem',
+      noHelperText: '2.75rem',
+    };
+    if (disableVPCSelectors && !selectedRegionId) return margins.longHelperText;
+    if (disableVPCSelectors && selectedRegionId) return margins.shortHelperText;
+    return margins.noHelperText;
+  };
+
+  return (
+    <>
+      <Typography
+        sx={(theme: Theme) => ({
+          marginTop: theme.spacingFunction(20),
+          marginBottom: theme.spacingFunction(4),
+        })}
+        variant="h3"
+      >
+        Assign a VPC
+      </Typography>
+
+      <Typography>Assign this cluster to an existing VPC.</Typography>
+      <Box style={{ display: 'flex' }}>
+        <Autocomplete
+          data-testid="database-vpc-selector"
+          disabled={disableVPCSelectors}
+          errorText={error?.[0].reason}
+          helperText={disableVPCSelectors ? vpcHelperTextCopy : undefined}
+          label="VPC"
+          loading={isLoading}
+          noOptionsText="There are no VPCs in the selected region."
+          onChange={(e, value) => {
+            if (!value) {
+              onChange('private_network.subnet_id', null);
+              onChange('private_network.public_access', false);
+            }
+            onConfigurationChange(value ?? null);
+            onChange('private_network.vpc_id', value?.id ?? null);
+          }}
+          options={vpcs ?? []}
+          placeholder="Select a VPC"
+          sx={{ width: '354px' }}
+          value={selectedVPC ?? null}
+        />
+        <TooltipIcon
+          status="help"
+          sxTooltipIcon={{
+            marginTop: getVPCTooltipIconMargin(),
+            padding: '0px 8px',
+          }}
+          text="A cluster may be assigned only to a VPC in the same region."
+          tooltipPosition="top"
+        />
+      </Box>
+
+      {selectedVPC ? (
+        <>
+          <Autocomplete
+            data-testid="database-subnet-selector"
+            disabled={disableVPCSelectors}
+            errorText={errors?.private_network?.subnet_id}
+            getOptionLabel={(subnet) => `${subnet.label} (${subnet.ipv4})`}
+            label="Subnet"
+            onChange={(e, value) => {
+              onChange('private_network.subnet_id', value?.id ?? null);
+            }}
+            options={selectedVPC?.subnets ?? []}
+            placeholder="Select a subnet"
+            value={selectedSubnet ?? null}
+          />
+          <Box
+            sx={(theme: Theme) => ({
+              marginTop: theme.spacingFunction(20),
+            })}
+          >
+            <Checkbox
+              checked={privateNetworkValues.public_access ?? false}
+              data-testid="database-public-access-checkbox"
+              onChange={(e, value) => {
+                onChange('private_network.public_access', value ?? null);
+              }}
+              text={'Enable public access'}
+              toolTipText={
+                'Adds a public endpoint to the database in addition to the private VPC endpoint.'
+              }
+            />
+          </Box>
+        </>
+      ) : (
+        <Notice
+          sx={(theme: Theme) => ({
+            marginTop: theme.spacingFunction(20),
+          })}
+          text="The cluster will have public access by default if a VPC is not assigned."
+          variant="info"
+        />
+      )}
+    </>
+  );
+};

--- a/packages/validation/src/databases.schema.ts
+++ b/packages/validation/src/databases.schema.ts
@@ -18,6 +18,18 @@ export const createDatabaseSchema = object({
   replication_commit_type: string().notRequired().nullable(), // TODO (UIE-8214) remove POST GA
 });
 
+export const getDynamicDatabaseSchema = (isVPCSelected: boolean) => {
+  if (!isVPCSelected) {
+    return createDatabaseSchema;
+  }
+
+  return createDatabaseSchema.shape({
+    private_network: object().shape({
+      subnet_id: number().nullable().required('Subnet is required.'),
+    }),
+  });
+};
+
 export const updateDatabaseSchema = object({
   label: string().notRequired().min(3, LABEL_MESSAGE).max(32, LABEL_MESSAGE),
   allow_list: array().of(string()).notRequired(),


### PR DESCRIPTION
## Description 📝

This pull request updates the DBaaS Create flow, adding a Configure Networking section and handling new VPC feature. This new section will contain: 
- The 'Manage Access' field that previously existed on the page
- New 'Assign a VPC' field with VPC, Subnet and Public access fields for selection

This also implements the new `databaseVpc` feature flag that handles displaying the new layout and VPC functionality.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Implements Configure Networking field in DB Create
- Moves 'Manage Access' under this new field
- Adds new Assign a VPC field that allows users to select VPCs, associated Subnets, and toggle public access and submit create POST with this data.

## Target release date 🗓️

6/3/2025

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![db-create-before](https://github.com/user-attachments/assets/bb6ad5d4-3777-43e0-af59-2866ef301929) | ![db-create-vpc-disabled](https://github.com/user-attachments/assets/f1b3596a-86ee-49f9-b7f6-0d14ff377adf)![db-create-vpc-enabled](https://github.com/user-attachments/assets/a9700158-7b46-49d6-a76a-ace3c351607d)![db-create-after-vpc-2](https://github.com/user-attachments/assets/3378d489-3dfb-4a2e-b715-c24a36565908)|

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Make sure you have `databaseVpc` feature flag enabled
- Make sure you have access to both Databases and VPC (Networking > VPC) tabs on the right navigation panel.
- In the VPC tab, select (Create VPC) and create VPCs with Subnets under a specific region (You can also use mock data and skip configuring these)
- After the VPCs and Subnets have been created, access the Database Create page (Databases > Create Database Cluster)
- After the steps above, you should be able to test this feature.

### Reproduction steps
N/A

### Verification steps

- [ ] Verify that the 'Configure Networking' section is now visible when the feature flag is toggled on (databaseVpc)
- [ ] Verify that 'Manage access' is under this new section
- [ ] Verify that 'Assign a VPC' is displayed.
- [ ] Verify that 'VPC' selector field is disabled when no region is selected
- [ ] Verify that 'VPC' selector field is disabled when VPCs aren't available for the selected region
- [ ] Verify that VPC dropdown is enabled when a region that supports VPCs and has VPCs available is selected
- [ ] Verify that the notification banner is displayed when no VPC selections are made
- [ ] Select a VPC and see that the 'Subnet' and 'Enable public access' fields display below it
- [ ] Select the Subnet to see the list of available subnets from the currently selected VPC
- [ ] Submit and confirm that new 'private_network' properties get provided to the backend (vpc_id, subnet_id, public_access) based 'Assign a VPC' field state.
- [ ] Verify that when `databaseVpc` feature flag is off, the old layout and functionality is applied.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

---

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

---
