### PR TITLE
upcoming: [DI-25149[] - Removing tags filter for linode flow

### DIFF
--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/AlertsResourcesFilterRenderer.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/AlertsResourcesFilterRenderer.test.tsx
@@ -52,26 +52,5 @@ describe('AlertsResourcesFilterRenderer', () => {
     );
 
     expect(getByPlaceholderText('Select Regions')).toBeInTheDocument();
-
-    const tagProps = getAlertResourceFilterProps({
-      filterKey: 'tags',
-      handleFilterChange: handleFilterChangeMock,
-      handleFilteredRegionsChange: handleFilterChangeMock,
-      regionOptions: [],
-      tagOptions: ['tag1', 'tag2'],
-    });
-    const tagPropKeys = Object.keys(tagProps);
-    expect(tagPropKeys.includes('handleFilterChange')).toBeTruthy();
-    expect(tagPropKeys.includes('handleSelectionChange')).toBeFalsy();
-
-    // Check for region filter
-    renderWithTheme(
-      <AlertResourcesFilterRenderer
-        component={serviceToFiltersMap['linode'][1].component}
-        componentProps={tagProps}
-      />
-    );
-
-    expect(getByPlaceholderText('Select Tags')).toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/constants.ts
@@ -1,13 +1,8 @@
-import React from 'react';
-
 import { engineTypeMap } from '../constants';
 import { AlertsEngineTypeFilter } from './AlertsEngineTypeFilter';
 import { AlertsRegionFilter } from './AlertsRegionFilter';
-import { AlertsTagFilter } from './AlertsTagsFilter';
-import { TextWithExtraInfo } from './TextWithExtraInfo';
 
 import type { AlertInstance } from './DisplayAlertResources';
-import type { TextWithInfoProp } from './TextWithExtraInfo';
 import type {
   AlertAdditionalFilterKey,
   ServiceColumns,
@@ -58,14 +53,6 @@ export const serviceTypeBasedColumns: ServiceColumns<AlertInstance> = {
       label: 'Region',
       sortingKey: 'region',
     },
-    {
-      accessor: ({ tags }) =>
-        React.createElement<Required<TextWithInfoProp>>(TextWithExtraInfo, {
-          values: tags ?? [],
-        }),
-      label: 'Tags',
-      sortingKey: 'tags',
-    },
   ],
 };
 
@@ -80,7 +67,6 @@ export const serviceToFiltersMap: Record<
   ],
   linode: [
     { component: AlertsRegionFilter, filterKey: 'region' },
-    { component: AlertsTagFilter, filterKey: 'tags' },
   ],
 };
 export const applicableAdditionalFilterKeys: AlertAdditionalFilterKey[] = [

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/constants.ts
@@ -65,9 +65,7 @@ export const serviceToFiltersMap: Record<
     { component: AlertsEngineTypeFilter, filterKey: 'engineType' },
     { component: AlertsRegionFilter, filterKey: 'region' },
   ],
-  linode: [
-    { component: AlertsRegionFilter, filterKey: 'region' },
-  ],
+  linode: [{ component: AlertsRegionFilter, filterKey: 'region' }],
 };
 export const applicableAdditionalFilterKeys: AlertAdditionalFilterKey[] = [
   'engineType', // Extendable in future for filter keys like 'tags', 'plan', etc.


### PR DESCRIPTION
## Description 📝

Removing the tags filter and column in Entity table in Alert flow

## Changes  🔄
- Excluded the tags component for linode from the entity filter configuration
- Excluded the tags component for linode from the entity column configuration 
- Excluded the test case to check for tags in entity table

## Target release date 🗓️
Upcoming release

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-05-28 at 16 37 05](https://github.com/user-attachments/assets/c222ea92-b1d5-4742-9b90-138f41772d4f) | ![Screenshot 2025-05-28 at 16 36 17](https://github.com/user-attachments/assets/0877b9d4-3c28-4fec-85e7-5b6a92b404b2) |
| ![Screenshot 2025-05-28 at 16 36 55](https://github.com/user-attachments/assets/2a6e6e73-b5d4-4f02-9747-87072c420c66) | ![Screenshot 2025-05-28 at 16 36 33](https://github.com/user-attachments/assets/3ef5bc1f-1edf-465b-b112-6e3daae3423b)|
## How to test 🧪

### Prerequisites

(How to setup test environment)

- Navigate to alerts and in dev tools click on Enable MSW with Legacy MSW Handlers
![image](https://github.com/user-attachments/assets/d955fefc-d816-46e1-8157-b89f433bf2d5)
- Choose any alert that has the Linode service type 
- To check the Create flow, please choose the Service Type as Linode and then proceed to check the Entity table

### Verification steps

(How to verify changes)

- [ ] Tags column in the entities table should not be visible in the Show-details page for the Linode Alert
- [ ] Tags column in the entities table should not be visible in the Edit page for the Linode Alert
- [ ] Tags filter in the entities table should not be visible in the Edit page for the Linode Alert
- [ ] Tags column in the entities table should not be visible in the Create page for the Linode Alert
- [ ] Tags filter in the entities table should not be visible in the Create page for the Linode Alert

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>