### PR TITLE
fix: [M3-10080] - Missing query invalidations

### DIFF
--- a/packages/queries/src/linodes/linodes.ts
+++ b/packages/queries/src/linodes/linodes.ts
@@ -425,6 +425,11 @@ export const useCloneLinodeMutation = () => {
         linodeQueries.linode(linode.id).queryKey,
         linode,
       );
+      /**
+       * For restricted users, we need to invalidate grants when a Linode is cloned
+       * so that Cloud Manager reflects the correct permissions for the newly created Linode.
+       */
+      queryClient.invalidateQueries(profileQueries.grants);
     },
   });
 };

--- a/packages/queries/src/support/support.ts
+++ b/packages/queries/src/support/support.ts
@@ -5,7 +5,7 @@ import {
   getTicket,
   getTicketReplies,
   getTickets,
-} from '@linode/api-v4/lib/support';
+} from '@linode/api-v4';
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 import {
   keepPreviousData,
@@ -15,18 +15,15 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 
+import { accountQueries } from '../account';
+
 import type {
   ReplyRequest,
   SupportReply,
   SupportTicket,
   TicketRequest,
 } from '@linode/api-v4';
-import type {
-  APIError,
-  Filter,
-  Params,
-  ResourcePage,
-} from '@linode/api-v4/lib/types';
+import type { APIError, Filter, Params, ResourcePage } from '@linode/api-v4';
 
 export const supportQueries = createQueryKeys('support', {
   ticket: (id: number) => ({
@@ -107,6 +104,13 @@ export const useSupportTicketCloseMutation = (id: number) => {
       });
       queryClient.invalidateQueries({
         queryKey: supportQueries.ticket(id).queryKey,
+      });
+      /**
+       * When a support ticket is closed, invalidate account notifications
+       * because, in some cases, closing a ticket can dismiss a notification.
+       */
+      queryClient.invalidateQueries({
+        queryKey: accountQueries.notifications.queryKey,
       });
     },
   });


### PR DESCRIPTION
## Description 📝

This PR adds two cache invalidations. See code comments for what they do / why they are needed

## How to test 🧪

### Linode Clone Grants Fix
- Login as a restricted user that has access to some Linode
- Clone that Linode as the restricted user
- Verify that once Cloud Manager sends you to the newly created Linode's details page, you have the expected permissions to read/write the Linode. This should just work without the user needing to refresh the page

### Support Ticket Fix
> [!note]
> This one is hard to test. I just so happen to have an "important" support ticket on my account that was causing a notification and noticed that this needed to be fixed

- Somehow have an account with an important support ticket (one that triggers a notification)
- Close the ticket by clicking "Close Ticket" on the support ticket detail page 
- Verify the notification goes away without needing to refresh the page

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>