### PR TITLE
test: Disable nodebalancerVpc flag in cypress tests

### DIFF
--- a/packages/manager/cypress/e2e/core/vpc/vpc-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/vpc/vpc-create.spec.ts
@@ -2,6 +2,7 @@ import { linodeFactory, regionFactory } from '@linode/utilities';
 import { grantsFactory, profileFactory } from '@linode/utilities';
 import { subnetFactory, vpcFactory } from '@src/factories';
 import { mockGetUser } from 'support/intercepts/account';
+import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
 /**
  * @file Integration tests for VPC create flow.
  */
@@ -48,6 +49,13 @@ describe('VPC create flow', () => {
    * - Confirms that UI handles API errors gracefully.
    * - Confirms that UI redirects to created VPC page after creating a VPC.
    */
+  beforeEach(() => {
+    // TODO - Remove mock once `nodebalancerVpc` feature flag is removed.
+    mockAppendFeatureFlags({
+      nodebalancerVpc: false,
+    }).as('getFeatureFlags');
+  });
+
   it('can create a VPC', () => {
     const mockVPCRegion = extendRegion(
       regionFactory.build({
@@ -83,7 +91,7 @@ describe('VPC create flow', () => {
     mockGetRegions([mockVPCRegion]).as('getRegions');
 
     cy.visitWithLogin('/vpcs/create');
-    cy.wait('@getRegions');
+    cy.wait(['@getRegions', '@getFeatureFlags']);
 
     ui.regionSelect.find().click();
     cy.focused().type(`${mockVPCRegion.label}{enter}`);
@@ -281,7 +289,7 @@ describe('VPC create flow', () => {
     mockGetRegions([mockVPCRegion]).as('getRegions');
 
     cy.visitWithLogin('/vpcs/create');
-    cy.wait('@getRegions');
+    cy.wait(['@getRegions', '@getFeatureFlags']);
 
     ui.regionSelect.find().click().type(`${mockVPCRegion.label}{enter}`);
 

--- a/packages/manager/cypress/e2e/core/vpc/vpc-linodes-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/vpc/vpc-linodes-update.spec.ts
@@ -16,6 +16,7 @@ import {
   mockDeleteLinodeConfigInterface,
   mockGetLinodeConfigs,
 } from 'support/intercepts/configs';
+import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
 import { mockGetLinodes } from 'support/intercepts/linodes';
 import {
   mockCreateSubnet,
@@ -45,6 +46,13 @@ describe('VPC assign/unassign flows', () => {
     mockConfig = linodeConfigFactory.build({
       id: randomNumber(),
     });
+  });
+
+  beforeEach(() => {
+    // TODO - Remove mock once `nodebalancerVpc` feature flag is removed.
+    mockAppendFeatureFlags({
+      nodebalancerVpc: false,
+    }).as('getFeatureFlags');
   });
 
   /*
@@ -84,7 +92,7 @@ describe('VPC assign/unassign flows', () => {
     mockGetLinodes([mockLinode]).as('getLinodes');
 
     cy.visitWithLogin(`/vpcs/${mockVPC.id}`);
-    cy.wait(['@getVPC', '@getSubnets']);
+    cy.wait(['@getVPC', '@getSubnets', '@getFeatureFlags']);
 
     // confirm that vpc and subnet details get displayed
     cy.findByText(mockVPC.label).should('be.visible');
@@ -230,7 +238,7 @@ describe('VPC assign/unassign flows', () => {
     mockGetLinodes([mockLinode, mockSecondLinode]).as('getLinodes');
 
     cy.visitWithLogin(`/vpcs/${mockVPC.id}`);
-    cy.wait(['@getVPC', '@getSubnets', '@getLinodes']);
+    cy.wait(['@getVPC', '@getSubnets', '@getLinodes', '@getFeatureFlags']);
 
     // confirm that subnet should get displayed on VPC's detail page
     cy.findByText(mockVPC.label).should('be.visible');


### PR DESCRIPTION
## Changes  🔄
- Disable nodebalancerVpc flag in vpc e2e tests

## Target release date 🗓️


## How to test 🧪

### Reproduction steps

-

### Verification steps

- [ ] Run `pnpm cy:run -s "cypress/e2e/core/vpc/vpc-linodes-update.spec.ts,cypress/e2e/core/vpc/vpc-create.spec.ts"`
- [ ] Verify that all tests pass

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
