### PR TITLE
upcoming: [DI-25592] - Added EntityScopeSelect component for create alert page

### DIFF
--- a/packages/api-v4/src/cloudpulse/services.ts
+++ b/packages/api-v4/src/cloudpulse/services.ts
@@ -12,7 +12,7 @@ import type {
   JWEToken,
   JWETokenPayLoad,
   MetricDefinition,
-  ServiceTypes,
+  Service,
   ServiceTypesList,
 } from './types';
 import type { Filter, Params, ResourcePage } from 'src/types';
@@ -51,7 +51,7 @@ export const getCloudPulseServiceTypes = () =>
   );
 
 export const getCloudPulseServiceByServiceType = (serviceType: string) =>
-  Request<ServiceTypes>(
+  Request<Service>(
     setURL(`${API_ROOT}/monitor/services/${encodeURIComponent(serviceType)}`),
     setMethod('GET'),
   );

--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -10,6 +10,7 @@ export type DimensionFilterOperatorType =
   | 'startswith';
 export type AlertDefinitionType = 'system' | 'user';
 export type AlertStatusType = 'disabled' | 'enabled' | 'failed' | 'in progress';
+export type AlertDefinitionScope = 'account' | 'entity' | 'region';
 export type CriteriaConditionType = 'ALL';
 export type MetricUnitType =
   | 'bit_per_second'
@@ -163,12 +164,14 @@ export interface CloudPulseMetricsList {
   values: [number, string][];
 }
 
-export interface ServiceTypes {
-  alert: {
-    evaluation_periods_seconds: number[];
-    polling_interval_seconds: number[];
-    scope: string[];
-  };
+export interface ServiceAlert {
+  evaluation_periods_seconds: number[];
+  polling_interval_seconds: number[];
+  scope: AlertDefinitionScope[];
+}
+
+export interface Service {
+  alert: ServiceAlert;
   is_beta: boolean;
   label: string;
   regions: string;
@@ -176,7 +179,7 @@ export interface ServiceTypes {
 }
 
 export interface ServiceTypesList {
-  data: ServiceTypes[];
+  data: Service[];
 }
 
 export interface CreateAlertDefinitionPayload {
@@ -239,6 +242,7 @@ export interface Alert {
   rule_criteria: {
     rules: AlertDefinitionMetricCriteria[];
   };
+  scope: AlertDefinitionScope;
   service_type: AlertServiceType;
   severity: AlertSeverityType;
   status: AlertStatusType;
@@ -326,6 +330,7 @@ export interface EditAlertDefinitionPayload {
   rule_criteria?: {
     rules: MetricCriteria[];
   };
+  scope: AlertDefinitionScope;
   severity?: AlertSeverityType;
   status?: AlertStatusType;
   tags?: string[];

--- a/packages/manager/src/factories/cloudpulse/alerts.ts
+++ b/packages/manager/src/factories/cloudpulse/alerts.ts
@@ -110,4 +110,5 @@ export const alertFactory = Factory.Sync.makeFactory<Alert>({
   type: 'system',
   updated: new Date().toISOString(),
   updated_by: 'system',
+  scope: 'entity',
 });

--- a/packages/manager/src/factories/cloudpulse/services.ts
+++ b/packages/manager/src/factories/cloudpulse/services.ts
@@ -1,15 +1,18 @@
+import { type Service } from '@linode/api-v4';
 import { Factory } from '@linode/utilities';
 
-import type { ServiceTypes } from '@linode/api-v4';
+import type { ServiceAlert } from '@linode/api-v4';
 
-export const serviceTypesFactory = Factory.Sync.makeFactory<ServiceTypes>({
+export const serviceAlertFactory = Factory.Sync.makeFactory<ServiceAlert>({
+  polling_interval_seconds: [1, 5, 10, 15],
+  evaluation_periods_seconds: [5, 10, 15, 20],
+  scope: ['entity', 'region', 'account'],
+});
+
+export const serviceTypesFactory = Factory.Sync.makeFactory<Service>({
   label: Factory.each((i) => `Factory ServiceType-${i}`),
   service_type: Factory.each((i) => `Factory ServiceType-${i}`),
   is_beta: false,
   regions: '*',
-  alert: {
-    polling_interval_seconds: [1, 5, 10, 15],
-    evaluation_periods_seconds: [5, 10, 15, 20],
-    scope: ['entity', 'region', 'account'],
-  },
+  alert: serviceAlertFactory.build(),
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.tsx
@@ -62,6 +62,7 @@ const initialValues: CreateAlertDefinitionForm = {
   severity: null,
   tags: [''],
   trigger_conditions: triggerConditionInitialValues,
+  scope: null,
 };
 
 const overrides = [

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/AlertEntityScopeSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/AlertEntityScopeSelect.test.tsx
@@ -1,0 +1,68 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { serviceAlertFactory, serviceTypesFactory } from 'src/factories';
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
+
+import { AlertEntityScopeSelect } from './AlertEntityScopeSelect';
+
+const queryMock = vi.hoisted(() => ({
+  useCloudPulseServiceByServiceType: vi.fn(),
+}));
+
+vi.mock('src/queries/cloudpulse/services.ts', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useCloudPulseServiceByServiceType:
+    queryMock.useCloudPulseServiceByServiceType,
+}));
+
+describe('AlertEntityGroupingSelect', () => {
+  it('should render the component', () => {
+    queryMock.useCloudPulseServiceByServiceType.mockReturnValue({
+      isLoading: false,
+      data: serviceTypesFactory.build(),
+    });
+    renderWithThemeAndHookFormContext({
+      component: <AlertEntityScopeSelect name="scope" serviceType="linode" />,
+    });
+
+    expect(screen.getByTestId('entity-grouping')).toBeInTheDocument();
+    expect(screen.getByLabelText('Scope')).toBeInTheDocument();
+  });
+
+  it('Select option from drop down', async () => {
+    renderWithThemeAndHookFormContext({
+      component: <AlertEntityScopeSelect name="scope" serviceType="dbaas" />,
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open' }));
+    await userEvent.click(screen.getByRole('option', { name: 'Account' }));
+
+    expect(screen.getByRole('combobox')).toHaveAttribute('value', 'Account');
+  });
+
+  it('should disable options that are not available for the service type', async () => {
+    queryMock.useCloudPulseServiceByServiceType.mockReturnValue({
+      isLoading: false,
+      data: serviceTypesFactory.build({
+        alert: serviceAlertFactory.build({
+          scope: ['entity'],
+        }),
+      }),
+    });
+
+    renderWithThemeAndHookFormContext({
+      component: <AlertEntityScopeSelect name="scope" serviceType="dbaas" />,
+    });
+
+    expect(screen.getByRole('combobox')).toHaveAttribute('value', 'Entity');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open' }));
+
+    expect(screen.getByRole('option', { name: 'Account' })).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+});

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/AlertEntityScopeSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/AlertEntityScopeSelect.tsx
@@ -1,0 +1,133 @@
+import { Autocomplete, Box, ListItem, SelectedIcon } from '@linode/ui';
+import React from 'react';
+import {
+  Controller,
+  type FieldPathByValue,
+  useFormContext,
+} from 'react-hook-form';
+
+import { useCloudPulseServiceByServiceType } from 'src/queries/cloudpulse/services';
+
+import {
+  ALERT_SCOPE_TOOLTIP_TEXT,
+  entityGroupingOptions,
+} from '../../constants';
+
+import type { AlertFormMode } from '../../constants';
+import type { CreateAlertDefinitionForm } from '../types';
+import type { AlertDefinitionScope, AlertServiceType } from '@linode/api-v4';
+interface ScopeOption {
+  disabled: boolean;
+  label: string;
+  value: AlertDefinitionScope;
+}
+interface AlertEntityScopeSelectProps {
+  formMode?: AlertFormMode;
+  name: FieldPathByValue<
+    CreateAlertDefinitionForm,
+    AlertDefinitionScope | null
+  >;
+  serviceType: AlertServiceType | null;
+}
+export const AlertEntityScopeSelect = (props: AlertEntityScopeSelectProps) => {
+  const { name, serviceType, formMode = 'create' } = props;
+  const { isLoading, data } = useCloudPulseServiceByServiceType(
+    serviceType ?? '',
+    serviceType !== null
+  );
+  const { control, setValue } = useFormContext<CreateAlertDefinitionForm>();
+
+  const options: ScopeOption[] = React.useMemo(() => {
+    const scopes = data?.alert?.scope ?? [];
+    return scopes.length === 0
+      ? []
+      : entityGroupingOptions.map((option) => ({
+          ...option,
+          disabled: !scopes.includes(option.value),
+        }));
+  }, [data?.alert?.scope]);
+
+  const getSelectedOption = (
+    value: null | string,
+    options: ScopeOption[]
+  ): null | ScopeOption => {
+    if (options.length === 0) {
+      return null;
+    }
+
+    let selectedOption =
+      options.find((option) => option.value === value) ?? null;
+
+    if (!selectedOption || selectedOption.disabled) {
+      selectedOption = options.find((o) => !o.disabled) ?? null;
+    }
+
+    return selectedOption;
+  };
+
+  React.useEffect(() => {
+    if (formMode === 'create') {
+      if (options.length === 0) {
+        setValue(name, null);
+        return;
+      }
+      const selectedOption = getSelectedOption(null, options);
+
+      // Update the form value only if we're in create mode
+      setValue(name, selectedOption?.value ?? null);
+    }
+  }, [formMode, name, options, setValue]);
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field, fieldState }) => {
+        return (
+          <Autocomplete
+            data-testid="entity-grouping"
+            disableClearable={options.length !== 0}
+            disabled={!serviceType || isLoading}
+            errorText={fieldState.error?.message}
+            getOptionLabel={(option) => option.label}
+            label="Scope"
+            loading={isLoading}
+            onBlur={field.onBlur}
+            onChange={(_, selectedValue) => {
+              const value = selectedValue?.value;
+              field.onChange(value);
+
+              /*
+                TODO: This will be uncommented in future PRs when regions support is added.
+
+               setValue('regions', value === 'region' ? [] : undefined);
+               setValue('entity_ids', value === 'entity' ? [] : undefined);
+              */
+            }}
+            options={options}
+            placeholder="Select a scope"
+            renderOption={(props, option, { selected }) => {
+              const { key, ...rest } = props;
+              return (
+                <ListItem
+                  {...rest}
+                  aria-disabled={option.disabled}
+                  data-qa-option
+                  key={key}
+                >
+                  <Box flexGrow={1}>{option.label}</Box>
+                  <SelectedIcon visible={selected} />
+                </ListItem>
+              );
+            }}
+            size="medium"
+            textFieldProps={{
+              labelTooltipText: ALERT_SCOPE_TOOLTIP_TEXT,
+            }}
+            value={getSelectedOption(field.value, options)}
+          />
+        );
+      }}
+    />
+  );
+};

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/types.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/types.ts
@@ -1,4 +1,5 @@
 import type {
+  AlertDefinitionScope,
   AlertServiceType,
   AlertSeverityType,
   ChannelType,
@@ -20,6 +21,7 @@ export interface CreateAlertDefinitionForm
   rule_criteria: {
     rules: MetricCriteriaForm[];
   };
+  scope: AlertDefinitionScope | null;
   serviceType: AlertServiceType | null;
   severity: AlertSeverityType | null;
   trigger_conditions: TriggerConditionForm;

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/utils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/utils.test.ts
@@ -66,6 +66,7 @@ it('should correctly convert an alert definition values to the required format',
     severity,
     tags,
     trigger_conditions,
+    scope,
   } = alert;
   const expected: EditAlertPayloadWithService = {
     alertId: id,
@@ -84,6 +85,7 @@ it('should correctly convert an alert definition values to the required format',
     severity,
     tags,
     trigger_conditions,
+    scope,
   };
 
   expect(convertAlertDefinitionValues(alert, serviceType)).toEqual(expected);

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/utils.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/utils.ts
@@ -256,10 +256,12 @@ export const convertAlertDefinitionValues = (
     severity,
     tags,
     trigger_conditions,
+    scope,
   }: Alert,
   serviceType: AlertServiceType
 ): EditAlertPayloadWithService => {
   return {
+    scope,
     alertId: id,
     channel_ids: alert_channels.map((channel) => channel.id),
     description: description || undefined,

--- a/packages/manager/src/features/CloudPulse/Alerts/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/constants.ts
@@ -2,6 +2,7 @@ import type { FieldPath } from 'react-hook-form';
 
 import type { CreateAlertDefinitionForm } from './CreateAlert/types';
 import type {
+  AlertDefinitionScope,
   AlertSeverityType,
   AlertStatusType,
   ChannelType,
@@ -123,6 +124,12 @@ export const pollingIntervalOptions = {
   ],
 };
 
+export const entityGroupingOptions: Item<string, AlertDefinitionScope>[] = [
+  { label: 'Account', value: 'account' },
+  { label: 'Region', value: 'region' },
+  { label: 'Entity', value: 'entity' },
+];
+
 export const severityMap: Record<AlertSeverityType, string> = {
   0: 'Severe',
   1: 'Medium',
@@ -202,3 +209,8 @@ export const CREATE_ALERT_SUCCESS_MESSAGE =
 
 export const UPDATE_ALERT_SUCCESS_MESSAGE =
   'Alert successfully updated. It may take a few minutes for your changes to take effect.';
+
+export const ALERT_SCOPE_TOOLTIP_TEXT =
+  'The set of entities to which the alert applies: account-wide, specific regions, or individual entities.';
+
+export type AlertFormMode = 'create' | 'edit' | 'view';

--- a/packages/manager/src/features/CloudPulse/Utils/utils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/utils.ts
@@ -8,7 +8,7 @@ import type {
   APIError,
   Dashboard,
   ResourcePage,
-  ServiceTypes,
+  Service,
   ServiceTypesList,
   TimeDuration,
 } from '@linode/api-v4';
@@ -128,7 +128,7 @@ export const formattedServiceTypes = (
   if (rawServiceTypes === undefined || rawServiceTypes.data.length === 0) {
     return [];
   }
-  return rawServiceTypes.data.map((obj: ServiceTypes) => obj.service_type);
+  return rawServiceTypes.data.map((obj: Service) => obj.service_type);
 };
 
 /**

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -98,6 +98,7 @@ import {
   possiblePostgresReplicationTypes,
   postgresConfigResponse,
   promoFactory,
+  serviceAlertFactory,
   serviceTypesFactory,
   stackScriptFactory,
   staticObjects,
@@ -2822,6 +2823,7 @@ export const handlers = [
             label: 'Linodes',
             service_type: 'linode',
             regions: 'us-iad,us-east',
+            alert: serviceAlertFactory.build({ scope: ['entity'] }),
           })
         : serviceTypesFactory.build({
             label: 'Databases',

--- a/packages/manager/src/queries/cloudpulse/services.ts
+++ b/packages/manager/src/queries/cloudpulse/services.ts
@@ -9,7 +9,7 @@ import type {
   JWETokenPayLoad,
   MetricDefinition,
   ResourcePage,
-  ServiceTypes,
+  Service,
   ServiceTypesList,
 } from '@linode/api-v4';
 import type { Params } from '@linode/api-v4';
@@ -50,7 +50,7 @@ export const useCloudPulseServiceByServiceType = (
   serviceType: string,
   enabled: boolean = true
 ) => {
-  return useQuery<ServiceTypes, APIError[]>({
+  return useQuery<Service, APIError[]>({
     ...queryFactory.serviceByServiceType(serviceType),
     enabled,
   });

--- a/packages/validation/src/cloudpulse.schema.ts
+++ b/packages/validation/src/cloudpulse.schema.ts
@@ -77,6 +77,10 @@ export const createAlertDefinitionSchema = object({
     .min(1, 'At least one notification channel is required.'),
   tags: array().of(string().defined()).optional(),
   entity_ids: array().of(string().defined()).optional(),
+  scope: string()
+    .oneOf(['entity', 'region', 'account'])
+    .defined()
+    .required(fieldErrorMessage),
 });
 
 export const editAlertDefinitionSchema = object({
@@ -120,4 +124,5 @@ export const editAlertDefinitionSchema = object({
   status: string()
     .oneOf(['enabled', 'disabled', 'in progress', 'failed'])
     .optional(),
+  scope: string().oneOf(['entity', 'region', 'account']).required(),
 });


### PR DESCRIPTION

## Description 📝
 Added an EntityScopeSelect dropdown for alert create & edit page.
## Changes  🔄

List any change(s) relevant to the reviewer.

1. EntityScopeSelect component is added
2. Added scope property in alert related types
3. Added a ServiceAlert interface in cloudpulse types.ts
4. Renamed ServiceTypes interface to Service for better naming convention.

## Target release date 🗓️

July 1st

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
|![Screenshot 2025-06-13 at 6 20 55 PM](https://github.com/user-attachments/assets/af31a222-c0f5-48ed-802e-ac812dfd5849)|![Screenshot 2025-06-13 at 6 20 45 PM](https://github.com/user-attachments/assets/4fd75269-0b0f-4627-991b-8a72db6cf3cb)|
|![Screenshot 2025-06-13 at 6 21 06 PM](https://github.com/user-attachments/assets/f59fb841-244e-4e51-816d-3f0acd2990a6)|![Screenshot 2025-06-13 at 6 20 36 PM](https://github.com/user-attachments/assets/ee46e40a-1b43-4822-ab9c-b68772ca4ddf)|
|![Screenshot 2025-06-13 at 6 21 18 PM](https://github.com/user-attachments/assets/241b335e-17ce-480c-b23b-265d17e8996f)|![Screenshot 2025-06-13 at 6 20 21 PM](https://github.com/user-attachments/assets/67d7f52a-35c8-42b1-84cd-83937aaab576)|

## How to test 🧪

1. Switch as mock user and got to alerts from mega menu
2. Click on create alert button that will take you to create alert page
3.  At line 213 after severity select in CreateAlertDefinition.tsx,  add the below code to show entity scope select
`<AlertEntityScopeSelect name="scope"  serviceType={serviceTypeWatcher}  />`
4. You can select service type and based on that scope select dropdown will behave.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
