### PR TITLE
test: [M3-9913] - Replace mock data that resembles real secrets

### DIFF
--- a/packages/manager/cypress/e2e/core/account/oauth-apps.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/oauth-apps.spec.ts
@@ -1,4 +1,5 @@
 import { oauthClientFactory } from '@src/factories';
+import { mockDataPrefix } from 'support/constants/cypress';
 import {
   mockCreateOAuthApp,
   mockDeleteOAuthApps,
@@ -146,12 +147,16 @@ describe('OAuth Apps', () => {
     const oauthApps = [
       oauthClientFactory.build({
         label: randomLabel(),
-        secret: randomHex(64),
+        secret:
+          mockDataPrefix['secret'] +
+          randomHex(64 - mockDataPrefix['secret'].length),
       }),
       oauthClientFactory.build({
         label: randomLabel(),
         public: true,
-        secret: randomHex(64),
+        secret:
+          mockDataPrefix['secret'] +
+          randomHex(64 - mockDataPrefix['secret'].length),
       }),
     ];
 
@@ -361,7 +366,9 @@ describe('OAuth Apps', () => {
   it('Resets an OAuth App', () => {
     const privateOauthApp = oauthClientFactory.build({
       label: randomLabel(5),
-      secret: randomHex(64),
+      secret:
+        mockDataPrefix['secret'] +
+        randomHex(64 - mockDataPrefix['secret'].length),
     });
 
     mockGetOAuthApps([privateOauthApp]).as('getOAuthApps');

--- a/packages/manager/cypress/e2e/core/account/personal-access-tokens.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/personal-access-tokens.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import { profileFactory } from '@linode/utilities';
+import { mockDataPrefix } from 'support/constants/cypress';
 import {
   mockCreatePersonalAccessToken,
   mockGetAppTokens,
@@ -32,7 +33,9 @@ describe('Personal access tokens', () => {
   it('can create personal access tokens', () => {
     const token = appTokenFactory.build({
       label: randomLabel(),
-      token: randomString(64),
+      token:
+        mockDataPrefix['token'] +
+        randomString(64 - mockDataPrefix['token'].length),
     });
 
     mockGetPersonalAccessTokens([]).as('getTokens');
@@ -182,7 +185,9 @@ describe('Personal access tokens', () => {
   it('sends scope as "*" when all permissions are set to read/write', () => {
     const token = appTokenFactory.build({
       label: randomLabel(),
-      token: randomString(64),
+      token:
+        mockDataPrefix['token'] +
+        randomString(64 - mockDataPrefix['token'].length),
     });
 
     mockCreatePersonalAccessToken(token).as('createToken');
@@ -253,7 +258,9 @@ describe('Personal access tokens', () => {
   it('can rename and revoke personal access tokens', () => {
     const oldToken: Token = appTokenFactory.build({
       label: randomLabel(),
-      token: randomString(64),
+      token:
+        mockDataPrefix['token'] +
+        randomString(64 - mockDataPrefix['token'].length),
     });
 
     const newToken: Token = {
@@ -345,7 +352,9 @@ describe('Personal access tokens', () => {
   it('disables API token creation and editing for a proxy user', () => {
     const proxyToken: Token = appTokenFactory.build({
       label: randomLabel(),
-      token: randomString(64),
+      token:
+        mockDataPrefix['token'] +
+        randomString(64 - mockDataPrefix['token'].length),
     });
     const proxyUserProfile = profileFactory.build({ user_type: 'proxy' });
 

--- a/packages/manager/cypress/e2e/core/account/third-party-access-tokens.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/third-party-access-tokens.spec.ts
@@ -2,6 +2,7 @@ import { getProfile } from '@linode/api-v4/lib/profile';
 import { accessFactory, appTokenFactory } from '@src/factories';
 import 'cypress-file-upload';
 import { authenticate } from 'support/api/authentication';
+import { mockDataPrefix } from 'support/constants/cypress';
 import {
   mockGetAppTokens,
   mockGetPersonalAccessTokens,
@@ -21,7 +22,9 @@ describe('Third party access tokens', () => {
   beforeEach(() => {
     token = appTokenFactory.build({
       label: randomLabel(),
-      token: randomString(64),
+      token:
+        mockDataPrefix['token'] +
+        randomString(64 - mockDataPrefix['token'].length),
     });
 
     mockGetPersonalAccessTokens([]).as('getTokens');

--- a/packages/manager/cypress/e2e/core/account/two-factor-auth.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/two-factor-auth.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import { profileFactory, securityQuestionsFactory } from '@linode/utilities';
+import { mockDataPrefix } from 'support/constants/cypress';
 import {
   mockConfirmTwoFactorAuth,
   mockDisableTwoFactorAuth,
@@ -141,7 +142,9 @@ describe('Two-factor authentication', () => {
   it('can enable two factor auth', () => {
     const invalidToken = randomToken();
     const validToken = randomToken();
-    const mockedKey = randomHex(16);
+    const mockedKey =
+      mockDataPrefix['secret'] +
+      randomHex(16 - mockDataPrefix['secret'].length);
     const mockedScratchCode = randomScratchCode();
 
     // Mock profile data to ensure that 2FA is disabled.
@@ -298,7 +301,10 @@ describe('Two-factor authentication', () => {
     cy.wait('@getSecurityQuestions');
 
     getTwoFactorSection().within(() => {
-      mockEnableTwoFactorAuth(randomHex(16)).as('resetTwoFactorAuth');
+      mockEnableTwoFactorAuth(
+        mockDataPrefix['secret'] +
+          randomHex(16 - mockDataPrefix['secret'].length)
+      ).as('resetTwoFactorAuth');
 
       // Confirm that reset link is present, click on it.
       cy.findByText('Reset two-factor authentication')

--- a/packages/manager/cypress/e2e/core/parentChild/token-scopes.spec.ts
+++ b/packages/manager/cypress/e2e/core/parentChild/token-scopes.spec.ts
@@ -2,6 +2,7 @@ import { grantsFactory, profileFactory } from '@linode/utilities';
 import { accountFactory, appTokenFactory } from '@src/factories';
 import { accountUserFactory } from '@src/factories/accountUsers';
 import { DateTime } from 'luxon';
+import { mockDataPrefix } from 'support/constants/cypress';
 import {
   mockGetAccount,
   mockGetChildAccounts,
@@ -44,7 +45,8 @@ const mockParentAccountToken = appTokenFactory.build({
   label: `${mockParentAccount.company}_proxy`,
   scopes: '*',
   thumbnail_url: undefined,
-  token: randomString(32),
+  token:
+    mockDataPrefix['token'] + randomString(32 - mockDataPrefix['token'].length),
   website: undefined,
 });
 

--- a/packages/manager/cypress/support/constants/cypress.ts
+++ b/packages/manager/cypress/support/constants/cypress.ts
@@ -16,3 +16,11 @@ export const entityTag = 'cy-test';
  * clean-up purposes.
  */
 export const entityPrefix = `${entityTag}-`;
+
+/**
+ * Prefix for fake mock data to avoid resembling real secrets.
+ */
+export const mockDataPrefix = {
+  secret: 'MockSecret_',
+  token: 'MockToken_',
+};

--- a/packages/manager/cypress/support/intercepts/cloudpulse.ts
+++ b/packages/manager/cypress/support/intercepts/cloudpulse.ts
@@ -5,6 +5,7 @@
  */
 
 import { cloudPulseServiceMap } from 'support/constants/cloudpulse';
+import { mockDataPrefix } from 'support/constants/cypress';
 import { makeErrorResponse } from 'support/util/errors';
 import { apiMatcher } from 'support/util/intercepts';
 import { paginateResponse } from 'support/util/paginate';
@@ -139,7 +140,9 @@ export const mockCreateCloudPulseJWEToken = (
   serviceType: string,
   token?: string
 ): Cypress.Chainable<null> => {
-  const mockToken = token ?? randomString(62);
+  const mockToken =
+    token ??
+    mockDataPrefix['token'] + randomString(62 - mockDataPrefix['token'].length);
   return cy.intercept(
     'POST',
     apiMatcher(`/monitor/services/${serviceType}/token`),


### PR DESCRIPTION
## Description 📝

Replace mock data that resembles real secrets

## Changes  🔄

List any change(s) relevant to the reviewer.

- Add `mockDataPrefix` to indicate the secrets are fake.

## How to test 🧪
```
pnpm cy:run -s "cypress/e2e/core/account/oauth-apps.spec.ts,cypress/e2e/core/account/personal-access-tokens.spec.ts,cypress/e2e/core/account/third-party-access-tokens.spec.ts,cypress/e2e/core/account/two-factor-auth.spec.ts,cypress/e2e/core/parentChild/token-scopes.spec.ts"
```
