### PR TITLE
refactor: [M3-9367] - Move betas queries

### DIFF
--- a/packages/manager/.changeset/pr-12358-removed-1749569954130.md
+++ b/packages/manager/.changeset/pr-12358-removed-1749569954130.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Removed
+---
+
+Moved betas queries and dependencies to shared `queries` package ([#12358](https://github.com/linode/manager/pull/12358))

--- a/packages/manager/src/features/Betas/BetaSignup.tsx
+++ b/packages/manager/src/features/Betas/BetaSignup.tsx
@@ -1,4 +1,4 @@
-import { useCreateAccountBetaMutation } from '@linode/queries';
+import { useBetaQuery, useCreateAccountBetaMutation } from '@linode/queries';
 import {
   ActionsPanel,
   Checkbox,
@@ -18,7 +18,6 @@ import * as React from 'react';
 
 import { LandingHeader } from 'src/components/LandingHeader/LandingHeader';
 import { Markdown } from 'src/components/Markdown/Markdown';
-import { useBetaQuery } from 'src/queries/betas';
 
 export const BetaSignup = () => {
   const betaAgreement = `### Early Adopter Testing Program

--- a/packages/manager/src/features/Betas/BetasLanding.tsx
+++ b/packages/manager/src/features/Betas/BetasLanding.tsx
@@ -1,4 +1,4 @@
-import { useAccountBetasQuery } from '@linode/queries';
+import { useAccountBetasQuery, useBetasQuery } from '@linode/queries';
 import { Stack } from '@linode/ui';
 import { categorizeBetasByStatus } from '@linode/utilities';
 import { createLazyRoute } from '@tanstack/react-router';
@@ -8,7 +8,6 @@ import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { LandingHeader } from 'src/components/LandingHeader/LandingHeader';
 import { ProductInformationBanner } from 'src/components/ProductInformationBanner/ProductInformationBanner';
 import { BetaDetailsList } from 'src/features/Betas/BetaDetailsList';
-import { useBetasQuery } from 'src/queries/betas';
 
 import type { AccountBeta, Beta } from '@linode/api-v4';
 

--- a/packages/queries/.changeset/pr-12358-added-1749569989585.md
+++ b/packages/queries/.changeset/pr-12358-added-1749569989585.md
@@ -1,0 +1,5 @@
+---
+"@linode/queries": Added
+---
+
+Created `betas/` directory and migrated relevant query keys and hooks ([#12358](https://github.com/linode/manager/pull/12358))

--- a/packages/queries/src/betas/betas.ts
+++ b/packages/queries/src/betas/betas.ts
@@ -1,6 +1,6 @@
-import { getBeta, getBetas } from '@linode/api-v4/lib/betas';
-import { createQueryKeys } from '@lukemorales/query-key-factory';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { betaQueries } from './keys';
 
 import type { Beta } from '@linode/api-v4/lib/betas';
 import type {
@@ -9,17 +9,6 @@ import type {
   Params,
   ResourcePage,
 } from '@linode/api-v4/lib/types';
-
-export const betaQueries = createQueryKeys('betas', {
-  beta: (id: string) => ({
-    queryFn: () => getBeta(id),
-    queryKey: [id],
-  }),
-  paginated: (params: Params = {}, filter: Filter = {}) => ({
-    queryFn: () => getBetas(params, filter),
-    queryKey: [params, filter],
-  }),
-});
 
 export const useBetasQuery = (params?: Params, filter?: Filter) =>
   useQuery<ResourcePage<Beta>, APIError[]>({

--- a/packages/queries/src/betas/index.ts
+++ b/packages/queries/src/betas/index.ts
@@ -1,0 +1,2 @@
+export * from './betas';
+export * from './keys';

--- a/packages/queries/src/betas/keys.ts
+++ b/packages/queries/src/betas/keys.ts
@@ -1,0 +1,15 @@
+import { getBeta, getBetas } from '@linode/api-v4/lib/betas';
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+
+import type { Filter, Params } from '@linode/api-v4/lib/types';
+
+export const betaQueries = createQueryKeys('betas', {
+  beta: (id: string) => ({
+    queryFn: () => getBeta(id),
+    queryKey: [id],
+  }),
+  paginated: (params: Params = {}, filter: Filter = {}) => ({
+    queryFn: () => getBetas(params, filter),
+    queryKey: [params, filter],
+  }),
+});

--- a/packages/queries/src/index.ts
+++ b/packages/queries/src/index.ts
@@ -1,5 +1,6 @@
 export * from './account';
 export * from './base';
+export * from './betas';
 export * from './domains';
 export * from './eventHandlers';
 export * from './firewalls';


### PR DESCRIPTION
## Description 📝
Migrates betas queries, as well as all dependencies, under the  `@linode/queries` package.

## Changes  🔄
- Creates new `betas/` directory in the `@linode/queries` package with the following structure:
```
types/
|__ index.ts
|__betas.ts
|__keys.ts
```
- Updates import paths throughout `packages/manager`.

## How to test 🧪
- Rely on e2e tests and CI pipeline to ensure changes do not break the application.
- No changes to the UI as a result of this PR.

### Verification steps
- Verify that the betas feature works as expected.
- Verify that other major flows continue to work as expected.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
