### PR TITLE
fix: [M3-10146] - Port Hyperlink for Nodebalancer showing error

### DIFF
--- a/packages/manager/.changeset/pr-12366-fixed-1749660945872.md
+++ b/packages/manager/.changeset/pr-12366-fixed-1749660945872.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Routing issue when clicking port links on Nodebalancer Summary Page ([#12366](https://github.com/linode/manager/pull/12366))

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurationsWrapper.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurationsWrapper.tsx
@@ -5,7 +5,7 @@ import {
 } from '@linode/queries';
 import { CircleProgress, ErrorState } from '@linode/ui';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useParams } from '@tanstack/react-router';
+import { useMatchRoute, useParams } from '@tanstack/react-router';
 import React from 'react';
 
 import { useIsNodebalancerVPCEnabled } from '../utils';
@@ -18,11 +18,17 @@ import type { APIError } from '@linode/api-v4';
 export const NodeBalancerConfigurationsWrapper = () => {
   const queryClient = useQueryClient();
 
-  const { id: nodeBalancerId } = useParams({
-    from: '/nodebalancers/$id/configurations',
+  const matchRoute = useMatchRoute();
+
+  const routeParams = useParams({ from: '/nodebalancers/$id/configurations' });
+  const nodeBalancerId = routeParams.id;
+
+  const configParams = matchRoute({
+    to: '/nodebalancers/$id/configurations/$configId',
+    fuzzy: false,
   });
 
-  const { configId } = useParams({ strict: false });
+  const configId = configParams !== false ? configParams.configId : undefined;
 
   const { data: grants } = useGrants();
   const { data: nodeBalancer } = useNodeBalancerQuery(+nodeBalancerId);

--- a/packages/manager/src/routes/nodeBalancers/index.ts
+++ b/packages/manager/src/routes/nodeBalancers/index.ts
@@ -55,8 +55,8 @@ const nodeBalancerDetailConfigurationsRoute = createRoute({
 );
 
 const nodeBalancerDetailConfigurationRoute = createRoute({
-  getParentRoute: () => nodeBalancersRoute,
-  path: '$id/configurations/$configId',
+  getParentRoute: () => nodeBalancerDetailConfigurationsRoute,
+  path: '$configId',
 }).lazy(() =>
   import('./nodeBalancersLazyRoutes').then((m) => m.nodeBalancerDetailLazyRoute)
 );


### PR DESCRIPTION
## Description

- This PR Fixes a routing issue where clicking on a port under the NodeBalancer Summary page causes an "Invariant Failed" error instead of navigating to the correct configuration.

## Changes

- Fixed port link routing on the NodeBalancer Summary page.

## Target Release

**6/17**

## Preview

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/963648e9-1d40-4375-80ad-eff56d3a3def) | ![After](https://github.com/user-attachments/assets/2b6698c2-bf00-45c1-8ed6-b6d5a6a84fda) |

## How to Test

1. Create a NodeBalancer with configurations.
2. Navigate to `/nodebalancers`.
3. Click on a port under the NodeBalancer Summary.
4. Verify it redirects to the correct configuration page.

<details>
<summary>Author Checklists</summary>

### As an Author, I considered:  
- [x] Self-review  
- [x] Contribution guidelines  
- [x] Small, focused PR  
- [x] Changeset added if needed  
- [x] Tests added or updated  
- [x] No sensitive info  
- [x] Feature flag if needed  
- [x] Reproduction steps  
- [x] Docs updated if needed  
- [x] Mobile and a11y support  

### Before moving from Draft to Open:  
- [x] All unit tests passing  
- [x] TypeScript compiles  
- [x] Linting passes  

</details>
