### PR TITLE
feat: [UIE-8887] - IAM RBAC: assign new role drawer fix

### DIFF
--- a/packages/manager/.changeset/pr-12356-upcoming-features-1749556168543.md
+++ b/packages/manager/.changeset/pr-12356-upcoming-features-1749556168543.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Inconsistent layout when entity names are long and previously assigned roles reappear when reopening the Assign New Roles Drawer ([#12356](https://github.com/linode/manager/pull/12356))

--- a/packages/manager/src/features/IAM/Shared/Entities/Entities.tsx
+++ b/packages/manager/src/features/IAM/Shared/Entities/Entities.tsx
@@ -106,8 +106,16 @@ export const Entities = ({
         )}
         sx={{
           marginTop: 0,
+          '& .MuiChip-root': {
+            padding: theme.tokens.spacing.S4,
+            height: 'auto',
+          },
           '& .MuiInputLabel-root': {
             color: theme.tokens.alias.Content.Text.Primary.Default,
+          },
+          '& .MuiChip-labelMedium': {
+            textWrap: 'auto',
+            height: 'auto',
           },
         }}
         value={value || []}

--- a/packages/manager/src/features/IAM/Users/UserRoles/AssignNewRoleDrawer.tsx
+++ b/packages/manager/src/features/IAM/Users/UserRoles/AssignNewRoleDrawer.tsx
@@ -3,7 +3,7 @@ import { useTheme } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import { useQueryClient } from '@tanstack/react-query';
 import { enqueueSnackbar } from 'notistack';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { FormProvider, useFieldArray, useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 
@@ -94,6 +94,13 @@ export const AssignNewRoleDrawer = ({ onClose, open }: Props) => {
     onClose();
   };
 
+  useEffect(() => {
+    if (open) {
+      reset({
+        roles: [{ role: null, entities: null }],
+      });
+    }
+  }, [open, reset]);
   // TODO - add a link 'Learn more" - UIE-8534
   return (
     <Drawer onClose={handleClose} open={open} title="Assign New Roles">
@@ -149,7 +156,7 @@ export const AssignNewRoleDrawer = ({ onClose, open }: Props) => {
             ))}
 
           {/* If all roles are filled, allow them to add another */}
-          {roles.length > 0 && roles.every((field) => field.role) && (
+          {roles.length > 0 && roles.every((field) => field.role?.value) && (
             <StyledLinkButtonBox sx={{ marginTop: theme.tokens.spacing.S12 }}>
               <LinkButton onClick={() => append({ role: null })}>
                 Add another role


### PR DESCRIPTION
## Description 📝

Fixes a layout issue and resolves a bug when assigning roles a second time in the Assign New Roles Drawer.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Fixed layout issue in the Assign New Roles Drawer when an entity has a long name.
- Resolved issue where previously assigned roles reappeared after reopening the drawer and clicking the "Add another role" button.

## Target release date 🗓️

June 17th

## Preview 📷

**Include a screenshot or screen recording of the change.**

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-06-10 at 1 26 37 PM](https://github.com/user-attachments/assets/76670b0b-041b-44de-bb4f-0468a72674ab) | ![Screenshot 2025-06-10 at 1 26 07 PM](https://github.com/user-attachments/assets/b9c35fc7-fc4a-46ce-a52d-4ba7ee40142e) |
| <video src="https://github.com/user-attachments/assets/2b6c30e1-3e2b-42df-9204-4970cb2e00e5" /> | <video src="https://github.com/user-attachments/assets/9ca13379-0816-427a-9f3a-5f2eafdc9683" /> | 

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Ensure the Identity and Access Beta flag is enabled in dev tools
- Use devenv and login as vagrant user

### Verification steps

(How to verify changes)

- [ ] Go to the Assigned Roles tab.
- [ ] Click Assign New Roles.
- [ ] Add `account_image_creator` and `image_admin` for `kwojtowi-test-instance-Ubuntu 24.04 LTS Disk` entity.
- [ ] Verify that the width of the gray block is consistent and the layout is not broken.
- [ ] Click the Assign button, the drawer should close.
- [ ] Open the Assign New Roles drawer again.
- [ ] Select a role and click the Add another role button.
- [ ] Verify that previously assigned roles do not reappear, and that the Add another role button is visible.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
