### PR TITLE
fix: [M3-10067] - Remove custom styling for SMS Notice

### DIFF
--- a/packages/manager/.changeset/pr-12301-fixed-1748616080981.md
+++ b/packages/manager/.changeset/pr-12301-fixed-1748616080981.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Remove custom styling for SMS Notice ([#12301](https://github.com/linode/manager/pull/12301))

--- a/packages/manager/src/features/Profile/AuthenticationSettings/SMSMessaging.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/SMSMessaging.tsx
@@ -1,12 +1,5 @@
 import { useProfile, useSMSOptOutMutation } from '@linode/queries';
-import {
-  ActionsPanel,
-  Box,
-  Button,
-  Notice,
-  omittedProps,
-  Typography,
-} from '@linode/ui';
+import { ActionsPanel, Box, Button, Notice, Typography } from '@linode/ui';
 import { styled } from '@mui/material/styles';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
@@ -49,21 +42,18 @@ export const SMSMessaging = () => {
 
   return (
     <>
-      <StyledNotice
-        hasVerifiedPhoneNumber={hasVerifiedPhoneNumber}
+      <Notice
         spacingBottom={16}
         spacingLeft={1}
         spacingTop={12}
         variant={hasVerifiedPhoneNumber ? 'success' : 'warning'}
       >
         <Typography sx={{ fontSize: '0.875rem !important' }}>
-          <b>
-            {hasVerifiedPhoneNumber
-              ? 'You have opted in to SMS messaging.'
-              : 'You are opted out of SMS messaging.'}
-          </b>
+          {hasVerifiedPhoneNumber
+            ? 'You have opted in to SMS messaging.'
+            : 'You are opted out of SMS messaging.'}
         </Typography>
-      </StyledNotice>
+      </Notice>
       <StyledCopy>
         An authentication code is sent via SMS as part of the phone verification
         process. Messages are not sent for any other reason. SMS authentication
@@ -130,14 +120,3 @@ const StyledCopy = styled(Typography, {
   lineHeight: '20px',
   maxWidth: 960,
 }));
-
-const StyledNotice = styled(Notice, {
-  label: 'StyledNotice',
-  shouldForwardProp: omittedProps(['hasVerifiedPhoneNumber']),
-})<{ hasVerifiedPhoneNumber: boolean }>(
-  ({ hasVerifiedPhoneNumber, theme }) => ({
-    borderLeft: hasVerifiedPhoneNumber
-      ? `5px solid ${theme.color.green}`
-      : `5px solid ${theme.color.yellow}`,
-  })
-);


### PR DESCRIPTION
## Description 📝
The SMS Notice component currently has custom styling that clashes with our Akamai Design System (ADS) recommendations. These custom styles need to be identified and removed to ensure consistency with our design system standards.

## Changes  🔄
- Removed styled component
- Removed bolding

## Target release date 🗓️
N/A

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-05-29 at 2 58 25 PM](https://github.com/user-attachments/assets/e45b02c7-d422-45c6-a5b2-8ad6fdde04ec) | ![Screenshot 2025-05-29 at 2 59 34 PM](https://github.com/user-attachments/assets/4ef10b03-81b3-4c30-906c-3f9b1aa151c4) |
| ![Screenshot 2025-05-29 at 2 58 15 PM](https://github.com/user-attachments/assets/a98a6a38-fbc4-4814-a167-326676632b24) | ![Screenshot 2025-05-29 at 2 59 40 PM](https://github.com/user-attachments/assets/389bfc91-a95f-46bd-8415-e265e837cff6) |

## How to test 🧪

### Verification steps
- Go to /profile/auth
- Ensure you have opted out of SMS or have an account that has
- Observe banner changes

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>