### PR TITLE
fix: [M3-10108] - Fix query params type issue

### DIFF
--- a/packages/manager/src/features/Search/SearchLanding.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.tsx
@@ -15,7 +15,7 @@ export const SearchLanding = () => {
 
   const { combinedResults, entityErrors, isLoading, searchResultsByEntity } =
     useCMSearch({
-      query,
+      query: String(query || ''), // Query params may be numeric, so convert to string.
     });
 
   const errors = getErrorsFromErrorMap(entityErrors);

--- a/packages/manager/src/features/Search/refinedSearch.ts
+++ b/packages/manager/src/features/Search/refinedSearch.ts
@@ -57,6 +57,9 @@ export const refinedSearch = (
 };
 
 export const formatQuery = (query: string) => {
+  if (!query || typeof query !== 'string') {
+    return '';
+  }
   return query.trim().replace(' && ', ' AND ').replace(' || ', ' OR ');
 };
 

--- a/packages/manager/src/features/Search/utils.ts
+++ b/packages/manager/src/features/Search/utils.ts
@@ -113,7 +113,11 @@ export const search = (
   entities: SearchableItem[],
   inputValue: string
 ): SearchResults => {
-  if (!inputValue || inputValue === '') {
+  if (
+    !inputValue ||
+    typeof inputValue !== 'string' ||
+    inputValue.trim() === ''
+  ) {
     return { combinedResults: [], searchResultsByEntity: emptyResults };
   }
 

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -70,7 +70,8 @@ export const SearchBar = () => {
         return;
       }
 
-      setSearchText(q);
+      // Query params may be numeric, so convert to string.
+      setSearchText(String(q));
     }
   }, [history.location]);
 


### PR DESCRIPTION
## Description 📝
This took some investigation because the issue was happening during renders. Both `SearchBar` and `SearchLanding` have the same root issue - they're receiving query parameters that might be numbers instead of strings, so the fix should be applied in both places.

The error occurs because the function attempts to call `.trim()` on a non-string value.

## Changes  🔄
- Added better type guards to `search` and `formatQuery` util. This was NOT the underlying root issue, but it should protect us if this issue crops up elsewhere in the app.
- Fixed root issues by ensuring we convert the query to a string before sending it to utils.

## Target release date 🗓️
N/A

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img width="472" alt="Screenshot 2025-06-05 at 9 47 22 AM" src="https://github.com/user-attachments/assets/f17890b7-9ea9-4f02-8844-be0678365dd3" /> | <img width="831" alt="Screenshot 2025-06-05 at 9 45 19 AM" src="https://github.com/user-attachments/assets/c52d81a1-fa44-4642-9492-a2db9d26366f" /> |

## How to test 🧪

### Verification steps
- In global search, type `1234` in the query
- Observe there's no longer any type errors triggering our error boundary.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>