### PR TITLE
Release Hotfix Branch - 6-12-2025

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -103,6 +103,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fix inconsistent layout when entity names are long and previously assigned roles reappear when reopening the Assign New Roles Drawer ([#12356](https://github.com/linode/manager/pull/12356))
 - Fix delete button not disabled for subnets associated with a NodeBalancer on the VPC Subnet page ([#12365](https://github.com/linode/manager/pull/12365))
 - Update `interface` firewall entity type to `linode_interface` ([#12367](https://github.com/linode/manager/pull/12367))
+- UX description changes for VPC section on Create NodeBalancers page ([#12368](https://github.com/linode/manager/pull/12368))
 
 ## [2025-06-03] - v1.143.0
 

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed:
 
+- Inability for restricted users to configure High Availability or IP ACLs on LKE clusters ([#11274](https://github.com/linode/manager/pull/11274))
 - Radio button size in plans table ([#12261](https://github.com/linode/manager/pull/12261))
 - Styling issues in `DomainRecords` and `forwardRef` console errors in Object Storage Access ([#12279](https://github.com/linode/manager/pull/12279))
 - Radio button styling inconsistencies across themes and states ([#12284](https://github.com/linode/manager/pull/12284))

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -662,30 +662,6 @@ describe('LKE Cluster Creation with DC-specific pricing', () => {
 });
 
 describe('LKE Cluster Creation with ACL', () => {
-  /**
-   * - Confirms ACL flow does not exist if account doesn't have the corresponding capability
-   */
-  it('does not show the ACL flow without the LKE ACL capability', () => {
-    mockGetAccount(
-      accountFactory.build({
-        capabilities: [],
-      })
-    ).as('getAccount');
-
-    cy.visitWithLogin('/kubernetes/clusters');
-
-    ui.button
-      .findByTitle('Create Cluster')
-      .should('be.visible')
-      .should('be.enabled')
-      .click();
-
-    cy.url().should('endWith', '/kubernetes/create');
-    cy.wait(['@getAccount']);
-
-    cy.contains('Control Plane ACL').should('not.exist');
-  });
-
   // setting up mocks
   const clusterLabel = randomLabel();
   const mockRegion = regionFactory.build({
@@ -713,14 +689,6 @@ describe('LKE Cluster Creation with ACL', () => {
 
   describe('with LKE IPACL account capability', () => {
     beforeEach(() => {
-      mockGetAccount(
-        accountFactory.build({
-          capabilities: [
-            'LKE HA Control Planes',
-            'LKE Network Access Control List (IP ACL)',
-          ],
-        })
-      ).as('getAccount');
       mockGetRegions([mockRegion]).as('getRegions');
       mockGetLinodeTypes(mockLinodeTypes).as('getLinodeTypes');
       mockGetRegionAvailability(mockRegion.id, []).as('getRegionAvailability');
@@ -755,7 +723,7 @@ describe('LKE Cluster Creation with ACL', () => {
         .click();
 
       cy.url().should('endWith', '/kubernetes/create');
-      cy.wait(['@getAccount', '@getRegions', '@getLinodeTypes']);
+      cy.wait(['@getRegions', '@getLinodeTypes']);
 
       // Fill out LKE creation form label, region, and Kubernetes version fields.
       cy.findByLabelText('Cluster Label').should('be.visible').click();
@@ -857,7 +825,6 @@ describe('LKE Cluster Creation with ACL', () => {
         .click();
 
       cy.url().should('endWith', '/kubernetes/create');
-      cy.wait(['@getAccount']);
 
       // Fill out LKE creation form label, region, and Kubernetes version fields.
       cy.findByLabelText('Cluster Label').should('be.visible').click();
@@ -989,11 +956,7 @@ describe('LKE Cluster Creation with ACL', () => {
       );
       mockGetAccount(
         accountFactory.build({
-          capabilities: [
-            'Kubernetes Enterprise',
-            'LKE HA Control Planes',
-            'LKE Network Access Control List (IP ACL)',
-          ],
+          capabilities: ['Kubernetes Enterprise'],
         })
       ).as('getAccount');
       mockGetTieredKubernetesVersions('enterprise', [
@@ -1202,7 +1165,6 @@ describe('LKE Cluster Creation with ACL', () => {
         .click();
 
       cy.url().should('endWith', '/kubernetes/create');
-      cy.wait(['@getAccount']);
 
       // Fill out LKE creation form label, region, and Kubernetes version fields.
       cy.findByLabelText('Cluster Label').should('be.visible').click();
@@ -1386,11 +1348,7 @@ describe('LKE Cluster Creation with LKE-E', () => {
       ).as('getAccountBeta');
       mockGetAccount(
         accountFactory.build({
-          capabilities: [
-            'Kubernetes Enterprise',
-            'LKE HA Control Planes',
-            'LKE Network Access Control List (IP ACL)',
-          ],
+          capabilities: ['Kubernetes Enterprise'],
         })
       ).as('getAccount');
       mockGetTieredKubernetesVersions('enterprise', [

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -2588,679 +2588,636 @@ describe('LKE cluster updates', () => {
 describe('LKE ACL updates', () => {
   const mockCluster = kubernetesClusterFactory.build();
   const mockRevisionId = randomString(20);
-
   /**
-   * - Confirms LKE ACL is only rendered if an account has the corresponding capability
+   * - Confirms ACL can be enabled from the summary page
+   * - Confirms revision ID can be updated
+   * - Confirms both IPv4 and IPv6 can be updated and that summary page and drawer updates as a result
    */
-  it('does not show ACL without the LKE ACL capability', () => {
-    mockGetAccount(
-      accountFactory.build({
-        capabilities: [],
-      })
-    ).as('getAccount');
+  it('can enable ACL on an LKE cluster with ACL pre-installed and edit IPs', () => {
+    const mockACLOptions = kubernetesControlPlaneACLOptionsFactory.build({
+      addresses: { ipv4: ['10.0.3.0/24'], ipv6: undefined },
+      enabled: false,
+    });
+    const mockUpdatedACLOptions1 =
+      kubernetesControlPlaneACLOptionsFactory.build({
+        addresses: { ipv4: ['10.0.0.0/24'], ipv6: undefined },
+        enabled: true,
+        'revision-id': mockRevisionId,
+      });
+    const mockControlPaneACL = kubernetesControlPlaneACLFactory.build({
+      acl: mockACLOptions,
+    });
+    const mockUpdatedControlPlaneACL1 = kubernetesControlPlaneACLFactory.build({
+      acl: mockUpdatedACLOptions1,
+    });
 
     mockGetCluster(mockCluster).as('getCluster');
-    cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
-    cy.wait(['@getAccount', '@getCluster']);
+    mockGetControlPlaneACL(mockCluster.id, mockControlPaneACL).as(
+      'getControlPlaneACL'
+    );
+    mockUpdateControlPlaneACL(mockCluster.id, mockUpdatedControlPlaneACL1).as(
+      'updateControlPlaneACL'
+    );
 
-    cy.contains('Control Plane ACL').should('not.exist');
+    cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
+    cy.wait(['@getCluster', '@getControlPlaneACL']);
+
+    // confirm summary panel
+    cy.contains('Control Plane ACL').should('be.visible');
+    ui.button
+      .findByTitle('Enable')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    ui.drawer
+      .findByTitle(`Control Plane ACL for ${mockCluster.label}`)
+      .should('be.visible')
+      .within(() => {
+        // Confirm submit button is disabled if form has not been changed
+        ui.button
+          .findByTitle('Update')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('not.be.enabled');
+
+        // Enable ACL
+        cy.contains('Activation Status').should('be.visible');
+        ui.toggle
+          .find()
+          .should('have.attr', 'data-qa-toggle', 'false')
+          .should('be.visible')
+          .click();
+
+        // confirm submit button is now enabled
+        ui.button
+          .findByTitle('Update')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled');
+
+        // Edit Revision ID
+        cy.findByLabelText('Revision ID').should(
+          'have.value',
+          mockACLOptions['revision-id']
+        );
+        cy.findByLabelText('Revision ID').clear();
+        cy.focused().type(mockRevisionId);
+
+        // Addresses section: confirm current IPv4 value and enter new IP
+        cy.findByDisplayValue('10.0.3.0/24').should('be.visible').click();
+        cy.focused().clear();
+        cy.focused().type('10.0.0.0/24');
+
+        // submit
+        ui.button
+          .findByTitle('Update')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    cy.wait(['@updateControlPlaneACL']);
+
+    // confirm summary panel updates
+    cy.contains('Control Plane ACL').should('be.visible');
+    cy.findByText('Enable').should('not.exist');
+    ui.button
+      .findByTitle('Enabled (1 IP Address)')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    // update mocks
+    const mockUpdatedACLOptions2 =
+      kubernetesControlPlaneACLOptionsFactory.build({
+        addresses: {
+          ipv4: ['10.0.0.0/24'],
+          ipv6: [
+            '8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e',
+            'f4a2:b849:4a24:d0d9:15f0:704b:f943:718f',
+          ],
+        },
+        enabled: true,
+        'revision-id': mockRevisionId,
+      });
+    const mockUpdatedControlPlaneACL2 = kubernetesControlPlaneACLFactory.build({
+      acl: mockUpdatedACLOptions2,
+    });
+    mockUpdateControlPlaneACL(mockCluster.id, mockUpdatedControlPlaneACL2).as(
+      'updateControlPlaneACL2'
+    );
+
+    // confirm data within drawer is updated and edit IPs again
+    ui.drawer
+      .findByTitle(`Control Plane ACL for ${mockCluster.label}`)
+      .should('be.visible')
+      .within(() => {
+        // Confirm submit button is disabled if form has not been changed
+        ui.button
+          .findByTitle('Update')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('not.be.enabled');
+
+        // confirm enable toggle was updated
+        ui.toggle
+          .find()
+          .should('have.attr', 'data-qa-toggle', 'true')
+          .should('be.visible');
+
+        // confirm Revision ID was updated
+        cy.findByLabelText('Revision ID').should('have.value', mockRevisionId);
+
+        // clear Revision ID
+        cy.findByLabelText('Revision ID').clear();
+
+        // update IPv6 addresses
+        cy.findByDisplayValue('10.0.0.0/24').should('be.visible');
+        cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
+          .should('be.visible')
+          .click();
+        cy.focused().type('8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e');
+        cy.findByText('Add IPv6 Address')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+        cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-1')
+          .should('be.visible')
+          .click();
+        cy.focused().type('f4a2:b849:4a24:d0d9:15f0:704b:f943:718f');
+
+        // submit
+        ui.button
+          .findByTitle('Update')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    cy.wait(['@updateControlPlaneACL2']);
+
+    // confirm summary panel updates
+    cy.contains('Control Plane ACL').should('be.visible');
+    cy.findByText('Enable').should('not.exist');
+    ui.button
+      .findByTitle('Enabled (3 IP Addresses)')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    // confirm data within drawer is updated again
+    ui.drawer
+      .findByTitle(`Control Plane ACL for ${mockCluster.label}`)
+      .should('be.visible')
+      .within(() => {
+        // confirm Revision ID was "regenerated" after being cleared instead of displaying an empty string
+        cy.findByLabelText('Revision ID').should('have.value', mockRevisionId);
+        // confirm updated IPv6 addresses display
+        cy.findByDisplayValue('8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e').should(
+          'be.visible'
+        );
+        cy.findByDisplayValue('f4a2:b849:4a24:d0d9:15f0:704b:f943:718f').should(
+          'be.visible'
+        );
+      });
   });
 
-  describe('with LKE ACL account capability', () => {
-    beforeEach(() => {
-      mockGetAccount(
-        accountFactory.build({
-          capabilities: ['LKE Network Access Control List (IP ACL)'],
-        })
-      ).as('getAccount');
+  /**
+   * - Confirms ACL can be disabled from the summary page (for standard tier only)
+   */
+  it('can disable ACL on a standard tier cluster', () => {
+    const mockACLOptions = kubernetesControlPlaneACLOptionsFactory.build({
+      addresses: {
+        ipv4: [],
+        ipv6: [],
+      },
+      enabled: true,
     });
 
-    /**
-     * - Confirms ACL can be enabled from the summary page
-     * - Confirms revision ID can be updated
-     * - Confirms both IPv4 and IPv6 can be updated and that summary page and drawer updates as a result
-     */
-    it('can enable ACL on an LKE cluster with ACL pre-installed and edit IPs', () => {
-      const mockACLOptions = kubernetesControlPlaneACLOptionsFactory.build({
-        addresses: { ipv4: ['10.0.3.0/24'], ipv6: undefined },
+    const mockDisabledACLOptions =
+      kubernetesControlPlaneACLOptionsFactory.build({
+        addresses: {
+          ipv4: [''],
+          ipv6: [''],
+        },
         enabled: false,
+        'revision-id': '',
       });
-      const mockUpdatedACLOptions1 =
-        kubernetesControlPlaneACLOptionsFactory.build({
-          addresses: { ipv4: ['10.0.0.0/24'], ipv6: undefined },
-          enabled: true,
-          'revision-id': mockRevisionId,
-        });
-      const mockControlPaneACL = kubernetesControlPlaneACLFactory.build({
-        acl: mockACLOptions,
-      });
-      const mockUpdatedControlPlaneACL1 =
-        kubernetesControlPlaneACLFactory.build({
-          acl: mockUpdatedACLOptions1,
-        });
-
-      mockGetCluster(mockCluster).as('getCluster');
-      mockGetControlPlaneACL(mockCluster.id, mockControlPaneACL).as(
-        'getControlPlaneACL'
-      );
-      mockUpdateControlPlaneACL(mockCluster.id, mockUpdatedControlPlaneACL1).as(
-        'updateControlPlaneACL'
-      );
-
-      cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
-      cy.wait(['@getAccount', '@getCluster', '@getControlPlaneACL']);
-
-      // confirm summary panel
-      cy.contains('Control Plane ACL').should('be.visible');
-      ui.button
-        .findByTitle('Enable')
-        .should('be.visible')
-        .should('be.enabled')
-        .click();
-
-      ui.drawer
-        .findByTitle(`Control Plane ACL for ${mockCluster.label}`)
-        .should('be.visible')
-        .within(() => {
-          // Confirm submit button is disabled if form has not been changed
-          ui.button
-            .findByTitle('Update')
-            .scrollIntoView()
-            .should('be.visible')
-            .should('not.be.enabled');
-
-          // Enable ACL
-          cy.contains('Activation Status').should('be.visible');
-          ui.toggle
-            .find()
-            .should('have.attr', 'data-qa-toggle', 'false')
-            .should('be.visible')
-            .click();
-
-          // confirm submit button is now enabled
-          ui.button
-            .findByTitle('Update')
-            .scrollIntoView()
-            .should('be.visible')
-            .should('be.enabled');
-
-          // Edit Revision ID
-          cy.findByLabelText('Revision ID').should(
-            'have.value',
-            mockACLOptions['revision-id']
-          );
-          cy.findByLabelText('Revision ID').clear();
-          cy.focused().type(mockRevisionId);
-
-          // Addresses section: confirm current IPv4 value and enter new IP
-          cy.findByDisplayValue('10.0.3.0/24').should('be.visible').click();
-          cy.focused().clear();
-          cy.focused().type('10.0.0.0/24');
-
-          // submit
-          ui.button
-            .findByTitle('Update')
-            .scrollIntoView()
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-        });
-
-      cy.wait(['@updateControlPlaneACL']);
-
-      // confirm summary panel updates
-      cy.contains('Control Plane ACL').should('be.visible');
-      cy.findByText('Enable').should('not.exist');
-      ui.button
-        .findByTitle('Enabled (1 IP Address)')
-        .should('be.visible')
-        .should('be.enabled')
-        .click();
-
-      // update mocks
-      const mockUpdatedACLOptions2 =
-        kubernetesControlPlaneACLOptionsFactory.build({
-          addresses: {
-            ipv4: ['10.0.0.0/24'],
-            ipv6: [
-              '8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e',
-              'f4a2:b849:4a24:d0d9:15f0:704b:f943:718f',
-            ],
-          },
-          enabled: true,
-          'revision-id': mockRevisionId,
-        });
-      const mockUpdatedControlPlaneACL2 =
-        kubernetesControlPlaneACLFactory.build({
-          acl: mockUpdatedACLOptions2,
-        });
-      mockUpdateControlPlaneACL(mockCluster.id, mockUpdatedControlPlaneACL2).as(
-        'updateControlPlaneACL2'
-      );
-
-      // confirm data within drawer is updated and edit IPs again
-      ui.drawer
-        .findByTitle(`Control Plane ACL for ${mockCluster.label}`)
-        .should('be.visible')
-        .within(() => {
-          // Confirm submit button is disabled if form has not been changed
-          ui.button
-            .findByTitle('Update')
-            .scrollIntoView()
-            .should('be.visible')
-            .should('not.be.enabled');
-
-          // confirm enable toggle was updated
-          ui.toggle
-            .find()
-            .should('have.attr', 'data-qa-toggle', 'true')
-            .should('be.visible');
-
-          // confirm Revision ID was updated
-          cy.findByLabelText('Revision ID').should(
-            'have.value',
-            mockRevisionId
-          );
-
-          // clear Revision ID
-          cy.findByLabelText('Revision ID').clear();
-
-          // update IPv6 addresses
-          cy.findByDisplayValue('10.0.0.0/24').should('be.visible');
-          cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
-            .should('be.visible')
-            .click();
-          cy.focused().type('8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e');
-          cy.findByText('Add IPv6 Address')
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-          cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-1')
-            .should('be.visible')
-            .click();
-          cy.focused().type('f4a2:b849:4a24:d0d9:15f0:704b:f943:718f');
-
-          // submit
-          ui.button
-            .findByTitle('Update')
-            .scrollIntoView()
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-        });
-
-      cy.wait(['@updateControlPlaneACL2']);
-
-      // confirm summary panel updates
-      cy.contains('Control Plane ACL').should('be.visible');
-      cy.findByText('Enable').should('not.exist');
-      ui.button
-        .findByTitle('Enabled (3 IP Addresses)')
-        .should('be.visible')
-        .should('be.enabled')
-        .click();
-
-      // confirm data within drawer is updated again
-      ui.drawer
-        .findByTitle(`Control Plane ACL for ${mockCluster.label}`)
-        .should('be.visible')
-        .within(() => {
-          // confirm Revision ID was "regenerated" after being cleared instead of displaying an empty string
-          cy.findByLabelText('Revision ID').should(
-            'have.value',
-            mockRevisionId
-          );
-          // confirm updated IPv6 addresses display
-          cy.findByDisplayValue(
-            '8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e'
-          ).should('be.visible');
-          cy.findByDisplayValue(
-            'f4a2:b849:4a24:d0d9:15f0:704b:f943:718f'
-          ).should('be.visible');
-        });
+    const mockControlPaneACL = kubernetesControlPlaneACLFactory.build({
+      acl: mockACLOptions,
+    });
+    const mockUpdatedControlPlaneACL = kubernetesControlPlaneACLFactory.build({
+      acl: mockDisabledACLOptions,
     });
 
-    /**
-     * - Confirms ACL can be disabled from the summary page (for standard tier only)
-     */
-    it('can disable ACL on a standard tier cluster', () => {
-      const mockACLOptions = kubernetesControlPlaneACLOptionsFactory.build({
-        addresses: {
-          ipv4: [],
-          ipv6: [],
-        },
-        enabled: true,
+    mockGetCluster(mockCluster).as('getCluster');
+    mockGetControlPlaneACL(mockCluster.id, mockControlPaneACL).as(
+      'getControlPlaneACL'
+    );
+    mockUpdateControlPlaneACL(mockCluster.id, mockUpdatedControlPlaneACL).as(
+      'updateControlPlaneACL'
+    );
+
+    cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
+    cy.wait(['@getCluster', '@getControlPlaneACL']);
+
+    // confirm summary panel
+    cy.contains('Control Plane ACL').should('be.visible');
+    ui.button
+      .findByTitle('Enabled (0 IP Addresses)')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    ui.drawer
+      .findByTitle(`Control Plane ACL for ${mockCluster.label}`)
+      .should('be.visible')
+      .within(() => {
+        // Confirm submit button is disabled if form has not been changed
+        ui.button
+          .findByTitle('Update')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('not.be.enabled');
+
+        // Activation Status section: toggle off 'Enable'
+        cy.contains('Activation Status').should('be.visible');
+        ui.toggle
+          .find()
+          .should('have.attr', 'data-qa-toggle', 'true')
+          .should('be.visible')
+          .click();
+
+        // confirm submit button is now enabled
+        ui.button
+          .findByTitle('Update')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled');
+
+        // confirm Revision ID section
+        cy.findByLabelText('Revision ID').should(
+          'have.value',
+          mockDisabledACLOptions['revision-id']
+        );
+
+        // confirm IPv4 and IPv6 address sections
+        cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0')
+          .should('be.visible')
+          .should('have.value', mockDisabledACLOptions.addresses?.ipv4?.[0]);
+        cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
+          .should('be.visible')
+          .should('have.value', mockDisabledACLOptions.addresses?.ipv6?.[0]);
+
+        // submit
+        ui.button
+          .findByTitle('Update')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
       });
 
-      const mockDisabledACLOptions =
-        kubernetesControlPlaneACLOptionsFactory.build({
-          addresses: {
-            ipv4: [''],
-            ipv6: [''],
-          },
-          enabled: false,
-          'revision-id': '',
-        });
-      const mockControlPaneACL = kubernetesControlPlaneACLFactory.build({
-        acl: mockACLOptions,
+    cy.wait(['@updateControlPlaneACL']);
+
+    // confirm summary panel updates
+    cy.contains('Control Plane ACL').should('be.visible');
+    cy.findByText('Enabled (0 IP Addresses)').should('not.exist');
+    ui.button
+      .findByTitle('Enable')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    // confirm data within drawer is updated
+    ui.drawer
+      .findByTitle(`Control Plane ACL for ${mockCluster.label}`)
+      .should('be.visible')
+      .within(() => {
+        // confirm enable toggle was updated
+        ui.toggle
+          .find()
+          .should('have.attr', 'data-qa-toggle', 'false')
+          .should('be.visible');
+
+        // confirm Revision ID section remains empty
+        cy.findByLabelText('Revision ID').should(
+          'have.value',
+          mockDisabledACLOptions['revision-id']
+        );
+
+        // confirm IPv4 and IPv6 address sections remain empty
+        cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0')
+          .should('be.visible')
+          .should('have.value', mockDisabledACLOptions.addresses?.ipv4?.[0]);
+        cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
+          .should('be.visible')
+          .should('have.value', mockDisabledACLOptions.addresses?.ipv6?.[0]);
       });
-      const mockUpdatedControlPlaneACL = kubernetesControlPlaneACLFactory.build(
-        {
-          acl: mockDisabledACLOptions,
-        }
-      );
+  });
 
-      mockGetCluster(mockCluster).as('getCluster');
-      mockGetControlPlaneACL(mockCluster.id, mockControlPaneACL).as(
-        'getControlPlaneACL'
-      );
-      mockUpdateControlPlaneACL(mockCluster.id, mockUpdatedControlPlaneACL).as(
-        'updateControlPlaneACL'
-      );
-
-      cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
-      cy.wait(['@getAccount', '@getCluster', '@getControlPlaneACL']);
-
-      // confirm summary panel
-      cy.contains('Control Plane ACL').should('be.visible');
-      ui.button
-        .findByTitle('Enabled (0 IP Addresses)')
-        .should('be.visible')
-        .should('be.enabled')
-        .click();
-
-      ui.drawer
-        .findByTitle(`Control Plane ACL for ${mockCluster.label}`)
-        .should('be.visible')
-        .within(() => {
-          // Confirm submit button is disabled if form has not been changed
-          ui.button
-            .findByTitle('Update')
-            .scrollIntoView()
-            .should('be.visible')
-            .should('not.be.enabled');
-
-          // Activation Status section: toggle off 'Enable'
-          cy.contains('Activation Status').should('be.visible');
-          ui.toggle
-            .find()
-            .should('have.attr', 'data-qa-toggle', 'true')
-            .should('be.visible')
-            .click();
-
-          // confirm submit button is now enabled
-          ui.button
-            .findByTitle('Update')
-            .scrollIntoView()
-            .should('be.visible')
-            .should('be.enabled');
-
-          // confirm Revision ID section
-          cy.findByLabelText('Revision ID').should(
-            'have.value',
-            mockDisabledACLOptions['revision-id']
-          );
-
-          // confirm IPv4 and IPv6 address sections
-          cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0')
-            .should('be.visible')
-            .should('have.value', mockDisabledACLOptions.addresses?.ipv4?.[0]);
-          cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
-            .should('be.visible')
-            .should('have.value', mockDisabledACLOptions.addresses?.ipv6?.[0]);
-
-          // submit
-          ui.button
-            .findByTitle('Update')
-            .scrollIntoView()
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-        });
-
-      cy.wait(['@updateControlPlaneACL']);
-
-      // confirm summary panel updates
-      cy.contains('Control Plane ACL').should('be.visible');
-      cy.findByText('Enabled (0 IP Addresses)').should('not.exist');
-      ui.button
-        .findByTitle('Enable')
-        .should('be.visible')
-        .should('be.enabled')
-        .click();
-
-      // confirm data within drawer is updated
-      ui.drawer
-        .findByTitle(`Control Plane ACL for ${mockCluster.label}`)
-        .should('be.visible')
-        .within(() => {
-          // confirm enable toggle was updated
-          ui.toggle
-            .find()
-            .should('have.attr', 'data-qa-toggle', 'false')
-            .should('be.visible');
-
-          // confirm Revision ID section remains empty
-          cy.findByLabelText('Revision ID').should(
-            'have.value',
-            mockDisabledACLOptions['revision-id']
-          );
-
-          // confirm IPv4 and IPv6 address sections remain empty
-          cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0')
-            .should('be.visible')
-            .should('have.value', mockDisabledACLOptions.addresses?.ipv4?.[0]);
-          cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
-            .should('be.visible')
-            .should('have.value', mockDisabledACLOptions.addresses?.ipv6?.[0]);
-        });
+  /**
+   * - Confirms ACL can be enabled from the summary page when cluster does not have ACL pre-installed
+   * - Confirms drawer appearance when APL is not pre-installed
+   * - Confirms that request to correct endpoint is sent
+   */
+  it('can enable ACL on an LKE cluster with ACL not pre-installed and edit IPs', () => {
+    const mockACLOptions = kubernetesControlPlaneACLOptionsFactory.build({
+      addresses: { ipv4: ['10.0.0.0/24'] },
+      enabled: true,
+    });
+    const mockControlPaneACL = kubernetesControlPlaneACLFactory.build({
+      acl: mockACLOptions,
     });
 
-    /**
-     * - Confirms ACL can be enabled from the summary page when cluster does not have ACL pre-installed
-     * - Confirms drawer appearance when APL is not pre-installed
-     * - Confirms that request to correct endpoint is sent
-     */
-    it('can enable ACL on an LKE cluster with ACL not pre-installed and edit IPs', () => {
-      const mockACLOptions = kubernetesControlPlaneACLOptionsFactory.build({
-        addresses: { ipv4: ['10.0.0.0/24'] },
-        enabled: true,
+    mockGetCluster(mockCluster).as('getCluster');
+    mockGetControlPlaneACLError(mockCluster.id).as('getControlPlaneACLError');
+    mockUpdateCluster(mockCluster.id, {
+      ...mockCluster,
+      control_plane: mockControlPaneACL,
+    }).as('updateCluster');
+    mockGetClusterPools(mockCluster.id, mockNodePools).as('getNodePools');
+
+    cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
+    cy.wait(['@getCluster', '@getControlPlaneACLError', '@getNodePools']);
+
+    cy.contains('Control Plane ACL').should('be.visible');
+    cy.findAllByTestId('circle-progress').should('be.visible');
+
+    // query retries once if failed
+    cy.wait('@getControlPlaneACLError');
+
+    ui.button
+      .findByTitle('Enable')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    mockGetControlPlaneACL(mockCluster.id, mockControlPaneACL).as(
+      'getControlPlaneACL'
+    );
+
+    ui.drawer
+      .findByTitle(`Control Plane ACL for ${mockCluster.label}`)
+      .should('be.visible')
+      .within(() => {
+        // Confirm installation notice is displayed
+        cy.contains(
+          'Control Plane ACL has not yet been installed on this cluster. During installation, it may take up to 15 minutes for the access control list to be fully enforced.'
+        ).should('be.visible');
+
+        // Confirm Activation Status section and Enable ACL
+        cy.contains('Activation Status').should('be.visible');
+        ui.toggle
+          .find()
+          .should('have.attr', 'data-qa-toggle', 'false')
+          .should('be.visible')
+          .click();
+
+        // Revision ID section does not exist
+        cy.contains('Revision ID').should('not.exist');
+
+        // Addresses section: add IP addresses
+        cy.findByText('Addresses').should('be.visible');
+        cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0')
+          .should('be.visible')
+          .click();
+        cy.focused().type('10.0.0.0/24');
+
+        cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
+          .should('be.visible')
+          .click();
+        cy.focused().type('8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e');
+
+        // submit
+        ui.button
+          .findByTitle('Update')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
       });
-      const mockControlPaneACL = kubernetesControlPlaneACLFactory.build({
-        acl: mockACLOptions,
+
+    cy.wait(['@updateCluster', '@getControlPlaneACL']);
+
+    // confirm summary panel updates
+    cy.contains('Control Plane ACL').should('be.visible');
+    cy.findByText('Enabled (2 IP Addresses)').should('be.exist');
+  });
+
+  /**
+   * - Confirms IP validation error appears when a bad IP is entered
+   * - Confirms IP validation error disappears when a valid IP is entered
+   * - Confirms API error appears as expected and doesn't crash the page
+   */
+  it('can handle validation and API errors', () => {
+    const mockACLOptions = kubernetesControlPlaneACLOptionsFactory.build({
+      addresses: { ipv4: undefined, ipv6: undefined },
+      enabled: true,
+    });
+    const mockControlPaneACL = kubernetesControlPlaneACLFactory.build({
+      acl: mockACLOptions,
+    });
+    const mockErrorMessage = 'Control Plane ACL error: failed to update ACL';
+
+    mockGetCluster(mockCluster).as('getCluster');
+    mockGetControlPlaneACL(mockCluster.id, mockControlPaneACL).as(
+      'getControlPlaneACL'
+    );
+
+    mockUpdateControlPlaneACLError(mockCluster.id, mockErrorMessage, 400).as(
+      'updateControlPlaneACLError'
+    );
+
+    cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
+    cy.wait(['@getCluster', '@getControlPlaneACL']);
+
+    // confirm summary panel
+    cy.contains('Control Plane ACL').should('be.visible');
+    ui.button
+      .findByTitle('Enabled (0 IP Addresses)')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    ui.drawer
+      .findByTitle(`Control Plane ACL for ${mockCluster.label}`)
+      .should('be.visible')
+      .within(() => {
+        // Confirm ACL IP validation works as expected for IPv4
+        cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0')
+          .should('be.visible')
+          .click();
+        cy.focused().type('invalid ip');
+        // click out of textbox and confirm error is visible
+        cy.contains('Addresses').should('be.visible').click();
+        cy.contains('Must be a valid IPv4 address.').should('be.visible');
+        // enter valid IP
+        cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0')
+          .should('be.visible')
+          .click();
+        cy.focused().clear();
+        cy.focused().type('10.0.0.0/24');
+        // Click out of textbox and confirm error is gone
+        cy.contains('Addresses').should('be.visible').click();
+        cy.contains('Must be a valid IPv4 address.').should('not.exist');
+
+        // Confirm ACL IP validation works as expected for IPv6
+        cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
+          .should('be.visible')
+          .click();
+        cy.focused().type('invalid ip');
+        // click out of textbox and confirm error is visible
+        cy.findByText('Addresses').should('be.visible').click();
+        cy.contains('Must be a valid IPv6 address.').should('be.visible');
+        // enter valid IP
+        cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
+          .should('be.visible')
+          .click();
+        cy.focused().clear();
+        cy.focused().type('8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e');
+        // Click out of textbox and confirm error is gone
+        cy.findByText('Addresses').should('be.visible').click();
+        cy.contains('Must be a valid IPv6 address.').should('not.exist');
+
+        // submit
+        ui.button
+          .findByTitle('Update')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
       });
 
-      mockGetCluster(mockCluster).as('getCluster');
-      mockGetControlPlaneACLError(mockCluster.id).as('getControlPlaneACLError');
-      mockUpdateCluster(mockCluster.id, {
-        ...mockCluster,
-        control_plane: mockControlPaneACL,
-      }).as('updateCluster');
-      mockGetClusterPools(mockCluster.id, mockNodePools).as('getNodePools');
+    cy.wait(['@updateControlPlaneACLError']);
+    cy.contains(mockErrorMessage).should('be.visible');
+  });
 
-      cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
-      cy.wait([
-        '@getAccount',
-        '@getCluster',
-        '@getControlPlaneACLError',
-        '@getNodePools',
-      ]);
-
-      cy.contains('Control Plane ACL').should('be.visible');
-      cy.findAllByTestId('circle-progress').should('be.visible');
-
-      // query retries once if failed
-      cy.wait('@getControlPlaneACLError');
-
-      ui.button
-        .findByTitle('Enable')
-        .should('be.visible')
-        .should('be.enabled')
-        .click();
-
-      mockGetControlPlaneACL(mockCluster.id, mockControlPaneACL).as(
-        'getControlPlaneACL'
-      );
-
-      ui.drawer
-        .findByTitle(`Control Plane ACL for ${mockCluster.label}`)
-        .should('be.visible')
-        .within(() => {
-          // Confirm installation notice is displayed
-          cy.contains(
-            'Control Plane ACL has not yet been installed on this cluster. During installation, it may take up to 15 minutes for the access control list to be fully enforced.'
-          ).should('be.visible');
-
-          // Confirm Activation Status section and Enable ACL
-          cy.contains('Activation Status').should('be.visible');
-          ui.toggle
-            .find()
-            .should('have.attr', 'data-qa-toggle', 'false')
-            .should('be.visible')
-            .click();
-
-          // Revision ID section does not exist
-          cy.contains('Revision ID').should('not.exist');
-
-          // Addresses section: add IP addresses
-          cy.findByText('Addresses').should('be.visible');
-          cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0')
-            .should('be.visible')
-            .click();
-          cy.focused().type('10.0.0.0/24');
-
-          cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
-            .should('be.visible')
-            .click();
-          cy.focused().type('8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e');
-
-          // submit
-          ui.button
-            .findByTitle('Update')
-            .scrollIntoView()
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-        });
-
-      cy.wait(['@updateCluster', '@getControlPlaneACL']);
-
-      // confirm summary panel updates
-      cy.contains('Control Plane ACL').should('be.visible');
-      cy.findByText('Enabled (2 IP Addresses)').should('be.exist');
+  it('can handle validation for an enterprise cluster', () => {
+    const mockEnterpriseCluster = kubernetesClusterFactory.build({
+      tier: 'enterprise',
+    });
+    const mockACLOptions = kubernetesControlPlaneACLOptionsFactory.build({
+      addresses: { ipv4: [], ipv6: [] },
+      enabled: true,
+    });
+    const mockUpdatedOptions = kubernetesControlPlaneACLOptionsFactory.build({
+      addresses: {
+        ipv4: [],
+        ipv6: ['8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e'],
+      },
+      enabled: true,
+    });
+    const mockControlPaneACL = kubernetesControlPlaneACLFactory.build({
+      acl: mockACLOptions,
+    });
+    const mockUpdatedControlPaneACL = kubernetesControlPlaneACLFactory.build({
+      acl: mockUpdatedOptions,
     });
 
-    /**
-     * - Confirms IP validation error appears when a bad IP is entered
-     * - Confirms IP validation error disappears when a valid IP is entered
-     * - Confirms API error appears as expected and doesn't crash the page
-     */
-    it('can handle validation and API errors', () => {
-      const mockACLOptions = kubernetesControlPlaneACLOptionsFactory.build({
-        addresses: { ipv4: undefined, ipv6: undefined },
-        enabled: true,
-      });
-      const mockControlPaneACL = kubernetesControlPlaneACLFactory.build({
-        acl: mockACLOptions,
-      });
-      const mockErrorMessage = 'Control Plane ACL error: failed to update ACL';
+    mockGetCluster(mockEnterpriseCluster).as('getCluster');
+    mockGetControlPlaneACL(mockEnterpriseCluster.id, mockControlPaneACL).as(
+      'getControlPlaneACL'
+    );
+    mockUpdateControlPlaneACL(
+      mockEnterpriseCluster.id,
+      mockUpdatedControlPaneACL
+    ).as('updateControlPlaneACL');
 
-      mockGetCluster(mockCluster).as('getCluster');
-      mockGetControlPlaneACL(mockCluster.id, mockControlPaneACL).as(
-        'getControlPlaneACL'
-      );
+    cy.visitWithLogin(`/kubernetes/clusters/${mockEnterpriseCluster.id}`);
+    cy.wait(['@getCluster', '@getControlPlaneACL']);
 
-      mockUpdateControlPlaneACLError(mockCluster.id, mockErrorMessage, 400).as(
-        'updateControlPlaneACLError'
-      );
+    cy.contains('Control Plane ACL').should('be.visible');
+    ui.button
+      .findByTitle('Enabled (0 IP Addresses)')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
 
-      cy.visitWithLogin(`/kubernetes/clusters/${mockCluster.id}`);
-      cy.wait(['@getAccount', '@getCluster', '@getControlPlaneACL']);
+    ui.drawer
+      .findByTitle(`Control Plane ACL for ${mockEnterpriseCluster.label}`)
+      .should('be.visible')
+      .within(() => {
+        // Confirm the checkbox is not checked by default
+        cy.findByRole('checkbox', { name: /Provide an ACL later/ }).should(
+          'not.be.checked'
+        );
 
-      // confirm summary panel
-      cy.contains('Control Plane ACL').should('be.visible');
-      ui.button
-        .findByTitle('Enabled (0 IP Addresses)')
-        .should('be.visible')
-        .should('be.enabled')
-        .click();
+        cy.findByLabelText('Revision ID').click();
+        cy.focused().clear();
+        cy.focused().type('1');
 
-      ui.drawer
-        .findByTitle(`Control Plane ACL for ${mockCluster.label}`)
-        .should('be.visible')
-        .within(() => {
-          // Confirm ACL IP validation works as expected for IPv4
-          cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0')
-            .should('be.visible')
-            .click();
-          cy.focused().type('invalid ip');
-          // click out of textbox and confirm error is visible
-          cy.contains('Addresses').should('be.visible').click();
-          cy.contains('Must be a valid IPv4 address.').should('be.visible');
-          // enter valid IP
-          cy.findByLabelText('IPv4 Addresses or CIDRs ip-address-0')
-            .should('be.visible')
-            .click();
-          cy.focused().clear();
-          cy.focused().type('10.0.0.0/24');
-          // Click out of textbox and confirm error is gone
-          cy.contains('Addresses').should('be.visible').click();
-          cy.contains('Must be a valid IPv4 address.').should('not.exist');
+        // Try to submit the form without any IPs
+        ui.button
+          .findByTitle('Update')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
 
-          // Confirm ACL IP validation works as expected for IPv6
-          cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
-            .should('be.visible')
-            .click();
-          cy.focused().type('invalid ip');
-          // click out of textbox and confirm error is visible
-          cy.findByText('Addresses').should('be.visible').click();
-          cy.contains('Must be a valid IPv6 address.').should('be.visible');
-          // enter valid IP
-          cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
-            .should('be.visible')
-            .click();
-          cy.focused().clear();
-          cy.focused().type('8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e');
-          // Click out of textbox and confirm error is gone
-          cy.findByText('Addresses').should('be.visible').click();
-          cy.contains('Must be a valid IPv6 address.').should('not.exist');
+        // Confirm validation error prevents this
+        cy.findByText(
+          'At least one IP address or CIDR range is required for LKE Enterprise.'
+        ).should('be.visible');
 
-          // submit
-          ui.button
-            .findByTitle('Update')
-            .scrollIntoView()
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-        });
+        // Add at least one IP
+        cy.findByText('Add IPv6 Address').click();
+        cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
+          .should('be.visible')
+          .click();
+        cy.focused().clear();
+        cy.focused().type('8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e');
 
-      cy.wait(['@updateControlPlaneACLError']);
-      cy.contains(mockErrorMessage).should('be.visible');
-    });
+        // Resubmit the form
+        ui.button
+          .findByTitle('Update')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
 
-    it('can handle validation for an enterprise cluster', () => {
-      const mockEnterpriseCluster = kubernetesClusterFactory.build({
-        tier: 'enterprise',
-      });
-      const mockACLOptions = kubernetesControlPlaneACLOptionsFactory.build({
-        addresses: { ipv4: [], ipv6: [] },
-        enabled: true,
-      });
-      const mockUpdatedOptions = kubernetesControlPlaneACLOptionsFactory.build({
-        addresses: {
-          ipv4: [],
-          ipv6: ['8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e'],
-        },
-        enabled: true,
-      });
-      const mockControlPaneACL = kubernetesControlPlaneACLFactory.build({
-        acl: mockACLOptions,
-      });
-      const mockUpdatedControlPaneACL = kubernetesControlPlaneACLFactory.build({
-        acl: mockUpdatedOptions,
+        // Confirm error message disappears
+        cy.findByText(
+          'At least one IP address or CIDR range is required for LKE Enterprise.'
+        ).should('not.exist');
       });
 
-      mockGetCluster(mockEnterpriseCluster).as('getCluster');
-      mockGetControlPlaneACL(mockEnterpriseCluster.id, mockControlPaneACL).as(
-        'getControlPlaneACL'
-      );
-      mockUpdateControlPlaneACL(
-        mockEnterpriseCluster.id,
-        mockUpdatedControlPaneACL
-      ).as('updateControlPlaneACL');
+    cy.wait('@updateControlPlaneACL');
 
-      cy.visitWithLogin(`/kubernetes/clusters/${mockEnterpriseCluster.id}`);
-      cy.wait(['@getAccount', '@getCluster', '@getControlPlaneACL']);
+    ui.button
+      .findByTitle('Enabled (1 IP Address)')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
 
-      cy.contains('Control Plane ACL').should('be.visible');
-      ui.button
-        .findByTitle('Enabled (0 IP Addresses)')
-        .should('be.visible')
-        .should('be.enabled')
-        .click();
+    ui.drawer
+      .findByTitle(`Control Plane ACL for ${mockEnterpriseCluster.label}`)
+      .should('be.visible')
+      .within(() => {
+        // Clear the existing IP
+        cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
+          .should('be.visible')
+          .click();
+        cy.focused().clear();
 
-      ui.drawer
-        .findByTitle(`Control Plane ACL for ${mockEnterpriseCluster.label}`)
-        .should('be.visible')
-        .within(() => {
-          // Confirm the checkbox is not checked by default
-          cy.findByRole('checkbox', { name: /Provide an ACL later/ }).should(
-            'not.be.checked'
-          );
+        // Check the acknowledgement checkbox
+        cy.findByRole('checkbox', { name: /Provide an ACL later/ }).click();
 
-          cy.findByLabelText('Revision ID').click();
-          cy.focused().clear();
-          cy.focused().type('1');
+        // Confirm the form can submit without any IPs if the acknowledgement is checked
+        ui.button
+          .findByTitle('Update')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
 
-          // Try to submit the form without any IPs
-          ui.button
-            .findByTitle('Update')
-            .scrollIntoView()
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-
-          // Confirm validation error prevents this
-          cy.findByText(
-            'At least one IP address or CIDR range is required for LKE Enterprise.'
-          ).should('be.visible');
-
-          // Add at least one IP
-          cy.findByText('Add IPv6 Address').click();
-          cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
-            .should('be.visible')
-            .click();
-          cy.focused().clear();
-          cy.focused().type('8e61:f9e9:8d40:6e0a:cbff:c97a:2692:827e');
-
-          // Resubmit the form
-          ui.button
-            .findByTitle('Update')
-            .scrollIntoView()
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-
-          // Confirm error message disappears
-          cy.findByText(
-            'At least one IP address or CIDR range is required for LKE Enterprise.'
-          ).should('not.exist');
-        });
-
-      cy.wait('@updateControlPlaneACL');
-
-      ui.button
-        .findByTitle('Enabled (1 IP Address)')
-        .should('be.visible')
-        .should('be.enabled')
-        .click();
-
-      ui.drawer
-        .findByTitle(`Control Plane ACL for ${mockEnterpriseCluster.label}`)
-        .should('be.visible')
-        .within(() => {
-          // Clear the existing IP
-          cy.findByLabelText('IPv6 Addresses or CIDRs ip-address-0')
-            .should('be.visible')
-            .click();
-          cy.focused().clear();
-
-          // Check the acknowledgement checkbox
-          cy.findByRole('checkbox', { name: /Provide an ACL later/ }).click();
-
-          // Confirm the form can submit without any IPs if the acknowledgement is checked
-          ui.button
-            .findByTitle('Update')
-            .scrollIntoView()
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-
-          // Confirm error message disappears
-          cy.contains(
-            'At least one IP address or CIDR range is required for LKE Enterprise.'
-          ).should('not.exist');
-        });
-    });
+        // Confirm error message disappears
+        cy.contains(
+          'At least one IP address or CIDR range is required for LKE Enterprise.'
+        ).should('not.exist');
+      });
   });
 });

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -1,5 +1,4 @@
 import {
-  useAccount,
   useAllTypes,
   useMutateAccountAgreements,
   useRegionsQuery,
@@ -30,8 +29,6 @@ import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
 import { RegionHelperText } from 'src/components/SelectRegionPanel/RegionHelperText';
 import { getRestrictedResourceText } from 'src/features/Account/utils';
 import {
-  getKubeControlPlaneACL,
-  getKubeHighAvailability,
   getLatestVersion,
   useAPLAvailability,
   useIsLkeEnterpriseEnabled,
@@ -109,11 +106,8 @@ export const CreateCluster = () => {
 
   const { data, error: regionsError } = useRegionsQuery();
   const regionsData = data ?? [];
-  const { data: account } = useAccount();
   const { showAPL } = useAPLAvailability();
   const { isUsingBetaEndpoint } = useKubernetesBetaEndpoint();
-  const { showHighAvailability } = getKubeHighAvailability(account);
-  const { showControlPlaneACL } = getKubeControlPlaneACL(account);
   const [ipV4Addr, setIPv4Addr] = React.useState<ExtendedIP[]>([
     stringToExtendedIP(''),
   ]);
@@ -513,7 +507,7 @@ export const CreateCluster = () => {
                 marginTop: showAPL ? 1 : 4,
               }}
             />
-            {showHighAvailability && selectedTier !== 'enterprise' && (
+            {selectedTier !== 'enterprise' && (
               <Box data-testid="ha-control-plane">
                 <HAControlPlane
                   highAvailabilityPrice={
@@ -530,41 +524,40 @@ export const CreateCluster = () => {
               </Box>
             )}
             {selectedTier === 'enterprise' && <ClusterNetworkingPanel />}
-            {showControlPlaneACL && (
-              <>
-                <Divider
-                  sx={{ marginTop: selectedTier === 'enterprise' ? 4 : 1 }}
-                />
-                <ControlPlaneACLPane
-                  enableControlPlaneACL={controlPlaneACL}
-                  errorText={errorMap.control_plane}
-                  handleIPv4Change={(newIpV4Addr: ExtendedIP[]) => {
-                    const validatedIPs = validateIPs(newIpV4Addr, {
-                      allowEmptyAddress: true,
-                      errorMessage: 'Must be a valid IPv4 address.',
-                    });
-                    setIPv4Addr(validatedIPs);
-                  }}
-                  handleIPv6Change={(newIpV6Addr: ExtendedIP[]) => {
-                    const validatedIPs = validateIPs(newIpV6Addr, {
-                      allowEmptyAddress: true,
-                      errorMessage: 'Must be a valid IPv6 address.',
-                    });
-                    setIPv6Addr(validatedIPs);
-                  }}
-                  handleIsAcknowledgementChecked={(isChecked: boolean) => {
-                    setIsACLAcknowledgementChecked(isChecked);
-                    setIPv4Addr([stringToExtendedIP('')]);
-                    setIPv6Addr([stringToExtendedIP('')]);
-                  }}
-                  ipV4Addr={ipV4Addr}
-                  ipV6Addr={ipV6Addr}
-                  isAcknowledgementChecked={isACLAcknowledgementChecked}
-                  selectedTier={selectedTier}
-                  setControlPlaneACL={setControlPlaneACL}
-                />
-              </>
-            )}
+            <>
+              <Divider
+                sx={{ marginTop: selectedTier === 'enterprise' ? 4 : 1 }}
+              />
+              <ControlPlaneACLPane
+                enableControlPlaneACL={controlPlaneACL}
+                errorText={errorMap.control_plane}
+                handleIPv4Change={(newIpV4Addr: ExtendedIP[]) => {
+                  const validatedIPs = validateIPs(newIpV4Addr, {
+                    allowEmptyAddress: true,
+                    errorMessage: 'Must be a valid IPv4 address.',
+                  });
+                  setIPv4Addr(validatedIPs);
+                }}
+                handleIPv6Change={(newIpV6Addr: ExtendedIP[]) => {
+                  const validatedIPs = validateIPs(newIpV6Addr, {
+                    allowEmptyAddress: true,
+                    errorMessage: 'Must be a valid IPv6 address.',
+                  });
+                  setIPv6Addr(validatedIPs);
+                }}
+                handleIsAcknowledgementChecked={(isChecked: boolean) => {
+                  setIsACLAcknowledgementChecked(isChecked);
+                  setIPv4Addr([stringToExtendedIP('')]);
+                  setIPv6Addr([stringToExtendedIP('')]);
+                }}
+                ipV4Addr={ipV4Addr}
+                ipV6Addr={ipV6Addr}
+                isAcknowledgementChecked={isACLAcknowledgementChecked}
+                selectedTier={selectedTier}
+                setControlPlaneACL={setControlPlaneACL}
+              />
+            </>
+
             <Divider sx={{ marginBottom: 4 }} />
             <NodePoolPanel
               addNodePool={(pool: KubeNodePoolResponse) => addPool(pool)}
@@ -613,7 +606,6 @@ export const CreateCluster = () => {
             region={selectedRegion?.id}
             regionsData={regionsData}
             removePool={removePool}
-            showHighAvailability={showHighAvailability}
             submitting={submitting}
             toggleHasAgreed={toggleHasAgreed}
             updateFor={[

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
@@ -22,7 +22,6 @@ const props: Props = {
   region: 'us-east',
   regionsData: regionFactory.buildList(1),
   removePool: vi.fn(),
-  showHighAvailability: true,
   submitting: false,
   toggleHasAgreed: vi.fn(),
   updatePool: vi.fn(),

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -38,7 +38,6 @@ export interface Props {
   region: string | undefined;
   regionsData: Region[];
   removePool: (poolIdx: number) => void;
-  showHighAvailability: boolean | undefined;
   submitting: boolean;
   toggleHasAgreed: () => void;
   updatePool: (poolIdx: number, updatedPool: KubeNodePoolResponse) => void;
@@ -55,7 +54,6 @@ export const KubeCheckoutBar = (props: Props) => {
     region,
     regionsData,
     removePool,
-    showHighAvailability,
     submitting,
     toggleHasAgreed,
     updatePool,
@@ -82,9 +80,7 @@ export const KubeCheckoutBar = (props: Props) => {
   const gdprConditions = !hasAgreed && showGDPRCheckbox;
 
   const haConditions =
-    highAvailability === undefined &&
-    showHighAvailability &&
-    highAvailabilityPrice !== undefined;
+    highAvailability === undefined && highAvailabilityPrice !== undefined;
 
   const disableCheckout = Boolean(
     needsAPool ||

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeEntityDetailFooter.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeEntityDetailFooter.tsx
@@ -22,6 +22,7 @@ import type { KubernetesControlPlaneACLPayload } from '@linode/api-v4';
 
 interface FooterProps {
   aclData: KubernetesControlPlaneACLPayload | undefined;
+  areClusterLinodesReadOnly: boolean;
   clusterCreated: string;
   clusterId: number;
   clusterLabel: string;
@@ -30,7 +31,6 @@ interface FooterProps {
   isClusterReadOnly: boolean;
   isLoadingKubernetesACL: boolean;
   setControlPlaneACLDrawerOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  showControlPlaneACL: boolean;
 }
 
 export const KubeEntityDetailFooter = React.memo((props: FooterProps) => {
@@ -39,6 +39,7 @@ export const KubeEntityDetailFooter = React.memo((props: FooterProps) => {
   const { data: profile } = useProfile();
   const {
     aclData,
+    areClusterLinodesReadOnly,
     clusterCreated,
     clusterId,
     clusterLabel,
@@ -47,7 +48,6 @@ export const KubeEntityDetailFooter = React.memo((props: FooterProps) => {
     isClusterReadOnly,
     isLoadingKubernetesACL,
     setControlPlaneACLDrawerOpen,
-    showControlPlaneACL,
   } = props;
 
   const enabledACL = aclData?.acl.enabled ?? false;
@@ -118,29 +118,27 @@ export const KubeEntityDetailFooter = React.memo((props: FooterProps) => {
             <StyledLabelBox component="span">Cluster ID:</StyledLabelBox>{' '}
             {clusterId}
           </StyledListItem>
-          {showControlPlaneACL && (
-            <StyledListItem
-              sx={{
-                alignItems: 'center',
-              }}
-            >
-              <StyledLabelBox component="span">
-                Control Plane ACL:{' '}
-              </StyledLabelBox>{' '}
-              {isLoadingKubernetesACL ? (
-                <Box component="span" sx={{ paddingLeft: 1 }}>
-                  <CircleProgress noPadding size="sm" />
-                </Box>
-              ) : (
-                <StyledLinkButton
-                  disabled={isClusterReadOnly}
-                  onClick={() => setControlPlaneACLDrawerOpen(true)}
-                >
-                  {buttonCopyACL}
-                </StyledLinkButton>
-              )}
-            </StyledListItem>
-          )}
+          <StyledListItem
+            sx={{
+              alignItems: 'center',
+            }}
+          >
+            <StyledLabelBox component="span">
+              Control Plane ACL:{' '}
+            </StyledLabelBox>{' '}
+            {isLoadingKubernetesACL ? (
+              <Box component="span" sx={{ paddingLeft: 1 }}>
+                <CircleProgress noPadding size="sm" />
+              </Box>
+            ) : (
+              <StyledLinkButton
+                disabled={isClusterReadOnly}
+                onClick={() => setControlPlaneACLDrawerOpen(true)}
+              >
+                {buttonCopyACL}
+              </StyledLinkButton>
+            )}
+          </StyledListItem>
         </StyledBox>
         <StyledBox>
           <StyledListItem
@@ -176,7 +174,7 @@ export const KubeEntityDetailFooter = React.memo((props: FooterProps) => {
         }}
       >
         <TagCell
-          disabled={isClusterReadOnly}
+          disabled={areClusterLinodesReadOnly}
           entityLabel={clusterLabel}
           sx={{
             width: '100%',

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -10,6 +10,7 @@ import {
   useKubernetesBetaEndpoint,
 } from 'src/features/Kubernetes/kubeUtils';
 import { getKubeHighAvailability } from 'src/features/Kubernetes/kubeUtils';
+import { useIsResourceRestricted } from 'src/hooks/useIsResourceRestricted';
 import {
   useKubernetesClusterMutation,
   useKubernetesClusterQuery,
@@ -43,11 +44,19 @@ export const KubernetesClusterDetail = () => {
   const { mutateAsync: updateKubernetesCluster } =
     useKubernetesClusterMutation(id);
 
-  const { isClusterHighlyAvailable, showHighAvailability } =
-    getKubeHighAvailability(account, cluster);
+  const { isClusterHighlyAvailable } = getKubeHighAvailability(
+    account,
+    cluster
+  );
 
   const [updateError, setUpdateError] = React.useState<string | undefined>();
   const [isUpgradeToHAOpen, setIsUpgradeToHAOpen] = React.useState(false);
+
+  const isClusterReadOnly = useIsResourceRestricted({
+    grantLevel: 'read_only',
+    grantType: 'lkecluster',
+    id: cluster?.id,
+  });
 
   if (error) {
     return (
@@ -107,7 +116,7 @@ export const KubernetesClusterDetail = () => {
         docsLabel="Docs"
         docsLink="https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-lke-linode-kubernetes-engine"
         onButtonClick={
-          showHighAvailability && !isClusterHighlyAvailable
+          !isClusterHighlyAvailable && !isClusterReadOnly
             ? handleUpgradeToHA
             : undefined
         }

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeClusterDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeClusterDialog.tsx
@@ -14,6 +14,7 @@ import {
   localStorageWarning,
   nodesDeletionWarning,
 } from 'src/features/Kubernetes/constants';
+import { useIsResourceRestricted } from 'src/hooks/useIsResourceRestricted';
 import {
   useKubernetesClusterMutation,
   useKubernetesTypesQuery,
@@ -68,6 +69,12 @@ export const UpgradeKubernetesClusterToHADialog = React.memo((props: Props) => {
     (type) => type.id === 'lke-ha'
   );
 
+  const isClusterReadOnly = useIsResourceRestricted({
+    grantLevel: 'read_only',
+    grantType: 'lkecluster',
+    id: clusterID,
+  });
+
   const onUpgrade = () => {
     setSubmitting(true);
     setError(undefined);
@@ -94,7 +101,7 @@ export const UpgradeKubernetesClusterToHADialog = React.memo((props: Props) => {
     <ActionsPanel
       primaryButtonProps={{
         'data-testid': 'confirm',
-        disabled: !checked,
+        disabled: !checked || isClusterReadOnly,
         label: 'Upgrade to HA',
         loading: submitting,
         onClick: onUpgrade,

--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -171,17 +171,12 @@ export const getKubeHighAvailability = (
   account: Account | undefined,
   cluster?: KubernetesCluster | null
 ) => {
-  const showHighAvailability = account?.capabilities.includes(
-    'LKE HA Control Planes'
-  );
-
   const isClusterHighlyAvailable = Boolean(
-    showHighAvailability && cluster?.control_plane.high_availability
+    cluster?.control_plane.high_availability
   );
 
   return {
     isClusterHighlyAvailable,
-    showHighAvailability,
   };
 };
 
@@ -217,17 +212,10 @@ export const getKubeControlPlaneACL = (
   account: Account | undefined,
   cluster?: KubernetesCluster | null
 ) => {
-  const showControlPlaneACL = account?.capabilities.includes(
-    'LKE Network Access Control List (IP ACL)'
-  );
-
-  const isClusterControlPlaneACLd = Boolean(
-    showControlPlaneACL && cluster?.control_plane.acl
-  );
+  const isClusterControlPlaneACLd = Boolean(cluster?.control_plane.acl);
 
   return {
     isClusterControlPlaneACLd,
-    showControlPlaneACL,
   };
 };
 

--- a/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
+++ b/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
@@ -87,11 +87,10 @@ export const ConfigNodeIPSelect = React.memo((props: Props) => {
 
   const noOptionsText = useMemo(() => {
     if (!vpcId) {
-      return 'No options - Please ensure you have at least 1 Linode with a private IP located in the selected region.';
+      return 'Please ensure you have at least 1 Linode with a private IP located in the selected region.';
     } else if (vpcId && !subnetId) {
-      return 'No options - Select a Subnet within the chosen VPC.';
-    } else
-      return 'No options - The selected Subnet must have at least one Linode.';
+      return 'Select a subnet within the chosen VPC.';
+    } else return 'The selected subnet must have at least one Linode.';
   }, [vpcId, subnetId]);
 
   return (

--- a/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
+++ b/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
@@ -87,11 +87,11 @@ export const ConfigNodeIPSelect = React.memo((props: Props) => {
 
   const noOptionsText = useMemo(() => {
     if (!vpcId) {
-      return 'No options - please ensure you have at least 1 Linode with a private IP located in the selected region.';
+      return 'No options - Please ensure you have at least 1 Linode with a private IP located in the selected region.';
     } else if (vpcId && !subnetId) {
-      return 'No options - please ensure you have selected a Subnet from the selected VPC';
+      return 'No options - Select a Subnet within the chosen VPC.';
     } else
-      return 'No options - please ensure you have at least 1 Linode in the selected VPC.';
+      return 'No options - The selected Subnet must have at least one Linode.';
   }, [vpcId, subnetId]);
 
   return (

--- a/packages/manager/src/features/NodeBalancers/VPCPanel.test.tsx
+++ b/packages/manager/src/features/NodeBalancers/VPCPanel.test.tsx
@@ -181,7 +181,7 @@ describe('VPCPanel', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByLabelText('Auto-assign a /30 CIDR for this NodeBalancer')
+        screen.getByLabelText('Auto-assign IPs for this NodeBalancer')
       ).toBeChecked();
     });
   });
@@ -231,7 +231,7 @@ describe('VPCPanel', () => {
     );
 
     const checkbox = screen.getByLabelText(
-      'Auto-assign a /30 CIDR for this NodeBalancer'
+      'Auto-assign IPs for this NodeBalancer'
     );
 
     await userEvent.click(checkbox);

--- a/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
@@ -84,7 +84,7 @@ export const VPCPanel = (props: Props) => {
           </Typography>
           <Autocomplete
             data-testid="vpc-select"
-            disabled={disabled}
+            disabled={disabled || !regionSupportsVPC}
             errorText={vpcError}
             helperText={
               regionSelected && !regionSupportsVPC

--- a/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
@@ -51,6 +51,7 @@ export const VPCPanel = (props: Props) => {
   const { data: region } = useRegionQuery(regionSelected);
 
   const regionSupportsVPC = region?.capabilities.includes('VPCs') || false;
+  const vpcSelectDisabled = !!regionSelected && !regionSupportsVPC;
 
   const {
     data: vpcs,
@@ -84,7 +85,7 @@ export const VPCPanel = (props: Props) => {
           </Typography>
           <Autocomplete
             data-testid="vpc-select"
-            disabled={disabled || !regionSupportsVPC}
+            disabled={disabled || vpcSelectDisabled}
             errorText={vpcError}
             helperText={
               regionSelected && !regionSupportsVPC

--- a/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
@@ -15,12 +15,10 @@ import {
 import { useMediaQuery, useTheme } from '@mui/material';
 import React from 'react';
 
+import { Code } from 'src/components/Code/Code';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
-import {
-  NB_AUTO_ASSIGN_CIDR_TOOLTIP,
-  NODEBALANCER_REGION_CAVEAT_HELPER_TEXT,
-} from '../VPCs/constants';
+import { NODEBALANCER_REGION_CAVEAT_HELPER_TEXT } from '../VPCs/constants';
 
 import type { APIError, NodeBalancerVpcPayload, VPC } from '@linode/api-v4';
 
@@ -81,8 +79,8 @@ export const VPCPanel = (props: Props) => {
         <Typography variant="h2">VPC</Typography>
         <Stack spacing={1.5}>
           <Typography>
-            Select a VPC if your NodeBalancer will use backend nodes within a
-            VPC.
+            Complete this section to allow this NodeBalancer to communicate with
+            backend nodes in a VPC.
           </Typography>
           <Autocomplete
             data-testid="vpc-select"
@@ -126,9 +124,7 @@ export const VPCPanel = (props: Props) => {
               <Notice
                 spacingBottom={16}
                 spacingTop={8}
-                text={
-                  'Once a NodeBalancer is created, its VPC configuration cannot be changed.'
-                }
+                text={"The VPC can't be changed after NodeBalancer creation."}
                 variant="warning"
               />
               <Autocomplete
@@ -147,8 +143,7 @@ export const VPCPanel = (props: Props) => {
                 textFieldProps={{
                   helperText: (
                     <Typography mb={2}>
-                      Select a subnet in which to allocate the VPC CIDR for the
-                      NodeBalancer.
+                      The VPC subnet for this NodeBalancer.
                     </Typography>
                   ),
                   helperTextPosition: 'top',
@@ -192,11 +187,25 @@ export const VPCPanel = (props: Props) => {
                           flexDirection="row"
                         >
                           <Typography noWrap={!isSmallBp}>
-                            Auto-assign a /30 CIDR for this NodeBalancer
+                            Auto-assign IPs for this NodeBalancer
                           </Typography>
                           <TooltipIcon
                             status="help"
-                            text={NB_AUTO_ASSIGN_CIDR_TOOLTIP}
+                            text={
+                              <Typography
+                                component={'span'}
+                                sx={{ whiteSpace: 'pre-line' }}
+                              >
+                                When enabled, the system automatically allocates
+                                a <Code>/30</Code> CIDR from the specified
+                                Subnet for the NodeBalancer&apos;s backend nodes
+                                in the VPC.
+                                <br />
+                                <br /> Disable this option to assign a{' '}
+                                <Code>/30</Code> IPv4 CIDR subnet range for this
+                                NodeBalancer.
+                              </Typography>
+                            }
                             tooltipPosition="right"
                           />
                         </Box>
@@ -217,8 +226,6 @@ export const VPCPanel = (props: Props) => {
                         onChange={(e) =>
                           ipv4Change(e.target.value ?? '', index)
                         }
-                        // eslint-disable-next-line sonarjs/no-hardcoded-ip
-                        placeholder="10.0.0.24"
                         required
                         slotProps={{
                           input: {

--- a/packages/manager/src/features/VPCs/constants.ts
+++ b/packages/manager/src/features/VPCs/constants.ts
@@ -23,9 +23,6 @@ export const REGIONAL_LINODE_MESSAGE =
 export const MULTIPLE_CONFIGURATIONS_MESSAGE =
   'This Linode has multiple configurations. Select which configuration you would like added to the subnet.';
 
-export const NB_AUTO_ASSIGN_CIDR_TOOLTIP =
-  "Automatically allocates a /30 CIDR for the NodeBalancer's backend interface. If the range doesn't have enough available IPs, the creation fails.";
-
 export const VPC_AUTO_ASSIGN_IPV4_TOOLTIP =
   'Automatically assign an IPv4 address as the private IP address for this Linode in the VPC.';
 

--- a/packages/manager/src/queries/cloudpulse/services.ts
+++ b/packages/manager/src/queries/cloudpulse/services.ts
@@ -48,7 +48,7 @@ export const useCloudPulseServiceTypes = (enabled: boolean) => {
 
 export const useCloudPulseServiceByServiceType = (
   serviceType: string,
-  enabled: boolean = true
+  enabled: boolean = false
 ) => {
   return useQuery<ServiceTypes, APIError[]>({
     ...queryFactory.serviceByServiceType(serviceType),

--- a/packages/ui/src/foundations/themes/dark.ts
+++ b/packages/ui/src/foundations/themes/dark.ts
@@ -203,6 +203,7 @@ const MuiTableHeadSvgStyles = {
 };
 
 const MuiTableZebraHoverStyles = {
+  // In dark theme, we exclude disabled rows from hover styling to maintain accessibility
   '&.MuiTableRow-hover:not(.disabled-row):hover, &.Mui-selected:not(.disabled-row), &.Mui-selected:not(.disabled-row):hover':
     {
       background: Table.Row.Background.Hover,
@@ -967,6 +968,7 @@ export const darkTheme: ThemeOptions = {
             backgroundColor: Table.HeaderNested.Background,
           },
           // The `hover` rule isn't implemented correctly in MUI, so we apply it here.
+          // In dark theme, we exclude disabled rows from hover styling to maintain accessibility
           '&.MuiTableRow-hover:not(.disabled-row):hover, &.Mui-selected:not(.disabled-row), &.Mui-selected:not(.disabled-row):hover':
             {
               backgroundColor: Table.Row.Background.Hover,

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -243,7 +243,7 @@ const MuiTableHeadSvgStyles = {
 };
 
 const MuiTableZebraHoverStyles = {
-  '&.MuiTableRow-hover:not(.disabled-row):hover, &.Mui-selected:not(.disabled-row), &.Mui-selected:not(.disabled-row):hover':
+  '&.MuiTableRow-hover:hover, &.Mui-selected, &.Mui-selected:hover':
     {
       background: Table.Row.Background.Hover,
     },

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -1561,7 +1561,7 @@ export const lightTheme: ThemeOptions = {
             backgroundColor: Table.HeaderNested.Background,
           },
           // The `hover` rule isn't implemented correctly in MUI, so we apply it here.
-          '&.MuiTableRow-hover:not(.disabled-row):hover, &.Mui-selected:not(.disabled-row), &.Mui-selected:not(.disabled-row):hover':
+          '&.MuiTableRow-hover:hover, &.Mui-selected, &.Mui-selected:hover':
             {
               backgroundColor: Table.Row.Background.Hover,
             },


### PR DESCRIPTION
## Description 📝

Highlight the Pull Request's context and intentions.

## Changes  🔄
- Fixed issue where table headers had hoverable background color in light mode.
- NB-VPC: add descriptions finalized by UX on Create NodeBalancer page (#12368)
- Fixed: Set default `enabled` to `false` for `useCloudPulseServiceByServiceType` query
   - This query is no longer used in the develop branch for the next release (June 24th), but we are keeping it in `cloudpulse/services` for potential future use. In staging, however, it is currently tied to feature flag work, and we do not want it to be called. This change prevents the query from running in staging or upcoming prod release (June 17th)
- Fixed: Remove account capability checks preventing restricted users from enabling HA and ACL on Kubernetes clusters

## Target release date 🗓️
6/17

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img width="1008" alt="Screenshot 2025-06-12 at 3 29 47 PM" src="https://github.com/user-attachments/assets/a434f09d-6a5f-4653-9e18-505c73c00277" /> | <img width="1006" alt="Screenshot 2025-06-12 at 3 29 55 PM" src="https://github.com/user-attachments/assets/4a649d46-a87c-4964-8a77-05c3a020a60f" /> |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- ...
- ...

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>