### PR TITLE
chore: [M3-10082] - Remove `ramda` from the `utilities` package

### DIFF
--- a/packages/utilities/.changeset/pr-12313-added-1748968238140.md
+++ b/packages/utilities/.changeset/pr-12313-added-1748968238140.md
@@ -1,0 +1,5 @@
+---
+"@linode/utilities": Added
+---
+
+Unit test for `getAll` ([#12313](https://github.com/linode/manager/pull/12313))

--- a/packages/utilities/.changeset/pr-12313-removed-1748968164214.md
+++ b/packages/utilities/.changeset/pr-12313-removed-1748968164214.md
@@ -1,0 +1,5 @@
+---
+"@linode/utilities": Removed
+---
+
+Ramda dependency ([#12313](https://github.com/linode/manager/pull/12313))

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@linode/api-v4": "workspace:*",
     "luxon": "3.4.4",
-    "ramda": "~0.25.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -43,7 +42,6 @@
     "@testing-library/jest-dom": "~6.4.2",
     "@testing-library/react": "~16.0.0",
     "@types/luxon": "3.4.2",
-    "@types/ramda": "0.25.16",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.18",
     "factory.ts": "^0.5.1"

--- a/packages/utilities/src/helpers/getAll.test.ts
+++ b/packages/utilities/src/helpers/getAll.test.ts
@@ -37,16 +37,6 @@ describe('getAll', () => {
 
     const result = await getAllLinodes();
 
-    // Verify the data is present and in the correct order
-    expect(result.data).toStrictEqual([
-      ...firstPage.data,
-      ...secondPage.data,
-      ...thirdPage.data,
-    ]);
-
-    // Verify the result count is correct
-    expect(result.results).toBe(75);
-
     // Verify the getter function was called the correct number of times total
     expect(getLinodes).toHaveBeenCalledTimes(3);
 
@@ -68,5 +58,15 @@ describe('getAll', () => {
       { page: 3, page_size: 25 },
       undefined,
     );
+
+    // Verify the data is present and in the correct order
+    expect(result.data).toStrictEqual([
+      ...firstPage.data,
+      ...secondPage.data,
+      ...thirdPage.data,
+    ]);
+
+    // Verify the result count is correct
+    expect(result.results).toBe(75);
   });
 });

--- a/packages/utilities/src/helpers/getAll.test.ts
+++ b/packages/utilities/src/helpers/getAll.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { linodeFactory } from '../factories';
+import { getAll } from './getAll';
+
+describe('getAll', () => {
+  it('should fetch the first page, then all other pages', async () => {
+    const getLinodes = vi.fn();
+    const getAllLinodes = getAll(getLinodes, 25);
+
+    const firstPage = {
+      data: linodeFactory.buildList(25),
+      page: 1,
+      pages: 3,
+      results: 75,
+    };
+
+    const secondPage = {
+      data: linodeFactory.buildList(25),
+      page: 2,
+      pages: 3,
+      results: 75,
+    };
+
+    const thirdPage = {
+      data: linodeFactory.buildList(25),
+      page: 3,
+      pages: 3,
+      results: 75,
+    };
+
+    getLinodes.mockImplementationOnce(async () => firstPage);
+
+    getLinodes.mockImplementationOnce(async () => secondPage);
+
+    getLinodes.mockImplementationOnce(async () => thirdPage);
+
+    const result = await getAllLinodes();
+
+    // Verify the data is present and in the correct order
+    expect(result.data).toStrictEqual([
+      ...firstPage.data,
+      ...secondPage.data,
+      ...thirdPage.data,
+    ]);
+
+    // Verify the result count is correct
+    expect(result.results).toBe(75);
+
+    // Verify the getter function was called the correct number of times total
+    expect(getLinodes).toHaveBeenCalledTimes(3);
+
+    // Lastly, verify each function call had the correct params
+
+    // The first call should not include a page number, but should include the given page size
+    expect(getLinodes).toHaveBeenNthCalledWith(1, { page_size: 25 }, undefined);
+
+    // The second call should include the page number and page size
+    expect(getLinodes).toHaveBeenNthCalledWith(
+      2,
+      { page: 2, page_size: 25 },
+      undefined,
+    );
+
+    // The third call should include the page number and page size
+    expect(getLinodes).toHaveBeenNthCalledWith(
+      3,
+      { page: 3, page_size: 25 },
+      undefined,
+    );
+  });
+});

--- a/packages/utilities/src/helpers/getAll.test.ts
+++ b/packages/utilities/src/helpers/getAll.test.ts
@@ -40,7 +40,7 @@ describe('getAll', () => {
     // Verify the getter function was called the correct number of times total
     expect(getLinodes).toHaveBeenCalledTimes(3);
 
-    // Lastly, verify each function call had the correct params
+    // Verify each call to our "getter" function has the correct params
 
     // The first call should not include a page number, but should include the given page size
     expect(getLinodes).toHaveBeenNthCalledWith(1, { page_size: 25 }, undefined);

--- a/packages/utilities/src/helpers/getAll.ts
+++ b/packages/utilities/src/helpers/getAll.ts
@@ -74,6 +74,7 @@ export const getAll: <T>(
 
         const promises: Promise<any>[] = [];
 
+        // For all remaining pages, build a promise for each page that will be resolved in parallel.
         for (let i = page + 1; i < pages + 1; i++) {
           const promise = getter({ ...pagination, page: i }, filter).then(
             (response) => response.data,

--- a/packages/utilities/src/helpers/getAll.ts
+++ b/packages/utilities/src/helpers/getAll.ts
@@ -1,5 +1,3 @@
-import { range } from 'ramda';
-
 import { API_MAX_PAGE_SIZE } from '../constants';
 
 import type { Filter, Params } from '@linode/api-v4';
@@ -74,18 +72,16 @@ export const getAll: <T>(
           cb(results);
         }
 
-        // Create an iterable list of the remaining pages.
-        const remainingPages = range(page + 1, pages + 1);
-
         const promises: Promise<any>[] = [];
-        remainingPages.forEach((thisPage) => {
-          const promise = getter(
-            { ...pagination, page: thisPage },
-            filter,
-          ).then((response) => response.data);
+
+        for (let i = page + 1; i < pages + 1; i++) {
+          const promise = getter({ ...pagination, page: i }, filter).then(
+            (response) => response.data,
+          );
+
           promises.push(promise);
-        });
-        //
+        }
+
         return (
           Promise.all(promises)
             /** We're given data[][], so we flatten that, and append the first page response. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -768,9 +768,6 @@ importers:
       luxon:
         specifier: 3.4.4
         version: 3.4.4
-      ramda:
-        specifier: ~0.25.0
-        version: 0.25.0
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -793,9 +790,6 @@ importers:
       '@types/luxon':
         specifier: 3.4.2
         version: 3.4.2
-      '@types/ramda':
-        specifier: 0.25.16
-        version: 0.25.16
       '@types/react':
         specifier: ^18.2.55
         version: 18.3.12


### PR DESCRIPTION
## Description 📝

- Removes `ramda` 👹 from the `@linode/utilities` package by removing it from the `getAll` helper function
- Adds a unit test for the `getAll` function 🧪 

## How to test 🧪

- Verify the new ramda-less code seems safe, performant, and does the same thing as the old code

```sh
pnpm test getAll
```

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
