### PR TITLE
upcoming: [M3-9987] - Update `interface` firewall entity type to `linode_interface`

### DIFF
--- a/packages/api-v4/.changeset/pr-12367-upcoming-features-1749659461264.md
+++ b/packages/api-v4/.changeset/pr-12367-upcoming-features-1749659461264.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Upcoming Features
+---
+
+Change references of `interface` to `linode_interface` for firewall types ([#12367](https://github.com/linode/manager/pull/12367))

--- a/packages/api-v4/src/firewalls/types.ts
+++ b/packages/api-v4/src/firewalls/types.ts
@@ -71,7 +71,7 @@ export interface FirewallTemplate {
 
 export interface CreateFirewallPayload {
   devices?: null | {
-    linode_interface?: number[];
+    linode_interfaces?: number[];
     linodes?: number[];
     nodebalancers?: number[];
   };

--- a/packages/api-v4/src/firewalls/types.ts
+++ b/packages/api-v4/src/firewalls/types.ts
@@ -2,7 +2,10 @@ export type FirewallStatus = 'deleted' | 'disabled' | 'enabled';
 
 export type FirewallRuleProtocol = 'ALL' | 'ICMP' | 'IPENCAP' | 'TCP' | 'UDP';
 
-export type FirewallDeviceEntityType = 'interface' | 'linode' | 'nodebalancer';
+export type FirewallDeviceEntityType =
+  | 'linode'
+  | 'linode_interface'
+  | 'nodebalancer';
 
 export type FirewallPolicyType = 'ACCEPT' | 'DROP';
 
@@ -68,7 +71,7 @@ export interface FirewallTemplate {
 
 export interface CreateFirewallPayload {
   devices?: null | {
-    interfaces?: number[];
+    linode_interface?: number[];
     linodes?: number[];
     nodebalancers?: number[];
   };

--- a/packages/manager/.changeset/pr-12367-upcoming-features-1749660136458.md
+++ b/packages/manager/.changeset/pr-12367-upcoming-features-1749660136458.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Update `interface` firewall entity type to `linode_interface` ([#12367](https://github.com/linode/manager/pull/12367))

--- a/packages/manager/cypress/e2e/core/firewalls/add-device-to-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/add-device-to-firewall.spec.ts
@@ -77,7 +77,7 @@ describe('Can add Linode and Linode Interface devices to firewalls', () => {
     });
     const mockInterfaceDevice = firewallDeviceFactory.build({
       entity: {
-        type: 'interface',
+        type: 'linode_interface',
         id: mockLinodeInterface.id,
         url: `/v4/linode/instances/${mockNewInterfaceLinode.id}/interfaces/${mockLinodeInterface.id}`,
       },
@@ -223,7 +223,7 @@ describe('Can add Linode and Linode Interface devices to firewalls', () => {
 
     const mockInterfaceDevice = firewallDeviceFactory.build({
       entity: {
-        type: 'interface',
+        type: 'linode_interface',
         id: mockVPCInterface.id,
         url: `/v4/linode/instances/${mockMultipleEligibleInterfacesLinode.id}/interfaces/${mockVPCInterface.id}`,
       },
@@ -353,7 +353,7 @@ describe('Can add Linode and Linode Interface devices to firewalls', () => {
     });
     const mockInterfaceDevice = firewallDeviceFactory.build({
       entity: {
-        type: 'interface',
+        type: 'linode_interface',
         id: mockPublicInterface.id,
         url: `/v4/linode/instances/${mockAlreadyAssignedLILinode.id}/interfaces/${mockPublicInterface.id}`,
       },

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddLinodeDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddLinodeDrawer.tsx
@@ -72,7 +72,7 @@ export const AddLinodeDrawer = (props: Props) => {
     () =>
       new Set<number>(
         allFirewallEntities
-          .filter((service) => service.type === 'interface')
+          .filter((service) => service.type === 'linode_interface')
           .map((service) => service.id)
       ),
     [allFirewallEntities]
@@ -211,7 +211,7 @@ export const AddLinodeDrawer = (props: Props) => {
         addDevice({
           firewallId: Number(id),
           id: interfaceInfo.interfaceId,
-          type: 'interface',
+          type: 'linode_interface',
         })
       )
     );

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceRow.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceRow.tsx
@@ -18,7 +18,7 @@ export const FirewallDeviceRow = React.memo((props: FirewallDeviceRowProps) => {
   const { device, isLinodeRelatedDevice } = props;
   const { id, label, type, url } = device.entity;
 
-  const isInterfaceDevice = type === 'interface';
+  const isInterfaceDevice = type === 'linode_interface';
   // for Linode Interfaces, the url comes in as '/v4/linode/instances/:linodeId/interfaces/:interfaceId
   // we need the Linode ID to create a link
   const entityId = isInterfaceDevice ? Number(url.split('/')[4]) : id;

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceTable.tsx
@@ -52,7 +52,9 @@ export const FirewallDeviceTable = React.memo(
 
     const linodeInterfaceDevices =
       type === 'linode'
-        ? allDevices?.filter((device) => device.entity.type === 'interface')
+        ? allDevices?.filter(
+            (device) => device.entity.type === 'linode_interface'
+          )
         : [];
 
     // only fire this query if we have linode interface devices. We fetch the Linodes those devices are attached to
@@ -66,7 +68,7 @@ export const FirewallDeviceTable = React.memo(
     );
 
     const updatedDevices = devices.map((device) => {
-      if (device.entity.type === 'interface') {
+      if (device.entity.type === 'linode_interface') {
         const linodeId = getLinodeIdFromInterfaceDevice(device.entity);
         const associatedLinode = linodesWithInterfaces?.find(
           (linode) => linode.id === linodeId

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/RemoveDeviceDialog.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/RemoveDeviceDialog.tsx
@@ -41,7 +41,7 @@ export const RemoveDeviceDialog = React.memo((props: Props) => {
   const deviceType = device?.entity.type;
 
   const entityLabelToUse =
-    deviceType === 'interface'
+    deviceType === 'linode_interface'
       ? `(ID: ${device?.entity.id})`
       : device?.entity.label;
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/constants.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/constants.ts
@@ -1,7 +1,7 @@
 import type { FirewallDeviceEntityType } from '@linode/api-v4';
 
 export const formattedTypes: Record<FirewallDeviceEntityType, string> = {
-  interface: 'Linode Interface',
+  linode_interface: 'Linode Interface',
   linode: 'Linode',
   nodebalancer: 'NodeBalancer',
 };

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -95,7 +95,7 @@ export const FirewallDetail = () => {
         acc.nodebalancerCount += 1;
       } else if (
         isLinodeInterfacesEnabled &&
-        device.entity.type === 'interface'
+        device.entity.type === 'linode_interface'
       ) {
         const linodeId = getLinodeIdFromInterfaceDevice(device.entity);
         if (!acc.seenLinodeIdsForInterfaces.has(linodeId)) {

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
@@ -36,7 +36,7 @@ export const FirewallRow = React.memo((props: FirewallRowProps) => {
 
   const neededLinodeIdsForInterfaceDevices = entities
     .slice(0, 3) // only take the first three entities since we only show those entity links
-    .filter((entity) => entity.type === 'interface')
+    .filter((entity) => entity.type === 'linode_interface')
     .map((entity) => {
       return { id: getLinodeIdFromInterfaceDevice(entity) };
     });
@@ -151,7 +151,7 @@ const getDevicesCellString = (inputs: DeviceLinkInputs) => {
   } = inputs;
   const filteredEntities = isLinodeInterfacesEnabled
     ? entities
-    : entities.filter((entity) => entity.type !== 'interface');
+    : entities.filter((entity) => entity.type !== 'linode_interface');
 
   if (filteredEntities.length === 0) {
     return 'None assigned';
@@ -178,7 +178,7 @@ export const getDeviceLinks = (
     <>
       {firstThree.map((entity, idx) => {
         // TODO @Linode Interfaces - switch to parent entity when endpoints are updated
-        const isInterfaceDevice = entity.type === 'interface';
+        const isInterfaceDevice = entity.type === 'linode_interface';
         let entityLabel = entity.label;
         let entityLink = `/${entity.type}s/${entity.id}/${
           entity.type === 'linode' ? 'networking' : 'summary'

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/EditInterfaceDrawer/EditInterfaceForm.utils.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/EditInterfaceDrawer/EditInterfaceForm.utils.ts
@@ -71,7 +71,8 @@ export const useUpdateLinodeInterfaceFirewallMutation = (
         );
         // Find the Firewall device by checking the entity
         const device = devices.find(
-          (d) => d.entity.id === interfaceId && d.entity.type === 'interface'
+          (d) =>
+            d.entity.id === interfaceId && d.entity.type === 'linode_interface'
         );
         if (device) {
           await deleteFirewallDevice({
@@ -81,7 +82,7 @@ export const useUpdateLinodeInterfaceFirewallMutation = (
           await createFirewallDevice({
             firewallId: firewall_id,
             id: interfaceId,
-            type: 'interface',
+            type: 'linode_interface',
           });
         } else {
           return Promise.reject([
@@ -96,7 +97,7 @@ export const useUpdateLinodeInterfaceFirewallMutation = (
         await createFirewallDevice({
           firewallId: firewall_id,
           id: interfaceId,
-          type: 'interface',
+          type: 'linode_interface',
         });
 
         return firewall_id;
@@ -110,7 +111,8 @@ export const useUpdateLinodeInterfaceFirewallMutation = (
         );
         // Find the Firewall device by checking the entity
         const device = devices.find(
-          (d) => d.entity.id === interfaceId && d.entity.type === 'interface'
+          (d) =>
+            d.entity.id === interfaceId && d.entity.type === 'linode_interface'
         );
         if (device) {
           await deleteFirewallDevice({

--- a/packages/manager/src/mocks/presets/crud/handlers/linodes.ts
+++ b/packages/manager/src/mocks/presets/crud/handlers/linodes.ts
@@ -336,7 +336,7 @@ export const createLinode = (mockState: MockState) => [
               entityId: vpcInterface.id,
               entityLabel: linode.label,
               firewallId: vpcIfacePayload.firewall_id,
-              interfaceType: 'interface',
+              interfaceType: 'linode_interface',
               mockState,
             });
           }
@@ -368,7 +368,7 @@ export const createLinode = (mockState: MockState) => [
             entityId: publicInterface.id,
             entityLabel: linode.label,
             firewallId: interfacePayload.firewall_id,
-            interfaceType: 'interface',
+            interfaceType: 'linode_interface',
             mockState,
           });
         }

--- a/packages/validation/.changeset/pr-12367-upcoming-features-1749660085808.md
+++ b/packages/validation/.changeset/pr-12367-upcoming-features-1749660085808.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Upcoming Features
+---
+
+Change references of `interface` to `linode_interface` for firewall validation ([#12367](https://github.com/linode/manager/pull/12367))

--- a/packages/validation/src/firewalls.schema.ts
+++ b/packages/validation/src/firewalls.schema.ts
@@ -182,7 +182,7 @@ const CreateFirewallDevicesSchema = object()
   .shape({
     linodes: array().of(number().defined()),
     nodebalancers: array().of(number().defined()),
-    interfaces: array().of(number().defined()),
+    linode_interfaces: array().of(number().defined()),
   })
   .notRequired();
 
@@ -205,7 +205,7 @@ export const UpdateFirewallSchema = object().shape({
 
 export const FirewallDeviceSchema = object({
   type: string()
-    .oneOf(['linode', 'nodebalancer', 'interface'])
+    .oneOf(['linode', 'nodebalancer', 'linode_interface'])
     .required('Device type is required.'),
   id: number().required('ID is required.'),
 });


### PR DESCRIPTION
## Description 📝
API is updating the 'interface' firewall entity type to 'linode_interface' for the upcoming 6/17 release (see API's pr in ticket comments). This PR addresses those changes on our end.

> [!NOTE]  
> This PR is dependent on the API

## Changes  🔄
- "interfaces" array in POST firewall object -> linode_interfaces
- "interface" firewall entity type -> "linode_interface"

## Target release date 🗓️
6/17

## Preview 📷
No visual changes

## How to test 🧪

DevEnv is needed for this - these changes are not yet out in prod

### Verification steps
- confirm existing tests pass
- Confirm no regressions to firewall flows
  - Creating a Linode with a firewall
  - Editing an interface's firewall from the Edit Interface drawer
  - Adding / removing an interface device from the firewall's detail page
  - Creating a new firewall

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
