### PR TITLE
upcoming: [DI-25153] - Enable and integration of delete alert API

### DIFF
--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.test.tsx
@@ -6,7 +6,10 @@ import { alertFactory } from 'src/factories';
 import { formatDate } from 'src/utilities/formatDate';
 import { renderWithThemeAndRouter } from 'src/utilities/testHelpers';
 
-import { UPDATE_ALERT_SUCCESS_MESSAGE } from '../constants';
+import {
+  DELETE_ALERT_SUCCESS_MESSAGE,
+  UPDATE_ALERT_SUCCESS_MESSAGE,
+} from '../constants';
 import { AlertsListTable } from './AlertListTable';
 
 const queryMocks = vi.hoisted(() => ({
@@ -214,5 +217,60 @@ describe('Alert List Table test', () => {
     expect(screen.getByText('tag1')).toBeVisible();
     expect(screen.getByText('tag2')).toBeVisible();
   });
-  // TODO: Add tests for the delete alert functionality once API's are available
+
+  it('should show success snackbar when deleting alert succeeds', async () => {
+    const alert = alertFactory.build({ type: 'user' });
+    renderWithThemeAndRouter(
+      <AlertsListTable
+        alerts={[alert]}
+        isLoading={false}
+        scrollToElement={mockScroll}
+        services={[{ label: 'Linode', value: 'linode' }]}
+      />
+    );
+
+    const actionMenu = screen.getByLabelText(
+      `Action menu for Alert ${alert.label}`
+    );
+    await userEvent.click(actionMenu);
+    await userEvent.click(screen.getByText('Delete'));
+
+    expect(screen.getByText(`Delete ${alert.label}?`)).toBeVisible();
+    const textInput = screen.getByTestId('textfield-input');
+    await userEvent.type(textInput, alert.label);
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(screen.getByText(DELETE_ALERT_SUCCESS_MESSAGE)).toBeVisible();
+  });
+
+  it('should show the proper api error message in error snackbar when deleting alert fails with a reason', async () => {
+    queryMocks.useDeleteAlertDefinitionMutation.mockReturnValue({
+      mutateAsync: vi
+        .fn()
+        .mockRejectedValue([{ reason: 'Deleting alert failed.' }]),
+    });
+
+    const alert = alertFactory.build({ type: 'user' });
+    renderWithThemeAndRouter(
+      <AlertsListTable
+        alerts={[alert]}
+        isLoading={false}
+        scrollToElement={mockScroll}
+        services={[{ label: 'Linode', value: 'linode' }]}
+      />
+    );
+
+    const actionMenu = screen.getByLabelText(
+      `Action menu for Alert ${alert.label}`
+    );
+    await userEvent.click(actionMenu);
+    await userEvent.click(screen.getByText('Delete'));
+
+    expect(screen.getByText(`Delete ${alert.label}?`)).toBeVisible();
+    const textInput = screen.getByTestId('textfield-input');
+    await userEvent.type(textInput, alert.label);
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(screen.getByText('Deleting alert failed.')).toBeVisible();
+  });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.tsx
@@ -27,7 +27,10 @@ import {
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 import { AlertConfirmationDialog } from '../AlertsLanding/AlertConfirmationDialog';
-import { UPDATE_ALERT_SUCCESS_MESSAGE } from '../constants';
+import {
+  DELETE_ALERT_SUCCESS_MESSAGE,
+  UPDATE_ALERT_SUCCESS_MESSAGE,
+} from '../constants';
 import { AlertsTable } from './AlertsTable';
 import { AlertListingTableLabelMap } from './constants';
 import { GroupedAlertsTable } from './GroupedAlertsTable';
@@ -164,7 +167,9 @@ export const AlertsListTable = React.memo((props: AlertsListTableProps) => {
 
       deleteAlertDefinition(payload)
         .then(() => {
-          enqueueSnackbar('Alert deleted', { variant: 'success' });
+          enqueueSnackbar(DELETE_ALERT_SUCCESS_MESSAGE, {
+            variant: 'success',
+          });
         })
         .catch((deleteError: APIError[]) => {
           const errorResponse = getAPIErrorOrDefault(

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
@@ -44,9 +44,7 @@ export const getAlertTypeToActionsList = (
       title: getTitleForStatusChange(alertStatus),
     },
     {
-      disabled:
-        /* Hardcoding it to be disabled for now as the API's are not ready yet, once they're available will remove the true. */
-        alertStatus === 'in progress' || alertStatus === 'failed' || true,
+      disabled: alertStatus === 'in progress' || alertStatus === 'failed',
       onClick: handleDelete,
       title: 'Delete',
     },

--- a/packages/manager/src/features/CloudPulse/Alerts/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/constants.ts
@@ -202,3 +202,5 @@ export const CREATE_ALERT_SUCCESS_MESSAGE =
 
 export const UPDATE_ALERT_SUCCESS_MESSAGE =
   'Alert successfully updated. It may take a few minutes for your changes to take effect.';
+
+export const DELETE_ALERT_SUCCESS_MESSAGE = 'Alert successfully deleted.';


### PR DESCRIPTION
## Description 📝

Enabling the Delete Action item

## Changes  🔄

- Removed the true condition for disabling the Delete button 
- Added Unit Tests

## Target release date 🗓️
1st July 

## Preview 📷
https://github.com/user-attachments/assets/5c97356a-1899-4164-a7a2-a64917094121


## How to test 🧪

### Prerequisites

(How to setup test environment)

- Navigate to Alerts under Monitor
- Choose an alert and click on the Action Menu
- Click on Delete and enter the label name in the confirmation box to delete the Alert.
- APIs are available in Dev and Prod.

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>