### PR TITLE
fix: [M3-10068, M3-10078] - Fix Broken Spacing for Banner and remove console error

### DIFF
--- a/packages/manager/.changeset/pr-12328-fixed-1749044302497.md
+++ b/packages/manager/.changeset/pr-12328-fixed-1749044302497.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Broken Spacing for Banner Component and remove console error from NB summary page ([#12328](https://github.com/linode/manager/pull/12328))
+Broken Spacing for Banner Component ([#12328](https://github.com/linode/manager/pull/12328))

--- a/packages/manager/.changeset/pr-12328-fixed-1749044302497.md
+++ b/packages/manager/.changeset/pr-12328-fixed-1749044302497.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Broken Spacing for Banner Component and remove console error from NB summary page ([#12328](https://github.com/linode/manager/pull/12328))

--- a/packages/manager/.changeset/pr-12328-fixed-1749044302497.md
+++ b/packages/manager/.changeset/pr-12328-fixed-1749044302497.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Broken Spacing for Banner Component ([#12328](https://github.com/linode/manager/pull/12328))
+Broken Spacing for Banner Component and link missing accessible aria label on NodeBalancer summary page ([#12328](https://github.com/linode/manager/pull/12328))

--- a/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
+++ b/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
@@ -88,15 +88,38 @@ export const DismissibleBanner = (props: Props) => {
 
   return (
     <Notice bgcolor={(theme) => theme.palette.background.paper} {...rest}>
-      <Stack direction="row">
+      <Stack
+        justifyContent="space-between"
+        sx={{
+          alignItems: { sm: 'center' },
+          flexDirection: {
+            xs: 'column',
+            sm: 'row',
+          },
+          ml: {
+            xs: '8px',
+            sm: '0px',
+          },
+        }}
+      >
         <Stack direction="column" flex={1} justifyContent="center">
           {children}
         </Stack>
         <Stack
-          alignSelf="flex-start"
+          alignItems="center"
           direction="row"
-          justifyContent="flex-end"
           spacing={1}
+          sx={(theme) => ({
+            mt: {
+              xs: theme.spacing(2),
+              sm: theme.spacing(0),
+            },
+            ml: {
+              xs: theme.spacing(0),
+              sm: theme.spacing(12),
+              md: theme.spacing(24),
+            },
+          })}
         >
           {actionButton}
           {dismissible ? dismissibleButton : null}

--- a/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
+++ b/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
@@ -98,10 +98,6 @@ export const DismissibleBanner = (props: Props) => {
               xs: 'column',
               sm: 'row',
             },
-            ml: {
-              xs: '8px',
-              sm: '0px',
-            },
           }}
         >
           <Stack direction="column" flex={1} justifyContent="center">

--- a/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
+++ b/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
@@ -96,8 +96,10 @@ export const DismissibleBanner = (props: Props) => {
           alignSelf="flex-start"
           direction="row"
           justifyContent="flex-end"
-          marginLeft="24px"
           spacing={1}
+          sx={(theme) => ({
+            marginLeft: theme.spacingFunction(24),
+          })}
         >
           {actionButton}
           {dismissible ? dismissibleButton : null}

--- a/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
+++ b/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
@@ -88,22 +88,61 @@ export const DismissibleBanner = (props: Props) => {
 
   return (
     <Notice bgcolor={(theme) => theme.palette.background.paper} {...rest}>
-      <Stack direction="row">
-        <Stack direction="column" flex={1} justifyContent="center">
-          {children}
-        </Stack>
+      <Stack direction="row" spacing={1}>
         <Stack
-          alignSelf="flex-start"
-          direction="row"
-          justifyContent="flex-end"
-          spacing={1}
-          sx={(theme) => ({
-            marginLeft: theme.spacingFunction(24),
-          })}
+          flex={1}
+          justifyContent="space-between"
+          sx={{
+            alignItems: { sm: 'center' },
+            flexDirection: {
+              xs: 'column',
+              sm: 'row',
+            },
+            ml: {
+              xs: '8px',
+              sm: '0px',
+            },
+          }}
         >
-          {actionButton}
-          {dismissible ? dismissibleButton : null}
+          <Stack direction="column" flex={1} justifyContent="center">
+            {children}
+          </Stack>
+          <Stack
+            direction="row"
+            spacing={1}
+            sx={(theme) => ({
+              alignItems: {
+                sm: 'center',
+              },
+              paddingLeft: {
+                sm: 4,
+              },
+              mt: {
+                xs: theme.spacingFunction(12),
+                sm: theme.spacingFunction(0),
+              },
+              ml: {
+                xs: theme.spacingFunction(0),
+                sm: theme.spacingFunction(12),
+                md: theme.spacing(24),
+              },
+            })}
+          >
+            {actionButton}
+          </Stack>
         </Stack>
+        {dismissible && (
+          <Stack
+            sx={{
+              alignSelf: {
+                sm: 'center',
+                xs: 'flex-start',
+              },
+            }}
+          >
+            {dismissible ? dismissibleButton : null}
+          </Stack>
+        )}
       </Stack>
     </Notice>
   );

--- a/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
+++ b/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
@@ -88,38 +88,16 @@ export const DismissibleBanner = (props: Props) => {
 
   return (
     <Notice bgcolor={(theme) => theme.palette.background.paper} {...rest}>
-      <Stack
-        justifyContent="space-between"
-        sx={{
-          alignItems: { sm: 'center' },
-          flexDirection: {
-            xs: 'column',
-            sm: 'row',
-          },
-          ml: {
-            xs: '8px',
-            sm: '0px',
-          },
-        }}
-      >
+      <Stack direction="row">
         <Stack direction="column" flex={1} justifyContent="center">
           {children}
         </Stack>
         <Stack
-          alignItems="center"
+          alignSelf="flex-start"
           direction="row"
+          justifyContent="flex-end"
+          marginLeft="24px"
           spacing={1}
-          sx={(theme) => ({
-            mt: {
-              xs: theme.spacing(2),
-              sm: theme.spacing(0),
-            },
-            ml: {
-              xs: theme.spacing(0),
-              sm: theme.spacing(12),
-              md: theme.spacing(24),
-            },
-          })}
         >
           {actionButton}
           {dismissible ? dismissibleButton : null}

--- a/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
+++ b/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
@@ -114,17 +114,12 @@ export const DismissibleBanner = (props: Props) => {
               alignItems: {
                 sm: 'center',
               },
-              paddingLeft: {
-                sm: 4,
-              },
               mt: {
                 xs: theme.spacingFunction(12),
                 sm: theme.spacingFunction(0),
               },
               ml: {
-                xs: theme.spacingFunction(0),
-                sm: theme.spacingFunction(12),
-                md: theme.spacing(24),
+                sm: theme.spacingFunction(24),
               },
             })}
           >
@@ -140,7 +135,7 @@ export const DismissibleBanner = (props: Props) => {
               },
             }}
           >
-            {dismissible ? dismissibleButton : null}
+            {dismissibleButton}
           </Stack>
         )}
       </Stack>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -227,7 +227,11 @@ export const SummaryPanel = () => {
               <strong>VPC:</strong>{' '}
               {vpcConfig?.data.map((vpc, i) => (
                 <React.Fragment key={vpc.id}>
-                  <Link className="secondaryLink" to={`/vpcs/${vpc.vpc_id}`}>
+                  <Link
+                    accessibleAriaLabel={`VPC ${vpcDetails?.label}`}
+                    className="secondaryLink"
+                    to={`/vpcs/${vpc.vpc_id}`}
+                  >
                     {vpcDetails?.label}
                   </Link>
                   {i < vpcConfig.data.length - 1 ? ', ' : ''}


### PR DESCRIPTION
## Description

This PR fixes broken spacing in the **Banner** component and removes a console error from the **NodeBalancer Details** page.

## Changes

- Fixed spacing issues in the `Banner` component.
- Removed console error on the `/nodebalancers/${nb-id}/summary` page.

## Target Release Date

N/A

## Preview

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/49c5d6b3-d621-4e73-8c84-20726561d187) | ![After](https://github.com/user-attachments/assets/b152e069-35ab-4350-b811-a58da6b458c3) |
| ![Before](https://github.com/user-attachments/assets/c5af816d-d02a-4fdd-ad42-f96ec26da497)  | <video src="" />  |

## How to Test

- [ ] Navigate to `/nodebalancers/${nb-id}/summary` and ensure no console errors appear.
- [ ] Confirm that the spacing issue in `Banner` components has been resolved.


<details>
<summary>Author Checklists</summary>

### As an Author, I considered:  
- [x] Self-review  
- [x] Contribution guidelines  
- [x] Small, focused PR  
- [x] Changeset added if needed  
- [x] Tests added or updated  
- [x] No sensitive info  
- [x] Feature flag if needed  
- [x] Reproduction steps  
- [x] Docs updated if needed  
- [x] Mobile and a11y support  

### Before moving from Draft to Open:  
- [x] All unit tests passing  
- [x] TypeScript compiles  
- [x] Linting passes  

</details>
