### PR TITLE
feat: [UIE-8617, UIE-8801] - DBaaS - Implementing Manage Networking functionality

### DIFF
--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -128,7 +128,7 @@ export interface DatabaseInstance {
 export type ClusterSize = 1 | 2 | 3;
 
 export interface PrivateNetwork {
-  public_access: boolean;
+  public_access?: boolean;
   subnet_id: null | number;
   vpc_id: null | number;
 }
@@ -241,6 +241,7 @@ export interface UpdateDatabasePayload {
   cluster_size?: number;
   engine_config?: DatabaseInstanceAdvancedConfig;
   label?: string;
+  private_network?: null | PrivateNetwork;
   type?: string;
   updates?: UpdatesSchedule;
   version?: string;

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreateNetworkingConfiguration.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreateNetworkingConfiguration.tsx
@@ -47,6 +47,7 @@ export const DatabaseCreateNetworkingConfiguration = (
       <DatabaseCreateAccessControls {...accessControlsConfiguration} />
       <DatabaseVPCSelector
         errors={errors}
+        mode="create"
         onChange={onChange}
         onConfigurationChange={onNetworkingConfigurationChange}
         privateNetworkValues={privateNetworkValues}

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseVPCSelector.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseVPCSelector.test.tsx
@@ -1,4 +1,5 @@
 import { regionFactory } from '@linode/utilities';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -54,6 +55,15 @@ const setUpBaseMocks = () => {
   });
 };
 
+const initialHelperText =
+  'In the Select Engine and Region section, select a region with an existing VPC to see available VPCs.';
+const altHelperText = 'No VPC is available in the selected region.';
+
+const vpcSelectorTestId = 'database-vpc-selector';
+const subnetSelectorTestId = 'database-subnet-selector';
+const vpcPlaceholder = 'Select a VPC';
+const subnetPlaceholder = 'Select a subnet';
+
 describe('DatabaseVPCSelector', () => {
   const mockProps = {
     errors: {},
@@ -66,6 +76,7 @@ describe('DatabaseVPCSelector', () => {
     },
     resetFormFields: vi.fn(),
     selectedRegionId: '',
+    mode: 'create' as 'create' | 'networking',
   };
 
   beforeEach(() => {
@@ -81,25 +92,21 @@ describe('DatabaseVPCSelector', () => {
   });
 
   it('Should render the VPC selector heading', () => {
-    const { getByText } = renderWithTheme(
-      <DatabaseVPCSelector {...mockProps} />
-    );
-    expect(getByText('Assign a VPC', { exact: true })).toBeInTheDocument();
+    renderWithTheme(<DatabaseVPCSelector {...mockProps} />);
+    const vpcField = screen.getByText('Assign a VPC', { exact: true });
+    expect(vpcField).toBeInTheDocument();
   });
 
   it('Should render VPC autocomplete in initial disabled state', () => {
-    const { getByTestId, getByText } = renderWithTheme(
-      <DatabaseVPCSelector {...mockProps} />
-    );
-    const vpcSelector = getByTestId('database-vpc-selector');
+    renderWithTheme(<DatabaseVPCSelector {...mockProps} />);
+    const vpcSelector = screen.getByTestId(vpcSelectorTestId);
     expect(vpcSelector).toBeInTheDocument();
-    expect(vpcSelector.querySelector('input')).toBeDisabled();
-    expect(
-      getByText(
-        'In the Select Engine and Region section, select a region with an existing VPC to see available VPCs.',
-        { exact: true }
-      )
-    ).toBeInTheDocument();
+    const vpcSelectorInput = screen.getByPlaceholderText(vpcPlaceholder);
+    expect(vpcSelectorInput).toBeDisabled();
+    const expectedHelperText = screen.getByText(initialHelperText, {
+      exact: true,
+    });
+    expect(expectedHelperText).toBeInTheDocument();
   });
 
   it('Should enable VPC autocomplete when VPCs are available', () => {
@@ -120,13 +127,12 @@ describe('DatabaseVPCSelector', () => {
     });
 
     const mockEnabledProps = { ...mockProps, selectedRegionId: 'us-east' };
-    const { getByTestId } = renderWithTheme(
-      <DatabaseVPCSelector {...mockEnabledProps} />
-    );
+    renderWithTheme(<DatabaseVPCSelector {...mockEnabledProps} />);
 
-    const vpcSelector = getByTestId('database-vpc-selector');
+    const vpcSelector = screen.getByTestId(vpcSelectorTestId);
     expect(vpcSelector).toBeInTheDocument();
-    expect(vpcSelector.querySelector('input')).toBeEnabled();
+    const vpcSelectorInput = screen.getByPlaceholderText(vpcPlaceholder);
+    expect(vpcSelectorInput).toBeEnabled();
   });
 
   it('Should enable Subnet autocomplete when VPC is selected', async () => {
@@ -150,18 +156,16 @@ describe('DatabaseVPCSelector', () => {
       privateNetworkValues: mockPrivateNetwork,
       selectedRegionId: 'us-east',
     };
-    const { getByTestId } = renderWithTheme(
-      <DatabaseVPCSelector {...mockEnabledProps} />
-    );
+    renderWithTheme(<DatabaseVPCSelector {...mockEnabledProps} />);
 
-    const vpcSelector = getByTestId('database-vpc-selector');
-    const vpcSelectorInput = vpcSelector.querySelector(
-      'input'
+    const vpcInput = screen.getByPlaceholderText(
+      vpcPlaceholder
     ) as HTMLInputElement;
-    expect(vpcSelectorInput?.value).toBe(mockVPCWithSubnet.label);
-    const subnetSelector = getByTestId('database-subnet-selector');
+    expect(vpcInput?.value).toBe(mockVPCWithSubnet.label);
+    const subnetSelector = screen.getByTestId(subnetSelectorTestId);
     expect(subnetSelector).toBeInTheDocument();
-    expect(subnetSelector.querySelector('input')).toBeEnabled();
+    const subnetInput = screen.getByPlaceholderText(subnetPlaceholder);
+    expect(subnetInput).toBeEnabled();
   });
 
   it('Should set fields for VPC, Subnet, and Public Access based on privateNetworkValues values', async () => {
@@ -185,23 +189,24 @@ describe('DatabaseVPCSelector', () => {
       privateNetworkValues: mockPrivateNetwork,
       selectedRegionId: 'us-east',
     };
-    const { getByTestId } = renderWithTheme(
-      <DatabaseVPCSelector {...mockEnabledProps} />
-    );
+    renderWithTheme(<DatabaseVPCSelector {...mockEnabledProps} />);
 
-    const vpcSelector = getByTestId('database-vpc-selector');
-    const vpcSelectorInput = vpcSelector.querySelector(
-      'input'
+    const vpcInput = screen.getByPlaceholderText(
+      vpcPlaceholder
     ) as HTMLInputElement;
-    const subnetSelector = getByTestId('database-subnet-selector');
+    const subnetSelector = screen.getByTestId(subnetSelectorTestId);
     const expectedSubnetValue = `${mockSubnets[0].label} (${mockSubnets[0].ipv4})`;
-    const publicAccessCheckbox = getByTestId('database-public-access-checkbox');
-
-    expect(vpcSelectorInput?.value).toBe(mockVPCWithSubnet.label);
-    expect(subnetSelector).toBeInTheDocument();
-    expect(subnetSelector.querySelector('input')?.value).toBe(
-      expectedSubnetValue
+    const publicAccessCheckbox = screen.getByTestId(
+      'database-public-access-checkbox'
     );
+
+    expect(vpcInput?.value).toBe(mockVPCWithSubnet.label);
+    expect(subnetSelector).toBeInTheDocument();
+
+    const subnetInput = screen.getByPlaceholderText(
+      subnetPlaceholder
+    ) as HTMLInputElement;
+    expect(subnetInput?.value).toBe(expectedSubnetValue);
     expect(publicAccessCheckbox).toBeInTheDocument();
     expect(publicAccessCheckbox.querySelector('input')).toBeChecked();
   });
@@ -235,7 +240,7 @@ describe('DatabaseVPCSelector', () => {
     const resetFormFields = vi.fn();
     const onConfigurationChange = vi.fn();
 
-    const { rerender, getByTestId } = renderWithTheme(
+    const { rerender } = renderWithTheme(
       <DatabaseVPCSelector
         {...mockProps}
         onConfigurationChange={onConfigurationChange}
@@ -261,13 +266,13 @@ describe('DatabaseVPCSelector', () => {
 
     expect(resetFormFields).toHaveBeenCalled();
     expect(onConfigurationChange).toHaveBeenCalledWith(null);
-    const vpcSelector = getByTestId('database-vpc-selector');
-    expect((vpcSelector.querySelector('input') as HTMLInputElement).value).toBe(
-      ''
-    );
+    const vpcInput = screen.getByPlaceholderText(
+      vpcPlaceholder
+    ) as HTMLInputElement;
+    expect((vpcInput as HTMLInputElement).value).toBe('');
   });
 
-  it('Should NOT clear VPC and subnet when selectedRegionId changes from undefined to a valid region', () => {
+  it('Should not clear VPC and subnet when selectedRegionId changes from undefined to a valid region', () => {
     // Initial render with no region selected
     queryMocks.useRegionQuery.mockReturnValue({ data: null });
     queryMocks.useAllVPCsQuery.mockReturnValue({ data: [], isLoading: false });
@@ -302,30 +307,26 @@ describe('DatabaseVPCSelector', () => {
   });
 
   it('Should show long helper text when no region is selected', () => {
-    const { getByText } = renderWithTheme(
-      <DatabaseVPCSelector {...mockProps} selectedRegionId="" />
-    );
-    expect(
-      getByText(
-        'In the Select Engine and Region section, select a region with an existing VPC to see available VPCs.',
-        { exact: true }
-      )
-    ).toBeInTheDocument();
+    renderWithTheme(<DatabaseVPCSelector {...mockProps} selectedRegionId="" />);
+    const expectedHelperText = screen.getByText(initialHelperText, {
+      exact: true,
+    });
+    expect(expectedHelperText).toBeInTheDocument();
   });
 
   it('Should show short helper text when a region is selected but no VPCs are available', () => {
     queryMocks.useRegionQuery.mockReturnValue({ data: mockRegion });
     queryMocks.useAllVPCsQuery.mockReturnValue({ data: [], isLoading: false });
 
-    const { getByText } = renderWithTheme(
+    renderWithTheme(
       <DatabaseVPCSelector {...mockProps} selectedRegionId="us-east" />
     );
-    expect(
-      getByText('No VPC is available in the selected region.', { exact: true })
-    ).toBeInTheDocument();
+
+    const expectedHelperText = screen.getByText(altHelperText, { exact: true });
+    expect(expectedHelperText).toBeInTheDocument();
   });
 
-  it('Should NOT show helper text when VPCs are available', () => {
+  it('Should not show helper text when VPCs are available', () => {
     const vpcWithSubnet = vpcFactory.build({
       region: 'us-east',
       subnets: subnetFactory.buildList(1, { ipv4: mockIpv4 }),
@@ -336,17 +337,42 @@ describe('DatabaseVPCSelector', () => {
       isLoading: false,
     });
 
-    const { queryByText } = renderWithTheme(
+    renderWithTheme(
       <DatabaseVPCSelector {...mockProps} selectedRegionId="us-east" />
     );
-    expect(
-      queryByText('No VPC is available in the selected region.')
-    ).not.toBeInTheDocument();
-    expect(
-      queryByText(
-        'In the Select Engine and Region section, select a region with an existing VPC to see available VPCs.'
-      )
-    ).not.toBeInTheDocument();
+    const expectedAltHelperText = screen.queryByText(altHelperText);
+    const expectedInitialHelperText = screen.queryByText(initialHelperText);
+    expect(expectedAltHelperText).not.toBeInTheDocument();
+    expect(expectedInitialHelperText).not.toBeInTheDocument();
+  });
+
+  it('Should show vpc validation error text when there is a vpc error', () => {
+    setUpBaseMocks();
+    const mockPrivateNetwork: PrivateNetwork = {
+      vpc_id: 1234,
+      subnet_id: null,
+      public_access: false,
+    };
+
+    const mockErrors = {
+      private_network: {
+        vpc_id: 'VPC is required.',
+      },
+    };
+
+    renderWithTheme(
+      <DatabaseVPCSelector
+        {...mockProps}
+        errors={mockErrors}
+        privateNetworkValues={mockPrivateNetwork}
+        selectedRegionId="us-east"
+      />
+    );
+
+    const subnetSelector = screen.getByTestId(subnetSelectorTestId);
+    expect(subnetSelector).toBeInTheDocument();
+    const expectedValidationError = screen.getByText('VPC is required.');
+    expect(expectedValidationError).toBeInTheDocument();
   });
 
   it('Should show subnet validation error text when there is a subnet error', () => {
@@ -363,7 +389,7 @@ describe('DatabaseVPCSelector', () => {
       },
     };
 
-    const { getByTestId, getByText } = renderWithTheme(
+    renderWithTheme(
       <DatabaseVPCSelector
         {...mockProps}
         errors={mockErrors}
@@ -372,9 +398,10 @@ describe('DatabaseVPCSelector', () => {
       />
     );
 
-    const subnetSelector = getByTestId('database-subnet-selector');
+    const subnetSelector = screen.getByTestId(subnetSelectorTestId);
     expect(subnetSelector).toBeInTheDocument();
-    expect(getByText('Subnet is required.')).toBeInTheDocument();
+    const expectedValidationError = screen.getByText('Subnet is required.');
+    expect(expectedValidationError).toBeInTheDocument();
   });
 
   it('Should clear subnet field when the VPC field is cleared', async () => {
@@ -388,7 +415,7 @@ describe('DatabaseVPCSelector', () => {
       public_access: false,
     };
 
-    const { getByTestId } = renderWithTheme(
+    renderWithTheme(
       <DatabaseVPCSelector
         {...mockProps}
         onChange={onChange}
@@ -398,7 +425,7 @@ describe('DatabaseVPCSelector', () => {
     );
 
     // Simulate clearing the VPC field (user clears the Autocomplete)
-    const vpcSelector = getByTestId('database-vpc-selector');
+    const vpcSelector = screen.getByTestId(vpcSelectorTestId);
     const clearButton = vpcSelector.querySelector(
       'button[title="Clear"]'
     ) as HTMLElement;
@@ -423,7 +450,7 @@ describe('DatabaseVPCSelector', () => {
       public_access: false,
     };
 
-    const { getByTestId, findByText } = renderWithTheme(
+    renderWithTheme(
       <DatabaseVPCSelector
         {...mockProps}
         onChange={onChange}
@@ -433,14 +460,14 @@ describe('DatabaseVPCSelector', () => {
     );
 
     // Simulate selecting a VPC from the Autocomplete
-    const vpcSelector = getByTestId('database-vpc-selector').querySelector(
-      'input'
+    const vpcInput = screen.getByPlaceholderText(
+      vpcPlaceholder
     ) as HTMLInputElement;
     // Open the autocomplete dropdown
-    await userEvent.click(vpcSelector);
+    await userEvent.click(vpcInput);
 
     // Select the option
-    const newVPC = await findByText('VPC 1');
+    const newVPC = await screen.findByText('VPC 1');
     await userEvent.click(newVPC);
 
     expect(onChange).toHaveBeenCalledWith(
@@ -460,7 +487,7 @@ describe('DatabaseVPCSelector', () => {
       public_access: false,
     };
 
-    const { getByTestId, findByText } = renderWithTheme(
+    renderWithTheme(
       <DatabaseVPCSelector
         {...mockProps}
         onChange={onChange}
@@ -470,15 +497,15 @@ describe('DatabaseVPCSelector', () => {
     );
 
     // Simulate selecting a Subnet from the Autocomplete
-    const subnetSelector = getByTestId(
-      'database-subnet-selector'
-    ).querySelector('input') as HTMLInputElement;
+    const subnetInput = screen.getByPlaceholderText(
+      subnetPlaceholder
+    ) as HTMLInputElement;
 
-    await userEvent.click(subnetSelector);
+    await userEvent.click(subnetInput);
 
     // Select the option
     const expectedSubnetLabel = `${mockSubnets[0].label} (${mockSubnets[0].ipv4})`;
-    const newSubnet = await findByText(expectedSubnetLabel);
+    const newSubnet = await screen.findByText(expectedSubnetLabel);
     await userEvent.click(newSubnet);
 
     expect(onChange).toHaveBeenCalledWith(

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworking.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworking.test.tsx
@@ -2,24 +2,38 @@ import { screen } from '@testing-library/react';
 import * as React from 'react';
 import { describe, it } from 'vitest';
 
-import { vpcFactory } from 'src/factories';
+import { subnetFactory, vpcFactory } from 'src/factories';
 import { databaseFactory } from 'src/factories/databases';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { DatabaseManageNetworking } from './DatabaseManageNetworking';
 
 const defaultPlatform = 'rdbms-default';
+const mockVPC = vpcFactory.build({ id: 12345 });
+const mockSubnet = subnetFactory.build({ id: 1 });
+const mockPrivateNetwork = {
+  vpc_id: mockVPC.id,
+  subnet_id: mockSubnet.id,
+  public_access: false,
+};
+const mockDatabase = databaseFactory.build({
+  platform: defaultPlatform,
+  private_network: mockPrivateNetwork,
+});
+
+const errorStateMessage =
+  'There was a problem retrieving your VPC assignment settings. Refresh the page or try again later.';
 
 // Hoist query mocks
 const queryMocks = vi.hoisted(() => ({
-  useVPCQuery: vi.fn().mockReturnValue({ data: {} }),
+  useAllVPCsQuery: vi.fn().mockReturnValue({ data: [] }),
 }));
 
 vi.mock('@linode/queries', async () => {
   const actual = await vi.importActual('@linode/queries');
   return {
     ...actual,
-    useVPCQuery: queryMocks.useVPCQuery,
+    useAllVPCsQuery: queryMocks.useAllVPCsQuery,
   };
 });
 
@@ -28,15 +42,19 @@ const loadingTestId = 'circle-progress';
 describe('DatabaseManageNetworking Component', () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    queryMocks.useVPCQuery.mockReturnValue({
-      data: vpcFactory.build(),
+    queryMocks.useAllVPCsQuery.mockReturnValue({
+      data: [vpcFactory.build()],
     });
   });
 
   it('Should render Manage Networking field with Public grid variation when no VPC is configured for the database', () => {
-    const mockDatabase = databaseFactory.build({ platform: defaultPlatform });
-    mockDatabase.private_network = null;
-    renderWithTheme(<DatabaseManageNetworking database={mockDatabase} />);
+    const publicAccessDatabase = databaseFactory.build({
+      platform: defaultPlatform,
+      private_network: null,
+    });
+    renderWithTheme(
+      <DatabaseManageNetworking database={publicAccessDatabase} />
+    );
 
     const heading = screen.getByRole('heading');
     expect(heading.textContent).toBe('Manage Networking');
@@ -47,50 +65,45 @@ describe('DatabaseManageNetworking Component', () => {
   });
 
   it('should render a loading state', async () => {
-    queryMocks.useVPCQuery.mockReturnValue({
+    queryMocks.useAllVPCsQuery.mockReturnValue({
       isLoading: true,
-      data: null,
+      data: [],
     });
-    const mockDatabase = databaseFactory.build({ platform: defaultPlatform });
     renderWithTheme(<DatabaseManageNetworking database={mockDatabase} />);
-    // Should render a loading state
+    // Should render loading state
     const loadingSpinner = screen.getByTestId(loadingTestId);
     expect(loadingSpinner).toBeInTheDocument();
   });
 
-  it('should render error state when a VPC is configured, but useVPCQuery responds with an error', async () => {
-    queryMocks.useVPCQuery.mockReturnValue({
+  it('should render error state when a VPC is configured, but useAllVPCsQuery responds with an error', async () => {
+    queryMocks.useAllVPCsQuery.mockReturnValue({
       error: new Error('Failed to fetch VPC'),
     });
-    const mockDatabase = databaseFactory.build({ platform: defaultPlatform });
     renderWithTheme(<DatabaseManageNetworking database={mockDatabase} />);
-    // Should render a loading state
-    const expectedErrorText =
-      'There was a problem retrieving your VPC. Please try again later.';
+    const expectedErrorText = errorStateMessage;
     const errorState = screen.getByText(expectedErrorText);
     expect(errorState).toBeInTheDocument();
   });
 
-  it('should render error state when a VPC is configured, but useVPCQuery responds without a VPC', async () => {
-    queryMocks.useVPCQuery.mockReturnValue({
-      data: null,
+  it('Should render error state when all VPCs query response is successful, but configured VPC is not found', () => {
+    const altVPCId = mockVPC.id + 1;
+    const altMockVPC = vpcFactory.build({ id: altVPCId });
+    queryMocks.useAllVPCsQuery.mockReturnValue({
+      data: [altMockVPC],
+      isLoading: false,
     });
-    const mockDatabase = databaseFactory.build({ platform: defaultPlatform });
     renderWithTheme(<DatabaseManageNetworking database={mockDatabase} />);
-    // Should render a loading state
-    const expectedErrorText =
-      'There was a problem retrieving your VPC. Please try again later.';
-    const errorState = screen.getByText(expectedErrorText);
-    expect(errorState).toBeInTheDocument();
+
+    const expectedErrorMessage = errorStateMessage;
+    const errorMessage = screen.getByText(expectedErrorMessage);
+    expect(errorMessage).toBeInTheDocument();
   });
 
   it('Should render Manage Networking field with VPC grid variation when VPC is configured for the database', () => {
-    queryMocks.useVPCQuery.mockReturnValue({
+    queryMocks.useAllVPCsQuery.mockReturnValue({
       isLoading: false,
-      data: vpcFactory.build(),
-      error: null,
+      data: [mockVPC],
     });
-    const mockDatabase = databaseFactory.build({ platform: defaultPlatform });
     renderWithTheme(<DatabaseManageNetworking database={mockDatabase} />);
 
     const heading = screen.getByRole('heading');

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworking.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworking.tsx
@@ -1,4 +1,4 @@
-import { useVPCQuery } from '@linode/queries';
+import { useAllVPCsQuery } from '@linode/queries';
 import { Button, CircleProgress, ErrorState, Typography } from '@linode/ui';
 import { Grid } from '@mui/material';
 import React from 'react';
@@ -10,6 +10,8 @@ import {
   StyledLabelTypography,
   StyledValueGrid,
 } from '../DatabaseSummary/DatabaseSummaryClusterConfiguration.style';
+import DatabaseManageNetworkingDrawer from './DatabaseManageNetworkingDrawer';
+import { DatabaseNetworkingUnassignVPCDialog } from './DatabaseNetworkingUnassignVPCDialog';
 
 import type { Database } from '@linode/api-v4';
 import type { Theme } from '@mui/material';
@@ -58,17 +60,34 @@ export const DatabaseManageNetworking = ({ database }: Props) => {
   }));
 
   const { classes } = useStyles();
+  const [isManageNetworkingDrawerOpen, setIsManageNetworkingDrawerOpen] =
+    React.useState(false);
+  const [isUnassignVPCDialogOpen, setIsUnassignVPCDialogOpen] =
+    React.useState(false);
+
   const vpcId = Number(database.private_network?.vpc_id);
   const hasVPCConfigured = Boolean(vpcId);
   const gridContainerSize = { lg: 7, md: 10 };
   const gridValueSize = { md: 8, xs: 9 };
   const gridLabelSize = { md: 4, xs: 3 };
 
-  const { data: vpc, isLoading, error } = useVPCQuery(vpcId, hasVPCConfigured);
+  const {
+    data: vpcs,
+    error,
+    isLoading,
+  } = useAllVPCsQuery({
+    enabled: !!database?.region,
+    filter: { region: database?.region },
+  });
 
-  const currentSubnet = vpc?.subnets.find(
+  const currentVPC = React.useMemo(() => {
+    return vpcs?.find((vpc) => vpc.id === vpcId);
+  }, [vpcs, vpcId]);
+
+  const currentSubnet = currentVPC?.subnets.find(
     (subnet) => subnet.id === database?.private_network?.subnet_id
   );
+  const hasVPCs = Boolean(vpcs && vpcs.length > 0);
 
   const readOnlyHost = () => {
     const defaultValue = 'N/A';
@@ -76,13 +95,22 @@ export const DatabaseManageNetworking = ({ database }: Props) => {
     return <span>{value}</span>;
   };
 
+  const onManageAccess = () => {
+    setIsManageNetworkingDrawerOpen(true);
+  };
+
+  const handleUnassignVPC = () => {
+    setIsManageNetworkingDrawerOpen(false);
+    setIsUnassignVPCDialogOpen(true);
+  };
+
   if (isLoading) {
     return <CircleProgress />;
   }
 
-  if (error || (hasVPCConfigured && !vpc)) {
+  if (error || (hasVPCConfigured && !currentVPC)) {
     return (
-      <ErrorState errorText="There was a problem retrieving your VPC. Please try again later." />
+      <ErrorState errorText="There was a problem retrieving your VPC assignment settings. Refresh the page or try again later." />
     );
   }
 
@@ -104,8 +132,10 @@ export const DatabaseManageNetworking = ({ database }: Props) => {
         <Button
           buttonType="outlined"
           className={classes.manageNetworkingBtn}
-          disabled={true} // TODO (UIE-8617): Add Manage Networking functionality
-          onClick={() => null}
+          disabled={!hasVPCs}
+          onClick={onManageAccess}
+          TooltipProps={{ placement: 'top' }}
+          tooltipText="To manage networking, you need to have a VPC in the same region as the database cluster."
         >
           Manage Networking
         </Button>
@@ -123,7 +153,9 @@ export const DatabaseManageNetworking = ({ database }: Props) => {
             <Grid size={gridLabelSize}>
               <StyledLabelTypography>VPC</StyledLabelTypography>
             </Grid>
-            <StyledValueGrid size={gridValueSize}>{vpc?.label}</StyledValueGrid>
+            <StyledValueGrid size={gridValueSize}>
+              {currentVPC?.label}
+            </StyledValueGrid>
             <Grid size={gridLabelSize}>
               <StyledLabelTypography>Subnet</StyledLabelTypography>
             </Grid>
@@ -160,6 +192,25 @@ export const DatabaseManageNetworking = ({ database }: Props) => {
           </>
         )}
       </StyledGridContainer>
+
+      {isManageNetworkingDrawerOpen && (
+        <DatabaseManageNetworkingDrawer
+          database={database}
+          onClose={() => setIsManageNetworkingDrawerOpen(false)}
+          onUnassign={handleUnassignVPC}
+          open={isManageNetworkingDrawerOpen}
+          vpc={currentVPC}
+        />
+      )}
+      {!isManageNetworkingDrawerOpen && isUnassignVPCDialogOpen && (
+        <DatabaseNetworkingUnassignVPCDialog
+          databaseEngine={database?.engine}
+          databaseId={database?.id}
+          databaseLabel={database?.label}
+          onClose={() => setIsUnassignVPCDialogOpen(false)}
+          open={isUnassignVPCDialogOpen}
+        />
+      )}
     </>
   );
 };

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworkingDrawer.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworkingDrawer.test.tsx
@@ -1,0 +1,186 @@
+import { regionFactory } from '@linode/utilities';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { describe, it } from 'vitest';
+
+import { subnetFactory, vpcFactory } from 'src/factories';
+import { databaseFactory } from 'src/factories/databases';
+import {
+  renderWithTheme,
+  renderWithThemeAndRouter,
+} from 'src/utilities/testHelpers';
+
+import DatabaseManageNetworkingDrawer from './DatabaseManageNetworkingDrawer';
+
+const defaultPlatform = 'rdbms-default';
+const mockSubnets = [
+  subnetFactory.build({ id: 1 }),
+  subnetFactory.build({ id: 2 }),
+];
+const mockVPC = vpcFactory.build({ id: 12345 });
+const mockPrivateNetwork = {
+  vpc_id: mockVPC.id,
+  subnet_id: mockSubnets[0].id,
+  public_access: false,
+};
+const mockDatabase = databaseFactory.build({
+  platform: defaultPlatform,
+  private_network: mockPrivateNetwork,
+  engine: 'mysql',
+  id: 1,
+});
+
+const mockProps = {
+  database: mockDatabase,
+  onClose: vi.fn(),
+  onUnassign: vi.fn(),
+  open: true,
+  vpc: mockVPC,
+};
+
+const mockRegion = regionFactory.build({
+  capabilities: ['VPCs'],
+  id: 'us-east',
+  label: 'Newark, NJ',
+});
+
+const saveButtonTestId = 'save-networking-button';
+
+// Hoist query mocks
+const queryMocks = vi.hoisted(() => {
+  return {
+    useRegionQuery: vi.fn().mockReturnValue({}),
+    useAllVPCsQuery: vi.fn().mockReturnValue({ data: [] }),
+    useDatabaseMutation: vi.fn(),
+    useNavigate: vi.fn(() => vi.fn()),
+  };
+});
+
+vi.mock('@linode/queries', async () => {
+  const actual = await vi.importActual('@linode/queries');
+  return {
+    ...actual,
+    useAllVPCsQuery: queryMocks.useAllVPCsQuery,
+    useDatabaseMutation: queryMocks.useDatabaseMutation,
+    useRegionQuery: queryMocks.useRegionQuery,
+  };
+});
+
+vi.mock('@tanstack/react-router', async () => {
+  const actual = await vi.importActual('@tanstack/react-router');
+  return {
+    ...actual,
+    useNavigate: queryMocks.useNavigate,
+  };
+});
+
+describe('DatabaseManageNetworkingDrawer Component', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    queryMocks.useAllVPCsQuery.mockReturnValue({
+      data: [mockVPC],
+    });
+  });
+
+  it('Should render the VPC Selector', () => {
+    queryMocks.useRegionQuery.mockReturnValue({
+      data: mockRegion,
+    });
+    renderWithThemeAndRouter(<DatabaseManageNetworkingDrawer {...mockProps} />);
+
+    const vpcSelectorLabel = screen.getByText('Assign a VPC');
+    expect(vpcSelectorLabel).toBeInTheDocument();
+  });
+
+  it(`should display Unassign button when database has networking configuration`, async () => {
+    queryMocks.useRegionQuery.mockReturnValue({
+      data: mockRegion,
+    });
+    await renderWithThemeAndRouter(
+      <DatabaseManageNetworkingDrawer {...mockProps} />
+    );
+
+    const unassignButton = screen.getByText('Unassign VPC');
+    expect(unassignButton).toBeInTheDocument();
+  });
+
+  it(`should not display the Unassign button when database has no networking configuration`, async () => {
+    queryMocks.useRegionQuery.mockReturnValue({
+      data: mockRegion,
+    });
+    // Create an alternative props object with DB Cluster with no networking configuration
+    const altProps = {
+      ...mockProps,
+      database: { ...mockDatabase, private_network: null },
+    };
+    await renderWithThemeAndRouter(
+      <DatabaseManageNetworkingDrawer {...altProps} />
+    );
+
+    expect(screen.queryByText('Unassign VPC')).not.toBeInTheDocument();
+  });
+
+  it(`should disable Save when when loaded without any changes to the form`, async () => {
+    queryMocks.useRegionQuery.mockReturnValue({
+      data: mockRegion,
+    });
+    await renderWithTheme(<DatabaseManageNetworkingDrawer {...mockProps} />);
+    const saveButton = screen.getByTestId(saveButtonTestId);
+    expect(saveButton).toBeDisabled();
+  });
+
+  it(`should enable Save when networking configuration has changed and is valid`, async () => {
+    queryMocks.useRegionQuery.mockReturnValue({
+      data: mockRegion,
+    });
+    await renderWithThemeAndRouter(
+      <DatabaseManageNetworkingDrawer {...mockProps} />,
+      {
+        initialRoute: `/databases/${mockProps.database.engine}/${mockProps.database.id}/networking`,
+      }
+    );
+
+    const accessCheckbox = screen.getByTestId(
+      'database-public-access-checkbox'
+    );
+    await userEvent.click(accessCheckbox);
+
+    const saveButton = screen.getByTestId(saveButtonTestId);
+    expect(saveButton).toBeEnabled();
+  });
+
+  it(`should navigate to summary`, async () => {
+    queryMocks.useRegionQuery.mockReturnValue({
+      data: mockRegion,
+    });
+    const mockNavigate = vi.fn();
+    queryMocks.useNavigate.mockReturnValue(mockNavigate);
+
+    renderWithThemeAndRouter(
+      <DatabaseManageNetworkingDrawer {...mockProps} />,
+      {
+        initialRoute: `/databases/${mockProps.database.engine}/${mockProps.database.id}/networking`,
+      }
+    );
+
+    const accessCheckbox = screen.getByTestId(
+      'database-public-access-checkbox'
+    );
+    await userEvent.click(accessCheckbox);
+
+    const saveButton = screen.getByTestId(saveButtonTestId);
+    expect(saveButton).toBeEnabled();
+    await userEvent.click(saveButton);
+    // Check that navigation occurs after form submission
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        params: {
+          engine: mockProps.database.engine,
+          databaseId: mockProps.database.id,
+        },
+        to: '/databases/$engine/$databaseId',
+      });
+    });
+  });
+});

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworkingDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworkingDrawer.tsx
@@ -1,0 +1,156 @@
+import { Box, Button, Drawer, Notice } from '@linode/ui';
+import { useNavigate } from '@tanstack/react-router';
+import { useFormik } from 'formik';
+import { enqueueSnackbar } from 'notistack';
+import * as React from 'react';
+import { boolean, number, object } from 'yup';
+
+import { useDatabaseMutation } from 'src/queries/databases/databases';
+
+import { DatabaseVPCSelector } from '../../DatabaseCreate/DatabaseVPCSelector';
+
+import type {
+  Database,
+  PrivateNetwork,
+  UpdateDatabasePayload,
+  VPC,
+} from '@linode/api-v4';
+import type { Theme } from '@linode/ui';
+import type { ObjectSchema } from 'yup';
+
+interface Props {
+  database: Database;
+  onClose: () => void;
+  onUnassign: () => void;
+  open: boolean;
+  vpc: undefined | VPC;
+}
+
+export type ManageNetworkingFormValues = {
+  private_network: PrivateNetwork;
+};
+
+const privateNetworkSchema: ObjectSchema<ManageNetworkingFormValues> = object({
+  private_network: object().shape({
+    vpc_id: number().required('VPC is required.'),
+    subnet_id: number().required('Subnet is required.'),
+    public_access: boolean().default(false),
+  }),
+});
+
+const DatabaseManageNetworkingDrawer = (props: Props) => {
+  const { database, vpc, onClose, onUnassign, open } = props;
+  const navigate = useNavigate();
+
+  // Set up initial values for the form. These fields will be empty if no VPC is configured.
+  const initialValues: ManageNetworkingFormValues = {
+    private_network: {
+      vpc_id: vpc?.id ?? null,
+      subnet_id: database?.private_network?.subnet_id ?? null,
+      public_access: database?.private_network?.public_access ?? false,
+    },
+  };
+
+  const submitForm = () => {
+    const payload: UpdateDatabasePayload = { ...values };
+
+    updateDatabase(payload).then(() => {
+      enqueueSnackbar('Changes are being applied.', {
+        variant: 'info',
+      });
+
+      navigate({
+        to: '/databases/$engine/$databaseId',
+        params: {
+          engine: database.engine,
+          databaseId: database.id,
+        },
+      });
+    });
+  };
+
+  const { errors, handleSubmit, isValid, dirty, setFieldValue, values } =
+    useFormik<ManageNetworkingFormValues>({
+      initialValues,
+      onSubmit: submitForm,
+      validationSchema: privateNetworkSchema,
+    });
+
+  const hasVPCConfigured = !!database?.private_network?.vpc_id;
+  const hasConfigChanged =
+    values.private_network.vpc_id !== database?.private_network?.vpc_id ||
+    values.private_network.subnet_id !== database?.private_network?.subnet_id ||
+    values.private_network.public_access !==
+      database?.private_network?.public_access;
+
+  const isSaveDisabled = !dirty || !isValid || !hasConfigChanged;
+
+  const {
+    error: manageNetworkingError,
+    isPending: submitInProgress,
+    mutateAsync: updateDatabase,
+  } = useDatabaseMutation(database.engine, database.id);
+
+  return (
+    <Drawer onClose={onClose} open={open} title="Manage Networking">
+      {manageNetworkingError && (
+        <Notice text={manageNetworkingError[0].reason} variant="error" />
+      )}
+      <form onSubmit={handleSubmit}>
+        <DatabaseVPCSelector
+          errors={errors}
+          mode="networking"
+          onChange={(field: string, value: boolean | null | number) =>
+            setFieldValue(field, value)
+          }
+          privateNetworkValues={values.private_network}
+          selectedRegionId={database?.region}
+        />
+        <Box
+          sx={(theme: Theme) => ({
+            marginTop: theme.spacingFunction(50),
+            paddingTop: theme.spacingFunction(8),
+            paddingBottom: theme.spacingFunction(8),
+            display: 'flex',
+            justifyContent: hasVPCConfigured ? 'space-between' : 'flex-end',
+          })}
+        >
+          {hasVPCConfigured && (
+            <Button
+              buttonType="outlined"
+              disabled={!hasVPCConfigured}
+              loading={false}
+              onClick={onUnassign}
+            >
+              Unassign VPC
+            </Button>
+          )}
+          <Box>
+            <Button
+              buttonType="secondary"
+              disabled={false}
+              loading={false}
+              onClick={onClose}
+            >
+              Cancel
+            </Button>
+            <Button
+              buttonType="primary"
+              data-testid="save-networking-button"
+              disabled={isSaveDisabled}
+              loading={submitInProgress}
+              sx={(theme: Theme) => ({
+                marginLeft: theme.spacingFunction(12),
+              })}
+              type="submit"
+            >
+              Save
+            </Button>
+          </Box>
+        </Box>
+      </form>
+    </Drawer>
+  );
+};
+
+export default DatabaseManageNetworkingDrawer;

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseNetworkingUnassignVPCDialog.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseNetworkingUnassignVPCDialog.test.tsx
@@ -1,0 +1,88 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { describe, it } from 'vitest';
+
+import { subnetFactory, vpcFactory } from 'src/factories';
+import { databaseFactory } from 'src/factories/databases';
+import { renderWithThemeAndRouter } from 'src/utilities/testHelpers';
+
+import { DatabaseNetworkingUnassignVPCDialog } from './DatabaseNetworkingUnassignVPCDialog';
+
+const defaultPlatform = 'rdbms-default';
+const mockSubnets = [
+  subnetFactory.build({ id: 1 }),
+  subnetFactory.build({ id: 2 }),
+];
+const mockVPC = vpcFactory.build({ id: 12345 });
+const mockPrivateNetwork = {
+  vpc_id: mockVPC.id,
+  subnet_id: mockSubnets[0].id,
+  public_access: false,
+};
+const mockDatabase = databaseFactory.build({
+  platform: defaultPlatform,
+  private_network: mockPrivateNetwork,
+  engine: 'mysql',
+  id: 1,
+});
+
+const mockProps = {
+  databaseEngine: mockDatabase.engine,
+  databaseId: mockDatabase.id,
+  databaseLabel: mockDatabase.label,
+  onClose: vi.fn(),
+  open: true,
+};
+
+const unassignButtonTestId = 'unassign-button';
+
+// Hoist query mocks
+const queryMocks = vi.hoisted(() => {
+  return {
+    useDatabaseMutation: vi.fn(),
+    useNavigate: vi.fn(() => vi.fn()),
+  };
+});
+
+vi.mock('@linode/queries', async () => {
+  const actual = await vi.importActual('@linode/queries');
+  return {
+    ...actual,
+    useDatabaseMutation: queryMocks.useDatabaseMutation,
+  };
+});
+
+vi.mock('@tanstack/react-router', async () => {
+  const actual = await vi.importActual('@tanstack/react-router');
+  return {
+    ...actual,
+    useNavigate: queryMocks.useNavigate,
+  };
+});
+
+describe('DatabaseNetworkingUnassignVPCDialog Component', () => {
+  it(`should navigate to summary after unassigning`, async () => {
+    const mockNavigate = vi.fn();
+    queryMocks.useNavigate.mockReturnValue(mockNavigate);
+    await renderWithThemeAndRouter(
+      <DatabaseNetworkingUnassignVPCDialog {...mockProps} />,
+      {
+        initialRoute: `/databases/${mockProps.databaseEngine}/${mockProps.databaseId}/networking`,
+      }
+    );
+
+    const unassignButton = screen.getByTestId(unassignButtonTestId);
+    await userEvent.click(unassignButton);
+    // Check that navigation occurs after unassign button is clicked
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        params: {
+          engine: mockProps.databaseEngine,
+          databaseId: mockProps.databaseId,
+        },
+        to: '/databases/$engine/$databaseId',
+      });
+    });
+  });
+});

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseNetworkingUnassignVPCDialog.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseNetworkingUnassignVPCDialog.tsx
@@ -1,0 +1,98 @@
+import { ActionsPanel, Notice, Typography } from '@linode/ui';
+import { useNavigate } from '@tanstack/react-router';
+import { enqueueSnackbar } from 'notistack';
+import React from 'react';
+
+import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
+import { useDatabaseMutation } from 'src/queries/databases/databases';
+
+import type { Engine, UpdateDatabasePayload } from '@linode/api-v4';
+import type { Theme } from '@linode/ui';
+
+interface Props {
+  databaseEngine: Engine;
+  databaseId: number;
+  databaseLabel: string;
+  onClose: () => void;
+  open: boolean;
+}
+
+export const DatabaseNetworkingUnassignVPCDialog = (props: Props) => {
+  const { databaseEngine, databaseId, databaseLabel, onClose, open } = props;
+
+  const navigate = useNavigate();
+
+  const {
+    error,
+    isPending: submitInProgress,
+    mutateAsync: updateDatabase,
+  } = useDatabaseMutation(databaseEngine, databaseId);
+
+  const onUnassign = async () => {
+    const payload: UpdateDatabasePayload = { private_network: null };
+
+    updateDatabase(payload).then(() => {
+      onClose();
+      enqueueSnackbar('Changes are being applied.', {
+        variant: 'info',
+      });
+
+      navigate({
+        to: '/databases/$engine/$databaseId',
+        params: {
+          engine: databaseEngine,
+          databaseId,
+        },
+      });
+    });
+  };
+
+  const renderActions = (
+    onClose: () => void,
+    onConfirm: () => void,
+    loading: boolean
+  ) => {
+    return (
+      <ActionsPanel
+        primaryButtonProps={{
+          'data-testid': 'unassign-button',
+          label: 'Unassign',
+          loading,
+          onClick: onConfirm,
+        }}
+        secondaryButtonProps={{ label: 'Cancel', onClick: onClose }}
+      />
+    );
+  };
+
+  return (
+    <ConfirmationDialog
+      actions={renderActions(onClose, onUnassign, submitInProgress)}
+      onClose={onClose}
+      open={open}
+      title={`Unassign ${databaseLabel} from VPC?`}
+    >
+      {error && <Notice variant="error">{error[0].reason}</Notice>}
+      <Typography>
+        The unassignment of the VPC will cause a temporary downtime during the
+        transition and will make the cluster accessible only via its public IP.
+      </Typography>
+
+      <Typography
+        sx={(theme: Theme) => ({
+          marginTop: theme.spacingFunction(20),
+          marginBottom: theme.spacingFunction(20),
+        })}
+      >
+        Once unassigned, review the allowed IP list to help prevent unauthorized
+        access and clear DNS caches to ensure that applications resolve the new
+        IP addresses correctly.
+      </Typography>
+
+      <Typography>
+        Note that if you want to change the VPC assigned to the cluster, you can
+        do it without unassigning the current VPC first.
+      </Typography>
+    </ConfirmationDialog>
+  );
+};

--- a/packages/manager/src/features/Databases/constants.ts
+++ b/packages/manager/src/features/Databases/constants.ts
@@ -39,3 +39,5 @@ export const LEARN_MORE_LINK =
   'https://techdocs.akamai.com/cloud-computing/docs/aiven-manage-database#ipv6-support';
 export const ADVANCED_CONFIG_LEARN_MORE_LINK =
   'https://techdocs.akamai.com/cloud-computing/docs/advanced-configuration-parameters';
+export const MANAGE_NETWORKING_LEARN_MORE_LINK =
+  'https://techdocs.akamai.com/cloud-computing/docs/aiven-manage-database#manage-networking';


### PR DESCRIPTION
## Description 📝
Implementing Manage Networking functionality for Networking tab in DB details and adding Learn More link. Users can now access the Manage Networking drawer to manage their VPCs. From here they can modify existing VPC configurations or unassign a VPC.

This PR also includes some updated error handling and bug fixes.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Manage Networking button now enables/disables based on VPC availability
- Manage Access opens a drawer where users can select/modify a VPC configuration
- The Unassign VPC button in the Manage Access Drawer opens a confirmation dialog where users confirm that they want to assign a VPC.
- A learn more link is now displayed for the text in the VPC selector for both Create and in the Manage Access drawer.

## Target release date 🗓️

6/17/2025

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![manage-networking-initial](https://github.com/user-attachments/assets/0868458d-74fa-4f08-a885-be9455ef8000)| ![networking-with-manage-networking-enabled](https://github.com/user-attachments/assets/fcfc6be1-3c16-4a28-85a2-1875a7890673)
After (Additional Screenshots)
| ![manage-networking-disabled](https://github.com/user-attachments/assets/2c29645c-6315-4d33-a200-1d4416228b7e)|
![Manage Networking Drawer](https://github.com/user-attachments/assets/51543479-96d0-4d1d-ac76-f4181bc23b2d)| ![unassign-dialog](https://github.com/user-attachments/assets/910c905c-5cf0-43d2-a733-1577420c266d)


## How to test 🧪

### Prerequisites

(How to setup test environment)

- Make sure you have the `databaseVpc` feature flag enabled
- Make sure you have access to the Databases tab on the right navigation panel.
- Make sure you have new databases available and can access their details and view the Networking tab
- To test database VPC configuration functionality, you'll have to use mock data as this data is not currently available from the backend.
- Have VPCs created for a region
- Instructions on setting up mock data will be provided in a comment below.

### Verification steps

(How to verify changes)

- [ ] Access the Networking tab for a new database cluster with VPCs available for the region
- [ ] See that the 'Manage Access' button enables/disables based on if VPCs are available for the region
- [ ] Access the drawer by clicking the 'Manage Access' button.
- [ ] Verify that, VPCs are preselected based on `private_network` property for the database cluster
- [ ] Verify that, if database has no VPC configuration VPC and Subnet fields are not preselected
- [ ] Verify that validation errors are thrown when VPC or Subnet field are modified
- [ ] Verify that making a valid change to the configuration enables the Save button
- [ ] Save and confirm that the `private_network` object is provided in the updateDatabase PUT request and you are navigated to the summary
- [ ] Select Unassign VPC and open the unassign dialog
- [ ] Select Unassign and confirm that `private_network` object is provided with vpc_id as null for the PUT request and that you are navigated to the summary

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
