### PR TITLE
change: [M3-10061] - Update copy for LKE premium CPU notice

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Remove the `Accordion` wrapper from the default Alerts tab and replace it with `Paper` on the Linode details page ([#12215](https://github.com/linode/manager/pull/12215))
 - Update LKE flows for APL General Availability ([#12268](https://github.com/linode/manager/pull/12268))
+- Copy for premium plan recommendation for LKE ([#12300](https://github.com/linode/manager/pull/12300))
 
 ### Fixed:
 

--- a/packages/manager/src/features/Kubernetes/CreateCluster/PremiumCPUPlanNotice.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/PremiumCPUPlanNotice.tsx
@@ -6,8 +6,9 @@ import type { NoticeProps } from '@linode/ui';
 export const PremiumCPUPlanNotice = (props: NoticeProps) => {
   return (
     <Notice variant="info" {...props}>
-      Select Premium CPU instances for scenarios where low latency or high
-      throughput is expected.
+      To accommodate Enterprise workloads, especially where potential resource
+      contention can impact your workloads, using Premium instances is highly
+      recommended and required to achieve peak performance.
     </Notice>
   );
 };

--- a/packages/manager/src/features/Kubernetes/CreateCluster/PremiumCPUPlanNotice.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/PremiumCPUPlanNotice.tsx
@@ -6,9 +6,9 @@ import type { NoticeProps } from '@linode/ui';
 export const PremiumCPUPlanNotice = (props: NoticeProps) => {
   return (
     <Notice variant="info" {...props}>
-      To accommodate enterprise workloads, especially where potential resource
-      contention can impact your workloads, using Premium instances is highly
-      recommended and required to achieve peak performance.
+      To accommodate enterprise workloads, especially where resource contention
+      can impact your workloads, using Premium instances is highly recommended
+      and required to achieve peak performance.
     </Notice>
   );
 };

--- a/packages/manager/src/features/Kubernetes/CreateCluster/PremiumCPUPlanNotice.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/PremiumCPUPlanNotice.tsx
@@ -6,7 +6,7 @@ import type { NoticeProps } from '@linode/ui';
 export const PremiumCPUPlanNotice = (props: NoticeProps) => {
   return (
     <Notice variant="info" {...props}>
-      To accommodate Enterprise workloads, especially where potential resource
+      To accommodate enterprise workloads, especially where potential resource
       contention can impact your workloads, using Premium instances is highly
       recommended and required to achieve peak performance.
     </Notice>


### PR DESCRIPTION
## Description 📝

We've had an internal request to update the copy for  the existing info notice we display encouraging premium plan use for LKE node pools.

This copy should be displayed for all LKE tiers (standard and enterprise).

## Changes  🔄
- Update the copy in the notice, which is used on both the create cluster and 'Add a Node Pool' cluster details flow.

> [!NOTE] 
> I'm going to let this sit before merging for a day to let any final copy changes settle.

## Target release date 🗓️

⚠️  6/3/25 - this PR is pointed at staging

## Preview 📷

| Before  | After   |
| ------- | ------- |
| Create flow: ![Screenshot 2025-05-29 at 12 20 04 PM](https://github.com/user-attachments/assets/6237a3a2-c78c-418c-a7c9-7a94c131222a) Add a Node Pool drawer: ![Screenshot 2025-05-29 at 12 20 26 PM](https://github.com/user-attachments/assets/486b4e96-8281-44fc-9636-71d2d9b2a981)| Create flow: ![Screenshot 2025-05-29 at 12 20 47 PM](https://github.com/user-attachments/assets/f6dc0eb5-8f26-4b3d-ac7f-c0368bdc2dbf) Add a Node Pool drawer: ![Screenshot 2025-05-29 at 12 21 04 PM](https://github.com/user-attachments/assets/ce26bd00-a6a2-40bc-85f5-a44922cb11f4) |

## How to test 🧪

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Go to https://cloud.linode.com/kubernetes/create or the cluster details page of an existing cluster -> 'Add a Node Pool' and observe the notice with its current copy

### Verification steps

(How to verify changes)

- [ ] Check out this branch and do the same. Observe the copy change. Observe that the notice is still present, regardless of cluster tier selection (it applies to both).

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>