### PR TITLE
feat: [UIE-8619, UIE-8616, UIE-8753] - DBaaS - Creating new Networking tab in DB details,

### DIFF
--- a/packages/api-v4/.changeset/pr-12324-changed-1748976166235.md
+++ b/packages/api-v4/.changeset/pr-12324-changed-1748976166235.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Changed
+---
+
+BaseDatabase type now includes private_network property ([#12324](https://github.com/linode/manager/pull/12324))

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -196,6 +196,7 @@ export interface PendingUpdates {
 // Database is the base interface for the shape of data returned by /databases/{engine}/instances
 interface BaseDatabase extends DatabaseInstance {
   port: number;
+  private_network?: null | PrivateNetwork; //  TODO (UIE-8831): Confirm whether this still needs to be optional (?) post VPC release.
   /** @Deprecated used by rdbms-legacy only, rdbms-default always uses TLS */
   ssl_connection: boolean;
   total_disk_size_gb: number;

--- a/packages/manager/.changeset/pr-12324-upcoming-features-1748976069707.md
+++ b/packages/manager/.changeset/pr-12324-upcoming-features-1748976069707.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Creating Networking tab for database cluster details, Adding Connection Type field to Summary, and moving Manage Access to Networking tab ([#12324](https://github.com/linode/manager/pull/12324))

--- a/packages/manager/.changeset/pr-12324-upcoming-features-1748976069707.md
+++ b/packages/manager/.changeset/pr-12324-upcoming-features-1748976069707.md
@@ -2,4 +2,4 @@
 "@linode/manager": Upcoming Features
 ---
 
-Creating Networking tab for database cluster details, Adding Connection Type field to Summary, and moving Manage Access to Networking tab ([#12324](https://github.com/linode/manager/pull/12324))
+Add Networking tab for database cluster details, add Connection Type field to Summary, and move Manage Access to Networking tab ([#12324](https://github.com/linode/manager/pull/12324))

--- a/packages/manager/cypress/e2e/core/databases/update-database.spec.ts
+++ b/packages/manager/cypress/e2e/core/databases/update-database.spec.ts
@@ -21,6 +21,7 @@ import {
   mockUpdateDatabase,
   mockUpdateSuspendResumeDatabase,
 } from 'support/intercepts/databases';
+import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
 import { ui } from 'support/ui';
 import {
   randomIp,
@@ -273,6 +274,14 @@ const validateSuspendResume = (
         .click();
     });
 
+  // Cannot change maintenance schedule when database/cluster is suspended or resuming.
+  modifyMaintenanceWindow('Day of Week', 'Wednesday');
+  cy.wait('@updateDatabase');
+  cy.findByText(errorMessage).should('be.visible');
+
+  // Navigate to "Networking" tab.
+  ui.tabList.findTabByTitle('Networking').click();
+
   // Cannot add or remove allowed IPs when database/cluster is suspended or resuming.
   removeAllowedIp(allowedIp);
   cy.wait('@updateDatabase');
@@ -290,11 +299,6 @@ const validateSuspendResume = (
     cy.findByText(errorMessage).should('be.visible');
     ui.drawerCloseButton.find().click();
   });
-
-  // Cannot change maintenance schedule when database/cluster is suspended or resuming.
-  modifyMaintenanceWindow('Day of Week', 'Wednesday');
-  cy.wait('@updateDatabase');
-  cy.findByText(errorMessage).should('be.visible');
 };
 
 const validateActionItems = (state: string, label: string) => {
@@ -332,6 +336,11 @@ const validateActionItems = (state: string, label: string) => {
 };
 
 describe('Update database clusters', () => {
+  beforeEach(() => {
+    mockAppendFeatureFlags({
+      databaseVpc: true,
+    });
+  });
   databaseConfigurations.forEach(
     (configuration: DatabaseClusterConfiguration) => {
       describe(`updates a ${configuration.linodeType} ${configuration.engine} v${configuration.version}.x ${configuration.clusterSize}-node cluster`, () => {
@@ -418,25 +427,7 @@ describe('Update database clusters', () => {
           resetRootPassword();
           cy.wait('@resetRootPassword');
 
-          // Remove allowed IP, manage IP access control.
-          mockUpdateDatabase(database.id, database.engine, {
-            ...database,
-            allow_list: [],
-          }).as('updateDatabaseAllowedIp');
-          removeAllowedIp(allowedIp);
-          cy.wait('@updateDatabaseAllowedIp');
-
-          mockUpdateDatabase(database.id, database.engine, {
-            ...database,
-            allow_list: [newAllowedIp],
-          }).as('updateAccessControl');
-          manageAccessControl([newAllowedIp]);
-          cy.wait('@updateAccessControl');
-          cy.get('[data-qa-access-controls]').within(() => {
-            cy.findByText(newAllowedIp).should('be.visible');
-          });
-
-          // Change maintenance window and databe version upgrade.
+          // Change maintenance window and database version upgrade.
           mockUpdateDatabase(database.id, database.engine, database).as(
             'updateDatabaseMaintenance'
           );
@@ -453,6 +444,28 @@ describe('Update database clusters', () => {
           ui.toast.assertMessage(
             'Maintenance Window settings saved successfully.'
           );
+
+          // Navigate to "Networking" tab.
+          ui.tabList.findTabByTitle('Networking').click();
+
+          // Remove allowed IP, manage IP access control.
+          mockUpdateDatabase(database.id, database.engine, {
+            ...database,
+            allow_list: [],
+          }).as('updateDatabaseAllowedIp');
+          removeAllowedIp(allowedIp);
+          cy.wait('@updateDatabaseAllowedIp');
+
+          mockUpdateDatabase(database.id, database.engine, {
+            ...database,
+            allow_list: [newAllowedIp],
+          }).as('updateAccessControl');
+
+          manageAccessControl([newAllowedIp]);
+          cy.wait('@updateAccessControl');
+          cy.get('[data-qa-access-controls]').within(() => {
+            cy.findByText(newAllowedIp).should('be.visible');
+          });
         });
 
         /*
@@ -545,24 +558,6 @@ describe('Update database clusters', () => {
                 .click();
             });
 
-          // Remove allowed IP, manage IP access control.
-          mockUpdateDatabase(database.id, database.engine, {
-            ...database,
-            allow_list: [],
-          }).as('updateDatabaseAllowedIp');
-          removeAllowedIp(allowedIp);
-          cy.wait('@updateDatabaseAllowedIp');
-
-          mockUpdateDatabase(database.id, database.engine, {
-            ...database,
-            allow_list: [newAllowedIp],
-          }).as('updateAccessControl');
-          manageAccessControl([newAllowedIp]);
-          cy.wait('@updateAccessControl');
-          cy.get('[data-qa-access-controls]').within(() => {
-            cy.findByText(newAllowedIp).should('be.visible');
-          });
-
           // Change maintenance window and databe version upgrade.
           mockUpdateDatabase(database.id, database.engine, database).as(
             'updateDatabaseMaintenance'
@@ -584,6 +579,28 @@ describe('Update database clusters', () => {
           cy.get('[data-qa-settings-button="Suspend Cluster"]').should(
             'be.disabled'
           );
+
+          // Navigate to "Networking" tab.
+          ui.tabList.findTabByTitle('Networking').click();
+
+          // Remove allowed IP, manage IP access control.
+          mockUpdateDatabase(database.id, database.engine, {
+            ...database,
+            allow_list: [],
+          }).as('updateDatabaseAllowedIp');
+          removeAllowedIp(allowedIp);
+          cy.wait('@updateDatabaseAllowedIp');
+
+          mockUpdateDatabase(database.id, database.engine, {
+            ...database,
+            allow_list: [newAllowedIp],
+          }).as('updateAccessControl');
+
+          manageAccessControl([newAllowedIp]);
+          cy.wait('@updateAccessControl');
+          cy.get('[data-qa-access-controls]').within(() => {
+            cy.findByText(newAllowedIp).should('be.visible');
+          });
         });
 
         /*

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -229,6 +229,11 @@ export const databaseFactory = Factory.Sync.makeFactory<Database>({
   },
   oldest_restore_time: '2024-09-15T17:15:12',
   platform: Factory.each((i) => (adb10(i) ? 'rdbms-legacy' : 'rdbms-default')),
+  private_network: {
+    public_access: false,
+    subnet_id: 1,
+    vpc_id: 123,
+  },
   port: 3306,
   region: 'us-east',
   ssl_connection: false,

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworking.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworking.test.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react';
+import { describe, it } from 'vitest';
+
+import { vpcFactory } from 'src/factories';
+import { databaseFactory } from 'src/factories/databases';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { DatabaseManageNetworking } from './DatabaseManageNetworking';
+
+// Hoist query mocks
+const queryMocks = vi.hoisted(() => ({
+  useVPCQuery: vi.fn().mockReturnValue({ data: {} }),
+}));
+
+vi.mock('@linode/queries', async () => {
+  const actual = await vi.importActual('@linode/queries');
+  return {
+    ...actual,
+    useVPCQuery: queryMocks.useVPCQuery,
+  };
+});
+
+const loadingTestId = 'circle-progress';
+
+describe('DatabaseManageNetworking Component', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    queryMocks.useVPCQuery.mockReturnValue({
+      data: vpcFactory.build(),
+    });
+  });
+
+  it('Should render Manage Networking field with Public grid variation when no VPC is configured for the database', () => {
+    const mockDatabase = databaseFactory.build({ platform: 'rdbms-default' });
+    mockDatabase.private_network = null;
+    const { getByRole, queryByText } = renderWithTheme(
+      <DatabaseManageNetworking database={mockDatabase} />
+    );
+
+    const heading = getByRole('heading');
+    expect(heading.textContent).toBe('Manage Networking');
+    const connectionTypeLabel = queryByText('Connection Type');
+    expect(connectionTypeLabel).toBeInTheDocument();
+    const connectionTypeValue = queryByText('Public');
+    expect(connectionTypeValue).toBeInTheDocument();
+  });
+
+  it('should render a loading state', async () => {
+    queryMocks.useVPCQuery.mockReturnValue({
+      isLoading: true,
+      data: null,
+    });
+    const mockDatabase = databaseFactory.build({ platform: 'rdbms-default' });
+    const { getByTestId } = await renderWithTheme(
+      <DatabaseManageNetworking database={mockDatabase} />
+    );
+    // Should render a loading state
+    expect(getByTestId(loadingTestId)).toBeInTheDocument();
+  });
+
+  it('should render error state when a VPC is configured, but useVPCQuery responds with an error', async () => {
+    queryMocks.useVPCQuery.mockReturnValue({
+      error: new Error('Failed to fetch VPC'),
+    });
+    const mockDatabase = databaseFactory.build({ platform: 'rdbms-default' });
+    const { getByText } = await renderWithTheme(
+      <DatabaseManageNetworking database={mockDatabase} />
+    );
+    // Should render a loading state
+    const expectedErrorText =
+      'There was a problem retrieving your VPC. Please try again later.';
+    const errorState = getByText(expectedErrorText);
+    expect(errorState).toBeInTheDocument();
+  });
+
+  it('should render error state when a VPC is configured, but useVPCQuery responds without a VPC', async () => {
+    queryMocks.useVPCQuery.mockReturnValue({
+      data: null,
+    });
+    const mockDatabase = databaseFactory.build({ platform: 'rdbms-default' });
+    const { getByText } = await renderWithTheme(
+      <DatabaseManageNetworking database={mockDatabase} />
+    );
+    // Should render a loading state
+    const expectedErrorText =
+      'There was a problem retrieving your VPC. Please try again later.';
+    const errorState = getByText(expectedErrorText);
+    expect(errorState).toBeInTheDocument();
+  });
+
+  it('Should render Manage Networking field with VPC grid variation when VPC is configured for the database', () => {
+    queryMocks.useVPCQuery.mockReturnValue({
+      isLoading: false,
+      data: vpcFactory.build(),
+      error: null,
+    });
+    const mockDatabase = databaseFactory.build({ platform: 'rdbms-default' });
+    const { getByRole, queryByText, getAllByText } = renderWithTheme(
+      <DatabaseManageNetworking database={mockDatabase} />
+    );
+
+    const heading = getByRole('heading');
+    expect(heading.textContent).toBe('Manage Networking');
+    const connectionTypeLabel = queryByText('Connection Type');
+    expect(connectionTypeLabel).toBeInTheDocument();
+    const connectionTypeValue = getAllByText('VPC');
+    expect(connectionTypeValue.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworking.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworking.test.tsx
@@ -1,3 +1,4 @@
+import { screen } from '@testing-library/react';
 import * as React from 'react';
 import { describe, it } from 'vitest';
 
@@ -6,6 +7,8 @@ import { databaseFactory } from 'src/factories/databases';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { DatabaseManageNetworking } from './DatabaseManageNetworking';
+
+const defaultPlatform = 'rdbms-default';
 
 // Hoist query mocks
 const queryMocks = vi.hoisted(() => ({
@@ -31,17 +34,15 @@ describe('DatabaseManageNetworking Component', () => {
   });
 
   it('Should render Manage Networking field with Public grid variation when no VPC is configured for the database', () => {
-    const mockDatabase = databaseFactory.build({ platform: 'rdbms-default' });
+    const mockDatabase = databaseFactory.build({ platform: defaultPlatform });
     mockDatabase.private_network = null;
-    const { getByRole, queryByText } = renderWithTheme(
-      <DatabaseManageNetworking database={mockDatabase} />
-    );
+    renderWithTheme(<DatabaseManageNetworking database={mockDatabase} />);
 
-    const heading = getByRole('heading');
+    const heading = screen.getByRole('heading');
     expect(heading.textContent).toBe('Manage Networking');
-    const connectionTypeLabel = queryByText('Connection Type');
+    const connectionTypeLabel = screen.queryByText('Connection Type');
     expect(connectionTypeLabel).toBeInTheDocument();
-    const connectionTypeValue = queryByText('Public');
+    const connectionTypeValue = screen.queryByText('Public');
     expect(connectionTypeValue).toBeInTheDocument();
   });
 
@@ -50,26 +51,23 @@ describe('DatabaseManageNetworking Component', () => {
       isLoading: true,
       data: null,
     });
-    const mockDatabase = databaseFactory.build({ platform: 'rdbms-default' });
-    const { getByTestId } = await renderWithTheme(
-      <DatabaseManageNetworking database={mockDatabase} />
-    );
+    const mockDatabase = databaseFactory.build({ platform: defaultPlatform });
+    renderWithTheme(<DatabaseManageNetworking database={mockDatabase} />);
     // Should render a loading state
-    expect(getByTestId(loadingTestId)).toBeInTheDocument();
+    const loadingSpinner = screen.getByTestId(loadingTestId);
+    expect(loadingSpinner).toBeInTheDocument();
   });
 
   it('should render error state when a VPC is configured, but useVPCQuery responds with an error', async () => {
     queryMocks.useVPCQuery.mockReturnValue({
       error: new Error('Failed to fetch VPC'),
     });
-    const mockDatabase = databaseFactory.build({ platform: 'rdbms-default' });
-    const { getByText } = await renderWithTheme(
-      <DatabaseManageNetworking database={mockDatabase} />
-    );
+    const mockDatabase = databaseFactory.build({ platform: defaultPlatform });
+    renderWithTheme(<DatabaseManageNetworking database={mockDatabase} />);
     // Should render a loading state
     const expectedErrorText =
       'There was a problem retrieving your VPC. Please try again later.';
-    const errorState = getByText(expectedErrorText);
+    const errorState = screen.getByText(expectedErrorText);
     expect(errorState).toBeInTheDocument();
   });
 
@@ -77,14 +75,12 @@ describe('DatabaseManageNetworking Component', () => {
     queryMocks.useVPCQuery.mockReturnValue({
       data: null,
     });
-    const mockDatabase = databaseFactory.build({ platform: 'rdbms-default' });
-    const { getByText } = await renderWithTheme(
-      <DatabaseManageNetworking database={mockDatabase} />
-    );
+    const mockDatabase = databaseFactory.build({ platform: defaultPlatform });
+    renderWithTheme(<DatabaseManageNetworking database={mockDatabase} />);
     // Should render a loading state
     const expectedErrorText =
       'There was a problem retrieving your VPC. Please try again later.';
-    const errorState = getByText(expectedErrorText);
+    const errorState = screen.getByText(expectedErrorText);
     expect(errorState).toBeInTheDocument();
   });
 
@@ -94,16 +90,14 @@ describe('DatabaseManageNetworking Component', () => {
       data: vpcFactory.build(),
       error: null,
     });
-    const mockDatabase = databaseFactory.build({ platform: 'rdbms-default' });
-    const { getByRole, queryByText, getAllByText } = renderWithTheme(
-      <DatabaseManageNetworking database={mockDatabase} />
-    );
+    const mockDatabase = databaseFactory.build({ platform: defaultPlatform });
+    renderWithTheme(<DatabaseManageNetworking database={mockDatabase} />);
 
-    const heading = getByRole('heading');
+    const heading = screen.getByRole('heading');
     expect(heading.textContent).toBe('Manage Networking');
-    const connectionTypeLabel = queryByText('Connection Type');
+    const connectionTypeLabel = screen.queryByText('Connection Type');
     expect(connectionTypeLabel).toBeInTheDocument();
-    const connectionTypeValue = getAllByText('VPC');
+    const connectionTypeValue = screen.getAllByText('VPC');
     expect(connectionTypeValue.length).toBeGreaterThan(0);
   });
 });

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworking.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworking.tsx
@@ -1,0 +1,170 @@
+import { useVPCQuery } from '@linode/queries';
+import { Button, CircleProgress, ErrorState, Typography } from '@linode/ui';
+import { Grid } from '@mui/material';
+import React from 'react';
+import { makeStyles } from 'tss-react/mui';
+
+import { getReadOnlyHost } from '../../utilities';
+import {
+  StyledGridContainer,
+  StyledLabelTypography,
+  StyledValueGrid,
+} from '../DatabaseSummary/DatabaseSummaryClusterConfiguration.style';
+
+import type { Database } from '@linode/api-v4';
+import type { Theme } from '@mui/material';
+
+interface Props {
+  database: Database;
+  disabled?: boolean;
+}
+
+export const DatabaseManageNetworking = ({ database }: Props) => {
+  const useStyles = makeStyles()((theme: Theme) => ({
+    manageNetworkingBtn: {
+      minWidth: 225,
+      [theme.breakpoints.down('md')]: {
+        alignSelf: 'flex-start',
+        marginBottom: '1rem',
+      },
+    },
+    sectionText: {
+      marginBottom: '1rem',
+      marginRight: 0,
+      [theme.breakpoints.down('sm')]: {
+        width: '100%',
+      },
+      width: '65%',
+    },
+    sectionTitle: {
+      marginBottom: '0.25rem',
+    },
+    sectionTitleAndText: {
+      width: '100%',
+    },
+    topSection: {
+      alignItems: 'center',
+      display: 'flex',
+      justifyContent: 'space-between',
+      [theme.breakpoints.down('md')]: {
+        flexDirection: 'column',
+      },
+    },
+    provisioningText: {
+      font: theme.font.normal,
+      fontStyle: 'italic',
+    },
+  }));
+
+  const { classes } = useStyles();
+  const vpcId = Number(database.private_network?.vpc_id);
+  const hasVPCConfigured = Boolean(vpcId);
+  const gridContainerSize = { lg: 7, md: 10 };
+  const gridValueSize = { md: 8, xs: 9 };
+  const gridLabelSize = { md: 4, xs: 3 };
+
+  const { data: vpc, isLoading, error } = useVPCQuery(vpcId, hasVPCConfigured);
+
+  const currentSubnet = React.useMemo(
+    () =>
+      vpc?.subnets.find(
+        (subnet) => subnet.id === database?.private_network?.subnet_id
+      ),
+    [vpc]
+  );
+
+  const readOnlyHost = () => {
+    const defaultValue = 'N/A';
+    const value = getReadOnlyHost(database)
+      ? getReadOnlyHost(database)
+      : defaultValue;
+    return <span>{value}</span>;
+  };
+
+  if (isLoading) {
+    return <CircleProgress />;
+  }
+
+  if (error || (hasVPCConfigured && !vpc)) {
+    return (
+      <ErrorState errorText="There was a problem retrieving your VPC. Please try again later." />
+    );
+  }
+
+  return (
+    <>
+      <div className={classes.topSection}>
+        <div className={classes.sectionTitleAndText}>
+          <div className={classes.sectionTitle}>
+            <Typography variant="h3">Manage Networking</Typography>
+          </div>
+          <Typography sx={{ maxWidth: '500px' }}>
+            Update access settings or the VPC assignment.
+            <br />
+            Note that a change of VPC assignment settings can disrupt service
+            availability. Avoid writing data to the database while a change is
+            in progress.
+          </Typography>
+        </div>
+        <Button
+          buttonType="outlined"
+          className={classes.manageNetworkingBtn}
+          disabled={true} // Disabled until manage networking is fully implemented
+          onClick={() => null}
+        >
+          Manage Networking
+        </Button>
+      </div>
+
+      <StyledGridContainer container size={gridContainerSize} spacing={0}>
+        <Grid size={gridLabelSize}>
+          <StyledLabelTypography>Connection Type</StyledLabelTypography>
+        </Grid>
+        <StyledValueGrid size={gridValueSize}>
+          {hasVPCConfigured ? 'VPC' : 'Public'}
+        </StyledValueGrid>
+        {hasVPCConfigured ? (
+          <>
+            <Grid size={gridLabelSize}>
+              <StyledLabelTypography>VPC</StyledLabelTypography>
+            </Grid>
+            <StyledValueGrid size={gridValueSize}>{vpc?.label}</StyledValueGrid>
+            <Grid size={gridLabelSize}>
+              <StyledLabelTypography>Subnet</StyledLabelTypography>
+            </Grid>
+            <StyledValueGrid size={gridValueSize}>
+              {`${currentSubnet?.label} (${currentSubnet?.ipv4})`}
+            </StyledValueGrid>
+          </>
+        ) : null}
+
+        <Grid size={gridLabelSize}>
+          <StyledLabelTypography>Host</StyledLabelTypography>
+        </Grid>
+        <StyledValueGrid size={gridValueSize}>
+          {database.hosts?.primary ? (
+            database.hosts?.primary
+          ) : (
+            <span className={classes.provisioningText}>
+              Your hostname will appear here once it is available.
+            </span>
+          )}
+        </StyledValueGrid>
+        <Grid size={gridLabelSize}>
+          <StyledLabelTypography>Read-only Host</StyledLabelTypography>
+        </Grid>
+        <StyledValueGrid size={gridValueSize}>{readOnlyHost()}</StyledValueGrid>
+        {hasVPCConfigured ? (
+          <>
+            <Grid size={gridLabelSize}>
+              <StyledLabelTypography>Public Access</StyledLabelTypography>
+            </Grid>
+            <StyledValueGrid size={gridValueSize}>
+              {database?.private_network?.public_access ? 'Yes' : 'No'}
+            </StyledValueGrid>
+          </>
+        ) : null}
+      </StyledGridContainer>
+    </>
+  );
+};

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworking.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworking.tsx
@@ -25,6 +25,7 @@ export const DatabaseManageNetworking = ({ database }: Props) => {
       minWidth: 225,
       [theme.breakpoints.down('md')]: {
         alignSelf: 'flex-start',
+        marginTop: '1rem',
         marginBottom: '1rem',
       },
     },
@@ -123,7 +124,7 @@ export const DatabaseManageNetworking = ({ database }: Props) => {
         <StyledValueGrid size={gridValueSize}>
           {hasVPCConfigured ? 'VPC' : 'Public'}
         </StyledValueGrid>
-        {hasVPCConfigured ? (
+        {hasVPCConfigured && (
           <>
             <Grid size={gridLabelSize}>
               <StyledLabelTypography>VPC</StyledLabelTypography>
@@ -136,7 +137,7 @@ export const DatabaseManageNetworking = ({ database }: Props) => {
               {`${currentSubnet?.label} (${currentSubnet?.ipv4})`}
             </StyledValueGrid>
           </>
-        ) : null}
+        )}
 
         <Grid size={gridLabelSize}>
           <StyledLabelTypography>Host</StyledLabelTypography>
@@ -154,7 +155,7 @@ export const DatabaseManageNetworking = ({ database }: Props) => {
           <StyledLabelTypography>Read-only Host</StyledLabelTypography>
         </Grid>
         <StyledValueGrid size={gridValueSize}>{readOnlyHost()}</StyledValueGrid>
-        {hasVPCConfigured ? (
+        {hasVPCConfigured && (
           <>
             <Grid size={gridLabelSize}>
               <StyledLabelTypography>Public Access</StyledLabelTypography>
@@ -163,7 +164,7 @@ export const DatabaseManageNetworking = ({ database }: Props) => {
               {database?.private_network?.public_access ? 'Yes' : 'No'}
             </StyledValueGrid>
           </>
-        ) : null}
+        )}
       </StyledGridContainer>
     </>
   );

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworking.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworking.tsx
@@ -66,19 +66,13 @@ export const DatabaseManageNetworking = ({ database }: Props) => {
 
   const { data: vpc, isLoading, error } = useVPCQuery(vpcId, hasVPCConfigured);
 
-  const currentSubnet = React.useMemo(
-    () =>
-      vpc?.subnets.find(
-        (subnet) => subnet.id === database?.private_network?.subnet_id
-      ),
-    [vpc]
+  const currentSubnet = vpc?.subnets.find(
+    (subnet) => subnet.id === database?.private_network?.subnet_id
   );
 
   const readOnlyHost = () => {
     const defaultValue = 'N/A';
-    const value = getReadOnlyHost(database)
-      ? getReadOnlyHost(database)
-      : defaultValue;
+    const value = getReadOnlyHost(database) || defaultValue;
     return <span>{value}</span>;
   };
 
@@ -110,7 +104,7 @@ export const DatabaseManageNetworking = ({ database }: Props) => {
         <Button
           buttonType="outlined"
           className={classes.manageNetworkingBtn}
-          disabled={true} // Disabled until manage networking is fully implemented
+          disabled={true} // TODO (UIE-8617): Add Manage Networking functionality
           onClick={() => null}
         >
           Manage Networking

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseNetworking.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseNetworking.test.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { describe, it } from 'vitest';
+
+import { vpcFactory } from 'src/factories';
+import { databaseFactory } from 'src/factories/databases';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { DatabaseNetworking } from './DatabaseNetworking';
+
+// Hoist query mocks
+const queryMocks = vi.hoisted(() => ({
+  useVPCQuery: vi.fn().mockReturnValue({ data: {} }),
+}));
+
+vi.mock('@linode/queries', async () => {
+  const actual = await vi.importActual('@linode/queries');
+  return {
+    ...actual,
+    useVPCQuery: queryMocks.useVPCQuery,
+  };
+});
+
+describe('DatabaseNetworking Component', () => {
+  const mockProps = {
+    database: databaseFactory.build({ platform: 'rdbms-default' }),
+    disabled: false,
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    queryMocks.useVPCQuery.mockReturnValue({
+      data: vpcFactory.build(),
+    });
+  });
+
+  it('Should render the Manage Access and Manage Networking sections', () => {
+    const { getAllByRole } = renderWithTheme(
+      <DatabaseNetworking {...mockProps} />
+    );
+    const headings = getAllByRole('heading');
+    expect(headings[0].textContent).toBe('Manage Access');
+    expect(headings[1].textContent).toBe('Manage Networking');
+  });
+});

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseNetworking.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseNetworking.tsx
@@ -1,0 +1,32 @@
+import { Divider, Paper, Stack, Typography } from '@linode/ui';
+import React from 'react';
+
+import { ACCESS_CONTROLS_IN_SETTINGS_TEXT } from '../../constants';
+import AccessControls from '../AccessControls';
+import { DatabaseManageNetworking } from './DatabaseManageNetworking';
+
+import type { Database } from '@linode/api-v4';
+
+interface Props {
+  database: Database;
+  disabled?: boolean;
+}
+
+export const DatabaseNetworking = ({ database, disabled }: Props) => {
+  const accessControlCopy = (
+    <Typography>{ACCESS_CONTROLS_IN_SETTINGS_TEXT}</Typography>
+  );
+
+  return (
+    <Paper sx={{ marginTop: 2 }}>
+      <Stack divider={<Divider spacingBottom={0} spacingTop={0} />} spacing={3}>
+        <AccessControls
+          database={database}
+          description={accessControlCopy}
+          disabled={disabled}
+        />
+        <DatabaseManageNetworking database={database} />
+      </Stack>
+    </Paper>
+  );
+};

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.test.tsx
@@ -55,7 +55,7 @@ describe('DatabaseSettings Component', () => {
     await renderWithThemeAndRouter(<DatabaseSettings database={database} />);
   });
 
-  it('Should render a Paper component with headers for Manage Access, Reseting the Root password, and Deleting the Cluster', async () => {
+  it('should render a Paper component with headers for Manage Access, Resetting the Root password, and Deleting the Cluster', async () => {
     spy.mockReturnValue(v2GA());
     const { container, getAllByRole } = await renderWithThemeAndRouter(
       <DatabaseSettings database={database} />
@@ -67,6 +67,32 @@ describe('DatabaseSettings Component', () => {
     expect(headings[1].textContent).toBe('Manage Access');
     expect(headings[2].textContent).toBe('Reset the Root Password');
     expect(headings[3].textContent).toBe('Delete the Cluster');
+  });
+
+  it('should not render Manage Access for a default database when databaseVpc flag is enabled', async () => {
+    spy.mockReturnValue(v2GA());
+    const defaultDatabase = databaseFactory.build({
+      platform: 'rdbms-default',
+    });
+    const { getAllByRole } = await renderWithThemeAndRouter(
+      <DatabaseSettings database={defaultDatabase} />,
+      { flags: { databaseVpc: true } }
+    );
+    const headings = getAllByRole('heading');
+    expect(headings[1].textContent).not.toBe('Manage Access');
+  });
+
+  it('should render Manage Access for a legacy database when databaseVpc flag is enabled', async () => {
+    spy.mockReturnValue(v2GA());
+    const legacyDatabase = databaseFactory.build({
+      platform: 'rdbms-legacy',
+    });
+    const { getAllByRole } = await renderWithThemeAndRouter(
+      <DatabaseSettings database={legacyDatabase} />,
+      { flags: { databaseVpc: true } }
+    );
+    const headings = getAllByRole('heading');
+    expect(headings[0].textContent).toBe('Manage Access');
   });
 
   it.each([

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.tsx
@@ -15,8 +15,10 @@ import { DatabaseSettingsReviewUpdatesDialog } from 'src/features/Databases/Data
 import { DatabaseSettingsUpgradeVersionDialog } from 'src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsUpgradeVersionDialog';
 import {
   isDefaultDatabase,
+  isLegacyDatabase,
   useIsDatabasesEnabled,
 } from 'src/features/Databases/utilities';
+import { useFlags } from 'src/hooks/useFlags';
 
 import AccessControls from '../AccessControls';
 import DatabaseSettingsDeleteClusterDialog from './DatabaseSettingsDeleteClusterDialog';
@@ -37,7 +39,9 @@ export const DatabaseSettings: React.FC<Props> = (props) => {
   const { database, disabled } = props;
   const { data: profile } = useProfile();
   const { isDatabasesV2GA } = useIsDatabasesEnabled();
+  const flags = useFlags();
   const isDefaultDB = isDefaultDatabase(database);
+  const isVPCEnabled = flags.databaseVpc;
 
   const accessControlCopy = (
     <Typography>
@@ -125,11 +129,13 @@ export const DatabaseSettings: React.FC<Props> = (props) => {
               sectionTitle={'Suspend Cluster'}
             />
           )}
-          <AccessControls
-            database={database}
-            description={accessControlCopy}
-            disabled={disabled}
-          />
+          {!isVPCEnabled || isLegacyDatabase(database) ? (
+            <AccessControls
+              database={database}
+              description={accessControlCopy}
+              disabled={disabled}
+            />
+          ) : null}
           <DatabaseSettingsMenuItem
             buttonText="Reset Root Password"
             descriptiveText={resetRootPasswordCopy}

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.tsx
@@ -129,13 +129,13 @@ export const DatabaseSettings: React.FC<Props> = (props) => {
               sectionTitle={'Suspend Cluster'}
             />
           )}
-          {!isVPCEnabled || isLegacyDatabase(database) ? (
+          {(!isVPCEnabled || isLegacyDatabase(database)) && (
             <AccessControls
               database={database}
               description={accessControlCopy}
               disabled={disabled}
             />
-          ) : null}
+          )}
           <DatabaseSettingsMenuItem
             buttonText="Reset Root Password"
             descriptiveText={resetRootPasswordCopy}

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.test.tsx
@@ -102,6 +102,96 @@ describe('DatabaseSummaryConnectionDetails', () => {
     expect(queryAllByText('N/A')).toHaveLength(1);
   });
 
+  it('should display Connection Type for default database when databaseVpc flag is enabled', async () => {
+    queryMocks.useDatabaseCredentialsQuery.mockReturnValue({});
+
+    const database = databaseFactory.build({
+      platform: 'rdbms-default',
+    }) as Database;
+
+    const { queryAllByText } = renderWithTheme(
+      <DatabaseSummaryConnectionDetails database={database} />,
+      { flags: { databaseVpc: true } }
+    );
+
+    await waitFor(() => {
+      expect(queryAllByText('Connection Type')).toHaveLength(1);
+      expect(queryAllByText('VPC')).toHaveLength(1);
+    });
+  });
+
+  it('should display Connection Type as Private for default database with VPC when databaseVpc flag is enabled', async () => {
+    queryMocks.useDatabaseCredentialsQuery.mockReturnValue({});
+
+    const database = databaseFactory.build({
+      platform: 'rdbms-default',
+    }) as Database;
+
+    const { queryAllByText } = renderWithTheme(
+      <DatabaseSummaryConnectionDetails database={database} />,
+      { flags: { databaseVpc: true } }
+    );
+
+    await waitFor(() => {
+      expect(queryAllByText('Connection Type')).toHaveLength(1);
+      expect(queryAllByText('VPC')).toHaveLength(1);
+    });
+  });
+
+  it('should display Connection Type as Public for default database with no VPC when databaseVpc flag is enabled', async () => {
+    queryMocks.useDatabaseCredentialsQuery.mockReturnValue({});
+
+    const database = databaseFactory.build({
+      platform: 'rdbms-default',
+    }) as Database;
+
+    database.private_network = null;
+
+    const { queryAllByText } = renderWithTheme(
+      <DatabaseSummaryConnectionDetails database={database} />,
+      { flags: { databaseVpc: true } }
+    );
+
+    await waitFor(() => {
+      expect(queryAllByText('Connection Type')).toHaveLength(1);
+      expect(queryAllByText('Public')).toHaveLength(1);
+    });
+  });
+
+  it('should not display Connection Type for default database when databaseVpc flag is disabled', async () => {
+    queryMocks.useDatabaseCredentialsQuery.mockReturnValue({});
+
+    const database = databaseFactory.build({
+      platform: 'rdbms-default',
+    }) as Database;
+
+    const { queryByText } = renderWithTheme(
+      <DatabaseSummaryConnectionDetails database={database} />,
+      { flags: { databaseVpc: false } }
+    );
+
+    await waitFor(() => {
+      expect(queryByText('Connection Type')).toBeNull();
+    });
+  });
+
+  it('should not display Connection Type for a legacy database databaseVpc flag is enabled ', async () => {
+    queryMocks.useDatabaseCredentialsQuery.mockReturnValue({});
+
+    const database = databaseFactory.build({
+      platform: 'rdbms-default',
+    }) as Database;
+
+    const { queryByText } = renderWithTheme(
+      <DatabaseSummaryConnectionDetails database={database} />,
+      { flags: { databaseVpc: false } }
+    );
+
+    await waitFor(() => {
+      expect(queryByText('Connection Type')).toBeNull();
+    });
+  });
+
   it('should display correctly for legacy db', async () => {
     queryMocks.useDatabaseCredentialsQuery.mockReturnValue({
       data: {

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -124,9 +124,7 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
 
   const readOnlyHost = () => {
     const defaultValue = isLegacy ? '-' : 'N/A';
-    const value = getReadOnlyHost(database)
-      ? getReadOnlyHost(database)
-      : defaultValue;
+    const value = getReadOnlyHost(database) || defaultValue;
     const hasHost = value !== '-' && value !== 'N/A';
     return (
       <>
@@ -327,7 +325,7 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
         <StyledValueGrid size={{ md: 8, xs: 9 }}>
           {database.ssl_connection ? 'ENABLED' : 'DISABLED'}
         </StyledValueGrid>
-        {displayConnectionType ? (
+        {displayConnectionType && (
           <>
             <Grid
               size={{
@@ -352,7 +350,7 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
               </Link>
             </StyledValueGrid>
           </>
-        ) : null}
+        )}
       </StyledGridContainer>
       <div className={classes.actionBtnsCtn}>
         {database.ssl_connection ? caCertificateJSX : null}

--- a/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
@@ -208,7 +208,7 @@ export const DatabaseDetail = () => {
             variant="warning"
           />
         )}
-        {isVPCEnabled && onSettingsTab ? (
+        {isVPCEnabled && onSettingsTab && (
           <DismissibleBanner
             preferenceKey="database-manage-access-moved-notice"
             variant="info"
@@ -218,7 +218,7 @@ export const DatabaseDetail = () => {
               Networking tab.
             </Typography>
           </DismissibleBanner>
-        ) : null}
+        )}
 
         <TabPanels>
           <SafeTabPanel

--- a/packages/manager/src/features/Databases/utilities.test.ts
+++ b/packages/manager/src/features/Databases/utilities.test.ts
@@ -8,6 +8,7 @@ import {
 } from 'src/factories';
 import {
   getDatabasesDescription,
+  getReadOnlyHost,
   hasPendingUpdates,
   isDateOutsideBackup,
   isDefaultDatabase,
@@ -561,5 +562,35 @@ describe('upgradableVersions', () => {
   it('should return undefined when no engines are provided', () => {
     const result = upgradableVersions('mysql', '8.0.26', undefined);
     expect(result).toBeUndefined();
+  });
+});
+
+describe('getReadOnlyHost', () => {
+  it('should return the standby host from the database when present', () => {
+    const db: Database = databaseFactory.build();
+    const mockHosts = {
+      primary: 'primary.example.com',
+      standby: 'standby.example.com',
+      secondary: 'secondary.example.com',
+    };
+    db.hosts = mockHosts;
+    const result = getReadOnlyHost(db);
+    expect(result).toBe(mockHosts.standby);
+  });
+
+  it('should return the secondary host from the database if standby is not present', () => {
+    const db: Database = databaseFactory.build();
+    const mockHosts = {
+      primary: 'primary.example.com',
+      secondary: 'secondary.example.com',
+    };
+    db.hosts = mockHosts;
+    const result = getReadOnlyHost(db);
+    expect(result).toBe(mockHosts.secondary);
+  });
+
+  it('should return an empty string when no database data is provided', () => {
+    const result = getReadOnlyHost({} as Database);
+    expect(result).toBe('');
   });
 });

--- a/packages/manager/src/features/Databases/utilities.ts
+++ b/packages/manager/src/features/Databases/utilities.ts
@@ -6,6 +6,7 @@ import { useFlags } from 'src/hooks/useFlags';
 import { useDatabaseTypesQuery } from 'src/queries/databases/databases';
 
 import type {
+  Database,
   DatabaseEngine,
   DatabaseFork,
   DatabaseInstance,
@@ -245,3 +246,6 @@ export const upgradableVersions = (
   version: string,
   engines?: Pick<DatabaseEngine, 'engine' | 'version'>[]
 ) => engines?.filter((e) => e.engine === engine && e.version > version);
+
+export const getReadOnlyHost = (database: Database | undefined) =>
+  database?.hosts?.standby ?? database?.hosts?.secondary ?? '';

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -309,6 +309,9 @@ const databases = [
       db.ssl_connection = true;
     }
     const database = databaseFactory.build(db);
+    if (database.platform !== 'rdbms-default') {
+      delete database.private_network;
+    }
     return HttpResponse.json(database);
   }),
 

--- a/packages/manager/src/routes/databases/index.ts
+++ b/packages/manager/src/routes/databases/index.ts
@@ -92,6 +92,13 @@ const databasesDetailMetricsRoute = createRoute({
   import('./databasesLazyRoutes').then((m) => m.databaseDetailLazyRoute)
 );
 
+const databasesDetailNetworkingRoute = createRoute({
+  getParentRoute: () => databasesDetailRoute,
+  path: 'networking',
+}).lazy(() =>
+  import('./databasesLazyRoutes').then((m) => m.databaseDetailLazyRoute)
+);
+
 export const databasesRouteTree = databasesRoute.addChildren([
   databasesIndexRoute,
   databasesCreateRoute,
@@ -102,5 +109,6 @@ export const databasesRouteTree = databasesRoute.addChildren([
     databasesDetailSettingsRoute,
     databasesDetailConfigsRoute,
     databasesDetailMetricsRoute,
+    databasesDetailNetworkingRoute,
   ]),
 ]);


### PR DESCRIPTION
## Description 📝

This pull request creates a new Networking tab in DB details, moves Manage Access to this Networking tab, and updates the Summary tab to include a new Connection Type field that displays the Connection Type (Public vs P directs to the Networking tab.

## Changes  🔄

List any change(s) relevant to the reviewer.

- New Networking tab has been added created for database details
- This tab appears after Summary and Metrics
- Tab will contain two fields, Manage Access and Manage Networking
- Manage Access field has been moved here from the Settings tab and has the same behavior
- Manage Networking contains a grid showing data relating to the Connection configuration (VPC vs No VPC)
- Summary has been updated to include a row for Connection type with a link to the Networking tab

**Note:**  Manage Networking button is disabled and not functional. It will be implemented in the next PR.

These changes are toggled on/off via the `databaseVpc` feature flag

## Target release date 🗓️
6/17/2025

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![DBaaS-Summary-Networking](https://github.com/user-attachments/assets/2fdc3840-b4dd-4b5e-9194-f45ee1e7a621)| 
|![DBaaS-Summary-before](https://github.com/user-attachments/assets/6d7b15d5-468b-496b-8ee4-2c41855e8d3b) | ![DBaaS-Summary-after](https://github.com/user-attachments/assets/4145abd5-66a7-4662-a5ce-d21a4d9abf6d)|
| ![DBaaS-Summary-Settings-before](https://github.com/user-attachments/assets/f126ff95-d05c-4165-9bd3-7b28a2764cb1) | ![DBaaS-Summary-Settings-after](https://github.com/user-attachments/assets/c931682a-0534-43a8-8401-c4eb58e87170)|




## How to test 🧪

### Prerequisites

(How to setup test environment)

- Make sure you have the `databaseVpc` feature flag enabled
- Make sure you have access to the Databases tab on the right navigation panel.
- Make sure you have both new and legacy databases available
- To test VPC functionality, you'll have to use mock data as VPC data is not currently available

### Verification steps

(How to verify changes)

- [ ] Access the Databases tab on the right and access a new database cluster's details via the cluster label
- [ ] View the summary and see that the Connection Type field is displayed
- [ ] Access the Networking tab via the details tab at the top, or by selecting the 'View Details' link in the Connection Type field.
- [ ] Check that Manage Access is available under this new tab and works as expected
- [ ] Check that Manage Networking displays a grid with a Connection type of "VPC"
- [ ] Check that this grid displays the following fields: Connection Type, VPC, Subnet, Host, Read-only Host, Public Access
- [ ] Confirm that the 'Manage Networking' button is disabled.
- [ ] Navigate to the Settings tab and see that Manage Access has been removed and a banner is displayed at the top mentioning this relocation.
- [ ] Navigate back to the Database landing page and access a legacy database cluster's details.
- [ ] See that Connection Type field is not displayed in the summary
- [ ] See that Networking tab is not visible
- [ ] Navigate to the Settings tab and see that the Manage Access field is displayed and there is no banner.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
