### PR TITLE
chore: [M3-10089] - Update `qrcode.react` to `4.2.0`

### DIFF
--- a/packages/manager/.changeset/pr-12322-tech-stories-1748968017220.md
+++ b/packages/manager/.changeset/pr-12322-tech-stories-1748968017220.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Upgrade `qrcode.react` to `4.2.0` ([#12322](https://github.com/linode/manager/pull/12322))

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -68,7 +68,7 @@
     "markdown-it": "^14.1.0",
     "md5": "^2.2.1",
     "notistack": "^3.0.1",
-    "qrcode.react": "^0.8.0",
+    "qrcode.react": "^4.2.0",
     "ramda": "~0.25.0",
     "react": "^18.2.0",
     "react-csv": "^2.0.3",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -159,7 +159,6 @@
     "@types/md5": "^2.1.32",
     "@types/mocha": "^10.0.2",
     "@types/node": "^20.17.0",
-    "@types/qrcode.react": "^0.8.0",
     "@types/ramda": "0.25.16",
     "@types/react": "^18.2.55",
     "@types/react-csv": "^1.1.3",

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/QRCodeForm.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/QRCodeForm.tsx
@@ -1,7 +1,7 @@
 import { Typography } from '@linode/ui';
 import { styled } from '@mui/material/styles';
-import QRCode from 'qrcode.react';
-import * as React from 'react';
+import { QRCodeCanvas } from 'qrcode.react';
+import React from 'react';
 
 import { CopyableTextField } from 'src/components/CopyableTextField/CopyableTextField';
 
@@ -18,7 +18,7 @@ export const QRCodeForm = (props: Props) => {
         Scan this QR code to add your Cloud Manager account to your 2FA app:
       </StyledInstructions>
       <StyledQRCodeContainer>
-        <QRCode
+        <QRCodeCanvas
           data-qa-qr-code
           level="H" // QR code error checking level ("High"); gives a higher resolution code
           size={200}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,8 +279,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       qrcode.react:
-        specifier: ^0.8.0
-        version: 0.8.0(react@18.3.1)
+        specifier: ^4.2.0
+        version: 4.2.0(react@18.3.1)
       ramda:
         specifier: ~0.25.0
         version: 0.25.0
@@ -5572,13 +5572,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qr.js@0.0.0:
-    resolution: {integrity: sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==}
-
-  qrcode.react@0.8.0:
-    resolution: {integrity: sha512-16wKpuFvLwciIq2YAsfmPUCnSR8GrYPsXRK5KVdcIuX0+W/MKZbBkFhl44ttRx4TWZHqRjfztoWOxdPF0Hb9JA==}
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
     peerDependencies:
-      react: ^15.5.3 || ^16.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
@@ -12100,12 +12097,8 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qr.js@0.0.0: {}
-
-  qrcode.react@0.8.0(react@18.3.1):
+  qrcode.react@4.2.0(react@18.3.1):
     dependencies:
-      prop-types: 15.8.1
-      qr.js: 0.0.0
       react: 18.3.1
 
   qs@6.14.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -453,9 +453,6 @@ importers:
       '@types/node':
         specifier: ^20.17.0
         version: 20.17.6
-      '@types/qrcode.react':
-        specifier: ^0.8.0
-        version: 0.8.2
       '@types/ramda':
         specifier: 0.25.16
         version: 0.25.16
@@ -2698,9 +2695,6 @@ packages:
 
   '@types/prop-types@15.7.14':
     resolution: {integrity: sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==}
-
-  '@types/qrcode.react@0.8.2':
-    resolution: {integrity: sha512-nxGOQzQBV3Ny1g7uMGa3jTAi7SNHUUJ91K7EMO1FEQtb38A4vwq3pZvz0QcfIN7ypP4xTwl7G6NIQMCZZQoXIQ==}
 
   '@types/raf@3.4.3':
     resolution: {integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==}
@@ -8622,10 +8616,6 @@ snapshots:
   '@types/prop-types@15.7.13': {}
 
   '@types/prop-types@15.7.14': {}
-
-  '@types/qrcode.react@0.8.2':
-    dependencies:
-      '@types/react': 18.3.12
 
   '@types/raf@3.4.3':
     optional: true


### PR DESCRIPTION
## Description 📝

- Updates `qrcode.react` to the latest version 📦  to resolve a pnpm peerDependency warning
  - I'm also doing this a a percaution for compatibility with React 19. React 19 may work without updating this, but I'm doing it to be safe
- Removes `@types/qrcode.react` because `qrcode.react`  ships its own types! 🎉 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-06-03 at 11 18 49 AM](https://github.com/user-attachments/assets/959aaa33-0fcf-437e-bc54-a81c90535104) | ![Screenshot 2025-06-03 at 12 25 12 PM](https://github.com/user-attachments/assets/6272714d-38a8-4e25-9222-9261fed387b9) |
| pnpm warns about `qrcode.react`'s React peerDependency  | Warning is gone |




## How to test 🧪

- Checkout this PR or use a preview link
- Go to `http://localhost:3000/profile/auth`
- Go through the 2FA setup / reset process and verify the QR code works as expected
- Verify the QR code is styled the same as it is in production. (Verify there are no style regressions)

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>