### PR TITLE
upcoming: [M3-10151] - UX description changes for VPC Section in the create NodeBalancers page

### DIFF
--- a/packages/manager/.changeset/pr-12368-upcoming-features-1749718711216.md
+++ b/packages/manager/.changeset/pr-12368-upcoming-features-1749718711216.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-UX description changes for VPC Section in the ceate NodeBalancers page ([#12368](https://github.com/linode/manager/pull/12368))

--- a/packages/manager/.changeset/pr-12368-upcoming-features-1749718711216.md
+++ b/packages/manager/.changeset/pr-12368-upcoming-features-1749718711216.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+UX description changes for VPC Section in the ceate NodeBalancers page ([#12368](https://github.com/linode/manager/pull/12368))

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -103,6 +103,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fix inconsistent layout when entity names are long and previously assigned roles reappear when reopening the Assign New Roles Drawer ([#12356](https://github.com/linode/manager/pull/12356))
 - Fix delete button not disabled for subnets associated with a NodeBalancer on the VPC Subnet page ([#12365](https://github.com/linode/manager/pull/12365))
 - Update `interface` firewall entity type to `linode_interface` ([#12367](https://github.com/linode/manager/pull/12367))
+- UX description changes for VPC section on Create NodeBalancers page ([#12368](https://github.com/linode/manager/pull/12368))
 
 ## [2025-06-03] - v1.143.0
 

--- a/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
+++ b/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
@@ -87,11 +87,11 @@ export const ConfigNodeIPSelect = React.memo((props: Props) => {
 
   const noOptionsText = useMemo(() => {
     if (!vpcId) {
-      return 'No options - please ensure you have at least 1 Linode with a private IP located in the selected region.';
+      return 'No options - Please ensure you have at least 1 Linode with a private IP located in the selected region.';
     } else if (vpcId && !subnetId) {
-      return 'No options - please ensure you have selected a Subnet from the selected VPC';
+      return 'No options - Select a Subnet within the chosen VPC.';
     } else
-      return 'No options - please ensure you have at least 1 Linode in the selected VPC.';
+      return 'No options - The selected Subnet must have at least one Linode.';
   }, [vpcId, subnetId]);
 
   return (

--- a/packages/manager/src/features/NodeBalancers/VPCPanel.test.tsx
+++ b/packages/manager/src/features/NodeBalancers/VPCPanel.test.tsx
@@ -181,7 +181,7 @@ describe('VPCPanel', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByLabelText('Auto-assign a /30 CIDR for this NodeBalancer')
+        screen.getByLabelText('Auto-assign IPs for this NodeBalancer')
       ).toBeChecked();
     });
   });
@@ -231,7 +231,7 @@ describe('VPCPanel', () => {
     );
 
     const checkbox = screen.getByLabelText(
-      'Auto-assign a /30 CIDR for this NodeBalancer'
+      'Auto-assign IPs for this NodeBalancer'
     );
 
     await userEvent.click(checkbox);

--- a/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
@@ -221,8 +221,6 @@ export const VPCPanel = (props: Props) => {
                         onChange={(e) =>
                           ipv4Change(e.target.value ?? '', index)
                         }
-                        // eslint-disable-next-line sonarjs/no-hardcoded-ip
-                        placeholder="10.0.0.24"
                         required
                         slotProps={{
                           input: {

--- a/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
@@ -15,12 +15,10 @@ import {
 import { useMediaQuery, useTheme } from '@mui/material';
 import React from 'react';
 
+import { Code } from 'src/components/Code/Code';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
-import {
-  NB_AUTO_ASSIGN_CIDR_TOOLTIP,
-  NODEBALANCER_REGION_CAVEAT_HELPER_TEXT,
-} from '../VPCs/constants';
+import { NODEBALANCER_REGION_CAVEAT_HELPER_TEXT } from '../VPCs/constants';
 
 import type { APIError, NodeBalancerVpcPayload, VPC } from '@linode/api-v4';
 
@@ -198,7 +196,13 @@ export const VPCPanel = (props: Props) => {
                                 component={'span'}
                                 sx={{ whiteSpace: 'pre-line' }}
                               >
-                                {NB_AUTO_ASSIGN_CIDR_TOOLTIP}
+                                When enabled, the system automatically allocates
+                                a <Code>/30</Code> CIDR from the specified
+                                Subnet for the NodeBalancer&apos;s backend nodes
+                                in the VPC.
+                                <br />
+                                <br /> Disable to assign a <Code>/30</Code> IPv4
+                                CIDR subnet range for this NodeBalancer.
                               </Typography>
                             }
                             tooltipPosition="right"

--- a/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
@@ -201,8 +201,9 @@ export const VPCPanel = (props: Props) => {
                                 Subnet for the NodeBalancer&apos;s backend nodes
                                 in the VPC.
                                 <br />
-                                <br /> Disable to assign a <Code>/30</Code> IPv4
-                                CIDR subnet range for this NodeBalancer.
+                                <br /> Disable this option to assign a{' '}
+                                <Code>/30</Code> IPv4 CIDR subnet range for this
+                                NodeBalancer.
                               </Typography>
                             }
                             tooltipPosition="right"

--- a/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
@@ -126,9 +126,7 @@ export const VPCPanel = (props: Props) => {
               <Notice
                 spacingBottom={16}
                 spacingTop={8}
-                text={
-                  'Once a NodeBalancer is created, its VPC configuration cannot be changed.'
-                }
+                text={"The VPC can't be changed after NodeBalancer creation."}
                 variant="warning"
               />
               <Autocomplete
@@ -147,8 +145,7 @@ export const VPCPanel = (props: Props) => {
                 textFieldProps={{
                   helperText: (
                     <Typography mb={2}>
-                      Select a subnet in which to allocate the VPC CIDR for the
-                      NodeBalancer.
+                      The VPC subnet for this NodeBalancer.
                     </Typography>
                   ),
                   helperTextPosition: 'top',
@@ -192,11 +189,18 @@ export const VPCPanel = (props: Props) => {
                           flexDirection="row"
                         >
                           <Typography noWrap={!isSmallBp}>
-                            Auto-assign a /30 CIDR for this NodeBalancer
+                            Auto-assign IPs for this NodeBalancer
                           </Typography>
                           <TooltipIcon
                             status="help"
-                            text={NB_AUTO_ASSIGN_CIDR_TOOLTIP}
+                            text={
+                              <Typography
+                                component={'span'}
+                                sx={{ whiteSpace: 'pre-line' }}
+                              >
+                                {NB_AUTO_ASSIGN_CIDR_TOOLTIP}
+                              </Typography>
+                            }
                             tooltipPosition="right"
                           />
                         </Box>

--- a/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
@@ -81,8 +81,8 @@ export const VPCPanel = (props: Props) => {
         <Typography variant="h2">VPC</Typography>
         <Stack spacing={1.5}>
           <Typography>
-            Select a VPC if your NodeBalancer will use backend nodes within a
-            VPC.
+            Complete this section to allow this NodeBalancer to communicate with
+            backend nodes in a VPC.
           </Typography>
           <Autocomplete
             data-testid="vpc-select"

--- a/packages/manager/src/features/VPCs/constants.ts
+++ b/packages/manager/src/features/VPCs/constants.ts
@@ -23,9 +23,6 @@ export const REGIONAL_LINODE_MESSAGE =
 export const MULTIPLE_CONFIGURATIONS_MESSAGE =
   'This Linode has multiple configurations. Select which configuration you would like added to the subnet.';
 
-export const NB_AUTO_ASSIGN_CIDR_TOOLTIP =
-  "When enabled, the system automatically allocates a `/30` CIDR from the specified Subnet for the NodeBalancer's backend nodes in the VPC. \n\n Disable to define a `/30` NodeBalancer IPv4 CIDR Subnet range. ";
-
 export const VPC_AUTO_ASSIGN_IPV4_TOOLTIP =
   'Automatically assign an IPv4 address as the private IP address for this Linode in the VPC.';
 

--- a/packages/manager/src/features/VPCs/constants.ts
+++ b/packages/manager/src/features/VPCs/constants.ts
@@ -24,7 +24,7 @@ export const MULTIPLE_CONFIGURATIONS_MESSAGE =
   'This Linode has multiple configurations. Select which configuration you would like added to the subnet.';
 
 export const NB_AUTO_ASSIGN_CIDR_TOOLTIP =
-  "Automatically allocates a /30 CIDR for the NodeBalancer's backend interface. If the range doesn't have enough available IPs, the creation fails.";
+  "When enabled, the system automatically allocates a `/30` CIDR from the specified Subnet for the NodeBalancer's backend nodes in the VPC. \n\n Disable to define a `/30` NodeBalancer IPv4 CIDR Subnet range. ";
 
 export const VPC_AUTO_ASSIGN_IPV4_TOOLTIP =
   'Automatically assign an IPv4 address as the private IP address for this Linode in the VPC.';


### PR DESCRIPTION
## Changes  🔄

- Add descriptions finalized by UX

## Target release date 🗓️

6/17

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/9208d44c-110d-4ea5-8578-175caaeb5b3f) | ![image](https://github.com/user-attachments/assets/d59cc2a5-fc7a-4148-88ec-597405096774) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Toggle the NodeBalancer-VPC Integration feature flag
- Navigate to the Create Nodebalancer page

### Verification steps

- [ ] Verify that you are able to see the textual changes
- [ ] Verify there is no grammatical errors

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>