### PR TITLE
feat: [UIE-8806, UIE-8881, UIE-8882, UIE-8931 ] - IAM RBAC: fix bugs

### DIFF
--- a/packages/manager/src/features/IAM/Roles/RolesTable/AssignSelectedRolesDrawer.tsx
+++ b/packages/manager/src/features/IAM/Roles/RolesTable/AssignSelectedRolesDrawer.tsx
@@ -22,10 +22,7 @@ import {
   useUserRolesMutation,
 } from 'src/queries/iam/iam';
 
-import {
-  INTERNAL_ERROR_UPDATE_PERMISSION,
-  NO_CHANGES_SAVED,
-} from '../../Shared/constants';
+import { INTERNAL_ERROR_NO_CHANGES_SAVED } from '../../Shared/constants';
 import { mergeAssignedRolesIntoExistingRoles } from '../../Shared/utilities';
 
 import type { AssignNewRoleFormValues } from '../../Shared/utilities';
@@ -109,7 +106,9 @@ export const AssignSelectedRolesDrawer = ({
 
       handleClose();
     } catch (error) {
-      setError(error.field ?? 'root', { message: error[0].reason });
+      setError(error.field ?? 'root', {
+        message: INTERNAL_ERROR_NO_CHANGES_SAVED,
+      });
     }
   };
 
@@ -127,13 +126,7 @@ export const AssignSelectedRolesDrawer = ({
       <FormProvider {...form}>
         <form onSubmit={handleSubmit(onSubmit)}>
           {formState.errors.root?.message && (
-            <Notice variant="error">
-              <Typography>
-                {INTERNAL_ERROR_UPDATE_PERMISSION}
-                <br />
-                {NO_CHANGES_SAVED}
-              </Typography>
-            </Notice>
+            <Notice text={formState.errors.root?.message} variant="error" />
           )}
           <Typography sx={{ marginBottom: 2.5 }}>
             Select the user you want to assign selected roles to. Some roles

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.tsx
@@ -18,7 +18,12 @@ import {
 } from 'src/queries/iam/iam';
 
 import { AssignedPermissionsPanel } from '../AssignedPermissionsPanel/AssignedPermissionsPanel';
-import { changeUserRole, getAllRoles, getRoleByName } from '../utilities';
+import {
+  changeUserRole,
+  getAllRoles,
+  getErrorMessage,
+  getRoleByName,
+} from '../utilities';
 
 import type { DrawerModes, EntitiesOption, ExtendedRoleView } from '../types';
 import type { RolesType } from '../utilities';
@@ -110,9 +115,9 @@ export const ChangeRoleDrawer = ({ mode, onClose, open, role }: Props) => {
 
       handleClose();
     } catch (errors) {
-      for (const error of errors) {
-        setError(error?.field ?? 'root', { message: error.reason });
-      }
+      setError('root', {
+        message: getErrorMessage(errors),
+      });
     }
   };
 

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/UnassignRoleConfirmationDialog.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/UnassignRoleConfirmationDialog.tsx
@@ -6,7 +6,7 @@ import { useParams } from 'react-router-dom';
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
 import { useUserRoles, useUserRolesMutation } from 'src/queries/iam/iam';
 
-import { deleteUserRole } from '../utilities';
+import { deleteUserRole, getErrorMessage } from '../utilities';
 
 import type { ExtendedRoleView } from '../types';
 
@@ -74,7 +74,7 @@ export const UnassignRoleConfirmationDialog = (props: Props) => {
           style={{ padding: 0 }}
         />
       }
-      error={error?.[0].reason}
+      error={getErrorMessage(error)}
       onClose={onClose}
       open={open}
       title={`Unassign the ${role?.name} role?`}

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/UpdateEntitiesDrawer.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/UpdateEntitiesDrawer.tsx
@@ -7,6 +7,7 @@ import { useParams } from 'react-router-dom';
 import { useUserRoles, useUserRolesMutation } from 'src/queries/iam/iam';
 
 import { AssignedPermissionsPanel } from '../AssignedPermissionsPanel/AssignedPermissionsPanel';
+import { INTERNAL_ERROR_NO_CHANGES_SAVED } from '../constants';
 import { toEntityAccess } from '../utilities';
 
 import type { EntitiesOption, ExtendedRoleView } from '../types';
@@ -93,7 +94,9 @@ export const UpdateEntitiesDrawer = ({ onClose, open, role }: Props) => {
       handleClose();
     } catch (errors) {
       for (const error of errors) {
-        setError(error?.field ?? 'root', { message: error.reason });
+        setError(error?.field ?? 'root', {
+          message: INTERNAL_ERROR_NO_CHANGES_SAVED,
+        });
       }
     }
   };

--- a/packages/manager/src/features/IAM/Shared/Entities/utils.test.ts
+++ b/packages/manager/src/features/IAM/Shared/Entities/utils.test.ts
@@ -15,9 +15,7 @@ describe('getCreateLinkForEntityType', () => {
     expect(getCreateLinkForEntityType('placement_group')).toBe(
       '/placement-groups/create'
     );
-    expect(getCreateLinkForEntityType('lkecluster')).toBe(
-      '/kubernetes/clusters'
-    );
+    expect(getCreateLinkForEntityType('lkecluster')).toBe('/kubernetes/create');
   });
 });
 

--- a/packages/manager/src/features/IAM/Shared/Entities/utils.ts
+++ b/packages/manager/src/features/IAM/Shared/Entities/utils.ts
@@ -33,7 +33,7 @@ export const getCreateLinkForEntityType = (
   }
 
   if (entityType === 'lkecluster') {
-    return '/kubernetes/clusters';
+    return '/kubernetes/create';
   }
 
   return `/${entityType}s/create`;

--- a/packages/manager/src/features/IAM/Shared/constants.ts
+++ b/packages/manager/src/features/IAM/Shared/constants.ts
@@ -7,9 +7,9 @@ export const NO_ASSIGNED_ROLES_TEXT = `The user doesn't have any roles assigned 
 
 export const NO_ASSIGNED_ENTITIES_TEXT = `The user doesn't have any entity access roles assigned yet. Once you assign the user a role on specific entities, these entities will show up here.`;
 
-export const INTERNAL_ERROR_UPDATE_PERMISSION = `Internal Error - Issue with updating permissions.`;
+export const INTERNAL_ERROR_NO_CHANGES_SAVED = `Internal Error. No changes were saved.`;
 
-export const NO_CHANGES_SAVED = `No changes were saved.`;
+export const LAST_ACCOUNT_ADMIN_ERROR = `Failed to unassigned the role. You need to have at least one user with the account_admin role on your acount.`;
 
 export const ERROR_STATE_TEXT =
   'An unexpected error occurred. Refresh the page or try again later.';

--- a/packages/manager/src/features/IAM/Shared/utilities.test.ts
+++ b/packages/manager/src/features/IAM/Shared/utilities.test.ts
@@ -2,11 +2,16 @@ import { accountRolesFactory } from 'src/factories/accountRoles';
 import { userRolesFactory } from 'src/factories/userRoles';
 
 import {
+  INTERNAL_ERROR_NO_CHANGES_SAVED,
+  LAST_ACCOUNT_ADMIN_ERROR,
+} from './constants';
+import {
   changeRoleForEntity,
   changeUserRole,
   deleteUserEntity,
   deleteUserRole,
   getAllRoles,
+  getErrorMessage,
   getFacadeRoleDescription,
   getFormattedEntityType,
   getRoleByName,
@@ -815,5 +820,39 @@ describe('mapEntityTypesForSelect', () => {
         value: 'volume',
       },
     ]);
+  });
+});
+
+describe('getErrorMessage', () => {
+  it('should return LAST_ACCOUNT_ADMIN_ERROR if the error contains "Removing last account admin"', () => {
+    const errors = [
+      {
+        reason: 'Request made to janus is invalid',
+        field: 'Bad janus request',
+      },
+      {
+        reason:
+          'Can not remove account admin access from the last account admin on the account',
+        field: 'Removing last account admin',
+      },
+    ];
+    const result = getErrorMessage(errors);
+    expect(result).toBe(LAST_ACCOUNT_ADMIN_ERROR);
+  });
+
+  it('should return INTERNAL_ERROR_NO_CHANGES_SAVED if the error does not contain "Removing last account admin"', () => {
+    const errors = [
+      {
+        field: 'An unexpected error occurred.',
+        reason: 'An unexpected error occurred.',
+      },
+    ];
+    const result = getErrorMessage(errors);
+    expect(result).toBe(INTERNAL_ERROR_NO_CHANGES_SAVED);
+  });
+
+  it('should return undefined if there are no errors', () => {
+    const result = getErrorMessage(null);
+    expect(result).toBeUndefined();
   });
 });

--- a/packages/manager/src/features/IAM/Shared/utilities.ts
+++ b/packages/manager/src/features/IAM/Shared/utilities.ts
@@ -1,6 +1,10 @@
 import { capitalize, capitalizeAllWords } from '@linode/utilities';
 
-import { PAID_ENTITY_TYPES } from './constants';
+import {
+  INTERNAL_ERROR_NO_CHANGES_SAVED,
+  LAST_ACCOUNT_ADMIN_ERROR,
+  PAID_ENTITY_TYPES,
+} from './constants';
 
 import type {
   EntitiesOption,
@@ -12,6 +16,7 @@ import type {
 import type {
   AccountAccessRole,
   AccountEntity,
+  APIError,
   EntityAccess,
   EntityAccessRole,
   EntityType,
@@ -514,4 +519,16 @@ export const mergeAssignedRolesIntoExistingRoles = (
     });
   });
   return selectedPlusExistingRoles;
+};
+
+export const getErrorMessage = (error: APIError[] | null) => {
+  const isLastAccountAdmin = error?.some(
+    (err) => err.field === 'Removing last account admin'
+  );
+
+  const errorMessage = isLastAccountAdmin
+    ? LAST_ACCOUNT_ADMIN_ERROR
+    : INTERNAL_ERROR_NO_CHANGES_SAVED;
+
+  return error ? errorMessage : undefined;
 };

--- a/packages/manager/src/features/IAM/Users/UserEntities/ChangeRoleForEntityDrawer.tsx
+++ b/packages/manager/src/features/IAM/Users/UserEntities/ChangeRoleForEntityDrawer.tsx
@@ -18,6 +18,7 @@ import {
 } from 'src/queries/iam/iam';
 
 import { AssignedPermissionsPanel } from '../../Shared/AssignedPermissionsPanel/AssignedPermissionsPanel';
+import { INTERNAL_ERROR_NO_CHANGES_SAVED } from '../../Shared/constants';
 import {
   changeRoleForEntity,
   getAllRoles,
@@ -114,7 +115,9 @@ export const ChangeRoleForEntityDrawer = ({
       handleClose();
     } catch (errors) {
       for (const error of errors) {
-        setError(error?.field ?? 'root', { message: error.reason });
+        setError(error?.field ?? 'root', {
+          message: INTERNAL_ERROR_NO_CHANGES_SAVED,
+        });
       }
     }
   };

--- a/packages/manager/src/features/IAM/Users/UserRoles/AssignNewRoleDrawer.tsx
+++ b/packages/manager/src/features/IAM/Users/UserRoles/AssignNewRoleDrawer.tsx
@@ -14,10 +14,7 @@ import { AssignSingleRole } from 'src/features/IAM/Users/UserRoles/AssignSingleR
 import { useAccountRoles, useUserRolesMutation } from 'src/queries/iam/iam';
 import { iamQueries } from 'src/queries/iam/queries';
 
-import {
-  INTERNAL_ERROR_UPDATE_PERMISSION,
-  NO_CHANGES_SAVED,
-} from '../../Shared/constants';
+import { INTERNAL_ERROR_NO_CHANGES_SAVED } from '../../Shared/constants';
 import {
   getAllRoles,
   mergeAssignedRolesIntoExistingRoles,
@@ -85,7 +82,9 @@ export const AssignNewRoleDrawer = ({ onClose, open }: Props) => {
       enqueueSnackbar(`Roles added.`, { variant: 'success' });
       handleClose();
     } catch (error) {
-      setError(error.field ?? 'root', { message: error[0].reason });
+      setError(error.field ?? 'root', {
+        message: INTERNAL_ERROR_NO_CHANGES_SAVED,
+      });
     }
   };
 
@@ -107,13 +106,7 @@ export const AssignNewRoleDrawer = ({ onClose, open }: Props) => {
       <FormProvider {...form}>
         <form onSubmit={handleSubmit(onSubmit)}>
           {formState.errors.root?.message && (
-            <Notice variant="error">
-              <Typography>
-                {INTERNAL_ERROR_UPDATE_PERMISSION}
-                <br />
-                {NO_CHANGES_SAVED}
-              </Typography>
-            </Notice>
+            <Notice text={formState.errors.root?.message} variant="error" />
           )}
 
           <Typography sx={{ marginBottom: 2.5 }}>


### PR DESCRIPTION
## Description 📝

Standardize drawer error messages, fix the create lkluster link, and display a specific error when attempting to remove/change the role of the last account admin

## Changes  🔄

List any change(s) relevant to the reviewer.

- Fix the link for creating a lkcluster
- Standardize error messages across all drawers
- Show the error for removing/changing role for the last account admin for the account

## Target release date 🗓️

7/1

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| 📷 | ![image](https://github.com/user-attachments/assets/d8bf2114-a681-4875-be09-b535ae1a2d77) |
| 📷 | ![image](https://github.com/user-attachments/assets/20f6245a-b764-4080-a518-be9e33a1e4f2) |
| ![image](https://github.com/user-attachments/assets/379d3f74-b550-48a8-b40d-e312a6bb6021) | ![image](https://github.com/user-attachments/assets/4a648613-b106-4612-b98f-798607eb3d9f)|
| 📷 | ![image](https://github.com/user-attachments/assets/112af8d1-08ae-4005-88c0-ab2e4a4c0ee5) |
| 📷 | ![image](https://github.com/user-attachments/assets/d4d67873-ef09-4258-90e5-acf790145699) |
| 📷 | ![image](https://github.com/user-attachments/assets/06cd6406-8d9f-468f-afa2-05bef49ed8eb) |
| 📷 | ![image](https://github.com/user-attachments/assets/ec23ef6d-4087-4791-9e78-0458e2c5a0db) |


## How to test 🧪

### Prerequisites

(How to setup test environment)

- Ensure the Identity and Access Beta flag is enabled in dev tools
- Use devenv and login as vagrant user or use mock data
- Click is to see a specific user
- Click on the Assigned Roles tab

### Verification steps

(How to verify changes)

- [ ] Confirm that link is valid
- [ ] Confirm there is an error message for removing/changing role for the last account admin
- [ ] Confirm there is one error message across all drawers

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

---

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

---
